### PR TITLE
fix(ci): perf-budgets no longer gates its own DB start on an unrelated job's step

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -264,7 +264,6 @@ jobs:
         with:
           flavor: integration
       - name: Start the dev infra stack (compose + app role)
-        if: steps.funded.outputs.configured == 'yes'
         working-directory: .
         run: make db-up
       # The step separates "a budget breached" from "the lane could not run",


### PR DESCRIPTION
## Summary
- The `perf-budgets` job's "Start the dev infra stack" step carried `if: steps.funded.outputs.configured == 'yes'` — but `id: funded` is a step that exists only in the sibling `llm-use-cases` job. Step outputs are scoped per job, so this condition always evaluated to false, `make db-up` never ran, and the very next step reliably failed dialing Postgres on `127.0.0.1:15432` ("connection refused") every time the job actually ran.
- `perf-budgets` benchmarks Postgres query latency and has no dependency on the model-eval funding check to begin with. The job is already correctly gated at the job level on the Monday schedule or the `perf` dispatch input, so the stray condition is simply removed.
- Verified with `actionlint` (via Docker) against the whole `.github/workflows/` directory: clean.

Fixes margince#3318, filed automatically by the same workflow's own `report` job on the run that hit this: https://github.com/margince/margince/actions/runs/33372060309

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scheduled.yml'))"` — parses
- [x] `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest .github/workflows/*.yml` — no findings
- [ ] Next Monday's scheduled run (or a manual `workflow_dispatch` with `perf: true`) reaches an actual budget verdict instead of failing on a DB connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `perf-budgets` job so its `make db-up` step runs unconditionally instead of being gated on an output that exists only in a sibling job, which always skipped it and caused the job to fail on a Postgres connection error. The job-level gating already covers when this should run, and the step now works as intended.

<sup>Written for commit 25b5bad5b8bbf396304d9235504d524c59388397. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Performance budget checks now reliably start the required database during scheduled or manually triggered runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->