### PR TITLE
fix(frontend): drop the duplicate capture_confidentiality_verdict key

### DIFF
--- a/frontend/src/app/ai-activity-lines.ts
+++ b/frontend/src/app/ai-activity-lines.ts
@@ -147,7 +147,6 @@ export const ACTIVITY_LINE: Readonly<
   capture_classify: SYSTEM_SWEEP,
   capture_confidentiality_verdict: SYSTEM_SWEEP,
   capture_counterparty_verdict: SYSTEM_SWEEP,
-  capture_confidentiality_verdict: SYSTEM_SWEEP,
   enrich: notDisplayed(
     "it reaches nobody, and it would not be worth showing if it did — recording only the first half is what made this read like a gap somebody should close. Reachability: the one production site is the signature-enrichment pass, which runs under a system principal with no on_behalf_of, so ResolveActor scopes every occurrence to the workspace with a NULL actor_user_id while the personal feed selects on actor_user_id. Worth: it could not be per-person even if it were reachable. The pass mints ONE correlation id for the whole run (api/jobs.yaml capture_enrich, up to 100 candidates in series), and the occurrence key is correlation+task, so every candidate collapses into ONE row — a per-person subject would make that single row flap from one person to the next rather than narrate any of them. What a reader actually wants from this pass is what it FOUND, which is durable and already drawn as evidence-or-omit provenance on the person record. The ticker's own `enrich` key names DIFFERENT work (a provider run on a person, and the organization page's Enrich card, which runs cold_start rather than this task), which is what makes this one easy to mistake for visible",
   ),

--- a/frontend/src/app/ai-activity-orb.ts
+++ b/frontend/src/app/ai-activity-orb.ts
@@ -34,7 +34,6 @@ export const ACTIVITY_LANE: Readonly<Record<ActivityKind, AgentLane>> = {
   capture_classify: "ingest",
   capture_confidentiality_verdict: "ingest",
   capture_counterparty_verdict: "ingest",
-  capture_confidentiality_verdict: "ingest",
   cold_start: "ingest",
   document_extract: "ingest",
   enrich: "ingest",


### PR DESCRIPTION
## Summary
- #3372 added a second `capture_confidentiality_verdict` entry to both `ACTIVITY_LANE` (`ai-activity-orb.ts`) and `ACTIVITY_LINE` (`ai-activity-lines.ts`), on top of the one #3371 had just added — one line below `capture_counterparty_verdict` in both files, reading as a copy of the wrong neighbour.
- Both values are identical to the existing entry, so nothing behaved differently at runtime — TypeScript's duplicate-object-key check (TS1117) is what caught it, and it fails `make check-fe`'s `fe-typecheck-composed` lane (which depends on `tsc -b`/the composed build; `tsc -p tsconfig.json` alone does not build project references and reports zero errors on this exact tree, so it's easy to miss by hand).
- Found by margince-qc-61, whose own drift gate compiles the product's frontend against its own types and caught this on a fresh checkout of `origin/main` — verified three ways (`tsc -b`, `tsc -p tsconfig.composed.json`, ruled out its own tsconfig being stricter) before reporting it.

Fixes margince#3385

## Test plan
- [x] `make fe-typecheck-composed` — clean (the actual CI gate; verified against a fresh `pnpm install`)
- [x] `git diff` — two-line removal, no other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes duplicate `capture_confidentiality_verdict` keys from `ACTIVITY_LANE` and `ACTIVITY_LINE`. The duplicates had no runtime effect, but they failed TypeScript's duplicate-object-key check (TS1117) and broke the frontend typecheck build. This restores a clean `make fe-typecheck-composed` run.

<sup>Written for commit 8c2ce55f4422adcfbb5dfec8eb0184095689a2c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AI activity displays so confidentiality verdict events are no longer incorrectly categorized as system sweeps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->