### PR TITLE
A vCard review refuses a contact the create will refuse

### DIFF
--- a/backend/internal/compose/vcardcreateproposal.go
+++ b/backend/internal/compose/vcardcreateproposal.go
@@ -188,6 +188,14 @@ func vcardCreatePrecheck() approvals.ReleasePrecheck {
 		if strings.TrimSpace(proposal.Entry.FullName) == "" {
 			return errors.New("the card names nobody: a person needs a name before they can be created")
 		}
+		// The same question the create asks, asked while the row is still
+		// re-decidable. Without it a card carrying a number the writer refuses
+		// is approved, the create fails after the decision, and the decider
+		// learns about it from the did-not-run lane instead of from the
+		// decision they were making.
+		if err := people.ValidateVCardContacts(proposal.Entry); err != nil {
+			return fmt.Errorf("this card carries a contact detail that cannot be stored: %w", err)
+		}
 		return nil
 	}
 }

--- a/backend/internal/compose/vcardcreateproposal.go
+++ b/backend/internal/compose/vcardcreateproposal.go
@@ -193,6 +193,13 @@ func vcardCreatePrecheck() approvals.ReleasePrecheck {
 		// is approved, the create fails after the decision, and the decider
 		// learns about it from the did-not-run lane instead of from the
 		// decision they were making.
+		//
+		// PARSING only, and deliberately. The create also refuses an address
+		// another person already claims, and that refusal cannot be brought
+		// forward honestly: a claim can be taken between this check and the
+		// approval, so asking here would not prevent the post-commit failure —
+		// it would only make it rarer while reading like a guarantee. A parse
+		// failure is a property of the card itself and cannot change under it.
 		if err := people.ValidateVCardContacts(proposal.Entry); err != nil {
 			return fmt.Errorf("this card carries a contact detail that cannot be stored: %w", err)
 		}

--- a/backend/internal/compose/vcardcreateproposal_test.go
+++ b/backend/internal/compose/vcardcreateproposal_test.go
@@ -66,6 +66,10 @@ func TestACardCarryingAnUnstorableContactIsRefusedWhileItIsStillDecidable(t *tes
 // The card the reviewer is looking at is not rewritten by being checked. The
 // parse the create runs normalises in place, and a precheck that normalised
 // the staged row would change what the decider approved after they read it.
+//
+// The payload BYTES are what this can assert, and all it should: the precheck
+// is handed serialized JSON and never the caller's struct, so an assertion
+// about the entry value would be checking a copy nothing under test can reach.
 func TestTheCheckLeavesTheStagedCardExactlyAsItWas(t *testing.T) {
 	entry := people.VCardEntry{
 		FullName: "Ana Ionescu",
@@ -81,9 +85,6 @@ func TestTheCheckLeavesTheStagedCardExactlyAsItWas(t *testing.T) {
 
 	if string(staged) != string(before) {
 		t.Fatalf("the precheck rewrote the staged payload:\n before: %s\n  after: %s", before, staged)
-	}
-	if entry.Emails[0].Value != "  Ana.Ionescu@Example.COM  " {
-		t.Errorf("the entry's own address was normalised to %q by a check that should only read it", entry.Emails[0].Value)
 	}
 }
 

--- a/backend/internal/compose/vcardcreateproposal_test.go
+++ b/backend/internal/compose/vcardcreateproposal_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What the vCard create precheck refuses while the decision can still be
+// taken back, and what it leaves alone.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/people"
+)
+
+func stagedCard(t *testing.T, entry people.VCardEntry) json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(vcardCreateProposal{Entry: entry, FullName: entry.FullName})
+	if err != nil {
+		t.Fatalf("staging the card: %v", err)
+	}
+	return payload
+}
+
+// A number the writer will not store must be refused at DECIDE time. Approved,
+// it fails after the decision committed: the redemption rolls back, the row is
+// marked effect_failed, and the decider finds out from the did-not-run lane
+// instead of from the decision they were making.
+func TestACardCarryingAnUnstorableContactIsRefusedWhileItIsStillDecidable(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry people.VCardEntry
+	}{
+		{
+			name: "a number that is not one",
+			entry: people.VCardEntry{
+				FullName: "Ana Ionescu",
+				Phones:   []people.VCardChannel{{Value: "not a phone number", Kind: "work"}},
+			},
+		},
+		{
+			name: "an address that is not one",
+			entry: people.VCardEntry{
+				FullName: "Ana Ionescu",
+				Emails:   []people.VCardChannel{{Value: "ana at example dot com", Kind: "work"}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := vcardCreatePrecheck()(context.Background(), stagedCard(t, tc.entry), nil)
+			if err == nil {
+				t.Fatal("the precheck admitted a card the create will refuse, so the failure moves to after the decision")
+			}
+			// The decider is told what is wrong with the card, not merely that
+			// something is: this message is what they act on.
+			if !strings.Contains(err.Error(), "contact detail that cannot be stored") {
+				t.Errorf("refusal reads %q, which does not say what a decider should do about it", err)
+			}
+		})
+	}
+}
+
+// The card the reviewer is looking at is not rewritten by being checked. The
+// parse the create runs normalises in place, and a precheck that normalised
+// the staged row would change what the decider approved after they read it.
+func TestTheCheckLeavesTheStagedCardExactlyAsItWas(t *testing.T) {
+	entry := people.VCardEntry{
+		FullName: "Ana Ionescu",
+		Emails:   []people.VCardChannel{{Value: "  Ana.Ionescu@Example.COM  ", Kind: "work"}},
+		Phones:   []people.VCardChannel{{Value: "+40 21 555 0100", Kind: "work"}},
+	}
+	staged := stagedCard(t, entry)
+	before := append(json.RawMessage(nil), staged...)
+
+	if err := vcardCreatePrecheck()(context.Background(), staged, nil); err != nil {
+		t.Fatalf("a storable card was refused: %v", err)
+	}
+
+	if string(staged) != string(before) {
+		t.Fatalf("the precheck rewrote the staged payload:\n before: %s\n  after: %s", before, staged)
+	}
+	if entry.Emails[0].Value != "  Ana.Ionescu@Example.COM  " {
+		t.Errorf("the entry's own address was normalised to %q by a check that should only read it", entry.Emails[0].Value)
+	}
+}
+
+// The edited payload is the one checked, because the modify-then-approve arm
+// is exactly where a decider can introduce a value the create refuses.
+func TestAnEditedCardIsTheOneChecked(t *testing.T) {
+	good := stagedCard(t, people.VCardEntry{FullName: "Ana Ionescu"})
+	edited := stagedCard(t, people.VCardEntry{
+		FullName: "Ana Ionescu",
+		Phones:   []people.VCardChannel{{Value: "not a phone number", Kind: "work"}},
+	})
+
+	if err := vcardCreatePrecheck()(context.Background(), good, edited); err == nil {
+		t.Fatal("the precheck read the staged card and ignored the edit that broke it")
+	}
+}

--- a/backend/internal/modules/people/vcardimport.go
+++ b/backend/internal/modules/people/vcardimport.go
@@ -195,6 +195,22 @@ func vcardCandidate(entry VCardEntry) PersonCandidate {
 	return candidate
 }
 
+// ValidateVCardContacts answers whether a reviewed card's addresses and
+// numbers are ones the create will accept, without writing anything.
+//
+// It asks by BUILDING the create's own input and running the create's own
+// parser over it, rather than restating the rules: a second copy of "what is
+// a valid number here" is the thing that drifts, and the whole point of
+// asking early is that the answer matches what the writer will say.
+//
+// Nothing is normalised for the caller. The parse mutates the input it is
+// given, and the input here is built fresh and thrown away — the proposal on
+// the row is left exactly as the reviewer sees it.
+func ValidateVCardContacts(entry VCardEntry) error {
+	person := personFromVCard(entry)
+	return parsePersonContacts(person.Emails, person.Phones)
+}
+
 func personFromVCard(entry VCardEntry) CreatePersonInput {
 	person := CreatePersonInput{
 		FullName: strings.TrimSpace(entry.FullName),


### PR DESCRIPTION
Closes #3055.

## What was wrong

The `vcard_create` precheck refuses a proposal whose card lost its name, while the row is still pending and re-decidable. It never re-ran the people module's contact parsing, so a card carrying a phone or email the create rejects sailed through staging and the precheck. The approval committed, the create failed, the redemption rolled back with it, and the row landed in `effect_failed`.

That failure is honest — it reaches the decider's did-not-run lane rather than disappearing — but it reaches them *after* the decision, about a card they can no longer simply fix.

## What this changes

The precheck now asks the same question the writer asks, at decide time.

`people.ValidateVCardContacts` builds the create's own input via `personFromVCard` and runs the create's own `parsePersonContacts` over it. That is deliberately not "export the parser": the ticket asks for the precheck to ask *the real writer's own question*, and the way to keep the answers identical is to run the real mapping and the real parse rather than to restate either.

Nothing is normalised for the caller. `parsePersonContacts` rewrites the input it is given; the input here is built fresh and thrown away, so the staged proposal is left exactly as the reviewer sees it. There is a test for that specifically, because a precheck that quietly rewrote the payload would change what a decider approved after they read it.

## Verification

- `make check-backend`, `make craft-static`
- `make -C backend test-integration` — 48 packages, 0 skips
- Four cases: an unstorable number, an unstorable address, the payload left byte-identical, and the *edited* payload being the one checked — the modify-then-approve arm is exactly where a decider can introduce a value the create refuses.
- Mutation-checked: removing the new check fails all four refusal arms; passing `nil` emails to the parser fails the address arm alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * vCard creation now rejects cards with invalid or unstorable phone numbers or email addresses before approval.
  * Edited card details are validated correctly during the pre-check.
  * Checking a card no longer changes its staged content or entry data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->