### PR TITLE
fix(drafting): a voice retry may not trade a phrasing violation for a voice one

### DIFF
--- a/backend/internal/compose/accountdraft/voicefloor.go
+++ b/backend/internal/compose/accountdraft/voicefloor.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/margince/margince/backend/internal/compose/draftcheck"
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/ai"
 )
@@ -71,15 +72,48 @@ func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftv
 // somebody we have never written to — and score as an improvement while being
 // a regression a reader would notice first.
 //
-// Phrasing must not get WORSE rather than having to be perfect: the draft that
-// reaches here is usually clean, but the loop serves its better attempt rather
-// than a spotless one, and demanding zero would discard a genuine voice fix
-// over a finding the first draft carried too.
+// The phrasing test is a SUBSET, not a count. Findings are not
+// interchangeable: a false "Re:" claims a message nobody sent us, where a
+// wellbeing opener is filler, and counting them equal would let a retry trade
+// the second for the first and be served. So the retry may carry only findings
+// the draft it replaces already carried.
+//
+// It is a subset rather than emptiness because the loop serves its better
+// attempt rather than a spotless one. Demanding zero findings would discard a
+// genuine voice fix over a phrasing finding the incumbent carried too — and the
+// incumbent is what we would keep instead, findings and all.
 func improves(in Input, current, retried Draft, violations []ai.VoiceViolation) bool {
 	if len(draftvoice.Violations(retried.Subject, retried.Body)) >= len(violations) {
 		return false
 	}
-	return phrasingFindings(in, retried) <= phrasingFindings(in, current)
+	return noNewPhrasingFindings(phrasingFindings(in, current), phrasingFindings(in, retried))
+}
+
+// noNewPhrasingFindings reports whether every finding against the retry was
+// already a finding against the draft it would replace.
+//
+// A multiset: two of the same finding is worse than one, so the incumbent's
+// copies are consumed as they are matched. Rule and Phrase together identify
+// one — Why is the same sentence for every finding of a rule, so it adds
+// nothing to the comparison.
+func noNewPhrasingFindings(current, retried []draftcheck.Finding) bool {
+	remaining := make(map[draftcheck.Finding]int, len(current))
+	for _, finding := range current {
+		remaining[identity(finding)]++
+	}
+	for _, finding := range retried {
+		key := identity(finding)
+		if remaining[key] == 0 {
+			return false
+		}
+		remaining[key]--
+	}
+	return true
+}
+
+// identity is the part of a finding that says WHICH finding it is.
+func identity(finding draftcheck.Finding) draftcheck.Finding {
+	return draftcheck.Finding{Rule: finding.Rule, Phrase: finding.Phrase}
 }
 
 // servable reports whether a draft is still one the contract can carry. The

--- a/backend/internal/compose/accountdraft/voicefloor.go
+++ b/backend/internal/compose/accountdraft/voicefloor.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package accountdraft
+
+// The deterministic anti-AI floor a VOICED draft passes through, after the
+// shared correct-and-retry loop has already cleared the phrasing rules.
+//
+// Its whole job is comparing one draft against another, which is why every
+// step here answers the same question: is what I am about to serve better than
+// what I already have? A step that cannot answer yes leaves the draft alone.
+
+import (
+	"context"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
+	"github.com/margince/margince/backend/internal/modules/ai"
+)
+
+// applyVoiceFloor is the deterministic anti-AI pass a voiced draft must clear:
+// detect on the raw text, one critic retry that fixes the SENTENCE, then the
+// sanitizer for what is left to remove mechanically.
+//
+// It runs only for a voiced draft. An unvoiced one is already governed by the
+// shared rules and by draftcheck, and running a second retry over every draft
+// would double the model spend of the common case to fix the rare one.
+//
+// Every step can only improve the draft, never replace it with a worse one.
+// The retry is kept only if it clears more voice violations AND adds no
+// phrasing finding — see improves. The sanitizer's edits are kept only if what
+// survives them is still a draft: it deletes characters, so a subject that was
+// nothing but an em dash comes back empty, and an empty subject is not a
+// message the contract allows.
+//
+// A draft that still trips the floor after all of that is served anyway. The
+// alternative is the deterministic floor — a two-line opener — and a rep who
+// asked for a draft is better served by an imperfect real message than by a
+// stub, which is the same trade Write makes when the model is down.
+func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, draft Draft) (Draft, error) {
+	if !voice.OK {
+		return draft, nil
+	}
+	// Detect on the RAW draft: a violation the sanitizer could mechanically
+	// remove still earns the retry, because the retry rewrites the sentence
+	// where the sanitizer only deletes the punctuation.
+	violations := draftvoice.Violations(draft.Subject, draft.Body)
+	if len(violations) > 0 {
+		retried, retryErr := writeWithModel(ctx, lane, in, voice, draftvoice.Feedback(violations))
+		if retryErr == nil && improves(in, draft, retried, violations) {
+			draft = retried
+		}
+	}
+	sanitized := draft
+	sanitized.Subject, sanitized.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
+	if !servable(sanitized) {
+		return draft, nil
+	}
+	return sanitized, nil
+}
+
+// improves reports whether the retried draft is better than the one it would
+// replace, on BOTH measures.
+//
+// Two measures, because the retry is answering only one of them. It arrives
+// through this package's correct-and-retry loop, so the draft it replaces has
+// already cleared the phrasing rules; the retry prompt names the voice
+// violations and says nothing about the phrasing findings the first pass fixed.
+// A retry judged on voice alone can therefore drop an em dash and invent a
+// shared history in the same breath — "we help companies", on a message to
+// somebody we have never written to — and score as an improvement while being
+// a regression a reader would notice first.
+//
+// Phrasing must not get WORSE rather than having to be perfect: the draft that
+// reaches here is usually clean, but the loop serves its better attempt rather
+// than a spotless one, and demanding zero would discard a genuine voice fix
+// over a finding the first draft carried too.
+func improves(in Input, current, retried Draft, violations []ai.VoiceViolation) bool {
+	if len(draftvoice.Violations(retried.Subject, retried.Body)) >= len(violations) {
+		return false
+	}
+	return phrasingFindings(in, retried) <= phrasingFindings(in, current)
+}
+
+// servable reports whether a draft is still one the contract can carry. The
+// sanitizer removes characters, so a draft made only of what it removes comes
+// back empty — and an empty subject or body is not a message.
+func servable(draft Draft) bool {
+	return strings.TrimSpace(draft.Subject) != "" && strings.TrimSpace(draft.Body) != ""
+}

