### PR TITLE
main is red: the generated tables and one ladder census are a version behind

### DIFF
--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15716,7 +15716,7 @@ type CaptureTraceEntryOutcome string
 
 // CaptureTraceResolution What later became of a DEFERRED message's sender, read from the disposition ledger rather than copied into the trace: the ledger is keyed by sender and the trace by message, and one sender's answer covers several messages.
 type CaptureTraceResolution struct {
-	// Kind Who wrote, when the verdict said: person | role_mailbox | organization_sender | newsletter | transactional | spam.
+	// Kind Who wrote, when the verdict said: person | role_mailbox | organization_sender | newsletter | transactional | spam | personal | advisor. The last two belong to the mailbox owner rather than to the business: personal is a private correspondent, advisor a professional they engage personally.
 	Kind       *string                      `json:"kind,omitempty"`
 	ResolvedAt *time.Time                   `json:"resolved_at,omitempty"`
 	Status     CaptureTraceResolutionStatus `json:"status"`

--- a/backend/internal/modules/ai/routing_test.go
+++ b/backend/internal/modules/ai/routing_test.go
@@ -206,7 +206,7 @@ func TestUnboundLadderWarnings(t *testing.T) {
 			},
 			want: []string{
 				"task capture_classify: no bound tier on ladder [local_small cheap_cloud]; calls will be refused",
-				"task capture_counterparty_verdict: no bound tier on ladder [local_small cheap_cloud]; calls will be refused",
+				"task capture_counterparty_verdict: no bound tier on ladder [local_small]; calls will be refused",
 				"task enrich: no bound tier on ladder [local_small cheap_cloud]; calls will be refused",
 			},
 		},
@@ -217,7 +217,7 @@ func TestUnboundLadderWarnings(t *testing.T) {
 				"task agent_loop: no bound tier on ladder [cheap_cloud premium]; calls will be refused",
 				"task brief_ranking: no bound tier on ladder [premium cheap_cloud]; calls will be refused",
 				"task capture_classify: no bound tier on ladder [local_small cheap_cloud]; calls will be refused",
-				"task capture_counterparty_verdict: no bound tier on ladder [local_small cheap_cloud]; calls will be refused",
+				"task capture_counterparty_verdict: no bound tier on ladder [local_small]; calls will be refused",
 				"task cert_judge: no bound tier on ladder [premium cheap_cloud]; calls will be refused",
 				"task cold_start: no bound tier on ladder [cheap_cloud premium]; calls will be refused",
 				"task corpus_ask: no bound tier on ladder [premium]; calls will be refused",

--- a/backend/internal/modules/ai/tasks_gen.go
+++ b/backend/internal/modules/ai/tasks_gen.go
@@ -12,7 +12,7 @@ const (
 	// TaskBriefRanking is the one Premium-frontier default (§1.2 RATIFY): genuinely multi-hop reasoning
 	TaskBriefRanking    Task = "brief_ranking"
 	TaskCaptureClassify Task = "capture_classify"
-	// TaskCaptureCounterpartyVerdict is ADR-0072/A118: the ambiguous first-time-sender creation gate — real|noise|unsure per address, floor 0.7 (below → unsure, never noise). Release-blocking false-noise eval threshold. The no-payload posture is the `no_payload` field above (ADR-0074); it was formerly asserted in this prose and matched by substring.
+	// TaskCaptureCounterpartyVerdict is ADR-0072/A118: the ambiguous first-time-sender creation gate — real|noise|unsure per address, floor 0.7 (below → unsure, never noise). Release-blocking false-noise eval threshold. The no-payload posture is the `no_payload` field above (ADR-0074); it was formerly asserted in this prose and matched by substring. Local-only ladder: the prompt carries subject and body, and this is the task that decides whether a sender is personal — a cloud rung would send a founder's family mail off the machine to ask whether it was family mail.
 	TaskCaptureCounterpartyVerdict Task = "capture_counterparty_verdict"
 	// TaskCertJudge is the aicert quality judge — pinned to its own router in the cert lane, never the candidate's binding
 	TaskCertJudge Task = "cert_judge"
@@ -79,7 +79,7 @@ const (
 // TaskContractHash is the sha256 of api/ai-tasks.yaml at generation
 // time: a build fingerprint the cert runner can compare against a
 // freshly hashed contract file to catch a stale generated table.
-const TaskContractHash = "17ca4cd56ba6d2d2ee1696ab8341d9f1915a03cc7f25c818f2eeebb8292ffbd1"
+const TaskContractHash = "9936380b886c3b946b6664a83a5ca2dd26ae5dce12fef3ba92cdd09a55eea54e"
 
 // AllTasks returns every contract task, sorted — the completeness
 // check a certification run walks to prove it covers every routed
@@ -119,7 +119,7 @@ var taskLadders = map[Task][]Tier{
 	TaskAgentLoop:                  {TierCheapCloud, TierPremium},
 	TaskBriefRanking:               {TierPremium, TierCheapCloud},
 	TaskCaptureClassify:            {TierLocalSmall, TierCheapCloud},
-	TaskCaptureCounterpartyVerdict: {TierLocalSmall, TierCheapCloud},
+	TaskCaptureCounterpartyVerdict: {TierLocalSmall},
 	TaskCertJudge:                  {TierPremium, TierCheapCloud},
 	TaskColdStart:                  {TierCheapCloud, TierPremium},
 	TaskCorpusAsk:                  {TierPremium},


### PR DESCRIPTION
`main` does not build its own generated artifacts.

## What is wrong

On a clean checkout of `main`, `make -C backend gen` produces a diff:

- `backend/internal/contracts/api_gen.go` — the capture-trace resolution `kind` doc is missing `personal` and `advisor`
- `backend/internal/modules/ai/tasks_gen.go` — `TaskCaptureCounterpartyVerdict`'s ladder and the contract hash

and `internal/modules/ai` then fails, because the routing census still expects that task to have a `cheap_cloud` rung after the ladder was narrowed to `[local_small]`.

Two changes landed against the same contracts without seeing each other: each was green on its own branch, and neither re-ran against the other's contract. That is the classic semantic conflict a per-branch CI cannot catch.

## The fix

Regenerated, and the census updated to the ladder the contract now declares. The narrowing itself is right and stands: deciding whether a sender is personal means reading a personal message, so the task that decides it has no business on a cloud rung — which is what the contract's own new comment says.

Nothing here is a judgement call; it is the tree catching up with two merges.

## Verification

- `make check-backend`, `make check-fe`, `make craft-static`
- `make -C backend test-integration` — 48 packages, 0 skips

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated AI routing test expectations to reflect the current counterparty warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->