### PR TITLE
The attention page names its subjects one type at a time

### DIFF
--- a/backend/internal/compose/attention/labels.go
+++ b/backend/internal/compose/attention/labels.go
@@ -28,23 +28,33 @@ import (
 // subjects unnamed and the client resolves them itself, which was the
 // contract before this seam existed.
 type Names interface {
-	Label(ctx context.Context, entityType string, id ids.UUID) (label string, ok bool, err error)
+	// Labels answers the display names of one TYPE's records, keyed by id.
+	//
+	// A record the caller may not read — gone, archived, or out of their row
+	// scope — is simply absent from the answer, which is the same refusal the
+	// single-record form used to report as ok=false. Absence is not an error:
+	// the contract says an unnamed subject means "the caller may not read
+	// it", and the id still travels because existence of the reference is the
+	// producer's claim, not this resolver's to retract.
+	//
+	// One call per type, not per record: an implementation is expected to ask
+	// its store once. That is the whole reason this seam is shaped by type.
+	Labels(ctx context.Context, entityType string, ids []ids.UUID) (map[ids.UUID]string, error)
 }
 
 // fillSubjectLabels names every subject the lanes produced, one gated read
-// per DISTINCT record — the same subject on three cards costs one read.
+// per subject TYPE — every person on the page costs one query, not one each.
 //
 // It walks the assembled answer rather than each renderer, so a producer
 // added tomorrow gets its labels by existing. The lanes are enumerated from
 // the contract struct; a new lane must be added here, and the wiring test
 // that asserts every lane's labels is what notices one that was not.
 //
-// The cost is bounded by the lanes' own caps, and honestly stated: on a
-// feed whose every lane is full it is up to ~200 sequential single-row
-// gated gets — the at-risk lane alone can admit a hundred candidates. The
-// batched resolver (one query per subject TYPE) is the named follow-up
-// that removes that; the cache below already collapses duplicates, and
-// today's real feeds sit far below the ceiling.
+// The cost is bounded by the number of subject TYPES the page carries —
+// six, today — rather than by how full the lanes are. It used to be one
+// gated single-row get per distinct record, which on a feed whose every
+// lane is full is around two hundred sequential reads: cheap individually,
+// linear in exactly the thing a busy workspace has more of.
 //
 // A non-refusal error PROPAGATES and fails the read, deliberately: the
 // contract says an absent label means "the caller may not read it", and
@@ -65,30 +75,50 @@ func (s *Service) fillSubjectLabels(ctx context.Context, out *crmcontracts.Atten
 			lanes = append(lanes, optional)
 		}
 	}
-	type subjectKey struct {
-		kind crmcontracts.AttentionSubjectType
-		id   ids.UUID
-	}
-	resolved := map[subjectKey]*string{}
+	// Gathered before anything is asked, so each type is one question. The
+	// ids are DEDUPED per type — the same person on three cards is one id in
+	// the query — and the order they were met in is kept, so a store that
+	// bounds its answer drops the same records for the same page rather than
+	// a different set each read.
+	wanted := map[crmcontracts.AttentionSubjectType][]ids.UUID{}
+	seen := map[crmcontracts.AttentionSubjectType]map[ids.UUID]bool{}
 	for _, lane := range lanes {
 		for i := range *lane {
 			subject := (*lane)[i].Subject
 			if subject == nil || subject.Label != nil {
 				continue
 			}
-			key := subjectKey{kind: subject.Type, id: ids.UUID(subject.Id)}
-			label, seen := resolved[key]
-			if !seen {
-				name, ok, err := s.names.Label(ctx, string(subject.Type), ids.UUID(subject.Id))
-				if err != nil {
-					return err
-				}
-				if ok {
-					label = &name
-				}
-				resolved[key] = label
+			id := ids.UUID(subject.Id)
+			if seen[subject.Type] == nil {
+				seen[subject.Type] = map[ids.UUID]bool{}
 			}
-			subject.Label = label
+			if seen[subject.Type][id] {
+				continue
+			}
+			seen[subject.Type][id] = true
+			wanted[subject.Type] = append(wanted[subject.Type], id)
+		}
+	}
+
+	resolved := map[crmcontracts.AttentionSubjectType]map[ids.UUID]string{}
+	for kind, batch := range wanted {
+		labels, err := s.names.Labels(ctx, string(kind), batch)
+		if err != nil {
+			return err
+		}
+		resolved[kind] = labels
+	}
+
+	for _, lane := range lanes {
+		for i := range *lane {
+			subject := (*lane)[i].Subject
+			if subject == nil || subject.Label != nil {
+				continue
+			}
+			if label, ok := resolved[subject.Type][ids.UUID(subject.Id)]; ok {
+				name := label
+				subject.Label = &name
+			}
 		}
 	}
 	return nil

--- a/backend/internal/compose/attention/labels_test.go
+++ b/backend/internal/compose/attention/labels_test.go
@@ -15,20 +15,30 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// stubNames answers from a fixed map and counts every ask, so a test can
-// assert both the answer and that one record costs one read.
+// stubNames answers from a fixed map and records every ask, so a test can
+// assert both the answer and the SHAPE of the asking — how many calls, and
+// which ids each one carried.
 type stubNames struct {
 	labels map[ids.UUID]string
-	asked  map[ids.UUID]int
+	// calls is one entry per Labels call, in order, each the ids it named.
+	calls [][]ids.UUID
+	// asked counts how many times each id was named across every call.
+	asked map[ids.UUID]int
 }
 
-func (s *stubNames) Label(_ context.Context, _ string, id ids.UUID) (string, bool, error) {
+func (s *stubNames) Labels(_ context.Context, _ string, want []ids.UUID) (map[ids.UUID]string, error) {
 	if s.asked == nil {
 		s.asked = map[ids.UUID]int{}
 	}
-	s.asked[id]++
-	label, ok := s.labels[id]
-	return label, ok, nil
+	s.calls = append(s.calls, append([]ids.UUID(nil), want...))
+	out := map[ids.UUID]string{}
+	for _, id := range want {
+		s.asked[id]++
+		if label, ok := s.labels[id]; ok {
+			out[id] = label
+		}
+	}
+	return out, nil
 }
 
 func TestABoundResolverNamesEveryCardOnce(t *testing.T) {
@@ -133,6 +143,49 @@ func TestEveryLanesSubjectsAreNamed(t *testing.T) {
 			if item.Subject != nil && item.Subject.Label == nil {
 				t.Errorf("%s carries an unnamed subject: %+v", name, item.Subject)
 			}
+		}
+	}
+}
+
+// The claim the batched seam exists for: two records cost ONE read, not two.
+//
+// The old shape was a gated single-row get per distinct record — cheap per
+// read, and linear in exactly what a busy workspace has more of, since a full
+// at-risk lane alone admits a hundred candidates.
+func TestTwoRecordsOfOneTypeCostOneRead(t *testing.T) {
+	firstDeal, secondDeal := ids.NewV7(), ids.NewV7()
+	names := &stubNames{labels: map[ids.UUID]string{
+		firstDeal: "Fleet retrofit GmbH", secondDeal: "Weber rollout",
+	}}
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
+		stubBriefing{rows: []BriefEntry{
+			{ID: ids.NewV7(), DealID: firstDeal, Rank: 1},
+			{ID: ids.NewV7(), DealID: secondDeal, Rank: 2},
+		}}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, names,
+		fixedClock)
+
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+
+	if len(names.calls) != 1 {
+		t.Fatalf("two deals cost %d resolver calls, want 1: %v", len(names.calls), names.calls)
+	}
+	if len(names.calls[0]) != 2 {
+		t.Fatalf("the one call named %d ids, want both deals in it: %v", len(names.calls[0]), names.calls[0])
+	}
+	// And both cards came back named, so batching did not cost the answer.
+	named := map[string]bool{}
+	for _, item := range out.ThisMorning {
+		if item.Subject != nil && item.Subject.Label != nil {
+			named[*item.Subject.Label] = true
+		}
+	}
+	for _, want := range []string{"Fleet retrofit GmbH", "Weber rollout"} {
+		if !named[want] {
+			t.Errorf("no card carries %q; the batch answered but the fill did not use it", want)
 		}
 	}
 }