--- a/backend/internal/compose/accountdraft/voicefloor_test.go
+++ b/backend/internal/compose/accountdraft/voicefloor_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
 
@@ -93,6 +95,39 @@ func TestARetryThatClearsNothingIsDiscarded(t *testing.T) {
 	}
 	if !strings.Contains(draft.Body, "Shall we pick this up?") {
 		t.Errorf("the composer kept a retry that cleared no violation; body = %q", draft.Body)
+	}
+}
+
+// A retry that clears a voice violation may not smuggle in a draftcheck one.
+//
+// The floor runs AFTER draftcore.CorrectOnce, so the draft it receives has
+// already cleared draftcheck. The retry it may substitute has not: it is a
+// fresh answer, written to a prompt that names the voice violations and says
+// nothing about the phrasing rules the first pass already fixed. Counting only
+// voice violations lets a retry that drops an em dash and invents a shared
+// history — "we help companies", on a first-touch message — replace a draft
+// that was clean by both measures.
+func TestARetryThatTradesAVoiceViolationForAPhrasingOneIsDiscarded(t *testing.T) {
+	// A spaced em dash: one voice violation, no draftcheck finding.
+	const first = `{"subject":"Rollout","body":"Hi Sarah,\n\nThe rollout — Phase 2 — is ready. Shall we pick this up?"}`
+	// The em dash is gone, so it clears MORE voice violations than the first.
+	// It also claims a sales pitch draftcheck refuses on a first message.
+	const retry = `{"subject":"Rollout","body":"Hi Sarah,\n\nWe help companies like yours. Shall we pick this up?"}`
+	lane := &sequencedLane{answers: []string{first, retry}}
+
+	// A FIRST-TOUCH envelope, which is what makes "we help companies" a
+	// finding: the invention rules only bind where there is no prior
+	// correspondence to have established anything.
+	in := sampleInput()
+	in.Envelope = draftfloor.Envelope{ConversationState: string(convstate.BandNone)}
+
+	draft, _, err := Write(context.Background(), lane, in, voiced())
+	if err != nil {
+		t.Fatalf("the voiced draft failed: %v", err)
+	}
+	if strings.Contains(strings.ToLower(draft.Body), "we help companies") {
+		t.Errorf("the floor served a retry carrying a phrasing rule the first draft had cleared; "+
+			"body = %q", draft.Body)
 	}
 }
 

--- a/backend/internal/compose/accountdraft/voicefloor_test.go
+++ b/backend/internal/compose/accountdraft/voicefloor_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
@@ -144,5 +145,65 @@ func TestAnUnvoicedDraftRunsNoVoiceRetry(t *testing.T) {
 	}
 	if lane.calls != 1 {
 		t.Errorf("an unvoiced draft made %d model calls; it must make exactly one", lane.calls)
+	}
+}
+
+// A retry that fixes the voice and adds no phrasing finding IS served.
+//
+// The acceptance case, and the one that keeps the three rejection tests
+// honest: without it, an improves() hardwired to false would leave every other
+// test in this file green while the floor's retry became dead code.
+func TestARetryThatFixesTheVoiceIsServed(t *testing.T) {
+	// One voice violation, no phrasing finding.
+	const first = `{"subject":"Rollout","body":"Hi Sarah,\n\nThe rollout — Phase 2 — is ready. Shall we pick this up?"}`
+	// The dash is gone and nothing else is wrong.
+	const retry = `{"subject":"Rollout","body":"Hi Sarah,\n\nPhase 2 of the rollout is ready. Shall we pick this up?"}`
+	lane := &sequencedLane{answers: []string{first, retry}}
+
+	draft, by, err := Write(context.Background(), lane, sampleInput(), voiced())
+	if err != nil {
+		t.Fatalf("the voiced draft failed: %v", err)
+	}
+	if lane.calls != 2 {
+		t.Fatalf("the floor made %d model calls; a violation earns exactly one retry", lane.calls)
+	}
+	if by != crmcontracts.Model {
+		t.Errorf("generated_by = %v, want the model: the floor degraded a served draft", by)
+	}
+	if !strings.Contains(draft.Body, "Phase 2 of the rollout is ready") {
+		t.Errorf("the floor discarded a retry that fixed the voice and broke nothing; body = %q", draft.Body)
+	}
+}
+
+// A retry may not trade one phrasing finding for a DIFFERENT one of equal count.
+//
+// Findings are not interchangeable. A false "Re:" claims a message nobody sent
+// us; a wellbeing opener is filler. Counting them equal would let the retry
+// swap the second for the first and be served.
+func TestARetryThatSwapsOnePhrasingFindingForAnotherIsDiscarded(t *testing.T) {
+	// Three answers, because two retries run in sequence and only the second
+	// is this floor's.
+	//
+	// The first draft carries a wellbeing opener, so draftcore.CorrectOnce
+	// spends its own retry on it. That retry (the second answer) clears the
+	// opener but keeps an em dash, which is a voice violation and no phrasing
+	// finding — so the loop serves it and THIS floor gets it. The floor's own
+	// retry is the third answer: it clears the dash, and claims a thread
+	// nobody started in exchange.
+	//
+	// Both drafts the floor compares therefore carry exactly ONE phrasing
+	// finding, and they are different rules. A floor comparing counts would
+	// serve the "Re:"; one comparing which findings fired keeps the incumbent.
+	const first = `{"subject":"Rollout","body":"Hi Sarah,\n\nI hope this finds you well. Phase 2 is ready."}`
+	const loopRetry = `{"subject":"Rollout","body":"Hi Sarah,\n\nI hope this finds you well. The rollout — Phase 2 — is ready."}`
+	const floorRetry = `{"subject":"Re: Rollout","body":"Hi Sarah,\n\nPhase 2 of the rollout is ready."}`
+	lane := &sequencedLane{answers: []string{first, loopRetry, floorRetry}}
+
+	draft, _, err := Write(context.Background(), lane, sampleInput(), voiced())
+	if err != nil {
+		t.Fatalf("the voiced draft failed: %v", err)
+	}
+	if strings.HasPrefix(draft.Subject, "Re:") {
+		t.Errorf("the floor served a retry claiming a thread nobody started; subject = %q", draft.Subject)
 	}
 }

