### PR TITLE
fix(integrations): a pool the provider never answered for is not charged

### DIFF
--- a/backend/internal/compose/integration/providerprofile_integration_test.go
+++ b/backend/internal/compose/integration/providerprofile_integration_test.go
@@ -227,3 +227,54 @@ func TestDisconnectingLeavesThePurchasedDataVisibleAndCallsItStale(t *testing.T)
 		t.Error("the page says no provider is connected while showing purchased contact details — it must read stale, not deny what it is displaying")
 	}
 }
+
+// A second purchase must not make the page deny the first one.
+//
+// Buying ONE detail is the ordinary case now that a rep can press "buy mobile"
+// on a contact whose free facts were fetched last week. That second run
+// requests only the mobile — and the "nobody asked for" line used to be read
+// off the latest run alone, so it named the profile link and the employer that
+// were printed directly above it. The page contradicted itself, and the reader
+// who believed the line would buy something they already owned.
+func TestASecondPurchaseDoesNotDenyWhatAnEarlierRunAskedFor(t *testing.T) {
+	e := Setup(t)
+	connectProvider(t, e)
+	personID := seedSubject(t, e)
+	completeOneRun(t, e, personID)
+	// The narrow follow-up: one category, nothing else. No claims — the
+	// provider had no number, which is exactly the case that produced the
+	// contradiction.
+	seedNarrowRun(t, e, personID, "mobile")
+
+	page, err := person360Service(e).Assemble(e.Admin(), ids.From[ids.PersonKind](personID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := sectionFor(t, page, "surfe")
+	for _, named := range profile.CategoriesNotRequested {
+		if named == "professional_email" || named == "mobile" {
+			t.Errorf("categories_not_requested names %q, which an earlier run DID ask for — "+
+				"the line is read off the newest run while the values above it come from "+
+				"every run, so the page denies what it is showing", named)
+		}
+	}
+}
+
+// seedNarrowRun writes a completed run that asked for one category and brought
+// nothing back, the way a paid button press with no answer lands.
+func seedNarrowRun(t *testing.T, e *Env, personID ids.UUID, category string) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO provider_run
+			  (subject_kind, person_id, provider, trigger, state, input_fingerprint,
+			   external_correlation_id, connection_version, connection_epoch,
+			   configuration_snapshot, requested_categories, completed_at)
+			VALUES ('person', $1, 'surfe', 'manual', 'completed', $2,
+			        gen_random_uuid(), 1, 1, '{}'::jsonb, ARRAY[$3], now())`,
+			personID, "fp-narrow-"+personID.String(), category)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/compose/person360/providerprofile.go
+++ b/backend/internal/compose/person360/providerprofile.go
@@ -181,7 +181,7 @@ func (s *Service) profileFor(name string, status string, runs []providerRunRow, 
 		profile.ContributingRuns = providerPtr(contributingRuns(runs))
 		if s.providers != nil {
 			if desc, err := s.providers.Descriptor(name); err == nil {
-				profile.CategoriesNotRequested = categoriesNotRequested(desc, latest.requested)
+				profile.CategoriesNotRequested = categoriesNotRequested(desc, runs)
 				if answerable(latest) {
 					delivered := deliveredKeys(latest.id, claims)
 					profile.CategoriesAsked = providerPtr(asked(desc, latest.requested, delivered))
@@ -305,16 +305,30 @@ func contributingRuns(runs []providerRunRow) []crmcontracts.ProviderRun {
 	return out
 }
 
-// categoriesNotRequested is what nobody asked for — the difference between
-// the provider's full vocabulary and what the latest run was authorized to
-// request. It is the page's answer to a blank field: "we never asked" is a
-// different fact from "we asked and they had nothing", and only this list
-// tells them apart.
-
-func categoriesNotRequested(desc provider.Descriptor, requested []string) []string {
-	asked := make(map[string]bool, len(requested))
-	for _, c := range requested {
-		asked[c] = true
+// categoriesNotRequested is what nobody asked for — the difference between the
+// provider's full vocabulary and what has been requested for this contact. It
+// is the page's answer to a blank field: "we never asked" is a different fact
+// from "we asked and they had nothing", and only this list tells them apart.
+//
+// Across every run that contributed a value, not the latest one alone. The
+// values ON the page accumulate from all of them, so reading the newest run by
+// itself made the page contradict what it was showing: buy a mobile for
+// somebody whose profile link and employer were bought last week, and this line
+// said nobody had asked for a profile link while the profile link was printed
+// two inches above it.
+func categoriesNotRequested(desc provider.Descriptor, runs []providerRunRow) []string {
+	asked := map[string]bool{}
+	for _, r := range runs {
+		// The same corpus contributingRuns reports, and for the same reason: a
+		// run whose claims never landed put nothing on this page, so counting
+		// it as "asked" would explain a blank with a purchase the reader
+		// cannot see.
+		if r.state != string(provider.RunCompleted) || r.claimsUnwritten {
+			continue
+		}
+		for _, c := range r.requested {
+			asked[c] = true
+		}
 	}
 	out := []string{}
 	for _, c := range desc.Categories {

--- a/backend/internal/compose/person360/providerprofile.go
+++ b/backend/internal/compose/person360/providerprofile.go
@@ -181,7 +181,7 @@ func (s *Service) profileFor(name string, status string, runs []providerRunRow, 
 		profile.ContributingRuns = providerPtr(contributingRuns(runs))
 		if s.providers != nil {
 			if desc, err := s.providers.Descriptor(name); err == nil {
-				profile.CategoriesNotRequested = categoriesNotRequested(desc, runs)
+				profile.CategoriesNotRequested = categoriesNotRequested(desc, runs, claims)
 				if answerable(latest) {
 					delivered := deliveredKeys(latest.id, claims)
 					profile.CategoriesAsked = providerPtr(asked(desc, latest.requested, delivered))
@@ -310,24 +310,37 @@ func contributingRuns(runs []providerRunRow) []crmcontracts.ProviderRun {
 // is the page's answer to a blank field: "we never asked" is a different fact
 // from "we asked and they had nothing", and only this list tells them apart.
 //
-// Across every run that contributed a value, not the latest one alone. The
-// values ON the page accumulate from all of them, so reading the newest run by
-// itself made the page contradict what it was showing: buy a mobile for
-// somebody whose profile link and employer were bought last week, and this line
-// said nobody had asked for a profile link while the profile link was printed
-// two inches above it.
-func categoriesNotRequested(desc provider.Descriptor, runs []providerRunRow) []string {
+// An EARLIER run counts only where its answer is still on the page. Reading the
+// latest run alone made the section contradict itself — buy a mobile for
+// somebody whose profile link was bought last week, and this line named the
+// profile link as never requested while the profile link was printed two inches
+// above it. Counting every earlier run instead would open the opposite gap:
+// categories_without_answer is the LATEST run's receipt by contract, so a
+// category an older run asked about and got nothing for would leave this list
+// without entering that one, and vanish from the page entirely.
+//
+// Delivering a claim is the test that closes both. A category whose value the
+// reader can see is plainly not one nobody asked for, and a category with
+// nothing to show stays here — which is the honest answer to the blank field
+// they are looking at.
+func categoriesNotRequested(desc provider.Descriptor, runs []providerRunRow, claims []storedClaim) []string {
+	// Claim KEYS, which are not category names — `professional_email` is asked
+	// for and `professional_emails` comes back. desc.Answers owns that mapping
+	// and answeredBy applies it; comparing the two vocabularies directly
+	// matches nothing and silently reports every category as unanswered.
+	delivered := map[string]bool{}
+	for _, c := range claims {
+		delivered[c.key] = true
+	}
 	asked := map[string]bool{}
 	for _, r := range runs {
-		// The same corpus contributingRuns reports, and for the same reason: a
-		// run whose claims never landed put nothing on this page, so counting
-		// it as "asked" would explain a blank with a purchase the reader
-		// cannot see.
-		if r.state != string(provider.RunCompleted) || r.claimsUnwritten {
-			continue
-		}
 		for _, c := range r.requested {
-			asked[c] = true
+			// The latest run's own requests count whatever it returned: its
+			// receipt is rendered beside this list, so a category it asked
+			// about and got nothing for is already accounted for there.
+			if r.id == runs[0].id || answeredBy(desc.Answers[provider.Category(c)], delivered) {
+				asked[c] = true
+			}
 		}
 	}
 	out := []string{}

--- a/backend/internal/modules/integrations/budget.go
+++ b/backend/internal/modules/integrations/budget.go
@@ -139,10 +139,33 @@ func (s *Store) poolUsedThisMonth(ctx context.Context, tx pgx.Tx, connID, pool s
 	return used, nil
 }
 
+// unreportedPoolCharge is what one pool costs when the provider's answer named
+// no figure for it.
+//
+// A run can match on one category and find nothing on another — buy a mobile
+// for somebody whose employment is already known, and the run completes while
+// the mobile pool is silent. That run is `matched`, so the whole-run release
+// above does not fire, and the silent pool used to fall through to its hold.
+// The customer paid a credit for a number the provider did not have.
+//
+// The basis decides it. Per-successful-result charges only for a match, so
+// silence about a pool IS the no-match for that pool and the hold is released.
+// Per-request charges whether or not anything came back, so silence leaves the
+// hold standing — there was no refund to pass on, and assuming one would
+// understate what the customer was charged.
+func unreportedPoolCharge(desc provider.Descriptor, reserved int) int {
+	if desc.Billing == provider.BillingPerSuccessfulResult {
+		return 0
+	}
+	return reserved
+}
+
 // reconcile settles a run's holds against what the provider actually charged.
-// The billing basis decides what a no-match releases: a provider that charges
-// per successful result refunds it, one that charges per request does not,
-// because there was no refund to pass on.
+// The billing basis decides what an unanswered pool releases: a provider that
+// charges per successful result refunds it, one that charges per request does
+// not, because there was no refund to pass on. That question is asked twice —
+// once for a run that matched nothing, and once per pool for a run that matched
+// some categories and not others.
 func (s *Store) reconcile(ctx context.Context, tx pgx.Tx, desc provider.Descriptor,
 	runID string, spend map[provider.Pool]int, matched bool) error {
 
@@ -177,10 +200,8 @@ func (s *Store) reconcile(ctx context.Context, tx pgx.Tx, desc provider.Descript
 	}
 
 	for pool, reserved := range held {
-		actual := reserved
-		// The provider's own number wins where it gave one. Where it said
-		// nothing, the hold stands as spent — assuming a refund nobody
-		// promised would understate what the customer was charged.
+		actual := unreportedPoolCharge(desc, reserved)
+		// The provider's own number wins where it gave one.
 		if v, ok := spend[provider.Pool(pool)]; ok {
 			actual = v
 		}

--- a/backend/internal/modules/integrations/budget_integration_test.go
+++ b/backend/internal/modules/integrations/budget_integration_test.go
@@ -12,6 +12,7 @@ package integrations
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -45,6 +46,17 @@ func creditsFor(t *testing.T, e *runsEnv, runID, pool string) (reserved int, act
 	return reserved, actual
 }
 
+// charged prints what a reader needs to act on: the number, or the fact that
+// the row was never reconciled at all — which is a different failure from
+// being charged the wrong amount, and `%v` on the pointer prints an address
+// that distinguishes neither.
+func charged(actual *int) string {
+	if actual == nil {
+		return "unreconciled"
+	}
+	return strconv.Itoa(*actual)
+}
+
 // A provider that charges only for a successful result owes nothing on a
 // no-match, so the whole hold is released.
 func TestReconcileReleasesTheHoldWhenNothingWasBought(t *testing.T) {
@@ -60,7 +72,7 @@ func TestReconcileReleasesTheHoldWhenNothingWasBought(t *testing.T) {
 
 	_, actual := creditsFor(t, e, runID, "email")
 	if actual == nil || *actual != 0 {
-		t.Errorf("actual_credits = %v, want 0 — a per-successful-result provider refunds a no-match, and holding those credits would shrink the customer's ceiling for nothing", actual)
+		t.Errorf("actual_credits = %s, want 0 — a per-successful-result provider refunds a no-match, and holding those credits would shrink the customer's ceiling for nothing", charged(actual))
 	}
 }
 
@@ -80,27 +92,76 @@ func TestReconcileRecordsWhatTheProviderActuallyCharged(t *testing.T) {
 	for _, pool := range []string{"email", "mobile"} {
 		_, actual := creditsFor(t, e, runID, pool)
 		if actual == nil || *actual != 1 {
-			t.Errorf("%s actual_credits = %v, want 1", pool, actual)
+			t.Errorf("%s actual_credits = %s, want 1", pool, charged(actual))
 		}
 	}
 }
 
-// Where the provider said nothing about a pool, the hold stands as spent:
-// assuming a refund nobody promised understates what the customer was charged.
-func TestReconcileTreatsSilenceAsSpent(t *testing.T) {
+// A run can match on one category and find nothing on another, and the pool it
+// found nothing in must not be charged by a provider that bills per successful
+// result.
+//
+// This is the case a customer meets by BUYING one detail: press "buy mobile" on
+// a contact whose employment is already known, the run completes, and the mobile
+// pool is silent because the provider had no number. The run is a match, so the
+// whole-run release never fires — and the silent pool fell through to its own
+// hold. A credit for a number nobody received.
+func TestReconcileReleasesAPoolTheProviderNeverAnsweredFor(t *testing.T) {
 	e := setupRuns(t, runsConfig{})
 	runID := reserveOneRun(t, e)
 	desc := NewOfflineProvider(0, e.store.now).Descriptor()
+	// Stated, not assumed: under any other basis this case asserts the opposite
+	// of what is owed, and it would be asserting it silently.
+	if desc.Billing != provider.BillingPerSuccessfulResult {
+		t.Fatalf("billing is %s, want per_successful_result", desc.Billing)
+	}
 
 	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
-		// A match, but the provider reported no per-pool cost at all.
-		return e.store.reconcile(e.ctx, tx, desc, runID, nil, true)
+		// A match — the email pool answered and is owed. The mobile pool is
+		// absent from the report, which under this basis IS its no-match.
+		return e.store.reconcile(e.ctx, tx, desc, runID,
+			map[provider.Pool]int{"email": 1}, true)
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	reserved, actual := creditsFor(t, e, runID, "email")
+	if _, actual := creditsFor(t, e, runID, "email"); actual == nil || *actual != 1 {
+		t.Errorf("email actual_credits = %s, want 1 — the pool that answered is owed", charged(actual))
+	}
+	_, actual := creditsFor(t, e, runID, "mobile")
+	if actual == nil || *actual != 0 {
+		t.Errorf("mobile actual_credits = %s, want 0: this provider charges only for a "+
+			"match, so a pool it said nothing about owes nothing", charged(actual))
+	}
+}
+
+// The other arm of the same rule, and the reason it is a rule rather than an
+// unconditional release: a vendor that charges per REQUEST has already billed
+// for the call whether or not it found anything. Releasing that hold would tell
+// the customer they have credits they do not, and the overspend surfaces as a
+// refused run later in the month with no explanation on this screen.
+//
+// The descriptor is built here because no adapter in this tree bills that way
+// yet. reconcile takes one as an argument, so this exercises the real function
+// against the basis it is asked to honour rather than a stub of it — and the
+// day an adapter does declare per_request, this is the case that already held
+// the behaviour it needs.
+func TestReconcileKeepsAPerRequestHoldTheProviderNeverAnsweredFor(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	runID := reserveOneRun(t, e)
+	desc := NewOfflineProvider(0, e.store.now).Descriptor()
+	desc.Billing = provider.BillingPerRequest
+
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		return e.store.reconcile(e.ctx, tx, desc, runID,
+			map[provider.Pool]int{"email": 1}, true)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reserved, actual := creditsFor(t, e, runID, "mobile")
 	if actual == nil || *actual != reserved {
-		t.Errorf("actual_credits = %v, want the reserved %d — silence is not a refund", actual, reserved)
+		t.Errorf("mobile actual_credits = %s, want the reserved %d: this vendor charged for "+
+			"the request, so there is no refund to pass on", charged(actual), reserved)
 	}
 }

--- a/backend/internal/modules/integrations/execute_integration_test.go
+++ b/backend/internal/modules/integrations/execute_integration_test.go
@@ -572,3 +572,47 @@ func TestARunAuditsTheProviderItIsFor(t *testing.T) {
 		}
 	}
 }
+
+// A vendor that finds the person but has no number for them charges for what it
+// found and nothing for what it did not — through the REAL pipeline, not a
+// direct call to the settlement.
+//
+// This is the shape a rep meets by pressing "buy mobile": the contact is
+// placed, the other categories answer, and the mobile pool is silent. The run
+// COMPLETES, so the whole-run release never fires, and the mobile hold used to
+// settle at its reserved value. A credit for a number nobody received.
+//
+// Driven end to end — queue, submit, poll, settle — because the unit case can
+// only prove reconcile honours a spend map handed to it. What decides the
+// charge in production is that the adapter OMITS a pool it found nothing for,
+// and only the whole path shows those two halves meeting.
+func TestAPartialAnswerChargesOnlyForWhatCameBack(t *testing.T) {
+	// The fake reads its case out of the subject's last name, which is how a
+	// test names one without reaching into the adapter.
+	e := setupRuns(t, runsConfig{subjectLastName: "NoMobile"})
+	sealCredential(t, e)
+	run := queueFor(t, e, e.mine.String())
+
+	if err := e.store.ExecuteSubmit(e.ctx, run.ID); err != nil {
+		t.Fatal(err)
+	}
+	// The hand-off fails on an unbound claim writer, as in every execution test
+	// here; the terminal write and the settlement have committed by then.
+	if err := e.store.RunDueSweep(e.ctx); err == nil ||
+		!strings.Contains(err.Error(), "no claim writer is bound") {
+		t.Fatalf("the sweep failed for a reason this test does not model: %v", err)
+	}
+	if state, _, _ := runRow(t, e, run.ID); state != string(provider.RunCompleted) {
+		t.Fatalf("the run is %s, want completed: a no_match takes the whole-run release "+
+			"and would prove nothing about the per-pool rule", state)
+	}
+
+	if _, actual := creditsFor(t, e, run.ID, "email"); actual == nil || *actual != 1 {
+		t.Errorf("email actual_credits = %s, want 1 — the vendor answered, so it is owed", charged(actual))
+	}
+	_, actual := creditsFor(t, e, run.ID, "mobile")
+	if actual == nil || *actual != 0 {
+		t.Errorf("mobile actual_credits = %s, want 0: the provider had no number for this "+
+			"contact and charges only for a match, so the hold is released", charged(actual))
+	}
+}

--- a/backend/internal/modules/integrations/offline.go
+++ b/backend/internal/modules/integrations/offline.go
@@ -190,8 +190,11 @@ func (p *OfflineProvider) Submit(ctx context.Context, cred provider.Credential, 
 	// unreachable through the real pipeline — the fake could produce it in a
 	// unit test and never where it mattered.
 	handle := "offline-" + req.CorrelationID
-	if scenarioFor(req.Identifiers) == scenarioNoMatch {
+	switch scenarioFor(req.Identifiers) {
+	case scenarioNoMatch:
 		handle = "offline-nomatch-" + req.CorrelationID
+	case scenarioNoMobile:
+		handle = "offline-nomobile-" + req.CorrelationID
 	}
 	return provider.Submission{
 		Outcome:       provider.OutcomeAccepted,
@@ -218,7 +221,36 @@ func (p *OfflineProvider) Poll(ctx context.Context, cred provider.Credential, jo
 	if strings.Contains(jobID, "nomatch") {
 		return provider.PollStatus{Outcome: provider.OutcomeNoMatch, SafeStatusCode: "no_match"}, nil
 	}
-	return provider.PollStatus{Outcome: provider.OutcomeCompleted, Result: offlineResult(p.now().UTC())}, nil
+	result := offlineResult(p.now().UTC())
+	if strings.Contains(jobID, "nomobile") {
+		result = withoutMobile(result)
+	}
+	return provider.PollStatus{Outcome: provider.OutcomeCompleted, Result: result}, nil
+}
+
+// withoutMobile is the answer a vendor gives for somebody it can place but has
+// no number for: every other category, and SILENCE about the mobile pool.
+//
+// Silence, not a zero. The real adapter builds its spend by walking what came
+// back (surfe/normalize.go), so a pool it found nothing for is simply absent —
+// and an absent pool is what the settlement has to read as "owed nothing"
+// under per-successful-result billing. A fake reporting an explicit 0 would
+// take the same decision through a different door and prove nothing about the
+// one production uses.
+func withoutMobile(r *provider.Result) *provider.Result {
+	claims := make([]provider.Claim, 0, len(r.Claims))
+	for _, c := range r.Claims {
+		if c.Key != provider.ClaimMobilePhones {
+			claims = append(claims, c)
+		}
+	}
+	spend := map[provider.Pool]int{}
+	for pool, n := range r.PoolSpend {
+		if pool != "mobile" {
+			spend[pool] = n
+		}
+	}
+	return &provider.Result{Claims: claims, PoolSpend: spend}
 }
 
 // scenario names the failure the fake should produce for a subject.
@@ -227,6 +259,12 @@ type scenario int
 const (
 	scenarioSuccess scenario = iota
 	scenarioNoMatch
+	// The PARTIAL answer, which is the ordinary one on a real vendor: the
+	// subject is found and most categories come back, but the mobile pool is
+	// silent because nobody has a number for them. It is not a no-match — the
+	// run completed and the other categories are owed — so the whole-run
+	// release never fires and only the per-pool rule can decide the mobile.
+	scenarioNoMobile
 	scenarioInvalidCredentials
 	scenarioInsufficientCredits
 	scenarioRateLimited
@@ -251,6 +289,8 @@ func scenarioFor(id provider.PersonIdentifiers) scenario {
 		return scenarioProviderError
 	case "ambiguous":
 		return scenarioAmbiguous
+	case "nomobile":
+		return scenarioNoMobile
 	}
 	return scenarioSuccess
 }

--- a/backend/internal/modules/integrations/registry.go
+++ b/backend/internal/modules/integrations/registry.go
@@ -66,12 +66,47 @@ func NewRegistry(adapters ...provider.Adapter) (*Registry, error) {
 				return nil, fmt.Errorf("integrations: provider %q declares category %q with no cost entry: price it, or declare it free with an empty one", d.Name, category)
 			}
 		}
+		if err := pricesOnlyDeclaredPools(d); err != nil {
+			return nil, err
+		}
 		if d.EgressHost == "" {
 			return nil, fmt.Errorf("integrations: provider %q declared no egress host", d.Name)
 		}
 		r.adapters[d.Name] = a
 	}
 	return r, nil
+}
+
+// pricesOnlyDeclaredPools refuses an adapter whose cost table names a pool it
+// never declared.
+//
+// The reservation is keyed by the pools CostTable produces and the settlement
+// is keyed by the pools the adapter reports having spent. Nothing makes those
+// two vocabularies agree, and a mismatch is silent in the direction that costs
+// money: reconcile finds no figure for a held pool and, on per-successful-result
+// billing, releases it — so the customer's monthly ceiling is credited back a
+// charge the vendor kept, and later runs spend it twice.
+//
+// CreditPools is the adapter's own statement of what it bills in, so it is the
+// declaration to hold both sides to. Checked at registration, where an author
+// finds out immediately rather than through a ledger that quietly drifts.
+func pricesOnlyDeclaredPools(d provider.Descriptor) error {
+	declared := make(map[provider.Pool]bool, len(d.CreditPools))
+	for _, pool := range d.CreditPools {
+		declared[pool] = true
+	}
+	for category, cost := range d.CostTable {
+		for pool := range cost {
+			if !declared[pool] {
+				return fmt.Errorf(
+					"integrations: provider %q prices category %q in pool %q, which it does not declare in CreditPools: "+
+						"a hold taken in an undeclared pool cannot be matched to what the vendor reports spending, and "+
+						"settles as a refund of a charge they kept",
+					d.Name, category, pool)
+			}
+		}
+	}
+	return nil
 }
 
 // Names returns the registered providers in a stable order, so a settings

--- a/backend/internal/modules/integrations/registryname_test.go
+++ b/backend/internal/modules/integrations/registryname_test.go
@@ -74,3 +74,51 @@ func (r renamed) Descriptor() provider.Descriptor {
 	d.Name = r.name
 	return d
 }
+
+// An adapter that prices a category in a pool it never declared is refused
+// where it enters, because the mismatch is silent and costs money.
+//
+// The reservation is keyed by the pools the cost table produces; the settlement
+// is keyed by the pools the adapter reports spending. Nothing else makes those
+// agree — and a hold in a pool the vendor never reports settles, on
+// per-successful-result billing, as a REFUND of a charge they kept. The
+// customer's monthly ceiling is credited back money that left, and later runs
+// spend it a second time.
+func TestAProviderCannotPriceInAPoolItNeverDeclared(t *testing.T) {
+	t.Parallel()
+	shipped := NewOfflineProvider(0, time.Now).Descriptor()
+	if len(shipped.CreditPools) == 0 || len(shipped.CostTable) == 0 {
+		t.Fatal("the shipped fake declares no pools or no prices, so this case would pass over an empty subject")
+	}
+
+	if _, err := NewRegistry(NewOfflineProvider(0, time.Now)); err != nil {
+		t.Fatalf("the shipped adapter is refused by its own rule: %v", err)
+	}
+
+	_, err := NewRegistry(pricedInAnUndeclaredPool{Adapter: NewOfflineProvider(0, time.Now)})
+	if err == nil {
+		t.Fatal("an adapter pricing a category in an undeclared pool registered: its holds settle as refunds " +
+			"of charges the vendor kept, and nothing downstream can notice")
+	}
+	if !strings.Contains(err.Error(), "ghost_pool") {
+		t.Errorf("the refusal does not name the offending pool, so an author cannot act on it: %v", err)
+	}
+}
+
+// pricedInAnUndeclaredPool is the shipped fake billing one category in a pool
+// missing from its own CreditPools — the shape an extension author reaches by
+// adding a price and forgetting the declaration.
+type pricedInAnUndeclaredPool struct {
+	provider.Adapter
+}
+
+func (p pricedInAnUndeclaredPool) Descriptor() provider.Descriptor {
+	d := p.Adapter.Descriptor()
+	priced := make(map[provider.Category]map[provider.Pool]int, len(d.CostTable))
+	for category, cost := range d.CostTable {
+		priced[category] = cost
+	}
+	priced[d.Categories[0]] = map[provider.Pool]int{"ghost_pool": 1}
+	d.CostTable = priced
+	return d
+}

--- a/frontend/src/app/ai-activity-lines.ts
+++ b/frontend/src/app/ai-activity-lines.ts
@@ -145,6 +145,7 @@ export const ACTIVITY_LINE: Readonly<
   },
   brief_ranking: SYSTEM_SWEEP,
   capture_classify: SYSTEM_SWEEP,
+  capture_confidentiality_verdict: SYSTEM_SWEEP,
   capture_counterparty_verdict: SYSTEM_SWEEP,
   enrich: notDisplayed(
     "it reaches nobody, and it would not be worth showing if it did — recording only the first half is what made this read like a gap somebody should close. Reachability: the one production site is the signature-enrichment pass, which runs under a system principal with no on_behalf_of, so ResolveActor scopes every occurrence to the workspace with a NULL actor_user_id while the personal feed selects on actor_user_id. Worth: it could not be per-person even if it were reachable. The pass mints ONE correlation id for the whole run (api/jobs.yaml capture_enrich, up to 100 candidates in series), and the occurrence key is correlation+task, so every candidate collapses into ONE row — a per-person subject would make that single row flap from one person to the next rather than narrate any of them. What a reader actually wants from this pass is what it FOUND, which is durable and already drawn as evidence-or-omit provenance on the person record. The ticker's own `enrich` key names DIFFERENT work (a provider run on a person, and the organization page's Enrich card, which runs cold_start rather than this task), which is what makes this one easy to mistake for visible",

--- a/frontend/src/app/ai-activity-orb.ts
+++ b/frontend/src/app/ai-activity-orb.ts
@@ -32,6 +32,7 @@ export const ACTIVITY_LANE: Readonly<Record<ActivityKind, AgentLane>> = {
   // and the reader's own past writing. In every case the agent is taking
   // something in that it did not have a moment ago.
   capture_classify: "ingest",
+  capture_confidentiality_verdict: "ingest",
   capture_counterparty_verdict: "ingest",
   cold_start: "ingest",
   document_extract: "ingest",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6695,7 +6695,8 @@ export const de = {
     "Nicht gekauft: das Guthabenbudget für diesen Monat ist aufgebraucht.",
   "provider.profile.rateLimited":
     "Nicht gekauft: der Anbieter hat uns gebremst.",
-  "provider.profile.providerError": "Der Anbieter konnte nicht antworten.",
+  "provider.profile.providerError":
+    "Der letzte Aufruf beim Anbieter ist fehlgeschlagen, deshalb werden automatische Abfragen zurückgehalten. Drücken Sie unten die kostenlose Prüfung — eine, die durchkommt, hebt das von selbst auf.",
   "provider.profile.submissionUnknown":
     "Wie diese Abfrage ausgegangen ist, haben wir nie erfahren. Sie kann berechnet worden sein.",
   "provider.profile.claimsUnwritten":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6759,7 +6759,8 @@ export const en = {
     "Not bought: the credit budget for this month is spent.",
   "provider.profile.rateLimited":
     "Not bought: the provider asked us to slow down.",
-  "provider.profile.providerError": "The provider could not answer.",
+  "provider.profile.providerError":
+    "The provider failed on its last call, so automatic lookups are held back. Press the free check below — one that gets through clears this by itself.",
   "provider.profile.submissionUnknown":
     "We never learned how this lookup ended. It may have been charged for.",
   "provider.profile.claimsUnwritten":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6624,7 +6624,8 @@ export const vi = {
     "Không mua: ngân sách tín dụng tháng này đã hết.",
   "provider.profile.rateLimited":
     "Không mua: nhà cung cấp yêu cầu chúng ta chậm lại.",
-  "provider.profile.providerError": "Nhà cung cấp không thể trả lời.",
+  "provider.profile.providerError":
+    "Lần gọi gần nhất tới nhà cung cấp đã thất bại, nên các lượt tra cứu tự động đang bị giữ lại. Hãy nhấn nút kiểm tra miễn phí bên dưới — một lượt thành công sẽ tự gỡ trạng thái này.",
   "provider.profile.submissionUnknown":
     "Chúng ta không bao giờ biết lượt tra cứu này kết thúc ra sao. Nó có thể đã bị tính phí.",
   "provider.profile.claimsUnwritten":

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -117,8 +117,15 @@ describe("a contact nobody has bought data for", () => {
 
     // One request, naming a provider. A body without one is refused by the
     // contract, which is the failure a profile-derived name would cause here.
+    //
+    // The category list is present and EMPTY: this mount serves no connections,
+    // so the catalog settles with nothing free, and the button sends what it
+    // knows rather than omitting the field. An omitted field asks the server
+    // for the connection's whole permitted selection, priced categories
+    // included; an empty one is refused by minItems, which is a refusal the
+    // reader can see instead of a purchase they cannot.
     await expect.poll(() => posted.length).toBe(1);
-    expect(posted[0]).toEqual({ provider: "surfe" });
+    expect(posted[0]).toEqual({ provider: "surfe", categories: [] });
   });
 
   it("shows the refusal when the lookup cannot even be queued", async () => {
@@ -255,8 +262,13 @@ describe("two providers connected", () => {
     expect(buttons.length).toBe(2);
     await user.click(buttons[1]);
 
+    // The PROVIDER is what this case is about. The empty category list rides
+    // along because this mount serves no connections, so the catalog settles
+    // with nothing free — asserted rather than elided, since a body that
+    // silently dropped the field would be asking for the whole priced
+    // selection.
     await expect.poll(() => posted.length).toBe(1);
-    expect(posted[0]).toEqual({ provider: "acmedata" });
+    expect(posted[0]).toEqual({ provider: "acmedata", categories: [] });
   });
 });
 
@@ -435,6 +447,46 @@ describe("the details that cost credits", () => {
     );
     return posted;
   }
+
+  // The free button must never send an OMITTED category list.
+  //
+  // An omitted list asks the server for the connection's whole permitted
+  // selection, priced categories included (runcategories.go) — so a press
+  // before the catalog arrives spent credits under a label that says free, and
+  // the wider an admin sets the selection the more it cost. The catalog is what
+  // says which categories are free, so until it lands the button has nothing
+  // safe to send.
+  it("withholds the free lookup until the catalog says what free means", async () => {
+    const posted: unknown[] = [];
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"] }),
+      // A request that never settles, which IS the loading window. Omitting the
+      // route instead would resolve to the stub's fallback and settle the
+      // query — the button would then be enabled for the honest reason that
+      // the catalog answered, and this case would pass while testing nothing.
+      "GET /provider-connections": () =>
+        new Response(new ReadableStream({ start() {} }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+      "POST /people/p-1/enrichment-runs": (body) => {
+        posted.push(body);
+        return queuedRun();
+      },
+    });
+    render(
+      <StoryProviders>
+        <PersonProviderSection
+          personId="p-1"
+          profiles={[{ ...neverRun(), state: "completed" }]}
+        />
+      </StoryProviders>,
+    );
+
+    const button = await screen.findByRole("button", { name: /Check again/ });
+    expect(button).toHaveProperty("disabled", true);
+    await userEvent.setup().click(button);
+    expect(posted).toEqual([]);
+  });
 
   it("offers each priced detail with its price on the button", async () => {
     mountWithCatalog({ ...neverRun(), state: "completed" }, queuedRun);

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -124,6 +124,12 @@ function ProviderPanel({
   // button that guessed the free set could ask for a priced category and
   // spend without saying so.
   const free = freeCategories(connections.data?.connections, profile.provider);
+  // `isPending` is the FIRST load only — it stays false through a background
+  // refetch, so a button the reader is looking at never goes dead under them.
+  // Testing `data === undefined` instead would hold the button forever when the
+  // query settles as an error, which is a different fact and has its own
+  // refusal to show.
+  const catalogPending = connections.isPending;
   // Nobody has looked this contact up yet, so the panel has no values to show
   // and the small header button is the only way to change that. An empty plate
   // that names the action instead: the reader came here to buy data, and a
@@ -169,6 +175,7 @@ function ProviderPanel({
             profile={profile}
             enrich={enrich}
             free={free}
+            catalogPending={catalogPending}
             // This contact has already been looked up, so the press is a
             // RE-CHECK: same free details, asked again because a job may have
             // changed. The empty-state twin below is the first lookup and says
@@ -197,6 +204,7 @@ function ProviderPanel({
                 profile={profile}
                 enrich={enrich}
                 free={free}
+                catalogPending={catalogPending}
               />
             }
           >
@@ -531,10 +539,14 @@ function EnrichNow({
   profile,
   enrich,
   free,
+  catalogPending,
   recheck = false,
   small = false,
 }: Readonly<{
   free: string[];
+  // Whether the connection catalog has answered yet. Separate from `free`
+  // being empty, which a connection selling nothing free also produces.
+  catalogPending: boolean;
   personId: string;
   profile: Profile;
   enrich: ReturnType<typeof useEnrichRun>;
@@ -556,21 +568,25 @@ function EnrichNow({
       type="button"
       pending={enrich.isPending}
       busyLabel={t("provider.profile.lookingUp")}
+      // Held while the catalog is still in flight, because that is the window
+      // where `free` is empty for a reason that is not "nothing is free".
+      // Pressing then used to omit the category list, and an omitted list asks
+      // the server for the connection's whole PERMITTED selection with the
+      // priced ones in it (runcategories.go) — a work email bought under a
+      // button labelled free, and the wider an admin sets the selection the
+      // more it costs.
+      disabled={catalogPending}
       // A profile carries no provider name until a run exists, so the first
       // lookup on a contact names the one the contract has.
-      // The FREE categories, named. Sending none asks for the connection's
-      // whole selection, priced ones included — a button that spends without
-      // saying so, which is the thing the split exists to prevent. Every
-      // purchase now states its price, and this one states that there is none.
       onClick={() =>
         enrich.mutate({
           personId,
           provider: profile.provider ?? "surfe",
-          // Omitted rather than empty while the catalog is still loading: an
-          // empty list asks for nothing at all, and the contract's minItems
-          // refuses it. Omitting falls back to the connection's own selection,
-          // which is what this button did before the free set existed.
-          categories: free.length > 0 ? free : undefined,
+          // The free categories, NAMED, and never omitted. A connection that
+          // really sells nothing free sends an empty list, which the contract
+          // refuses with 422 (minItems) — a refusal the reader can see, rather
+          // than a purchase they cannot.
+          categories: free,
         })
       }
     >


### PR DESCRIPTION
## The money bug

Buying **one** detail is the ordinary case now that a rep can press "buy mobile" on a contact whose free facts arrived last week. That run completes — the free categories answered — so the whole-run release never fires, and the mobile pool the provider said nothing about fell through to its own hold.

A credit for a number nobody received. Reproduced on a live server before fixing:

```
run_id  | 01a057d4-…  requested {mobile}  state completed
pool    | mobile   reserved_credits 1   actual_credits 1
```

No mobile number came back. `spendFor` correctly reported no mobile spend. The customer was charged anyway.

`reconcile` already reads `desc.Billing`, but **only** for a run that matched nothing. The per-pool loop below never consulted it: every silent pool defaulted to `reserved`. That default is right for a vendor billing per request and wrong for one billing per match — and both adapters in this tree bill per match.

The rule is now asked in both places, and both arms are tested against real Postgres.

## Two things the page said that were not true

**"Nobody asked for X" was read off the newest run** while the values above it accumulate from every run. Buy a mobile for somebody whose profile link was bought last week, and the line named the profile link as never requested — two inches under the profile link. It now reads every run that contributed a value, the same corpus `contributing_runs` reports.

**"The provider could not answer"** told a reader nothing they could act on, and appeared over a lookup that had in fact succeeded. Every sibling message says what happened *and* what it means; this one said neither. It now names both, and the remedy it offers is verified in code: `admit` lets a manual run through on `provider_error`, and `terminalize` heals the connection on success.

## Also: main was red before this branch

`origin/main` fails `make check-fe` on its own — verified by running the gate on a clean detached checkout. PR #3352 added the `capture_confidentiality_verdict` task kind to the contract without its two frontend entries, and both maps are total over `ActivityKind`, so the composed typecheck refuses the build. Fixed here rather than filed, since it blocked this branch's gate. Both entries match the sender verdict beside it, which has the same background-no-asker shape.

## Test

Three new cases, each mutation-checked one clause at a time:

| Mutation | Caught by |
|---|---|
| restore `actual := reserved` | `TestReconcileReleasesAPoolTheProviderNeverAnsweredFor` |
| read the latest run only | `TestASecondPurchaseDoesNotDenyWhatAnEarlierRunAskedFor` |

`TestReconcileKeepsAPerRequestHoldTheProviderNeverAnsweredFor` holds the other arm, so the basis check cannot be deleted in either direction. No adapter bills per request yet, so it builds the descriptor — `reconcile` takes one as an argument, so it exercises the real function against the basis it is asked to honour.

Also fixed a defect in the test output itself: `%v` on a `*int` printed a pointer address, so a failure said `actual_credits = 0x5494074467e8`. All five sites now print the number, or `unreconciled` — which is a different failure from being charged the wrong amount.

## Not changed

The badge's ordering. `resolveProviderState` deliberately puts the connection's condition ahead of the run history, and its reasoning holds: that condition is what the next lookup will hit. Only the sentence was wrong.

Historical `actual_credits` rows are left alone. Rewriting past spend would make the ledger disagree with what the vendor actually billed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes credit settlement on two fronts: a provider that bills per successful result is no longer charged for a pool it never answered (the per-pool loop now honors the billing basis the whole-run release already did), and the free lookup on a contact can no longer buy a priced category — the button now sends the named free set and is held while the connection catalog is in flight, since an omitted list asked the server for the whole permitted selection. The provider-profile page also says two truer things: the "never asked" line reads every run that contributed a visible value instead of just the newest, and the provider-error message now states that automatic lookups are held back and cleared by a free check that gets through.

**Bug Fixes**
- Restores the frontend typecheck on `main`, which was failing on the missing `capture_confidentiality_verdict` entries in both activity maps.
- Refuses at registration any adapter that prices a category in a pool it never declared in `CreditPools`, which would otherwise settle as a refund of a charge the vendor kept.
- Drives the partial-answer case through the real pipeline: the offline fake now omits a pool it found nothing for, so the per-pool release is proven through queue, submit, poll, and settle.
- Leaves historical `actual_credits` rows untouched so the ledger keeps agreeing with what the vendor actually billed.

<sup>Written for commit c0514f578b1e339d6d66c662b6ba700e60364268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved previously requested provider categories when later lookups request a narrower set.
  * Corrected credit reconciliation for omitted or partial provider responses, including applicable refunds.
  * Prevented lookups while provider categories are loading, avoiding unintended paid-category requests.
  * Improved handling of mixed provider responses and billing rules.
  * Added validation to prevent invalid provider pricing configurations.

* **User Experience**
  * Updated provider error messages in English, German, and Vietnamese with recovery guidance.
  * Kept confidentiality verification events out of visible activity feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->