--- a/backend/internal/compose/attentionnames.go
+++ b/backend/internal/compose/attentionnames.go
@@ -21,7 +21,6 @@ import (
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/projects"
-	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -37,73 +36,56 @@ type attentionNames struct {
 
 var _ attention.Names = attentionNames{}
 
-// Label answers one record's display name under the caller's scope.
+// Labels answers a set of one type's display names under the caller's scope.
 //
-// The person/organization/lead arms reuse the SAME face builders the merge
-// cards use (personFace and siblings below in this package), so the two
-// surfaces cannot come to spell one record's name two ways. A type outside
-// this vocabulary answers absent rather than guessing — the subject enum
-// and this switch are held together by the wiring test that labels every
-// lane.
-func (n attentionNames) Label(ctx context.Context, entityType string, id ids.UUID) (string, bool, error) {
-	label, err := n.read(ctx, entityType, id)
+// One store read per TYPE, which is the whole point of the seam's shape: a
+// page carrying a hundred people asks about people once. Each store's read
+// carries that record's own object grant and row-scope clause, so a label is
+// exactly as visible as the record, and this seam holds no authority of its
+// own.
+//
+// A whole-read refusal — this caller may not read PEOPLE at all — costs the
+// type's labels and nothing else, because the contract's "absent when the
+// caller may not read it" is the same answer for one record or a hundred.
+// Any other error propagates: a database that will not answer must not read
+// as a page of records the reader lacks grants for.
+//
+// A type outside this vocabulary answers nothing rather than guessing — the
+// subject enum and this switch are held together by the wiring test that
+// labels every lane.
+func (n attentionNames) Labels(ctx context.Context, entityType string, want []ids.UUID) (map[ids.UUID]string, error) {
+	labels, err := n.read(ctx, entityType, want)
 	switch {
 	case errors.Is(err, apperrors.ErrPermissionDenied), errors.Is(err, apperrors.ErrNotFound):
-		return "", false, nil
+		// No labels, and no error: "the caller may not read it" is the same
+		// answer for one record or a hundred. An empty map rather than nil,
+		// so a caller reading it back cannot tell a refusal from an empty
+		// page — there is nothing here they are meant to tell apart.
+		return map[ids.UUID]string{}, nil
 	case err != nil:
-		return "", false, err
-	case label == "":
-		// A record can honestly have no name (a lead captured with none); an
-		// empty label is absent, not a blank string on a card.
-		return "", false, nil
+		return nil, err
 	default:
-		return label, true, nil
+		return labels, nil
 	}
 }
 
-func (n attentionNames) read(ctx context.Context, entityType string, id ids.UUID) (string, error) {
+func (n attentionNames) read(ctx context.Context, entityType string, want []ids.UUID) (map[ids.UUID]string, error) {
 	switch entityType {
 	case flipObjectPerson:
-		row, err := n.people.GetPerson(ctx, ids.From[ids.PersonKind](id), storekit.LiveOnly)
-		if err != nil {
-			return "", err
-		}
-		return personFace(row).Label, nil
+		return n.people.PersonLabels(ctx, want)
 	case flipObjectOrganization:
-		row, err := n.people.GetOrganization(ctx, ids.From[ids.OrganizationKind](id), storekit.LiveOnly)
-		if err != nil {
-			return "", err
-		}
-		return organizationFace(row).Label, nil
+		return n.people.OrganizationLabels(ctx, want)
 	case flipObjectLead:
-		row, err := n.people.GetLead(ctx, ids.From[ids.LeadKind](id), storekit.LiveOnly)
-		if err != nil {
-			return "", err
-		}
-		return leadFace(row).Label, nil
+		return n.people.LeadLabels(ctx, want)
 	case string(datasource.RecordDeal):
-		row, err := n.deals.GetDeal(ctx, ids.From[ids.DealKind](id), storekit.LiveOnly)
-		if err != nil {
-			return "", err
-		}
-		return row.Name, nil
+		return n.deals.DealLabels(ctx, want)
 	case string(datasource.EntityActivity):
-		row, err := n.activities.GetActivity(ctx, ids.From[ids.ActivityKind](id), storekit.LiveOnly)
-		if err != nil {
-			return "", err
-		}
-		if row.Subject == nil {
-			return "", nil
-		}
-		return *row.Subject, nil
+		return n.activities.ActivityLabels(ctx, want)
 	case string(datasource.RecordProject):
-		row, err := n.projects.GetProject(ctx, ids.From[ids.ProjectKind](id), storekit.LiveOnly)
-		if err != nil {
-			return "", err
-		}
-		return row.Name, nil
+		return n.projects.ProjectLabels(ctx, want)
 	default:
-		return "", nil
+		// A type outside the vocabulary names nothing rather than guessing.
+		return map[ids.UUID]string{}, nil
 	}
 }
 

--- a/backend/internal/compose/attentionnames_integration_test.go
+++ b/backend/internal/compose/attentionnames_integration_test.go
@@ -285,3 +285,47 @@ func TestEveryShapesLabelsAgreeWithTheirOwnSingleRead(t *testing.T) {
 		}
 	})
 }
+
+// A type with no subjects on the page asks nothing at all. The fill pass only
+// calls for types it met, but the store must be safe to call with an empty
+// set regardless — an `id = ANY('{}')` would be a query run to learn nothing.
+func TestATypeWithNothingToNameAsksNothing(t *testing.T) {
+	e := integration.Setup(t)
+	names := namesOver(e)
+	reader := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+
+	for _, kind := range []string{"person", "organization", "deal", "activity", "lead", "project"} {
+		labels, err := names.Labels(reader, kind, nil)
+		if err != nil {
+			t.Fatalf("naming an empty set of %s: %v", kind, err)
+		}
+		if len(labels) != 0 {
+			t.Fatalf("%s answered %v for an empty ask", kind, labels)
+		}
+	}
+}
+
+// A reader who may not read the OBJECT at all loses the labels and nothing
+// else. The lane still renders, the ids still travel, and the page does not
+// fail because one of its producers named a record this reader has no grant
+// for — which is the same promise as a record they cannot see.
+func TestAnObjectGrantTheReaderLacksCostsOnlyItsLabels(t *testing.T) {
+	e := integration.Setup(t)
+	names := namesOver(e)
+	person := e.SeedPerson(t, "Dana Weiss", nil)
+
+	// A rep holding no person grant at all.
+	ungranted := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects:  map[string]principal.ObjectGrant{"deal": {Read: true}},
+		RowScope: principal.RowScopeTeam,
+	})
+
+	labels, err := names.Labels(ungranted, "person", []ids.UUID{person})
+	if err != nil {
+		t.Fatalf("a missing grant must cost the labels, not fail the page: %v", err)
+	}
+	if len(labels) != 0 {
+		t.Fatalf("labels = %v for a reader with no person grant", labels)
+	}
+}

