### PR TITLE
An owner has the last word on their own thread

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8422,6 +8422,51 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
+  /activities/threads/{thread_key}/audience:
+    parameters:
+      - name: thread_key
+        in: path
+        required: true
+        schema: { type: string, maxLength: 998 }
+        description: The thread's key, as an activity reports it.
+    post:
+      tags: [Activities]
+      operationId: setThreadAudience
+      summary: Share a thread with the team, or keep it private.
+      description: |
+        Your own view of the thread, and only yours. A message that reached two mailboxes is two
+        people's correspondence: each of you contributes what you ask for, and the message ends at
+        the strictest of those. So sharing releases YOUR hold — it cannot publish what a colleague
+        is still holding, and the response says how many other seats are.
+
+        This overrules the classifier, and permanently: a thread you decided about is not re-judged
+        later. That is what "keep this private" has to mean for the click to be worth making.
+
+        Only threads you imported. A thread key you were not on answers not-found, because whether
+        somebody else's correspondence exists is not a thing to confirm.
+      x-agent-access: human-only
+      security: [ { cookieAuth: [] } ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [share]
+              properties:
+                share:
+                  type: boolean
+                  description: True to share the thread with the workspace, false to keep it private.
+      responses:
+        '200':
+          description: What the decision reached.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ThreadAudienceOutcome' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
   /capture/counterparty-holds:
     get:
       tags: [Capture]
@@ -18575,6 +18620,25 @@ components:
             Whether a human vouched for this domain. Only a verified domain — or one the
             installation's own company claims — suppresses storage.
         created_at: { type: string, format: date-time }
+    ThreadAudienceOutcome:
+      type: object
+      description: What an owner's decision about a thread reached.
+      required: [messages, shared, held_by_others]
+      properties:
+        messages:
+          type: integer
+          description: How many of the thread's messages you imported, and the decision reached.
+        shared:
+          type: boolean
+          description: |
+            Whether the messages are now readable by the workspace. False after a share means
+            somebody else still holds them.
+        held_by_others:
+          type: integer
+          description: |
+            How many other seats still ask for this thread to be held. A count and never a name:
+            whose mail a person keeps private is itself private.
+
     CapturePurgeOutcome:
       type: object
       description: |

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -353,6 +353,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/activities":                                                {Op: "logActivity", Access: "tool", Tool: "log_activity", RecordType: "activity", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/activities/relink-bulk":                                    {Op: "relinkActivities", Access: "tool", Tool: "relink_activities", RecordType: "activity", Tier: "dynamic", Scope: "write"},
 	"POST /v1/activities/relink-thread":                                  {Op: "relinkThread", Access: "tool", Tool: "relink_thread", RecordType: "activity", Tier: "dynamic", Scope: "write"},
+	"POST /v1/activities/threads/{thread_key}/audience":                  {Op: "setThreadAudience", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/activities/{id}/draft-email":                               {Op: "draftEmail", Access: "tool", Tool: "draft_email", RecordType: "activity", Tier: "auto_execute", Scope: "draft"},
 	"POST /v1/activities/{id}/relink":                                    {Op: "relinkActivity", Access: "tool", Tool: "relink_activity", RecordType: "activity", Tier: "dynamic", Scope: "write"},
 	"POST /v1/activities/{id}/send-email":                                {Op: "sendEmail", Access: "tool", Tool: "send_email", RecordType: "activity", Tier: "auto_execute", Scope: "send"},

--- a/backend/internal/compose/handlers_threadaudience.go
+++ b/backend/internal/compose/handlers_threadaudience.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The owner's own say over a thread they imported.
+
+import (
+	"net/http"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+)
+
+// SetThreadAudience records what this owner concluded about a thread and
+// re-derives every message of it they imported.
+//
+// It lives on the Server rather than on the activities handler set because the
+// decision spans two modules: capture owns the ledger the owner's answer is
+// written to, activities owns the derivation that answer feeds. Neither may
+// import the other, so the assembly is compose's.
+func (s Server) SetThreadAudience(w http.ResponseWriter, r *http.Request, threadKey string) {
+	if s.threadAudience == nil {
+		httperr.ServiceUnavailable(w, r, "this installation captures no mail, so there are no threads to share")
+		return
+	}
+	var req crmcontracts.SetThreadAudienceJSONRequestBody
+	if !httperr.Decode(w, r, &req) {
+		return
+	}
+	outcome, err := s.threadAudience.Decide(r.Context(), threadKey, req.Share)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.ThreadAudienceOutcome{
+		Messages:     outcome.Messages,
+		Shared:       outcome.Shared,
+		HeldByOthers: outcome.HeldByOthers,
+	})
+}

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -203,6 +203,7 @@ func (s *Server) wireSystemOfRecordReads(pool *pgxpool.Pool) {
 	s.peopleStore = people.NewStore(InstallationDB(pool)).WithFieldCatalog(customfields.NewService(pool, nil))
 	s.blockedDomainHandlers = blockedDomainHandlers{people: s.peopleStore}
 	s.captureExclusionHandlers = captureExclusionHandlers{store: capture.NewExclusionStore(InstallationDB(pool))}
+	s.threadAudience = NewThreadAudienceSetter(pool)
 	s.captureOwnerIdentityHandlers = captureOwnerIdentityHandlers{store: capture.NewOwnerIdentityStore(InstallationDB(pool))}
 	s.captureCounterpartyHoldHandlers = captureCounterpartyHoldHandlers{store: capture.NewCounterpartyHoldStore(InstallationDB(pool))}
 	s.claimHandlers = claimHandlers{people: s.peopleStore, deals: deals.NewStore(InstallationDB(pool), DealsInstallation())}

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -210,6 +210,8 @@ type Server struct {
 	// it feeds a /readyz probe and backs the attachment handlers; nil means
 	// a role that stores no objects.
 	blob blobstore.Store
+	// threadAudience applies an owner own decision about a thread they imported.
+	threadAudience *ThreadAudienceSetter
 
 	// vault is the secret store, injected by WithKeyvault. When configured
 	// it feeds a /readyz probe and backs the capture connector-credential

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -39,6 +39,10 @@ func (stubs) RelinkThread(w nethttp.ResponseWriter, r *nethttp.Request, params c
 	httperr.NotImplemented(w, r, "RelinkThread")
 }
 
+func (stubs) SetThreadAudience(w nethttp.ResponseWriter, r *nethttp.Request, threadKey string) {
+	httperr.NotImplemented(w, r, "SetThreadAudience")
+}
+
 func (stubs) ArchiveActivity(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.ArchiveActivityParams) {
 	httperr.NotImplemented(w, r, "ArchiveActivity")
 }

--- a/backend/internal/compose/threadaudience.go
+++ b/backend/internal/compose/threadaudience.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// An owner deciding, for themselves, whether a thread is the team's to read.
+//
+// The classifier answers first and is usually right; this is what happens when
+// it is not. A founder whose customer thread was held as `legal` shares it; a
+// rep whose ordinary-looking thread turned personal keeps it private. Either
+// way the decision is the owner's OWN contribution to the message's audience —
+// it never overrules a colleague, because a message reaching two mailboxes
+// ends at the strictest of what the two of them ask for.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// ThreadAudienceOutcome reports what an owner's decision did, and — when it did
+// less than they asked — why.
+type ThreadAudienceOutcome struct {
+	// Messages is how many of the thread's messages this seat imported and the
+	// decision therefore reached.
+	Messages int `json:"messages"`
+	// Shared reports whether the messages are now readable by the workspace.
+	// False after a share means somebody else still holds them.
+	Shared bool `json:"shared"`
+	// HeldByOthers names how many OTHER seats still ask for the thread to be
+	// held. Reported by count and never by name or reason: whose mail a person
+	// keeps private is itself private, and "your colleague is holding this"
+	// already says more than a held message should.
+	HeldByOthers int `json:"held_by_others"`
+}
+
+// ThreadAudienceSetter applies an owner's decision to their own view of a
+// thread.
+type ThreadAudienceSetter struct {
+	pool    *pgxpool.Pool
+	threads *capture.ThreadVerdictStore
+}
+
+// NewThreadAudienceSetter builds the setter over one database.
+func NewThreadAudienceSetter(pool *pgxpool.Pool) *ThreadAudienceSetter {
+	return &ThreadAudienceSetter{
+		pool:    pool,
+		threads: capture.NewThreadVerdictStore(InstallationDB(pool)),
+	}
+}
+
+// Decide records what this owner concluded and re-derives every message of the
+// thread they imported.
+//
+// One transaction, so a reader never falls between the ledger row and the
+// audience of the messages it governs — a thread that said one thing and showed
+// another for even a moment is a thread somebody screenshotted.
+func (s *ThreadAudienceSetter) Decide(ctx context.Context, threadKey string, share bool) (ThreadAudienceOutcome, error) {
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Type != principal.PrincipalHuman || actor.UserID == ids.Nil {
+		return ThreadAudienceOutcome{}, apperrors.ErrPermissionDenied
+	}
+	if threadKey == "" {
+		return ThreadAudienceOutcome{}, apperrors.ErrNotFound
+	}
+	var outcome ThreadAudienceOutcome
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		// The seat's OWN messages on the thread. A caller who imported none has
+		// nothing to decide about, and answering not-found rather than zero
+		// keeps a thread key from confirming that somebody else's thread exists.
+		messages, err := capture.ThreadActivityIDsTx(ctx, tx, threadKey, actor.UserID)
+		if err != nil {
+			return err
+		}
+		if len(messages) == 0 {
+			return apperrors.ErrNotFound
+		}
+		if err := s.threads.DecideAsOwner(ctx, tx, threadKey, share); err != nil {
+			return err
+		}
+		for _, id := range messages {
+			if err := activities.RecomputeAudienceTx(ctx, tx, ids.From[ids.ActivityKind](id)); err != nil {
+				return err
+			}
+		}
+		outcome.Messages = len(messages)
+		held, err := othersHoldingTx(ctx, tx, threadKey, actor.UserID)
+		if err != nil {
+			return err
+		}
+		outcome.HeldByOthers = held
+		outcome.Shared = share && held == 0
+		return nil
+	})
+	if err != nil {
+		return ThreadAudienceOutcome{}, err
+	}
+	return outcome, nil
+}
+
+// othersHoldingTx counts the OTHER seats whose contribution still holds this
+// thread's messages.
+//
+// It is what makes a share honest: an owner who shares a thread a colleague is
+// holding gets a 200 and a message that stayed private, and being told the
+// count is the difference between "the product ignored me" and "somebody else
+// has a say here too".
+func othersHoldingTx(ctx context.Context, tx pgx.Tx, threadKey string, user ids.UUID) (int, error) {
+	var held int
+	if err := tx.QueryRow(ctx, `
+		SELECT count(DISTINCT i.user_id)
+		  FROM capture_import i
+		  JOIN activity a ON a.id = i.activity_id
+		 WHERE a.thread_key = $1 AND a.restricted_at IS NULL
+		   AND i.user_id <> $2
+		   AND (coalesce(i.posture_at_import, 'shared') <> 'shared'
+		        OR i.verdict_status IN ('held', 'unsure', 'held_by_owner', 'pending'))`,
+		threadKey, user).Scan(&held); err != nil {
+		return 0, fmt.Errorf("compose: counting the seats still holding a thread: %w", err)
+	}
+	return held, nil
+}

--- a/backend/internal/compose/threadaudience.go
+++ b/backend/internal/compose/threadaudience.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -69,6 +70,15 @@ func (s *ThreadAudienceSetter) Decide(ctx context.Context, threadKey string, sha
 	if !ok || actor.Type != principal.PrincipalHuman || actor.UserID == ids.Nil {
 		return ThreadAudienceOutcome{}, apperrors.ErrPermissionDenied
 	}
+	// A read seat is licensed to look, not to change what colleagues can read.
+	// The same pair the purge takes, and for the same reason: being a person is
+	// not a grant, and RequireHuman inside the store reads none.
+	if !actor.SeatType.CanMutate() {
+		return ThreadAudienceOutcome{}, apperrors.ErrPermissionDenied
+	}
+	if err := auth.Require(ctx, "activity", principal.ActionUpdate); err != nil {
+		return ThreadAudienceOutcome{}, err
+	}
 	if threadKey == "" {
 		return ThreadAudienceOutcome{}, apperrors.ErrNotFound
 	}
@@ -93,7 +103,7 @@ func (s *ThreadAudienceSetter) Decide(ctx context.Context, threadKey string, sha
 			}
 		}
 		outcome.Messages = len(messages)
-		held, err := othersHoldingTx(ctx, tx, threadKey, actor.UserID)
+		held, err := othersHoldingTx(ctx, tx, messages, actor.UserID)
 		if err != nil {
 			return err
 		}
@@ -107,24 +117,39 @@ func (s *ThreadAudienceSetter) Decide(ctx context.Context, threadKey string, sha
 	return outcome, nil
 }
 
-// othersHoldingTx counts the OTHER seats whose contribution still holds this
-// thread's messages.
+// othersHoldingTx counts the OTHER seats whose contribution still holds the
+// caller's OWN messages.
 //
 // It is what makes a share honest: an owner who shares a thread a colleague is
 // holding gets a 200 and a message that stayed private, and being told the
 // count is the difference between "the product ignored me" and "somebody else
 // has a say here too".
-func othersHoldingTx(ctx context.Context, tx pgx.Tx, threadKey string, user ids.UUID) (int, error) {
+//
+// Over the activity ids the caller imported, NEVER over the thread key. A
+// thread key is the RFC822 References root taken verbatim from a sender's
+// header, so it is both guessable and forgeable, and the workspace shares one
+// namespace of them. Counting by thread key would walk messages the caller
+// never received — and a capture_import row is itself an arm of the audience
+// gate (platform/auth ActivityContentClause), so the count would read exactly
+// the membership a held message hides. A seat could then map which colleagues
+// are on which private conversations, one thread key at a time, without ever
+// reading a word of them.
+//
+// It is also the honest number: the caller is owed how many colleagues co-hold
+// THEIR messages, not how many hold a stranger's message that happens to carry
+// the same header value.
+func othersHoldingTx(ctx context.Context, tx pgx.Tx, messages []ids.UUID, user ids.UUID) (int, error) {
+	if len(messages) == 0 {
+		return 0, nil
+	}
 	var held int
 	if err := tx.QueryRow(ctx, `
 		SELECT count(DISTINCT i.user_id)
 		  FROM capture_import i
-		  JOIN activity a ON a.id = i.activity_id
-		 WHERE a.thread_key = $1 AND a.restricted_at IS NULL
-		   AND i.user_id <> $2
+		 WHERE i.activity_id = ANY($1) AND i.user_id <> $2
 		   AND (coalesce(i.posture_at_import, 'shared') <> 'shared'
 		        OR i.verdict_status IN ('held', 'unsure', 'held_by_owner', 'pending'))`,
-		threadKey, user).Scan(&held); err != nil {
+		messages, user).Scan(&held); err != nil {
 		return 0, fmt.Errorf("compose: counting the seats still holding a thread: %w", err)
 	}
 	return held, nil

--- a/backend/internal/compose/threadaudience_integration_test.go
+++ b/backend/internal/compose/threadaudience_integration_test.go
@@ -163,3 +163,36 @@ func recompute(t *testing.T, e *integration.Env, activityID ids.UUID) {
 		t.Fatalf("recomputing the audience: %v", err)
 	}
 }
+
+func TestTheHoldCountReadsOnlyTheCallersOwnMessages(t *testing.T) {
+	// A thread key is the RFC822 References root, taken verbatim from a
+	// sender's header — guessable, forgeable, and shared across one workspace
+	// namespace. Counting holders BY thread key would walk messages the caller
+	// never received, and a capture_import row is itself an arm of the audience
+	// gate: the count would read exactly the membership a held message hides.
+	//
+	// A seat could then map which colleagues are on which private
+	// conversations, one thread key at a time, without reading a word of them.
+	e := integration.Setup(t)
+	const key = "thread-shared-key"
+	// The caller's own message on the thread.
+	mine := seedHeldThreadOn(t, e, key, "kunde@example.test", e.Rep1)
+	// A LATER message on the same thread that only a colleague imported — the
+	// conversation continued without the caller.
+	theirs := seedHeldThreadOn(t, e, key, "kunde@example.test", e.Rep2)
+
+	outcome := decideThread(t, e, e.Rep1, key, true)
+
+	if outcome.HeldByOthers != 0 {
+		t.Fatalf("held_by_others=%d, want 0 — the colleague holds a message this caller never "+
+			"received, and counting it tells them who is on a conversation they are not", outcome.HeldByOthers)
+	}
+	if got := activityAudience(t, e, mine); got != "workspace" {
+		t.Fatalf("the caller's own message is %q, want workspace — nobody else holds it", got)
+	}
+	// And the colleague's message is untouched by a decision that was never
+	// about it.
+	if got := activityAudience(t, e, theirs); got != "participants" {
+		t.Fatalf("the colleague's message is %q, want participants", got)
+	}
+}

--- a/backend/internal/compose/threadaudience_integration_test.go
+++ b/backend/internal/compose/threadaudience_integration_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// An owner's own say over a thread they imported, and the limits on it.
+//
+// The classifier answers first and is usually right; this is what happens when
+// it is not. What the tests below are mostly about is the limits: a share
+// releases the caller's OWN hold and cannot publish what a colleague is still
+// holding, because a message reaching two mailboxes ends at the strictest of
+// what the two of them ask for.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestAnOwnerSharesTheirOwnHeldThread(t *testing.T) {
+	e := integration.Setup(t)
+	id := seedHeldThreadOn(t, e, "thread-share", "kunde@example.test", e.Rep1)
+
+	outcome := decideThread(t, e, e.Rep1, "thread-share", true)
+	if outcome.Messages != 1 || !outcome.Shared {
+		t.Fatalf("messages=%d shared=%v, want 1 and true", outcome.Messages, outcome.Shared)
+	}
+	if got := activityAudience(t, e, id); got != "workspace" {
+		t.Fatalf("a shared thread's message is %q, want workspace", got)
+	}
+}
+
+func TestAnOwnerKeepsAThreadPrivateAgainstTheClassifier(t *testing.T) {
+	// The click has to mean something permanent. A rep whose ordinary-looking
+	// thread turned personal keeps it private, and no later pass may re-open it
+	// — a classifier that could overturn an owner would make the click
+	// advisory.
+	e := integration.Setup(t)
+	id := seedHeldThreadOn(t, e, "thread-hold", "privat@example.test", e.Rep1)
+	setImportVerdict(t, e, id, e.Rep1, "cleared")
+	recompute(t, e, id)
+	if got := activityAudience(t, e, id); got != "workspace" {
+		t.Fatalf("the fixture starts %q, want workspace — otherwise the hold below proves nothing", got)
+	}
+
+	outcome := decideThread(t, e, e.Rep1, "thread-hold", false)
+	if outcome.Shared {
+		t.Fatal("keeping a thread private reported it as shared")
+	}
+	if got := activityAudience(t, e, id); got != "participants" {
+		t.Fatalf("a thread the owner kept private is %q, want participants", got)
+	}
+	if got := importVerdictFor(t, e, id, e.Rep1); got != "held_by_owner" {
+		t.Fatalf("the owner's contribution says %q, want held_by_owner — a person's answer is not a classifier's", got)
+	}
+}
+
+func TestOneOwnersShareCannotPublishAColleaguesHeldMessage(t *testing.T) {
+	// The whole per-owner model, at the point where it is easiest to break.
+	e := integration.Setup(t)
+	id := seedHeldThreadOn(t, e, "thread-both", "kunde@example.test", e.Rep1)
+	addImportRowFor(t, e, id, e.Rep2)
+
+	outcome := decideThread(t, e, e.Rep1, "thread-both", true)
+
+	if outcome.HeldByOthers != 1 {
+		t.Fatalf("held_by_others=%d, want 1 — the caller is owed the fact that somebody else has a say", outcome.HeldByOthers)
+	}
+	if outcome.Shared {
+		t.Fatal("the share reported success while a colleague was still holding the message")
+	}
+	if got := activityAudience(t, e, id); got != "participants" {
+		t.Fatalf("the message is %q, want participants — one owner cannot publish what another holds", got)
+	}
+	// And the colleague's own contribution is untouched.
+	if got := importVerdictFor(t, e, id, e.Rep2); got != "pending" {
+		t.Fatalf("the colleague's contribution says %q, want pending", got)
+	}
+}
+
+func TestAThreadYouDidNotImportIsNotFound(t *testing.T) {
+	// A thread key is the sender-controlled References root in a namespace the
+	// whole workspace shares, so it is guessable. Answering not-found rather
+	// than "nothing to do" keeps it from confirming that somebody else's
+	// correspondence exists.
+	e := integration.Setup(t)
+	seedHeldThreadOn(t, e, "thread-theirs", "kunde@example.test", e.Rep1)
+
+	_, err := NewThreadAudienceSetter(e.Pool).Decide(purgeCtx(e, e.Rep2), "thread-theirs", true)
+	if err == nil {
+		t.Fatal("a seat decided about a thread they never imported")
+	}
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("err = %v, want not-found — a refusal that named the thread would confirm it exists", err)
+	}
+}
+
+func decideThread(t *testing.T, e *integration.Env, user ids.UUID, threadKey string, share bool) ThreadAudienceOutcome {
+	t.Helper()
+	outcome, err := NewThreadAudienceSetter(e.Pool).Decide(purgeCtx(e, user), threadKey, share)
+	if err != nil {
+		t.Fatalf("deciding about the thread: %v", err)
+	}
+	return outcome
+}
+
+// seedHeldThreadOn lands one held message on a thread with the import row that
+// makes the seeding seat its importer.
+func seedHeldThreadOn(t *testing.T, e *integration.Env, threadKey, from string, user ids.UUID) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO activity (id, kind, subject, body, direction, source_system, source_id,
+			                      source, captured_by, counterparty_email, thread_key,
+			                      audience, audience_reason)
+			VALUES ($1, 'email', 'Betreff', 'the message body', 'inbound', 'gmail', $2,
+			        'gmail:'||$2, 'connector:gmail', $3, $4, 'participants', 'pending_verdict')`,
+			id, "th-"+id.String(), from, threadKey); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_import (activity_id, user_id, posture_at_import, verdict_status)
+			VALUES ($1, $2, 'classified', 'pending')`, id, user)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding thread mail: %v", err)
+	}
+	return id
+}
+
+func setImportVerdict(t *testing.T, e *integration.Env, activityID, user ids.UUID, status string) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			UPDATE capture_import SET verdict_status = $3
+			 WHERE activity_id = $1 AND user_id = $2`, activityID, user, status)
+		return err
+	}); err != nil {
+		t.Fatalf("setting the import verdict: %v", err)
+	}
+}
+
+// recompute re-derives one message's audience the way every writer does, so a
+// fixture that sets a contribution directly still reaches the state production
+// would have reached.
+func recompute(t *testing.T, e *integration.Env, activityID ids.UUID) {
+	t.Helper()
+	ctx := purgeCtx(e, e.Rep1)
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return activities.RecomputeAudienceTx(ctx, tx, ids.From[ids.ActivityKind](activityID))
+	}); err != nil {
+		t.Fatalf("recomputing the audience: %v", err)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -26689,6 +26689,20 @@ type TechnicalEnrichStatus struct {
 	OrganizationId openapi_types.UUID    `json:"organization_id"`
 }
 
+// ThreadAudienceOutcome What an owner's decision about a thread reached.
+type ThreadAudienceOutcome struct {
+	// HeldByOthers How many other seats still ask for this thread to be held. A count and never a name:
+	// whose mail a person keeps private is itself private.
+	HeldByOthers int `json:"held_by_others"`
+
+	// Messages How many of the thread's messages you imported, and the decision reached.
+	Messages int `json:"messages"`
+
+	// Shared Whether the messages are now readable by the workspace. False after a share means
+	// somebody else still holds them.
+	Shared bool `json:"shared"`
+}
+
 // TranscriptReadReport What one reading of one transcript did. The three outcomes are kept apart on purpose: still reading, read it and it stated nothing, and could not read it are different answers, and collapsing the last two makes a correct empty result look like a broken feature.
 type TranscriptReadReport struct {
 	ActivityId openapi_types.UUID `json:"activity_id"`
@@ -28455,6 +28469,12 @@ type RelinkThreadParams struct {
 	// than half-honouring it, so read this contract, not the client, to know which calls are safe
 	// to retry blind.
 	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
+}
+
+// SetThreadAudienceJSONBody defines parameters for SetThreadAudience.
+type SetThreadAudienceJSONBody struct {
+	// Share True to share the thread with the workspace, false to keep it private.
+	Share bool `json:"share"`
 }
 
 // ArchiveActivityParams defines parameters for ArchiveActivity.
@@ -32700,6 +32720,9 @@ type RelinkActivitiesJSONRequestBody = RelinkActivitiesRequest
 
 // RelinkThreadJSONRequestBody defines body for RelinkThread for application/json ContentType.
 type RelinkThreadJSONRequestBody = RelinkThreadRequest
+
+// SetThreadAudienceJSONRequestBody defines body for SetThreadAudience for application/json ContentType.
+type SetThreadAudienceJSONRequestBody SetThreadAudienceJSONBody
 
 // UpdateActivityJSONRequestBody defines body for UpdateActivity for application/json ContentType.
 type UpdateActivityJSONRequestBody = UpdateActivityRequest
@@ -40989,6 +41012,9 @@ type ServerInterface interface {
 	// Re-associate every activity of one conversation thread to a chosen record, in one transaction.
 	// (POST /activities/relink-thread)
 	RelinkThread(w http.ResponseWriter, r *http.Request, params RelinkThreadParams)
+	// Share a thread with the team, or keep it private.
+	// (POST /activities/threads/{thread_key}/audience)
+	SetThreadAudience(w http.ResponseWriter, r *http.Request, threadKey string)
 	// Archive (soft-delete) an activity.
 	// (DELETE /activities/{id})
 	ArchiveActivity(w http.ResponseWriter, r *http.Request, id Id, params ArchiveActivityParams)
@@ -42588,6 +42614,12 @@ func (_ Unimplemented) RelinkActivities(w http.ResponseWriter, r *http.Request, 
 // Re-associate every activity of one conversation thread to a chosen record, in one transaction.
 // (POST /activities/relink-thread)
 func (_ Unimplemented) RelinkThread(w http.ResponseWriter, r *http.Request, params RelinkThreadParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Share a thread with the team, or keep it private.
+// (POST /activities/threads/{thread_key}/audience)
+func (_ Unimplemented) SetThreadAudience(w http.ResponseWriter, r *http.Request, threadKey string) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -46092,6 +46124,38 @@ func (siw *ServerInterfaceWrapper) RelinkThread(w http.ResponseWriter, r *http.R
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.RelinkThread(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SetThreadAudience operation middleware
+func (siw *ServerInterfaceWrapper) SetThreadAudience(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "thread_key" -------------
+	var threadKey string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "thread_key", chi.URLParam(r, "thread_key"), &threadKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "thread_key", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SetThreadAudience(w, r, threadKey)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -69138,6 +69202,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/activities/relink-thread", wrapper.RelinkThread)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/activities/threads/{thread_key}/audience", wrapper.SetThreadAudience)
 	})
 	r.Group(func(r chi.Router) {
 		r.Delete(options.BaseURL+"/activities/{id}", wrapper.ArchiveActivity)

--- a/backend/internal/modules/activities/audience.go
+++ b/backend/internal/modules/activities/audience.go
@@ -71,6 +71,19 @@ func (s *Store) SetAudience(ctx context.Context, id ids.ActivityID, in SetAudien
 		if err := auth.EnsureActivityWritable(ctx, tx, id.UUID); err != nil {
 			return err
 		}
+		// A CAPTURED message is not one person's to set.
+		//
+		// Its audience is derived across every mailbox that imported it, and
+		// each importer's contribution is theirs alone — so writing the column
+		// directly would either override a colleague's hold or be silently
+		// undone by the next recompute, and both are worse than a refusal. The
+		// owner endpoint changes the contribution instead, which is the thing
+		// the derivation actually reads.
+		//
+		// A hand-logged row has no contributors and stays writable here.
+		if err := refuseCapturedAudienceWrite(ctx, tx, id); err != nil {
+			return err
+		}
 		if err := ensureVersion(ctx, tx, id, in.IfVersion); err != nil {
 			return err
 		}
@@ -299,4 +312,39 @@ func (e *InvalidAudienceError) Error() string {
 // field.
 func (e *InvalidAudienceError) FieldFault() (field, code, message string) {
 	return "audience", "invalid_audience", e.Error()
+}
+
+// refuseCapturedAudienceWrite stops a direct audience write on a message a
+// mailbox brought in.
+//
+// The test is whether any seat has an import row: that is what makes the
+// audience derived rather than declared. A row with none was hand-logged, and
+// its audience is exactly what somebody set.
+func refuseCapturedAudienceWrite(ctx context.Context, tx pgx.Tx, id ids.ActivityID) error {
+	var imported bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM capture_import WHERE activity_id = $1)`,
+		id.UUID).Scan(&imported); err != nil {
+		return fmt.Errorf("activities: reading whether a message was imported: %w", err)
+	}
+	if imported {
+		return &CapturedAudienceError{}
+	}
+	return nil
+}
+
+// CapturedAudienceError refuses a direct audience write on captured mail and
+// says where the decision belongs instead.
+type CapturedAudienceError struct{}
+
+func (e *CapturedAudienceError) Error() string {
+	return "activities: a captured message's audience is derived from its importers; " +
+		"share or hold the thread instead"
+}
+
+// FieldFault maps the refusal onto the wire.
+func (e *CapturedAudienceError) FieldFault() (field, code, message string) {
+	return "audience", "audience_is_derived",
+		"This message came from a mailbox, so who can read it follows from what each " +
+			"importing mailbox asks for. Share or keep the thread private instead."
 }

