### PR TITLE
main is red: a new AI task reaches neither of the two maps the ticker needs

### DIFF
--- a/frontend/src/app/ai-activity-lines.ts
+++ b/frontend/src/app/ai-activity-lines.ts
@@ -146,6 +146,7 @@ export const ACTIVITY_LINE: Readonly<
   brief_ranking: SYSTEM_SWEEP,
   capture_classify: SYSTEM_SWEEP,
   capture_counterparty_verdict: SYSTEM_SWEEP,
+  capture_confidentiality_verdict: SYSTEM_SWEEP,
   enrich: notDisplayed(
     "it reaches nobody, and it would not be worth showing if it did — recording only the first half is what made this read like a gap somebody should close. Reachability: the one production site is the signature-enrichment pass, which runs under a system principal with no on_behalf_of, so ResolveActor scopes every occurrence to the workspace with a NULL actor_user_id while the personal feed selects on actor_user_id. Worth: it could not be per-person even if it were reachable. The pass mints ONE correlation id for the whole run (api/jobs.yaml capture_enrich, up to 100 candidates in series), and the occurrence key is correlation+task, so every candidate collapses into ONE row — a per-person subject would make that single row flap from one person to the next rather than narrate any of them. What a reader actually wants from this pass is what it FOUND, which is durable and already drawn as evidence-or-omit provenance on the person record. The ticker's own `enrich` key names DIFFERENT work (a provider run on a person, and the organization page's Enrich card, which runs cold_start rather than this task), which is what makes this one easy to mistake for visible",
   ),

--- a/frontend/src/app/ai-activity-orb.ts
+++ b/frontend/src/app/ai-activity-orb.ts
@@ -33,6 +33,7 @@ export const ACTIVITY_LANE: Readonly<Record<ActivityKind, AgentLane>> = {
   // something in that it did not have a moment ago.
   capture_classify: "ingest",
   capture_counterparty_verdict: "ingest",
+  capture_confidentiality_verdict: "ingest",
   cold_start: "ingest",
   document_extract: "ingest",
   enrich: "ingest",


### PR DESCRIPTION
`main`'s composed typecheck fails.

## What is wrong

`capture_confidentiality_verdict` was added to `api/ai-tasks.yaml` without an entry in either frontend map keyed by the generated task union:

- `frontend/src/app/ai-activity-lines.ts` — the per-state i18n keys
- `frontend/src/app/ai-activity-orb.ts` — which lane the orb draws it in

Both are exhaustive `Readonly<Record<Task, …>>`, so the omission fails `tsc` on screens the change never touched:

```
src/app/ai-activity-lines.ts(70,14): error TS2741: Property 'capture_confidentiality_verdict' is missing …
src/app/ai-activity-orb.ts(30,14):   error TS2741: Property 'capture_confidentiality_verdict' is missing …
```

The exhaustive Record is doing exactly its job — this is the failure it exists to produce — and the branch that added the task was green before the union regenerated under it.

## The fix

It is a background sweep with `no_payload: true` and a local-only ladder, sitting beside `capture_counterparty_verdict` in the contract for the same stated reason: the prompt carries the message itself, so the decision about whether something is private does not leave the machine. It reaches nobody's personal feed, so it takes that task's answer in both maps — `SYSTEM_SWEEP` and the `ingest` lane.

## Verification

- `make check-fe`, `make check-backend`, `make craft-static`
- `make -C backend test-integration` — 48 packages, 0 skips

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity classification for confidentiality verification during content ingestion.
  * Prevented internal confidentiality checks from appearing in the user-facing activity feed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->