### PR TITLE
feat(company): the intro request has a door

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1578,6 +1578,21 @@ export const de = {
   "co.people.map.scopePartial":
     "{count} im Buying-Team · {hidden} weitere für dich nicht sichtbar.",
   "co.people.board.readFromMessages": "Aus ihren Nachrichten gelesen",
+  "co.intro.title": "Um eine Vorstellung bitten",
+  "co.intro.who": "{colleague} wird gebeten, Sie {contact} vorzustellen.",
+  "co.intro.write": "Nachricht schreiben",
+  "co.intro.writing": "Wird geschrieben",
+  "co.intro.fromTemplate":
+    "Aus einer Vorlage geschrieben — in dieser Installation ist kein Modell eingerichtet.",
+  "co.intro.subject": "Betreff",
+  "co.intro.body": "Nachricht",
+  "co.intro.basedOn": "Grundlage",
+  "co.intro.copy": "Kopieren",
+  "co.intro.copyFailed":
+    "Der Browser hat das Kopieren nicht zugelassen. Markieren Sie die Nachricht und kopieren Sie sie selbst.",
+  "co.intro.copied": "Kopiert",
+  "co.intro.openMail": "Im E-Mail-Programm öffnen",
+  "co.map.askIntro": "Um Vorstellung bitten",
   "co.people.board.suggest": "Rollen vorschlagen",
   "co.people.board.suggesting": "Nachrichten werden gelesen",
   "co.people.board.suggestNoDeal":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1618,6 +1618,21 @@ export const en = {
   "co.people.map.scopePartial":
     "{count} on the buying team · {hidden} more you cannot see.",
   "co.people.board.readFromMessages": "Read from their messages",
+  "co.intro.title": "Ask for an introduction",
+  "co.intro.who": "Asking {colleague} to introduce you to {contact}.",
+  "co.intro.write": "Write the message",
+  "co.intro.writing": "Writing",
+  "co.intro.fromTemplate":
+    "Written from a template — this installation has no model configured.",
+  "co.intro.subject": "Subject",
+  "co.intro.body": "Message",
+  "co.intro.basedOn": "Based on",
+  "co.intro.copy": "Copy",
+  "co.intro.copyFailed":
+    "This browser would not let the page copy. Select the message and copy it yourself.",
+  "co.intro.copied": "Copied",
+  "co.intro.openMail": "Open in your mail app",
+  "co.map.askIntro": "Ask for an intro",
   "co.people.board.suggest": "Suggest roles",
   "co.people.board.suggesting": "Reading their messages",
   "co.people.board.suggestNoDeal":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1572,6 +1572,21 @@ export const vi = {
   "co.people.map.scopePartial":
     "{count} trong nhóm · {hidden} người khác bạn không thấy.",
   "co.people.board.readFromMessages": "Đọc từ tin nhắn của họ",
+  "co.intro.title": "Nhờ giới thiệu",
+  "co.intro.who": "Nhờ {colleague} giới thiệu bạn với {contact}.",
+  "co.intro.write": "Viết tin nhắn",
+  "co.intro.writing": "Đang viết",
+  "co.intro.fromTemplate":
+    "Được viết từ mẫu — bản cài đặt này chưa cấu hình mô hình nào.",
+  "co.intro.subject": "Tiêu đề",
+  "co.intro.body": "Tin nhắn",
+  "co.intro.basedOn": "Dựa trên",
+  "co.intro.copy": "Sao chép",
+  "co.intro.copyFailed":
+    "Trình duyệt không cho phép trang sao chép. Hãy chọn tin nhắn và tự sao chép.",
+  "co.intro.copied": "Đã sao chép",
+  "co.intro.openMail": "Mở trong ứng dụng email",
+  "co.map.askIntro": "Nhờ giới thiệu",
   "co.people.board.suggest": "Đề xuất vai trò",
   "co.people.board.suggesting": "Đang đọc tin nhắn của họ",
   "co.people.board.suggestNoDeal":

--- a/frontend/src/screens/companypeople/companypeople.css
+++ b/frontend/src/screens/companypeople/companypeople.css
@@ -44,3 +44,38 @@
   gap: var(--space-1);
   margin-top: var(--space-1);
 }
+
+/* The introduction request. A form the reader edits before taking it away, so
+ * the fields get room rather than the compact shape a confirm dialog uses. */
+.cp-intro-who {
+  margin: 0 0 var(--space-3);
+  color: var(--textMeta);
+}
+
+.cp-intro-mark {
+  margin: 0 0 var(--space-2);
+}
+
+.cp-intro-field {
+  display: block;
+  margin: var(--space-3) 0 var(--space-1);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-semibold);
+}
+
+.cp-intro-why {
+  margin: var(--space-3) 0 var(--space-1);
+  color: var(--textMeta);
+}
+
+.cp-intro-error {
+  margin: var(--space-2) 0 0;
+  color: var(--danger);
+}
+
+.cp-intro-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}

