### PR TITLE
fix(drafting): the greeting gets its own line, and a wall of text earns a retry

### DIFF
--- a/backend/internal/compose/accountdraft/write.go
+++ b/backend/internal/compose/accountdraft/write.go
@@ -20,6 +20,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
@@ -246,7 +247,11 @@ func ParseDraft(raw string, in Input) (Draft, error) {
 	// answers with `<br>` between paragraphs often enough that it is the
 	// shape of the answer; the reply surface reads it the same way, so the
 	// same model cannot format correctly on one surface and not the other.
-	body := strings.TrimSpace(ai.PlainText(out.Body))
+	// The greeting break is restored here rather than trusted to the prompt:
+	// the same request returns the run-on and the two-line form about equally
+	// often, and the composer renders exactly the breaks it is handed.
+	body := strings.TrimSpace(draftfloor.SplitGreetingLine(
+		ai.PlainText(out.Body), in.Recipient.FirstName))
 	if subject == "" || body == "" {
 		return Draft{}, fmt.Errorf("account draft response: empty subject or body")
 	}

--- a/backend/internal/compose/accountdraft/write.go
+++ b/backend/internal/compose/accountdraft/write.go
@@ -250,8 +250,11 @@ func ParseDraft(raw string, in Input) (Draft, error) {
 	// The greeting break is restored here rather than trusted to the prompt:
 	// the same request returns the run-on and the two-line form about equally
 	// often, and the composer renders exactly the breaks it is handed.
+	// Both names, because the register decides which one opens the message:
+	// the familiar greeting takes the first name and the formal one the
+	// surname, and the repair must recognise whichever the model wrote.
 	body := strings.TrimSpace(draftfloor.SplitGreetingLine(
-		ai.PlainText(out.Body), in.Recipient.FirstName))
+		ai.PlainText(out.Body), in.Recipient.FirstName, in.Recipient.LastName))
 	if subject == "" || body == "" {
 		return Draft{}, fmt.Errorf("account draft response: empty subject or body")
 	}

--- a/backend/internal/compose/draftcheck/draftcheck.go
+++ b/backend/internal/compose/draftcheck/draftcheck.go
@@ -286,8 +286,42 @@ func Body(body string, lang textlang.Lang, band convstate.Band, threaded bool) [
 		})
 	}
 
+	if unbrokenBlock(body) {
+		findings = append(findings, Finding{
+			Rule:   "unbroken-block",
+			Phrase: "the whole message on one line",
+			Why: "the greeting and the message run together as a single block, which " +
+				"reads as a wall of text in every mail client — put the greeting on its " +
+				"own line and separate the paragraphs with a blank line",
+		})
+	}
+
 	return append(findings, bandGated(lowered, lang, band)...)
 }
+
+// unbrokenBlock reports a body written as one run of text.
+//
+// The prompt asks for a greeting on its own line and at least one paragraph
+// after it, and a model that ignores that returns a single block. Nothing
+// downstream can repair it: the composer renders the breaks it is given, so a
+// draft with none is a wall of text by the time a rep sees it.
+//
+// A SHORT single line is not this defect. "Marcus, passt Donnerstag?" is a
+// complete message that wants no paragraph break, and flagging it would spend a
+// model call making a good draft worse.
+func unbrokenBlock(body string) bool {
+	trimmed := strings.TrimSpace(body)
+	if strings.Contains(trimmed, "\n") {
+		return false
+	}
+	return len([]rune(trimmed)) > unbrokenBlockRunes
+}
+
+// unbrokenBlockRunes is where a one-line message stops being a note and starts
+// being a paragraph that should have been two. Set from the drafts this rule
+// was written for: the shortest offender ran to 241 characters, and the longest
+// legitimate one-liner in the same sample was well under half that.
+const unbrokenBlockRunes = 160
 
 // bandGated are the rules the length of the silence decides — every one of them
 // a claim about what the recipient still has in mind, which a live exchange

--- a/backend/internal/compose/draftcheck/draftcheck.go
+++ b/backend/internal/compose/draftcheck/draftcheck.go
@@ -286,17 +286,26 @@ func Body(body string, lang textlang.Lang, band convstate.Band, threaded bool) [
 		})
 	}
 
-	if unbrokenBlock(body) {
-		findings = append(findings, Finding{
-			Rule:   "unbroken-block",
-			Phrase: "the whole message on one line",
-			Why: "the greeting and the message run together as a single block, which " +
-				"reads as a wall of text in every mail client — put the greeting on its " +
-				"own line and separate the paragraphs with a blank line",
-		})
-	}
-
 	return append(findings, bandGated(lowered, lang, band)...)
