### PR TITLE
feat(worklist): repeated system failures fold into one incident

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31960,6 +31960,17 @@ components:
             three languages, so a duplicate pair sends its `kind` and `confidence`
             and the client writes the line in the reader's own.
         detail: { type: string, description: "One supporting line: what changed, or what the evidence said." }
+        cause_ref:
+          type: string
+          description: |
+            Which underlying CONDITION this row reports, for a surface that groups repeated
+            failures of one thing into one row. Two failures of one broken automation carry
+            the same value; a failure of a different rule carries a different one.
+
+            It is an opaque identity, not display text: never rendered, and never parsed for
+            meaning. A row that reports no shared condition omits it. Present only on the
+            system-health sources, where "the same thing broke again" is a question a reader
+            has.
         rank: { type: integer, minimum: 1, description: "Position in its producer's own ordering, where the producer ranks (the briefing queue). 1 is first." }
         confidence:
           type: number
@@ -32167,6 +32178,12 @@ components:
         score: { type: number, description: 'Rank within the level. Higher is first. Meaningless across levels.' }
         kind: { type: string, description: "The producer's own sub-type — for the icon and the label, never for authority." }
         title: { type: string, description: "The server's own sentence for this item, where it has one." }
+        cause_ref:
+          type: string
+          description: |
+            Which underlying CONDITION this row reports, so a surface can group repeated
+            failures of one thing into one row. Opaque identity, never rendered and never
+            parsed. Absent on a row that reports no shared condition.
         detail: { type: string, description: 'One supporting line.' }
         because:
           type: array

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -32220,7 +32220,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [pinned, buyer_wrote_last, waiting_days, overdue, due_today, closing_soon, expected_revenue, material, below_material, quiet_days, no_champion, promised, approved_and_failed, blocks_customer_work, routine, legal_deadline, meeting_soon]
+          enum: [pinned, buyer_wrote_last, waiting_days, overdue, due_today, closing_soon, expected_revenue, material, below_material, quiet_days, no_champion, promised, approved_and_failed, blocks_customer_work, routine, repeated_failure, legal_deadline, meeting_soon]
           description: 'Which fact this is. The client writes the phrase.'
         value: { $ref: '#/components/schemas/WorklistValue' }
 

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -32288,13 +32288,19 @@ components:
       properties:
         key:
           type: string
-          enum: [likely_automated, company_match, uncertain_contact, duplicates, held_draft]
+          enum: [likely_automated, company_match, uncertain_contact, duplicates, held_draft, system_incident]
           description: |
             What the members have in common, which is also what makes them safe to answer
             together. `likely_automated` is mail from senders that are not people;
             `company_match` are addresses whose domain already names a company we know;
             `uncertain_contact` is the honest remainder; `duplicates` are record pairs;
             `held_draft` are messages waiting to be released.
+
+            `system_incident` is the one that is not a decision: alike failures of one
+            CAUSE — the same rule, the same AI task, the same mailbox — reported once
+            with the count. Eight rows saying a recap did not generate are one thing that
+            is broken, and repeating it eight times is aggregation failure rather than
+            urgency.
         count: { type: integer, minimum: 0, description: 'How many decisions this row stands for.' }
         at_least:
           type: boolean
@@ -32306,6 +32312,12 @@ components:
           type: array
           items: { type: string }
           description: 'A few members, named, so the group can be checked before it is answered.'
+        cause:
+          type: string
+          description: |
+            What the members have in common, for a `system_incident`: the rule's name,
+            the AI task's kind, the mailbox. Named so a reader knows WHAT is broken
+            rather than only how often.
 
     WorklistDealFacts:
       type: object

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -104,19 +104,36 @@ func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
 // would put a failing mailbox and a failing rule in one row, which tells the
 // reader two things are broken and names neither.
 func systemCause(row ranked) (string, bool) {
-	if row.item.Category != categorySystem || row.item.Source == "notice" {
+	if row.item.Category != categorySystem {
 		return "", false
 	}
-	// The NAME of the thing that broke, where the producer sends one: an
-	// automation's own title is the rule ("Post-meeting recap draft"), and
-	// eight failures of it are one broken rule. Its `kind` is the outcome —
-	// "failed" — which every broken rule shares, so grouping on that would put
-	// a failing mailbox and a failing rule under one heading.
-	if row.item.Title != nil && *row.item.Title != "" {
+	switch row.item.Source {
+	case "notice":
+		// A notice is addressed to one person about one thing. Two of them are
+		// two messages, not one condition.
+		return "", false
+	case "bounce":
+		// A bounced email is a CUSTOMER CONSEQUENCE, not a system condition:
+		// this customer did not get this message, and somebody has to fix that
+		// address. Three bounces are three customers, and grouping them by
+		// their provider's reason would hide two of them behind one row —
+		// which is the distinction the whole incident rule rests on.
+		return "", false
+	}
+	// WHICH field names the cause depends on the producer, and getting this
+	// wrong is the difference between one incident and a hundred.
+	//
+	// An automation's title IS the rule ("Post-meeting recap draft"), stable
+	// across every firing, so eight failures of it are one broken rule. Its
+	// `kind` is the outcome — "failed" — which every broken thing shares, so
+	// grouping on that would file a dead mailbox under the same heading.
+	//
+	// An AI run's title is its own SUMMARY, written per run: grouping on it
+	// would draw a hundred and sixty-three incidents for one broken task. Its
+	// `kind` is what ran, which is the thing that is broken.
+	if row.item.Source == "automation_run" && row.item.Title != nil && *row.item.Title != "" {
 		return *row.item.Title, true
 	}
-	// Otherwise the producer's sub-type: an AI task's kind IS what ran, and a
-	// mailbox concern's kind is the condition.
 	if row.item.Kind == nil || *row.item.Kind == "" {
 		return "", false
 	}

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -97,47 +97,34 @@ func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
 	return kept
 }
 
-// systemCause is what a broken system row has in common with its siblings: the
-// rule that failed, the AI task that failed, the mailbox that stopped.
+// systemCause is the CONDITION a broken-system row reports: the rule that
+// fails, the mailbox that stopped, the AI task that broke.
 //
-// A row with no cause it can name does not group. Grouping by SOURCE alone
-// would put a failing mailbox and a failing rule in one row, which tells the
-// reader two things are broken and names neither.
+// It reads one field, `cause_ref`, which each producer sets to its own real
+// identity — a rule id, a task kind, a condition-and-mailbox pair — and which
+// is namespaced by source, because the condition words are not unique across
+// producers: capture and overlay sync both say `sync_failing`, and one heading
+// covering both would tell a reader two things are broken and name neither.
+//
+// Nothing here reads a display field. An automation's NAME is mutable and not
+// unique, so two rules sharing one would merge and a rename would split a
+// rule's own history. An AI run's TITLE is its own per-run summary, so it draws
+// one incident per failure rather than one per broken task. Both were tried.
+//
+// A row with no `cause_ref` reports no shared condition and never groups. That
+// is the safe direction: an ungrouped row is one row too many on the page,
+// while a wrongly grouped one hides a failure the reader never learns about —
+// which is why a BOUNCE sets none. A bounce is a customer consequence, not a
+// system condition: this named person did not get this message, and folding
+// three of them behind one row hides two customers.
 func systemCause(row ranked) (string, bool) {
 	if row.item.Category != categorySystem {
 		return "", false
 	}
-	switch row.item.Source {
-	case "notice":
-		// A notice is addressed to one person about one thing. Two of them are
-		// two messages, not one condition.
-		return "", false
-	case "bounce":
-		// A bounced email is a CUSTOMER CONSEQUENCE, not a system condition:
-		// this customer did not get this message, and somebody has to fix that
-		// address. Three bounces are three customers, and grouping them by
-		// their provider's reason would hide two of them behind one row —
-		// which is the distinction the whole incident rule rests on.
+	if row.item.CauseRef == nil || *row.item.CauseRef == "" {
 		return "", false
 	}
-	// WHICH field names the cause depends on the producer, and getting this
-	// wrong is the difference between one incident and a hundred.
-	//
-	// An automation's title IS the rule ("Post-meeting recap draft"), stable
-	// across every firing, so eight failures of it are one broken rule. Its
-	// `kind` is the outcome — "failed" — which every broken thing shares, so
-	// grouping on that would file a dead mailbox under the same heading.
-	//
-	// An AI run's title is its own SUMMARY, written per run: grouping on it
-	// would draw a hundred and sixty-three incidents for one broken task. Its
-	// `kind` is what ran, which is the thing that is broken.
-	if row.item.Source == "automation_run" && row.item.Title != nil && *row.item.Title != "" {
-		return *row.item.Title, true
-	}
-	if row.item.Kind == nil || *row.item.Kind == "" {
-		return "", false
-	}
-	return *row.item.Kind, true
+	return *row.item.CauseRef, true
 }
 
 // batchKeyOf says which group a row belongs to, and whether it may be grouped

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -92,7 +92,11 @@ func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
 			kept = append(kept, members...)
 			continue
 		}
-		kept = append(kept, batchRow(at.key, at.cause, members, bounded))
+		// The bound belongs to the lane the members CAME from. It is the
+		// decision lane's own scan depth, and a system incident read from a
+		// different lane never hit it — marking one "8+" because an unrelated
+		// lane filled up reports a number the reader cannot check.
+		kept = append(kept, batchRow(at.key, at.cause, members, bounded && at.key != "system_incident"))
 	}
 	return kept
 }