--- a/frontend/src/screens/companypeople/introrequest.stories.tsx
+++ b/frontend/src/screens/companypeople/introrequest.stories.tsx
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "../story-utils";
+import { IntroRequestModal } from "./introrequest";
+
+// The dialog that turns a route into a move.
+//
+// Its three states are the three answers the endpoint gives: not yet asked, a
+// draft to take away, and a refusal. The middle one is what a reader spends
+// their time in, which is why the draft is editable rather than read-only.
+
+const meta = {
+  title: "Records/Company 360/People/Intro request",
+  component: IntroRequestModal,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof IntroRequestModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const TARGET = {
+  personId: "p-1",
+  personName: "Philipp Königs",
+  viaUserId: "u-1",
+  viaName: "Sofia Meier",
+};
+
+/** Answers every draft request with the same message. */
+function story(draft: unknown, status = 200) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute({ organization: ["read"], person: ["read"] }),
+      "POST /organizations/o-1/intro-request-draft": () =>
+        jsonResponse(draft, status),
+    });
+    return (
+      <StoryProviders>
+        <IntroRequestModal
+          orgId="o-1"
+          target={TARGET}
+          dealId="d-1"
+          onClose={() => {}}
+        />
+      </StoryProviders>
+    );
+  };
+}
+
+/** Before anything is written: who is being asked, and about whom. */
+export const BeforeWriting: Story = {
+  args: { orgId: "o-1", target: TARGET, onClose: () => {} },
+  render: story({}),
+};
+
+/**
+ * A model wrote it, and the tag says so. Press into the message and the tag
+ * becomes "typed by you" — a sentence a person rewrote is no longer the
+ * machine's.
+ */
+export const ModelDraft: Story = {
+  args: { orgId: "o-1", target: TARGET, onClose: () => {} },
+  render: story({
+    subject: "Could you introduce me to Philipp Königs?",
+    body:
+      "Hi Sofia,\n\nYou and Philipp have been in touch (developing, last around " +
+      "20 August). I would like to talk to him about the retrofit — would you " +
+      "be up for introducing us?\n\nThanks!",
+    generated_by: "model",
+    ai_generated: true,
+    reasoning: [
+      {
+        kind: "relationship",
+        label: "Sofia Meier knows Philipp Königs (developing)",
+      },
+      { kind: "deal", label: "Retrofit 2026" },
+    ],
+  }),
+};
+
+/**
+ * No model configured, so the template wrote it — and says so. The message is
+ * still sendable, which is the whole reason this site has a floor and the role
+ * reading does not.
+ */
+export const TemplateDraft: Story = {
+  args: { orgId: "o-1", target: TARGET, onClose: () => {} },
+  render: story({
+    subject: "Could you introduce me to Philipp Königs?",
+    body:
+      "Hi Sofia,\n\nYou and Philipp Königs have been in touch (developing, last " +
+      "around 2026-08-20). Would you be up for introducing us?\n\nIt is about " +
+      "Retrofit 2026.\n\nThanks!",
+    generated_by: "deterministic",
+    ai_generated: false,
+    reasoning: [
+      {
+        kind: "relationship",
+        label: "Sofia Meier knows Philipp Königs (developing)",
+      },
+    ],
+  }),
+};
+
+/** The colleague has no recorded route, so there is no favour to ask. */
+export const Refused: Story = {
+  args: { orgId: "o-1", target: TARGET, onClose: () => {} },
+  render: story({ code: "not_found", title: "Not Found" }, 404),
+};

