### PR TITLE
fix(person): the bought-data tab shows a lookup while it is happening

### DIFF
--- a/backend/internal/compose/integration/providerprofile_integration_test.go
+++ b/backend/internal/compose/integration/providerprofile_integration_test.go
@@ -278,3 +278,65 @@ func seedNarrowRun(t *testing.T, e *Env, personID ids.UUID, category string) {
 		t.Fatal(err)
 	}
 }
+
+// The page must not say nobody asked for a value it is showing.
+//
+// Claims outlive the runs that fetched them: a merge relinks the losing side's
+// purchases onto the survivor, and a seeded or imported installation holds
+// claims with no run at all. Deciding "never asked for" from the run history
+// alone printed that sentence directly above the mobile number it was denying.
+func TestACategoryOnThePageIsNeverCalledUnrequested(t *testing.T) {
+	e := Setup(t)
+	connectProvider(t, e)
+	personID := seedSubject(t, e)
+	// A purchase with NO run behind it, which is what a merge or a seed leaves.
+	seedOrphanClaim(t, e, personID, "mobile_phones",
+		`[{"value": "+49 170 0000000"}]`)
+	// Plus a run that asked for something else entirely, so the list is built
+	// from a run history that never mentions the mobile.
+	seedNarrowRun(t, e, personID, "linkedin_profile")
+
+	page, err := person360Service(e).Assemble(e.Admin(), ids.From[ids.PersonKind](personID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := sectionFor(t, page, "surfe")
+	if len(profile.MobilePhones) == 0 {
+		t.Fatal("the seeded number is not on the page, so this case cannot prove anything")
+	}
+	for _, named := range profile.CategoriesNotRequested {
+		if named == "mobile" {
+			t.Error("categories_not_requested names \"mobile\" while the page shows a mobile " +
+				"number — the reader is told nobody bought the thing they are looking at")
+		}
+	}
+}
+
+// seedOrphanClaim writes a stored claim with no run of its own, the way a merge
+// relink and a seeded installation both leave one.
+func seedOrphanClaim(t *testing.T, e *Env, personID ids.UUID, key, value string) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		var runID string
+		if err := tx.QueryRow(context.Background(), `
+			INSERT INTO provider_run
+			  (subject_kind, person_id, provider, trigger, state, input_fingerprint,
+			   external_correlation_id, connection_version, connection_epoch,
+			   configuration_snapshot, requested_categories, completed_at)
+			VALUES ('person', $1, 'surfe', 'manual', 'completed', $2,
+			        gen_random_uuid(), 1, 1, '{}'::jsonb, ARRAY['job_history'], now())
+			RETURNING id::text`, personID, "fp-orphan-"+personID.String()).Scan(&runID); err != nil {
+			return err
+		}
+		// The claim names a category that run never requested — which is exactly
+		// the shape a relink leaves behind.
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO person_provider_claim
+			  (person_id, run_id, provider, claim_key, value_json, source, captured_by, retrieved_at)
+			VALUES ($1, $2, 'surfe', $3, $4::jsonb, 'provider', 'connector:surfe', now())`,
+			personID, runID, key, value)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/compose/integrationswiring.go
+++ b/backend/internal/compose/integrationswiring.go
@@ -135,7 +135,7 @@ func providerClaimWriter(ctx context.Context, tx pgx.Tx, w integrations.ClaimWri
 
 // providerStoredClaimApplier folds a purchase the domain already stored onto
 // the record, for the catch-up sweep.
-func providerStoredClaimApplier(ctx context.Context, tx pgx.Tx, personID, runID string) error {
+func providerStoredClaimApplier(ctx context.Context, tx pgx.Tx, personID, runID string) (bool, error) {
 	return people.ApplyStoredProviderClaims(ctx, tx, personID, runID)
 }
 

--- a/backend/internal/compose/person360/providerprofile.go
+++ b/backend/internal/compose/person360/providerprofile.go
@@ -230,11 +230,16 @@ type providerRunRow struct {
 	connectionVersion int64
 	state             string
 	claimsUnwritten   bool
-	safeCode          string
-	requested         []string
-	skipReason        string
-	createdAt         time.Time
-	completedAt       *time.Time
+	// Whether this run's answers have been offered to the record. The page
+	// waits on it: the apply commits AFTER the run completes, so a client
+	// that stopped at the terminal state would refresh one step before the
+	// values it is waiting for exist.
+	applied     bool
+	safeCode    string
+	requested   []string
+	skipReason  string
+	createdAt   time.Time
+	completedAt *time.Time
 }
 
 // providerRuns reads this person's run history, newest first. Scrubbed runs
@@ -243,6 +248,7 @@ type providerRunRow struct {
 func (s *Service) providerRuns(ctx context.Context, tx pgx.Tx, personID ids.PersonID) ([]providerRunRow, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT id, provider, trigger, connection_version, state, claims_unwritten,
+		       applied_at IS NOT NULL,
 		       coalesce(last_safe_status_code, ''), coalesce(skip_reason, ''),
 		       requested_categories, created_at, completed_at
 		  FROM provider_run
@@ -256,7 +262,7 @@ func (s *Service) providerRuns(ctx context.Context, tx pgx.Tx, personID ids.Pers
 	for rows.Next() {
 		var r providerRunRow
 		if err := rows.Scan(&r.id, &r.providerName, &r.trigger, &r.connectionVersion, &r.state, &r.claimsUnwritten,
-			&r.safeCode, &r.skipReason, &r.requested, &r.createdAt, &r.completedAt); err != nil {
+			&r.applied, &r.safeCode, &r.skipReason, &r.requested, &r.createdAt, &r.completedAt); err != nil {
 			return nil, fmt.Errorf("person360: scanning a provider run: %w", err)
 		}
 		out = append(out, r)
@@ -283,6 +289,7 @@ func toWireRun(r providerRunRow) crmcontracts.ProviderRun {
 		Trigger:             crmcontracts.ProviderRunTrigger(r.trigger),
 		State:               crmcontracts.ProviderRunState(r.state),
 		ClaimsUnwritten:     r.claimsUnwritten,
+		Applied:             &r.applied,
 		RequestedCategories: r.requested,
 		ConnectionVersion:   r.connectionVersion,
 		CreatedAt:           r.createdAt,
@@ -310,19 +317,22 @@ func contributingRuns(runs []providerRunRow) []crmcontracts.ProviderRun {
 // is the page's answer to a blank field: "we never asked" is a different fact
 // from "we asked and they had nothing", and only this list tells them apart.
 //
-// An EARLIER run counts only where its answer is still on the page. Reading the
-// latest run alone made the section contradict itself — buy a mobile for
-// somebody whose profile link was bought last week, and this line named the
-// profile link as never requested while the profile link was printed two inches
-// above it. Counting every earlier run instead would open the opposite gap:
-// categories_without_answer is the LATEST run's receipt by contract, so a
+// Two things take a category off this list, and they answer the question from
+// opposite ends. The LATEST run's own requests count whatever they returned,
+// because its receipt is rendered beside this list and already says what came
+// back empty. And any category whose value is ON THE PAGE counts, whatever the
+// run history says.
+//
+// The second is what stops the section contradicting itself. Reading runs alone
+// printed "never asked for: mobile number" directly above a mobile number,
+// because claims outlive the runs that fetched them: a merge relinks the losing
+// side's purchases to the survivor, and a seeded or imported installation holds
+// claims with no run at all.
+//
+// Counting every earlier RUN instead would open the opposite gap:
+// categories_without_answer is the latest run's receipt by contract, so a
 // category an older run asked about and got nothing for would leave this list
 // without entering that one, and vanish from the page entirely.
-//
-// Delivering a claim is the test that closes both. A category whose value the
-// reader can see is plainly not one nobody asked for, and a category with
-// nothing to show stays here — which is the honest answer to the blank field
-// they are looking at.
 func categoriesNotRequested(desc provider.Descriptor, runs []providerRunRow, claims []storedClaim) []string {
 	// Claim KEYS, which are not category names — `professional_email` is asked
 	// for and `professional_emails` comes back. desc.Answers owns that mapping
@@ -338,16 +348,23 @@ func categoriesNotRequested(desc provider.Descriptor, runs []providerRunRow, cla
 			// The latest run's own requests count whatever it returned: its
 			// receipt is rendered beside this list, so a category it asked
 			// about and got nothing for is already accounted for there.
-			if r.id == runs[0].id || answeredBy(desc.Answers[provider.Category(c)], delivered) {
+			if r.id == runs[0].id {
 				asked[c] = true
 			}
 		}
 	}
 	out := []string{}
 	for _, c := range desc.Categories {
-		if !asked[string(c)] {
-			out = append(out, string(c))
+		// A category whose value is ON THE PAGE is never one nobody asked for,
+		// whatever the run history says. Claims outlive the runs that fetched
+		// them — a merge relinks the losing side's purchases to the survivor,
+		// and a seeded or imported installation holds claims with no run at all
+		// — so deciding this from runs alone printed "never asked for: mobile
+		// number" directly above the mobile number.
+		if asked[string(c)] || answeredBy(desc.Answers[c], delivered) {
+			continue
 		}
+		out = append(out, string(c))
 	}
 	sort.Strings(out)
 	return out

--- a/backend/internal/modules/integrations/backfill_integration_test.go
+++ b/backend/internal/modules/integrations/backfill_integration_test.go
@@ -17,6 +17,7 @@ package integrations
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -244,4 +245,64 @@ func TestAHumanCanProbeADegradedConnection(t *testing.T) {
 				"transient vendor condition becomes a sustained one", status)
 		}
 	}
+}
+
+// A completed run with no claims stored yet must not be recorded as applied.
+//
+// The terminal state commits in one transaction and the hand-off writes the
+// claims in the next, so a sweep tick landing between them finds a completed
+// run with nothing to fold. Treating that as success stamps applied_at over a
+// purchase the record never received — and applied_at is what a waiting client
+// reads, so it stops one step before the values exist and nothing comes back to
+// say they arrived.
+func TestASweepDoesNotCallAnEmptyRunApplied(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	runID := seedCompletedRunWithoutClaims(t, e)
+
+	var applied int
+	e.store.WithStoredClaimApplier(
+		func(context.Context, pgx.Tx, string, string) (bool, error) {
+			applied++
+			// What the real applier answers with nothing stored.
+			return false, nil
+		})
+	e.store.WithSubjectHold(
+		func(context.Context, pgx.Tx, string) (FenceVerdict, error) {
+			return FenceVerdict{Allowed: true}, nil
+		})
+
+	if err := e.store.applyStoredPurchases(e.ctx, "surfe"); err != nil {
+		t.Fatal(err)
+	}
+	if applied == 0 {
+		t.Fatal("the sweep never reached the run, so this case proves nothing about the stamp")
+	}
+
+	var stamped *time.Time
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT applied_at FROM provider_run WHERE id = $1`, runID).Scan(&stamped); err != nil {
+		t.Fatal(err)
+	}
+	if stamped != nil {
+		t.Error("a run with no stored claims was stamped as applied: the page stops waiting " +
+			"on that stamp, so the values land after nothing is watching for them")
+	}
+}
+
+// seedCompletedRunWithoutClaims is the window between the terminal commit and
+// the hand-off: completed, not exhausted, and holding nothing.
+func seedCompletedRunWithoutClaims(t *testing.T, e *runsEnv) string {
+	t.Helper()
+	var runID string
+	if err := e.owner.QueryRow(context.Background(), `
+		INSERT INTO provider_run
+		  (subject_kind, person_id, provider, trigger, state, input_fingerprint,
+		   external_correlation_id, connection_version, connection_epoch,
+		   configuration_snapshot, requested_categories, completed_at)
+		VALUES ('person', $1, 'surfe', 'manual', 'completed', $2,
+		        gen_random_uuid(), 1, 1, '{}'::jsonb, ARRAY['linkedin_profile'], now())
+		RETURNING id::text`, e.mine, "fp-unstored-"+e.mine.String()).Scan(&runID); err != nil {
+		t.Fatal(err)
+	}
+	return runID
 }

