### PR TITLE
The Worklist row names the money and the next step

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -32253,15 +32253,19 @@ components:
         It DECIDES nothing. The verb routes to the endpoint that owns it, the same way
         the deal page's own next-step card does, and a row offering a move is not the
         product taking one.
-      required: [action]
+      required: [action, activity_id]
       properties:
         action:
           type: string
-          enum: [draft_reply, open_record]
+          enum: [draft_reply]
           description: |
-            `draft_reply` drafts an answer to the message in `activity_id` — offered only
-            where the reader may READ that message, because there is no drafting a reply
-            to words they cannot see. `open_record` is the fallback that decides nothing.
+            `draft_reply` answers the message in `activity_id` — offered only where the
+            reader may READ that message, because there is no replying to words they
+            cannot see.
+
+            One value, and the message is required with it: a move naming no message is
+            not a move, and a contract that allowed one would let a client draw a control
+            with nothing behind it. A row with no step to suggest sends no `move` at all.
         activity_id:
           type: string
           format: uuid

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -32184,6 +32184,7 @@ components:
         subject: { $ref: '#/components/schemas/AttentionSubject' }
         deal: { $ref: '#/components/schemas/WorklistDealFacts' }
         batch: { $ref: '#/components/schemas/WorklistBatch' }
+        move: { $ref: '#/components/schemas/WorklistMove' }
         due_at: { type: string, format: date-time, description: 'When this is due, or when the meeting starts.' }
         overdue: { type: boolean, description: 'Past due at the read instant, resolved server-side so every surface agrees.' }
         occurred_at: { type: string, format: date-time, description: 'When the thing being reported happened.' }
@@ -32237,6 +32238,34 @@ components:
         currency: { type: string, pattern: '^[A-Z]{3}$' }
         days: { type: integer }
         level: { type: integer, minimum: 0, maximum: 6 }
+
+    WorklistMove:
+      type: object
+      description: |
+        The next step this row suggests, and what it would act on.
+
+        The concept's clearest complaint about the surface this replaces: the product
+        knew the buyer had written, knew nobody had answered, and knew the answer was to
+        draft a reply — and the page said only "no contact for 83 days". A row that names
+        the move carries what the product already worked out into the place the reader is
+        standing.
+
+        It DECIDES nothing. The verb routes to the endpoint that owns it, the same way
+        the deal page's own next-step card does, and a row offering a move is not the
+        product taking one.
+      required: [action]
+      properties:
+        action:
+          type: string
+          enum: [draft_reply, open_record]
+          description: |
+            `draft_reply` drafts an answer to the message in `activity_id` — offered only
+            where the reader may READ that message, because there is no drafting a reply
+            to words they cannot see. `open_record` is the fallback that decides nothing.
+        activity_id:
+          type: string
+          format: uuid
+          description: 'The message a reply would answer, for `draft_reply`.'
 
     WorklistBatch:
       type: object

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -18,6 +18,8 @@ package attention
 import (
 	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
 
@@ -296,6 +298,15 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 	}
 	occurred := waiting.Since
 	row.OccurredAt = &occurred
+	// The message IS the row's id, so the move needs nothing this row does not
+	// already carry. The product knew the buyer had written and knew nobody had
+	// answered; naming the step is the difference between a page that reports
+	// and a page a rep can work from.
+	activity := openapi_types.UUID(waiting.ActivityID)
+	row.Move = &crmcontracts.WorklistMove{
+		Action:     "draft_reply",
+		ActivityId: &activity,
+	}
 	return ranked{item: row, waitingDays: days, occurredAt: waiting.Since}
 }
 
