### PR TITLE
First run no longer demands a Google OAuth app

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -9158,14 +9158,15 @@ paths:
       description: |
         The onboarding gate's one question, answered in one place. A fresh installation cannot
         read a company website until it can call a model, and cannot capture mail until it has a
-        Google app — so onboarding asks here rather than composing the answer out of several
+        Google app — so a client asks here rather than composing the answer out of several
         surfaces and drifting from whatever the server actually requires.
 
-        `blocking` is the SERVER's policy, not the screen's. A step that is unconfigured and
-        blocking is one the installation may not proceed past; a step may be unconfigured and
-        non-blocking, which is how a posture that does not need it (a deployment serving no mail,
-        say) is expressed without the client having to know that rule. `complete` is exactly
-        "no blocking step is unconfigured", so a client never recomputes it.
+        `blocking` is the SERVER's policy, not the screen's, and the two questions are not the
+        same one. A step that is unconfigured and blocking is one the installation may not
+        proceed past; a step may be unconfigured and non-blocking, which is how something an
+        installation can be used without (mail capture, on a deployment with no Google app) is
+        reported as still outstanding rather than as a gate. `complete` is exactly "no blocking
+        step is unconfigured", so a client never recomputes it.
 
         Human session only. An agent never reads or completes an installation's setup.
       responses:

--- a/backend/internal/compose/handlers_installation_setup.go
+++ b/backend/internal/compose/handlers_installation_setup.go
@@ -96,11 +96,12 @@ func (h installationSetupHandlers) GetInstallationSetup(w http.ResponseWriter, r
 	// the server owns, so the sequence is pinned by
 	// TestTheSetupReportListsTheStepsInTheOrderOnboardingWalksThem.
 	//
-	// ONLY THE MODEL BINDING BLOCKS. Without one the product cannot perform the
-	// cold-start read that first run is, so there is nothing to let a reader
-	// through to. A Google app buys mailbox capture and nothing else: an
-	// installation signing in with passwords and no external provider is fully
-	// usable without one.
+	// ONLY THE MODEL BINDING BLOCKS, pinned by
+	// TestOnlyTheModelBindingBlocksFirstRun. Without one the product cannot
+	// perform the cold-start read that first run is, so there is nothing to let
+	// a reader through to. A Google app buys mailbox capture and nothing else:
+	// an installation signing in with passwords and no external provider is
+	// fully usable without one.
 	//
 	// The app is configured from settings, where the card carries the redirect
 	// URIs Google's console asks for. The step stays in the report because that
@@ -167,8 +168,7 @@ func (h installationSetupHandlers) aiConfigured(ctx context.Context) (bool, erro
 // The environment's copy counts, in the same precedence the connect transport
 // applies — see envGoogleApp. A nil store is a role that composed no vault, and
 // then only the environment can answer: it reads as unconfigured rather than
-// erroring, because a reader on that installation genuinely cannot complete this
-// step and the gate has to say so rather than fail.
+// erroring, so the report can still name the step outstanding.
 func (h installationSetupHandlers) googleConfigured(ctx context.Context) (bool, error) {
 	if h.envGoogleApp {
 		return true, nil

--- a/backend/internal/compose/handlers_installation_setup.go
+++ b/backend/internal/compose/handlers_installation_setup.go
@@ -91,20 +91,27 @@ func (h installationSetupHandlers) GetInstallationSetup(w http.ResponseWriter, r
 	}
 
 	// ORDER IS THE CONTRACT. `steps` is declared as "every setup step, in the
-	// order a reader should complete them", and onboarding walks it in the order
-	// it arrives: AI models, then the Google app. That is not cosmetic — a
-	// person who has bound no model cannot be shown a cold start, and the Gmail
-	// step is the one they can skip past without the product being unusable. A
-	// client sorting these itself would be re-deciding a sequence the server
-	// already owns, so the sequence is pinned by
+	// order a reader should complete them", and a client walks it in the order
+	// it arrives. A client sorting these itself would be re-deciding a sequence
+	// the server owns, so the sequence is pinned by
 	// TestTheSetupReportListsTheStepsInTheOrderOnboardingWalksThem.
 	//
-	// Both blocking, which is this installation's policy and the reason the
-	// field exists rather than being implied: a client that assumed "every step
-	// blocks" would have to be changed the day one of them stops.
+	// ONLY THE MODEL BINDING BLOCKS. Without one the product cannot perform the
+	// cold-start read that first run is, so there is nothing to let a reader
+	// through to. A Google app buys mailbox capture and nothing else: an
+	// installation signing in with passwords and no external provider is fully
+	// usable without one, so demanding it at the gate locked an operator with no
+	// Google app out of every route — the company profile is written from behind
+	// this gate, and its absence is what redirects them back to it.
+	//
+	// The app is configured from settings, where the card carries the redirect
+	// URIs Google's console asks for. The step stays in the report because that
+	// is what `blocking` is for: reporting it and calling it optional is the
+	// answer, and dropping it would make the two postures indistinguishable to a
+	// reader asking what is left to do.
 	steps := []crmcontracts.InstallationSetupStep{
 		{Step: crmcontracts.InstallationSetupStepStepAiModels, Configured: aiReady, Blocking: true},
-		{Step: crmcontracts.InstallationSetupStepStepGoogleApp, Configured: googleReady, Blocking: true},
+		{Step: crmcontracts.InstallationSetupStepStepGoogleApp, Configured: googleReady, Blocking: false},
 	}
 	complete := true
 	for _, s := range steps {

--- a/backend/internal/compose/handlers_installation_setup.go
+++ b/backend/internal/compose/handlers_installation_setup.go
@@ -100,9 +100,7 @@ func (h installationSetupHandlers) GetInstallationSetup(w http.ResponseWriter, r
 	// cold-start read that first run is, so there is nothing to let a reader
 	// through to. A Google app buys mailbox capture and nothing else: an
 	// installation signing in with passwords and no external provider is fully
-	// usable without one, so demanding it at the gate locked an operator with no
-	// Google app out of every route — the company profile is written from behind
-	// this gate, and its absence is what redirects them back to it.
+	// usable without one.
 	//
 	// The app is configured from settings, where the card carries the redirect
 	// URIs Google's console asks for. The step stays in the report because that

--- a/backend/internal/compose/handlers_installation_setup.go
+++ b/backend/internal/compose/handlers_installation_setup.go
@@ -44,9 +44,9 @@ type installationSetupHandlers struct {
 	//
 	// It is part of the answer because it is part of what the connect transport
 	// resolves: the stored app wins, and the environment is the fallback. An
-	// installation that has always exported the pair has a working Gmail
-	// integration, and reporting its setup step unconfigured would block it at a
-	// gate over a credential it already has.
+	// installation that exports the pair has a working Gmail integration, so
+	// reporting its step unconfigured would tell an operator to go and store an
+	// app the process already resolves.
 	//
 	// The two are not two sources of truth for STORAGE — the setting is the only
 	// place a write lands. They are one honest reading of a two-source
@@ -106,8 +106,9 @@ func (h installationSetupHandlers) GetInstallationSetup(w http.ResponseWriter, r
 	// The app is configured from settings, where the card carries the redirect
 	// URIs Google's console asks for. The step stays in the report because that
 	// is what `blocking` is for: reporting it and calling it optional is the
-	// answer, and dropping it would make the two postures indistinguishable to a
-	// reader asking what is left to do.
+	// answer. Dropping it would leave an installation that has no app and one
+	// that has a working Gmail integration reporting the same thing to a reader
+	// asking what is left to do.
 	steps := []crmcontracts.InstallationSetupStep{
 		{Step: crmcontracts.InstallationSetupStepStepAiModels, Configured: aiReady, Blocking: true},
 		{Step: crmcontracts.InstallationSetupStepStepGoogleApp, Configured: googleReady, Blocking: false},

--- a/backend/internal/compose/integration/googleapp_http_integration_test.go
+++ b/backend/internal/compose/integration/googleapp_http_integration_test.go
@@ -326,10 +326,13 @@ func TestAStoredGoogleAppOutranksTheEnvironmentForBothProviders(t *testing.T) {
 	}
 }
 
-// bindCloudRouting binds a CLOUD vendor on every tier. Cloud is the point: it
-// is the case that needs a credential, and a local-only binding would report the
-// AI step configured with no key at all — which is correct, and would prove
-// nothing about the rule the callers are here for.
+// bindCloudRouting binds a cloud vendor on every tier this rule needs — one
+// bound cloud tier is enough for CloudProvidersBound to name it, and the
+// routing surface carries more than these three.
+//
+// Cloud is the point: it is the case that needs a credential, and a local-only
+// binding would report the AI step configured with no key at all — which is
+// correct, and would prove nothing about the rule the callers are here for.
 func bindCloudRouting(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	binding := crmcontracts.AiTierBinding{Provider: "gemini", Model: "gemini-3.1-flash-lite"}
@@ -368,11 +371,13 @@ func storeCloudProviderKey(t *testing.T, e *apptest.AppEnv) {
 // pins is the policy: unconfigured and non-blocking, and an installation that
 // has bound a model is complete without ever touching Google.
 //
-// It reads every step rather than only the Google one on purpose. The frontend
-// draws nothing for a blocking step it has no panel for, and `ai_models` is the
-// only panel it has — so "ai_models is the sole blocker" is the invariant that
-// keeps the far side of the wire honest, and a test naming just `google_app`
-// would not fail the day a third step arrived blocking.
+// It reads every step rather than only the Google one on purpose: a test naming
+// just `google_app` would not fail the day a third step arrived blocking.
+//
+// Both halves are asserted. A loop that only rejects blockers OTHER than
+// ai_models proves nothing about ai_models itself, and reading that back out of
+// `complete` would be reasoning from the server's own arithmetic — which is
+// exactly what readSetup exists to avoid.
 func TestOnlyTheModelBindingBlocksFirstRun(t *testing.T) {
 	e := setupGoogleAppHTTP(t)
 
@@ -382,18 +387,26 @@ func TestOnlyTheModelBindingBlocksFirstRun(t *testing.T) {
 			t.Errorf("step %q blocks first run; only ai_models may, because it is the only one onboarding can ask for", step.Step)
 		}
 	}
+	if step := setupStep(t, e, crmcontracts.InstallationSetupStepStepAiModels); !step.Blocking {
+		t.Error("ai_models does not block first run, so nothing gates the cold-start read the product cannot run without")
+	}
 	if fresh.Complete {
 		t.Fatal("a fresh installation reports setup complete with no model bound")
 	}
 	bindCloudRouting(t, e)
 	storeCloudProviderKey(t, e)
 
+	// ONE report answers both halves. Completeness and the Google step read from
+	// two separate GETs would let the sentence below describe a pairing neither
+	// response ever carried.
 	setup := readSetup(t, e)
 	if !setup.Complete {
 		t.Errorf("setup reads incomplete with a model bound and keyed: %+v", setup.Steps)
 	}
-	if step := setupStep(t, e, crmcontracts.InstallationSetupStepStepGoogleApp); step.Configured {
-		t.Fatal("the Google app reads configured though none was ever stored, so completeness above proves nothing about skipping it")
+	for _, step := range setup.Steps {
+		if step.Step == crmcontracts.InstallationSetupStepStepGoogleApp && step.Configured {
+			t.Fatal("the Google app reads configured though none was ever stored, so completeness in this same report proves nothing about skipping it")
+		}
 	}
 }
 

--- a/backend/internal/compose/integration/googleapp_http_integration_test.go
+++ b/backend/internal/compose/integration/googleapp_http_integration_test.go
@@ -364,11 +364,8 @@ func storeCloudProviderKey(t *testing.T, e *apptest.AppEnv) {
 // ONLY the model binding blocks first run.
 //
 // An installation deployed without a Google app is fully usable — password
-// sign-in, no external provider — and a blocking Google step locked such an
-// operator out of the entire product: onboarding refuses to show the company
-// form while a blocking step is outstanding, the company profile is written from
-// that form, and its absence is what redirects every route back to onboarding.
-// The only escape was to write the anchor organization over the API.
+// sign-in, no external provider — so a Google app has no place gating the
+// company form onboarding writes from.
 //
 // The step is still REPORTED, so a surface can say it is outstanding, and it is
 // still second, so nothing here weakens the order above. What this pins is the

--- a/backend/internal/compose/integration/googleapp_http_integration_test.go
+++ b/backend/internal/compose/integration/googleapp_http_integration_test.go
@@ -196,12 +196,7 @@ func setupStep(t *testing.T, e *apptest.AppEnv, which crmcontracts.InstallationS
 func TestInstallationSetupOverHTTPTracksTheGoogleApp(t *testing.T) {
 	e := setupGoogleAppHTTP(t)
 
-	googleStep := func(t *testing.T) crmcontracts.InstallationSetupStep {
-		t.Helper()
-		return setupStep(t, e, crmcontracts.InstallationSetupStepStepGoogleApp)
-	}
-
-	if step := googleStep(t); step.Configured {
+	if step := setupStep(t, e, crmcontracts.InstallationSetupStepStepGoogleApp); step.Configured {
 		t.Fatal("a fresh installation reports the Google app as configured")
 	}
 	secret := httpSecret
@@ -209,13 +204,13 @@ func TestInstallationSetupOverHTTPTracksTheGoogleApp(t *testing.T) {
 		crmcontracts.GoogleAppInput{ClientId: httpClientID, ClientSecret: &secret}, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("PUT google-app → %d, want 204", status)
 	}
-	if step := googleStep(t); !step.Configured {
+	if step := setupStep(t, e, crmcontracts.InstallationSetupStepStepGoogleApp); !step.Configured {
 		t.Fatal("the setup report still calls the Google app unconfigured after it was stored")
 	}
 	if status := e.Call(t, "DELETE", "/v1/installation/google-app", nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("DELETE google-app → %d, want 204", status)
 	}
-	if step := googleStep(t); step.Configured {
+	if step := setupStep(t, e, crmcontracts.InstallationSetupStepStepGoogleApp); step.Configured {
 		t.Fatal("the setup report still calls the Google app configured after it was removed")
 	}
 }
@@ -367,10 +362,11 @@ func storeCloudProviderKey(t *testing.T, e *apptest.AppEnv) {
 // sign-in, no external provider — so a Google app has no place gating the
 // company form onboarding writes from.
 //
-// The step is still REPORTED, so a surface can say it is outstanding, and it is
-// still second, so nothing here weakens the order above. What this pins is the
-// policy: unconfigured and non-blocking, and an installation that has bound a
-// model is complete without ever touching Google.
+// The step is still REPORTED, so a surface can say it is outstanding, and it
+// is still second, so nothing here weakens the order
+// TestTheSetupReportListsTheStepsInTheOrderOnboardingWalksThem pins. What this
+// pins is the policy: unconfigured and non-blocking, and an installation that
+// has bound a model is complete without ever touching Google.
 //
 // It reads every step rather than only the Google one on purpose. The frontend
 // draws nothing for a blocking step it has no panel for, and `ai_models` is the
@@ -380,13 +376,13 @@ func storeCloudProviderKey(t *testing.T, e *apptest.AppEnv) {
 func TestOnlyTheModelBindingBlocksFirstRun(t *testing.T) {
 	e := setupGoogleAppHTTP(t)
 
-	for _, step := range readSetup(t, e).Steps {
+	fresh := readSetup(t, e)
+	for _, step := range fresh.Steps {
 		if step.Blocking && step.Step != crmcontracts.InstallationSetupStepStepAiModels {
 			t.Errorf("step %q blocks first run; only ai_models may, because it is the only one onboarding can ask for", step.Step)
 		}
 	}
-
-	if setup := readSetup(t, e); setup.Complete {
+	if fresh.Complete {
 		t.Fatal("a fresh installation reports setup complete with no model bound")
 	}
 	bindCloudRouting(t, e)
@@ -410,26 +406,21 @@ func TestOnlyTheModelBindingBlocksFirstRun(t *testing.T) {
 func TestInstallationSetupNeedsBothABindingAndItsKey(t *testing.T) {
 	e := setupGoogleAppHTTP(t)
 
-	aiStep := func(t *testing.T) crmcontracts.InstallationSetupStep {
-		t.Helper()
-		return setupStep(t, e, crmcontracts.InstallationSetupStepStepAiModels)
-	}
-
-	if step := aiStep(t); step.Configured {
+	if step := setupStep(t, e, crmcontracts.InstallationSetupStepStepAiModels); step.Configured {
 		t.Fatal("a fresh installation reports the AI step as configured with nothing bound")
 	}
 
 	bindCloudRouting(t, e)
 
 	// Bound, and still NOT configured: the vendor has no key.
-	if step := aiStep(t); step.Configured {
+	if step := setupStep(t, e, crmcontracts.InstallationSetupStepStepAiModels); step.Configured {
 		t.Error("the AI step reads configured with a cloud vendor bound and no key for it — onboarding would wave the admin through into a cold start that cannot make a call")
 	}
 
 	storeCloudProviderKey(t, e)
 
 	// Both halves present: now it is configured.
-	if step := aiStep(t); !step.Configured {
+	if step := setupStep(t, e, crmcontracts.InstallationSetupStepStepAiModels); !step.Configured {
 		t.Error("the AI step still reads unconfigured with a binding AND its key stored")
 	}
 }

--- a/backend/internal/compose/integration/googleapp_http_integration_test.go
+++ b/backend/internal/compose/integration/googleapp_http_integration_test.go
@@ -163,24 +163,42 @@ func TestGoogleAppOverHTTPLetsAReadSeatLookAndNotTouch(t *testing.T) {
 	}
 }
 
-// The setup report is what onboarding gates on, so it has to move when the
+// readSetup is the whole report, which is what `complete` has to be read from:
+// the field is the server's own verdict and a test recomputing it from the step
+// list would be asserting its own arithmetic rather than the installation's
+// policy.
+func readSetup(t *testing.T, e *apptest.AppEnv) crmcontracts.InstallationSetup {
+	t.Helper()
+	var setup crmcontracts.InstallationSetup
+	if status := e.Call(t, "GET", "/v1/installation/setup", nil, nil, &setup); status != http.StatusOK {
+		t.Fatalf("GET installation/setup → %d, want 200", status)
+	}
+	return setup
+}
+
+// setupStep is one named step out of the report. A step the report never names
+// is fatal rather than a zero value: every assertion below is about what the
+// step SAYS, and a silently absent one would read as "not configured, not
+// blocking" and pass.
+func setupStep(t *testing.T, e *apptest.AppEnv, which crmcontracts.InstallationSetupStepStep) crmcontracts.InstallationSetupStep {
+	t.Helper()
+	for _, s := range readSetup(t, e).Steps {
+		if s.Step == which {
+			return s
+		}
+	}
+	t.Fatalf("the setup report names no %q step, so no surface can say whether it is outstanding", which)
+	return crmcontracts.InstallationSetupStep{}
+}
+
+// The setup report is what onboarding reads, so it has to move when the
 // installation does rather than reporting a constant.
 func TestInstallationSetupOverHTTPTracksTheGoogleApp(t *testing.T) {
 	e := setupGoogleAppHTTP(t)
 
 	googleStep := func(t *testing.T) crmcontracts.InstallationSetupStep {
 		t.Helper()
-		var setup crmcontracts.InstallationSetup
-		if status := e.Call(t, "GET", "/v1/installation/setup", nil, nil, &setup); status != http.StatusOK {
-			t.Fatalf("GET installation/setup → %d, want 200", status)
-		}
-		for _, s := range setup.Steps {
-			if s.Step == crmcontracts.InstallationSetupStepStepGoogleApp {
-				return s
-			}
-		}
-		t.Fatal("the setup report names no google_app step, so onboarding has nothing to gate on")
-		return crmcontracts.InstallationSetupStep{}
+		return setupStep(t, e, crmcontracts.InstallationSetupStepStepGoogleApp)
 	}
 
 	if step := googleStep(t); step.Configured {
@@ -313,37 +331,12 @@ func TestAStoredGoogleAppOutranksTheEnvironmentForBothProviders(t *testing.T) {
 	}
 }
 
-// The AI step of the setup report, which is the other half of what onboarding
-// gates on — and the half with the rule worth pinning: a BINDING alone does not
-// make the step configured. Every cloud vendor the binding names needs a
-// credential too, because a bound installation with no key fails on its first
-// real call, and reporting it ready would send an admin through onboarding into
-// a cold start that cannot run.
-func TestInstallationSetupNeedsBothABindingAndItsKey(t *testing.T) {
-	e := setupGoogleAppHTTP(t)
-
-	aiStep := func(t *testing.T) crmcontracts.InstallationSetupStep {
-		t.Helper()
-		var setup crmcontracts.InstallationSetup
-		if status := e.Call(t, "GET", "/v1/installation/setup", nil, nil, &setup); status != http.StatusOK {
-			t.Fatalf("GET installation/setup → %d, want 200", status)
-		}
-		for _, s := range setup.Steps {
-			if s.Step == crmcontracts.InstallationSetupStepStepAiModels {
-				return s
-			}
-		}
-		t.Fatal("the setup report names no ai_models step, so onboarding has nothing to gate on")
-		return crmcontracts.InstallationSetupStep{}
-	}
-
-	if step := aiStep(t); step.Configured {
-		t.Fatal("a fresh installation reports the AI step as configured with nothing bound")
-	}
-
-	// Bind a CLOUD vendor on every tier. Cloud is the point: it is the case that
-	// needs a credential, and a local-only binding would pass this step with no
-	// key at all — which is correct, and would prove nothing here.
+// bindCloudRouting binds a CLOUD vendor on every tier. Cloud is the point: it
+// is the case that needs a credential, and a local-only binding would report the
+// AI step configured with no key at all — which is correct, and would prove
+// nothing about the rule the callers are here for.
+func bindCloudRouting(t *testing.T, e *apptest.AppEnv) {
+	t.Helper()
 	binding := crmcontracts.AiTierBinding{Provider: "gemini", Model: "gemini-3.1-flash-lite"}
 	routing := crmcontracts.AiRouting{
 		Profile: "eu_hosted",
@@ -355,17 +348,88 @@ func TestInstallationSetupNeedsBothABindingAndItsKey(t *testing.T) {
 	if status := e.Call(t, "PUT", "/v1/ai/routing", routing, nil, nil); status != http.StatusOK && status != http.StatusNoContent {
 		t.Fatalf("PUT ai/routing → %d, want 200 or 204", status)
 	}
+}
+
+// storeCloudProviderKey gives the vendor bindCloudRouting bound its credential —
+// the second half of what makes the AI step configured.
+func storeCloudProviderKey(t *testing.T, e *apptest.AppEnv) {
+	t.Helper()
+	key := "AIza-test-key"
+	if status := e.Call(t, "PUT", "/v1/ai/provider-keys/gemini",
+		crmcontracts.AiProviderKeyInput{ApiKey: &key}, nil, nil); status != http.StatusNoContent && status != http.StatusOK {
+		t.Fatalf("PUT provider key → %d, want 200 or 204", status)
+	}
+}
+
+// ONLY the model binding blocks first run.
+//
+// An installation deployed without a Google app is fully usable — password
+// sign-in, no external provider — and a blocking Google step locked such an
+// operator out of the entire product: onboarding refuses to show the company
+// form while a blocking step is outstanding, the company profile is written from
+// that form, and its absence is what redirects every route back to onboarding.
+// The only escape was to write the anchor organization over the API.
+//
+// The step is still REPORTED, so a surface can say it is outstanding, and it is
+// still second, so nothing here weakens the order above. What this pins is the
+// policy: unconfigured and non-blocking, and an installation that has bound a
+// model is complete without ever touching Google.
+//
+// It reads every step rather than only the Google one on purpose. The frontend
+// draws nothing for a blocking step it has no panel for, and `ai_models` is the
+// only panel it has — so "ai_models is the sole blocker" is the invariant that
+// keeps the far side of the wire honest, and a test naming just `google_app`
+// would not fail the day a third step arrived blocking.
+func TestOnlyTheModelBindingBlocksFirstRun(t *testing.T) {
+	e := setupGoogleAppHTTP(t)
+
+	for _, step := range readSetup(t, e).Steps {
+		if step.Blocking && step.Step != crmcontracts.InstallationSetupStepStepAiModels {
+			t.Errorf("step %q blocks first run; only ai_models may, because it is the only one onboarding can ask for", step.Step)
+		}
+	}
+
+	if setup := readSetup(t, e); setup.Complete {
+		t.Fatal("a fresh installation reports setup complete with no model bound")
+	}
+	bindCloudRouting(t, e)
+	storeCloudProviderKey(t, e)
+
+	setup := readSetup(t, e)
+	if !setup.Complete {
+		t.Errorf("setup reads incomplete with a model bound and keyed: %+v", setup.Steps)
+	}
+	if step := setupStep(t, e, crmcontracts.InstallationSetupStepStepGoogleApp); step.Configured {
+		t.Fatal("the Google app reads configured though none was ever stored, so completeness above proves nothing about skipping it")
+	}
+}
+
+// The AI step of the setup report, which is the other half of what onboarding
+// reads — and the half with the rule worth pinning: a BINDING alone does not
+// make the step configured. Every cloud vendor the binding names needs a
+// credential too, because a bound installation with no key fails on its first
+// real call, and reporting it ready would send an admin through onboarding into
+// a cold start that cannot run.
+func TestInstallationSetupNeedsBothABindingAndItsKey(t *testing.T) {
+	e := setupGoogleAppHTTP(t)
+
+	aiStep := func(t *testing.T) crmcontracts.InstallationSetupStep {
+		t.Helper()
+		return setupStep(t, e, crmcontracts.InstallationSetupStepStepAiModels)
+	}
+
+	if step := aiStep(t); step.Configured {
+		t.Fatal("a fresh installation reports the AI step as configured with nothing bound")
+	}
+
+	bindCloudRouting(t, e)
 
 	// Bound, and still NOT configured: the vendor has no key.
 	if step := aiStep(t); step.Configured {
 		t.Error("the AI step reads configured with a cloud vendor bound and no key for it — onboarding would wave the admin through into a cold start that cannot make a call")
 	}
 
-	key := "AIza-test-key"
-	if status := e.Call(t, "PUT", "/v1/ai/provider-keys/gemini",
-		crmcontracts.AiProviderKeyInput{ApiKey: &key}, nil, nil); status != http.StatusNoContent && status != http.StatusOK {
-		t.Fatalf("PUT provider key → %d, want 200 or 204", status)
-	}
+	storeCloudProviderKey(t, e)
 
 	// Both halves present: now it is configured.
 	if step := aiStep(t); !step.Configured {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -6185,14 +6185,15 @@ export interface paths {
          * What this installation still has to be configured with before it can be used.
          * @description The onboarding gate's one question, answered in one place. A fresh installation cannot
          *     read a company website until it can call a model, and cannot capture mail until it has a
-         *     Google app — so onboarding asks here rather than composing the answer out of several
+         *     Google app — so a client asks here rather than composing the answer out of several
          *     surfaces and drifting from whatever the server actually requires.
          *
-         *     `blocking` is the SERVER's policy, not the screen's. A step that is unconfigured and
-         *     blocking is one the installation may not proceed past; a step may be unconfigured and
-         *     non-blocking, which is how a posture that does not need it (a deployment serving no mail,
-         *     say) is expressed without the client having to know that rule. `complete` is exactly
-         *     "no blocking step is unconfigured", so a client never recomputes it.
+         *     `blocking` is the SERVER's policy, not the screen's, and the two questions are not the
+         *     same one. A step that is unconfigured and blocking is one the installation may not
+         *     proceed past; a step may be unconfigured and non-blocking, which is how something an
+         *     installation can be used without (mail capture, on a deployment with no Google app) is
+         *     reported as still outstanding rather than as a gate. `complete` is exactly "no blocking
+         *     step is unconfigured", so a client never recomputes it.
          *
          *     Human session only. An agent never reads or completes an installation's setup.
          */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6005,6 +6005,10 @@ export const de = {
   "googleApp.redirectTitle": "Autorisierte Weiterleitungs-URIs",
   "googleApp.fromEnvironment":
     "Aus der Konfiguration dieser Installation in Verwendung: {clientId}. Eine hier gespeicherte App ersetzt sie, solange eine gespeichert ist.",
+  "googleApp.clientId": "Client-ID",
+  "googleApp.clientSecret": "Client-Secret",
+  "googleApp.clientIdPlaceholder":
+    "000000000000-xxxx.apps.googleusercontent.com",
   "firstRun.continue": "Weiter",
   "firstRun.ai.title": "Modellanbieter wählen",
   "firstRun.ai.sub":
@@ -6017,13 +6021,6 @@ export const de = {
   "firstRun.ai.modelHint":
     "Ein Ausgangspunkt. Die angezeigten Preise gelten je Million Token, Eingabe → Ausgabe; jede Modell-ID, die Ihr Anbieter bedient, ist möglich.",
   "firstRun.ai.embedModel": "Embedding-Modell",
-  "firstRun.google.title": "Google-App verbinden",
-  "firstRun.google.sub":
-    "Postfächer werden über eine Google-OAuth-App verbunden, die Ihnen gehört. Mail wird also mit den Zugangsdaten Ihrer Organisation gelesen. Später unter Einstellungen änderbar.",
-  "firstRun.google.clientIdPlaceholder":
-    "000000000000-xxxx.apps.googleusercontent.com",
-  "firstRun.google.clientId": "Client-ID",
-  "firstRun.google.clientSecret": "Client-Secret",
   "aiProviderKeys.title": "Anbieter-Schlüssel",
   "aiProviderKeys.sub":
     "Die Zugangsdaten, mit denen diese Installation die Modellanbieter aufruft. Ein Schlüssel wird im Schlüsseltresor versiegelt und nie wieder angezeigt — ersetze ihn, wenn du ihn ändern willst.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6054,6 +6054,10 @@ export const en = {
   "googleApp.redirectTitle": "Authorized redirect URIs",
   "googleApp.fromEnvironment":
     "In use from this deployment’s configuration: {clientId}. Storing an app here replaces it for as long as one is stored.",
+  "googleApp.clientId": "Client ID",
+  "googleApp.clientSecret": "Client secret",
+  "googleApp.clientIdPlaceholder":
+    "000000000000-xxxx.apps.googleusercontent.com",
   "firstRun.continue": "Continue",
   "firstRun.ai.title": "Choose a model provider",
   "firstRun.ai.sub":
@@ -6066,13 +6070,6 @@ export const en = {
   "firstRun.ai.modelHint":
     "A starting point. The listed prices are per million tokens, in → out; any model id your provider serves will do.",
   "firstRun.ai.embedModel": "Embedding model",
-  "firstRun.google.title": "Connect a Google app",
-  "firstRun.google.sub":
-    "Mailboxes are connected through a Google OAuth app you own, so mail is read with your organization’s own credentials. You can change this later under Settings.",
-  "firstRun.google.clientIdPlaceholder":
-    "000000000000-xxxx.apps.googleusercontent.com",
-  "firstRun.google.clientId": "Client ID",
-  "firstRun.google.clientSecret": "Client secret",
   // Which vendor this installation's text is sent to. Admin/ops only, on both
   // verbs â see the ai_routing RBAC object.
   "aiProviderKeys.title": "Model provider keys",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -50,9 +50,9 @@ const KEPT_IN_ENGLISH = new Set<string>([
   // translating them here would have the form ask for something the page they
   // are copying from does not call by that name. The placeholder is an id
   // SHAPE rather than prose and is the same string everywhere.
-  "firstRun.google.clientId",
-  "firstRun.google.clientSecret",
-  "firstRun.google.clientIdPlaceholder",
+  "googleApp.clientId",
+  "googleApp.clientSecret",
+  "googleApp.clientIdPlaceholder",
   // "Embeddings" is the vocabulary of the routing document itself, which this
   // form renders raw beside `premium` and `gemini`. The host placeholder is a
   // URL, which is the same string in every language.

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -5946,6 +5946,10 @@ export const vi = {
   "googleApp.redirectTitle": "URI chuyển hướng được uỷ quyền",
   "googleApp.fromEnvironment":
     "Đang dùng từ cấu hình triển khai này: {clientId}. Lưu một ứng dụng tại đây sẽ thay thế nó trong thời gian còn lưu.",
+  "googleApp.clientId": "Client ID",
+  "googleApp.clientSecret": "Client secret",
+  "googleApp.clientIdPlaceholder":
+    "000000000000-xxxx.apps.googleusercontent.com",
   "firstRun.continue": "Tiếp tục",
   "firstRun.ai.title": "Chọn nhà cung cấp mô hình",
   "firstRun.ai.sub":
@@ -5958,13 +5962,6 @@ export const vi = {
   "firstRun.ai.modelHint":
     "Chỉ là điểm khởi đầu. Giá hiển thị tính trên mỗi triệu token, đầu vào → đầu ra; bất kỳ mã mô hình nào nhà cung cấp phục vụ đều dùng được.",
   "firstRun.ai.embedModel": "Mô hình embedding",
-  "firstRun.google.title": "Kết nối ứng dụng Google",
-  "firstRun.google.sub":
-    "Hộp thư được kết nối qua ứng dụng Google OAuth của bạn, nên thư được đọc bằng thông tin xác thực của tổ chức bạn. Có thể đổi sau trong Cài đặt.",
-  "firstRun.google.clientIdPlaceholder":
-    "000000000000-xxxx.apps.googleusercontent.com",
-  "firstRun.google.clientId": "Client ID",
-  "firstRun.google.clientSecret": "Client secret",
   "aiProviderKeys.title": "Khóa nhà cung cấp mô hình",
   "aiProviderKeys.sub":
     "Thông tin xác thực mà bản cài đặt này dùng để gọi từng nhà cung cấp mô hình. Khóa được niêm phong trong kho khóa và không bao giờ hiển thị lại — hãy thay thế nếu bạn cần đổi.",

--- a/frontend/src/screens/google-app.test.tsx
+++ b/frontend/src/screens/google-app.test.tsx
@@ -183,9 +183,9 @@ describe("the Google app card", () => {
     });
   });
 
-  // The secret cannot be read back, every mailbox is connected through this
-  // app, and removing it re-opens the first-run gate — so a stray click must
-  // not be enough.
+  // The secret cannot be read back and every mailbox is connected through this
+  // app, so removing it silently ends capture for the whole installation — a
+  // stray click must not be enough.
   it("deletes nothing until the removal is confirmed", async () => {
     const user = userEvent.setup();
     const { calls } = mount(stored());

--- a/frontend/src/screens/google-app.tsx
+++ b/frontend/src/screens/google-app.tsx
@@ -13,10 +13,11 @@ import { problemMessageOf, QueryGate, throwProblem } from "./common";
 /**
  * The Google OAuth app a mailbox connection is made through.
  *
- * This file owns the endpoint's hooks and onboarding's first-run step borrows
- * them, rather than each writing its own: how long a client SECRET lives in a
- * mutation's `variables` is not a rule worth having two answers to, and the
- * onboarding screen is the one most likely to be written in a hurry.
+ * The ONLY form that writes it, and the only place first run sends an operator
+ * for it: the app is optional, and a second form would be one that cannot show
+ * the redirect URIs below — the half an operator has to paste into Google's
+ * console. So how long a client SECRET lives in a mutation's `variables` has
+ * one answer here rather than two answers to compare.
  *
  * The secret is never read back. `GET` answers whether one is stored and the
  * client id, which is not a secret — it travels in every authorization redirect,
@@ -55,8 +56,8 @@ export function useSetGoogleApp() {
       }
     },
     onSuccess: async () => {
-      // Both: the card's own view, and the first-run report that gates
-      // onboarding on this very step.
+      // Both: the card's own view, and the setup report, which names this
+      // step as outstanding whether or not it blocks anything.
       await queryClient.invalidateQueries({
         queryKey: ["installation-google-app"],
       });
@@ -214,7 +215,7 @@ export function GoogleAppCard() {
               </p>
               <RedirectUris uris={status.redirect_uris} />
               <Field
-                label={t("firstRun.google.clientId")}
+                label={t("googleApp.clientId")}
                 hint={
                   status.source === "stored"
                     ? t("googleApp.replaceHint")
@@ -228,12 +229,12 @@ export function GoogleAppCard() {
                     value={clientId}
                     autoComplete="off"
                     disabled={!canManage || busy}
-                    placeholder={t("firstRun.google.clientIdPlaceholder")}
+                    placeholder={t("googleApp.clientIdPlaceholder")}
                     onChange={(e) => setClientId(e.target.value)}
                   />
                 )}
               </Field>
-              <Field label={t("firstRun.google.clientSecret")}>
+              <Field label={t("googleApp.clientSecret")}>
                 {(control) => (
                   <TextInput
                     {...control}

--- a/frontend/src/screens/installation-setup.test.tsx
+++ b/frontend/src/screens/installation-setup.test.tsx
@@ -10,17 +10,21 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
 import { pickOption, pickSuggestion } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { jsonResponse } from "./company.fixtures";
-import { InstallationSetup } from "./installation-setup";
+import { InstallationSetup, outstandingStep } from "./installation-setup";
 
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
 });
 
-type Step = { step: string; configured: boolean; blocking: boolean };
+// The wire row, spelled from the generated contract rather than as a loose
+// `string`: a fixture naming a step the server cannot report would be a test of
+// a shape nothing serves.
+type Step = components["schemas"]["InstallationSetupStep"];
 
 // The seeded price sheet a fresh installation is provisioned with, which is
 // also the catalogue both model fields offer from. The full wire row, prices
@@ -73,16 +77,24 @@ const SEEDED_SHEET = [
   ),
 ];
 
-/** The server's answer, in the order the server gives it. */
+/**
+ * The server's answer, in the order and with the policy the server gives it:
+ * the model binding blocks, the Google app is reported and does not.
+ *
+ * `complete` follows from the blocking steps alone, because that is what the
+ * contract says it means — a fixture that waited on the Google app too would be
+ * describing an installation this server never reports, and the screen under
+ * test would be passing against a shape that does not exist.
+ */
 function setupReport(
   ai: boolean,
   google: boolean,
 ): { complete: boolean; steps: Step[] } {
   return {
-    complete: ai && google,
+    complete: ai,
     steps: [
       { step: "ai_models", configured: ai, blocking: true },
-      { step: "google_app", configured: google, blocking: true },
+      { step: "google_app", configured: google, blocking: false },
     ],
   };
 }
@@ -114,33 +126,82 @@ function mount(
       <LocaleProvider>{children}</LocaleProvider>
     </QueryClientProvider>
   );
-  render(<InstallationSetup />, { wrapper: Wrap });
-  return { writes };
+  const { container } = render(<InstallationSetup />, { wrapper: Wrap });
+  return { writes, container, qc };
+}
+
+/**
+ * Waits until the report has actually ARRIVED.
+ *
+ * Every "draws nothing" assertion below needs this, and none of them can get it
+ * from the DOM: the screen renders nothing while the query is in flight for
+ * exactly the same reason it renders nothing when the step is done, so a
+ * `waitFor` over an absence is satisfied by the first pending frame and the test
+ * passes without the answer ever landing. That is not a slow assertion, it is a
+ * vacuous one — it passed against a build that rendered the model form for a
+ * step it was never given.
+ */
+async function reportArrived(qc: QueryClient) {
+  await waitFor(() =>
+    expect(qc.getQueryState(["installation-setup"])?.status).toBe("success"),
+  );
 }
 
 describe("the first-run setup gate", () => {
-  // The order is the product decision the server pins: somebody with no model
-  // bound cannot be shown a cold start, while the mailbox can wait.
-  it("asks for the model binding before the Google app", async () => {
+  // The model binding is the one thing a cold start cannot proceed without, so
+  // it is the one thing asked for here.
+  it("asks for the model binding", async () => {
     mount(setupReport(false, false));
     expect(await screen.findByText("Choose a model provider")).toBeTruthy();
-    expect(screen.queryByText("Connect a Google app")).toBeNull();
   });
 
-  it("asks for the Google app once the models are bound", async () => {
-    mount(setupReport(true, false));
-    expect(await screen.findByText("Connect a Google app")).toBeTruthy();
-    expect(screen.queryByText("Choose a model provider")).toBeNull();
+  // The regression this screen was built wrong for. An installation with no
+  // Google app never reaches the company form, so `GET /company` keeps
+  // answering 404 and the shell's onboarding gate rewrites every route back to
+  // onboarding — an operator deploying without a Google app was locked out of
+  // the whole product, with `PUT /v1/company` the only way past.
+  it("lets a reader through with the models bound and no Google app", async () => {
+    // The panel is gone entirely rather than replaced by a Google one: the app
+    // is stored from settings, where the card also shows the redirect URIs
+    // Google's console asks for.
+    const { container, qc } = mount(setupReport(true, false));
+    await reportArrived(qc);
+    expect(container.innerHTML).toBe("");
   });
 
   // Nothing at all when there is nothing outstanding, so a caller can put this
   // in front of the next screen without asking the same question twice.
   it("draws nothing once every blocking step is done", async () => {
-    mount(setupReport(true, true));
-    await waitFor(() =>
-      expect(screen.queryByText("Choose a model provider")).toBeNull(),
-    );
-    expect(screen.queryByText("Connect a Google app")).toBeNull();
+    const { container, qc } = mount(setupReport(true, true));
+    await reportArrived(qc);
+    expect(container.innerHTML).toBe("");
+  });
+
+  // A frontend older than its server, meeting a blocking step it has no panel
+  // for. It lets the reader PAST rather than drawing the panel it does have —
+  // the model form under a `google_app` heading would take a reader's API key
+  // against a step they were never asked about — and past is what matters,
+  // because the caller gates on this same predicate and would otherwise hold an
+  // empty screen in front of them forever. The server pins ai_models as the
+  // only blocker (TestOnlyTheModelBindingBlocksFirstRun); this is the far side
+  // of that, for the deployment where the two versions disagree.
+  it("lets a reader past a blocking step it has no panel for", async () => {
+    const report: { complete: boolean; steps: Step[] } = {
+      complete: false,
+      steps: [
+        { step: "ai_models", configured: true, blocking: true },
+        { step: "google_app", configured: false, blocking: true },
+      ],
+    };
+    // The caller's own question, asked the caller's way. An empty screen alone
+    // would not tell the two failures apart: a gate that lets nobody through
+    // and a gate that is finished both draw nothing, and it is this answer the
+    // onboarding act reads to decide whether to keep the gate up at all.
+    expect(outstandingStep(report)).toBeUndefined();
+
+    const { container, qc } = mount(report);
+    await reportArrived(qc);
+    expect(container.innerHTML).toBe("");
   });
 
   // The key BEFORE the binding: a binding whose vendor has no key reads as
@@ -227,24 +288,6 @@ describe("the first-run setup gate", () => {
     expect(
       screen.getByRole("button", { name: "Continue" }).getAttribute("disabled"),
     ).toBeNull();
-  });
-
-  it("sends the Google app as one pair", async () => {
-    const user = userEvent.setup();
-    const { writes } = mount(setupReport(true, false));
-    await screen.findByText("Connect a Google app");
-    await user.type(
-      screen.getByLabelText("Client ID"),
-      "123-abc.apps.googleusercontent.com",
-    );
-    await user.type(screen.getByLabelText("Client secret"), "GOCSPX-secret");
-    await user.click(screen.getByRole("button", { name: "Continue" }));
-    await waitFor(() => expect(writes.length).toBe(1));
-    expect(writes[0].url).toBe("/v1/installation/google-app");
-    expect(writes[0].body).toEqual({
-      client_id: "123-abc.apps.googleusercontent.com",
-      client_secret: "GOCSPX-secret",
-    });
   });
 
   // A first-time admin should not have to know a model id by heart. The sheet

--- a/frontend/src/screens/installation-setup.tsx
+++ b/frontend/src/screens/installation-setup.tsx
@@ -11,7 +11,6 @@ import { useLocale, useT } from "../i18n";
 import { suggestionsFor, useAiModelCatalogue } from "./ai-models";
 import { useSetProviderKey } from "./ai-provider-keys";
 import { problemMessageOf, throwProblem } from "./common";
-import { useSetGoogleApp } from "./google-app";
 import {
   SETUP_PROVIDER_IDS,
   SETUP_PROVIDERS,
@@ -19,8 +18,11 @@ import {
 } from "./setup-providers";
 
 /**
- * What a fresh installation must be told before it can be used, asked in the
- * order the server lists it: the model binding, then the Google app.
+ * What a fresh installation must be told before it can be used: the model
+ * binding, which is the one step the server calls blocking. Everything else the
+ * report names — the Google app today — is configured from settings, because an
+ * installation with no Google app is fully usable and demanding one here locked
+ * its operator out of every route.
  *
  * WHY THIS IS NOT THE SETTINGS CARDS. `AiRoutingCard` re-points lanes an
  * installation ALREADY binds — it says so and refuses an empty one, which is
@@ -54,16 +56,34 @@ export function useInstallationSetup() {
 }
 
 /**
- * The first step that is not done yet, in the server's order.
+ * The steps this screen has a panel for. Today the model binding is the whole
+ * list, and the server agrees — it reports every other step non-blocking, held
+ * by TestOnlyTheModelBindingBlocksFirstRun.
+ *
+ * It is read by `outstandingStep` rather than only by the render, and that is
+ * the point. A frontend older than its server would otherwise meet a blocking
+ * step it has no panel for, and the caller — which gates on this same
+ * function — would keep drawing a component that renders nothing: a reader held
+ * behind an empty screen, with nothing on it to say what it wants.
+ */
+const ASKABLE_STEPS: readonly Step["step"][] = ["ai_models"];
+
+/**
+ * The first step that is not done yet AND that this screen can ask for, in the
+ * server's order.
  *
  * `steps` is optional-chained as well as `setup`: an answer that arrives
  * without it is not an answer, and the alternative is this throwing inside a
  * render — which takes down the screen it was meant to stand in front of.
  * Undefined here reads as "nothing outstanding", which lets the reader past
- * rather than trapping them behind a gate that cannot say what it wants.
+ * rather than trapping them behind a gate that cannot say what it wants. A
+ * blocking step with no panel takes the same exit, for the same reason: past a
+ * gate is somewhere, and a settings screen can still be reached from there.
  */
 export function outstandingStep(setup: Setup | undefined): Step | undefined {
-  return setup?.steps?.find((s) => s.blocking && !s.configured);
+  return setup?.steps?.find(
+    (s) => s.blocking && !s.configured && ASKABLE_STEPS.includes(s.step),
+  );
 }
 
 function useBindModels() {
@@ -287,71 +307,6 @@ function AiStep() {
   );
 }
 
-/** The Google step: the OAuth app a mailbox connection is made through. */
-function GoogleStep() {
-  const t = useT();
-  const [clientId, setClientId] = useState("");
-  const [clientSecret, setClientSecret] = useState("");
-  const save = useSetGoogleApp();
-  const ready = clientId.trim() !== "" && clientSecret.trim() !== "";
-
-  return (
-    <Panel title={t("firstRun.google.title")}>
-      <PanelBody>
-        <p className="t-body">{t("firstRun.google.sub")}</p>
-        {save.error && (
-          <Callout tone="danger">{problemMessageOf(save.error, t)}</Callout>
-        )}
-        <Field label={t("firstRun.google.clientId")}>
-          {(control) => (
-            <TextInput
-              {...control}
-              value={clientId}
-              disabled={save.isPending}
-              autoComplete="off"
-              placeholder={t("firstRun.google.clientIdPlaceholder")}
-              onChange={(e) => setClientId(e.target.value)}
-            />
-          )}
-        </Field>
-        <Field label={t("firstRun.google.clientSecret")}>
-          {(control) => (
-            <TextInput
-              {...control}
-              type="password"
-              autoComplete="off"
-              value={clientSecret}
-              disabled={save.isPending}
-              onChange={(e) => setClientSecret(e.target.value)}
-            />
-          )}
-        </Field>
-        <Button
-          variant="primary"
-          pending={save.isPending}
-          disabled={!ready}
-          onClick={() => {
-            save.reset();
-            save.mutate(
-              { clientId: clientId.trim(), clientSecret: clientSecret.trim() },
-              {
-                onSuccess: () => {
-                  // Cleared on the way out rather than left in state: the field
-                  // is the only copy this app holds, and it has done its job.
-                  setClientSecret("");
-                  save.reset();
-                },
-              },
-            );
-          }}
-        >
-          {t("firstRun.continue")}
-        </Button>
-      </PanelBody>
-    </Panel>
-  );
-}
-
 /**
  * The setup gate. Renders nothing once the server says the installation is
  * complete, so the caller can put it in front of whatever comes next without
@@ -372,5 +327,9 @@ export function InstallationSetup() {
   if (setup.isPending || !step) {
     return null;
   }
-  return step.step === "ai_models" ? <AiStep /> : <GoogleStep />;
+  // ASKABLE_STEPS is what `outstandingStep` filtered on, so the step in hand is
+  // the model binding. The Google app is configured from settings instead,
+  // where the card can also show the redirect URIs Google's console asks for —
+  // which a cold-start panel never could.
+  return <AiStep />;
 }

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -742,9 +742,13 @@ export function CompanyAct({
 
   // BEFORE the website question, and before the read theatre: an installation
   // that has bound no model cannot perform a cold-start read at all, so asking
-  // for a website first would take an answer and then refuse to act on it. The
-  // component draws nothing once the server says every blocking step is done,
-  // which is what lets this sit in front of the gate rather than beside it.
+  // for a website first would take an answer and then refuse to act on it.
+  //
+  // The condition and the component read the SAME predicate, which is why this
+  // can sit in front of the gate rather than beside it: `outstandingStep`
+  // answers only with a step the component has a panel for, so there is no
+  // report that keeps this branch taken while the component below draws
+  // nothing.
   if (setupOutstanding) {
     return <InstallationSetup />;
   }


### PR DESCRIPTION
Closes #3296.

## The trap

`GET /installation/setup` reported **both** its steps blocking. Onboarding
refuses to show the company form while a blocking step is outstanding, the
company profile is written from that form, and its absence is what makes the
shell rewrite every route back to `#/onboarding/company`. So an operator
deploying without a Google app was locked out of the whole product — `PUT
/v1/company` over the API was the only way past, which is how UAT got through.

The handler's own comment already conceded the point: *"the Gmail step is the one
they can skip past without the product being unusable."* The code did not do what
the comment said.

## The change

**Only the model binding blocks.** Without one the product cannot perform the
cold-start read that first run *is*, so there is nothing to let a reader through
to. A Google app buys mailbox capture and nothing else, and an installation
signing in with passwords and no external provider is fully usable without one.

The step is still **reported**, and reported as optional. That is what `blocking`
is for; dropping it would make "not configured" and "not needed" indistinguishable
to a reader asking what is left to do.

**The first-run Google panel goes with it.** It was a second Google-app form —
`GoogleAppCard` in Settings → General is the first, and the better one, because it
also shows the redirect URIs Google's console asks for, which a cold-start panel
never could. The three field labels the two shared move to that card's own
`googleApp.*` namespace, where their only reader now lives.

A skip button was the other option and was rejected: the skip state cannot live
inside `InstallationSetup` (it unmounts precisely when the parent stops rendering
it), so it would have meant adding wizard state to a 900-line file to preserve a
form that duplicates a better one three clicks away.

## The version-skew case

`outstandingStep` now answers only with a step the screen has a panel for. The
caller gates on that same function, so without the filter a frontend older than
its server would meet a blocking step it cannot draw and hold the reader behind an
**empty** screen — the same lockout, with nothing on it to say what was wanted.
It lets them past instead, which is what the rest of that function already does
with an answer it cannot read.

## What holds it

One gate on each side of the wire, both watched failing against the defect:

- `TestOnlyTheModelBindingBlocksFirstRun` reads **every** step rather than only
  the Google one, so it still fails the day a third arrives blocking, and asserts
  `complete` off the wire rather than recomputing it.
- The screen is pinned to let a reader past a blocking step it has no panel for —
  asserted through `outstandingStep`, because an empty screen alone cannot tell a
  gate that lets nobody through from a gate that is finished.

Three "draws nothing" assertions in that suite were **vacuous** as written: the
screen renders nothing while the query is in flight for exactly the same reason it
renders nothing when the step is done, so a `waitFor` over an absence was satisfied
by the first pending frame. They passed against a build that answered the wrong
step with the model form. They now wait for the report to land.

## Fixed along the way

Comments that had drifted or now said something false: the setup endpoint's
contract description, the handler's ordering note, `google-app.tsx`'s "onboarding
borrows these hooks" header and its cache-invalidation note, `google-app.test.tsx`'s
"removing it re-opens the first-run gate", and `company-act.tsx`'s claim about when
the component draws nothing.

## Manual test

On a real cold-start stack with no Google app and no `GOOGLE_CLIENT_ID` in the
environment — the deployment the issue was found on. Recordings in the first
comment.

Before: `{"complete":false,"steps":[{"ai_models":blocking,unconfigured},{"google_app":non-blocking,unconfigured}]}`

1. First run asked **one** question, *Choose a model provider*. No Google panel
   before or after it.
2. Entered a vendor key → straight to the company question. This is the step the
   issue could never reach.
3. Answered the interview, saved → *"Company profile confirmed."*
4. `#/settings/users` — the exact route the issue reports as hijacked — rendered.
   No redirect.
5. Settings → General carries the Google app card: three authorized redirect URIs
   with copy buttons, Client ID, Client secret, *Store app*.

After: `complete: true` with the Google app never stored, and `GET /company` → 200.

No migration, no contract shape change (`blocking` and both enum values already
existed), no prompt change — so no aicert re-pin.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes first-run onboarding so an installation with no Google OAuth app can get past the setup gate—previously both setup steps were blocking, and the company form's absence redirected every route back to onboarding.

**Bug Fixes**

- Only the model binding blocks first run now; the Google app step is reported but optional.
- Removed the first-run Google panel; the app is configured from Settings → General, which also shows Google's redirect URIs.
- `outstandingStep` only returns steps the setup screen has a panel for, so an older frontend lets a reader past an unknown blocking step instead of holding an empty screen.
- No migration or contract shape change—`blocking` and the existing enum values were already in place.

<sup>Written for commit 150963ba704cc86abd2e3146bc4264f3eeb2362d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google app setup is now optional during onboarding.
  * First-run completion is blocked only until an AI model is configured.
  * Cloud model setup requires the associated provider key.
  * Added worklist indicators for repeated failures and system incidents.
  * Added message-sourced relationship context and updated Google app labels across supported languages.

* **Bug Fixes**
  * Setup screens no longer display empty panels for unsupported steps.

* **Tests**
  * Added coverage for optional Google setup and model-provider requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->