### PR TITLE
feat(company): a role the product read can be confirmed or corrected

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -23902,6 +23902,31 @@ components:
         full_name: { type: string }
         role: { type: string }
         engagement: { $ref: '#/components/schemas/ContactEngagement' }
+        relationship_version:
+          type: integer
+          format: int64
+          minimum: 1
+          description: |
+            The seat row's version, for the `If-Match` a patch against it carries.
+
+            Without it a reader confirming a role would overwrite whatever a colleague
+            changed while the page was open, and the write that lost would leave no
+            trace — the point of the conditional write is that the second one is
+            refused rather than silently winning.
+        relationship_id:
+          type: string
+          format: uuid
+          description: |
+            The seat's own row, which is what a reader patches to disagree with it —
+            confirming the role, or changing it.
+
+            Carried for every seat rather than only a read one. A colleague correcting
+            a role another colleague typed is the same write on the same row, and
+            omitting the id there would leave exactly the human-typed seats
+            uncorrectable from this card.
+
+            Absent only when the caller lacks the relationship grant, which is the same
+            condition that withholds the committee itself.
         ai_suggested:
           type: boolean
           description: |

--- a/backend/internal/compose/integration/org360/org360_roleproposals_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_roleproposals_integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/integration"
 	org360svc "github.com/margince/margince/backend/internal/compose/org360"
+	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
@@ -447,4 +448,114 @@ func blockFor(t *testing.T, prompt, mine, theirs string) string {
 		return rest[:end]
 	}
 	return rest