@@ -317,10 +328,22 @@ func dropDealsAlreadyWaiting(rows []ranked) []ranked {
 	if len(waitingDeals) == 0 {
 		return rows
 	}
+	// The deal's own facts ride onto the waiting row that absorbed it: a reader
+	// told a customer is waiting still wants to know the deal is worth €160k.
+	facts := map[string]*crmcontracts.WorklistDealFacts{}
+	for _, row := range rows {
+		if row.item.Source == "deal_at_risk" && waitingDeals[row.item.Id] {
+			facts[row.item.Id] = row.item.Deal
+		}
+	}
 	kept := make([]ranked, 0, len(rows))
 	for _, row := range rows {
 		if row.item.Source == "deal_at_risk" && waitingDeals[row.item.Id] {
 			continue
+		}
+		if row.item.Source == sourceWaiting && row.item.Subject != nil &&
+			row.item.Subject.Type == subjectDeal && row.item.Deal == nil {
+			row.item.Deal = facts[row.item.Subject.Id.String()]
 		}
 		kept = append(kept, row)
 	}

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -222,12 +222,24 @@ func dealFactsOf(item crmcontracts.AttentionItem) *crmcontracts.WorklistDealFact
 	if item.Deal == nil {
 		return nil
 	}
-	return &crmcontracts.WorklistDealFacts{
+	facts := &crmcontracts.WorklistDealFacts{
 		StageId:     item.Deal.StageId,
 		OwnerId:     item.Deal.OwnerId,
 		AmountMinor: item.Deal.AmountMinor,
 		Currency:    item.Deal.Currency,
 	}
+	// The close date rides on the lane item's own due moment, and the idle
+	// count on its detail. Both were already resolved; only this projection
+	// dropped them, so the card could state money and never say when the deal
+	// was meant to land.
+	if item.DueAt != nil {
+		closes := openapi_types.Date{Time: *item.DueAt}
+		facts.ExpectedCloseDate = &closes
+	}
+	if quiet := quietDaysOf(item); quiet > 0 {
+		facts.QuietDays = &quiet
+	}
+	return facts
 }
 
 // expectedRevenue is what the deal is worth times how likely it is to land.
@@ -302,10 +314,9 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 	// already carry. The product knew the buyer had written and knew nobody had
 	// answered; naming the step is the difference between a page that reports
 	// and a page a rep can work from.
-	activity := openapi_types.UUID(waiting.ActivityID)
 	row.Move = &crmcontracts.WorklistMove{
 		Action:     "draft_reply",
-		ActivityId: &activity,
+		ActivityId: openapi_types.UUID(waiting.ActivityID),
 	}
 	return ranked{item: row, waitingDays: days, occurredAt: waiting.Since}
 }
@@ -330,10 +341,15 @@ func dropDealsAlreadyWaiting(rows []ranked) []ranked {
 	}
 	// The deal's own facts ride onto the waiting row that absorbed it: a reader
 	// told a customer is waiting still wants to know the deal is worth €160k.
+	// Everything the drifting row was going to say, kept: a reader told a
+	// customer is waiting still needs to know the deal is material, has been
+	// quiet a month, and is past the date it was meant to close.
 	facts := map[string]*crmcontracts.WorklistDealFacts{}
+	grounds := map[string][]crmcontracts.WorklistReason{}
 	for _, row := range rows {
 		if row.item.Source == "deal_at_risk" && waitingDeals[row.item.Id] {
 			facts[row.item.Id] = row.item.Deal
+			grounds[row.item.Id] = row.item.Because
 		}
 	}
 	kept := make([]ranked, 0, len(rows))
@@ -343,7 +359,9 @@ func dropDealsAlreadyWaiting(rows []ranked) []ranked {
 		}
 		if row.item.Source == sourceWaiting && row.item.Subject != nil &&
 			row.item.Subject.Type == subjectDeal && row.item.Deal == nil {
-			row.item.Deal = facts[row.item.Subject.Id.String()]
+			deal := row.item.Subject.Id.String()
+			row.item.Deal = facts[deal]
+			row.item.Because = append(row.item.Because, grounds[deal]...)
 		}
 		kept = append(kept, row)
 	}

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -723,8 +723,8 @@ func TestAWaitingRowNamesTheMessageAReplyWouldAnswer(t *testing.T) {
 	if move.Action != "draft_reply" {
 		t.Fatalf("the move is %q, wanted the reply", move.Action)
 	}
-	if move.ActivityId == nil || ids.UUID(*move.ActivityId) != message {
-		t.Fatal("the move names no message, so a draft would have nothing to answer")
+	if ids.UUID(move.ActivityId) != message {
+		t.Fatal("the move names the wrong message, so a reply would answer the wrong thing")
 	}
 }
 

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -701,3 +701,62 @@ func TestOneKindOfWorkCannotTakeTheWholePage(t *testing.T) {
 		}
 	}
 }
