### PR TITLE
fix(records): the check button stays busy until the register answers

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29191,6 +29191,16 @@ components:
           description: |
             The day the REGISTER reported, not the day this installation recorded it. A receipt
             attests to when the register was asked.
+        recorded_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: |
+            When this installation WROTE the consultation, on its own clock. Distinct from
+            `checked_at` on purpose, and the distinction is load-bearing: VIES answers with a
+            date and no time, so two consultations on one day carry the same `checked_at`. A
+            client waiting for a re-check to land would wait forever on that field, and the
+            server's own rate floor reads this one for the same reason.
 
     TechnicalEnrichStatus:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29154,7 +29154,7 @@ components:
       description: |
         One company's current VAT standing, and the evidence for it. The row keeps only the
         CURRENT consultation; what a re-check overwrote lives in the audit trail.
-      required: [organization_id, vat_number, status, checked_at]
+      required: [organization_id, vat_number, status, checked_at, recorded_at]
       properties:
         organization_id: { type: string, format: uuid }
         vat_number:

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -22706,6 +22706,13 @@ type OrganizationVatCheck struct {
 	ConsultationNumber *string            `json:"consultation_number,omitempty"`
 	OrganizationId     openapi_types.UUID `json:"organization_id"`
 
+	// RecordedAt When this installation WROTE the consultation, on its own clock. Distinct from
+	// `checked_at` on purpose, and the distinction is load-bearing: VIES answers with a
+	// date and no time, so two consultations on one day carry the same `checked_at`. A
+	// client waiting for a re-check to land would wait forever on that field, and the
+	// server's own rate floor reads this one for the same reason.
+	RecordedAt *time.Time `json:"recorded_at,omitempty"`
+
 	// RegisteredAddress The address the register holds, when it returned one.
 	RegisteredAddress *string `json:"registered_address,omitempty"`
 

--- a/backend/internal/modules/people/handlers_organization.go
+++ b/backend/internal/modules/people/handlers_organization.go
@@ -277,6 +277,7 @@ func vatCheckWire(check VatCheck) crmcontracts.OrganizationVatCheck {
 		RegisteredName:     absentWhenEmpty(check.RegisteredName),
 		RegisteredAddress:  absentWhenEmpty(check.RegisteredAddress),
 		CheckedAt:          check.CheckedAt,
+		RecordedAt:         &check.RecordedAt,
 	}
 }
 

--- a/backend/internal/modules/people/organization_vat_check.go
+++ b/backend/internal/modules/people/organization_vat_check.go
@@ -78,6 +78,12 @@ type VatCheck struct {
 	RegisteredName     string
 	RegisteredAddress  string
 	CheckedAt          time.Time
+	// RecordedAt is when THIS INSTALLATION wrote the row, on its own clock.
+	// Separate from CheckedAt because VIES answers with a date and no time, so
+	// two consultations on one day carry the same CheckedAt: anything asking
+	// "has a new answer landed" has to read this one or it never sees a
+	// same-day re-check.
+	RecordedAt time.Time
 }
 
 // ErrVatCheckNotRecorded says this company's VAT ID has never been consulted.