--- a/backend/internal/compose/attentionnames_integration_test.go
+++ b/backend/internal/compose/attentionnames_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/projects"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 func namesOver(e *integration.Env) attentionNames {
@@ -218,6 +219,56 @@ func TestEveryShapesLabelsAgreeWithTheirOwnSingleRead(t *testing.T) {
 			t.Fatalf("the batch %s a deal the single get %s — the two reads disagree about one record",
 				map[bool]string{true: "named", false: "withheld"}[named],
 				map[bool]string{true: "answered", false: "refused"}[err == nil])
+		}
+	})
+
+	t.Run("lead", func(t *testing.T) {
+		named := integration.SeedIDRow(t, owner,
+			`INSERT INTO lead (id, full_name, source, captured_by) VALUES ($1, 'Ana Ionescu', 'import', 'human:x')`)
+		// A lead captured without a name: its face carries an empty label, so
+		// the batch answers absent rather than putting a blank on a card.
+		nameless := integration.SeedIDRow(t, owner,
+			`INSERT INTO lead (id, source, captured_by) VALUES ($1, 'import', 'human:x')`)
+
+		// A reader holding lead.read: AccountRepPerms does not, and a caller
+		// the grant refuses answers no labels — which is the refusal arm, not
+		// the read this case is about.
+		leadReader := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects:  map[string]principal.ObjectGrant{"lead": {Read: true}},
+			RowScope: principal.RowScopeTeam,
+		})
+
+		labels, err := names.Labels(leadReader, "lead", []ids.UUID{named, nameless})
+		if err != nil {
+			t.Fatalf("naming leads: %v", err)
+		}
+		if labels[named] != "Ana Ionescu" {
+			t.Errorf("label = %q for a named lead, want its name", labels[named])
+		}
+		if label, ok := labels[nameless]; ok {
+			t.Errorf("label = %q for a lead captured with no name, want absent", label)
+		}
+	})
+
+	t.Run("project", func(t *testing.T) {
+		org := e.SeedOrg(t, "Weber Projekte", nil)
+		project := integration.SeedIDRow(t, owner,
+			`INSERT INTO project (id, name, organization_id, source, captured_by)
+			 VALUES ($1, 'Depot rollout', '`+org.String()+`', 'manual', 'human:x')`)
+
+		projectReader := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects:  map[string]principal.ObjectGrant{"project": {Read: true}},
+			RowScope: principal.RowScopeTeam,
+		})
+
+		labels, err := names.Labels(projectReader, "project", []ids.UUID{project})
+		if err != nil {
+			t.Fatalf("naming projects: %v", err)
+		}
+		if labels[project] != "Depot rollout" {
+			t.Errorf("label = %q for a readable project, want its name", labels[project])
 		}
 	})
 

