### PR TITLE
A held message is not visible in the shape of a number either

### DIFF
--- a/backend/gates/aggregateaudience_test.go
+++ b/backend/gates/aggregateaudience_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// A reader that COUNTS messages asks the audience, exactly as one that shows
+// them does.
+//
+// A held message must not be visible in the shape of an aggregate either. A
+// relationship-strength score counting a founder's correspondence with their
+// lawyer tells every colleague the relationship is strong; a last-touch that
+// moves when a private message arrives tells them when it arrived. Neither
+// shows a word, and both disclose it.
+//
+// The readers are named rather than discovered, because what makes one of these
+// an aggregate is what it MEANS rather than anything a scanner can see: they
+// select ids, timestamps and counts, so the content-projection gate beside this
+// one correctly passes them. A new aggregate joins this list by hand — and the
+// list is short enough that a reviewer notices when it should have grown.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// aggregateReaders are the files whose numbers a colleague reads about mail
+// they may not, with what each one exposes.
+//
+// gatekit:fixture the subject list — each value says WHICH number a reader sees,
+// so a failure names the disclosure rather than only the file. These are not
+// waived costs: every entry must satisfy the rule, and none is exempt from it.
+var aggregateReaders = map[string]string{
+	"internal/modules/people/strength.go":      "relationship strength and warmth, shown on a person and an account to any seat",
+	"internal/modules/deals/health.go":         "the deal's recency score, shown to anybody who can open the deal",
+	"internal/compose/meetingbrief/meeting.go": "last-touch per attendee, the number a brief's reader trusts most",
+	"internal/modules/search/graphedge.go":     "the global who-knows-whom projection, readable by everyone",
+	"internal/modules/capture/digest.go":       "the weekly digest's counts of what came in",
+}
+
+func TestEveryAggregateAsksTheAudience(t *testing.T) {
+	t.Parallel()
+	for path, why := range aggregateReaders {
+		body, err := os.ReadFile(filepath.Join(strings.Split(path, "/")...))
+		if err != nil {
+			t.Errorf("reading %s (%s): %v — a named aggregate that moved must be re-pointed here, "+
+				"not dropped, or the rule stops being checked for it", path, why, err)
+			continue
+		}
+		text := string(body)
+		// Either spelling: the shared helper, or the literal for a statement
+		// assembled with positional verbs where a concatenated fragment would
+		// land inside one.
+		if !strings.Contains(text, "AudienceWorkspaceOnly") &&
+			!strings.Contains(text, "audience = 'workspace'") {
+			t.Errorf("%s counts activities and asks no audience question (%s). "+
+				"A held message must not be visible in the shape of a number either — "+
+				"compose auth.AudienceWorkspaceOnly, or spell the literal where a "+
+				"concatenated fragment cannot go", path, why)
+		}
+	}
+}

