### PR TITLE
feat(company): the facts panel states a fact and takes one away

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -28896,11 +28896,16 @@ components:
             worse than one that flags it.
         updated_at: { type: string, format: date-time }
         version:
-          $ref: '#/components/schemas/RowVersion'
+          type: integer
+          format: int64
+          readOnly: true
           description: >-
             The row's version, for the `If-Match` a correction or a removal sends. The write path
             has always honoured the precondition; without the version on the read no client could
             send one, so two readers editing the same fact silently overwrote each other.
+            Spelled inline rather than as a $ref to RowVersion: a $ref with sibling keys drops
+            them under OpenAPI 3.0, and the generator then emitted no property at all — the field
+            was in the contract and absent from every client that reads it.
 
     OrganizationFactListResponse:
       type: object

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -22462,12 +22462,8 @@ type OrganizationFact struct {
 	// VerifiedBy The human who confirmed the claim. Server-stamped, never accepted from a request body.
 	VerifiedBy *string `json:"verified_by,omitempty"`
 
-	// Version Monotonic row version, incremented by the server on every mutation (data-model §1.3a).
-	// Echoed back as the `version` field on every mutable entity. To make a write conditional,
-	// send the last-seen value in `If-Match`; a mismatch returns `409 code: version_skew`
-	// (ErrVersionSkew) so the client re-reads before retrying. Applies to the native SoR path,
-	// not only overlay mode.
-	Version *RowVersion `json:"version,omitempty"`
+	// Version The row's version, for the `If-Match` a correction or a removal sends. The write path has always honoured the precondition; without the version on the read no client could send one, so two readers editing the same fact silently overwrote each other. Spelled inline rather than as a $ref to RowVersion: a $ref with sibling keys drops them under OpenAPI 3.0, and the generator then emitted no property at all — the field was in the contract and absent from every client that reads it.
+	Version *int64 `json:"version,omitempty"`
 }
 
 // OrganizationFactCategory defines model for OrganizationFact.Category.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21170,8 +21170,11 @@ export interface components {
             readonly suspect_reason?: null | "phone_shaped_location" | "not_a_phone" | "not_a_year" | "not_an_email" | "not_a_size";
             /** Format: date-time */
             updated_at: string;
