### PR TITLE
The subject-request queue is human-only where it is advertised

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -10498,11 +10498,12 @@ paths:
       tags: [Compliance]
       operationId: listDataSubjectRequests
       summary: List GDPR data-subject requests (B-E11.30).
+      security: [ { cookieAuth: [] } ]   # human session only — rejects agent bearer/Passport (x-agent-access: human-only)
+      x-agent-access: human-only
       parameters:
         - { name: status, in: query, schema: { type: string, enum: [open, in_progress, fulfilled, rejected] } }
         - $ref: '#/components/parameters/Cursor'
         - $ref: '#/components/parameters/Limit'
-      x-mcp-tool: { verb: search_records, record_type: data_subject_request, tier: auto_execute, scope: read }
       responses:
         '200':
           description: A page of data-subject requests.

--- a/backend/gates/dsrqueueishumanonly_test.go
+++ b/backend/gates/dsrqueueishumanonly_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// The subject-request queue is human-only in the contract because it is
+// human-only in the store.
+//
+// consent's requireDSRAdmin refuses every principal that is not a HUMAN, and
+// it does so before it checks admin — so an agent tool pointed at this queue
+// can only ever be refused. An operation advertised on the tool surface that
+// can only 403 is not merely useless: it is a door the contract is already
+// holding open, and the day somebody relaxes the store gate the policy would
+// let agents straight through without anyone deciding that.
+//
+// Two of the three operations here were marked human-only and the third was
+// not, which is the drift this gate exists to catch — the miss was invisible
+// because nothing compares the contract's answer with the store's.
+//
+// The contract is PARSED rather than pattern-matched: writing the same
+// operation block-style instead of inline changes nothing about the document,
+// and a regex that walked onto a neighbouring path would report a confident
+// wrong answer about a list it was no longer reading.
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	dsrContract   = "api/crm.yaml"
+	dsrPathPrefix = "/data-subject-requests"
+	// dsrOperationFloor is what the queue declared when this gate was
+	// written. A census that reads zero operations — a renamed path, a
+	// restructured document — would otherwise certify nothing while passing.
+	dsrOperationFloor = 3
+)
+
+func TestTheSubjectRequestQueueIsHumanOnlyInTheContract(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile(dsrContract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Loosely typed on purpose: a path item carries `parameters` (a sequence)
+	// beside its verbs, which no fixed struct for an operation can hold.
+	var doc struct {
+		Paths map[string]map[string]any `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := 0
+	for path, operations := range doc.Paths {
+		if !strings.HasPrefix(path, dsrPathPrefix) {
+			continue
+		}
+		for method, raw := range operations {
+			operation, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			// `parameters` and `summary` sit beside the verbs on a path item;
+			// only the entries carrying an operationId are operations.
+			id, named := operation["operationId"].(string)
+			if !named || id == "" {
+				continue
+			}
+			seen++
+			if access, _ := operation["x-agent-access"].(string); access != "human-only" {
+				t.Errorf("%s %s (%s) is x-agent-access %q — the store refuses every non-human caller, so this can only ever 403",
+					strings.ToUpper(method), path, id, access)
+			}
+			if operation["x-mcp-tool"] != nil {
+				t.Errorf("%s %s (%s) still declares an x-mcp-tool — a human-only operation that names a tool puts it in the catalogue for agents to call and be refused",
+					strings.ToUpper(method), path, id)
+			}
+		}
+	}
+	if seen < dsrOperationFloor {
+		t.Fatalf("read %d operations under %s, want at least %d: this gate finds them by path prefix, so a rename leaves it certifying nothing",
+			seen, dsrPathPrefix, dsrOperationFloor)
+	}
+}

--- a/backend/gates/dsrqueueishumanonly_test.go
+++ b/backend/gates/dsrqueueishumanonly_test.go
@@ -9,15 +9,12 @@ package gates
 // human-only in the store.
 //
 // consent's requireDSRAdmin refuses every principal that is not a HUMAN, and
-// it does so before it checks admin — so an agent tool pointed at this queue
-// can only ever be refused. An operation advertised on the tool surface that
-// can only 403 is not merely useless: it is a door the contract is already
-// holding open, and the day somebody relaxes the store gate the policy would
-// let agents straight through without anyone deciding that.
-//
-// Two of the three operations here were marked human-only and the third was
-// not, which is the drift this gate exists to catch — the miss was invisible
-// because nothing compares the contract's answer with the store's.
+// it does so before it checks admin, so an agent pointed at this queue is
+// always refused. An operation advertised on the tool surface that can only
+// answer 403 is not merely useless: it is a door the contract holds open, and
+// relaxing the store gate would let agents through it without anyone deciding
+// that. The contract has to say what the store enforces, and nothing else
+// compares the two.
 //
 // The contract is PARSED rather than pattern-matched: writing the same
 // operation block-style instead of inline changes nothing about the document,
@@ -33,11 +30,11 @@ import (
 )
 
 const (
-	dsrContract   = "api/crm.yaml"
-	dsrPathPrefix = "/data-subject-requests"
-	// dsrOperationFloor is what the queue declared when this gate was
-	// written. A census that reads zero operations — a renamed path, a
-	// restructured document — would otherwise certify nothing while passing.
+	dsrContract  = "api/crm.yaml"
+	dsrQueuePath = "/data-subject-requests"
+	// dsrOperationFloor is what the queue declares. A census that reads zero
+	// operations — a renamed path, a restructured document — would otherwise
+	// certify nothing while passing.
 	dsrOperationFloor = 3
 )
 
@@ -58,7 +55,11 @@ func TestTheSubjectRequestQueueIsHumanOnlyInTheContract(t *testing.T) {
 
 	seen := 0
 	for path, operations := range doc.Paths {
-		if !strings.HasPrefix(path, dsrPathPrefix) {
+		// The queue itself and its descendants, never a NEIGHBOUR that merely
+		// starts with the same letters: `/data-subject-requests-v2` is a
+		// different surface, and matching it would let a rename satisfy the
+		// floor below while this checked nothing the name still refers to.
+		if path != dsrQueuePath && !strings.HasPrefix(path, dsrQueuePath+"/") {
 			continue
 		}
 		for method, raw := range operations {
@@ -84,7 +85,7 @@ func TestTheSubjectRequestQueueIsHumanOnlyInTheContract(t *testing.T) {
 		}
 	}
 	if seen < dsrOperationFloor {
-		t.Fatalf("read %d operations under %s, want at least %d: this gate finds them by path prefix, so a rename leaves it certifying nothing",
-			seen, dsrPathPrefix, dsrOperationFloor)
+		t.Fatalf("read %d operations under %s, want at least %d: this gate finds them by path, so a rename leaves it certifying nothing",
+			seen, dsrQueuePath, dsrOperationFloor)
 	}
 }

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -204,7 +204,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/connectors":                                                 {Op: "listConnectors", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/contracts/{id}":                                             {Op: "getContract", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/custom-fields":                                              {Op: "listCustomFields", Access: "tool", Tool: "search_records", RecordType: "custom_field", Tier: "auto_execute", Scope: "read"},
-	"GET /v1/data-subject-requests":                                      {Op: "listDataSubjectRequests", Access: "tool", Tool: "search_records", RecordType: "data_subject_request", Tier: "auto_execute", Scope: "read"},
+	"GET /v1/data-subject-requests":                                      {Op: "listDataSubjectRequests", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/deal-rooms":                                                 {Op: "listDealRooms", Access: "tool", Tool: "search_records", RecordType: "deal_room", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/deal-rooms/{id}":                                            {Op: "getDealRoom", Access: "tool", Tool: "read_record", RecordType: "deal_room", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/deal-rooms/{id}/documents":                                  {Op: "listDealRoomDocuments", Access: "tool", Tool: "search_records", RecordType: "deal_room_document", Tier: "auto_execute", Scope: "read"},

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -51751,8 +51751,6 @@ func (siw *ServerInterfaceWrapper) ListDataSubjectRequests(w http.ResponseWriter
 
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
 	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
 
 	r = r.WithContext(ctx)

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (54)
+## Parity (55)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -36,6 +36,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `contractvocabulary_test.go` | H3 | A membership set built from a generated enum's own constants must hold every member of that enum. |
 | `corepicklistcontract_test.go` | H3 | The core picklist value sets against the contract that owns them. |
 | `dedupeevidencefields_test.go` | H1 | The dedupe evidence snapshot is stored as free JSON, so nothing about a field name is checked when it is written. |
+| `dsrqueueishumanonly_test.go` | H2 | The subject-request queue is human-only in the contract because it is human-only in the store. |
 | `enumsync_test.go` | H3 | The enum-vocabulary sync as a fitness function: where domain logic branches on a typed Go enum, its constant set must equal the schema's CHECK (col IN (...)) set for the column it mirrors. |
 | `filtervocabularyparity_test.go` | H3 | Two surfaces answer a filtered question: the list/segment compiler in `platform/database/storekit`, and the query compiler in `modules/search`. |
 | `frontendapprovalkinds_test.go` | H1 | Every kind a proposal can be staged under must have words a reader recognises, or the queue prints the wire enum at them. |


### PR DESCRIPTION
Closes #3059.

## The decision the ticket asked for

The ticket asks whether the operation should be `x-agent-access: human-only`, or whether the tool listing is wanted. The evidence turned out to be one-sided, so I took it rather than sending it back:

- `consent.requireDSRAdmin` refuses every principal that is not `PrincipalHuman`, **before** it reaches `auth.RequireAdmin`. An agent calling the tool is always refused at the store.
- Its two siblings on the same path — `createDataSubjectRequest` and `updateDataSubjectRequest` — are already `security: [cookieAuth]` + `x-agent-access: human-only`, and carry no `x-mcp-tool`.

So this was not a design choice anybody made; it was one of three operations missing the treatment the other two have. Wanting the tool listing would mean wanting an entry that can only ever 403.

## What changed

`listDataSubjectRequests` gains the siblings' two lines and loses its `x-mcp-tool`. The regenerated policy now reads:

```
-"GET /v1/data-subject-requests": {Op: "listDataSubjectRequests", Access: "tool", Tool: "search_records", RecordType: "data_subject_request", Tier: "auto_execute", Scope: "read"},
+"GET /v1/data-subject-requests": {Op: "listDataSubjectRequests", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
```

## The gate

Nothing failed while the contract and the store disagreed, which is why two of three were marked and the third was not. `TestTheSubjectRequestQueueIsHumanOnlyInTheContract` now requires every operation under `/data-subject-requests` to be human-only and to declare no tool, with a floor so a renamed path fails loudly instead of certifying nothing. The contract is parsed rather than pattern-matched, for the reason the sibling contract gates give: reflowing an operation must not move the match onto a neighbour.

The ticket's own sharper point is what the gate is really for — *"if the store gate were ever loosened the policy would already be holding the door open."* Now it cannot be, without something failing.

## Verification

- `make check-backend`, `make check-fe`, `make craft-static`
- `make -C backend test-integration` — 48 packages, 0 skips
- Gate mutation-checked on both arms: removing the human-only marking, and restoring the `x-mcp-tool`, each fail it with their own message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access Control**
  * Data subject request operations now require human-session authentication.
  * Agent bearer and Passport access is no longer accepted.
  * These operations are no longer exposed as MCP tools.

* **Quality Assurance**
  * Added automated checks to verify consistent human-only access controls and prevent similarly named endpoints from being incorrectly included.

* **Documentation**
  * Updated the gate inventory to reflect the expanded parity coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->