--- a/backend/internal/compose/accountdraft/write.go
+++ b/backend/internal/compose/accountdraft/write.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/margince/margince/backend/internal/compose/draftcheck"
 	"github.com/margince/margince/backend/internal/compose/draftcore"
 	"github.com/margince/margince/backend/internal/compose/draftrules"
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
@@ -157,9 +158,9 @@ func draftSubject(in Input) func(Draft) (string, bool) {
 }
 
 // phrasingFindings is what the shared phrasing rules say is wrong with a draft.
-func phrasingFindings(in Input, draft Draft) int {
-	return len(draftcore.Findings(draft, in.Envelope.Lang(), in.Envelope.Band(),
-		draftText, draftSubject(in)))
+func phrasingFindings(in Input, draft Draft) []draftcheck.Finding {
+	return draftcore.Findings(draft, in.Envelope.Lang(), in.Envelope.Band(),
+		draftText, draftSubject(in))
 }
 
 func writeWithModel(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, correction string) (Draft, error) {

--- a/backend/internal/compose/accountdraft/write.go
+++ b/backend/internal/compose/accountdraft/write.go
@@ -133,8 +133,7 @@ func writeChecked(ctx context.Context, lane Completer, in Input, voice draftvoic
 		func(ctx context.Context, correction string) (Draft, error) {
 			return writeWithModel(ctx, lane, in, voice, correction)
 		},
-		func(d Draft) (string, []string) { return d.Body, reasonLabels(d.Reasoning) },
-		func(d Draft) (string, bool) { return d.Subject, in.Threaded() },
+		draftText, draftSubject(in),
 		// No observer: this package holds no logger, and a retry that does not
 		// help still returns a real draft. The reply surface, which has one,
 		// reports it.
@@ -146,53 +145,21 @@ func writeChecked(ctx context.Context, lane Completer, in Input, voice draftvoic
 	return applyVoiceFloor(ctx, lane, in, voice, draft)
 }
 
-// applyVoiceFloor is the deterministic anti-AI pass a voiced draft must clear:
-// detect on the raw text, one critic retry that fixes the SENTENCE, then the
-// sanitizer for what is left to remove mechanically.
-//
-// It runs only for a voiced draft. An unvoiced one is already governed by the
-// shared rules and by draftcheck, and running a second retry over every draft
-// would double the model spend of the common case to fix the rare one.
-//
-// Every step can only improve the draft, never replace it with a worse one.
-// The retry is kept only if it clears MORE violations than the attempt it
-// replaces — a retry is one more model answer, not a better one by definition,
-// and it is written without the draftcheck findings the first pass already
-// cleared. The sanitizer's edits are kept only if what survives them is still a
-// draft: it deletes characters, so a subject that was nothing but an em dash
-// comes back empty, and an empty subject is not a message the contract allows.
-//
-// A draft that still trips the floor after all of that is served anyway. The
-// alternative is the deterministic floor — a two-line opener — and a rep who
-// asked for a draft is better served by an imperfect real message than by a
-// stub, which is the same trade Write makes when the model is down.
-func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, draft Draft) (Draft, error) {
-	if !voice.OK {
-		return draft, nil
-	}
-	// Detect on the RAW draft: a violation the sanitizer could mechanically
-	// remove still earns the retry, because the retry rewrites the sentence
-	// where the sanitizer only deletes the punctuation.
-	violations := draftvoice.Violations(draft.Subject, draft.Body)
-	if len(violations) > 0 {
-		retried, retryErr := writeWithModel(ctx, lane, in, voice, draftvoice.Feedback(violations))
-		if retryErr == nil && len(draftvoice.Violations(retried.Subject, retried.Body)) < len(violations) {
-			draft = retried
-		}
-	}
-	sanitized := draft
-	sanitized.Subject, sanitized.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
-	if !servable(sanitized) {
-		return draft, nil
-	}
-	return sanitized, nil
+// draftText and draftSubject say which parts of a draft the phrasing rules
+// read. Both passes that check a draft take them from here rather than each
+// spelling the accessors inline: the voice floor's whole job is comparing one
+// draft against another, and a comparison whose two sides read different fields
+// measures nothing.
+func draftText(d Draft) (string, []string) { return d.Body, reasonLabels(d.Reasoning) }
+
+func draftSubject(in Input) func(Draft) (string, bool) {
+	return func(d Draft) (string, bool) { return d.Subject, in.Threaded() }
 }
 
-// servable reports whether a draft is still one the contract can carry. The
-// sanitizer removes characters, so a draft made only of what it removes comes
-// back empty — and an empty subject or body is not a message.
-func servable(draft Draft) bool {
-	return strings.TrimSpace(draft.Subject) != "" && strings.TrimSpace(draft.Body) != ""
+// phrasingFindings is what the shared phrasing rules say is wrong with a draft.
+func phrasingFindings(in Input, draft Draft) int {
+	return len(draftcore.Findings(draft, in.Envelope.Lang(), in.Envelope.Band(),
+		draftText, draftSubject(in)))
 }
 
 func writeWithModel(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, correction string) (Draft, error) {

--- a/backend/internal/compose/draftcore/draftcore.go
+++ b/backend/internal/compose/draftcore/draftcore.go
@@ -82,26 +82,39 @@ type SubjectOf[D any] func(D) (subject string, threaded bool)
 // When the retry does not clear the findings, the attempt carrying FEWER of them
 // is served. A second attempt is not automatically better, and the count is the
 // only evidence available without asking a model to judge its own output.
+// Findings is everything the phrasing rules say is wrong with one draft.
+//
+// Exported because CorrectOnce is not the only pass that has to ask. The voice
+// floor runs AFTER this loop and may substitute a retried draft, so it needs
+// the same answer to know whether the substitution regressed anything — and a
+// second spelling of "what is wrong with a draft" would drift from this one
+// until the two disagreed about a phrase in front of a user.
+func Findings[D any](
+	draft D, lang textlang.Lang, band convstate.Band, textOf TextOf[D], subjectOf SubjectOf[D],
+) []draftcheck.Finding {
+	body, reasoning := textOf(draft)
+	// Whether this draft answers a real inbound message decides more than the
+	// subject's reply prefix: a reply is written from the counterparty's own
+	// words, so it may echo a call THEY named, where a message opening a new
+	// conversation has no such ground to stand on.
+	subject, threaded := "", false
+	if subjectOf != nil {
+		subject, threaded = subjectOf(draft)
+	}
+	findings := append(draftcheck.Body(body, lang, band, threaded),
+		draftcheck.Reasoning(reasoning, lang, band)...)
+	if subjectOf != nil {
+		findings = append(findings, draftcheck.Subject(subject, lang, band, threaded)...)
+	}
+	return findings
+}
+
 func CorrectOnce[D any](
 	ctx context.Context, lang textlang.Lang, band convstate.Band,
 	write Writer[D], textOf TextOf[D], subjectOf SubjectOf[D], observe Observer,
 ) (D, error) {
 	check := func(draft D) []draftcheck.Finding {
-		body, reasoning := textOf(draft)
-		// Whether this draft answers a real inbound message decides more than the
-		// subject's reply prefix: a reply is written from the counterparty's own
-		// words, so it may echo a call THEY named, where a message opening a new
-		// conversation has no such ground to stand on.
-		subject, threaded := "", false
-		if subjectOf != nil {
-			subject, threaded = subjectOf(draft)
-		}
-		findings := append(draftcheck.Body(body, lang, band, threaded),
-			draftcheck.Reasoning(reasoning, lang, band)...)
-		if subjectOf != nil {
-			findings = append(findings, draftcheck.Subject(subject, lang, band, threaded)...)
-		}
-		return findings
+		return Findings(draft, lang, band, textOf, subjectOf)
 	}
 
 	draft, err := write(ctx, "")

--- a/backend/internal/compose/persondraft/voicefloor.go
+++ b/backend/internal/compose/persondraft/voicefloor.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/margince/margince/backend/internal/compose/draftcheck"
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/ai"
 )
@@ -71,15 +72,48 @@ func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftv
 // somebody we have never written to — and score as an improvement while being
 // a regression a reader would notice first.
 //
-// Phrasing must not get WORSE rather than having to be perfect: the draft that
-// reaches here is usually clean, but the loop serves its better attempt rather
-// than a spotless one, and demanding zero would discard a genuine voice fix
-// over a finding the first draft carried too.
+// The phrasing test is a SUBSET, not a count. Findings are not
+// interchangeable: a false "Re:" claims a message nobody sent us, where a
+// wellbeing opener is filler, and counting them equal would let a retry trade
+// the second for the first and be served. So the retry may carry only findings
+// the draft it replaces already carried.
+//
+// It is a subset rather than emptiness because the loop serves its better
+// attempt rather than a spotless one. Demanding zero findings would discard a
+// genuine voice fix over a phrasing finding the incumbent carried too — and the
+// incumbent is what we would keep instead, findings and all.
 func improves(in Input, current, retried Draft, violations []ai.VoiceViolation) bool {
 	if len(draftvoice.Violations(retried.Subject, retried.Body)) >= len(violations) {
 		return false
 	}
-	return phrasingFindings(in, retried) <= phrasingFindings(in, current)
+	return noNewPhrasingFindings(phrasingFindings(in, current), phrasingFindings(in, retried))
+}
+
+// noNewPhrasingFindings reports whether every finding against the retry was
+// already a finding against the draft it would replace.
+//
+// A multiset: two of the same finding is worse than one, so the incumbent's
+// copies are consumed as they are matched. Rule and Phrase together identify
+// one — Why is the same sentence for every finding of a rule, so it adds
+// nothing to the comparison.
+func noNewPhrasingFindings(current, retried []draftcheck.Finding) bool {
+	remaining := make(map[draftcheck.Finding]int, len(current))
+	for _, finding := range current {
+		remaining[identity(finding)]++
+	}
+	for _, finding := range retried {
+		key := identity(finding)
+		if remaining[key] == 0 {
+			return false
+		}
+		remaining[key]--
+	}
+	return true
+}
+
+// identity is the part of a finding that says WHICH finding it is.
+func identity(finding draftcheck.Finding) draftcheck.Finding {
+	return draftcheck.Finding{Rule: finding.Rule, Phrase: finding.Phrase}
 }
 
 // servable reports whether a draft is still one the contract can carry. The

--- a/backend/internal/compose/persondraft/voicefloor.go
+++ b/backend/internal/compose/persondraft/voicefloor.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package persondraft
+
+// The deterministic anti-AI floor a VOICED draft passes through, after the
+// shared correct-and-retry loop has already cleared the phrasing rules.
+//
+// Its whole job is comparing one draft against another, which is why every
+// step here answers the same question: is what I am about to serve better than
+// what I already have? A step that cannot answer yes leaves the draft alone.
+
+import (
+	"context"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
+	"github.com/margince/margince/backend/internal/modules/ai"
+)
+
+// applyVoiceFloor is the deterministic anti-AI pass a voiced draft must clear:
+// detect on the raw text, one critic retry that fixes the SENTENCE, then the
+// sanitizer for what is left to remove mechanically.
+//
+// It runs only for a voiced draft. An unvoiced one is already governed by the
+// shared rules and by draftcheck, and running a second retry over every draft
+// would double the model spend of the common case to fix the rare one.
+//
+// Every step can only improve the draft, never replace it with a worse one.
+// The retry is kept only if it clears more voice violations AND adds no
+// phrasing finding — see improves. The sanitizer's edits are kept only if what
+// survives them is still a draft: it deletes characters, so a subject that was
+// nothing but an em dash comes back empty, and an empty subject is not a
+// message the contract allows.
+//
+// A draft that still trips the floor after all of that is served anyway. The
+// alternative is the deterministic floor — a two-line opener — and a rep who
+// asked for a draft is better served by an imperfect real message than by a
+// stub, which is the same trade Write makes when the model is down.
+func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, draft Draft) (Draft, error) {
+	if !voice.OK {
+		return draft, nil
+	}
+	// Detect on the RAW draft: a violation the sanitizer could mechanically
+	// remove still earns the retry, because the retry rewrites the sentence
+	// where the sanitizer only deletes the punctuation.
+	violations := draftvoice.Violations(draft.Subject, draft.Body)
+	if len(violations) > 0 {
+		retried, retryErr := writeWithModel(ctx, lane, in, voice, draftvoice.Feedback(violations))
+		if retryErr == nil && improves(in, draft, retried, violations) {
+			draft = retried
+		}
+	}
+	sanitized := draft
+	sanitized.Subject, sanitized.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
+	if !servable(sanitized) {
+		return draft, nil
+	}
+	return sanitized, nil
+}
+
+// improves reports whether the retried draft is better than the one it would
+// replace, on BOTH measures.
+//
+// Two measures, because the retry is answering only one of them. It arrives
+// through this package's correct-and-retry loop, so the draft it replaces has
+// already cleared the phrasing rules; the retry prompt names the voice
+// violations and says nothing about the phrasing findings the first pass fixed.
+// A retry judged on voice alone can therefore drop an em dash and invent a
+// shared history in the same breath — "we help companies", on a message to
+// somebody we have never written to — and score as an improvement while being
+// a regression a reader would notice first.
+//
+// Phrasing must not get WORSE rather than having to be perfect: the draft that
+// reaches here is usually clean, but the loop serves its better attempt rather
+// than a spotless one, and demanding zero would discard a genuine voice fix
+// over a finding the first draft carried too.
+func improves(in Input, current, retried Draft, violations []ai.VoiceViolation) bool {
+	if len(draftvoice.Violations(retried.Subject, retried.Body)) >= len(violations) {
+		return false
+	}
+	return phrasingFindings(in, retried) <= phrasingFindings(in, current)
+}
+
+// servable reports whether a draft is still one the contract can carry. The
+// sanitizer removes characters, so a draft made only of what it removes comes
+// back empty — and an empty subject or body is not a message.
+func servable(draft Draft) bool {
+	return strings.TrimSpace(draft.Subject) != "" && strings.TrimSpace(draft.Body) != ""
+}

--- a/backend/internal/compose/persondraft/voicefloor_test.go
+++ b/backend/internal/compose/persondraft/voicefloor_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package persondraft
+
+// The anti-AI floor a voiced draft passes through, and the guarantee it owes:
+// every step may improve the draft and none may replace it with a worse one.
+//
+// The account composer carries the same floor and the same tests. Both, on
+// purpose: the two were written from one template, and a fix applied to one of
+// them is exactly the drift a pair of tests exists to catch.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
+	"github.com/margince/margince/backend/internal/shared/ports/model"
+)
+
+// sequencedLane answers each call with the next scripted response, so a test
+// can describe a first attempt and the retry that follows it.
+type sequencedLane struct {
+	answers []string
+	err     error
+	calls   int
+}
+
+func (l *sequencedLane) Complete(_ context.Context, _ model.Request) (model.Response, error) {
+	l.calls++
+	if l.err != nil {
+		return model.Response{}, l.err
+	}
+	if l.calls > len(l.answers) {
+		return model.Response{}, errors.New("the lane was called more times than the test scripted")
+	}
+	return model.Response{Text: l.answers[l.calls-1]}, nil
+}
+
+func floorInput() Input {
+	return Input{
+		Recipient: RecipientIn{
+			ID: "019fe7ae-0000-7000-8000-000000000001", Name: "Sarah Cole",
+			FirstName: "Sarah", Email: "sarah@glazedfrog.example",
+		},
+	}
+}
+
+func voiced() draftvoice.Context {
+	return draftvoice.Context{
+		Profile: ai.VoiceProfile{PersonalityMD: "I write short."},
+		Version: ai.VoiceProfileVersion{ProfileVersion: 1, VoiceProfileMD: "Sentences stay under twelve words."},
+		OK:      true,
+	}
+}
+
+// A retry that clears a voice violation may not smuggle in a phrasing one.
+//
+// The floor runs AFTER draftcore.CorrectOnce, so the draft it receives has
+// already cleared the phrasing rules. The retry it may substitute has not: it
+// is a fresh answer, written to a prompt that names the voice violations and
+// says nothing about the phrasing findings the first pass fixed. Counting only
+// voice violations lets a retry that drops an em dash and invents a shared
+// history — "we help companies", to somebody we have never written to —
+// replace a draft that was clean by both measures.
+func TestARetryThatTradesAVoiceViolationForAPhrasingOneIsDiscarded(t *testing.T) {
+	const first = `{"subject":"Rollout","body":"Hi Sarah,\n\nThe rollout — Phase 2 — is ready. Shall we pick this up?"}`
+	const retry = `{"subject":"Rollout","body":"Hi Sarah,\n\nWe help companies like yours. Shall we pick this up?"}`
+	lane := &sequencedLane{answers: []string{first, retry}}
+
+	// A FIRST-TOUCH envelope, which is what makes "we help companies" a
+	// finding: the invention rules only bind where there is no prior
+	// correspondence to have established anything.
+	in := floorInput()
+	in.Envelope = draftfloor.Envelope{ConversationState: string(convstate.BandNone)}
+
+	draft, _, err := Write(context.Background(), lane, in, voiced())
+	if err != nil {
+		t.Fatalf("the voiced draft failed: %v", err)
+	}
+	if strings.Contains(strings.ToLower(draft.Body), "we help companies") {
+		t.Errorf("the floor served a retry carrying a phrasing rule the first draft had cleared; "+
+			"body = %q", draft.Body)
+	}
+}
+
+// A retry that clears nothing is discarded, and the first attempt stands.
+func TestARetryThatClearsNothingIsDiscarded(t *testing.T) {
+	const first = `{"subject":"Rollout — Phase 2","body":"Hi Sarah,\n\nShall we pick this up?"}`
+	// The retry keeps the violation AND loses the recipient's name, so a test
+	// that could not tell the two apart would pass on either being served.
+	const retry = `{"subject":"Rollout — Phase 2","body":"Hi there,\n\nAnything to add?"}`
+	lane := &sequencedLane{answers: []string{first, retry}}
+
+	draft, _, err := Write(context.Background(), lane, floorInput(), voiced())
+	if err != nil {
+		t.Fatalf("the voiced draft failed: %v", err)
+	}
+	if lane.calls != 2 {
+		t.Fatalf("the floor made %d model calls; a violation earns exactly one retry", lane.calls)
+	}
+	if !strings.Contains(draft.Body, "Shall we pick this up?") {
+		t.Errorf("the composer kept a retry that cleared no violation; body = %q", draft.Body)
+	}
+}
+
+// A draft the sanitizer would empty is served unsanitized rather than blank.
+//
+// The sanitizer deletes characters. A subject made only of what it deletes
+// comes back as the empty string, and an empty subject is not a message the
+// contract can carry — so the pre-sanitizer draft, imperfect but real, is what
+// the rep gets.
+func TestASanitizerThatWouldEmptyTheDraftIsNotApplied(t *testing.T) {
+	// A subject that is NOTHING but a spaced em dash: it survives the parse,
+	// which only refuses an empty string, and the sanitizer removes the whole
+	// of it. A subject that merely CONTAINS one is not this case — the
+	// sanitizer rewrites it to a comma and the draft is never empty.
+	const answer = `{"subject":" — ","body":"Hi Sarah,\n\nShall we pick this up?"}`
+	lane := &sequencedLane{answers: []string{answer, answer}}
+
+	draft, _, err := Write(context.Background(), lane, floorInput(), voiced())
+	if err != nil {
+		t.Fatalf("the voiced draft failed: %v", err)
+	}
+	if strings.TrimSpace(draft.Subject) == "" {
+		t.Error("the composer served a draft with an empty subject, which is not a message a rep can send")
+	}
+	if strings.TrimSpace(draft.Body) == "" {
+		t.Error("the composer served a draft with an empty body")
+	}
+}
+
+// An unvoiced draft costs no second model call.
+func TestAnUnvoicedDraftRunsNoVoiceRetry(t *testing.T) {
+	const answer = `{"subject":"Rollout — Phase 2","body":"Hi Sarah,\n\nShall we pick this up?"}`
+	lane := &sequencedLane{answers: []string{answer}}
+
+	if _, _, err := Write(context.Background(), lane, floorInput(), draftvoice.Context{}); err != nil {
+		t.Fatalf("the unvoiced draft failed: %v", err)
+	}
+	if lane.calls != 1 {
+		t.Errorf("an unvoiced draft made %d model calls; it must make exactly one", lane.calls)
+	}
+}

--- a/backend/internal/compose/persondraft/voicefloor_test.go
+++ b/backend/internal/compose/persondraft/voicefloor_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
@@ -145,5 +146,65 @@ func TestAnUnvoicedDraftRunsNoVoiceRetry(t *testing.T) {
 	}
 	if lane.calls != 1 {
 		t.Errorf("an unvoiced draft made %d model calls; it must make exactly one", lane.calls)
+	}
+}
+
+// A retry that fixes the voice and adds no phrasing finding IS served.
+//
+// The acceptance case, and the one that keeps the three rejection tests
+// honest: without it, an improves() hardwired to false would leave every other
+// test in this file green while the floor's retry became dead code.
+func TestARetryThatFixesTheVoiceIsServed(t *testing.T) {
+	// One voice violation, no phrasing finding.
+	const first = `{"subject":"Rollout","body":"Hi Sarah,\n\nThe rollout — Phase 2 — is ready. Shall we pick this up?"}`
+	// The dash is gone and nothing else is wrong.
+	const retry = `{"subject":"Rollout","body":"Hi Sarah,\n\nPhase 2 of the rollout is ready. Shall we pick this up?"}`
+	lane := &sequencedLane{answers: []string{first, retry}}
+
+	draft, by, err := Write(context.Background(), lane, floorInput(), voiced())
+	if err != nil {
+		t.Fatalf("the voiced draft failed: %v", err)
+	}
+	if lane.calls != 2 {
+		t.Fatalf("the floor made %d model calls; a violation earns exactly one retry", lane.calls)
+	}
+	if by != crmcontracts.Model {
+		t.Errorf("generated_by = %v, want the model: the floor degraded a served draft", by)
+	}
+	if !strings.Contains(draft.Body, "Phase 2 of the rollout is ready") {
+		t.Errorf("the floor discarded a retry that fixed the voice and broke nothing; body = %q", draft.Body)
+	}
+}
+
+// A retry may not trade one phrasing finding for a DIFFERENT one of equal count.
+//
+// Findings are not interchangeable. A false "Re:" claims a message nobody sent
+// us; a wellbeing opener is filler. Counting them equal would let the retry
+// swap the second for the first and be served.
+func TestARetryThatSwapsOnePhrasingFindingForAnotherIsDiscarded(t *testing.T) {
+	// Three answers, because two retries run in sequence and only the second
+	// is this floor's.
+	//
+	// The first draft carries a wellbeing opener, so draftcore.CorrectOnce
+	// spends its own retry on it. That retry (the second answer) clears the
+	// opener but keeps an em dash, which is a voice violation and no phrasing
+	// finding — so the loop serves it and THIS floor gets it. The floor's own
+	// retry is the third answer: it clears the dash, and claims a thread
+	// nobody started in exchange.
+	//
+	// Both drafts the floor compares therefore carry exactly ONE phrasing
+	// finding, and they are different rules. A floor comparing counts would
+	// serve the "Re:"; one comparing which findings fired keeps the incumbent.
+	const first = `{"subject":"Rollout","body":"Hi Sarah,\n\nI hope this finds you well. Phase 2 is ready."}`
+	const loopRetry = `{"subject":"Rollout","body":"Hi Sarah,\n\nI hope this finds you well. The rollout — Phase 2 — is ready."}`
+	const floorRetry = `{"subject":"Re: Rollout","body":"Hi Sarah,\n\nPhase 2 of the rollout is ready."}`
+	lane := &sequencedLane{answers: []string{first, loopRetry, floorRetry}}
+
+	draft, _, err := Write(context.Background(), lane, floorInput(), voiced())
+	if err != nil {
+		t.Fatalf("the voiced draft failed: %v", err)
+	}
+	if strings.HasPrefix(draft.Subject, "Re:") {
+		t.Errorf("the floor served a retry claiming a thread nobody started; subject = %q", draft.Subject)
 	}
 }

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -137,8 +137,7 @@ func writeChecked(ctx context.Context, lane Completer, in Input, voice draftvoic
 		func(ctx context.Context, correction string) (Draft, error) {
 			return writeWithModel(ctx, lane, in, voice, correction)
 		},
-		func(d Draft) (string, []string) { return d.Body, reasonLabels(d.Reasoning) },
-		func(d Draft) (string, bool) { return d.Subject, in.Threaded() },
+		draftText, draftSubject(in),
 		// No observer: this package holds no logger, and a retry that does not
 		// help still returns a real draft. The reply surface, which has one,
 		// reports it.
@@ -150,53 +149,21 @@ func writeChecked(ctx context.Context, lane Completer, in Input, voice draftvoic
 	return applyVoiceFloor(ctx, lane, in, voice, draft)
 }
 
-// applyVoiceFloor is the deterministic anti-AI pass a voiced draft must clear:
-// detect on the raw text, one critic retry that fixes the SENTENCE, then the
-// sanitizer for what is left to remove mechanically.
-//
-// It runs only for a voiced draft. An unvoiced one is already governed by the
-// shared rules and by draftcheck, and running a second retry over every draft
-// would double the model spend of the common case to fix the rare one.
-//
-// Every step can only improve the draft, never replace it with a worse one.
-// The retry is kept only if it clears MORE violations than the attempt it
-// replaces — a retry is one more model answer, not a better one by definition,
-// and it is written without the draftcheck findings the first pass already
-// cleared. The sanitizer's edits are kept only if what survives them is still a
-// draft: it deletes characters, so a subject that was nothing but an em dash
-// comes back empty, and an empty subject is not a message the contract allows.
-//
-// A draft that still trips the floor after all of that is served anyway. The
-// alternative is the deterministic floor — a two-line opener — and a rep who
-// asked for a draft is better served by an imperfect real message than by a
-// stub, which is the same trade Write makes when the model is down.
-func applyVoiceFloor(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, draft Draft) (Draft, error) {
-	if !voice.OK {
-		return draft, nil
-	}
-	// Detect on the RAW draft: a violation the sanitizer could mechanically
-	// remove still earns the retry, because the retry rewrites the sentence
-	// where the sanitizer only deletes the punctuation.
-	violations := draftvoice.Violations(draft.Subject, draft.Body)
-	if len(violations) > 0 {
-		retried, retryErr := writeWithModel(ctx, lane, in, voice, draftvoice.Feedback(violations))
-		if retryErr == nil && len(draftvoice.Violations(retried.Subject, retried.Body)) < len(violations) {
-			draft = retried
-		}
-	}
-	sanitized := draft
-	sanitized.Subject, sanitized.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
-	if !servable(sanitized) {
-		return draft, nil
-	}
-	return sanitized, nil
+// draftText and draftSubject say which parts of a draft the phrasing rules
+// read. Both passes that check a draft take them from here rather than each
+// spelling the accessors inline: the voice floor's whole job is comparing one
+// draft against another, and a comparison whose two sides read different fields
+// measures nothing.
+func draftText(d Draft) (string, []string) { return d.Body, reasonLabels(d.Reasoning) }
+
+func draftSubject(in Input) func(Draft) (string, bool) {
+	return func(d Draft) (string, bool) { return d.Subject, in.Threaded() }
 }
 
-// servable reports whether a draft is still one the contract can carry. The
-// sanitizer removes characters, so a draft made only of what it removes comes
-// back empty — and an empty subject or body is not a message.
-func servable(draft Draft) bool {
-	return strings.TrimSpace(draft.Subject) != "" && strings.TrimSpace(draft.Body) != ""
+// phrasingFindings is what the shared phrasing rules say is wrong with a draft.
+func phrasingFindings(in Input, draft Draft) int {
+	return len(draftcore.Findings(draft, in.Envelope.Lang(), in.Envelope.Band(),
+		draftText, draftSubject(in)))
 }
 
 func writeWithModel(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, correction string) (Draft, error) {

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/margince/margince/backend/internal/compose/draftcheck"
 	"github.com/margince/margince/backend/internal/compose/draftcore"
 	"github.com/margince/margince/backend/internal/compose/draftrules"
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
@@ -161,9 +162,9 @@ func draftSubject(in Input) func(Draft) (string, bool) {
 }
 
 // phrasingFindings is what the shared phrasing rules say is wrong with a draft.
-func phrasingFindings(in Input, draft Draft) int {
-	return len(draftcore.Findings(draft, in.Envelope.Lang(), in.Envelope.Band(),
-		draftText, draftSubject(in)))
+func phrasingFindings(in Input, draft Draft) []draftcheck.Finding {
+	return draftcore.Findings(draft, in.Envelope.Lang(), in.Envelope.Band(),
+		draftText, draftSubject(in))
 }
 
 func writeWithModel(ctx context.Context, lane Completer, in Input, voice draftvoice.Context, correction string) (Draft, error) {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15716,7 +15716,7 @@ type CaptureTraceEntryOutcome string
 
 // CaptureTraceResolution What later became of a DEFERRED message's sender, read from the disposition ledger rather than copied into the trace: the ledger is keyed by sender and the trace by message, and one sender's answer covers several messages.
 type CaptureTraceResolution struct {
-	// Kind Who wrote, when the verdict said: person | role_mailbox | organization_sender | newsletter | transactional | spam.
+	// Kind Who wrote, when the verdict said: person | role_mailbox | organization_sender | newsletter | transactional | spam | personal | advisor. The last two belong to the mailbox owner rather than to the business: personal is a private correspondent, advisor a professional they engage personally.
 	Kind       *string                      `json:"kind,omitempty"`
 	ResolvedAt *time.Time                   `json:"resolved_at,omitempty"`
 	Status     CaptureTraceResolutionStatus `json:"status"`

--- a/backend/internal/modules/ai/routing_test.go
+++ b/backend/internal/modules/ai/routing_test.go
@@ -206,7 +206,7 @@ func TestUnboundLadderWarnings(t *testing.T) {
 			},
 			want: []string{
 				"task capture_classify: no bound tier on ladder [local_small cheap_cloud]; calls will be refused",
-				"task capture_counterparty_verdict: no bound tier on ladder [local_small cheap_cloud]; calls will be refused",
+				"task capture_counterparty_verdict: no bound tier on ladder [local_small]; calls will be refused",
 				"task enrich: no bound tier on ladder [local_small cheap_cloud]; calls will be refused",
 			},
 		},
@@ -217,7 +217,7 @@ func TestUnboundLadderWarnings(t *testing.T) {
 				"task agent_loop: no bound tier on ladder [cheap_cloud premium]; calls will be refused",
 				"task brief_ranking: no bound tier on ladder [premium cheap_cloud]; calls will be refused",
 				"task capture_classify: no bound tier on ladder [local_small cheap_cloud]; calls will be refused",
-				"task capture_counterparty_verdict: no bound tier on ladder [local_small cheap_cloud]; calls will be refused",
+				"task capture_counterparty_verdict: no bound tier on ladder [local_small]; calls will be refused",
 				"task cert_judge: no bound tier on ladder [premium cheap_cloud]; calls will be refused",
 				"task cold_start: no bound tier on ladder [cheap_cloud premium]; calls will be refused",
 				"task corpus_ask: no bound tier on ladder [premium]; calls will be refused",

--- a/backend/internal/modules/ai/tasks_gen.go
+++ b/backend/internal/modules/ai/tasks_gen.go
@@ -12,7 +12,7 @@ const (
 	// TaskBriefRanking is the one Premium-frontier default (§1.2 RATIFY): genuinely multi-hop reasoning
 	TaskBriefRanking    Task = "brief_ranking"
 	TaskCaptureClassify Task = "capture_classify"
-	// TaskCaptureCounterpartyVerdict is ADR-0072/A118: the ambiguous first-time-sender creation gate — real|noise|unsure per address, floor 0.7 (below → unsure, never noise). Release-blocking false-noise eval threshold. The no-payload posture is the `no_payload` field above (ADR-0074); it was formerly asserted in this prose and matched by substring.
+	// TaskCaptureCounterpartyVerdict is ADR-0072/A118: the ambiguous first-time-sender creation gate — real|noise|unsure per address, floor 0.7 (below → unsure, never noise). Release-blocking false-noise eval threshold. The no-payload posture is the `no_payload` field above (ADR-0074); it was formerly asserted in this prose and matched by substring. Local-only ladder: the prompt carries subject and body, and this is the task that decides whether a sender is personal — a cloud rung would send a founder's family mail off the machine to ask whether it was family mail.
 	TaskCaptureCounterpartyVerdict Task = "capture_counterparty_verdict"
 	// TaskCertJudge is the aicert quality judge — pinned to its own router in the cert lane, never the candidate's binding
 	TaskCertJudge Task = "cert_judge"
@@ -79,7 +79,7 @@ const (
 // TaskContractHash is the sha256 of api/ai-tasks.yaml at generation
 // time: a build fingerprint the cert runner can compare against a
 // freshly hashed contract file to catch a stale generated table.
-const TaskContractHash = "17ca4cd56ba6d2d2ee1696ab8341d9f1915a03cc7f25c818f2eeebb8292ffbd1"
+const TaskContractHash = "9936380b886c3b946b6664a83a5ca2dd26ae5dce12fef3ba92cdd09a55eea54e"
 
 // AllTasks returns every contract task, sorted — the completeness
 // check a certification run walks to prove it covers every routed
@@ -119,7 +119,7 @@ var taskLadders = map[Task][]Tier{
 	TaskAgentLoop:                  {TierCheapCloud, TierPremium},
 	TaskBriefRanking:               {TierPremium, TierCheapCloud},
 	TaskCaptureClassify:            {TierLocalSmall, TierCheapCloud},
-	TaskCaptureCounterpartyVerdict: {TierLocalSmall, TierCheapCloud},
+	TaskCaptureCounterpartyVerdict: {TierLocalSmall},
 	TaskCertJudge:                  {TierPremium, TierCheapCloud},
 	TaskColdStart:                  {TierCheapCloud, TierPremium},
 	TaskCorpusAsk:                  {TierPremium},


### PR DESCRIPTION
The anti-AI floor runs after draftcore.CorrectOnce, so the draft it
receives has already cleared the phrasing rules. The retry it may
substitute has not: it is a fresh answer to a prompt that names the voice
violations and says nothing about the phrasing findings the first pass
fixed.

Comparing only voice violations let a retry that drops an em dash and
invents a shared history in the same breath score as an improvement. On a
first-touch message the retry could add "we help companies" — a claim
draftcheck refuses precisely because nothing supports it when we have
never written to this person — and replace a draft that was clean by both
measures.

A retry is now kept only when it clears more voice violations AND adds no
phrasing finding. Phrasing must not get worse rather than having to be
perfect: the loop serves its better attempt rather than a spotless one,
and demanding zero would discard a genuine voice fix over a finding the
first draft carried too.

draftcore.Findings is the shared spelling of what is wrong with a draft,
extracted from CorrectOnce's own closure so the loop and the floor cannot
drift about what counts. Both composers take the accessors from one place
for the same reason: a comparison whose two sides read different fields
measures nothing.

voicefloor.go in both packages carries the floor, its guarantee and its
tests. accountdraft/write.go had crossed the 500-line cap; persondraft is
split the same way rather than only the file that failed, because the two
are written from one template and a split applied to one of them is the
drift the pair exists to prevent.

Both composers' floors are mutation-checked on both clauses: reverting to
the voice-only comparison fails the new test, and dropping the voice
clause fails the existing one.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

## Also in this branch

Two stale-generation fixes that make `make check-backend` pass at all. Both are pre-existing on main — `make drift` fails on plain `origin/main` with none of this branch's code:

- `make gen` output for the capture counterparty-verdict tier ladder and a capture-trace doc comment, left unregenerated by #3335.
- The routing warning test in `internal/modules/ai`, which still expected the ladder that change replaced.

## Verification

- `make check-backend` green (full gate).
- `make craft-static` — 0 blocker, 0 major, 0 minor. `make rls-store-path`, `make no-jurisdiction` — OK.
- Both composers' floors mutation-checked on both clauses: reverting to the voice-only comparison fails the new test; dropping the voice clause fails the existing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the voice retry so a retry that clears a voice violation cannot also introduce a phrasing one: previously the retry was judged only on voice violations and could replace a clean draft with one adding an unsupported claim like "we help companies" on a first-touch message.

**Bug Fixes**
- A retry is now kept only when it clears more voice violations and its phrasing findings are a subset of the incumbent's — findings are compared by identity, not count, so a retry cannot swap a wellbeing opener for a false "Re:" of equal count.
- `draftcore.Findings` is shared between the correct-and-retry loop and the voice floor so both measure the same draft the same way; both composers now carry the floor in a dedicated `voicefloor.go`.
- Sanitization is skipped when it would empty the subject or body, and unvoiced drafts skip the floor entirely.
- Also lands two stale-generation fixes that make `make drift` fail on plain `main`: the capture counterparty-verdict tier ladder and the capture-trace doc comment, plus the routing warning test still expecting the old ladder.

<sup>Written for commit fcea397723afd7fd1cd9b8b2acd8e60c84b8b24d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quality checks for voiced drafts.
  * Retries are kept only when they reduce voice issues without introducing new phrasing problems.
  * Prevented sanitization from serving empty subjects or bodies.
  * Unvoiced drafts and unsalvageable results remain unchanged.

* **Tests**
  * Added coverage for voice-retry selection and sanitization safeguards.
  * Updated routing expectations for shortened fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->