### PR TITLE
fix(ai): propose_roles declares its company context, and main is green again

### DIFF
--- a/backend/api/ai-tasks.yaml
+++ b/backend/api/ai-tasks.yaml
@@ -118,6 +118,7 @@ tasks:
     execution_mode: interactive
     on_budget_exhausted: degrade
     status: planned
+    company_context: none
     doc: "PLANNED — the reading and its gate exist (compose/proposeroles) and are tested offline; the site arrives with the endpoint that calls them, because a planned task declares no site and therefore cannot present as certified. Read the buying roles out of what a contact has actually written — who signs, who carries it inside, who can stop it. Floor 0.75, higher than enrich's 0.6 because a wrong role misdirects a whole deal while a wrong phone number is a typo. A job title is NEVER evidence: the contract says a role is recorded and never inferred from one, so a proposal citing only a title is dropped. Every proposal quotes the message it was read from, verbatim, and a snippet that is not in the source it names is dropped rather than trusted. Written DIRECTLY as a seat, attributed to agent:propose_roles and reversible, per the installation's auto-write posture; the record carries the evidence so a reader can check it and the mark stays until a human confirms."
 
   enrich:

--- a/backend/internal/modules/ai/routing_test.go
+++ b/backend/internal/modules/ai/routing_test.go
@@ -228,6 +228,7 @@ func TestUnboundLadderWarnings(t *testing.T) {
 				"task growth_fit: no bound tier on ladder [cheap_cloud premium]; calls will be refused",
 				"task nl_search: no bound tier on ladder [cheap_cloud premium]; calls will be refused",
 				"task offer_draft: no bound tier on ladder [cheap_cloud premium]; calls will be refused",
+				"task propose_roles: no bound tier on ladder [cheap_cloud premium]; calls will be refused",
 				"task rate_extract: no bound tier on ladder [premium cheap_cloud]; calls will be refused",
 				"task signal_extract: no bound tier on ladder [cheap_cloud premium]; calls will be refused",
 				"task site_extract: no bound tier on ladder [premium]; calls will be refused",

--- a/backend/internal/modules/ai/tasks_gen.go
+++ b/backend/internal/modules/ai/tasks_gen.go
@@ -81,7 +81,7 @@ const (
 // TaskContractHash is the sha256 of api/ai-tasks.yaml at generation
 // time: a build fingerprint the cert runner can compare against a
 // freshly hashed contract file to catch a stale generated table.
-const TaskContractHash = "46875e88404bca352bfc28138c8cbe1de47a46375a6679f8b3dbb46172dd6f02"
+const TaskContractHash = "dd95ae802145e4177a40bc778cb3963c29addf056d16aede6c1f676b46b6fb45"
 
 // AllTasks returns every contract task, sorted — the completeness
 // check a certification run walks to prove it covers every routed
@@ -398,6 +398,7 @@ var taskCompanyContext = map[Task]CompanyContextPolicy{
 	TaskGrowthFit:                  {Scopes: []string{"offer", "positioning", "proof"}, TokenBudget: 1200, Conditional: false},
 	TaskNlSearch:                   {Scopes: []string{"offer", "market"}, TokenBudget: 600, Conditional: false},
 	TaskOfferDraft:                 {Scopes: []string{"offer", "positioning", "proof"}, TokenBudget: 1600, Conditional: false},
+	TaskProposeRoles:               {TokenBudget: 0, Conditional: false},
 	TaskRateExtract:                {TokenBudget: 0, Conditional: false},
 	TaskSignalExtract:              {TokenBudget: 0, Conditional: false},
 	TaskSiteExtract:                {TokenBudget: 0, Conditional: false},


### PR DESCRIPTION
Two tests fail on main right now. Both come from one missing line: `propose_roles` declares no `company_context` in `backend/api/ai-tasks.yaml`, and `TestEveryContractScopeNameResolves` requires every task to state one.

The task reads buying roles out of what a contact has written, so it needs no company context. It declares `none`, the same as every other reading task.

Declaring it also makes `propose_roles` visible to the routing-warning census in `routing_test.go`, which hard-codes its expected list of tasks — so the missing line is added there too. That list is a hand-maintained copy of the task catalog and will need editing again for the next task added.

`make check-backend` and `make craft-static` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two failing tests on main by declaring `propose_roles` has no company context, so `make check-backend` and `make craft-static` are green again.

Adds `company_context: none` to the task and updates the routing test's hard-coded task list, which will need editing for the next task added.

<sup>Written for commit 0c122b157b3e2d67234a6e31b5147bfb871c0221. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role proposal behavior when no ladder tier is bound by surfacing an appropriate warning.

* **Tests**
  * Added coverage to verify the warning is returned in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->