### PR TITLE
feat(drafting): every composed email is written in the sender's own voice

### DIFF
--- a/backend/internal/compose/accountdraft/service.go
+++ b/backend/internal/compose/accountdraft/service.go
@@ -12,9 +12,11 @@ package accountdraft
 
 import (
 	"context"
+	"log/slog"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/compose/org360"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
@@ -69,6 +71,21 @@ type Service struct {
 	lane     Completer
 	envelope *draftfloor.Resolver
 	dossier  Dossier
+	// voice reads the sender's own Voice DNA. It is the READ seam, not the
+	// voice store: this package promises to write nothing, and a store handed
+	// in whole would carry the learning-signal writes with it.
+	voice draftvoice.Reader
+	log   *slog.Logger
+}
+
+// WithVoice binds the sender's voice profile read, so a rep who has built one
+// gets their own writing here and not only when they answer a mail. Without it
+// the draft is written under the shared rules alone, which is what a
+// deployment with no voice lane has.
+func (s *Service) WithVoice(reader draftvoice.Reader, log *slog.Logger) *Service {
+	s.voice = reader
+	s.log = log
+	return s
 }
 
 // WithDossier feeds the draft what the company IS, from a dossier already
@@ -142,7 +159,9 @@ func (s *Service) Draft(
 		return crmcontracts.AccountEmailDraft{}, err
 	}
 	in.Dossier = s.facts(ctx, orgID)
-	draft, by, err := Write(ctx, s.lane, in)
+	// Loaded after the 360 read, so a caller who may not read this account is
+	// refused before their voice profile is touched at all.
+	draft, by, err := Write(ctx, s.lane, in, draftvoice.Load(ctx, s.voice, s.log))
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}

--- a/backend/internal/compose/accountdraft/voicefloor_test.go
+++ b/backend/internal/compose/accountdraft/voicefloor_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package accountdraft
+
+// The anti-AI floor a voiced draft passes through, and the guarantee it owes:
+// every step may improve the draft and none may replace it with a worse one.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/ports/model"
+)
+
+// sequencedLane answers each call with the next scripted response, so a test
+// can describe a first attempt and the retry that follows it.
+type sequencedLane struct {
+	answers []string
+	err     error
+	calls   int
+}
+
+func (l *sequencedLane) Complete(_ context.Context, _ model.Request) (model.Response, error) {
+	l.calls++
+	if l.err != nil {
+		return model.Response{}, l.err
+	}
+	if l.calls > len(l.answers) {
+		return model.Response{}, errors.New("the lane was called more times than the test scripted")
+	}
+	return model.Response{Text: l.answers[l.calls-1]}, nil
+}
+
+func voiced() draftvoice.Context {
+	return draftvoice.Context{
+		Profile: ai.VoiceProfile{PersonalityMD: "I write short."},
+		Version: ai.VoiceProfileVersion{ProfileVersion: 1, VoiceProfileMD: "Sentences stay under twelve words."},
+		OK:      true,
+	}
+}
+
+// A draft the sanitizer would empty is served unsanitized rather than blank.
+//
+// The sanitizer deletes characters. A subject made only of what it deletes
+// comes back as the empty string, and an empty subject is not a message the
+// contract can carry — so the pre-sanitizer draft, imperfect but real, is what
+// the rep gets. Without this the composer answers a rep's "Write email" with a
+// draft that has no subject at all.
+func TestASanitizerThatWouldEmptyTheDraftIsNotApplied(t *testing.T) {
+	// A subject that is NOTHING but a spaced em dash: it survives the parse,
+	// which only refuses an empty string, and the sanitizer removes the whole
+	// of it. A subject that merely CONTAINS one is not this case — the
+	// sanitizer rewrites it to a comma and the draft is never empty, so a
+	// fixture built from one cannot fail however the code behaves.
+	const answer = `{"subject":" — ","body":"Hi Sarah,\n\nShall we pick this up?"}`
+	lane := &sequencedLane{answers: []string{answer, answer}}
+
+	draft, _, err := Write(context.Background(), lane, sampleInput(), voiced())
+	if err != nil {
+		t.Fatalf("the voiced draft failed: %v", err)
+	}
+	if strings.TrimSpace(draft.Subject) == "" {
+		t.Error("the composer served a draft with an empty subject, which is not a message a rep can send")
+	}
+	if strings.TrimSpace(draft.Body) == "" {
+		t.Error("the composer served a draft with an empty body")
+	}
+}
+
+// A retry that clears nothing is discarded, and the first attempt stands.
+//
+// A retry is one more model answer, not a better one by definition: it is
+// written without the draftcheck findings the first pass already cleared, so
+// keeping it unconditionally can trade a clean draft for a dirty one.
+func TestARetryThatClearsNothingIsDiscarded(t *testing.T) {
+	const first = `{"subject":"Rollout — Phase 2","body":"Hi Sarah,\n\nShall we pick this up?"}`
+	// The retry keeps the violation AND loses the recipient's name, so a test
+	// that could not tell the two apart would pass on either being served.
+	const retry = `{"subject":"Rollout — Phase 2","body":"Hi there,\n\nAnything to add?"}`
+	lane := &sequencedLane{answers: []string{first, retry}}
+
+	draft, _, err := Write(context.Background(), lane, sampleInput(), voiced())
+	if err != nil {
+		t.Fatalf("the voiced draft failed: %v", err)
+	}
+	if lane.calls != 2 {
+		t.Fatalf("the floor made %d model calls; a violation earns exactly one retry", lane.calls)
+	}
+	if !strings.Contains(draft.Body, "Shall we pick this up?") {
+		t.Errorf("the composer kept a retry that cleared no violation; body = %q", draft.Body)
+	}
+}
+
+// An unvoiced draft costs no second model call.
+//
+// The floor exists for the voiced path. Running it over every draft would
+// double the model spend of the common case to fix the rare one.
+func TestAnUnvoicedDraftRunsNoVoiceRetry(t *testing.T) {
+	const answer = `{"subject":"Rollout — Phase 2","body":"Hi Sarah,\n\nShall we pick this up?"}`
+	lane := &sequencedLane{answers: []string{answer}}
+
+	if _, _, err := Write(context.Background(), lane, sampleInput(), draftvoice.Context{}); err != nil {
+		t.Fatalf("the unvoiced draft failed: %v", err)
+	}
+	if lane.calls != 1 {
+		t.Errorf("an unvoiced draft made %d model calls; it must make exactly one", lane.calls)
+	}
+}

