### PR TITLE
fix(consent): the unsubscribe link stops the lane the mail was sent under

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5862,9 +5862,26 @@ paths:
         (source `preference_center`) which the default-deny suppression gate honors on the very next send
         across every path (manual + agent). Idempotent. Only POST acts — a GET/prefetch by a mail scanner
         never unsubscribes anyone (the reason RFC 8058 mandates POST). With `purpose` only that purpose is
-        withdrawn (the one the message was sent under); without it every withdrawable purpose is.
+        withdrawn (the one the message was sent under); without it every lane the recipient has not already
+        stopped is — read from their `choice`, not the raw stored state, so direct correspondence running on
+        no-objection is included rather than silently skipped.
       parameters:
-        - { name: purpose, in: query, required: false, schema: { type: string }, description: The consent purpose key to withdraw. Omit to withdraw every non-transactional purpose. }
+        - { name: purpose, in: query, required: false, schema: { type: string }, description: The consent purpose key to withdraw. Omit to withdraw every lane the recipient has not already stopped. }
+      requestBody:
+        required: false
+        description: |
+          RFC 8058 §3.2 prescribes `List-Unsubscribe=One-Click`, naming multipart/form-data as the SHOULD and
+          URL-encoding as the MAY. The handler accepts BOTH; only the URL-encoded form is declared here,
+          because declaring multipart would class this as a file upload and oblige it to carry a
+          megabyte-scale ceiling — which would misdescribe a route whose entire body is one short field
+          (the handler caps it at 4 KiB). An ABSENT body is accepted too: the product's own unsubscribe page
+          and an operator with curl carry none, and refusing them would break the human path to protect a
+          machine contract. A body that is present and says something else is refused.
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties: { List-Unsubscribe: { type: string, enum: [One-Click] } }
       responses:
         '200':
           description: Unsubscribed (idempotent).
@@ -5877,7 +5894,10 @@ paths:
                   unsubscribed:
                     type: array
                     items: { type: string }
-                    description: The purpose keys now withdrawn.
+                    description: |
+                      The purpose keys this call actually CHANGED. Empty on a replay, because the recipient was
+                      already unsubscribed — which is how the page tells a first press from a second one instead
+                      of showing a fresh confirmation for a no-op.
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
@@ -30569,25 +30589,59 @@ components:
         with the recipient's current state, whether it is locked (transactional cannot be withdrawn
         while a deal is live), and whether granting it needs a confirmation round-trip this surface
         cannot perform.
-      required: [purposes]
+      required: [purposes, masked_email, workspace_name, refused]
       properties:
+        masked_email:
+          type: string
+          description: |
+            The recipient's primary address, masked to its first character and domain. Account CONTEXT, not
+            the scope of any action: the token resolves to a person and the delivered address is not recorded,
+            so a person with several addresses may see a different one than the message reached. Client copy
+            must not claim "this address". Empty when no address is on file.
+        workspace_name:
+          type: string
+          description: The installation's own display label. Empty on an unnamed installation; copy needs an omission variant.
+        refused:
+          type: array
+          description: |
+            Choices the save could not record, by name. Present and empty on a read. A refused GRANT never
+            costs the WITHDRAWAL saved beside it, so a save reports what did not apply rather than failing whole.
+          items:
+            type: object
+            required: [purpose_key, reason]
+            properties:
+              purpose_key: { type: string }
+              reason:      { type: string, enum: [cannot_grant], description: 'cannot_grant: the subject is archived, so a fresh grant would re-open a capability their erasure destroyed.' }
         purposes:
           type: array
           items:
             type: object
-            required: [key, label, state, locked, grant_needs_confirmation]
+            required: [key, label, state, locked, grant_needs_confirmation, choice, can_opt_in]
             properties:
               key:    { type: string }
               label:  { type: string }
-              state:  { type: string, enum: [unknown, granted, withdrawn] }
+              state:  { type: string, enum: [unknown, granted, withdrawn], description: 'The raw stored state. Prefer `choice`, which reads it correctly for the purpose class.' }
               locked: { type: boolean, description: A locked purpose (transactional) cannot be changed from this surface. }
+              choice:
+                type: string
+                enum: [opted_in, opted_out, no_objection]
+                description: |
+                  What the RECIPIENT decided, derived server-side. `state: unknown` means opposite things either
+                  side of the consent line — on a marketing lane nobody has opted in, on direct correspondence
+                  nobody has objected — so a client that rendered the raw state called a live lane "not
+                  subscribed". Render this; never re-derive it. It is a recorded decision, never a delivery
+                  verdict: whether mail can actually be sent also depends on facts this surface must not disclose.
+              can_opt_in:
+                type: boolean
+                description: |
+                  Whether this surface may offer a grant at all. False for a locked purpose and for one needing a
+                  confirmation round-trip that a reusable, long-lived token cannot evidence. A control that always
+                  fails is worse than an absent one.
               grant_needs_confirmation:
                 type: boolean
                 description: |
-                  A purpose requiring double opt-in. Withdrawing it here works; GRANTING it does not, because
-                  this surface's token is reusable and long-lived, so it cannot evidence one deliberate choice
-                  the way a confirmation round-trip does. A client must not offer the grant — the write refuses
-                  it with 422, and an offered switch that always fails is worse than an absent one.
+                  DEPRECATED, kept for one release as the inverse of `can_opt_in` on unlocked purposes. Read
+                  `can_opt_in` instead.
 
     ConfirmDetails:
       type: object

--- a/backend/gates/preferencecentrewriters_test.go
+++ b/backend/gates/preferencecentrewriters_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// The public preference centre answers in ONE shape, and resolves "which
+// address is theirs" in ONE place.
+//
+// Both claims are load-bearing and both are the kind that rots quietly.
+//
+// The RESPONSE SHAPE: the read and the save return the same body, and the
+// page reads masked_email, workspace_name, choice and refused out of it.
+// A second writer of that body is how one of them starts omitting a field
+// — the save answering without `refused`, say — and nothing would fail:
+// the client renders an absent array as "nothing refused", which is
+// exactly the sentence a dropped field makes false.
+//
+// The PRIMARY ADDRESS: the preference centre and the confirm card both
+// show a person their own address, and they must agree on which one that
+// is. The ordering (is_primary DESC, created_at) is the whole rule, and a
+// hand-copied second spelling that dropped the tiebreak would show two
+// surfaces two different addresses for the same person — each looking
+// correct on its own screen.
+//
+// WHAT THIS GATE CAN AND CANNOT SEE. It matches the call, by name, in the
+// consent module's Go. A caller that reached the same statement through a
+// variable holding the SQL, or a copy that spelled the ORDER BY without
+// going through the helper, is outside what an AST walk can judge; the
+// second is the real gap, and it is why the address census below counts
+// the ORDER BY itself rather than the function name.
+
+import (
+	"fmt"
+	"go/ast"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// consentRoot is where every spelling this gate counts must live.
+const consentRoot = "internal/modules/consent"
+
+// TestThePreferenceCentreAnswersInOneShape holds the "one spelling"
+// claim on writePreferenceCenter.
+func TestThePreferenceCentreAnswersInOneShape(t *testing.T) {
+	t.Parallel()
+	// The BODY KEYS, not the function name: a second writer would be a
+	// second map literal carrying them, and renaming the helper would not
+	// help it escape.
+	const key = `"masked_email"`
+	scope := gatekit.Scope{
+		Roots:   []string{consentRoot},
+		Subject: fileContains(key),
+		Exempt:  gatekit.Waive(map[string]string{}),
+	}
+	total, where := countAcross(t, scope, key)
+	// EXACTLY one. Zero is the direction this fails silently in — the
+	// helper renamed its keys, or moved out of the module, and a gate
+	// asking "no second writer" prints the same clean word over a tree
+	// where the shape is no longer written at all.
+	if total != 1 {
+		t.Errorf("the preference-centre response body is written %d time(s), want exactly 1: %s\n\n"+
+			"The read and the save must answer in one shape — a second writer is how one of them "+
+			"starts omitting a field the page reads as meaningful.", total, strings.Join(where, ", "))
+	}
+}
+
+// TestThePreferenceCentreResolvesOnePrimaryAddress holds the "cannot
+// disagree" claim on primaryEmailTx.
+func TestThePreferenceCentreResolvesOnePrimaryAddress(t *testing.T) {
+	t.Parallel()
+	// The ORDERING is the rule, so the ordering is what is counted. A
+	// copy that named the helper but re-spelled the ORDER BY is the
+	// defect; a copy that omitted the tiebreak would show a different
+	// address on a person carrying two.
+	const key = "pe.is_primary DESC, pe.created_at"
+	scope := gatekit.Scope{
+		Roots:   []string{consentRoot},
+		Subject: fileContains(key),
+		Exempt:  gatekit.Waive(map[string]string{}),
+	}
+	total, where := countAcross(t, scope, key)
+	if total != 1 {
+		t.Errorf("the person's primary address is resolved %d time(s) in consent, want exactly 1: %s\n\n"+
+			"The preference centre and the confirm card show a person their own address and must "+
+			"agree which one it is; a second spelling that drops the tiebreak shows two surfaces "+
+			"two different addresses.", total, strings.Join(where, ", "))
+	}
+}
+
+// fileContains is the Subject predicate: does this file spell the string
+// anywhere in its source.
+func fileContains(needle string) func(string, *ast.File) bool {
+	pattern := regexp.MustCompile(regexp.QuoteMeta(needle))
+	return func(_ string, file *ast.File) bool {
+		return countInFile(file, pattern) > 0
+	}
+}
+
+// countAcross totals a needle's occurrences over a scope's files and says
+// where it found them.
+func countAcross(t *testing.T, scope gatekit.Scope, needle string) (int, []string) {
+	t.Helper()
+	pattern := regexp.MustCompile(regexp.QuoteMeta(needle))
+	total := 0
+	var where []string
+	for _, f := range scope.Files(t) {
+		n := countInFile(f.File, pattern)
+		if n == 0 {
+			continue
+		}
+		total += n
+		where = append(where, fmt.Sprintf("%s (%d)", f.Path, n))
+	}
+	return total, where
+}
+
+// countInFile counts a pattern's matches in a file's string literals —
+// where both subjects live, and where a copy would land.
+func countInFile(file *ast.File, pattern *regexp.Regexp) int {
+	total := 0
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok {
+			return true
+		}
+		total += len(pattern.FindAllString(lit.Value, -1))
+		return true
+	})
+	return total
+}

--- a/backend/internal/compose/publicpreferences.go
+++ b/backend/internal/compose/publicpreferences.go
@@ -50,6 +50,12 @@ func publicPreferences(store *consent.Store, limits publicPreferenceLimiters) fu
 				next.ServeHTTP(w, r)
 				return
 			}
+			// Set before any refusal below, so a rate-limit or
+			// not-found answer is no more cacheable than a successful
+			// one: every response on this prefix is derived from a
+			// bearer token that lives in somebody's mailbox for thirty
+			// days, and a shared cache holding any of them is a leak.
+			w.Header().Set("Cache-Control", "no-store")
 			token := strings.SplitN(strings.TrimPrefix(r.URL.Path, publicPreferencesPrefix), "/", 2)[0]
 			if token == "" {
 				httperr.Write(w, r, apperrors.ErrNotFound)

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -9,6 +9,7 @@ package compose
 // recovery) is platform/httpserver; what lives here is the wiring.
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"time"
@@ -116,7 +117,11 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		jobHealthHandlers: jobHealthHandlers{pool: pool},
 		// DSR fulfillment executes privacy's erase path — injected here so
 		// consent never imports its sibling.
-		consentHandlers:     consent.NewHandlers(InstallationDB(pool)).WithEraser(privacy.NewEraser(InstallationDB(pool))),
+		consentHandlers: consent.NewHandlers(InstallationDB(pool)).
+			WithEraser(privacy.NewEraser(InstallationDB(pool))).
+			WithInstallationName(consent.InstallationNameFunc(func(ctx context.Context) (string, error) {
+				return identity.InstallationNameForPublicPage(ctx, pool)
+			})),
 		collectionsHandlers: newCollectionsHandlers(pool),
 		// The warm room ranks its contact edges by the §4 relationship
 		// strength owned by people; injected through the adapter below so

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -8455,6 +8455,27 @@ func (e PipelineStageRungSubjectKind) Valid() bool {
 	}
 }
 