--- a/frontend/src/screens/companypeople/introrequest.test.tsx
+++ b/frontend/src/screens/companypeople/introrequest.test.tsx
@@ -1,0 +1,225 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, expect, test, vi } from "vitest";
+import { LocaleProvider } from "../../i18n";
+import { IntroRequestModal, type IntroTarget } from "./introrequest";
+
+afterEach(cleanup);
+
+function render(ui: ReactNode, locale: "en" | "de" = "en") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial={locale}>{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const TARGET: IntroTarget = {
+  personId: "p-1",
+  personName: "Philipp Königs",
+  viaUserId: "u-1",
+  viaName: "Sofia Meier",
+};
+
+function stub(draft: unknown, status = 200) {
+  const calls: { url: string; body: string }[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+    const request = input as Request;
+    const url = typeof input === "string" ? input : request.url;
+    calls.push({ url, body: request.text ? await request.text() : "" });
+    return new Response(JSON.stringify(draft), {
+      status,
+      headers: {
+        "content-type":
+          status >= 400 ? "application/problem+json" : "application/json",
+      },
+    });
+  });
+  return calls;
+}
+
+const WRITTEN = {
+  subject: "Could you introduce me to Philipp Königs?",
+  body: "Hi Sofia,\n\nYou and Philipp Königs have been in touch. Would you introduce us?",
+  generated_by: "model",
+  ai_generated: true,
+  reasoning: [
+    {
+      kind: "relationship",
+      label: "Sofia Meier knows Philipp Königs (strong)",
+    },
+  ],
+};
+
+test("names who is being asked, and about whom, before anything is written", async () => {
+  stub(WRITTEN);
+  render(<IntroRequestModal orgId="o-1" target={TARGET} onClose={() => {}} />);
+  expect(
+    await screen.findByText(
+      /Asking Sofia Meier to introduce you to Philipp Königs/,
+    ),
+  ).toBeTruthy();
+});
+
+// The draft carries the deal when one is selected, because an introduction for
+// a specific transaction says so and one for the account does not.
+test("sends the deal when there is one, and both required ids", async () => {
+  const calls = stub(WRITTEN);
+  const user = userEvent.setup();
+  render(
+    <IntroRequestModal
+      orgId="o-1"
+      target={TARGET}
+      dealId="d-1"
+      onClose={() => {}}
+    />,
+  );
+  await user.click(
+    await screen.findByRole("button", { name: /Write the message/i }),
+  );
+  await screen.findByDisplayValue(/Could you introduce me to Philipp Königs/);
+  const sent = calls.find((call) => call.url.includes("intro-request-draft"));
+  expect(sent).toBeTruthy();
+  expect(JSON.parse(sent?.body ?? "{}")).toEqual({
+    person_id: "p-1",
+    via_user_id: "u-1",
+    deal_id: "d-1",
+  });
+});
+
+// A reader who edits owns the words. The tag has to follow, or the product
+// keeps claiming authorship of a sentence a person wrote.
+test("the message becomes the reader's once they edit it", async () => {
+  stub(WRITTEN);
+  const user = userEvent.setup();
+  render(<IntroRequestModal orgId="o-1" target={TARGET} onClose={() => {}} />);
+  await user.click(
+    await screen.findByRole("button", { name: /Write the message/i }),
+  );
+
+  const body = await screen.findByLabelText("Message");
+  expect(screen.queryByText(/typed by you/i)).toBeNull();
+  // A REWRITE, not a typo fix. One keystroke is not authorship, and claiming
+  // it would credit the reader with a message the model wrote.
+  await user.type(body, " Thanks — happy to explain what it is about first.");
+  expect(await screen.findByText(/typed by you/i)).toBeTruthy();
+});
+
+// One keystroke is not authorship. Flipping the mark on the first character
+// credits the reader with a message the model wrote — the same misattribution
+// the mark exists to prevent, in the other direction.
+test("a typo fix does not claim the message as the reader's", async () => {
+  stub(WRITTEN);
+  const user = userEvent.setup();
+  render(<IntroRequestModal orgId="o-1" target={TARGET} onClose={() => {}} />);
+  await user.click(
+    await screen.findByRole("button", { name: /Write the message/i }),
+  );
+  await user.type(await screen.findByLabelText("Message"), "!");
+  expect(screen.queryByText(/typed by you/i)).toBeNull();
+});
+
+// A browser that refuses clipboard access must SAY so. A button that silently
+// does nothing leaves a reader pressing it and wondering why their paste is
+// empty.
+test("says so when the browser will not let the page copy", async () => {
+  stub(WRITTEN);
+  const user = userEvent.setup();
+  render(<IntroRequestModal orgId="o-1" target={TARGET} onClose={() => {}} />);
+  await user.click(
+    await screen.findByRole("button", { name: /Write the message/i }),
+  );
+  // AFTER setup, which installs a clipboard of its own — taken away here to
+  // model the browser that never offered one.
+  const original = navigator.clipboard;
+  Object.defineProperty(navigator, "clipboard", {
+    value: undefined,
+    configurable: true,
+  });
+  await user.click(await screen.findByRole("button", { name: /^Copy$/ }));
+  expect(await screen.findByText(/would not let the page copy/i)).toBeTruthy();
+  Object.defineProperty(navigator, "clipboard", {
+    value: original,
+    configurable: true,
+  });
+});
+
+// With no model configured the endpoint answers from a template. Saying so is
+// the difference between a reader trusting the phrasing and wondering why it
+// reads flat.
+test("says when the message came from a template rather than a model", async () => {
+  stub({ ...WRITTEN, generated_by: "deterministic", ai_generated: false });
+  const user = userEvent.setup();
+  render(<IntroRequestModal orgId="o-1" target={TARGET} onClose={() => {}} />);
+  await user.click(
+    await screen.findByRole("button", { name: /Write the message/i }),
+  );
+  expect(await screen.findByText(/Written from a template/)).toBeTruthy();
+});
+
+// A refusal has to reach the reader. The endpoint answers 404 for a colleague
+// with no recorded route, and a dialog that swallowed it would look broken.
+test("shows the refusal rather than an empty form", async () => {
+  stub({ code: "not_found", detail: "no such route" }, 404);
+  const user = userEvent.setup();
+  render(<IntroRequestModal orgId="o-1" target={TARGET} onClose={() => {}} />);
+  await user.click(
+    await screen.findByRole("button", { name: /Write the message/i }),
+  );
+  // The SERVER'S OWN WORDS. Asserting only that some text appeared passed
+  // against a version that threw the raw body, where every refusal — 403, 404
+  // and 422 alike — collapsed into "the request failed, no cause reported".
+  expect(await screen.findByText(/no such route/)).toBeTruthy();
+  expect(screen.queryByLabelText("Message")).toBeNull();
+});
+
+test("renders in German under a German locale", async () => {
+  stub(WRITTEN);
+  render(
+    <IntroRequestModal orgId="o-1" target={TARGET} onClose={() => {}} />,
+    "de",
+  );
+  expect(await screen.findByText("Um eine Vorstellung bitten")).toBeTruthy();
+});
+
+// A DRAFT MUST NOT FOLLOW THE READER TO ANOTHER CONTACT.
+//
+// The dialog holds a draft and the reader's edits, and React reuses a
+// component across prop changes. Drafting for one person and then opening
+// another showed the FIRST person's message under the second one's name —
+// which a reader would send. The screen keys the dialog on who is being asked
+// about; this proves the dialog itself starts clean when it does.
+test("a fresh target starts with no draft", async () => {
+  stub(WRITTEN);
+  const user = userEvent.setup();
+  const first = render(
+    <IntroRequestModal orgId="o-1" target={TARGET} onClose={() => {}} />,
+  );
+  await user.click(
+    await screen.findByRole("button", { name: /Write the message/i }),
+  );
+  await screen.findByLabelText("Message");
+  first.unmount();
+
+  render(
+    <IntroRequestModal
+      orgId="o-1"
+      target={{ ...TARGET, personId: "p-2", personName: "Jan Roth" }}
+      onClose={() => {}}
+    />,
+  );
+  // No message yet: the verb is offered, not somebody else's draft.
+  expect(screen.queryByLabelText("Message")).toBeNull();
+  expect(
+    await screen.findByRole("button", { name: /Write the message/i }),
+  ).toBeTruthy();
+});