--- a/backend/internal/compose/attentionnames_integration_test.go
+++ b/backend/internal/compose/attentionnames_integration_test.go
@@ -43,20 +43,53 @@ func TestALabelIsExactlyAsVisibleAsItsRecord(t *testing.T) {
 
 	reader := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.RepPerms)
 
-	label, ok, err := names.Label(reader, "person", visible)
+	// BOTH in one ask, which is the batched seam's whole shape and also the
+	// sharper test: the visible one must come back named and the private one
+	// must not, from the same query. A batch that answered per-set rather
+	// than per-row would either name both or name neither.
+	labels, err := names.Labels(reader, "person", []ids.UUID{visible, private})
 	if err != nil {
-		t.Fatalf("naming a visible person: %v", err)
+		t.Fatalf("naming a page of people: %v", err)
 	}
-	if !ok || label != "Dana Weiss" {
-		t.Fatalf("label = %q ok=%v, want the person's name — a resolver that cannot name a readable record makes every card anonymous", label, ok)
+	if labels[visible] != "Dana Weiss" {
+		t.Fatalf("label = %q, want the person's name — a resolver that cannot name a readable record makes every card anonymous", labels[visible])
 	}
+	if label, named := labels[private]; named {
+		t.Fatalf("label = %q for another rep's capture-private contact — the label pass just disclosed a record the row scope hides", label)
+	}
+}
 
-	label, ok, err = names.Label(reader, "person", private)
+// A record with no name of its own is ABSENT rather than blank: a card
+// showing an empty string where a record should be says less than one
+// showing nothing, and the single-record form answered ok=false for it.
+func TestARecordWithNoNameIsAbsentRatherThanBlank(t *testing.T) {
+	e := integration.Setup(t)
+	names := namesOver(e)
+	nameless := e.SeedPerson(t, "", nil)
+	reader := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.RepPerms)
+
+	labels, err := names.Labels(reader, "person", []ids.UUID{nameless})
 	if err != nil {
-		t.Fatalf("a withheld record must cost the label, not fail the read: %v", err)
+		t.Fatalf("naming a nameless person: %v", err)
 	}
-	if ok || label != "" {
-		t.Fatalf("label = %q ok=%v for another rep's capture-private contact — the label pass just disclosed a record the row scope hides", label, ok)
+	if label, named := labels[nameless]; named {
+		t.Fatalf("label = %q for a person captured without a name, want absent", label)
+	}
+}
+
+// An id nobody has ever minted is absent, not an error: the producer's claim
+// that a reference exists is not this resolver's to fail the page over.
+func TestAnIdThatNamesNothingIsAbsentNotAnError(t *testing.T) {
+	e := integration.Setup(t)
+	names := namesOver(e)
+	reader := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.RepPerms)
+
+	labels, err := names.Labels(reader, "person", []ids.UUID{ids.NewV7()})
+	if err != nil {
+		t.Fatalf("naming a record that does not exist: %v", err)
+	}
+	if len(labels) != 0 {
+		t.Fatalf("labels = %v for an id naming nothing, want none", labels)
 	}
 }
 
@@ -64,8 +97,9 @@ func TestAnUnknownSubjectTypeAnswersAbsentNotAGuess(t *testing.T) {
 	e := integration.Setup(t)
 	names := namesOver(e)
 	reader := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.RepPerms)
-	if _, ok, err := names.Label(reader, "warehouse", ids.NewV7()); err != nil || ok {
-		t.Fatalf("ok=%v err=%v for a type outside the vocabulary, want absent and no error", ok, err)
+	labels, err := names.Labels(reader, "warehouse", []ids.UUID{ids.NewV7()})
+	if err != nil || len(labels) != 0 {
+		t.Fatalf("labels=%v err=%v for a type outside the vocabulary, want none and no error", labels, err)
 	}
 }
 