--- a/backend/internal/compose/accountdraft/write.go
+++ b/backend/internal/compose/accountdraft/write.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/draftcore"
 	"github.com/margince/margince/backend/internal/compose/draftrules"
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
@@ -48,10 +49,19 @@ Each reasoning entry names ONE input you actually used, in the reader's words, s
 If the summary gives you nothing but the recipient, write a short honest opener and return an empty reasoning array. Do not invent a reason.`
 
 // draftSystemFor assembles this call's system turn: what this surface is for,
-// the rules every drafting surface shares, and THIS call's data boundary (see
-// promptfence.Fence.Rule).
-func draftSystemFor(fence promptfence.Fence) string {
-	return draftSystem + "\n\n" + draftrules.Shared + "\n" + fence.Rule("account summary")
+// the rules every drafting surface shares, THIS call's data boundary (see
+// promptfence.Fence.Rule), and — when the sender has a voice profile — what
+// that profile is allowed to govern.
+//
+// The voice rule is conditional because the block it describes is: a system
+// turn telling the model to obey a profile that never arrives in the user turn
+// is an instruction pointing at nothing.
+func draftSystemFor(fence promptfence.Fence, voiced bool) string {
+	system := draftSystem + "\n\n" + draftrules.Shared
+	if voiced {
+		system += "\n\n" + draftvoice.SystemRule
+	}
+	return system + "\n" + fence.Rule("account summary")
 }
 
 // draftSchema is the response shape the validated lane enforces.
@@ -95,13 +105,13 @@ type modelReason struct {
 // is the deployment saying this role runs no model, and the deterministic
 // floor is the answer.
 func Write(
-	ctx context.Context, lane Completer, in Input,
+	ctx context.Context, lane Completer, in Input, voice draftvoice.Context,
 ) (Draft, crmcontracts.WrittenBy, error) {
 	floor := Deterministic(in)
 	if lane == nil {
 		return floor, crmcontracts.Deterministic, nil
 	}
-	written, err := writeChecked(ctx, lane, in)
+	written, err := writeChecked(ctx, lane, in, voice)
 	if err != nil {
 		// A model that is down, over budget or answering nonsense must not cost
 		// the rep their draft: the floor is a real message they can edit, and
@@ -118,10 +128,10 @@ func Write(
 // writeChecked drafts through the shared correct-and-retry loop, so this
 // surface cannot drift from the other two about what a rejected phrase is or
 // how many chances the model gets to fix one.
-func writeChecked(ctx context.Context, lane Completer, in Input) (Draft, error) {
-	return draftcore.CorrectOnce(ctx, in.Envelope.Lang(), in.Envelope.Band(),
+func writeChecked(ctx context.Context, lane Completer, in Input, voice draftvoice.Context) (Draft, error) {
+	draft, err := draftcore.CorrectOnce(ctx, in.Envelope.Lang(), in.Envelope.Band(),
 		func(ctx context.Context, correction string) (Draft, error) {
-			return writeWithModel(ctx, lane, in, correction)
+			return writeWithModel(ctx, lane, in, voice, correction)
 		},
 		func(d Draft) (string, []string) { return d.Body, reasonLabels(d.Reasoning) },
 		func(d Draft) (string, bool) { return d.Subject, in.Threaded() },
@@ -130,10 +140,45 @@ func writeChecked(ctx context.Context, lane Completer, in Input) (Draft, error) 
 		// reports it.
 		nil,
 	)
+	if err != nil {
+		return Draft{}, err
+	}
+	return applyVoiceFloor(ctx, lane, in, voice, draft)
 }
 
-func writeWithModel(ctx context.Context, lane Completer, in Input, correction string) (Draft, error) {
-	req, err := groundedRequest(in)
+// applyVoiceFloor is the deterministic anti-AI pass a voiced draft must clear:
+// detect on the raw text, one critic retry that fixes the SENTENCE, then the
+// sanitizer for what is left to remove mechanically.
+//
+// It runs only for a voiced draft. An unvoiced one is already governed by the
+// shared rules and by draftcheck, and running a second retry over every draft
+// would double the model spend of the common case to fix the rare one.
+//
+// A draft that still trips the floor after all of that is served anyway, with
+// the sanitizer's edits kept. The alternative is the deterministic floor — a
+// two-line opener — and a rep who asked for a draft is better served by an
+// imperfect real message than by a stub, which is the same trade Write makes
+// when the model is down.
+func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, draft Draft) (Draft, error) {
+	if !voice.OK {
+		return draft, nil
+	}
+	// Detect on the RAW draft: a violation the sanitizer could mechanically
+	// remove still earns the retry, because the retry rewrites the sentence
+	// where the sanitizer only deletes the punctuation.
+	violations := draftvoice.Violations(draft.Subject, draft.Body)
+	if len(violations) > 0 {
+		retried, retryErr := writeWithModel(ctx, lane, in, voice, draftvoice.Feedback(violations))
+		if retryErr == nil {
+			draft = retried
+		}
+	}
+	draft.Subject, draft.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
+	return draft, nil
+}
+
+func writeWithModel(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, correction string) (Draft, error) {
+	req, err := buildRequest(in, voice)
 	if err != nil {
 		return Draft{}, err
 	}
@@ -150,26 +195,33 @@ func writeWithModel(ctx context.Context, lane Completer, in Input, correction st
 	return ParseDraft(res.Text, in)
 }
 
-// groundedRequest builds the model call: the system prompt naming this call's
+// buildRequest builds the model call: the system prompt naming this call's
 // boundary, and the account summary INSIDE it.
 //
 // The caller's intent is the one input outside the fence, and it is outside
 // because the caller typed it: fencing a person's own instruction would tell
 // the model to treat the reader as an attacker.
 //
-//promptvoice:exempt the reply is an email the salesperson sends under their OWN name. Margince's personality inside a customer-facing draft would be Margince signing somebody else's mail; compose/draftrules carries the user's own voice instead.
-func groundedRequest(in Input) (model.Request, error) {
+// The sender's voice profile, when they have one, rides the user turn under
+// this call's own fence — it is corpus text, so it is data and never
+// instruction.
+//
+//promptvoice:exempt this is an email the salesperson sends under their OWN name, so it carries THEIR voice (draftvoice) rather than Margince's personality — Margince's voice inside a customer-facing draft would be Margince signing somebody else's mail.
+func buildRequest(in Input, voice draftvoice.Context) (model.Request, error) {
 	fence := promptfence.New()
 	payload, err := json.Marshal(fencedInput(in))
 	if err != nil {
 		return model.Request{}, fmt.Errorf("marshal account draft input: %w", err)
 	}
 	content := fence.Wrap(string(payload))
+	if block := voice.Block(fence); block != "" {
+		content += "\n\n" + block
+	}
 	if in.Intent != "" {
 		content += "\n\nThe salesperson asks for: " + in.Intent
 	}
 	return model.Request{
-		System:   draftSystemFor(fence),
+		System:   draftSystemFor(fence, voice.OK),
 		Messages: []model.Message{{Role: "user", Content: content}},
 		// Thinking headroom. A reasoning model spends output tokens on internal
 		// thinking BEFORE its answer, and that thinking counts against the cap —
@@ -397,7 +449,12 @@ var (
 // SystemPromptFor is the assembled system turn, for the compose-level parity
 // gate that asserts every drafting surface writes under the same shared rules.
 // Exported for that assertion alone: the surface itself calls draftSystemFor.
-func SystemPromptFor(fence promptfence.Fence) string { return draftSystemFor(fence) }
+func SystemPromptFor(fence promptfence.Fence) string { return draftSystemFor(fence, false) }
+
+// VoicedSystemPromptFor is the system turn a draft written under a sender's
+// voice profile carries. The parity gate reads BOTH: a surface with two system
+// turns has two chances to drop the shared rules.
+func VoicedSystemPromptFor(fence promptfence.Fence) string { return draftSystemFor(fence, true) }
 
 // reasonLabels is the provenance a draft shows the rep, for the checks that
 // judge it. The labels alone: an entity id is a citation the filter already
@@ -410,7 +467,10 @@ func reasonLabels(reasons []Reason) []string {
 	return out
 }
 
-// GroundedRequest is the request this site sends, for the compose-level gate
-// that asserts every drafting surface carries thinking headroom. Exported for
-// that assertion alone; the site itself calls groundedRequest.
-func GroundedRequest(in Input) (model.Request, error) { return groundedRequest(in) }
+// GroundedRequest is the request this site sends, for the compose-level gates
+// that assert every drafting surface carries thinking headroom and that a
+// loaded voice profile reaches the model's user turn. Exported for those
+// assertions alone; the site itself calls buildRequest.
+func GroundedRequest(in Input, voice draftvoice.Context) (model.Request, error) {
+	return buildRequest(in, voice)
+}

--- a/backend/internal/compose/accountdraft/write.go
+++ b/backend/internal/compose/accountdraft/write.go
@@ -154,11 +154,18 @@ func writeChecked(ctx context.Context, lane Completer, in Input, voice draftvoic
 // shared rules and by draftcheck, and running a second retry over every draft
 // would double the model spend of the common case to fix the rare one.
 //
-// A draft that still trips the floor after all of that is served anyway, with
-// the sanitizer's edits kept. The alternative is the deterministic floor — a
-// two-line opener — and a rep who asked for a draft is better served by an
-// imperfect real message than by a stub, which is the same trade Write makes
-// when the model is down.
+// Every step can only improve the draft, never replace it with a worse one.
+// The retry is kept only if it clears MORE violations than the attempt it
+// replaces — a retry is one more model answer, not a better one by definition,
+// and it is written without the draftcheck findings the first pass already
+// cleared. The sanitizer's edits are kept only if what survives them is still a
+// draft: it deletes characters, so a subject that was nothing but an em dash
+// comes back empty, and an empty subject is not a message the contract allows.
+//
+// A draft that still trips the floor after all of that is served anyway. The
+// alternative is the deterministic floor — a two-line opener — and a rep who
+// asked for a draft is better served by an imperfect real message than by a
+// stub, which is the same trade Write makes when the model is down.
 func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, draft Draft) (Draft, error) {
 	if !voice.OK {
 		return draft, nil
@@ -169,12 +176,23 @@ func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftv
 	violations := draftvoice.Violations(draft.Subject, draft.Body)
 	if len(violations) > 0 {
 		retried, retryErr := writeWithModel(ctx, lane, in, voice, draftvoice.Feedback(violations))
-		if retryErr == nil {
+		if retryErr == nil && len(draftvoice.Violations(retried.Subject, retried.Body)) < len(violations) {
 			draft = retried
 		}
 	}
-	draft.Subject, draft.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
-	return draft, nil
+	sanitized := draft
+	sanitized.Subject, sanitized.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
+	if !servable(sanitized) {
+		return draft, nil
+	}
+	return sanitized, nil
+}
+
+// servable reports whether a draft is still one the contract can carry. The
+// sanitizer removes characters, so a draft made only of what it removes comes
+// back empty — and an empty subject or body is not a message.
+func servable(draft Draft) bool {
+	return strings.TrimSpace(draft.Subject) != "" && strings.TrimSpace(draft.Body) != ""
 }
 
 func writeWithModel(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, correction string) (Draft, error) {

--- a/backend/internal/compose/accountdraft/write_test.go
+++ b/backend/internal/compose/accountdraft/write_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
@@ -56,7 +57,7 @@ func TestTheReasonsNeverAppearInTheBody(t *testing.T) {
 	  "entity_id":"019fe7ae-0000-7000-8000-000000000002"}]}`
 	lane := &scriptedLane{answer: answer}
 