--- a/backend/internal/modules/integrations/backfillselect.go
+++ b/backend/internal/modules/integrations/backfillselect.go
@@ -207,8 +207,15 @@ func (s *Store) applyOneStored(ctx context.Context, tx pgx.Tx, runID, personID s
 		// gives for the same reason.
 		return s.discardClaims(ctx, tx, runID)
 	}
-	if err := s.applyStoredClaims(ctx, tx, personID, runID); err != nil {
+	applied, err := s.applyStoredClaims(ctx, tx, personID, runID)
+	if err != nil {
 		return err
+	}
+	if !applied {
+		// Nothing was stored yet: the hand-off that writes the claims has not
+		// committed. Left unstamped so the next tick tries again, rather than
+		// recorded as applied over a record that never received anything.
+		return nil
 	}
 	if _, err := tx.Exec(ctx,
 		`UPDATE provider_run SET applied_at = now() WHERE id = $1`, runID); err != nil {

--- a/backend/internal/modules/integrations/handoff.go
+++ b/backend/internal/modules/integrations/handoff.go
@@ -75,7 +75,14 @@ type WriteClaimsFunc func(ctx context.Context, tx pgx.Tx, w ClaimWrite) error
 // Its own callback rather than a second use of WriteClaimsFunc: that one takes
 // the claims it is about to store, and a sweep has none to hand over. Passing an
 // empty slice would make the writer's contract depend on which caller it was.
-type ApplyStoredClaimsFunc func(ctx context.Context, tx pgx.Tx, personID, runID string) error
+//
+// It reports whether it FOUND anything to apply. A run reaches its terminal
+// state in one transaction and its claims arrive in the next, so a sweep landing
+// in that window sees a completed run with nothing stored — and treating that as
+// applied stamps a purchase that has not reached the record. The stamp is what a
+// waiting client reads, so the false one stops it one step before the values
+// exist and nothing comes back to say they arrived.
+type ApplyStoredClaimsFunc func(ctx context.Context, tx pgx.Tx, personID, runID string) (applied bool, err error)
 
 // WithStoredClaimApplier binds it. Without it the sweep applies nothing and
 // says so by leaving applied_at NULL, which is the honest record for a build

--- a/backend/internal/modules/people/providerclaimapply.go
+++ b/backend/internal/modules/people/providerclaimapply.go
@@ -177,19 +177,26 @@ func connectorCapturedBy(providerName string) string { return "connector:" + pro
 // One statement's difference from the hand-off path, and everything after it is
 // shared: a purchase applied late must land exactly as one applied on arrival,
 // or the record would depend on when the sweep happened to reach it.
-func ApplyStoredProviderClaims(ctx context.Context, tx pgx.Tx, personID, runID string) error {
+// It answers whether there was anything to apply. A run commits its terminal
+// state before the hand-off writes its claims, so a sweep can arrive between the
+// two and find none — and the caller must not record that as applied.
+func ApplyStoredProviderClaims(ctx context.Context, tx pgx.Tx, personID, runID string) (bool, error) {
 	claims, err := storedClaimsOfRun(ctx, tx, runID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if len(claims) == 0 {
-		return nil
+		return false, nil
 	}
 	providerName, err := claimProviderOfRun(ctx, tx, runID)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return ApplyProviderClaims(ctx, tx, runID, personID, providerName, claims)
+	// Applied is about having FOUND the purchase, not about any field moving:
+	// a run whose values the record already held has been folded, and telling a
+	// waiting client otherwise would keep it waiting for a change that is never
+	// coming.
+	return true, ApplyProviderClaims(ctx, tx, runID, personID, providerName, claims)
 }
 
 // storedClaimsOfRun reads back what one run bought, in the shape the applier

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6728,6 +6728,8 @@ export const de = {
     "Diesen Kontakt hat noch niemand nachgeschlagen.",
   "provider.profile.queued": "In der Warteschlange",
   "provider.profile.inProgress": "Wird nachgeschlagen …",
+  "provider.profile.working":
+    "{provider} wird gefragt. Das dauert bis zu einer Minute.",
   "provider.profile.completed": "Gefunden",
   "provider.profile.noMatch": "Der Anbieter hatte nichts zu diesem Kontakt.",
   "provider.profile.stale":
@@ -6739,7 +6741,7 @@ export const de = {
   "provider.profile.rateLimited":
     "Nicht gekauft: der Anbieter hat uns gebremst.",
   "provider.profile.providerError":
-    "Der letzte Aufruf beim Anbieter ist fehlgeschlagen, deshalb werden automatische Abfragen zurückgehalten. Drücken Sie unten die kostenlose Prüfung — eine, die durchkommt, hebt das von selbst auf.",
+    "Der letzte Aufruf beim Anbieter ist fehlgeschlagen. Automatische Abfragen pausieren; eine kostenlose Prüfung, die durchkommt, setzt sie fort.",
   "provider.profile.submissionUnknown":
     "Wie diese Abfrage ausgegangen ist, haben wir nie erfahren. Sie kann berechnet worden sein.",
   "provider.profile.claimsUnwritten":
@@ -6762,8 +6764,7 @@ export const de = {
   "provider.profile.location": "Standort",
   "provider.profile.departments": "Bereiche",
   "provider.profile.seniorities": "Ebene",
-  "provider.profile.notRequested":
-    "Nicht angefragt: {categories}. Eine Lücke heißt hier, dass niemand danach gekauft hat — nicht, dass der Anbieter nichts hatte.",
+  "provider.profile.notRequested": "Nie angefragt: {categories}.",
   "provider.profile.buy": "{category} kaufen · {credits} Credit",
   "provider.freeTier.hint":
     "LinkedIn-Profil, aktuelle Rolle und Werdegang kosten keine Credits. Am besten anlassen: jeder neue Kontakt bekommt sie, ohne dass jemand entscheiden muss.",
@@ -6772,8 +6773,7 @@ export const de = {
   "provider.profile.receiptAt": "Abgefragt am {at}.",
   "provider.profile.receipt":
     "Abgefragt am {at} · {asked} Angaben angefragt, {answered} zurückbekommen.",
-  "provider.profile.noAnswer":
-    "Angefragt und nicht gefunden: {categories}. Der Anbieter wurde gefragt und hatte zu diesem Kontakt nichts.",
+  "provider.profile.noAnswer": "Angefragt, nichts gefunden: {categories}.",
   "provider.category.professionalEmail": "geschäftliche E-Mail",
   "provider.category.personalEmail": "private E-Mail",
   "provider.category.mobile": "Mobilnummer",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6730,6 +6730,8 @@ export const de = {
   "provider.profile.inProgress": "Wird nachgeschlagen …",
   "provider.profile.working":
     "{provider} wird gefragt. Das dauert bis zu einer Minute.",
+  "provider.profile.landing":
+    "Antwort da. Sie wird in den Datensatz übernommen.",
   "provider.profile.completed": "Gefunden",
   "provider.profile.noMatch": "Der Anbieter hatte nichts zu diesem Kontakt.",
   "provider.profile.stale":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6791,6 +6791,7 @@ export const en = {
   "provider.profile.queued": "Queued",
   "provider.profile.inProgress": "Looking them up…",
   "provider.profile.working": "Asking {provider}. This takes up to a minute.",
+  "provider.profile.landing": "Answer received. Putting it on the record.",
   "provider.profile.completed": "Found",
   "provider.profile.noMatch": "The provider had nothing for this contact.",
   "provider.profile.stale":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6790,6 +6790,7 @@ export const en = {
   "provider.profile.neverRun": "Nobody has looked this contact up yet.",
   "provider.profile.queued": "Queued",
   "provider.profile.inProgress": "Looking them up…",
+  "provider.profile.working": "Asking {provider}. This takes up to a minute.",
   "provider.profile.completed": "Found",
   "provider.profile.noMatch": "The provider had nothing for this contact.",
   "provider.profile.stale":
@@ -6801,7 +6802,7 @@ export const en = {
   "provider.profile.rateLimited":
     "Not bought: the provider asked us to slow down.",
   "provider.profile.providerError":
-    "The provider failed on its last call, so automatic lookups are held back. Press the free check below — one that gets through clears this by itself.",
+    "The last call to the provider failed. Automatic lookups are paused; a free check that gets through resumes them.",
   "provider.profile.submissionUnknown":
     "We never learned how this lookup ended. It may have been charged for.",
   "provider.profile.claimsUnwritten":
@@ -6824,8 +6825,7 @@ export const en = {
   "provider.profile.location": "Location",
   "provider.profile.departments": "Departments",
   "provider.profile.seniorities": "Seniority",
-  "provider.profile.notRequested":
-    "Not asked for: {categories}. A blank here means nobody bought it, not that the provider had nothing.",
+  "provider.profile.notRequested": "Never asked for: {categories}.",
   // The receipt. Without it a lookup that returned one detail out of six read
   // exactly like one that returned all six, and nothing on the page said when
   // the answer arrived.
@@ -6838,8 +6838,7 @@ export const en = {
   "provider.profile.receiptAt": "Looked up {at}.",
   "provider.profile.receipt":
     "Looked up {at} · asked for {asked} details, got {answered} back.",
-  "provider.profile.noAnswer":
-    "Asked for and not found: {categories}. The provider was asked and had nothing for this contact.",
+  "provider.profile.noAnswer": "Asked for, none found: {categories}.",
   // The provider's own vocabulary, in words a reader knows. Not translated
   // one-for-one from the key: these are what a rep would call the thing.
   "provider.category.professionalEmail": "work email",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6655,6 +6655,7 @@ export const vi = {
   "provider.profile.neverRun": "Chưa ai tra cứu liên hệ này.",
   "provider.profile.queued": "Trong hàng đợi",
   "provider.profile.inProgress": "Đang tra cứu…",
+  "provider.profile.working": "Đang hỏi {provider}. Việc này mất tới một phút.",
   "provider.profile.completed": "Đã tìm thấy",
   "provider.profile.noMatch": "Nhà cung cấp không có gì về liên hệ này.",
   "provider.profile.stale":
@@ -6666,7 +6667,7 @@ export const vi = {
   "provider.profile.rateLimited":
     "Không mua: nhà cung cấp yêu cầu chúng ta chậm lại.",
   "provider.profile.providerError":
-    "Lần gọi gần nhất tới nhà cung cấp đã thất bại, nên các lượt tra cứu tự động đang bị giữ lại. Hãy nhấn nút kiểm tra miễn phí bên dưới — một lượt thành công sẽ tự gỡ trạng thái này.",
+    "Lần gọi gần nhất tới nhà cung cấp đã thất bại. Tra cứu tự động đang tạm dừng; một lượt kiểm tra miễn phí thành công sẽ tiếp tục chúng.",
   "provider.profile.submissionUnknown":
     "Chúng ta không bao giờ biết lượt tra cứu này kết thúc ra sao. Nó có thể đã bị tính phí.",
   "provider.profile.claimsUnwritten":
@@ -6689,8 +6690,7 @@ export const vi = {
   "provider.profile.location": "Địa điểm",
   "provider.profile.departments": "Bộ phận",
   "provider.profile.seniorities": "Cấp bậc",
-  "provider.profile.notRequested":
-    "Không hỏi tới: {categories}. Chỗ trống ở đây nghĩa là không ai mua, chứ không phải nhà cung cấp không có.",
+  "provider.profile.notRequested": "Chưa bao giờ hỏi tới: {categories}.",
   "provider.profile.buy": "Mua {category} · {credits} tín dụng",
   "provider.freeTier.hint":
     "Hồ sơ LinkedIn, vai trò hiện tại và quá trình làm việc không tốn tín dụng. Nên bật: mọi liên hệ mới đều có chúng mà không ai phải quyết định.",
@@ -6699,8 +6699,7 @@ export const vi = {
   "provider.profile.receiptAt": "Tra cứu ngày {at}.",
   "provider.profile.receipt":
     "Tra cứu ngày {at} · đã hỏi {asked} thông tin, nhận về {answered}.",
-  "provider.profile.noAnswer":
-    "Đã hỏi nhưng không tìm thấy: {categories}. Nhà cung cấp đã được hỏi và không có gì về liên hệ này.",
+  "provider.profile.noAnswer": "Đã hỏi, không có: {categories}.",
   "provider.category.professionalEmail": "email công việc",
   "provider.category.personalEmail": "email cá nhân",
   "provider.category.mobile": "số di động",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6656,6 +6656,7 @@ export const vi = {
   "provider.profile.queued": "Trong hàng đợi",
   "provider.profile.inProgress": "Đang tra cứu…",
   "provider.profile.working": "Đang hỏi {provider}. Việc này mất tới một phút.",
+  "provider.profile.landing": "Đã có câu trả lời. Đang ghi vào hồ sơ.",
   "provider.profile.completed": "Đã tìm thấy",
   "provider.profile.noMatch": "Nhà cung cấp không có gì về liên hệ này.",
   "provider.profile.stale":

--- a/frontend/src/screens/personprovider.stories.tsx
+++ b/frontend/src/screens/personprovider.stories.tsx
@@ -185,6 +185,42 @@ export const InProgress: Story = {
 };
 
 /**
+ * A lookup running under a connection whose LAST call failed — the state a
+ * reader is most likely to be pressing from, because the failure message tells
+ * them to press it.
+ *
+ * The section reports the connection's condition ahead of the run, which is
+ * right for a page at rest and wrong here: it named a failure from hours ago
+ * over a lookup that was working. The header now says what is happening and the
+ * line above the values says who is being asked.
+ */
+export const RunningOnAnImpairedConnection: Story = {
+  render: section(
+    profile({
+      state: "provider_error",
+      latest_run: {
+        ...completedProviderRun,
+        state: "in_progress",
+        applied: false,
+      },
+    }),
+  ),
+};
+
+/**
+ * Bought, and the values have not reached the record yet. The apply commits
+ * AFTER the run completes, so a page that stopped watching at `completed`
+ * refreshed one step before the thing being waited for existed.
+ */
+export const CompletedButNotYetApplied: Story = {
+  render: section(
+    profile({
+      latest_run: { ...completedProviderRun, applied: false },
+    }),
+  ),
+};
+
+/**
  * The credential the provider was bought through has expired. An operator
  * fault rather than a data one, so it says which — a generic failure here would
  * send somebody looking at the person instead of at the connection.

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -3,7 +3,11 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import type { components } from "../api/schema";
-import { PersonProviderSection } from "./personprovider";
+import {
+  keepPolling,
+  PersonProviderSection,
+  POLL_LIMIT,
+} from "./personprovider";
 import {
   completedProviderRun,
   providerCompletedProfile,
@@ -580,6 +584,23 @@ describe("watching a run that is still moving", () => {
     applied: false,
   });
 
+  // A run the platform stops advancing leaves its flags exactly as they are,
+  // and every ordinary way out of `stillMoving` is a state the platform writes.
+  // Without a ceiling an open tab asks after it every 2.5 seconds until it is
+  // closed — so the page gives up, which is a thing a reader can see.
+  it("stops asking after a run the platform never finishes", () => {
+    const stuck = {
+      ...completedProviderRun,
+      id: "run-stuck",
+      applied: false,
+    };
+    // The rule is still true about the run itself: this is a ceiling on asking,
+    // not a claim that the run finished.
+    expect(keepPolling(stuck, 0)).toBe(true);
+    expect(keepPolling(stuck, POLL_LIMIT - 1)).toBe(true);
+    expect(keepPolling(stuck, POLL_LIMIT)).toBe(false);
+  });
+
   // The half a reader can see. The poll below is what makes the page correct;
   // this is what stops it looking broken while it works.
   it("says a lookup is happening, and does not report the old failure over it", async () => {
@@ -605,6 +626,68 @@ describe("watching a run that is still moving", () => {
     // live one, which is what sent Lars looking for a broken button.
     expect(screen.queryByText(/last call to the provider failed/)).toBeNull();
     expect(await screen.findByText("Looking them up…")).toBeDefined();
+  });
+
+  // Two phases, and the reader is told which. Once the provider has answered,
+  // saying "asking Surfe" reports work nobody is doing — the vendor is done and
+  // the values are being folded onto the record.
+  it("says the answer is landing once the provider has finished", async () => {
+    const unapplied = {
+      ...completedProviderRun,
+      id: "run-landing",
+      applied: false,
+    };
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"] }),
+      "GET /people/p-1/enrichment-runs/run-landing": () =>
+        jsonResponse(unapplied),
+    });
+    render(
+      <StoryProviders>
+        <PersonProviderSection
+          personId="p-1"
+          profiles={[
+            { ...neverRun(), state: "completed", latest_run: unapplied },
+          ]}
+        />
+      </StoryProviders>,
+    );
+
+    expect(
+      await screen.findByText("Answer received. Putting it on the record."),
+    ).toBeDefined();
+    expect(screen.queryByText(/Asking Surfe/)).toBeNull();
+  });
+
+  // The money case. The server's duplicate-spend fence covers the LIVE run
+  // states only, so a completed-but-unapplied run is buyable again — and the
+  // claim has not landed yet, so nothing else hides the button either. Two
+  // presses, two charges, for one detail.
+  it("offers no purchase button while a run's values are still landing", async () => {
+    const unapplied = {
+      ...completedProviderRun,
+      id: "run-landing-2",
+      applied: false,
+    };
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"] }),
+      "GET /people/p-1/enrichment-runs/run-landing-2": () =>
+        jsonResponse(unapplied),
+    });
+    render(
+      <StoryProviders>
+        <PersonProviderSection
+          personId="p-1"
+          profiles={[
+            { ...neverRun(), state: "completed", latest_run: unapplied },
+          ]}
+        />
+      </StoryProviders>,
+    );
+
+    await screen.findByText("Answer received. Putting it on the record.");
+    expect(screen.queryByRole("button", { name: /Buy / })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Check again/ })).toBeNull();
   });
 
   it("polls a live run even while the connection reads as failed", async () => {

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -367,7 +367,7 @@ describe("a lookup that came back mostly empty", () => {
   it("names the categories the provider had nothing for, in words a rep knows", async () => {
     mount(mostlyEmpty(), queuedRun);
 
-    const line = await screen.findByText(/Asked for and not found/);
+    const line = await screen.findByText(/Asked for, none found/);
     // The provider's vocabulary is a set of keys — `professional_email`,
     // `linkedin_profile`. Printed raw they are not words anybody uses.
     expect(line.textContent).toContain("work email");
@@ -559,5 +559,131 @@ describe("the details that cost credits", () => {
     await screen.findByText(providerCompletedProfile.emails[0].value);
     expect(screen.queryByRole("button", { name: /Buy work email/ })).toBeNull();
     expect(screen.queryByRole("button", { name: /Buy mobile/ })).toBeNull();
+  });
+});
+
+// The watch arms off the RUN, never off the section's state.
+//
+// The section answers "what should this reader know about enrichment here", and
+// the CONNECTION's condition outranks the run history in that answer — so on a
+// connection that last failed, the section reads provider_error while a run the
+// reader just started is genuinely in flight. Arming off the section left the
+// watch asleep through exactly that lookup: it completed, the page never
+// re-read, and for the half-minute it took the button looked dead. That is the
+// state a reader is MOST likely to be pressing from, because the message beside
+// it tells them to.
+describe("watching a run that is still moving", () => {
+  const inFlight = (): components["schemas"]["ProviderRun"] => ({
+    ...completedProviderRun,
+    id: "run-live",
+    state: "in_progress",
+    applied: false,
+  });
+
+  // The half a reader can see. The poll below is what makes the page correct;
+  // this is what stops it looking broken while it works.
+  it("says a lookup is happening, and does not report the old failure over it", async () => {
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"] }),
+      "GET /people/p-1/enrichment-runs/run-live": () =>
+        jsonResponse(inFlight()),
+    });
+    render(
+      <StoryProviders>
+        <PersonProviderSection
+          personId="p-1"
+          profiles={[
+            { ...neverRun(), state: "provider_error", latest_run: inFlight() },
+          ]}
+        />
+      </StoryProviders>,
+    );
+
+    expect(await screen.findByText(/Asking Surfe/)).toBeDefined();
+    // The connection's last failure is real and belongs on the page at rest.
+    // Over a lookup the reader is watching it is a stale fact dressed as a
+    // live one, which is what sent Lars looking for a broken button.
+    expect(screen.queryByText(/last call to the provider failed/)).toBeNull();
+    expect(await screen.findByText("Looking them up…")).toBeDefined();
+  });
+
+  it("polls a live run even while the connection reads as failed", async () => {
+    let polls = 0;
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"] }),
+      "GET /people/p-1/enrichment-runs/run-live": () => {
+        polls += 1;
+        return jsonResponse(inFlight());
+      },
+    });
+    render(
+      <StoryProviders>
+        <PersonProviderSection
+          personId="p-1"
+          profiles={[
+            // The section is impaired; the run underneath it is not.
+            { ...neverRun(), state: "provider_error", latest_run: inFlight() },
+          ]}
+        />
+      </StoryProviders>,
+    );
+
+    await expect.poll(() => polls).toBeGreaterThan(0);
+  });
+
+  // A run whose values have not been folded onto the record yet is not done
+  // from this page's point of view: the apply commits AFTER the run completes,
+  // so a watch that stopped at `completed` refreshed one step before the thing
+  // the reader is waiting for existed.
+  it("keeps watching a completed run until its values are applied", async () => {
+    let polls = 0;
+    const unapplied = {
+      ...completedProviderRun,
+      id: "run-unapplied",
+      applied: false,
+    };
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"] }),
+      "GET /people/p-1/enrichment-runs/run-unapplied": () => {
+        polls += 1;
+        return jsonResponse(unapplied);
+      },
+    });
+    render(
+      <StoryProviders>
+        <PersonProviderSection
+          personId="p-1"
+          profiles={[
+            { ...neverRun(), state: "completed", latest_run: unapplied },
+          ]}
+        />
+      </StoryProviders>,
+    );
+
+    await expect.poll(() => polls).toBeGreaterThan(0);
+  });
+
+  // And it stops. A watch with no end condition is a request every 2.5 seconds
+  // for as long as the tab is open.
+  it("does not watch a run whose values are already on the record", async () => {
+    let polls = 0;
+    installFetchStub({
+      "GET /me": meRoute({ person: ["read", "update"] }),
+      "GET /people/p-1/enrichment-runs/run-1": () => {
+        polls += 1;
+        return jsonResponse(completedProviderRun);
+      },
+    });
+    render(
+      <StoryProviders>
+        <PersonProviderSection
+          personId="p-1"
+          profiles={[providerCompletedProfile]}
+        />
+      </StoryProviders>,
+    );
+
+    await screen.findByRole("button", { name: /Check again/ });
+    expect(polls).toBe(0);
   });
 });

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -146,6 +146,11 @@ function ProviderPanel({
   // cannot answer: it reports the connection's condition ahead of the run, so
   // a live run under a connection that last failed reads as provider_error.
   const running = stillMoving(profile.latest_run);
+  // Two phases, and the reader cares which. `asking` is the provider working;
+  // `landing` is the provider done and the values being folded onto the record.
+  // Both keep the watch alive, and saying "asking Surfe" over the second one
+  // reports work nobody is doing — the vendor has already answered.
+  const asking = running && profile.latest_run?.state !== "completed";
   // The vendor as the reader should see it named. Spelled once and used by
   // both the heading and the plate: two spellings would let a section headed
   // "Surfe" explain a purchase from "surfe".
@@ -179,8 +184,12 @@ function ProviderPanel({
         // `in_progress` rather than with a tone picked here: a local answer
         // would be a second opinion about what running looks like, and the two
         // would drift the first time the shared one changed.
-        <Badge tone={profileTone(running ? "in_progress" : profile.state)}>
-          {t(profileLabel(running ? "in_progress" : profile.state))}
+        <Badge tone={profileTone(asking ? "in_progress" : profile.state)}>
+          {t(
+            asking
+              ? "provider.profile.inProgress"
+              : profileLabel(profile.state),
+          )}
         </Badge>
       }
       actions={
@@ -191,6 +200,7 @@ function ProviderPanel({
             enrich={enrich}
             free={free}
             catalogPending={catalogPending}
+            running={running}
             // This contact has already been looked up, so the press is a
             // RE-CHECK: same free details, asked again because a job may have
             // changed. The empty-state twin below is the first lookup and says
@@ -218,7 +228,9 @@ function ProviderPanel({
             caveat about what is under it. */}
         {running && (
           <Callout tone="info" live="status">
-            {t("provider.profile.working", { provider: name })}
+            {asking
+              ? t("provider.profile.working", { provider: name })
+              : t("provider.profile.landing")}
           </Callout>
         )}
         {firstRun ? (
@@ -231,6 +243,7 @@ function ProviderPanel({
                 enrich={enrich}
                 free={free}
                 catalogPending={catalogPending}
+                running={running}
               />
             }
           >
@@ -239,7 +252,12 @@ function ProviderPanel({
         ) : (
           <ProviderValues profile={profile} />
         )}
-        <BuyPriced personId={personId} profile={profile} enrich={enrich} />
+        <BuyPriced
+          personId={personId}
+          profile={profile}
+          enrich={enrich}
+          running={running}
+        />
         <RunWatch personId={personId} profile={profile} />
       </PanelBody>
     </Panel>
@@ -258,10 +276,15 @@ function BuyPriced({
   personId,
   profile,
   enrich,
+  running,
 }: Readonly<{
   personId: string;
   profile: Profile;
   enrich: ReturnType<typeof useEnrichRun>;
+  // Whether a run is still moving, from the panel that already asked. Not
+  // recomputed here: two answers to "is a lookup happening" would drift, and
+  // the one that drifts wrong leaves a spending button on screen.
+  running: boolean;
 }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -277,7 +300,7 @@ function BuyPriced({
       (connection?.configuration.categories?.[entry.category] ?? false) &&
       !alreadyHeld(profile, entry.category),
   );
-  if (buyable.length === 0 || !canEnrichNow(profile.state)) {
+  if (buyable.length === 0 || !canEnrichNow(profile.state, running)) {
     return null;
   }
   return (
@@ -583,10 +606,14 @@ function EnrichNow({
   enrich,
   free,
   catalogPending,
+  running,
   recheck = false,
   small = false,
 }: Readonly<{
   free: string[];
+  /** Whether a run is still moving. See canEnrichNow: the section state alone
+   *  cannot answer it, and a button offered over a live run spends twice. */
+  running: boolean;
   // Whether the connection catalog has answered yet. Separate from `free`
   // being empty, which a connection selling nothing free also produces.
   catalogPending: boolean;
@@ -602,7 +629,7 @@ function EnrichNow({
   small?: boolean;
 }>) {
   const t = useT();
-  if (!canEnrichNow(profile.state)) {
+  if (!canEnrichNow(profile.state, running)) {
     return null;
   }
   return (
@@ -686,9 +713,41 @@ function useRunWatch(personId: string, profile: Profile) {
     // The same rule the arming uses, read from the answer just received rather
     // than from the prop: the prop only changes when the page refetches, which
     // is the thing this poll exists to cause.
-    refetchInterval: (query) => (stillMoving(query.state.data) ? 2500 : false),
+    //
+    // Under a CEILING, because the rule alone has no end. Every ordinary route
+    // out of `stillMoving` is a state the platform writes — a terminal run, an
+    // exhausted hand-off — so a run the workers stop advancing leaves these
+    // flags exactly as they are, and a tab left open asks for it every 2.5
+    // seconds until it is closed. The ceiling turns that into a page that
+    // stopped waiting, which is a thing a reader can see and act on.
+    refetchInterval: (query) =>
+      keepPolling(query.state.data, query.state.dataUpdateCount)
+        ? POLL_EVERY_MS
+        : false,
   });
 }
+
+/** Whether the page asks after this run again.
+ *
+ *  The rule and its ceiling in one place, so a test can put the ceiling to it
+ *  without waiting out ten minutes of real interval. */
+export function keepPolling(
+  run: components["schemas"]["ProviderRun"] | undefined,
+  asked: number,
+): boolean {
+  return stillMoving(run) && asked < POLL_LIMIT;
+}
+
+const POLL_EVERY_MS = 2500;
+
+/** How many times the page asks after a run before giving up on it.
+ *
+ *  Ten minutes at POLL_EVERY_MS. Long enough to cover the slowest honest path —
+ *  the hand-off's retry ladder, which ends by writing `claims_unwritten` and
+ *  stopping the watch on its own — and short enough that a genuinely stuck run
+ *  stops costing a request every few seconds for as long as somebody leaves the
+ *  tab open. */
+export const POLL_LIMIT = 240;
 
 /** The run states that are still moving. `submitting` counts: the run is
  *  mid-flight to the provider, and treating it as finished would offer a

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -3,25 +3,25 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Search } from "lucide-react";
+import type { ReactNode } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { Badge, Button, EmptyState } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { EvidenceMark } from "../design-system/evidencemark";
-import { Eyebrow } from "../design-system/eyebrow";
+import { type Fact, FactList } from "../design-system/factlist";
 import { Panel, PanelBody } from "../design-system/panel";
 import {
   ProviderMark,
   providerBrandName,
 } from "../design-system/provider-mark";
 import { formatDateAbbrev, formatNumber } from "../format/format";
-import { useLocale, useT } from "../i18n";
+import { type Locale, useLocale, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 import { categoryNames } from "./provider-categories";
 import {
   canEnrichNow,
-  isRunning,
   profileLabel,
   profileTone,
   useProviderConnections,
@@ -142,6 +142,10 @@ function ProviderPanel({
   // says never_run and carries purchases, and a plate reading "nothing bought"
   // over somebody's bought mobile number invites paying for it twice.
   const firstRun = profile.state === "never_run" && !hasValues(profile);
+  // Whether a lookup is happening RIGHT NOW, which the section's own state
+  // cannot answer: it reports the connection's condition ahead of the run, so
+  // a live run under a connection that last failed reads as provider_error.
+  const running = stillMoving(profile.latest_run);
   // The vendor as the reader should see it named. Spelled once and used by
   // both the heading and the plate: two spellings would let a section headed
   // "Surfe" explain a purchase from "surfe".
@@ -164,8 +168,19 @@ function ProviderPanel({
         </span>
       }
       titleAction={
-        <Badge tone={profileTone(profile.state)}>
-          {t(profileLabel(profile.state))}
+        // A live run outranks the section's own state in the HEADER, which is
+        // the one place the two disagree honestly. The section state answers
+        // "what should this reader know about enrichment here" and puts the
+        // connection's condition first — right for a page at rest, wrong over
+        // a lookup the reader is watching, where it reports a failure from
+        // hours ago as though it were the thing happening now.
+        //
+        // Through the same two maps every other state uses, asked with
+        // `in_progress` rather than with a tone picked here: a local answer
+        // would be a second opinion about what running looks like, and the two
+        // would drift the first time the shared one changed.
+        <Badge tone={profileTone(running ? "in_progress" : profile.state)}>
+          {t(profileLabel(running ? "in_progress" : profile.state))}
         </Badge>
       }
       actions={
@@ -193,6 +208,17 @@ function ProviderPanel({
           // it is a skipped run, and the state badge above says which.
           <Callout tone="danger" live="alert">
             {problemMessageOf(enrich.error, t)}
+          </Callout>
+        )}
+        {/* A lookup takes about half a minute, and for that half-minute the
+            panel used to be identical to one where nothing had happened: no
+            line, no change, the same buttons. A reader who pressed and saw
+            nothing move concluded the button was broken, which was the only
+            conclusion available to them. Above the values, because it is a
+            caveat about what is under it. */}
+        {running && (
+          <Callout tone="info" live="status">
+            {t("provider.profile.working", { provider: name })}
           </Callout>
         )}
         {firstRun ? (
@@ -361,115 +387,11 @@ function RunReceipt({ profile }: Readonly<{ profile: Profile }>) {
 
 function ProviderValues({ profile }: Readonly<{ profile: Profile }>) {
   const t = useT();
-  const { locale } = useLocale();
-  const source = boughtFrom(profile);
+  const facts = useProviderFacts(profile);
   return (
     <>
       <RunReceipt profile={profile} />
-      {profile.emails.length > 0 && (
-        <div>
-          <Eyebrow as="h4">{t("provider.profile.emails")}</Eyebrow>
-          {profile.emails.map((email) => (
-            <div key={email.value}>
-              <EvidenceMark value={email.value} source={source} />{" "}
-              {email.email_type && (
-                <span className="t-caption">
-                  {/* Which label this is, and WHOSE it is. An address the
-                      provider did not classify is labelled from what we
-                      asked for, and saying so is the whole point of the
-                      distinction. */}
-                  {email.email_type_source === "provider"
-                    ? t("provider.profile.emailType.provider", {
-                        type: email.email_type,
-                      })
-                    : t("provider.profile.emailType.requested", {
-                        type: email.email_type,
-                      })}
-                </span>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-      {profile.mobile_phones.length > 0 && (
-        <div>
-          <Eyebrow as="h4">{t("provider.profile.mobiles")}</Eyebrow>
-          {profile.mobile_phones.map((phone) => (
-            <div key={phone.value}>
-              <EvidenceMark value={phone.value} source={source} />{" "}
-              {phone.confidence != null && (
-                <span className="t-caption">
-                  {t("provider.profile.confidence", {
-                    percent: formatNumber(
-                      Math.round(phone.confidence * 100),
-                      locale,
-                    ),
-                  })}
-                </span>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-      {profile.linkedin_url && (
-        <div>
-          <Eyebrow as="h4">{t("provider.profile.linkedin")}</Eyebrow>
-          <EvidenceMark value={profile.linkedin_url} source={source} />
-        </div>
-      )}
-      {profile.current_employment && (
-        <div>
-          <Eyebrow as="h4">{t("provider.profile.employment")}</Eyebrow>
-          <EvidenceMark
-            value={[
-              profile.current_employment.job_title,
-              profile.current_employment.company_name,
-            ]
-              .filter(Boolean)
-              .join(" · ")}
-            source={source}
-          />
-        </div>
-      )}
-      {profile.job_history.length > 0 && (
-        <div>
-          <Eyebrow as="h4">{t("provider.profile.jobHistory")}</Eyebrow>
-          {profile.job_history.map((job) => (
-            <div key={`${job.company_name}-${job.job_title ?? ""}`}>
-              <EvidenceMark
-                value={[job.job_title, job.company_name]
-                  .filter(Boolean)
-                  .join(" · ")}
-                source={source}
-              />
-            </div>
-          ))}
-        </div>
-      )}
-      {profile.location && (
-        <div>
-          <Eyebrow as="h4">{t("provider.profile.location")}</Eyebrow>
-          <EvidenceMark value={profile.location} source={source} />
-        </div>
-      )}
-      {profile.departments.length > 0 && (
-        <div>
-          <Eyebrow as="h4">{t("provider.profile.departments")}</Eyebrow>
-          <EvidenceMark
-            value={profile.departments.join(", ")}
-            source={source}
-          />
-        </div>
-      )}
-      {profile.seniorities.length > 0 && (
-        <div>
-          <Eyebrow as="h4">{t("provider.profile.seniorities")}</Eyebrow>
-          <EvidenceMark
-            value={profile.seniorities.join(", ")}
-            source={source}
-          />
-        </div>
-      )}
+      <FactList facts={facts} />
       {(profile.categories_without_answer?.length ?? 0) > 0 && (
         // What was PAID for and came back empty. The other half of the same
         // question as the line below, and the half that was missing: a run
@@ -497,6 +419,127 @@ function ProviderValues({ profile }: Readonly<{ profile: Profile }>) {
       )}
     </>
   );
+}
+
+/** Every bought value as one label→value table.
+ *
+ *  Nine stacked `<div><Eyebrow/>…</div>` blocks before this, each styling
+ *  itself: a reader scanning for the mobile number read nine headings down the
+ *  card instead of one column of labels. `FactList` is the catalog's primitive
+ *  for exactly this shape and it is what every other record surface uses.
+ *
+ *  Rows are BUILT rather than rendered conditionally, because FactList takes an
+ *  array: a fact with no value is left out entirely, and an empty `<dd>` would
+ *  claim we know the value and it is blank.
+ */
+function useProviderFacts(profile: Profile): Fact[] {
+  const t = useT();
+  const { locale } = useLocale();
+  const source = boughtFrom(profile);
+  const mark = (value: string) => (
+    <EvidenceMark value={value} source={source} />
+  );
+  return [
+    ...reachFacts(profile, t, locale, mark),
+    ...roleFacts(profile, t, mark),
+  ];
+}
+
+type Translate = ReturnType<typeof useT>;
+type Mark = (value: string) => ReactNode;
+
+/** How to reach them: the addresses and numbers somebody paid for, each with
+ *  the qualifier that decides whether to trust it. */
+function reachFacts(
+  profile: Profile,
+  t: Translate,
+  locale: Locale,
+  mark: Mark,
+): Fact[] {
+  const facts: Fact[] = profile.emails.map((email) => ({
+    key: `email-${email.value}`,
+    term: t("provider.profile.emails"),
+    value: mark(email.value),
+    // Which label this is, and WHOSE it is. An address the provider did not
+    // classify is labelled from what we asked for, and saying so is the whole
+    // point of the distinction.
+    note: email.email_type
+      ? t(
+          email.email_type_source === "provider"
+            ? "provider.profile.emailType.provider"
+            : "provider.profile.emailType.requested",
+          { type: email.email_type },
+        )
+      : undefined,
+  }));
+  for (const phone of profile.mobile_phones) {
+    facts.push({
+      key: `phone-${phone.value}`,
+      term: t("provider.profile.mobiles"),
+      value: mark(phone.value),
+      note:
+        phone.confidence == null
+          ? undefined
+          : t("provider.profile.confidence", {
+              percent: formatNumber(Math.round(phone.confidence * 100), locale),
+            }),
+    });
+  }
+  if (profile.linkedin_url) {
+    facts.push({
+      key: "linkedin",
+      term: t("provider.profile.linkedin"),
+      value: mark(profile.linkedin_url),
+    });
+  }
+  return facts;
+}
+
+/** Who they are: where they work now, where they worked before, and the three
+ *  attributes the provider files them under. */
+function roleFacts(profile: Profile, t: Translate, mark: Mark): Fact[] {
+  const facts: Fact[] = [];
+  if (profile.current_employment) {
+    facts.push({
+      key: "employment",
+      term: t("provider.profile.employment"),
+      value: mark(roleLine(profile.current_employment)),
+    });
+  }
+  for (const job of profile.job_history) {
+    facts.push({
+      key: `job-${job.company_name}-${job.job_title ?? ""}`,
+      term: t("provider.profile.jobHistory"),
+      value: mark(roleLine(job)),
+    });
+  }
+  for (const [key, term, value] of [
+    ["location", "provider.profile.location", profile.location],
+    [
+      "departments",
+      "provider.profile.departments",
+      profile.departments.join(", "),
+    ],
+    [
+      "seniorities",
+      "provider.profile.seniorities",
+      profile.seniorities.join(", "),
+    ],
+  ] as const) {
+    if (value) {
+      facts.push({ key, term: t(term), value: mark(value) });
+    }
+  }
+  return facts;
+}
+
+/** A role as one line: what they do, and where. Either half may be absent —
+ *  the provider returns a company with no title often enough that joining
+ *  unconditionally printed a leading separator. */
+function roleLine(
+  role: Readonly<{ job_title?: string | null; company_name?: string | null }>,
+): string {
+  return [role.job_title, role.company_name].filter(Boolean).join(" · ");
 }
 
 /** The lookup itself, hoisted so the header button and the first-run plate
@@ -617,21 +660,33 @@ function useRunWatch(personId: string, profile: Profile) {
       if (error) {
         throwProblem(error);
       }
-      // A run that has stopped moving is the page's cue to re-read: the
-      // claims land in the same transaction as the terminal state, so by
-      // now the section has something new to show.
-      if (data && !RUNNING_RUN_STATES.has(data.state)) {
+      // Re-read on every answer that is not still moving, INCLUDING the
+      // completed-but-unapplied tick. That tick is what turns the section from
+      // "asking the provider" into the values themselves, and skipping it left
+      // the page one refresh short of the thing being waited for.
+      if (!stillMoving(data)) {
         void queryClient.invalidateQueries({
           queryKey: ["person360", personId],
         });
       }
       return data;
     },
-    enabled: runId != null && isRunning(profile.state),
-    refetchInterval: (query) =>
-      query.state.data && RUNNING_RUN_STATES.has(query.state.data.state)
-        ? 2500
-        : false,
+    // The RUN's own state, never the section's. The section answers "what
+    // should this reader know about enrichment here", and the CONNECTION's
+    // condition outranks the run history in that answer — so on an impaired
+    // connection the section reads provider_error while a run the reader just
+    // started is genuinely in flight. Arming off the section left the watch
+    // asleep through exactly that lookup: it completed, the page never
+    // re-read, and the button looked dead for the half-minute it took.
+    //
+    // `applied` and `claims_unwritten` extend it past the terminal state: a run
+    // is not done from this page's point of view until its values are ON the
+    // record, and the apply commits after the run completes.
+    enabled: runId != null && stillMoving(profile.latest_run),
+    // The same rule the arming uses, read from the answer just received rather
+    // than from the prop: the prop only changes when the page refetches, which
+    // is the thing this poll exists to cause.
+    refetchInterval: (query) => (stillMoving(query.state.data) ? 2500 : false),
   });
 }
 
@@ -641,6 +696,32 @@ function useRunWatch(personId: string, profile: Profile) {
 const RUNNING_RUN_STATES = new Set<
   components["schemas"]["ProviderRun"]["state"]
 >(["queued", "submitting", "in_progress"]);
+
+/** Whether this page should keep watching a run.
+ *
+ *  Longer than the run machine's own idea of moving. A completed run's values
+ *  reach the record in a SECOND commit, so a watch that stopped at `completed`
+ *  refreshed the page one step before the thing the reader is waiting for — the
+ *  values — existed. `applied` is the server saying that step happened.
+ *
+ *  `claims_unwritten` ends it too, and is not the same fact: the purchase
+ *  succeeded and the hand-off did not, so nothing further is coming and the
+ *  section says so rather than spinning forever.
+ *
+ *  A page opened AFTER the run completed but before the apply committed still
+ *  starts the watch, which is why this is asked of the run rather than of the
+ *  click that started it. */
+function stillMoving(
+  run: components["schemas"]["ProviderRun"] | undefined,
+): boolean {
+  if (!run) {
+    return false;
+  }
+  if (RUNNING_RUN_STATES.has(run.state)) {
+    return true;
+  }
+  return run.state === "completed" && !run.applied && !run.claims_unwritten;
+}
 
 /** The categories this connection buys for nothing, from the server's own
  *  catalog. Empty while the connections are still loading, which keeps a

--- a/frontend/src/screens/provider-status.test.ts
+++ b/frontend/src/screens/provider-status.test.ts
@@ -76,20 +76,34 @@ describe("the provider status vocabulary", () => {
     // state where both answers were true would be a double-spend invitation.
     for (const state of PROFILE_STATES) {
       if (isRunning(state)) {
-        expect(canEnrichNow(state), state).toBe(false);
+        expect(canEnrichNow(state, true), state).toBe(false);
       }
+    }
+  });
+
+  it("refuses a purchase over a live run whatever the section says", () => {
+    // The section state cannot answer "is a run happening": it puts the
+    // CONNECTION's condition first, so a live run under a connection whose
+    // last call failed reads provider_error — and a run that is completed but
+    // whose values have not been folded onto the record yet reads completed.
+    //
+    // Both are states this function otherwise permits, and the server's
+    // duplicate-spend fence covers only the live run states, so the priced
+    // button offered in that window buys the same detail a second time.
+    for (const state of PROFILE_STATES) {
+      expect(canEnrichNow(state, true), state).toBe(false);
     }
   });
 
   it("offers the purchase exactly where one could succeed", () => {
     // not_connected has nobody to ask; not_eligible has been refused for
     // this subject. Every other terminal state is a fair retry.
-    expect(canEnrichNow("not_connected")).toBe(false);
-    expect(canEnrichNow("not_eligible")).toBe(false);
-    expect(canEnrichNow("never_run")).toBe(true);
-    expect(canEnrichNow("no_match")).toBe(true);
-    expect(canEnrichNow("completed")).toBe(true);
-    expect(canEnrichNow("provider_error")).toBe(true);
+    expect(canEnrichNow("not_connected", false)).toBe(false);
+    expect(canEnrichNow("not_eligible", false)).toBe(false);
+    expect(canEnrichNow("never_run", false)).toBe(true);
+    expect(canEnrichNow("no_match", false)).toBe(true);
+    expect(canEnrichNow("completed", false)).toBe(true);
+    expect(canEnrichNow("provider_error", false)).toBe(true);
   });
 
   it("colours a refused key as danger and an unconnected provider as neither", () => {

--- a/frontend/src/screens/provider-status.ts
+++ b/frontend/src/screens/provider-status.ts
@@ -146,18 +146,29 @@ export function isRunning(state: ProviderProfileState): boolean {
  *  refuses it — and not where no provider is connected, since there is
  *  nothing to ask.
  *
+ *  `running` is the CALLER's answer, from the run, because this state cannot
+ *  give it. Two ways it is wrong on its own, and both leave a spending button
+ *  where there should be none: it puts the connection's condition first, so a
+ *  live run under a connection whose last call failed reads `provider_error`;
+ *  and a run that is `completed` but whose values have not been folded onto the
+ *  record yet reads `completed`, while the duplicate-spend fence in the server
+ *  covers only the live states — so the same priced detail is buyable twice.
+ *
  *  `stale` is refused for the same reason as `not_connected`, and the two are
  *  one fact wearing two labels: stale IS the disconnected provider whose
  *  purchases we retained. The section says so ("the provider is no longer
  *  connected, so this cannot be refreshed"), and the server agrees — a run
  *  needs a connected connection. A button beside that sentence is one the
  *  server was always going to refuse. */
-export function canEnrichNow(state: ProviderProfileState): boolean {
+export function canEnrichNow(
+  state: ProviderProfileState,
+  running: boolean,
+): boolean {
   return (
     state !== "not_connected" &&
     state !== "not_eligible" &&
     state !== "stale" &&
-    !isRunning(state)
+    !running
   );
 }
 


### PR DESCRIPTION
## What was broken

Pressing "check again" changed nothing on screen for the half-minute the provider took. No line, no badge, no refresh when it landed. A working lookup and a dead button were the same picture, and the reasonable conclusion from that picture is that the button is broken — which is what a reader concluded, twice.

**The watch armed off the SECTION's state.** That state answers "what should this reader know about enrichment here" and deliberately puts the connection's condition ahead of the run — so on a connection whose last call failed it reads `provider_error` while a run is genuinely in flight. That is precisely the state a reader presses from, because the message beside it tells them to. It now arms off the run, which is what `useRunWatch`'s own comment already claimed it did.

**It also stopped one step too early.** A completed run's values reach the record in a second commit, so `applied` and `claims_unwritten` decide when to stop rather than the terminal state alone. A page opened after the run completed but before the apply committed now starts watching rather than sitting on stale values.

## Two bugs only a browser found

Both shipped green through every test on both sides. I clicked through this one rather than reasoning about it, which is the only reason they surfaced.

**`applied` was never sent on the wire.** The contract declares the field, the column is set, `toWireRun` never populated it. So the new stop-rule read "not applied yet" forever: the page fetched the values correctly and kept saying "asking the provider" underneath them. Every test on both sides passed against a field neither of them read.

**"Never asked for: mobile number" printed directly above a mobile number.** Claims outlive the runs that fetched them — a merge relinks the losing side's purchases onto the survivor, a seeded or imported installation holds claims with no run at all — so deciding that line from run history alone denies values the page is showing. A category whose value is on the page is now never named in it.

## The rework

The values were nine hand-rolled `<div><Eyebrow>label</Eyebrow>value</div>` blocks, each styling itself. They are one **`FactList`** — the catalog's primitive for exactly "label→value pairs a reader scans" — so a reader looking for the mobile number reads one column of labels rather than nine headings. The qualifiers (`65% confidence`, `professional, because that is what we asked for`) move to the row's own `note` slot.

Two stories added for states that had none: a run live under an impaired connection, and completed-but-not-yet-applied.

## The copy

Three messages stated a fact and then explained the fact:

- `"Not asked for: X. A blank here means nobody bought it, not that the provider had nothing."` → `"Never asked for: X."`
- `"Asked for and not found: X. The provider was asked and had nothing for this contact."` → `"Asked for, none found: X."`
- The provider-error line lost its second sentence.

## Verified in a browser

On an isolated stack with the connection forced to `provider_error` — the exact reported state:

| Step | Result |
|---|---|
| Press "Check again · free" | Badge → "Looking them up…", line → "Asking Surfe. This takes up to a minute.", failure message gone |
| Run lands (~35s) | Page refreshes itself, badge → "Found", values appear |
| Line under the values | "Never asked for: personal email." — the only category genuinely never fetched |

## Test

Four new cases, each mutation-checked:

| Mutation | Caught by |
|---|---|
| arm off the section state | polls-a-live-run + keeps-watching-until-applied |
| drop the `applied` clause | keeps-watching-until-applied |
| remove the live line and badge override | says-a-lookup-is-happening |
| decide "not requested" from runs alone | a-category-on-the-page-is-never-called-unrequested |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bought-data tab so a running lookup is visible, the page refreshes when the values land, and the same priced detail can't be bought twice while a lookup is still being written. A working lookup no longer looks like a dead button, and pressing twice no longer charges twice.

**Behavior**
- The watch arms off the run's own state instead of the section's, which read `provider_error` on an impaired connection while a run was in flight.
- Buying is refused while a run is still moving even when the section reads `provider_error` or `completed`; the server's duplicate-spend fence only covers live run states, so the priced button could buy an unapplied detail a second time.
- Polling continues past a completed run until the values are applied, with a 10-minute ceiling after which the page stops asking.
- The sweep no longer stamps an empty run as applied: a tick landing between the terminal commit and the hand-off would otherwise record a purchase the record never received, so empty runs stay unstamped for the next tick.
- The header and a live line name the two phases — asking the provider, then the answer landing — instead of repeating a failure from hours ago or saying "asking" after the provider already answered.

**Data and display**
- `applied` was never populated on the wire, so the stop rule read "not applied yet" forever; the column and contract declared it, `toWireRun` omitted it.
- A category whose value is on the page is never named "never asked for" — claims outlive the runs that fetched them.
- The nine hand-rolled label-and-value blocks are one `FactList`.
- Three messages that stated a fact and then explained it now just state the fact.

<sup>Written for commit 756f67f4f3685fb465f2e5d9d36cf32ac29f3fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live lookup status to provider profiles, including progress, completion, and error messages.
  * Profiles now recognize results from earlier or imported lookups when displaying provider categories.
  * Lookup monitoring refreshes profiles as results are applied.

* **Improvements**
  * Enrichment and purchase controls are disabled while a lookup is active.
  * Updated English, German, and Vietnamese messaging for lookup progress, errors, and missing results.

* **Bug Fixes**
  * Completed lookups without results can be retried instead of being marked finished prematurely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->