### PR TITLE
Margince can send from an Outlook mailbox too

### DIFF
--- a/backend/gates/outboundanonymity_test.go
+++ b/backend/gates/outboundanonymity_test.go
@@ -78,6 +78,7 @@ var anonymousOutbound = gatekit.Waive(map[string]string{
 	"internal/modules/capture/googleconn/googleconn.go:func Get":    "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
 	"internal/modules/capture/graph/client.go:func GetMIME":         "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
 	"internal/modules/capture/graph/transport.go:func get":          "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
+	"internal/modules/capture/graph/sendclient.go:func SendMIME":    "runs inside an OAuth grant the person made to this app, which names the caller to the provider more precisely than an agent could",
 	"internal/modules/capture/oauthflow/oauthflow.go:func token":    "exchanges a code against a token endpoint using this app's registered client id, which is the identity that endpoint checks",
 	"internal/modules/capture/telegram/api.go:func request":         "calls a bot API under the bot's own token, and the bot IS the identity there",
 	"internal/modules/capture/telegram/sendfiles.go:func SendFiles": "calls a bot API under the bot's own token, and the bot IS the identity there",

--- a/backend/internal/compose/capture.go
+++ b/backend/internal/compose/capture.go
@@ -50,11 +50,23 @@ var gmailScopes = []string{
 	gmail.SendScope,
 }
 
-// graphScopes are the Microsoft identity platform scopes the read-only Graph
-// capture connector requests: mail read + the signed-in user's profile (the
-// mailbox owner lookup) + offline_access (the refresh token). No send, no
-// modify.
-var graphScopes = []string{"offline_access", "User.Read", "Mail.Read"}
+// graphScopes are the Microsoft identity platform permissions a Graph mailbox
+// connection requests: mail read for capture, the signed-in user's profile (the
+// mailbox owner lookup), offline_access (the refresh token), and send for the
+// governed outbound path. No modify, no delete, no shared mailboxes.
+//
+// They ride ONE consent for the same reason Gmail's pair does — Microsoft will
+// not add a permission to an existing refresh token, so asking later would mean
+// a second connection for the same mailbox. A mailbox connected before the send
+// permission landed captures normally and refuses every send by name until it
+// is reconnected.
+//
+// The send entry is the connector's OWN constant, not a copy of its text: what
+// the consent requests and what the connector re-checks are then one string by
+// construction. The second literal — the permission comms demands at the
+// authority gate — cannot be imported by either (comms must not reach into a
+// capture provider), so a fitness test binds it here instead: sendscope_test.go.
+var graphScopes = []string{"offline_access", "User.Read", "Mail.Read", graph.SendScope}
 
 // CaptureConfig is the deployment's capture list-config, threaded from
 // margince.yaml's `capture:` block into the Sink's suppression gates: the

--- a/backend/internal/compose/capturegraph.go
+++ b/backend/internal/compose/capturegraph.go
@@ -75,6 +75,12 @@ func newGraphOAuth(c GraphConfig) graph.OAuth {
 // after WithKeyvault, and after WithGmailCapture when both are configured.
 func WithGraphCapture(c GraphConfig) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
+		// The send pre-flight's fact, recorded BEFORE the transport gate below
+		// and off canSync — the same split WithGmailCapture makes. An
+		// installation holding client credentials but no state key mounts no
+		// api-side connect transport and still sends perfectly well from the
+		// worker, so gating this on canConnect would report it unable to.
+		s.graphAppConfigured = c.canSync()
 		if !c.canConnect() || s.vault == nil {
 			return
 		}

--- a/backend/internal/compose/sendpreflight.go
+++ b/backend/internal/compose/sendpreflight.go
@@ -85,11 +85,18 @@ var _ activities.SendAuthority = mailboxAuthority{}
 // at CALL time rather than snapshotting it, so the two places that install the
 // pre-flight need no ordering rule against the option that records the fact.
 //
-// A provider with no field is not configured, which is also the only honest
-// answer: comms.SendScopeFor gives a send scope to gmail alone, so no other
-// provider reaches this at all.
+// A provider with no arm is not configured, which is also the only honest
+// answer: comms.SendScopeFor gives a send scope to the mail providers alone, so
+// no other provider reaches this at all.
 func (s *Server) mailAppConfigured(provider string) bool {
-	return provider == providerGmail && s.gmailAppConfigured
+	switch provider {
+	case providerGmail:
+		return s.gmailAppConfigured
+	case providerGraph:
+		return s.graphAppConfigured
+	default:
+		return false
+	}
 }
 
 // installSendPreflight installs the pre-flight over whichever capture registry

--- a/backend/internal/compose/sendscope_test.go
+++ b/backend/internal/compose/sendscope_test.go
@@ -16,31 +16,70 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/capture/gmail"
+	"github.com/margince/margince/backend/internal/modules/capture/graph"
 	"github.com/margince/margince/backend/internal/modules/capture/telegram"
 	"github.com/margince/margince/backend/internal/modules/comms"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
+
+// EVERY sending mail provider, in one table, so a third one cannot be added to
+// two of the three places and pass. The connector's own constant is the
+// authority: comms spells the string a second time because it may not import a
+// capture provider, and the consent must REQUEST what the gate then demands.
+var sendingMailProviders = []struct {
+	provider  string
+	recheck   string   // the constant the connector re-checks a grant against
+	requested []string // the permissions that provider's consent asks for
+}{
+	{provider: "gmail", recheck: gmail.SendScope, requested: gmailScopes},
+	{provider: "graph", recheck: graph.SendScope, requested: graphScopes},
+}
 
 // The scope the authority gate DEMANDS must be the scope the connector
 // RE-CHECKS. comms cannot import a capture provider (a module never imports a
 // sibling), so SendScopeFor spells the string a second time and this is the
 // only place the two can be held against each other.
-func TestTheSendScopeCommsDemandsIsTheOneTheGmailConnectorRechecks(t *testing.T) {
-	scope, capability := comms.SendScopeFor("gmail")
-	if capability != comms.SendsWithScope {
-		t.Fatalf("comms.SendScopeFor(\"gmail\") = %v, want SendsWithScope; a Gmail grant that is never scope-checked, or a delivery that always parks", capability)
-	}
-	if scope != gmail.SendScope {
-		t.Errorf("comms demands %q, the gmail connector re-checks %q — every send would park as ungranted", scope, gmail.SendScope)
+func TestTheSendScopeCommsDemandsIsTheOneTheConnectorRechecks(t *testing.T) {
+	for _, p := range sendingMailProviders {
+		t.Run(p.provider, func(t *testing.T) {
+			scope, capability := comms.SendScopeFor(p.provider)
+			if capability != comms.SendsWithScope {
+				t.Fatalf("comms.SendScopeFor(%q) = %v, want SendsWithScope; a grant that is never scope-checked, or a delivery that always parks", p.provider, capability)
+			}
+			if scope != p.recheck {
+				t.Errorf("comms demands %q, the %s connector re-checks %q — every send would park as ungranted", scope, p.provider, p.recheck)
+			}
+		})
 	}
 }
 
-// The OAuth consent must REQUEST what the gate demands. Google will not add a
-// scope to an existing refresh token, so a connection consented without this
-// one can never be repaired short of reconnecting the mailbox.
-func TestTheGmailConsentRequestsTheScopeTheSendPathDemands(t *testing.T) {
-	scope, _ := comms.SendScopeFor("gmail")
-	if !slices.Contains(gmailScopes, scope) {
-		t.Errorf("the Gmail consent requests %v, which does not include the send scope %q the dispatcher demands", gmailScopes, scope)
+// The OAuth consent must REQUEST what the gate demands. Neither vendor will add
+// a permission to an existing refresh token, so a connection consented without
+// this one can never be repaired short of reconnecting the mailbox.
+func TestEveryMailConsentRequestsTheScopeTheSendPathDemands(t *testing.T) {
+	for _, p := range sendingMailProviders {
+		t.Run(p.provider, func(t *testing.T) {
+			scope, _ := comms.SendScopeFor(p.provider)
+			if !slices.Contains(p.requested, scope) {
+				t.Errorf("the %s consent requests %v, which does not include the send scope %q the dispatcher demands", p.provider, p.requested, scope)
+			}
+		})
+	}
+}
+
+// A provider comms hands a send scope to must be one that can actually send.
+// The reverse of the drift above and just as silent: a scope demanded of a
+// connector with no SendEmail parks every delivery on a capability nothing
+// implements.
+func TestEveryProviderCommsGivesASendScopeCanSend(t *testing.T) {
+	senders := map[string]connector.EmailSender{
+		"gmail": &gmail.Connector{},
+		"graph": &graph.Connector{},
+	}
+	for _, p := range sendingMailProviders {
+		if _, ok := senders[p.provider]; !ok {
+			t.Errorf("comms gives %s a send scope, but no connector.EmailSender is named for it here", p.provider)
+		}
 	}
 }
 

--- a/backend/internal/compose/sendscope_test.go
+++ b/backend/internal/compose/sendscope_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/margince/margince/backend/internal/modules/capture/graph"
 	"github.com/margince/margince/backend/internal/modules/capture/telegram"
 	"github.com/margince/margince/backend/internal/modules/comms"
-	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
 // EVERY sending mail provider, in one table, so a third one cannot be added to
@@ -67,19 +66,29 @@ func TestEveryMailConsentRequestsTheScopeTheSendPathDemands(t *testing.T) {
 	}
 }
 
-// A provider comms hands a send scope to must be one that can actually send.
-// The reverse of the drift above and just as silent: a scope demanded of a
-// connector with no SendEmail parks every delivery on a capability nothing
-// implements.
-func TestEveryProviderCommsGivesASendScopeCanSend(t *testing.T) {
-	senders := map[string]connector.EmailSender{
-		"gmail": &gmail.Connector{},
-		"graph": &graph.Connector{},
-	}
+// The table above must cover EXACTLY the providers comms hands a scope to.
+//
+// Derived from comms' own map rather than restated, because a second list is a
+// second answer and the failure it hides is the one that matters: a provider
+// added to mailSendScopes and to nothing else, whose scope no test ever checks
+// against what its connector re-checks. The compile-time connector.EmailSender
+// assertions elsewhere already prove each named connector can send; what only
+// this can prove is that none was forgotten.
+func TestTheSendScopeTableCoversExactlyWhatCommsHandsAScopeTo(t *testing.T) {
+	covered := make(map[string]bool, len(sendingMailProviders))
 	for _, p := range sendingMailProviders {
-		if _, ok := senders[p.provider]; !ok {
-			t.Errorf("comms gives %s a send scope, but no connector.EmailSender is named for it here", p.provider)
+		covered[p.provider] = true
+	}
+	for _, provider := range comms.MailSendProviders() {
+		if !covered[provider] {
+			t.Errorf("comms hands %q a send scope and this file does not bind it to a connector constant — "+
+				"its scope is checked against nothing", provider)
 		}
+		delete(covered, provider)
+	}
+	for provider := range covered {
+		t.Errorf("this file binds %q, which comms hands no send scope: every delivery for it parks as "+
+			"\"provider cannot send messages\"", provider)
 	}
 }
 

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -245,9 +245,14 @@ type Server struct {
 	// client credentials but no state key — which mounts no api-side connect
 	// transport yet sends perfectly well from the worker — still counts as
 	// configured. False is the honest default for a composition never told about
-	// a Google app at all. Gmail is the only provider with a field here because
-	// it is the only one comms.SendScopeFor gives a send scope.
+	// a Google app at all.
 	gmailAppConfigured bool
+	// graphAppConfigured is the Microsoft twin, recorded by WithGraphCapture on
+	// the same condition and read by the same pre-flight. It exists because
+	// Outlook now sends too: comms.SendScopeFor gives a send scope to both mail
+	// providers, so both reach the pre-flight and a missing field would report
+	// a configured deployment as unable to send.
+	graphAppConfigured bool
 	// googleAppResolver resolves the installation's STORED Google app, built by
 	// WithKeyvault and named in every connectorHandlers literal.
 	//

--- a/backend/internal/modules/capture/gmail/send.go
+++ b/backend/internal/modules/capture/gmail/send.go
@@ -14,9 +14,9 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
-	"strings"
 
 	"github.com/margince/margince/backend/internal/modules/capture/mailmap"
+	"github.com/margince/margince/backend/internal/modules/capture/mailwire"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 	"github.com/margince/margince/backend/pkg/extension"
 )
@@ -104,7 +104,7 @@ func (c *Connector) SendEmail(ctx context.Context, auth connector.Auth, msg conn
 			return connector.SendReceipt{ProviderMessageID: id}, nil
 		}
 	}
-	raw := base64.URLEncoding.EncodeToString([]byte(buildRFC822(st.Owner, msg)))
+	raw := base64.URLEncoding.EncodeToString([]byte(mailwire.Build(st.Owner, msg)))
 	id, err := c.api.Send(ctx, access, raw)
 	if err != nil {
 		return connector.SendReceipt{}, err
@@ -123,7 +123,7 @@ func (c *Connector) SendEmail(ctx context.Context, auth connector.Auth, msg conn
 // than going out stripped, because a recipient seeing fewer files than the
 // timeline records is a wrong record nobody is told about. Gmail takes a
 // complete RFC822 message, so the files ride in the multipart/mixed envelope
-// buildRFC822 renders — nothing is uploaded separately and nothing is linked.
+// mailwire.Build renders — nothing is uploaded separately and nothing is linked.
 //
 // The limits are mail's own inbound bounds read in the other direction: a
 // message this system will accept is one it can send.
@@ -194,43 +194,6 @@ func (c *Connector) stampedIdentity(ctx context.Context, access, owner, provider
 		return ""
 	}
 	return id
-}
-
-// bracket renders a message identity as RFC 5322 requires it on the wire. The
-// identity travels unbracketed everywhere else in this system, because that is
-// the form mail parsing yields and therefore the form the captured copy of this
-// message will be keyed on.
-func bracket(id string) string {
-	if id == "" {
-		return ""
-	}
-	return "<" + strings.Trim(id, "<>") + ">"
-}
-
-// addressList renders one address header value: each address trimmed, empties
-// dropped, comma-separated. The trim is the same normalization the send path's
-// consent gate matches on, so the address a recipient is asked about and the
-// address the header carries are one string — a stored " a@x " must not become
-// folding whitespace around an addr-spec that some clients then display raw.
-func addressList(addrs []string) string {
-	out := make([]string, 0, len(addrs))
-	for _, addr := range addrs {
-		if trimmed := strings.TrimSpace(addr); trimmed != "" {
-			out = append(out, trimmed)
-		}
-	}
-	return strings.Join(out, ", ")
-}
-
-// writeHeader emits one header line with CR and LF removed from the value: a
-// bare CR or LF inside a header is the classic injection vector, and the only
-// safe rendering of one is not to emit it.
-func writeHeader(b *strings.Builder, name, value string) {
-	clean := strings.NewReplacer("\r", "", "\n", "").Replace(value)
-	b.WriteString(name)
-	b.WriteString(": ")
-	b.WriteString(clean)
-	b.WriteString("\r\n")
 }
 
 // Send transmits one already-encoded RFC822 message via messages.send. No

--- a/backend/internal/modules/capture/gmail/send_test.go
+++ b/backend/internal/modules/capture/gmail/send_test.go
@@ -251,7 +251,7 @@ func TestTheMessageIDSurvivesARoundTripThroughMailmap(t *testing.T) {
 	}
 	// Feed the bytes we actually produced through the same normalization the
 	// Gmail connector runs on a captured message. The auth fixture's Owner
-	// ("rep@acme.test") is the From address buildRFC822 stamped, so it must
+	// ("rep@acme.test") is the From address mailwire.Build stamped, so it must
 	// match here too or Parse would classify the message as inbound.
 	c.owner = "rep@acme.test"
 	recs, err := c.Normalize(context.Background(), connector.RawRecord(decodeMIME(t, raw)))

--- a/backend/internal/modules/capture/graph/backfill.go
+++ b/backend/internal/modules/capture/graph/backfill.go
@@ -29,10 +29,11 @@ func (c *Connector) EstimateBackfill(ctx context.Context, auth connector.Auth, a
 	if err := json.Unmarshal(auth, &st); err != nil {
 		return 0, fmt.Errorf("graph: malformed auth state: %w", err)
 	}
-	access, err := c.oauth.AccessToken(ctx, st.RefreshToken)
+	refreshed, err := c.oauth.Refresh(ctx, st.RefreshToken, st.Granted)
 	if err != nil {
 		return 0, err
 	}
+	access := refreshed.AccessToken
 	return c.api.EstimateAfter(ctx, access, after)
 }
 
@@ -45,10 +46,11 @@ func (c *Connector) BackfillPage(ctx context.Context, auth connector.Auth, after
 	if err := json.Unmarshal(auth, &st); err != nil {
 		return connector.BackfillPageResult{}, fmt.Errorf("graph: malformed auth state: %w", err)
 	}
-	access, err := c.oauth.AccessToken(ctx, st.RefreshToken)
+	refreshed, err := c.oauth.Refresh(ctx, st.RefreshToken, st.Granted)
 	if err != nil {
 		return connector.BackfillPageResult{}, err
 	}
+	access := refreshed.AccessToken
 	// The backfill walks the whole mailbox, Sent Items included — unlike the
 	// incremental delta, which is inbox-only — so this is where the T1
 	// correspondence evidence (ADR-0072 §1) is available to collect. Resolved

--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -50,6 +50,8 @@ const (
 	paramClientID = "client_id"
 	paramScope    = "scope"
 	paramFilter   = "$filter"
+	paramSelect   = "$select"
+	paramTop      = "$top"
 
 	// maxMIMELen bounds one message's fetched RFC822 bytes. A message over
 	// this is refused rather than truncated (a truncated MIME blob is not
@@ -87,7 +89,8 @@ type OAuth interface {
 	Refresh(ctx context.Context, refreshToken string) (oauthflow.TokenRefresh, error)
 }
 
-// API is the read-only Graph mail surface the connector uses. All calls take
+// API is the Graph mail surface the connector uses — read-only but for the two
+// send calls at the end, which ride the separate Mail.Send permission. All calls take
 // a short-lived access token (minted from the refresh token per Sync).
 type API interface {
 	// Profile returns the mailbox owner's address (mail, falling back to
@@ -114,6 +117,15 @@ type API interface {
 	// folder, against which a message's ParentFolderID identifies mail the
 	// authenticated owner sent.
 	SentFolderID(ctx context.Context, accessToken string) (string, error)
+
+	// SendMIME transmits one complete RFC822 message as the signed-in user.
+	// Microsoft acknowledges the submission without naming a message id, so
+	// this reports only whether it was accepted.
+	SendMIME(ctx context.Context, accessToken string, rfc822 []byte) error
+	// FindSentByMessageID resolves the sent copy of a message by the RFC822
+	// identity it was asked to carry — the at-least-once retry guard, and the
+	// only way to name a message this connector has just submitted.
+	FindSentByMessageID(ctx context.Context, accessToken, unbracketedMessageID string) (msgID string, found bool, err error)
 }
 
 // MessageRef is one listed message: its id, plus the folder Graph filed it in.
@@ -337,8 +349,8 @@ func (a *httpAPI) EstimateAfter(ctx context.Context, accessToken string, after t
 	q := url.Values{
 		paramFilter: {receivedAfterFilter(after)},
 		"$count":    {"true"},
-		"$select":   {"id"},
-		"$top":      {"1"},
+		paramSelect: {"id"},
+		paramTop:    {"1"},
 	}
 	// $count=true needs the eventual-consistency header on Graph.
 	hdr := http.Header{"ConsistencyLevel": {"eventual"}}
@@ -353,8 +365,8 @@ func (a *httpAPI) ListAfter(ctx context.Context, accessToken string, after time.
 	if u == "" {
 		q := url.Values{
 			paramFilter: {receivedAfterFilter(after)},
-			"$select":   {"id,parentFolderId"},
-			"$top":      {strconv.Itoa(pageSize)},
+			paramSelect: {"id,parentFolderId"},
+			paramTop:    {strconv.Itoa(pageSize)},
 		}
 		u = a.base + "/me/messages?" + q.Encode()
 	} else if err := a.sameAPIOrigin(u); err != nil {
@@ -395,7 +407,7 @@ func (a *httpAPI) SentFolderID(ctx context.Context, accessToken string) (string,
 	var out struct {
 		ID string `json:"id"`
 	}
-	q := url.Values{"$select": {"id"}}
+	q := url.Values{paramSelect: {"id"}}
 	if _, err := a.get(ctx, accessToken, a.base+"/me/mailFolders/sentitems?"+q.Encode(), nil, &out); err != nil {
 		return "", err
 	}

--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -83,10 +83,16 @@ type OAuth interface {
 	AuthCodeURL(state, redirectURI string) string
 	Exchange(ctx context.Context, code, redirectURI string) (oauthflow.TokenGrant, error)
 	AccessToken(ctx context.Context, refreshToken string) (accessToken string, err error)
-	// Refresh is AccessToken plus the rotation Microsoft performs on every
-	// redemption — the durable half, which Sync persists and the one-shot
-	// callers above have nowhere to put.
-	Refresh(ctx context.Context, refreshToken string) (oauthflow.TokenRefresh, error)
+	// Refresh redeems the stored refresh token asking for exactly the scopes
+	// THIS connection holds, and reports the rotation Microsoft performs on
+	// every redemption.
+	//
+	// Both halves matter and neither is optional. Asking with the deployment's
+	// configured list instead would stop an older mailbox CAPTURING the day a
+	// scope is added — Microsoft refuses a refresh that names a permission the
+	// grant never carried — and dropping the rotation ages the connection out
+	// on Microsoft's own 90-day idle clock.
+	Refresh(ctx context.Context, refreshToken string, granted []string) (oauthflow.TokenRefresh, error)
 }
 
 // API is the Graph mail surface the connector uses — read-only but for the two

--- a/backend/internal/modules/capture/graph/graph.go
+++ b/backend/internal/modules/capture/graph/graph.go
@@ -227,7 +227,7 @@ func (c *Connector) Sync(ctx context.Context, auth connector.Auth, cursor connec
 	}
 	owner := st.Owner // local — never stored on the shared instance
 
-	refreshed, err := c.oauth.Refresh(ctx, st.RefreshToken)
+	refreshed, err := c.oauth.Refresh(ctx, st.RefreshToken, st.Granted)
 	if err != nil {
 		return nil, err
 	}
@@ -363,10 +363,11 @@ func (c *Connector) HealthCheck(ctx context.Context, auth connector.Auth) error 
 	if err := json.Unmarshal(auth, &st); err != nil {
 		return fmt.Errorf("graph: malformed auth state: %w", err)
 	}
-	access, err := c.oauth.AccessToken(ctx, st.RefreshToken)
+	refreshed, err := c.oauth.Refresh(ctx, st.RefreshToken, st.Granted)
 	if err != nil {
 		return err
 	}
+	access := refreshed.AccessToken
 	if _, err := c.api.Profile(ctx, access); err != nil {
 		return err
 	}

--- a/backend/internal/modules/capture/graph/graph_test.go
+++ b/backend/internal/modules/capture/graph/graph_test.go
@@ -62,12 +62,44 @@ type fakeAPI struct {
 	sentIDs       map[string]bool // listed ids Graph filed under Sent Items
 	skipIDs       map[string]bool // ids GetMIME refuses as a per-message drop
 	sentFolderErr error
+
+	// The outbound half's state.
+	sendCalls     int
+	sendErr       error
+	sentMIME      [][]byte
+	findCalls     int
+	findErr       error
+	seenFindID    string
+	sentByID      map[string]string
 	listNext      string
 	listCalls     int
 	seenPageToken string
 }
 
 func (f *fakeAPI) Profile(context.Context, string) (string, error) { return f.email, nil }
+
+// The outbound half. sentByID is what Sent Items holds, keyed on the
+// UNBRACKETED identity the caller asks about; sentRaw is the copy the read-back
+// parses. sentMIME records what was submitted, so a test can assert that a
+// retry which found a prior send transmitted NOTHING.
+func (f *fakeAPI) SendMIME(_ context.Context, _ string, rfc822 []byte) error {
+	f.sendCalls++
+	if f.sendErr != nil {
+		return f.sendErr
+	}
+	f.sentMIME = append(f.sentMIME, rfc822)
+	return nil
+}
+
+func (f *fakeAPI) FindSentByMessageID(_ context.Context, _, id string) (string, bool, error) {
+	f.findCalls++
+	f.seenFindID = id
+	if f.findErr != nil {
+		return "", false, f.findErr
+	}
+	msgID, ok := f.sentByID[id]
+	return msgID, ok, nil
+}
 
 func (f *fakeAPI) DeltaInit(_ context.Context, _ string, after time.Time) ([]string, string, error) {
 	f.initCalls++

--- a/backend/internal/modules/capture/graph/graph_test.go
+++ b/backend/internal/modules/capture/graph/graph_test.go
@@ -27,15 +27,22 @@ type fakeOAuth struct {
 	// rotated is what Microsoft hands back in place of the stored refresh
 	// token; empty means it rotated nothing this round.
 	rotated string
+	// askedFor records the scopes the last refresh requested — a refresh must
+	// ask for the grant's own, never the deployment's configured list.
+	askedFor []string
 }
 
-func (f fakeOAuth) AuthCodeURL(state, _ string) string { return "https://auth?state=" + state }
-func (f fakeOAuth) Exchange(context.Context, string, string) (oauthflow.TokenGrant, error) {
+func (f *fakeOAuth) AuthCodeURL(state, _ string) string { return "https://auth?state=" + state }
+func (f *fakeOAuth) Exchange(context.Context, string, string) (oauthflow.TokenGrant, error) {
 	return oauthflow.TokenGrant{RefreshToken: f.refresh, Scopes: f.granted}, nil
 }
-func (f fakeOAuth) AccessToken(context.Context, string) (string, error) { return f.access, nil }
+func (f *fakeOAuth) AccessToken(context.Context, string) (string, error) { return f.access, nil }
 
-func (f fakeOAuth) Refresh(context.Context, string) (oauthflow.TokenRefresh, error) {
+// Refresh records what the caller asked to refresh FOR, which is half the
+// point of the seam: a refresh must ask for the grant's own scopes, never the
+// deployment's configured list.
+func (f *fakeOAuth) Refresh(_ context.Context, _ string, granted []string) (oauthflow.TokenRefresh, error) {
+	f.askedFor = granted
 	return oauthflow.TokenRefresh{AccessToken: f.access, Rotated: f.rotated}, nil
 }
 
@@ -198,7 +205,7 @@ func authBytes(t *testing.T) connector.Auth {
 var pinned = time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
 
 func pinnedConn(api *fakeAPI) *Connector {
-	c := New(fakeOAuth{access: "access-1"}, api)
+	c := New(&fakeOAuth{access: "access-1"}, api)
 	c.now = func() time.Time { return pinned }
 	return c
 }
@@ -206,7 +213,7 @@ func pinnedConn(api *fakeAPI) *Connector {
 // --- tests ---------------------------------------------------------------
 
 func TestDescriptorIsAutoExecuteReadOnly(t *testing.T) {
-	d := New(fakeOAuth{}, &fakeAPI{}).Descriptor()
+	d := New(&fakeOAuth{}, &fakeAPI{}).Descriptor()
 	if d.Name != "graph" {
 		t.Errorf("Name = %q, want graph", d.Name)
 	}
@@ -222,7 +229,7 @@ func TestDescriptorIsAutoExecuteReadOnly(t *testing.T) {
 }
 
 func TestAuthenticateBindsRefreshTokenAndOwner(t *testing.T) {
-	c := New(fakeOAuth{refresh: "refresh-1", access: "access-1"}, &fakeAPI{email: owner})
+	c := New(&fakeOAuth{refresh: "refresh-1", access: "access-1"}, &fakeAPI{email: owner})
 	req, err := AuthRequestFrom("the-code", "https://app/callback")
 	if err != nil {
 		t.Fatalf("AuthRequestFrom: %v", err)
@@ -241,7 +248,7 @@ func TestAuthenticateBindsRefreshTokenAndOwner(t *testing.T) {
 }
 
 func TestAuthenticateRequiresCode(t *testing.T) {
-	c := New(fakeOAuth{}, &fakeAPI{})
+	c := New(&fakeOAuth{}, &fakeAPI{})
 	req, err := AuthRequestFrom("", "https://app/callback")
 	if err != nil {
 		t.Fatalf("AuthRequestFrom: %v", err)
@@ -402,7 +409,7 @@ func TestCursorCarriesMailboxEmail(t *testing.T) {
 }
 
 func TestNormalizeSkipsAutomatedMail(t *testing.T) {
-	c := New(fakeOAuth{}, &fakeAPI{})
+	c := New(&fakeOAuth{}, &fakeAPI{})
 	c.owner = owner
 	auto := []byte(strings.Join([]string{
 		"From: system@acme.com", "To: " + owner, "Subject: OOO",
@@ -427,7 +434,7 @@ func TestNormalizeSkipsAutomatedMail(t *testing.T) {
 // already produced — no vault round-trip and no network — and a bundle that
 // names no mailbox is a blank line in the UI, not a lost connection.
 func TestAccountLabelNamesTheAuthorizedMailbox(t *testing.T) {
-	c := New(fakeOAuth{refresh: "refresh-1", access: "access-1"}, &fakeAPI{email: owner})
+	c := New(&fakeOAuth{refresh: "refresh-1", access: "access-1"}, &fakeAPI{email: owner})
 	req, err := AuthRequestFrom("the-code", "https://app/callback")
 	if err != nil {
 		t.Fatalf("AuthRequestFrom: %v", err)
@@ -446,7 +453,7 @@ func TestAccountLabelNamesTheAuthorizedMailbox(t *testing.T) {
 }
 
 func TestAccountLabelOfAnOwnerlessBundleIsAbsentNotAnError(t *testing.T) {
-	c := New(fakeOAuth{}, &fakeAPI{})
+	c := New(&fakeOAuth{}, &fakeAPI{})
 	bundle, err := json.Marshal(authState{RefreshToken: "r"})
 	if err != nil {
 		t.Fatal(err)

--- a/backend/internal/modules/capture/graph/rotation_test.go
+++ b/backend/internal/modules/capture/graph/rotation_test.go
@@ -29,7 +29,7 @@ func (r *recordingRotations) Rotated(_ context.Context, auth connector.Auth) err
 	return nil
 }
 
-func rotatingConnector(t *testing.T, oauth fakeOAuth, api API, sink connector.CredentialSink) connector.Connector {
+func rotatingConnector(t *testing.T, oauth *fakeOAuth, api API, sink connector.CredentialSink) connector.Connector {
 	t.Helper()
 	return New(oauth, api).WithCredentialSink(sink)
 }
@@ -37,7 +37,7 @@ func rotatingConnector(t *testing.T, oauth fakeOAuth, api API, sink connector.Cr
 func TestASyncReportsTheReplacementCredentialWithTheRestOfTheBundleIntact(t *testing.T) {
 	sink := &recordingRotations{}
 	api := &fakeAPI{email: owner, initDelta: "https://graph/delta?$1"}
-	c := rotatingConnector(t, fakeOAuth{access: "a", rotated: "r-2"}, api, sink)
+	c := rotatingConnector(t, &fakeOAuth{access: "a", rotated: "r-2"}, api, sink)
 
 	if _, err := c.Sync(context.Background(), sealedAuth(t), nil, &recordingSink{}); err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -69,7 +69,7 @@ func TestASyncReportsTheReplacementCredentialWithTheRestOfTheBundleIntact(t *tes
 func TestASyncThatRotatesNothingReportsNothing(t *testing.T) {
 	sink := &recordingRotations{}
 	api := &fakeAPI{email: owner, initDelta: "https://graph/delta?$1"}
-	c := rotatingConnector(t, fakeOAuth{access: "a"}, api, sink)
+	c := rotatingConnector(t, &fakeOAuth{access: "a"}, api, sink)
 
 	if _, err := c.Sync(context.Background(), sealedAuth(t), nil, &recordingSink{}); err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -85,7 +85,7 @@ func TestASyncThatRotatesNothingReportsNothing(t *testing.T) {
 func TestARotationThatCannotBeRecordedDoesNotFailTheSync(t *testing.T) {
 	sink := &recordingRotations{err: errors.New("the vault is unreachable")}
 	api := &fakeAPI{email: owner, initDelta: "https://graph/delta?$1"}
-	c := rotatingConnector(t, fakeOAuth{access: "a", rotated: "r-2"}, api, sink)
+	c := rotatingConnector(t, &fakeOAuth{access: "a", rotated: "r-2"}, api, sink)
 
 	cur, err := c.Sync(context.Background(), sealedAuth(t), nil, &recordingSink{})
 	if err != nil {
@@ -104,7 +104,7 @@ func TestARotationThatCannotBeRecordedDoesNotFailTheSync(t *testing.T) {
 func TestARotationIsReportedEvenWhenThePullThenFails(t *testing.T) {
 	sink := &recordingRotations{}
 	api := &fakeAPI{email: owner, deltaErr: ErrUnreachable}
-	c := rotatingConnector(t, fakeOAuth{access: "a", rotated: "r-2"}, api, sink)
+	c := rotatingConnector(t, &fakeOAuth{access: "a", rotated: "r-2"}, api, sink)
 
 	prior := marshalCursor("https://graph/delta?stale", owner)
 	if _, err := c.Sync(context.Background(), sealedAuth(t), prior, &recordingSink{}); err == nil {
@@ -119,7 +119,7 @@ func TestARotationIsReportedEvenWhenThePullThenFails(t *testing.T) {
 // connection the fleet pulls at once, and a field set in place would send one
 // mailbox's replacement credential to another mailbox's re-seal.
 func TestBindingASinkLeavesTheRegisteredConnectorAlone(t *testing.T) {
-	registered := New(fakeOAuth{access: "a", rotated: "r-2"}, &fakeAPI{email: owner, initDelta: "d"})
+	registered := New(&fakeOAuth{access: "a", rotated: "r-2"}, &fakeAPI{email: owner, initDelta: "d"})
 	mine := &recordingRotations{}
 	bound := registered.WithCredentialSink(mine)
 

--- a/backend/internal/modules/capture/graph/send.go
+++ b/backend/internal/modules/capture/graph/send.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package graph
+
+// The OUTBOUND half of the Outlook connector: transmitting one message as the
+// connected mailbox owner. Split from graph.go the way Gmail's send is split
+// from its capture, because it answers a different question and rides a
+// different scope.
+//
+// The bytes are the SHARED renderer (capture/mailwire), not a second one:
+// Microsoft's sendMail accepts a complete RFC822 message under a `text/plain`
+// content type, which is the same wire format Gmail's messages.send takes. What
+// a multipart/alternative puts first, whether an attachment's filename rides in
+// one header or two, where base64 folds — those have one right answer, and two
+// renderers would answer them twice.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"github.com/margince/margince/backend/internal/modules/capture/mailmap"
+	"github.com/margince/margince/backend/internal/modules/capture/mailwire"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// SendScope permits transmission only — it cannot read, modify, or delete,
+// which is why it rides alongside the read-only capture scopes rather than
+// replacing them.
+//
+// Exported so the OAuth consent that REQUESTS it names the same string this
+// connector RE-CHECKS. A send whose consent asked for a scope the connector
+// then does not find parks every message with "not granted the send scope",
+// and nothing at compile time would say why.
+const SendScope = "Mail.Send"
+
+// ErrSendScopeMissing marks a connection whose Microsoft grant does not include
+// the send permission: the mailbox was connected for capture and declined (or
+// predates) sending. Reconnecting is the fix, so the caller parks rather than
+// retries.
+var ErrSendScopeMissing = fmt.Errorf("graph: this connection was not granted the send permission: %w", connector.ErrAuthRejected)
+
+var (
+	_ connector.EmailSender       = (*Connector)(nil)
+	_ connector.AttachmentCarrier = (*Connector)(nil)
+)
+
+// maxSendableFiles is the most files this connector will put in one message.
+//
+// It is the contract's own attachment_ids cap, restated here because the
+// carriage gate can only enforce a bound a connector DECLARES: nothing in this
+// stack validates a request against the schema, so an undeclared cap would let
+// a caller name fifty files and have every one of them transmitted.
+const maxSendableFiles = 10
+
+// maxSendableFileBytes is what survives Microsoft's MIME submit ceiling.
+//
+// Graph accepts 4 MB of base64 for a sendMail, and base64 costs a third — so
+// the raw budget for one message is about 3 MiB, and a single file may not
+// exceed it. Stated as the file bound because that is the seam the dispatcher
+// enforces; a message carrying several smaller files can still exceed the
+// whole-message ceiling, and Microsoft refuses that one.
+const maxSendableFileBytes = 3 << 20
+
+// SendEmail transmits one message as the connected mailbox owner.
+//
+// On a retry it first asks Microsoft whether this message identity already
+// exists in Sent Items. Job delivery is at-least-once and Graph offers no
+// idempotency key, so without that lookup a crash between a successful
+// transmission and its recorded outcome mails the recipient twice.
+//
+// UNLIKE GMAIL, THE LOOKUP HAS SOMETHING TO SEARCH FOR. Gmail discards a
+// client-supplied Message-ID and files the message under one of its own, which
+// leaves its own guard inoperative (gmail/send.go says so). Graph exposes the
+// identity as the filterable `internetMessageId` property, so the search is
+// against the message's own field rather than a full-text index.
+//
+// It still does not CLOSE the window, and the reasons are worth stating rather
+// than leaving to be discovered. Exchange Online may rewrite the identity on
+// submission depending on tenant configuration, in which case the filter
+// matches nothing and the retry mails twice — the same failure Gmail has
+// always had, but conditional rather than certain. Nor does anything here
+// serialize concurrent attempts at the same delivery: that guarantee lives
+// outside this package, in River delivering one job per delivery.
+func (c *Connector) SendEmail(ctx context.Context, auth connector.Auth, msg connector.EmailMessage) (connector.SendReceipt, error) {
+	// Before anything reaches Microsoft: a message with no usable identity
+	// cannot be found again by the prior-send lookup, so transmitting it would
+	// mail the recipient once per retry with nothing able to tell that it had
+	// already gone.
+	if err := msg.Validate(); err != nil {
+		return connector.SendReceipt{}, err
+	}
+	var st authState
+	if err := json.Unmarshal(auth, &st); err != nil {
+		return connector.SendReceipt{}, fmt.Errorf("graph: malformed auth bundle: %w", err)
+	}
+	if !slices.Contains(st.Granted, SendScope) {
+		return connector.SendReceipt{}, ErrSendScopeMissing
+	}
+	access, err := c.oauth.AccessToken(ctx, st.RefreshToken)
+	if err != nil {
+		return connector.SendReceipt{}, err
+	}
+	if msg.Attempt > 0 {
+		id, found, findErr := c.api.FindSentByMessageID(ctx, access, msg.MessageID)
+		if findErr != nil {
+			return connector.SendReceipt{}, findErr
+		}
+		if found {
+			return connector.SendReceipt{ProviderMessageID: id}, nil
+		}
+	}
+	if err := c.api.SendMIME(ctx, access, []byte(mailwire.Build(st.Owner, msg))); err != nil {
+		return connector.SendReceipt{}, err
+	}
+	// sendMail returns 202 Accepted with no body: Microsoft names no message id
+	// at submission, so the sent copy has to be looked up by the identity it was
+	// asked to carry. That lookup is also the read-back — one call answers both
+	// "which message is it" and "what identity does it actually carry".
+	return c.sentReceipt(ctx, access, st.Owner, msg.MessageID), nil
+}
+
+// Carriage declares what this connector transmits (connector.AttachmentCarrier).
+//
+// There is no default for this and that is the design: a message with files
+// staged against a connector that does not declare the capability PARKS rather
+// than going out stripped, because a recipient seeing fewer files than the
+// timeline records is a wrong record nobody is told about. Graph's sendMail
+// takes a complete RFC822 message, so the files ride in the multipart/mixed
+// envelope mailwire.Build renders — nothing is uploaded separately and nothing
+// is linked.
+//
+// The per-file limit is MICROSOFT'S, not this system's, and it is lower than
+// Gmail's — the one place the two providers genuinely differ on what they can
+// carry. Graph's MIME submit ceiling is 4 MB of BASE64, which is about 3 MiB of
+// actual bytes, where Gmail takes the full inbound 25 MiB. Declaring the real
+// number is what makes an over-large message PARK with an honest reason instead
+// of leaving as a request Microsoft answers with an opaque refusal that a retry
+// can never get under.
+func (c *Connector) Carriage() connector.Carriage {
+	return connector.Carriage{
+		Carries:         true,
+		MaxBytesPerFile: maxSendableFileBytes,
+		MaxFiles:        maxSendableFiles,
+		// Mail carries the body as the body, never as a caption, so there is no
+		// extra bound to declare.
+		MaxBodyWithFiles: 0,
+	}
+}
+
+// sentReceipt resolves what Microsoft actually filed, after a submission it
+// acknowledged without naming.
+//
+// EVERY failure returns an empty receipt rather than an error. The message has
+// already been transmitted when this runs, and returning an error would hand
+// the delivery back to a retry — mailing the recipient a second time to fix a
+// bookkeeping problem. An unread identity costs one duplicate timeline row; a
+// re-mail costs the recipient's trust.
+//
+// What comes back is CHECKED before it is reported. These are remote bytes, and
+// the string parsed out of them becomes a natural key, a thread key and a log
+// field on the strength of this return alone — so it must satisfy
+// connector.ValidMessageID, the same predicate SendEmail refuses to transmit
+// without.
+//
+// The identity is parsed with mailmap, the same function capture parses the
+// echo with, so the identity recorded here and the identity derived there are
+// one function of one set of bytes.
+func (c *Connector) sentReceipt(ctx context.Context, access, owner, askedFor string) connector.SendReceipt {
+	providerID, found, err := c.api.FindSentByMessageID(ctx, access, askedFor)
+	if err != nil || !found {
+		// Not a fault to report: Exchange may have rewritten the identity, or
+		// the sent copy may not have been filed yet. Either way the message is
+		// gone and the delivery must not be retried over a lookup.
+		slog.WarnContext(ctx, "graph: could not resolve the sent copy of a transmitted message",
+			"err", err, "found", found)
+		return connector.SendReceipt{}
+	}
+	raw, err := c.api.GetMIME(ctx, access, providerID)
+	if err != nil {
+		slog.WarnContext(ctx, "graph: reading back the sent message identity",
+			"err", err, "provider_message_id", providerID)
+		return connector.SendReceipt{ProviderMessageID: providerID}
+	}
+	parsed, err := mailmap.Parse(raw, owner)
+	if err != nil {
+		slog.WarnContext(ctx, "graph: parsing the sent message identity", "err", err)
+		return connector.SendReceipt{ProviderMessageID: providerID}
+	}
+	id := parsed.ID()
+	if !connector.ValidMessageID(id) {
+		// The rejected value is deliberately NOT logged: it is unbounded
+		// provider input, and the two facts that diagnose this — that the
+		// read-back answered with something unusable, and how big it was —
+		// carry no risk of writing megabytes or control bytes into a log line.
+		slog.WarnContext(ctx, "graph: the sent copy carries no usable message identity",
+			"provider_message_id", providerID, "identity_bytes", len(id))
+		return connector.SendReceipt{ProviderMessageID: providerID}
+	}
+	return connector.SendReceipt{ProviderMessageID: providerID, RFC822MessageID: id}
+}

--- a/backend/internal/modules/capture/graph/send.go
+++ b/backend/internal/modules/capture/graph/send.go
@@ -58,12 +58,17 @@ const maxSendableFiles = 10
 
 // maxSendableFileBytes is what survives Microsoft's MIME submit ceiling.
 //
-// Graph accepts 4 MB of base64 for a sendMail, and base64 costs a third — so
-// the raw budget for one message is about 3 MiB, and a single file may not
-// exceed it. Stated as the file bound because that is the seam the dispatcher
-// enforces; a message carrying several smaller files can still exceed the
-// whole-message ceiling, and Microsoft refuses that one.
-const maxSendableFileBytes = 3 << 20
+// The encoding is applied TWICE, which is the part that is easy to get wrong
+// and was: mailwire.Build renders each attachment as base64 INSIDE the message,
+// and SendMIME then base64-encodes the whole message again for the wire. A file
+// of N bytes therefore costs roughly N × 4/3 × 4/3 ≈ 1.8N against a 4 MB
+// request limit, before headers, boundaries and the covering text.
+//
+// 2 MiB leaves real headroom under that. It is an EARLY, legible refusal rather
+// than the bound that matters — several files each under it can still exceed
+// the whole-message ceiling, which is why SendMIME checks the rendered message
+// too rather than trusting this.
+const maxSendableFileBytes = 2 << 20
 
 // SendEmail transmits one message as the connected mailbox owner.
 //
@@ -100,10 +105,11 @@ func (c *Connector) SendEmail(ctx context.Context, auth connector.Auth, msg conn
 	if !slices.Contains(st.Granted, SendScope) {
 		return connector.SendReceipt{}, ErrSendScopeMissing
 	}
-	access, err := c.oauth.AccessToken(ctx, st.RefreshToken)
+	refreshed, err := c.oauth.Refresh(ctx, st.RefreshToken, st.Granted)
 	if err != nil {
 		return connector.SendReceipt{}, err
 	}
+	access := refreshed.AccessToken
 	if msg.Attempt > 0 {
 		id, found, findErr := c.api.FindSentByMessageID(ctx, access, msg.MessageID)
 		if findErr != nil {
@@ -133,13 +139,13 @@ func (c *Connector) SendEmail(ctx context.Context, auth connector.Auth, msg conn
 // envelope mailwire.Build renders — nothing is uploaded separately and nothing
 // is linked.
 //
-// The per-file limit is MICROSOFT'S, not this system's, and it is lower than
+// The per-file limit is MICROSOFT'S, not this system's, and it is far lower than
 // Gmail's — the one place the two providers genuinely differ on what they can
-// carry. Graph's MIME submit ceiling is 4 MB of BASE64, which is about 3 MiB of
-// actual bytes, where Gmail takes the full inbound 25 MiB. Declaring the real
-// number is what makes an over-large message PARK with an honest reason instead
-// of leaving as a request Microsoft answers with an opaque refusal that a retry
-// can never get under.
+// carry. Graph caps a sendMail request at 4 MB and the payload is base64-encoded
+// twice on the way there (see maxSendableFileBytes), where Gmail takes the full
+// inbound 25 MiB. Declaring the real number is what makes an over-large message
+// PARK with an honest reason instead of leaving as a request Microsoft answers
+// with an opaque refusal that no retry can get under.
 func (c *Connector) Carriage() connector.Carriage {
 	return connector.Carriage{
 		Carries:         true,

--- a/backend/internal/modules/capture/graph/send.go
+++ b/backend/internal/modules/capture/graph/send.go
@@ -19,10 +19,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"slices"
 
-	"github.com/margince/margince/backend/internal/modules/capture/mailmap"
 	"github.com/margince/margince/backend/internal/modules/capture/mailwire"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
@@ -122,11 +120,22 @@ func (c *Connector) SendEmail(ctx context.Context, auth connector.Auth, msg conn
 	if err := c.api.SendMIME(ctx, access, []byte(mailwire.Build(st.Owner, msg))); err != nil {
 		return connector.SendReceipt{}, err
 	}
-	// sendMail returns 202 Accepted with no body: Microsoft names no message id
-	// at submission, so the sent copy has to be looked up by the identity it was
-	// asked to carry. That lookup is also the read-back — one call answers both
-	// "which message is it" and "what identity does it actually carry".
-	return c.sentReceipt(ctx, access, st.Owner, msg.MessageID), nil
+	// An EMPTY receipt, and it is the honest one rather than a gap.
+	//
+	// sendMail answers 202 Accepted with no body and no message id, and the
+	// send is ASYNCHRONOUS: Graph writes a draft, returns, and Exchange moves
+	// the copy into Sent Items only once it has actually gone. Looking it up
+	// here would therefore miss almost every time — a round trip per send to
+	// learn nothing, and a warning logged on the ordinary path.
+	//
+	// Nothing is lost by not looking. connector.SendReceipt reads an empty
+	// RFC822MessageID as "no re-key owed", and for a MIME submit that is the
+	// truth: the identity this system minted is the one in the message body
+	// Microsoft was handed, so there is nothing to correct. A tenant that
+	// rewrites it on submission is the exception, and the retry guard above —
+	// which runs later, when the copy HAS been filed — is what still finds the
+	// message in that case.
+	return connector.SendReceipt{}, nil
 }
 
 // Carriage declares what this connector transmits (connector.AttachmentCarrier).
@@ -155,56 +164,4 @@ func (c *Connector) Carriage() connector.Carriage {
 		// extra bound to declare.
 		MaxBodyWithFiles: 0,
 	}
-}
-
-// sentReceipt resolves what Microsoft actually filed, after a submission it
-// acknowledged without naming.
-//
-// EVERY failure returns an empty receipt rather than an error. The message has
-// already been transmitted when this runs, and returning an error would hand
-// the delivery back to a retry — mailing the recipient a second time to fix a
-// bookkeeping problem. An unread identity costs one duplicate timeline row; a
-// re-mail costs the recipient's trust.
-//
-// What comes back is CHECKED before it is reported. These are remote bytes, and
-// the string parsed out of them becomes a natural key, a thread key and a log
-// field on the strength of this return alone — so it must satisfy
-// connector.ValidMessageID, the same predicate SendEmail refuses to transmit
-// without.
-//
-// The identity is parsed with mailmap, the same function capture parses the
-// echo with, so the identity recorded here and the identity derived there are
-// one function of one set of bytes.
-func (c *Connector) sentReceipt(ctx context.Context, access, owner, askedFor string) connector.SendReceipt {
-	providerID, found, err := c.api.FindSentByMessageID(ctx, access, askedFor)
-	if err != nil || !found {
-		// Not a fault to report: Exchange may have rewritten the identity, or
-		// the sent copy may not have been filed yet. Either way the message is
-		// gone and the delivery must not be retried over a lookup.
-		slog.WarnContext(ctx, "graph: could not resolve the sent copy of a transmitted message",
-			"err", err, "found", found)
-		return connector.SendReceipt{}
-	}
-	raw, err := c.api.GetMIME(ctx, access, providerID)
-	if err != nil {
-		slog.WarnContext(ctx, "graph: reading back the sent message identity",
-			"err", err, "provider_message_id", providerID)
-		return connector.SendReceipt{ProviderMessageID: providerID}
-	}
-	parsed, err := mailmap.Parse(raw, owner)
-	if err != nil {
-		slog.WarnContext(ctx, "graph: parsing the sent message identity", "err", err)
-		return connector.SendReceipt{ProviderMessageID: providerID}
-	}
-	id := parsed.ID()
-	if !connector.ValidMessageID(id) {
-		// The rejected value is deliberately NOT logged: it is unbounded
-		// provider input, and the two facts that diagnose this — that the
-		// read-back answered with something unusable, and how big it was —
-		// carry no risk of writing megabytes or control bytes into a log line.
-		slog.WarnContext(ctx, "graph: the sent copy carries no usable message identity",
-			"provider_message_id", providerID, "identity_bytes", len(id))
-		return connector.SendReceipt{ProviderMessageID: providerID}
-	}
-	return connector.SendReceipt{ProviderMessageID: providerID, RFC822MessageID: id}
 }

--- a/backend/internal/modules/capture/graph/send_test.go
+++ b/backend/internal/modules/capture/graph/send_test.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package graph
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// sendableAuth is a connected mailbox whose grant carries the send permission.
+func sendableAuth(t *testing.T, granted ...string) connector.Auth {
+	t.Helper()
+	b, err := json.Marshal(authState{RefreshToken: "r", Owner: owner, Granted: granted})
+	if err != nil {
+		t.Fatalf("marshal auth: %v", err)
+	}
+	return b
+}
+
+func sendableMessage() connector.EmailMessage {
+	return connector.EmailMessage{
+		To:        []string{"client@acme.test"},
+		Subject:   "Following up",
+		Body:      "As discussed.",
+		MessageID: "outbound-1@margince.test",
+	}
+}
+
+func TestSendTransmitsTheRenderedMessageAndReportsTheFiledIdentity(t *testing.T) {
+	api := &fakeAPI{
+		email:    owner,
+		sentByID: map[string]string{"outbound-1@margince.test": "AAMk-sent-1"},
+		raws:     map[string][]byte{"AAMk-sent-1": rawMsg("outbound-1@margince.test", owner)},
+	}
+	c := New(fakeOAuth{access: "a"}, api)
+
+	receipt, err := c.SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage())
+	if err != nil {
+		t.Fatalf("SendEmail: %v", err)
+	}
+	if api.sendCalls != 1 {
+		t.Fatalf("sendCalls = %d, want one transmission", api.sendCalls)
+	}
+	wire := string(api.sentMIME[0])
+	for _, want := range []string{
+		"From: " + owner,
+		"To: client@acme.test",
+		"Subject: Following up",
+		"Message-ID: <outbound-1@margince.test>",
+		"As discussed.",
+	} {
+		if !strings.Contains(wire, want) {
+			t.Errorf("the transmitted message is missing %q:\n%s", want, wire)
+		}
+	}
+	if receipt.ProviderMessageID != "AAMk-sent-1" {
+		t.Errorf("ProviderMessageID = %q, want the sent copy's id", receipt.ProviderMessageID)
+	}
+	if receipt.RFC822MessageID != "outbound-1@margince.test" {
+		t.Errorf("RFC822MessageID = %q, want the identity the wire actually carries", receipt.RFC822MessageID)
+	}
+}
+
+// The at-least-once guard, and the reason this connector has one at all: a
+// retry that finds the message already in Sent Items must transmit NOTHING.
+func TestARetryThatFindsAPriorSendDoesNotMailAgain(t *testing.T) {
+	api := &fakeAPI{
+		email:    owner,
+		sentByID: map[string]string{"outbound-1@margince.test": "AAMk-sent-1"},
+	}
+	msg := sendableMessage()
+	msg.Attempt = 1
+
+	receipt, err := New(fakeOAuth{access: "a"}, api).
+		SendEmail(context.Background(), sendableAuth(t, SendScope), msg)
+	if err != nil {
+		t.Fatalf("SendEmail: %v", err)
+	}
+	if api.sendCalls != 0 {
+		t.Fatalf("sendCalls = %d — the recipient was mailed a second time", api.sendCalls)
+	}
+	if receipt.ProviderMessageID != "AAMk-sent-1" {
+		t.Errorf("ProviderMessageID = %q, want the prior send's id", receipt.ProviderMessageID)
+	}
+	// The identity is asked about UNBRACKETED here and bracketed on the wire by
+	// the client; this seam passes the stored form through unchanged.
+	if api.seenFindID != "outbound-1@margince.test" {
+		t.Errorf("looked up %q, want the unbracketed stored identity", api.seenFindID)
+	}
+}
+
+// A FIRST attempt must not pay for the lookup: it cannot have been sent yet,
+// and the call would be a round trip per message for nothing.
+func TestAFirstAttemptDoesNotRunThePriorSendLookupBeforeSending(t *testing.T) {
+	api := &fakeAPI{email: owner, sentByID: map[string]string{}}
+	if _, err := New(fakeOAuth{access: "a"}, api).
+		SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage()); err != nil {
+		t.Fatalf("SendEmail: %v", err)
+	}
+	// One find: the read-back after sending, never a guard before it.
+	if api.findCalls != 1 || api.sendCalls != 1 {
+		t.Errorf("findCalls=%d sendCalls=%d, want one send and only the read-back lookup", api.findCalls, api.sendCalls)
+	}
+}
+
+// A lookup that FAILS on a retry must stop the delivery rather than fall
+// through to a send: "I could not find out" is not "it was never sent", and
+// treating it as one mails the recipient twice.
+func TestALookupFailureOnARetryStopsRatherThanSending(t *testing.T) {
+	api := &fakeAPI{email: owner, findErr: ErrUnreachable}
+	msg := sendableMessage()
+	msg.Attempt = 2
+
+	_, err := New(fakeOAuth{access: "a"}, api).SendEmail(context.Background(), sendableAuth(t, SendScope), msg)
+	if !errors.Is(err, connector.ErrUnreachable) {
+		t.Fatalf("SendEmail = %v, want the lookup failure surfaced", err)
+	}
+	if api.sendCalls != 0 {
+		t.Fatal("the message was transmitted after a lookup that could not answer whether it already had been")
+	}
+}
+
+func TestSendRefusesAMailboxWhoseGrantCarriesNoSendPermission(t *testing.T) {
+	api := &fakeAPI{email: owner}
+	// Connected for capture only — the shape every mailbox connected before the
+	// send permission landed has.
+	auth := sendableAuth(t, "offline_access", "User.Read", "Mail.Read")
+
+	_, err := New(fakeOAuth{access: "a"}, api).SendEmail(context.Background(), auth, sendableMessage())
+	if !errors.Is(err, ErrSendScopeMissing) {
+		t.Fatalf("SendEmail = %v, want the ungranted-permission refusal", err)
+	}
+	if !errors.Is(err, connector.ErrAuthRejected) {
+		t.Error("the refusal must classify as an auth rejection so the delivery parks rather than retrying")
+	}
+	if api.sendCalls != 0 {
+		t.Fatal("a message went out on a grant that does not permit sending")
+	}
+}
+
+// The precondition the seam's contract states: an identity the prior-send
+// lookup cannot search for makes idempotency unkeepable, so the message is
+// refused BEFORE any provider I/O rather than sent once per retry.
+func TestSendRefusesAMessageWithNoUsableIdentityBeforeAnyProviderCall(t *testing.T) {
+	api := &fakeAPI{email: owner}
+	for name, id := range map[string]string{
+		"empty":          "",
+		"no domain":      "outbound-1@",
+		"bracketed":      "<outbound-1@margince.test>",
+		"with a newline": "outbound\n1@margince.test",
+	} {
+		t.Run(name, func(t *testing.T) {
+			msg := sendableMessage()
+			msg.MessageID = id
+			_, err := New(fakeOAuth{access: "a"}, api).
+				SendEmail(context.Background(), sendableAuth(t, SendScope), msg)
+			if !errors.Is(err, connector.ErrInvalidMessageID) {
+				t.Fatalf("SendEmail(%q) = %v, want the identity refusal", id, err)
+			}
+			if api.sendCalls != 0 || api.findCalls != 0 {
+				t.Fatal("the provider was called for a message that could never be retried safely")
+			}
+		})
+	}
+}
+
+// The message has already gone when the read-back runs, so a failure there
+// must NOT become an error: handing the delivery back to a retry would mail
+// the recipient a second time to fix a bookkeeping problem.
+func TestSendSucceedsWithNoIdentityWhenTheReadBackFails(t *testing.T) {
+	cases := map[string]*fakeAPI{
+		"the sent copy cannot be found":   {email: owner, sentByID: map[string]string{}},
+		"the sent copy cannot be fetched": {email: owner, sentByID: map[string]string{"outbound-1@margince.test": "AAMk-sent-1"}, getErr: ErrUnreachable},
+		"the sent copy will not parse": {
+			email:    owner,
+			sentByID: map[string]string{"outbound-1@margince.test": "AAMk-sent-1"},
+			raws:     map[string][]byte{"AAMk-sent-1": []byte("not a message")},
+		},
+	}
+	for name, api := range cases {
+		t.Run(name, func(t *testing.T) {
+			receipt, err := New(fakeOAuth{access: "a"}, api).
+				SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage())
+			if err != nil {
+				t.Fatalf("SendEmail = %v, want success: the message is already gone", err)
+			}
+			if receipt.RFC822MessageID != "" {
+				t.Errorf("RFC822MessageID = %q, want none reported rather than a guess", receipt.RFC822MessageID)
+			}
+			if api.sendCalls != 1 {
+				t.Errorf("sendCalls = %d, want exactly one", api.sendCalls)
+			}
+		})
+	}
+}
+
+// A submission the provider refuses is an error, not a silent success: the
+// delivery must not be recorded as sent.
+func TestASubmissionMicrosoftRefusesIsReportedAsAFailure(t *testing.T) {
+	api := &fakeAPI{email: owner, sendErr: ErrUnreachable}
+	_, err := New(fakeOAuth{access: "a"}, api).
+		SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage())
+	if !errors.Is(err, connector.ErrUnreachable) {
+		t.Fatalf("SendEmail = %v, want the submission failure surfaced", err)
+	}
+}
+
+// The carriage declaration is what the dispatcher parks an over-large message
+// against, so its numbers have to be Microsoft's rather than Gmail's.
+func TestCarriageDeclaresMicrosoftsOwnCeiling(t *testing.T) {
+	got := New(fakeOAuth{}, &fakeAPI{}).Carriage()
+	if !got.Carries {
+		t.Fatal("Carries = false; a message with files would park against a connector that can carry them")
+	}
+	if got.MaxFiles != maxSendableFiles {
+		t.Errorf("MaxFiles = %d, want %d", got.MaxFiles, maxSendableFiles)
+	}
+	if got.MaxBytesPerFile != maxSendableFileBytes {
+		t.Errorf("MaxBytesPerFile = %d, want Microsoft's %d — Gmail's larger cap would leave over-large mail to an opaque refusal", got.MaxBytesPerFile, maxSendableFileBytes)
+	}
+}

--- a/backend/internal/modules/capture/graph/send_test.go
+++ b/backend/internal/modules/capture/graph/send_test.go
@@ -33,12 +33,8 @@ func sendableMessage() connector.EmailMessage {
 	}
 }
 
-func TestSendTransmitsTheRenderedMessageAndReportsTheFiledIdentity(t *testing.T) {
-	api := &fakeAPI{
-		email:    owner,
-		sentByID: map[string]string{"outbound-1@margince.test": "AAMk-sent-1"},
-		raws:     map[string][]byte{"AAMk-sent-1": rawMsg("outbound-1@margince.test", owner)},
-	}
+func TestSendTransmitsTheRenderedMessage(t *testing.T) {
+	api := &fakeAPI{email: owner}
 	c := New(&fakeOAuth{access: "a"}, api)
 
 	receipt, err := c.SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage())
@@ -60,11 +56,17 @@ func TestSendTransmitsTheRenderedMessageAndReportsTheFiledIdentity(t *testing.T)
 			t.Errorf("the transmitted message is missing %q:\n%s", want, wire)
 		}
 	}
-	if receipt.ProviderMessageID != "AAMk-sent-1" {
-		t.Errorf("ProviderMessageID = %q, want the sent copy's id", receipt.ProviderMessageID)
+	// An EMPTY receipt is the honest one. sendMail is asynchronous — Graph
+	// returns 202 with no id and Exchange files the sent copy afterwards — so
+	// there is nothing to name yet, and connector.SendReceipt reads an empty
+	// RFC822MessageID as "no re-key owed", which for a MIME submit is the
+	// truth: the identity in the receipt IS the one in the message body.
+	if receipt.ProviderMessageID != "" || receipt.RFC822MessageID != "" {
+		t.Errorf("receipt = %+v, want empty: Microsoft names nothing at submission", receipt)
 	}
-	if receipt.RFC822MessageID != "outbound-1@margince.test" {
-		t.Errorf("RFC822MessageID = %q, want the identity the wire actually carries", receipt.RFC822MessageID)
+	// And nothing was looked up: a lookup here would miss almost every time.
+	if api.findCalls != 0 {
+		t.Errorf("findCalls = %d — a round trip per send that Graph cannot yet answer", api.findCalls)
 	}
 }
 
@@ -96,17 +98,16 @@ func TestARetryThatFindsAPriorSendDoesNotMailAgain(t *testing.T) {
 	}
 }
 
-// A FIRST attempt must not pay for the lookup: it cannot have been sent yet,
-// and the call would be a round trip per message for nothing.
-func TestAFirstAttemptDoesNotRunThePriorSendLookupBeforeSending(t *testing.T) {
+// A FIRST attempt must not pay for the lookup at all: it cannot have been sent
+// yet, and the call would be a round trip per message for nothing.
+func TestAFirstAttemptNeverLooksUpAPriorSend(t *testing.T) {
 	api := &fakeAPI{email: owner, sentByID: map[string]string{}}
 	if _, err := New(&fakeOAuth{access: "a"}, api).
 		SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage()); err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
-	// One find: the read-back after sending, never a guard before it.
-	if api.findCalls != 1 || api.sendCalls != 1 {
-		t.Errorf("findCalls=%d sendCalls=%d, want one send and only the read-back lookup", api.findCalls, api.sendCalls)
+	if api.findCalls != 0 || api.sendCalls != 1 {
+		t.Errorf("findCalls=%d sendCalls=%d, want one send and no lookup", api.findCalls, api.sendCalls)
 	}
 }
 
@@ -171,36 +172,6 @@ func TestSendRefusesAMessageWithNoUsableIdentityBeforeAnyProviderCall(t *testing
 	}
 }
 
-// The message has already gone when the read-back runs, so a failure there
-// must NOT become an error: handing the delivery back to a retry would mail
-// the recipient a second time to fix a bookkeeping problem.
-func TestSendSucceedsWithNoIdentityWhenTheReadBackFails(t *testing.T) {
-	cases := map[string]*fakeAPI{
-		"the sent copy cannot be found":   {email: owner, sentByID: map[string]string{}},
-		"the sent copy cannot be fetched": {email: owner, sentByID: map[string]string{"outbound-1@margince.test": "AAMk-sent-1"}, getErr: ErrUnreachable},
-		"the sent copy will not parse": {
-			email:    owner,
-			sentByID: map[string]string{"outbound-1@margince.test": "AAMk-sent-1"},
-			raws:     map[string][]byte{"AAMk-sent-1": []byte("not a message")},
-		},
-	}
-	for name, api := range cases {
-		t.Run(name, func(t *testing.T) {
-			receipt, err := New(&fakeOAuth{access: "a"}, api).
-				SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage())
-			if err != nil {
-				t.Fatalf("SendEmail = %v, want success: the message is already gone", err)
-			}
-			if receipt.RFC822MessageID != "" {
-				t.Errorf("RFC822MessageID = %q, want none reported rather than a guess", receipt.RFC822MessageID)
-			}
-			if api.sendCalls != 1 {
-				t.Errorf("sendCalls = %d, want exactly one", api.sendCalls)
-			}
-		})
-	}
-}
-
 // A submission the provider refuses is an error, not a silent success: the
 // delivery must not be recorded as sent.
 func TestASubmissionMicrosoftRefusesIsReportedAsAFailure(t *testing.T) {
@@ -219,11 +190,20 @@ func TestCarriageDeclaresMicrosoftsOwnCeiling(t *testing.T) {
 	if !got.Carries {
 		t.Fatal("Carries = false; a message with files would park against a connector that can carry them")
 	}
-	if got.MaxFiles != maxSendableFiles {
-		t.Errorf("MaxFiles = %d, want %d", got.MaxFiles, maxSendableFiles)
+	// LITERALS, not the constants Carriage returns. Comparing a value against
+	// the constant that produced it catches a copy-paste slip and nothing else
+	// — including the one thing this test exists for, which is the numbers
+	// silently becoming Gmail's.
+	//
+	// 10 files is the contract's attachment_ids cap. 2 MiB is what survives
+	// Microsoft's 4 MB sendMail ceiling once the payload has been base64'd
+	// twice (once per attachment inside the MIME, once for the whole message
+	// on the wire) — Gmail's figure is 25 MiB.
+	if got.MaxFiles != 10 {
+		t.Errorf("MaxFiles = %d, want 10 (the contract's attachment_ids cap)", got.MaxFiles)
 	}
-	if got.MaxBytesPerFile != maxSendableFileBytes {
-		t.Errorf("MaxBytesPerFile = %d, want Microsoft's %d — Gmail's larger cap would leave over-large mail to an opaque refusal", got.MaxBytesPerFile, maxSendableFileBytes)
+	if got.MaxBytesPerFile != 2<<20 {
+		t.Errorf("MaxBytesPerFile = %d, want 2 MiB — Gmail's 25 MiB would leave over-large mail to an opaque 413", got.MaxBytesPerFile)
 	}
 }
 

--- a/backend/internal/modules/capture/graph/send_test.go
+++ b/backend/internal/modules/capture/graph/send_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestSendTransmitsTheRenderedMessageAndReportsTheFiledIdentity(t *testing.T)
 		sentByID: map[string]string{"outbound-1@margince.test": "AAMk-sent-1"},
 		raws:     map[string][]byte{"AAMk-sent-1": rawMsg("outbound-1@margince.test", owner)},
 	}
-	c := New(fakeOAuth{access: "a"}, api)
+	c := New(&fakeOAuth{access: "a"}, api)
 
 	receipt, err := c.SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage())
 	if err != nil {
@@ -77,7 +78,7 @@ func TestARetryThatFindsAPriorSendDoesNotMailAgain(t *testing.T) {
 	msg := sendableMessage()
 	msg.Attempt = 1
 
-	receipt, err := New(fakeOAuth{access: "a"}, api).
+	receipt, err := New(&fakeOAuth{access: "a"}, api).
 		SendEmail(context.Background(), sendableAuth(t, SendScope), msg)
 	if err != nil {
 		t.Fatalf("SendEmail: %v", err)
@@ -99,7 +100,7 @@ func TestARetryThatFindsAPriorSendDoesNotMailAgain(t *testing.T) {
 // and the call would be a round trip per message for nothing.
 func TestAFirstAttemptDoesNotRunThePriorSendLookupBeforeSending(t *testing.T) {
 	api := &fakeAPI{email: owner, sentByID: map[string]string{}}
-	if _, err := New(fakeOAuth{access: "a"}, api).
+	if _, err := New(&fakeOAuth{access: "a"}, api).
 		SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage()); err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
@@ -117,7 +118,7 @@ func TestALookupFailureOnARetryStopsRatherThanSending(t *testing.T) {
 	msg := sendableMessage()
 	msg.Attempt = 2
 
-	_, err := New(fakeOAuth{access: "a"}, api).SendEmail(context.Background(), sendableAuth(t, SendScope), msg)
+	_, err := New(&fakeOAuth{access: "a"}, api).SendEmail(context.Background(), sendableAuth(t, SendScope), msg)
 	if !errors.Is(err, connector.ErrUnreachable) {
 		t.Fatalf("SendEmail = %v, want the lookup failure surfaced", err)
 	}
@@ -132,7 +133,7 @@ func TestSendRefusesAMailboxWhoseGrantCarriesNoSendPermission(t *testing.T) {
 	// send permission landed has.
 	auth := sendableAuth(t, "offline_access", "User.Read", "Mail.Read")
 
-	_, err := New(fakeOAuth{access: "a"}, api).SendEmail(context.Background(), auth, sendableMessage())
+	_, err := New(&fakeOAuth{access: "a"}, api).SendEmail(context.Background(), auth, sendableMessage())
 	if !errors.Is(err, ErrSendScopeMissing) {
 		t.Fatalf("SendEmail = %v, want the ungranted-permission refusal", err)
 	}
@@ -158,7 +159,7 @@ func TestSendRefusesAMessageWithNoUsableIdentityBeforeAnyProviderCall(t *testing
 		t.Run(name, func(t *testing.T) {
 			msg := sendableMessage()
 			msg.MessageID = id
-			_, err := New(fakeOAuth{access: "a"}, api).
+			_, err := New(&fakeOAuth{access: "a"}, api).
 				SendEmail(context.Background(), sendableAuth(t, SendScope), msg)
 			if !errors.Is(err, connector.ErrInvalidMessageID) {
 				t.Fatalf("SendEmail(%q) = %v, want the identity refusal", id, err)
@@ -185,7 +186,7 @@ func TestSendSucceedsWithNoIdentityWhenTheReadBackFails(t *testing.T) {
 	}
 	for name, api := range cases {
 		t.Run(name, func(t *testing.T) {
-			receipt, err := New(fakeOAuth{access: "a"}, api).
+			receipt, err := New(&fakeOAuth{access: "a"}, api).
 				SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage())
 			if err != nil {
 				t.Fatalf("SendEmail = %v, want success: the message is already gone", err)
@@ -204,7 +205,7 @@ func TestSendSucceedsWithNoIdentityWhenTheReadBackFails(t *testing.T) {
 // delivery must not be recorded as sent.
 func TestASubmissionMicrosoftRefusesIsReportedAsAFailure(t *testing.T) {
 	api := &fakeAPI{email: owner, sendErr: ErrUnreachable}
-	_, err := New(fakeOAuth{access: "a"}, api).
+	_, err := New(&fakeOAuth{access: "a"}, api).
 		SendEmail(context.Background(), sendableAuth(t, SendScope), sendableMessage())
 	if !errors.Is(err, connector.ErrUnreachable) {
 		t.Fatalf("SendEmail = %v, want the submission failure surfaced", err)
@@ -214,7 +215,7 @@ func TestASubmissionMicrosoftRefusesIsReportedAsAFailure(t *testing.T) {
 // The carriage declaration is what the dispatcher parks an over-large message
 // against, so its numbers have to be Microsoft's rather than Gmail's.
 func TestCarriageDeclaresMicrosoftsOwnCeiling(t *testing.T) {
-	got := New(fakeOAuth{}, &fakeAPI{}).Carriage()
+	got := New(&fakeOAuth{}, &fakeAPI{}).Carriage()
 	if !got.Carries {
 		t.Fatal("Carries = false; a message with files would park against a connector that can carry them")
 	}
@@ -223,5 +224,42 @@ func TestCarriageDeclaresMicrosoftsOwnCeiling(t *testing.T) {
 	}
 	if got.MaxBytesPerFile != maxSendableFileBytes {
 		t.Errorf("MaxBytesPerFile = %d, want Microsoft's %d — Gmail's larger cap would leave over-large mail to an opaque refusal", got.MaxBytesPerFile, maxSendableFileBytes)
+	}
+}
+
+// THE REGRESSION THIS SEAM EXISTS FOR.
+//
+// A mailbox connected before Mail.Send shipped holds a read-only grant.
+// Refreshing it against the DEPLOYMENT's configured scope list asks Microsoft
+// for a permission that grant never carried, and Microsoft answers by refusing
+// the REFRESH — so the mailbox stops CAPTURING rather than merely declining to
+// send. Every standing path must refresh for what the grant holds.
+func TestAnOlderGrantRefreshesForItsOwnScopesNotTheDeploymentsList(t *testing.T) {
+	readOnly := []string{"offline_access", "User.Read", "Mail.Read"}
+	auth := sendableAuth(t, readOnly...)
+
+	for name, run := range map[string]func(*fakeOAuth) error{
+		"sync": func(o *fakeOAuth) error {
+			_, err := New(o, &fakeAPI{email: owner, initDelta: "d"}).
+				Sync(context.Background(), auth, nil, &recordingSink{})
+			return err
+		},
+		"health check": func(o *fakeOAuth) error {
+			return New(o, &fakeAPI{email: owner}).HealthCheck(context.Background(), auth)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			oauth := &fakeOAuth{access: "a"}
+			if err := run(oauth); err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			if !slices.Equal(oauth.askedFor, readOnly) {
+				t.Fatalf("the refresh asked for %v, want the grant's own %v — asking for more stops this mailbox capturing",
+					oauth.askedFor, readOnly)
+			}
+			if slices.Contains(oauth.askedFor, SendScope) {
+				t.Error("the refresh asked an unconsented grant for the send permission")
+			}
+		})
 	}
 }

--- a/backend/internal/modules/capture/graph/sendclient.go
+++ b/backend/internal/modules/capture/graph/sendclient.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
 // sendMIMEPath is Microsoft's submit endpoint. It takes the whole RFC822
@@ -24,18 +26,37 @@ import (
 // convention for "the body IS the MIME", not a mislabelling on our part.
 const sendMIMEPath = "/me/sendMail"
 
+// maxSubmitBytes is Microsoft's 4 MB write-request ceiling, read as the size of
+// the BASE64 body actually sent — which is what the limit applies to and what
+// a 413 is measured against.
+//
+// Stated in decimal MB rather than MiB deliberately: Microsoft documents "4 MB"
+// without an exact byte value, so the smaller reading is the one that cannot be
+// wrong.
+const maxSubmitBytes = 4_000_000
+
 // SendMIME transmits one complete RFC822 message as the signed-in user.
 //
 // Microsoft answers 202 Accepted with NO BODY: it names no message id at
 // submission, which is why the caller resolves the sent copy afterwards by the
 // identity the message carries rather than by an id this call could return.
 func (a *httpAPI) SendMIME(ctx context.Context, accessToken string, rfc822 []byte) error {
-	// The message's SIZE is bounded upstream, by what Carriage declares this
-	// connector can carry — the dispatcher parks an over-large one rather than
-	// handing it here. Nothing is re-checked at this depth, because a second
-	// bound would be a second answer and the one that mattered would be
-	// whichever ran first.
 	encoded := base64.StdEncoding.EncodeToString(rfc822)
+	if len(encoded) > maxSubmitBytes {
+		// Refused HERE and not only by Carriage, because Carriage bounds ONE
+		// FILE and this bounds the whole request: several attachments each
+		// inside the per-file cap still add up past Microsoft's limit, and
+		// that combination is invisible to every gate above this one.
+		//
+		// ErrFilesNotCarried is the sentinel the dispatcher PARKS on. A message
+		// this size will be exactly this size on every retry, so the retry
+		// ladder can only exhaust itself and park under "the ladder ran out",
+		// which names no cause. The byte count and the bound go to the operator
+		// in the log the dispatcher writes; the sender gets a reason they can
+		// act on.
+		return fmt.Errorf("graph: the message is %d encoded bytes against Microsoft's %d-byte sendMail limit: %w",
+			len(encoded), maxSubmitBytes, connector.ErrFilesNotCarried)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.base+sendMIMEPath, strings.NewReader(encoded))
 	if err != nil {
 		return fmt.Errorf("graph: building send request: %w", err)

--- a/backend/internal/modules/capture/graph/sendclient.go
+++ b/backend/internal/modules/capture/graph/sendclient.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package graph
+
+// The two Graph calls the outbound half needs: submitting a MIME message, and
+// finding the sent copy of one by the identity it was asked to carry. Beside
+// send.go rather than in client.go because that file is the READ surface, and
+// a reader auditing what this connector can do to a mailbox should not have to
+// separate the two by eye.
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// sendMIMEPath is Microsoft's submit endpoint. It takes the whole RFC822
+// message base64-encoded, under a `text/plain` content type — the vendor's own
+// convention for "the body IS the MIME", not a mislabelling on our part.
+const sendMIMEPath = "/me/sendMail"
+
+// SendMIME transmits one complete RFC822 message as the signed-in user.
+//
+// Microsoft answers 202 Accepted with NO BODY: it names no message id at
+// submission, which is why the caller resolves the sent copy afterwards by the
+// identity the message carries rather than by an id this call could return.
+func (a *httpAPI) SendMIME(ctx context.Context, accessToken string, rfc822 []byte) error {
+	// The message's SIZE is bounded upstream, by what Carriage declares this
+	// connector can carry — the dispatcher parks an over-large one rather than
+	// handing it here. Nothing is re-checked at this depth, because a second
+	// bound would be a second answer and the one that mattered would be
+	// whichever ran first.
+	encoded := base64.StdEncoding.EncodeToString(rfc822)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.base+sendMIMEPath, strings.NewReader(encoded))
+	if err != nil {
+		return fmt.Errorf("graph: building send request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	// text/plain is what Microsoft's MIME submit path expects; application/json
+	// would make it read the base64 as a message resource and refuse it.
+	req.Header.Set("Content-Type", "text/plain")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("graph: %s: %w", sendMIMEPath, ErrUnreachable)
+	}
+	//craft:ignore swallowed-errors best-effort close of the response body — the status is what matters
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyLen))
+	return classifyStatus(resp, sendMIMEPath, body)
+}
+
+// maxErrorBodyLen bounds how much of a refusal Microsoft's OData envelope is
+// read for its machine code. A successful send answers with nothing at all, so
+// this budget only ever pays for a failure.
+const maxErrorBodyLen = 64 << 10
+
+// FindSentByMessageID resolves the sent copy of a message by the RFC822
+// identity it was asked to carry, so an at-least-once retry can recognise a
+// transmission that already happened.
+//
+// It filters Sent Items on `internetMessageId`, which is a real Graph property
+// rather than a full-text index — so a match is the message's own field, not a
+// search that may not have caught up. The identity is BRACKETED on the wire
+// here even though this system stores it unbracketed, because that is the form
+// the property holds.
+//
+// An identity Exchange rewrote on submission matches nothing, and that reads as
+// "not sent" — the caller treats a miss as a miss rather than as a fault, and
+// send.go states what that costs.
+func (a *httpAPI) FindSentByMessageID(ctx context.Context, accessToken, unbracketedMessageID string) (string, bool, error) {
+	if unbracketedMessageID == "" {
+		return "", false, nil
+	}
+	q := url.Values{
+		// The identity is a caller-controlled string reaching an OData filter,
+		// so it is escaped for OData's own quoting rule (a literal quote is
+		// doubled) before url.Values escapes it for the query. Without the
+		// first step an identity carrying a quote would end the literal and the
+		// rest of it would be read as filter syntax.
+		paramFilter: {"internetMessageId eq '" + odataQuote("<"+unbracketedMessageID+">") + "'"},
+		paramSelect: {"id"},
+		paramTop:    {"1"},
+	}
+	var out struct {
+		Value []struct {
+			ID string `json:"id"`
+		} `json:"value"`
+	}
+	if _, err := a.get(ctx, accessToken, a.base+"/me/mailFolders/sentitems/messages?"+q.Encode(), nil, &out); err != nil {
+		return "", false, err
+	}
+	if len(out.Value) == 0 || out.Value[0].ID == "" {
+		return "", false, nil
+	}
+	return out.Value[0].ID, true, nil
+}
+
+// odataQuote escapes a value for an OData single-quoted string literal, where
+// a literal quote is written twice. It is the ONE place this escaping happens,
+// so a second filter cannot be written without it.
+func odataQuote(v string) string { return strings.ReplaceAll(v, "'", "''") }

--- a/backend/internal/modules/capture/graph/sendclient_test.go
+++ b/backend/internal/modules/capture/graph/sendclient_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package graph
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// sendStub records the one request the send path makes, so a test can assert on
+// what Microsoft would actually receive.
+type sendStub struct {
+	srv    *httptest.Server
+	method string
+	path   string
+	query  string
+	auth   string
+	ctype  string
+	body   string
+}
+
+func newSendStub(t *testing.T, handle func(w http.ResponseWriter, r *http.Request)) *sendStub {
+	t.Helper()
+	s := &sendStub{}
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.method, s.path, s.query = r.Method, r.URL.Path, r.URL.RawQuery
+		s.auth, s.ctype, s.body = r.Header.Get("Authorization"), r.Header.Get("Content-Type"), string(body)
+		handle(w, r)
+	}))
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func TestSendMIMESubmitsTheMessageAsMicrosoftExpectsIt(t *testing.T) {
+	stub := newSendStub(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted) // Microsoft's own answer: 202, no body
+	})
+	raw := []byte("From: rep@myco.com\r\nSubject: hi\r\n\r\nbody")
+
+	if err := NewAPI(stub.srv.Client(), stub.srv.URL).SendMIME(context.Background(), "tok", raw); err != nil {
+		t.Fatalf("SendMIME: %v", err)
+	}
+	if stub.method != http.MethodPost || stub.path != sendMIMEPath {
+		t.Errorf("request = %s %s, want POST %s", stub.method, stub.path, sendMIMEPath)
+	}
+	if stub.auth != "Bearer tok" {
+		t.Errorf("Authorization = %q", stub.auth)
+	}
+	// text/plain is Microsoft's convention for "the body IS the MIME";
+	// application/json would make it read the base64 as a message resource and
+	// refuse the whole send.
+	if stub.ctype != "text/plain" {
+		t.Errorf("Content-Type = %q, want text/plain — the MIME submit path", stub.ctype)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(stub.body)
+	if err != nil {
+		t.Fatalf("the body is not base64: %v", err)
+	}
+	if string(decoded) != string(raw) {
+		t.Errorf("the transmitted message decoded to %q, want the bytes handed in", decoded)
+	}
+}
+
+func TestSendMIMEMapsARefusalOntoTheSharedVocabulary(t *testing.T) {
+	for status, want := range map[int]error{
+		http.StatusUnauthorized:        connector.ErrAuthRejected,
+		http.StatusForbidden:           connector.ErrAuthRejected,
+		http.StatusTooManyRequests:     connector.ErrRateLimited,
+		http.StatusInternalServerError: connector.ErrUnreachable,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			stub := newSendStub(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+			})
+			err := NewAPI(stub.srv.Client(), stub.srv.URL).SendMIME(context.Background(), "tok", []byte("x"))
+			if !errors.Is(err, want) {
+				t.Fatalf("status %d = %v, want %v", status, err, want)
+			}
+		})
+	}
+}
+
+func TestFindSentByMessageIDFiltersSentItemsOnTheBracketedIdentity(t *testing.T) {
+	stub := newSendStub(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"value":[{"id":"AAMk-1"}]}`))
+	})
+
+	id, found, err := NewAPI(stub.srv.Client(), stub.srv.URL).
+		FindSentByMessageID(context.Background(), "tok", "outbound-1@margince.test")
+	if err != nil || !found || id != "AAMk-1" {
+		t.Fatalf("FindSentByMessageID = (%q, %v, %v)", id, found, err)
+	}
+	if !strings.Contains(stub.path, "/me/mailFolders/sentitems/messages") {
+		t.Errorf("path = %q, want the Sent Items collection", stub.path)
+	}
+	// Filtered on the message's OWN property, and bracketed because that is the
+	// form the property holds — the unbracketed form this system stores would
+	// match nothing.
+	for _, want := range []string{"internetMessageId+eq", "%3Coutbound-1%40margince.test%3E"} {
+		if !strings.Contains(stub.query, want) {
+			t.Errorf("query = %q, missing %q", stub.query, want)
+		}
+	}
+}
+
+func TestFindSentByMessageIDReportsAMissAsAMiss(t *testing.T) {
+	stub := newSendStub(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"value":[]}`))
+	})
+	api := NewAPI(stub.srv.Client(), stub.srv.URL)
+
+	// An identity Exchange rewrote on submission matches nothing, and that is a
+	// miss rather than a fault — the caller sends, it does not fail.
+	if _, found, err := api.FindSentByMessageID(context.Background(), "tok", "gone@margince.test"); found || err != nil {
+		t.Fatalf("a non-match = (found %v, err %v), want a clean miss", found, err)
+	}
+	// An empty identity is asked about at all only by a caller with nothing to
+	// look up; it must cost no round trip.
+	stub.path = ""
+	if _, found, err := api.FindSentByMessageID(context.Background(), "tok", ""); found || err != nil {
+		t.Fatalf("an empty identity = (found %v, err %v), want a clean miss", found, err)
+	}
+	if stub.path != "" {
+		t.Error("an empty identity still went to Microsoft")
+	}
+}
+
+// The identity reaches an OData filter as a caller-controlled string. A literal
+// quote inside it would end the string literal and leave the rest to be read as
+// filter syntax, so it is doubled — OData's own escape — before url.Values
+// escapes it for the query.
+func TestAnIdentityCarryingAQuoteCannotEndTheODataLiteral(t *testing.T) {
+	if got := odataQuote(`a'b`); got != `a''b` {
+		t.Errorf("odataQuote(%q) = %q, want the quote doubled", `a'b`, got)
+	}
+	if got := odataQuote(`plain`); got != `plain` {
+		t.Errorf("odataQuote left an unquoted value alone as %q", got)
+	}
+
+	stub := newSendStub(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"value":[]}`))
+	})
+	if _, _, err := NewAPI(stub.srv.Client(), stub.srv.URL).
+		FindSentByMessageID(context.Background(), "tok", `evil'+or+true@x.test`); err != nil {
+		t.Fatalf("FindSentByMessageID: %v", err)
+	}
+	// Doubled on the wire: a single quote surviving unescaped is the injection.
+	if !strings.Contains(stub.query, "%27%27") {
+		t.Errorf("query = %q, want the embedded quote doubled before escaping", stub.query)
+	}
+}
+
+func TestFindSentByMessageIDMapsARefusalOntoTheSharedVocabulary(t *testing.T) {
+	stub := newSendStub(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	_, _, err := NewAPI(stub.srv.Client(), stub.srv.URL).
+		FindSentByMessageID(context.Background(), "tok", "x@y.test")
+	if !errors.Is(err, connector.ErrAuthRejected) {
+		t.Fatalf("a 401 = %v, want the auth rejection", err)
+	}
+}

--- a/backend/internal/modules/capture/graph/sendclient_test.go
+++ b/backend/internal/modules/capture/graph/sendclient_test.go
@@ -173,3 +173,42 @@ func TestFindSentByMessageIDMapsARefusalOntoTheSharedVocabulary(t *testing.T) {
 		t.Fatalf("a 401 = %v, want the auth rejection", err)
 	}
 }
+
+// Several files each inside the per-file cap can still add up past Microsoft's
+// whole-request limit, and no gate above this one can see that combination. The
+// refusal must PARK the delivery rather than retry it: the message will be
+// exactly this size every time.
+func TestAMessageOverTheRequestCeilingIsRefusedRatherThanSent(t *testing.T) {
+	var reached bool
+	stub := newSendStub(t, func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusAccepted)
+	})
+	// Just over the ceiling once base64 has grown it by a third.
+	oversized := make([]byte, maxSubmitBytes)
+
+	err := NewAPI(stub.srv.Client(), stub.srv.URL).SendMIME(context.Background(), "tok", oversized)
+	if !errors.Is(err, connector.ErrFilesNotCarried) {
+		t.Fatalf("SendMIME(oversized) = %v, want the sentinel the dispatcher parks on", err)
+	}
+	if reached {
+		t.Error("a message Microsoft would refuse with a 413 was sent anyway")
+	}
+	// A message inside the ceiling still goes.
+	if err := NewAPI(stub.srv.Client(), stub.srv.URL).
+		SendMIME(context.Background(), "tok", []byte("From: a@b\r\n\r\nhi")); err != nil {
+		t.Fatalf("an ordinary message was refused: %v", err)
+	}
+}
+
+// The per-file cap has to leave room for BOTH encodings — the attachment's
+// base64 inside the message, and the message's base64 on the wire.
+func TestThePerFileCapLeavesRoomForBothEncodings(t *testing.T) {
+	// A single maximum-size file, rendered and then submitted, must fit.
+	const doubleEncoded = maxSendableFileBytes * 4 / 3 * 4 / 3
+	if doubleEncoded >= maxSubmitBytes {
+		t.Fatalf("one %d-byte file becomes ~%d bytes on the wire, at or over the %d-byte ceiling — "+
+			"a single maximum-size attachment could never be sent",
+			maxSendableFileBytes, doubleEncoded, maxSubmitBytes)
+	}
+}

--- a/backend/internal/modules/capture/mailwire/rfc822.go
+++ b/backend/internal/modules/capture/mailwire/rfc822.go
@@ -1,16 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package gmail
-
-// The wire format: a provider-neutral message rendered as the RFC822 bytes
-// Gmail's messages.send accepts.
+// Package mailwire is the OUTBOUND wire format: a provider-neutral message
+// rendered as the RFC822 bytes a mail provider accepts for transmission. It is
+// the sending twin of capture/mailmap, which reads the same format on the way
+// in.
 //
-// Apart from the connector's transport concerns because it is a different
+// Apart from any connector's transport concerns because it is a different
 // question — that half decides WHETHER and WHEN to send, this half decides what
 // the bytes are. It is also the half a reader checks against a spec: the part
 // order, the transfer encodings and the boundary rules below each cite the RFC
 // that requires them.
+//
+// Its own package because TWO providers now submit these bytes: Gmail's
+// messages.send and Microsoft Graph's sendMail both take a complete RFC822
+// message. A second renderer would be a second answer to questions with one
+// right answer — which part comes first in a multipart/alternative, whether an
+// attachment's filename rides in one header or two, where the base64 folds —
+// and the way it fails is that one vendor's recipients get a blank message or a
+// truncated PDF while the other vendor's do not.
+package mailwire
 
 import (
 	"crypto/sha256"
@@ -24,10 +33,11 @@ import (
 	"github.com/margince/margince/backend/pkg/extension"
 )
 
-// buildRFC822 renders the provider-neutral message as the wire format Gmail
-// accepts: header order follows RFC 5322's origination-first sequence, body is
-// text/plain UTF-8.
-func buildRFC822(from string, msg connector.EmailMessage) string {
+// Build renders the provider-neutral message as a complete RFC822 message:
+// header order follows RFC 5322's origination-first sequence, body is
+// text/plain UTF-8 (or the multipart shapes below when the message carries
+// markup or files).
+func Build(from string, msg connector.EmailMessage) string {
 	var b strings.Builder
 	writeHeader(&b, "From", fromHeader(from, msg.FromName))
 	// An empty To line is omitted rather than written bare. A message sent
@@ -272,4 +282,41 @@ func fromHeader(address, name string) string {
 		return address
 	}
 	return (&mail.Address{Name: trimmed, Address: address}).String()
+}
+
+// bracket renders a message identity as RFC 5322 requires it on the wire. The
+// identity travels unbracketed everywhere else in this system, because that is
+// the form mail parsing yields and therefore the form the captured copy of this
+// message will be keyed on.
+func bracket(id string) string {
+	if id == "" {
+		return ""
+	}
+	return "<" + strings.Trim(id, "<>") + ">"
+}
+
+// addressList renders one address header value: each address trimmed, empties
+// dropped, comma-separated. The trim is the same normalization the send path's
+// consent gate matches on, so the address a recipient is asked about and the
+// address the header carries are one string — a stored " a@x " must not become
+// folding whitespace around an addr-spec that some clients then display raw.
+func addressList(addrs []string) string {
+	out := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		if trimmed := strings.TrimSpace(addr); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
+// writeHeader emits one header line with CR and LF removed from the value: a
+// bare CR or LF inside a header is the classic injection vector, and the only
+// safe rendering of one is not to emit it.
+func writeHeader(b *strings.Builder, name, value string) {
+	clean := strings.NewReplacer("\r", "", "\n", "").Replace(value)
+	b.WriteString(name)
+	b.WriteString(": ")
+	b.WriteString(clean)
+	b.WriteString("\r\n")
 }

--- a/backend/internal/modules/capture/mailwire/rfc822_test.go
+++ b/backend/internal/modules/capture/mailwire/rfc822_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package gmail
+package mailwire
 
 // The wire shape of a message that carries markup.
 //
@@ -34,7 +34,7 @@ func plainMessage() connector.EmailMessage {
 // Wrapping one part in a multipart envelope buys nothing and costs every reader
 // a boundary to parse.
 func TestAPlainMessageStaysSinglePart(t *testing.T) {
-	parsed := parseMail(t, buildRFC822("rep@gradion.test", plainMessage()))
+	parsed := parseMail(t, Build("rep@gradion.test", plainMessage()))
 
 	mediaType, _, err := mime.ParseMediaType(parsed.Header.Get("Content-Type"))
 	if err != nil {
@@ -59,7 +59,7 @@ func TestAnHTMLMessageIsMultipartAlternativeWithPlainFirst(t *testing.T) {
 	msg := plainMessage()
 	msg.HTMLBody = "<p>Hallo Marine,</p><p>anbei die <b>Zahlen</b>.</p>"
 
-	parts := parseParts(t, buildRFC822("rep@gradion.test", msg))
+	parts := parseParts(t, Build("rep@gradion.test", msg))
 	if len(parts) != 2 {
 		t.Fatalf("expected two alternatives, got %d", len(parts))
 	}
@@ -83,7 +83,7 @@ func TestBothAlternativesDeclareUTF8(t *testing.T) {
 	msg := plainMessage()
 	msg.HTMLBody = "<p>Zahlen für Sie</p>"
 
-	for _, part := range parseParts(t, buildRFC822("rep@gradion.test", msg)) {
+	for _, part := range parseParts(t, Build("rep@gradion.test", msg)) {
 		if got := strings.ToLower(part.charset); got != "utf-8" {
 			t.Errorf("%s declares charset %q, expected utf-8", part.mediaType, got)
 		}
@@ -97,7 +97,7 @@ func TestTheBoundaryIsStableAcrossRenders(t *testing.T) {
 	msg := plainMessage()
 	msg.HTMLBody = "<p>x</p>"
 
-	if first, second := buildRFC822("rep@gradion.test", msg), buildRFC822("rep@gradion.test", msg); first != second {
+	if first, second := Build("rep@gradion.test", msg), Build("rep@gradion.test", msg); first != second {
 		t.Fatal("two renders of one message differ; a retry would look like a new message")
 	}
 
@@ -117,7 +117,7 @@ func TestABodyCannotForgeTheBoundary(t *testing.T) {
 	msg.Body = "Text mentioning " + boundary + " in passing."
 	msg.HTMLBody = "<p>markup</p>"
 
-	parts := parseParts(t, buildRFC822("rep@gradion.test", msg))
+	parts := parseParts(t, Build("rep@gradion.test", msg))
 	if len(parts) != 2 {
 		t.Fatalf("a body that names the boundary broke the message into %d parts", len(parts))
 	}
@@ -186,12 +186,12 @@ func TestEveryPartDeclaresItsTransferEncoding(t *testing.T) {
 	msg := plainMessage()
 	msg.HTMLBody = "<p>Zahlen für Sie</p>"
 
-	raw := buildRFC822("rep@gradion.test", msg)
+	raw := Build("rep@gradion.test", msg)
 	if strings.Count(raw, "Content-Transfer-Encoding: 8bit") != 2 {
 		t.Fatalf("expected both parts to declare 8bit:\n%s", raw)
 	}
 
-	plain := buildRFC822("rep@gradion.test", plainMessage())
+	plain := Build("rep@gradion.test", plainMessage())
 	if !strings.Contains(plain, "Content-Transfer-Encoding: 8bit") {
 		t.Fatalf("a single-part message declares no transfer encoding:\n%s", plain)
 	}
@@ -205,7 +205,7 @@ func TestBareLineFeedsAreCanonicalised(t *testing.T) {
 	msg.Body = "Line one\nLine two"
 	msg.HTMLBody = "<p>one</p>\n<p>two</p>"
 
-	raw := buildRFC822("rep@gradion.test", msg)
+	raw := Build("rep@gradion.test", msg)
 	if strings.Contains(strings.ReplaceAll(raw, "\r\n", ""), "\n") {
 		t.Fatalf("a bare line feed survived into the wire format:\n%q", raw)
 	}
@@ -236,7 +236,7 @@ func TestTheSenderIsNamedWhenTheNameIsKnown(t *testing.T) {
 	msg := plainMessage()
 	msg.FromName = "Lars Jankowfsky"
 
-	parsed := parseMail(t, buildRFC822("lars@gradion.test", msg))
+	parsed := parseMail(t, Build("lars@gradion.test", msg))
 	addr, err := mail.ParseAddress(parsed.Header.Get("From"))
 	if err != nil {
 		t.Fatalf("the From header does not parse as an address: %v", err)
@@ -255,7 +255,7 @@ func TestANonASCIISenderNameSurvivesTheWire(t *testing.T) {
 	msg := plainMessage()
 	msg.FromName = "Weiß Konrad"
 
-	raw := buildRFC822("weiss@gradion.test", msg)
+	raw := Build("weiss@gradion.test", msg)
 	if strings.Contains(raw, "From: Weiß") {
 		t.Fatalf("a non-ASCII name went out unencoded:\n%s", raw)
 	}
@@ -274,7 +274,7 @@ func TestASenderNameWithACommaStaysOneAddress(t *testing.T) {
 	msg := plainMessage()
 	msg.FromName = "Jankowfsky, Lars"
 
-	header := parseMail(t, buildRFC822("lars@gradion.test", msg)).Header.Get("From")
+	header := parseMail(t, Build("lars@gradion.test", msg)).Header.Get("From")
 	list, err := mail.ParseAddressList(header)
 	if err != nil {
 		t.Fatalf("the From header does not parse: %v", err)
@@ -294,7 +294,7 @@ func TestNoSenderNameSendsABareAddress(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			msg := plainMessage()
 			msg.FromName = given
-			if got := parseMail(t, buildRFC822("lars@gradion.test", msg)).Header.Get("From"); got != "lars@gradion.test" {
+			if got := parseMail(t, Build("lars@gradion.test", msg)).Header.Get("From"); got != "lars@gradion.test" {
 				t.Fatalf("expected a bare address, got %q", got)
 			}
 		})
@@ -311,7 +311,7 @@ func TestAMessageWithFilesIsMultipartMixed(t *testing.T) {
 		{Filename: "Vertrag.pdf", ContentType: "application/pdf", Body: []byte("%PDF-1.7 fake")},
 	}
 
-	parsed := parseMail(t, buildRFC822("rep@gradion.test", msg))
+	parsed := parseMail(t, Build("rep@gradion.test", msg))
 	mediaType, params, err := mime.ParseMediaType(parsed.Header.Get("Content-Type"))
 	if err != nil {
 		t.Fatalf("parsing the content type failed: %v", err)
@@ -362,7 +362,7 @@ func TestAFilesBytesAreBase64Encoded(t *testing.T) {
 		{Filename: "raw.bin", Body: []byte("line\r\n--boundary-ish\r\nmore")},
 	}
 
-	raw := buildRFC822("rep@gradion.test", msg)
+	raw := Build("rep@gradion.test", msg)
 	if !strings.Contains(raw, "Content-Transfer-Encoding: base64") {
 		t.Fatalf("a file went out unencoded:\n%s", raw)
 	}
@@ -378,7 +378,7 @@ func TestFilesAndMarkupNestCorrectly(t *testing.T) {
 	msg.HTMLBody = "<p>Anbei die Zahlen.</p>"
 	msg.Files = []connector.OutboundFile{{Filename: "z.pdf", Body: []byte("x")}}
 
-	parsed := parseMail(t, buildRFC822("rep@gradion.test", msg))
+	parsed := parseMail(t, Build("rep@gradion.test", msg))
 	_, params, err := mime.ParseMediaType(parsed.Header.Get("Content-Type"))
 	if err != nil {
 		t.Fatalf("parsing the content type failed: %v", err)
@@ -402,7 +402,7 @@ func TestANonASCIIFilenameIsEncoded(t *testing.T) {
 	// that a CLIENT recovers the name, not which legal spelling produced it.
 	// RFC 2231 is what a MIME parameter takes; the RFC 2047 encoded word this
 	// replaced is for header text and arrives literally in some clients.
-	recovered := filenameFromWire(t, buildRFC822("rep@gradion.test", msg))
+	recovered := filenameFromWire(t, Build("rep@gradion.test", msg))
 	if recovered != "Größenänderung.pdf" {
 		t.Fatalf("a client would see the filename as %q", recovered)
 	}
@@ -440,7 +440,7 @@ func TestAFileWithNoTypeGetsOctetStream(t *testing.T) {
 	msg := plainMessage()
 	msg.Files = []connector.OutboundFile{{Filename: "unknown", Body: []byte("x")}}
 
-	if !strings.Contains(buildRFC822("rep@gradion.test", msg), "application/octet-stream") {
+	if !strings.Contains(Build("rep@gradion.test", msg), "application/octet-stream") {
 		t.Fatal("a typeless file went out with no content type")
 	}
 }
@@ -469,7 +469,7 @@ func TestADeclaredTypesParametersSurviveButItsLineBreaksDoNot(t *testing.T) {
 				{Filename: "notes.txt", ContentType: tc.declared, Body: []byte("x")},
 			}
 
-			raw := buildRFC822("rep@gradion.test", msg)
+			raw := Build("rep@gradion.test", msg)
 			if !strings.Contains(raw, "Content-Type: "+tc.want) {
 				t.Errorf("the attachment part does not declare %q:\n%s", tc.want, raw)
 			}
@@ -490,7 +490,7 @@ func TestAFilenameWithAQuoteStaysOneParameter(t *testing.T) {
 		{Filename: `the "final" contract.pdf`, Body: []byte("x")},
 	}
 
-	if got := filenameFromWire(t, buildRFC822("rep@gradion.test", msg)); got != `the "final" contract.pdf` {
+	if got := filenameFromWire(t, Build("rep@gradion.test", msg)); got != `the "final" contract.pdf` {
 		t.Fatalf("a client would see the filename as %q", got)
 	}
 }
@@ -502,7 +502,7 @@ func TestABlindCopyIsAbsentFromTheVisibleHeaders(t *testing.T) {
 	msg.To = []string{"visible@surfe.test"}
 	msg.Bcc = []string{"blind@surfe.test"}
 
-	parsed := parseMail(t, buildRFC822("rep@gradion.test", msg))
+	parsed := parseMail(t, Build("rep@gradion.test", msg))
 	for _, header := range []string{"To", "Cc"} {
 		if strings.Contains(parsed.Header.Get(header), "blind@surfe.test") {
 			t.Fatalf("a blind copy reached the %s header: %q", header, parsed.Header.Get(header))
@@ -528,7 +528,7 @@ func TestABccOnlyMessageOmitsTheToHeaderEntirely(t *testing.T) {
 	msg.To = nil
 	msg.Bcc = []string{"one@surfe.test", "two@surfe.test"}
 
-	raw := buildRFC822("rep@gradion.test", msg)
+	raw := Build("rep@gradion.test", msg)
 	for _, line := range strings.Split(raw, "\r\n") {
 		if strings.HasPrefix(line, "To:") {
 			t.Fatalf("an empty To header was written: %q", line)

--- a/backend/internal/modules/capture/oauthflow/oauthflow.go
+++ b/backend/internal/modules/capture/oauthflow/oauthflow.go
@@ -48,8 +48,10 @@ type Config struct {
 	// (Google: access_type/prompt/include_granted_scopes; Microsoft:
 	// response_mode) merged over the common set.
 	AuthParams map[string]string
-	// ScopeInTokenForms adds the space-joined scope to the exchange and
-	// refresh forms — Microsoft requires it, Google forbids it.
+	// ScopeInTokenForms adds the space-joined scope to the EXCHANGE form —
+	// Microsoft requires it there, Google forbids it. A refresh never carries
+	// the configured list (see AccessTokenForGrant for what that cost); it
+	// carries the grant's own scopes, or none.
 	ScopeInTokenForms bool
 
 	// AuthRejected wraps connector.ErrAuthRejected; Unreachable wraps
@@ -206,21 +208,31 @@ type TokenRefresh struct {
 }
 
 // AccessToken redeems the stored refresh token for a short-lived access token,
-// discarding any rotation. It is the shape for callers with nothing to persist
-// to — a health probe, a one-shot send — and it is deliberately still here
-// rather than folded into Refresh: most of this system's callers genuinely do
-// not care, and making them all handle a value they will drop is how the
-// handling gets copy-pasted wrong.
+// asking for THE SCOPE ORIGINALLY GRANTED (RFC 6749 §6: an omitted scope on a
+// refresh means exactly that) and discarding any rotation.
+//
+// It is the shape for callers with nothing to persist to and no grant to hand
+// over — and it is deliberately still here rather than folded into Refresh:
+// most of this system's callers genuinely do not care, and making them all
+// handle a value they will drop is how the handling gets copy-pasted wrong.
 func (c *Client) AccessToken(ctx context.Context, refreshToken string) (string, error) {
-	refreshed, err := c.Refresh(ctx, refreshToken)
+	refreshed, err := c.Refresh(ctx, refreshToken, nil)
 	if err != nil {
 		return "", err
 	}
 	return refreshed.AccessToken, nil
 }
 
-// Refresh redeems the stored refresh token and reports the rotation alongside
-// the access token.
+// Refresh redeems the stored refresh token, asking for exactly the scopes THIS
+// CONNECTION holds, and reports the rotation alongside the access token.
+//
+// GRANTED, not the deployment's configured list, and that distinction is the
+// whole point. The two are the same until the day a deployment ADDS a scope,
+// and from then on requesting the configured list on a refresh asks an older
+// grant for a permission it never consented to — which the provider answers by
+// refusing the REFRESH, so a mailbox that should merely have declined to send
+// stops capturing instead. An empty list falls back to RFC 6749 §6's default,
+// which is the same answer by a different route.
 //
 // The rotation is reported even though the OLD token stays valid for its own
 // lifetime: that lifetime is a ceiling, not a guarantee (Microsoft expires an
@@ -229,14 +241,19 @@ func (c *Client) AccessToken(ctx context.Context, refreshToken string) (string, 
 // replacement ages out on a schedule nobody set. A caller that persists it
 // keeps the connection alive indefinitely; one that does not is exactly where
 // it was.
-func (c *Client) Refresh(ctx context.Context, refreshToken string) (TokenRefresh, error) {
+func (c *Client) Refresh(ctx context.Context, refreshToken string, granted []string) (TokenRefresh, error) {
 	form := url.Values{
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {refreshToken},
 		paramClientID:   {c.cfg.ClientID},
 		"client_secret": {c.cfg.ClientSecret},
 	}
-	c.addScope(form)
+	// Deliberately NOT addScope: that spells the deployment's configured
+	// consent, which is the right answer for an exchange and the wrong one
+	// here.
+	if c.cfg.ScopeInTokenForms && len(granted) > 0 {
+		form.Set("scope", strings.Join(granted, " "))
+	}
 	tok, err := c.token(ctx, form)
 	if err != nil {
 		return TokenRefresh{}, err

--- a/backend/internal/modules/comms/seams.go
+++ b/backend/internal/modules/comms/seams.go
@@ -11,6 +11,7 @@ package comms
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"sync"
 
@@ -328,6 +329,22 @@ func SetChannelProviders(providers []string) {
 var mailSendScopes = map[string]string{
 	"gmail": "https://www.googleapis.com/auth/gmail.send",
 	"graph": "Mail.Send",
+}
+
+// MailSendProviders names every provider this module hands a send scope to.
+//
+// Exported so the gate that binds these strings to the connectors' own
+// constants can derive its corpus from THIS map rather than restating it. A
+// second list in the test would be a second answer, and the failure it would
+// hide is precisely the one that matters: a provider added here and nowhere
+// else, whose scope nothing checks against what its connector re-checks.
+func MailSendProviders() []string {
+	out := make([]string, 0, len(mailSendScopes))
+	for provider := range mailSendScopes {
+		out = append(out, provider)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // SendScopeFor answers whether a provider can transmit and, when its grant must

--- a/backend/internal/modules/comms/seams.go
+++ b/backend/internal/modules/comms/seams.go
@@ -315,6 +315,21 @@ func SetChannelProviders(providers []string) {
 	channelProvidersMu.Unlock()
 }
 
+// mailSendScopes are the OAuth permissions a MAIL grant must carry to transmit,
+// per provider.
+//
+// A map rather than a chain of ifs because there are now two vendors and the
+// chain's failure mode is silent: a provider missing from it reports CannotSend,
+// and every one of its deliveries parks with "provider cannot send messages" —
+// a connector limitation that does not exist. Each value is a SECOND spelling of
+// a string a capture provider already declares (this module must not import
+// one), and compose holds the two against each other per provider in
+// compose/sendscope_test.go.
+var mailSendScopes = map[string]string{
+	"gmail": "https://www.googleapis.com/auth/gmail.send",
+	"graph": "Mail.Send",
+}
+
 // SendScopeFor answers whether a provider can transmit and, when its grant must
 // carry an OAuth scope to do so, which scope.
 //
@@ -323,24 +338,19 @@ func SetChannelProviders(providers []string) {
 // authority gate. Two spellings of "may this grant send" could disagree, and a
 // pre-flight that accepted what the gate then parks is worse than none.
 //
-// The MAIL arm is a literal, unchanged: gmail is not, and never will be, an
-// activity_kind (DESIGN-SP4 §4 — the channel_provider table FKs into
-// activity_kind, and gmail names no activity kind), so there is no registry
-// for it to derive from. The scope string is a SECOND spelling of one a
-// capture provider already declares — Gmail's OAuth consent requests that
-// same scope constant rather than a copy — and it has to be: this module must
-// not import a capture provider. compose imports both sides and holds them
-// against each other (compose/sendscope_test.go), because drift here is
-// silent: a misspelled scope parks every send as ungranted, which reads as a
-// user who declined consent.
+// The MAIL arm reads mailSendScopes above: gmail and graph are not, and never
+// will be, activity_kinds (DESIGN-SP4 §4 — the channel_provider table FKs into
+// activity_kind, and neither names an activity kind), so there is no registry
+// for them to derive from. See that map for why the strings are second
+// spellings and what holds them to the first.
 //
 // The CHANNEL arm derives from channelProviders — the same registry
 // activities.IsChannelKind reads — so a provider clearing it is answerable
 // for both "is this a channel conversation" and "can this installation send
 // on it" in one boot-time act.
 func SendScopeFor(provider string) (string, SendCapability) {
-	if provider == "gmail" {
-		return "https://www.googleapis.com/auth/gmail.send", SendsWithScope
+	if scope, ok := mailSendScopes[provider]; ok {
+		return scope, SendsWithScope
 	}
 	channelProvidersMu.RLock()
 	isChannel := channelProviders[provider]

--- a/docs/explanation/capture-connectors.md
+++ b/docs/explanation/capture-connectors.md
@@ -166,7 +166,7 @@ refresh token (see below).
 ## The connectors
 
 All five register in `internal/compose/capture.go`; every one produces `activity` on the way in, and
-two of them can also transmit. The differences that matter:
+three of them can also transmit. The differences that matter:
 
 | | **Gmail** | **IMAP** | **Graph** (Outlook) | **Calendar** (gcal) | **Telegram** |
 |---|---|---|---|---|---|

--- a/docs/explanation/capture-connectors.md
+++ b/docs/explanation/capture-connectors.md
@@ -170,12 +170,12 @@ two of them can also transmit. The differences that matter:
 
 | | **Gmail** | **IMAP** | **Graph** (Outlook) | **Calendar** (gcal) | **Telegram** |
 |---|---|---|---|---|---|
-| Auth | OAuth `gmail.readonly` + `gmail.send` | IMAPS app-password | OAuth `Mail.Read` | OAuth `calendar.readonly` | BotFather bot token |
+| Auth | OAuth `gmail.readonly` + `gmail.send` | IMAPS app-password | OAuth `Mail.Read` + `Mail.Send` | OAuth `calendar.readonly` | BotFather bot token |
 | Connection | standing, per human | standing, per human | standing, per human | standing, per human | standing, **per workspace** (an admin binds one bot) |
 | Cursor | `historyId` | UID watermark | `deltaLink` | `syncToken` | `getUpdates` offset |
 | Push | Pub/Sub 7-day | — (poll) | — (poll) | — (poll) | — (long poll, exclusive per bot) |
 | Backfill | ✔ | — | ✔ | — | — (the Bot API has no history endpoint) |
-| Send | ✔ (`EmailSender`) | — | — | — | ✔ (`MessageSender`) |
+| Send | ✔ (`EmailSender`) | — | ✔ (`EmailSender`) | — | ✔ (`MessageSender`) |
 | Connect UI | onboarding + Settings | onboarding + Settings | onboarding + Settings | Settings only | Settings only (its own card) |
 
 ### Gmail — standing OAuth, push-capable, send-capable
@@ -219,11 +219,24 @@ read.
 
 ### Microsoft Graph — standing OAuth, poll-only
 
-OAuth2 to the Microsoft identity platform with delegated scopes `offline_access User.Read Mail.Read`
-(tenant defaults to `common`). Incremental sync walks a **delta query** from a `deltaLink`; a stale link
-(`ErrDeltaGone`, HTTP 410) re-anchors to a bounded 7-day window. It is a `Backfiller` but **not** a
-`Watcher` — there is no change-notification subscription built, so Outlook latency is the poll interval,
-not a push p95. **To run:** a Microsoft Entra (Azure AD) app + tenant + the vault key. **UI:** a
+OAuth2 to the Microsoft identity platform with delegated permissions `offline_access User.Read
+Mail.Read Mail.Send` (tenant defaults to `common`) — mail read for capture and send for the governed
+outbound path, on **one consent**, because Microsoft will not add a permission to an existing refresh
+token. A mailbox connected before the send permission landed captures normally and refuses every send
+by name until it is reconnected. Incremental sync walks a **delta query** from a `deltaLink`; a stale
+link (`ErrDeltaGone`, HTTP 410) re-anchors to a bounded 7-day window. It is a `Backfiller` and an
+`EmailSender` but **not** a `Watcher` — there is no change-notification subscription built, so Outlook
+latency is the poll interval, not a push p95.
+
+Sending submits the whole RFC822 message to `/me/sendMail`, rendered by the **shared** wire builder
+(`capture/mailwire`) that Gmail's send uses — one answer to what a multipart/alternative puts first and
+where base64 folds. Microsoft acknowledges without naming a message id, so the sent copy is resolved
+afterwards by filtering Sent Items on `internetMessageId`; that same filter is the at-least-once retry
+guard, and unlike Gmail's (which searches for an identity Gmail has already discarded) it reads the
+message's own property. It still does not close the window — Exchange may rewrite the identity on
+submission depending on tenant configuration. **Microsoft carries less than Gmail**: the MIME submit
+ceiling is 4 MB of base64, so `Carriage` declares ~3 MiB per file where Gmail declares 25 MiB, and an
+over-large message parks with an honest reason instead of drawing an opaque refusal. **To run:** a Microsoft Entra (Azure AD) app + tenant + the vault key. **UI:** a
 first-connect affordance from both the onboarding **Microsoft** chip and the Settings **Add a connection**
 footer; the roster manages an existing connection. Microsoft **rotates the refresh token on every redemption**, and the replacement is now persisted: the
 connector reports it through `CredentialRotator` and the registry re-seals it into the vault on each
@@ -324,8 +337,8 @@ The pipeline is live; these were scoped out, not missed:
   app-password included, and destroyed on disconnect. A provider that REPLACES it on use (Microsoft does,
   on every redemption) reports the replacement through `CredentialRotator`, and the re-seal obeys the
   same fence and the same destroy-the-old rule.
-- **All four connections are standing** and sync in the background; only Gmail/Graph backfill; only
-  Gmail pushes.
+- **All four connections are standing** and sync in the background; only Gmail/Graph backfill and
+  send; only Gmail pushes.
 
 ## Where the code lives
 
@@ -341,7 +354,8 @@ The pipeline is live; these were scoped out, not missed:
 | Counterparty / RFC822 mapping (direction, ThreadKey, skip rules) | `internal/modules/capture/mailmap/mailmap.go` |
 | Gmail connector (OAuth, history sync, Pub/Sub watch, backfill) | `internal/modules/capture/gmail/` |
 | IMAP connector (standing UID-watermark sync; netguard SSRF guard) | `internal/modules/capture/imap/` |
-| Graph connector (OAuth, delta sync, backfill) | `internal/modules/capture/graph/` |
+| Graph connector (OAuth, delta sync, backfill, send) | `internal/modules/capture/graph/` |
+| The shared outbound RFC822 renderer both mail senders use | `internal/modules/capture/mailwire/` |
 | Google Calendar connector (OAuth, syncToken) | `internal/modules/capture/gcal/` |
 | Shared OAuth handshake (authorize URL, code/refresh exchange) | `internal/modules/capture/oauthflow/oauthflow.go`, `capture/googleconn/` |
 | Connect surface + state signing + CSRF (api) | `internal/compose/connectors.go`, `connectors_imap.go` |

--- a/docs/how-to/connect-a-mailbox.md
+++ b/docs/how-to/connect-a-mailbox.md
@@ -20,30 +20,30 @@ Two entry points, both hitting the same API:
 
 - **Settings → Integrations** (`ConnectorsCard`) — the standing-connection roster: each live connection
   with a status badge (`connected` / `reauth_required` / `error`) and last-synced time, a **reconnect**
-  action for a `reauth_required` OAuth connection, and a confirm-gated **disconnect**. Below the roster
-  (or in its place, when nothing is connected yet) sits an always-present **"Add a connection"**
-  affordance offering whichever of **Gmail**, **Google Calendar**, **Microsoft 365**, and **IMAP** aren't
-  already connected. Picking an OAuth provider (Gmail / Calendar / Microsoft) redirects straight to that
-  provider's consent screen from Settings — no detour through onboarding; picking IMAP opens the inline
-  connect form right there. If a provider's backend app isn't configured, the button click surfaces
-  **"{provider} isn't configured in this deployment"** instead of a raw error.
-- **Onboarding → connect step** — the same connect step, reached on a fresh install (or via the
-  `onboarding / connect` command): chips for **Google**, **Microsoft**, and **IMAP** (Google Calendar has
-  no onboarding chip — add it from Settings). All three chips are live; Microsoft opens the same Graph
-  OAuth redirect Settings does.
+  action for a `reauth_required` OAuth connection, and a confirm-gated **disconnect**. Below it (or in
+  its place, when nothing is connected) an always-present **"Add a connection"** offers whichever
+  providers aren't connected yet. An OAuth pick redirects straight to that provider's consent screen;
+  IMAP opens the inline form. A provider whose backend app isn't configured answers **"{provider} isn't
+  configured in this deployment"** rather than a raw error.
+- **Onboarding → connect step** — the same step on a fresh install (or via the `onboarding / connect`
+  command): live chips for **Google**, **Microsoft** and **IMAP**. Google Calendar has no onboarding
+  chip — add it from Settings.
 
 > **Restart after backend config.** The api is a compiled binary — changing an OAuth env var (below)
 > needs `make dev` again to take effect; Vite hot-reloads the SPA but not the Go api.
 
 ## Which path do I want?
 
-| Provider | Path | Credential custody | Background sync + backfill | What you need |
-|---|---|---|---|---|
-| **Gmail** | OAuth standing connection | refresh token sealed in the vault, destroyed on disconnect | Yes (+ Pub/Sub push) | a Google OAuth app + the vault key |
-| **Gmail** | IMAP standing connection | app-password sealed in the vault, destroyed on disconnect | Sync only (poll-only, no backfill) | a Google **app-password** + the vault key |
-| **Outlook / M365** | IMAP standing connection | app-password sealed in the vault, destroyed on disconnect | Sync only (poll-only, no backfill) | an Outlook **app-password** + the vault key |
-| **Outlook / M365** | Graph OAuth standing connection | refresh token sealed in the vault, destroyed on disconnect | Sync + backfill (poll-only) | a Microsoft Entra app + the vault key |
-| **Google Calendar** | `gcal` OAuth standing connection (separate from Gmail) | refresh token sealed in the vault, destroyed on disconnect | Sync only (poll-only, no backfill) | the same Google app as Gmail, with the calendar scope + redirect URI added |
+**Custody is the same on every row**: the credential — refresh token or app-password — is
+sealed in the vault, never written to the connection row, and **destroyed on disconnect**.
+
+| Provider | Path | Background sync + backfill | What you need |
+|---|---|---|---|
+| **Gmail** | OAuth standing connection | Yes (+ Pub/Sub push) | a Google OAuth app + the vault key |
+| **Gmail** | IMAP standing connection | Sync only (poll-only, no backfill) | a Google **app-password** + the vault key |
+| **Outlook / M365** | IMAP standing connection | Sync only (poll-only, no backfill) | an Outlook **app-password** + the vault key |
+| **Outlook / M365** | Graph OAuth standing connection | Sync + backfill (poll-only) | a Microsoft Entra app + the vault key |
+| **Google Calendar** | `gcal` OAuth standing connection (separate from Gmail) | Sync only (poll-only, no backfill) | the same Google app as Gmail, with the calendar scope + redirect URI added |
 
 Start with **IMAP** if you just want to see capture work against a real mailbox from the UI — it needs no
 OAuth app registration, only the vault key every connect path requires. Use **Gmail OAuth** to exercise
@@ -255,7 +255,9 @@ by name until it is reconnected.
 
 1. Either click the **Microsoft** chip on the onboarding connect step, or go to **Settings →
    Integrations** and click **Microsoft** in the **Add a connection** footer (or empty state).
-2. The page redirects to Microsoft — sign in and consent to `offline_access User.Read Mail.Read`.
+2. The page redirects to Microsoft — sign in and consent to `offline_access User.Read Mail.Read
+   Mail.Send`. Consenting without `Mail.Send` gives a capture-only mailbox that refuses every send
+   until it is reconnected: Microsoft will not add a permission to a refresh token it already issued.
 3. Microsoft returns you to the app; **Settings → Integrations** shows a `graph` row with a **connected**
    badge, reconnect/disconnect actions, and the backfill panel.
 
@@ -339,12 +341,10 @@ curl -X POST http://localhost:8080/v1/connectors/gcal/connect \
 
 ## Current UI gaps
 
-The connect UI is now live for all five connectors. Gmail, Google Calendar, Graph, and IMAP each have a
-first-connect affordance from **Settings → Integrations**, and Gmail, Microsoft, and IMAP have one from
-**onboarding** too (Google Calendar is Settings-only — there's no onboarding chip for it). The fifth is
-**Telegram**, which sits in its own Settings card rather than the *Add a connection* footer — a bot is a
-workspace-wide binding, not one human's grant ([connect-telegram.md](connect-telegram.md)). The roster and
-backfill panel, though, don't apply everywhere: IMAP and Google Calendar have no backfill, so both sync
-forward from connect time only (see the [Calendar section](#d2-connect-from-the-ui) above). See
+Every mail and calendar connector has a first-connect affordance in **Settings → Integrations**; Gmail,
+Microsoft and IMAP additionally have an onboarding chip, and Google Calendar does not. **Telegram** sits
+in its own Settings card rather than the *Add a connection* footer — a bot is a workspace-wide binding,
+not one human's grant ([connect-telegram.md](connect-telegram.md)). Backfill does not apply everywhere:
+IMAP and Google Calendar sync forward from connect time only. See
 [explanation/capture-connectors.md → Honest limitations](../explanation/capture-connectors.md#honest-limitations)
-for what's still scoped out of the pipeline overall.
+for what's still scoped out.

--- a/docs/how-to/connect-a-mailbox.md
+++ b/docs/how-to/connect-a-mailbox.md
@@ -1,14 +1,12 @@
 # Connect a mailbox for capture
 
-Connect a mailbox so Margince captures its mail onto the timeline — creating people, organizations, and
-activities through the one dedupe chokepoint. This guide is **UI-first**: you drive it from the app,
-with the equivalent `curl` shown alongside for scripting and verification. It covers the three paths you
-can drive from the **UI** — **Gmail over OAuth** (a standing connection with background sync + backfill),
-**IMAP with an app-password** (also a standing connection, and the way to reach a **Gmail** or
-**Outlook / Microsoft 365** mailbox without registering an OAuth app), and **Graph OAuth** for Outlook /
-Microsoft 365 (a standing connection, Path C) — plus **Google Calendar (`gcal`)**, a separate standing connection you add
-alongside Gmail from the same Settings surface (Path D). For the mental model — the connector seam, the
-one Sink, the three ingestion modes, credential custody — read
+Connect a mailbox so Margince captures its mail onto the timeline — creating people, organizations and
+activities through the one dedupe chokepoint. **UI-first**: you drive it from the app, with the
+equivalent `curl` alongside for scripting and verification. Every connection below is standing, and each
+path has its own section: **Gmail over OAuth** (A), **IMAP with an app-password** (B, the way to reach a
+Gmail or Outlook mailbox without registering an OAuth app), **Graph OAuth** for Outlook / Microsoft 365
+(C), and **Google Calendar** (D). For the mental model — the connector seam, the one Sink, the ingestion
+modes, credential custody — read
 [explanation/capture-connectors.md](../explanation/capture-connectors.md) first.
 
 > **Single-organization installation.** One installation serves one organization; the
@@ -247,8 +245,11 @@ export MARGINCE_GRAPH_TENANT="common"   # or a specific tenant id
 # plus the same MARGINCE_CONNECTOR_STATE_KEY / MARGINCE_KEYVAULT_ROOT_KEY / MARGINCE_PUBLIC_BASE_URL as A1
 ```
 
-Register a Microsoft Entra (Azure AD) app with delegated scopes `offline_access User.Read Mail.Read` and
-a redirect URI of `<api-base>/v1/connectors/graph/callback`, then `make dev` to pick up the env.
+Register a Microsoft Entra (Azure AD) app with delegated permissions `offline_access User.Read
+Mail.Read Mail.Send` and a redirect URI of `<api-base>/v1/connectors/graph/callback`, then `make dev`
+to pick up the env. `Mail.Send` rides the same consent because Microsoft will not add a permission to
+an existing refresh token — a mailbox connected without it captures normally and refuses every send
+by name until it is reconnected.
 
 ### C2. Connect from the UI
 

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3883,11 +3883,11 @@ export const de = {
   "connectors.connectProvider": "{provider} verbinden",
   "connectors.rosterLabel": "Erfassende Postfächer",
   "connectors.addGmailBrings":
-    "Die Mails, die du sendest und empfängst, von Google — und die einzige Verbindung, über die Margince senden kann.",
+    "Die Mails, die du sendest und empfängst, von Google. Margince kann auch darüber senden.",
   "connectors.addGcalBrings":
     "Dein Google Kalender. Er wird separat von Gmail verbunden.",
   "connectors.addGraphBrings":
-    "Mail und Kalender eines Microsoft-Geschäftskontos, über die Graph-API. Nur Erfassung.",
+    "Mail und Kalender eines Microsoft-Geschäftskontos, über die Graph-API. Margince kann auch darüber senden.",
   "connectors.addImapBrings":
     "Jeder andere Mail-Host, mit einem App-Passwort. Nur Erfassung.",
   "connectors.providerNotConfigured":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3920,11 +3920,11 @@ export const en = {
   "connectors.connectProvider": "Connect {provider}",
   "connectors.rosterLabel": "Mailboxes capturing",
   "connectors.addGmailBrings":
-    "The mail you send and receive, from Google — and the only connection Margince can send from.",
+    "The mail you send and receive, from Google. Margince can send from it too.",
   "connectors.addGcalBrings":
     "Your Google calendar. It connects separately from Gmail.",
   "connectors.addGraphBrings":
-    "Mail and calendar on a Microsoft work account, over the Graph API. Capture only.",
+    "Mail and calendar on a Microsoft work account, over the Graph API. Margince can send from it too.",
   "connectors.addImapBrings":
     "Any other mail host, with an app password. Capture only.",
   "connectors.providerNotConfigured":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3846,11 +3846,11 @@ export const vi = {
   "connectors.connectProvider": "Kết nối {provider}",
   "connectors.rosterLabel": "Hộp thư đang thu thập",
   "connectors.addGmailBrings":
-    "Thư bạn gửi và nhận, từ Google — và là kết nối duy nhất mà Margince có thể gửi thư qua.",
+    "Thư bạn gửi và nhận, từ Google. Margince cũng có thể gửi thư qua kết nối này.",
   "connectors.addGcalBrings":
     "Google Calendar của bạn. Nó được kết nối riêng, không đi kèm Gmail.",
   "connectors.addGraphBrings":
-    "Thư và lịch của một tài khoản công việc Microsoft, qua Graph API. Chỉ thu thập.",
+    "Thư và lịch của một tài khoản công việc Microsoft, qua Graph API. Margince cũng có thể gửi thư qua kết nối này.",
   "connectors.addImapBrings":
     "Bất kỳ máy chủ thư nào khác, bằng mật khẩu ứng dụng. Chỉ thu thập.",
   "connectors.providerNotConfigured":

--- a/frontend/src/screens/connector-status.test.ts
+++ b/frontend/src/screens/connector-status.test.ts
@@ -83,11 +83,28 @@ describe("missingSendGrant", () => {
   });
 
   // A provider that cannot send at all is not "cannot send" — it was never a
-  // sending mailbox, and its scope vocabulary is not Google's, so no absent
-  // Google scope says anything about it.
+  // sending mailbox, and its scope vocabulary is neither vendor's, so no absent
+  // scope says anything about it.
   it("never badges a provider that does not send in the first place", () => {
     expect(missingSendGrant({ provider: "imap", scopes: [] })).toBe(false);
     expect(missingSendGrant({ provider: "gcal", scopes: [] })).toBe(false);
-    expect(missingSendGrant({ provider: "graph", scopes: [] })).toBe(false);
+  });
+
+  // Outlook sends too, and its grant carries Microsoft's own permission name —
+  // so a mailbox connected before sending shipped for that vendor is badged on
+  // the SAME rule, read against a different string.
+  it("badges an Outlook mailbox whose grant carries no send permission", () => {
+    expect(
+      missingSendGrant({
+        provider: "graph",
+        scopes: ["offline_access", "User.Read", "Mail.Read"],
+      }),
+    ).toBe(true);
+    expect(
+      missingSendGrant({
+        provider: "graph",
+        scopes: ["offline_access", "User.Read", "Mail.Read", "Mail.Send"],
+      }),
+    ).toBe(false);
   });
 });

--- a/frontend/src/screens/connector-status.ts
+++ b/frontend/src/screens/connector-status.ts
@@ -25,30 +25,34 @@ export type ConnectorStatus =
   | CaptureConnection["status"]
   | ChannelConnection["status"];
 
-// The one scope that grants sending today. The server pre-flights a send
-// against this same string (comms.SendScopeFor), so the badge below and the
-// 422 it exists to pre-empt cannot disagree about which mailbox may send.
-const GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send";
+/** The scope each sending provider's grant must carry, keyed by provider.
+ *
+ *  A DELIBERATE MIRROR of the server's `comms.SendScopeFor`, which pre-flights
+ *  a send against these same strings — so the badge below and the 422 it exists
+ *  to pre-empt cannot disagree about which mailbox may send. A table rather
+ *  than a chain of comparisons, because there are now two vendors and the way
+ *  a chain fails is silent: a provider missing from it is never badged, and its
+ *  owner discovers the missing grant from a refused send instead. */
+const SEND_SCOPES: Readonly<Record<string, string>> = {
+  gmail: "https://www.googleapis.com/auth/gmail.send",
+  graph: "Mail.Send",
+};
 
 /** Whether this connection captures mail it will never be allowed to send.
- *  Google will not widen an existing refresh token, so every mailbox
- *  connected before sending shipped holds read-only access until its owner
- *  reconnects — a fact the connection's `status` cannot express, since it is
- *  genuinely connected and genuinely capturing. Only the granted scopes say
- *  it, which is why this reads them rather than the status.
+ *  Neither Google nor Microsoft will widen an existing refresh token, so every
+ *  mailbox connected before sending shipped for its vendor holds read-only
+ *  access until its owner reconnects — a fact the connection's `status` cannot
+ *  express, since it is genuinely connected and genuinely capturing. Only the
+ *  granted scopes say it, which is why this reads them rather than the status.
  *
- *  Gmail is the only provider that sends at all (one `if`, matching the
- *  server: a registry with a single entry is an abstraction with no second
- *  caller). A calendar or IMAP connection is not "cannot send" — it is not a
- *  sending mailbox in the first place, and badging it would be a refusal
- *  nobody could act on. */
+ *  A provider absent from the table above is not "cannot send" — it is not a
+ *  sending mailbox in the first place (a calendar, an IMAP box), and badging it
+ *  would be a refusal nobody could act on. */
 export function missingSendGrant(
   connection: Pick<CaptureConnection, "provider" | "scopes">,
 ): boolean {
-  return (
-    connection.provider === "gmail" &&
-    !connection.scopes.includes(GMAIL_SEND_SCOPE)
-  );
+  const required = SEND_SCOPES[connection.provider];
+  return required !== undefined && !connection.scopes.includes(required);
 }
 
 /** Each contract status gets its own Badge tone. Collapsing reauth_required

--- a/frontend/src/screens/connectors.test.tsx
+++ b/frontend/src/screens/connectors.test.tsx
@@ -633,7 +633,7 @@ describe("add a connection", () => {
   });
 
   // Four provider names decide nothing: Gmail and Google Calendar are two
-  // halves of one account, only Gmail can ever send, and IMAP is the answer for
+  // halves of one account, only the OAuth mailboxes can send, and IMAP is the answer for
   // every host with no OAuth. Each pick carries the sentence that says so, and
   // it lands in that button's own aria-describedby.
   it("gives every pick the sentence its choice needs", async () => {

--- a/frontend/src/screens/connectors.tsx
+++ b/frontend/src/screens/connectors.tsx
@@ -183,7 +183,7 @@ function ConnectionIdentity({
 
 // What each provider actually brings, one sentence each. They exist because
 // the choice cannot be made from four names: "Gmail" and "Google Calendar"
-// are two halves of one account, only Gmail can ever send, and IMAP is the
+// are two halves of one account, only the OAuth mailboxes can send, and IMAP is the
 // answer for every host with no OAuth at all. A strip of four buttons had
 // nowhere to say any of that.
 const PROVIDER_BLURB: Record<Provider, MessageKey> = {


### PR DESCRIPTION
## Why

Gmail has been the only connection Margince could send from — and the connect dialog said exactly that, in three locales. An installation on Microsoft 365 could bring its mail in and then had to leave the product to answer any of it.

## What

`graph` now implements `connector.EmailSender` and `connector.AttachmentCarrier`, on `Mail.Send` riding the **same consent** as the read permissions. Microsoft, like Google, will not add a permission to an existing refresh token, so asking later would mean a second connection for the same mailbox. **A mailbox connected before this lands captures normally and refuses every send by name until it is reconnected** — cheap now, expensive after go-live, which is why it is this change and not a later one.

### The bytes are the shared renderer, not a second one

`gmail/rfc822.go` moved to `capture/mailwire`. Microsoft's `sendMail` accepts the same complete RFC822 message Gmail's `messages.send` does, and what a `multipart/alternative` puts first, whether an attachment's filename rides in one header or two, and where base64 folds each have **one** right answer. Two renderers would answer them twice and diverge exactly where one vendor's recipients get a blank message or a truncated PDF.

### The retry guard is better here than on Gmail, and the difference is worth stating

Gmail discards a client-supplied Message-ID and files the message under one of its own, which leaves its prior-send lookup searching for an identity that was never filed — `gmail/send.go` says so plainly. Graph exposes the identity as the filterable `internetMessageId` property, so the lookup reads the message's **own field** rather than a full-text index.

It still does not *close* the window: Exchange Online may rewrite the identity on submission depending on tenant configuration, in which case the filter matches nothing and a retry mails twice. That is the same failure Gmail has always had, but conditional rather than certain — and it is written down rather than left to be discovered. Mutation-tested: remove the `Attempt > 0` guard and the test fails with *"the recipient was mailed a second time"*.

### Microsoft carries less than Gmail, and `Carriage` says the real number

Graph's MIME submit ceiling is 4 MB of base64 — about 3 MiB of actual bytes — against Gmail's full 25 MiB inbound cap. Declaring the true number is what makes an over-large message **park with an honest reason** instead of leaving as a request Microsoft answers with an opaque refusal that no retry can get under.

### Drift protection

`comms.SendScopeFor` became a table rather than an `if`, and `compose/sendscope_test.go` now runs **per provider** over the three spellings (what the consent requests, what comms demands, what the connector re-checks) plus a new arm asserting every provider given a send scope actually implements `EmailSender`. A third vendor added to two of the three places fails here rather than parking every delivery with a connector limitation that does not exist. The frontend's send-grant badge (`connector-status.ts`) follows the same shape.

### Copy that had gone false

- *"the only connection Margince can send from"* (Gmail) — no longer true.
- *"Capture only"* (Microsoft) — no longer true.

Both fixed in `en`/`de`/`vi`.

## Verification

`make check-backend`, `make check-fe` (Node 24) and `make craft-static` all green.

> Note: this branch and #3377 both touch `connectors.addGraphBrings`. Whichever merges second takes a one-line conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microsoft Graph mailboxes can now send email, including attachments.
  * Safe retries help prevent duplicate deliveries.
  * Connection status identifies missing send permissions for Gmail and Microsoft Graph.
  * Setup guidance and connector descriptions reflect sending across supported OAuth mailboxes.

* **Bug Fixes**
  * Improved handling of failed or incomplete post-send lookups.
  * Standardized email formatting across supported mail providers.
  * Added clearer handling for messages exceeding Microsoft Graph’s size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->