-	draft, by, err := Write(context.Background(), lane, sampleInput())
+	draft, by, err := Write(context.Background(), lane, sampleInput(), draftvoice.Context{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +80,7 @@ func TestAReasonCitingARecordTheReaderCannotSeeIsDropped(t *testing.T) {
 	  {"kind":"deal","label":"a deal you cannot see","entity_type":"deal",
 	   "entity_id":"019fe7ae-0000-7000-8000-0000000000ff"},
 	  {"kind":"intent","label":"shorter"}]}`
-	draft, _, err := Write(context.Background(), &scriptedLane{answer: answer}, sampleInput())
+	draft, _, err := Write(context.Background(), &scriptedLane{answer: answer}, sampleInput(), draftvoice.Context{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +100,7 @@ func TestAReasonCitingTheRightIdAsTheWrongKindIsDropped(t *testing.T) {
 	answer := `{"subject":"S","body":"B","reasoning":[
 	  {"kind":"deal","label":"mislabelled","entity_type":"person",
 	   "entity_id":"019fe7ae-0000-7000-8000-000000000002"}]}`
-	draft, _, err := Write(context.Background(), &scriptedLane{answer: answer}, sampleInput())
+	draft, _, err := Write(context.Background(), &scriptedLane{answer: answer}, sampleInput(), draftvoice.Context{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +116,7 @@ func TestAnUncitedReasonSurvivesOnlyForTheCallersOwnIntent(t *testing.T) {
 	  {"kind":"deal","label":"something about a deal"},
 	  {"kind":"dossier","label":"something about the company"},
 	  {"kind":"intent","label":"shorter"}]}`
-	draft, _, err := Write(context.Background(), &scriptedLane{answer: answer}, sampleInput())
+	draft, _, err := Write(context.Background(), &scriptedLane{answer: answer}, sampleInput(), draftvoice.Context{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +130,7 @@ func TestAnUncitedReasonSurvivesOnlyForTheCallersOwnIntent(t *testing.T) {
 // unlabelled chip, because the composer groups reasons by kind.
 func TestAnUnknownReasonKindIsDropped(t *testing.T) {
 	answer := `{"subject":"S","body":"B","reasoning":[{"kind":"vibes","label":"a feeling"}]}`
-	draft, _, err := Write(context.Background(), &scriptedLane{answer: answer}, sampleInput())
+	draft, _, err := Write(context.Background(), &scriptedLane{answer: answer}, sampleInput(), draftvoice.Context{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +148,7 @@ func TestAFailedLaneDegradesToTheFloorRatherThanErroring(t *testing.T) {
 		"empty":    {answer: `{"subject":"","body":""}`},
 	} {
 		t.Run(name, func(t *testing.T) {
-			draft, by, err := Write(context.Background(), lane, sampleInput())
+			draft, by, err := Write(context.Background(), lane, sampleInput(), draftvoice.Context{})
 			if err != nil {
 				t.Fatalf("a bad answer must degrade, not error: %v", err)
 			}
@@ -166,7 +167,7 @@ func TestAFailedLaneDegradesToTheFloorRatherThanErroring(t *testing.T) {
 // boundary rather than concatenated into the instructions.
 func TestTheAccountSummaryTravelsInsideAFence(t *testing.T) {
 	lane := &scriptedLane{answer: `{"subject":"S","body":"B"}`}
-	if _, _, err := Write(context.Background(), lane, sampleInput()); err != nil {
+	if _, _, err := Write(context.Background(), lane, sampleInput(), draftvoice.Context{}); err != nil {
 		t.Fatal(err)
 	}
 	req := lane.seen[0]
@@ -186,7 +187,7 @@ func TestTheCallersOwnIntentIsOutsideTheFence(t *testing.T) {
 	in := sampleInput()
 	in.Intent = "keep it short"
 	lane := &scriptedLane{answer: `{"subject":"S","body":"B"}`}
-	if _, _, err := Write(context.Background(), lane, in); err != nil {
+	if _, _, err := Write(context.Background(), lane, in, draftvoice.Context{}); err != nil {
 		t.Fatal(err)
 	}
 	content := lane.seen[0].Messages[0].Content
@@ -235,7 +236,7 @@ func TestAFencedAnswerIsRead(t *testing.T) {
 		"\n```"
 	lane := &scriptedLane{answer: answer}
 
-	draft, by, err := Write(context.Background(), lane, sampleInput())
+	draft, by, err := Write(context.Background(), lane, sampleInput(), draftvoice.Context{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/certcase_composerdraft.go
+++ b/backend/internal/compose/certcase_composerdraft.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/accountdraft"
 	"github.com/margince/margince/backend/internal/compose/aitasks"
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/compose/persondraft"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
@@ -114,7 +115,10 @@ type personDraftCase struct{ in persondraft.Input }
 // product sends rather than a copy of it assembled here.
 func (c *personDraftCase) Run(ctx context.Context, completer aitasks.Completer) (aitasks.Trace, error) {
 	recorder := &composerRecorder{completer: completer}
-	draft, _, err := persondraft.Write(ctx, recorder, c.in)
+	// No voice profile: a certification case measures the prompt this site
+	// sends every user, and a profile is one user's own writing rather than a
+	// property of the site.
+	draft, _, err := persondraft.Write(ctx, recorder, c.in, draftvoice.Context{})
 	return composerTrace(personDraftSite, recorder, draft.Body, err)
 }
 
@@ -133,7 +137,7 @@ type accountDraftCase struct{ in accountdraft.Input }
 
 func (c *accountDraftCase) Run(ctx context.Context, completer aitasks.Completer) (aitasks.Trace, error) {
 	recorder := &composerRecorder{completer: completer}
-	draft, _, err := accountdraft.Write(ctx, recorder, c.in)
+	draft, _, err := accountdraft.Write(ctx, recorder, c.in, draftvoice.Context{})
 	return composerTrace(accountDraftSite, recorder, draft.Body, err)
 }
 

--- a/backend/internal/compose/certcase_replydraft.go
+++ b/backend/internal/compose/certcase_replydraft.go
@@ -48,6 +48,7 @@ import (
 	"strings"
 
 	"github.com/margince/margince/backend/internal/compose/aitasks"
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
@@ -134,7 +135,7 @@ func (replyDraftCases) Prepare(fixture, expected json.RawMessage) (aitasks.Prepa
 	switch want {
 	case replyDraftRegisterPlain:
 	case replyDraftRegisterVoiced:
-		if !voice.ok {
+		if !voice.OK {
 			return nil, fmt.Errorf(
 				"%s: the scenario expects the %q register from a workspace with no Voice DNA state, "+
 					"and the plain variant is the only prompt that call can send",
@@ -190,22 +191,22 @@ func refuseUnsendableActivity(activity replyActivityData) error {
 // trusted, because drafting shows at most two verbatim examples and drops the
 // rest without saying so: a fixture whose examples do not survive that would
 // certify a block the product never assembles.
-func replyDraftVoiceState(artifact *replyDraftVoiceArtifact) (voiceContext, error) {
+func replyDraftVoiceState(artifact *replyDraftVoiceArtifact) (draftvoice.Context, error) {
 	if artifact == nil {
-		return voiceContext{}, nil
+		return draftvoice.Context{}, nil
 	}
 	if strings.TrimSpace(artifact.VoiceProfileMD) == "" {
-		return voiceContext{}, fmt.Errorf(
+		return draftvoice.Context{}, fmt.Errorf(
 			"%s: the fixture's profile carries no derived voice profile, and only a built one is ever active",
 			replyDraftSite)
 	}
 	profileJSON, err := replyDraftStoredJSON(replyDraftProfileArtifact{Exemplars: artifact.Exemplars})
 	if err != nil {
-		return voiceContext{}, fmt.Errorf("%s: the fixture's verbatim examples are not storable: %w", replyDraftSite, err)
+		return draftvoice.Context{}, fmt.Errorf("%s: the fixture's verbatim examples are not storable: %w", replyDraftSite, err)
 	}
 	statsJSON, err := replyDraftStoredJSON(artifact.Stats)
 	if err != nil {
-		return voiceContext{}, fmt.Errorf("%s: the fixture's style fingerprint is not storable: %w", replyDraftSite, err)
+		return draftvoice.Context{}, fmt.Errorf("%s: the fixture's style fingerprint is not storable: %w", replyDraftSite, err)
 	}
 	version := ai.VoiceProfileVersion{
 		ProfileVersion: artifact.ProfileVersion,
@@ -214,16 +215,16 @@ func replyDraftVoiceState(artifact *replyDraftVoiceArtifact) (voiceContext, erro
 		StatsJSON:      statsJSON,
 	}
 	if shown := ai.VersionExemplars(version); !slices.Equal(shown, artifact.Exemplars) {
-		return voiceContext{}, fmt.Errorf(
+		return draftvoice.Context{}, fmt.Errorf(
 			"%s: the fixture supplies %d verbatim examples and drafting shows %d",
 			replyDraftSite, len(artifact.Exemplars), len(shown))
 	}
-	return voiceContext{
+	return draftvoice.Context{
 		// The profile id keys the learning signal, never a prompt, so it is
 		// minted here for the same reason the anchor is.
-		profile: ai.VoiceProfile{ID: ids.NewV7(), PersonalityMD: artifact.PersonalityMD},
-		version: version,
-		ok:      true,
+		Profile: ai.VoiceProfile{ID: ids.NewV7(), PersonalityMD: artifact.PersonalityMD},
+		Version: version,
+		OK:      true,
 	}, nil
 }
 
@@ -252,7 +253,7 @@ func replyDraftStoredJSON[T any](value T) (map[string]any, error) {
 // voice state that selects which variant it is answered in.
 type replyDraftCase struct {
 	activity replyActivityData
-	voice    voiceContext
+	voice    draftvoice.Context
 	anchor   ids.UUID
 	expected string
 }

--- a/backend/internal/compose/draftmaxtokens_test.go
+++ b/backend/internal/compose/draftmaxtokens_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose/accountdraft"
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/compose/persondraft"
 	"github.com/margince/margince/backend/internal/modules/ai"
 )
@@ -23,14 +24,14 @@ import (
 func TestEveryDraftingRequestCarriesThinkingHeadroom(t *testing.T) {
 	person, err := persondraft.GroundedRequest(persondraft.Input{
 		Recipient: persondraft.RecipientIn{ID: "p1", Name: "Marek", FirstName: "Marek"},
-	})
+	}, draftvoice.Context{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	account, err := accountdraft.GroundedRequest(accountdraft.Input{
 		Company:   "Northwind",
 		Recipient: accountdraft.RecipientIn{ID: "p1", Name: "Priya"},
-	})
+	}, draftvoice.Context{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/draftrulesparity_test.go
+++ b/backend/internal/compose/draftrulesparity_test.go
@@ -65,8 +65,14 @@ func draftingSurfaces(fence promptfence.Fence) map[string][]string {
 			replyDraftSystemFor(replyDraftVoiceSystem, fence),
 			replyDraftSystemFor(firstDraftSystem, fence),
 		},
-		"persondraft/write.go":  {persondraft.SystemPromptFor(fence)},
-		"accountdraft/write.go": {accountdraft.SystemPromptFor(fence)},
+		"persondraft/write.go": {
+			persondraft.SystemPromptFor(fence),
+			persondraft.VoicedSystemPromptFor(fence),
+		},
+		"accountdraft/write.go": {
+			accountdraft.SystemPromptFor(fence),
+			accountdraft.VoicedSystemPromptFor(fence),
+		},
 	}
 }
 

--- a/backend/internal/compose/draftvoice/doc.go
+++ b/backend/internal/compose/draftvoice/doc.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package draftvoice is the one spelling of how a drafting surface writes in
+// the SENDER's own voice.
+//
+// Three surfaces generate outbound email — the reply to an activity, the person
+// composer, and account-started outbound — and only the reply drafter read the
+// actor's Voice DNA. The other two composed draftrules.Shared and a comment
+// claiming that block "carries the user's own voice instead". It does not:
+// draftrules holds language, register, greeting and formatting rules, and not
+// one sentence of how this particular person writes. So a rep who had built a
+// voice profile got their own voice when they answered a mail and a generic one
+// when they started a message from a contact's page — the same person, the same
+// mailbox, two different writers.
+//
+// What lives here is everything a surface needs to draft under a profile:
+// loading the actor's active one (Load), rendering it into the calling call's
+// fence (Context.Block), and the deterministic anti-AI floor that decides
+// whether the voiced draft may be served (Floor).
+//
+// **It reads and never writes.** The learning signals a served draft feeds back
+// — RecordDraftedSignal, RejectDraft — are NOT here, because two of the three
+// callers are packages built with no pool at all, and that zero-write guarantee
+// is a dependency rather than a rule somebody remembers. The reply drafter keeps
+// its own signal recording beside its store.
+//
+// Held by: TestEveryDraftingSurfaceLoadsTheSenderVoice
+// (internal/compose/draftvoiceparity_test.go), which sweeps the tree for the
+// surfaces composing draftrules.Shared and fails when one of them reaches a
+// model without a voice seam.
+package draftvoice

--- a/backend/internal/compose/draftvoice/voice.go
+++ b/backend/internal/compose/draftvoice/voice.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftvoice
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
+)
+
+// Reader is the seam a surface binds to load the acting user's voice. It is an
+// interface rather than *ai.VoiceStore so the two composers can take one
+// without taking a pool: what they need is a read, and a store handed to them
+// whole would also hand them the writes their packages promise not to have.
+type Reader interface {
+	ActiveVoiceForActor(ctx context.Context) (ai.VoiceProfile, ai.VoiceProfileVersion, bool, error)
+}
+
+// Context is a loaded profile, or the absence of one.
+//
+// Absence is the ordinary case, not a failure: most users have never built a
+// profile, and a draft written without one is the product working. OK is what
+// separates "this rep has a voice" from "this rep does not", and every caller
+// branches on it rather than on a nil check somewhere further down.
+type Context struct {
+	Profile ai.VoiceProfile
+	Version ai.VoiceProfileVersion
+	OK      bool
+}
+
+// Load resolves the actor's active voice. A lookup failure degrades to no voice
+// with the reason logged: a broken voice read must never take drafting down,
+// because the draft is the thing the rep asked for and the voice is how it is
+// phrased. reader may be nil, which is a deployment that wired no voice lane.
+func Load(ctx context.Context, reader Reader, log *slog.Logger) Context {
+	if reader == nil {
+		return Context{}
+	}
+	profile, version, ok, err := reader.ActiveVoiceForActor(ctx)
+	if err != nil {
+		if log == nil {
+			log = slog.Default()
+		}
+		log.WarnContext(ctx, "voice profile lookup failed; drafting without voice", "err", err)
+		return Context{}
+	}
+	return Context{Profile: profile, Version: version, OK: ok}
+}
+
+// Block renders the profile for the CALLING call's user turn.
+//
+// It takes the caller's fence rather than making its own: the block is
+// prepended to that call's user turn, so it must be bounded by the marker that
+// call's system prompt declares. A block fenced with its own nonce is text the
+// model was never told to treat as data.
+//
+// Everything rendered descends from corpus text — the artifact carries verbatim
+// quotes and the exemplars ARE corpus excerpts — so each piece sits inside the
+// boundary unedited. The exemplars are shown to be imitated verbatim, which is
+// exactly why they may not be rewritten on the way in.
+func (c Context) Block(fence promptfence.Fence) string {
+	if !c.OK {
+		return ""
+	}
+	var block strings.Builder
+	block.WriteString("Voice profile:\n")
+	if personality := strings.TrimSpace(c.Profile.PersonalityMD); personality != "" {
+		block.WriteString("Human-authored identity (highest priority):\n" + fence.Wrap(personality) + "\n\n")
+	}
+	block.WriteString(fence.Wrap(strings.TrimSpace(c.Version.VoiceProfileMD)))
+	for _, exemplar := range ai.VersionExemplars(c.Version) {
+		fmt.Fprintf(&block, "\n\nVerbatim example (%s %s):\n%s",
+			exemplar.Register, exemplar.Kind, fence.Wrap(exemplar.Text))
+	}
+	stats := ai.DecodeVersionStats(c.Version)
+	fmt.Fprintf(&block, "\n\nStylometric guardrails — limits, NOT targets: mean sentence length ≈ %.0f words (do not write a wall of short sentences to hit it), em dashes per 100 words ≈ %.2f (at 0, treat them as forbidden).",
+		stats.MeanSentenceWords, stats.EmDashPer100Words)
+	block.WriteString("\n\n" + VocabularyRule)
+	return block.String()
+}
+
+// VocabularyRule is the one instruction a stylometric profile cannot carry: the
+// words themselves. A profile measures sentence length and punctuation, so
+// without this a model writes the author's rhythm in its own vocabulary — and
+// the tell a reader notices first is a translated metaphor no native speaker
+// says.
+const VocabularyRule = "Vocabulary: use the words this author uses, including the terms they borrow from other languages. " +
+	"Keep a borrowed term in the form they write it — never translate a metaphor into a compound word native speakers do not say. " +
+	"When unsure a word is real in their language, use the plainer wording they would."
+
+// SystemRule is what a voiced call's system turn says about the block arriving
+// in its user turn. Without it the model is handed a profile with no statement
+// of what outranks what, and the failure is the expensive direction: a draft
+// that bends a fact to fit the author's habitual phrasing.
+const SystemRule = `VOICE PROFILE
+The user turn carries the sender's own voice profile. It controls expression — rhythm, vocabulary, directness, sentence length, structure — and never facts.
+Obey its avoid rules. Treat its style metrics as limits, not targets.
+Where the profile and a grounding rule disagree, the grounding rule wins: a fact bent to fit a phrasing is the one error the sender cannot see before it goes out.`
+
+// Violations runs the deterministic floor over the two texts a draft is made
+// of, independently. Concatenation would hide a canned opener inside the body,
+// because the opener rule anchors at the start of the text it is given.
+func Violations(subject, body string) []ai.VoiceViolation {
+	return append(ai.DetectAIPatterns(subject), ai.DetectAIPatterns(body)...)
+}
+
+// Feedback is the critic turn: what the last attempt broke, so the retry fixes
+// the sentence rather than the punctuation.
+func Feedback(violations []ai.VoiceViolation) string {
+	var b strings.Builder
+	b.WriteString("\n\nThe previous attempt violated these hard rules; rewrite without them:\n")
+	for _, violation := range violations {
+		b.WriteString("- " + violation.Detail + "\n")
+	}
+	return b.String()
+}
+
+// Sanitize removes what the floor can mechanically remove, after the retry has
+// had its chance at the sentence.
+func Sanitize(subject, body string) (string, string) {
+	return ai.SanitizeAIPatterns(subject), ai.SanitizeAIPatterns(body)
+}

--- a/backend/internal/compose/draftvoiceparity_test.go
+++ b/backend/internal/compose/draftvoiceparity_test.go
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Every surface that drafts an email a person sends under their own name reads
+// that person's own voice, and this is what keeps that true.
+//
+// Before this, only the reply drafter did. The two composers carried a comment
+// saying draftrules "carries the user's own voice instead" — it does not, and
+// nothing failed when it stopped being true, because nothing had ever checked.
+// The result reached users as the same rep getting two different writers
+// depending on which button they pressed.
+//
+// WHICH surfaces is derived from the tree, for the reason the shared-rules
+// census next door is: a hand-written list is a thing to forget to add to, and
+// forgetting is the failure. The corpus is the same one — every production file
+// under compose that composes draftrules.Shared — because a file that writes
+// correspondence under the shared rules is exactly a file that writes it in
+// somebody's name.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/accountdraft"
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
+	"github.com/margince/margince/backend/internal/compose/persondraft"
+	"github.com/margince/margince/backend/internal/compose/promptvoice"
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
+	"github.com/margince/margince/backend/internal/shared/ports/model"
+)
+
+// newDraftFence is the boundary a composer call declares. One per call in
+// production; one per test here, for the same reason.
+func newDraftFence() promptfence.Fence { return promptfence.New() }
+
+// voicedComposerPrompts is each composer's system turn WITH a profile loaded.
+// Both, always: the two were written from one template, and a rule applied to
+// one of them is exactly the drift a parity gate exists to catch.
+func voicedComposerPrompts(fence promptfence.Fence) map[string]string {
+	return map[string]string{
+		"the person composer":  persondraft.VoicedSystemPromptFor(fence),
+		"the account composer": accountdraft.VoicedSystemPromptFor(fence),
+	}
+}
+
+// unvoicedComposerPrompts is each composer's system turn with no profile.
+func unvoicedComposerPrompts(fence promptfence.Fence) map[string]string {
+	return map[string]string{
+		"the person composer":  persondraft.SystemPromptFor(fence),
+		"the account composer": accountdraft.SystemPromptFor(fence),
+	}
+}
+
+// aiVoiceProfileWithPersonality is a fixture profile carrying the one field a
+// human writes by hand.
+func aiVoiceProfileWithPersonality(personality string) ai.VoiceProfile {
+	return ai.VoiceProfile{PersonalityMD: personality}
+}
+
+// aiVoiceVersionWithProfile is a fixture active version carrying the derived
+// profile the builder writes.
+func aiVoiceVersionWithProfile(profileMD string) ai.VoiceProfileVersion {
+	return ai.VoiceProfileVersion{ProfileVersion: 1, VoiceProfileMD: profileMD}
+}
+
+// Every drafting surface reaches the sender's voice seam.
+//
+// It asserts the IMPORT rather than a rendered prompt, and that is the honest
+// bar for a census: a voiced prompt only exists when a profile is loaded, so
+// there is no assembled string to compare for a surface that has none. What can
+// be checked without a profile is whether the surface can reach the seam at
+// all, and one that cannot is one no profile could ever reach.
+//
+// The prompt itself is checked where a profile exists to render:
+// TestAVoicedComposerPromptCarriesTheProfile below.
+//
+// A SURFACE, not a file. The reply drafter composes the shared rules in
+// replydraftmodel.go and loads the voice in replydraftvoice.go beside it, which
+// is one surface split across two files for length rather than two surfaces. So
+// the unit is the directory: a file that composes the rules is satisfied by any
+// production file in its own package reaching draftvoice. Anything wider would
+// let compose's several hundred files answer for each other.
+func TestEveryDraftingSurfaceLoadsTheSenderVoice(t *testing.T) {
+	surfaces := filesComposingTheSharedRules(t)
+	if len(surfaces) == 0 {
+		t.Fatal("no file under internal/compose composes draftrules.Shared, so this gate is reading an " +
+			"empty tree rather than a governed one")
+	}
+	for _, where := range surfaces {
+		if !packageCalls(t, where, "draftvoice", "Load") {
+			t.Errorf("%s drafts correspondence a person sends under their own name, but nothing in its "+
+				"package calls draftvoice.Load — so a rep who has built a voice profile is written by a "+
+				"generic writer here and by their own voice elsewhere. Load it with draftvoice.Load and "+
+				"render it into the call's user turn with Context.Block", where)
+		}
+	}
+}
+
+// packageCalls reports whether any production file in the package holding path
+// calls pkg.fn.
+//
+// The CALL, not the import. A surface that imports draftvoice for its Context
+// type and never loads one compiles, reads as governed to an import census, and
+// sends every draft with an empty profile — which is the exact defect this gate
+// was written for, so an import check would pass on the bug it is named after.
+func packageCalls(t *testing.T, path, pkg, fn string) bool {
+	t.Helper()
+	dir := filepath.Dir(path)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading the package at %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") ||
+			strings.HasSuffix(name, "_test.go") || strings.HasSuffix(name, "_gen.go") {
+			continue
+		}
+		if fileCalls(t, filepath.Join(dir, name), pkg, fn) {
+			return true
+		}
+	}
+	return false
+}
+
+// fileCalls reports whether the file holds a pkg.fn call expression.
+func fileCalls(t *testing.T, path, pkg, fn string) bool {
+	t.Helper()
+	parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	found := false
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != fn {
+			return true
+		}
+		ident, ok := selector.X.(*ast.Ident)
+		if ok && ident.Name == pkg {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// A voiced composer prompt actually carries the profile.
+//
+// The import census above proves a surface CAN reach the seam. This proves the
+// reach lands: the block the model receives holds the author's own words, and
+// the system turn states what that block is allowed to govern. Both composers
+// are checked, because both were written from the same template and a fix
+// applied to one of them is the failure this pair exists to catch.
+func TestAVoicedComposerPromptCarriesTheProfile(t *testing.T) {
+	const personality = "I write short. I never say circling back."
+	voice := draftvoice.Context{
+		Profile: aiVoiceProfileWithPersonality(personality),
+		Version: aiVoiceVersionWithProfile("Sentences run under twelve words."),
+		OK:      true,
+	}
+	// Through each composer's OWN request builder, not through Block alone: a
+	// block that renders correctly and is never added to the user turn is the
+	// defect this test is named for, and asserting on Block would pass on it.
+	for what, req := range voicedComposerRequests(t, voice) {
+		sent := userTurn(t, what, req)
+		missing := false
+		for _, want := range []string{personality, "Sentences run under twelve words.", draftvoice.VocabularyRule} {
+			if !strings.Contains(sent, want) {
+				t.Errorf("%s sends no %q to the model, so it is told to write in a voice it was never "+
+					"shown", what, want)
+				missing = true
+			}
+		}
+		// Absent text cannot be fenced, and reporting it as unfenced would send
+		// the next reader after the wrong defect.
+		if missing {
+			continue
+		}
+		// The author's own words are DATA — a profile is corpus text, and
+		// corpus text routinely quotes what somebody else wrote. So the
+		// personality must sit between a fence open and the next close, never
+		// loose in the turn.
+		//
+		// Read structurally rather than against a fence built here: each
+		// request mints its OWN nonce, so a marker this test constructed would
+		// never match the one the request carries.
+		if !fencedIn(t, sent, personality) {
+			t.Errorf("%s carries the author's own text outside this call's fence, so a profile built "+
+				"from a mail somebody sent them could instruct the model", what)
+		}
+	}
+}
+
+// voicedComposerRequests is the model request each composer builds for a
+// sender who has a voice profile.
+func voicedComposerRequests(t *testing.T, voice draftvoice.Context) map[string]model.Request {
+	t.Helper()
+	person, err := persondraft.GroundedRequest(persondraft.Input{
+		Recipient: persondraft.RecipientIn{ID: "p1", Name: "Marek", FirstName: "Marek"},
+	}, voice)
+	if err != nil {
+		t.Fatalf("the person composer builds no request: %v", err)
+	}
+	account, err := accountdraft.GroundedRequest(accountdraft.Input{
+		Company:   "Northwind",
+		Recipient: accountdraft.RecipientIn{ID: "p1", Name: "Priya"},
+	}, voice)
+	if err != nil {
+		t.Fatalf("the account composer builds no request: %v", err)
+	}
+	return map[string]model.Request{
+		"the person composer":  person,
+		"the account composer": account,
+	}
+}
+
+// fencedIn reports whether every occurrence of text in turn sits inside a
+// fenced span — after an opening marker and before that span's close.
+//
+// The markers are read OFF THE TURN, because the nonce is minted per call and a
+// marker this test constructed would never match the one the request carries.
+// The turn's own opening marker is found by asking promptfence to parse it,
+// rather than by spelling the prefix here: a literal copy of that prefix would
+// be a second spelling of it, and would go quietly permissive — matching
+// nothing, so finding no unfenced text — the day the real one changed.
+func fencedIn(t *testing.T, turn, text string) bool {
+	t.Helper()
+	opening, closing := markersOf(t, turn)
+	idx := strings.Index(turn, text)
+	if idx < 0 {
+		return false
+	}
+	for idx >= 0 {
+		before := turn[:idx]
+		lastOpen := strings.LastIndex(before, opening)
+		lastClose := strings.LastIndex(before, closing)
+		if lastOpen < 0 || lastClose > lastOpen {
+			return false
+		}
+		next := strings.Index(turn[idx+len(text):], text)
+		if next < 0 {
+			return true
+		}
+		idx = idx + len(text) + next
+	}
+	return true
+}
+
+// markersOf recovers the fence this turn was built with, from the turn.
+//
+// It reads the first "<…>" tag and hands it to promptfence.FromMarker, which
+// answers only for a marker that package could have minted — so a tag from the
+// payload rather than from the boundary is refused here rather than silently
+// becoming the boundary this gate measures against.
+func markersOf(t *testing.T, turn string) (opening, closing string) {
+	t.Helper()
+	start := strings.Index(turn, "<")
+	for start >= 0 {
+		end := strings.Index(turn[start:], ">")
+		if end < 0 {
+			break
+		}
+		tag := turn[start : start+end+1]
+		if fence, ok := promptfence.FromMarker(strings.TrimSuffix(strings.TrimPrefix(tag, "<"), ">")); ok {
+			return fence.Open(), fence.Close()
+		}
+		next := strings.Index(turn[start+1:], "<")
+		if next < 0 {
+			break
+		}
+		start = start + 1 + next
+	}
+	t.Fatal("the composer's user turn carries no fence marker promptfence could have minted, so there " +
+		"is no boundary to measure the profile against")
+	return "", ""
+}
+
+// userTurn is the one message a composer sends, which is where the profile has
+// to arrive: a block in the system turn would be an instruction, and a voice
+// profile is the author's own text.
+func userTurn(t *testing.T, what string, req model.Request) string {
+	t.Helper()
+	if len(req.Messages) != 1 {
+		t.Fatalf("%s sends %d messages; this gate reads the single user turn", what, len(req.Messages))
+	}
+	return req.Messages[0].Content
+}
+
+// An unvoiced surface says nothing about a profile.
+//
+// The mirror of the test above, and the one that catches the cheap fix: a
+// system turn that always names the voice rule would pass a "carries the rule"
+// check while pointing at a block that never arrives.
+func TestAnUnvoicedComposerPromptNamesNoProfile(t *testing.T) {
+	fence := newDraftFence()
+	for what, system := range unvoicedComposerPrompts(fence) {
+		if strings.Contains(system, draftvoice.SystemRule) {
+			t.Errorf("%s tells the model to obey a voice profile even when none is loaded, so it points "+
+				"at a block that never arrives in the user turn", what)
+		}
+	}
+	for what, system := range voicedComposerPrompts(fence) {
+		if !strings.Contains(system, draftvoice.SystemRule) {
+			t.Errorf("%s sends a voice profile without telling the model what it governs, so nothing "+
+				"stops a fact being bent to fit the author's phrasing", what)
+		}
+	}
+}
+
+// Margince's own personality stays out of correspondence.
+//
+// A draft goes out over the USER's name, so Margince's voice inside one would
+// be Margince signing somebody else's mail. This is the rule the two composers'
+// promptvoice:exempt waivers claim, asserted rather than trusted — a waiver's
+// stated reason can be false, and this is the one that would be expensive.
+func TestNoComposerPromptCarriesMargincesOwnVoice(t *testing.T) {
+	fence := newDraftFence()
+	prompts := voicedComposerPrompts(fence)
+	for what, system := range unvoicedComposerPrompts(fence) {
+		prompts[what] = system
+	}
+	for what, system := range prompts {
+		if strings.Contains(system, promptvoice.Heading) {
+			t.Errorf("%s carries Margince's own voice block, which would have Margince's personality "+
+				"sign a mail the user sends under their name", what)
+		}
+	}
+}

--- a/backend/internal/compose/draftvoiceparity_test.go
+++ b/backend/internal/compose/draftvoiceparity_test.go
@@ -65,10 +65,22 @@ func aiVoiceProfileWithPersonality(personality string) ai.VoiceProfile {
 	return ai.VoiceProfile{PersonalityMD: personality}
 }
 
-// aiVoiceVersionWithProfile is a fixture active version carrying the derived
-// profile the builder writes.
-func aiVoiceVersionWithProfile(profileMD string) ai.VoiceProfileVersion {
-	return ai.VoiceProfileVersion{ProfileVersion: 1, VoiceProfileMD: profileMD}
+// aiVoiceVersionWithExemplar is a fixture active version carrying the derived
+// profile the builder writes AND one verbatim excerpt of the author's own mail.
+//
+// The exemplar is stored the way the voice store hands it back — inside
+// profile_json — so the block under test is assembled by the same decoder
+// production assembles it with, rather than by a shape only this test produces.
+func aiVoiceVersionWithExemplar(profileMD, exemplar string) ai.VoiceProfileVersion {
+	return ai.VoiceProfileVersion{
+		ProfileVersion: 1,
+		VoiceProfileMD: profileMD,
+		ProfileJSON: map[string]any{
+			"exemplars": []any{map[string]any{
+				"register": "du", "kind": "email", "text": exemplar,
+			}},
+		},
+	}
 }
 
 // Every drafting surface reaches the sender's voice seam.
@@ -95,23 +107,28 @@ func TestEveryDraftingSurfaceLoadsTheSenderVoice(t *testing.T) {
 			"empty tree rather than a governed one")
 	}
 	for _, where := range surfaces {
-		if !packageCalls(t, where, "draftvoice", "Load") {
+		if !packagePassesOnALoadedVoice(t, where) {
 			t.Errorf("%s drafts correspondence a person sends under their own name, but nothing in its "+
-				"package calls draftvoice.Load — so a rep who has built a voice profile is written by a "+
-				"generic writer here and by their own voice elsewhere. Load it with draftvoice.Load and "+
-				"render it into the call's user turn with Context.Block", where)
+				"package passes a draftvoice.Load result on to anything — so a rep who has built a voice "+
+				"profile is written by a generic writer here and by their own voice elsewhere. Load it "+
+				"with draftvoice.Load and hand the result to the call that renders the prompt", where)
 		}
 	}
 }
 
-// packageCalls reports whether any production file in the package holding path
-// calls pkg.fn.
+// packagePassesOnALoadedVoice reports whether some production file in the
+// package holding path calls draftvoice.Load AND uses the result — as an
+// argument, or assigned to a name that is later used.
 //
-// The CALL, not the import. A surface that imports draftvoice for its Context
-// type and never loads one compiles, reads as governed to an import census, and
-// sends every draft with an empty profile — which is the exact defect this gate
-// was written for, so an import check would pass on the bug it is named after.
-func packageCalls(t *testing.T, path, pkg, fn string) bool {
+// The USE, not just the call. A bare draftvoice.Load(...) whose answer is
+// discarded compiles, satisfies a call census, and leaves every draft unvoiced;
+// so does a live call sitting in a function the drafting path never reaches.
+// This cannot chase the second case — a static reader does not know which
+// functions run — and it is not the whole guarantee on its own. The behaviour
+// is pinned by TestAVoicedComposerPromptCarriesTheProfile, which drives each
+// composer's real request builder; this sweep is what notices a NEW surface
+// that never wired the seam at all.
+func packagePassesOnALoadedVoice(t *testing.T, path string) bool {
 	t.Helper()
 	dir := filepath.Dir(path)
 	entries, err := os.ReadDir(dir)
@@ -124,40 +141,125 @@ func packageCalls(t *testing.T, path, pkg, fn string) bool {
 			strings.HasSuffix(name, "_test.go") || strings.HasSuffix(name, "_gen.go") {
 			continue
 		}
-		if fileCalls(t, filepath.Join(dir, name), pkg, fn) {
+		if fileUsesALoadedVoice(t, filepath.Join(dir, name)) {
 			return true
 		}
 	}
 	return false
 }
 
-// fileCalls reports whether the file holds a pkg.fn call expression.
-func fileCalls(t *testing.T, path, pkg, fn string) bool {
+// fileUsesALoadedVoice reports whether the file calls draftvoice.Load in a
+// position where its answer goes somewhere: returned to a caller, passed as an
+// argument to another call, or bound to a name that is read again.
+func fileUsesALoadedVoice(t *testing.T, path string) bool {
 	t.Helper()
 	parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
 	if err != nil {
 		t.Fatalf("reading %s: %v", path, err)
 	}
-	found := false
+	used := false
 	ast.Inspect(parsed, func(n ast.Node) bool {
-		if found {
+		if used {
 			return false
 		}
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		selector, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || selector.Sel.Name != fn {
-			return true
-		}
-		ident, ok := selector.X.(*ast.Ident)
-		if ok && ident.Name == pkg {
-			found = true
+		switch node := n.(type) {
+		case *ast.ReturnStmt:
+			// Handed back to a caller: return draftvoice.Load(...). The reply
+			// drafter's loadVoice is this shape, and a reader that knew only
+			// about arguments and assignments would report it as unwired.
+			for _, result := range node.Results {
+				if isVoiceLoadCall(result) {
+					used = true
+					return false
+				}
+			}
+		case *ast.CallExpr:
+			// Passed straight into another call: Write(ctx, lane, in, Load(...)).
+			for _, arg := range node.Args {
+				if isVoiceLoadCall(arg) {
+					used = true
+					return false
+				}
+			}
+		case *ast.AssignStmt:
+			// Bound to a name, which must then be read somewhere in the file.
+			for i, rhs := range node.Rhs {
+				if !isVoiceLoadCall(rhs) || i >= len(node.Lhs) {
+					continue
+				}
+				name, ok := node.Lhs[i].(*ast.Ident)
+				if ok && name.Name != "_" && identReadElsewhere(parsed, name) {
+					used = true
+					return false
+				}
+			}
 		}
 		return true
 	})
-	return found
+	return used
+}
+
+// isVoiceLoadCall reports whether an expression is a draftvoice.Load call.
+func isVoiceLoadCall(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "Load" {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && pkg.Name == "draftvoice"
+}
+
+// identReadElsewhere reports whether the name is genuinely read again away from
+// where it was defined — a value assigned and never read is a value discarded.
+//
+// A mention under `_ = name` does not count. That statement exists to silence
+// the compiler about an unused variable, so counting it would let the one shape
+// it appears in — a loaded voice deliberately parked — read as a voice in use.
+func identReadElsewhere(file *ast.File, defined *ast.Ident) bool {
+	discards := blankAssignedNames(file)
+	read := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if read {
+			return false
+		}
+		ident, ok := n.(*ast.Ident)
+		if !ok || ident.Name != defined.Name || ident.Pos() == defined.Pos() {
+			return true
+		}
+		if discards[ident.Pos()] {
+			return true
+		}
+		read = true
+		return false
+	})
+	return read
+}
+
+// blankAssignedNames collects the positions of identifiers that appear only as
+// the right-hand side of a `_ = name` statement.
+func blankAssignedNames(file *ast.File) map[token.Pos]bool {
+	out := map[token.Pos]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, lhs := range assign.Lhs {
+			name, ok := lhs.(*ast.Ident)
+			if !ok || name.Name != "_" || i >= len(assign.Rhs) {
+				continue
+			}
+			if rhs, ok := assign.Rhs[i].(*ast.Ident); ok {
+				out[rhs.Pos()] = true
+			}
+		}
+		return true
+	})
+	return out
 }
 
 // A voiced composer prompt actually carries the profile.
@@ -168,10 +270,19 @@ func fileCalls(t *testing.T, path, pkg, fn string) bool {
 // are checked, because both were written from the same template and a fix
 // applied to one of them is the failure this pair exists to catch.
 func TestAVoicedComposerPromptCarriesTheProfile(t *testing.T) {
-	const personality = "I write short. I never say circling back."
+	// Every field that descends from the author's corpus, each with its own
+	// recognisable text: an exemplar IS a verbatim excerpt of somebody's mail,
+	// so a gate that checked only the hand-written personality would leave the
+	// two fields most likely to quote a third party unwatched.
+	const (
+		personality = "I write short. I never say circling back."
+		derived     = "Sentences run under twelve words."
+		exemplar    = "Servus Martin, das Angebot geht morgen raus."
+	)
+	corpus := []string{personality, derived, exemplar}
 	voice := draftvoice.Context{
 		Profile: aiVoiceProfileWithPersonality(personality),
-		Version: aiVoiceVersionWithProfile("Sentences run under twelve words."),
+		Version: aiVoiceVersionWithExemplar(derived, exemplar),
 		OK:      true,
 	}
 	// Through each composer's OWN request builder, not through Block alone: a
@@ -180,7 +291,7 @@ func TestAVoicedComposerPromptCarriesTheProfile(t *testing.T) {
 	for what, req := range voicedComposerRequests(t, voice) {
 		sent := userTurn(t, what, req)
 		missing := false
-		for _, want := range []string{personality, "Sentences run under twelve words.", draftvoice.VocabularyRule} {
+		for _, want := range append(append([]string{}, corpus...), draftvoice.VocabularyRule) {
 			if !strings.Contains(sent, want) {
 				t.Errorf("%s sends no %q to the model, so it is told to write in a voice it was never "+
 					"shown", what, want)
@@ -200,9 +311,20 @@ func TestAVoicedComposerPromptCarriesTheProfile(t *testing.T) {
 		// Read structurally rather than against a fence built here: each
 		// request mints its OWN nonce, so a marker this test constructed would
 		// never match the one the request carries.
-		if !fencedIn(t, sent, personality) {
-			t.Errorf("%s carries the author's own text outside this call's fence, so a profile built "+
-				"from a mail somebody sent them could instruct the model", what)
+		for _, text := range corpus {
+			if !fencedIn(t, sent, text) {
+				t.Errorf("%s carries the author's own %q outside this call's fence, so a profile built "+
+					"from a mail somebody sent them could instruct the model", what, text)
+			}
+		}
+		// The system turn is where instructions live. Corpus text there is an
+		// instruction whatever it says, and no fence in the user turn can
+		// undo that.
+		for _, text := range corpus {
+			if strings.Contains(req.System, text) {
+				t.Errorf("%s copies the author's own %q into the system turn, where it reads as an "+
+					"instruction rather than as data", what, text)
+			}
 		}
 	}
 }
@@ -231,7 +353,12 @@ func voicedComposerRequests(t *testing.T, voice draftvoice.Context) map[string]m
 }
 
 // fencedIn reports whether every occurrence of text in turn sits inside a
-// fenced span — after an opening marker and before that span's close.
+// CLOSED fenced span: after an opening marker, and with that span's close
+// still to come.
+//
+// Both halves are required. A check that only looked backwards would accept an
+// opening marker never closed, which is not a boundary — everything after it,
+// including the rest of the prompt, would read as one unterminated span.
 //
 // The markers are read OFF THE TURN, because the nonce is minted per call and a
 // marker this test constructed would never match the one the request carries.
@@ -251,6 +378,14 @@ func fencedIn(t *testing.T, turn, text string) bool {
 		lastOpen := strings.LastIndex(before, opening)
 		lastClose := strings.LastIndex(before, closing)
 		if lastOpen < 0 || lastClose > lastOpen {
+			return false
+		}
+		// The span must also END. Without this, fence.Open()+text — an opening
+		// marker with no close — passes as fenced.
+		after := turn[idx+len(text):]
+		nextClose := strings.Index(after, closing)
+		nextOpen := strings.Index(after, opening)
+		if nextClose < 0 || (nextOpen >= 0 && nextOpen < nextClose) {
 			return false
 		}
 		next := strings.Index(turn[idx+len(text):], text)
@@ -331,9 +466,16 @@ func TestAnUnvoicedComposerPromptNamesNoProfile(t *testing.T) {
 // stated reason can be false, and this is the one that would be expensive.
 func TestNoComposerPromptCarriesMargincesOwnVoice(t *testing.T) {
 	fence := newDraftFence()
-	prompts := voicedComposerPrompts(fence)
+	// Merged under DISTINCT keys. Both maps are keyed by composer, so writing
+	// one into the other replaced every voiced prompt with its unvoiced twin
+	// and left the voiced half untested — which is the half a Margince-voice
+	// regression would land in.
+	prompts := map[string]string{}
+	for what, system := range voicedComposerPrompts(fence) {
+		prompts[what+" (voiced)"] = system
+	}
 	for what, system := range unvoicedComposerPrompts(fence) {
-		prompts[what] = system
+		prompts[what+" (unvoiced)"] = system
 	}
 	for what, system := range prompts {
 		if strings.Contains(system, promptvoice.Heading) {

--- a/backend/internal/compose/persondraft/commitment_test.go
+++ b/backend/internal/compose/persondraft/commitment_test.go
@@ -10,6 +10,7 @@ import (
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
@@ -276,7 +277,7 @@ func TestTheSnippetTravelsInsideTheFence(t *testing.T) {
 	in.Recipient = RecipientIn{ID: "p1", FirstName: "Marek"}
 	in.Envelope = envelopeAt(textlang.German, convstate.BandFresh)
 
-	req, err := groundedRequest(in)
+	req, err := buildRequest(in, draftvoice.Context{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/persondraft/service.go
+++ b/backend/internal/compose/persondraft/service.go
@@ -12,9 +12,11 @@ package persondraft
 
 import (
 	"context"
+	"log/slog"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/compose/person360"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
@@ -58,6 +60,11 @@ type Service struct {
 	view     Assembler
 	lane     Completer
 	envelope *draftfloor.Resolver
+	// voice reads the sender's own Voice DNA. It is the READ seam, not the
+	// voice store: this package promises to write nothing, and a store handed
+	// in whole would carry the learning-signal writes with it.
+	voice draftvoice.Reader
+	log   *slog.Logger
 }
 
 // NewService binds the draft to the composite read it is grounded in and the
@@ -75,6 +82,16 @@ func (s *Service) WithEnvelope(resolver *draftfloor.Resolver) *Service {
 	if resolver != nil {
 		s.envelope = resolver
 	}
+	return s
+}
+
+// WithVoice binds the sender's voice profile read, so a rep who has built one
+// gets their own writing here and not only when they answer a mail. Without it
+// the draft is written under the shared rules alone, which is what a
+// deployment with no voice lane has.
+func (s *Service) WithVoice(reader draftvoice.Reader, log *slog.Logger) *Service {
+	s.voice = reader
+	s.log = log
 	return s
 }
 
@@ -104,7 +121,9 @@ func (s *Service) Draft(
 		return crmcontracts.AccountEmailDraft{}, httperr.Validation("project_id", "not_found",
 			"that project is not one this person is part of, or you cannot see it")
 	}
-	draft, by, err := Write(ctx, s.lane, in)
+	// Loaded after the 360 read, so a caller who may not read this person is
+	// refused before their voice profile is touched at all.
+	draft, by, err := Write(ctx, s.lane, in, draftvoice.Load(ctx, s.voice, s.log))
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -158,11 +158,18 @@ func writeChecked(ctx context.Context, lane Completer, in Input, voice draftvoic
 // shared rules and by draftcheck, and running a second retry over every draft
 // would double the model spend of the common case to fix the rare one.
 //
-// A draft that still trips the floor after all of that is served anyway, with
-// the sanitizer's edits kept. The alternative is the deterministic floor — a
-// two-line opener — and a rep who asked for a draft is better served by an
-// imperfect real message than by a stub, which is the same trade Write makes
-// when the model is down.
+// Every step can only improve the draft, never replace it with a worse one.
+// The retry is kept only if it clears MORE violations than the attempt it
+// replaces — a retry is one more model answer, not a better one by definition,
+// and it is written without the draftcheck findings the first pass already
+// cleared. The sanitizer's edits are kept only if what survives them is still a
+// draft: it deletes characters, so a subject that was nothing but an em dash
+// comes back empty, and an empty subject is not a message the contract allows.
+//
+// A draft that still trips the floor after all of that is served anyway. The
+// alternative is the deterministic floor — a two-line opener — and a rep who
+// asked for a draft is better served by an imperfect real message than by a
+// stub, which is the same trade Write makes when the model is down.
 func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, draft Draft) (Draft, error) {
 	if !voice.OK {
 		return draft, nil
@@ -173,12 +180,23 @@ func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftv
 	violations := draftvoice.Violations(draft.Subject, draft.Body)
 	if len(violations) > 0 {
 		retried, retryErr := writeWithModel(ctx, lane, in, voice, draftvoice.Feedback(violations))
-		if retryErr == nil {
+		if retryErr == nil && len(draftvoice.Violations(retried.Subject, retried.Body)) < len(violations) {
 			draft = retried
 		}
 	}
-	draft.Subject, draft.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
-	return draft, nil
+	sanitized := draft
+	sanitized.Subject, sanitized.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
+	if !servable(sanitized) {
+		return draft, nil
+	}
+	return sanitized, nil
+}
+
+// servable reports whether a draft is still one the contract can carry. The
+// sanitizer removes characters, so a draft made only of what it removes comes
+// back empty — and an empty subject or body is not a message.
+func servable(draft Draft) bool {
+	return strings.TrimSpace(draft.Subject) != "" && strings.TrimSpace(draft.Body) != ""
 }
 
 func writeWithModel(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, correction string) (Draft, error) {

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/draftcore"
 	"github.com/margince/margince/backend/internal/compose/draftrules"
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
@@ -52,10 +53,19 @@ sections_omitted names what the reader of this summary was not allowed to see. S
 If the summary gives you nothing but the recipient, write a short honest opener and return an empty reasoning array. Do not invent a reason.`
 
 // draftSystemFor assembles this call's system turn: what this surface is for,
-// the rules every drafting surface shares, and THIS call's data boundary (see
-// promptfence.Fence.Rule).
-func draftSystemFor(fence promptfence.Fence) string {
-	return draftSystem + "\n\n" + draftrules.Shared + "\n" + fence.Rule("contact summary")
+// the rules every drafting surface shares, THIS call's data boundary (see
+// promptfence.Fence.Rule), and — when the sender has a voice profile — what
+// that profile is allowed to govern.
+//
+// The voice rule is conditional because the block it describes is: a system
+// turn telling the model to obey a profile that never arrives in the user turn
+// is an instruction pointing at nothing.
+func draftSystemFor(fence promptfence.Fence, voiced bool) string {
+	system := draftSystem + "\n\n" + draftrules.Shared
+	if voiced {
+		system += "\n\n" + draftvoice.SystemRule
+	}
+	return system + "\n" + fence.Rule("contact summary")
 }
 
 // draftSchema is the response shape the validated lane enforces.
@@ -99,13 +109,13 @@ type modelReason struct {
 // the deployment saying this role runs no model, and the deterministic floor is
 // the answer.
 func Write(
-	ctx context.Context, lane Completer, in Input,
+	ctx context.Context, lane Completer, in Input, voice draftvoice.Context,
 ) (Draft, crmcontracts.WrittenBy, error) {
 	floor := Deterministic(in)
 	if lane == nil {
 		return floor, crmcontracts.Deterministic, nil
 	}
-	written, err := writeChecked(ctx, lane, in)
+	written, err := writeChecked(ctx, lane, in, voice)
 	if err != nil {
 		// A model that is down, over budget or answering nonsense must not cost
 		// the rep their draft: the floor is a real message they can edit, and
@@ -122,10 +132,10 @@ func Write(
 // writeChecked drafts through the shared correct-and-retry loop, so this
 // surface cannot drift from the other two about what a rejected phrase is or
 // how many chances the model gets to fix one.
-func writeChecked(ctx context.Context, lane Completer, in Input) (Draft, error) {
-	return draftcore.CorrectOnce(ctx, in.Envelope.Lang(), in.Envelope.Band(),
+func writeChecked(ctx context.Context, lane Completer, in Input, voice draftvoice.Context) (Draft, error) {
+	draft, err := draftcore.CorrectOnce(ctx, in.Envelope.Lang(), in.Envelope.Band(),
 		func(ctx context.Context, correction string) (Draft, error) {
-			return writeWithModel(ctx, lane, in, correction)
+			return writeWithModel(ctx, lane, in, voice, correction)
 		},
 		func(d Draft) (string, []string) { return d.Body, reasonLabels(d.Reasoning) },
 		func(d Draft) (string, bool) { return d.Subject, in.Threaded() },
@@ -134,10 +144,45 @@ func writeChecked(ctx context.Context, lane Completer, in Input) (Draft, error) 
 		// reports it.
 		nil,
 	)
+	if err != nil {
+		return Draft{}, err
+	}
+	return applyVoiceFloor(ctx, lane, in, voice, draft)
 }
 
-func writeWithModel(ctx context.Context, lane Completer, in Input, correction string) (Draft, error) {
-	req, err := groundedRequest(in)
+// applyVoiceFloor is the deterministic anti-AI pass a voiced draft must clear:
+// detect on the raw text, one critic retry that fixes the SENTENCE, then the
+// sanitizer for what is left to remove mechanically.
+//
+// It runs only for a voiced draft. An unvoiced one is already governed by the
+// shared rules and by draftcheck, and running a second retry over every draft
+// would double the model spend of the common case to fix the rare one.
+//
+// A draft that still trips the floor after all of that is served anyway, with
+// the sanitizer's edits kept. The alternative is the deterministic floor — a
+// two-line opener — and a rep who asked for a draft is better served by an
+// imperfect real message than by a stub, which is the same trade Write makes
+// when the model is down.
+func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, draft Draft) (Draft, error) {
+	if !voice.OK {
+		return draft, nil
+	}
+	// Detect on the RAW draft: a violation the sanitizer could mechanically
+	// remove still earns the retry, because the retry rewrites the sentence
+	// where the sanitizer only deletes the punctuation.
+	violations := draftvoice.Violations(draft.Subject, draft.Body)
+	if len(violations) > 0 {
+		retried, retryErr := writeWithModel(ctx, lane, in, voice, draftvoice.Feedback(violations))
+		if retryErr == nil {
+			draft = retried
+		}
+	}
+	draft.Subject, draft.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
+	return draft, nil
+}
+
+func writeWithModel(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, correction string) (Draft, error) {
+	req, err := buildRequest(in, voice)
 	if err != nil {
 		return Draft{}, err
 	}
@@ -154,26 +199,33 @@ func writeWithModel(ctx context.Context, lane Completer, in Input, correction st
 	return ParseDraft(res.Text, in)
 }
 
-// groundedRequest builds the model call: the system prompt naming this call's
+// buildRequest builds the model call: the system prompt naming this call's
 // boundary, and the contact summary INSIDE it.
 //
 // The caller's intent is the one input outside the fence, and it is outside
 // because the caller typed it: fencing a person's own instruction would tell
 // the model to treat the reader as an attacker.
 //
-//promptvoice:exempt the reply is an email the salesperson sends under their OWN name — see accountdraft/write.go for the same reason; the user's voice governs a draft, not Margince's.
-func groundedRequest(in Input) (model.Request, error) {
+// The sender's voice profile, when they have one, rides the user turn under
+// this call's own fence — it is corpus text, so it is data and never
+// instruction.
+//
+//promptvoice:exempt this is an email the salesperson sends under their OWN name, so it carries THEIR voice (draftvoice) rather than Margince's personality — Margince's voice inside a customer-facing draft would be Margince signing somebody else's mail.
+func buildRequest(in Input, voice draftvoice.Context) (model.Request, error) {
 	fence := promptfence.New()
 	payload, err := json.Marshal(fencedInput(in))
 	if err != nil {
 		return model.Request{}, fmt.Errorf("marshal person draft input: %w", err)
 	}
 	content := fence.Wrap(string(payload))
+	if block := voice.Block(fence); block != "" {
+		content += "\n\n" + block
+	}
 	if in.Intent != "" {
 		content += "\n\nThe salesperson asks for: " + in.Intent
 	}
 	return model.Request{
-		System:   draftSystemFor(fence),
+		System:   draftSystemFor(fence, voice.OK),
 		Messages: []model.Message{{Role: "user", Content: content}},
 		// Thinking headroom. A reasoning model spends output tokens on internal
 		// thinking BEFORE its answer, and that thinking counts against the cap —
@@ -323,7 +375,12 @@ var (
 // SystemPromptFor is the assembled system turn, for the compose-level parity
 // gate that asserts every drafting surface writes under the same shared rules.
 // Exported for that assertion alone: the surface itself calls draftSystemFor.
-func SystemPromptFor(fence promptfence.Fence) string { return draftSystemFor(fence) }
+func SystemPromptFor(fence promptfence.Fence) string { return draftSystemFor(fence, false) }
+
+// VoicedSystemPromptFor is the system turn a draft written under a sender's
+// voice profile carries. The parity gate reads BOTH: a surface with two system
+// turns has two chances to drop the shared rules.
+func VoicedSystemPromptFor(fence promptfence.Fence) string { return draftSystemFor(fence, true) }
 
 // reasonLabels is the provenance a draft shows the rep, for the checks that
 // judge it. The labels alone: an entity id is a citation the filter already
@@ -336,7 +393,10 @@ func reasonLabels(reasons []Reason) []string {
 	return out
 }
 
-// GroundedRequest is the request this site sends, for the compose-level gate
-// that asserts every drafting surface carries thinking headroom. Exported for
-// that assertion alone; the site itself calls groundedRequest.
-func GroundedRequest(in Input) (model.Request, error) { return groundedRequest(in) }
+// GroundedRequest is the request this site sends, for the compose-level gates
+// that assert every drafting surface carries thinking headroom and that a
+// loaded voice profile reaches the model's user turn. Exported for those
+// assertions alone; the site itself calls buildRequest.
+func GroundedRequest(in Input, voice draftvoice.Context) (model.Request, error) {
+	return buildRequest(in, voice)
+}

--- a/backend/internal/compose/replydraft_test.go
+++ b/backend/internal/compose/replydraft_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
@@ -105,11 +106,11 @@ func (b *sequencedBrainStub) Complete(_ context.Context, req model.Request) (mod
 	return b.responses[index], nil
 }
 
-func testVoiceContext() voiceContext {
-	return voiceContext{
-		ok:      true,
-		profile: ai.VoiceProfile{PersonalityMD: "Blunt, never hedges."},
-		version: ai.VoiceProfileVersion{
+func testVoiceContext() draftvoice.Context {
+	return draftvoice.Context{
+		OK:      true,
+		Profile: ai.VoiceProfile{PersonalityMD: "Blunt, never hedges."},
+		Version: ai.VoiceProfileVersion{
 			ProfileVersion: 3,
 			VoiceProfileMD: "# Voice DNA\n\n## How you think\n\nVerdict first.",
 			ProfileJSON: map[string]any{"exemplars": []any{
@@ -220,7 +221,7 @@ func TestVoicedDraftWithoutAProfileIsThePlainPath(t *testing.T) {
 	}}
 	drafter := replyDrafter{brain: brain}
 	_, version, _, err := drafter.completeVoiced(context.Background(), ids.NewV7(),
-		replyActivityData{Subject: "plan", Thread: "inbound_mail"}, voiceContext{})
+		replyActivityData{Subject: "plan", Thread: "inbound_mail"}, draftvoice.Context{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/replydraftvoice.go
+++ b/backend/internal/compose/replydraftvoice.go
@@ -12,48 +12,42 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"strings"
 
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 )
 
-// voiceContext is the loaded active profile a voiced draft injects.
-type voiceContext struct {
-	profile ai.VoiceProfile
-	version ai.VoiceProfileVersion
-	ok      bool
-}
-
-// loadVoice resolves the actor's active voice; any lookup failure degrades
-// to the plain draft with the failure visible in the log — a broken voice
-// read must never take reply drafting down with it.
-func (d replyDrafter) loadVoice(ctx context.Context) voiceContext {
+// loadVoice resolves the actor's active voice through the same seam the two
+// composers use, so a reply and a composed mail cannot disagree about whose
+// voice they are written in.
+//
+// Held by: TestEveryDraftingSurfaceLoadsTheSenderVoice
+// (backend/internal/compose/draftvoiceparity_test.go), which sweeps the tree
+// for every surface composing draftrules.Shared and fails when one of them
+// reaches a model without calling draftvoice.Load.
+//
+// A nil store is a deployment with no voice lane; a lookup failure degrades to
+// the plain draft with the reason logged, because a broken voice read must
+// never take reply drafting down with it.
+func (d replyDrafter) loadVoice(ctx context.Context) draftvoice.Context {
 	if d.voice == nil {
-		return voiceContext{}
+		return draftvoice.Context{}
 	}
-	profile, version, ok, err := d.voice.ActiveVoiceForActor(ctx)
-	if err != nil {
-		d.logger().WarnContext(ctx, "voice profile lookup failed; drafting without voice", "err", err)
-		return voiceContext{}
-	}
-	return voiceContext{profile: profile, version: version, ok: ok}
+	return draftvoice.Load(ctx, d.voice, d.logger())
 }
 
 // completeVoiced drafts with the voice block when one is loaded, enforcing
 // the deterministic anti-AI floor: detect → one critic retry → sanitize →
 // on surviving violations fall back to the plain draft and record the
 // failure as a rejected learning signal.
-func (d replyDrafter) completeVoiced(ctx context.Context, anchor ids.UUID, data replyActivityData, voice voiceContext) (replyDraft, *int, *string, error) {
-	if !voice.ok {
+func (d replyDrafter) completeVoiced(ctx context.Context, anchor ids.UUID, data replyActivityData, voice draftvoice.Context) (replyDraft, *int, *string, error) {
+	if !voice.OK {
 		draft, err := d.completeChecked(ctx, replyDraftSystem, data, nil)
 		return draft, nil, nil, err
 	}
-	block := func(fence promptfence.Fence) string {
-		return voiceDraftPromptBlock(voice.profile.PersonalityMD, voice.version.VoiceProfileMD,
-			ai.VersionExemplars(voice.version), ai.DecodeVersionStats(voice.version), fence)
-	}
+	block := voice.Block
 	draft, err := d.completeChecked(ctx, replyDraftSystem, data, block)
 	if err != nil {
 		return replyDraft{}, nil, nil, err
@@ -64,16 +58,15 @@ func (d replyDrafter) completeVoiced(ctx context.Context, anchor ids.UUID, data 
 	// retry fixes the sentence, not just the punctuation.
 	if violations := voiceDraftViolations(draft); len(violations) > 0 {
 		withFeedback := func(fence promptfence.Fence) string {
-			return block(fence) + voiceViolationFeedback(violations)
+			return block(fence) + draftvoice.Feedback(violations)
 		}
 		retried, retryErr := d.complete(ctx, data, withFeedback)
 		if retryErr == nil {
 			draft = retried
 		}
 	}
-	draft.Subject = ai.SanitizeAIPatterns(draft.Subject)
-	draft.Body = ai.SanitizeAIPatterns(draft.Body)
-	version := voice.version.ProfileVersion
+	draft.Subject, draft.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
+	version := voice.Version.ProfileVersion
 	// The sanitizer edits text, so the floor AND the shape are re-checked on
 	// what would actually be served.
 	if len(voiceDraftViolations(draft)) > 0 || validateReplyDraft(draft) != nil {
@@ -91,48 +84,39 @@ func (d replyDrafter) completeVoiced(ctx context.Context, anchor ids.UUID, data 
 // voiceDraftViolations runs the deterministic floor over subject and body
 // independently; concatenation would hide a canned opener inside the body.
 func voiceDraftViolations(draft replyDraft) []ai.VoiceViolation {
-	return append(ai.DetectAIPatterns(draft.Subject), ai.DetectAIPatterns(draft.Body)...)
-}
-
-func voiceViolationFeedback(violations []ai.VoiceViolation) string {
-	var b strings.Builder
-	b.WriteString("\n\nThe previous attempt violated these hard rules; rewrite without them:\n")
-	for _, violation := range violations {
-		b.WriteString("- " + violation.Detail + "\n")
-	}
-	return b.String()
+	return draftvoice.Violations(draft.Subject, draft.Body)
 }
 
 // voiceDraftRef keys one served draft for learning-signal feedback. It
 // covers profile, version, anchor, and the full draft: two drafts for the
 // same activity with the same body but different subjects — or from
 // different profile versions — never collide.
-func voiceDraftRef(voice voiceContext, anchor ids.UUID, draft replyDraft) string {
+func voiceDraftRef(voice draftvoice.Context, anchor ids.UUID, draft replyDraft) string {
 	sum := sha256.Sum256([]byte(draft.Subject + "\n" + draft.Body))
 	return fmt.Sprintf("replydraft:%s:%s:v%d:%s",
-		voice.profile.ID, anchor, voice.version.ProfileVersion, hex.EncodeToString(sum[:8]))
+		voice.Profile.ID, anchor, voice.Version.ProfileVersion, hex.EncodeToString(sum[:8]))
 }
 
-func (d replyDrafter) recordVoiceDraft(ctx context.Context, voice voiceContext, anchor ids.UUID, draft replyDraft) {
+func (d replyDrafter) recordVoiceDraft(ctx context.Context, voice draftvoice.Context, anchor ids.UUID, draft replyDraft) {
 	if d.voice == nil {
 		return
 	}
-	if err := d.voice.RecordDraftedSignal(ctx, voice.profile.ID, voice.version.ProfileVersion,
+	if err := d.voice.RecordDraftedSignal(ctx, voice.Profile.ID, voice.Version.ProfileVersion,
 		voiceDraftRef(voice, anchor, draft), draft.Body); err != nil {
 		d.logger().WarnContext(ctx, "voice draft signal not recorded", "err", err)
 	}
 }
 
-func (d replyDrafter) recordVoiceRejection(ctx context.Context, voice voiceContext, anchor ids.UUID, draft replyDraft) {
+func (d replyDrafter) recordVoiceRejection(ctx context.Context, voice draftvoice.Context, anchor ids.UUID, draft replyDraft) {
 	if d.voice == nil {
 		return
 	}
 	ref := voiceDraftRef(voice, anchor, draft)
-	if err := d.voice.RecordDraftedSignal(ctx, voice.profile.ID, voice.version.ProfileVersion, ref, draft.Body); err != nil {
+	if err := d.voice.RecordDraftedSignal(ctx, voice.Profile.ID, voice.Version.ProfileVersion, ref, draft.Body); err != nil {
 		d.logger().WarnContext(ctx, "voice rejection signal not recorded", "err", err)
 		return
 	}
-	if _, err := d.voice.RejectDraft(ctx, voice.profile.ID, ref); err != nil {
+	if _, err := d.voice.RejectDraft(ctx, voice.Profile.ID, ref); err != nil {
 		d.logger().WarnContext(ctx, "voice rejection signal not recorded", "err", err)
 	}
 }

--- a/backend/internal/compose/serveroptions_companyview.go
+++ b/backend/internal/compose/serveroptions_companyview.go
@@ -27,6 +27,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose/meetingbrief"
 	"github.com/margince/margince/backend/internal/compose/orgbrief"
 	"github.com/margince/margince/backend/internal/compose/orgdossier"
+	"github.com/margince/margince/backend/internal/modules/ai"
 )
 
 // WithAccountDraft binds the lane that writes an account-started email
@@ -37,14 +38,16 @@ import (
 // deployment running no model still has a rep who pressed "Write email", and
 // a short opener they edit beats a refusal.
 //
-// It takes no pool, unlike every other option here. That is the zero-write
-// guarantee expressed as a dependency: drafting reads the caller's 360 and
-// writes nothing, so there is nothing for a transaction to do.
+// The pool it takes is for READS only — the sender's own voice profile and the
+// identity behind the envelope. Drafting still writes nothing; accountdraft is
+// handed the voice READ seam rather than the store, so the zero-write
+// guarantee stays a dependency rather than a rule somebody remembers.
 func WithAccountDraft(brain completer) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		svc := accountdraft.NewService(s.org360Svc, brain).
 			WithEnvelope(draftEnvelope(pool, s.log)).
-			WithDossier(s.orgDossierSvc)
+			WithDossier(s.orgDossierSvc).
+			WithVoice(ai.NewVoiceStore(InstallationDB(pool)), s.log)
 		s.accountDraftHandlers = accountdraft.NewHandlers(svc, s.sorDispatch.isOverlay)
 	}
 }

--- a/backend/internal/compose/serveroptions_personview.go
+++ b/backend/internal/compose/serveroptions_personview.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/compose/persondraft"
+	"github.com/margince/margince/backend/internal/modules/ai"
 )
 
 // WithPersonDraft binds the lane that writes an email to one contact — the
@@ -24,13 +25,15 @@ import (
 // deployment running no model still has a rep who pressed "Write email", and a
 // short opener they edit beats a refusal.
 //
-// It takes no pool. That is the zero-write guarantee expressed as a dependency:
-// drafting reads the caller's 360 and writes nothing, so there is nothing for a
-// transaction to do.
+// The pool it takes is for READS only — the sender's own voice profile and the
+// identity behind the envelope. Drafting still writes nothing; persondraft is
+// handed the voice READ seam rather than the store, so the zero-write
+// guarantee stays a dependency rather than a rule somebody remembers.
 func WithPersonDraft(brain completer) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
 		svc := persondraft.NewService(s.person360Svc, brain).
-			WithEnvelope(draftEnvelope(pool, s.log))
+			WithEnvelope(draftEnvelope(pool, s.log)).
+			WithVoice(ai.NewVoiceStore(InstallationDB(pool)), s.log)
 		s.personDraftHandlers = persondraft.NewHandlers(svc, s.sorDispatch.isOverlay)
 	}
 }


### PR DESCRIPTION
A rep who has built a Voice DNA profile got their own writing only when
they answered a mail. Pressing "Draft with AI" on a contact or a company
gave them a generic writer instead — same person, same mailbox, two
different voices depending on which button they pressed.

Only the reply drafter ever called ActiveVoiceForActor. The two composers
carried a comment claiming compose/draftrules "carries the user's own
voice instead". It does not: draftrules holds language, register,
greeting and formatting rules and not one sentence of how a particular
person writes. Nothing failed when that comment stopped being true,
because nothing had ever checked it.

compose/draftvoice is now the one spelling of drafting under a profile:
Load resolves the actor's active voice, Context.Block renders it into the
calling call's fence, and Violations/Feedback/Sanitize are the
deterministic anti-AI floor. All three surfaces use it — the reply
drafter's own lane is now a caller rather than a second implementation.

The composers keep their zero-write guarantee. They are handed
draftvoice.Reader, a read seam, rather than the voice store, so the
learning-signal writes stay where the pool is.

Two gates hold it. TestEveryDraftingSurfaceLoadsTheSenderVoice sweeps the
tree for files composing draftrules.Shared and fails when one reaches a
model without calling draftvoice.Load — it checks the CALL, because a
surface that imports the package for its type and never loads a profile
is the exact defect being fixed. TestAVoicedComposerPromptCarriesTheProfile
asserts through each composer's own request builder that the profile
reaches the user turn inside that call's fence, with the marker read off
the turn rather than spelled here.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

## Verification

- `make check-backend` green (full gate, including gates + lint + arch-lint + drift).
- `make craft-static` — 0 blocker, 0 major, 0 minor.
- `make rls-store-path`, `make no-jurisdiction` — both OK.
- Both new gates mutation-checked: removing either composer's `draftvoice.Load` call fails the census; dropping the block from the user turn, sending it unfenced, and always emitting the voice system rule each fail the prompt gates with the message naming the actual defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Every composed email now uses the sender's own Voice DNA profile, not just reply drafts. Previously, a rep who built a Voice DNA profile got their own writing when answering a mail, but "Draft with AI" on a contact or company produced a generic writer — same person, same mailbox, two different voices.

- Adds `draftvoice` as the single voiced-drafting path: loads the actor's active voice, renders it into the call's fence, and runs the deterministic anti-AI floor (detect → one retry → sanitize).
- Routes the person and account composers through `draftvoice.Load`; the reply drafter now calls the same seam instead of its own duplicate implementation.
- The floor never replaces a draft with a worse one: a retry is kept only if it clears more violations than the attempt it replaces, and a sanitized draft only if it is still a complete message.
- The composers keep their zero-write guarantee by receiving the `draftvoice.Reader` read seam, never the voice store.
- Adds two gates: one sweeps the tree to fail any drafting surface composing `draftrules.Shared` without calling `draftvoice.Load`; the other asserts a loaded profile reaches the model's user turn inside the call's fence.

**Migration**
- `WithAccountDraft` and `WithPersonDraft` now take a `pgxpool.Pool` (for reads only) and bind `WithVoice(ai.NewVoiceStore(...))`.

<sup>Written for commit d135431091ee65c9c6257b3df7e663f17fa4df08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Drafts can reflect the sender’s active writing voice, including profile guidance, vocabulary, and style preferences.
  - Person, account, and reply drafts consistently support voice-aware instructions.
- **Bug Fixes**
  - Voice-aware drafts detect unwanted AI-like patterns, request one corrective revision, and sanitize results when appropriate.
  - Drafting continues without voice personalization when profile data is unavailable.
- **Tests**
  - Added coverage for voice-profile handling, prompt safety, draft quality safeguards, and consistent behavior across drafting surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->