### PR TITLE
Only the firing that completes a task writes a completion

### DIFF
--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -18,11 +18,13 @@ package activities
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 	"github.com/margince/margince/backend/internal/shared/ports/workflow"
@@ -191,6 +193,17 @@ func (w followUpAutoResolve) linkedLeads(ctx context.Context, activityID ids.Act
 // UPDATE would be invisible history. Replays are harmless: a completed
 // task no longer matches the open filter.
 //
+// The selection and the completions are separate transactions, so two
+// firings for one lead — an activity.captured racing a lead.promoted — can
+// both select the same open task. Each completion therefore carries the
+// version the selection read, and a task somebody else finished first
+// answers version skew and is SKIPPED. Without it the loser writes
+// is_done = true over a row that already says so, and the task's history
+// shows two identical completions of the same thing.
+//
+// The count is what THIS call completed, which is also why skew is not an
+// error: another firing completing the task is the outcome this one wanted.
+//
 // "System-minted" is decided by source AND captured_by together: source
 // rides the client create wire verbatim (any caller can spell "system" —
 // see systemSource's doc), while captured_by is stamped from the authenticated
@@ -199,10 +212,14 @@ func (w followUpAutoResolve) linkedLeads(ctx context.Context, activityID ids.Act
 // leaves a call that takes no read gate of its own; each completion's
 // write is gated inside UpdateActivity.
 func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.LeadID) (int, error) {
-	var open []ids.ActivityID
+	type openTask struct {
+		id      ids.ActivityID
+		version int64
+	}
+	var open []openTask
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			SELECT a.id FROM activity a
+			SELECT a.id, a.version FROM activity a
 			JOIN activity_link l ON l.activity_id = a.id
 			WHERE l.lead_id = $1 AND a.kind = $2 AND a.source = $3
 			  AND (a.captured_by = $4 OR a.captured_by LIKE $5)
@@ -214,11 +231,11 @@ func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.L
 		}
 		defer rows.Close()
 		for rows.Next() {
-			var id ids.ActivityID
-			if err := rows.Scan(&id); err != nil {
+			var task openTask
+			if err := rows.Scan(&task.id, &task.version); err != nil {
 				return err
 			}
-			open = append(open, id)
+			open = append(open, task)
 		}
 		return rows.Err()
 	})
@@ -226,10 +243,22 @@ func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.L
 		return 0, err
 	}
 	done := true
