### PR TITLE
docs(how-to): checking a company's VAT number

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ no code, no API, just the app.
 - [connect-a-mailbox.md](how-to/connect-a-mailbox.md) — connect a mailbox for capture: Gmail OAuth (standing sync + backfill), IMAP app-password, Microsoft Graph OAuth, or Google Calendar — all standing connections.
 - [enrich-with-a-local-llm.md](how-to/enrich-with-a-local-llm.md) — point the AI lanes at a local Ollama and enrich a company with no cloud key.
 - [read-what-a-company-runs.md](how-to/read-what-a-company-runs.md) — the technical lookup: what DNS, certificate logs and a homepage fingerprint write onto a company, what triggers it, and the one setting that turns it on.
+- [check-a-vat-number.md](how-to/check-a-vat-number.md) — ask the EU register whether a company's stated VAT ID is real, read the receipt a tax authority accepts, and the one setting that turns it on.
 - [connect-telegram.md](how-to/connect-telegram.md) — bind a workspace-level Telegram bot for pull ingress and governed replies.
 - [import-your-linkedin-network.md](how-to/import-your-linkedin-network.md) — import your own `Connections.csv` as graph substrate, and read the reach it buys.
 - [import-a-company-spreadsheet.md](how-to/import-a-company-spreadsheet.md) — bring a CSV of companies in: the column mapping, what the preview counts, and how a row names the company it corrects.