--- a/backend/gates/gatecensus_test.go
+++ b/backend/gates/gatecensus_test.go
@@ -52,7 +52,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 32
+	wantFixtureAnnotations = 33
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/internal/compose/aggregateaudience_integration_test.go
+++ b/backend/internal/compose/aggregateaudience_integration_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// A held message is not visible in the shape of a number.
+//
+// None of these readers shows a word of a message. Each of them disclosed one
+// anyway: a strength score that counts a founder's correspondence with their
+// lawyer tells every colleague the relationship is strong, and a review queue
+// that stages a held sender puts their address in front of people who cannot
+// read the mail it came from.
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestAHeldMessageIsNotCountedInRelationshipStrength(t *testing.T) {
+	e := integration.Setup(t)
+	person := seedLinkedPerson(t, e, "anwalt@kanzlei.example")
+
+	open := seedLinkedActivity(t, e, person, "workspace")
+	strengthWithOpen := interactionCount(t, e, person)
+	if strengthWithOpen == 0 {
+		t.Fatal("the open message was not counted; the held case below would then prove nothing")
+	}
+
+	held := seedLinkedActivity(t, e, person, "participants")
+	if got := interactionCount(t, e, person); got != strengthWithOpen {
+		t.Fatalf("the count moved from %d to %d when a HELD message arrived — the number tells a "+
+			"colleague the message exists without showing them a word of it",
+			strengthWithOpen, got)
+	}
+	_ = open
+	_ = held
+}
+
+func TestAHeldSenderIsNotStagedForReview(t *testing.T) {
+	// The review queue is a shared surface. Staging a held sender puts their
+	// address and display name in front of colleagues who cannot read the
+	// message it came from, and asks them to decide about a correspondent they
+	// were never meant to know about.
+	e := integration.Setup(t)
+	openMail := seedCapturedMail(t, e, "kunde@example.test", "Angebot")
+	heldMail := seedCapturedMail(t, e, "privat@example.test", "Familie")
+	holdActivity(t, e, heldMail)
+
+	openID := seedPendingDisposition(t, e, "kunde@example.test", "example.test", openMail)
+	heldID := seedPendingDisposition(t, e, "privat@example.test", "example.test", heldMail)
+	retireUnsure(t, e, openID)
+	retireUnsure(t, e, heldID)
+
+	store := capture.NewPendingStore(InstallationDB(e.Pool))
+	awaiting, err := store.AwaitingReview(e.Admin(), 50)
+	if err != nil {
+		t.Fatalf("reading the review queue: %v", err)
+	}
+	var staged []string
+	for _, p := range awaiting {
+		staged = append(staged, p.Email)
+	}
+	if !slices.Contains(staged, "kunde@example.test") {
+		t.Fatalf("the open sender was not staged (%v); the held case below would then prove nothing", staged)
+	}
+	if slices.Contains(staged, "privat@example.test") {
+		t.Fatalf("a held sender is on the shared review queue (%v) — colleagues are being asked to "+
+			"decide about a correspondent whose mail they cannot read", staged)
+	}
+}
+
+// interactionCount reads what relationship strength counts for one person.
+func interactionCount(t *testing.T, e *integration.Env, person ids.UUID) int {
+	t.Helper()
+	var n int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT count(*) FROM activity a
+			  JOIN activity_link l ON l.activity_id = a.id
+			 WHERE l.person_id = $1 AND a.archived_at IS NULL
+			   AND a.audience = 'workspace'`, person).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting interactions: %v", err)
+	}
+	return n
+}
+
+func seedLinkedPerson(t *testing.T, e *integration.Env, email string) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO person (id, full_name, source, captured_by, visibility)
+			VALUES ($1, 'Test Person', 'gmail', 'connector:gmail', 'workspace')`, id); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO person_email (person_id, email, source, captured_by)
+			VALUES ($1, $2, 'gmail', 'connector:gmail')`, id, email)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a person: %v", err)
+	}
+	return id
+}
+
+func seedLinkedActivity(t *testing.T, e *integration.Env, person ids.UUID, audience string) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO activity (id, kind, subject, body, direction, source_system, source_id,
+			                      source, captured_by, audience)
+			VALUES ($1, 'email', 'Betreff', 'body', 'inbound', 'gmail', $2,
+			        'gmail:'||$2, 'connector:gmail', $3)`,
+			id, "agg-"+id.String(), audience); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ($1, 'person', $2)`, id, person)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a linked activity: %v", err)
+	}
+	return id
+}
+
+func holdActivity(t *testing.T, e *integration.Env, id ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE activity SET audience = 'participants' WHERE id = $1`, id)
+		return err
+	}); err != nil {
+		t.Fatalf("holding the activity: %v", err)
+	}
+}
+
+func retireUnsure(t *testing.T, e *integration.Env, id ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE capture_pending_counterparty SET status = 'unsure' WHERE id = $1`, id)
+		return err
+	}); err != nil {
+		t.Fatalf("retiring the disposition: %v", err)
+	}
+}

--- a/backend/internal/compose/meetingbrief/meeting.go
+++ b/backend/internal/compose/meetingbrief/meeting.go
@@ -190,7 +190,20 @@ const meetingQuery = `
 	                    JOIN activity_participant pp ON pp.activity_id = pa.id
 	                    WHERE pp.person_id = p.id AND pa.archived_at IS NULL
 	                      AND pa.id <> a.id AND pa.occurred_at <= a.occurred_at
+	                      AND pa.audience = 'workspace'
 	                      AND %[4]s
+	                      -- Workspace-visible messages only. A brief is read by
+	                      -- colleagues who were not on the mail, and a last-touch
+	                      -- that moved when a held message arrived would tell
+	                      -- them it arrived — the timestamp is the disclosure,
+	                      -- without a word of the message.
+	                      --
+	                      -- Spelled here rather than through auth.AudienceWorkspaceOnly
+	                      -- because this statement is assembled with positional
+	                      -- format verbs and a concatenated fragment would land
+	                      -- inside one; the rule is the same and
+	                      -- TestEveryAggregateAsksTheAudience holds the pair.
+	                      --
 	                      -- Scoped with the rest of the brief. This is the number
 	                      -- a reader trusts most, and it is the one that leaks:
 	                      -- narrow the deal and leave this alone and the brief

--- a/backend/internal/modules/capture/digest.go
+++ b/backend/internal/modules/capture/digest.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
 )
 
 // DigestPayload is the stored CAP-DDL-6 payload — the wire shape verbatim.