+}
+
+// CONFIRMING IS AN EDIT THAT CHANGES NOTHING, AND IT STILL CLEARS THE MARK.
+//
+// The card's Confirm sends the seat's role back unchanged, and the whole
+// design rests on the relationship writer reassigning captured_by to whoever
+// edits. If that writer ever short-circuits a patch whose fields all match,
+// Confirm becomes a button that reports success and changes nothing — the mark
+// stays, the reader presses it again, and nothing they do ever takes.
+func TestConfirmingAReadRoleClearsTheMarkWithoutChangingIt(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+	svc := org360Service(e)
+
+	org, deal := seedRoleDeal(t, e)
+	buyer := e.SeedPerson(t, "Ute Sommer", nil)
+	employ(t, e, buyer, org, "Chief Financial Officer")
+	source := wrote(t, e, buyer, org, "Re: Angebot",
+		"I sign off the budget for this, so send the figures to me directly.", 3)
+
+	lane := &scriptedLane{reply: `{"proposals":[{
+		"person_id":"` + buyer.String() + `","role":"economic_buyer",
+		"evidence_snippet":"I sign off the budget for this, so send",
+		"source_id":"` + source.String() + `","confidence":0.9}]}`}
+	if _, err := svc.ProposeRoles(ctx, lane, ids.DealID{UUID: deal}); err != nil {
+		t.Fatalf("proposing roles: %v", err)
+	}
+
+	before, err := svc.Coverage(ctx, ids.OrganizationID{UUID: org})
+	if err != nil {
+		t.Fatalf("reading coverage: %v", err)
+	}
+	seat := before.Committee.Seats[0]
+	if seat.AiSuggested == nil || !*seat.AiSuggested {
+		t.Fatal("the written seat is not marked, so the clearing below proves nothing")
+	}
+	if seat.RelationshipId == nil || seat.RelationshipVersion == nil {
+		t.Fatal("the seat carries no row to patch, so the card cannot confirm it")
+	}
+
+	// Exactly what the card sends: the same role, nothing else.
+	role := seat.Role
+	if _, err := e.People.UpdateRelationship(ctx, ids.UUID(*seat.RelationshipId),
+		people.UpdateRelationshipInput{Role: &role}); err != nil {
+		t.Fatalf("confirming the seat: %v", err)
+	}
+
+	after, err := svc.Coverage(ctx, ids.OrganizationID{UUID: org})
+	if err != nil {
+		t.Fatalf("re-reading coverage: %v", err)
+	}
+	confirmed := after.Committee.Seats[0]
+	if confirmed.AiSuggested != nil && *confirmed.AiSuggested {
+		t.Fatal("the mark survived a human's edit, so Confirm reports success and does nothing")
+	}
+	if confirmed.Role != role {
+		t.Fatalf("confirming changed the role to %q", confirmed.Role)
+	}
+}
+
+// A PERSON CAN HOLD TWO ROLES ON ONE DEAL, and each card must address its own
+// row.
+//
+// The table's uniqueness key is (deal_id, person_id, role), so this is a shape
+// the database permits. Keyed by person alone, both cards carried whichever
+// row the scan returned last — so Confirm on one patched the other, changing a
+// role the reader was not looking at or colliding with the uniqueness index.
+func TestASeatCardAddressesItsOwnRowWhenAPersonHoldsTwoRoles(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+	svc := org360Service(e)
+
+	org, deal := seedRoleDeal(t, e)
+	both := e.SeedPerson(t, "Ute Sommer", nil)
+	employ(t, e, both, org, "Chief Financial Officer")
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, deal_id, role, source, captured_by)
+		VALUES ('deal_stakeholder', $1, $2, 'economic_buyer', 'manual', 'human:x')`, both, deal)
+	e.WsExec(t, `INSERT INTO relationship (kind, person_id, deal_id, role, source, captured_by)
+		VALUES ('deal_stakeholder', $1, $2, 'champion', 'ai_proposal', 'agent:propose_roles')`,
+		both, deal)
+
+	got, err := svc.Coverage(ctx, ids.OrganizationID{UUID: org})
+	if err != nil {
+		t.Fatalf("reading coverage: %v", err)
+	}
+	rows := map[string]string{}
+	marked := map[string]bool{}
+	for _, seat := range got.Committee.Seats {
+		if seat.RelationshipId == nil {
+			t.Fatalf("seat %q carries no row to patch", seat.Role)
+		}
+		rows[seat.Role] = seat.RelationshipId.String()
+		marked[seat.Role] = seat.AiSuggested != nil && *seat.AiSuggested
+	}
+	if len(rows) != 2 {
+		t.Fatalf("read %d seats for a person holding two roles: %+v", len(rows), rows)
+	}
+	if rows["champion"] == rows["economic_buyer"] {
+		t.Fatalf("both cards address the same row (%s) — confirming one patches the other",
+			rows["champion"])
+	}
+	// And the provenance follows the ROW, not the person: one seat was typed
+	// and one was read, and a mark shared between them would offer to confirm
+	// a colleague's own answer.
+	if !marked["champion"] {
+		t.Fatal("the read seat is not marked")
+	}
+	if marked["economic_buyer"] {
+		t.Fatal("a seat a person typed is marked as the product's reading")
+	}
 }

--- a/backend/internal/compose/org360/coverage.go
+++ b/backend/internal/compose/org360/coverage.go
@@ -239,8 +239,19 @@ func (s *Service) wireCommittee(
 		if route, ok := routes[seat.PersonID]; ok {
 			wire.Routes = &route
 		}
-		if mark, ok := marks[seat.PersonID]; ok && mark.suggested {
-			wire.AiSuggested = &mark.suggested
+		if mark, ok := marks[seatKey{person: seat.PersonID, role: seat.Role}]; ok {
+			if mark.suggested {
+				wire.AiSuggested = &mark.suggested
+			}
+			// Carried for EVERY seat, not only a read one: a colleague changing
+			// a role a colleague typed is the same patch on the same row, and
+			// giving the card the id only where the product happens to have
+			// written the seat would make the human-typed ones the ones a
+			// reader cannot correct.
+			id := openapi_types.UUID(mark.relationshipID)
+			wire.RelationshipId = &id
+			version := mark.version
+			wire.RelationshipVersion = &version
 		}
 		out.Seats = append(out.Seats, wire)
 	}
@@ -331,9 +342,30 @@ func seatCount(ctx context.Context, tx pgx.Tx, dealID ids.DealID) (int, error) {
 	return total, nil
 }
 
+// seatKey identifies ONE seat, which is a person AND a role.
+//
+// The table's own uniqueness key is (deal_id, person_id, role), so a person can
+// legitimately hold two roles on one deal. Keyed by person alone, both cards
+// carried whichever row the scan returned last — so Confirm on one could patch
+// the other, changing a role the reader was not looking at or colliding with
+// the uniqueness index.
+type seatKey struct {
+	person ids.UUID
+	role   string
+}
+
 // seatMark is what a seat's own row says about where it came from.
 type seatMark struct {
 	suggested bool
+	// relationshipID is the seat's own row, which a reader needs in order to
+	// disagree with it. Confirming or changing a role is a patch on THIS row,
+	// and the person id alone cannot name it: the same contact can sit on two
+	// deals, and the two seats are different rows.
+	relationshipID ids.UUID
+	// version is what the seat's patch sends as If-Match. Without it a reader
+	// confirming a role overwrites whatever a colleague changed while the page
+	// was open, and the losing write leaves no trace.
+	version int64
 }
 
 // suggestedSeats reads the provenance of the committee's own rows.
@@ -344,8 +376,8 @@ type seatMark struct {
 // rather than by a column somebody has to remember to set.
 func suggestedSeats(
 	ctx context.Context, tx pgx.Tx, dealID ids.DealID, seats []deals.DealStakeholder,
-) (map[ids.UUID]seatMark, error) {
-	out := map[ids.UUID]seatMark{}
+) (map[seatKey]seatMark, error) {
+	out := map[seatKey]seatMark{}
 	if len(seats) == 0 {
 		return out, nil
 	}
@@ -373,7 +405,7 @@ func suggestedSeats(
 	// archived rows, so filtering ended ones here as well would drop the
 	// provenance of a seat still on the board and quietly unmark it.
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
-		SELECT r.person_id, r.captured_by = $%d
+		SELECT r.person_id, coalesce(r.role, ''), r.captured_by = $%d, r.id, r.version
 		  FROM relationship r
 		 WHERE r.kind = 'deal_stakeholder' AND r.person_id = ANY($%d)
 		   AND r.deal_id = $%d AND r.archived_at IS NULL
@@ -383,12 +415,13 @@ func suggestedSeats(
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var id ids.UUID
+		var key seatKey
 		var mark seatMark
-		if err := rows.Scan(&id, &mark.suggested); err != nil {
+		if err := rows.Scan(&key.person, &key.role, &mark.suggested,
+			&mark.relationshipID, &mark.version); err != nil {
 			return nil, err
 		}
-		out[id] = mark
+		out[key] = mark
 	}
 	return out, rows.Err()
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -22332,7 +22332,27 @@ type OrganizationCoverageSeat struct {
 	Engagement *ContactEngagement `json:"engagement,omitempty"`
 	FullName   string             `json:"full_name"`
 	PersonId   openapi_types.UUID `json:"person_id"`
-	Role       string             `json:"role"`
+
+	// RelationshipId The seat's own row, which is what a reader patches to disagree with it —
+	// confirming the role, or changing it.
+	//
+	// Carried for every seat rather than only a read one. A colleague correcting
+	// a role another colleague typed is the same write on the same row, and
+	// omitting the id there would leave exactly the human-typed seats
+	// uncorrectable from this card.
+	//
+	// Absent only when the caller lacks the relationship grant, which is the same
+	// condition that withholds the committee itself.
+	RelationshipId *openapi_types.UUID `json:"relationship_id,omitempty"`
+
+	// RelationshipVersion The seat row's version, for the `If-Match` a patch against it carries.
+	//
+	// Without it a reader confirming a role would overwrite whatever a colleague
+	// changed while the page was open, and the write that lost would leave no
+	// trace — the point of the conditional write is that the second one is
+	// refused rather than silently winning.
+	RelationshipVersion *int64 `json:"relationship_version,omitempty"`
+	Role                string `json:"role"`
 
 	// Routes Who on our side can actually reach this contact, strongest first (ADR-0089/A134).
 	//

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16742,6 +16742,30 @@ export interface components {
             role: string;
             engagement?: components["schemas"]["ContactEngagement"];
             /**
+             * Format: int64
+             * @description The seat row's version, for the `If-Match` a patch against it carries.
+             *
+             *     Without it a reader confirming a role would overwrite whatever a colleague
+             *     changed while the page was open, and the write that lost would leave no
+             *     trace — the point of the conditional write is that the second one is
+             *     refused rather than silently winning.
+             */
+            relationship_version?: number;
+            /**
+             * Format: uuid
+             * @description The seat's own row, which is what a reader patches to disagree with it —
+             *     confirming the role, or changing it.
+             *
+             *     Carried for every seat rather than only a read one. A colleague correcting
+             *     a role another colleague typed is the same write on the same row, and
+             *     omitting the id there would leave exactly the human-typed seats
+             *     uncorrectable from this card.
+             *
+             *     Absent only when the caller lacks the relationship grant, which is the same
+             *     condition that withholds the committee itself.
+             */
+            relationship_id?: string;
+            /**
              * @description The seat was read out of the contact's own messages rather than typed by a
              *     person, and nobody has confirmed it yet.
              *

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1578,6 +1578,21 @@ export const de = {
   "co.people.map.scopePartial":
     "{count} im Buying-Team · {hidden} weitere für dich nicht sichtbar.",
   "co.people.board.readFromMessages": "Aus ihren Nachrichten gelesen",
+  "co.people.board.suggest": "Rollen vorschlagen",
+  "co.people.board.suggesting": "Nachrichten werden gelesen",
+  "co.people.board.suggestNoDeal":
+    "Rollen gehören zu einem Deal, und dieses Unternehmen hat keinen offenen.",
+  "co.people.board.suggestWrote":
+    "{count} aus ihren eigenen Worten eingetragen.",
+  "co.people.board.suggestUnavailable":
+    "Für das Lesen von Rollen wird ein Modell benötigt; in dieser Installation ist keines eingerichtet.",
+  "co.people.board.suggestNothing":
+    "In ihren Nachrichten steht nicht, wer entscheidet.",
+  "co.people.board.suggestRefused":
+    "Nichts war eindeutig genug. {count} Lesung(en) wurden wegen schwacher Belege verworfen.",
+  "co.people.board.confirm": "Bestätigen",
+  "co.people.board.confirming": "Wird bestätigt",
+  "co.people.board.change": "Rolle ändern",
   "co.reach.answered": "Antwortet",
   "co.reach.silent": "Keine Antwort",
   "co.reach.untried": "Nie angesprochen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1618,6 +1618,19 @@ export const en = {
   "co.people.map.scopePartial":
     "{count} on the buying team · {hidden} more you cannot see.",
   "co.people.board.readFromMessages": "Read from their messages",
+  "co.people.board.suggest": "Suggest roles",
+  "co.people.board.suggesting": "Reading their messages",
+  "co.people.board.suggestNoDeal":
+    "Roles are recorded on a deal, and this account has no open one.",
+  "co.people.board.suggestWrote": "Seated {count} from what they wrote.",
+  "co.people.board.suggestUnavailable":
+    "Reading roles needs a model, and this installation has none configured.",
+  "co.people.board.suggestNothing": "Nothing in their messages says who buys.",
+  "co.people.board.suggestRefused":
+    "Nothing was clear enough to record. {count} reading(s) were dropped for weak evidence.",
+  "co.people.board.confirm": "Confirm",
+  "co.people.board.confirming": "Confirming",
+  "co.people.board.change": "Change role",
   "co.reach.answered": "Answered",
   "co.reach.silent": "No reply",
   "co.reach.untried": "Not approached",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1572,6 +1572,20 @@ export const vi = {
   "co.people.map.scopePartial":
     "{count} trong nhóm · {hidden} người khác bạn không thấy.",
   "co.people.board.readFromMessages": "Đọc từ tin nhắn của họ",
+  "co.people.board.suggest": "Đề xuất vai trò",
+  "co.people.board.suggesting": "Đang đọc tin nhắn của họ",
+  "co.people.board.suggestNoDeal":
+    "Vai trò được ghi trên một thương vụ, và khách hàng này không có thương vụ nào đang mở.",
+  "co.people.board.suggestWrote": "Đã ghi {count} người từ chính lời họ viết.",
+  "co.people.board.suggestUnavailable":
+    "Đọc vai trò cần một mô hình, và bản cài đặt này chưa cấu hình mô hình nào.",
+  "co.people.board.suggestNothing":
+    "Tin nhắn của họ không cho biết ai là người quyết định.",
+  "co.people.board.suggestRefused":
+    "Không có gì đủ rõ để ghi lại. {count} kết quả đã bị loại vì bằng chứng yếu.",
+  "co.people.board.confirm": "Xác nhận",
+  "co.people.board.confirming": "Đang xác nhận",
+  "co.people.board.change": "Đổi vai trò",
   "co.reach.answered": "Đã hồi đáp",
   "co.reach.silent": "Chưa có hồi đáp",
   "co.reach.untried": "Chưa tiếp cận",

--- a/frontend/src/screens/companypeople/companypeople.css
+++ b/frontend/src/screens/companypeople/companypeople.css
@@ -17,3 +17,30 @@
   font-weight: var(--fw-semibold);
   color: var(--aiText);
 }
+
+/* The switcher and the reading verb in one row.
+ *
+ * Wraps rather than compressing: at 390px the two do not fit side by side, and
+ * a button squeezed to an icon is a verb the reader can no longer read. */
+.cp-board-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  margin-bottom: var(--space-2);
+}
+
+/* What the last reading did. A line, not a toast: the reader may be looking at
+ * the board rather than the button when it answers, and a message that has
+ * already faded cannot tell them why nothing changed. */
+.cp-write-note {
+  margin: 0 0 var(--space-2);
+  color: var(--textMeta);
+}
+
+/* The two verbs on an unconfirmed seat. */
+.cp-seat-verbs {
+  display: flex;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}

--- a/frontend/src/screens/companypeople/summary.stories.tsx
+++ b/frontend/src/screens/companypeople/summary.stories.tsx
@@ -140,3 +140,62 @@ export const SeatsHidden: Story = {
     }),
   ),
 };
+
+/**
+ * A seat the product read out of the contact's own messages, beside one a
+ * colleague typed.
+ *
+ * The whole point of the treatment is the CONTRAST: dashed indigo says a
+ * machine decided this and nobody has confirmed it, and the seat next to it
+ * carries none of the marking because a person already answered. Only the read
+ * one offers Confirm and Change role — agreeing with a colleague on their
+ * behalf is not a verb this page has.
+ */
+export const SeatReadFromMessages: Story = {
+  args: { orgId: "o-1", accountName: "Brandt GmbH", onNarrow: () => {} },
+  render: story(
+    coverage({
+      deals: [{ deal_id: "d-1", name: "Retrofit 2026" }],
+      selected_deal_id: "d-1",
+      committee: {
+        seats: [
+          {
+            person_id: "p-1",
+            full_name: "Ute Sommer",
+            role: "economic_buyer",
+            engagement: "answered",
+            relationship_id: "r-1",
+            relationship_version: 1,
+            ai_suggested: true,
+          },
+          {
+            person_id: "p-2",
+            full_name: "Jan Roth",
+            role: "champion",
+            engagement: "no_reply",
+            relationship_id: "r-2",
+            relationship_version: 1,
+          },
+        ],
+        gaps: [],
+        unlisted_seats: 0,
+      },
+    }),
+  ),
+};
+
+/**
+ * No open deal, so the reading has nowhere to record a role.
+ *
+ * The button stays visible and says why. Hidden, it would teach a reader
+ * nothing about what the account is missing.
+ */
+export const NoDealToReadRolesOnto: Story = {
+  args: { orgId: "o-1", accountName: "Brandt GmbH", onNarrow: () => {} },
+  render: story(
+    coverage({
+      deals: [],
+      committee: { seats: [], gaps: [], unlisted_seats: 0 },
+    }),
+  ),
+};

--- a/frontend/src/screens/companypeople/summary.test.tsx
+++ b/frontend/src/screens/companypeople/summary.test.tsx
@@ -31,14 +31,25 @@ function render(ui: ReactNode, locale: "en" | "de" = "en") {
   );
 }
 
-function stub(coverage: Partial<Coverage>) {
-  const body: Coverage = {
+/** What the writes answered, and every URL the component actually sent. */
+type Writes = {
+  proposals?: unknown;
+  proposalStatus?: number;
+  calls: string[];
+};
+
+function coverageBody(coverage: Partial<Coverage>): Coverage {
+  return {
     as_of: "2026-08-31T09:00:00Z",
     summary: { contacts_total: 3, answered: 1, no_reply: 0, untried: 2 },
     deals: [],
     completeness: { committee_read: true },
     ...coverage,
   } as Coverage;
+}
+
+function stub(coverage: Partial<Coverage>, writes?: Writes) {
+  const body = coverageBody(coverage);
   vi.stubGlobal("fetch", (input: RequestInfo | URL) => {
     const url =
       typeof input === "string"
@@ -46,11 +57,25 @@ function stub(coverage: Partial<Coverage>) {
         : input instanceof URL
           ? input.href
           : input.url;
+    writes?.calls.push(url);
     if (url.includes("/coverage")) {
       return Promise.resolve(
         new Response(JSON.stringify(body), {
           status: 200,
           headers: { "content-type": "application/json" },
+        }),
+      );
+    }
+    if (url.includes("/role-proposals")) {
+      return Promise.resolve(
+        new Response(JSON.stringify(writes?.proposals ?? {}), {
+          status: writes?.proposalStatus ?? 200,
+          headers: {
+            "content-type":
+              (writes?.proposalStatus ?? 200) >= 400
+                ? "application/problem+json"
+                : "application/json",
+          },
         }),
       );
     }
@@ -339,4 +364,250 @@ test("marks a seat the product read, and only that one", async () => {
   expect(marks).toHaveLength(1);
   // The mark sits on the seat that was read, not the one that was typed.
   expect(marks[0]?.closest("[data-suggested='true']")).not.toBeNull();
+});
+
+/** An account with one open deal and one seat the product read. */
+function suggestedCoverage(): Partial<Coverage> {
+  return {
+    deals: [{ deal_id: "d-1", name: "Retrofit 2026" }],
+    selected_deal_id: "d-1",
+    committee: {
+      seats: [
+        {
+          person_id: "p-1",
+          full_name: "Ute Sommer",
+          role: "economic_buyer",
+          engagement: "answered",
+          relationship_id: "r-1",
+          relationship_version: 1,
+          ai_suggested: true,
+        },
+      ],
+      gaps: [],
+      unlisted_seats: 0,
+    },
+  } as Partial<Coverage>;
+}
+
+test("reads the roles from the deal, and refreshes the board after", async () => {
+  const writes: Writes = {
+    calls: [],
+    proposals: {
+      written: [
+        {
+          person_id: "p-1",
+          full_name: "Ute Sommer",
+          role: "economic_buyer",
+          evidence_snippet: "I sign off the budget for this, so send",
+          source_activity_id: "a-1",
+          confidence: 0.9,
+        },
+      ],
+      skipped: 0,
+      generated_by: "model",
+    },
+  };
+  stub(suggestedCoverage(), writes);
+  const user = userEvent.setup();
+  render(
+    <CoverageBand orgId="o-1" accountName="Brandt GmbH" onNarrow={() => {}} />,
+  );
+
+  await user.click(
+    await screen.findByRole("button", { name: /Suggest roles/i }),
+  );
+  await screen.findByText(/Seated 1 from what they wrote/);
+  // The POST goes to the DEAL; the refresh reads the ACCOUNT. A component that
+  // refreshed the deal instead would show the board as it was before the write.
+  expect(
+    writes.calls.some((url) => url.includes("/deals/d-1/role-proposals")),
+  ).toBe(true);
+  expect(
+    writes.calls.filter((url) => url.includes("/organizations/o-1/coverage"))
+      .length,
+  ).toBeGreaterThan(1);
+});
+
+// The two empty answers are DIFFERENT facts. "Nothing was said" sends a reader
+// to the correspondence; "everything was refused" tells them the product looked
+// and would not stand behind what it found.
+test("tells nothing-proposed apart from everything-refused", async () => {
+  stub(suggestedCoverage(), {
+    calls: [],
+    proposals: { written: [], skipped: 0, generated_by: "model" },
+  });
+  const user = userEvent.setup();
+  const first = render(
+    <CoverageBand orgId="o-1" accountName="Brandt GmbH" onNarrow={() => {}} />,
+  );
+  await user.click(
+    await screen.findByRole("button", { name: /Suggest roles/i }),
+  );
+  await screen.findByText(/Nothing in their messages says who buys/);
+  first.unmount();
+
+  stub(suggestedCoverage(), {
+    calls: [],
+    proposals: { written: [], skipped: 3, generated_by: "model" },
+  });
+  render(
+    <CoverageBand orgId="o-1" accountName="Brandt GmbH" onNarrow={() => {}} />,
+  );
+  await user.click(
+    await screen.findByRole("button", { name: /Suggest roles/i }),
+  );
+  await screen.findByText(/3 reading\(s\) were dropped/);
+});
+
+// A role is recorded on a deal. Hidden, the button teaches nothing; disabled
+// with the reason, it says what the account is missing.
+test("says why it cannot read roles when the account has no open deal", async () => {
+  stub({ committee: { seats: [], gaps: ["champion"], unlisted_seats: 0 } });
+  render(
+    <CoverageBand orgId="o-1" accountName="Brandt GmbH" onNarrow={() => {}} />,
+  );
+  const button = await screen.findByRole("button", { name: /Suggest roles/i });
+  expect((button as HTMLButtonElement).disabled).toBe(true);
+  expect(await screen.findByText(/Roles are recorded on a deal/)).toBeTruthy();
+});
+
+// Confirming writes the SAME role back. That looks like a no-op and is not:
+// the store reassigns captured_by to the editing human, which is what turns
+// the machine's reading into a person's answer.
+test("confirming patches the seat's own row with the role unchanged", async () => {
+  const writes: Writes = { calls: [] };
+  stub(suggestedCoverage(), writes);
+  const user = userEvent.setup();
+  render(
+    <CoverageBand orgId="o-1" accountName="Brandt GmbH" onNarrow={() => {}} />,
+  );
+
+  await user.click(await screen.findByRole("button", { name: /^Confirm$/ }));
+  await waitFor(() =>
+    expect(writes.calls.some((url) => url.includes("/relationships/r-1"))).toBe(
+      true,
+    ),
+  );
+});
+
+// The verbs belong to an UNCONFIRMED seat only. A seat a colleague typed is
+// already theirs and nothing about it is waiting for an answer, so offering to
+// confirm it would be agreeing with them on their behalf.
+test("offers no verbs on a seat a person typed", async () => {
+  stub({
+    deals: [{ deal_id: "d-1", name: "Retrofit 2026" }],
+    selected_deal_id: "d-1",
+    committee: {
+      seats: [
+        {
+          person_id: "p-2",
+          full_name: "Jan Roth",
+          role: "champion",
+          engagement: "answered",
+          relationship_id: "r-2",
+          relationship_version: 1,
+        },
+      ],
+      gaps: [],
+      unlisted_seats: 0,
+    },
+  } as Partial<Coverage>);
+  render(
+    <CoverageBand orgId="o-1" accountName="Brandt GmbH" onNarrow={() => {}} />,
+  );
+  await screen.findByText("Jan Roth");
+  expect(screen.queryByRole("button", { name: /^Confirm$/ })).toBeNull();
+  expect(screen.queryByRole("button", { name: /Change role/i })).toBeNull();
+});
+
+// A seat with no version cannot be patched conditionally, and an unconditional
+// confirm would overwrite whatever a colleague changed. The verbs are not
+// offered rather than offered and silently dropped: a button that reports
+// nothing and does nothing is worse than one that is not there.
+test("offers no verbs when the seat carries no version to pin the write", async () => {
+  stub({
+    deals: [{ deal_id: "d-1", name: "Retrofit 2026" }],
+    selected_deal_id: "d-1",
+    committee: {
+      seats: [
+        {
+          person_id: "p-1",
+          full_name: "Ute Sommer",
+          role: "economic_buyer",
+          engagement: "answered",
+          relationship_id: "r-1",
+          ai_suggested: true,
+        },
+      ],
+      gaps: [],
+      unlisted_seats: 0,
+    },
+  } as Partial<Coverage>);
+  render(
+    <CoverageBand orgId="o-1" accountName="Brandt GmbH" onNarrow={() => {}} />,
+  );
+  await screen.findByText("Ute Sommer");
+  expect(screen.queryByRole("button", { name: /^Confirm$/ })).toBeNull();
+});
+
+// A concurrent edit must say so in words a reader can act on. The sentinel's
+// own text is "version skew", which tells them nothing about what to do.
+test("says a concurrent edit happened rather than printing the sentinel", async () => {
+  const writes: Writes = { calls: [] };
+  stub(suggestedCoverage(), writes);
+  vi.stubGlobal("fetch", (input: RequestInfo | URL) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    if (url.includes("/relationships/")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ code: "version_skew", detail: "version skew" }),
+          {
+            status: 409,
+            headers: { "content-type": "application/problem+json" },
+          },
+        ),
+      );
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(coverageBody(suggestedCoverage())), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+  const user = userEvent.setup();
+  render(
+    <CoverageBand orgId="o-1" accountName="Brandt GmbH" onNarrow={() => {}} />,
+  );
+  await user.click(await screen.findByRole("button", { name: /^Confirm$/ }));
+  await screen.findByText(/changed since you opened it/);
+  expect(screen.queryByText("version skew")).toBeNull();
+});
+
+// An installation with no model lane answers 501, and the handler's own words
+// name a Go function. A reader is owed a sentence about the product.
+test("says the reading needs a model rather than naming a handler", async () => {
+  stub(suggestedCoverage(), {
+    calls: [],
+    proposalStatus: 501,
+    proposals: {
+      code: "not_implemented",
+      detail:
+        "operation ProposeDealRoles (no model path configured) is specified but not yet implemented",
+    },
+  });
+  const user = userEvent.setup();
+  render(
+    <CoverageBand orgId="o-1" accountName="Brandt GmbH" onNarrow={() => {}} />,
+  );
+  await user.click(
+    await screen.findByRole("button", { name: /Suggest roles/i }),
+  );
+  await screen.findByText(/Reading roles needs a model/);
+  expect(screen.queryByText(/ProposeDealRoles/)).toBeNull();
 });

--- a/frontend/src/screens/companypeople/summary.tsx
+++ b/frontend/src/screens/companypeople/summary.tsx
@@ -1,15 +1,29 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Sparkles } from "lucide-react";
 import { useMemo, useState } from "react";
 import { api } from "../../api/client";
 import type { components } from "../../api/schema";
+import { ifMatch } from "../../api/version";
+import { navigate } from "../../app/router";
 import { useUrlParams } from "../../app/urlstate";
-import { Badge, SegmentedControl, StatCard } from "../../design-system/atoms";
+import {
+  Badge,
+  Button,
+  SegmentedControl,
+  StatCard,
+} from "../../design-system/atoms";
 import { PipelineBoard } from "../../design-system/composed";
 import { RelationshipMap } from "../../design-system/relationshipmap";
 import { StatStrip } from "../../design-system/statstrip";
+import { ProvenanceTag } from "../../design-system/trust";
 import { formatNumber } from "../../format/format";
 import { type Locale, useLocale, useT } from "../../i18n";
-import { throwProblem } from "../common";
+import {
+  isVersionSkewOf,
+  problemCodeOf,
+  problemMessageOf,
+  throwProblem,
+} from "../common";
 import { EntityRef } from "../entityref";
 import { mapModelFromCoverage } from "./mapmodel";
 import "./companypeople.css";
@@ -114,7 +128,11 @@ export function CoverageBand({
           onOpen={() => onNarrow("untried")}
         />
       </StatStrip>
-      <CommitteeBoard coverage={coverage} accountName={accountName} />
+      <CommitteeBoard
+        coverage={coverage}
+        accountName={accountName}
+        orgId={orgId}
+      />
     </>
   );
 }
@@ -249,7 +267,8 @@ function CommitteeReading({ coverage }: Readonly<{ coverage: Coverage }>) {
 function CommitteeBoard({
   coverage,
   accountName,
-}: Readonly<{ coverage: Coverage; accountName: string }>) {
+  orgId,
+}: Readonly<{ coverage: Coverage; accountName: string; orgId: string }>) {
   const t = useT();
   const { locale } = useLocale();
   const [view, setView] = useState<"board" | "map">("board");
@@ -268,6 +287,15 @@ function CommitteeBoard({
     }
     setParams(out);
   };
+  const writes = useCommitteeWrites(orgId, coverage.selected_deal_id);
+  const renderSeat = (seat: Seat) => (
+    <SeatCard
+      seat={seat}
+      onConfirm={writes.confirm}
+      onChange={writes.change}
+      confirming={writes.confirming}
+    />
+  );
   const model = useMemo(
     () => mapModelFromCoverage(coverage, accountName, mapCopy(t)),
     [coverage, accountName, t],
@@ -316,11 +344,21 @@ function CommitteeBoard({
       }}
     />
   );
+  // The switcher and the reading sit in one row, so the verb is where the
+  // committee is in BOTH views: a button that appears only on the board would
+  // make the map a place where the gap can be seen and not filled.
+  const toolbar = (
+    <div className="cp-board-tools">
+      {switcher}
+      <SuggestRoles writes={writes} dealId={coverage.selected_deal_id} />
+    </div>
+  );
 
   if (view === "map") {
     return (
       <>
-        {switcher}
+        {toolbar}
+        {writes.note}
         <RelationshipMap
           model={model}
           focusId={focusId}
@@ -348,11 +386,12 @@ function CommitteeBoard({
 
   return (
     <>
-      {switcher}
+      {toolbar}
+      {writes.note}
       <PipelineBoard
         variant="plain"
         columns={columns}
-        renderCard={(record) => <SeatCard seat={record.seat} />}
+        renderCard={(record) => renderSeat(record.seat)}
         columnExtras={(column) =>
           // The gap, where it is: a critical role nobody holds says so in the
           // column that would hold them, not in a line underneath the board.
@@ -415,7 +454,17 @@ function mapCopy(t: ReturnType<typeof useT>) {
   };
 }
 
-function SeatCard({ seat }: Readonly<{ seat: Seat }>) {
+function SeatCard({
+  seat,
+  onConfirm,
+  onChange,
+  confirming,
+}: Readonly<{
+  seat: Seat;
+  onConfirm: (seat: Seat) => void;
+  onChange: (seat: Seat) => void;
+  confirming: ReadonlySet<string>;
+}>) {
   const t = useT();
   // Indigo, dashed, and only here: the treatment means "a machine decided this
   // and nobody has confirmed it". A seat a colleague typed carries none of it,
@@ -428,7 +477,12 @@ function SeatCard({ seat }: Readonly<{ seat: Seat }>) {
       data-suggested={suggested ? "true" : undefined}
     >
       {suggested && (
-        <p className="cp-seat-mark">{t("co.people.board.readFromMessages")}</p>
+        <p className="cp-seat-mark">
+          <ProvenanceTag
+            provenance={{ kind: "agent", agent: "propose_roles" }}
+          />{" "}
+          {t("co.people.board.readFromMessages")}
+        </p>
       )}
       <EntityRef kind="person" id={seat.person_id} name={seat.full_name} />
       {seat.engagement && (
@@ -450,6 +504,231 @@ function SeatCard({ seat }: Readonly<{ seat: Seat }>) {
           )}
         </Badge>
       )}
+      {/* Only an UNCONFIRMED seat offers the two verbs, and only when the
+       * caller can address the row. Confirming a seat a colleague typed
+       * would be agreeing with them on their behalf; the row is already
+       * theirs, and nothing about it is waiting for an answer. */}
+      {/* BOTH halves, because the write needs both. Rendering on the id alone
+       * gave an enabled button whose click was silently dropped when the
+       * version was missing — a control that reports nothing and does
+       * nothing, which is worse than one that is not offered. */}
+      {suggested && seat.relationship_id && seat.relationship_version && (
+        <div className="cp-seat-verbs">
+          <Button
+            small
+            onClick={() => onConfirm(seat)}
+            pending={confirming.has(seat.relationship_id)}
+            busyLabel={t("co.people.board.confirming")}
+          >
+            {t("co.people.board.confirm")}
+          </Button>
+          <Button small variant="ghost" onClick={() => onChange(seat)}>
+            {t("co.people.board.change")}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
+
+/**
+ * useCommitteeWrites is the three writes this board performs.
+ *
+ * The reading POSTs to the deal and then invalidates the ACCOUNT's coverage,
+ * which is the key this whole band reads under: a seat written to a deal is a
+ * change to the committee the account shows, and refreshing the deal alone
+ * would leave the board displaying the state before the write.
+ *
+ * Confirm and Change are the same patch on the same row. The store reassigns
+ * `captured_by` to whoever edits, so a human touching the row is what clears
+ * the mark — there is no separate "confirmed" column, and there does not need
+ * to be: the question the mark asks is "did a person answer this", and an edit
+ * IS that answer.
+ */
+function useCommitteeWrites(orgId: string, dealId: string | null | undefined) {
+  const t = useT();
+  const { locale } = useLocale();
+  const queryClient = useQueryClient();
+  const refresh = () => {
+    queryClient.invalidateQueries({
+      queryKey: ["organization-coverage", orgId],
+    });
+  };
+
+  const suggest = useMutation({
+    mutationFn: async (dealId: string) => {
+      const { data, error } = await api.POST("/deals/{id}/role-proposals", {
+        params: { path: { id: dealId } },
+      });
+      if (error || !data) {
+        return throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: refresh,
+  });
+
+  // WHICH row is being confirmed, held here rather than read off the mutation.
+  // One observer serves every card, and TanStack switches it to the newest
+  // call — so a second confirm took the first's spinner away and swallowed its
+  // outcome. The set is what lets two cards be busy at once and each keep its
+  // own.
+  const [confirming, setConfirming] = useState<ReadonlySet<string>>(new Set());
+  const patch = useMutation({
+    onMutate: (seat: SeatPatch) => {
+      setConfirming((busy) => new Set(busy).add(seat.relationshipId));
+    },
+    onSettled: (_data, _error, seat) => {
+      setConfirming((busy) => {
+        const next = new Set(busy);
+        next.delete(seat.relationshipId);
+        return next;
+      });
+    },
+    mutationFn: async (seat: SeatPatch) => {
+      const { error } = await api.PATCH("/relationships/{id}", {
+        // The conditional write. A colleague may have changed this seat while
+        // the page was open, and without the version the confirmation would
+        // overwrite them — the losing write leaving no trace, which is the one
+        // outcome a concurrent edit must not have.
+        params: { path: { id: seat.relationshipId }, ...ifMatch(seat.version) },
+        body: { role: seat.role },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: refresh,
+  });
+
+  return {
+    suggest,
+    confirming,
+    // Confirming writes the role back UNCHANGED. That looks like a no-op and
+    // is not: the store reassigns captured_by to the editing human, so the
+    // same role written by a person is what turns the machine's reading into
+    // theirs.
+    confirm: (seat: Seat) => {
+      if (seat.relationship_id && seat.relationship_version !== undefined) {
+        patch.mutate({
+          relationshipId: seat.relationship_id,
+          role: seat.role,
+          version: seat.relationship_version,
+        });
+      }
+    },
+    // The DEAL's stakeholder panel, which is where a role is actually edited.
+    // The contact's own page shows the role as a read-only badge, so sending a
+    // reader there was a verb that promised an edit and delivered a label.
+    change: () => {
+      if (dealId) {
+        navigate({ screen: "deals", id: dealId });
+      }
+    },
+    note: <WriteNote suggest={suggest} patch={patch} locale={locale} t={t} />,
+  };
+}
+
+/**
+ * WriteNote says what the last write did, in words rather than a count alone.
+ *
+ * The two empty answers are DIFFERENT facts and get different sentences.
+ * Nothing proposed means their messages do not say who buys; everything
+ * refused means the product read something and would not stand behind it. A
+ * single "no roles found" would report the second as the first, and a reader
+ * would go looking for evidence that was in fact considered and dropped.
+ */
+function WriteNote({
+  suggest,
+  patch,
+  locale,
+  t,
+}: Readonly<{
+  suggest: ReturnType<
+    typeof useMutation<DealRoleProposalResult, Error, string>
+  >;
+  patch: ReturnType<typeof useMutation<void, Error, SeatPatch>>;
+  locale: Locale;
+  t: ReturnType<typeof useT>;
+}>) {
+  // The PATCH's failure first. A suggestion that failed minutes ago would
+  // otherwise mask the confirm the reader just pressed, and the older message
+  // is the less relevant one exactly when a newer write has gone wrong.
+  if (patch.isError) {
+    return (
+      <p className="t-caption cp-write-note">
+        {isVersionSkewOf(patch.error)
+          ? t("edit.versionSkew")
+          : problemMessageOf(patch.error, t)}
+      </p>
+    );
+  }
+  if (suggest.isError) {
+    return (
+      <p className="t-caption cp-write-note">
+        {problemCodeOf(suggest.error) === "not_implemented"
+          ? t("co.people.board.suggestUnavailable")
+          : problemMessageOf(suggest.error, t)}
+      </p>
+    );
+  }
+  const result = suggest.data;
+  if (!result) {
+    return null;
+  }
+  if (result.written.length > 0) {
+    return (
+      <p className="t-caption cp-write-note">
+        {t("co.people.board.suggestWrote", {
+          count: formatNumber(result.written.length, locale),
+        })}
+      </p>
+    );
+  }
+  return (
+    <p className="t-caption cp-write-note">
+      {result.skipped > 0
+        ? t("co.people.board.suggestRefused", {
+            count: formatNumber(result.skipped, locale),
+          })
+        : t("co.people.board.suggestNothing")}
+    </p>
+  );
+}
+
+/**
+ * SuggestRoles is the verb that reads the committee out of the correspondence.
+ *
+ * Disabled with a REASON rather than hidden when the account has no open deal:
+ * a role is recorded on a deal, and a reader who cannot see why the button is
+ * inert learns nothing about what to do instead.
+ */
+function SuggestRoles({
+  writes,
+  dealId,
+}: Readonly<{
+  writes: {
+    suggest: ReturnType<
+      typeof useMutation<DealRoleProposalResult, Error, string>
+    >;
+  };
+  dealId: string | null | undefined;
+}>) {
+  const t = useT();
+  return (
+    <Button
+      small
+      variant="ai"
+      onClick={() => dealId && writes.suggest.mutate(dealId)}
+      reason={dealId ? undefined : t("co.people.board.suggestNoDeal")}
+      pending={writes.suggest.isPending}
+      busyLabel={t("co.people.board.suggesting")}
+    >
+      <Sparkles aria-hidden="true" />
+      {t("co.people.board.suggest")}
+    </Button>
+  );
+}
+
+type DealRoleProposalResult = components["schemas"]["DealRoleProposalResult"];
+type SeatPatch = { relationshipId: string; role: string; version: number };


### PR DESCRIPTION
The reading endpoint shipped in #3369 with no way to press it and no way to disagree with what it wrote. This is both.

The People tab's committee board grows a **Suggest roles** button beside the board/map switcher, so the verb is where the committee is in either view. It POSTs to the selected deal and invalidates the **account's** coverage, because a seat written to a deal changes the committee the account shows.

A seat the product read carries two verbs. **Confirm** writes the same role back — which looks like a no-op and is not: the relationship store reassigns `captured_by` to whoever edits, so a person writing the role is what turns a machine's reading into their answer. There is no separate `confirmed` column and there does not need to be. That assumption is now held by an integration test, mutation-checked.

Only an unconfirmed seat offers them. A seat a colleague typed is already theirs, and offering to confirm it would be agreeing with them on their behalf.

## What review caught

- **A person can hold two roles on one deal** — the table's key is `(deal_id, person_id, role)`. The provenance mark was keyed by person alone, so both cards carried whichever row the scan returned last, and Confirm on one patched the other. Now keyed by person *and* role.
- **No `If-Match`** — confirming would silently overwrite a colleague's concurrent edit, with the losing write leaving no trace.
- **One shared pending state** — a second confirm stole the first's spinner and swallowed its outcome. Now per-row.
- **A silent no-op** — the verbs rendered on `relationship_id` alone but the write needed the version too, so a click could be dropped with no error.
- **Raw internals as copy** — a 409 printed "version skew" and a 501 printed a Go function name.
- **"Change role" led nowhere** — it navigated to the contact page, which shows the role as a read-only badge. It now goes to the deal's stakeholder panel, where roles are actually edited.

## Tests

22 frontend tests, 11 integration tests. The two empty answers get different sentences: "nothing in their messages says who buys" versus "3 readings were dropped for weak evidence" — collapsing them would report the second as the first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Suggest roles button and per-seat Confirm/Change actions for roles the product read, so readers can accept or correct a machine's reading. Previously the reading endpoint wrote roles with no way to disagree.

**Key details**
- Suggest posts to the selected deal and refreshes the account's coverage so the new seat appears.
- Confirm patches the same role back, wiping the AI-suggested mark via `captured_by` reassignment; no separate confirmed column exists.
- Verbs show only on unconfirmed seats, and only when the seat carries both its relationship id and version.
- The patch sends `If-Match` with the version, so a concurrent edit is refused rather than silently overwritten.
- Error responses now show readable messages (e.g., "changed since you opened it") instead of sentinel codes or handler names.
- The two empty outcomes get different copy: nothing in messages vs. readings dropped for weak evidence.

<sup>Written for commit 48250326921e954bde30cca5704c0b615e0c0d24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-assisted suggestions for customer buying roles, with options to confirm or change suggested roles.
  * Added clear loading, empty, unavailable, refusal, success, and error states.
  * Added safeguards to prevent updates when seat information is unavailable or has changed.
  * Added support for contacts holding multiple roles without mixing their records.
  * Added English, German, and Vietnamese translations.
* **Bug Fixes**
  * Improved role confirmation behavior and board refreshes after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->