### PR TITLE
fix(compose): main is red on an embedded-field selector

### DIFF
--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -150,7 +150,7 @@ func WithBlobstore(store blobstore.Store) Option {
 		// no objects has no purge, which is honest — destroying the rows and
 		// leaving the files would report mail as gone while its attachments sat
 		// in the bucket.
-		s.captureExclusionHandlers.purger = NewCapturePurger(pool,
+		s.purger = NewCapturePurger(pool,
 			NewRetentionServiceFor(InstallationDB(pool), store, slog.Default()))
 		// Captured mail carries files too. Recorded as the STORE, which the sink
 		// turns into a writer when it is built: a keeper assigned here would be


### PR DESCRIPTION
`make lint` fails on a clean checkout of main. Verified by checking out `origin/main` detached and running it there — the finding is not from any feature branch.

```
internal/compose/serveroptions.go:153:5: QF1008: could remove embedded field "captureExclusionHandlers" from selector (staticcheck)
```

Landed with #3382. One line, no behaviour change: `s.purger` reaches the same field through the embedded struct.

Filed as its own PR rather than folded into the feature branch I was on, so it lands whether or not that one does.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes an unnecessary embedded field selector that made `make lint` fail on a clean checkout of main. The assignment now uses `s.purger` directly, which reaches the same field without triggering staticcheck's QF1008, and behavior is unchanged.

<sup>Written for commit f62c2bd6d7d9f791f88802cc04c2cb07bc33ab89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected capture cleanup handling so expired data is purged as expected.
  * Retention behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->