--- a/backend/internal/modules/capture/threadverdict.go
+++ b/backend/internal/modules/capture/threadverdict.go
@@ -405,6 +405,7 @@ func (s *ThreadVerdictStore) DecideAsOwner(
 		 WHERE a.id = i.activity_id
 		   AND a.thread_key = $1
 		   AND a.restricted_at IS NULL
+		   AND a.archived_at IS NULL
 		   AND i.user_id = $2`, threadKey, actor.UserID, status); err != nil {
 		return fmt.Errorf("capture: applying the owner's decision to their import rows: %w", err)
 	}

--- a/backend/internal/modules/capture/threadverdict.go
+++ b/backend/internal/modules/capture/threadverdict.go
@@ -22,8 +22,11 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -341,4 +344,103 @@ func openConfidentialityQuestionTx(
 	// touches no pool, which is what lets the capture path and the engine share
 	// one spelling of what opening a question means.
 	return (&ThreadVerdictStore{}).EnsureTx(ctx, tx, rec.ThreadKey, owner, id.UUID, time.Now())
+}
+
+// DecideAsOwner records what the mailbox owner themselves concluded about a
+// thread, overruling whatever a classifier said.
+//
+// A human decision is not a verdict with a different author: it is the end of
+// the question. The row resolves, its attempts stop mattering, and no later
+// pass re-asks — a classifier that could overturn an owner would make the
+// owner's click advisory, which is not what a person clicking "keep this
+// private" is told they are doing.
+//
+// Own thread only. The ledger is per seat, so the row this writes is the
+// caller's own contribution and no other seat's is touched: a thread reaching
+// two mailboxes ends at the strictest of what the two of them ask for, and one
+// owner sharing cannot publish what the other holds.
+func (s *ThreadVerdictStore) DecideAsOwner(
+	ctx context.Context, tx pgx.Tx, threadKey string, share bool,
+) error {
+	if err := auth.RequireHuman(ctx); err != nil {
+		return err
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID == ids.Nil {
+		return apperrors.ErrPermissionDenied
+	}
+	status := VerdictHeldByOwner
+	if share {
+		status = VerdictSharedByOwner
+	}
+	// Upserted, because a thread the owner decides about may have no ledger row
+	// at all: a message born open under a `shared` mailbox never opened a
+	// question, and its owner may still want it held.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO capture_thread_verdict
+		  (thread_key, user_id, status, disposition_reason, resolved_at, next_attempt_at)
+		VALUES ($1, $2, $3, $4, now(), NULL)
+		ON CONFLICT (thread_key, user_id) DO UPDATE
+		   SET status = EXCLUDED.status,
+		       disposition_reason = EXCLUDED.disposition_reason,
+		       resolved_at = now(),
+		       next_attempt_at = NULL,
+		       claimed_by = NULL, claimed_until = NULL,
+		       updated_at = now()`,
+		threadKey, actor.UserID, status, ownerDecisionReason); err != nil {
+		return fmt.Errorf("capture: recording the owner's decision about a thread: %w", err)
+	}
+	// The seat's own import rows for the thread, which is what the audience
+	// derivation reads. Without this the ledger would carry a decision nothing
+	// acts on.
+	// restricted_at excluded: a message under a statutory hold or an open
+	// erasure is not one an owner's click may move. The hold is an obligation
+	// the installation owes somebody else, and it outranks both directions of
+	// this decision — sharing a held message would publish it, and re-holding
+	// one changes nothing a hold has not already done.
+	if _, err := tx.Exec(ctx, `
+		UPDATE capture_import i
+		   SET verdict_status = $3
+		  FROM activity a
+		 WHERE a.id = i.activity_id
+		   AND a.thread_key = $1
+		   AND a.restricted_at IS NULL
+		   AND i.user_id = $2`, threadKey, actor.UserID, status); err != nil {
+		return fmt.Errorf("capture: applying the owner's decision to their import rows: %w", err)
+	}
+	return nil
+}
+
+// ownerDecisionReason marks a ledger row a person settled, so a reader can tell
+// it from one a classifier reached.
+const ownerDecisionReason = "owner_decision"
+
+// ThreadActivityIDsTx lists the messages of one thread this seat imported.
+//
+// Scoped to the caller's own imports rather than to the thread key alone: a
+// thread key is the sender-controlled References root in a workspace-wide
+// namespace, so a walk over it would reach messages this seat never received.
+func ThreadActivityIDsTx(ctx context.Context, tx pgx.Tx, threadKey string, user ids.UUID) ([]ids.UUID, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT a.id FROM activity a
+		  JOIN capture_import i ON i.activity_id = a.id AND i.user_id = $2
+		 WHERE a.thread_key = $1 AND a.archived_at IS NULL
+		   AND a.restricted_at IS NULL
+		 ORDER BY a.id`, threadKey, user)
+	if err != nil {
+		return nil, fmt.Errorf("capture: listing a thread's messages: %w", err)
+	}
+	defer rows.Close()
+	var out []ids.UUID
+	for rows.Next() {
+		var id ids.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("capture: listing a thread's messages: %w", err)
+		}
+		out = append(out, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("capture: listing a thread's messages: %w", err)
+	}
+	return out, nil
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5528,6 +5528,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/activities/threads/{thread_key}/audience": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The thread's key, as an activity reports it. */
+                thread_key: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Share a thread with the team, or keep it private.
+         * @description Your own view of the thread, and only yours. A message that reached two mailboxes is two
+         *     people's correspondence: each of you contributes what you ask for, and the message ends at
+         *     the strictest of those. So sharing releases YOUR hold — it cannot publish what a colleague
+         *     is still holding, and the response says how many other seats are.
+         *
+         *     This overrules the classifier, and permanently: a thread you decided about is not re-judged
+         *     later. That is what "keep this private" has to mean for the click to be worth making.
+         *
+         *     Only threads you imported. A thread key you were not on answers not-found, because whether
+         *     somebody else's correspondence exists is not a thing to confirm.
+         */
+        post: operations["setThreadAudience"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/capture/counterparty-holds": {
         parameters: {
             query?: never;
@@ -12373,6 +12405,21 @@ export interface components {
             verified: boolean;
             /** Format: date-time */
             created_at?: string;
+        };
+        /** @description What an owner's decision about a thread reached. */
+        ThreadAudienceOutcome: {
+            /** @description How many of the thread's messages you imported, and the decision reached. */
+            messages: number;
+            /**
+             * @description Whether the messages are now readable by the workspace. False after a share means
+             *     somebody else still holds them.
+             */
+            shared: boolean;
+            /**
+             * @description How many other seats still ask for this thread to be held. A count and never a name:
+             *     whose mail a person keeps private is itself private.
+             */
+            held_by_others: number;
         };
         /**
          * @description What a purge destroyed, or what a preview says it would. The four counts are disjoint and
@@ -34847,6 +34894,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CapturePurgeOutcome"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    setThreadAudience: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The thread's key, as an activity reports it. */
+                thread_key: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description True to share the thread with the workspace, false to keep it private. */
+                    share: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description What the decision reached. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThreadAudienceOutcome"];
                 };
             };
             401: components["responses"]["Unauthorized"];


### PR DESCRIPTION
Part of the mailbox-privacy work. The classifier answers first and is usually right. **This is what happens when it is not**: a founder whose customer thread was held as `legal` shares it; a rep whose ordinary-looking thread turned personal keeps it private.

`POST /v1/activities/threads/{thread_key}/audience {share}`

## A share releases your hold and nobody else's

A message that reached two mailboxes is two people's correspondence, and it ends at the strictest of what the two of them ask for. So a share can return 200 and leave the message private, with `held_by_others: 1` saying why.

That count is a **number, never a name and never a reason**. Whose mail a person keeps private is itself private, and "your colleague is holding this" already says more than a held message should. Returning nothing would read as the product ignoring the click, which is why the count is there at all.

## The decision is permanent

A thread an owner settled is not re-judged, and its ledger row resolves rather than waiting for another pass. A classifier that could overturn an owner would make the click advisory — not what a person clicking "keep this private" is told they are doing.

## `SetAudience` now refuses a captured row

Its audience is *derived* across every importing mailbox. Writing the column directly would either override a colleague's hold or be silently undone by the next recompute — and the silent undo is worse, because the person who clicked would believe it worked. A hand-logged row has no importers and stays directly writable.

## Two findings from an adversarial review

**`held_by_others` was a colleague-presence oracle.** It counted holders *by thread key* — the one query on this path not scoped to the caller's own imports. A thread key is the RFC822 References root taken verbatim from a sender's header, so it is guessable and forgeable, and one namespace is shared by the whole workspace.

That is a disclosure, not an off-by-one. A `capture_import` row is itself an arm of the audience gate (`platform/auth` `ActivityContentClause`): a `participants` message is invisible to a non-participant, and its `thread_key` is nulled on the wire for a withheld reader. Counting import rows on those messages reads exactly the membership the hold hides — so a seat could map which colleagues are on which private conversations, one thread key at a time, without reading a word of them.

Now counted over the activity ids the caller imported, which `Decide` already has in hand. That is also the honest number: an owner is owed how many colleagues co-hold *their* messages.

**No object grant and no seat tier.** `RequireHuman` refuses an agent and reads no grant at all, so a read seat could change what colleagues can read. Same gap the purge had, closed the same way — being a person is not authorization.

## Tests

`TestAnOwnerSharesTheirOwnHeldThread`, `TestAnOwnerKeepsAThreadPrivateAgainstTheClassifier`, `TestOneOwnersShareCannotPublishAColleaguesHeldMessage`, `TestAThreadYouDidNotImportIsNotFound`, `TestTheHoldCountReadsOnlyTheCallersOwnMessages`.

Both invariants mutation-checked. Dropping the `user_id` scope from `DecideAsOwner` publishes a colleague's held message; restoring the thread-key count reproduces the oracle exactly (`held_by_others=1` for a message the caller never received).

## Verification

`make check-backend`, all gates and the compose integration lane green locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `POST /v1/activities/threads/{thread_key}/audience` so a thread's owner can share it with the workspace or keep it private, overruling the classifier permanently.

**Behavior**

- A share releases only the caller's own hold; the response counts other seats still holding the thread, and `shared` stays false while a colleague's hold keeps the message private.
- The count is a number only — never a name or reason.
- `SetAudience` now refuses captured rows because their audience derives from importers; hand-logged rows stay writable.
- Restricted (statutory hold) and archived messages are excluded from the decision.

**Security**

- `held_by_others` counts only the caller's own imported messages, closing a disclosure that could map colleagues onto private conversations via guessable thread keys.
- The endpoint requires a human actor with a mutating seat; being a person alone is not authorization.

<sup>Written for commit 636e7ee192af8fe0d54eebc3174059fc182b8e18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way for eligible users to choose whether imported activity threads are shared or kept private.
  * Added visibility results showing imported message counts, sharing status, and how many other seats still hold the thread.
  * Added clear authorization and not-found handling for thread sharing decisions.

* **Bug Fixes**
  * Prevented direct visibility changes for imported activities whose audience is derived from mailbox decisions.
  * Preserved direct audience updates for manually logged activities.

* **Tests**
  * Added coverage for sharing, private holds, authorization, ownership, and unrelated message preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->