### PR TITLE
An edit is one reading of the record, not three

### DIFF
--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -567,11 +567,11 @@ function CompanyEditAction({
         })),
         ...cf.recordSlice(org),
       }}
-      update={async (values, rows) => {
+      update={async (values, rows, opened) => {
         const { data, error } = await api.PATCH("/organizations/{id}", {
           params: {
             path: { id: org.id },
-            ...ifMatch(requireVersion(org.version)),
+            ...ifMatch(requireVersion(opened?.version)),
           },
           body: {
             ...mapOrgUpdate(values, rows ?? {}, org.domains),
@@ -579,7 +579,7 @@ function CompanyEditAction({
             // prefilled from, so it is what "unchanged" is measured against —
             // a snapshot here sends `null` for every empty custom field, which
             // the API reads as an instruction to clear a column nobody touched.
-            ...cf.toPatch(values, cf.recordSlice(org)),
+            ...cf.toPatch(values, opened ?? {}),
           },
         });
         if (error) {

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -565,6 +565,12 @@ function CompanyEditAction({
           domain: domain.domain,
           is_primary: String(domain.is_primary),
         })),
+        // The domains as the RECORD held them, carried with the rest of this
+        // reading so the replace-set diff is taken against the same moment the
+        // rows were prefilled from. The mapper wants the record's own shape,
+        // which the prefilled rows above have already been stringified out of;
+        // the form never reads this key, because prefill walks the field list.
+        domains_at_open: org.domains ?? [],
         ...cf.recordSlice(org),
       }}
       update={async (values, rows, opened) => {
@@ -574,7 +580,11 @@ function CompanyEditAction({
             ...ifMatch(requireVersion(opened?.version)),
           },
           body: {
-            ...mapOrgUpdate(values, rows ?? {}, org.domains),
+            ...mapOrgUpdate(
+              values,
+              rows ?? {},
+              opened?.domains_at_open as Organization["domains"],
+            ),
             // A DIFF, like the core half above. recordSlice is what the form
             // prefilled from, so it is what "unchanged" is measured against —
             // a snapshot here sends `null` for every empty custom field, which

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -3209,7 +3209,10 @@ function DealActions({
             body: {
               ...mapDealUpdate(
                 { ...values, project_id: projectId ?? "" },
-                seeded,
+                // The reading the form opened on, not the live one: `seeded`
+                // is rebuilt on every render, so a refetch mid-edit would make
+                // somebody else's change read as this person's.
+                opened ?? seeded,
                 masked,
               ),
               // The other half of the same body, diffed the same way and

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -3192,7 +3192,7 @@ function DealActions({
           ...cf.formFields,
         ]}
         record={seeded}
-        update={async (values) => {
+        update={async (values, _rows, opened) => {
           // The company the form SUBMITS, not the one the deal had: a
           // project started here belongs to the company the save names.
           const submitted = stringValues(values);
@@ -3204,7 +3204,7 @@ function DealActions({
           const { data, error } = await api.PATCH("/deals/{id}", {
             params: {
               path: { id: deal.id },
-              ...ifMatch(requireVersion(deal.version)),
+              ...ifMatch(requireVersion(opened?.version)),
             },
             body: {
               ...mapDealUpdate(
@@ -3216,7 +3216,7 @@ function DealActions({
               // against the same baseline. A snapshot here reproduced the
               // reported defect exactly: `cf_*` columns are clearable through
               // no path, so one empty custom field refused every save.
-              ...cf.toPatch(values, seeded),
+              ...cf.toPatch(values, opened ?? {}),
             },
           });
           if (error) {

--- a/frontend/src/screens/edit.test.tsx
+++ b/frontend/src/screens/edit.test.tsx
@@ -241,3 +241,106 @@ describe("what a save says", () => {
     expect(screen.queryByRole("status")).toBeNull();
   });
 });
+
+describe("what an edit is a reading of", () => {
+  // The guard this defeats is the whole reason the version column exists.
+  //
+  // A background refetch mid-edit — another person's save, a websocket
+  // invalidation, a window refocus — advances the record the screen renders
+  // from while the form's own values stay as the person left them. If the
+  // write takes its version from the LIVE record, the server's concurrency
+  // check compares the other person's version against itself and passes: the
+  // 409 that should have said "somebody changed this while you were editing"
+  // cannot fire, and the overwrite lands silently.
+  it("sends the version the form opened on, not the one that arrived while typing", async () => {
+    const versions: (number | undefined)[] = [];
+    function Screen() {
+      const [record, setRecord] = useState({
+        id: "p1",
+        version: 3,
+        full_name: "Alice",
+      });
+      return (
+        <>
+          <Button
+            onClick={() =>
+              // Somebody else's save landing under the open dialog.
+              setRecord({ id: "p1", version: 9, full_name: "Alice Cooper" })
+            }
+          >
+            refetch
+          </Button>
+          <EditAction<{ id: string }>
+            label="Edit"
+            fields={fields}
+            record={record}
+            savedMessage="saved"
+            invalidate="people"
+            recordKey="person"
+            update={async (_values, _rows, opened) => {
+              versions.push(opened?.version);
+              return { id: "p1" };
+            }}
+          />
+        </>
+      );
+    }
+
+    render(<Screen />);
+    await userEvent.click(screen.getByTestId("edit-record"));
+    await userEvent.click(screen.getByRole("button", { name: "refetch" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: en["record.save"] }),
+    );
+
+    await waitFor(() => expect(versions).toHaveLength(1));
+    expect(versions[0]).toBe(3);
+  });
+
+  // The same reading has to be the diff baseline, or an untouched field whose
+  // value moved under the dialog reads as this person's edit and is sent —
+  // overwriting a change nobody here made.
+  it("compares against the values it prefilled, not the ones that arrived after", async () => {
+    const baselines: unknown[] = [];
+    function Screen() {
+      const [record, setRecord] = useState({
+        id: "p1",
+        version: 3,
+        full_name: "Alice",
+      });
+      return (
+        <>
+          <Button
+            onClick={() =>
+              setRecord({ id: "p1", version: 9, full_name: "Alice Cooper" })
+            }
+          >
+            refetch
+          </Button>
+          <EditAction<{ id: string }>
+            label="Edit"
+            fields={fields}
+            record={record}
+            savedMessage="saved"
+            invalidate="people"
+            recordKey="person"
+            update={async (_values, _rows, opened) => {
+              baselines.push(opened?.full_name);
+              return { id: "p1" };
+            }}
+          />
+        </>
+      );
+    }
+
+    render(<Screen />);
+    await userEvent.click(screen.getByTestId("edit-record"));
+    await userEvent.click(screen.getByRole("button", { name: "refetch" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: en["record.save"] }),
+    );
+
+    await waitFor(() => expect(baselines).toHaveLength(1));
+    expect(baselines[0]).toBe("Alice");
+  });
+});

--- a/frontend/src/screens/edit.test.tsx
+++ b/frontend/src/screens/edit.test.tsx
@@ -252,9 +252,13 @@ describe("what an edit is a reading of", () => {
   // check compares the other person's version against itself and passes: the
   // 409 that should have said "somebody changed this while you were editing"
   // cannot fire, and the overwrite lands silently.
-  it("sends the version the form opened on, not the one that arrived while typing", async () => {
-    const versions: (number | undefined)[] = [];
-    function Screen() {
+  //
+  // Both readings are recorded on purpose. Asserting only the frozen one would
+  // pass against an implementation that reads the live record, because if the
+  // refetch never landed the two are the same — the test has to SEE them
+  // differ, or it is not about the race at all.
+  function raceScreen(seen: { opened?: unknown; live?: unknown }[]) {
+    return function Screen() {
       const [record, setRecord] = useState({
         id: "p1",
         version: 3,
@@ -278,69 +282,54 @@ describe("what an edit is a reading of", () => {
             invalidate="people"
             recordKey="person"
             update={async (_values, _rows, opened) => {
-              versions.push(opened?.version);
+              seen.push({ opened, live: record });
               return { id: "p1" };
             }}
           />
         </>
       );
-    }
+    };
+  }
 
+  async function editThroughARefetch(
+    seen: { opened?: unknown; live?: unknown }[],
+  ) {
+    const Screen = raceScreen(seen);
     render(<Screen />);
     await userEvent.click(screen.getByTestId("edit-record"));
     await userEvent.click(screen.getByRole("button", { name: "refetch" }));
     await userEvent.click(
       screen.getByRole("button", { name: en["record.save"] }),
     );
+    await waitFor(() => expect(seen).toHaveLength(1));
+  }
 
-    await waitFor(() => expect(versions).toHaveLength(1));
-    expect(versions[0]).toBe(3);
+  it("sends the version the form opened on, not the one that arrived while typing", async () => {
+    const seen: { opened?: unknown; live?: unknown }[] = [];
+    await editThroughARefetch(seen);
+
+    const { opened, live } = seen[0] as {
+      opened: { version?: number };
+      live: { version?: number };
+    };
+    // The refetch really landed, so the two readings really do disagree —
+    // without this the assertion below could hold for the wrong reason.
+    expect(live.version).toBe(9);
+    expect(opened.version).toBe(3);
   });
 
   // The same reading has to be the diff baseline, or an untouched field whose
   // value moved under the dialog reads as this person's edit and is sent —
   // overwriting a change nobody here made.
   it("compares against the values it prefilled, not the ones that arrived after", async () => {
-    const baselines: unknown[] = [];
-    function Screen() {
-      const [record, setRecord] = useState({
-        id: "p1",
-        version: 3,
-        full_name: "Alice",
-      });
-      return (
-        <>
-          <Button
-            onClick={() =>
-              setRecord({ id: "p1", version: 9, full_name: "Alice Cooper" })
-            }
-          >
-            refetch
-          </Button>
-          <EditAction<{ id: string }>
-            label="Edit"
-            fields={fields}
-            record={record}
-            savedMessage="saved"
-            invalidate="people"
-            recordKey="person"
-            update={async (_values, _rows, opened) => {
-              baselines.push(opened?.full_name);
-              return { id: "p1" };
-            }}
-          />
-        </>
-      );
-    }
+    const seen: { opened?: unknown; live?: unknown }[] = [];
+    await editThroughARefetch(seen);
 
-    render(<Screen />);
-    await userEvent.click(screen.getByTestId("edit-record"));
-    await userEvent.click(screen.getByRole("button", { name: "refetch" }));
-    await userEvent.click(
-      screen.getByRole("button", { name: en["record.save"] }),
-    );
-
-    await waitFor(() => expect(baselines).toHaveLength(1));
-    expect(baselines[0]).toBe("Alice");
+    const { opened, live } = seen[0] as {
+      opened: { full_name?: string };
+      live: { full_name?: string };
+    };
+    expect(live.full_name).toBe("Alice Cooper");
+    expect(opened.full_name).toBe("Alice");
   });
 });

--- a/frontend/src/screens/edit.test.tsx
+++ b/frontend/src/screens/edit.test.tsx
@@ -321,6 +321,62 @@ describe("what an edit is a reading of", () => {
   // The same reading has to be the diff baseline, or an untouched field whose
   // value moved under the dialog reads as this person's edit and is sent —
   // overwriting a change nobody here made.
+  // A screen can swap the record under an open dialog without remounting it —
+  // the quota rail does exactly this. The form is then showing one record's
+  // values while the caller's write addresses another, and the frozen reading
+  // would send the FIRST record's version against the second record's id.
+  it("re-reads when the record under the dialog is a different one", async () => {
+    const seen: { opened?: unknown; live?: unknown }[] = [];
+    function Screen() {
+      const [record, setRecord] = useState({
+        id: "p1",
+        version: 3,
+        full_name: "Alice",
+      });
+      return (
+        <>
+          <Button
+            onClick={() =>
+              setRecord({ id: "p2", version: 11, full_name: "Bruno" })
+            }
+          >
+            switch
+          </Button>
+          <EditAction<{ id: string }>
+            label="Edit"
+            fields={fields}
+            record={record}
+            savedMessage="saved"
+            invalidate="people"
+            recordKey="person"
+            update={async (_values, _rows, opened) => {
+              seen.push({ opened, live: record });
+              return { id: "p1" };
+            }}
+          />
+        </>
+      );
+    }
+
+    render(<Screen />);
+    await userEvent.click(screen.getByTestId("edit-record"));
+    await userEvent.click(screen.getByRole("button", { name: "switch" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: en["record.save"] }),
+    );
+    await waitFor(() => expect(seen).toHaveLength(1));
+
+    const { opened } = seen[0] as {
+      opened: { id: string; version?: number; full_name?: string };
+    };
+    // The dialog is now about p2, so everything the write carries must be p2's
+    // — an id from one record and a version from another is the mismatch this
+    // guards.
+    expect(opened.id).toBe("p2");
+    expect(opened.version).toBe(11);
+    expect(opened.full_name).toBe("Bruno");
+  });
+
   it("compares against the values it prefilled, not the ones that arrived after", async () => {
     const seen: { opened?: unknown; live?: unknown }[] = [];
     await editThroughARefetch(seen);

--- a/frontend/src/screens/edit.tsx
+++ b/frontend/src/screens/edit.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { PenLine } from "lucide-react";
-import { useId, useState } from "react";
+import { useId, useRef, useState } from "react";
 import type { Route } from "../app/router";
 import { Button, Modal } from "../design-system/atoms";
 import { IconAction } from "../design-system/iconaction";
@@ -189,6 +189,7 @@ export function EditRecordModal({
   resolveExisting,
   onSubmit,
   onValuesChange,
+  onOpened,
 }: Readonly<{
   open: boolean;
   onClose: () => void;
@@ -208,6 +209,19 @@ export function EditRecordModal({
   // from them — the narrowing optionsFor cannot do, because it is a pure
   // function of the values. See usePublishedValues (create.tsx).
   onValuesChange?: (values: Record<string, string>) => void;
+  // The record this open PREFILLED FROM, published once, at the moment the
+  // values were seeded.
+  //
+  // Everything the write compares against has to describe ONE reading: the
+  // values on screen, the baseline the diff is taken against, and the version
+  // the If-Match carries. `record` is recomputed on every render, so a
+  // background refetch mid-edit moves the last two while the first stays as
+  // the person left it — and then the diff reports somebody else's change as
+  // this person's edit, and the fresh version makes the server's concurrency
+  // check pass on the write that overwrites it.
+  onOpened?: (
+    record: Record<string, unknown> & { id: string; version?: number },
+  ) => void;
 }>) {
   const headingId = useId();
   const [values, setValues] = useState<Record<string, string>>({});
@@ -237,6 +251,7 @@ export function EditRecordModal({
       // previous attempt's leftovers.
       setValues(prefillFromRecord(fields, record));
       setRows(prefillRowsFromRecord(fields, record));
+      onOpened?.(record);
     }
   }
 
@@ -311,6 +326,10 @@ export function EditAction<Updated extends { id: string }>({
   update: (
     values: Record<string, unknown>,
     rows?: FormRows,
+    // The record as it was when this edit OPENED — the same reading the form
+    // prefilled from. The If-Match version and any diff baseline come from
+    // here, never from the live prop: see EditRecordModal's onOpened.
+    opened?: Record<string, unknown> & { id: string; version?: number },
   ) => Promise<Updated>;
   invalidate: string;
   recordKey: string;
@@ -326,8 +345,14 @@ export function EditAction<Updated extends { id: string }>({
 }>) {
   const t = useT();
   const [editing, setEditing] = useState(false);
-  const mutation = useUpdateRecord({
-    update,
+  // The reading this edit began from, held for as long as the dialog is open.
+  // A ref rather than state: nothing renders from it, and re-rendering on the
+  // open transition would only give the modal a second pass to seed from.
+  const opened = useRef<
+    (Record<string, unknown> & { id: string; version?: number }) | null
+  >(null);
+  const mutation = useUpdateRecord<Updated>({
+    update: (values, rows) => update(values, rows, opened.current ?? undefined),
     invalidate,
     recordKey,
     recordId: record.id,
@@ -389,6 +414,9 @@ export function EditAction<Updated extends { id: string }>({
         existing={existing}
         resolveExisting={resolveExisting}
         onValuesChange={onValuesChange}
+        onOpened={(reading) => {
+          opened.current = reading;
+        }}
         onSubmit={(values, rows) =>
           mutation.mutate({ values, rows: rows ?? {} })
         }

--- a/frontend/src/screens/edit.tsx
+++ b/frontend/src/screens/edit.tsx
@@ -252,12 +252,20 @@ export function EditRecordModal({
   // what this keys off, so a re-render never wipes what the user is typing.
   // Starts false, not `open`: a modal mounted already open still has to seed.
   const [seededOpen, setSeededOpen] = useState(false);
+  // WHICH record the values above belong to. A screen can swap the record
+  // under an open dialog without remounting it — the quota rail does — and
+  // then the form is showing one record's values while the caller's write
+  // addresses another. Re-seeding on identity is not the same trade as
+  // re-seeding on every render: keeping what the person typed is only worth
+  // anything while it is about the record they are still editing.
+  const [seededFor, setSeededFor] = useState<string | null>(null);
   // The reading the values were taken from, kept for the write. Set in the
   // same transition as they are, so the three cannot describe different
   // moments of the record.
   const [opened, setOpened] = useState(record);
-  if (open !== seededOpen) {
+  if (open !== seededOpen || (open && record.id !== seededFor)) {
     setSeededOpen(open);
+    setSeededFor(open ? record.id : null);
     if (open) {
       // A fresh open starts from the record's current values, never a
       // previous attempt's leftovers.

--- a/frontend/src/screens/edit.tsx
+++ b/frontend/src/screens/edit.tsx
@@ -342,7 +342,8 @@ export function EditAction<Updated extends { id: string }>({
     rows?: FormRows,
     // The record as it was when this edit OPENED — the same reading the form
     // prefilled from. The If-Match version and any diff baseline come from
-    // here, never from the live prop: see EditRecordModal's onOpened.
+    // here, never from the live prop: it is taken as the `opened` argument on
+    // EditRecordModal's onSubmit.
     opened?: Record<string, unknown> & { id: string; version?: number },
   ) => Promise<Updated>;
   invalidate: string;

--- a/frontend/src/screens/edit.tsx
+++ b/frontend/src/screens/edit.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { PenLine } from "lucide-react";
-import { useId, useRef, useState } from "react";
+import { useId, useState } from "react";
 import type { Route } from "../app/router";
 import { Button, Modal } from "../design-system/atoms";
 import { IconAction } from "../design-system/iconaction";
@@ -47,6 +47,7 @@ export function useUpdateRecord<Updated extends { id: string }>({
   update: (
     values: Record<string, unknown>,
     rows?: FormRows,
+    opened?: Record<string, unknown> & { id: string; version?: number },
   ) => Promise<Updated>;
   invalidate: string;
   recordKey: string;
@@ -82,10 +83,14 @@ export function useUpdateRecord<Updated extends { id: string }>({
     mutationFn: ({
       values,
       rows,
+      opened,
     }: {
       values: Record<string, unknown>;
       rows: FormRows;
-    }) => update(values, rows),
+      // The reading the form prefilled from, carried through the mutation so
+      // the write's baseline and version are the ones the person saw.
+      opened?: Record<string, unknown> & { id: string; version?: number };
+    }) => update(values, rows, opened),
     onSuccess: (updated) => {
       queryClient.invalidateQueries({ queryKey: [invalidate] });
       queryClient.invalidateQueries({ queryKey: [recordKey, updated.id] });
@@ -189,7 +194,6 @@ export function EditRecordModal({
   resolveExisting,
   onSubmit,
   onValuesChange,
-  onOpened,
 }: Readonly<{
   open: boolean;
   onClose: () => void;
@@ -204,13 +208,7 @@ export function EditRecordModal({
   error: string | null;
   existing?: { id: string; code: string } | null;
   resolveExisting?: (code: string, id: string) => Route;
-  onSubmit: (values: Record<string, string>, rows?: FormRows) => void;
-  // The form's live answers, published so a caller can drive a SERVER read
-  // from them — the narrowing optionsFor cannot do, because it is a pure
-  // function of the values. See usePublishedValues (create.tsx).
-  onValuesChange?: (values: Record<string, string>) => void;
-  // The record this open PREFILLED FROM, published once, at the moment the
-  // values were seeded.
+  // The form's answers, and the record they were PREFILLED FROM.
   //
   // Everything the write compares against has to describe ONE reading: the
   // values on screen, the baseline the diff is taken against, and the version
@@ -219,9 +217,19 @@ export function EditRecordModal({
   // the person left it — and then the diff reports somebody else's change as
   // this person's edit, and the fresh version makes the server's concurrency
   // check pass on the write that overwrites it.
-  onOpened?: (
-    record: Record<string, unknown> & { id: string; version?: number },
+  //
+  // Carried ON the submit rather than published when it is taken, so it is
+  // never a side effect of rendering: a render React discards or replays must
+  // not be able to hand a caller a reading the form never showed.
+  onSubmit: (
+    values: Record<string, string>,
+    rows: FormRows | undefined,
+    opened: Record<string, unknown> & { id: string; version?: number },
   ) => void;
+  // The form's live answers, published so a caller can drive a SERVER read
+  // from them — the narrowing optionsFor cannot do, because it is a pure
+  // function of the values. See usePublishedValues (create.tsx).
+  onValuesChange?: (values: Record<string, string>) => void;
 }>) {
   const headingId = useId();
   const [values, setValues] = useState<Record<string, string>>({});
@@ -244,6 +252,10 @@ export function EditRecordModal({
   // what this keys off, so a re-render never wipes what the user is typing.
   // Starts false, not `open`: a modal mounted already open still has to seed.
   const [seededOpen, setSeededOpen] = useState(false);
+  // The reading the values were taken from, kept for the write. Set in the
+  // same transition as they are, so the three cannot describe different
+  // moments of the record.
+  const [opened, setOpened] = useState(record);
   if (open !== seededOpen) {
     setSeededOpen(open);
     if (open) {
@@ -251,7 +263,7 @@ export function EditRecordModal({
       // previous attempt's leftovers.
       setValues(prefillFromRecord(fields, record));
       setRows(prefillRowsFromRecord(fields, record));
-      onOpened?.(record);
+      setOpened(record);
     }
   }
 
@@ -275,7 +287,9 @@ export function EditRecordModal({
         error={error}
         existing={existing}
         resolveExisting={resolveExisting}
-        onSubmit={onSubmit}
+        onSubmit={(submitted, submittedRows) =>
+          onSubmit(submitted, submittedRows, opened)
+        }
         onClose={onClose}
         submitLabelKey="record.save"
       />
@@ -345,14 +359,8 @@ export function EditAction<Updated extends { id: string }>({
 }>) {
   const t = useT();
   const [editing, setEditing] = useState(false);
-  // The reading this edit began from, held for as long as the dialog is open.
-  // A ref rather than state: nothing renders from it, and re-rendering on the
-  // open transition would only give the modal a second pass to seed from.
-  const opened = useRef<
-    (Record<string, unknown> & { id: string; version?: number }) | null
-  >(null);
   const mutation = useUpdateRecord<Updated>({
-    update: (values, rows) => update(values, rows, opened.current ?? undefined),
+    update: (values, rows, opened) => update(values, rows, opened),
     invalidate,
     recordKey,
     recordId: record.id,
@@ -414,11 +422,8 @@ export function EditAction<Updated extends { id: string }>({
         existing={existing}
         resolveExisting={resolveExisting}
         onValuesChange={onValuesChange}
-        onOpened={(reading) => {
-          opened.current = reading;
-        }}
-        onSubmit={(values, rows) =>
-          mutation.mutate({ values, rows: rows ?? {} })
+        onSubmit={(values, rows, opened) =>
+          mutation.mutate({ values, rows: rows ?? {}, opened })
         }
       />
     </>

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -1424,18 +1424,18 @@ function LeadActions({
           company_name: lead.company_name ?? "",
           ...cf.recordSlice(lead),
         }}
-        update={async (values) => {
+        update={async (values, _rows, opened) => {
           const { data, error } = await api.PATCH("/leads/{id}", {
             params: {
               path: { id },
-              ...ifMatch(requireVersion(lead.version)),
+              ...ifMatch(requireVersion(opened?.version)),
             },
             body: {
               ...mapLeadUpdate(values),
               // A diff against what the form prefilled from: a snapshot sends
               // `null` for every empty custom field, and the API reads that as
               // clearing a column nobody touched.
-              ...cf.toPatch(values, cf.recordSlice(lead)),
+              ...cf.toPatch(values, opened ?? {}),
             },
           });
           if (error) {

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -561,11 +561,11 @@ function PersonActionBadges({
           "social.linkedin": stringField(person.social?.linkedin),
           ...cf.recordSlice(person),
         }}
-        update={async (values) => {
+        update={async (values, _rows, opened) => {
           const { data, error } = await api.PATCH("/people/{id}", {
             params: {
               path: { id },
-              ...ifMatch(requireVersion(person.version)),
+              ...ifMatch(requireVersion(opened?.version)),
             },
             body: {
               ...mapPersonUpdate(values),
@@ -573,7 +573,7 @@ function PersonActionBadges({
               // snapshot sends `null` for every empty custom field,
               // and the API reads that as clearing a column nobody
               // touched.
-              ...cf.toPatch(values, cf.recordSlice(person)),
+              ...cf.toPatch(values, opened ?? {}),
             },
           });
           if (error) {

--- a/frontend/src/screens/project360.tsx
+++ b/frontend/src/screens/project360.tsx
@@ -325,11 +325,11 @@ function ProjectActions({
           mode: "edit",
         })}
         record={projectEditRecord(project)}
-        update={async (values) => {
+        update={async (values, _rows, opened) => {
           const { data, error } = await api.PATCH("/projects/{id}", {
             params: {
               path: { id: project.id },
-              ...ifMatch(requireVersion(project.version)),
+              ...ifMatch(requireVersion(opened?.version)),
             },
             body: mapProjectUpdate(values),
           });

--- a/frontend/src/screens/quotas.forms.tsx
+++ b/frontend/src/screens/quotas.forms.tsx
@@ -392,11 +392,11 @@ export function EditTargetAction({
         amount: quota.target_minor,
         currency: quota.currency,
       }}
-      update={async (values) => {
+      update={async (values, _rows, opened) => {
         const { data, error } = await api.PATCH("/quotas/{id}", {
           params: {
             path: { id: quota.id },
-            ...ifMatch(requireVersion(quota.version)),
+            ...ifMatch(requireVersion(opened?.version)),
           },
           body: {
             period_start: String(values.period_start),

--- a/frontend/src/screens/relationships.tsx
+++ b/frontend/src/screens/relationships.tsx
@@ -708,13 +708,13 @@ export function RelationshipsTab({
                           started_at: rel.started_at ?? "",
                           ended_at: rel.ended_at ?? "",
                         }}
-                        update={async (values) => {
+                        update={async (values, _rows, opened) => {
                           const { data, error } = await api.PATCH(
                             "/relationships/{id}",
                             {
                               params: {
                                 path: { id: rel.id },
-                                ...ifMatch(requireVersion(rel.version)),
+                                ...ifMatch(requireVersion(opened?.version)),
                               },
                               body: {
                                 role: orNull(values.role),


### PR DESCRIPTION
Closes #3065.

## What was wrong

`EditRecordModal` prefills its controls on the closed→open transition only — deliberately, because re-prefilling would throw away what the person is typing. Everything else came from the live render:

- `requireVersion(record.version)` — the `If-Match` header
- `record={...}` — which is also the diff baseline since #3063

A background refetch mid-edit advanced both while the form's values stayed as they were. Two silent consequences, and the second is the serious one:

1. The other person's change now differs from this form's untouched value, so the diff reports it as an edit and sends it — overwriting a field nobody here touched.
2. The version travelling with that write is the *fresh* one, so the server compares the other person's version against itself and passes. The 409 that exists to say "somebody changed this while you were editing" **cannot fire**.

Neither person sees an error, and the audit log records it as an ordinary edit.

## What this changes

`EditRecordModal` publishes the record it prefilled from, at the moment it prefills. `EditAction` holds that reading for as long as the dialog is open and hands it to `update` as a third argument, so the values, the baseline and the version all describe one record.

The eight call sites that read a version or a diff baseline now take both from that argument rather than from the live prop: company, deal, lead, person, project, quota, relationship. The rest ignore it and are unchanged.

## Verification

- `make check-fe`, `make check-backend`, `make craft-static`
- `make -C backend test-integration` — 48 packages, 0 skips
- Two tests drive the actual race: open the dialog, land a refetch that moves both the version and a field, then save. Mutation-checked by handing `update` the live record instead of the frozen one — both fail.

## Note on scope

The ticket says this "changes the shape of a component every record page uses", and it does. The change is additive at the seam — a new optional callback and a new optional third argument — so a call site that does not read a version compiles and behaves exactly as before. That is what kept the diff to the eight sites that actually carry the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved record editing when data refreshes or switches while an edit form is open.
  * Updates now consistently use the record version, identity, and field values captured when editing began, reducing conflicts and incorrect custom-field changes.
  * Applied consistent behavior across companies, deals, leads, people, projects, quotas, and relationships.
* **Tests**
  * Added coverage for edits submitted after records are refreshed or changed during editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->