@@ -75,7 +109,43 @@ func TestTheResolverHoldsNoAuthorityOfItsOwn(t *testing.T) {
 	e := integration.Setup(t)
 	names := namesOver(e)
 	person := e.SeedPerson(t, "Dana Weiss", nil)
-	if _, ok, err := names.Label(context.Background(), "person", person); err == nil && ok {
+	labels, err := names.Labels(context.Background(), "person", []ids.UUID{person})
+	if err == nil && len(labels) > 0 {
 		t.Fatal("an unauthenticated ask was answered — the resolver carries authority its callers never granted")
+	}
+}
+
+// A subject line is CONTENT, and the batch must withhold it exactly as the
+// single-record read does.
+//
+// The card names the message a rep is being told about; on a limited thread
+// the reader may know the row exists and may not read what it says. A batched
+// read that filtered on the audience instead of selecting THROUGH it would
+// have answered the row's subject to everyone who could discover it.
+func TestALimitedMessagesSubjectIsWithheldFromTheBatchToo(t *testing.T) {
+	e := integration.Setup(t)
+	names := namesOver(e)
+	owner := integration.OwnerConn(t)
+
+	open := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'Renewal terms', now(), 'manual', 'human:x')`)
+	limited := integration.SeedIDRow(t, owner, `INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'email', 'Board compensation', now(), 'manual', 'human:someone-else')`)
+	if _, err := owner.Exec(context.Background(),
+		`UPDATE activity SET audience = 'participants' WHERE id = $1`, limited); err != nil {
+		t.Fatalf("limiting the message: %v", err)
+	}
+
+	reader := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+
+	labels, err := names.Labels(reader, "activity", []ids.UUID{open, limited})
+	if err != nil {
+		t.Fatalf("naming a page of messages: %v", err)
+	}
+	if labels[open] != "Renewal terms" {
+		t.Errorf("label = %q for an open message, want its subject", labels[open])
+	}
+	if label, named := labels[limited]; named {
+		t.Fatalf("label = %q for a message this reader is not on — the batch just disclosed what a limited thread says", label)
 	}
 }

--- a/backend/internal/compose/attentionnames_integration_test.go
+++ b/backend/internal/compose/attentionnames_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/projects"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -148,4 +149,88 @@ func TestALimitedMessagesSubjectIsWithheldFromTheBatchToo(t *testing.T) {
 	if label, named := labels[limited]; named {
 		t.Fatalf("label = %q for a message this reader is not on — the batch just disclosed what a limited thread says", label)
 	}
+}
+
+// The other shapes, each over the store that owns it.
+//
+// The organization arm carries the discriminating proof — capture-private is
+// a posture this reader demonstrably cannot see through, and neutering the
+// scope clause fails it. The deal arm asserts something weaker on purpose:
+// that the batch and the single get AGREE. A deal owned by another team's rep
+// is still visible to this reader in this fixture — deal visibility is wider
+// than ownership — so an exclusion assertion there would pass whatever the
+// clause did, which is a test that proves nothing while looking like it does.
+// Agreement is the invariant that actually matters anyway: whatever GetDeal
+// decides, the batch must decide the same.
+func TestEveryShapesLabelsAgreeWithTheirOwnSingleRead(t *testing.T) {
+	e := integration.Setup(t)
+	names := namesOver(e)
+	owner := integration.OwnerConn(t)
+	reader := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+
+	t.Run("organization", func(t *testing.T) {
+		mine := e.SeedOrg(t, "Weber GmbH", nil)
+		theirs := e.SeedOrg(t, "Zeta Holding", &e.Rep3)
+		e.MakeCapturePrivate(t, "organization", theirs, e.Rep3)
+
+		labels, err := names.Labels(reader, "organization", []ids.UUID{mine, theirs})
+		if err != nil {
+			t.Fatalf("naming companies: %v", err)
+		}
+		if labels[mine] != "Weber GmbH" {
+			t.Errorf("label = %q for a readable company, want its name", labels[mine])
+		}
+		if label, named := labels[theirs]; named {
+			t.Fatalf("label = %q for another rep's capture-private company", label)
+		}
+	})
+
+	t.Run("deal", func(t *testing.T) {
+		pipeline := integration.SeedIDRow(t, owner,
+			`INSERT INTO pipeline (id, name, is_default, position) VALUES ($1, 'Names', false, 0)`)
+		stage := integration.SeedIDRow(t, owner,
+			`INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+			 VALUES ($1, '`+pipeline.String()+`', 'Open', 0, 'open', 30)`)
+		mine := e.SeedDeal(t, "Fleet retrofit",
+			ids.From[ids.PipelineKind](pipeline), ids.From[ids.StageKind](stage), &e.Rep1)
+		theirs := e.SeedDeal(t, "Someone else's renewal",
+			ids.From[ids.PipelineKind](pipeline), ids.From[ids.StageKind](stage), &e.Rep3)
+		// Owned directly, because CreateDeal runs as the admin here and the
+		// owner it records is not necessarily the one asked for — and a deal
+		// this reader can see anyway would make the assertion below pass
+		// whatever the scope clause did.
+		e.WsExec(t, `UPDATE deal SET owner_id = $2 WHERE id = $1`, theirs, e.Rep3)
+
+		labels, err := names.Labels(reader, "deal", []ids.UUID{mine, theirs})
+		if err != nil {
+			t.Fatalf("naming deals: %v", err)
+		}
+		if labels[mine] != "Fleet retrofit" {
+			t.Errorf("label = %q for the reader's own deal, want its name", labels[mine])
+		}
+		// Against the SINGLE get rather than against an assumption about what
+		// a rep may see: the batch's whole promise is that it decides what the
+		// one-at-a-time read decides.
+		_, err = deals.NewStore(InstallationDB(e.Pool), DealsInstallation()).
+			GetDeal(reader, ids.From[ids.DealKind](theirs), storekit.LiveOnly)
+		_, named := labels[theirs]
+		if named != (err == nil) {
+			t.Fatalf("the batch %s a deal the single get %s — the two reads disagree about one record",
+				map[bool]string{true: "named", false: "withheld"}[named],
+				map[bool]string{true: "answered", false: "refused"}[err == nil])
+		}
+	})
+
+	t.Run("archived records are absent", func(t *testing.T) {
+		gone := e.SeedPerson(t, "Archived Contact", nil)
+		e.WsExec(t, `UPDATE person SET archived_at = now() WHERE id = $1`, gone)
+
+		labels, err := names.Labels(reader, "person", []ids.UUID{gone})
+		if err != nil {
+			t.Fatalf("naming an archived person: %v", err)
+		}
+		if label, named := labels[gone]; named {
+			t.Fatalf("label = %q for an archived record — the batch names what every live read refuses", label)
+		}
+	})
 }

--- a/backend/internal/modules/activities/labels.go
+++ b/backend/internal/modules/activities/labels.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Subject lines for a SET of activities, in one query.
+//
+// The attention feed names every subject on the page. Read one at a time that
+// is a round trip per card; read together it is one query over the page.
+//
+// An activity is gated twice and this read carries both, because a subject
+// line is CONTENT: the discover clause decides which rows the caller may know
+// about at all, and the audience arm decides, per row, whether what was said
+// comes along. A row the caller may see but not read answers no label — the
+// same withholding readActivity performs when it nulls Subject on a withheld
+// row — rather than a name from a message that is none of their business.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// ActivityLabels answers each named activity's subject line, under the
+// caller's own grants. A message with no subject, and one whose content is
+// withheld from this caller, are both absent.
+func (s *Store) ActivityLabels(ctx context.Context, want []ids.UUID) (map[ids.UUID]string, error) {
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	labels := map[ids.UUID]string{}
+	if len(want) == 0 {
+		return labels, nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idsPos := arg(want)
+	discover, err := auth.ActivityDiscoverClause(ctx, "a", arg)
+	if err != nil {
+		return nil, err
+	}
+	if discover == "" {
+		discover = scopeUnbounded
+	}
+	content, err := auth.ActivityAudienceArm(ctx, "a", arg)
+	if err != nil {
+		return nil, err
+	}
+	err = s.tx(ctx, func(tx pgx.Tx) error {
+		// The subject is selected THROUGH the audience arm rather than
+		// filtered by it: a withheld row still answers, with no name, which
+		// is the same answer a reader gets for a record that is simply gone.
+		// Filtering on it instead would make "withheld" and "absent"
+		// indistinguishable here, which they are — deliberately — everywhere
+		// else this feed speaks.
+		rows, err := tx.Query(ctx, fmt.Sprintf(`
+			SELECT a.id, coalesce(CASE WHEN (%s) THEN a.subject END, '')
+			  FROM activity a
+			 WHERE a.id = ANY($%d) AND a.archived_at IS NULL AND (%s)`,
+			content, idsPos, discover), args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id ids.UUID
+			var label string
+			if err := rows.Scan(&id, &label); err != nil {
+				return err
+			}
+			if label != "" {
+				labels[id] = label
+			}
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("activities: reading activity subjects: %w", err)
+	}
+	return labels, nil
+}

--- a/backend/internal/modules/activities/labels.go
+++ b/backend/internal/modules/activities/labels.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -58,26 +59,13 @@ func (s *Store) ActivityLabels(ctx context.Context, want []ids.UUID) (map[ids.UU
 		// Filtering on it instead would make "withheld" and "absent"
 		// indistinguishable here, which they are — deliberately — everywhere
 		// else this feed speaks.
-		rows, err := tx.Query(ctx, fmt.Sprintf(`
+		found, err := storekit.LabelsByID(ctx, tx, fmt.Sprintf(`
 			SELECT a.id, coalesce(CASE WHEN (%s) THEN a.subject END, '')
 			  FROM activity a
 			 WHERE a.id = ANY($%d) AND a.archived_at IS NULL AND (%s)`,
 			content, idsPos, discover), args...)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var id ids.UUID