@@ -426,13 +432,15 @@ func upsertVatCheckTx(ctx context.Context, tx pgx.Tx, check VatCheck, capturedBy
 func readVatCheckTx(ctx context.Context, tx pgx.Tx, org ids.OrganizationID) (VatCheck, error) {
 	const read = `
 		SELECT vat_number, status, COALESCE(consultation_number, ''),
-		       COALESCE(registered_name, ''), COALESCE(registered_address, ''), checked_at
+		       COALESCE(registered_name, ''), COALESCE(registered_address, ''),
+		       checked_at, updated_at
 		  FROM organization_vat_check
 		 WHERE organization_id = $1`
 	found := VatCheck{OrganizationID: org}
 	var status string
 	err := tx.QueryRow(ctx, read, org.UUID).Scan(&found.Number, &status,
-		&found.ConsultationNumber, &found.RegisteredName, &found.RegisteredAddress, &found.CheckedAt)
+		&found.ConsultationNumber, &found.RegisteredName, &found.RegisteredAddress,
+		&found.CheckedAt, &found.RecordedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return VatCheck{}, ErrVatCheckNotRecorded
 	}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21418,6 +21418,15 @@ export interface components {
              *     attests to when the register was asked.
              */
             checked_at: string;
+            /**
+             * Format: date-time
+             * @description When this installation WROTE the consultation, on its own clock. Distinct from
+             *     `checked_at` on purpose, and the distinction is load-bearing: VIES answers with a
+             *     date and no time, so two consultations on one day carry the same `checked_at`. A
+             *     client waiting for a re-check to land would wait forever on that field, and the
+             *     server's own rate floor reads this one for the same reason.
+             */
+            readonly recorded_at?: string;
         };
         /**
          * @description What each public source last did for one account. Per lane rather than per run: the

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21426,7 +21426,7 @@ export interface components {
              *     client waiting for a re-check to land would wait forever on that field, and the
              *     server's own rate floor reads this one for the same reason.
              */
-            readonly recorded_at?: string;
+            readonly recorded_at: string;
         };
         /**
          * @description What each public source last did for one account. Per lane rather than per run: the

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1607,8 +1607,9 @@ export const de = {
     "Die USt-IdNr. dieser Firma wurde noch nicht abgefragt. Das passiert von selbst, sobald die Nummer aus dem Impressum gelesen wird — oder Sie fragen jetzt beim Register nach.",
   "co.vat.askNow": "Beim Register abfragen",
   "co.vat.askAgain": "Erneut abfragen",
-  "co.vat.asked":
-    "Angefragt. Die Antwort des Registers erscheint hier, sobald sie vorliegt.",
+  "co.vat.askingBusy": "Register wird gefragt",
+  "co.vat.asking":
+    "Das Register wird gefragt — die Antwort erscheint hier, sobald sie vorliegt.",
   "co.tech.title": "Technik",
   "co.tech.sub":
     "Was diese Firma öffentlich betreibt — gelesen aus ihren DNS-Einträgen, ihren Zertifikaten und ihrer eigenen Startseite.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1647,7 +1647,9 @@ export const en = {
     "This company's VAT ID has not been consulted. It is checked on its own when the number is read from the company's imprint, and you can ask the register now.",
   "co.vat.askNow": "Check with the register",
   "co.vat.askAgain": "Check again",
-  "co.vat.asked": "Asked. The register's answer appears here once it replies.",
+  "co.vat.askingBusy": "Asking the register",
+  "co.vat.asking":
+    "Asking the register — the answer appears here once it replies.",
   "co.tech.title": "Technology",
   "co.tech.sub":
     "What this company publicly runs, read from its DNS records, its certificates and its own homepage.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1602,8 +1602,9 @@ export const vi = {
     "Mã số thuế GTGT của công ty này chưa được tra cứu. Việc này diễn ra tự động khi mã số được đọc từ trang thông tin pháp lý của công ty, hoặc bạn có thể tra cứu ngay.",
   "co.vat.askNow": "Tra cứu tại cơ quan đăng ký",
   "co.vat.askAgain": "Tra cứu lại",
-  "co.vat.asked":
-    "Đã gửi yêu cầu. Câu trả lời sẽ hiện ở đây khi cơ quan đăng ký phản hồi.",
+  "co.vat.askingBusy": "Đang hỏi cơ quan đăng ký",
+  "co.vat.asking":
+    "Đang hỏi cơ quan đăng ký — câu trả lời sẽ hiện ở đây khi có.",
   "co.tech.title": "Công nghệ",
   "co.tech.sub":
     "Những gì công ty này công khai vận hành, đọc từ bản ghi DNS, chứng chỉ và trang chủ của họ.",

--- a/frontend/src/screens/companyvatmark.stories.tsx
+++ b/frontend/src/screens/companyvatmark.stories.tsx
@@ -50,6 +50,7 @@ const CHECKED: VatCheck = {
   registered_name: "Muster Handels GmbH",
   registered_address: "Musterstraße 1, 10115 Berlin",
   checked_at: "2026-08-14T09:12:00Z",
+  recorded_at: "2026-08-14T09:12:31Z",
 };
 
 // The row as the rail draws it: the label, the value, the mark. The mark has to

--- a/frontend/src/screens/companyvatmark.stories.tsx
+++ b/frontend/src/screens/companyvatmark.stories.tsx
@@ -166,6 +166,23 @@ export const AskedTooSoon: Story = {
   },
 };
 
+/** Asked, and waiting. The button stays busy until the register replies rather
+ * than until the request is accepted — the POST answers in milliseconds and the
+ * answer arrives seconds later, so a button that cleared on the 202 invited a
+ * second consultation for a check already running. Press it here: it refuses,
+ * keeps focus, and says what it is doing. */
+export const AskedAndWaiting: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /me": CAN_WRITE,
+      // The register never answers, which is what holds the wait open.
+      [ROUTE]: () => jsonResponse(CHECKED),
+      [ASK]: () => new Response(null, { status: 202 }),
+    });
+    return inRow(NUMBER);
+  },
+};
+
 /** A viewer who may read the company and not change it. The verdict and the
  * receipt are theirs to read; consulting the register is not. */
 export const WithoutTheGrantToAsk: Story = {

--- a/frontend/src/screens/companyvatmark.test.tsx
+++ b/frontend/src/screens/companyvatmark.test.tsx
@@ -354,6 +354,100 @@ describe("the VAT mark beside the number", () => {
     expect(gets).toEqual(["invalid", "valid"]);
   });
 
+  it("refuses a second press while the register is still being asked", async () => {
+    // The window the reader actually meets: the POST answers 202 in
+    // milliseconds and the register replies seconds later, so a button that
+    // cleared on the 202 was live again for the whole wait. A second press
+    // queues a second consultation, or meets the five-minute floor and shows a
+    // rate-limit refusal for a check that is already running.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const posts: string[] = [];
+    stubFetch(async (request) => {
+      const { pathname } = new URL(request.url);
+      if (pathname.endsWith("/me")) {
+        return jsonResponse(
+          meFixture({ allow: { organization: ["read", "update"] } }),
+        );
+      }
+      if (request.method === "POST") {
+        posts.push(pathname);
+        return new Response(null, { status: 202 });
+      }
+      // The register never replies, which is what holds the wait open.
+      return jsonResponse(CHECKED);
+    });
+    render(mark());
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "VAT ID: Valid" }),
+    );
+    const ask = await screen.findByRole("button", { name: "Check again" });
+    fireEvent.click(ask);
+    await screen.findByText(/answer appears here once it replies/);
+
+    // Pressed four more times while the answer is outstanding.
+    fireEvent.click(ask);
+    fireEvent.click(ask);
+    fireEvent.click(ask);
+    fireEvent.click(ask);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(posts).toHaveLength(1);
+    // Refused by being BUSY, not by being disabled: focus stays where the
+    // reader put it, which is what aria-disabled is for.
+    expect(ask).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("takes a press again once the register has answered", async () => {
+    // The other half, and the one that stops the fix being a control nobody can
+    // use twice: the wait ends when the answer lands, not when the poll runs
+    // out of attempts.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let verdict = "invalid";
+    const posts: string[] = [];
+    stubFetch(async (request) => {
+      const { pathname } = new URL(request.url);
+      if (pathname.endsWith("/me")) {
+        return jsonResponse(
+          meFixture({ allow: { organization: ["read", "update"] } }),
+        );
+      }
+      if (request.method === "POST") {
+        posts.push(pathname);
+        verdict = "valid";
+        return new Response(null, { status: 202 });
+      }
+      return jsonResponse({
+        ...CHECKED,
+        status: verdict,
+        // The date MOVES with the answer, which is the signal the wait reads.
+        checked_at:
+          verdict === "valid" ? "2026-08-15T10:00:00Z" : CHECKED.checked_at,
+      });
+    });
+    render(mark());
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "VAT ID: Not valid" }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Check again" }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    // The answer landed, so the button is pressable again — well before the
+    // poll's own last attempt fifteen seconds out.
+    const ask = await screen.findByRole("button", { name: "Check again" });
+    expect(ask).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(ask);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(posts).toHaveLength(2);
+  });
+
   it("draws nothing while the read is in flight", () => {
     stubFetch(
       () =>

--- a/frontend/src/screens/companyvatmark.test.tsx
+++ b/frontend/src/screens/companyvatmark.test.tsx
@@ -37,6 +37,7 @@ const CHECKED = {
   consultation_number: "WAPIAAAAXk3rN2p9",
   registered_name: "Muster Handels GmbH",
   checked_at: "2026-08-14T09:12:00Z",
+  recorded_at: "2026-08-14T09:12:31Z",
 };
 
 function jsonResponse(body: unknown, status = 200) {
@@ -423,8 +424,13 @@ describe("the VAT mark beside the number", () => {
         ...CHECKED,
         status: verdict,
         // The date MOVES with the answer, which is the signal the wait reads.
-        checked_at:
-          verdict === "valid" ? "2026-08-15T10:00:00Z" : CHECKED.checked_at,
+        // checked_at deliberately does NOT move: VIES answers with a date and
+        // no time, so a same-day re-check carries the one it already had. Only
+        // recorded_at moves, and a wait reading the wrong field would hang here
+        // exactly as it would in front of a reader.
+        checked_at: CHECKED.checked_at,
+        recorded_at:
+          verdict === "valid" ? "2026-08-14T09:20:00Z" : CHECKED.recorded_at,
       });
     });
     render(mark());

--- a/frontend/src/screens/companyvatmark.test.tsx
+++ b/frontend/src/screens/companyvatmark.test.tsx
@@ -207,7 +207,7 @@ describe("the VAT mark beside the number", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByText(/answer appears here once it replies/),
+        screen.queryByText(/the answer appears here once it replies/),
       ).toBeNull();
     });
   });
