### PR TITLE
main is red: the preference fixture predates two fields its type gained

### DIFF
--- a/frontend/src/screens/preferences.logic.test.ts
+++ b/frontend/src/screens/preferences.logic.test.ts
@@ -13,6 +13,10 @@ const purposes: PurposeView[] = [
     label: "Deal & service messages",
     state: "granted",
     locked: true,
+    // A locked purpose cannot be offered a grant from this surface, which is
+    // what can_opt_in says; the choice is what the recipient decided.
+    choice: "opted_in",
+    can_opt_in: false,
     grant_needs_confirmation: false,
   },
   {
@@ -20,6 +24,8 @@ const purposes: PurposeView[] = [
     label: "Product updates",
     state: "granted",
     locked: false,
+    choice: "opted_in",
+    can_opt_in: true,
     grant_needs_confirmation: false,
   },
   {
@@ -27,6 +33,8 @@ const purposes: PurposeView[] = [
     label: "Events",
     state: "withdrawn",
     locked: false,
+    choice: "opted_out",
+    can_opt_in: true,
     grant_needs_confirmation: false,
   },
   {
@@ -34,6 +42,10 @@ const purposes: PurposeView[] = [
     label: "Surveys",
     state: "unknown",
     locked: false,
+    // "unknown" reads differently either side of the consent line, which is
+    // why the server derives `choice` at all: nobody has objected here.
+    choice: "no_objection",
+    can_opt_in: true,
     grant_needs_confirmation: false,
   },
 ];
@@ -47,6 +59,10 @@ const doiPurposes: PurposeView[] = [
     label: "Newsletter",
     state: "withdrawn",
     locked: false,
+    choice: "opted_out",
+    // A purpose needing a confirmation round-trip cannot be granted from
+    // here either, for the same reason a locked one cannot.
+    can_opt_in: false,
     grant_needs_confirmation: true,
   },
   {
@@ -54,6 +70,8 @@ const doiPurposes: PurposeView[] = [
     label: "Already subscribed",
     state: "granted",
     locked: false,
+    choice: "opted_in",
+    can_opt_in: false,
     grant_needs_confirmation: true,
   },
 ];


### PR DESCRIPTION
`main`'s composed typecheck fails.

`PreferenceCenter`'s purposes gained `choice` and `can_opt_in`, and the fixture in `preferences.logic.test.ts` still describes the older shape:

```
src/screens/preferences.logic.test.ts(11,3): error TS2739: Type '{ … }' is missing the following properties … : choice, can_opt_in
```

Reproduced on a clean `origin/main` worktree, so it is not an interaction with any branch. Same shape as the other reds today: a contract change green on its own branch, and an exhaustive type doing its job once the generated union landed under it.

## What the values are

Filled in from the contract's own description rather than invented:

- `choice` follows the recorded state — granted is `opted_in`, withdrawn is `opted_out`, and `unknown` on this fixture's research purpose is `no_objection`, which is the reading the field exists to make unambiguous.
- `can_opt_in` is false exactly where the surface may not offer a grant: a locked purpose, and one needing a confirmation round-trip.

Nothing in the client reads either field yet, so this changes no behaviour — the tests pass unchanged.

## One thing worth a look, not fixed here

The contract says of `choice`: *"Render this; never re-derive it"*, because `unknown` means opposite things either side of the consent line. `preferences.logic.ts`'s `displayOn` still derives from the raw `state`. That is presumably the point of whatever change added the fields and may already be in flight — flagging it rather than changing a consent surface's rendering inside a red-main fix.

## Verification

- `make check-fe` — the composed typecheck passes and `preferences.logic.test.ts` is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded preference scenarios to cover locked, opted-out, unknown, and confirmation-required consent states.
  * Improved test coverage for purposes that cannot be enabled through the preferences screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->