-			var label string
-			if err := rows.Scan(&id, &label); err != nil {
-				return err
-			}
-			if label != "" {
-				labels[id] = label
-			}
-		}
-		return rows.Err()
+		labels = found
+		return err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("activities: reading activity subjects: %w", err)

--- a/backend/internal/modules/deals/labels.go
+++ b/backend/internal/modules/deals/labels.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// Display names for a SET of deals, in one query.
+//
+// The attention feed names every subject on the page and the at-risk lane
+// alone can carry a hundred deals. One gated get each is a hundred round
+// trips whose count grows with how busy the pipeline is; together it is one
+// query over the same page.
+//
+// It carries the object grant and the row-scope clause GetDeal carries, so a
+// name is exactly as visible as the deal. A deal the caller cannot see is
+// ABSENT from the answer rather than refused — one unreadable member is not a
+// failure of a question about a set.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// DealLabels answers each named deal's own name, under the caller's grants.
+func (s *Store) DealLabels(ctx context.Context, want []ids.UUID) (map[ids.UUID]string, error) {
+	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	labels := map[ids.UUID]string{}
+	if len(want) == 0 {
+		return labels, nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idsPos := arg(want)
+	scope, err := auth.ScopeClauseFor(ctx, dealTable, "d", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		scope = "true"
+	}
+	err = s.Tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, fmt.Sprintf(`
+			SELECT d.id, coalesce(d.name, '')
+			  FROM %s d
+			 WHERE d.id = ANY($%d) AND d.archived_at IS NULL AND (%s)`,
+			dealTable, idsPos, scope), args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id ids.UUID
+			var label string
+			if err := rows.Scan(&id, &label); err != nil {
+				return err
+			}
+			if label != "" {
+				labels[id] = label
+			}
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("deals: reading deal names: %w", err)
+	}
+	return labels, nil
+}