@@ -336,7 +336,7 @@ describe("the VAT mark beside the number", () => {
       await screen.findByRole("button", { name: "VAT ID: Not valid" }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Check again" }));
-    await screen.findByText(/answer appears here once it replies/);
+    await screen.findByText(/the answer appears here once it replies/);
 
     // The timers have to be fake BEFORE the poll schedules itself, or the
     // setTimeout it registers belongs to the real clock and advancing a fake
@@ -384,7 +384,7 @@ describe("the VAT mark beside the number", () => {
     );
     const ask = await screen.findByRole("button", { name: "Check again" });
     fireEvent.click(ask);
-    await screen.findByText(/answer appears here once it replies/);
+    await screen.findByText(/the answer appears here once it replies/);
 
     // Pressed four more times while the answer is outstanding.
     fireEvent.click(ask);
@@ -406,7 +406,9 @@ describe("the VAT mark beside the number", () => {
     // use twice: the wait ends when the answer lands, not when the poll runs
     // out of attempts.
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    let verdict = "invalid";
+    // The verdict does not change; `answered` is what the register replying
+    // moves, and it is the only thing this test varies.
+    let answered = false;
     const posts: string[] = [];
     stubFetch(async (request) => {
       const { pathname } = new URL(request.url);
@@ -417,20 +419,24 @@ describe("the VAT mark beside the number", () => {
       }
       if (request.method === "POST") {
         posts.push(pathname);
-        verdict = "valid";
+        answered = true;
         return new Response(null, { status: 202 });
       }
       return jsonResponse({
         ...CHECKED,
-        status: verdict,
+        // The VERDICT is held constant on purpose: an implementation that
+        // cleared the wait on any change to the answer would pass while reading
+        // the wrong field. Only recorded_at moves — which is also the honest
+        // case, since re-checking usually confirms what the register said last
+        // time.
+        status: "invalid",
         // The date MOVES with the answer, which is the signal the wait reads.
         // checked_at deliberately does NOT move: VIES answers with a date and
         // no time, so a same-day re-check carries the one it already had. Only
         // recorded_at moves, and a wait reading the wrong field would hang here
         // exactly as it would in front of a reader.
         checked_at: CHECKED.checked_at,
-        recorded_at:
-          verdict === "valid" ? "2026-08-14T09:20:00Z" : CHECKED.recorded_at,
+        recorded_at: answered ? "2026-08-14T09:20:00Z" : CHECKED.recorded_at,
       });
     });
     render(mark());
@@ -452,6 +458,82 @@ describe("the VAT mark beside the number", () => {
       await vi.advanceTimersByTimeAsync(100);
     });
     expect(posts).toHaveLength(2);
+  });
+
+  it("still refuses after the panel is closed and reopened", async () => {
+    // Popover unmounts its children on close, and its own comment says nothing
+    // inside is meant to hold state a reader expects to find again. A wait held
+    // in there died with the panel, so reopening offered an enabled button for
+    // a consultation still running on the server — the duplicate press this
+    // whole change refuses.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const posts: string[] = [];
+    stubFetch(async (request) => {
+      const { pathname } = new URL(request.url);
+      if (pathname.endsWith("/me")) {
+        return jsonResponse(
+          meFixture({ allow: { organization: ["read", "update"] } }),
+        );
+      }
+      if (request.method === "POST") {
+        posts.push(pathname);
+        return new Response(null, { status: 202 });
+      }
+      // The register never replies, so the wait is still outstanding.
+      return jsonResponse(CHECKED);
+    });
+    render(mark());
+
+    const glyph = await screen.findByRole("button", { name: "VAT ID: Valid" });
+    fireEvent.click(glyph);
+    fireEvent.click(await screen.findByRole("button", { name: "Check again" }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    // Shut the panel and open it again.
+    fireEvent.click(glyph);
+    fireEvent.click(glyph);
+
+    const ask = await screen.findByRole("button", { name: "Check again" });
+    expect(ask).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(ask);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(posts).toHaveLength(1);
+  });
+
+  it("sends one consultation for two clicks in the same frame", async () => {
+    // The button's busy state is computed from a LATER render, so two clicks
+    // inside one frame both passed it. The guard on the press reads the value
+    // this render already holds.
+    const posts: string[] = [];
+    stubFetch(async (request) => {
+      const { pathname } = new URL(request.url);
+      if (pathname.endsWith("/me")) {
+        return jsonResponse(
+          meFixture({ allow: { organization: ["read", "update"] } }),
+        );
+      }
+      if (request.method === "POST") {
+        posts.push(pathname);
+        return new Response(null, { status: 202 });
+      }
+      return jsonResponse(CHECKED);
+    });
+    render(mark());
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "VAT ID: Valid" }),
+    );
+    const ask = await screen.findByRole("button", { name: "Check again" });
+    // No await between them: this is the double-click a reader actually makes.
+    fireEvent.click(ask);
+    fireEvent.click(ask);
+    await screen.findByText(/the answer appears here once it replies/);
+
+    expect(posts).toHaveLength(1);
   });
 
   it("draws nothing while the read is in flight", () => {

--- a/frontend/src/screens/companyvatmark.tsx
+++ b/frontend/src/screens/companyvatmark.tsx
@@ -214,7 +214,11 @@ export function VatMark({
         ) : (
           <VatReceipt check={answer} locale={locale} zone={zone} />
         )}
-        <AskTheRegister orgId={orgId} consulted={answer !== null} />
+        <AskTheRegister
+          orgId={orgId}
+          consulted={answer !== null}
+          answeredAt={answer?.checked_at ?? null}
+        />
         {/* The number this mark answers for, last: a receipt names what it was
             issued for, and the row above the mark can be edited after a check
             — so a mark that showed only a verdict could sit beside a number
@@ -304,13 +308,34 @@ function VatReceipt({
 function AskTheRegister({
   orgId,
   consulted,
-}: Readonly<{ orgId: string; consulted: boolean }>): ReactNode {
+  answeredAt,
+}: Readonly<{
+  orgId: string;
+  consulted: boolean;
+  // When the consultation on record was last written. The wait ends when this
+  // MOVES: that is the register having replied, and it is the only signal the
+  // client gets — the answer arrives out of band, in a worker.
+  answeredAt: string | null;
+}>): ReactNode {
   const t = useT();
   const queryClient = useQueryClient();
   const canEdit = useCan("organization", "update");
-  // The organization whose answer we are waiting for, or null. Set by the
-  // mutation and cleared once the poll below has run its course.
-  const [waitingFor, setWaitingFor] = useState<string | null>(null);
+  // The organization whose answer we are waiting for, and what the record said
+  // when the wait began. Null when nothing is outstanding.
+  //
+  // The date is what ENDS the wait: a consultation the worker completes writes
+  // a new one, so the moment it differs the register has replied. Waiting on
+  // the poll's own schedule instead would hold the button for the full fifteen
+  // seconds after an answer that arrived in two.
+  const [waitingFor, setWaitingFor] = useState<{
+    orgId: string;
+    since: string | null;
+  } | null>(null);
+  useEffect(() => {
+    if (waitingFor !== null && answeredAt !== waitingFor.since) {
+      setWaitingFor(null);
+    }
+  }, [answeredAt, waitingFor]);
   const ask = useMutation({
     // The organization is a VARIABLE rather than a closure over this render: a
     // click landing between the commit and React Query re-arming the options
@@ -340,7 +365,7 @@ function AskTheRegister({
     // what the mutation RETURNED rather than this render's orgId, so a click in
     // React Query's re-arming window cannot poll the company the reader was
     // looking at a moment ago.
-    onSuccess: (asked) => setWaitingFor(asked),
+    onSuccess: (asked) => setWaitingFor({ orgId: asked, since: answeredAt }),
   });
 
   // The register answers out of band, so the only way the mark learns is to
@@ -360,7 +385,13 @@ function AskTheRegister({
         // this poll lives inside a popover panel the reader may have closed. A
         // request that answered nothing because a panel shut is the shape of
         // bug this whole change exists to stop.
-        void queryClient.refetchQueries({ queryKey: vatCheckKey(waitingFor) });
+        void queryClient.refetchQueries({
+          queryKey: vatCheckKey(waitingFor.orgId),
+        });
+        // The last attempt ends the wait whether or not an answer came. A
+        // register that never replies must not leave the button busy forever:
+        // the reader is then stuck with a control they cannot press and no
+        // reason given.
         if (attempt === VAT_POLL_DELAYS_MS.length - 1) {
           setWaitingFor(null);
         }
@@ -378,15 +409,27 @@ function AskTheRegister({
   }
   return (
     <div className="vatmark-ask">
+      {/* Busy until the ANSWER lands, not until the request is accepted. The
+          POST returns a 202 in milliseconds and the register replies seconds
+          later, so a button that cleared on the 202 was pressable again for
+          the whole wait — and a second press queues a second consultation, or
+          meets the five-minute floor and shows a rate-limit refusal for a check
+          that is already running. Either way the reader is told something
+          false about a request they made correctly. */}
       <Button
         variant="ghost"
         small
-        pending={ask.isPending}
+        pending={ask.isPending || waitingFor !== null}
+        busyLabel={t("co.vat.asked")}
         onClick={() => ask.mutate(orgId)}
       >
         {t(consulted ? "co.vat.askAgain" : "co.vat.askNow")}
       </Button>
-      {ask.isSuccess && <p className="t-caption">{t("co.vat.asked")}</p>}
+      {/* The wait is NOT stated twice. `busyLabel` above already puts this
+          sentence in the button's own description, where a reader with focus on
+          it hears it; a paragraph repeating it is a second copy that a screen
+          reader reads out again and that can disagree with the button's state
+          the moment either changes. */}
       {ask.error !== null && (
         <p className="t-caption" role="status">
           {problemMessageOf(ask.error, t)}

--- a/frontend/src/screens/companyvatmark.tsx
+++ b/frontend/src/screens/companyvatmark.tsx
@@ -3,7 +3,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ShieldAlert, ShieldCheck, ShieldQuestion } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useCan } from "../app/capability";
@@ -163,6 +163,13 @@ export function VatMark({
     },
   });
 
+  // Called BEFORE the early returns below, because a hook that runs on some
+  // renders and not others breaks the Rules of Hooks the moment the read flips
+  // between pending and settled — which it does on every mount. It also has to
+  // outlive the popover: the wait it holds is the reason a closed panel no
+  // longer forgets a consultation still running.
+  const ask = useAskTheRegister(orgId, check.data?.recorded_at ?? null);
+
   // A read still in flight draws nothing rather than a third state: the mark
   // sits inside a value the reader is already looking at, and a glyph that
   // appears a beat later under the eye is worse than one that appears with the
@@ -214,11 +221,7 @@ export function VatMark({
         ) : (
           <VatReceipt check={answer} locale={locale} zone={zone} />
         )}
-        <AskTheRegister
-          orgId={orgId}
-          consulted={answer !== null}
-          answeredAt={answer?.recorded_at ?? null}
-        />
+        <AskTheRegister consulted={answer !== null} ask={ask} />
         {/* The number this mark answers for, last: a receipt names what it was
             issued for, and the row above the mark can be edited after a check
             — so a mark that showed only a verdict could sit beside a number
@@ -299,39 +302,27 @@ function VatReceipt({
 }
 
 /**
- * AskTheRegister consults the register again about the number on record.
+ * useAskTheRegister owns the consultation a person asks for, and it lives on
+ * the MARK rather than inside the popover panel.
+ *
+ * That placement is the whole point. `Popover` unmounts its children on close
+ * and says so — nothing in there is meant to hold state a reader expects to
+ * find again. A wait held inside it dies when the panel shuts, so reopening it
+ * offered an enabled button for a consultation still running on the server,
+ * which is the duplicate press this exists to refuse.
  *
  * Nothing re-asks on a schedule — a verdict going stale is not an event the
  * product can observe — so without this a stored answer stood forever, and a
  * rep who knew a registration had changed at the registry could not act on it.
  */
-function AskTheRegister({
-  orgId,
-  consulted,
-  answeredAt,
-}: Readonly<{
-  orgId: string;
-  consulted: boolean;
-  // When the consultation on record was last WRITTEN, on this installation's
-  // clock. The wait ends when it moves, which is the register having replied —
-  // the answer arrives out of band, in a worker, so there is no other signal.
-  //
-  // Deliberately not `checked_at`: that is the REGISTER's date, and VIES sends
-  // a date with no time. Two consultations on one day carry the same one, so a
-  // wait reading it would never end for a re-check made the same afternoon —
-  // exactly the case this button is for.
-  answeredAt: string | null;
-}>): ReactNode {
-  const t = useT();
+function useAskTheRegister(orgId: string, answeredAt: string | null) {
   const queryClient = useQueryClient();
-  const canEdit = useCan("organization", "update");
-  // The organization whose answer we are waiting for, and what the record said
-  // when the wait began. Null when nothing is outstanding.
+  // The organization whose answer is outstanding, and what the record said when
+  // the wait began. Null when nothing is in flight.
   //
-  // The date is what ENDS the wait: a consultation the worker completes writes
-  // a new one, so the moment it differs the register has replied. Waiting on
-  // the poll's own schedule instead would hold the button for the full fifteen
-  // seconds after an answer that arrived in two.
+  // The date is what ENDS the wait: the worker writes a new one when the
+  // register replies. Waiting on the poll's own schedule instead would hold the
+  // button for the full fifteen seconds after an answer that arrived in two.
   const [waitingFor, setWaitingFor] = useState<{
     orgId: string;
     since: string | null;
@@ -341,14 +332,18 @@ function AskTheRegister({
       setWaitingFor(null);
     }
   }, [answeredAt, waitingFor]);
+
   const ask = useMutation({
-    // The organization is a VARIABLE rather than a closure over this render: a
-    // click landing between the commit and React Query re-arming the options
-    // would otherwise run against the previous render's id.
-    mutationFn: async (id: string) => {
+    // Both the organization and the BASELINE travel as mutation variables. The
+    // id for the reason every mutationFn here takes one — a click landing
+    // before React Query re-arms its options would otherwise run against the
+    // previous render's value — and the baseline for a sharper version of the
+    // same hazard: closed over, a stale `answeredAt` makes the effect above see
+    // a mismatch immediately and clear a wait that had not started.
+    mutationFn: async (asked: { orgId: string; since: string | null }) => {
       const { error, response } = await api.POST(
         "/organizations/{id}/vat-check",
-        { params: { path: { id } } },
+        { params: { path: { id: asked.orgId } } },
       );
       // `response.ok` as well as `error`, and the second is what catches a
       // failure here: this endpoint answers 202 with NO BODY, so a bodiless
@@ -357,28 +352,20 @@ function AskTheRegister({
       if (error || !response.ok) {
         throwProblem(error);
       }
-      return id;
+      return asked;
     },
-    // Deliberately NOT invalidating here. The consultation is QUEUED — 202,
-    // no body — and the worker has not asked the register yet, so a refetch on
+    // Deliberately NOT invalidating here. The consultation is QUEUED — 202, no
+    // body — and the worker has not asked the register yet, so a refetch on
     // success re-reads the OLD verdict and caches it as though it were the
-    // answer to this request. The reader would then watch a stale word settle
-    // under a line saying the register had been asked.
-    //
-    // Waiting is the honest surface instead: the panel says the answer appears
-    // once it replies, and the poll below is what makes that true. Keyed on
-    // what the mutation RETURNED rather than this render's orgId, so a click in
-    // React Query's re-arming window cannot poll the company the reader was
-    // looking at a moment ago.
-    onSuccess: (asked) => setWaitingFor({ orgId: asked, since: answeredAt }),
+    // answer to this request. The poll below is what makes the panel's promise
+    // true instead.
+    onSuccess: (asked) => setWaitingFor(asked),
   });
 
   // The register answers out of band, so the only way the mark learns is to
   // look again. A few spaced attempts rather than a subscription: the whole
   // exchange is one HTTP call the worker makes, usually inside a second or two,
-  // and a socket for that would be machinery nobody needs. The attempts stop
-  // whether or not an answer arrived — a poll that ran forever would keep
-  // asking about a company the reader left.
+  // and a socket for that would be machinery nobody needs.
   useEffect(() => {
     if (waitingFor === null) {
       return;
@@ -386,10 +373,8 @@ function AskTheRegister({
     const timers = VAT_POLL_DELAYS_MS.map((delay, attempt) =>
       setTimeout(() => {
         // refetchQueries, not invalidateQueries: the second marks the entry
-        // stale and refetches only where an observer is currently mounted, and
-        // this poll lives inside a popover panel the reader may have closed. A
-        // request that answered nothing because a panel shut is the shape of
-        // bug this whole change exists to stop.
+        // stale and refetches only where an observer is mounted, and the panel
+        // that displays this may be closed while the wait runs on.
         void queryClient.refetchQueries({
           queryKey: vatCheckKey(waitingFor.orgId),
         });
@@ -409,6 +394,43 @@ function AskTheRegister({
     };
   }, [waitingFor, queryClient]);
 
+  const waiting = ask.isPending || waitingFor !== null;
+  // Every state React holds — `isPending`, `waitingFor` — is a fact about a
+  // render that has already happened, so two clicks inside one frame both read
+  // "not busy" and both sent a consultation. This ref is set in the handler
+  // itself, which is the only thing that can refuse the second click of a
+  // double-click.
+  const inFlight = useRef(false);
+  useEffect(() => {
+    if (!waiting) {
+      inFlight.current = false;
+    }
+  }, [waiting]);
+  return {
+    waiting,
+    error: ask.error,
+    press: () => {
+      if (waiting || inFlight.current) {
+        return;
+      }
+      inFlight.current = true;
+      ask.mutate({ orgId, since: answeredAt });
+    },
+  };
+}
+
+/** AskTheRegister draws the verb and what the wait is doing. The state lives on
+ * the mark above, so closing the panel does not forget an outstanding
+ * consultation. */
+function AskTheRegister({
+  consulted,
+  ask,
+}: Readonly<{
+  consulted: boolean;
+  ask: ReturnType<typeof useAskTheRegister>;
+}>): ReactNode {
+  const t = useT();
+  const canEdit = useCan("organization", "update");
   if (!canEdit) {
     return null;
   }
@@ -424,17 +446,23 @@ function AskTheRegister({
       <Button
         variant="ghost"
         small
-        pending={ask.isPending || waitingFor !== null}
-        busyLabel={t("co.vat.asked")}
-        onClick={() => ask.mutate(orgId)}
+        pending={ask.waiting}
+        busyLabel={t("co.vat.askingBusy")}
+        onClick={ask.press}
       >
         {t(consulted ? "co.vat.askAgain" : "co.vat.askNow")}
       </Button>
-      {/* The wait is NOT stated twice. `busyLabel` above already puts this
-          sentence in the button's own description, where a reader with focus on
-          it hears it; a paragraph repeating it is a second copy that a screen
-          reader reads out again and that can disagree with the button's state
-          the moment either changes. */}
+      {/* Said in WORDS as well as in the button's busy mark: a spinner beside
+          an unchanged label leaves a sighted reader guessing whether their
+          press landed, while `busyLabel` reaches only a screen reader.
+          Deliberately not the SAME sentence as that one — a reader who gets
+          both would hear the fact twice, so the description is short ("Asking
+          the register") and this carries what happens next. */}
+      {ask.waiting && (
+        <p className="t-caption" role="status">
+          {t("co.vat.asking")}
+        </p>
+      )}
       {ask.error !== null && (
         <p className="t-caption" role="status">
           {problemMessageOf(ask.error, t)}

--- a/frontend/src/screens/companyvatmark.tsx
+++ b/frontend/src/screens/companyvatmark.tsx
@@ -217,7 +217,7 @@ export function VatMark({
         <AskTheRegister
           orgId={orgId}
           consulted={answer !== null}
-          answeredAt={answer?.checked_at ?? null}
+          answeredAt={answer?.recorded_at ?? null}
         />
         {/* The number this mark answers for, last: a receipt names what it was
             issued for, and the row above the mark can be edited after a check
@@ -312,9 +312,14 @@ function AskTheRegister({
 }: Readonly<{
   orgId: string;
   consulted: boolean;
-  // When the consultation on record was last written. The wait ends when this
-  // MOVES: that is the register having replied, and it is the only signal the
-  // client gets — the answer arrives out of band, in a worker.
+  // When the consultation on record was last WRITTEN, on this installation's
+  // clock. The wait ends when it moves, which is the register having replied —
+  // the answer arrives out of band, in a worker, so there is no other signal.
+  //
+  // Deliberately not `checked_at`: that is the REGISTER's date, and VIES sends
+  // a date with no time. Two consultations on one day carry the same one, so a
+  // wait reading it would never end for a re-check made the same afternoon —
+  // exactly the case this button is for.
   answeredAt: string | null;
 }>): ReactNode {
   const t = useT();


### PR DESCRIPTION
## What was wrong

The "Check again" button cleared its busy state on the POST's **202**. That is the request being *accepted*, which takes milliseconds; the EU register replies seconds later. So the button was pressable for the whole wait, and a reader who clicked repeatedly got one of two wrong outcomes:

- a second consultation queued for a check already running, or
- the server's five-minute floor refusing them with a rate-limit message **about their own in-flight request**.

Either way the product told them something false about something they did correctly.

## What changed

**The button is busy until the answer lands**, not until the request is accepted. The wait ends when the consultation's record changes, which is the register having replied — the answer is written by a worker, out of band, so there is no other signal. The last poll attempt clears the wait regardless, because a register that never replies must not leave a reader with a control they cannot press and no reason given.

**`recorded_at` is new on the wire, and required.** The only date the client had was `checked_at`, which is the *register's* — and VIES sends a date with no time, so two consultations on one day carry the same one. A wait reading it would never end for a same-day re-check, which is exactly what this button is for. This is the same trap the server's own rate floor hit, fixed there by reading `updated_at`; this puts that column on the wire.

## Fixed after review

- **The wait died with the popover.** It lived inside the panel, and `Popover` unmounts its children on close — its own comment says nothing in there is meant to hold state a reader expects to find again. Closing and reopening offered an enabled button for a running consultation. The wait, the poll and the mutation now live on the mark.
- **Two clicks in one frame sent two requests.** Every state React holds describes a render that already happened, so both clicks read "not busy". A ref set in the handler itself is the only thing that can refuse the second.
- **The baseline travels as a mutation variable.** Closed over, a click landing before React Query re-arms its options captured the previous render's timestamp, and the effect then cleared a wait that had not started.
- **A sighted reader gets words again.** A spinner beside an unchanged label left them guessing. The visible line and the screen-reader description say different things on purpose, so nobody hears the same fact twice.

## Testing

- `make check-fe`, `make check-backend`, `make test-it DIR=backend/internal/modules/people` — all green, before and after the rebase
- 17 tests on the mark; the new ones cover the busy refusal, the press returning after an answer, the close/reopen, and the same-frame double click
- Mutation-checked: reverting the busy state, the early clear, the in-flight ref, or reading `checked_at` instead of `recorded_at` each fails exactly the test that claims it
- **Verified in a browser against the live EU register: 14 clicks produced 1 request**, with `aria-disabled="true"` and the visible wait notice on screen

One note on the verification: the first browser run showed 14 requests from 14 clicks, and that was a stale-stack artefact rather than the code — `make dev` from a linked worktree serves the *primary* checkout, so both Vite and the API were running `main`. Confirmed by `lsof` on the serving processes, then re-run against this branch's own build.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the VAT "Check again" button busy until the EU register answers instead of until the POST is accepted (202, milliseconds). A reader who pressed again during the wait previously queued a duplicate consultation or hit the server's five-minute rate floor; the button now stays busy until `recorded_at` changes, and the last poll attempt clears the wait regardless so a silent register never leaves it stuck.

**Bug Fixes**
- The wait lives on the mark, so closing and reopening the panel no longer offers an enabled button for a running consultation.
- A ref set in the click handler refuses two clicks in one frame, which React state alone cannot do.
- The wait baseline travels as a mutation variable so a stale closure cannot clear a wait that never started.

**Migration**
- `OrganizationVatCheck.recorded_at` is required; it is the installation's write time, distinct from `checked_at`, which VIES sends as a date with no time. Without it a same-day re-check never moves a field the client can see.

<sup>Written for commit 631673a902110ebf2489e45998512aa5632865be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VAT status records now show when the consultation was recorded, separately from the register’s check date.
  * Added clearer VAT consultation states, including in-progress and busy messages in English, German, and Vietnamese.

* **Bug Fixes**
  * Prevented duplicate VAT consultations while a request is pending, including after closing and reopening the consultation panel.
  * New consultations can be started once an updated result is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->