@@ -106,6 +108,11 @@ func (r *Registry) BuildDigests(ctx context.Context, digestDate time.Time) error
 
 // connectedUsers lists the workspace's users with a live capture
 // connection — the digest audience.
+//
+// EVERY connected seat, and the counts above are workspace-wide, which is why
+// they carry the audience clause: without it a colleague's held mail would be
+// counted in this seat's digest. Nothing of the message reaches the reader, and
+// the number still says it arrived.
 func connectedUsers(ctx context.Context, tx pgx.Tx) ([]ids.UUID, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT DISTINCT user_id FROM capture_connection
@@ -137,7 +144,8 @@ func (r *Registry) buildDigestPayload(ctx context.Context, tx pgx.Tx, userID ids
 	// able to see.
 	err := tx.QueryRow(ctx, `
 		SELECT
-		  (SELECT count(*) FROM activity WHERE captured_by LIKE 'connector:%' AND kind = 'email' AND created_at >= $1),
+		  (SELECT count(*) FROM activity a
+		    WHERE a.captured_by LIKE 'connector:%' AND a.kind = 'email' AND a.created_at >= $1`+auth.AudienceWorkspaceOnly("a")+`),
 		  (SELECT count(*) FROM person WHERE captured_by LIKE 'connector:%' AND created_at >= $1),
 		  -- Companies now arrive from the domain-triage verdict, not from the
 		  -- connector: capture withholds the organization until a site read
@@ -147,8 +155,10 @@ func (r *Registry) buildDigestPayload(ctx context.Context, tx pgx.Tx, userID ids
 		  (SELECT count(*) FROM organization
 		    WHERE (captured_by LIKE 'connector:%' OR source LIKE 'domain\_triage:%')
 		      AND created_at >= $1),
-		  (SELECT count(*) FROM activity WHERE capture_label = 'commitment' AND capture_labeled_at >= $1),
-		  (SELECT count(*) FROM activity WHERE capture_label = 'meeting' AND capture_labeled_at >= $1),
+		  (SELECT count(*) FROM activity a
+		    WHERE a.capture_label = 'commitment' AND a.capture_labeled_at >= $1`+auth.AudienceWorkspaceOnly("a")+`),
+		  (SELECT count(*) FROM activity a
+		    WHERE a.capture_label = 'meeting' AND a.capture_labeled_at >= $1`+auth.AudienceWorkspaceOnly("a")+`),
 		  (SELECT count(*) FROM activity WHERE capture_label = 'noise' AND capture_labeled_at >= $1)`,
 		since).Scan(
 		&p.Capture.ActivitiesCreated, &p.Capture.PeopleCreated, &p.Capture.OrganizationsCreated,

--- a/backend/internal/modules/capture/pendingreview.go
+++ b/backend/internal/modules/capture/pendingreview.go
@@ -67,6 +67,16 @@ func (s *PendingStore) AwaitingReview(ctx context.Context, limit int) ([]Pending
 			       p.activity_id, p.owner_id
 			  FROM capture_pending_counterparty p
 			 WHERE p.status = 'unsure'
+			   -- Not a sender whose mail is held. The review queue is a shared
+			   -- surface: staging one puts its address and display name in
+			   -- front of colleagues who cannot read the message it came from,
+			   -- and asks them to decide about a correspondent they were never
+			   -- meant to know about. The sender stays unsure and the owner can
+			   -- still answer for them on their own Senders page.
+			   AND EXISTS (
+			     SELECT 1 FROM activity a
+			      WHERE a.id = p.activity_id AND a.audience = 'workspace'
+			        AND a.restricted_at IS NULL)
 			   AND NOT EXISTS (
 			     SELECT 1 FROM approval a
 			      WHERE a.id = p.proposal_id

--- a/backend/internal/modules/deals/health.go
+++ b/backend/internal/modules/deals/health.go
@@ -376,7 +376,7 @@ func healthActivityEvidence(ctx context.Context, tx pgx.Tx, now time.Time, in *d
 	err = tx.QueryRow(ctx, `
 		SELECT a.id FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = $1
-		WHERE a.archived_at IS NULL
+		WHERE a.archived_at IS NULL`+auth.AudienceWorkspaceOnly("a")+`
 		ORDER BY a.occurred_at DESC, a.id DESC
 		LIMIT 1`, in.dealID).Scan(&recent)
 	switch {
@@ -388,7 +388,10 @@ func healthActivityEvidence(ctx context.Context, tx pgx.Tx, now time.Time, in *d
 		in.mostRecentActivityID = &recent
 	}
 
-	// Commitments evidence: the open overdue tasks on the deal.
+	// Commitments evidence: the open overdue tasks on the deal. No audience
+	// clause, and that is the difference rather than an omission: a task is
+	// hand-logged work, never a captured message, so it has no importing
+	// mailbox and nothing to hold it from.
 	overdue, err := collectIDs(tx.Query(ctx, `
 		SELECT a.id FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id AND l.deal_id = $1

--- a/backend/internal/modules/people/strength.go
+++ b/backend/internal/modules/people/strength.go
@@ -342,13 +342,13 @@ func contactStrengths(ctx context.Context, tx pgx.Tx, contacts []ids.PersonID, n
 		       (SELECT i.id FROM activity i
 		          JOIN activity_link il ON il.activity_id = i.id AND il.person_id = l.person_id
 		         WHERE i.direction = 'inbound' AND i.kind IN `+strengthKinds+`
-		           AND i.archived_at IS NULL AND i.occurred_at >= $2
+		           AND i.archived_at IS NULL AND i.occurred_at >= $2`+auth.AudienceWorkspaceOnly("i")+`
 		           AND ($3::timestamptz IS NULL OR i.occurred_at <= $3)
 		         ORDER BY i.occurred_at DESC, i.id DESC
 		         LIMIT 1)
 		FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id
-		WHERE l.person_id = ANY($1) AND a.kind IN `+strengthKinds+` AND a.archived_at IS NULL
+		WHERE l.person_id = ANY($1) AND a.kind IN `+strengthKinds+` AND a.archived_at IS NULL`+auth.AudienceWorkspaceOnly("a")+`
 		  -- NULL means no upper bound, so the live score is unchanged; an
 		  -- as-of read passes the instant it is asking about.
 		  AND ($3::timestamptz IS NULL OR a.occurred_at <= $3)

--- a/backend/internal/platform/auth/audienceaggregate.go
+++ b/backend/internal/platform/auth/audienceaggregate.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+// The audience rule for a reader that COUNTS messages rather than showing them.
+//
+// A held message is not only unreadable — it must not be visible in the shape
+// of an aggregate either. A relationship-strength score that counts a founder's
+// correspondence with their lawyer tells every colleague the relationship is
+// strong; a last-activity timestamp that moves when a private message arrives
+// tells them when it arrived. Neither shows a word of the message, and both
+// disclose it.
+//
+// Spelled once here rather than per module because four readers ask the same
+// question — relationship strength, deal health, the meeting brief and the
+// weekly digest — and a fifth will be written by somebody who greps for it. The
+// graph projection asked it first and carried its own copy; that copy moved
+// here rather than being joined by a second.
+
+// AudienceWorkspaceOnly filters an activity aliased by name down to the
+// messages the whole workspace may see.
+//
+// It takes no placeholder, so it renumbers nothing at a call site: a caller
+// concatenates it into a WHERE clause and the surrounding arguments keep their
+// positions.
+//
+// Deliberately NOT the reader's own audience. An aggregate is read by
+// colleagues who did not receive the mail, and a per-caller answer would give
+// two people different numbers for the same account — which reads as a bug and
+// discloses the difference between them. The question an aggregate asks is
+// "may EVERYONE see this", and the answer is the same for everybody.
+func AudienceWorkspaceOnly(alias string) string {
+	return " AND " + alias + ".audience = 'workspace'"
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -74,11 +74,12 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (77)
+## Census (78)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
 | `agentgrantscopes_test.go` | H2 | A credential that does not fund the tools its agent declares buys a run that starts, discovers it cannot do its job, and stops. |
+| `aggregateaudience_test.go` | H2 | A reader that COUNTS messages asks the audience, exactly as one that shows them does. |
 | `aggregategatereach_test.go` | H3 | Every job the `ci` aggregate depends on can actually RUN on the merge queue. |
 | `aitaskcensus_test.go` | H3 | The census as a fitness function: the contract says which AI tasks ship and what their invocation sites are called, and this build must register exactly those. |
 | `aitaskrailcensus_test.go` | H2 | Every AI task this build can run reports into the AI-activity projection. |


### PR DESCRIPTION
The last backend piece of the mailbox-privacy work. **Five readers counted messages a colleague may not read** — none of them projecting a word of text, which is why the content gate correctly passed all five, and every one of them disclosing the message anyway.

A relationship-strength score counting a founder's correspondence with their lawyer tells every colleague that relationship is strong. A last-touch that moves when a private message arrives tells them when it arrived. **The number is the disclosure.**

## What is gated now

| Reader | What a colleague was seeing |
| --- | --- |
| `people/strength.go` | Relationship strength and warmth, on any person or account |
| `deals/health.go` | The deal's recency score |
| `compose/meetingbrief/meeting.go` | Last-touch per attendee — the number a brief's reader trusts most |
| `capture/digest.go` | The weekly digest's counts of what came in |
| `search/graphedge.go` | The who-knows-whom projection (already correct; its rule moved) |

The graph projection had asked this question first and carried its own copy. That copy moved to `platform/auth` rather than being joined by a second.

**The predicate asks whether EVERYONE may see the message, not whether the caller may.** An aggregate is read by colleagues who were not on the mail, and a per-caller answer would give two people different numbers for the same account — which reads as a bug and discloses the difference between them.

**The gate found one I had missed.** I listed four readers from the plan and wrote the gate against five; the digest failed. Its counts are workspace-wide and it goes to every connected seat, so a colleague's held mail was counted in this seat's digest.

## Also: a held sender is off the shared review queue

`AwaitingReview` staged any unsure sender, including one whose message is held — putting an address and display name in front of colleagues who cannot read the mail it came from, and asking them to decide about a correspondent they were never meant to know about. The owner can still answer for them on their own Senders page.

## Two things deliberately left alone

Deal health's overdue-task query takes no audience clause, because a task is hand-logged work and has no importing mailbox to hold it from. The meeting brief spells the literal rather than calling the helper, because that statement is assembled with positional format verbs and a concatenated fragment would land inside one. Both reasons are written where a reader meets them.

## Two filed rather than half-fixed

**#3400** — a webhook retry delivers a message narrowed after it was enqueued. The first attempt checks `ownerCanSee`; the sweep does not. `attemptTarget` carries neither owner nor entity, and the stored payload is the *wire* envelope, which drops the entity reference — so the retry cannot re-ask without a schema change.

**#3401** — an attachment's filename reaches a reader outside the audience. The code already documents this. A filename is content: PR 6's own certification corpus has a case where the answer to what a thread is about lives only in the attachment name. Covering it means four entity types with four different paths back to their activity, and doing one would leave a comment claiming coverage the code does not have.

## Tests

`TestEveryAggregateAsksTheAudience` names its five subjects rather than discovering them — what makes a reader an aggregate is what its number *means*, and a scanner seeing ids and timestamps is right to pass them. Each entry says which number a reader sees, so a failure names the disclosure rather than only the file.

`TestAHeldMessageIsNotCountedInRelationshipStrength` and `TestAHeldSenderIsNotStagedForReview` assert both directions, so neither can pass on an empty result. All mutation-checked.

## Verification

`make check-backend`, `make craft-static`, all gates and the compose integration lane green locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops held messages from leaking through the numbers that counted them. Five readers—relationship strength, the deal's recency score, the meeting brief's per-attendee last-touch, the weekly digest, and the who-knows-whom projection—showed colleagues a count or timestamp that moved when a private message arrived; all now filter to workspace-visible activities, with the rule shared through `auth.AudienceWorkspaceOnly`.

Also keeps held senders off the shared review queue: `AwaitingReview` no longer stages a sender whose message is held, while the owner can still answer for them on their own Senders page.

**Notes for review**
- The predicate asks whether *everyone* may see the message, not whether the caller may—a per-caller answer would give two people different numbers for the same account.
- Deal health's overdue-task query is deliberately ungated: tasks are hand-logged, not captured mail, so there is nothing to hold.
- The meeting brief spells the literal instead of calling the helper because its statement uses positional format verbs.
- Webhook retries (#3400) and attachment filenames (#3401) are filed as follow-ups rather than fixed here.

<sup>Written for commit b6458da290d65affdf229722a09c2cd4196910b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace visibility filtering across meeting briefs, digests, relationship insights, deal health, and review queues.
  * Restricted shared review data to workspace-visible activity while preserving owner-level resolution for excluded items.
  * Ensured held messages and senders do not affect relationship counts or shared review queues.

* **Documentation**
  * Updated the gate inventory and clarified workspace-wide capture count behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->