--- a/frontend/src/screens/companypeople/introrequest.tsx
+++ b/frontend/src/screens/companypeople/introrequest.tsx
@@ -1,0 +1,250 @@
+import { useMutation } from "@tanstack/react-query";
+import { useId, useState } from "react";
+import { api } from "../../api/client";
+import type { components } from "../../api/schema";
+import { Button, Modal } from "../../design-system/atoms";
+import { ProvenanceTag } from "../../design-system/trust";
+import { useT } from "../../i18n";
+import { problemMessageOf, throwProblem } from "../common";
+
+// Asking a colleague for the introduction.
+//
+// The map already tells a reader that Sofia is the warmest way in to Philipp.
+// This is the dialog that helps them ask her, and it hands the message BACK
+// rather than sending it: there is no colleague-to-colleague channel in this
+// product, and the reader sends this under their own name from their own mail
+// client.
+
+type Draft = components["schemas"]["AccountEmailDraft"];
+
+export type IntroTarget = Readonly<{
+  personId: string;
+  personName: string;
+  viaUserId: string;
+  viaName: string;
+}>;
+
+/**
+ * IntroRequestModal drafts the ask and lets the reader take it away.
+ *
+ * The draft is EDITABLE before it is copied. What comes back is a suggestion in
+ * the reader's own voice-to-be, not a message the product stands behind — and a
+ * dialog that only offered Copy would make every small correction a trip
+ * through the clipboard.
+ */
+export function IntroRequestModal({
+  orgId,
+  target,
+  dealId,
+  onClose,
+}: Readonly<{
+  orgId: string;
+  target: IntroTarget | null;
+  dealId?: string | null;
+  onClose: () => void;
+}>) {
+  const t = useT();
+  const titleId = useId();
+  // The reader's edits, held apart from the draft so a re-draft does not
+  // silently discard them and an untouched field still follows the model.
+  const [edited, setEdited] = useState<{
+    subject: string;
+    body: string;
+  } | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
+
+  const draft = useMutation({
+    mutationFn: async (ask: IntroTarget): Promise<Draft> => {
+      const { data, error } = await api.POST(
+        "/organizations/{id}/intro-request-draft",
+        {
+          params: { path: { id: orgId } },
+          body: {
+            person_id: ask.personId,
+            via_user_id: ask.viaUserId,
+            ...(dealId ? { deal_id: dealId } : {}),
+          },
+        },
+      );
+      if (error || !data) {
+        // Through the house helper, so the shared mapper can read the server's
+        // own detail and its permission copy. Thrown raw, every refusal —
+        // 403, 404, 422 alike — collapsed into "the request failed, no cause
+        // reported", which tells a reader nothing about what to do.
+        return throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      setEdited(null);
+      setCopied(false);
+    },
+  });
+
+  const written = draft.data;
+  const subject = edited?.subject ?? written?.subject ?? "";
+  const body = edited?.body ?? written?.body ?? "";
+  // A reader who edits owns the words — but ONE KEYSTROKE is not authorship.
+  // Flipping the tag on the first character claimed a mostly model-written
+  // message as the reader's, which is the same misattribution in the other
+  // direction: the mark exists so a reader can tell whose sentences these are.
+  const changed =
+    edited !== null &&
+    (edited.subject !== written?.subject || edited.body !== written?.body);
+  const rewritten = changed && editDistanceIsSubstantial(edited, written);
+
+  return (
+    <Modal open={target !== null} onClose={onClose} labelledBy={titleId}>
+      <h2 id={titleId}>{t("co.intro.title")}</h2>
+      {target && (
+        <p className="t-caption cp-intro-who">
+          {t("co.intro.who", {
+            colleague: target.viaName,
+            contact: target.personName,
+          })}
+        </p>
+      )}
+      {!written && (
+        <div className="cp-intro-actions">
+          <Button
+            variant="ai"
+            onClick={() => target && draft.mutate(target)}
+            pending={draft.isPending}
+            busyLabel={t("co.intro.writing")}
+          >
+            {t("co.intro.write")}
+          </Button>
+        </div>
+      )}
+      {draft.isError && (
+        <p className="t-caption cp-intro-error">
+          {problemMessageOf(draft.error, t)}
+        </p>
+      )}
+      {written && (
+        <>
+          <p className="cp-intro-mark">
+            <ProvenanceTag
+              provenance={
+                rewritten
+                  ? { kind: "human", self: true }
+                  : { kind: "agent", agent: "draft_reply" }
+              }
+            />
+            {written.generated_by === "deterministic" && !rewritten && (
+              <span className="t-caption"> {t("co.intro.fromTemplate")}</span>
+            )}
+          </p>
+          <label className="cp-intro-field" htmlFor={`${titleId}-subject`}>
+            {t("co.intro.subject")}
+          </label>
+          <input
+            id={`${titleId}-subject`}
+            value={subject}
+            onChange={(event) => {
+              setEdited({ subject: event.target.value, body });
+              setCopied(false);
+            }}
+          />
+          <label className="cp-intro-field" htmlFor={`${titleId}-body`}>
+            {t("co.intro.body")}
+          </label>
+          <textarea
+            id={`${titleId}-body`}
+            rows={10}
+            value={body}
+            onChange={(event) => {
+              setEdited({ subject, body: event.target.value });
+              // The clipboard still holds the OLDER text, so a button that
+              // went on saying "Copied" would be describing a message the
+              // reader can no longer paste.
+              setCopied(false);
+            }}
+          />
+          {written.reasoning && written.reasoning.length > 0 && (
+            <>
+              <p className="t-caption cp-intro-why">{t("co.intro.basedOn")}</p>
+              <ul className="chips">
+                {written.reasoning.map((reason) => (
+                  <li key={`${reason.kind}:${reason.label}`}>{reason.label}</li>
+                ))}
+              </ul>
+            </>
+          )}
+          {copyFailed && (
+            <p className="t-caption cp-intro-error">
+              {t("co.intro.copyFailed")}
+            </p>
+          )}
+          <div className="cp-intro-actions">
+            {/* Copy first, because it is the one that always works. A mailto:
+             * depends on the reader having a mail client bound to the
+             * protocol, and a button that silently does nothing is worse than
+             * one they did not press. */}
+            <Button
+              onClick={() => {
+                // A browser with no clipboard access, or a refused write, must
+                // SAY so. Silently doing nothing leaves a reader pressing a
+                // button and wondering why their paste is empty.
+                const writer = navigator.clipboard;
+                if (!writer) {
+                  setCopyFailed(true);
+                  return;
+                }
+                writer
+                  .writeText(`${subject}\n\n${body}`)
+                  .then(() => {
+                    setCopied(true);
+                    setCopyFailed(false);
+                  })
+                  .catch(() => setCopyFailed(true));
+              }}
+            >
+              {copied ? t("co.intro.copied") : t("co.intro.copy")}
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                window.location.href = `mailto:?subject=${encodeURIComponent(
+                  subject,
+                )}&body=${encodeURIComponent(body)}`;
+              }}
+            >
+              {t("co.intro.openMail")}
+            </Button>
+          </div>
+        </>
+      )}
+    </Modal>
+  );
+}
+
+/**
+ * editDistanceIsSubstantial reports whether the reader has made the message
+ * theirs, rather than fixing a word in it.
+ *
+ * A tenth of the body is the line, and it is a judgement rather than a
+ * measurement: the mark answers "whose sentences are these", and neither
+ * answer is free. Flipping on the first keystroke credits a reader with a
+ * message the model wrote; never flipping credits the model with one they
+ * rewrote. A tenth is where a correction stops being a correction.
+ */
+function editDistanceIsSubstantial(
+  edited: { subject: string; body: string } | null,
+  written: Draft | undefined,
+): boolean {
+  if (!edited || !written) {
+    return false;
+  }
+  if (edited.subject !== written.subject) {
+    return true;
+  }
+  const before = written.body;
+  const after = edited.body;
+  if (before === after) {
+    return false;
+  }
+  const shifted = Math.abs(after.length - before.length);
+  return shifted > Math.max(12, before.length / 10);
+}