-	for _, id := range open {
-		if _, err := s.UpdateActivity(ctx, id, UpdateActivityInput{IsDone: &done}); err != nil {
-			return 0, fmt.Errorf("completing system task %s: %w", id, err)
+	completed := 0
+	for _, task := range open {
+		version := task.version
+		_, err := s.UpdateActivity(ctx, task.id, UpdateActivityInput{IsDone: &done, IfVersion: &version})
+		if errors.Is(err, apperrors.ErrVersionSkew) {
+			// Somebody moved this row between the selection and here. If it
+			// was the sibling firing, the task is complete and a second
+			// completion event would be the only thing this write added; if
+			// it was an ordinary edit, the next firing sees it still open and
+			// finishes it.
+			continue
 		}
+		if err != nil {
+			return 0, fmt.Errorf("completing system task %s: %w", task.id, err)
+		}
+		completed++
 	}
-	return len(open), nil
+	return completed, nil
 }

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
@@ -242,23 +243,66 @@ func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.L
 	if err != nil {
 		return 0, err
 	}
-	done := true
 	completed := 0
 	for _, task := range open {
-		version := task.version
-		_, err := s.UpdateActivity(ctx, task.id, UpdateActivityInput{IsDone: &done, IfVersion: &version})
-		if errors.Is(err, apperrors.ErrVersionSkew) {
-			// Somebody moved this row between the selection and here. If it
-			// was the sibling firing, the task is complete and a second
-			// completion event would be the only thing this write added; if
-			// it was an ordinary edit, the next firing sees it still open and
-			// finishes it.
-			continue
-		}
+		flipped, err := s.completeSystemTask(ctx, task.id, task.version)
 		if err != nil {
 			return 0, fmt.Errorf("completing system task %s: %w", task.id, err)
 		}
-		completed++
+		if flipped {
+			completed++
+		}
 	}
 	return completed, nil
+}
+
+// completionAttempts bounds the re-read below. Each attempt is a lost race
+// with a DIFFERENT writer, so more than a couple means a row somebody is
+// editing continuously; failing then is honest, and the workflow's own retry
+// is the right place for the wait.
+const completionAttempts = 3
+
+// completeSystemTask completes one selected task, answering whether THIS call
+// is what flipped it.
+//
+// The version is the one the selection read, so a row that moved underneath
+// answers skew rather than writing. What happens next depends on why it moved,
+// and the two reasons are not alike:
+//
+//   - a sibling firing completed it — there is nothing left to do, and writing
+//     anyway would put a second identical completion in the task's history;
+//   - anything else touched it — the task is still open and still has to be
+//     completed, because the loop that opened it has closed and no later
+//     firing is promised.
+//
+// So skew is a re-read, not a skip. Skipping unconditionally trades a noisy
+// history for a follow-up task that can stay open forever, which is the worse
+// of the two.
+func (s *Store) completeSystemTask(ctx context.Context, id ids.ActivityID, version int64) (bool, error) {
+	done := true
+	for attempt := 0; attempt < completionAttempts; attempt++ {
+		_, err := s.UpdateActivity(ctx, id, UpdateActivityInput{IsDone: &done, IfVersion: &version})
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, apperrors.ErrVersionSkew) {
+			return false, err
+		}
+		current, err := s.GetActivity(ctx, id, storekit.LiveOnly)
+		if errors.Is(err, apperrors.ErrNotFound) {
+			// Archived under us: there is no task to finish.
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if current.IsDone != nil && *current.IsDone {
+			return false, nil
+		}
+		if current.Version == nil {
+			return false, fmt.Errorf("task %s reports no version to retry against", id)
+		}
+		version = int64(*current.Version)
+	}
+	return false, fmt.Errorf("task %s was edited under every one of %d completion attempts", id, completionAttempts)
 }

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -285,12 +285,18 @@ func (s *Store) completeSystemTask(ctx context.Context, id ids.ActivityID, versi
 		if err == nil {
 			return true, nil
 		}
+		if errors.Is(err, apperrors.ErrNotFound) {
+			// Archived between the selection and the write: the row lock is
+			// taken live, so a task that has gone answers not-found. There is
+			// no task to finish and nothing here went wrong — failing the
+			// firing would strand every OTHER task it selected.
+			return false, nil
+		}
 		if !errors.Is(err, apperrors.ErrVersionSkew) {
 			return false, err
 		}
 		current, err := s.GetActivity(ctx, id, storekit.LiveOnly)
 		if errors.Is(err, apperrors.ErrNotFound) {
-			// Archived under us: there is no task to finish.
 			return false, nil
 		}
 		if err != nil {

--- a/backend/internal/modules/activities/followupresolve_integration_test.go
+++ b/backend/internal/modules/activities/followupresolve_integration_test.go
@@ -380,6 +380,68 @@ func TestAnEditUnderTheFiringDoesNotLeaveTheTaskOpen(t *testing.T) {
 	}
 }
 
+// A task archived between the selection and the write is gone, not a failure.
+// The row lock is taken live, so the completion answers not-found — and
+// failing the firing on it would strand every other task the same call
+// selected.
+func TestATaskArchivedUnderTheFiringIsNotAFailure(t *testing.T) {
+	e := setupResolve(t)
+	task := e.seedTask(t, "system", "system")
+	other := e.seedTask(t, "system", "system")
+	ctx := e.systemCtx()
+	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
+
+	blocking, err := e.owner.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := blocking.Exec(context.Background(),
+		`SELECT id FROM activity WHERE id = $1 FOR UPDATE`, task); err != nil {
+		t.Fatal(err)
+	}
+
+	firing := make(chan firingResult, 1)
+	go func() {
+		completed, err := store.CompleteOpenSystemTasksForLead(ctx, ids.From[ids.LeadKind](e.lead))
+		firing <- firingResult{completed, err}
+	}()
+	t.Cleanup(func() {
+		//craft:ignore swallowed-errors the lock is normally released by the Commit below and this rollback is then a designed no-op; on the failure paths it is the release itself, and a failing release could tell this test nothing its own assertions have not
+		_ = blocking.Rollback(context.Background())
+		select {
+		case <-firing:
+		case <-time.After(10 * time.Second):
+			t.Error("the firing never returned after the lock was released")
+		}
+	})
+
+	e.waitForBlockedWriter(t, firing)
+
+	if _, err := blocking.Exec(context.Background(),
+		`UPDATE activity SET archived_at = now() WHERE id = $1`, task); err != nil {
+		t.Fatal(err)
+	}
+	if err := blocking.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	var got firingResult
+	select {
+	case got = <-firing:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the firing never returned after the archive committed")
+	}
+	firing <- got
+
+	if got.err != nil {
+		t.Fatalf("a task that went away failed the firing: %v", got.err)
+	}
+	// The OTHER task is the point: a failure here would have stranded it.
+	if !e.isDone(t, other) {
+		t.Fatal("the firing stopped at the archived task and left its sibling open")
+	}
+}
+
 // firingResult is one CompleteOpenSystemTasksForLead call's answer, carried
 // back from the goroutine that raced.
 type firingResult struct {

--- a/backend/internal/modules/activities/followupresolve_integration_test.go
+++ b/backend/internal/modules/activities/followupresolve_integration_test.go
@@ -310,6 +310,18 @@ func TestATaskArchivedUnderTheFiringIsNotAFailure(t *testing.T) {
 	if !e.isDone(t, sibling) {
 		t.Fatal("the firing stopped at the archived task and left its sibling open")
 	}
+	// And the archived task itself is left alone. Completing it would write an
+	// activity.updated event about a record that is no longer on any timeline,
+	// which is the opposite of the skip this branch exists for.
+	if e.isDone(t, task) {
+		t.Error("the firing completed a task that had been archived under it")
+	}
+	if events := e.completionEvents(t, task); events != 0 {
+		t.Errorf("the firing wrote %d activity.updated event(s) for an archived task", events)
+	}
+	if got.completed != 1 {
+		t.Errorf("the firing reports %d completions, want only the sibling", got.completed)
+	}
 }
 
 // blockedFiring is the shape all three race cases are: hold the task's row,

--- a/backend/internal/modules/activities/followupresolve_integration_test.go
+++ b/backend/internal/modules/activities/followupresolve_integration_test.go
@@ -233,3 +233,142 @@ func TestALeadLeavingTheOpenPoolCompletesItsSystemTasks(t *testing.T) {
 		t.Error("the promoted lead's system follow-up is still open — a reminder chasing a closed loop")
 	}
 }
+
+// Two firings for one lead — an activity.captured racing a lead.promoted —
+// both select the same open task while it is still open. Only the one that
+// actually flips it may write a completion: the other adds an audit row and an
+// activity.updated event saying the task was finished, about a task that was
+// already finished, and the record's history then shows the same thing
+// happening twice.
+//
+// The interleaving is FORCED rather than hoped for. A sequential second call
+// proves nothing here — it re-runs the open-task query, finds nothing, and
+// writes nothing whatever the completion path does. What has to be reproduced
+// is a firing that selected the task while it was open and reaches its write
+// after somebody else finished it, so the row is locked under it until that
+// has happened.
+func TestAFiringThatSelectedBeforeSomebodyElseFinishedWritesNothing(t *testing.T) {
+	e := setupResolve(t)
+	task := e.seedTask(t, "system", "system")
+	ctx := e.systemCtx()
+	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
+
+	// Hold the row so the firing below gets past its selection and stops at
+	// its write, which is exactly where the loser of the race stands.
+	blocking, err := e.owner.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := blocking.Exec(context.Background(),
+		`SELECT id FROM activity WHERE id = $1 FOR UPDATE`, task); err != nil {
+		t.Fatal(err)
+	}
+
+	loser := make(chan firingResult, 1)
+	go func() {
+		completed, err := store.CompleteOpenSystemTasksForLead(ctx, ids.From[ids.LeadKind](e.lead))
+		loser <- firingResult{completed, err}
+	}()
+	// However this test ends, the lock is released and the firing is waited
+	// for: a goroutine still holding a pooled connection outlives the test and
+	// the next one resets the database under it.
+	t.Cleanup(func() {
+		//craft:ignore swallowed-errors the lock is normally released by the Commit above and this rollback is then a designed no-op; on the failure paths it is the release itself, and there is nothing a failing release could tell this test that its own assertions have not already said
+		_ = blocking.Rollback(context.Background())
+		select {
+		case <-loser:
+		case <-time.After(10 * time.Second):
+			t.Error("the firing never returned after the lock was released")
+		}
+	})
+
+	e.waitForBlockedWriter(t, loser)
+
+	// The winner: the task is completed and its version moves, under the lock
+	// the loser is waiting on.
+	if _, err := blocking.Exec(context.Background(),
+		`UPDATE activity SET is_done = true, done_at = now(), version = version + 1 WHERE id = $1`, task); err != nil {
+		t.Fatal(err)
+	}
+	if err := blocking.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	var got firingResult
+	select {
+	case got = <-loser:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the firing never returned after the winner committed")
+	}
+	// Drained here, so the cleanup above finds the channel empty and does not
+	// wait for a result that has already been read.
+	loser <- got
+	if got.err != nil {
+		t.Fatalf("the losing firing failed instead of standing down: %v", got.err)
+	}
+	if got.completed != 0 {
+		t.Errorf("the losing firing reports %d completions, want none — it completed nothing", got.completed)
+	}
+	if events := e.completionEvents(t, task); events != 0 {
+		t.Fatalf("the losing firing wrote %d activity.updated event(s) for a task it did not finish", events)
+	}
+}
+
+// firingResult is one CompleteOpenSystemTasksForLead call's answer, carried
+// back from the goroutine that raced.
+type firingResult struct {
+	completed int
+	err       error
+}
+
+// waitForBlockedWriter waits until the firing under test is stopped on the row
+// lock. Polled rather than slept on: the point of the test is the ordering,
+// and a fixed pause would either be flaky or slow.
+func (e *resolveEnv) waitForBlockedWriter(t *testing.T, firing <-chan firingResult) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		// A firing that RETURNED never reached the write, so the ordering this
+		// test needs did not happen and nothing it goes on to assert would
+		// mean anything. Said here rather than as a timeout, because "it
+		// finished early" and "it never started" are different faults.
+		select {
+		case got := <-firing:
+			t.Fatalf("the firing returned before it blocked (completed=%d err=%v): the race was never set up",
+				got.completed, got.err)
+		default:
+		}
+		var blocked int
+		// A waiter on a ROW lock does not appear as an ungranted lock on the
+		// relation — it waits on the holder's transaction id — so the wait
+		// event is what says it is stopped. Not its `state`: a backend parked
+		// on a lock inside a transaction reports "idle in transaction", and
+		// requiring "active" here looks right and finds nothing.
+		if err := e.owner.QueryRow(context.Background(),
+			`SELECT count(*) FROM pg_stat_activity
+			  WHERE wait_event_type = 'Lock' AND pid <> pg_backend_pid()
+			    AND datname = current_database()`).Scan(&blocked); err != nil {
+			t.Fatal(err)
+		}
+		if blocked > 0 {
+			return
+		}
+		//craft:ignore test-sleep the wait IS on the condition — a backend stopped on the lock — and this is only the interval between checks; the deadline above fails the test loudly rather than letting it pass on a race that never happened
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("no writer ever blocked on the row: the race this test reproduces did not happen, so it proves nothing")
+}
+
+// completionEvents counts the activity.updated events this task produced — the
+// noise a redundant write leaves behind.
+func (e *resolveEnv) completionEvents(t *testing.T, id ids.UUID) int {
+	t.Helper()
+	var count int
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM event_outbox
+		  WHERE envelope->>'type' = 'activity.updated'
+		    AND envelope->'entity'->>'id' = $1::text`, id.String()).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}

--- a/backend/internal/modules/activities/followupresolve_integration_test.go
+++ b/backend/internal/modules/activities/followupresolve_integration_test.go
@@ -314,6 +314,72 @@ func TestAFiringThatSelectedBeforeSomebodyElseFinishedWritesNothing(t *testing.T
 	}
 }
 
+// An ordinary edit that lands between the selection and the completion moves
+// the version without finishing anything. The task still has to be completed:
+// the loop that opened it has closed, and no later firing is promised for this
+// lead — treating every version change as "somebody else did it" trades a noisy
+// history for a follow-up that stays open forever.
+func TestAnEditUnderTheFiringDoesNotLeaveTheTaskOpen(t *testing.T) {
+	e := setupResolve(t)
+	task := e.seedTask(t, "system", "system")
+	ctx := e.systemCtx()
+	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
+
+	blocking, err := e.owner.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := blocking.Exec(context.Background(),
+		`SELECT id FROM activity WHERE id = $1 FOR UPDATE`, task); err != nil {
+		t.Fatal(err)
+	}
+
+	firing := make(chan firingResult, 1)
+	go func() {
+		completed, err := store.CompleteOpenSystemTasksForLead(ctx, ids.From[ids.LeadKind](e.lead))
+		firing <- firingResult{completed, err}
+	}()
+	t.Cleanup(func() {
+		//craft:ignore swallowed-errors the lock is normally released by the Commit below and this rollback is then a designed no-op; on the failure paths it is the release itself, and a failing release could tell this test nothing its own assertions have not
+		_ = blocking.Rollback(context.Background())
+		select {
+		case <-firing:
+		case <-time.After(10 * time.Second):
+			t.Error("the firing never returned after the lock was released")
+		}
+	})
+
+	e.waitForBlockedWriter(t, firing)
+
+	// Not a completion: somebody retitled the task. The version moves and the
+	// task stays open.
+	if _, err := blocking.Exec(context.Background(),
+		`UPDATE activity SET subject = 'Follow up (renamed)', version = version + 1 WHERE id = $1`, task); err != nil {
+		t.Fatal(err)
+	}
+	if err := blocking.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	var got firingResult
+	select {
+	case got = <-firing:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the firing never returned after the edit committed")
+	}
+	firing <- got
+
+	if got.err != nil {
+		t.Fatalf("the firing failed instead of completing the task it selected: %v", got.err)
+	}
+	if got.completed != 1 {
+		t.Errorf("the firing completed %d tasks, want the one it selected — an edit is not somebody else finishing it", got.completed)
+	}
+	if !e.isDone(t, task) {
+		t.Fatal("the task is still open after the firing that was supposed to close it — a rename cost the follow-up its completion")
+	}
+}
+
 // firingResult is one CompleteOpenSystemTasksForLead call's answer, carried
 // back from the goroutine that raced.
 type firingResult struct {
@@ -339,15 +405,18 @@ func (e *resolveEnv) waitForBlockedWriter(t *testing.T, firing <-chan firingResu
 		default:
 		}
 		var blocked int
+		// Blocked BY US specifically, through pg_blocking_pids: any other
+		// waiter in this database would otherwise release the wait early and
+		// the test would go on to assert about a race it never set up.
+		//
 		// A waiter on a ROW lock does not appear as an ungranted lock on the
-		// relation — it waits on the holder's transaction id — so the wait
-		// event is what says it is stopped. Not its `state`: a backend parked
-		// on a lock inside a transaction reports "idle in transaction", and
-		// requiring "active" here looks right and finds nothing.
+		// relation — it waits on the holder's transaction id — and its
+		// `state` reads "idle in transaction" rather than "active", so
+		// neither of those is what identifies it.
 		if err := e.owner.QueryRow(context.Background(),
 			`SELECT count(*) FROM pg_stat_activity
-			  WHERE wait_event_type = 'Lock' AND pid <> pg_backend_pid()
-			    AND datname = current_database()`).Scan(&blocked); err != nil {
+			  WHERE datname = current_database()
+			    AND pg_backend_pid() = ANY(pg_blocking_pids(pid))`).Scan(&blocked); err != nil {
 			t.Fatal(err)
 		}
 		if blocked > 0 {

--- a/backend/internal/modules/activities/followupresolve_integration_test.go
+++ b/backend/internal/modules/activities/followupresolve_integration_test.go
@@ -243,66 +243,17 @@ func TestALeadLeavingTheOpenPoolCompletesItsSystemTasks(t *testing.T) {
 //
 // The interleaving is FORCED rather than hoped for. A sequential second call
 // proves nothing here — it re-runs the open-task query, finds nothing, and
-// writes nothing whatever the completion path does. What has to be reproduced
-// is a firing that selected the task while it was open and reaches its write
-// after somebody else finished it, so the row is locked under it until that
-// has happened.
+// writes nothing whatever the completion path does.
 func TestAFiringThatSelectedBeforeSomebodyElseFinishedWritesNothing(t *testing.T) {
 	e := setupResolve(t)
 	task := e.seedTask(t, "system", "system")
-	ctx := e.systemCtx()
-	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
 
-	// Hold the row so the firing below gets past its selection and stops at
-	// its write, which is exactly where the loser of the race stands.
-	blocking, err := e.owner.Begin(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := blocking.Exec(context.Background(),
-		`SELECT id FROM activity WHERE id = $1 FOR UPDATE`, task); err != nil {
-		t.Fatal(err)
-	}
-
-	loser := make(chan firingResult, 1)
-	go func() {
-		completed, err := store.CompleteOpenSystemTasksForLead(ctx, ids.From[ids.LeadKind](e.lead))
-		loser <- firingResult{completed, err}
-	}()
-	// However this test ends, the lock is released and the firing is waited
-	// for: a goroutine still holding a pooled connection outlives the test and
-	// the next one resets the database under it.
-	t.Cleanup(func() {
-		//craft:ignore swallowed-errors the lock is normally released by the Commit above and this rollback is then a designed no-op; on the failure paths it is the release itself, and there is nothing a failing release could tell this test that its own assertions have not already said
-		_ = blocking.Rollback(context.Background())
-		select {
-		case <-loser:
-		case <-time.After(10 * time.Second):
-			t.Error("the firing never returned after the lock was released")
-		}
-	})
-
-	e.waitForBlockedWriter(t, loser)
-
+	firing := e.startBlockedFiring(t, task)
 	// The winner: the task is completed and its version moves, under the lock
-	// the loser is waiting on.
-	if _, err := blocking.Exec(context.Background(),
-		`UPDATE activity SET is_done = true, done_at = now(), version = version + 1 WHERE id = $1`, task); err != nil {
-		t.Fatal(err)
-	}
-	if err := blocking.Commit(context.Background()); err != nil {
-		t.Fatal(err)
-	}
+	// the firing is waiting on.
+	firing.exec(`UPDATE activity SET is_done = true, done_at = now(), version = version + 1 WHERE id = $1`, task)
+	got := firing.release()
 
-	var got firingResult
-	select {
-	case got = <-loser:
-	case <-time.After(10 * time.Second):
-		t.Fatal("the firing never returned after the winner committed")
-	}
-	// Drained here, so the cleanup above finds the channel empty and does not
-	// wait for a result that has already been read.
-	loser <- got
 	if got.err != nil {
 		t.Fatalf("the losing firing failed instead of standing down: %v", got.err)
 	}
@@ -322,52 +273,12 @@ func TestAFiringThatSelectedBeforeSomebodyElseFinishedWritesNothing(t *testing.T
 func TestAnEditUnderTheFiringDoesNotLeaveTheTaskOpen(t *testing.T) {
 	e := setupResolve(t)
 	task := e.seedTask(t, "system", "system")
-	ctx := e.systemCtx()
-	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
 
-	blocking, err := e.owner.Begin(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := blocking.Exec(context.Background(),
-		`SELECT id FROM activity WHERE id = $1 FOR UPDATE`, task); err != nil {
-		t.Fatal(err)
-	}
-
-	firing := make(chan firingResult, 1)
-	go func() {
-		completed, err := store.CompleteOpenSystemTasksForLead(ctx, ids.From[ids.LeadKind](e.lead))
-		firing <- firingResult{completed, err}
-	}()
-	t.Cleanup(func() {
-		//craft:ignore swallowed-errors the lock is normally released by the Commit below and this rollback is then a designed no-op; on the failure paths it is the release itself, and a failing release could tell this test nothing its own assertions have not
-		_ = blocking.Rollback(context.Background())
-		select {
-		case <-firing:
-		case <-time.After(10 * time.Second):
-			t.Error("the firing never returned after the lock was released")
-		}
-	})
-
-	e.waitForBlockedWriter(t, firing)
-
+	firing := e.startBlockedFiring(t, task)
 	// Not a completion: somebody retitled the task. The version moves and the
 	// task stays open.
-	if _, err := blocking.Exec(context.Background(),
-		`UPDATE activity SET subject = 'Follow up (renamed)', version = version + 1 WHERE id = $1`, task); err != nil {
-		t.Fatal(err)
-	}
-	if err := blocking.Commit(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-
-	var got firingResult
-	select {
-	case got = <-firing:
-	case <-time.After(10 * time.Second):
-		t.Fatal("the firing never returned after the edit committed")
-	}
-	firing <- got
+	firing.exec(`UPDATE activity SET subject = 'Follow up (renamed)', version = version + 1 WHERE id = $1`, task)
+	got := firing.release()
 
 	if got.err != nil {
 		t.Fatalf("the firing failed instead of completing the task it selected: %v", got.err)
@@ -382,15 +293,41 @@ func TestAnEditUnderTheFiringDoesNotLeaveTheTaskOpen(t *testing.T) {
 
 // A task archived between the selection and the write is gone, not a failure.
 // The row lock is taken live, so the completion answers not-found — and
-// failing the firing on it would strand every other task the same call
-// selected.
+// failing the firing on it would strand every OTHER task the same call
+// selected, which is what the sibling below is here to catch.
 func TestATaskArchivedUnderTheFiringIsNotAFailure(t *testing.T) {
 	e := setupResolve(t)
 	task := e.seedTask(t, "system", "system")
-	other := e.seedTask(t, "system", "system")
-	ctx := e.systemCtx()
-	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
+	sibling := e.seedTask(t, "system", "system")
 
+	firing := e.startBlockedFiring(t, task)
+	firing.exec(`UPDATE activity SET archived_at = now() WHERE id = $1`, task)
+	got := firing.release()
+
+	if got.err != nil {
+		t.Fatalf("a task that went away failed the firing: %v", got.err)
+	}
+	if !e.isDone(t, sibling) {
+		t.Fatal("the firing stopped at the archived task and left its sibling open")
+	}
+}
+
+// blockedFiring is the shape all three race cases are: hold the task's row,
+// start a firing that gets past its SELECT and stops at its write, act under
+// the lock, then release and read what the firing did.
+//
+// One harness rather than three copies, because what makes these tests mean
+// anything is the ORDERING — and the ordering is the part that took two
+// corrections to get right (a waiter shows neither as an ungranted relation
+// lock nor as an `active` backend). A change to it has to land in one place.
+type blockedFiring struct {
+	t        *testing.T
+	blocking pgx.Tx
+	done     chan firingResult
+}
+
+func (e *resolveEnv) startBlockedFiring(t *testing.T, task ids.UUID) *blockedFiring {
+	t.Helper()
 	blocking, err := e.owner.Begin(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -400,46 +337,56 @@ func TestATaskArchivedUnderTheFiringIsNotAFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	firing := make(chan firingResult, 1)
+	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
+	ctx := e.systemCtx()
+	done := make(chan firingResult, 1)
 	go func() {
 		completed, err := store.CompleteOpenSystemTasksForLead(ctx, ids.From[ids.LeadKind](e.lead))
-		firing <- firingResult{completed, err}
+		done <- firingResult{completed, err}
 	}()
+
+	b := &blockedFiring{t: t, blocking: blocking, done: done}
+	// However the test ends, the lock is released and the firing is waited
+	// for: a goroutine still holding a pooled connection outlives the test,
+	// and the next one resets the database under it.
 	t.Cleanup(func() {
-		//craft:ignore swallowed-errors the lock is normally released by the Commit below and this rollback is then a designed no-op; on the failure paths it is the release itself, and a failing release could tell this test nothing its own assertions have not
+		//craft:ignore swallowed-errors the lock is normally released by release() and this rollback is then a designed no-op; on the failure paths it is the release itself, and a failing release could tell this test nothing its own assertions have not
 		_ = blocking.Rollback(context.Background())
 		select {
-		case <-firing:
+		case <-done:
 		case <-time.After(10 * time.Second):
 			t.Error("the firing never returned after the lock was released")
 		}
 	})
 
-	e.waitForBlockedWriter(t, firing)
+	e.waitForBlockedWriter(t, done)
+	return b
+}
 
-	if _, err := blocking.Exec(context.Background(),
-		`UPDATE activity SET archived_at = now() WHERE id = $1`, task); err != nil {
-		t.Fatal(err)
+// exec runs one statement UNDER the held lock — what the winner of the race
+// did before this firing could reach its write.
+func (b *blockedFiring) exec(sql string, args ...any) {
+	b.t.Helper()
+	if _, err := b.blocking.Exec(context.Background(), sql, args...); err != nil {
+		b.t.Fatal(err)
 	}
-	if err := blocking.Commit(context.Background()); err != nil {
-		t.Fatal(err)
-	}
+}
 
+// release commits the blocking transaction and answers what the firing then
+// did. The result is put back for the cleanup above, so both can read it.
+func (b *blockedFiring) release() firingResult {
+	b.t.Helper()
+	if err := b.blocking.Commit(context.Background()); err != nil {
+		b.t.Fatal(err)
+	}
 	var got firingResult
 	select {
-	case got = <-firing:
+	case got = <-b.done:
 	case <-time.After(10 * time.Second):
-		t.Fatal("the firing never returned after the archive committed")
+		b.t.Fatal("the firing never returned after the lock was released")
 	}
-	firing <- got
-
-	if got.err != nil {
-		t.Fatalf("a task that went away failed the firing: %v", got.err)
-	}
-	// The OTHER task is the point: a failure here would have stranded it.
-	if !e.isDone(t, other) {
-		t.Fatal("the firing stopped at the archived task and left its sibling open")
-	}
+	b.done <- got
+	return got
 }
 
 // firingResult is one CompleteOpenSystemTasksForLead call's answer, carried


### PR DESCRIPTION
Addresses finding **2** of #3038. Finding 1 is analysed below and I have not attempted it — see the ticket comment.

## What was wrong

`CompleteOpenSystemTasksForLead` selects the open system tasks in one transaction and completes each in its own. Two firings for one lead — an `activity.captured` racing a `lead.promoted` — can both select the same open task.

`UpdateActivity` takes a row lock, so the second cannot lose the first's write. It can still *make* one: it sets `is_done = true` over a row that already says so, which writes an audit row and a second `activity.updated` event. No wrong state, but the task's history shows the same completion twice.

## The fix

Each completion now carries the version its selection read. A task somebody else finished first answers `ErrVersionSkew` and is skipped, using the optimistic-concurrency mechanism the write path already has rather than adding a second one.

The returned count becomes what *this* call completed, which is also why skew is not an error: another firing completing the task is the outcome this one wanted. If the version moved for some other reason, the next firing sees the task still open and finishes it.

## On the test

The first version of this test passed without the fix, and I nearly shipped it. A sequential second call proves nothing here — it re-runs the open-task query, finds nothing, and writes nothing whatever the completion path does. That is the "replays are harmless" case the function already documented, not the race.

The test now forces the interleaving: it holds the row, waits until the firing is actually parked on the lock, then completes and bumps the version under it. Mutation-checked — removing the version guard fails it with `the losing firing wrote 1 activity.updated event(s) for a task it did not finish`, in isolation and in the full package.

Two details worth knowing if you touch that helper: a waiter on a row lock does not show as an ungranted lock on the *relation* (it waits on the holder's transaction id), and a backend parked on a lock inside a transaction reports `idle in transaction`, not `active` — a probe requiring `active` looks right and finds nothing.

## Verification

- `make check-backend`, `make craft-static`
- `make -C backend test-integration` — 48 packages, 0 skips
- Two `//craft:ignore` waivers, each with its reason: the cleanup rollback (a designed no-op after the commit) and the poll interval (the wait is on the condition; the deadline fails loudly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system task completion when concurrent edits cause version conflicts.
  * Retries still-open tasks using their latest version and skips archived or already-completed tasks.
  * Prevents duplicate completion events and ensures completion counts reflect only tasks completed by the current operation.
  * Persistent conflicts and unrelated errors continue to be reported.

* **Tests**
  * Added coverage for concurrent edits, duplicate completions, and tasks archived during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->