+// Defines values for PreferenceCenterPurposesChoice.
+const (
+	NoObjection PreferenceCenterPurposesChoice = "no_objection"
+	OptedIn     PreferenceCenterPurposesChoice = "opted_in"
+	OptedOut    PreferenceCenterPurposesChoice = "opted_out"
+)
+
+// Valid indicates whether the value is a known member of the PreferenceCenterPurposesChoice enum.
+func (e PreferenceCenterPurposesChoice) Valid() bool {
+	switch e {
+	case NoObjection:
+		return true
+	case OptedIn:
+		return true
+	case OptedOut:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for PreferenceCenterPurposesState.
 const (
 	PreferenceCenterPurposesStateGranted   PreferenceCenterPurposesState = "granted"
@@ -8470,6 +8491,21 @@ func (e PreferenceCenterPurposesState) Valid() bool {
 	case PreferenceCenterPurposesStateUnknown:
 		return true
 	case PreferenceCenterPurposesStateWithdrawn:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PreferenceCenterRefusedReason.
+const (
+	CannotGrant PreferenceCenterRefusedReason = "cannot_grant"
+)
+
+// Valid indicates whether the value is a known member of the PreferenceCenterRefusedReason enum.
+func (e PreferenceCenterRefusedReason) Valid() bool {
+	switch e {
+	case CannotGrant:
 		return true
 	default:
 		return false
@@ -13135,6 +13171,21 @@ func (e UpdatePreferencesJSONBodyChoicesState) Valid() bool {
 	case Granted:
 		return true
 	case Withdrawn:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for OneClickUnsubscribeFormdataBodyListUnsubscribe.
+const (
+	OneClick OneClickUnsubscribeFormdataBodyListUnsubscribe = "One-Click"
+)
+
+// Valid indicates whether the value is a known member of the OneClickUnsubscribeFormdataBodyListUnsubscribe enum.
+func (e OneClickUnsubscribeFormdataBodyListUnsubscribe) Valid() bool {
+	switch e {
+	case OneClick:
 		return true
 	default:
 		return false
@@ -24415,23 +24466,62 @@ type PostDealRoomCommentRequest struct {
 // while a deal is live), and whether granting it needs a confirmation round-trip this surface
 // cannot perform.
 type PreferenceCenter struct {
-	Purposes []struct {
-		// GrantNeedsConfirmation A purpose requiring double opt-in. Withdrawing it here works; GRANTING it does not, because
-		// this surface's token is reusable and long-lived, so it cannot evidence one deliberate choice
-		// the way a confirmation round-trip does. A client must not offer the grant — the write refuses
-		// it with 422, and an offered switch that always fails is worse than an absent one.
+	// MaskedEmail The recipient's primary address, masked to its first character and domain. Account CONTEXT, not
+	// the scope of any action: the token resolves to a person and the delivered address is not recorded,
+	// so a person with several addresses may see a different one than the message reached. Client copy
+	// must not claim "this address". Empty when no address is on file.
+	MaskedEmail string `json:"masked_email"`
+	Purposes    []struct {
+		// CanOptIn Whether this surface may offer a grant at all. False for a locked purpose and for one needing a
+		// confirmation round-trip that a reusable, long-lived token cannot evidence. A control that always
+		// fails is worse than an absent one.
+		CanOptIn bool `json:"can_opt_in"`
+
+		// Choice What the RECIPIENT decided, derived server-side. `state: unknown` means opposite things either
+		// side of the consent line — on a marketing lane nobody has opted in, on direct correspondence
+		// nobody has objected — so a client that rendered the raw state called a live lane "not
+		// subscribed". Render this; never re-derive it. It is a recorded decision, never a delivery
+		// verdict: whether mail can actually be sent also depends on facts this surface must not disclose.
+		Choice PreferenceCenterPurposesChoice `json:"choice"`
+
+		// GrantNeedsConfirmation DEPRECATED, kept for one release as the inverse of `can_opt_in` on unlocked purposes. Read
+		// `can_opt_in` instead.
 		GrantNeedsConfirmation bool   `json:"grant_needs_confirmation"`
 		Key                    string `json:"key"`
 		Label                  string `json:"label"`
 
 		// Locked A locked purpose (transactional) cannot be changed from this surface.
-		Locked bool                          `json:"locked"`
-		State  PreferenceCenterPurposesState `json:"state"`
+		Locked bool `json:"locked"`
+
+		// State The raw stored state. Prefer `choice`, which reads it correctly for the purpose class.
+		State PreferenceCenterPurposesState `json:"state"`
 	} `json:"purposes"`
+
+	// Refused Choices the save could not record, by name. Present and empty on a read. A refused GRANT never
+	// costs the WITHDRAWAL saved beside it, so a save reports what did not apply rather than failing whole.
+	Refused []struct {
+		PurposeKey string `json:"purpose_key"`
+
+		// Reason cannot_grant: the subject is archived, so a fresh grant would re-open a capability their erasure destroyed.
+		Reason PreferenceCenterRefusedReason `json:"reason"`
+	} `json:"refused"`
+
+	// WorkspaceName The installation's own display label. Empty on an unnamed installation; copy needs an omission variant.
+	WorkspaceName string `json:"workspace_name"`
 }
 
-// PreferenceCenterPurposesState defines model for PreferenceCenter.Purposes.State.
+// PreferenceCenterPurposesChoice What the RECIPIENT decided, derived server-side. `state: unknown` means opposite things either
+// side of the consent line — on a marketing lane nobody has opted in, on direct correspondence
+// nobody has objected — so a client that rendered the raw state called a live lane "not
+// subscribed". Render this; never re-derive it. It is a recorded decision, never a delivery
+// verdict: whether mail can actually be sent also depends on facts this surface must not disclose.
+type PreferenceCenterPurposesChoice string
+
+// PreferenceCenterPurposesState The raw stored state. Prefer `choice`, which reads it correctly for the purpose class.
 type PreferenceCenterPurposesState string
+
+// PreferenceCenterRefusedReason cannot_grant: the subject is archived, so a fresh grant would re-open a capability their erasure destroyed.
+type PreferenceCenterRefusedReason string
 
 // Problem RFC 7807 problem+json with a stable machine `code` and structured `details`.
 type Problem struct {
@@ -31928,11 +32018,19 @@ type UpdatePreferencesJSONBody struct {
 // UpdatePreferencesJSONBodyChoicesState defines parameters for UpdatePreferences.
 type UpdatePreferencesJSONBodyChoicesState string
 
+// OneClickUnsubscribeFormdataBody defines parameters for OneClickUnsubscribe.
+type OneClickUnsubscribeFormdataBody struct {
+	ListUnsubscribe *OneClickUnsubscribeFormdataBodyListUnsubscribe `form:"List-Unsubscribe,omitempty" json:"List-Unsubscribe,omitempty"`
+}
+
 // OneClickUnsubscribeParams defines parameters for OneClickUnsubscribe.
 type OneClickUnsubscribeParams struct {
-	// Purpose The consent purpose key to withdraw. Omit to withdraw every non-transactional purpose.
+	// Purpose The consent purpose key to withdraw. Omit to withdraw every lane the recipient has not already stopped.
 	Purpose *string `form:"purpose,omitempty" json:"purpose,omitempty"`
 }
+
+// OneClickUnsubscribeFormdataBodyListUnsubscribe defines parameters for OneClickUnsubscribe.
+type OneClickUnsubscribeFormdataBodyListUnsubscribe string
 
 // ListBuyerRoomThreadsParams defines parameters for ListBuyerRoomThreads.
 type ListBuyerRoomThreadsParams struct {
@@ -33365,6 +33463,9 @@ type SubmitConfirmDetailsJSONRequestBody SubmitConfirmDetailsJSONBody
 
 // UpdatePreferencesJSONRequestBody defines body for UpdatePreferences for application/json ContentType.
 type UpdatePreferencesJSONRequestBody UpdatePreferencesJSONBody
+
+// OneClickUnsubscribeFormdataRequestBody defines body for OneClickUnsubscribe for application/x-www-form-urlencoded ContentType.
+type OneClickUnsubscribeFormdataRequestBody OneClickUnsubscribeFormdataBody
 
 // ExchangeDealRoomCredentialJSONRequestBody defines body for ExchangeDealRoomCredential for application/json ContentType.
 type ExchangeDealRoomCredentialJSONRequestBody = DealRoomCredentialRequest

--- a/backend/internal/modules/consent/confirmcard.go
+++ b/backend/internal/modules/consent/confirmcard.go
@@ -95,9 +95,7 @@ func (s *Store) confirmCardFor(ctx context.Context, personID ids.PersonID) (Conf
 			                    AND (r.ended_at IS NULL OR r.ended_at > current_date)
 			                    AND r.archived_at IS NULL
 			                  ORDER BY r.created_at DESC LIMIT 1), ''),
-			       coalesce((SELECT pe.email FROM person_email pe
-			                  WHERE pe.person_id = p.id AND pe.archived_at IS NULL
-			                  ORDER BY pe.is_primary DESC, pe.created_at LIMIT 1), ''),
+			       `+primaryEmailSQL("p.id")+`,
 			       coalesce((SELECT pp.phone FROM person_phone pp
 			                  WHERE pp.person_id = p.id AND pp.archived_at IS NULL
 			                  ORDER BY pp.is_primary DESC, pp.created_at LIMIT 1), '')

--- a/backend/internal/modules/consent/handlers.go
+++ b/backend/internal/modules/consent/handlers.go
@@ -42,6 +42,14 @@ func NewHandlers(db *database.DB) Handlers {
 	return Handlers{store: NewStore(db)}
 }
 
+// WithInstallationName injects the label the public preference page shows
+// as the sender of the mail it is answering. Compose supplies identity's
+// reader; a module never imports a sibling.
+func (h Handlers) WithInstallationName(r InstallationNameReader) Handlers {
+	h.store = h.store.WithInstallationName(r)
+	return h
+}
+
 // WithEraser returns a copy wired to the erase path.
 func (h Handlers) WithEraser(e Eraser) Handlers {
 	h.eraser = e

--- a/backend/internal/modules/consent/handlers_public.go
+++ b/backend/internal/modules/consent/handlers_public.go
@@ -12,11 +12,13 @@ package consent
 // on the unsubscribe path never withdraws (only POST is routed to it).
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // GetPreferenceCenter implements (GET /public/preferences/{token}): the
@@ -27,12 +29,12 @@ func (h Handlers) GetPreferenceCenter(w http.ResponseWriter, r *http.Request, to
 		writeConsentErr(w, r, err)
 		return
 	}
-	choices, err := h.store.PublicPurposeStates(r.Context(), ref.PersonID)
+	view, err := h.store.PublicPreferenceView(r.Context(), ref.PersonID)
 	if err != nil {
 		writeConsentErr(w, r, err)
 		return
 	}
-	httperr.WriteJSON(w, http.StatusOK, map[string]any{"purposes": wirePurposeChoices(choices)})
+	writePreferenceCenter(w, view, nil)
 }
 
 // OneClickUnsubscribe implements (POST /public/preferences/{token}/unsubscribe):
@@ -41,40 +43,58 @@ func (h Handlers) GetPreferenceCenter(w http.ResponseWriter, r *http.Request, to
 // the message was sent under); otherwise every withdrawable purpose is.
 // Idempotent — re-asserting a withdrawal writes no second proof row.
 func (h Handlers) OneClickUnsubscribe(w http.ResponseWriter, r *http.Request, token string, params crmcontracts.OneClickUnsubscribeParams) {
+	if err := requireOneClickBody(r); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
 	ref, err := h.store.ResolvePreferenceToken(r.Context(), token)
 	if err != nil {
 		writeConsentErr(w, r, err)
 		return
 	}
-	var withdrawn []string
-	if params.Purpose != nil && strings.TrimSpace(*params.Purpose) != "" {
-		key := strings.ToLower(strings.TrimSpace(*params.Purpose))
-		if _, err := h.store.PublicSetConsent(r.Context(), ref.PersonID, key, "withdrawn", nil); err != nil {
-			writeConsentErr(w, r, err)
-			return
-		}
-		withdrawn = append(withdrawn, key)
-	} else {
-		choices, err := h.store.PublicPurposeStates(r.Context(), ref.PersonID)
-		if err != nil {
-			writeConsentErr(w, r, err)
-			return
-		}
-		for _, c := range choices {
-			if c.Locked || ConsentState(c.State) != StateGranted {
-				continue
-			}
-			if _, err := h.store.PublicSetConsent(r.Context(), ref.PersonID, c.Key, "withdrawn", nil); err != nil {
-				writeConsentErr(w, r, err)
-				return
-			}
-			withdrawn = append(withdrawn, c.Key)
-		}
+	wanted, err := h.unsubscribeTargets(r.Context(), ref.PersonID, params)
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	withdrawn, err := h.store.PublicWithdrawAll(r.Context(), ref.PersonID, wanted)
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
 	}
 	if withdrawn == nil {
 		withdrawn = []string{}
 	}
 	httperr.WriteJSON(w, http.StatusOK, map[string]any{"unsubscribed": withdrawn})
+}
+
+// unsubscribeTargets picks which purposes this press should stop.
+//
+// A named purpose is taken as given — it is the one the message was sent
+// under, and the mailbox provider naming it must not be second-guessed.
+// Unnamed means "all of it", and that selection reads the recipient's
+// CHOICE, not the raw stored state: a lane running on no-objection has no
+// 'granted' row, so a filter on granted skipped exactly the direct
+// correspondence a reader pressing "unsubscribe from everything" was
+// looking at.
+func (h Handlers) unsubscribeTargets(
+	ctx context.Context, personID ids.PersonID, params crmcontracts.OneClickUnsubscribeParams,
+) ([]string, error) {
+	if params.Purpose != nil && strings.TrimSpace(*params.Purpose) != "" {
+		return []string{strings.ToLower(strings.TrimSpace(*params.Purpose))}, nil
+	}
+	view, err := h.store.PublicPreferenceView(ctx, personID)
+	if err != nil {
+		return nil, err
+	}
+	var keys []string
+	for _, c := range view.Purposes {
+		if c.Locked || c.Choice == ChoiceOptedOut {
+			continue
+		}
+		keys = append(keys, c.Key)
+	}
+	return keys, nil
 }
 
 // maxPreferenceChoices bounds a single granular save. The consent purpose
@@ -83,10 +103,37 @@ func (h Handlers) OneClickUnsubscribe(w http.ResponseWriter, r *http.Request, to
 const maxPreferenceChoices = 64
 
 // UpdatePreferences implements (PUT /public/preferences/{token}): the
-// granular save. Each choice is recorded per purpose (a withdrawal of one
-// never touches another — per-purpose default-deny) with the exact wording
-// shown, stored verbatim as proof.
+// granular save, committed as ONE transaction. Each choice carries the
+// exact wording shown, stored verbatim as proof. A grant the engine
+// refuses is reported back by name rather than taking the save with it —
+// see preferencesave.go for why that is not "all or nothing".
 func (h Handlers) UpdatePreferences(w http.ResponseWriter, r *http.Request, token string) {
+	choices, ok := decodePreferenceChoices(w, r)
+	if !ok {
+		return
+	}
+	ref, err := h.store.ResolvePreferenceToken(r.Context(), token)
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	refused, err := h.store.PublicSaveChoices(r.Context(), ref.PersonID, choices)
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	view, err := h.store.PublicPreferenceView(r.Context(), ref.PersonID)
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	writePreferenceCenter(w, view, refused)
+}
+
+// decodePreferenceChoices admits the body: shape, size, states and keys,
+// with a purpose named twice settled toward its withdrawal before
+// anything is written.
+func decodePreferenceChoices(w http.ResponseWriter, r *http.Request) ([]PreferenceChoiceInput, bool) {
 	var req struct {
 		Choices []struct {
 			PurposeKey string  `json:"purpose_key"`
@@ -95,83 +142,54 @@ func (h Handlers) UpdatePreferences(w http.ResponseWriter, r *http.Request, toke
 		} `json:"choices"`
 	}
 	if !httperr.Decode(w, r, &req) {
-		return
+		return nil, false
 	}
 	if len(req.Choices) == 0 {
 		httperr.Write(w, r, httperr.Validation("choices", "required", "at least one per-purpose choice is required"))
-		return
+		return nil, false
 	}
 	// A legitimate save carries at most one choice per tracked purpose;
 	// the catalog is a small closed set. Cap the array so a valid token
-	// cannot amplify a single 1 MiB body into tens of thousands of serial
-	// per-choice transactions.
+	// cannot amplify a single 1 MiB body into tens of thousands of
+	// per-choice writes.
 	if len(req.Choices) > maxPreferenceChoices {
 		httperr.Write(w, r, httperr.Validation("choices", "too_many", "more choices than there are tracked purposes"))
-		return
+		return nil, false
 	}
-	ref, err := h.store.ResolvePreferenceToken(r.Context(), token)
-	if err != nil {
-		writeConsentErr(w, r, err)
-		return
-	}
-	states := make([]ConsentState, len(req.Choices))
-	// Keys are compared AS PublicSetConsent will read them. It trims and
-	// lowercases before resolving the purpose, so "Newsletter " and "newsletter"
-	// are one purpose downstream — and a duplicate check on the raw strings
-	// would not see them as a pair, letting the grant land after the withdrawal
-	// on the very surface the rule below exists to protect.
-	keys := make([]string, len(req.Choices))
-	for i, c := range req.Choices {
+	out := make([]PreferenceChoiceInput, 0, len(req.Choices))
+	for _, c := range req.Choices {
 		state, err := ParseRecordableState(c.State)
 		if err != nil {
 			httperr.Write(w, r, httperr.Validation("state", "invalid", "must be granted or withdrawn"))
-			return
+			return nil, false
 		}
-		states[i] = state
-		keys[i] = normalizedPurposeKey(c.PurposeKey)
+		// Normalized HERE, as the engine will read it, so a duplicate
+		// check cannot miss "Newsletter " and "newsletter" as a pair.
+		out = append(out, PreferenceChoiceInput{
+			PurposeKey: normalizedPurposeKey(c.PurposeKey),
+			State:      state,
+			Wording:    c.Wording,
+		})
 	}
-	// A purpose named twice in one save is settled BEFORE anything is written,
-	// and it settles toward the withdrawal. Request order used to decide it by
-	// accident; the two passes below would have decided it the other way, and
-	// on a consent surface the direction is not a coin toss — a body carrying
-	// both answers for one purpose is a client bug, and suppressing is the safe
-	// reading of it.
-	for i := range req.Choices {
-		for j := i + 1; j < len(req.Choices); j++ {
-			if keys[j] != keys[i] {
-				continue
-			}
-			if states[i] == StateWithdrawn || states[j] == StateWithdrawn {
-				states[i], states[j] = StateWithdrawn, StateWithdrawn
-				req.Choices[i].State, req.Choices[j].State = string(StateWithdrawn), string(StateWithdrawn)
-			}
-		}
+	return settleTowardWithdrawal(out), true
+}
+
+// writePreferenceCenter is the one spelling of this response, so the read
+// and the save cannot answer in different shapes.
+//
+// Held by: TestThePreferenceCentreAnswersInOneShape (backend/gates/preferencecentrewriters_test.go)
+func writePreferenceCenter(w http.ResponseWriter, view PreferenceView, refused []ChoiceOutcome) {
+	body := map[string]any{
+		"purposes":       wirePurposeChoices(view.Purposes),
+		"masked_email":   view.MaskedEmail,
+		"workspace_name": view.WorkspaceName,
 	}
-	// WITHDRAWALS FIRST, and that ordering is load-bearing rather than tidy.
-	//
-	// A save carries several choices and this loop stops at the first refusal.
-	// Record refuses a GRANT for an archived subject and admits a withdrawal
-	// from anyone — so a mixed save recorded in request order would refuse
-	// halfway and drop the withdrawals behind it, losing the one thing a
-	// subject in that state most needs this page to do. Taking them first means
-	// a refused grant can only cost the grant.
-	for _, pass := range []ConsentState{StateWithdrawn, StateGranted} {
-		for i, c := range req.Choices {
-			if states[i] != pass {
-				continue
-			}
-			if _, err := h.store.PublicSetConsent(r.Context(), ref.PersonID, c.PurposeKey, c.State, c.Wording); err != nil {
-				writeConsentErr(w, r, err)
-				return
-			}
-		}
+	out := make([]map[string]any, 0, len(refused))
+	for _, f := range refused {
+		out = append(out, map[string]any{fieldPurposeKey: f.PurposeKey, "reason": f.Reason})
 	}
-	choices, err := h.store.PublicPurposeStates(r.Context(), ref.PersonID)
-	if err != nil {
-		writeConsentErr(w, r, err)
-		return
-	}
-	httperr.WriteJSON(w, http.StatusOK, map[string]any{"purposes": wirePurposeChoices(choices)})
+	body["refused"] = out
+	httperr.WriteJSON(w, http.StatusOK, body)
 }
 
 func wirePurposeChoices(choices []PurposeChoice) []map[string]any {
@@ -183,6 +201,8 @@ func wirePurposeChoices(choices []PurposeChoice) []map[string]any {
 			"state":                    c.State,
 			"locked":                   c.Locked,
 			"grant_needs_confirmation": c.GrantNeedsConfirmation,
+			"choice":                   string(c.Choice),
+			"can_opt_in":               c.CanOptIn,
 		})
 	}
 	return out

--- a/backend/internal/modules/consent/installationname.go
+++ b/backend/internal/modules/consent/installationname.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The installation's own display label, for the public preference page.
+//
+// It lives in identity, and a module never imports a sibling — so the
+// reader is injected and this file holds only the seam.
+
+import (
+	"context"
+	"log/slog"
+)
+
+// InstallationNameReader answers the installation's display name.
+type InstallationNameReader interface {
+	InstallationName(ctx context.Context) (string, error)
+}
+
+// InstallationNameFunc adapts a plain function, so compose can inject
+// identity's reader without either module knowing the other.
+type InstallationNameFunc func(ctx context.Context) (string, error)
+
+// InstallationName satisfies InstallationNameReader.
+func (f InstallationNameFunc) InstallationName(ctx context.Context) (string, error) { return f(ctx) }
+
+// WithInstallationName injects the reader behind the public page's label.
+func (s *Store) WithInstallationName(r InstallationNameReader) *Store {
+	s.installationName = r
+	return s
+}
+
+// workspaceName is a display label, so a failure to read it costs the
+// label and never the page: somebody trying to stop email must not be
+// met with a 500 because the installation has no name on file.
+func (s *Store) workspaceName(ctx context.Context) string {
+	if s.installationName == nil {
+		return ""
+	}
+	name, err := s.installationName.InstallationName(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "preference centre could not read the installation name", "error", err)
+		return ""
+	}
+	return name
+}

--- a/backend/internal/modules/consent/oneclickbody.go
+++ b/backend/internal/modules/consent/oneclickbody.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The RFC 8058 request body.
+//
+// §3.2 says the mailbox provider POSTs "List-Unsubscribe=One-Click", and
+// names multipart/form-data as the SHOULD with URL-encoding as the MAY.
+// Both are therefore admitted: a check that took only the form encoding
+// would turn away a conforming receiver while looking correct against
+// Gmail, which happens to send the other one.
+//
+// Only the URL-encoded form is DECLARED in crm.yaml: naming multipart
+// there would class this route as a file upload and oblige it to declare
+// a megabyte-scale ceiling, which would misdescribe a body that is one
+// short field. The runtime still accepts multipart, which is what keeps
+// the RFC's preferred spelling working.
+//
+// An ABSENT body is admitted too. The product's own unsubscribe page and
+// any operator with curl press this endpoint without one, and refusing
+// them would break the human path to protect a machine contract. Only a
+// body that is present and says something else is refused.
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/platform/httperr"
+)
+
+const (
+	// oneClickField and oneClickValue are the exact pair RFC 8058 §3.2
+	// prescribes, spelled as the RFC spells them.
+	oneClickField = "List-Unsubscribe"
+	oneClickValue = "One-Click"
+	// oneClickBodyLimit leaves room for a multipart envelope's boundary
+	// and headers around a single short field, and nothing more.
+	oneClickBodyLimit = 4096
+)
+
+// requireOneClickBody admits an empty body, either RFC 8058 encoding of
+// the one-click pair, and nothing else.
+func requireOneClickBody(r *http.Request) error {
+	raw := strings.TrimSpace(r.Header.Get("Content-Type"))
+	if raw == "" {
+		// No content type: only an empty body is meaningful, and draining
+		// it keeps the connection reusable. A read failure here is the
+		// client hanging up on a request already decided, so it changes
+		// no verdict — but it is not silently discarded either.
+		if _, err := io.Copy(io.Discard, io.LimitReader(r.Body, oneClickBodyLimit)); err != nil {
+			slog.DebugContext(r.Context(), "one-click unsubscribe body could not be drained", "error", err)
+		}
+		return nil
+	}
+	mediaType, params, err := mime.ParseMediaType(raw)
+	if err != nil {
+		return httperr.Validation("body", "not_one_click", "unreadable content type on a one-click unsubscribe")
+	}
+	switch mediaType {
+	case "multipart/form-data":
+		return oneClickFromMultipart(r, params["boundary"])
+	case "application/x-www-form-urlencoded":
+		return oneClickFromForm(r)
+	default:
+		return httperr.Validation("body", "not_one_click", "a one-click unsubscribe carries the RFC 8058 form body")
+	}
+}
+
+// oneClickFromForm reads the URL-encoded spelling.
+func oneClickFromForm(r *http.Request) error {
+	body, err := io.ReadAll(io.LimitReader(r.Body, oneClickBodyLimit+1))
+	if err != nil {
+		return httperr.Validation("body", "not_one_click", "could not read the one-click body")
+	}
+	if len(body) > oneClickBodyLimit {
+		return httperr.Validation("body", "too_large", "a one-click unsubscribe body is a single short field")
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		return httperr.Validation("body", "not_one_click", "a one-click unsubscribe carries the RFC 8058 form body")
+	}
+	return admitOneClick(values.Get(oneClickField))
+}
+
+// oneClickFromMultipart reads the spelling RFC 8058 names first.
+func oneClickFromMultipart(r *http.Request, boundary string) error {
+	if boundary == "" {
+		return httperr.Validation("body", "not_one_click", "a multipart one-click unsubscribe needs its boundary")
+	}
+	form, err := multipart.NewReader(io.LimitReader(r.Body, oneClickBodyLimit+1), boundary).
+		ReadForm(oneClickBodyLimit)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return httperr.Validation("body", "not_one_click", "a one-click unsubscribe carries the RFC 8058 form body")
+	}
+	// RemoveAll deletes whatever multipart spilled to disk. It cannot
+	// change this request's verdict, but a failure means temp files are
+	// accumulating under an anonymous endpoint, which is worth saying out
+	// loud rather than dropping.
+	defer func() {
+		if err := form.RemoveAll(); err != nil {
+			slog.WarnContext(r.Context(), "one-click unsubscribe left its multipart scratch files behind",
+				"error", err)
+		}
+	}()
+	if len(form.Value[oneClickField]) == 0 {
+		return admitOneClick("")
+	}
+	return admitOneClick(form.Value[oneClickField][0])
+}
+
+// admitOneClick holds the field's value to the one the RFC names.
+func admitOneClick(value string) error {
+	if strings.TrimSpace(value) == oneClickValue {
+		return nil
+	}
+	return httperr.Validation("body", "not_one_click", "a one-click unsubscribe carries the RFC 8058 form body")
+}

--- a/backend/internal/modules/consent/oneclickbody.go
+++ b/backend/internal/modules/consent/oneclickbody.go
@@ -50,12 +50,18 @@ const (
 func requireOneClickBody(r *http.Request) error {
 	raw := strings.TrimSpace(r.Header.Get("Content-Type"))
 	if raw == "" {
-		// No content type: only an empty body is meaningful, and draining
-		// it keeps the connection reusable. A read failure here is the
-		// client hanging up on a request already decided, so it changes
-		// no verdict — but it is not silently discarded either.
-		if _, err := io.Copy(io.Discard, io.LimitReader(r.Body, oneClickBodyLimit)); err != nil {
+		// No content type: only an empty body is meaningful. Read one byte
+		// PAST the ceiling rather than draining to it — a reader stopped at
+		// the limit cannot tell a body that ended from one that went on, so
+		// draining to the cap would accept any size while appearing to
+		// enforce one.
+		n, err := io.Copy(io.Discard, io.LimitReader(r.Body, oneClickBodyLimit+1))
+		if err != nil {
 			slog.DebugContext(r.Context(), "one-click unsubscribe body could not be drained", "error", err)
+			return nil
+		}
+		if n > oneClickBodyLimit {
+			return httperr.Validation("body", "too_large", "a one-click unsubscribe body is a single short field")
 		}
 		return nil
 	}
@@ -97,8 +103,12 @@ func oneClickFromMultipart(r *http.Request, boundary string) error {
 	if boundary == "" {
 		return httperr.Validation("body", "not_one_click", "a multipart one-click unsubscribe needs its boundary")
 	}
-	form, err := multipart.NewReader(io.LimitReader(r.Body, oneClickBodyLimit+1), boundary).
-		ReadForm(oneClickBodyLimit)
+	// The limited reader is kept so the ceiling can be CHECKED after the
+	// parse: multipart stops at its closing boundary and is content with a
+	// valid form followed by any amount of epilogue, so a parser that
+	// merely succeeded proves nothing about the size of what arrived.
+	limited := &countingReader{inner: io.LimitReader(r.Body, oneClickBodyLimit+1)}
+	form, err := multipart.NewReader(limited, boundary).ReadForm(oneClickBodyLimit)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			return nil
@@ -109,12 +119,23 @@ func oneClickFromMultipart(r *http.Request, boundary string) error {
 	// change this request's verdict, but a failure means temp files are
 	// accumulating under an anonymous endpoint, which is worth saying out
 	// loud rather than dropping.
+	// Logged without the request context on purpose: this runs as the
+	// handler unwinds, when that context may already be cancelled, and a
+	// cleanup failure is about the server's disk rather than about this
+	// request.
 	defer func() {
 		if err := form.RemoveAll(); err != nil {
-			slog.WarnContext(r.Context(), "one-click unsubscribe left its multipart scratch files behind",
-				"error", err)
+			slog.Warn("one-click unsubscribe left its multipart scratch files behind", "error", err)
 		}
 	}()
+	// Drain whatever the parser left, so the epilogue counts toward the
+	// ceiling too, then hold it.
+	if _, err := io.Copy(io.Discard, limited); err != nil {
+		slog.DebugContext(r.Context(), "one-click unsubscribe body could not be drained", "error", err)
+	}
+	if limited.read > oneClickBodyLimit {
+		return httperr.Validation("body", "too_large", "a one-click unsubscribe body is a single short field")
+	}
 	if len(form.Value[oneClickField]) == 0 {
 		return admitOneClick("")
 	}
@@ -127,4 +148,17 @@ func admitOneClick(value string) error {
 		return nil
 	}
 	return httperr.Validation("body", "not_one_click", "a one-click unsubscribe carries the RFC 8058 form body")
+}
+
+// countingReader remembers how much passed through it, so a ceiling can be
+// held on a body somebody else's parser consumed.
+type countingReader struct {
+	inner io.Reader
+	read  int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.inner.Read(p)
+	c.read += int64(n)
+	return n, err
 }

--- a/backend/internal/modules/consent/oneclickbody_test.go
+++ b/backend/internal/modules/consent/oneclickbody_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func oneClickRequest(body, contentType string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/public/preferences/tok/unsubscribe", strings.NewReader(body))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return req
+}
+
+// What Gmail sends.
+func TestOneClickAcceptsTheURLEncodedBody(t *testing.T) {
+	if err := requireOneClickBody(
+		oneClickRequest("List-Unsubscribe=One-Click", "application/x-www-form-urlencoded"),
+	); err != nil {
+		t.Errorf("refused the RFC 8058 form body: %v", err)
+	}
+}
+
+// What RFC 8058 §3.2 actually names FIRST. A check written against Gmail
+// alone passes its own tests and turns away a conforming receiver.
+func TestOneClickAcceptsTheMultipartBody(t *testing.T) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	if err := w.WriteField(oneClickField, oneClickValue); err != nil {
+		t.Fatalf("build the multipart body: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close the multipart body: %v", err)
+	}
+	if err := requireOneClickBody(oneClickRequest(buf.String(), w.FormDataContentType())); err != nil {
+		t.Errorf("refused a multipart one-click body: %v", err)
+	}
+}
+
+// The product's own page and any operator with curl send no body at all.
+func TestOneClickAcceptsAnEmptyBody(t *testing.T) {
+	if err := requireOneClickBody(oneClickRequest("", "")); err != nil {
+		t.Errorf("refused an empty body: %v", err)
+	}
+	if err := requireOneClickBody(oneClickRequest("", "application/x-www-form-urlencoded")); err != nil {
+		t.Errorf("refused an empty form body: %v", err)
+	}
+}
+
+// A charset parameter is ordinary and must not change the verdict.
+func TestOneClickToleratesAContentTypeParameter(t *testing.T) {
+	if err := requireOneClickBody(
+		oneClickRequest("List-Unsubscribe=One-Click", "application/x-www-form-urlencoded; charset=utf-8"),
+	); err != nil {
+		t.Errorf("refused a parameterised content type: %v", err)
+	}
+}
+
+// Present and saying something else is the one case that is refused.
+func TestOneClickRefusesABodyThatIsNotOneClick(t *testing.T) {
+	cases := []struct {
+		name, body, contentType string
+	}{
+		{"a form without the pair", "Something=Else", "application/x-www-form-urlencoded"},
+		{"the wrong value", "List-Unsubscribe=Two-Click", "application/x-www-form-urlencoded"},
+		{"json", `{"List-Unsubscribe":"One-Click"}`, "application/json"},
+		{"multipart with no boundary", "whatever", "multipart/form-data"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := requireOneClickBody(oneClickRequest(c.body, c.contentType)); err == nil {
+				t.Error("admitted a body that is not the RFC 8058 one-click pair")
+			}
+		})
+	}
+}
+
+// A single short field has a small ceiling; anything past it is not a
+// mailbox provider following the RFC.
+func TestOneClickRefusesAnOversizedBody(t *testing.T) {
+	huge := "List-Unsubscribe=One-Click&pad=" + strings.Repeat("x", oneClickBodyLimit)
+	if err := requireOneClickBody(oneClickRequest(huge, "application/x-www-form-urlencoded")); err == nil {
+		t.Error("admitted an oversized one-click body")
+	}
+}

--- a/backend/internal/modules/consent/preference.go
+++ b/backend/internal/modules/consent/preference.go
@@ -68,6 +68,13 @@ type PurposeChoice struct {
 	// the client so the switch is never OFFERED as a grant, because the write
 	// refuses it and a control that always fails is worse than an absent one.
 	GrantNeedsConfirmation bool
+	// Choice is what the RECIPIENT decided, derived server-side from the
+	// stored state and the purpose class. The client renders it and never
+	// computes it: 'unknown' reads as off on a consent lane and as on for
+	// direct correspondence, and a page that guessed got that backwards.
+	Choice Choice
+	// CanOptIn: whether this surface may offer a grant at all.
+	CanOptIn bool
 }
 
 // preferenceTokenTTLDays is how long one preference link stays honoured

--- a/backend/internal/modules/consent/preferencesave.go
+++ b/backend/internal/modules/consent/preferencesave.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The preference centre's granular save, in ONE transaction.
+//
+// The rule that shapes this file: a refused GRANT must never cost the
+// WITHDRAWAL saved beside it. Record admits a suppression against any
+// subject and refuses a claim for an archived one, so a save that simply
+// aborted on the first refusal would drop the opt-out of the person who
+// most needs it — somebody who has already asked to be forgotten and is
+// now asking to be left alone. An "all or nothing" save is the obvious
+// shape and the wrong one.
+//
+// So: one commit, withdrawals recorded before grants, and a grant the
+// engine refuses is COLLECTED rather than fatal. Every other error still
+// rolls the whole transaction back, because a fault is not a decision.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// PreferenceChoiceInput is one row of a save, normalized: the key as the
+// engine will read it and a state already parsed.
+type PreferenceChoiceInput struct {
+	PurposeKey string
+	State      ConsentState
+	Wording    *string
+}
+
+// ChoiceOutcome reports one choice the save could not record. Applied
+// choices are not reported: the refreshed purpose list already carries
+// them, and a caller that has to diff two lists to find the failures is
+// a caller that will not bother.
+type ChoiceOutcome struct {
+	PurposeKey string
+	// Reason is a stable code the client renders, never a sentence: the
+	// page is public and its copy is translated.
+	Reason string
+}
+
+// ReasonCannotGrant says the subject cannot be granted this purpose.
+// Today that is an archived — including an Art. 17 anonymized — record,
+// whose erasure destroyed the very capability a fresh grant would re-open.
+const ReasonCannotGrant = "cannot_grant"
+
+// fieldPurposeKey names the purpose in a validation fault and on the wire,
+// so the client reads one spelling.
+const fieldPurposeKey = "purpose_key"
+
+// sourcePreferenceCenter marks every consent row this surface writes, so
+// a proof row says which surface the person used.
+const sourcePreferenceCenter = "preference_center"
+
+// settleTowardWithdrawal collapses a purpose named twice in one save onto
+// its withdrawal. A body carrying both answers for one purpose is a client
+// bug, and on a consent surface the safe reading of it is the suppressing
+// one — never request order, which decides it by accident.
+func settleTowardWithdrawal(choices []PreferenceChoiceInput) []PreferenceChoiceInput {
+	withdrawn := make(map[string]bool, len(choices))
+	for _, c := range choices {
+		if c.State == StateWithdrawn {
+			withdrawn[c.PurposeKey] = true
+		}
+	}
+	out := make([]PreferenceChoiceInput, 0, len(choices))
+	seen := make(map[string]bool, len(choices))
+	for _, c := range choices {
+		if seen[c.PurposeKey] {
+			continue
+		}
+		seen[c.PurposeKey] = true
+		if withdrawn[c.PurposeKey] {
+			c.State = StateWithdrawn
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// PublicSaveChoices records every choice of one save in a single
+// transaction and returns the ones it could not apply.
+//
+// Ordering inside the commit is withdrawals then grants. With one commit
+// that ordering no longer protects the withdrawals — the refusal handling
+// below does — but it keeps the audit trail reading in a fixed order
+// rather than in whatever order a client happened to serialize its form.
+func (s *Store) PublicSaveChoices(
+	ctx context.Context, personID ids.PersonID, choices []PreferenceChoiceInput,
+) ([]ChoiceOutcome, error) {
+	for _, c := range choices {
+		if LockedPurpose(c.PurposeKey) {
+			return nil, &ValidationError{
+				Field:  fieldPurposeKey,
+				Reason: "transactional consent is locked and cannot be changed from the preference center",
+			}
+		}
+	}
+	var refused []ChoiceOutcome
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		refused = nil
+		for _, pass := range []ConsentState{StateWithdrawn, StateGranted} {
+			for _, c := range choices {
+				if c.State != pass {
+					continue
+				}
+				outcome, applied, err := s.saveChoiceTx(ctx, tx, personID, c)
+				if err != nil {
+					return err
+				}
+				if !applied {
+					refused = append(refused, outcome)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return refused, nil
+}
+
+// saveChoiceTx records one choice. A refusal the engine is entitled to
+// make is returned as an outcome; anything else is an error that rolls
+// the save back.
+// The bool is "applied": a refusal the engine is entitled to make is not
+// an error, and a nil outcome beside a nil error would leave the caller
+// guessing which of the two it got.
+func (s *Store) saveChoiceTx(
+	ctx context.Context, tx pgx.Tx, personID ids.PersonID, c PreferenceChoiceInput,
+) (ChoiceOutcome, bool, error) {
+	purposeID, err := purposeByKeyTx(ctx, tx, c.PurposeKey)
+	if err != nil {
+		return ChoiceOutcome{}, false, err
+	}
+	source := sourcePreferenceCenter
+	in := RecordInput{
+		PersonID:   personID,
+		PurposeID:  purposeID,
+		NewState:   string(c.State),
+		Source:     &source,
+		PolicyText: c.Wording,
+	}
+	sub, state, err := admitRecord(ctx, in)
+	if err != nil {
+		return ChoiceOutcome{}, false, err
+	}
+	if _, err := s.recordAdmittedTx(ctx, tx, in, sub, state); err != nil {
+		// A GRANT for an archived subject is refused by the live-row probe,
+		// which answers ErrNotFound. On this surface that is not "no such
+		// record" — the token just resolved it — so it must not reach the
+		// client as a 404, and it must not take the rest of the save with it.
+		if c.State == StateGranted && errors.Is(err, apperrors.ErrNotFound) {
+			return ChoiceOutcome{PurposeKey: c.PurposeKey, Reason: ReasonCannotGrant}, false, nil
+		}
+		return ChoiceOutcome{}, false, err
+	}
+	return ChoiceOutcome{}, true, nil
+}
+
+// PublicWithdrawAll stops the named purposes in one transaction and
+// returns ONLY the ones this call actually changed.
+//
+// That return is the whole point. Record is idempotent, so a replayed
+// press writes nothing — but the old handler still echoed the purpose
+// back, and a page cannot tell a first press from a second one if the
+// answer is identical. Reporting the change makes "you are already
+// unsubscribed" representable instead of showing a fresh confirmation
+// for a no-op.
+func (s *Store) PublicWithdrawAll(
+	ctx context.Context, personID ids.PersonID, purposeKeys []string,
+) ([]string, error) {
+	var changed []string
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		changed = nil
+		for _, key := range purposeKeys {
+			key = normalizedPurposeKey(key)
+			if LockedPurpose(key) {
+				return &ValidationError{
+					Field:  "purpose",
+					Reason: "transactional consent is locked and cannot be withdrawn",
+				}
+			}
+			purposeID, err := purposeByKeyTx(ctx, tx, key)
+			if err != nil {
+				return err
+			}
+			source := sourcePreferenceCenter
+			in := RecordInput{
+				PersonID:  personID,
+				PurposeID: purposeID,
+				NewState:  string(StateWithdrawn),
+				Source:    &source,
+			}
+			sub, state, err := admitRecord(ctx, in)
+			if err != nil {
+				return err
+			}
+			out, err := s.recordAdmittedTx(ctx, tx, in, sub, state)
+			if err != nil {
+				return err
+			}
+			if out.Changed {
+				changed = append(changed, key)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return changed, nil
+}

--- a/backend/internal/modules/consent/preferencesave.go
+++ b/backend/internal/modules/consent/preferencesave.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -153,17 +154,41 @@ func (s *Store) saveChoiceTx(
 	if err != nil {
 		return ChoiceOutcome{}, false, err
 	}
-	if _, err := s.recordAdmittedTx(ctx, tx, in, sub, state); err != nil {
-		// A GRANT for an archived subject is refused by the live-row probe,
-		// which answers ErrNotFound. On this surface that is not "no such
-		// record" — the token just resolved it — so it must not reach the
-		// client as a 404, and it must not take the rest of the save with it.
-		if c.State == StateGranted && errors.Is(err, apperrors.ErrNotFound) {
+	// Whether the subject can take a GRANT at all is asked HERE rather than
+	// read off the error below. ErrNotFound is answered by more than one
+	// thing in the write — a purpose archived between the key lookup and the
+	// proof read answers it too — and a catch-all would report that genuine
+	// fault as an ordinary "you cannot opt in", telling the recipient their
+	// choice was declined when in truth nothing looked at it.
+	if c.State == StateGranted {
+		grantable, err := subjectTakesAGrantTx(ctx, tx, sub)
+		if err != nil {
+			return ChoiceOutcome{}, false, err
+		}
+		if !grantable {
 			return ChoiceOutcome{PurposeKey: c.PurposeKey, Reason: ReasonCannotGrant}, false, nil
 		}
+	}
+	if _, err := s.recordAdmittedTx(ctx, tx, in, sub, state); err != nil {
 		return ChoiceOutcome{}, false, err
 	}
 	return ChoiceOutcome{}, true, nil
+}
+
+// subjectTakesAGrantTx asks the one question the refusal above turns on:
+// is this subject still live enough to claim a lawful basis.
+//
+// The same probe recordAdmittedTx runs for a grant, asked in advance so
+// its refusal can be told apart from every other ErrNotFound in the write.
+func subjectTakesAGrantTx(ctx context.Context, tx pgx.Tx, sub subject) (bool, error) {
+	err := auth.EnsureWritableLive(ctx, tx, sub.entityType, sub.id)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, apperrors.ErrNotFound) {
+		return false, nil
+	}
+	return false, err
 }
 
 // PublicWithdrawAll stops the named purposes in one transaction and

--- a/backend/internal/modules/consent/preferencesave_integration_test.go
+++ b/backend/internal/modules/consent/preferencesave_integration_test.go
@@ -87,14 +87,34 @@ func TestASaveRecordsItsWithdrawalsEvenWhenAGrantIsRefused(t *testing.T) {
 		{"purpose_key":"doi_newsletter","state":"granted"},
 		{"purpose_key":"newsletter","state":"withdrawn"}]}`)
 
-	if rec.Code == http.StatusOK {
-		t.Errorf("status = %d — a grant for an archived subject must still be refused", rec.Code)
+	// 200 with the refusal NAMED, not a 4xx: the withdrawal beside it did
+	// land, and answering "failed" for a save that recorded the suppression
+	// would tell somebody who asked to be left alone that they had not been.
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 with the refusal reported", rec.Code)
 	}
 	if got := consentStateOf(t, e, e.newsletter); got != string(StateWithdrawn) {
 		t.Errorf("newsletter = %q, want withdrawn — the refused grant swallowed the withdrawal beside it", got)
 	}
 	if got := consentStateOf(t, e, e.doiNews); got == string(StateGranted) {
 		t.Error("the grant landed for an archived subject")
+	}
+	// And the save SAYS which choice it could not take, rather than leaving
+	// the page to diff two lists to find out.
+	var body struct {
+		Refused []struct {
+			PurposeKey string `json:"purpose_key"`
+			Reason     string `json:"reason"`
+		} `json:"refused"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode save response: %v", err)
+	}
+	if len(body.Refused) != 1 || body.Refused[0].PurposeKey != "doi_newsletter" {
+		t.Errorf("refused = %+v, want the doi_newsletter grant named", body.Refused)
+	}
+	if len(body.Refused) == 1 && body.Refused[0].Reason != ReasonCannotGrant {
+		t.Errorf("reason = %q, want %q", body.Refused[0].Reason, ReasonCannotGrant)
 	}
 }
 

--- a/backend/internal/modules/consent/preferenceunsubscribe_integration_test.go
+++ b/backend/internal/modules/consent/preferenceunsubscribe_integration_test.go
@@ -140,3 +140,20 @@ func TestUnsubscribeAllLeavesTransactionalAlone(t *testing.T) {
 		t.Error("transactional was withdrawn from the preference centre")
 	}
 }
+
+// A grant the subject cannot take is reported as a refusal, and a purpose
+// that genuinely is not there is NOT: the two both answer ErrNotFound
+// inside the write, and collapsing them would tell a recipient their
+// choice was declined when in truth nothing looked at it.
+func TestAnUnknownPurposeIsAFaultNotARefusal(t *testing.T) {
+	e := setupChannelConsent(t)
+	token := seedPreferenceToken(t, e)
+
+	rec := preferenceSave(t, e, token,
+		`{"choices":[{"purpose_key":"no_such_purpose","state":"granted"}]}`)
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("status = %d — a purpose the catalog does not carry must not read as an ordinary refusal: %s",
+			rec.Code, rec.Body.String())
+	}
+}

--- a/backend/internal/modules/consent/preferenceunsubscribe_integration_test.go
+++ b/backend/internal/modules/consent/preferenceunsubscribe_integration_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// What the one-click unsubscribe endpoint stops, and what it says it
+// stopped. Both were wrong in ways no unit test could see: one reported a
+// change that never happened, the other skipped the exact lane the link
+// was sent under.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// pressUnsubscribe drives the endpoint the way a mailbox provider or the
+// product's own page does, and returns the purposes it reports changing.
+func pressUnsubscribe(t *testing.T, e *channelConsentEnv, token string, purpose *string, body string) []string {
+	t.Helper()
+	h := NewHandlers(database.BindTo(e.store.db.Pool(), ids.From[ids.WorkspaceKind](e.ws)))
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem,
+		ID:   "system:public_preferences",
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/public/preferences/"+token+"/unsubscribe", strings.NewReader(body)).WithContext(ctx)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	rec := httptest.NewRecorder()
+	h.OneClickUnsubscribe(rec, req, token, crmcontracts.OneClickUnsubscribeParams{Purpose: purpose})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Unsubscribed []string `json:"unsubscribed"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode unsubscribe response: %v", err)
+	}
+	return out.Unsubscribed
+}
+
+// A second press is not a second unsubscribe, and the answer has to say
+// so: the page shows "you are already unsubscribed" on an empty array,
+// and the old handler echoed the purpose back either way — so a reader
+// who pressed twice got a fresh confirmation for a no-op.
+func TestAReplayedUnsubscribeReportsNothingChanged(t *testing.T) {
+	e := setupChannelConsent(t)
+	token := seedPreferenceToken(t, e)
+	key := "newsletter"
+
+	first := pressUnsubscribe(t, e, token, &key, "List-Unsubscribe=One-Click")
+	if len(first) != 1 || first[0] != key {
+		t.Fatalf("first press = %v, want [%s]", first, key)
+	}
+	second := pressUnsubscribe(t, e, token, &key, "List-Unsubscribe=One-Click")
+	if len(second) != 0 {
+		t.Errorf("replay = %v, want [] — nothing moved the second time", second)
+	}
+	if got := consentStateOf(t, e, e.newsletter); got != string(StateWithdrawn) {
+		t.Errorf("newsletter = %q, want withdrawn — the replay must not undo it", got)
+	}
+}
+
+// The incident's own case. Direct business correspondence runs on
+// no-objection, so it has no 'granted' row — and an unsubscribe-all that
+// filtered on granted walked straight past the only lane the recipient
+// was actually receiving mail under, while reporting success.
+func TestUnsubscribeAllStopsALiveBusinessCorrespondenceLane(t *testing.T) {
+	e := setupChannelConsent(t)
+	token := seedPreferenceToken(t, e)
+
+	// Seeded HERE with its real class, because the shared env inserts its
+	// purposes by hand and every one of them lands on the 'marketing'
+	// default — so the lane this test is about does not otherwise exist,
+	// and a test that read it from the env would be testing a marketing
+	// purpose under a business name.
+	business := ids.From[ids.PurposeKind](ids.NewV7())
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO consent_purpose (id, key, label, requires_double_opt_in, class)
+		 VALUES ($1, 'business_correspondence', 'Business correspondence', false, $2)`,
+		business, ClassBusinessCorrespondence); err != nil {
+		t.Fatalf("seed the business_correspondence purpose: %v", err)
+	}
+	// Nothing is seeded for it on purpose: no row at all is exactly the
+	// state a person is in when they have simply been written to.
+	if got := consentStateOf(t, e, business); got != "" {
+		t.Fatalf("precondition: business_correspondence = %q, want no row", got)
+	}
+
+	stopped := pressUnsubscribe(t, e, token, nil, "")
+
+	var sawBusiness bool
+	for _, key := range stopped {
+		if key == "business_correspondence" {
+			sawBusiness = true
+		}
+	}
+	if !sawBusiness {
+		t.Errorf("unsubscribe-all reported %v — it must stop the lane the mail was sent under", stopped)
+	}
+	if got := consentStateOf(t, e, business); got != string(StateWithdrawn) {
+		t.Errorf("business_correspondence = %q, want withdrawn", got)
+	}
+}
+
+// Transactional is never withdrawable, and an unsubscribe-all must not
+// try: the reader keeps the password-reset mail they will need.
+func TestUnsubscribeAllLeavesTransactionalAlone(t *testing.T) {
+	e := setupChannelConsent(t)
+	token := seedPreferenceToken(t, e)
+
+	for _, key := range pressUnsubscribe(t, e, token, nil, "") {
+		if key == PurposeTransactional {
+			t.Fatalf("unsubscribe-all withdrew %q", key)
+		}
+	}
+	var state string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT coalesce(max(pc.state), '') FROM person_consent pc
+		   JOIN consent_purpose cp ON cp.id = pc.purpose_id
+		  WHERE pc.person_id = $1 AND cp.key = $2`, e.person, PurposeTransactional).Scan(&state); err != nil {
+		t.Fatalf("read transactional state: %v", err)
+	}
+	if state == string(StateWithdrawn) {
+		t.Error("transactional was withdrawn from the preference centre")
+	}
+}

--- a/backend/internal/modules/consent/preferenceview.go
+++ b/backend/internal/modules/consent/preferenceview.go
@@ -29,6 +29,11 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
+// entityPerson is the subject table the preference centre speaks for. The
+// public surfaces only ever answer for a person: a lead has no mailbox
+// this link could have reached.
+const entityPerson = "person"
+
 // Choice is what the RECIPIENT decided, which is what the checkbox edits.
 type Choice string
 
@@ -60,15 +65,24 @@ type PreferenceView struct {
 
 // PublicPreferenceView reads everything the page needs in one transaction.
 func (s *Store) PublicPreferenceView(ctx context.Context, personID ids.PersonID) (PreferenceView, error) {
-	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+	if err := auth.Require(ctx, entityPerson, principal.ActionRead); err != nil {
 		return PreferenceView{}, err
 	}
 	var view PreferenceView
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		if err := auth.EnsureVisible(ctx, tx, "person", personID.UUID); err != nil {
+		if err := auth.EnsureVisible(ctx, tx, entityPerson, personID.UUID); err != nil {
 			return err
 		}
-		purposes, err := purposeStatesTx(ctx, tx, personID)
+		// Asked once for the whole view: an archived subject cannot take a
+		// grant on ANY purpose, and a page that offered the switch anyway
+		// would invite a choice the save is bound to refuse.
+		grantable, err := subjectTakesAGrantTx(ctx, tx, subject{
+			entityType: entityPerson, id: personID.UUID, column: personIDKey,
+		})
+		if err != nil {
+			return err
+		}
+		purposes, err := purposeStatesTx(ctx, tx, personID, grantable)
 		if err != nil {
 			return err
 		}
@@ -118,7 +132,7 @@ func primaryEmailTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID) (stri
 // phone_outreach is excluded: the verdict blocks it unconditionally
 // because no call path is configured, so offering its switch would offer
 // a control over something that cannot happen.
-func purposeStatesTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID) ([]PurposeChoice, error) {
+func purposeStatesTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID, grantable bool) ([]PurposeChoice, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT cp.key, cp.label, coalesce(pc.state, 'unknown'),
 		       cp.requires_double_opt_in, cp.class
@@ -141,9 +155,10 @@ func purposeStatesTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID) ([]P
 		c.Locked = LockedPurpose(c.Key)
 		c.Choice = choiceOf(state, Class(class))
 		// A locked purpose is not editable at all; otherwise a grant is
-		// offered only where the engine would accept one without a
-		// confirmation round-trip this token cannot evidence.
-		c.CanOptIn = !c.Locked && !c.GrantNeedsConfirmation
+		// offered only where the engine would accept one — without a
+		// confirmation round-trip this token cannot evidence, and against a
+		// subject still live enough to claim a lawful basis.
+		c.CanOptIn = !c.Locked && !c.GrantNeedsConfirmation && grantable
 		out = append(out, c)
 	}
 	return out, rows.Err()

--- a/backend/internal/modules/consent/preferenceview.go
+++ b/backend/internal/modules/consent/preferenceview.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What the public preference page is allowed to know.
+//
+// The page shows the recipient THEIR OWN DECISION and nothing about how
+// the product would treat them. That line matters: a verdict's reason
+// names relationship and timeline facts ("they wrote to you on the 3rd"),
+// and this surface sits behind a link that lives in a mailbox for thirty
+// days. So the wire carries a choice and a permission, never a verdict.
+//
+// It also decides the question the raw consent state cannot answer.
+// person_consent.state is 'unknown' both for a marketing lane nobody has
+// opted into and for business correspondence nobody has objected to —
+// the first is off, the second is on, and a page that rendered the raw
+// value called a live lane "not subscribed". The class decides which.
+
+import (
+	"context"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// Choice is what the RECIPIENT decided, which is what the checkbox edits.
+type Choice string
+
+const (
+	// ChoiceOptedIn means they asked for this.
+	ChoiceOptedIn Choice = "opted_in"
+	// ChoiceOptedOut means they asked us to stop. It overrides every basis.
+	ChoiceOptedOut Choice = "opted_out"
+	// ChoiceNoObjection means they have neither asked for it nor objected.
+	// The honest name for a lane that does not run on consent — direct
+	// business correspondence — where silence is not refusal. Calling it
+	// "subscribed" would misstate the lawful basis to the person it
+	// belongs to.
+	ChoiceNoObjection Choice = "no_objection"
+)
+
+// PreferenceView is the whole public read.
+type PreferenceView struct {
+	// MaskedEmail is the person's primary address, masked. NOT necessarily
+	// the mailbox that received the link: preference_token resolves to a
+	// person, and the delivered address is not recorded. The page shows it
+	// as account context and its copy never claims "this address".
+	MaskedEmail string
+	// WorkspaceName can be empty on an unnamed installation; every string
+	// that interpolates it needs an omission variant.
+	WorkspaceName string
+	Purposes      []PurposeChoice
+}
+
+// PublicPreferenceView reads everything the page needs in one transaction.
+func (s *Store) PublicPreferenceView(ctx context.Context, personID ids.PersonID) (PreferenceView, error) {
+	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+		return PreferenceView{}, err
+	}
+	var view PreferenceView
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		if err := auth.EnsureVisible(ctx, tx, "person", personID.UUID); err != nil {
+			return err
+		}
+		purposes, err := purposeStatesTx(ctx, tx, personID)
+		if err != nil {
+			return err
+		}
+		email, err := primaryEmailTx(ctx, tx, personID)
+		if err != nil {
+			return err
+		}
+		view = PreferenceView{MaskedEmail: MaskEmail(email), Purposes: purposes}
+		return nil
+	})
+	if err != nil {
+		return PreferenceView{}, err
+	}
+	view.WorkspaceName = s.workspaceName(ctx)
+	return view, nil
+}
+
+// primaryEmailSQL selects a person's primary live address, correlated on
+// the column named by ref.
+//
+// A fragment rather than a query, because its two callers need it in
+// different shapes: the preference centre reads the address alone, while
+// the confirm card reads it as one column of the card's single
+// round-trip, and splitting that into a second query to share a helper
+// would cost a round-trip to buy nothing. Sharing the TEXT is what keeps
+// the ordering — is_primary first, then oldest — spelled once. Drop the
+// tiebreak in one copy and two surfaces show the same person two
+// different addresses, each looking right on its own screen.
+//
+// Held by: TestThePreferenceCentreResolvesOnePrimaryAddress (backend/gates/preferencecentrewriters_test.go)
+func primaryEmailSQL(ref string) string {
+	return `coalesce((SELECT pe.email FROM person_email pe
+	                    WHERE pe.person_id = ` + ref + ` AND pe.archived_at IS NULL
+	                    ORDER BY pe.is_primary DESC, pe.created_at LIMIT 1), '')`
+}
+
+// primaryEmailTx reads the address on its own, for the preference centre.
+func primaryEmailTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID) (string, error) {
+	var email string
+	err := tx.QueryRow(ctx, `SELECT `+primaryEmailSQL("$1"), personID).Scan(&email)
+	return email, err
+}
+
+// purposeStatesTx reads the catalog with the recipient's decision on each
+// purpose.
+//
+// phone_outreach is excluded: the verdict blocks it unconditionally
+// because no call path is configured, so offering its switch would offer
+// a control over something that cannot happen.
+func purposeStatesTx(ctx context.Context, tx pgx.Tx, personID ids.PersonID) ([]PurposeChoice, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT cp.key, cp.label, coalesce(pc.state, 'unknown'),
+		       cp.requires_double_opt_in, cp.class
+		  FROM consent_purpose cp
+		  LEFT JOIN person_consent pc ON pc.purpose_id = cp.id AND pc.person_id = $1
+		 WHERE cp.archived_at IS NULL AND cp.class <> $2
+		 ORDER BY cp.key`, personID, ClassPhoneOutreach)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PurposeChoice
+	for rows.Next() {
+		var c PurposeChoice
+		var state, class string
+		if err := rows.Scan(&c.Key, &c.Label, &state, &c.GrantNeedsConfirmation, &class); err != nil {
+			return nil, err
+		}
+		c.State = state
+		c.Locked = LockedPurpose(c.Key)
+		c.Choice = choiceOf(state, Class(class))
+		// A locked purpose is not editable at all; otherwise a grant is
+		// offered only where the engine would accept one without a
+		// confirmation round-trip this token cannot evidence.
+		c.CanOptIn = !c.Locked && !c.GrantNeedsConfirmation
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// choiceOf reads the recipient's decision out of the stored state, which
+// needs the class to be read correctly.
+//
+// 'unknown' means opposite things either side of the consent line: on a
+// marketing lane nobody has opted in, so it is off; on a lane that does
+// not run on consent nobody has objected, so it is on. Transactional is
+// always on and cannot be changed.
+func choiceOf(state string, class Class) Choice {
+	switch ConsentState(state) {
+	case StateWithdrawn:
+		return ChoiceOptedOut
+	case StateGranted:
+		return ChoiceOptedIn
+	}
+	switch class {
+	case ClassTransactional, ClassBusinessCorrespondence:
+		return ChoiceNoObjection
+	default:
+		return ChoiceOptedOut
+	}
+}
+
+// maskedLocalRunes is how many bullets stand in for the local part —
+// FIXED, so the mask does not leak how long the address is.
+const maskedLocalRunes = 5
+
+// MaskEmail shows the first character and the domain: enough for the
+// holder to recognise their own mailbox, not enough to hand the address
+// to somebody who found the link.
+func MaskEmail(addr string) string {
+	addr = strings.TrimSpace(addr)
+	at := strings.LastIndex(addr, "@")
+	if at <= 0 || at == len(addr)-1 {
+		return ""
+	}
+	first, _ := utf8.DecodeRuneInString(addr[:at])
+	if first == utf8.RuneError {
+		return ""
+	}
+	return string(first) + strings.Repeat("•", maskedLocalRunes) + addr[at:]
+}

--- a/backend/internal/modules/consent/preferenceview_test.go
+++ b/backend/internal/modules/consent/preferenceview_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+import "testing"
+
+// The mask has to be recognisable to its owner and useless to anybody
+// else who has found the link.
+func TestMaskedEmailKeepsTheFirstRuneAndTheDomain(t *testing.T) {
+	if got := MaskEmail("marcus@example.com"); got != "m•••••@example.com" {
+		t.Errorf("MaskEmail = %q, want m•••••@example.com", got)
+	}
+}
+
+// A mask whose length tracked the address would hand back how long the
+// local part is, which is a fact about the address nobody asked to share.
+func TestMaskedEmailHidesTheLocalPartLength(t *testing.T) {
+	short := MaskEmail("jo@example.com")
+	long := MaskEmail("jonathan-quentin-smith@example.com")
+	if short != long {
+		t.Errorf("two local parts masked differently: %q vs %q", short, long)
+	}
+}
+
+func TestMaskedEmailOfAMultibyteLocalPart(t *testing.T) {
+	if got := MaskEmail("ünal@x.de"); got != "ü•••••@x.de" {
+		t.Errorf("MaskEmail = %q, want ü•••••@x.de", got)
+	}
+}
+
+// Nothing recognisable, nothing shown — never a bare domain or a stray
+// bullet string that reads like a real address.
+func TestMaskedEmailOfAnUnusableAddressIsEmpty(t *testing.T) {
+	for _, addr := range []string{"", "   ", "not-an-address", "@example.com", "trailing@"} {
+		if got := MaskEmail(addr); got != "" {
+			t.Errorf("MaskEmail(%q) = %q, want empty", addr, got)
+		}
+	}
+}
+
+// The question the raw consent state cannot answer on its own. 'unknown'
+// is off on a lane that runs on consent and ON for one that does not, and
+// reading it without the class is what called a live lane "not subscribed".
+func TestChoiceReadsUnknownAgainstTheClass(t *testing.T) {
+	cases := []struct {
+		name  string
+		state string
+		class Class
+		want  Choice
+	}{
+		{"marketing nobody opted into is off", "unknown", ClassMarketing, ChoiceOptedOut},
+		{"direct correspondence nobody objected to is on", "unknown", ClassBusinessCorrespondence, ChoiceNoObjection},
+		{"transactional is on", "unknown", ClassTransactional, ChoiceNoObjection},
+		{"an explicit grant is an opt-in", "granted", ClassMarketing, ChoiceOptedIn},
+		{"a withdrawal wins on any class", "withdrawn", ClassBusinessCorrespondence, ChoiceOptedOut},
+		{"a withdrawal wins on transactional too", "withdrawn", ClassTransactional, ChoiceOptedOut},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := choiceOf(c.state, c.class); got != c.want {
+				t.Errorf("choiceOf(%q, %q) = %q, want %q", c.state, c.class, got, c.want)
+			}
+		})
+	}
+}
+
+// A purpose named twice in one body is a client bug, and the safe reading
+// of it on a consent surface is the suppressing one — never request order,
+// which decides it by accident.
+func TestASaveSettlesADuplicatePurposeTowardTheWithdrawal(t *testing.T) {
+	out := settleTowardWithdrawal([]PreferenceChoiceInput{
+		{PurposeKey: "newsletter", State: StateGranted},
+		{PurposeKey: "newsletter", State: StateWithdrawn},
+	})
+	if len(out) != 1 {
+		t.Fatalf("got %d choices, want the duplicate collapsed", len(out))
+	}
+	if out[0].State != StateWithdrawn {
+		t.Errorf("state = %q, want withdrawn", out[0].State)
+	}
+}
+
+// The same, with the grant listed second — order must not decide it.
+func TestADuplicateSettlesTheSameWayInEitherOrder(t *testing.T) {
+	out := settleTowardWithdrawal([]PreferenceChoiceInput{
+		{PurposeKey: "newsletter", State: StateWithdrawn},
+		{PurposeKey: "newsletter", State: StateGranted},
+	})
+	if len(out) != 1 || out[0].State != StateWithdrawn {
+		t.Errorf("got %+v, want one withdrawn choice", out)
+	}
+}

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -27,6 +27,11 @@ type Store struct {
 	// db binds the installation's workspace itself (ADR-0091 §9 step 3).
 	db  *database.DB
 	now func() time.Time
+	// installationName answers what to call this installation on the public
+	// preference page. Injected because the name lives in identity and a
+	// module never imports a sibling; nil on any installation that has not
+	// wired it, which the page renders as an omission rather than a blank.
+	installationName InstallationNameReader
 }
 
 // NewStore binds the store to the pool every read and write runs through.
@@ -49,6 +54,13 @@ type State struct {
 	LawfulBasis            *string
 	DoubleOptInConfirmedAt *time.Time
 	UpdatedAt              *time.Time
+	// Changed says whether this call MOVED the record. False for an
+	// idempotent re-assertion and for a capture that declined to override
+	// a decision already on file. The preference centre's unsubscribe
+	// endpoint reports only what it actually changed, so a recipient who
+	// presses the link twice is told the truth the second time rather
+	// than being shown a fresh confirmation for a no-op.
+	Changed bool
 }
 
 type ProofEvent struct {
@@ -392,7 +404,7 @@ func (s *Store) recordAdmittedTx(
 	}
 	if current == in.NewState {
 		out = State{PurposeID: in.PurposeID, PurposeKey: purposeKey, State: current, LawfulBasis: in.LawfulBasis}
-		return out, nil // idempotent re-assertion: no proof row, no event, no fresh token demanded
+		return out, nil // idempotent re-assertion: no proof row, no event, no fresh token demanded (Changed stays false)
 	}
 	if in.NeverOverrideExisting && current != "" {
 		out = State{PurposeID: in.PurposeID, PurposeKey: purposeKey, State: current}
@@ -426,6 +438,7 @@ func (s *Store) recordAdmittedTx(
 	out = State{
 		PurposeID: in.PurposeID, PurposeKey: purposeKey, State: in.NewState,
 		LawfulBasis: in.LawfulBasis, DoubleOptInConfirmedAt: doiConfirmedAt, UpdatedAt: &capturedAt,
+		Changed: true,
 	}
 	return out, nil
 }

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -274,20 +274,13 @@ func (s *Service) Login(ctx context.Context, email, plaintext string) (Identity,
 		}
 
 		id = Identity{UserID: account.UserID, WorkspaceID: wsID, Email: email, DisplayName: account.DisplayName, SeatType: account.SeatType}
-		// The setting row read directly, not through platform/settings: this
-		// runs BEFORE a principal exists, and that package's readers take the
-		// installation_settings object gate, which has no actor to judge. The
-		// name is the installation's own label, not tenant data.
-		//
-		// coalesced, and to the empty string rather than an error: this is a
-		// display label on a login that has ALREADY succeeded. An installation
-		// with no stored name is a misconfiguration, and failing here would
-		// answer correct credentials with a 500 while wrong ones still got
-		// 401 — telling an attacker which passwords are right.
-		if err := tx.QueryRow(ctx,
-			`SELECT coalesce((SELECT value #>> '{}' FROM setting WHERE key = $1), '')`, Name.Key(),
-		).Scan(&id.WorkspaceName); err != nil {
-			return err
+		// Failing here would answer correct credentials with a 500 while
+		// wrong ones still got 401 — telling an attacker which passwords
+		// are right — so InstallationNameOf coalesces an absent row to
+		// the empty string rather than erroring.
+		var nameErr error
+		if id.WorkspaceName, nameErr = InstallationNameOf(ctx, tx); nameErr != nil {
+			return nameErr
 		}
 		var loadErr error
 		id.Roles, id.Teams, id.Permissions, loadErr = loadGrants(ctx, tx, account.UserID)

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -358,3 +358,36 @@ func BaseLanguageForPrompt(ctx context.Context, pool *pgxpool.Pool) string {
 	}
 	return lang
 }
+
+// InstallationNameOf reads the installation's own display label inside a
+// transaction the caller already holds.
+//
+// The setting row is read directly rather than through platform/settings:
+// this answers surfaces that run with no principal to judge the
+// installation_settings object gate — the login that has not built one
+// yet, and the public preference page, which has no seat at all. The name
+// is the installation's own label, not tenant data.
+//
+// Coalesced to the empty string rather than an error, for the same reason
+// the login does it: this is a display label, and an installation with no
+// stored name is a misconfiguration that must not turn a working page
+// into a 500.
+func InstallationNameOf(ctx context.Context, tx pgx.Tx) (string, error) {
+	var name string
+	err := tx.QueryRow(ctx,
+		`SELECT coalesce((SELECT value #>> '{}' FROM setting WHERE key = $1), '')`, Name.Key(),
+	).Scan(&name)
+	return name, err
+}
+
+// InstallationNameForPublicPage answers the installation's label for a
+// surface holding only a pool — the public preference centre's seam.
+func InstallationNameForPublicPage(ctx context.Context, pool *pgxpool.Pool) (string, error) {
+	var name string
+	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		var err error
+		name, err = InstallationNameOf(ctx, tx)
+		return err
+	})
+	return name, err
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -75,7 +75,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (78)
+## Census (79)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -140,6 +140,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `personprofilefieldwriter_test.go` | H2 | people.writePersonProfileField is the one writer of person\_profile\_field, and the one place the precedence rule lives: a machine fill claims an unanswered field, a human's acceptance replaces what is there. |
 | `piicoverage_test.go` | H2 | PII reach as a fitness function. |
 | `precheckwiring_test.go` | H2 | A precheck that exists but is not wired protects nothing. |
+| `preferencecentrewriters_test.go` | H2 | The public preference centre answers in ONE shape, and resolves "which address is theirs" in ONE place. |
 | `profilefieldreaders_test.go` | H2 | person\_profile\_field holds what a machine ASSERTED about a person, and ai\_feedback holds what a human then decided about that assertion. |
 | `projectionedgereaders_test.go` | H2 | The projection tier's read census. |
 | `promptlanguage_test.go` | H1 | Every prompt this product sends says what language to answer in, or says plainly why it does not need to. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3914,7 +3914,9 @@ export interface paths {
          *     (source `preference_center`) which the default-deny suppression gate honors on the very next send
          *     across every path (manual + agent). Idempotent. Only POST acts — a GET/prefetch by a mail scanner
          *     never unsubscribes anyone (the reason RFC 8058 mandates POST). With `purpose` only that purpose is
-         *     withdrawn (the one the message was sent under); without it every withdrawable purpose is.
+         *     withdrawn (the one the message was sent under); without it every lane the recipient has not already
+         *     stopped is — read from their `choice`, not the raw stored state, so direct correspondence running on
+         *     no-objection is included rather than silently skipped.
          */
         post: operations["oneClickUnsubscribe"];
         delete?: never;
@@ -22633,18 +22635,55 @@ export interface components {
          *     cannot perform.
          */
         PreferenceCenter: {
+            /**
+             * @description The recipient's primary address, masked to its first character and domain. Account CONTEXT, not
+             *     the scope of any action: the token resolves to a person and the delivered address is not recorded,
+             *     so a person with several addresses may see a different one than the message reached. Client copy
+             *     must not claim "this address". Empty when no address is on file.
+             */
+            masked_email: string;
+            /** @description The installation's own display label. Empty on an unnamed installation; copy needs an omission variant. */
+            workspace_name: string;
+            /**
+             * @description Choices the save could not record, by name. Present and empty on a read. A refused GRANT never
+             *     costs the WITHDRAWAL saved beside it, so a save reports what did not apply rather than failing whole.
+             */
+            refused: {
+                purpose_key: string;
+                /**
+                 * @description cannot_grant: the subject is archived, so a fresh grant would re-open a capability their erasure destroyed.
+                 * @enum {string}
+                 */
+                reason: "cannot_grant";
+            }[];
             purposes: {
                 key: string;
                 label: string;
-                /** @enum {string} */
+                /**
+                 * @description The raw stored state. Prefer `choice`, which reads it correctly for the purpose class.
+                 * @enum {string}
+                 */
                 state: "unknown" | "granted" | "withdrawn";
                 /** @description A locked purpose (transactional) cannot be changed from this surface. */
                 locked: boolean;
                 /**
-                 * @description A purpose requiring double opt-in. Withdrawing it here works; GRANTING it does not, because
-                 *     this surface's token is reusable and long-lived, so it cannot evidence one deliberate choice
-                 *     the way a confirmation round-trip does. A client must not offer the grant — the write refuses
-                 *     it with 422, and an offered switch that always fails is worse than an absent one.
+                 * @description What the RECIPIENT decided, derived server-side. `state: unknown` means opposite things either
+                 *     side of the consent line — on a marketing lane nobody has opted in, on direct correspondence
+                 *     nobody has objected — so a client that rendered the raw state called a live lane "not
+                 *     subscribed". Render this; never re-derive it. It is a recorded decision, never a delivery
+                 *     verdict: whether mail can actually be sent also depends on facts this surface must not disclose.
+                 * @enum {string}
+                 */
+                choice: "opted_in" | "opted_out" | "no_objection";
+                /**
+                 * @description Whether this surface may offer a grant at all. False for a locked purpose and for one needing a
+                 *     confirmation round-trip that a reusable, long-lived token cannot evidence. A control that always
+                 *     fails is worse than an absent one.
+                 */
+                can_opt_in: boolean;
+                /**
+                 * @description DEPRECATED, kept for one release as the inverse of `can_opt_in` on unlocked purposes. Read
+                 *     `can_opt_in` instead.
                  */
                 grant_needs_confirmation: boolean;
             }[];
@@ -32017,7 +32056,7 @@ export interface operations {
     oneClickUnsubscribe: {
         parameters: {
             query?: {
-                /** @description The consent purpose key to withdraw. Omit to withdraw every non-transactional purpose. */
+                /** @description The consent purpose key to withdraw. Omit to withdraw every lane the recipient has not already stopped. */
                 purpose?: string;
             };
             header?: never;
@@ -32026,7 +32065,23 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        /**
+         * @description RFC 8058 §3.2 prescribes `List-Unsubscribe=One-Click`, naming multipart/form-data as the SHOULD and
+         *     URL-encoding as the MAY. The handler accepts BOTH; only the URL-encoded form is declared here,
+         *     because declaring multipart would class this as a file upload and oblige it to carry a
+         *     megabyte-scale ceiling — which would misdescribe a route whose entire body is one short field
+         *     (the handler caps it at 4 KiB). An ABSENT body is accepted too: the product's own unsubscribe page
+         *     and an operator with curl carry none, and refusing them would break the human path to protect a
+         *     machine contract. A body that is present and says something else is refused.
+         */
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": {
+                    /** @enum {string} */
+                    "List-Unsubscribe"?: "One-Click";
+                };
+            };
+        };
         responses: {
             /** @description Unsubscribed (idempotent). */
             200: {
@@ -32035,7 +32090,11 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        /** @description The purpose keys now withdrawn. */
+                        /**
+                         * @description The purpose keys this call actually CHANGED. Empty on a replay, because the recipient was
+                         *     already unsubscribed — which is how the page tells a first press from a second one instead
+                         *     of showing a fresh confirmation for a no-op.
+                         */
                         unsubscribed: string[];
                     };
                 };


### PR DESCRIPTION
A German sales email sent through Margince carried two footer links that did not work, and this is the first of the changes that fix them. It closes the three defects that live in the consent module; the send path's URL model and the new pages follow separately.

## What was wrong

**Unsubscribe-all skipped the lane it was sent under.** The selection filtered on a stored `granted` row. Direct business correspondence runs on no-objection and has no such row, so "unsubscribe from everything" walked past the only lane a recipient was actually receiving mail under — and reported success. It now reads the recipient's derived choice, the same value the page draws the row from.

**A replayed press claimed to change something.** The handler echoed the purpose back whether or not the write moved anything, so a second click was indistinguishable from the first and the page could not say "you are already unsubscribed". `Record` now reports whether it moved the record and the response carries only what changed.

**The page could not tell a live lane from an unsubscribed one.** `person_consent.state` is `unknown` both for a marketing lane nobody opted into and for correspondence nobody objected to — off in one case, on in the other. The client was left to guess and guessed wrong. The server now derives `choice` and `can_opt_in`; the client renders them and never re-derives eligibility, which also depends on facts this surface must not disclose.

## Alongside

- The save commits in one transaction, but a grant refused for an archived subject is reported by name rather than taking the save with it. An all-or-nothing save would roll back the withdrawal beside it and answer 404 to somebody asking to be left alone — `TestASaveRecordsItsWithdrawalsEvenWhenAGrantIsRefused` proves it, and mutation-checking that path was how the regression was caught before it shipped.
- RFC 8058 bodies are validated, accepting multipart — the encoding the RFC names first, and one a check written against Gmail alone would have refused.
- `Cache-Control: no-store` on the whole public preference edge, set before any refusal so a 404 or a rate-limit answer is no more cacheable than a successful one.
- The GET exposes a masked address and the installation name. The masked address is account context, never the scope of an action: the token resolves to a person and the delivered address is not recorded.

## Notes

Two uniqueness claims in the new code are held by a gate rather than asserted in a comment — which immediately found the confirm card keeping its own copy of the primary-address ordering, now shared.

Deferred and filed: #3413 (the page can name a primary address when the link went to a secondary one — needs a column on `preference_token`), #3414 (unsubscribe-all selects and withdraws in separate transactions).

Local gate green, consent integration lane green, craft static clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the unsubscribe link so it stops the lane the mail was sent under, including no-objection business correspondence, and reports only what actually changed.

- Unsubscribe-all now selects lanes from the recipient's derived choice instead of raw stored state.
- A replayed press returns an empty `unsubscribed` list, so the page can tell "already unsubscribed" from a fresh confirmation.
- The server now exposes `choice` and `can_opt_in` per purpose; the client never re-derives eligibility.
- The save runs in one transaction, but a refused grant for an archived subject is reported by name rather than rolling back the withdrawals beside it.
- RFC 8058 one-click bodies accept both multipart and URL-encoded forms under a 4 KiB cap.
- Public preference responses carry `Cache-Control: no-store`, set before any refusal.

<sup>Written for commit dd7326302cc090df602a06540b34a1ea9a287846. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the public preference center with masked email, workspace name, current choices, and opt-in availability.
  * Added support for saving multiple preferences at once, including clear refusal results when consent cannot be granted.
  * Improved one-click unsubscribe support for empty, URL-encoded, and multipart requests.
  * Unsubscribe responses now report only purposes whose status changed.

* **Bug Fixes**
  * Replayed unsubscribe requests are handled idempotently.
  * Public preference pages are no longer cached.
  * Added validation for unknown purposes and oversized or invalid unsubscribe requests.

* **Documentation**
  * Updated API reference documentation and gate inventory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->