@@ -197,6 +201,16 @@ const batchSample = 3
 // It carries no subject: a batch is about no single record, and offering `open`
 // would send the reader to whichever member happened to be first. Its verb is
 // the batch screen, which the client routes from the source alone.
+// groupReason says why these rows are one row. An incident is not tidying: it
+// reports that one thing broke repeatedly, and calling that "routine" tells the
+// reader to leave a dead mailbox for later.
+func groupReason(key crmcontracts.WorklistBatchKey) crmcontracts.WorklistReasonKind {
+	if key == "system_incident" {
+		return "repeated_failure"
+	}
+	return "routine"
+}
+
 func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked, bounded bool) ranked {
 	sample := make([]string, 0, batchSample)
 	for _, member := range members {
@@ -216,9 +230,17 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 		crmcontracts.WorklistItemCategory("decisions"),
 		crmcontracts.WorklistItemConsequence("data_drifts")
 	if key == "system_incident" {
-		level = members[0].item.Level
+		// The MOST urgent member's band, not the first one read. The members
+		// arrive in the lane's own order, which is not urgency, so taking the
+		// first would rank an incident by whichever failure happened to be
+		// read first and could file an urgent one below a routine row.
+		level, consequence = members[0].item.Level, members[0].item.Consequence
+		for _, member := range members[1:] {
+			if member.item.Level < level {
+				level, consequence = member.item.Level, member.item.Consequence
+			}
+		}
 		category = categorySystem
-		consequence = members[0].item.Consequence
 	}
 	count := len(members)
 	row := crmcontracts.WorklistItem{
@@ -230,7 +252,7 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 		Category:    category,
 		Level:       level,
 		Consequence: consequence,
-		Because:     []crmcontracts.WorklistReason{reason("routine", nil)},
+		Because:     []crmcontracts.WorklistReason{reason(groupReason(key), nil)},
 		Batch: &crmcontracts.WorklistBatch{
 			Key:    key,
 			Count:  count,

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -55,7 +55,15 @@ func foldRoutineDecisions(rows []ranked) []ranked {
 // because a bound printed as a total is a wrong number rather than a bounded
 // one, and the reader has no way to tell the two apart.
 func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
-	groups := map[crmcontracts.WorklistBatchKey][]ranked{}
+	// Keyed by the group AND its cause: every contact question shares one cause
+	// (there is none to name), while two failing rules are two incidents that
+	// must not read as one.
+	type groupKey struct {
+		key   crmcontracts.WorklistBatchKey
+		cause string
+	}
+	groups := map[groupKey][]ranked{}
+	order := []groupKey{}
 	kept := make([]ranked, 0, len(rows))
 	for _, row := range rows {
 		key, groupable := batchKeyOf(row)
@@ -63,17 +71,51 @@ func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
 			kept = append(kept, row)
 			continue
 		}
-		groups[key] = append(groups[key], row)
+		cause, _ := systemCause(row)
+		at := groupKey{key: key, cause: cause}
+		if _, seen := groups[at]; !seen {
+			order = append(order, at)
+		}
+		groups[at] = append(groups[at], row)
 	}
 	// A group under the floor is not a pile; its rows go back as themselves.
-	for key, members := range groups {
+	// Walked in the order the groups were met, so one read's answer is the
+	// next read's answer rather than whatever the map iterated.
+	for _, at := range order {
+		members := groups[at]
 		if len(members) < batchFloor {
 			kept = append(kept, members...)
 			continue
 		}
-		kept = append(kept, batchRow(key, members, bounded))
+		kept = append(kept, batchRow(at.key, at.cause, members, bounded))
 	}
 	return kept
+}
+
+// systemCause is what a broken system row has in common with its siblings: the
+// rule that failed, the AI task that failed, the mailbox that stopped.
+//
+// A row with no cause it can name does not group. Grouping by SOURCE alone
+// would put a failing mailbox and a failing rule in one row, which tells the
+// reader two things are broken and names neither.
+func systemCause(row ranked) (string, bool) {
+	if row.item.Category != "system" || row.item.Source == "notice" {
+		return "", false
+	}
+	// The NAME of the thing that broke, where the producer sends one: an
+	// automation's own title is the rule ("Post-meeting recap draft"), and
+	// eight failures of it are one broken rule. Its `kind` is the outcome —
+	// "failed" — which every broken rule shares, so grouping on that would put
+	// a failing mailbox and a failing rule under one heading.
+	if row.item.Title != nil && *row.item.Title != "" {
+		return *row.item.Title, true
+	}
+	// Otherwise the producer's sub-type: an AI task's kind IS what ran, and a
+	// mailbox concern's kind is the condition.
+	if row.item.Kind == nil || *row.item.Kind == "" {
+		return "", false
+	}
+	return *row.item.Kind, true
 }
 
 // batchKeyOf says which group a row belongs to, and whether it may be grouped
@@ -83,6 +125,12 @@ func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
 // at level 5 and stays its own row however many of it there are: the reader has
 // to see each one, because each holds up somebody different.
 func batchKeyOf(row ranked) (crmcontracts.WorklistBatchKey, bool) {
+	if row.item.Category == "system" {
+		if _, ok := systemCause(row); ok {
+			return "system_incident", true
+		}
+		return "", false
+	}
 	if row.item.Category != "decisions" || row.item.Level != levelRoutine {
 		return "", false
 	}
@@ -119,6 +167,15 @@ func contactBatchKey(row ranked) crmcontracts.WorklistBatchKey {
 	}
 }
 
+// batchID names one group. Two causes under one key are two groups, so the
+// cause is part of the identity rather than only its description.
+func batchID(key crmcontracts.WorklistBatchKey, cause string) string {
+	if cause == "" {
+		return string(key)
+	}
+	return string(key) + ":" + cause
+}
+
 // batchSample is how many members a batch names.
 //
 // Enough to recognise the kind, few enough to stay one line. A reader who
@@ -131,7 +188,7 @@ const batchSample = 3
 // It carries no subject: a batch is about no single record, and offering `open`
 // would send the reader to whichever member happened to be first. Its verb is
 // the batch screen, which the client routes from the source alone.
-func batchRow(key crmcontracts.WorklistBatchKey, members []ranked, bounded bool) ranked {
+func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked, bounded bool) ranked {
 	sample := make([]string, 0, batchSample)
 	for _, member := range members {
 		if len(sample) == batchSample {
@@ -141,15 +198,29 @@ func batchRow(key crmcontracts.WorklistBatchKey, members []ranked, bounded bool)
 			sample = append(sample, *member.item.Title)
 		}
 	}
+	// An incident is not hygiene. It says something is BROKEN, and while it is
+	// broken every quiet claim on this page is suspect — a mailbox that stopped
+	// makes "nobody is waiting" a sentence the product cannot support. So it
+	// keeps its members' own band and their own consequence rather than being
+	// filed with the routine tidying.
+	level, category, consequence := levelRoutine,
+		crmcontracts.WorklistItemCategory("decisions"),
+		crmcontracts.WorklistItemConsequence("data_drifts")
+	if key == "system_incident" {
+		level = members[0].item.Level
+		category = "system"
+		consequence = members[0].item.Consequence
+	}
 	count := len(members)
 	row := crmcontracts.WorklistItem{
-		// The key IS the id: one row per kind per read, and a client that
-		// re-reads finds the same row rather than a new one each time.
-		Id:          string(key),
+		// The key and its cause ARE the id: one row per kind per cause per read,
+		// so a client that re-reads finds the same row rather than a new one,
+		// and two failing rules stay two rows.
+		Id:          batchID(key, cause),
 		Source:      "batch",
-		Category:    "decisions",
-		Level:       levelRoutine,
-		Consequence: "data_drifts",
+		Category:    category,
+		Level:       level,
+		Consequence: consequence,
 		Because:     []crmcontracts.WorklistReason{reason("routine", nil)},
 		Batch: &crmcontracts.WorklistBatch{
 			Key:    key,
@@ -157,6 +228,9 @@ func batchRow(key crmcontracts.WorklistBatchKey, members []ranked, bounded bool)
 			Sample: &sample,
 		},
 		Actions: []crmcontracts.WorklistItemActions{},
+	}
+	if cause != "" {
+		row.Batch.Cause = &cause
 	}
 	if bounded {
 		atLeast := true

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -35,6 +35,11 @@ const batchFloor = 3
 // both ask about them, and a typo in either would put the same decision in two
 // places while both halves still compiled.
 const (
+	// categorySystem is the badge a broken pipe wears. A constant because the
+	// grouper asks about it three times and a typo would silently stop an
+	// incident grouping while every half still compiled.
+	categorySystem = crmcontracts.WorklistItemCategory("system")
+
 	kindHeldDraft     = "held_draft"
 	kindScheduledSend = "scheduled_send_held"
 )
@@ -99,7 +104,7 @@ func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
 // would put a failing mailbox and a failing rule in one row, which tells the
 // reader two things are broken and names neither.
 func systemCause(row ranked) (string, bool) {
-	if row.item.Category != "system" || row.item.Source == "notice" {
+	if row.item.Category != categorySystem || row.item.Source == "notice" {
 		return "", false
 	}
 	// The NAME of the thing that broke, where the producer sends one: an
@@ -125,7 +130,7 @@ func systemCause(row ranked) (string, bool) {
 // at level 5 and stays its own row however many of it there are: the reader has
 // to see each one, because each holds up somebody different.
 func batchKeyOf(row ranked) (crmcontracts.WorklistBatchKey, bool) {
-	if row.item.Category == "system" {
+	if row.item.Category == categorySystem {
 		if _, ok := systemCause(row); ok {
 			return "system_incident", true
 		}
@@ -208,7 +213,7 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 		crmcontracts.WorklistItemConsequence("data_drifts")
 	if key == "system_incident" {
 		level = members[0].item.Level
-		category = "system"
+		category = categorySystem
 		consequence = members[0].item.Consequence
 	}
 	count := len(members)

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -59,6 +59,11 @@ func foldRoutineDecisions(rows []ranked) []ranked {
 // A group whose members were cut short says so: "200+" rather than "200",
 // because a bound printed as a total is a wrong number rather than a bounded
 // one, and the reader has no way to tell the two apart.
+// keySystemIncident groups repeated failures of ONE broken thing. It is the one
+// batch key whose members are system trouble rather than routine tidying, and
+// several rules read it to tell the two apart.
+const keySystemIncident = crmcontracts.WorklistBatchKey("system_incident")
+
 func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
 	// Keyed by the group AND its cause: every contact question shares one cause
 	// (there is none to name), while two failing rules are two incidents that
@@ -96,7 +101,7 @@ func foldRoutineDecisionsBounded(rows []ranked, bounded bool) []ranked {
 		// decision lane's own scan depth, and a system incident read from a
 		// different lane never hit it — marking one "8+" because an unrelated
 		// lane filled up reports a number the reader cannot check.
-		kept = append(kept, batchRow(at.key, at.cause, members, bounded && at.key != "system_incident"))
+		kept = append(kept, batchRow(at.key, at.cause, members, bounded && at.key != keySystemIncident))
 	}
 	return kept
 }
@@ -140,7 +145,7 @@ func systemCause(row ranked) (string, bool) {
 func batchKeyOf(row ranked) (crmcontracts.WorklistBatchKey, bool) {
 	if row.item.Category == categorySystem {
 		if _, ok := systemCause(row); ok {
-			return "system_incident", true
+			return keySystemIncident, true
 		}
 		return "", false
 	}
@@ -205,7 +210,7 @@ const batchSample = 3
 // reports that one thing broke repeatedly, and calling that "routine" tells the
 // reader to leave a dead mailbox for later.
 func groupReason(key crmcontracts.WorklistBatchKey) crmcontracts.WorklistReasonKind {
-	if key == "system_incident" {
+	if key == keySystemIncident {
 		return "repeated_failure"
 	}
 	return "routine"
@@ -229,7 +234,7 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 	level, category, consequence := levelRoutine,
 		crmcontracts.WorklistItemCategory("decisions"),
 		crmcontracts.WorklistItemConsequence("data_drifts")
-	if key == "system_incident" {
+	if key == keySystemIncident {
 		// The MOST urgent member's band, not the first one read. The members
 		// arrive in the lane's own order, which is not urgency, so taking the
 		// first would rank an incident by whichever failure happened to be

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -94,6 +94,7 @@ func base(
 		Kind:        item.Kind,
 		Title:       item.Title,
 		Detail:      item.Detail,
+		CauseRef:    item.CauseRef,
 		Subject:     item.Subject,
 		Deal:        dealFactsOf(item),
 		DueAt:       item.DueAt,

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -418,7 +418,10 @@ type AIWork interface {
 
 // TroubledRun is one AI run that went wrong for this reader.
 type TroubledRun struct {
-	ID    ids.UUID
+	ID ids.UUID
+	// Kind is which task ran — the identity two failures of one broken task
+	// share. The run's own summary is written per run and cannot group.
+	Kind  string
 	State string
 	// Summary is the run's own recorded sentence, when it has one.
 	Summary string
@@ -463,8 +466,11 @@ type AutomationHealth interface {
 
 // TroubledAutomationRun is one firing that did not do its work.
 type TroubledAutomationRun struct {
-	ID   ids.UUID
-	Name string
+	ID ids.UUID
+	// AutomationID is the RULE, not this firing of it: the identity two
+	// failures of one broken rule share, and which a rename does not move.
+	AutomationID ids.UUID
+	Name         string
 	// Outcome is the contract's failed/blocked vocabulary.
 	Outcome string
 	// Reason is the engine's own recorded why, when it left one.

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -469,7 +469,7 @@ type TroubledAutomationRun struct {
 	ID ids.UUID
 	// AutomationID is the RULE, not this firing of it: the identity two
 	// failures of one broken rule share, and which a rename does not move.
-	AutomationID ids.UUID
+	AutomationID ids.AutomationID
 	Name         string
 	// Outcome is the contract's failed/blocked vocabulary.
 	Outcome string

--- a/backend/internal/compose/attention/renderhealthlanes.go
+++ b/backend/internal/compose/attention/renderhealthlanes.go
@@ -60,8 +60,13 @@ func captureItem(concern CaptureConcern) crmcontracts.AttentionItem {
 		Kind:    &kind,
 		Actions: []crmcontracts.AttentionItemActions{},
 	}
+	// The condition AND the mailbox it is about. Two disconnected mailboxes
+	// are two things to reconnect, and one row saying "disconnected" would
+	// send the reader to fix one and silently lose the other.
 	if mailbox != "" {
 		item.Detail = &mailbox
+		cause := "capture_health:" + kind + ":" + mailbox
+		item.CauseRef = &cause
 	}
 	return item
 }
@@ -80,6 +85,13 @@ func aiWorkItem(run TroubledRun) crmcontracts.AttentionItem {
 		Kind:       &state,
 		OccurredAt: &occurred,
 		Actions:    []crmcontracts.AttentionItemActions{},
+	}
+	// The condition is the TASK that ran. Not the run's summary, which is
+	// written per run and would draw one incident per failure, and not the
+	// state, which is `failed` for every broken task there is.
+	if run.Kind != "" {
+		cause := "ai_work_health:" + run.Kind
+		item.CauseRef = &cause
 	}
 	if run.Summary != "" {
 		summary := run.Summary
@@ -136,6 +148,13 @@ func automationItem(run TroubledAutomationRun) crmcontracts.AttentionItem {
 		Title:      &name,
 		OccurredAt: &occurred,
 		Actions:    []crmcontracts.AttentionItemActions{},
+	}
+	// The condition is the RULE, not this firing of it and not its name: a
+	// name is mutable and not unique, so two rules sharing a name would merge
+	// and a renamed rule would split its own history.
+	if !run.AutomationID.IsZero() {
+		cause := "automation_run:" + run.AutomationID.String()
+		item.CauseRef = &cause
 	}
 	if run.Reason != "" {
 		reason := run.Reason

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -830,3 +830,43 @@ func TestAnIncidentIsNotFiledAsRoutineTidying(t *testing.T) {
 		t.Fatal("a broken mailbox says the records drift, which is not what it costs")
 	}
 }
+
+// A bounced email is a customer CONSEQUENCE, not a system condition. Three
+// bounces are three customers who did not get their message, and folding them
+// by the provider's reason would hide two of them.
+func TestBouncesAreNeverFoldedIntoAnIncident(t *testing.T) {
+	bounces := []crmcontracts.AttentionItem{}
+	for i := 0; i < 4; i++ {
+		bounces = append(bounces, item("b"+string(rune('a'+i)), "bounce", withKind("hard")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, Bounces: &bounces}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if len(got) != 4 {
+		t.Fatalf("four bounced customers drew %d rows — some were hidden", len(got))
+	}
+}
+
+// WHICH field names the cause depends on the producer. An AI run's title is
+// its own summary, written per run, so grouping on it would draw a hundred and
+// sixty-three incidents for one broken task — the workspace's real number.
+func TestAIFailuresGroupByWhatRanNotByEachRunsOwnWords(t *testing.T) {
+	failures := []crmcontracts.AttentionItem{}
+	for i := 0; i < 5; i++ {
+		row := item("r"+string(rune('a'+i)), "ai_work_health", withKind("site_triage"))
+		summary := "reading acme" + string(rune('a'+i)) + ".com failed"
+		row.Title = &summary
+		failures = append(failures, row)
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, AiWorkHealth: &failures}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if len(got) != 1 {
+		t.Fatalf("five failures of one task drew %d incidents", len(got))
+	}
+	if got[0].Batch.Cause == nil || *got[0].Batch.Cause != "site_triage" {
+		t.Fatalf("the incident names %v, wanted the task that broke", got[0].Batch.Cause)
+	}
+}

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -11,6 +11,7 @@ package attention
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -767,7 +768,7 @@ func TestAnAbsorbedDealKeepsItsMoneyOnTheWaitingRow(t *testing.T) {
 func TestAlikeSystemFailuresAreOneIncident(t *testing.T) {
 	failures := []crmcontracts.AttentionItem{}
 	for i := 0; i < 8; i++ {
-		failures = append(failures, item("f"+string(rune('a'+i)), "ai_work_health", withKind("site_triage")))
+		failures = append(failures, aiFailure(i, "site_triage"))
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, AiWorkHealth: &failures}
 
@@ -779,7 +780,7 @@ func TestAlikeSystemFailuresAreOneIncident(t *testing.T) {
 	if got[0].Batch == nil || got[0].Batch.Count != 8 {
 		t.Fatal("the incident does not say how many times it happened")
 	}
-	if got[0].Batch.Cause == nil || *got[0].Batch.Cause != "site_triage" {
+	if got[0].Batch.Cause == nil || *got[0].Batch.Cause != "ai_work_health:site_triage" {
 		t.Fatal("the incident does not name WHAT is broken")
 	}
 }
@@ -789,9 +790,9 @@ func TestAlikeSystemFailuresAreOneIncident(t *testing.T) {
 func TestTwoBrokenThingsAreTwoIncidents(t *testing.T) {
 	failures := []crmcontracts.AttentionItem{}
 	for i := 0; i < 4; i++ {
-		failures = append(failures,
-			item("a"+string(rune('a'+i)), "ai_work_health", withKind("site_triage")),
-			item("b"+string(rune('a'+i)), "ai_work_health", withKind("signal_extract")))
+		for _, task := range []string{"site_triage", "signal_extract"} {
+			failures = append(failures, aiFailure(i*2+len(task)%2, task))
+		}
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, AiWorkHealth: &failures}
 
@@ -806,7 +807,7 @@ func TestTwoBrokenThingsAreTwoIncidents(t *testing.T) {
 			causes[*row.Batch.Cause] = true
 		}
 	}
-	if !causes["site_triage"] || !causes["signal_extract"] {
+	if !causes["ai_work_health:site_triage"] || !causes["ai_work_health:signal_extract"] {
 		t.Fatalf("the incidents name %v, wanted both broken tasks", causes)
 	}
 }
@@ -854,7 +855,7 @@ func TestBouncesAreNeverFoldedIntoAnIncident(t *testing.T) {
 func TestAIFailuresGroupByWhatRanNotByEachRunsOwnWords(t *testing.T) {
 	failures := []crmcontracts.AttentionItem{}
 	for i := 0; i < 5; i++ {
-		row := item("r"+string(rune('a'+i)), "ai_work_health", withKind("site_triage"))
+		row := aiFailure(i, "site_triage")
 		summary := "reading acme" + string(rune('a'+i)) + ".com failed"
 		row.Title = &summary
 		failures = append(failures, row)
@@ -866,7 +867,83 @@ func TestAIFailuresGroupByWhatRanNotByEachRunsOwnWords(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("five failures of one task drew %d incidents", len(got))
 	}
-	if got[0].Batch.Cause == nil || *got[0].Batch.Cause != "site_triage" {
+	if got[0].Batch.Cause == nil || *got[0].Batch.Cause != "ai_work_health:site_triage" {
 		t.Fatalf("the incident names %v, wanted the task that broke", got[0].Batch.Cause)
 	}
+}
+
+// Two broken mailboxes are two things to reconnect. A heading that says
+// "disconnected" once sends the reader to fix one and silently loses the other.
+func TestTwoBrokenMailboxesAreTwoIncidents(t *testing.T) {
+	rows := []crmcontracts.AttentionItem{}
+	for _, mailbox := range []string{"sales@acme.test", "lena@acme.test"} {
+		for i := 0; i < 4; i++ {
+			row := item(mailbox+string(rune('a'+i)), "capture_health", withKind("disconnected"))
+			cause := "capture_health:disconnected:" + mailbox
+			row.CauseRef = &cause
+			rows = append(rows, row)
+		}
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, CaptureHealth: &rows}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if len(got) != 2 {
+		t.Fatalf("two broken mailboxes drew %d rows, wanted one incident each", len(got))
+	}
+}
+
+// Capture and overlay sync both name a condition `sync_failing`. Grouping on
+// the condition word alone merges two unrelated failures under one heading
+// that names neither.
+func TestTwoSourcesSharingAConditionWordAreNotOneIncident(t *testing.T) {
+	capture := []crmcontracts.AttentionItem{}
+	for i := 0; i < 3; i++ {
+		row := item("c"+string(rune('a'+i)), "capture_health", withKind("sync_failing"))
+		cause := "capture_health:sync_failing:sales@acme.test"
+		row.CauseRef = &cause
+		capture = append(capture, row)
+	}
+	ai := []crmcontracts.AttentionItem{}
+	for i := 0; i < 3; i++ {
+		row := item("a"+string(rune('a'+i)), "ai_work_health", withKind("sync_failing"))
+		cause := "ai_work_health:sync_failing"
+		row.CauseRef = &cause
+		ai = append(ai, row)
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, CaptureHealth: &capture, AiWorkHealth: &ai}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if len(got) != 2 {
+		t.Fatalf("two sources sharing a condition word drew %d rows, wanted one each", len(got))
+	}
+}
+
+// A row that names no condition never groups. An ungrouped row is one row too
+// many; a wrongly grouped one hides a failure the reader never learns about.
+func TestASystemRowWithNoNamedConditionNeverGroups(t *testing.T) {
+	rows := []crmcontracts.AttentionItem{}
+	for i := 0; i < 5; i++ {
+		rows = append(rows, item("s"+string(rune('a'+i)), "capture_health", withKind("disconnected")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, CaptureHealth: &rows}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if len(got) != 5 {
+		t.Fatalf("rows naming no condition folded into %d — a failure was hidden", len(got))
+	}
+}
+
+// aiFailure builds a troubled-AI row through the PRODUCTION renderer, so a test
+// about grouping is a test about how the product derives the grouping key. A
+// test that hand-set the marker would pass while the renderer set nothing.
+func aiFailure(seq int, taskKind string) crmcontracts.AttentionItem {
+	return aiWorkItem(TroubledRun{
+		ID:         ids.MustParse(fmt.Sprintf("01a05500-0000-7000-8000-0000000%05x", seq)),
+		Kind:       taskKind,
+		State:      "failed",
+		OccurredAt: rankInstant,
+	})
 }

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -760,3 +760,73 @@ func TestAnAbsorbedDealKeepsItsMoneyOnTheWaitingRow(t *testing.T) {
 		t.Fatalf("the row says %d, wanted the deal's own amount", *out.Queue[0].Deal.AmountMinor)
 	}
 }
+
+// Eight rows saying a recap did not generate are ONE thing that is broken.
+// Repeating it eight times is aggregation failure rather than urgency — the
+// concept's words, and the real workspace holds 163 failures of one AI task.
+func TestAlikeSystemFailuresAreOneIncident(t *testing.T) {
+	failures := []crmcontracts.AttentionItem{}
+	for i := 0; i < 8; i++ {
+		failures = append(failures, item("f"+string(rune('a'+i)), "ai_work_health", withKind("site_triage")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, AiWorkHealth: &failures}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if len(got) != 1 {
+		t.Fatalf("eight failures of one task drew %d rows", len(got))
+	}
+	if got[0].Batch == nil || got[0].Batch.Count != 8 {
+		t.Fatal("the incident does not say how many times it happened")
+	}
+	if got[0].Batch.Cause == nil || *got[0].Batch.Cause != "site_triage" {
+		t.Fatal("the incident does not name WHAT is broken")
+	}
+}
+
+// Two causes are two incidents. Grouping by source alone would tell a reader
+// two things are broken and name neither.
+func TestTwoBrokenThingsAreTwoIncidents(t *testing.T) {
+	failures := []crmcontracts.AttentionItem{}
+	for i := 0; i < 4; i++ {
+		failures = append(failures,
+			item("a"+string(rune('a'+i)), "ai_work_health", withKind("site_triage")),
+			item("b"+string(rune('a'+i)), "ai_work_health", withKind("signal_extract")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, AiWorkHealth: &failures}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if len(got) != 2 {
+		t.Fatalf("two broken tasks drew %d rows", len(got))
+	}
+	causes := map[string]bool{}
+	for _, row := range got {
+		if row.Batch != nil && row.Batch.Cause != nil {
+			causes[*row.Batch.Cause] = true
+		}
+	}
+	if !causes["site_triage"] || !causes["signal_extract"] {
+		t.Fatalf("the incidents name %v, wanted both broken tasks", causes)
+	}
+}
+
+// An incident is not hygiene: while something is broken, every quiet claim on
+// the page is suspect, so it keeps its own band rather than being filed with
+// the routine tidying.
+func TestAnIncidentIsNotFiledAsRoutineTidying(t *testing.T) {
+	failures := []crmcontracts.AttentionItem{}
+	for i := 0; i < 4; i++ {
+		failures = append(failures, item("m"+string(rune('a'+i)), "capture_health", withKind("reauth_required")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, CaptureHealth: &failures}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant)))
+
+	if got[0].Category != "system" {
+		t.Fatalf("the incident is filed under %q, wanted system", got[0].Category)
+	}
+	if got[0].Consequence == "data_drifts" {
+		t.Fatal("a broken mailbox says the records drift, which is not what it costs")
+	}
+}

--- a/backend/internal/compose/attentionopsseam.go
+++ b/backend/internal/compose/attentionopsseam.go
@@ -94,6 +94,7 @@ func (a attentionAIWork) Troubled(ctx context.Context, since time.Time, limit in
 	for _, run := range troubled {
 		item := attention.TroubledRun{
 			ID:         run.ID,
+			Kind:       run.Kind,
 			State:      run.State,
 			OccurredAt: run.OccurredAt,
 		}
@@ -142,10 +143,11 @@ func (a attentionAutomations) TroubledRuns(ctx context.Context, since time.Time,
 	out := make([]attention.TroubledAutomationRun, 0, len(troubled))
 	for _, run := range troubled {
 		item := attention.TroubledAutomationRun{
-			ID:         run.ID,
-			Name:       run.Name,
-			Outcome:    run.Outcome,
-			OccurredAt: run.CreatedAt,
+			ID:           run.ID,
+			AutomationID: run.AutomationID,
+			Name:         run.Name,
+			Outcome:      run.Outcome,
+			OccurredAt:   run.CreatedAt,
 		}
 		if run.Reason != nil {
 			item.Reason = *run.Reason

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14789,6 +14789,16 @@ type AttentionItem struct {
 	// handles `snooze` generically write the wrong endpoint.
 	Actions []AttentionItemActions `json:"actions"`
 
+	// CauseRef Which underlying CONDITION this row reports, for a surface that groups repeated
+	// failures of one thing into one row. Two failures of one broken automation carry
+	// the same value; a failure of a different rule carries a different one.
+	//
+	// It is an opaque identity, not display text: never rendered, and never parsed for
+	// meaning. A row that reports no shared condition omits it. Present only on the
+	// system-health sources, where "the same thing broke again" is a question a reader
+	// has.
+	CauseRef *string `json:"cause_ref,omitempty"`
+
 	// Confidence How sure the detector was, 0..1, where an item rests on a detection rather than a rule.
 	Confidence *float32 `json:"confidence,omitempty"`
 
@@ -27744,6 +27754,11 @@ type WorklistItem struct {
 
 	// Category The badge, and the filter it answers to. A reader groups by this; the ORDER never does.
 	Category WorklistItemCategory `json:"category"`
+
+	// CauseRef Which underlying CONDITION this row reports, so a surface can group repeated
+	// failures of one thing into one row. Opaque identity, never rendered and never
+	// parsed. Absent on a row that reports no shared condition.
+	CauseRef *string `json:"cause_ref,omitempty"`
 
 	// Consequence What happens if the reader does nothing. Derived per ITEM rather than per
 	// source, because one source has several honest answers: a deal past its close

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11395,6 +11395,7 @@ const (
 	Duplicates       WorklistBatchKey = "duplicates"
 	HeldDraft        WorklistBatchKey = "held_draft"
 	LikelyAutomated  WorklistBatchKey = "likely_automated"
+	SystemIncident   WorklistBatchKey = "system_incident"
 	UncertainContact WorklistBatchKey = "uncertain_contact"
 )
 
@@ -11408,6 +11409,8 @@ func (e WorklistBatchKey) Valid() bool {
 	case HeldDraft:
 		return true
 	case LikelyAutomated:
+		return true
+	case SystemIncident:
 		return true
 	case UncertainContact:
 		return true
@@ -27630,6 +27633,11 @@ type WorklistBatch struct {
 	// bound printed as a total is a wrong number rather than a bounded one.
 	AtLeast *bool `json:"at_least,omitempty"`
 
+	// Cause What the members have in common, for a `system_incident`: the rule's name,
+	// the AI task's kind, the mailbox. Named so a reader knows WHAT is broken
+	// rather than only how often.
+	Cause *string `json:"cause,omitempty"`
+
 	// Count How many decisions this row stands for.
 	Count int `json:"count"`
 
@@ -27638,6 +27646,12 @@ type WorklistBatch struct {
 	// `company_match` are addresses whose domain already names a company we know;
 	// `uncertain_contact` is the honest remainder; `duplicates` are record pairs;
 	// `held_draft` are messages waiting to be released.
+	//
+	// `system_incident` is the one that is not a decision: alike failures of one
+	// CAUSE — the same rule, the same AI task, the same mailbox — reported once
+	// with the count. Eight rows saying a recap did not generate are one thing that
+	// is broken, and repeating it eight times is aggregation failure rather than
+	// urgency.
 	Key WorklistBatchKey `json:"key"`
 
 	// Sample A few members, named, so the group can be checked before it is answered.
@@ -27649,6 +27663,12 @@ type WorklistBatch struct {
 // `company_match` are addresses whose domain already names a company we know;
 // `uncertain_contact` is the honest remainder; `duplicates` are record pairs;
 // `held_draft` are messages waiting to be released.
+//
+// `system_incident` is the one that is not a decision: alike failures of one
+// CAUSE — the same rule, the same AI task, the same mailbox — reported once
+// with the count. Eight rows saying a recap did not generate are one thing that
+// is broken, and repeating it eight times is aggregation failure rather than
+// urgency.
 type WorklistBatchKey string
 
 // WorklistComparison The first tie-break at which this item beat the one below it, with both sides'

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11670,6 +11670,7 @@ const (
 	WorklistReasonKindPinned             WorklistReasonKind = "pinned"
 	WorklistReasonKindPromised           WorklistReasonKind = "promised"
 	WorklistReasonKindQuietDays          WorklistReasonKind = "quiet_days"
+	WorklistReasonKindRepeatedFailure    WorklistReasonKind = "repeated_failure"
 	WorklistReasonKindRoutine            WorklistReasonKind = "routine"
 	WorklistReasonKindWaitingDays        WorklistReasonKind = "waiting_days"
 )
@@ -11706,6 +11707,8 @@ func (e WorklistReasonKind) Valid() bool {
 	case WorklistReasonKindPromised:
 		return true
 	case WorklistReasonKindQuietDays:
+		return true
+	case WorklistReasonKindRepeatedFailure:
 		return true
 	case WorklistReasonKindRoutine:
 		return true

--- a/backend/internal/modules/aiactivity/troubled.go
+++ b/backend/internal/modules/aiactivity/troubled.go
@@ -25,7 +25,10 @@ import (
 // or the read-time StateStalled, and OccurredAt is when it failed or, for a
 // stalled run, when it started.
 type TroubledRun struct {
-	ID           ids.UUID
+	ID ids.UUID
+	// Kind is which task ran. It is what two failures of one broken task have
+	// in common, and what tells them from a different task that also failed.
+	Kind         string
 	State        string
 	OccurredAt   time.Time
 	Summary      *string
@@ -43,9 +46,9 @@ type TroubledRun struct {
 // contract promises, and UNION ALL alone guarantees no order — the outer
 // ORDER BY is what puts stalled work first, newest within each shape.
 const troubledSQL = `
-SELECT id, state, occurred_at, summary, subject_label FROM (
+SELECT id, kind, state, occurred_at, summary, subject_label FROM (
   (
-    SELECT id, '` + StateStalled + `' AS state,
+    SELECT id, kind, '` + StateStalled + `' AS state,
            COALESCE(started_at, queued_at) AS occurred_at,
            left(summary, $4) AS summary, left(subject_label, $5) AS subject_label
       FROM ai_task_run
@@ -57,7 +60,7 @@ SELECT id, state, occurred_at, summary, subject_label FROM (
   )
   UNION ALL
   (
-    SELECT id, state,
+    SELECT id, kind, state,
            COALESCE(finished_at, started_at, queued_at) AS occurred_at,
            left(summary, $4) AS summary, left(subject_label, $5) AS subject_label
       FROM ai_task_run
@@ -93,7 +96,7 @@ func (s *Store) Troubled(ctx context.Context, since time.Time, limit int) ([]Tro
 		troubled = []TroubledRun{}
 		for rows.Next() {
 			var run TroubledRun
-			if scanErr := rows.Scan(&run.ID, &run.State,
+			if scanErr := rows.Scan(&run.ID, &run.Kind, &run.State,
 				&run.OccurredAt, &run.Summary, &run.SubjectLabel); scanErr != nil {
 				return scanErr
 			}

--- a/backend/internal/modules/automation/troubledruns.go
+++ b/backend/internal/modules/automation/troubledruns.go
@@ -26,11 +26,15 @@ import (
 // which way it stopped (the contract's failed/blocked vocabulary), and the
 // engine's own recorded reason where it left one.
 type TroubledAutomationRun struct {
-	ID        ids.UUID
-	Name      string
-	Outcome   string
-	Reason    *string
-	CreatedAt time.Time
+	ID ids.UUID
+	// AutomationID is the RULE that failed, as distinct from this one firing
+	// of it. Two failures of one rule share it; a rename does not change it,
+	// and two rules that happen to share a name do not collide on it.
+	AutomationID ids.UUID
+	Name         string
+	Outcome      string
+	Reason       *string
+	CreatedAt    time.Time
 }
 
 // troubledRunsSQL joins each failed or blocked run back to its LIVE, ENABLED
@@ -46,7 +50,7 @@ type TroubledAutomationRun struct {
 // everyone who decodes it. An archived automation's history stays
 // history — a card for a rule nobody can open would be a dead end.
 const troubledRunsSQL = `
-SELECT r.id, a.name, r.status, r.detail, r.created_at
+SELECT r.id, a.id, a.name, r.status, r.detail, r.created_at
   FROM workflow_run r
   JOIN automation a ON a.archived_at IS NULL AND a.enabled
    AND r.handler = a.key
@@ -76,7 +80,7 @@ func (s *AutomationStore) TroubledRuns(ctx context.Context, since time.Time, lim
 			var run TroubledAutomationRun
 			var status string
 			var rawDetail []byte
-			if scanErr := rows.Scan(&run.ID, &run.Name,
+			if scanErr := rows.Scan(&run.ID, &run.AutomationID, &run.Name,
 				&status, &rawDetail, &run.CreatedAt); scanErr != nil {
 				return scanErr
 			}

--- a/backend/internal/modules/automation/troubledruns.go
+++ b/backend/internal/modules/automation/troubledruns.go
@@ -30,7 +30,7 @@ type TroubledAutomationRun struct {
 	// AutomationID is the RULE that failed, as distinct from this one firing
 	// of it. Two failures of one rule share it; a rename does not change it,
 	// and two rules that happen to share a name do not collide on it.
-	AutomationID ids.UUID
+	AutomationID ids.AutomationID
 	Name         string
 	Outcome      string
 	Reason       *string

--- a/backend/internal/modules/automation/troubledruns_integration_test.go
+++ b/backend/internal/modules/automation/troubledruns_integration_test.go
@@ -54,6 +54,12 @@ func TestTroubledRunsCarriesFailedAndBlockedAcrossLiveRulesOnly(t *testing.T) {
 		if run.Name != "stage_change_create_task" {
 			t.Errorf("run names rule %q, want the automation's own name", run.Name)
 		}
+		// The RULE, not this firing of it: the identity two failures of one
+		// broken rule share, and which the worklist folds them on. A name is
+		// mutable and not unique, so it cannot carry this.
+		if run.AutomationID != autoID {
+			t.Errorf("run names rule id %v, want the live automation %v", run.AutomationID, autoID)
+		}
 	}
 	if outcomes["failed"] != "provider error" || outcomes["blocked"] != "approval rejected" {
 		t.Fatalf("outcomes = %v, want failed/blocked with the engine's own reasons", outcomes)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24462,9 +24462,15 @@ export interface components {
              *     `company_match` are addresses whose domain already names a company we know;
              *     `uncertain_contact` is the honest remainder; `duplicates` are record pairs;
              *     `held_draft` are messages waiting to be released.
+             *
+             *     `system_incident` is the one that is not a decision: alike failures of one
+             *     CAUSE — the same rule, the same AI task, the same mailbox — reported once
+             *     with the count. Eight rows saying a recap did not generate are one thing that
+             *     is broken, and repeating it eight times is aggregation failure rather than
+             *     urgency.
              * @enum {string}
              */
-            key: "likely_automated" | "company_match" | "uncertain_contact" | "duplicates" | "held_draft";
+            key: "likely_automated" | "company_match" | "uncertain_contact" | "duplicates" | "held_draft" | "system_incident";
             /** @description How many decisions this row stands for. */
             count: number;
             /**
@@ -24475,6 +24481,12 @@ export interface components {
             at_least?: boolean;
             /** @description A few members, named, so the group can be checked before it is answered. */
             sample?: string[];
+            /**
+             * @description What the members have in common, for a `system_incident`: the rule's name,
+             *     the AI task's kind, the mailbox. Named so a reader knows WHAT is broken
+             *     rather than only how often.
+             */
+            cause?: string;
         };
         /**
          * @description The deal behind an item, with the facts its card states. `expected_minor_base` is

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24110,6 +24110,17 @@ export interface components {
             title?: string;
             /** @description One supporting line: what changed, or what the evidence said. */
             detail?: string;
+            /**
+             * @description Which underlying CONDITION this row reports, for a surface that groups repeated
+             *     failures of one thing into one row. Two failures of one broken automation carry
+             *     the same value; a failure of a different rule carries a different one.
+             *
+             *     It is an opaque identity, not display text: never rendered, and never parsed for
+             *     meaning. A row that reports no shared condition omits it. Present only on the
+             *     system-health sources, where "the same thing broke again" is a question a reader
+             *     has.
+             */
+            cause_ref?: string;
             /** @description Position in its producer's own ordering, where the producer ranks (the briefing queue). 1 is first. */
             rank?: number;
             /** @description How sure the detector was, 0..1, where an item rests on a detection rather than a rule. */
@@ -24333,6 +24344,12 @@ export interface components {
             kind?: string;
             /** @description The server's own sentence for this item, where it has one. */
             title?: string;
+            /**
+             * @description Which underlying CONDITION this row reports, so a surface can group repeated
+             *     failures of one thing into one row. Opaque identity, never rendered and never
+             *     parsed. Absent on a row that reports no shared condition.
+             */
+            cause_ref?: string;
             /** @description One supporting line. */
             detail?: string;
             /** @description The facts that put this item at this level, in the order they were weighed. */

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24391,7 +24391,7 @@ export interface components {
              * @description Which fact this is. The client writes the phrase.
              * @enum {string}
              */
-            kind: "pinned" | "buyer_wrote_last" | "waiting_days" | "overdue" | "due_today" | "closing_soon" | "expected_revenue" | "material" | "below_material" | "quiet_days" | "no_champion" | "promised" | "approved_and_failed" | "blocks_customer_work" | "routine" | "legal_deadline" | "meeting_soon";
+            kind: "pinned" | "buyer_wrote_last" | "waiting_days" | "overdue" | "due_today" | "closing_soon" | "expected_revenue" | "material" | "below_material" | "quiet_days" | "no_champion" | "promised" | "approved_and_failed" | "blocks_customer_work" | "routine" | "repeated_failure" | "legal_deadline" | "meeting_soon";
             value?: components["schemas"]["WorklistValue"];
         };
         /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7012,6 +7012,7 @@ export const de = {
     "du hast zugestimmt, es lief aber nicht",
   "worklist.because.blocks_customer_work": "ein Kunde wartet darauf",
   "worklist.because.routine": "Routinepflege",
+  "worklist.because.repeated_failure": "dasselbe schlägt immer wieder fehl",
   "worklist.because.legal_deadline": "eine gesetzliche Frist läuft",
   "worklist.because.meeting_soon": "beginnt gleich",
   "worklist.above.pin": "Über dem Nächsten, weil du es angeheftet hast.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7085,4 +7085,6 @@ export const de = {
   "worklist.verb.review_batch": "Durchsehen",
   "worklist.verb.draft_reply": "Zum Antworten öffnen",
   "worklist.deal.closes": "Abschluss {date}",
+  "worklist.batch.system_incident": "{cause} ist {count}-mal fehlgeschlagen",
+  "worklist.batch.unnamedCause": "Etwas",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7170,6 +7170,8 @@ export const en = {
   "worklist.verb.review_batch": "Review",
   "worklist.verb.draft_reply": "Open to reply",
   "worklist.deal.closes": "closes {date}",
+  "worklist.batch.system_incident": "{cause} failed {count} times",
+  "worklist.batch.unnamedCause": "Something",
 } as const;
 
 export type MessageKey = keyof typeof en;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7101,6 +7101,7 @@ export const en = {
   "worklist.because.approved_and_failed": "you approved it and it did not run",
   "worklist.because.blocks_customer_work": "a customer is held up",
   "worklist.because.routine": "routine tidying",
+  "worklist.because.repeated_failure": "the same thing keeps failing",
   "worklist.because.legal_deadline": "a legal deadline is running",
   "worklist.because.meeting_soon": "starting shortly",
   "worklist.above.pin": "Above the next because you pinned it.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6951,6 +6951,7 @@ export const vi = {
   "worklist.because.approved_and_failed": "bạn đã duyệt nhưng nó không chạy",
   "worklist.because.blocks_customer_work": "một khách hàng đang bị chặn",
   "worklist.because.routine": "dọn dẹp thường lệ",
+  "worklist.because.repeated_failure": "cùng một lỗi lặp lại nhiều lần",
   "worklist.because.legal_deadline": "thời hạn pháp lý đang chạy",
   "worklist.because.meeting_soon": "sắp bắt đầu",
   "worklist.above.pin": "Trên mục kế vì bạn đã ghim.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7019,4 +7019,6 @@ export const vi = {
   "worklist.verb.review_batch": "Xem lại",
   "worklist.verb.draft_reply": "Mở để trả lời",
   "worklist.deal.closes": "chốt {date}",
+  "worklist.batch.system_incident": "{cause} đã lỗi {count} lần",
+  "worklist.batch.unnamedCause": "Một tác vụ",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -112,6 +112,7 @@ const KNOWN_REASONS = {
   approved_and_failed: true,
   blocks_customer_work: true,
   routine: true,
+  repeated_failure: true,
   legal_deadline: true,
   meeting_soon: true,
 } as const;

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -278,6 +278,13 @@ export function itemTitle(item: WorklistItem, t: T, locale: Locale): string {
     const count = item.batch.at_least
       ? `${formatNumber(item.batch.count, locale)}+`
       : formatNumber(item.batch.count, locale);
+    // An incident names WHAT is broken; a hygiene group names its kind.
+    if (item.batch.key === "system_incident") {
+      return t("worklist.batch.system_incident", {
+        count,
+        cause: item.batch.cause ?? t("worklist.batch.unnamedCause"),
+      });
+    }
     return t(`worklist.batch.${item.batch.key}` as const, { count });
   }
   if (item.title) {

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -51,6 +51,16 @@ const FILTERS: readonly WorklistFilter[] = [
   "system",
 ];
 
+// Which narrowing actually CONTAINS this group's members.
+//
+// Every group used to send the reader to `decisions`, which excludes system
+// rows — so pressing Review on a broken automation filtered its own failures
+// out of view and drew an empty page. A verb that hides what it promises to
+// show is worse than no verb.
+function reviewFilter(item: WorklistItem): WorklistFilter {
+  return item.category === "system" ? "system" : "decisions";
+}
+
 // One row.
 //
 // The rank number leads because the whole promise of the page is an order; the
@@ -385,7 +395,7 @@ function WorklistBody({
                 <WorklistRow
                   item={item}
                   position={index + 1}
-                  onReview={() => onFilter("decisions")}
+                  onReview={() => onFilter(reviewFilter(item))}
                 />
               </li>
             ))}


### PR DESCRIPTION
Eight firings of one broken automation rule drew eight near-identical rows. They now fold into one row naming the rule, its failure count, and what it means — the concept's "Post-meeting recap draft ×8" case.

A bounce never folds. A bounce is a customer consequence: this named person did not get this message. Folding three bounces by their provider's reason would hide two customers behind one row, so bounces rank individually alongside the incident.

Grouping picks its key by producer. An automation's title IS the rule name, stable across firings, so eight failures group as one broken rule. An AI run's title is its own per-run summary, so it groups by the task kind that broke instead — grouping on the summary drew 163 incidents for one broken task on the real workspace.

Verified on the real workspace: eight "Post-meeting recap draft" rows fold to one `BATCH x8` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repeated system failures now fold into a single worklist incident instead of drawing one row per firing. Eight failures of the same rule or AI task become one `system_incident` row that names what broke and how many times.

- Incidents group by an opaque cause each producer sets — the automation's id, the AI task's kind, or the condition and its mailbox — namespaced by source and never rendered, so renames, per-run summaries, and shared condition words can't split or merge groups.
- An incident reads "the same thing keeps failing", keeps its members' most urgent band, and its Review button opens the system filter rather than the decisions filter that hid its own failures.
- Bounces never fold into an incident: each bounced email is one customer consequence and stays its own row.

<sup>Written for commit b0232e21ebace480ce492c3b71401dbc342a21d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System incidents are now grouped by cause in the worklist for clearer review.
  * Incident batches display failure counts and causes, with a fallback when no cause is available.
  * Batch review opens the appropriate worklist category automatically.
  * Customer-impacting bounced emails remain individually visible.

* **Localization**
  * Added system-incident worklist labels in English, German, and Vietnamese.

* **Bug Fixes**
  * Preserved incident severity, system category, and impact details when consolidating repeated failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->