--- a/frontend/src/screens/companypeople/mapmodel.test.ts
+++ b/frontend/src/screens/companypeople/mapmodel.test.ts
@@ -3,7 +3,7 @@
 
 import { expect, test } from "vitest";
 import type { components } from "../../api/schema";
-import { type MapCopy, mapModelFromCoverage } from "./mapmodel";
+import { introTargetFor, type MapCopy, mapModelFromCoverage } from "./mapmodel";
 
 type Coverage = components["schemas"]["OrganizationCoverage"];
 
@@ -30,6 +30,7 @@ const COPY: MapCopy = {
   theyReplied: "they replied",
   neverWritten: "never written to",
   onDeal: "on the deal",
+  askIntro: "Ask for an intro",
 };
 
 function coverage(over: Partial<Coverage> = {}): Coverage {
@@ -308,4 +309,61 @@ test("joins an unrecognised role to the deal like every other seat", () => {
       (edge) => edge.kind === "membership" && edge.from === "p:p-9",
     ),
   ).toBeDefined();
+});
+
+// The verb goes ONLY on somebody who can actually be reached. Offering it on a
+// contact with no route sends the reader to a dialog that can only refuse: the
+// endpoint requires a recorded route and answers 404 without one.
+test("offers the intro verb only where a route exists", () => {
+  const reachable = mapModelFromCoverage(coverage(), "Brandt GmbH", COPY);
+  expect(
+    reachable.nodes.find((node) => node.id === "p:p-1")?.actions?.[0]?.id,
+  ).toBe("ask_intro");
+
+  const unreachable = mapModelFromCoverage(
+    coverage({
+      committee: {
+        seats: [
+          {
+            person_id: "p-1",
+            full_name: "Philipp Königs",
+            role: "economic_buyer",
+            engagement: "untried",
+            routes: { top: [], remainder: 0, untried: true },
+          },
+        ],
+        gaps: [],
+        unlisted_seats: 0,
+      },
+    } as Partial<Coverage>),
+    "Brandt GmbH",
+    COPY,
+  );
+  expect(
+    unreachable.nodes.find((node) => node.id === "p:p-1")?.actions,
+  ).toBeUndefined();
+});
+
+// The dialog asks the COLLEAGUE to introduce the reader to the CONTACT, and a
+// route edge runs colleague → person. Reading the ends the other way round
+// would ask the customer's own CFO to introduce us to our colleague.
+test("names the colleague to ask and the contact to be met, in that order", () => {
+  const model = mapModelFromCoverage(coverage(), "Brandt GmbH", COPY);
+  expect(introTargetFor(model, "p:p-1")).toEqual({
+    personId: "p-1",
+    personName: "Philipp Königs",
+    viaUserId: "u-1",
+    viaName: "Sofia Meier",
+  });
+});
+
+// A route edge points one way, so which end is the colleague depends on which
+// end was selected. Asked about a COLLEAGUE, this must refuse rather than read
+// the edge backwards — today nothing calls it that way, and a function correct
+// only because of where it happens to be called is one the next caller breaks.
+test("refuses a node that is not a person", () => {
+  const model = mapModelFromCoverage(coverage(), "Brandt GmbH", COPY);
+  for (const id of ["u:u-1", "org", "d:d-1", "gap:champion", "p:missing"]) {
+    expect(introTargetFor(model, id)).toBeNull();
+  }
 });

