### PR TITLE
fix(records): a number that is not a VAT ID reads as not valid

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29283,8 +29283,16 @@ components:
           type: string
           enum: [valid, invalid, unavailable]
           description: |
-            `valid` and `invalid` are answers ABOUT the number. `unavailable` is the register
-            declining to answer, and is a fact about the lookup rather than about the company.
+            `valid` and `invalid` are answers ABOUT the number, and `invalid` covers both a
+            number the register rejected and one that was never asked about because it is not
+            VAT-ID shaped: no request is made for a value that cannot be a VAT ID, and a reader
+            fixes their own field either way.
+
+            `unavailable` is no longer written. It meant the register declining to answer, but a
+            register that declines is snoozed or retried rather than recorded, so the only thing
+            that ever produced it was a malformed number — which now reads as what it is. The
+            value stays in the enum because rows written by older builds still carry it, and a
+            client reads it as `invalid`.
           # Pinned for the reason the lane enum above states: bare `Valid` and
           # `Invalid` read as nobody's constants and collide with the next enum
           # to use one of the words.

--- a/backend/internal/compose/vatcheckjobs.go
+++ b/backend/internal/compose/vatcheckjobs.go
@@ -203,14 +203,23 @@ func (w *vatCheckWorker) Work(ctx context.Context, job *river.Job[CheckOrganizat
 
 	result, err := w.checker.Check(wsCtx, number)
 	if errors.Is(err, vatcheck.ErrMalformedNumber) {
-		// The page stated something that is not a VAT ID. No request was made,
-		// so the register said NOTHING — recording `invalid` here would be
-		// indistinguishable from a negative answer it never gave. It is
-		// recorded as unanswered, which is what actually happened.
+		// The stated value is not a VAT ID, so no request was made — and the
+		// answer a reader needs is INVALID.
+		//
+		// It was recorded as unanswered on the reasoning that the register said
+		// nothing, which is true and is the wrong fact to surface: the reader
+		// met "Register did not answer" beside their own typo and was told a
+		// public service had failed them. Whether a number is fake or merely
+		// misspelled changes nothing they would do about it.
+		//
+		// Nothing else records unanswered. A register that declines is snoozed
+		// or retried rather than written (below), so this branch was the only
+		// producer of that status and the distinction it protected was never
+		// visible to anybody.
 		return jobs.FaultContext(wsCtx, store.RecordVatCheck(wsCtx, people.VatCheck{
 			OrganizationID: orgID,
 			Number:         number,
-			Status:         people.VatCheckUnavailable,
+			Status:         people.VatCheckInvalid,
 			CheckedAt:      w.clock(),
 		}))
 	}

--- a/backend/internal/compose/vatrecheckworker_integration_test.go
+++ b/backend/internal/compose/vatrecheckworker_integration_test.go
@@ -42,6 +42,15 @@ func (c *countingRegister) Check(_ context.Context, number string) (vatcheck.Res
 	return vatcheck.Result{Status: vatcheck.StatusValid, ConsultationNumber: "WAPIAAAA"}, nil
 }
 
+// A value that is not VAT-ID shaped is settled before any request: the client
+// refuses it rather than spending somebody else's service on it.
+type refusingRegister struct{ asked int }
+
+func (r *refusingRegister) Check(_ context.Context, _ string) (vatcheck.Result, error) {
+	r.asked++
+	return vatcheck.Result{}, vatcheck.ErrMalformedNumber
+}
+
 // vatRecheckEnv is one workspace holding a company whose VAT number has already
 // been consulted — the state in which the automatic rule declines.
 type vatRecheckEnv struct {
@@ -101,6 +110,42 @@ func (v *vatRecheckEnv) work(t *testing.T, requested bool) {
 	})
 	if err != nil {
 		t.Fatalf("working the consultation (requested=%v): %v", requested, err)
+	}
+}
+
+// A number that cannot be a VAT ID reads as INVALID, not as the register having
+// declined.
+//
+// It was recorded as unanswered on the reasoning that no request was made, so
+// the register said nothing — true, and the wrong fact to put in front of a
+// reader. Somebody looking at their own typo was told a public service had
+// failed them, and the thing they had to fix was on their own screen.
+func TestANumberThatIsNotAVatIdIsInvalid(t *testing.T) {
+	v := setupVatRecheck(t)
+	register := &refusingRegister{}
+	v.worker = newVatCheckWorker(v.Pool, register, func() time.Time {
+		return time.Date(2026, 8, 31, 9, 0, 0, 0, time.UTC)
+	})
+	ctx := v.Admin()
+	// Stated by a person, through the real writer — the shape a rep produces
+	// when they mistype into the field.
+	malformed := "122323235sdf"
+	if _, err := v.People.UpdateOrganizationProfileField(ctx, v.orgID, "register_vat",
+		people.ProfileFieldWriteInput{Value: &malformed}); err != nil {
+		t.Fatalf("state the malformed number: %v", err)
+	}
+
+	v.work(t, true)
+
+	if register.asked != 1 {
+		t.Fatalf("the client was consulted %d time(s), want 1 — it is what judges the shape", register.asked)
+	}
+	stored, err := v.People.VatCheckFor(ctx, v.orgID)
+	if err != nil {
+		t.Fatalf("read the recorded answer: %v", err)
+	}
+	if stored.Status != people.VatCheckInvalid {
+		t.Errorf("status = %q, want invalid — a reader fixes their own number either way", stored.Status)
 	}
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -22827,8 +22827,16 @@ type OrganizationVatCheck struct {
 	// RegisteredName Who the register says the number belongs to. Absent when it named nobody.
 	RegisteredName *string `json:"registered_name,omitempty"`
 
-	// Status `valid` and `invalid` are answers ABOUT the number. `unavailable` is the register
-	// declining to answer, and is a fact about the lookup rather than about the company.
+	// Status `valid` and `invalid` are answers ABOUT the number, and `invalid` covers both a
+	// number the register rejected and one that was never asked about because it is not
+	// VAT-ID shaped: no request is made for a value that cannot be a VAT ID, and a reader
+	// fixes their own field either way.
+	//
+	// `unavailable` is no longer written. It meant the register declining to answer, but a
+	// register that declines is snoozed or retried rather than recorded, so the only thing
+	// that ever produced it was a malformed number — which now reads as what it is. The
+	// value stays in the enum because rows written by older builds still carry it, and a
+	// client reads it as `invalid`.
 	Status OrganizationVatCheckStatus `json:"status"`
 
 	// VatNumber The number AS CONSULTED, which is not necessarily the number on the profile today.
@@ -22837,8 +22845,16 @@ type OrganizationVatCheck struct {
 	VatNumber string `json:"vat_number"`
 }
 
-// OrganizationVatCheckStatus `valid` and `invalid` are answers ABOUT the number. `unavailable` is the register
-// declining to answer, and is a fact about the lookup rather than about the company.
+// OrganizationVatCheckStatus `valid` and `invalid` are answers ABOUT the number, and `invalid` covers both a
+// number the register rejected and one that was never asked about because it is not
+// VAT-ID shaped: no request is made for a value that cannot be a VAT ID, and a reader
+// fixes their own field either way.
+//
+// `unavailable` is no longer written. It meant the register declining to answer, but a
+// register that declines is snoozed or retried rather than recorded, so the only thing
+// that ever produced it was a malformed number — which now reads as what it is. The
+// value stays in the enum because rows written by older builds still carry it, and a
+// client reads it as `invalid`.
 type OrganizationVatCheckStatus string
 
 // OverlayBudget The incumbent REST budget window's consumption and degradation band, its per-source breakdown, honest headroom, and the per-second Search window (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5).

--- a/docs/how-to/check-a-vat-number.md
+++ b/docs/how-to/check-a-vat-number.md
@@ -81,9 +81,13 @@ The shield beside the number carries it. Open it for the whole receipt.
 | Verdict | What it means |
 |---|---|
 | **Valid** | The register recognises the number. **Read Registered to before you trust it** — see below. |
-| **Not valid** | The register does not recognise it. A typo, a number that has been deregistered, or one that was never real. |
-| **Register did not answer** | A fact about the **lookup**, never about the company. A member state's register was offline, or the number was not VAT-ID shaped so no request was made. |
+| **Not valid** | The number does not hold up. A typo, a value that is not VAT-ID shaped at all, a number since deregistered, or one that was never real. |
 | *(grey, "not checked yet")* | Nobody has asked. Distinct from having asked and been told no. |
+
+Three states, and deliberately no fourth. A number the register rejects and a
+number it was never asked about — because the value cannot be a VAT ID — are the
+same problem on your record, and what you do about either is identical: fix the
+field. Splitting them would ask you to interpret a distinction you cannot act on.
 
 **Valid does not mean "belongs to this company."** A VAT ID copied from another company's imprint — a
 template reused, a subsidiary's number left in place — is a *real* number, so the register returns
@@ -175,9 +179,10 @@ psql "$DSN" -c "SELECT state, attempt FROM river_job
                  WHERE kind = 'check_organization_vat' ORDER BY id DESC LIMIT 3;"
 ```
 
-**The answer is always "Register did not answer".** Check the number's shape. A VAT ID starts with a
-two-letter country code — `122323235` is not one, and no request is made for a value that cannot be a VAT
-ID. Recorded as unanswered rather than invalid, because the register said nothing.
+**A number I know is real reads Not valid.** Check its shape first. A VAT ID starts with a two-letter
+country code — `122323235sdf` is not one, so no request is made and the answer is **Not valid** without
+the register ever being asked. Then check **Registered to**: a real number belonging to somebody else
+answers **Valid**, and only the name exposes it.
 
 **The shield shows a grey question mark I can press.** The check could not be **read** — a network or
 server fault, not a fact about the company. Pressing it reads again.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21457,8 +21457,16 @@ export interface components {
              */
             vat_number: string;
             /**
-             * @description `valid` and `invalid` are answers ABOUT the number. `unavailable` is the register
-             *     declining to answer, and is a fact about the lookup rather than about the company.
+             * @description `valid` and `invalid` are answers ABOUT the number, and `invalid` covers both a
+             *     number the register rejected and one that was never asked about because it is not
+             *     VAT-ID shaped: no request is made for a value that cannot be a VAT ID, and a reader
+             *     fixes their own field either way.
+             *
+             *     `unavailable` is no longer written. It meant the register declining to answer, but a
+             *     register that declines is snoozed or retried rather than recorded, so the only thing
+             *     that ever produced it was a malformed number — which now reads as what it is. The
+             *     value stays in the enum because rows written by older builds still carry it, and a
+             *     client reads it as `invalid`.
              * @enum {string}
              */
             status: "valid" | "invalid" | "unavailable";

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1631,7 +1631,6 @@ export const de = {
   "co.vat.receipt": "Abfrage-Nummer",
   "co.vat.status.valid": "Gültig",
   "co.vat.status.invalid": "Nicht gültig",
-  "co.vat.status.unavailable": "Register hat nicht geantwortet",
   "co.vat.noReceipt":
     "Keine vergeben. Das Register vergibt eine Abfrage-Nummer nur für eine Abfrage unter eurer eigenen USt-IdNr. — trag sie in den Einstellungen ein, dann trägt die nächste Abfrage einen Nachweis, den ein Finanzamt akzeptiert.",
   "co.vat.never":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1670,7 +1670,6 @@ export const en = {
   "co.vat.receipt": "Consultation number",
   "co.vat.status.valid": "Valid",
   "co.vat.status.invalid": "Not valid",
-  "co.vat.status.unavailable": "Register did not answer",
   "co.vat.noReceipt":
     "None issued. The register issues a receipt only for a check made under your own VAT ID — add yours in the settings and the next check carries proof a tax authority accepts.",
   "co.vat.never":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1624,7 +1624,6 @@ export const vi = {
   "co.vat.receipt": "Số tra cứu",
   "co.vat.status.valid": "Hợp lệ",
   "co.vat.status.invalid": "Không hợp lệ",
-  "co.vat.status.unavailable": "Sổ đăng ký không trả lời",
   "co.vat.noReceipt":
     "Chưa cấp. Sổ đăng ký chỉ cấp số tra cứu cho lần kiểm tra thực hiện dưới mã số thuế của chính bạn — hãy nhập mã số của bạn trong phần cài đặt, lần tra cứu tiếp theo sẽ có bằng chứng mà cơ quan thuế chấp nhận.",
   "co.vat.never":

--- a/frontend/src/screens/companyvatmark.stories.tsx
+++ b/frontend/src/screens/companyvatmark.stories.tsx
@@ -103,9 +103,12 @@ export const Invalid: Story = {
   },
 };
 
-/** The register declined to answer. A fact about the lookup, never about the
- * company — so it is stated without a warning tone. */
-export const RegisterSilent: Story = {
+/** A row an older build left behind, carrying `unavailable`. Nothing writes
+ * that status now — a value that is not VAT-ID shaped is recorded as invalid,
+ * and a register that declines is retried rather than written — so this is the
+ * version-skew case: it reads as NOT VALID, because three states is what a
+ * reader can act on and a fourth word would only ask them to interpret it. */
+export const StatusFromAnOlderBuild: Story = {
   render: () => {
     installFetchStub({
       "GET /me": CAN_WRITE,

--- a/frontend/src/screens/companyvatmark.test.tsx
+++ b/frontend/src/screens/companyvatmark.test.tsx
@@ -127,6 +127,20 @@ describe("the VAT mark beside the number", () => {
     ).toBeInTheDocument();
   });
 
+  it("reads a legacy unavailable row as not valid", async () => {
+    // Nothing writes that status now, but a row an older build left behind
+    // still says it. Three states is what a reader can act on — the number
+    // holds up, it does not, or nobody asked — and a fourth word would only
+    // ask them to work out which of the three it meant.
+    answerWith({ ...CHECKED, status: "unavailable" });
+
+    render(mark());
+
+    expect(
+      await screen.findByRole("button", { name: "VAT ID: Not valid" }),
+    ).toBeInTheDocument();
+  });
+
   it("says a company nobody has consulted is unchecked", async () => {
     answerWith({}, 404);
 

--- a/frontend/src/screens/companyvatmark.tsx
+++ b/frontend/src/screens/companyvatmark.tsx
@@ -26,9 +26,17 @@ export function vatCheckKey(orgId: string) {
 }
 
 /** What each verdict is called, which glyph carries it, and how strongly to say
- * it. `unavailable` is the register declining rather than a finding about the
- * company, so it stays untoned — colouring it would report an outage as a
- * problem with the account. */
+ * it.
+ *
+ * Three states and no more, because three is what a reader can act on: the
+ * number holds up, it does not, or nobody has asked. `unavailable` reads as
+ * NOT VALID rather than as a fourth idea — a number the register cannot
+ * recognise and a number it was never asked about are the same problem on the
+ * record, and the reader's next move is identical either way.
+ *
+ * Nothing writes `unavailable` today (the worker records a malformed number as
+ * invalid, and a declining register is retried rather than written), so this
+ * entry is for a row an older build left behind. */
 const VERDICTS: Readonly<
   Record<
     VatStatus,
@@ -46,8 +54,9 @@ const VERDICTS: Readonly<
     icon: <ShieldAlert aria-hidden />,
   },
   unavailable: {
-    label: "co.vat.status.unavailable",
-    icon: <ShieldQuestion aria-hidden />,
+    label: "co.vat.status.invalid",
+    tone: "danger",
+    icon: <ShieldAlert aria-hidden />,
   },
 };
 


### PR DESCRIPTION
## What was wrong

`122323235sdf` answered **"Register did not answer."**

The reader met a public service being blamed for their own typo, and the thing they had to fix was on their own screen.

The reasoning behind that was sound and surfaced the wrong fact. No request is made for a value that cannot be a VAT ID, so the register genuinely said nothing — and recording `invalid` looked like faking an answer it never gave. But whether a number is fake, mistyped or simply not VAT-ID shaped changes nothing a reader would do about it: **fix the field.** The distinction was real and unusable.

## What changed

**Three states, and deliberately no fourth.** The number holds up, it does not, or nobody has asked. A malformed number now records `invalid` and reads **Not valid**.

**Nothing else ever wrote `unavailable`.** A register that declines is snoozed when it says when to come back, and retried otherwise — never recorded. So the malformed branch was its only producer, and the distinction it protected was never visible to anybody. The value stays in the enum because rows written by older builds still carry it, and the mark reads it as **Not valid**.

The contract's own description now says both of those things, so the next reader of the enum does not have to reconstruct them.

## Testing

- `make check-fe` and `make check-backend` — both green, before and after the rebase
- `make test-it DIR=backend/internal/compose` — full lane green
- `TestANumberThatIsNotAVatIdIsInvalid` drives the real worker with a register client that refuses the shape, states the number through the real writer, and asserts what lands. It fails against the old status.
- The frontend keeps a case for a legacy `unavailable` row reading as **Not valid**, so the version-skew path is held rather than assumed.

## One thing about the rebase

This branch briefly also fixed two frontend lane maps missing `capture_confidentiality_verdict`, which had the composed typecheck red on `main`. Somebody landed the same fix while this was in flight, so the rebase produced duplicate keys. I took `main`'s version of both files and amended the commit message rather than leaving it claiming a fix the diff no longer contains.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A number that is not a VAT ID now records as `invalid` and reads **Not valid** instead of **Register did not answer**, so a reader's own typo is no longer blamed on the register.

- Nothing writes `unavailable` anymore — a register that declines is retried or snoozed rather than recorded — but the enum keeps it so rows older builds left behind still render, as **Not valid**.
- Removed the "Register did not answer" string from all locales.
- Updated the API contract descriptions and the how-to doc to explain the three statuses and why there is deliberately no fourth.

<sup>Written for commit 04d7d3ed8125520861547a086244566359d640bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VAT numbers that are malformed or rejected are now consistently shown as **Not valid**.
  * Legacy “Register did not answer” results are displayed as **Not valid** with the appropriate warning styling.
  * Malformed VAT numbers are recorded correctly instead of remaining unanswered.

* **Documentation**
  * Clarified VAT status meanings, lookup behavior, and troubleshooting guidance.
  * Explained how mismatched company registrations are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->