--- a/docs/how-to/check-a-vat-number.md
+++ b/docs/how-to/check-a-vat-number.md
@@ -1,0 +1,168 @@
+# Check a company's VAT number
+
+Margince can ask the EU VAT register whether a company's stated VAT ID is real, and keep the receipt.
+This guide is **UI-first**: you drive it from the company record, with the equivalent `curl` shown
+alongside for scripting and verification.
+
+Two things make this worth doing rather than trusting the number on a page. A VAT ID copied from a
+website's imprint is often somebody **else's** — a template reused, a subsidiary's number left in place —
+and only the register's own answer exposes that. And a business treating a sale as intra-EU has to be
+able to **show** it verified its counterpart; what a tax authority accepts is the *consultation number*
+the register issues, tied to the number asked about and the day it was asked.
+
+> **This is off unless an operator turns it on.** Without a register configured, a VAT number is stored
+> exactly as stated and never verified. [Turn it on](#turn-the-register-on) is the first section for a
+> reason: everything below does nothing until it is done.
+
+## Where the UI lives
+
+On a **company record**, in the right-hand **Details** panel, on the **Register / VAT ID** row.
+
+- The number itself is an inline field — click it to type or correct one.
+- Beside it sits a **shield mark** carrying the verdict. Green is valid, red is not valid, grey is
+  either "not checked yet" or "the register did not answer".
+- Clicking the shield opens the receipt: **Register answer**, **Number consulted**, **Registered to**,
+  **Consulted on**, **Consultation number**, and the button that asks again.
+
+The verdict is readable **without opening anything**. That is deliberate — whether a stated number holds
+up is the fact you want at a glance, and a number validating to a company nobody recognises is the
+finding this exists for.
+
+## Turn the register on
+
+The check needs a register to ask. Set it in `.env.local` at the repository root — the dev script sources
+that file and both the api and the worker inherit it, so no value lands in a config file:
+
+```
+MARGINCE_VAT_CHECK_BASE_URL=public
+MARGINCE_VAT_CHECK_REQUESTER=DE123456789
+```
+
+`public` is a shorthand, not a URL: it resolves to the European Commission's own VIES service. Point it
+at a different base URL to use a proxy or a test double.
+
+`MARGINCE_VAT_CHECK_REQUESTER` is **this installation's own VAT ID**, and it is separately optional. VIES
+issues a consultation number only for a check made under a requester's number, so without it the check
+still runs and still answers — it just comes back with no proof attached, and the card says
+*"None issued."* If you intend to rely on these checks for filings, set it.
+
+> **Restart after backend config.** The api is a compiled binary — changing an env var needs `make dev`
+> again to take effect. Vite hot-reloads the SPA but not the Go api, so a stale api keeps answering
+> happily and the feature breaks exactly like a bug in your own work.
+
+Both flags are also plain command-line flags (`--vat-check-base-url`, `--vat-check-requester`) on the
+worker, for a deployment that configures processes rather than environments.
+
+## Give a company a VAT number
+
+1. Open the company. In the right-hand **Details** panel, find **Register / VAT ID**.
+2. Click **Add VAT ID** (or the existing number to correct it), type the number, press Enter.
+
+Or:
+
+```bash
+curl -sS -b cookies.txt -X PATCH \
+  "$BASE/v1/organizations/$ORG/profile-fields/register_vat" \
+  -H 'content-type: application/json' \
+  -d '{"value":"DE811907980"}'
+```
+
+**Writing the number is what queues the first check.** You do not have to ask separately: a number that
+has just been stated has not been verified, so the consultation is queued in the same transaction as the
+write. A site read that finds a number in a German *Impressum* does the same thing.
+
+The number is normalised before it is consulted — case, spaces, dots, hyphens and slashes are dropped —
+so `de 811 907 980` and `DE811907980` are the same ID.
+
+## Read the answer
+
+The shield beside the number carries it. Open it for the whole receipt.
+
+| Verdict | What it means |
+|---|---|
+| **Valid** | The register recognises the number. |
+| **Not valid** | The register does not. Most often a copied imprint stating another company's ID — check **Registered to** against the company you think you have. |
+| **Register did not answer** | A fact about the **lookup**, never about the company. A member state's register was offline, or the number was not VAT-ID shaped so no request was made. |
+| *(grey, "not checked yet")* | Nobody has asked. Distinct from having asked and been told no. |
+
+**Consulted on** is the date the *register* reported, not the day this installation recorded it — a
+receipt attests to when the register was asked.
+
+## Ask again
+
+Nothing re-asks on a schedule. A verdict going stale is not an event the product can observe, so the
+automatic lanes consult only about a number they have not seen — which means a stored answer stands until
+somebody asks for a fresh one.
+
+Open the shield and press **Check again** (or **Check with the register**, on a company never consulted).
+
+```bash
+curl -sS -b cookies.txt -X POST "$BASE/v1/organizations/$ORG/vat-check"
+# 202 Accepted, no body
+```
+
+The button then stays **busy** until the register replies, saying *"Asking the register — the answer
+appears here once it replies."* It is not pressable again in the meantime: the request is accepted in
+milliseconds and the register answers seconds later, and a second press would either queue a duplicate
+consultation or meet the rate floor below and refuse you over your own in-flight request.
+
+The answer arrives on its own. It is written by a background worker, so the mark looks again a few times
+over the following seconds rather than making you reload.
+
+### Why a request can be refused
+
+| Answer | What to do |
+|---|---|
+| **429** *"This number was checked in the last few minutes…"* | Wait. The answer on the record **is** that check. The floor is five minutes per company. |
+| **404** *"This company states no VAT number yet."* | Add one in the Details panel; the write checks it automatically. |
+| **404** *"This installation does not consult the VAT register."* | [Turn it on](#turn-the-register-on). |
+
+The register is a shared public service consulted on one worker at roughly one request every two
+seconds, and its terms describe it as intended for occasional verification rather than bulk lookup. The
+five-minute floor and the human-only restriction on this endpoint are both there to keep an installation
+from being blocked for everybody — **an agent cannot press this button.**
+
+## What a number that changed looks like
+
+The VAT field stays editable after a check, so a receipt can end up beside a number nobody consulted.
+When that happens the panel says so: *"The number on this record has changed since this check. Ask the
+register again to check the new one."* The old verdict is still shown, because it is still true — about
+the old number.
+
+## Troubleshooting
+
+**The shield never appears.** The row draws it only once a number is stated. An empty VAT field has
+nothing to verify.
+
+**I pressed the button and nothing came back.** Almost always the register is not configured — see
+[Turn it on](#turn-the-register-on), and remember `make dev` after changing the env. Confirm with:
+
+```bash
+curl -sS -b cookies.txt "$BASE/v1/organizations/$ORG/vat-check"
+```
+
+`404` means never consulted; a body with `"status"` means an answer is on record.
+
+**The answer is always "Register did not answer".** Check the number's shape. A VAT ID starts with a
+two-letter country code — `122323235` is not one, and no request is made for a value that cannot be a VAT
+ID. Recorded as unanswered rather than invalid, because the register said nothing.
+
+**The shield shows a grey question mark I can press.** The check could not be **read** — a network or
+server fault, not a fact about the company. Pressing it reads again.
+
+## What is stored, and where
+
+One row per company, replaced on each check: the number as consulted, the verdict, the consultation
+number, the name and address the register holds, and both dates. The number as consulted is kept beside
+the answer on purpose — a profile field edited afterwards must not silently inherit a receipt issued for
+a different number.
+
+The history is the audit log's. Every check writes an audit entry, and a check somebody **asked for**
+writes its own entry naming who asked — the worker itself runs under a system principal, so without that
+row "a person spent a consultation on this company" would be answerable from nothing.
+
+## See also
+
+- [configuration.md](../reference/configuration.md) — every env var and flag, in one table.
+- [company-context.md](../explanation/company-context.md) — where a company's profile fields come from,
+  including the site read that finds a VAT number in a German imprint in the first place.


### PR DESCRIPTION
## What this is

A user-facing how-to for the VAT check, which shipped across four changes and had no page.

## Why it leads with configuration

The single most useful thing a reader can be told is not in the UI: **the check is off unless an operator sets `MARGINCE_VAT_CHECK_BASE_URL`.** Without it the button appears to work, the job runs, and the worker deliberately records nothing — so a reader presses, waits, and gets no answer with nothing on screen explaining why.

That is the first section, and it says where the value goes (`.env.local`, which `scripts/dev.sh` sources), what `public` resolves to, and that the api is a compiled binary so `make dev` has to run again.

## What else it covers

- **The shield and its four states** — valid, not valid, register did not answer, and never checked — with what each one asks the reader to do. "Not valid" is most often a copied imprint stating another company's ID, which is why **Registered to** matters more there than the verdict.
- **The receipt**, and why the consultation number is the half that carries weight for a filing.
- **Asking again**: a button rather than a schedule, why it stays busy until the register replies, and the three refusals — 429 with the five-minute floor, and two distinct 404s that ask for different things.
- **Why an agent cannot press it**, and the rate reasoning behind that.
- **Troubleshooting** for the two states a reader would otherwise read as bugs: a number with no country prefix answers "Register did not answer" rather than "not valid" (no request is made for a value that cannot be a VAT ID), and a stale api after an env change.

## Verified rather than written from memory

Every label, refusal sentence and behaviour in the guide was checked against the shipped code on `main` — the i18n catalogue for the copy, `handlers_organization.go` for the three refusal messages, `jobrunner.go` for how `public` resolves, and `companyraildetails.tsx` to confirm the Details panel is still the only place the field is edited after #3337.

One link I first wrote pointed at a page that does not exist (`enrich-a-company-from-its-website.md`); it now points at `explanation/company-context.md`, which does.

168 lines against the 350-line how-to budget. `go test ./gates/` green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing how-to guide for the VAT check feature, which shipped across four changes and had no documentation page. Also links the new page from the docs README.

**Guide contents**
- Leads with configuration: the check is off unless `MARGINCE_VAT_CHECK_BASE_URL` is set, and without it the button appears to work but records nothing.
- Covers the shield's four states, the receipt, asking again, the three refusal codes, and troubleshooting for behaviors readers would otherwise read as bugs.
- Every label, refusal message, and behavior was verified against the shipped code.

<sup>Written for commit d65f057747a6e7e98521ab75c80879e805355952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a how-to guide for validating company EU VAT IDs through the EU VAT register.
  * Documented configuration, VAT entry and normalization, automatic and manual checks, receipt interpretation, rate limits, asynchronous updates, changed numbers, troubleshooting, stored data, and audit logging.
  * Added equivalent `curl` examples and links to related documentation.
  * Added the guide to the documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->