### PR TITLE
feat(integrations): an admin can allow buying an email or a mobile

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6616,6 +6616,9 @@ export const de = {
     "Jeder Kontakt wird einmal nachgeschlagen — für das, was die Verbindung auswählt und der Anbieter nicht berechnet, in der Regel den beruflichen Profil-Link, die aktuelle Rolle samt Arbeitgeber und den Werdegang. E-Mail-Adressen und Mobilnummern werden so nie gekauft: die kosten Guthaben und bleiben eine Entscheidung pro Kontakt.",
   "provider.automaticLookupJurisdiction":
     "Schalt das aus, wenn deine Kontakte einem Recht unterliegen, das den Handel mit Personendaten verbietet, etwa dem vietnamesischen. Der Knopf auf dem einzelnen Kontakt funktioniert weiterhin, damit die Entscheidung bei dem bleibt, der sie trifft.",
+  "provider.buyable": "Kauf von {category} erlauben",
+  "provider.buyableHint":
+    "Dieser Schalter kauft nichts. Er stellt bei jedem Kontakt eine Schaltfläche bereit, zum Preis von {credits} Guthaben, damit jemand diese Angabe für eine einzelne Person kaufen kann.",
   "provider.backlog": "Noch nachzuschlagen",
   "provider.backlogRemaining_one": "{count} Kontakt",
   "provider.backlogRemaining_other": "{count} Kontakte",
@@ -6666,7 +6669,8 @@ export const de = {
     "Wie diese Abfrage ausgegangen ist, haben wir nie erfahren. Sie kann berechnet worden sein.",
   "provider.profile.claimsUnwritten":
     "Bezahlt, aber die Daten sind nie an diesem Datensatz angekommen. Niemand muss danach suchen — das hier ist die Lücke.",
-  "provider.profile.enrichNow": "Kontakt nachschlagen",
+  "provider.profile.enrichNow": "Kontakt nachschlagen · kostenlos",
+  "provider.profile.recheck": "Erneut prüfen · kostenlos",
   "provider.profile.lookingUp": "Wir fragen den Anbieter. Das dauert kurz.",
   "provider.profile.emptyTitle": "Für diesen Kontakt wurde noch nichts gekauft",
   "provider.profile.emptyBody":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6678,6 +6678,9 @@ export const en = {
     "Every contact is looked up once for whatever the connection selects that the provider charges nothing for — typically the professional profile link, the current role and employer, and the work history. Email addresses and mobile numbers are never bought this way: those cost credits and stay a decision you make per contact.",
   "provider.automaticLookupJurisdiction":
     "Switch this off if your contacts fall under a law that forbids trading personal data, Vietnam's among them. The button on each contact still works, which keeps the decision with the person making it.",
+  "provider.buyable": "Allow buying {category}",
+  "provider.buyableHint":
+    "Switching this on buys nothing. It puts a button on each contact, priced at {credits} credit, so somebody can buy this detail for one person at a time.",
   "provider.backlog": "Still to look up",
   "provider.backlogRemaining_one": "{count} contact",
   "provider.backlogRemaining_other": "{count} contacts",
@@ -6730,7 +6733,8 @@ export const en = {
     "We never learned how this lookup ended. It may have been charged for.",
   "provider.profile.claimsUnwritten":
     "Paid for, but the details never reached this record. Nobody has to hunt for them — this is the gap.",
-  "provider.profile.enrichNow": "Look this contact up",
+  "provider.profile.enrichNow": "Look this contact up · free",
+  "provider.profile.recheck": "Check again · free",
   "provider.profile.lookingUp": "Asking the provider. This takes a moment.",
   "provider.profile.emptyTitle": "Nothing bought for this contact yet",
   "provider.profile.emptyBody":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6549,6 +6549,9 @@ export const vi = {
     "Mỗi liên hệ được tra cứu một lần — cho những mục mà kết nối chọn và nhà cung cấp không tính phí, thường là liên kết hồ sơ nghề nghiệp, vai trò và nơi làm việc hiện tại, cùng quá trình công tác. Địa chỉ email và số di động không bao giờ được mua theo cách này: chúng tốn tín dụng và vẫn là quyết định cho từng liên hệ.",
   "provider.automaticLookupJurisdiction":
     "Hãy tắt mục này nếu liên hệ của bạn thuộc phạm vi luật cấm mua bán dữ liệu cá nhân, trong đó có luật Việt Nam. Nút trên từng liên hệ vẫn dùng được, để quyết định thuộc về người đưa ra nó.",
+  "provider.buyable": "Cho phép mua {category}",
+  "provider.buyableHint":
+    "Bật công tắc này không mua gì cả. Nó đặt một nút trên mỗi liên hệ, giá {credits} tín dụng, để ai đó mua thông tin này cho từng người một.",
   "provider.backlog": "Còn phải tra cứu",
   "provider.backlogRemaining_one": "{count} liên hệ",
   "provider.backlogRemaining_other": "{count} liên hệ",
@@ -6597,7 +6600,8 @@ export const vi = {
     "Chúng ta không bao giờ biết lượt tra cứu này kết thúc ra sao. Nó có thể đã bị tính phí.",
   "provider.profile.claimsUnwritten":
     "Đã trả tiền, nhưng thông tin chưa bao giờ đến hồ sơ này. Không ai phải đi tìm — đây chính là chỗ thiếu.",
-  "provider.profile.enrichNow": "Tra cứu liên hệ này",
+  "provider.profile.enrichNow": "Tra cứu liên hệ này · miễn phí",
+  "provider.profile.recheck": "Kiểm tra lại · miễn phí",
   "provider.profile.lookingUp": "Đang hỏi nhà cung cấp. Việc này mất một lát.",
   "provider.profile.emptyTitle": "Chưa mua dữ liệu nào cho liên hệ này",
   "provider.profile.emptyBody":

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -91,7 +91,7 @@ const ME_CONNECT_ONLY = meResponse("full", {
   delete: false,
 });
 
-function backend(principal: Me) {
+function backend(principal: Me, connection: ProviderConnection = CONNECTION) {
   return vi.fn(async (input: RequestInfo | URL) => {
     const request = input instanceof Request ? input : undefined;
     const path = new URL(String(request ? request.url : input)).pathname;
@@ -99,23 +99,27 @@ function backend(principal: Me) {
     // back into its cache. Routed by METHOD as well as path: the same path
     // serves the list this card reads on the way in.
     if (request?.method === "PATCH") {
-      return new Response(JSON.stringify(CONNECTION), {
+      return new Response(JSON.stringify(connection), {
         headers: { "Content-Type": "application/json" },
       });
     }
-    const body = routeBody(path, principal);
+    const body = routeBody(path, principal, connection);
     return new Response(JSON.stringify(body), {
       headers: { "Content-Type": "application/json" },
     });
   });
 }
 
-function routeBody(path: string, principal: Me): unknown {
+function routeBody(
+  path: string,
+  principal: Me,
+  connection: ProviderConnection,
+): unknown {
   if (path === "/v1/me") {
     return principal;
   }
   if (path === "/v1/provider-connections") {
-    return { data: [CONNECTION] };
+    return { data: [connection] };
   }
   if (path === "/v1/integrations/settings") {
     // Off, which is the state the flip below moves away from. The installation
@@ -186,8 +190,11 @@ describe("ProviderCard write posture", () => {
     await user.click(screen.getByRole("button", { name: MORE }));
   }
 
-  async function renderAs(principal: Me) {
-    const fetch = backend(principal);
+  async function renderAs(
+    principal: Me,
+    connection: ProviderConnection = CONNECTION,
+  ) {
+    const fetch = backend(principal, connection);
     vi.stubGlobal("fetch", fetch);
     render(
       <Providers>
@@ -322,6 +329,34 @@ describe("ProviderCard write posture", () => {
       expect(
         screen.getAllByRole("switch", { name: /^Allow buying / }),
       ).toHaveLength(1);
+    },
+    RENDER_TEST_MS,
+  );
+
+  // A provider nobody has connected is listed anyway, with its catalog, so the
+  // card can say what it sells before a key exists. It has no row, so the server
+  // sends no version — while the contract declares `version` required, which is
+  // why nothing in the types objects to reading it. The switches would render
+  // enabled, and every press would send `If-Match: undefined` and be refused as
+  // malformed: a control that can never work, in the state a first-time admin
+  // meets first.
+  it(
+    "offers no purchase switch before a key exists, since there is nothing to patch",
+    async () => {
+      const { version: _version, ...neverConnected } = CONNECTION;
+      await renderAs(ME_OPERATOR, {
+        ...neverConnected,
+        status: "disconnected",
+        credential_present: false,
+      } as ProviderConnection);
+
+      expect(
+        screen.queryAllByRole("switch", { name: /^Allow buying / }),
+      ).toHaveLength(0);
+      // The catalog IS present on this connection, so an empty catalog is not
+      // what made the switches absent — without this the case would pass over a
+      // card that simply had nothing to list.
+      expect(screen.getByRole("meter", { name: "email" })).toBeTruthy();
     },
     RENDER_TEST_MS,
   );

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -26,8 +26,18 @@ const CONNECTION: ProviderConnection = {
     preset: "full",
     automatic_individual_create: true,
     automatic_import: false,
-    categories: { professional: true },
+    // The work email OFF and the free profile link ON, which is what a fresh
+    // connection resolves to. A fixture with the paid one already on could not
+    // tell a switch that writes from one rendered off a constant.
+    categories: { linkedin_profile: true, professional_email: false },
   },
+  // Both halves, because the card treats them differently: the free set is what
+  // the automatic lookup takes and carries no switch of its own, and the priced
+  // set is what an admin may allow somebody to buy per contact.
+  catalog: [
+    { category: "linkedin_profile", free: true, cost: {} },
+    { category: "professional_email", free: false, cost: { email: 1 } },
+  ],
   credits: { pools: { email: 120 } },
   version: 4,
   created_at: "2026-01-05T09:00:00Z",
@@ -281,6 +291,78 @@ describe("ProviderCard write posture", () => {
     // Two waiters, not one: the card has to settle before the switch exists,
     // and the write it sends is awaited after. The ceiling covers the sum, or
     // the second can still be inside its own budget when the test is killed.
+    WRITE_TEST_MS,
+  );
+
+  // Allowing a purchase is not making one. The switch decides which buy buttons
+  // a rep is offered on a contact; every spend is still somebody pressing a
+  // priced button on one named record. Without this pair the card had no
+  // control at all for the paid half — the buy buttons existed on the contact
+  // page and nothing on any screen could switch their categories on, so an
+  // installation could see the price list and never reach it.
+  it(
+    "offers a switch per PRICED category, and none for the free ones",
+    async () => {
+      await renderAs(ME_OPERATOR);
+
+      expect(
+        screen.getByRole("switch", { name: "Allow buying work email" }),
+      ).toBeTruthy();
+      // The free set carries no switch: it is what the automatic lookup takes,
+      // the installation switch above already governs it as ONE decision, and a
+      // second control able to turn one of them off would half-disable that
+      // feature with nothing on screen explaining the difference.
+      expect(
+        screen.queryByRole("switch", { name: "Allow buying LinkedIn profile" }),
+      ).toBeNull();
+      // Counted, not just named. Asserting the absence of one spelling passes
+      // when the label is anything else — and it did, silently, until the
+      // filter was mutated away and this case stayed green over a card
+      // rendering a switch for every category the provider sells.
+      expect(
+        screen.getAllByRole("switch", { name: /^Allow buying / }),
+      ).toHaveLength(1);
+    },
+    RENDER_TEST_MS,
+  );
+
+  it(
+    "sends the WHOLE selection when one priced category is switched on",
+    async () => {
+      const user = userEvent.setup();
+      const fetch = await renderAs(ME_OPERATOR);
+
+      const buyEmail = screen.getByRole("switch", {
+        name: "Allow buying work email",
+      });
+      expect(buyEmail.getAttribute("aria-checked")).toBe("false");
+      await user.click(buyEmail);
+
+      const patched = () =>
+        fetch.mock.calls
+          .map(([input]) => (input instanceof Request ? input : undefined))
+          .find((request) => request?.method === "PATCH");
+      await waitFor(() => expect(patched()).toBeTruthy(), {
+        timeout: SETTLE_MS,
+      });
+      const request = patched() as Request;
+      expect(new URL(request.url).pathname).toBe(
+        "/v1/provider-connections/surfe",
+      );
+      // The free category rides along UNCHANGED. The patch replaces the map
+      // rather than merging into it, so a body carrying only the pressed pair
+      // would switch off every category not named — including the ones the
+      // automatic lookup runs on, silently stopping it from the paid tier's
+      // control.
+      expect(await request.clone().json()).toEqual({
+        configuration: {
+          categories: { linkedin_profile: true, professional_email: true },
+        },
+      });
+      // The version the card was rendered from, so two admins deciding what the
+      // installation may spend on cannot lose each other's write.
+      expect(request.headers.get("If-Match")).toBe("4");
+    },
     WRITE_TEST_MS,
   );
 

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -7,6 +7,7 @@ import { Plug, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { ifMatch } from "../api/version";
 import { useCanWrite } from "../app/capability";
 import {
   Badge,
@@ -28,6 +29,7 @@ import { Switch } from "../design-system/switch";
 import { formatNumber } from "../format/format";
 import { useLocale, usePlural, useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem, useMe } from "./common";
+import { categoryName } from "./provider-categories";
 import {
   connectionLabel,
   connectionTone,
@@ -417,6 +419,7 @@ function PolicyRow({
         )}
       />
       <LookupBacklogRow connection={connection} />
+      <PricedCategoryRows connection={connection} canEdit={canEdit} />
       {/* Under the row whose flip failed, at the row's full width, rather than
           squeezed into the control column beside the switch: the reason names
           what the reader just tried to change, and a sentence sharing a
@@ -434,6 +437,123 @@ function PolicyRow({
       )}
     </>
   );
+}
+
+// What this installation is willing to BUY, one switch per priced category.
+//
+// Switching one on does not spend anything and does not schedule anything. It
+// decides which buy buttons a rep is offered on a contact — every purchase is
+// still a person pressing a priced button on one named record, which is the
+// split the free tier exists to keep. So the switch means "available to buy",
+// never "will be bought", and the row's own copy has to say so: an admin who
+// reads it as the latter leaves the whole paid half of the product switched off.
+//
+// The free categories are deliberately NOT here. They are what the automatic
+// lookup takes, the switch above already governs them as one decision, and a
+// second control that could turn one of them off would be a way to half-disable
+// a feature with nothing on screen explaining the difference.
+function PricedCategoryRows({
+  connection,
+  canEdit,
+}: Readonly<{ connection: ProviderConnection; canEdit: boolean }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const patch = usePatchCategories();
+  const priced = (connection.catalog ?? []).filter((entry) => !entry.free);
+  if (priced.length === 0) {
+    return null;
+  }
+  const selection = connection.configuration.categories ?? {};
+  return (
+    <>
+      {priced.map((entry) => (
+        <SettingRow
+          key={entry.category}
+          label={t("provider.buyable", {
+            category: categoryName(entry.category, t),
+          })}
+          description={t("provider.buyableHint", {
+            credits: formatNumber(creditsOf(entry), locale),
+          })}
+          control={(control) => (
+            <Switch
+              describedBy={control["aria-describedby"]}
+              checked={selection[entry.category] ?? false}
+              // The WHOLE selection, not the one key. The contract's patch
+              // replaces the map rather than merging into it, so sending one
+              // pair would switch off every category not named — including the
+              // free ones the automatic lookup runs on.
+              onChange={(next) =>
+                patch.mutate({
+                  provider: connection.provider,
+                  version: connection.version,
+                  categories: { ...selection, [entry.category]: next },
+                })
+              }
+              reason={canEdit ? undefined : t("captureSettings.adminOnly")}
+              disabled={!canEdit}
+              pending={patch.isPending}
+              label={t("provider.buyable", {
+                category: categoryName(entry.category, t),
+              })}
+              labelHidden
+            />
+          )}
+        />
+      ))}
+      {patch.error && (
+        <div className="provider-row-note">
+          <Callout tone="danger" live="alert">
+            {problemMessageOf(patch.error, t)}
+          </Callout>
+        </div>
+      )}
+    </>
+  );
+}
+
+/** The credits one category costs, summed across pools. A category priced in
+ *  two pools is one purchase, and two figures on one row would read as a
+ *  choice between them. */
+function creditsOf(
+  entry: components["schemas"]["ProviderCategoryCost"],
+): number {
+  return Object.values(entry.cost).reduce((total, n) => total + n, 0);
+}
+
+type CategoryPatch = {
+  provider: components["schemas"]["Provider"];
+  version: number;
+  categories: Record<string, boolean>;
+};
+
+// Saving the fetch scope, with the version the card was rendered from.
+//
+// If-Match rather than a blind write: two admins on this card are two people
+// deciding what the installation may spend on, and a lost update there is a
+// category switched on by somebody who never saw it happen.
+function usePatchCategories() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ provider, version, categories }: CategoryPatch) => {
+      const { data, error } = await api.PATCH(
+        "/provider-connections/{provider}",
+        {
+          params: { path: { provider }, ...ifMatch(version) },
+          body: { configuration: { categories } },
+        },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["provider-connections"],
+      });
+    },
+  });
 }
 
 // How much of the installation is still waiting to be looked up.

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -460,7 +460,18 @@ function PricedCategoryRows({
   const { locale } = useLocale();
   const patch = usePatchCategories();
   const priced = (connection.catalog ?? []).filter((entry) => !entry.free);
-  if (priced.length === 0) {
+  // A provider nobody has connected is listed anyway — with its catalog, so the
+  // card can say what it sells before a key exists — but it has no row, and the
+  // server omits the version for one. The contract declares `version` required,
+  // so nothing in the types objects to reading it; at runtime the patch would
+  // carry `If-Match: undefined` and be refused as malformed every time.
+  //
+  // Absent rather than disabled: there is no connection to decide about yet, and
+  // a dead switch beside a key field reads as a permission the reader lacks.
+  // The switches appear with the connection, which is the order the decision
+  // actually has — a key, then what it may be spent on.
+  const version = connection.version;
+  if (priced.length === 0 || version === undefined) {
     return null;
   }
   const selection = connection.configuration.categories ?? {};
@@ -486,7 +497,7 @@ function PricedCategoryRows({
               onChange={(next) =>
                 patch.mutate({
                   provider: connection.provider,
-                  version: connection.version,
+                  version,
                   categories: { ...selection, [entry.category]: next },
                 })
               }

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -163,9 +163,17 @@ describe("a contact whose data was already bought", () => {
     expect(
       screen.queryByText("Nothing bought for this contact yet"),
     ).toBeNull();
+    // "Check again", not "look this contact up": this contact HAS been looked
+    // up, and the button offers the same free details a second time in case a
+    // job changed. The first-lookup wording on a record already showing a
+    // lookup reads as the control that fetches the email — the one thing this
+    // button never does, because that costs credits and has its own.
     expect(
-      await screen.findByRole("button", { name: /Look this contact up/ }),
+      await screen.findByRole("button", { name: /Check again/ }),
     ).toBeDefined();
+    expect(
+      screen.queryByRole("button", { name: /Look this contact up/ }),
+    ).toBeNull();
   });
 
   // A merge cancels the losing side's queued run and relinks the claims both
@@ -474,8 +482,11 @@ describe("the details that cost credits", () => {
       queuedRun,
     );
 
+    // A run that completed, so the button offers a re-check rather than a
+    // first lookup. Either wording drives the same press; what this case pins
+    // is WHAT it sends.
     await user.click(
-      await screen.findByRole("button", { name: /Look this contact up/ }),
+      await screen.findByRole("button", { name: /Check again/ }),
     );
 
     // The FREE set, named. Sending no categories asks for the connection's

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -17,8 +17,8 @@ import {
 } from "../design-system/provider-mark";
 import { formatDateAbbrev, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
-import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
+import { categoryNames } from "./provider-categories";
 import {
   canEnrichNow,
   isRunning,
@@ -169,6 +169,11 @@ function ProviderPanel({
             profile={profile}
             enrich={enrich}
             free={free}
+            // This contact has already been looked up, so the press is a
+            // RE-CHECK: same free details, asked again because a job may have
+            // changed. The empty-state twin below is the first lookup and says
+            // so instead.
+            recheck
             small
           />
         )
@@ -486,36 +491,6 @@ function ProviderValues({ profile }: Readonly<{ profile: Profile }>) {
   );
 }
 
-/** The categories a provider names, as words a reader knows.
- *
- *  The wire carries the provider's own vocabulary (`professional_email`,
- *  `linkedin_profile`), which is a key rather than a phrase — printed raw it
- *  puts `linkedin_profile, current_employment` in front of a rep.
- *
- *  A category this build has no word for keeps the provider's own: the
- *  vocabulary belongs to the provider, so an installation can declare one this
- *  frontend has never seen, and showing their word beats showing nothing. */
-const CATEGORY_LABELS: Record<string, MessageKey> = {
-  professional_email: "provider.category.professionalEmail",
-  personal_email: "provider.category.personalEmail",
-  mobile: "provider.category.mobile",
-  linkedin_profile: "provider.category.linkedin",
-  current_employment: "provider.category.currentEmployment",
-  job_history: "provider.category.jobHistory",
-};
-
-function categoryNames(
-  categories: readonly string[],
-  t: (key: MessageKey) => string,
-): string {
-  return categories
-    .map((category) => {
-      const label = CATEGORY_LABELS[category];
-      return label ? t(label) : category;
-    })
-    .join(", ");
-}
-
 /** The lookup itself, hoisted so the header button and the first-run plate
  *  drive ONE mutation: two `useMutation` calls would each carry their own
  *  pending and error state, and the reader would see a failure on whichever
@@ -556,12 +531,19 @@ function EnrichNow({
   profile,
   enrich,
   free,
+  recheck = false,
   small = false,
 }: Readonly<{
   free: string[];
   personId: string;
   profile: Profile;
   enrich: ReturnType<typeof useEnrichRun>;
+  // Whether this contact has been looked up before. The press buys the same
+  // free set either way; what differs is what the reader is being offered — a
+  // first lookup, or asking again in case a job changed. A button that says
+  // "look this contact up" on a record already showing a lookup reads as the
+  // thing that fetches the email, which is the one thing it never does.
+  recheck?: boolean;
   small?: boolean;
 }>) {
   const t = useT();
@@ -592,7 +574,8 @@ function EnrichNow({
         })
       }
     >
-      <Search size={15} aria-hidden="true" /> {t("provider.profile.enrichNow")}
+      <Search size={15} aria-hidden="true" />{" "}
+      {t(recheck ? "provider.profile.recheck" : "provider.profile.enrichNow")}
     </Button>
   );
 }

--- a/frontend/src/screens/provider-categories.ts
+++ b/frontend/src/screens/provider-categories.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { MessageKey } from "../i18n/en";
+
+/** The categories a provider names, as words a reader knows.
+ *
+ *  The wire carries the provider's own vocabulary (`professional_email`,
+ *  `linkedin_profile`), which is a key rather than a phrase — printed raw it
+ *  puts `linkedin_profile, current_employment` in front of a rep.
+ *
+ *  A category this build has no word for keeps the provider's own: the
+ *  vocabulary belongs to the provider, so an installation can declare one this
+ *  frontend has never seen, and showing their word beats showing nothing.
+ *
+ *  Shared by the two screens that name a category — the settings card, where an
+ *  admin decides what may be bought, and the contact panel, where somebody buys
+ *  it. Two copies would drift, and the drift a reader would see is the settings
+ *  switch and the buy button calling one purchase two different things.
+ */
+const CATEGORY_LABELS: Record<string, MessageKey> = {
+  professional_email: "provider.category.professionalEmail",
+  personal_email: "provider.category.personalEmail",
+  mobile: "provider.category.mobile",
+  linkedin_profile: "provider.category.linkedin",
+  current_employment: "provider.category.currentEmployment",
+  job_history: "provider.category.jobHistory",
+};
+
+/** One category's name, or the provider's own word when this build has none. */
+export function categoryName(
+  category: string,
+  t: (key: MessageKey) => string,
+): string {
+  const label = CATEGORY_LABELS[category];
+  return label ? t(label) : category;
+}
+
+/** Several categories, as one comma-joined phrase. */
+export function categoryNames(
+  categories: readonly string[],
+  t: (key: MessageKey) => string,
+): string {
+  return categories.map((category) => categoryName(category, t)).join(", ");
+}


### PR DESCRIPTION
## What was wrong

The buy buttons on a contact's **Data & tools** tab render only for a category the connection selects, and connecting resolves to the free set alone — deliberately, so a fresh connection spends nothing.

Nothing on any screen could then widen that selection. The settings card described the priced tier in an info note and offered no control for it. An installation could read the price list and never reach the thing it prices.

This is a regression from the lookup-posture change: replacing the two automatic switches with one installation switch removed `PolicyRow`, and the category selector went with it. The API still accepts `categories` in its existing PATCH, so this is frontend-only.

## What it does now

One switch per **priced** category, on the settings card beside the lookup posture. Switching one on buys nothing and schedules nothing — it decides which buy buttons a rep is offered, and every purchase is still a person pressing a priced button on one named contact. The row's copy says exactly that, because an admin who reads it as "start spending" leaves the paid half of the product switched off.

The **free** categories carry no switch. They are what the automatic lookup takes, the posture switch above governs them as one decision, and a second control able to turn one off would half-disable that feature with nothing on screen explaining the difference.

Two details that are load-bearing:

- **The patch sends the whole selection**, not the pressed pair. The contract replaces the map rather than merging into it, so a one-key body would switch off every category not named — including the free ones the catch-up sweep runs on.
- **Carried under `If-Match`**, through the shared `ifMatch()` helper. Two admins deciding what the installation may spend on must not lose each other's write, and the repo's If-Match census requires the helper rather than a hand-written header.

## Also: the free lookup button says which of two things it is

"Check again · free" once a contact has been looked up, "Look this contact up · free" the first time. It never buys an email, and the old single wording on a record already showing a lookup read as the control that does.

## Reuse

`categoryNames` moved to `provider-categories.ts`, shared by the card that decides what may be bought and the panel that buys it. Two copies would drift into the settings switch and the buy button calling one purchase different things.

## Test

Three new cases, each mutation-checked one clause at a time:

| Mutation | Caught by |
|---|---|
| send only the pressed pair | "sends the WHOLE selection" |
| show every category, not just priced | "offers a switch per PRICED category" |
| drop `If-Match` | that case **and** the repo's If-Match census |

The second mutation initially passed — my negative assertion named a label the code never renders ("professional profile" for what is spelled "LinkedIn profile"), so it could not fail. Fixed by counting the switches rather than naming one absent spelling.

Two existing tests updated: both mount a completed profile, so they now render the re-check wording. One of them gained the assertion that the first-lookup wording is gone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds switches on the provider settings card so an admin can allow buying priced categories like work email, which previously had no on-screen control. Each switch only makes the per-contact buy button available; it spends nothing itself.

**Bug Fixes**
- The settings card now offers one switch per priced category, and none for the free ones, which the automatic lookup still governs as one decision.
- The switches don't render before a connection key exists, since there is nothing to patch; a disabled control there would read as a missing permission.
- The free lookup button on an already-looked-up contact now reads "Check again · free" instead of "Look this contact up", so it no longer reads as the email-buying control.
- The patch sends the whole category selection rather than just the pressed pair, and is carried under `If-Match` so two admins don't lose each other's write.

**Refactors**
- Category naming moved into shared `provider-categories.ts`, reused by the settings card and the contact panel.

<sup>Written for commit 414b94b3170b82930f1e007cddfd6cdecff89f25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controls for enabling purchases by paid provider category.
  * Free contact lookups and re-checks are now clearly labeled.
  * Added distinct “Check again” actions for contacts with existing data.
  * Added localized category names and translations in English, German, and Vietnamese.
* **Bug Fixes**
  * Improved provider settings updates to preserve the complete category selection and prevent conflicting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->