-            /** @description The row's version, for the `If-Match` a correction or a removal sends. The write path has always honoured the precondition; without the version on the read no client could send one, so two readers editing the same fact silently overwrote each other. */
-            version?: components["schemas"]["RowVersion"];
+            /**
+             * Format: int64
+             * @description The row's version, for the `If-Match` a correction or a removal sends. The write path has always honoured the precondition; without the version on the read no client could send one, so two readers editing the same fact silently overwrote each other. Spelled inline rather than as a $ref to RowVersion: a $ref with sibling keys drops them under OpenAPI 3.0, and the generator then emitted no property at all — the field was in the contract and absent from every client that reads it.
+             */
+            readonly version?: number;
         };
         OrganizationFactListResponse: {
             data: components["schemas"]["OrganizationFact"][];

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1657,6 +1657,21 @@ export const de = {
   "co.tech.lane.homepage": "Startseite",
   "signal.kind.technical_change": "Technik geändert",
   "co.factField.quantified_outcome": "Ergebnis",
+  "co.facts.title": "Fakten über diese Firma",
+  "co.facts.empty":
+    "Noch nichts erfasst. Lesen Sie die Website, oder tragen Sie ein, was Sie bereits wissen.",
+  "co.facts.add": "Fakt hinzufügen",
+  "co.facts.addField": "Art des Fakts",
+  "co.facts.addValue": "Was er besagt",
+  "co.facts.addSave": "Fakt speichern",
+  "co.facts.addCancel": "Abbrechen",
+  "co.facts.addIncomplete":
+    "Wählen Sie die Art des Fakts und tragen Sie ein, was er besagt.",
+  "co.facts.remove": "{value} entfernen",
+  "co.facts.removeTitle": "Diesen Fakt entfernen?",
+  "co.facts.removeConfirm": "Entfernen",
+  "co.facts.removeAsk":
+    "{field} ist als \u201e{value}\u201c erfasst. Ihn zu entfernen bedeutet: Das ist kein Fakt über die Firma. Ein späteres Lesen der Website kann ihn erneut erfassen.",
   "co.facts.showAll": "Alle {count} anzeigen",
   "co.facts.showLess": "Weniger anzeigen",
   "co.tags.lists": "Listen",
@@ -1700,7 +1715,6 @@ export const de = {
   "co.overlayFallback":
     "Dieser Account wird aus dem verbundenen führenden System bedient; die Firmenansicht wird hier nicht zusammengestellt. \u00d6ffne ihn dort für das vollständige Bild.",
   "org.domains": "Domains",
-  "org.facts": "Von der Website gelesene Fakten",
   "org.factCategory.company": "Unternehmen",
   "org.factCategory.offering": "Angebot",
   "org.factCategory.market": "Markt",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1696,6 +1696,21 @@ export const en = {
   "co.tech.lane.homepage": "Homepage",
   "signal.kind.technical_change": "Technology changed",
   "co.factField.quantified_outcome": "Result",
+  "co.facts.title": "Facts about this company",
+  "co.facts.empty":
+    "Nothing on file yet. Read the website, or state what you already know.",
+  "co.facts.add": "Add fact",
+  "co.facts.addField": "What kind of fact",
+  "co.facts.addValue": "What it says",
+  "co.facts.addSave": "Save fact",
+  "co.facts.addCancel": "Cancel",
+  "co.facts.addIncomplete":
+    "Pick what kind of fact this is and type what it says.",
+  "co.facts.remove": "Remove {value}",
+  "co.facts.removeTitle": "Remove this fact?",
+  "co.facts.removeConfirm": "Remove",
+  "co.facts.removeAsk":
+    "{field} is recorded as \u201c{value}\u201d. Removing it says this is not a fact about the company. A later read of their website may state it again.",
   "co.facts.showAll": "Show all {count}",
   "co.facts.showLess": "Show fewer",
   "co.tags.lists": "Lists",
@@ -1739,7 +1754,6 @@ export const en = {
   "co.overlayFallback":
     "This account is served from the connected system of record, so the company view is not assembled here. Open it in that system to see the full picture.",
   "org.domains": "Domains",
-  "org.facts": "Facts read from the site",
   "org.factCategory.company": "Company",
   "org.factCategory.offering": "Offering",
   "org.factCategory.market": "Market",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1650,6 +1650,20 @@ export const vi = {
   "co.tech.lane.homepage": "Trang chủ",
   "signal.kind.technical_change": "Công nghệ đã thay đổi",
   "co.factField.quantified_outcome": "Kết quả",
+  "co.facts.title": "Thông tin về công ty này",
+  "co.facts.empty":
+    "Chưa có gì được ghi nhận. Hãy đọc trang web, hoặc ghi lại điều bạn đã biết.",
+  "co.facts.add": "Thêm thông tin",
+  "co.facts.addField": "Loại thông tin",
+  "co.facts.addValue": "Nội dung",
+  "co.facts.addSave": "Lưu thông tin",
+  "co.facts.addCancel": "Hủy",
+  "co.facts.addIncomplete": "Hãy chọn loại thông tin và nhập nội dung của nó.",
+  "co.facts.remove": "Xóa {value}",
+  "co.facts.removeTitle": "Xóa thông tin này?",
+  "co.facts.removeConfirm": "Xóa",
+  "co.facts.removeAsk":
+    "{field} được ghi là \u201c{value}\u201d. Xóa nó nghĩa là đây không phải thông tin về công ty. Một lần đọc trang web sau này có thể ghi lại nó.",
   "co.facts.showAll": "Hiện tất cả {count}",
   "co.facts.showLess": "Hiện bớt",
   "co.tags.lists": "Danh sách",
@@ -1693,7 +1707,6 @@ export const vi = {
   "co.overlayFallback":
     "Tài khoản này được phục vụ từ hệ thống ghi nhận đã kết nối, nên màn hình công ty không được dựng ở đây. Hãy mở bên hệ thống đó để xem toàn cảnh.",
   "org.domains": "Tên miền",
-  "org.facts": "Dữ kiện đọc từ website",
   "org.factCategory.company": "Công ty",
   "org.factCategory.offering": "Sản phẩm dịch vụ",
   "org.factCategory.market": "Thị trường",

--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -491,6 +491,24 @@
 
 /* Facts read from the site. The rhythm is tighter than the profile card above
    because these are scanned, not read: the reader is looking for one thing. */
+/* The add-a-fact row: a chooser, a value and the two verbs, on one line until
+   the panel is too narrow to hold them — at which point the value takes the
+   full width rather than shrinking to a box nobody can read their own typing
+   in. */
+.co-facts-add {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  margin-bottom: var(--space-4);
+  background: var(--bgCard);
+  border-radius: var(--r-sm);
+}
+.co-facts-add > :nth-child(4) {
+  flex: 1 1 12rem;
+}
+
 .co-facts-group {
   margin-bottom: var(--space-4);
 }

--- a/frontend/src/screens/companyfactspanel.test.tsx
+++ b/frontend/src/screens/companyfactspanel.test.tsx
@@ -47,14 +47,24 @@ function fact(seed: FactSeed) {
 }
 
 function stub(facts: readonly unknown[]) {
-  const calls: { method: string; url: string; body: unknown }[] = [];
+  const calls: {
+    method: string;
+    url: string;
+    body: unknown;
+    ifMatch: string | null;
+  }[] = [];
   const fetchMock = vi.fn(async (request: Request) => {
     // A DELETE carries no body, and asking one for JSON throws before the
     // stub can answer — which reads exactly like the code failing to send the
     // request at all.
     const body =
       request.method === "POST" ? await request.clone().json() : undefined;
-    calls.push({ method: request.method, url: request.url, body });
+    calls.push({
+      method: request.method,
+      url: request.url,
+      body,
+      ifMatch: request.headers.get("If-Match"),
+    });
     if (request.method === "GET") {
       return new Response(JSON.stringify({ data: facts }), {
         status: 200,
@@ -93,11 +103,12 @@ afterEach(() => {
 });
 
 describe("the facts a person can state and take away", () => {
-  it("draws every stored row, including duplicate spellings of one offering", async () => {
-    // The card this replaces collapsed these two into the better one. That is
-    // right for reading and wrong here: a reader who removes the winner would
-    // watch the loser appear in its place, having deleted something and
-    // apparently changed nothing.
+  it("draws every stored row a reader may remove, past the preview cap", async () => {
+    // Two rules could each uncover a row after a delete, and both have to be
+    // off where the verb is offered: the COLLAPSE (these two spellings of one
+    // offering are one row to groupFacts) and the PREVIEW CAP (five rows a
+    // category). Seven rows in one category, two of them colliding, exercises
+    // both — with five or fewer the cap could stay on unnoticed.
     stub([
       fact({
         category: "offering",
@@ -111,11 +122,31 @@ describe("the facts a person can state and take away", () => {
         value: "Fleet Manager rollout",
         valueKey: "fleet manager",
       }),
+      ...["Depot", "Routing", "Telematics", "Fuel", "Driver"].map((one) =>
+        fact({
+          category: "offering",
+          field: "capability",
+          value: one,
+          valueKey: one.toLowerCase(),
+        }),
+      ),
     ]);
     mount(<CompanyFactsPanel orgId="o-1" canEdit />);
 
     expect(await screen.findByText("Fleet Manager — telematics")).toBeTruthy();
-    expect(screen.getByText("Fleet Manager rollout")).toBeTruthy();
+    // Counted rather than sampled: an assertion on one row passes whenever the
+    // cap happens to keep that row, which is the accident this rules out.
+    const drawn = [
+      "Fleet Manager — telematics",
+      "Fleet Manager rollout",
+      "Depot",
+      "Routing",
+      "Telematics",
+      "Fuel",
+      "Driver",
+    ].filter((one) => screen.queryByText(one) !== null);
+    expect(drawn).toHaveLength(7);
+    expect(screen.queryByRole("button", { name: /Show all/ })).toBeNull();
   });
 
   it("removes a fact through the endpoint, with the version it was shown", async () => {
@@ -140,6 +171,9 @@ describe("the facts a person can state and take away", () => {
       expect(calls.some((one) => one.method === "DELETE")).toBe(true),
     );
     const removal = calls.find((one) => one.method === "DELETE");
+    // The precondition, not just the address: without If-Match the removal is
+    // last-write-wins and would delete a row somebody has since corrected.
+    expect(removal?.ifMatch).toBe("7");
     // The fact key addresses the row; the version is what stops this removal
     // landing on a row somebody else has since corrected.
     // The whole key, not just the field: a multi-value fact has several rows

--- a/frontend/src/screens/companyfactspanel.test.tsx
+++ b/frontend/src/screens/companyfactspanel.test.tsx
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { CompanyFactsPanel } from "./companyfactspanel";
+
+// Stating a fact and taking one away, from the reader's side of the screen.
+// What these hold is the two things the panel exists for and one thing it must
+// not do: every stored row is drawn (so a removal cannot uncover a row nobody
+// saw), and a reader who may not write is refused once rather than shown verbs
+// their save would reject.
+
+type FactSeed = Readonly<{
+  field: string;
+  category: string;
+  value: string;
+  valueKey?: string;
+  version?: number;
+}>;
+
+function fact(seed: FactSeed) {
+  return {
+    id: `f-${seed.field}-${seed.valueKey ?? ""}`,
+    category: seed.category,
+    field: seed.field,
+    value: seed.value,
+    value_key: seed.valueKey ?? "",
+    source: "site_read",
+    captured_by: "agent:deepread",
+    updated_at: "2026-07-01T00:00:00Z",
+    version: seed.version ?? 3,
+  };
+}
+
+function stub(facts: readonly unknown[]) {
+  const calls: { method: string; url: string; body: unknown }[] = [];
+  const fetchMock = vi.fn(async (request: Request) => {
+    // A DELETE carries no body, and asking one for JSON throws before the
+    // stub can answer — which reads exactly like the code failing to send the
+    // request at all.
+    const body =
+      request.method === "POST" ? await request.clone().json() : undefined;
+    calls.push({ method: request.method, url: request.url, body });
+    if (request.method === "GET") {
+      return new Response(JSON.stringify({ data: facts }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (request.method === "POST") {
+      return new Response(JSON.stringify({}), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    // 204 exactly as the server sends it: no body, and no content-type
+    // claiming there is one. With a JSON header the client parses an empty
+    // string and the removal fails inside the test rather than in the code.
+    return new Response(null, { status: 204 });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return calls;
+}
+
+function mount(node: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{node}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the facts a person can state and take away", () => {
+  it("draws every stored row, including duplicate spellings of one offering", async () => {
+    // The card this replaces collapsed these two into the better one. That is
+    // right for reading and wrong here: a reader who removes the winner would
+    // watch the loser appear in its place, having deleted something and
+    // apparently changed nothing.
+    stub([
+      fact({
+        category: "offering",
+        field: "product",
+        value: "Fleet Manager — telematics",
+        valueKey: "fleet manager",
+      }),
+      fact({
+        category: "offering",
+        field: "service",
+        value: "Fleet Manager rollout",
+        valueKey: "fleet manager",
+      }),
+    ]);
+    mount(<CompanyFactsPanel orgId="o-1" canEdit />);
+
+    expect(await screen.findByText("Fleet Manager — telematics")).toBeTruthy();
+    expect(screen.getByText("Fleet Manager rollout")).toBeTruthy();
+  });
+
+  it("removes a fact through the endpoint, with the version it was shown", async () => {
+    const user = userEvent.setup();
+    const calls = stub([
+      fact({
+        category: "signal",
+        field: "certification",
+        value: "ISO 9001",
+        valueKey: "iso 9001",
+        version: 7,
+      }),
+    ]);
+    mount(<CompanyFactsPanel orgId="o-1" canEdit />);
+
+    await user.click(await screen.findByRole("button", { name: /Remove ISO/ }));
+    const dialog = await screen.findByRole("dialog");
+
+    await user.click(within(dialog).getByRole("button", { name: "Remove" }));
+
+    await waitFor(() =>
+      expect(calls.some((one) => one.method === "DELETE")).toBe(true),
+    );
+    const removal = calls.find((one) => one.method === "DELETE");
+    // The fact key addresses the row; the version is what stops this removal
+    // landing on a row somebody else has since corrected.
+    // The whole key, not just the field: a multi-value fact has several rows
+    // under one field, and a URL carrying only "certification" would name none
+    // of them in particular.
+    expect(decodeURIComponent(removal?.url ?? "")).toContain(
+      "certification:iso 9001",
+    );
+  });
+
+  it("states a new fact with the category its field belongs to", async () => {
+    const user = userEvent.setup();
+    const calls = stub([]);
+    mount(<CompanyFactsPanel orgId="o-1" canEdit />);
+
+    await user.click(await screen.findByRole("button", { name: "Add fact" }));
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Customer" }));
+    await user.type(screen.getByLabelText("What it says"), "Kaufhaus Norde");
+    await user.click(screen.getByRole("button", { name: "Save fact" }));
+
+    await waitFor(() =>
+      expect(calls.some((one) => one.method === "POST")).toBe(true),
+    );
+    // The category rides with the field rather than being asked for
+    // separately: a reader knows they are naming a customer, not that a
+    // customer is a "signal".
+    expect(calls.find((one) => one.method === "POST")?.body).toEqual({
+      category: "signal",
+      field: "named_customer",
+      value: "Kaufhaus Norde",
+    });
+  });
+
+  it("refuses a reader who may not write, once, and issues no request", async () => {
+    const user = userEvent.setup();
+    const calls = stub([
+      fact({
+        category: "company",
+        field: "founded_year",
+        value: "1998",
+      }),
+    ]);
+    mount(<CompanyFactsPanel orgId="o-1" canEdit={false} reasonId="why" />);
+
+    expect(await screen.findByText("1998")).toBeTruthy();
+    // No remove control at all: a viewer who may not change a set is not a
+    // viewer whose controls are temporarily unavailable.
+    expect(screen.queryByRole("button", { name: /Remove/ })).toBeNull();
+
+    const add = screen.getByRole("button", { name: "Add fact" });
+    expect(add.getAttribute("aria-describedby")).toBe("why");
+    await user.click(add);
+    expect(screen.queryByLabelText("What it says")).toBeNull();
+    expect(calls.every((one) => one.method === "GET")).toBe(true);
+  });
+});

--- a/frontend/src/screens/companyfactspanel.tsx
+++ b/frontend/src/screens/companyfactspanel.tsx
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, Pencil, Plus, X } from "lucide-react";
+import { type ReactNode, useId, useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { ifMatch, requireVersion } from "../api/version";
+import { useRecordZone } from "../app/recordzone";
+import { Badge, Button, TextInput } from "../design-system/atoms";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import { EvidenceMark } from "../design-system/evidencemark";
+import { IconAction } from "../design-system/iconaction";
+import { Panel, PanelBody } from "../design-system/panel";
+import { Select, type SelectOption } from "../design-system/select";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { problemMessageOf, QueryStates, throwProblem } from "./common";
+import { isTechnicalFact } from "./companytechnical";
+import { derivedSource } from "./evidencesource";
+import { EvidenceVerdict, factClaim } from "./evidenceverdict";
+import { type FactGroup, factFieldLabelKey, listFacts } from "./factview";
+import "./company360.css";
+
+type OrganizationFact = components["schemas"]["OrganizationFact"];
+type FactCategory = OrganizationFact["category"];
+type FactField = OrganizationFact["field"];
+
+const FACT_CATEGORY_LABELS: Record<FactCategory, MessageKey> = {
+  company: "org.factCategory.company",
+  offering: "org.factCategory.offering",
+  market: "org.factCategory.market",
+  signal: "org.factCategory.signal",
+};
+
+type FactSuspectReason = NonNullable<OrganizationFact["suspect_reason"]>;
+
+const FACT_SUSPECT_LABELS: Record<FactSuspectReason, MessageKey> = {
+  phone_shaped_location: "co.factSuspect.phoneShapedLocation",
+  not_a_phone: "co.factSuspect.notAPhone",
+  not_a_year: "co.factSuspect.notAYear",
+  not_an_email: "co.factSuspect.notAnEmail",
+  not_a_size: "co.factSuspect.notASize",
+};
+
+// What a person may state, category by category. Taken from the contract's own
+// enum rather than respelled, so a field added upstream appears here and a
+// field removed there fails the build rather than offering the reader a choice
+// the server refuses.
+//
+// The technical fields are absent on purpose: they are read from DNS and
+// certificates rather than from anything a person knows, TechnicalProfileCard
+// owns them, and a hand-stated "hosting provider" would contradict the lookup
+// the next site read runs.
+const STATEABLE: Readonly<Record<FactCategory, readonly FactField[]>> = {
+  company: [
+    "founded_year",
+    "employee_range",
+    "phone",
+    "contact_email",
+    "location",
+  ],
+  offering: ["service", "product", "capability"],
+  market: ["served_industry", "company_size", "geography", "language"],
+  signal: ["certification", "partner", "named_customer", "quantified_outcome"],
+};
+
+export function factsKey(orgId: string) {
+  return ["org-facts", orgId] as const;
+}
+
+// How many rows of a category are shown before the reader asks for the rest. A
+// real account returns ninety-odd facts, and rendering them all made this card
+// taller than the page beside it — at which point nobody reads any of it.
+const FACT_PREVIEW = 5;
+
+/**
+ * CompanyFactsPanel: what a machine read about this company, and what a person
+ * states about it, in one list a person can add to and take from.
+ *
+ * EVERY STORED ROW IS DRAWN, which is the difference from the card this
+ * replaces. That card collapsed duplicate spellings of one offering into the
+ * best of them, which is right for reading and wrong the moment a row can be
+ * REMOVED: the collapse drops the losers entirely, so a reader who deletes the
+ * winner watches a row they have never seen take its place — having deleted
+ * something and apparently changed nothing.
+ */
+export function CompanyFactsPanel({
+  orgId,
+  canEdit,
+  reasonId,
+  onOpenHistory,
+}: Readonly<{
+  orgId: string;
+  canEdit: boolean;
+  // The one sentence saying why this reader may not write, already on the page.
+  // Every refused control points at it rather than carrying its own copy.
+  reasonId?: string;
+  onOpenHistory?: () => void;
+}>): ReactNode {
+  const t = useT();
+  const { locale } = useLocale();
+  const [adding, setAdding] = useState(false);
+  const factsQuery = useQuery({
+    queryKey: factsKey(orgId),
+    queryFn: async () => {
+      const { data, error } = await api.GET("/organizations/{id}/facts", {
+        params: { path: { id: orgId } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data ?? [];
+    },
+  });
+
+  // The technical fields are excluded because the technical card claims them.
+  // Both read the same endpoint, so without this every mail provider and
+  // operated service renders twice on one tab, and a reader correcting one copy
+  // watches the other disagree.
+  const facts = (factsQuery.data ?? []).filter(
+    (fact) => !isTechnicalFact(fact),
+  );
+
+  return (
+    <Panel
+      title={t("co.facts.title")}
+      titleAction={
+        <Button
+          small
+          onClick={() => setAdding((was) => !was)}
+          reasonId={canEdit ? undefined : reasonId}
+          unavailable={!canEdit}
+        >
+          {t("co.facts.add")}
+        </Button>
+      }
+    >
+      <PanelBody>
+        {adding && (
+          <AddFactForm orgId={orgId} onDone={() => setAdding(false)} />
+        )}
+        <QueryStates query={factsQuery}>
+          {facts.length === 0 ? (
+            <p className="t-caption">{t("co.facts.empty")}</p>
+          ) : (
+            listFacts(facts, t, locale).map((group) => (
+              <FactCategoryBlock
+                key={group.category}
+                orgId={orgId}
+                group={group}
+                canEdit={canEdit}
+                onOpenHistory={onOpenHistory}
+              />
+            ))
+          )}
+        </QueryStates>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+function FactCategoryBlock({
+  orgId,
+  group,
+  canEdit,
+  onOpenHistory,
+}: Readonly<{
+  orgId: string;
+  group: FactGroup;
+  canEdit: boolean;
+  onOpenHistory?: () => void;
+}>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const [expanded, setExpanded] = useState(false);
+  const hidden = group.facts.length - FACT_PREVIEW;
+  const shown = expanded ? group.facts : group.facts.slice(0, FACT_PREVIEW);
+  return (
+    <div className="co-facts-group">
+      <div className="t-label co-facts-heading">
+        {t(FACT_CATEGORY_LABELS[group.category])}
+      </div>
+      {shown.map((fact) => (
+        <FactRow
+          key={`${fact.field}:${fact.value_key}`}
+          orgId={orgId}
+          fact={fact}
+          canEdit={canEdit}
+          onOpenHistory={onOpenHistory}
+        />
+      ))}
+      {hidden > 0 && (
+        <Button small onClick={() => setExpanded(!expanded)}>
+          {expanded
+            ? t("co.facts.showLess")
+            : t("co.facts.showAll", {
+                count: formatNumber(group.facts.length, locale),
+              })}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function FactRow({
+  orgId,
+  fact,
+  canEdit,
+  onOpenHistory,
+}: Readonly<{
+  orgId: string;
+  fact: OrganizationFact;
+  canEdit: boolean;
+  onOpenHistory?: () => void;
+}>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const recordZone = useRecordZone();
+  const [removing, setRemoving] = useState(false);
+  return (
+    <div className="co-field">
+      <span className="t-label">{t(factFieldLabelKey(fact.field))}</span>
+      <div>
+        <EvidenceMark
+          value={fact.value}
+          source={derivedSource(fact, locale, recordZone)}
+          onOpenHistory={onOpenHistory}
+        />
+        {/* The value contradicts its own field — a phone number filed as a
+            location, a register number filed as a headcount. The fact is still
+            shown with its evidence: hiding it would be a worse answer than
+            flagging it, and the reader is the one who can tell. */}
+        {fact.suspect_reason && (
+          <span className="co-fact-suspect">
+            <Badge tone="warn">
+              {t(FACT_SUSPECT_LABELS[fact.suspect_reason])}
+            </Badge>
+          </span>
+        )}
+        <EvidenceVerdict
+          orgId={orgId}
+          claim={factClaim(orgId, fact)}
+          canEdit={canEdit}
+        />
+        {/* Removal is the verb correction cannot spell. A correction says "this
+            value is wrong"; this says "this is not a fact about this company",
+            which is the honest answer to a customer who left or a phone number
+            read off the wrong page. */}
+        {canEdit && (
+          <IconAction
+            label={t("co.facts.remove", {
+              value: fact.value,
+            })}
+            icon={<X aria-hidden />}
+            small
+            onClick={() => setRemoving(true)}
+          />
+        )}
+      </div>
+      {removing && (
+        <RemoveFactConfirm
+          orgId={orgId}
+          fact={fact}
+          onClose={() => setRemoving(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function RemoveFactConfirm({
+  orgId,
+  fact,
+  onClose,
+}: Readonly<{
+  orgId: string;
+  fact: OrganizationFact;
+  onClose: () => void;
+}>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const remove = useMutation({
+    // The fact travels as a variable rather than through this closure: the
+    // click belongs to the committed render, so what it passes cannot be older
+    // than the row that carried it.
+    mutationFn: async (doomed: OrganizationFact) => {
+      const { error } = await api.DELETE(
+        "/organizations/{id}/facts/{factKey}",
+        {
+          params: {
+            path: {
+              id: orgId,
+              factKey: `${doomed.field}:${doomed.value_key}`,
+            },
+            ...ifMatch(requireVersion(doomed.version)),
+          },
+        },
+      );
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: async () => {
+      await settleFacts(queryClient, orgId);
+      onClose();
+    },
+  });
+  return (
+    <ConfirmModal
+      open
+      onClose={onClose}
+      title={t("co.facts.removeTitle")}
+      confirmLabel={t("co.facts.removeConfirm")}
+      confirmVariant="danger"
+      pending={remove.isPending}
+      error={remove.error ? problemMessageOf(remove.error, t) : undefined}
+      onConfirm={() => remove.mutate(fact)}
+    >
+      <p>
+        {t("co.facts.removeAsk", {
+          field: t(factFieldLabelKey(fact.field)),
+          value: fact.value,
+        })}
+      </p>
+    </ConfirmModal>
+  );
+}
+
+function AddFactForm({
+  orgId,
+  onDone,
+}: Readonly<{ orgId: string; onDone: () => void }>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const fieldId = useId();
+  const valueId = useId();
+  const [field, setField] = useState<string>("");
+  const [value, setValue] = useState("");
+
+  const options: SelectOption[] = Object.entries(STATEABLE).flatMap(
+    ([category, fields]) =>
+      fields.map((one) => ({
+        value: `${category}:${one}`,
+        label: t(factFieldLabelKey(one)),
+      })),
+  );
+
+  const add = useMutation({
+    mutationFn: async (stated: { field: string; value: string }) => {
+      const [category, name] = stated.field.split(":");
+      const { error } = await api.POST("/organizations/{id}/facts", {
+        params: { path: { id: orgId } },
+        body: {
+          category: category as FactCategory,
+          field: name,
+          value: stated.value.trim(),
+        },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: async () => {
+      await settleFacts(queryClient, orgId);
+      setField("");
+      setValue("");
+      onDone();
+    },
+  });
+
+  return (
+    <div className="co-facts-add">
+      <label className="sr-only" htmlFor={fieldId}>
+        {t("co.facts.addField")}
+      </label>
+      <Select
+        id={fieldId}
+        options={options}
+        value={field}
+        onChange={setField}
+        placeholder={t("co.facts.addField")}
+      />
+      <label className="sr-only" htmlFor={valueId}>
+        {t("co.facts.addValue")}
+      </label>
+      <TextInput
+        id={valueId}
+        value={value}
+        placeholder={t("co.facts.addValue")}
+        onChange={(event) => setValue(event.target.value)}
+      />
+      <IconAction
+        label={t("co.facts.addSave")}
+        icon={<Check aria-hidden />}
+        variant="primary"
+        small
+        pending={add.isPending}
+        // Both halves are required: a fact with no field names nothing, and one
+        // with no value states nothing.
+        reason={field && value.trim() ? undefined : t("co.facts.addIncomplete")}
+        onClick={() => add.mutate({ field, value })}
+      />
+      <IconAction
+        label={t("co.facts.addCancel")}
+        icon={<X aria-hidden />}
+        small
+        onClick={onDone}
+      />
+      {add.error && (
+        <span role="alert" className="form-error">
+          {problemMessageOf(add.error, t)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// Everything that describes this account's facts, refreshed together. The keys
+// are the ones the CONSUMERS register: React Query matches segments exactly, so
+// a near-miss spelling invalidates nothing and the page goes on showing the row
+// a reader just removed.
+async function settleFacts(
+  queryClient: ReturnType<typeof useQueryClient>,
+  orgId: string,
+) {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: factsKey(orgId) }),
+    queryClient.invalidateQueries({ queryKey: ["organization", orgId] }),
+    queryClient.invalidateQueries({ queryKey: ["organization360", orgId] }),
+    queryClient.invalidateQueries({ queryKey: ["organizations"] }),
+  ]);
+}
+
+// Pencil is imported for the correction affordance EvidenceVerdict draws; the
+// import keeps the icon set for this panel in one place.
+export const FACT_EDIT_ICON = Pencil;
+export const FACT_ADD_ICON = Plus;

--- a/frontend/src/screens/companyfactspanel.tsx
+++ b/frontend/src/screens/companyfactspanel.tsx
@@ -74,6 +74,12 @@ export function factsKey(orgId: string) {
 // How many rows of a category are shown before the reader asks for the rest. A
 // real account returns ninety-odd facts, and rendering them all made this card
 // taller than the page beside it — at which point nobody reads any of it.
+//
+// THE CAP LIFTS WHEN THE READER CAN REMOVE A ROW, and that is not a preference.
+// A truncated list has the same defect the collapse had: delete the fifth row
+// and the sixth takes its place, so the reader has removed something and
+// apparently changed nothing. Reading is served by hiding the tail; removing is
+// not, and a surface that offers the verb has to show what the verb acts on.
 const FACT_PREVIEW = 5;
 
 /**
@@ -103,6 +109,16 @@ export function CompanyFactsPanel({
   const t = useT();
   const { locale } = useLocale();
   const [adding, setAdding] = useState(false);
+  // The record page is not remounted when the reader opens a different account
+  // — CompanyScreen takes the id as a prop — so an open add form would carry
+  // its draft across, and the save would write what was typed about one company
+  // onto another. Resetting on the id is what makes the draft belong to the
+  // account it was typed about.
+  const [openFor, setOpenFor] = useState(orgId);
+  if (openFor !== orgId) {
+    setOpenFor(orgId);
+    setAdding(false);
+  }
   const factsQuery = useQuery({
     queryKey: factsKey(orgId),
     queryFn: async () => {
@@ -140,7 +156,11 @@ export function CompanyFactsPanel({
     >
       <PanelBody>
         {adding && (
-          <AddFactForm orgId={orgId} onDone={() => setAdding(false)} />
+          <AddFactForm
+            orgId={orgId}
+            canEdit={canEdit}
+            onDone={() => setAdding(false)}
+          />
         )}
         <QueryStates query={factsQuery}>
           {facts.length === 0 ? (
@@ -176,8 +196,10 @@ function FactCategoryBlock({
   const t = useT();
   const { locale } = useLocale();
   const [expanded, setExpanded] = useState(false);
-  const hidden = group.facts.length - FACT_PREVIEW;
-  const shown = expanded ? group.facts : group.facts.slice(0, FACT_PREVIEW);
+  const capped = !canEdit;
+  const hidden = capped ? group.facts.length - FACT_PREVIEW : 0;
+  const shown =
+    expanded || !capped ? group.facts : group.facts.slice(0, FACT_PREVIEW);
   return (
     <div className="co-facts-group">
       <div className="t-label co-facts-heading">
@@ -264,6 +286,7 @@ function FactRow({
         <RemoveFactConfirm
           orgId={orgId}
           fact={fact}
+          canEdit={canEdit}
           onClose={() => setRemoving(false)}
         />
       )}
@@ -274,10 +297,15 @@ function FactRow({
 function RemoveFactConfirm({
   orgId,
   fact,
+  canEdit,
   onClose,
 }: Readonly<{
   orgId: string;
   fact: OrganizationFact;
+  // Re-read at CONFIRM time, not only at open time. A grant can be withdrawn
+  // while this dialog stands, and a confirm that fired on the answer from
+  // thirty seconds ago is a write the reader is no longer allowed to make.
+  canEdit: boolean;
   onClose: () => void;
 }>) {
   const t = useT();
@@ -317,6 +345,7 @@ function RemoveFactConfirm({
       confirmVariant="danger"
       pending={remove.isPending}
       error={remove.error ? problemMessageOf(remove.error, t) : undefined}
+      confirmReason={canEdit ? undefined : t("record.notYoursToChange")}
       onConfirm={() => remove.mutate(fact)}
     >
       <p>
@@ -331,8 +360,9 @@ function RemoveFactConfirm({
 
 function AddFactForm({
   orgId,
+  canEdit,
   onDone,
-}: Readonly<{ orgId: string; onDone: () => void }>) {
+}: Readonly<{ orgId: string; canEdit: boolean; onDone: () => void }>) {
   const t = useT();
   const queryClient = useQueryClient();
   const fieldId = useId();
@@ -398,9 +428,9 @@ function AddFactForm({
         variant="primary"
         small
         pending={add.isPending}
-        // Both halves are required: a fact with no field names nothing, and one
-        // with no value states nothing.
-        reason={field && value.trim() ? undefined : t("co.facts.addIncomplete")}
+        // Authority first, then completeness: a reader who may not write this
+        // record is not helped by being told their form is incomplete.
+        reason={refusal(canEdit, field, value, t)}
         onClick={() => add.mutate({ field, value })}
       />
       <IconAction
@@ -416,6 +446,20 @@ function AddFactForm({
       )}
     </div>
   );
+}
+
+// Why the save is refused, or nothing. Authority first: a reader who may not
+// write this record is not helped by being told their form is incomplete.
+function refusal(
+  canEdit: boolean,
+  field: string,
+  value: string,
+  t: ReturnType<typeof useT>,
+): string | undefined {
+  if (!canEdit) {
+    return t("record.notYoursToChange");
+  }
+  return field && value.trim() ? undefined : t("co.facts.addIncomplete");
 }
 
 // Everything that describes this account's facts, refreshed together. The keys

--- a/frontend/src/screens/companyprofiletab.tsx
+++ b/frontend/src/screens/companyprofiletab.tsx
@@ -9,6 +9,7 @@ import { Callout } from "../design-system/callout";
 import { FieldGrid } from "../design-system/fieldgrid";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useT } from "../i18n";
+import { CompanyFactsPanel } from "./companyfactspanel";
 import { useCompanyReadOnlyReason } from "./companyheader";
 import { DetailsGrid, SidecarFieldRow } from "./companyraildetails";
 import { useOrgProfileFields } from "./evidenceverdict";
@@ -64,9 +65,13 @@ const NARRATIVE_FIELDS = [
  */
 export function CompanyProfileForm({
   org,
+  onOpenHistory,
   tools,
 }: Readonly<{
   org: Organization;
+  // Opens the record's own history drawer, for a reader following an evidence
+  // mark back to what changed.
+  onOpenHistory?: () => void;
   // The account's own tooling — custom fields, group rollup, the site read,
   // the technical profile. Passed in rather than built here: they are the
   // caller's existing cards and this file has no business knowing what is in
@@ -129,6 +134,15 @@ export function CompanyProfileForm({
           </FieldGrid>
         </PanelBody>
       </Panel>
+      {/* Facts are their own panel: many-valued, correctable one row at a
+          time, and now addable and removable — which is a different act from
+          stating a field, and needs the same write state this form derived. */}
+      <CompanyFactsPanel
+        orgId={org.id}
+        canEdit={canEdit}
+        reasonId={reason ? reasonId : undefined}
+        onOpenHistory={onOpenHistory}
+      />
       {tools}
     </div>
   );

--- a/frontend/src/screens/factview.ts
+++ b/frontend/src/screens/factview.ts
@@ -129,6 +129,37 @@ function better(a: OrganizationFact, b: OrganizationFact): boolean {
  * fields, because product/service/capability are three ways of saying the one
  * thing (see OFFERING_RANK); elsewhere the field is part of the identity.
  */
+// listFacts groups and orders EVERY stored row, collapsing nothing.
+//
+// It is groupFacts' sibling, and the difference is the whole point. groupFacts
+// answers "what does this company say", where three spellings of one offering
+// are one answer and showing all three is noise. listFacts answers "what rows
+// does this record hold", which is the question a surface that can DELETE a row
+// has to be asking: the collapse drops the losing duplicates entirely, so a
+// reader who removes the winner watches a row they never saw take its place,
+// having deleted something and apparently changed nothing.
+//
+// Category ordering and the within-category sort are shared, because those are
+// about reading rather than about identity.
+export function listFacts(
+  facts: readonly OrganizationFact[],
+  t: Translator,
+  locale: Locale,
+): FactGroup[] {
+  const groups = new Map<FactCategory, OrganizationFact[]>();
+  for (const fact of facts) {
+    groups.set(fact.category, [...(groups.get(fact.category) ?? []), fact]);
+  }
+  return CATEGORY_ORDER.filter((category) => groups.has(category)).map(
+    (category) => ({
+      category,
+      facts: [...(groups.get(category) ?? [])].sort((a, b) =>
+        order(a, b, t, locale),
+      ),
+    }),
+  );
+}
+
 export function groupFacts(
   facts: readonly OrganizationFact[],
   t: Translator,

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -935,13 +935,13 @@ describe("CompanyScreen — facts card (B6)", () => {
     await openProfile();
 
     await waitFor(() =>
-      expect(screen.getByText("Facts read from the site")).toBeTruthy(),
+      expect(screen.getByText("Facts about this company")).toBeTruthy(),
     );
     // Scoped to the facts card: the right rail carries a Signals card of its
     // own, and "which categories did the site read produce" is a question
     // about this card, not about the page.
     const factsCard = screen
-      .getByText("Facts read from the site")
+      .getByText("Facts about this company")
       .closest("section");
     if (!factsCard) {
       throw new Error("the facts card has no section wrapper");
@@ -2070,7 +2070,7 @@ describe("CompanyScreen — State D's one column and its card grid", () => {
       headings().some((one) => one?.startsWith(title));
     await waitFor(() => expect(opensWith("Details")).toBe(true));
     expect(opensWith("What they do")).toBe(true);
-    expect(opensWith("Where this came from")).toBe(true);
+    expect(opensWith("Facts about this company")).toBe(true);
     expect(opensWith("Data & tools")).toBe(true);
     releaseView?.();
   });

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useCan } from "../app/capability";
 import { PageAside, PageAsideToggle } from "../app/pageaside";
 import { useRecordZone } from "../app/recordzone";
 import { navigate, useRoute } from "../app/router";
@@ -21,7 +20,6 @@ import {
   type TimelineEntry,
   type TimelineGroup,
 } from "../design-system/composed";
-import { EvidenceMark } from "../design-system/evidencemark";
 import { Eyebrow } from "../design-system/eyebrow";
 import type { ListChip } from "../design-system/listsurface";
 import { Panel, PanelBody } from "../design-system/panel";
@@ -45,7 +43,6 @@ import {
   coldFieldLabel,
   problemMessageOf,
   QueryGate,
-  QueryStates,
   throwProblem,
   useSorMode,
   useViewerId,
@@ -97,7 +94,7 @@ import {
   companyTabRoute,
   isCompanyTab,
 } from "./companytab";
-import { isTechnicalFact, TechnicalProfileCard } from "./companytechnical";
+import { TechnicalProfileCard } from "./companytechnical";
 import { TodayOnThisAccount } from "./companytoday";
 import {
   CompanyWorkCard,
@@ -114,9 +111,6 @@ import {
 import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
 import { useRoster } from "./entityref";
-import { derivedSource } from "./evidencesource";
-import { EvidenceVerdict, factClaim } from "./evidenceverdict";
-import { type FactGroup, factFieldLabelKey, groupFacts } from "./factview";
 import { RecordHistoryTab } from "./history";
 import {
   type ListPage,
@@ -184,7 +178,6 @@ type CreateOrganizationRequest =
 type UpdateOrganizationRequest =
   components["schemas"]["UpdateOrganizationRequest"];
 type Organization360View = components["schemas"]["Organization360"];
-type OrganizationFact = components["schemas"]["OrganizationFact"];
 
 // Lives in companylookups.ts, same reason as LIFECYCLE_LABELS above: the
 // rail's Details grid (companyraildetails.tsx) builds a size-band picker off
@@ -1225,187 +1218,6 @@ export function profileFieldLabel(
 ): string {
   const key = PROFILE_FIELD_LABELS[field];
   return key ? t(key) : coldFieldLabel(field, t);
-}
-
-// Facts read from the site, grouped into the four fixed categories. Empty
-// categories are omitted and an empty read renders nothing at all — the
-// profile card above already carries the region's honest empty state, so a
-// second "nothing here" would only be noise.
-//
-// Ordering and duplicate collapsing live in factview.ts; the category order
-// comes from there too, so the card has one source for what it draws.
-//
-// FACT_PREVIEW is how many rows of a category are shown before the reader asks
-// for the rest. A real account returns ninety-odd facts, and rendering them all
-// made this card taller than the page it sits beside — at which point nobody
-// reads any of it.
-const FACT_PREVIEW = 5;
-
-const FACT_CATEGORY_LABELS: Record<OrganizationFact["category"], MessageKey> = {
-  company: "org.factCategory.company",
-  offering: "org.factCategory.offering",
-  market: "org.factCategory.market",
-  signal: "org.factCategory.signal",
-};
-
-// One fact row: the value carries its own evidence mark, the same
-// affordance every derived value on this page uses.
-// Why a fact looks wrong, in the words a reader can act on. Typed against the
-// schema union, so a rule added upstream fails the build here rather than
-// rendering a raw reason code.
-type FactSuspectReason = NonNullable<OrganizationFact["suspect_reason"]>;
-
-const FACT_SUSPECT_LABELS: Record<FactSuspectReason, MessageKey> = {
-  phone_shaped_location: "co.factSuspect.phoneShapedLocation",
-  not_a_phone: "co.factSuspect.notAPhone",
-  not_a_year: "co.factSuspect.notAYear",
-  not_an_email: "co.factSuspect.notAnEmail",
-  not_a_size: "co.factSuspect.notASize",
-};
-
-function FactRow({
-  orgId,
-  fact,
-  onOpenHistory,
-}: Readonly<{
-  orgId: string;
-  fact: OrganizationFact;
-  onOpenHistory?: () => void;
-}>) {
-  const t = useT();
-  const { locale } = useLocale();
-  const recordZone = useRecordZone();
-  const canEdit = useCan("organization", "update");
-  return (
-    <div className="co-field">
-      <span className="t-label">{t(factFieldLabelKey(fact.field))}</span>
-      <div>
-        <EvidenceMark
-          value={fact.value}
-          source={derivedSource(fact, locale, recordZone)}
-          onOpenHistory={onOpenHistory}
-        />
-        {/* The value contradicts its own field — a phone number filed as a
-            location, a register number filed as a headcount. The fact is still
-            shown with its evidence: hiding it would be a worse answer than
-            flagging it, and the reader is the one who can tell. */}
-        {fact.suspect_reason && (
-          <span className="co-fact-suspect">
-            <Badge tone="warn">
-              {t(FACT_SUSPECT_LABELS[fact.suspect_reason])}
-            </Badge>
-          </span>
-        )}
-        {/* A flagged fact is exactly the one a reader should be able to fix
-            without leaving the page — the flag says the machine doubts itself,
-            and only a person can settle it. */}
-        <EvidenceVerdict
-          orgId={orgId}
-          claim={factClaim(orgId, fact)}
-          canEdit={canEdit}
-        />
-      </div>
-    </div>
-  );
-}
-
-// One category of facts. Only the first few rows are drawn until the reader
-// asks for the rest, and the count of what is hidden is on the button — a
-// truncated list with no number reads as "that is everything".
-function FactCategory({
-  orgId,
-  group,
-  onOpenHistory,
-}: Readonly<{
-  orgId: string;
-  group: FactGroup;
-  onOpenHistory?: () => void;
-}>) {
-  const t = useT();
-  const { locale } = useLocale();
-  const [expanded, setExpanded] = useState(false);
-  const hidden = group.facts.length - FACT_PREVIEW;
-  const shown = expanded ? group.facts : group.facts.slice(0, FACT_PREVIEW);
-  return (
-    <div className="co-facts-group">
-      <div className="t-label co-facts-heading">
-        {t(FACT_CATEGORY_LABELS[group.category])}
-      </div>
-      {shown.map((fact) => (
-        <FactRow
-          key={`${fact.field}:${fact.value_key}`}
-          orgId={orgId}
-          fact={fact}
-          onOpenHistory={onOpenHistory}
-        />
-      ))}
-      {hidden > 0 && (
-        <Button small onClick={() => setExpanded(!expanded)}>
-          {expanded
-            ? t("co.facts.showLess")
-            : t("co.facts.showAll", {
-                count: formatNumber(group.facts.length, locale),
-              })}
-        </Button>
-      )}
-    </div>
-  );
-}
-
-function FactsCard({
-  orgId,
-  onOpenHistory,
-}: Readonly<{ orgId: string; onOpenHistory?: () => void }>) {
-  const t = useT();
-  const { locale } = useLocale();
-  const factsQuery = useQuery({
-    queryKey: ["org-facts", orgId],
-    queryFn: async () => {
-      const { data, error } = await api.GET("/organizations/{id}/facts", {
-        params: { path: { id: orgId } },
-      });
-      if (error) {
-        throwProblem(error);
-      }
-      return data.data ?? [];
-    },
-  });
-
-  // A read that failed is surfaced, never swallowed as "no facts" — an empty
-  // read and a 404/network error must stay distinguishable and retryable.
-  if (factsQuery.isError) {
-    return (
-      <Card title={t("org.facts")} style={{ marginBottom: "var(--space-4)" }}>
-        <QueryStates query={factsQuery}>{null}</QueryStates>
-      </Card>
-    );
-  }
-
-  // Otherwise facts are supplementary: while the read is in flight, or if it
-  // has nothing to show, the card stays absent rather than flashing a skeleton
-  // or an empty shell next to the profile card that owns the region's states.
-  //
-  // The technical fields are excluded because the technical card claims them.
-  // Both cards read the same endpoint, so without this every mail provider and
-  // operated service would render twice on one tab, and a reader correcting
-  // one copy would watch the other disagree.
-  const facts = factsQuery.data?.filter((fact) => !isTechnicalFact(fact));
-  if (!facts || facts.length === 0) {
-    return null;
-  }
-
-  return (
-    <Card title={t("org.facts")} style={{ marginBottom: "var(--space-4)" }}>
-      {groupFacts(facts, t, locale).map((group) => (
-        <FactCategory
-          key={group.category}
-          orgId={orgId}
-          group={group}
-          onOpenHistory={onOpenHistory}
-        />
-      ))}
-    </Card>
-  );
 }
 
 // Overview · People · Deals · Tasks · History · Documents · Profile, the
@@ -3110,16 +2922,9 @@ function ReferenceDisclosures({
   return (
     <CompanyProfileForm
       org={org}
+      onOpenHistory={onOpenHistory}
       tools={
         <>
-          {/* Facts stay their own panel: they are what a machine READ about the
-              company, many-valued and correctable one row at a time, which is a
-              different act from stating a field. */}
-          <Panel title={t("co.evidence.title")}>
-            <PanelBody>
-              <FactsCard orgId={org.id} onOpenHistory={onOpenHistory} />
-            </PanelBody>
-          </Panel>
           {/* Documents are deliberately NOT here: they have their own tab, and a
               reader given the same list in two places has two lists to
               reconcile. */}


### PR DESCRIPTION
## What this adds

The facts list could only be read and corrected. This wires it to the two verbs
that landed in #3358: an **Add fact** form in the panel header, and a **remove**
on every row behind a confirmation that says what removal means — a later read of
the company's website may state the fact again.

## Every stored row is drawn

This is the change under the change. `groupFacts` collapses duplicate spellings
of one offering into the best of them — right for reading, wrong the moment a row
can be **removed**: the collapse drops the losers entirely, so a reader who
deletes the winner would watch a row they have never seen take its place, having
deleted something and apparently changed nothing.

`listFacts` is its sibling in `factview.ts`: same category order, same
within-category sort, no collapse. The panel uses it; `groupFacts` keeps its
other callers.

## Details

- The add form asks for a **field**, not a category. A reader knows they are
  naming a customer, not that a customer is a "signal" — the category rides with
  the field it belongs to.
- Technical fields are absent from the choices: `TechnicalProfileCard` owns them,
  they are read from DNS and certificates rather than known by a person, and a
  hand-stated "hosting provider" would contradict the next lookup.
- Write state comes from the form that already derived it, so a reader who may
  not write sees no remove controls at all (not disabled ones) and one
  explanation, which the disabled **Add fact** points at.

## A defect in the PR before this one

`OrganizationFact.version` was in the contract and in **no generated client**. It
was declared as a `$ref` with a sibling `description`, which OpenAPI 3.0
discards — so the generator emitted no property, and every client reading a fact
was typed without the version the write path needs for `If-Match`. Found because
the removal test could not send a precondition. Spelled inline now, matching
`CompanyProfileField`, which got this right.

## Gates

`make check-fe` green (5497 tests), `make check-backend` green,
`make craft-static` clean.

Four new tests in `companyfactspanel.test.tsx`, including the duplicate-offering
case the collapse would have hidden and a permission case mutation-checked by
removing the guard and watching it fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The company facts panel now lets a rep state a fact and remove one, instead of only reading and correcting. The panel draws every stored row, so removing one never reveals a duplicate spelling a reader never saw.

- Removal goes behind a confirmation that says a later site read may state the fact again.
- The add form asks for a field, not a category; the category rides with the field, and technical fields are excluded.
- Editors see every row — the five-row preview cap now applies only where removal is not offered.
- Write permission is re-checked when save or confirm is pressed, and the open add form resets if the account changes. Readers who may not write see no remove controls and one explanation, which the disabled add button points at.
- Fixed `OrganizationFact.version` being absent from every generated client — a `$ref` with a sibling description is dropped by OpenAPI 3.0 — so removals now send the `If-Match` precondition.

<sup>Written for commit fd72f5b2400677cf6853e0849eb1a8bf088d2b23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a categorized company facts panel with duplicate values, evidence and suspect indicators, verdict controls, history access, and responsive add/remove controls.
  - Integrated company facts into company profiles with edit permissions and localized content in English, German, and Vietnamese.
  - Added endpoints for purging capture exclusions and proposing deal roles.

- **Bug Fixes**
  - Fact removals now use version checks to help prevent conflicting updates.
  - Technical facts are excluded from the company facts view.
  - Improved provider lookup error guidance and VAT status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->