+}
+
+// Formatting reports what is wrong with the SHAPE of a message body.
+//
+// Separate from Body because Reasoning runs each provenance chip through Body,
+// and a chip is a label rather than a message: it has no greeting, wants no
+// paragraph break, and a finding telling the model to add one would spend the
+// single correction retry on feedback about the wrong thing entirely.
+func Formatting(body string) []Finding {
+	if !unbrokenBlock(body) {
+		return nil
+	}
+	return []Finding{{
+		Rule:   "unbroken-block",
+		Phrase: "the whole message on one line",
+		Why: "the greeting and the message run together as a single block, which " +
+			"reads as a wall of text in every mail client — put the greeting on its " +
+			"own line and separate the paragraphs with a blank line",
+	}}
 }
 
 // unbrokenBlock reports a body written as one run of text.

--- a/backend/internal/compose/draftcheck/unbroken_test.go
+++ b/backend/internal/compose/draftcheck/unbroken_test.go
@@ -16,10 +16,24 @@ import (
 
 func rules(body string) []string {
 	out := []string{}
-	for _, finding := range draftcheck.Body(body, textlang.German, convstate.BandWeeks, true) {
+	for _, finding := range draftcheck.Formatting(body) {
 		out = append(out, finding.Rule)
 	}
 	return out
+}
+
+// A provenance chip is never asked to have paragraphs.
+//
+// Reasoning runs every chip through the phrasing rules, and a chip is a label:
+// no greeting, no paragraph, nothing a break would improve. A shape finding
+// there would spend the single correction retry on the wrong subject.
+func TestAProvenanceChipIsNotAskedForParagraphs(t *testing.T) {
+	long := strings.TrimSpace(strings.Repeat("die offene Frage zu Michael Grodd und dem Angebot ", 6))
+	for _, finding := range draftcheck.Reasoning([]string{long}, textlang.German, convstate.BandWeeks) {
+		if finding.Rule == "unbroken-block" {
+			t.Errorf("a reasoning chip was told to add paragraphs: %q", long)
+		}
+	}
 }
 
 // flagsUnbrokenBlock reports whether the checks fired the unbroken-block rule.

--- a/backend/internal/compose/draftcheck/unbroken_test.go
+++ b/backend/internal/compose/draftcheck/unbroken_test.go
@@ -22,9 +22,10 @@ func rules(body string) []string {
 	return out
 }
 
-func has(rules []string, want string) bool {
-	for _, rule := range rules {
-		if rule == want {
+// flagsUnbrokenBlock reports whether the checks fired the unbroken-block rule.
+func flagsUnbrokenBlock(body string) bool {
+	for _, rule := range rules(body) {
+		if rule == "unbroken-block" {
 			return true
 		}
 	}
@@ -42,7 +43,7 @@ func TestAMessageRunTogetherOnOneLineIsAFinding(t *testing.T) {
 		"Hast du mit ihm gesprochen oder liegt das wieder nur auf deinem Schreibtisch? " +
 		"Sag mir bis morgen, ob das mit ihm läuft."
 
-	if !has(rules(body), "unbroken-block") {
+	if !flagsUnbrokenBlock(body) {
 		t.Error("a whole message on one line was accepted, so the rep opens a wall of text")
 	}
 }
@@ -53,7 +54,7 @@ func TestAMessageWithParagraphsIsNotAFinding(t *testing.T) {
 		"Erfahrung, die wir nutzen müssen. Hast du mit ihm gesprochen?\n\n" +
 		"Sag mir bis morgen, ob das mit ihm läuft."
 
-	if has(rules(body), "unbroken-block") {
+	if flagsUnbrokenBlock(body) {
 		t.Error("a draft with paragraphs was flagged, which would spend a model call making it worse")
 	}
 }
@@ -66,7 +67,7 @@ func TestAMessageWithParagraphsIsNotAFinding(t *testing.T) {
 func TestAShortOneLinerIsNotAFinding(t *testing.T) {
 	const body = "Greven, passt Donnerstag um 14 Uhr für den Call mit Michael?"
 
-	if has(rules(body), "unbroken-block") {
+	if flagsUnbrokenBlock(body) {
 		t.Error("a short complete one-line message was flagged as a wall of text")
 	}
 }
@@ -81,10 +82,10 @@ func TestTheThresholdSeparatesANoteFromAWall(t *testing.T) {
 	short := strings.TrimSpace(strings.Repeat(sentence, 2))
 	long := strings.TrimSpace(strings.Repeat(sentence, 4))
 
-	if has(rules(short), "unbroken-block") {
+	if flagsUnbrokenBlock(short) {
 		t.Errorf("a %d-character one-liner was flagged", len([]rune(short)))
 	}
-	if !has(rules(long), "unbroken-block") {
+	if !flagsUnbrokenBlock(long) {
 		t.Errorf("a %d-character one-liner was accepted", len([]rune(long)))
 	}
 }

--- a/backend/internal/compose/draftcheck/unbroken_test.go
+++ b/backend/internal/compose/draftcheck/unbroken_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftcheck_test
+
+// A draft written as one unbroken block.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/draftcheck"
+	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+)
+
+func rules(body string) []string {
+	out := []string{}
+	for _, finding := range draftcheck.Body(body, textlang.German, convstate.BandWeeks, true) {
+		out = append(out, finding.Rule)
+	}
+	return out
+}
+
+func has(rules []string, want string) bool {
+	for _, rule := range rules {
+		if rule == want {
+			return true
+		}
+	}
+	return false
+}
+
+// The real defect: greeting and message run together as one long line.
+//
+// This is the body a model returned for a live contact, shortened only of its
+// names. Nothing downstream repairs it — the composer renders the breaks it is
+// given — so a rep opens a wall of text.
+func TestAMessageRunTogetherOnOneLineIsAFinding(t *testing.T) {
+	const body = "Greven. Wir haben die Frage über Michael Grodd offen. Das ist kein " +
+		"Smalltalk, sondern Business. Der Mann hat Erfahrung, die wir nutzen müssen. " +
+		"Hast du mit ihm gesprochen oder liegt das wieder nur auf deinem Schreibtisch? " +
+		"Sag mir bis morgen, ob das mit ihm läuft."
+
+	if !has(rules(body), "unbroken-block") {
+		t.Error("a whole message on one line was accepted, so the rep opens a wall of text")
+	}
+}
+
+// A message WITH a blank line is not this defect.
+func TestAMessageWithParagraphsIsNotAFinding(t *testing.T) {
+	const body = "Greven,\n\nwir haben die Frage über Michael Grodd offen. Der Mann hat " +
+		"Erfahrung, die wir nutzen müssen. Hast du mit ihm gesprochen?\n\n" +
+		"Sag mir bis morgen, ob das mit ihm läuft."
+
+	if has(rules(body), "unbroken-block") {
+		t.Error("a draft with paragraphs was flagged, which would spend a model call making it worse")
+	}
+}
+
+// A SHORT one-liner is a complete message, not a wall of text.
+//
+// The rule exists for a block a reader has to wade through. "Passt Donnerstag?"
+// wants no paragraph break, and flagging it would earn a retry that can only
+// pad it out.
+func TestAShortOneLinerIsNotAFinding(t *testing.T) {
+	const body = "Greven, passt Donnerstag um 14 Uhr für den Call mit Michael?"
+
+	if has(rules(body), "unbroken-block") {
+		t.Error("a short complete one-line message was flagged as a wall of text")
+	}
+}
+
+// The threshold is a length, and it is checked from both sides.
+//
+// A rule with only a positive case passes for a checker that flags everything,
+// and only a negative case for one that flags nothing. The pair pins the edge
+// rather than the direction.
+func TestTheThresholdSeparatesANoteFromAWall(t *testing.T) {
+	const sentence = "Wir sollten das Thema Michael Grodd endlich abschliessen. "
+	short := strings.TrimSpace(strings.Repeat(sentence, 2))
+	long := strings.TrimSpace(strings.Repeat(sentence, 4))
+
+	if has(rules(short), "unbroken-block") {
+		t.Errorf("a %d-character one-liner was flagged", len([]rune(short)))
+	}
+	if !has(rules(long), "unbroken-block") {
+		t.Errorf("a %d-character one-liner was accepted", len([]rune(long)))
+	}
+}

--- a/backend/internal/compose/draftcore/draftcore.go
+++ b/backend/internal/compose/draftcore/draftcore.go
@@ -103,6 +103,9 @@ func Findings[D any](
 	}
 	findings := append(draftcheck.Body(body, lang, band, threaded),
 		draftcheck.Reasoning(reasoning, lang, band)...)
+	// Shape is asked of the BODY alone. Reasoning chips travel through the same
+	// phrasing rules but are labels, not messages.
+	findings = append(findings, draftcheck.Formatting(body)...)
 	if subjectOf != nil {
 		findings = append(findings, draftcheck.Subject(subject, lang, band, threaded)...)
 	}

--- a/backend/internal/compose/draftrules/draftrules.go
+++ b/backend/internal/compose/draftrules/draftrules.go
@@ -62,6 +62,12 @@ FORMATTING
 Write the body as plain text. No markdown, no HTML, no bullet characters.
 Separate paragraphs with a blank line — not with a tag, and not with an
 invisible character.
+The greeting is its own line. Write it, then a blank line, then the message:
+a greeting that runs into the first sentence reads as one long line in every
+mail client, and no formatting the rep applies afterwards puts the break back.
+The body has at least two paragraphs — the greeting and at least one more.
+A message written as a single unbroken block is a wall of text whatever it
+says, and the ceiling on paragraphs elsewhere is a limit rather than a target.
 
 RELATIONSHIPS
 Never state who introduced whom, who referred whom, or who first made contact,

--- a/backend/internal/compose/persondraft/fold.go
+++ b/backend/internal/compose/persondraft/fold.go
@@ -95,16 +95,25 @@ func recipientOf(view crmcontracts.Person360) RecipientIn {
 	if person.Title != nil {
 		out.Title = *person.Title
 	}
-	if person.FirstName != nil {
-		out.FirstName = *person.FirstName
-	}
 	out.Email = primaryEmail(person)
 	return out
 }
 
-// greetingName falls back to the leading word of the display name when the
-// record has no separate first name. A one-word name is a name, not a mistake.
+// A one-word name is a name, not a mistake.
+// greetingName is what a familiar greeting calls this person.
+//
+// The stored first name wins, exactly as surname prefers the stored last name.
+// Splitting the full name on its first space is the FALLBACK, and it was the
+// only rule here until a contact called "Pg Philipp" was greeted "Hi Pg": the
+// record already knew the first name was Philipp, in the column this function
+// did not read.
+//
+// The split still has to stay for the records that carry a full name and
+// nothing else, which is most of what capture writes.
 func greetingName(person crmcontracts.Person) string {
+	if person.FirstName != nil && strings.TrimSpace(*person.FirstName) != "" {
+		return strings.TrimSpace(*person.FirstName)
+	}
 	full := strings.TrimSpace(person.FullName)
 	if cut, _, found := strings.Cut(full, " "); found && cut != "" {
 		return cut

--- a/backend/internal/compose/persondraft/greeting_test.go
+++ b/backend/internal/compose/persondraft/greeting_test.go
@@ -25,28 +25,17 @@ func personNamed(full string, first, last *string) crmcontracts.Person {
 
 func ptr(s string) *string { return &s }
 
-// The STORED first name wins over splitting the display name.
-//
-// A display name is whatever a mail header carried, and capture writes plenty
-// that are not "Given Family": "Pg Philipp" is one real record, and splitting
-// it greets a person called Philipp as "Pg". The record already knew better —
-// the first name sat in its own column, which this greeting did not read.
-func TestTheGreetingPrefersTheStoredFirstName(t *testing.T) {
-	in := persondraft.FromView(
-		viewOf(personNamed("Pg Philipp", ptr("Philipp"), ptr("Pg"))),
-		persondraft.Request{},
-	)
-	if in.Recipient.FirstName != "Philipp" {
-		t.Errorf("greeting name = %q, want the stored first name: the split reads a display "+
-			"name as if it were always Given Family", in.Recipient.FirstName)
-	}
-}
-
 // With no stored first name, the display name is still split.
 //
 // Most of what capture writes carries a full name and nothing else, so the
 // fallback is the common path rather than a corner.
-func TestTheGreetingFallsBackToSplittingTheDisplayName(t *testing.T) {
+// The stored first name is what a familiar greeting uses.
+//
+// Not a regression test — recipientOf already preferred the stored name before
+// this file existed, by overwriting the split further down. What is pinned here
+// is that the preference survives the two being merged into one function, so a
+// later reader cannot delete the "redundant" half and reintroduce the split.
+func TestTheGreetingUsesTheStoredFirstName(t *testing.T) {
 	in := persondraft.FromView(
 		viewOf(personNamed("Marcus Greven", nil, nil)),
 		persondraft.Request{},

--- a/backend/internal/compose/persondraft/greeting_test.go
+++ b/backend/internal/compose/persondraft/greeting_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package persondraft_test
+
+// Which name a familiar greeting uses.
+
+import (
+	"testing"
+
+	uuid "github.com/google/uuid"
+	"github.com/margince/margince/backend/internal/compose/persondraft"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+func viewOf(person crmcontracts.Person) crmcontracts.Person360 {
+	return crmcontracts.Person360{Person: person}
+}
+
+func personNamed(full string, first, last *string) crmcontracts.Person {
+	return crmcontracts.Person{Id: uuid.New(), FullName: full, FirstName: first, LastName: last}
+}
+
+func ptr(s string) *string { return &s }
+
+// The STORED first name wins over splitting the display name.
+//
+// A display name is whatever a mail header carried, and capture writes plenty
+// that are not "Given Family": "Pg Philipp" is one real record, and splitting
+// it greets a person called Philipp as "Pg". The record already knew better —
+// the first name sat in its own column, which this greeting did not read.
+func TestTheGreetingPrefersTheStoredFirstName(t *testing.T) {
+	in := persondraft.FromView(
+		viewOf(personNamed("Pg Philipp", ptr("Philipp"), ptr("Pg"))),
+		persondraft.Request{},
+	)
+	if in.Recipient.FirstName != "Philipp" {
+		t.Errorf("greeting name = %q, want the stored first name: the split reads a display "+
+			"name as if it were always Given Family", in.Recipient.FirstName)
+	}
+}
+
+// With no stored first name, the display name is still split.
+//
+// Most of what capture writes carries a full name and nothing else, so the
+// fallback is the common path rather than a corner.
+func TestTheGreetingFallsBackToSplittingTheDisplayName(t *testing.T) {
+	in := persondraft.FromView(
+		viewOf(personNamed("Marcus Greven", nil, nil)),
+		persondraft.Request{},
+	)
+	if in.Recipient.FirstName != "Marcus" {
+		t.Errorf("greeting name = %q, want the first word of the display name", in.Recipient.FirstName)
+	}
+}
+
+// A blank stored first name is not a name.
+//
+// An empty string in the column is what a partial import leaves behind, and
+// greeting somebody "Hi ," is worse than greeting them by a split display name.
+func TestABlankStoredFirstNameFallsBack(t *testing.T) {
+	in := persondraft.FromView(
+		viewOf(personNamed("Marcus Greven", ptr("   "), nil)),
+		persondraft.Request{},
+	)
+	if in.Recipient.FirstName != "Marcus" {
+		t.Errorf("greeting name = %q, want the fallback: a blank column is not a name", in.Recipient.FirstName)
+	}
+}

--- a/backend/internal/compose/persondraft/greeting_test.go
+++ b/backend/internal/compose/persondraft/greeting_test.go
@@ -8,9 +8,11 @@ package persondraft_test
 import (
 	"testing"
 
-	uuid "github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	"github.com/margince/margince/backend/internal/compose/persondraft"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 func viewOf(person crmcontracts.Person) crmcontracts.Person360 {
@@ -18,7 +20,7 @@ func viewOf(person crmcontracts.Person) crmcontracts.Person360 {
 }
 
 func personNamed(full string, first, last *string) crmcontracts.Person {
-	return crmcontracts.Person{Id: uuid.New(), FullName: full, FirstName: first, LastName: last}
+	return crmcontracts.Person{Id: openapi_types.UUID(ids.NewV7()), FullName: full, FirstName: first, LastName: last}
 }
 
 func ptr(s string) *string { return &s }

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -253,8 +253,11 @@ func ParseDraft(raw string, in Input) (Draft, error) {
 	// The greeting break is restored here rather than trusted to the prompt:
 	// the same request returns the run-on and the two-line form about equally
 	// often, and the composer renders exactly the breaks it is handed.
+	// Both names, because the register decides which one opens the message:
+	// the familiar greeting takes the first name and the formal one the
+	// surname, and the repair must recognise whichever the model wrote.
 	body := strings.TrimSpace(draftfloor.SplitGreetingLine(
-		ai.PlainText(out.Body), in.Recipient.FirstName))
+		ai.PlainText(out.Body), in.Recipient.FirstName, in.Recipient.LastName))
 	if subject == "" || body == "" {
 		return Draft{}, fmt.Errorf("person draft response: empty subject or body")
 	}

--- a/backend/internal/compose/persondraft/write.go
+++ b/backend/internal/compose/persondraft/write.go
@@ -19,6 +19,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
 )
@@ -249,7 +250,11 @@ func ParseDraft(raw string, in Input) (Draft, error) {
 	// answers with `<br>` between paragraphs often enough that it is the
 	// shape of the answer; the reply surface reads it the same way, so the
 	// same model cannot format correctly on one surface and not the other.
-	body := strings.TrimSpace(ai.PlainText(out.Body))
+	// The greeting break is restored here rather than trusted to the prompt:
+	// the same request returns the run-on and the two-line form about equally
+	// often, and the composer renders exactly the breaks it is handed.
+	body := strings.TrimSpace(draftfloor.SplitGreetingLine(
+		ai.PlainText(out.Body), in.Recipient.FirstName))
 	if subject == "" || body == "" {
 		return Draft{}, fmt.Errorf("person draft response: empty subject or body")
 	}

--- a/backend/internal/shared/kernel/draftfloor/greetingline.go
+++ b/backend/internal/shared/kernel/draftfloor/greetingline.go
@@ -22,33 +22,59 @@ import "strings"
 // continues on the same line. A greeting already on its own line is left
 // alone, and so is a body that opens with anything else, because a break
 // inserted at the wrong place is worse than the run-on it was meant to fix.
-func SplitGreetingLine(body, recipient string) string {
+func SplitGreetingLine(body string, names ...string) string {
+	for _, candidate := range names {
+		if split, ok := splitOn(body, candidate); ok {
+			return split
+		}
+	}
+	return body
+}
+
+// splitOn attempts the repair for ONE candidate name, reporting whether it
+// applied. Several are tried because the greeting register decides which name
+// opens the message: the familiar form takes the first name, the formal form
+// the surname, and the repair has to recognise whichever the model wrote.
+func splitOn(body, recipient string) (string, bool) {
 	name := strings.TrimSpace(recipient)
 	if name == "" {
-		return body
+		return body, false
 	}
 	trimmed := strings.TrimLeft(body, " \t")
-	if !strings.HasPrefix(trimmed, name) {
-		return body
+	// Case-insensitively, because a model that lowercases the opening
+	// ("greven, kurz und schmerzlos") wrote the same greeting and the rep sees
+	// the same run-on line. The body keeps ITS spelling — only the match is
+	// relaxed, so nothing the model wrote is rewritten.
+	if !strings.HasPrefix(strings.ToLower(trimmed), strings.ToLower(name)) {
+		return body, false
+	}
+	// Sliced off the BODY by the name's byte length, so the greeting keeps the
+	// capitalisation the model chose. ToLower can change a string's length in
+	// general, so the two are compared above and never mixed here.
+	if len(trimmed) < len(name) {
+		return body, false
 	}
 	rest := trimmed[len(name):]
+	greeting := trimmed[:len(name)]
 	if rest == "" {
-		return body
+		return body, false
 	}
 	// The separator the greeting ends on. A comma is the ordinary one; a full
 	// stop is what the terser registers produce ("Greven. Wir haben…").
 	separator := rest[0]
 	if separator != ',' && separator != '.' {
-		return body
+		return body, false
 	}
 	after := rest[1:]
 	// Already broken: the greeting owns its line and there is nothing to move.
-	if strings.HasPrefix(after, "\n") {
-		return body
+	// CRLF counts — a body that arrives with Windows line endings is already
+	// formatted, and inserting a break in front of them stacks blank lines.
+	if strings.HasPrefix(after, "\n") || strings.HasPrefix(after, "\r\n") {
+		return body, false
 	}
 	message := strings.TrimLeft(after, " \t")
 	if message == "" {
-		return body
+		return body, false
 	}
-	return name + string(separator) + "\n\n" + message
+	return greeting + string(separator) + "\n\n" + message, true
 }

--- a/backend/internal/shared/kernel/draftfloor/greetingline.go
+++ b/backend/internal/shared/kernel/draftfloor/greetingline.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftfloor
+
+import "strings"
+
+// SplitGreetingLine puts the opening greeting on its own line.
+//
+// The prompt asks for it and a model obeys inconsistently: the same request
+// returns "Greven, kurz und schmerzlos. Was ist der Stand?" as often as the
+// two-line form, and the composer renders exactly the breaks it is given. So
+// the rep opens a wall of text for a reason no rule in the prompt can be
+// tightened enough to prevent — the same request, twice, gives both answers.
+//
+// This is a formatting repair and never a rewrite. It moves ONE break and
+// changes not a character of what the model wrote, which is what makes it safe
+// to run over generated prose: the words that go out are still the model's.
+//
+// It fires only where the split is unambiguous — the body opens with the
+// recipient's own name, followed by a comma or a full stop, and the message
+// continues on the same line. A greeting already on its own line is left
+// alone, and so is a body that opens with anything else, because a break
+// inserted at the wrong place is worse than the run-on it was meant to fix.
+func SplitGreetingLine(body, recipient string) string {
+	name := strings.TrimSpace(recipient)
+	if name == "" {
+		return body
+	}
+	trimmed := strings.TrimLeft(body, " \t")
+	if !strings.HasPrefix(trimmed, name) {
+		return body
+	}
+	rest := trimmed[len(name):]
+	if rest == "" {
+		return body
+	}
+	// The separator the greeting ends on. A comma is the ordinary one; a full
+	// stop is what the terser registers produce ("Greven. Wir haben…").
+	separator := rest[0]
+	if separator != ',' && separator != '.' {
+		return body
+	}
+	after := rest[1:]
+	// Already broken: the greeting owns its line and there is nothing to move.
+	if strings.HasPrefix(after, "\n") {
+		return body
+	}
+	message := strings.TrimLeft(after, " \t")
+	if message == "" {
+		return body
+	}
+	return name + string(separator) + "\n\n" + message
+}

--- a/backend/internal/shared/kernel/draftfloor/greetingline_test.go
+++ b/backend/internal/shared/kernel/draftfloor/greetingline_test.go
@@ -83,6 +83,74 @@ func TestTheSplitChangesNoWords(t *testing.T) {
 	}
 }
 
+// A lowercased greeting is the same greeting, and the same run-on line.
+//
+// The body keeps the spelling the model chose: only the match is relaxed, so
+// the repair still moves a break and rewrites nothing.
+func TestALowercasedGreetingIsSplitAndKeepsItsSpelling(t *testing.T) {
+	got := draftfloor.SplitGreetingLine("greven, kurz und schmerzlos. Was ist der Stand?", "Greven")
+	want := "greven,\n\nkurz und schmerzlos. Was ist der Stand?"
+	if got != want {
+		t.Errorf("got %q, want the greeting split with the model's own capitalisation", got)
+	}
+}
+
+// A name carrying non-ASCII letters splits at the right place.
+//
+// The separator is read as the byte after the name, and a multi-byte name
+// would put that index inside a rune if the length were counted in characters
+// rather than bytes.
+func TestANameWithUmlautsIsSplit(t *testing.T) {
+	got := draftfloor.SplitGreetingLine("Jörg, wie ist der Stand?", "Jörg")
+	want := "Jörg,\n\nwie ist der Stand?"
+	if got != want {
+		t.Errorf("got %q, want the split to land after the name", got)
+	}
+}
+
+// A name that already contains a full stop is not cut at its own title.
+func TestANameContainingAFullStopSplitsAfterTheWholeName(t *testing.T) {
+	got := draftfloor.SplitGreetingLine("Dr. Meier, wir haben die Frage offen.", "Dr. Meier")
+	want := "Dr. Meier,\n\nwir haben die Frage offen."
+	if got != want {
+		t.Errorf("got %q, want the split after the whole name rather than inside it", got)
+	}
+}
+
+// A FORMAL greeting opens on the surname, and is repaired too.
+//
+// Which name opens the message is the register's choice — the shared rules
+// send the formal form to the surname — so a repair that knew only the first
+// name left every formal draft running on.
+func TestAFormalGreetingOnTheSurnameIsSplit(t *testing.T) {
+	got := draftfloor.SplitGreetingLine("Greven, wir haben die Frage offen.", "Marcus", "Greven")
+	want := "Greven,\n\nwir haben die Frage offen."
+	if got != want {
+		t.Errorf("got %q, want the formal greeting on its own line", got)
+	}
+}
+
+// The first name is tried first, so a familiar greeting is unaffected by the
+// surname also being offered.
+func TestTheFirstNameStillWinsWhenBothAreOffered(t *testing.T) {
+	got := draftfloor.SplitGreetingLine("Marcus, wir haben die Frage offen.", "Marcus", "Greven")
+	want := "Marcus,\n\nwir haben die Frage offen."
+	if got != want {
+		t.Errorf("got %q, want the familiar greeting on its own line", got)
+	}
+}
+
+// A body already broken with CRLF is left alone.
+//
+// Windows line endings are still line endings. Treating them as unbroken
+// inserts a second break in front of the first and stacks blank lines.
+func TestACRLFBodyIsRecognisedAsAlreadyBroken(t *testing.T) {
+	const body = "Greven,\r\n\r\nwir haben die Frage offen."
+	if got := draftfloor.SplitGreetingLine(body, "Greven"); got != body {
+		t.Errorf("got %q, want the body unchanged", got)
+	}
+}
+
 // squeeze removes every space and newline, leaving only the characters that
 // carry meaning.
 func squeeze(s string) string {

--- a/backend/internal/shared/kernel/draftfloor/greetingline_test.go
+++ b/backend/internal/shared/kernel/draftfloor/greetingline_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftfloor_test
+
+// Putting the opening greeting on its own line.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
+)
+
+// The defect this exists for: greeting and message on one line.
+func TestAGreetingRunningIntoTheMessageIsSplit(t *testing.T) {
+	got := draftfloor.SplitGreetingLine("Greven, kurz und schmerzlos. Was ist der Stand?", "Greven")
+	want := "Greven,\n\nkurz und schmerzlos. Was ist der Stand?"
+	if got != want {
+		t.Errorf("got %q, want the greeting on its own line", got)
+	}
+}
+
+// The terser register ends the greeting on a full stop.
+func TestAGreetingEndingInAFullStopIsSplit(t *testing.T) {
+	got := draftfloor.SplitGreetingLine("Greven. Wir haben die Frage offen.", "Greven")
+	want := "Greven.\n\nWir haben die Frage offen."
+	if got != want {
+		t.Errorf("got %q, want the greeting on its own line", got)
+	}
+}
+
+// A greeting already on its own line is left exactly as it is.
+//
+// Rerunning the split must change nothing, or a second pass would keep adding
+// blank lines to a draft that was already right.
+func TestAGreetingAlreadyOnItsOwnLineIsUntouched(t *testing.T) {
+	const body = "Greven,\n\nwir haben die Frage offen."
+	if got := draftfloor.SplitGreetingLine(body, "Greven"); got != body {
+		t.Errorf("got %q, want the body unchanged", got)
+	}
+}
+
+// A body that does not open with the recipient's name is left alone.
+//
+// The repair is only safe where the split is unambiguous. A break guessed into
+// the middle of a sentence is worse than the run-on it replaced.
+func TestABodyNotOpeningOnTheNameIsUntouched(t *testing.T) {
+	const body = "Kurz und schmerzlos: was ist der Stand bei Michael?"
+	if got := draftfloor.SplitGreetingLine(body, "Greven"); got != body {
+		t.Errorf("got %q, want the body unchanged", got)
+	}
+}
+
+// The name has to be followed by a greeting separator, not more of a word.
+//
+// "Grevenstrasse" starts with "Greven" and is not a greeting. Splitting on the
+// prefix alone would cut a word in half.
+func TestANameThatIsOnlyAPrefixIsUntouched(t *testing.T) {
+	const body = "Grevenstrasse 4 ist die neue Adresse, sag ich dir nur kurz."
+	if got := draftfloor.SplitGreetingLine(body, "Greven"); got != body {
+		t.Errorf("got %q, want the body unchanged", got)
+	}
+}
+
+// With no recipient name there is nothing to anchor a split to.
+func TestNoRecipientNameLeavesTheBodyAlone(t *testing.T) {
+	const body = "Hallo, wir haben die Frage offen."
+	if got := draftfloor.SplitGreetingLine(body, ""); got != body {
+		t.Errorf("got %q, want the body unchanged", got)
+	}
+}
+
+// The split moves a break and never a word.
+//
+// It runs over model-written prose, so the guarantee that makes it safe is
+// that the words going out are still the model's. Compared with whitespace
+// removed, the text before and after must be identical.
+func TestTheSplitChangesNoWords(t *testing.T) {
+	const body = "Greven, kurz und schmerzlos. Was ist der Stand bei Michael Grodd?"
+	got := draftfloor.SplitGreetingLine(body, "Greven")
+	if squeeze(got) != squeeze(body) {
+		t.Errorf("the split rewrote the message: %q became %q", body, got)
+	}
+}
+
+// squeeze removes every space and newline, leaving only the characters that
+// carry meaning.
+func squeeze(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r != ' ' && r != '\n' && r != '\t' {
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}


### PR DESCRIPTION
Three defects a rep sees in every drafted mail.

The greeting ran into the first sentence: "Greven, kurz und schmerzlos.
Was ist der Stand?" on one line. The prompt never said the greeting owns a
line, and the model split it about half the time — the same request, twice,
gave both answers. The rule now says it, and draftfloor.SplitGreetingLine
repairs it deterministically afterwards, because a prompt rule a model
obeys half the time is not a fix. The repair moves ONE break and changes
no word, which is what makes it safe over generated prose; it fires only
where the body opens with the recipient's own name and a comma or full
stop, so a break is never guessed into the middle of a sentence.

Whole messages arrived as a single unbroken block. "Three short paragraphs
at most" is a ceiling with no floor, so one run-on paragraph was
compliant, and nothing downstream repairs it — the composer renders the
breaks it is handed. The shared rules now ask for at least two paragraphs,
and draftcheck reports an unbroken-block finding that earns the existing
retry. A SHORT one-liner is not the defect: "passt Donnerstag?" is a
complete message, so the rule binds above a length rather than on every
missing break.

greetingName ignored the stored first_name and split the display name
instead, while surname beside it preferred the stored last_name. A
contact whose record says Philipp was greeted "Hi Pg". Five contacts in
the dev data were affected. The stored name now wins, the split stays as
the fallback for records carrying only a full name, and the redundant
overwrite below it — which reintroduced untrimmed blanks — is gone.

Verified against the live contact this was reported on: five drafts in a
row now open with the greeting on its own line and carry paragraph
breaks, where the same request previously returned zero breaks about a
third of the time.

Every fix is mutation-checked. Reverting the greeting split's separator
guard splits "Grevenstrasse" mid-word; reverting its already-broken guard
double-splits a correct draft; removing the first_name preference
regreets Philipp as "Pg"; and the unbroken-block rule is checked in both
directions, since one that flags everything passes a positive-only test.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

## Verification

Against the live contact this was reported on, five drafts in a row: greeting on its own line every time, paragraph breaks every time. The same request previously returned zero breaks about a third of the time.

- `make check-backend` green (full gate). `make craft-static` — 0 blocker, 0 major, 0 minor.
- Every fix mutation-checked; details in the commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two drafting defects: the greeting ran into the body about half the time, and long drafts could arrive as one unbroken block.

- `draftfloor.SplitGreetingLine` deterministically moves the greeting onto its own line after generation, recognising whichever register the model used (first name for the familiar form, surname for the formal one) and changing no words.
- `draftcheck.Formatting` flags one-line bodies over 160 characters as a wall of text, which earns a retry; short one-liners stay exempt, and the check applies to the message body alone so provenance chips are not told to add paragraphs.

<sup>Written for commit 1fa6209c97108f866793a5e15164a1353d5239f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drafts now use the recipient’s stored first name when available, with a display-name fallback.
  * Added checks to identify overly long, unbroken message blocks.
  * Greetings can now be recognized using either the recipient’s first name or surname.

* **Improvements**
  * Greetings are automatically placed on their own line, followed by a blank line before the message.
  * Draft formatting preserves paragraph structure and restores missing greeting line breaks.
  * Added formatting guidance requiring at least two paragraphs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->