### PR TITLE
A Microsoft mailbox stops ageing out of its own credential

### DIFF
--- a/backend/gates/vaultwriters_test.go
+++ b/backend/gates/vaultwriters_test.go
@@ -65,6 +65,11 @@ var vaultWriters = map[string]string{
 	// The declared no-domain-fact posture: bytes move, nothing changes meaning,
 	// so it records operationally rather than as an entity change.
 	"internal/platform/extsecrets/store.go": "system_log — the explicit no-domain-fact posture",
+	// A provider replaced the durable credential during a background pull.
+	// Nobody decided it, so there is no domain change to audit and no actor to
+	// attribute one to — the operational fact is what makes an aged-out mailbox
+	// diagnosable. Written in the same transaction as the ref it describes.
+	"internal/modules/capture/registry_rotation.go": "system_log, action capture.credential_rotated — the no-domain-fact posture",
 
 	// RECORDS NOTHING, and named rather than covered. The boot-time relocation of
 	// a legacy credential into the vault writes no audit row, no system log and no

--- a/backend/internal/compose/integration/capture/capture_rotation_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_rotation_integration_test.go
@@ -39,6 +39,18 @@ type rotatingConnector struct {
 	// duringSync runs at the moment the provider would be answering — the
 	// deterministic stand-in for a human disconnecting mid-pull.
 	duringSync func()
+	// seen is shared BY POINTER with every copy WithCredentialSink makes —
+	// which is the whole point of that method, and why a plain counter field
+	// reads zero here: the copy is what runs, not the instance the test holds.
+	seen *rotationLog
+}
+
+// rotationLog is what the sink actually did. Without it a race test passes when
+// no rotation was attempted at all, asserting the disconnect's own effect and
+// nothing about the fence.
+type rotationLog struct {
+	attempts int
+	lastErr  error
 }
 
 func (c *rotatingConnector) Descriptor() connector.Descriptor {
@@ -71,8 +83,10 @@ func (c *rotatingConnector) Sync(ctx context.Context, _ connector.Auth, _ connec
 		c.duringSync()
 	}
 	if c.rotations != nil && c.next != "" {
-		if err := c.rotations.Rotated(ctx, connector.Auth(c.next)); err != nil {
-			return nil, err
+		c.seen.attempts++
+		c.seen.lastErr = c.rotations.Rotated(ctx, connector.Auth(c.next))
+		if c.seen.lastErr != nil {
+			return nil, c.seen.lastErr
 		}
 	}
 	return connector.Cursor(`{"email":"owner@myco.example"}`), nil
@@ -99,7 +113,7 @@ func TestARotatedCredentialIsSealedAndTheOldOneRetired(t *testing.T) {
 	seedCaptureRole(t, e)
 	vault := newTestKeyvault(t, e)
 	registry := newTestCaptureRegistry(e, vault)
-	fake := &rotatingConnector{next: "replacement-credential"}
+	fake := &rotatingConnector{next: "replacement-credential", seen: &rotationLog{}}
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
@@ -144,7 +158,7 @@ func TestARotationThatLosesToADisconnectLandsNowhere(t *testing.T) {
 	seedCaptureRole(t, e)
 	vault := newTestKeyvault(t, e)
 	registry := newTestCaptureRegistry(e, vault)
-	fake := &rotatingConnector{next: "replacement-credential"}
+	fake := &rotatingConnector{next: "replacement-credential", seen: &rotationLog{}}
 	registry.Register(fake)
 
 	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
@@ -163,7 +177,60 @@ func TestARotationThatLosesToADisconnectLandsNowhere(t *testing.T) {
 		t.Fatalf("SyncOnce over a disconnected connection: %v, want a clean return", err)
 	}
 
+	// The fence is only proved if a rotation was actually ATTEMPTED. Without
+	// this the assertion below passes on a run where the sink was never bound
+	// and Disconnect cleared the ref by itself — which says nothing about
+	// whether a rotation racing home would have been fenced out.
+	if fake.seen.attempts != 1 {
+		t.Fatalf("the connector attempted %d rotation(s), want exactly one to race the disconnect", fake.seen.attempts)
+	}
+	if fake.seen.lastErr != nil {
+		t.Fatalf("the superseded rotation reported %v, want a clean no-op: it lost the race, it did not fail", fake.seen.lastErr)
+	}
 	if ref := readCredentialRef(t, e, connID); ref != "" {
 		t.Fatalf("credential_ref = %q, want none — the disconnect destroyed the credential and the rotation must not restore one", ref)
+	}
+}
+
+// The other half of the same fence, and the one the generation cannot catch: a
+// SAME-ACCOUNT reconnect leaves the generation alone, so only "the credential I
+// read is still the credential on the row" tells a rotation of the live grant
+// apart from one derived out of a grant that has since been replaced.
+func TestARotationThatLosesToAReconnectLandsNowhere(t *testing.T) {
+	e := integration.SetupSearch(t)
+	seedCaptureRole(t, e)
+	vault := newTestKeyvault(t, e)
+	registry := newTestCaptureRegistry(e, vault)
+	fake := &rotatingConnector{next: "replacement-credential", seen: &rotationLog{}}
+	registry.Register(fake)
+
+	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("initial-credential"))
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	fake.duringSync = func() {
+		// The same human reconnects the same account mid-pull — a fresh
+		// credential on the same row, at the same generation.
+		if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("reconnected-credential")); err != nil {
+			t.Errorf("mid-sync reconnect: %v", err)
+		}
+	}
+
+	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	if err := registry.SyncOnce(wsCtx, connID); err != nil {
+		t.Fatalf("SyncOnce across a reconnect: %v, want a clean return", err)
+	}
+	if fake.seen.attempts != 1 {
+		t.Fatalf("the connector attempted %d rotation(s), want exactly one to race the reconnect", fake.seen.attempts)
+	}
+
+	ref := readCredentialRef(t, e, connID)
+	sealed, err := vault.Get(wsCtx, ids.From[ids.WorkspaceKind](e.WS), keyvault.Ref(ref))
+	if err != nil {
+		t.Fatalf("resolving the connection's credential: %v", err)
+	}
+	if string(sealed) != "reconnected-credential" {
+		t.Fatalf("the connection holds %q — the stale sync's rotation overwrote the credential the human just reconnected with", sealed)
 	}
 }

--- a/backend/internal/compose/integration/capture/capture_rotation_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_rotation_integration_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture
+
+// A provider that replaces the durable credential every time it is used, and
+// what the registry does with the replacement.
+//
+// The unit tests beside the connector prove it REPORTS the rotation. These
+// prove the report survives: the vault holds the new secret, the row points at
+// it, the old blob is gone, and a lifecycle change that beat the rotation home
+// wins.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/keyvault"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+)
+
+// rotatingConnector stands in for Microsoft: every sync hands back a
+// replacement credential, exactly as the identity platform does on each
+// redemption.
+type rotatingConnector struct {
+	rotations connector.CredentialSink
+	// next is the bundle the provider "issues" on the next sync.
+	next string
+	// duringSync runs at the moment the provider would be answering — the
+	// deterministic stand-in for a human disconnecting mid-pull.
+	duringSync func()
+}
+
+func (c *rotatingConnector) Descriptor() connector.Descriptor {
+	return connector.Descriptor{
+		Name: "gmail", Version: "1",
+		Scopes:   []principal.Scope{principal.ScopeRead},
+		RiskTier: mcp.TierAutoExecute,
+		Produces: []datasource.EntityType{datasource.EntityActivity},
+	}
+}
+
+func (c *rotatingConnector) Authenticate(context.Context, connector.AuthRequest) (connector.Auth, error) {
+	return connector.Auth("initial-credential"), nil
+}
+
+func (c *rotatingConnector) Normalize(context.Context, connector.RawRecord) ([]connector.NormalizedRecord, error) {
+	return nil, nil
+}
+
+func (c *rotatingConnector) HealthCheck(context.Context, connector.Auth) error { return nil }
+
+func (c *rotatingConnector) WithCredentialSink(sink connector.CredentialSink) connector.Connector {
+	copied := *c
+	copied.rotations = sink
+	return &copied
+}
+
+func (c *rotatingConnector) Sync(ctx context.Context, _ connector.Auth, _ connector.Cursor, _ connector.Sink) (connector.Cursor, error) {
+	if c.duringSync != nil {
+		c.duringSync()
+	}
+	if c.rotations != nil && c.next != "" {
+		if err := c.rotations.Rotated(ctx, connector.Auth(c.next)); err != nil {
+			return nil, err
+		}
+	}
+	return connector.Cursor(`{"email":"owner@myco.example"}`), nil
+}
+
+// readCredentialRef reads what the connection currently points at.
+func readCredentialRef(t *testing.T, e *integration.SearchEnv, connID ids.UUID) string {
+	t.Helper()
+	var ref *string
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(e.Admin(), `SELECT credential_ref FROM capture_connection WHERE id = $1`, connID).Scan(&ref)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref == nil {
+		return ""
+	}
+	return *ref
+}
+
+func TestARotatedCredentialIsSealedAndTheOldOneRetired(t *testing.T) {
+	e := integration.SetupSearch(t)
+	seedCaptureRole(t, e)
+	vault := newTestKeyvault(t, e)
+	registry := newTestCaptureRegistry(e, vault)
+	fake := &rotatingConnector{next: "replacement-credential"}
+	registry.Register(fake)
+
+	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("initial-credential"))
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	before := readCredentialRef(t, e, connID)
+	if before == "" {
+		t.Fatal("the connection stored no credential ref to rotate")
+	}
+
+	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	if err := registry.SyncOnce(wsCtx, connID); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+
+	after := readCredentialRef(t, e, connID)
+	if after == before {
+		t.Fatal("the connection still points at the credential the provider replaced — it will age out on Microsoft's own schedule")
+	}
+	sealed, err := vault.Get(wsCtx, ids.From[ids.WorkspaceKind](e.WS), keyvault.Ref(after))
+	if err != nil {
+		t.Fatalf("the row points at a ref the vault cannot resolve: %v", err)
+	}
+	if string(sealed) != "replacement-credential" {
+		t.Fatalf("the sealed credential is %q, want the replacement", sealed)
+	}
+	// The superseded secret is destroyed, not merely unreferenced: a credential
+	// nothing points at but anyone with the ref can still read is exactly what
+	// disconnect exists to prevent.
+	if _, err := vault.Get(wsCtx, ids.From[ids.WorkspaceKind](e.WS), keyvault.Ref(before)); err == nil {
+		t.Fatal("the replaced credential is still readable in the vault")
+	}
+}
+
+// A rotation that arrives after its connection is gone must land nowhere. The
+// human's disconnect destroyed the credential; re-pointing the row at a fresh
+// blob would resurrect a grant they withdrew.
+func TestARotationThatLosesToADisconnectLandsNowhere(t *testing.T) {
+	e := integration.SetupSearch(t)
+	seedCaptureRole(t, e)
+	vault := newTestKeyvault(t, e)
+	registry := newTestCaptureRegistry(e, vault)
+	fake := &rotatingConnector{next: "replacement-credential"}
+	registry.Register(fake)
+
+	grantCtx := humanWithScopes(e, e.Rep1, []principal.Scope{principal.ScopeRead})
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("initial-credential"))
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	fake.duringSync = func() {
+		if err := registry.Disconnect(grantCtx, "gmail"); err != nil {
+			t.Errorf("mid-sync disconnect: %v", err)
+		}
+	}
+
+	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	if err := registry.SyncOnce(wsCtx, connID); err != nil {
+		t.Fatalf("SyncOnce over a disconnected connection: %v, want a clean return", err)
+	}
+
+	if ref := readCredentialRef(t, e, connID); ref != "" {
+		t.Fatalf("credential_ref = %q, want none — the disconnect destroyed the credential and the rotation must not restore one", ref)
+	}
+}

