### PR TITLE
main is red: one task reached the ticker maps twice

### DIFF
--- a/frontend/src/app/ai-activity-lines.ts
+++ b/frontend/src/app/ai-activity-lines.ts
@@ -147,7 +147,6 @@ export const ACTIVITY_LINE: Readonly<
   capture_classify: SYSTEM_SWEEP,
   capture_confidentiality_verdict: SYSTEM_SWEEP,
   capture_counterparty_verdict: SYSTEM_SWEEP,
-  capture_confidentiality_verdict: SYSTEM_SWEEP,
   enrich: notDisplayed(
     "it reaches nobody, and it would not be worth showing if it did — recording only the first half is what made this read like a gap somebody should close. Reachability: the one production site is the signature-enrichment pass, which runs under a system principal with no on_behalf_of, so ResolveActor scopes every occurrence to the workspace with a NULL actor_user_id while the personal feed selects on actor_user_id. Worth: it could not be per-person even if it were reachable. The pass mints ONE correlation id for the whole run (api/jobs.yaml capture_enrich, up to 100 candidates in series), and the occurrence key is correlation+task, so every candidate collapses into ONE row — a per-person subject would make that single row flap from one person to the next rather than narrate any of them. What a reader actually wants from this pass is what it FOUND, which is durable and already drawn as evidence-or-omit provenance on the person record. The ticker's own `enrich` key names DIFFERENT work (a provider run on a person, and the organization page's Enrich card, which runs cold_start rather than this task), which is what makes this one easy to mistake for visible",
   ),

--- a/frontend/src/app/ai-activity-orb.ts
+++ b/frontend/src/app/ai-activity-orb.ts
@@ -34,7 +34,6 @@ export const ACTIVITY_LANE: Readonly<Record<ActivityKind, AgentLane>> = {
   capture_classify: "ingest",
   capture_confidentiality_verdict: "ingest",
   capture_counterparty_verdict: "ingest",
-  capture_confidentiality_verdict: "ingest",
   cold_start: "ingest",
   document_extract: "ingest",
   enrich: "ingest",


### PR DESCRIPTION
`main`'s composed typecheck fails again, on the opposite problem to #3371.

```
src/app/ai-activity-lines.ts(150,3): error TS1117: An object literal cannot have multiple properties with the same name.
src/app/ai-activity-orb.ts(37,3):   error TS1117: An object literal cannot have multiple properties with the same name.
```

Two fixes for the same omission were in flight at once and both merged, so `capture_confidentiality_verdict` is now in each map twice.

Mine is the entry removed — the other one sits in the alphabetical place the rest of the map keeps, so the file reads as it did before either of us touched it.

Worth noting for whoever looks at the pattern rather than the line: this is the third red on `main` today from the same shape — a change that is green on its own branch and only conflicts once another merge lands under it. An exhaustive `Record` keyed by a generated union is doing its job in each case; what nothing checks is the merge order.

## Verification

- `make check-fe` — the composed typecheck passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed confidentiality-verdict activity entries from activity displays.
  * Other activity types and existing functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->