--- a/frontend/src/screens/companypeople/mapmodel.ts
+++ b/frontend/src/screens/companypeople/mapmodel.ts
@@ -7,6 +7,8 @@ import type {
   MapNode,
   RelationshipMapModel,
 } from "../../design-system/relationshipmap.layout";
+import { routeFor } from "../../design-system/relationshipmap.layout";
+import type { IntroTarget } from "./introrequest";
 
 // The wire read, as the picture the map draws.
 //
@@ -43,6 +45,8 @@ export type MapCopy = Readonly<{
   theyReplied: string;
   neverWritten: string;
   onDeal: string;
+  /** The verb on a person somebody on our side can actually reach. */
+  askIntro: string;
 }>;
 
 /**
@@ -112,6 +116,11 @@ export function mapModelFromCoverage(
 
 function personNode(seat: Seat, copy: MapCopy): MapNode {
   const engagement = seat.engagement as MapEngagement | undefined;
+  // The verb goes ONLY on a seat somebody can actually reach. Asking for an
+  // introduction from nobody is not a move, and offering it on a contact with
+  // no route would send the reader to a dialog that can only refuse — the
+  // endpoint requires a recorded route and answers 404 without one.
+  const reachable = (seat.routes?.top ?? []).length > 0;
   return {
     id: `p:${seat.person_id}`,
     kind: "person",
@@ -123,8 +132,12 @@ function personNode(seat: Seat, copy: MapCopy): MapNode {
     sublabel: seat.routes ? undefined : copy.routesWithheld,
     engagement,
     engagementLabel: engagement ? copy.engagement[engagement] : undefined,
+    actions: reachable ? [{ id: ASK_INTRO, label: copy.askIntro }] : undefined,
   };
 }
+
+/** The action a person node offers when somebody on our side can reach them. */
+export const ASK_INTRO = "ask_intro";
 
 /**
  * routeEdges turns one seat's colleagues into lines.
@@ -264,5 +277,49 @@ function dealEdge(personId: string, dealId: string, copy: MapCopy): MapEdge {
     to: `d:${dealId}`,
     kind: "membership",
     words: copy.onDeal,
+  };
+}
+
+/**
+ * introTargetFor names the colleague to ask, from the map the reader is
+ * looking at.
+ *
+ * The STRONGEST route, which is the one the panel has already named as the
+ * best way in — so the dialog asks about the person the reader just read
+ * about, rather than whichever edge happened to be first.
+ *
+ * It refuses anything that is not a PERSON. A route edge runs colleague →
+ * person, so reading `from` as the colleague is only true for a person focus;
+ * on a colleague focus the same edge points the other way and this would ask
+ * the contact to introduce the reader to their own colleague. Today the action
+ * only sits on person nodes, which makes that unreachable — and a function
+ * that is correct only because of where it happens to be called is one the
+ * next caller breaks silently.
+ */
+export function introTargetFor(
+  model: RelationshipMapModel,
+  nodeId: string,
+): IntroTarget | null {
+  const person = model.nodes.find((node) => node.id === nodeId);
+  if (person?.kind !== "person") {
+    return null;
+  }
+  const { route } = routeFor(model, nodeId);
+  const best = route
+    ? model.edges.find((edge) => edge.id === route.edgeIds[0])
+    : null;
+  const colleague = best && model.nodes.find((node) => node.id === best.from);
+  if (!best || colleague?.kind !== "user") {
+    return null;
+  }
+  return {
+    // The ids the map draws with are PREFIXED so a person and a colleague
+    // cannot collide; the endpoint wants the bare uuid. Stripped by the node's
+    // own kind rather than by pattern, so a value that merely starts with the
+    // letters cannot be trimmed into a different record.
+    personId: nodeId.slice("p:".length),
+    personName: person.label,
+    viaUserId: colleague.id.slice("u:".length),
+    viaName: colleague.label,
   };
 }