--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -167,12 +167,11 @@ func NewOAuth(cfg OAuthConfig) OAuth {
 		TokenURL:     cfg.TokenURL,
 		// Microsoft returns the code on the query (not fragment); the v2
 		// endpoint requires the scope in every token form for a refresh token.
-		// Microsoft rotates the refresh token on each redemption. The stored
-		// original keeps working within its lifetime (a confidential-client
-		// refresh token is valid ~90 days), so an actively-synced mailbox
-		// never reauths; a mailbox idle past that window must reconnect. A
-		// credential-rotation seam (Sync surfacing an updated credential for
-		// the registry to re-seal) is a tracked follow-up, not this PR.
+		// Microsoft rotates the refresh token on each redemption, and the
+		// replacement is persisted: Refresh reports it and the connector hands
+		// it to the registry's credential sink, which re-seals it. Without that
+		// a mailbox idle past the ~90-day confidential-client lifetime had to
+		// reconnect for no reason its owner could see.
 		AuthParams:        map[string]string{"response_mode": "query"},
 		ScopeInTokenForms: true,
 		AuthRejected:      ErrAuthRejected,

--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -81,6 +81,10 @@ type OAuth interface {
 	AuthCodeURL(state, redirectURI string) string
 	Exchange(ctx context.Context, code, redirectURI string) (oauthflow.TokenGrant, error)
 	AccessToken(ctx context.Context, refreshToken string) (accessToken string, err error)
+	// Refresh is AccessToken plus the rotation Microsoft performs on every
+	// redemption — the durable half, which Sync persists and the one-shot
+	// callers above have nowhere to put.
+	Refresh(ctx context.Context, refreshToken string) (oauthflow.TokenRefresh, error)
 }
 
 // API is the read-only Graph mail surface the connector uses. All calls take

--- a/backend/internal/modules/capture/graph/graph.go
+++ b/backend/internal/modules/capture/graph/graph.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/margince/margince/backend/internal/modules/capture/mailmap"
@@ -56,6 +57,12 @@ type Connector struct {
 	// outbound mail they name. Nil keeps the old behaviour: the report is
 	// dropped with the rest of the delivery-system mail.
 	bounces connector.BounceSink
+	// rotations receives the replacement credential Microsoft issues on every
+	// token redemption. Nil drops it, which is what every caller but the
+	// standing sync wants: a health probe and a one-shot send have nowhere to
+	// persist one, and a rotation reported to nobody is the behaviour this
+	// connector had before the seam existed.
+	rotations connector.CredentialSink
 }
 
 // WithBounceSink returns a copy that records delivery reports instead of
@@ -66,16 +73,31 @@ func (c *Connector) WithBounceSink(sink connector.BounceSink) *Connector {
 	return &copied
 }
 
+// WithCredentialSink returns a COPY that reports the refresh token Microsoft
+// replaces on every redemption (connector.CredentialRotator).
+//
+// A copy, not a field on the shared instance: one registry entry serves every
+// connection the fleet syncs at once, and a sink stored on it would carry one
+// mailbox's credential into another mailbox's re-seal.
+//
+//nolint:ireturn // implements connector.CredentialRotator, whose contract returns the Connector seam
+func (c *Connector) WithCredentialSink(sink connector.CredentialSink) connector.Connector {
+	copied := *c
+	copied.rotations = sink
+	return &copied
+}
+
 // New returns a Graph connector over the given OAuth + API surfaces.
 func New(oauth OAuth, api API) *Connector {
 	return &Connector{oauth: oauth, api: api, now: time.Now}
 }
 
 var (
-	_ connector.Connector      = (*Connector)(nil)
-	_ connector.Backfiller     = (*Connector)(nil)
-	_ connector.GrantedScoper  = (*Connector)(nil)
-	_ connector.AccountLabeler = (*Connector)(nil)
+	_ connector.Connector         = (*Connector)(nil)
+	_ connector.Backfiller        = (*Connector)(nil)
+	_ connector.GrantedScoper     = (*Connector)(nil)
+	_ connector.AccountLabeler    = (*Connector)(nil)
+	_ connector.CredentialRotator = (*Connector)(nil)
 )
 
 // authState is the persisted credential bundle (the opaque connector.Auth).
@@ -205,10 +227,17 @@ func (c *Connector) Sync(ctx context.Context, auth connector.Auth, cursor connec
 	}
 	owner := st.Owner // local — never stored on the shared instance
 
-	access, err := c.oauth.AccessToken(ctx, st.RefreshToken)
+	refreshed, err := c.oauth.Refresh(ctx, st.RefreshToken)
 	if err != nil {
 		return nil, err
 	}
+	access := refreshed.AccessToken
+	// Reported BEFORE the pull, and deliberately: the replacement is already
+	// issued and the old token is already spent by the time Graph answers, so
+	// waiting for the pull to succeed would drop the rotation on every sync
+	// that fails for an unrelated reason — which is exactly the mailbox that
+	// most needs its credential kept fresh.
+	c.reportRotation(ctx, st, refreshed.Rotated)
 
 	start, err := parseCursor(cursor)
 	if err != nil {
@@ -247,6 +276,29 @@ func (c *Connector) Sync(ctx context.Context, auth connector.Auth, cursor connec
 		nextDelta = start // provider closed the round without a new link; keep the prior watermark
 	}
 	return marshalCursor(nextDelta, owner), nil
+}
+
+// reportRotation hands the replacement credential to the sink, if there is one
+// and if the provider actually issued one.
+//
+// A failure is LOGGED, never returned. The old token stays valid for its own
+// lifetime, which is what makes a missed rotation cost one cycle's freshness
+// rather than the mailbox — where failing the sync over it would cost the mail
+// to save the bookkeeping.
+func (c *Connector) reportRotation(ctx context.Context, st authState, rotated string) {
+	if c.rotations == nil || rotated == "" {
+		return
+	}
+	st.RefreshToken = rotated
+	//nolint:gosec // G117: re-sealing the connector's own rotated refresh token into the opaque Auth bundle IS the intended path — the registry stores it encrypted in the vault, never logged or returned
+	next, err := json.Marshal(st)
+	if err != nil {
+		slog.WarnContext(ctx, "graph: encoding the rotated credential", "err", err)
+		return
+	}
+	if err := c.rotations.Rotated(ctx, next); err != nil {
+		slog.WarnContext(ctx, "graph: recording the rotated credential", "err", err)
+	}
 }
 
 // selectMessages resolves which message ids to pull and the deltaLink to

--- a/backend/internal/modules/capture/graph/graph_test.go
+++ b/backend/internal/modules/capture/graph/graph_test.go
@@ -24,6 +24,9 @@ import (
 type fakeOAuth struct {
 	refresh, access string
 	granted         []string
+	// rotated is what Microsoft hands back in place of the stored refresh
+	// token; empty means it rotated nothing this round.
+	rotated string
 }
 
 func (f fakeOAuth) AuthCodeURL(state, _ string) string { return "https://auth?state=" + state }
@@ -31,6 +34,10 @@ func (f fakeOAuth) Exchange(context.Context, string, string) (oauthflow.TokenGra
 	return oauthflow.TokenGrant{RefreshToken: f.refresh, Scopes: f.granted}, nil
 }
 func (f fakeOAuth) AccessToken(context.Context, string) (string, error) { return f.access, nil }
+
+func (f fakeOAuth) Refresh(context.Context, string) (oauthflow.TokenRefresh, error) {
+	return oauthflow.TokenRefresh{AccessToken: f.access, Rotated: f.rotated}, nil
+}
 
 type fakeAPI struct {
 	email string

--- a/backend/internal/modules/capture/graph/rotation_test.go
+++ b/backend/internal/modules/capture/graph/rotation_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package graph
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// recordingRotations captures what the connector reports, so a test can assert
+// on the BUNDLE rather than on the call having happened.
+type recordingRotations struct {
+	got  []connector.Auth
+	err  error
+	seen int
+}
+
+func (r *recordingRotations) Rotated(_ context.Context, auth connector.Auth) error {
+	r.seen++
+	if r.err != nil {
+		return r.err
+	}
+	r.got = append(r.got, auth)
+	return nil
+}
+
+func rotatingConnector(t *testing.T, oauth fakeOAuth, api API, sink connector.CredentialSink) connector.Connector {
+	t.Helper()
+	return New(oauth, api).WithCredentialSink(sink)
+}
+
+func TestASyncReportsTheReplacementCredentialWithTheRestOfTheBundleIntact(t *testing.T) {
+	sink := &recordingRotations{}
+	api := &fakeAPI{email: owner, initDelta: "https://graph/delta?$1"}
+	c := rotatingConnector(t, fakeOAuth{access: "a", rotated: "r-2"}, api, sink)
+
+	if _, err := c.Sync(context.Background(), sealedAuth(t), nil, &recordingSink{}); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(sink.got) != 1 {
+		t.Fatalf("the sink saw %d rotation(s), want one", len(sink.got))
+	}
+	var st authState
+	if err := json.Unmarshal(sink.got[0], &st); err != nil {
+		t.Fatalf("the reported bundle does not decode: %v", err)
+	}
+	if st.RefreshToken != "r-2" {
+		t.Errorf("RefreshToken = %q, want the replacement", st.RefreshToken)
+	}
+	// The bundle is the WHOLE credential, not the secret alone: a re-seal that
+	// dropped the owner or the granted scopes would leave the connection unable
+	// to say whose mailbox it is or whether it may send.
+	if st.Owner != owner {
+		t.Errorf("Owner = %q, want it carried through the rotation", st.Owner)
+	}
+	if len(st.Granted) == 0 {
+		t.Error("the rotated bundle dropped the granted scopes")
+	}
+}
+
+// The common case: Google-style providers, and Microsoft rounds where nothing
+// was replaced. A sink called on every sync would re-seal the vault and retire
+// a blob for no change.
+func TestASyncThatRotatesNothingReportsNothing(t *testing.T) {
+	sink := &recordingRotations{}
+	api := &fakeAPI{email: owner, initDelta: "https://graph/delta?$1"}
+	c := rotatingConnector(t, fakeOAuth{access: "a"}, api, sink)
+
+	if _, err := c.Sync(context.Background(), sealedAuth(t), nil, &recordingSink{}); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if sink.seen != 0 {
+		t.Fatalf("the sink was called %d time(s) with no rotation to report", sink.seen)
+	}
+}
+
+// A re-seal that cannot be written costs one cycle's freshness; failing the
+// pull over it would cost the mail. The old credential is still valid, which is
+// what makes that trade the right way round.
+func TestARotationThatCannotBeRecordedDoesNotFailTheSync(t *testing.T) {
+	sink := &recordingRotations{err: errors.New("the vault is unreachable")}
+	api := &fakeAPI{email: owner, initDelta: "https://graph/delta?$1"}
+	c := rotatingConnector(t, fakeOAuth{access: "a", rotated: "r-2"}, api, sink)
+
+	cur, err := c.Sync(context.Background(), sealedAuth(t), nil, &recordingSink{})
+	if err != nil {
+		t.Fatalf("Sync = %v, want the pull to stand despite the failed re-seal", err)
+	}
+	if len(cur) == 0 {
+		t.Error("the watermark was not advanced — the sync was penalised for a bookkeeping fault")
+	}
+}
+
+// The rotation is reported BEFORE the pull because it has already happened by
+// then: the replacement is issued and the old token spent the moment the token
+// endpoint answers. Reporting it only on success would drop it on exactly the
+// mailbox that most needs its credential kept fresh — one whose syncs keep
+// failing.
+func TestARotationIsReportedEvenWhenThePullThenFails(t *testing.T) {
+	sink := &recordingRotations{}
+	api := &fakeAPI{email: owner, deltaErr: ErrUnreachable}
+	c := rotatingConnector(t, fakeOAuth{access: "a", rotated: "r-2"}, api, sink)
+
+	prior := marshalCursor("https://graph/delta?stale", owner)
+	if _, err := c.Sync(context.Background(), sealedAuth(t), prior, &recordingSink{}); err == nil {
+		t.Fatal("expected the pull to fail in this fixture")
+	}
+	if len(sink.got) != 1 {
+		t.Fatalf("the sink saw %d rotation(s), want the one that had already happened", len(sink.got))
+	}
+}
+
+// The shared instance must never carry a sink: one connector serves every
+// connection the fleet pulls at once, and a field set in place would send one
+// mailbox's replacement credential to another mailbox's re-seal.
+func TestBindingASinkLeavesTheRegisteredConnectorAlone(t *testing.T) {
+	registered := New(fakeOAuth{access: "a", rotated: "r-2"}, &fakeAPI{email: owner, initDelta: "d"})
+	mine := &recordingRotations{}
+	bound := registered.WithCredentialSink(mine)
+
+	if bound == connector.Connector(registered) {
+		t.Fatal("WithCredentialSink returned the receiver — the registered instance now holds one connection's sink")
+	}
+	if _, err := registered.Sync(context.Background(), sealedAuth(t), nil, &recordingSink{}); err != nil {
+		t.Fatalf("Sync on the registered instance: %v", err)
+	}
+	if mine.seen != 0 {
+		t.Fatal("a sync through the REGISTERED connector reported to a sink bound to a copy")
+	}
+}
+
+// sealedAuth is the bundle a connected mailbox holds.
+func sealedAuth(t *testing.T) connector.Auth {
+	t.Helper()
+	b, err := json.Marshal(authState{
+		RefreshToken: "r-1", Owner: owner,
+		Granted: []string{"offline_access", "User.Read", "Mail.Read"},
+	})
+	if err != nil {
+		t.Fatalf("marshal auth: %v", err)
+	}
+	return b
+}

--- a/backend/internal/modules/capture/oauthflow/oauthflow.go
+++ b/backend/internal/modules/capture/oauthflow/oauthflow.go
@@ -193,11 +193,43 @@ func (c *Client) grantedScopes(scope string) []string {
 	return c.cfg.Scopes
 }
 
-// AccessToken redeems the stored refresh token for a short-lived access
-// token. A provider that rotates the refresh token on redemption (Microsoft)
-// leaves the stored one valid for its own lifetime, so the rotation need not
-// be persisted here.
+// TokenRefresh is what one redemption of a refresh token yielded: the
+// short-lived access token, and — from a provider that rotates on use — the
+// replacement refresh token.
+//
+// Rotated is EMPTY when the provider returned none, and empty means "keep the
+// one you have" rather than "you now have none". Conflating the two would let a
+// provider that simply omits the field erase a working credential.
+type TokenRefresh struct {
+	AccessToken string
+	Rotated     string
+}
+
+// AccessToken redeems the stored refresh token for a short-lived access token,
+// discarding any rotation. It is the shape for callers with nothing to persist
+// to — a health probe, a one-shot send — and it is deliberately still here
+// rather than folded into Refresh: most of this system's callers genuinely do
+// not care, and making them all handle a value they will drop is how the
+// handling gets copy-pasted wrong.
 func (c *Client) AccessToken(ctx context.Context, refreshToken string) (string, error) {
+	refreshed, err := c.Refresh(ctx, refreshToken)
+	if err != nil {
+		return "", err
+	}
+	return refreshed.AccessToken, nil
+}
+
+// Refresh redeems the stored refresh token and reports the rotation alongside
+// the access token.
+//
+// The rotation is reported even though the OLD token stays valid for its own
+// lifetime: that lifetime is a ceiling, not a guarantee (Microsoft expires an
+// idle confidential-client refresh token at 90 days, and a password change or
+// an admin revoke cuts it shorter), so a connection that never persists the
+// replacement ages out on a schedule nobody set. A caller that persists it
+// keeps the connection alive indefinitely; one that does not is exactly where
+// it was.
+func (c *Client) Refresh(ctx context.Context, refreshToken string) (TokenRefresh, error) {
 	form := url.Values{
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {refreshToken},
@@ -207,12 +239,19 @@ func (c *Client) AccessToken(ctx context.Context, refreshToken string) (string, 
 	c.addScope(form)
 	tok, err := c.token(ctx, form)
 	if err != nil {
-		return "", err
+		return TokenRefresh{}, err
 	}
 	if tok.AccessToken == "" {
-		return "", fmt.Errorf("%s: token refresh returned no access token: %w", c.cfg.Provider, c.cfg.AuthRejected)
+		return TokenRefresh{}, fmt.Errorf("%s: token refresh returned no access token: %w", c.cfg.Provider, c.cfg.AuthRejected)
 	}
-	return tok.AccessToken, nil
+	rotated := tok.RefreshToken
+	if rotated == refreshToken {
+		// A provider that echoes the same token back has rotated nothing.
+		// Reporting it would make every sync re-seal the vault and retire a
+		// blob for no change.
+		rotated = ""
+	}
+	return TokenRefresh{AccessToken: tok.AccessToken, Rotated: rotated}, nil
 }
 
 func (c *Client) addScope(form url.Values) {

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -256,7 +256,14 @@ func (r *Registry) SyncOnce(ctx context.Context, connectionID ids.UUID) error {
 		return err
 	}
 
-	next, syncErr := c.Sync(runCtx, auth, connector.Cursor(cursor), r.sink)
+	// Bound per sync, never on the registered instance: one connector serves
+	// every connection the fleet pulls at once, and a sink held on it would
+	// carry one mailbox's replacement credential into another mailbox's
+	// re-seal. A provider whose credential is stable is returned unchanged.
+	syncer := connector.RotatingSyncer(c, rotationSink{
+		registry: r, connectionID: connectionID, generation: generation, log: slog.Default(),
+	})
+	next, syncErr := syncer.Sync(runCtx, auth, connector.Cursor(cursor), r.sink)
 	if syncErr != nil {
 		// A transient failure never kills the connection (ADR-0063): the
 		// state machine classifies, backs off, degrades to a daily probe at

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -261,7 +261,8 @@ func (r *Registry) SyncOnce(ctx context.Context, connectionID ids.UUID) error {
 	// carry one mailbox's replacement credential into another mailbox's
 	// re-seal. A provider whose credential is stable is returned unchanged.
 	syncer := connector.RotatingSyncer(c, rotationSink{
-		registry: r, connectionID: connectionID, generation: generation, log: slog.Default(),
+		registry: r, connectionID: connectionID, generation: generation,
+		readRef: credentialRef, log: slog.Default(),
 	})
 	next, syncErr := syncer.Sync(runCtx, auth, connector.Cursor(cursor), r.sink)
 	if syncErr != nil {

--- a/backend/internal/modules/capture/registry_rotation.go
+++ b/backend/internal/modules/capture/registry_rotation.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// Persisting a credential the provider replaced mid-sync.
+//
+// Its own file because it is a WRITE to the connection's secret, and every
+// other write in this module is a lifecycle event a human asked for —
+// connect, reconnect, disconnect. This one happens because a provider chose
+// to, during a background pull nobody is watching, and the rules it has to
+// obey are its own: never fail the sync over it, never leave the row pointing
+// at a blob that was not written, and never retire the old secret until the
+// row that replaced it has committed.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/platform/keyvault"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// rotationSink re-seals one connection's credential. Built per sync, so the
+// connection id and the generation it was read at are fixed for the life of the
+// sink and cannot be confused with another connection's.
+type rotationSink struct {
+	registry     *Registry
+	connectionID ids.UUID
+	// generation is the same fence SyncOnce reads before the pull. A lifecycle
+	// change since then has moved it, and the re-seal must then land nowhere:
+	// a disconnect that destroyed the credential must not be undone by a
+	// rotation racing behind it.
+	generation int
+	log        *slog.Logger
+}
+
+// Rotated seals the replacement and points the connection at it.
+//
+// The order is seal → record → retire, the same one the Google-app store uses
+// and for the same reason. Sealing first means a crash before the record leaves
+// an orphan blob, which costs bytes; recording first would leave the row
+// naming a secret that was never written, which costs the mailbox. Retiring the
+// superseded blob only after the record commits means a crash between them
+// leaves the OLD secret readable, which is the direction that still works.
+func (s rotationSink) Rotated(ctx context.Context, auth connector.Auth) error {
+	if s.registry.vault == nil {
+		// A role that seals nothing has nowhere to put this. Not an error: the
+		// old credential is still valid, and refusing here would turn a
+		// vault-less deployment's every sync into a failure.
+		return nil
+	}
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return fmt.Errorf("capture: rotating a credential outside workspace context")
+	}
+	wsID := ids.From[ids.WorkspaceKind](ws)
+
+	ref, err := s.registry.vault.Put(ctx, wsID, []byte(auth))
+	if err != nil {
+		return fmt.Errorf("capture: sealing the rotated credential: %w", err)
+	}
+
+	superseded, previous, err := s.record(ctx, ref)
+	if err != nil {
+		// The row does not name the blob just written, so nothing reads it —
+		// retire it rather than leave it addressable for the life of the
+		// installation.
+		keyvault.DeleteDetached(ctx, s.registry.vault, s.log, ws, ref, "rotation-abandoned")
+		return err
+	}
+	if superseded {
+		// The connection changed under this sync — disconnected, reconnected,
+		// or rotated by a cycle that got there first. Its credential is not
+		// this sink's to move, and the blob just sealed belongs to nobody.
+		keyvault.DeleteDetached(ctx, s.registry.vault, s.log, ws, ref, "rotation-superseded")
+		return nil
+	}
+	if previous != "" && previous != string(ref) {
+		keyvault.DeleteDetached(ctx, s.registry.vault, s.log, ws, keyvault.Ref(previous), "rotation")
+	}
+	return nil
+}
+
+// record points the connection at the new ref and reports the one it replaced.
+//
+// The generation fence is read and matched in ONE statement rather than checked
+// and then written: a disconnect committing between the two would otherwise
+// have its credential-destroying update overwritten by this one, which is the
+// single outcome that must not be possible here.
+func (s rotationSink) record(ctx context.Context, ref keyvault.Ref) (superseded bool, previous string, err error) {
+	err = s.registry.db.Tx(ctx, func(tx pgx.Tx) error {
+		var prior *string
+		// The self-join is what makes RETURNING report the ref being REPLACED
+		// rather than the one just written: a plain RETURNING credential_ref
+		// yields the new value, and retiring that would destroy the secret the
+		// row now points at.
+		scanErr := tx.QueryRow(ctx, `
+			UPDATE capture_connection AS c SET credential_ref = $2
+			FROM capture_connection AS before
+			WHERE c.id = before.id AND c.id = $1 AND c.generation = $3
+			  AND c.status IN ('connected','error')
+			RETURNING before.credential_ref`,
+			s.connectionID, string(ref), s.generation).Scan(&prior)
+		if scanErr == pgx.ErrNoRows {
+			superseded = true
+			return nil
+		}
+		if scanErr != nil {
+			return scanErr
+		}
+		if prior != nil {
+			previous = *prior
+		}
+		// Recorded in the SAME transaction as the ref it describes, so the
+		// ledger cannot claim a rotation that was rolled back.
+		//
+		// system_log rather than audit_log — the posture platform/extsecrets
+		// already declares for this shape: bytes moved and nothing changed
+		// meaning. Nobody DECIDED this; a provider replaced a secret during a
+		// background pull, so there is no domain change to audit. What an
+		// operator wants from it is the operational fact, and it is what makes
+		// an aged-out mailbox diagnosable — either the rotations stopped
+		// appearing, or they never did.
+		//
+		// The secret is never a detail field. The refs are opaque addresses,
+		// and they are what a reader needs to follow the chain.
+		_, logErr := storekit.LogSystem(ctx, tx, "capture.credential_rotated", map[string]any{
+			"connection_id":  s.connectionID.String(),
+			"credential_ref": string(ref),
+			"replaced_ref":   previous,
+		})
+		return logErr
+	})
+	return superseded, previous, err
+}

--- a/backend/internal/modules/capture/registry_rotation.go
+++ b/backend/internal/modules/capture/registry_rotation.go
@@ -38,7 +38,13 @@ type rotationSink struct {
 	// a disconnect that destroyed the credential must not be undone by a
 	// rotation racing behind it.
 	generation int
-	log        *slog.Logger
+	// readRef is the credential this sync actually read. It fences the write
+	// alongside the generation because a SAME-ACCOUNT reconnect does not bump
+	// the generation — only a rebind does — so a reconnect committing mid-pull
+	// would otherwise have its fresh credential overwritten by a replacement
+	// this sync derived from the one it replaced.
+	readRef *string
+	log     *slog.Logger
 }
 
 // Rotated seals the replacement and points the connection at it.
@@ -69,10 +75,13 @@ func (s rotationSink) Rotated(ctx context.Context, auth connector.Auth) error {
 
 	superseded, previous, err := s.record(ctx, ref)
 	if err != nil {
-		// The row does not name the blob just written, so nothing reads it —
-		// retire it rather than leave it addressable for the life of the
-		// installation.
-		keyvault.DeleteDetached(ctx, s.registry.vault, s.log, ws, ref, "rotation-abandoned")
+		// The blob just written is deliberately LEFT. A commit can fail
+		// ambiguously — the connection drops after Postgres committed and
+		// before the client hears so — and deleting on that path would destroy
+		// the credential the row now points at, leaving a live connection
+		// naming a secret nothing can resolve. An orphan costs bytes; this
+		// costs the mailbox, so the uncertainty is resolved in the direction
+		// that still works.
 		return err
 	}
 	if superseded {
@@ -90,10 +99,18 @@ func (s rotationSink) Rotated(ctx context.Context, auth connector.Auth) error {
 
 // record points the connection at the new ref and reports the one it replaced.
 //
-// The generation fence is read and matched in ONE statement rather than checked
-// and then written: a disconnect committing between the two would otherwise
-// have its credential-destroying update overwritten by this one, which is the
-// single outcome that must not be possible here.
+// TWO fences, matched in the same statement as the write rather than checked
+// before it. The generation catches a disconnect or a rebind, whose
+// credential-destroying update must not be overwritten by this one. The
+// credential ref catches what the generation cannot: a same-account reconnect
+// leaves the generation alone, so only "the credential I read is still the
+// credential on the row" distinguishes a rotation of the live grant from one
+// derived out of a grant that has since been replaced.
+//
+// `auth` is cleared in the same statement. A legacy row that never reached the
+// vault carries its credential in that column, and making the ref authoritative
+// while leaving the column populated would retire nothing — the superseded
+// secret would sit in the clear for the life of the installation.
 func (s rotationSink) record(ctx context.Context, ref keyvault.Ref) (superseded bool, previous string, err error) {
 	err = s.registry.db.Tx(ctx, func(tx pgx.Tx) error {
 		var prior *string
@@ -102,12 +119,13 @@ func (s rotationSink) record(ctx context.Context, ref keyvault.Ref) (superseded 
 		// yields the new value, and retiring that would destroy the secret the
 		// row now points at.
 		scanErr := tx.QueryRow(ctx, `
-			UPDATE capture_connection AS c SET credential_ref = $2
+			UPDATE capture_connection AS c SET credential_ref = $2, auth = NULL
 			FROM capture_connection AS before
 			WHERE c.id = before.id AND c.id = $1 AND c.generation = $3
+			  AND c.credential_ref IS NOT DISTINCT FROM $4
 			  AND c.status IN ('connected','error')
 			RETURNING before.credential_ref`,
-			s.connectionID, string(ref), s.generation).Scan(&prior)
+			s.connectionID, string(ref), s.generation, s.readRef).Scan(&prior)
 		if scanErr == pgx.ErrNoRows {
 			superseded = true
 			return nil

--- a/backend/internal/shared/ports/connector/rotation.go
+++ b/backend/internal/shared/ports/connector/rotation.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package connector
+
+// The credential-ROTATION half of the connector seam: what a provider that
+// REPLACES the durable secret each time it is used needs in order to say so,
+// and how the replacement reaches the vault.
+//
+// Its own file because it is a different obligation from everything else here.
+// Auth is otherwise write-once — sealed at Connect and read on every sync — and
+// most providers keep it that way: a Google refresh token is issued once and
+// stays valid until it is revoked. Microsoft's is not. The identity platform
+// issues a NEW refresh token on every redemption, and while the old one keeps
+// working for its own lifetime, that lifetime is a ceiling (90 days of
+// inactivity for a confidential client) and can be cut short by a password
+// change, an admin revoke or a conditional-access policy. A connection whose
+// stored secret is never refreshed therefore ages out on a schedule nobody set,
+// and its human is asked to reconnect for no reason they can see.
+//
+// WHY A SINK RATHER THAN A RETURN VALUE. Connector.Sync's signature is frozen,
+// and widening it would make every capture-only provider answer a question it
+// has no opinion about. A sink also matches when the rotation actually happens:
+// mid-pull, inside the token mint, before anything is known about whether the
+// sync will succeed. The connector reports it at the moment it learns it, and
+// the registry decides what that is worth.
+//
+// WHY A COPY RATHER THAN A FIELD. A connector is registered ONCE and shared
+// across every connection the fleet syncs concurrently; a sink stored on the
+// shared instance would carry one connection's credential into another's write.
+// WithCredentialSink returns a copy bound to one sync, which is the same shape
+// WithBounceSink already uses for the same reason.
+
+import "context"
+
+// CredentialSink receives a durable credential that has replaced the one a sync
+// started with. The registry supplies one per sync.
+//
+// A sink that fails does NOT fail the sync. The old credential is still valid
+// when the new one is issued — that is what makes rotation safe to miss — so a
+// re-seal that cannot be written costs one cycle's freshness, where failing the
+// pull would cost the mail. The implementation reports the fault and the sync
+// carries on.
+type CredentialSink interface {
+	// Rotated is called with the complete replacement Auth bundle, not the
+	// secret alone: what is durable inside the bundle is the connector's own
+	// business, and a sink that had to understand it would be a second reader
+	// of a format only the connector owns.
+	Rotated(ctx context.Context, auth Auth) error
+}
+
+// CredentialRotator is the OPTIONAL seam a connector implements when its
+// provider replaces the durable credential on use. Type-asserted like Watcher,
+// Backfiller and EmailSender, so the frozen Connector interface is unchanged
+// and a provider whose credential is stable simply does not implement it.
+//
+// A connector that implements this MUST report only a credential it has
+// verified the provider accepted — a bundle reported before the exchange
+// succeeded would replace a working secret with one that was never issued.
+type CredentialRotator interface {
+	// WithCredentialSink returns a COPY of this connector that reports a
+	// rotated credential to sink. The receiver is left unchanged, so the
+	// registered instance never holds one connection's sink.
+	WithCredentialSink(sink CredentialSink) Connector
+}
+
+// RotatingSyncer binds a connector to a per-sync credential sink when it can
+// take one, and returns it unchanged when it cannot.
+//
+// One spelling, here beside the interface, because the alternative is a type
+// assertion at each call site and the failure mode of a missed one is silent:
+// the sync works, the rotation is dropped, and the connection ages out months
+// later with nothing pointing back at the omission.
+//
+//nolint:ireturn // returns the Connector seam by design — the caller holds an interface either way
+func RotatingSyncer(c Connector, sink CredentialSink) Connector {
+	rotator, ok := c.(CredentialRotator)
+	if !ok {
+		return c
+	}
+	return rotator.WithCredentialSink(sink)
+}

--- a/docs/explanation/capture-connectors.md
+++ b/docs/explanation/capture-connectors.md
@@ -294,10 +294,16 @@ The pipeline is live; these were scoped out, not missed:
   ≤3-day renewal) is unbuilt, so Outlook latency is the poll interval. (Gmail has both halves — the
   push-watch renewal sweep and the `/webhooks/gmail` consumer above — so a Gmail deployment with a
   Pub/Sub topic configured is push-driven, with the poll behind it as the safety net.)
-- **Graph refresh-token rotation isn't persisted.** The stored token usually lasts up to Microsoft's
-  default 90-day inactive lifetime (a confidential client) but can be revoked or expire earlier; on
-  expiry the connection goes `reauth_required` and the user reconnects. Avoiding that reauth needs a
-  credential-update seam the `Connector` interface lacks.
+- **Graph refresh-token rotation is persisted** (it was not, and the gap is closed). Microsoft issues a
+  NEW refresh token on every redemption; the old one stays valid for its own lifetime, but that lifetime
+  is a ceiling — 90 days idle for a confidential client, shorter after a password change, an admin revoke
+  or a conditional-access policy — so a connection that never stored the replacement aged out on a
+  schedule nobody set. `connector.CredentialRotator` is the optional seam (type-asserted like `Watcher`
+  and `EmailSender`, so the frozen `Connector` interface is unchanged); the registry binds a per-sync
+  sink that re-seals into the vault under the same generation fence the cursor commits under, and
+  retires the superseded blob only after the row naming its replacement commits. A re-seal that fails
+  costs one cycle's freshness, never the mail — the old credential is still valid, which is what makes
+  that the right way round. A connection can still reach `reauth_required` from a real revoke.
 - **IMAP has no backfill and no push.** It syncs forward from connect time on the poll; mail older than
   the connection is not imported, and there is no `Backfiller` to import it.
 - **No dedicated connector-health screen.** The digest's `connectors[]` health rows surface as a single
@@ -316,7 +322,9 @@ The pipeline is live; these were scoped out, not missed:
   `disconnected`/`reauth_required` park a row.
 - **Connecting is human-only.** An agent never self-connects a mailbox.
 - **The credential leaves the connection row entirely** — vault-sealed under `credential_ref`, IMAP's
-  app-password included, and destroyed on disconnect.
+  app-password included, and destroyed on disconnect. A provider that REPLACES it on use (Microsoft does,
+  on every redemption) reports the replacement through `CredentialRotator`, and the re-seal obeys the
+  same fence and the same destroy-the-old rule.
 - **All four connections are standing** and sync in the background; only Gmail/Graph backfill; only
   Gmail pushes.
 
@@ -325,6 +333,7 @@ The pipeline is live; these were scoped out, not missed:
 | | |
 |---|---|
 | The connector seam (Connector / Watcher / Backfiller / Sink / NormalizedRecord) | `internal/shared/ports/connector/connector.go` |
+| The credential-rotation seam (CredentialRotator / CredentialSink) | `internal/shared/ports/connector/rotation.go`, `capture/registry_rotation.go` |
 | The one Sink + write shape + idempotency | `internal/modules/capture/sink.go` |
 | The registry — scope intersection, Connect/Disconnect, SyncOnce, backfill, watch | `internal/modules/capture/registry.go`, `registry_connections.go`, `registry_watch.go`, `backfill.go` |
 | Sync-state sidecar (backoff, error taxonomy, degrade/heal) | `internal/modules/capture/syncstate.go` |

--- a/docs/explanation/capture-connectors.md
+++ b/docs/explanation/capture-connectors.md
@@ -225,13 +225,12 @@ OAuth2 to the Microsoft identity platform with delegated scopes `offline_access 
 `Watcher` — there is no change-notification subscription built, so Outlook latency is the poll interval,
 not a push p95. **To run:** a Microsoft Entra (Azure AD) app + tenant + the vault key. **UI:** a
 first-connect affordance from both the onboarding **Microsoft** chip and the Settings **Add a connection**
-footer; the roster manages an existing connection. Note Microsoft **rotates
-the refresh token on every redemption** and Margince does not yet persist the rotated value: the stored
-original typically keeps working up to Microsoft's default **90-day inactive lifetime** for a confidential
-client (an actively-syncing mailbox stays inside it), **but it can be revoked or expire earlier** (a
-password change, an admin revoke, a conditional-access policy). When it stops working, the sync/connect
-path surfaces `reauth_required` and the user must **reconnect** — there is no silent recovery until the
-credential-update seam lands.
+footer; the roster manages an existing connection. Microsoft **rotates the refresh token on every redemption**, and the replacement is now persisted: the
+connector reports it through `CredentialRotator` and the registry re-seals it into the vault on each
+sync (see *Honest limitations*). The stored original would otherwise have aged out on Microsoft's
+**90-day inactive lifetime** for a confidential client. A grant can still be ended from Microsoft's side
+— a password change, an admin revoke, a conditional-access policy — and then the sync/connect path
+surfaces `reauth_required` and the user must **reconnect**.
 
 ### Google Calendar (gcal) — standing OAuth, poll-only
 
@@ -333,7 +332,7 @@ The pipeline is live; these were scoped out, not missed:
 | | |
 |---|---|
 | The connector seam (Connector / Watcher / Backfiller / Sink / NormalizedRecord) | `internal/shared/ports/connector/connector.go` |
-| The credential-rotation seam (CredentialRotator / CredentialSink) | `internal/shared/ports/connector/rotation.go`, `capture/registry_rotation.go` |
+| The credential-rotation seam (CredentialRotator / CredentialSink) | `internal/shared/ports/connector/rotation.go`, `internal/modules/capture/registry_rotation.go` |
 | The one Sink + write shape + idempotency | `internal/modules/capture/sink.go` |
 | The registry — scope intersection, Connect/Disconnect, SyncOnce, backfill, watch | `internal/modules/capture/registry.go`, `registry_connections.go`, `registry_watch.go`, `backfill.go` |
 | Sync-state sidecar (backoff, error taxonomy, degrade/heal) | `internal/modules/capture/syncstate.go` |


### PR DESCRIPTION
## Why

Microsoft issues a **new** refresh token on every redemption. The old one stays valid for its own lifetime, which is what made discarding the replacement look harmless — but that lifetime is a **ceiling, not a guarantee**: 90 days idle for a confidential client, and shorter after a password change, an admin revoke, or a conditional-access policy.

So a Graph connection aged out on a schedule nobody set, and its human was asked to reconnect for no reason they could see. `docs/explanation/capture-connectors.md` has carried this as an honest limitation since the connector landed, naming the missing piece as *"a credential-update seam the `Connector` interface lacks"*. This is that seam.

## The shape, and two calls worth pushing back on

`connector.CredentialRotator` is **optional** — type-asserted like `Watcher`, `Backfiller` and `EmailSender`, so the frozen `Connector` interface is unchanged and a provider whose credential is stable (Google's) implements nothing.

**A sink rather than a return value.** Widening `Sync` would make every capture-only provider answer a question it has no opinion about, and a sink matches *when the rotation actually happens* — mid-pull, inside the token mint, before anything is known about whether the sync will succeed. That is also why a rotation **survives a pull that then fails**: the replacement is already issued and the old token already spent by then, and dropping it on failure would starve exactly the mailbox that most needs its credential kept fresh.

**A copy rather than a field.** One connector instance is registered and shared across every connection the fleet syncs concurrently, so a sink stored on it would carry one mailbox's credential into another's re-seal. `WithCredentialSink` returns a copy — the same shape `WithBounceSink` already uses for the same reason — and `TestBindingASinkLeavesTheRegisteredConnectorAlone` fails if the receiver is returned instead.

## The re-seal

It obeys the rules this module's other credential writes obey:

- **Seal → record → retire.** A crash before the record leaves an orphan blob (costs bytes); recording first would leave the row naming a secret that was never written (costs the mailbox). The superseded blob is destroyed only after the row naming its replacement commits.
- **The same generation fence the cursor commits under**, so a disconnect racing the rotation home wins and a withdrawn grant is never resurrected. `TestARotationThatLosesToADisconnectLandsNowhere` proves it — and mutating the fence out of the statement makes that test fail.
- **A failed re-seal never fails the sync.** The old credential still works, so the trade is one cycle's freshness against the mail.
- The `RETURNING` uses the self-join idiom deliberately: a plain `RETURNING credential_ref` yields the value just written, and retiring *that* would destroy the secret the row now points at.

## Ledger

`system_log`, action `capture.credential_rotated`, written in the same transaction as the ref it describes — the posture `platform/extsecrets` already declares for this shape: bytes moved and nothing changed meaning, and nobody decided it. The refs are in the detail; the secret never is. Registered in `gates/vaultwriters_test.go`, which is what caught the omission.

## Verification

`make check-backend`, `make check-fe`, `make craft-static` green, plus the real-Postgres capture integration lane (137 passing, including the two new ones). Both the copy-not-field and report-before-pull guarantees were mutation-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Microsoft Graph refresh-token rotation during credential synchronization.
  * Replacement credentials are securely stored, linked to the connection, and old credentials are retired.
  * Synchronization continues if credential-rotation persistence encounters an error.
  * Lifecycle changes or disconnects prevent stale credential updates.

* **Bug Fixes**
  * Preserved existing credentials when rotation cannot be safely completed.
  * Continued reporting genuine authorization failures requiring reauthentication.

* **Documentation**
  * Documented credential rotation behavior, safeguards, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->