--- a/backend/internal/modules/deals/labels.go
+++ b/backend/internal/modules/deals/labels.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -46,26 +47,13 @@ func (s *Store) DealLabels(ctx context.Context, want []ids.UUID) (map[ids.UUID]s
 		scope = "true"
 	}
 	err = s.Tx(ctx, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, fmt.Sprintf(`
+		found, err := storekit.LabelsByID(ctx, tx, fmt.Sprintf(`
 			SELECT d.id, coalesce(d.name, '')
 			  FROM %s d
 			 WHERE d.id = ANY($%d) AND d.archived_at IS NULL AND (%s)`,
 			dealTable, idsPos, scope), args...)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var id ids.UUID
-			var label string
-			if err := rows.Scan(&id, &label); err != nil {
-				return err
-			}
-			if label != "" {
-				labels[id] = label
-			}
-		}
-		return rows.Err()
+		labels = found
+		return err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("deals: reading deal names: %w", err)

--- a/backend/internal/modules/people/labels.go
+++ b/backend/internal/modules/people/labels.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -71,28 +72,13 @@ func (s *Store) labelsOf(ctx context.Context, object, table, column string, want
 		scope = sqlAlwaysVisible
 	}
 	err = s.tx(ctx, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, fmt.Sprintf(`
+		found, err := storekit.LabelsByID(ctx, tx, fmt.Sprintf(`
 			SELECT r.id, coalesce(r.%s, '')
 			  FROM %s r
 			 WHERE r.id = ANY($%d) AND r.archived_at IS NULL AND (%s)`,
 			column, table, idsPos, scope), args...)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var id ids.UUID
-			var label string
-			if err := rows.Scan(&id, &label); err != nil {
-				return err
-			}
-			// An empty name is no name: a card showing a blank where a record
-			// should be says less than one showing nothing.
-			if label != "" {
-				labels[id] = label
-			}
-		}
-		return rows.Err()
+		labels = found
+		return err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("people: reading %s display names: %w", table, err)

--- a/backend/internal/modules/people/labels.go
+++ b/backend/internal/modules/people/labels.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Display names for a SET of this module's records, one query per shape.
+//
+// The attention feed names every subject on the page, and the page can carry
+// a hundred people. Read one at a time that is a hundred gated round trips
+// whose count grows with how busy the workspace is; read together it is one
+// query whose cost grows with the same page.
+//
+// Each read carries the object grant and the row-scope clause its
+// single-record get carries, so a name is exactly as visible as the record.
+// A record the caller may not see is ABSENT from the answer rather than
+// refused: the caller asked about a set, and one unreadable member is not a
+// failure of the question.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// PersonLabels answers each named person's display name, under the caller's
+// own grants. The column is full_name — the field personFace puts on a card —
+// and a person with none is absent rather than blank.
+func (s *Store) PersonLabels(ctx context.Context, want []ids.UUID) (map[ids.UUID]string, error) {
+	return s.labelsOf(ctx, entityPerson, "person", "full_name", want)
+}
+
+// OrganizationLabels answers each named company's display name.
+func (s *Store) OrganizationLabels(ctx context.Context, want []ids.UUID) (map[ids.UUID]string, error) {
+	return s.labelsOf(ctx, entityOrganization, "organization", "display_name", want)
+}
+
+// LeadLabels answers each named lead's display name. A lead captured without
+// one is absent, which is what its face does with an empty label.
+func (s *Store) LeadLabels(ctx context.Context, want []ids.UUID) (map[ids.UUID]string, error) {
+	return s.labelsOf(ctx, entityLead, "lead", "full_name", want)
+}
+
+// labelsOf is the one read the three shapes above are: the same grant, the
+// same row scope, the same archived exclusion, differing only in which table
+// and which column carries the name.
+//
+// The table and column are constants from the callers above and never reach
+// this from a request, which is what makes the format string safe here; the
+// ids travel as a parameter like every other value.
+func (s *Store) labelsOf(ctx context.Context, object, table, column string, want []ids.UUID) (map[ids.UUID]string, error) {
+	if err := auth.Require(ctx, object, principal.ActionRead); err != nil {
+		return nil, err
+	}
+	labels := map[ids.UUID]string{}
+	if len(want) == 0 {
+		return labels, nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idsPos := arg(want)
+	scope, err := auth.ScopeClauseFor(ctx, object, "r", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		scope = sqlAlwaysVisible
+	}
+	err = s.tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, fmt.Sprintf(`
+			SELECT r.id, coalesce(r.%s, '')
+			  FROM %s r
+			 WHERE r.id = ANY($%d) AND r.archived_at IS NULL AND (%s)`,
+			column, table, idsPos, scope), args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id ids.UUID
+			var label string
+			if err := rows.Scan(&id, &label); err != nil {
+				return err
+			}
+			// An empty name is no name: a card showing a blank where a record
+			// should be says less than one showing nothing.
+			if label != "" {
+				labels[id] = label
+			}
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("people: reading %s display names: %w", table, err)
+	}
+	return labels, nil
+}

--- a/backend/internal/modules/projects/labels.go
+++ b/backend/internal/modules/projects/labels.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -42,26 +43,13 @@ func (s *Store) ProjectLabels(ctx context.Context, want []ids.UUID) (map[ids.UUI
 		scope = "true"
 	}
 	err = s.Tx(ctx, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, fmt.Sprintf(`
+		found, err := storekit.LabelsByID(ctx, tx, fmt.Sprintf(`
 			SELECT p.id, coalesce(p.name, '')
 			  FROM project p
 			 WHERE p.id = ANY($%d) AND p.archived_at IS NULL AND (%s)`,
 			idsPos, scope), args...)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var id ids.UUID
-			var label string
-			if err := rows.Scan(&id, &label); err != nil {
-				return err
-			}
-			if label != "" {
-				labels[id] = label
-			}
-		}
-		return rows.Err()
+		labels = found
+		return err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("projects: reading project names: %w", err)

--- a/backend/internal/modules/projects/labels.go
+++ b/backend/internal/modules/projects/labels.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package projects
+
+// Display names for a SET of projects, in one query.
+//
+// The attention feed names every subject on the page; read one at a time that
+// is a round trip per card. It carries the object grant and the row-scope
+// clause GetProject carries, so a name is exactly as visible as the project,
+// and a project the caller cannot see is absent rather than refused.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// ProjectLabels answers each named project's own name, under the caller's
+// grants.
+func (s *Store) ProjectLabels(ctx context.Context, want []ids.UUID) (map[ids.UUID]string, error) {
+	if err := auth.Require(ctx, projectObject, principal.ActionRead); err != nil {
+		return nil, err
+	}
+	labels := map[ids.UUID]string{}
+	if len(want) == 0 {
+		return labels, nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idsPos := arg(want)
+	scope, err := auth.ScopeClauseFor(ctx, projectObject, "p", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		scope = "true"
+	}
+	err = s.Tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, fmt.Sprintf(`
+			SELECT p.id, coalesce(p.name, '')
+			  FROM project p
+			 WHERE p.id = ANY($%d) AND p.archived_at IS NULL AND (%s)`,
+			idsPos, scope), args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id ids.UUID
+			var label string
+			if err := rows.Scan(&id, &label); err != nil {
+				return err
+			}
+			if label != "" {
+				labels[id] = label
+			}
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("projects: reading project names: %w", err)
+	}
+	return labels, nil
+}

--- a/backend/internal/platform/database/storekit/labelsbyid.go
+++ b/backend/internal/platform/database/storekit/labelsbyid.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+// The display-name batch read, once.
+//
+// Several modules answer "the names of these records" for the attention
+// feed's label pass, and they differ only in which table, which column, and
+// which scope clause — the parts that are genuinely each module's own. What
+// they share is the part that must not drift: an empty name is ABSENT rather
+// than a blank string, because a card showing nothing where a record should
+// be says more than one showing "".
+//
+// The statement is the caller's, already carrying its own grant and row
+// scope; this holds no authority and adds no predicate.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// LabelsByID runs one already-scoped statement of the shape
+// `SELECT id, coalesce(<name>, ”) …` and collects the rows that carry a
+// name.
+//
+// A row the statement did not return is absent for whatever reason the
+// caller's own clauses decided — gone, archived, out of scope, withheld —
+// and this cannot tell those apart, which is the point: everywhere the label
+// pass speaks, they are the same answer.
+func LabelsByID(ctx context.Context, tx pgx.Tx, statement string, args ...any) (map[ids.UUID]string, error) {
+	labels := map[ids.UUID]string{}
+	rows, err := tx.Query(ctx, statement, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id ids.UUID
+		var label string
+		if err := rows.Scan(&id, &label); err != nil {
+			return nil, err
+		}
+		if label != "" {
+			labels[id] = label
+		}
+	}
+	return labels, rows.Err()
+}


### PR DESCRIPTION
Closes #3051.

## What changed

`attention.Names` was `Label(ctx, type, id)` — one gated single-row get per distinct subject. It is now `Labels(ctx, type, ids)`, one read per subject TYPE, and the fill pass groups the page's subjects before it asks anything.

Six batched reads land with it, each in the module that owns the record: `PersonLabels`, `OrganizationLabels`, `LeadLabels`, `DealLabels`, `ActivityLabels`, `ProjectLabels`.

## The part that needed care

A label must stay exactly as visible as the record behind it, and a batched read is where that quietly stops being true. Each new read carries the same object grant and the same row-scope clause (`auth.ScopeClauseFor`) its single-record get carries, plus the same archived exclusion.

The activity is the sharp one, because a subject line is *content*. It is gated twice: the discover clause decides which rows the caller may know about, and the audience arm decides per row whether what was said comes along. The subject is selected **through** the arm — `CASE WHEN (arm) THEN a.subject END` — rather than filtered by it, so a message the reader may discover but not read answers no name, which is what `readActivity` does when it nulls `Subject` on a withheld row.

A record the caller cannot see is **absent** from the answer rather than refused. They asked about a set; one unreadable member is not a failure of the question.

## Verification

- `make check-backend`, `make check-fe`, `make craft-static`
- `make -C backend test-integration` — 48 packages, 0 skips
- Both disclosure paths are mutation-checked against real Postgres, and both fail for the right reason:
  - neutering the row-scope clause → `label = "Zeta Privatkontakt" for another rep's capture-private contact`
  - neutering the audience arm → `label = "Board compensation" for a message this reader is not on`
- `TestTwoRecordsOfOneTypeCostOneRead` pins the claim the change exists for; removing the per-type dedupe fails it.

One note on method: my first row-scope mutation reported a pass, and it was a no-op — the anchor had not matched. The second attempt failed on an argument-count error rather than on disclosure, which is also not a proof. Only the third, which keeps the SQL well-formed and neuters only the predicate, actually demonstrates the clause is load-bearing. The two mutation results above are from that form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved attention cards by resolving related display names in efficient batches.

* **Bug Fixes**
  * Hidden, unavailable, archived, unnamed, or nonexistent records are now omitted cleanly.
  * Preserved display names for visible people, organizations, leads, deals, projects, and activities.
  * Improved handling of permission restrictions and unauthorized access without showing incorrect labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->