--- a/frontend/src/screens/companypeople/summary.tsx
+++ b/frontend/src/screens/companypeople/summary.tsx
@@ -25,7 +25,8 @@ import {
   throwProblem,
 } from "../common";
 import { EntityRef } from "../entityref";
-import { mapModelFromCoverage } from "./mapmodel";
+import { IntroRequestModal, type IntroTarget } from "./introrequest";
+import { ASK_INTRO, introTargetFor, mapModelFromCoverage } from "./mapmodel";
 import "./companypeople.css";
 
 // What the account looks like before the reader picks anybody.
@@ -296,6 +297,10 @@ function CommitteeBoard({
       confirming={writes.confirming}
     />
   );
+  // Who the reader is asking about, or null when the dialog is closed. Held
+  // here rather than in the map: the map is data-only by design, and a dialog
+  // that fetched would make it a screen.
+  const [asking, setAsking] = useState<IntroTarget | null>(null);
   const model = useMemo(
     () => mapModelFromCoverage(coverage, accountName, mapCopy(t)),
     [coverage, accountName, t],
@@ -379,7 +384,26 @@ function CommitteeBoard({
                 })
           }
           labels={mapLabels(t, locale)}
+          onAction={(nodeId, actionId) => {
+            if (actionId === ASK_INTRO) {
+              setAsking(introTargetFor(model, nodeId));
+            }
+          }}
         />
+        {/* KEYED ON WHO IS BEING ASKED ABOUT. The dialog holds a draft and the
+         * reader's edits, and React reuses a component across prop changes —
+         * so without this, drafting for one contact and then opening another
+         * showed the FIRST contact's message under the second one's name, and
+         * a slow reply could land in a dialog about somebody else. */}
+        {asking && (
+          <IntroRequestModal
+            key={`${asking.personId}:${asking.viaUserId}`}
+            orgId={orgId}
+            target={asking}
+            dealId={coverage.selected_deal_id}
+            onClose={() => setAsking(null)}
+          />
+        )}
       </>
     );
   }