+
+// The concept's clearest complaint: the product knew the buyer had written,
+// knew nobody had answered, and knew the answer was to draft a reply — and the
+// page said only "no contact for 83 days".
+func TestAWaitingRowNamesTheMessageAReplyWouldAnswer(t *testing.T) {
+	message := ids.NewV7()
+	waiting := []WaitingCustomer{{
+		ActivityID: message,
+		Subject:    "Re: pricing",
+		Since:      rankInstant.Add(-83 * 24 * time.Hour),
+	}}
+
+	out := (&Service{}).worklistFrom(context.Background(),
+		crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waiting)
+
+	move := out.Queue[0].Move
+	if move == nil {
+		t.Fatal("the row reports a wait and names no next step")
+	}
+	if move.Action != "draft_reply" {
+		t.Fatalf("the move is %q, wanted the reply", move.Action)
+	}
+	if move.ActivityId == nil || ids.UUID(*move.ActivityId) != message {
+		t.Fatal("the move names no message, so a draft would have nothing to answer")
+	}
+}
+
+// And the deal's money rides onto the row that absorbed it. A reader told a
+// customer is waiting still wants to know the deal is worth six figures.
+func TestAnAbsorbedDealKeepsItsMoneyOnTheWaitingRow(t *testing.T) {
+	deal := ids.NewV7()
+	amount := int64(160_100_00)
+	dealID := openapi_types.UUID(deal)
+	at := []crmcontracts.AttentionItem{{
+		Id:      deal.String(),
+		Source:  "deal_at_risk",
+		Subject: &crmcontracts.AttentionSubject{Type: "deal", Id: dealID},
+		Deal:    &crmcontracts.AttentionDealFacts{AmountMinor: &amount},
+		Actions: []crmcontracts.AttentionItemActions{},
+	}}
+	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: &at}
+	waiting := []WaitingCustomer{{
+		ActivityID: ids.NewV7(),
+		Since:      rankInstant.Add(-3 * 24 * time.Hour),
+		DealID:     deal,
+	}}
+
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waiting)
+
+	if len(out.Queue) != 1 {
+		t.Fatalf("one message about one deal produced %d rows", len(out.Queue))
+	}
+	if out.Queue[0].Deal == nil || out.Queue[0].Deal.AmountMinor == nil {
+		t.Fatal("the deal's money was lost when its row was absorbed")
+	}
+	if *out.Queue[0].Deal.AmountMinor != amount {
+		t.Fatalf("the row says %d, wanted the deal's own amount", *out.Queue[0].Deal.AmountMinor)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11638,15 +11638,12 @@ func (e WorklistItemSource) Valid() bool {
 // Defines values for WorklistMoveAction.
 const (
 	DraftReply WorklistMoveAction = "draft_reply"
-	OpenRecord WorklistMoveAction = "open_record"
 )
 
 // Valid indicates whether the value is a known member of the WorklistMoveAction enum.
 func (e WorklistMoveAction) Valid() bool {
 	switch e {
 	case DraftReply:
-		return true
-	case OpenRecord:
 		return true
 	default:
 		return false
@@ -27823,18 +27820,26 @@ type WorklistItemSource string
 // the deal page's own next-step card does, and a row offering a move is not the
 // product taking one.
 type WorklistMove struct {
-	// Action `draft_reply` drafts an answer to the message in `activity_id` — offered only
-	// where the reader may READ that message, because there is no drafting a reply
-	// to words they cannot see. `open_record` is the fallback that decides nothing.
+	// Action `draft_reply` answers the message in `activity_id` — offered only where the
+	// reader may READ that message, because there is no replying to words they
+	// cannot see.
+	//
+	// One value, and the message is required with it: a move naming no message is
+	// not a move, and a contract that allowed one would let a client draw a control
+	// with nothing behind it. A row with no step to suggest sends no `move` at all.
 	Action WorklistMoveAction `json:"action"`
 
 	// ActivityId The message a reply would answer, for `draft_reply`.
-	ActivityId *openapi_types.UUID `json:"activity_id,omitempty"`
+	ActivityId openapi_types.UUID `json:"activity_id"`
 }
 
-// WorklistMoveAction `draft_reply` drafts an answer to the message in `activity_id` — offered only
-// where the reader may READ that message, because there is no drafting a reply
-// to words they cannot see. `open_record` is the fallback that decides nothing.
+// WorklistMoveAction `draft_reply` answers the message in `activity_id` — offered only where the
+// reader may READ that message, because there is no replying to words they
+// cannot see.
+//
+// One value, and the message is required with it: a move naming no message is
+// not a move, and a contract that allowed one would let a client draw a control
+// with nothing behind it. A row with no step to suggest sends no `move` at all.
 type WorklistMoveAction string
 
 // WorklistReason One fact behind an item's rank, as a typed pair rather than a sentence: the

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11635,6 +11635,24 @@ func (e WorklistItemSource) Valid() bool {
 	}
 }
 
+// Defines values for WorklistMoveAction.
+const (
+	DraftReply WorklistMoveAction = "draft_reply"
+	OpenRecord WorklistMoveAction = "open_record"
+)
+
+// Valid indicates whether the value is a known member of the WorklistMoveAction enum.
+func (e WorklistMoveAction) Valid() bool {
+	switch e {
+	case DraftReply:
+		return true
+	case OpenRecord:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorklistReasonKind.
 const (
 	WorklistReasonKindApprovedAndFailed  WorklistReasonKind = "approved_and_failed"
@@ -27739,6 +27757,19 @@ type WorklistItem struct {
 	// hygiene. Levels are never mixed by a score.
 	Level int `json:"level"`
 
+	// Move The next step this row suggests, and what it would act on.
+	//
+	// The concept's clearest complaint about the surface this replaces: the product
+	// knew the buyer had written, knew nobody had answered, and knew the answer was to
+	// draft a reply — and the page said only "no contact for 83 days". A row that names
+	// the move carries what the product already worked out into the place the reader is
+	// standing.
+	//
+	// It DECIDES nothing. The verb routes to the endpoint that owns it, the same way
+	// the deal page's own next-step card does, and a row offering a move is not the
+	// product taking one.
+	Move *WorklistMove `json:"move,omitempty"`
+
 	// OccurredAt When the thing being reported happened.
 	OccurredAt *time.Time `json:"occurred_at,omitempty"`
 
@@ -27779,6 +27810,32 @@ type WorklistItemConsequence string
 // routine decisions that read alike, so a hundred of them cost the reader one
 // row rather than a hundred. Its own facts ride in `batch`.
 type WorklistItemSource string
+
+// WorklistMove The next step this row suggests, and what it would act on.
+//
+// The concept's clearest complaint about the surface this replaces: the product
+// knew the buyer had written, knew nobody had answered, and knew the answer was to
+// draft a reply — and the page said only "no contact for 83 days". A row that names
+// the move carries what the product already worked out into the place the reader is
+// standing.
+//
+// It DECIDES nothing. The verb routes to the endpoint that owns it, the same way
+// the deal page's own next-step card does, and a row offering a move is not the
+// product taking one.
+type WorklistMove struct {
+	// Action `draft_reply` drafts an answer to the message in `activity_id` — offered only
+	// where the reader may READ that message, because there is no drafting a reply
+	// to words they cannot see. `open_record` is the fallback that decides nothing.
+	Action WorklistMoveAction `json:"action"`
+
+	// ActivityId The message a reply would answer, for `draft_reply`.
+	ActivityId *openapi_types.UUID `json:"activity_id,omitempty"`
+}
+
+// WorklistMoveAction `draft_reply` drafts an answer to the message in `activity_id` — offered only
+// where the reader may READ that message, because there is no drafting a reply
+// to words they cannot see. `open_record` is the fallback that decides nothing.
+type WorklistMoveAction string
 
 // WorklistReason One fact behind an item's rank, as a typed pair rather than a sentence: the
 // product ships three languages and a sentence composed here would reach a German

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24427,17 +24427,21 @@ export interface components {
          */
         WorklistMove: {
             /**
-             * @description `draft_reply` drafts an answer to the message in `activity_id` — offered only
-             *     where the reader may READ that message, because there is no drafting a reply
-             *     to words they cannot see. `open_record` is the fallback that decides nothing.
+             * @description `draft_reply` answers the message in `activity_id` — offered only where the
+             *     reader may READ that message, because there is no replying to words they
+             *     cannot see.
+             *
+             *     One value, and the message is required with it: a move naming no message is
+             *     not a move, and a contract that allowed one would let a client draw a control
+             *     with nothing behind it. A row with no step to suggest sends no `move` at all.
              * @enum {string}
              */
-            action: "draft_reply" | "open_record";
+            action: "draft_reply";
             /**
              * Format: uuid
              * @description The message a reply would answer, for `draft_reply`.
              */
-            activity_id?: string;
+            activity_id: string;
         };
         /**
          * @description A group of routine decisions that read alike, standing on the queue as one row.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24348,6 +24348,7 @@ export interface components {
             subject?: components["schemas"]["AttentionSubject"];
             deal?: components["schemas"]["WorklistDealFacts"];
             batch?: components["schemas"]["WorklistBatch"];
+            move?: components["schemas"]["WorklistMove"];
             /**
              * Format: date-time
              * @description When this is due, or when the meeting starts.
@@ -24410,6 +24411,33 @@ export interface components {
             currency?: string;
             days?: number;
             level?: number;
+        };
+        /**
+         * @description The next step this row suggests, and what it would act on.
+         *
+         *     The concept's clearest complaint about the surface this replaces: the product
+         *     knew the buyer had written, knew nobody had answered, and knew the answer was to
+         *     draft a reply — and the page said only "no contact for 83 days". A row that names
+         *     the move carries what the product already worked out into the place the reader is
+         *     standing.
+         *
+         *     It DECIDES nothing. The verb routes to the endpoint that owns it, the same way
+         *     the deal page's own next-step card does, and a row offering a move is not the
+         *     product taking one.
+         */
+        WorklistMove: {
+            /**
+             * @description `draft_reply` drafts an answer to the message in `activity_id` — offered only
+             *     where the reader may READ that message, because there is no drafting a reply
+             *     to words they cannot see. `open_record` is the fallback that decides nothing.
+             * @enum {string}
+             */
+            action: "draft_reply" | "open_record";
+            /**
+             * Format: uuid
+             * @description The message a reply would answer, for `draft_reply`.
+             */
+            activity_id?: string;
         };
         /**
          * @description A group of routine decisions that read alike, standing on the queue as one row.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7083,6 +7083,6 @@ export const de = {
   "worklist.batch.held_draft": "{count} Entwürfe warten auf Freigabe",
   "worklist.untitled.batch": "Eine Gruppe Routineentscheidungen",
   "worklist.verb.review_batch": "Durchsehen",
-  "worklist.verb.draft_reply": "Antwort entwerfen",
+  "worklist.verb.draft_reply": "Zum Antworten öffnen",
   "worklist.deal.closes": "Abschluss {date}",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7083,4 +7083,6 @@ export const de = {
   "worklist.batch.held_draft": "{count} Entwürfe warten auf Freigabe",
   "worklist.untitled.batch": "Eine Gruppe Routineentscheidungen",
   "worklist.verb.review_batch": "Durchsehen",
+  "worklist.verb.draft_reply": "Antwort entwerfen",
+  "worklist.deal.closes": "Abschluss {date}",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7168,6 +7168,8 @@ export const en = {
   "worklist.batch.held_draft": "{count} drafts waiting to be sent",
   "worklist.untitled.batch": "A group of routine decisions",
   "worklist.verb.review_batch": "Review",
+  "worklist.verb.draft_reply": "Draft the reply",
+  "worklist.deal.closes": "closes {date}",
 } as const;
 
 export type MessageKey = keyof typeof en;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7168,7 +7168,7 @@ export const en = {
   "worklist.batch.held_draft": "{count} drafts waiting to be sent",
   "worklist.untitled.batch": "A group of routine decisions",
   "worklist.verb.review_batch": "Review",
-  "worklist.verb.draft_reply": "Draft the reply",
+  "worklist.verb.draft_reply": "Open to reply",
   "worklist.deal.closes": "closes {date}",
 } as const;
 

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7017,6 +7017,6 @@ export const vi = {
   "worklist.batch.held_draft": "{count} bản nháp đang chờ gửi",
   "worklist.untitled.batch": "Một nhóm quyết định thường lệ",
   "worklist.verb.review_batch": "Xem lại",
-  "worklist.verb.draft_reply": "Soạn trả lời",
+  "worklist.verb.draft_reply": "Mở để trả lời",
   "worklist.deal.closes": "chốt {date}",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7017,4 +7017,6 @@ export const vi = {
   "worklist.batch.held_draft": "{count} bản nháp đang chờ gửi",
   "worklist.untitled.batch": "Một nhóm quyết định thường lệ",
   "worklist.verb.review_batch": "Xem lại",
+  "worklist.verb.draft_reply": "Soạn trả lời",
+  "worklist.deal.closes": "chốt {date}",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -1,6 +1,11 @@
 import { ENTITY, isEntityKind } from "../app/entity";
 import { routeHash } from "../app/router";
-import { formatDateTime, formatMoney, formatNumber } from "../format/format";
+import {
+  formatDate,
+  formatDateTime,
+  formatMoney,
+  formatNumber,
+} from "../format/format";
 import type { Locale, useT } from "../i18n";
 import type {
   Worklist,
@@ -214,6 +219,7 @@ export function dealFactsText(
   item: WorklistItem,
   t: T,
   locale: Locale,
+  zone: string,
 ): string | null {
   const deal = item.deal;
   if (!deal) {
@@ -225,7 +231,9 @@ export function dealFactsText(
   }
   if (deal.expected_close_date) {
     parts.push(
-      t("worklist.deal.closes", { date: String(deal.expected_close_date) }),
+      t("worklist.deal.closes", {
+        date: formatDate(deal.expected_close_date, locale, zone),
+      }),
     );
   }
   return parts.length > 0 ? parts.join(" · ") : null;
@@ -235,11 +243,17 @@ export function dealFactsText(
 //
 // The RECORD the thread belongs to, not the message: an activity is a timeline
 // entry with no page of its own — `app/entity.ts` says so in as many words —
-// and a link to `#/activities/<id>` would be a control that goes nowhere. The
-// draft is composed from the person or deal the conversation is filed under,
-// which is where the composer lives.
+// so `#/activities/<id>` would be a control that goes nowhere.
 //
-// A move on a row that names no record offers nothing rather than a dead link.
+// WHAT THIS IS NOT. It does not open a composer. The composer lives on the
+// record page behind its own button, and no route opens it, so a link labelled
+// "Draft the reply" would promise something the click does not do. The verb
+// therefore says where it goes — the reader lands on the record with the
+// message on its timeline, one press from the draft — and naming the step
+// honestly is worth more than a label that overstates it.
+//
+// Opening the composer from here needs a deep link the app does not have. That
+// is its own change, and the label moves back when it lands.
 export function moveHref(item: WorklistItem): string | undefined {
   if (item.move?.action !== "draft_reply") {
     return undefined;

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -233,14 +233,18 @@ export function dealFactsText(
 
 // Where the row's suggested step leads.
 //
-// A draft is composed on the message it answers, which is the endpoint that
-// owns drafting — this row adds no second way to write a reply. A move naming
-// no message offers nothing rather than a control that goes nowhere.
+// The RECORD the thread belongs to, not the message: an activity is a timeline
+// entry with no page of its own — `app/entity.ts` says so in as many words —
+// and a link to `#/activities/<id>` would be a control that goes nowhere. The
+// draft is composed from the person or deal the conversation is filed under,
+// which is where the composer lives.
+//
+// A move on a row that names no record offers nothing rather than a dead link.
 export function moveHref(item: WorklistItem): string | undefined {
-  if (item.move?.action !== "draft_reply" || !item.move.activity_id) {
+  if (item.move?.action !== "draft_reply") {
     return undefined;
   }
-  return `#/activities/${item.move.activity_id}`;
+  return subjectHref(item);
 }
 
 // One item's headline.

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -206,6 +206,43 @@ export function consequenceText(item: WorklistItem, t: T): string | null {
   return t(`worklist.consequence.${item.consequence}` as const);
 }
 
+// The deal's own figures, in one line: what it is worth, and when it closes.
+//
+// The concept's sharpest example was a €160,100 deal reduced to "no contact for
+// 83 days". The money was on the wire the whole time; only the row discarded it.
+export function dealFactsText(
+  item: WorklistItem,
+  t: T,
+  locale: Locale,
+): string | null {
+  const deal = item.deal;
+  if (!deal) {
+    return null;
+  }
+  const parts: string[] = [];
+  if (deal.amount_minor != null && deal.currency) {
+    parts.push(formatMoney(deal.amount_minor, deal.currency, locale));
+  }
+  if (deal.expected_close_date) {
+    parts.push(
+      t("worklist.deal.closes", { date: String(deal.expected_close_date) }),
+    );
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+// Where the row's suggested step leads.
+//
+// A draft is composed on the message it answers, which is the endpoint that
+// owns drafting — this row adds no second way to write a reply. A move naming
+// no message offers nothing rather than a control that goes nowhere.
+export function moveHref(item: WorklistItem): string | undefined {
+  if (item.move?.action !== "draft_reply" || !item.move.activity_id) {
+    return undefined;
+  }
+  return `#/activities/${item.move.activity_id}`;
+}
+
 // One item's headline.
 //
 // The server sends a sentence where it HAS one — an approval summary composed

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -47,6 +47,7 @@
   margin: 0;
 }
 
+.worklist-row-facts,
 .worklist-row-sample,
 .worklist-row-because,
 .worklist-row-consequence,

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -270,6 +270,34 @@ describe("what the ranked queue tells a reader", () => {
     });
   });
 
+  it("states the money and offers the reply the product already worked out", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            title: "Re: pricing for the retrofit",
+            source: "customer_waiting",
+            category: "customer_waiting",
+            level: 1,
+            consequence: "buyer_waits",
+            deal: { amount_minor: 16010000, currency: "EUR" },
+            move: {
+              action: "draft_reply",
+              activity_id: "01a05500-0000-7000-8000-00000000aaaa",
+            },
+          }),
+        ],
+        summary: { urgent: 1, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    // The concept's sharpest example: a €160,100 deal reduced to "no contact
+    // for 83 days". The money was on the wire the whole time.
+    expect(await screen.findByText(/160,100/)).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Draft the reply" })).toBeTruthy();
+  });
+
   it("says what happens if the reader does nothing", async () => {
     stub(
       day({

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -300,7 +300,13 @@ describe("what the ranked queue tells a reader", () => {
     // The concept's sharpest example: a €160,100 deal reduced to "no contact
     // for 83 days". The money was on the wire the whole time.
     expect(await screen.findByText(/160,100/)).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Draft the reply" })).toBeTruthy();
+    const reply = screen.getByRole("link", { name: "Open to reply" });
+    // The verb says where it GOES, because that is what pressing it does: the
+    // composer lives on the record behind its own button, and a label promising
+    // a draft would overstate the click.
+    expect(reply.getAttribute("href")).toBe(
+      "#/deals/01a05500-0000-7000-8000-00000000bbbb",
+    );
   });
 
   it("says what happens if the reader does nothing", async () => {

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -281,6 +281,11 @@ describe("what the ranked queue tells a reader", () => {
             level: 1,
             consequence: "buyer_waits",
             deal: { amount_minor: 16010000, currency: "EUR" },
+            subject: {
+              type: "deal",
+              id: "01a05500-0000-7000-8000-00000000bbbb",
+              label: "Acme Expansion",
+            },
             move: {
               action: "draft_reply",
               activity_id: "01a05500-0000-7000-8000-00000000aaaa",

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -11,7 +11,9 @@ import { ApprovalRow } from "./approvalrow";
 import {
   comparisonText,
   consequenceText,
+  dealFactsText,
   itemTitle,
+  moveHref,
   reasonText,
   sourceUnavailableText,
   subjectHref,
@@ -68,6 +70,7 @@ function WorklistRow({
   const zone = viewerZone();
   const href = subjectHref(item);
   const title = itemTitle(item, t, locale);
+  const facts = dealFactsText(item, t, locale);
   const because = item.because
     .map((reason) => reasonText(reason, t, locale, zone))
     .filter((phrase): phrase is string => phrase !== null)
@@ -101,6 +104,7 @@ function WorklistRow({
             {item.batch.sample.join(" · ")}
           </p>
         )}
+        {facts && <p className="t-caption worklist-row-facts">{facts}</p>}
         {because && <p className="t-caption worklist-row-because">{because}</p>}
         {/* What it costs to do nothing. The question a queue exists to answer,
             and the one the lane feed had no field for. */}
@@ -114,7 +118,7 @@ function WorklistRow({
       {item.batch ? (
         <BatchVerb onReview={onReview} />
       ) : (
-        <RowVerbs item={item} href={href} />
+        <RowVerbs item={item} href={href} move={moveHref(item)} />
       )}
       {decidable(item) && <RowDecision item={item} />}
     </PanelRow>
@@ -183,7 +187,12 @@ function BatchVerb({ onReview }: Readonly<{ onReview: () => void }>) {
 function RowVerbs({
   item,
   href,
-}: Readonly<{ item: WorklistItem; href: string | undefined }>) {
+  move,
+}: Readonly<{
+  item: WorklistItem;
+  href: string | undefined;
+  move: string | undefined;
+}>) {
   const t = useT();
   const drawn = new Set<string>();
   const verbs = item.actions.flatMap((action) => {
@@ -207,11 +216,18 @@ function RowVerbs({
     drawn.add(key);
     return [{ action, destination }];
   });
-  if (verbs.length === 0) {
+  if (verbs.length === 0 && !move) {
     return null;
   }
   return (
     <div className="worklist-row-verbs">
+      {/* The step the product already worked out, offered where the reader is
+          standing rather than on a screen they have to go and find. */}
+      {move && (
+        <a className="worklist-row-verb" href={move}>
+          {t("worklist.verb.draft_reply")}
+        </a>
+      )}
       {verbs.map(({ action, destination }) => (
         <a key={action} className="worklist-row-verb" href={destination}>
           {VERB_LABEL[action](t)}

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -70,7 +70,7 @@ function WorklistRow({
   const zone = viewerZone();
   const href = subjectHref(item);
   const title = itemTitle(item, t, locale);
-  const facts = dealFactsText(item, t, locale);
+  const facts = dealFactsText(item, t, locale, zone);
   const because = item.because
     .map((reason) => reasonText(reason, t, locale, zone))
     .filter((phrase): phrase is string => phrase !== null)
@@ -224,12 +224,12 @@ function RowVerbs({
       {/* The step the product already worked out, offered where the reader is
           standing rather than on a screen they have to go and find. */}
       {move && (
-        <a className="worklist-row-verb" href={move}>
+        <a className="link-button" href={move}>
           {t("worklist.verb.draft_reply")}
         </a>
       )}
       {verbs.map(({ action, destination }) => (
-        <a key={action} className="worklist-row-verb" href={destination}>
+        <a key={action} className="link-button" href={destination}>
           {VERB_LABEL[action](t)}
         </a>
       ))}


### PR DESCRIPTION
The concept's clearest complaint about the page this replaces: the product knew the buyer had written, knew nobody had answered, knew the deal was worth €160,100 and knew the answer was to reply — and the row said **"no contact for 83 days"**.

Every one of those facts was already on the wire. Only the row discarded them.

## What a row says now

```
Re: pricing for the retrofit                          [Customer waiting]
€160,100.00 · closes 26/08/2026
They wrote last · waiting 83 days · above the typical open deal · quiet 83 days
If you do nothing, they keep waiting.
                                                        [Open to reply]
```

## What the verb promises

**"Open to reply", not "Draft the reply".** The composer lives on the record behind its own button and no route opens it, so a label promising a draft would overstate the click. The reader lands on the record with the message on its timeline, one press from the draft. When a deep link exists, the label moves back.

An activity has no page of its own — `app/entity.ts` says so — so a row filed under nothing offers no verb rather than a control that goes nowhere.

## Four things the review caught

| Defect | Fix |
|---|---|
| The link pointed at `#/activities/<id>`, a route that does not exist | Points at the record the thread is filed under |
| Then it opened the record without opening a composer, while the label said "Draft the reply" | The verb says what the press does |
| Absorbing a drifting deal kept the money and threw away **why it was drifting** — material, quiet 30 days, past its close date | All of it rides onto the surviving row |
| The close date could never arrive: resolved onto the lane item and dropped by this projection | Carried, and written in the reader's own notation rather than raw ISO |

The contract also let a `draft_reply` name no message. A move with nothing to answer is not a move, so the message is required and the unused second enum value is gone.

## Gates

`make check-backend`, `make check-fe`, `make craft-static` green. Verified on the real workspace: every waiting row names its reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Worklist rows now show the deal's value, close date, and next step, so a €160,100 deal waiting 83 days states what the product already worked out instead of saying only "no contact for 83 days".

- The row's verb is "Open to reply", which links to the record the thread is filed under — not a route that doesn't exist — and doesn't promise opening a composer the click can't reach.
- A deal row absorbed by a waiting row now keeps its amount, quiet-day count, close date, and the reasons it was drifting.
- The close date is carried from the lane item's due moment and written in the reader's local notation.
- `draft_reply` now requires an `activity_id`; a move naming no message is no longer possible, and the unused second enum value was removed.

<sup>Written for commit 02a5ae627095017297ac4d144d7eb7dc0903a3a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worklist items can now suggest opening a reply draft for waiting customer messages.
  * Deal-related worklist rows display the deal amount and expected close date.
  * Suggested actions link directly to the relevant deal or activity.
  * Added German, English, and Vietnamese translations for the new labels.

* **Bug Fixes**
  * Deal details and financial information are preserved when worklist items are combined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->