### PR TITLE
A privacy request links to the screen it is worked on

### DIFF
--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -7,6 +7,7 @@ import {
   formatNumber,
 } from "../format/format";
 import type { Locale, useT } from "../i18n";
+import { settingsAddress } from "./settings";
 import type {
   Worklist,
   WorklistComparison,
@@ -38,6 +39,32 @@ export function subjectHref(item: WorklistItem): string | undefined {
     return undefined;
   }
   return routeHash(ENTITY[subject.type].route(subject.id));
+}
+
+// Where a row goes when it names no record of its own.
+//
+// Most rows point at a record and reach it through the entity registry. A few
+// name a QUEUE instead — a data-subject request is worked on the privacy
+// screen and nowhere else — and without a destination those rows are a
+// sentence a reader cannot follow, on the one lane whose whole argument is a
+// legal clock somebody has to answer.
+//
+// A destination is not a verb: these rows still offer no action, because the
+// queue cannot perform one. It is the difference between telling somebody
+// where a room is and claiming to have opened the door.
+// Through settingsAddress, not a path spelled here: the settings registry
+// decides whether a tab sits under the admin segment, and a second spelling of
+// that decision would keep pointing at the old address the day it moves.
+const SOURCE_QUEUE: Partial<Record<WorklistItem["source"], string>> = {
+  dsr: routeHash(settingsAddress("privacy")),
+};
+
+// The address a row's headline links to: its record where it has one, the
+// queue that owns it where it does not, and nothing at all for a row that is
+// neither — a system condition fixed on a settings screen the card does not
+// pretend to know.
+export function rowHref(item: WorklistItem): string | undefined {
+  return subjectHref(item) ?? SOURCE_QUEUE[item.source];
 }
 
 // One comparator value, in the reader's notation.

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -310,6 +310,31 @@ describe("what the ranked queue tells a reader", () => {
     );
   });
 
+  it("sends a privacy request to the screen it is worked on", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "01a05500-0000-7000-8000-00000000dddd",
+            source: "dsr",
+            category: "system",
+            consequence: "legal_deadline_missed",
+          }),
+        ],
+        summary: { urgent: 1, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    // The row names no record — a request is worked on the privacy screen and
+    // nowhere else — so without this it is a legal clock a reader is told
+    // about and cannot follow.
+    const request = await screen.findByRole("link", {
+      name: "An open privacy request",
+    });
+    expect(request.getAttribute("href")).toBe("#/settings/admin/privacy");
+  });
+
   it("says what happens if the reader does nothing", async () => {
     stub(
       day({

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -15,8 +15,8 @@ import {
   itemTitle,
   moveHref,
   reasonText,
+  rowHref,
   sourceUnavailableText,
-  subjectHref,
 } from "./worklist.copy";
 import {
   useApproval,
@@ -78,7 +78,7 @@ function WorklistRow({
   const t = useT();
   const { locale } = useLocale();
   const zone = viewerZone();
-  const href = subjectHref(item);
+  const href = rowHref(item);
   const title = itemTitle(item, t, locale);
   const facts = dealFactsText(item, t, locale, zone);
   const because = item.because


### PR DESCRIPTION
Closes #2972.

## What was already there

Most of this ticket has shipped: the `dsr` lane exists, reads through the consent module's own `OpenDSRsDueSoonest`, is ordered soonest-deadline-first, and is withheld rather than empty for a caller the admin gate refuses — which is what the ticket asked for, and it cost no new code, exactly as predicted.

## What was missing

The ticket also asked that "the card links to the existing admin screen". It does not. A DSR row names no record, so it falls through `subjectHref` and renders as plain text: a reader is told a statutory clock is running and left to go and find the screen themselves.

That is the lane where it matters most. Every other row on the queue is a follow-up somebody might reasonably not make; this one is a compliance failure.

## What this adds

`rowHref` — a row's record where it has one, and where it does not, the queue that owns it. A data-subject request is worked on `#/settings/admin/privacy` and nowhere else, so that address is a property of the SOURCE rather than of the item.

The row still offers no verb. The ticket was explicit that fulfilment stays on the consent module's endpoints, and there is a gate forbidding a surface from advertising an action it cannot perform — a destination is not an action. It is the difference between telling somebody where a room is and claiming to have opened the door.

## Verification

- `make check-fe`
- `worklist.test.tsx` asserts the row renders as a link to the privacy screen; mutation-checked by removing the destination, which fails it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worklist items now link to the relevant subject record when available.
  * Open privacy requests now link directly to the privacy administration screen.

* **Bug Fixes**
  * Corrected worklist row navigation for data subject request items.
  * Improved navigation consistency across different worklist item types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->