### PR TITLE
main is red: a deliberate qualifier reads as a redundant one

### DIFF
--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -150,6 +150,7 @@ func WithBlobstore(store blobstore.Store) Option {
 		// no objects has no purge, which is honest — destroying the rows and
 		// leaving the files would report mail as gone while its attachments sat
 		// in the bucket.
+		//nolint:staticcheck // QF1008: the embedded field is named on purpose, and the file says why forty lines up — every call here is qualified through its own embedded field so that a second embed growing the same method never turns one of them into an ambiguous selector nobody wrote a test for.
 		s.captureExclusionHandlers.purger = NewCapturePurger(pool,
 			NewRetentionServiceFor(InstallationDB(pool), store, slog.Default()))
 		// Captured mail carries files too. Recorded as the STORE, which the sink


### PR DESCRIPTION
`main`'s lint fails:

```
internal/compose/serveroptions.go:153:5: QF1008: could remove embedded field "captureExclusionHandlers" from selector (staticcheck)
```

## Why not just take the suggestion

The file already answers this, forty lines above the flagged one:

> an ambiguous selector — each call is qualified through its own embedded field instead.

Every assignment in `WithBlobstore` is written through its own embedded field deliberately, so that a second embed growing the same field name never turns one of these into an ambiguous selector — a failure that would surface as a compile error in a file nobody was editing. Dropping the qualifier on this one line because it happens to be unambiguous *today* keeps the linter quiet and loses the property the convention exists for.

So it is suppressed at the line with that reason, in the `//nolint:<linter> // <why>` shape the rest of the tree uses.

## Verification

- `make check-backend` (with a cleaned golangci cache), `make craft-static`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a targeted static analysis suppression without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->