@@ -451,6 +475,7 @@ function mapCopy(t: ReturnType<typeof useT>) {
     theyReplied: t("co.people.map.replied"),
     neverWritten: t("co.people.map.never"),
     onDeal: t("co.people.map.onDeal"),
+    askIntro: t("co.map.askIntro"),
   };
 }
 


### PR DESCRIPTION
The intro-request endpoint shipped in #3397 and **nothing could reach it**. Only the generated schema mentioned it, so the capability existed and no reader could use it.

The door is the relationship map's detail panel, where a reader has just clicked a person and seen who can reach them. **Ask for an intro** drafts the message and hands it back — to copy, or to open in their own mail client. Nothing is sent.

The verb appears only on a seat somebody can actually reach: offering it on a contact with no route would send the reader to a dialog that can only refuse.

## Four defects found before merge

- **The dialog was not keyed on who it was about.** React reuses a component across prop changes, so drafting for one contact and then opening another showed the **first** contact's message under the second one's name. A reader would have sent it.
- **Every refusal collapsed into "the request failed, no cause reported"** — the mutation threw the raw body instead of using the house helper. My own test passed against this, because it asserted that *some* text appeared rather than the server's own words.
- **Copy was a silent no-op** where the browser allows no clipboard access, and went on saying "Copied" after an edit had made the clipboard stale.
- **`introTargetFor` read a route edge's ends as colleague → person**, which is true only for a person focus. Unreachable today, and a function correct only because of where it happens to be called is one the next caller breaks silently.

## One judgement worth naming

The authorship mark no longer flips on a single keystroke. Claiming a mostly model-written message as the reader's is the same misattribution as claiming their rewrite for the model — the mark exists so a reader can tell whose sentences these are.

Nine tests. Each fix was mutation-checked: the error-wrapping test goes red against the raw throw, and the person-kind guard goes red when relaxed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives the intro-request endpoint a door: an Ask for an intro button on the relationship map that drafts a message for the reader to copy or open in their mail client. Nothing is sent, and the verb appears only on a contact somebody can actually reach.

**Bug Fixes**
- Keys the dialog on who it is about so a draft for one contact cannot appear under another's name.
- Routes refusals through the shared error helper so the server's own words reach the reader.
- Reports when the browser blocks clipboard access, and clears the Copied label after an edit.
- Makes `introTargetFor` refuse non-person nodes instead of reading route edges backwards.
- Switches the authorship mark to "typed by you" only after a substantial rewrite, not one keystroke.

<sup>Written for commit 1470ac00ff94ac30b36ae8b6133b1413255806f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to request colleague introductions directly from the company relationship map.
  * Added an introduction request form with editable subject and message content.
  * Users can copy the message or open it in their email client.
  * Added context explaining suggested message content and identifying edits.
  * Added English, German, and Vietnamese translations.

* **Bug Fixes**
  * Added clear feedback for failed requests, clipboard actions, and server errors.
  * Introduction actions now appear only for contacts with reachable connection paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->