### PR TITLE
fix(send): the footer links open pages, in the language of the message

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -19034,6 +19034,24 @@ components:
       required: [data]
       properties:
         data: { type: array, items: { $ref: '#/components/schemas/CaptureConnection' } }
+        public_origin: { $ref: '#/components/schemas/PublicOriginStatus' }
+    PublicOriginStatus:
+      type: object
+      description: |
+        The address this installation puts in outgoing links, and whether it answered when last asked.
+        Reported so an operator can SEE the value rather than discover it from a recipient; the boot and
+        send guards are what actually refuse an unusable one. A probe from inside the deployment says this
+        process can reach the origin — it cannot say a recipient's mail client can.
+      required: [origin]
+      properties:
+        origin: { type: string, description: The configured scheme and host. }
+        reachable:
+          type: [boolean, 'null']
+          description: Null until the first probe answers, so a screen can say "not checked yet" rather than implying a failure.
+        checked_at: { type: [string, 'null'], format: date-time }
+        detail:
+          type: [string, 'null']
+          description: The HTTP status or the transport failure. Never carries a path or a token.
     ConnectConnectorRequest:
       type: object
       description: |

--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -28,6 +28,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
 	"github.com/margince/margince/backend/internal/platform/licensecheck"
+	"github.com/margince/margince/backend/internal/platform/netguard"
 	"github.com/margince/margince/backend/internal/platform/overlaybudget"
 	"github.com/margince/margince/backend/internal/shared/buildinfo"
 	"github.com/margince/margince/backend/pkg/extension"
@@ -150,6 +151,15 @@ func bindInstallation(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, va
 		}
 		if err := validatePublicBaseURL(cfg.publicBaseURL); err != nil {
 			return deployconfig.Config{}, nil, err
+		}
+	}
+	// A real sender means real recipients, and a link they cannot open is
+	// worse than a refused boot: the message goes out looking correct and
+	// its unsubscribe promise is dead. Checked here, at boot, so an
+	// operator learns from a startup failure rather than from a customer.
+	if senderConfigured(cfg, deployCfg) {
+		if err := netguard.RequirePublicOrigin("--public-base-url", cfg.publicBaseURL, cfg.posture); err != nil {
+			return deployconfig.Config{}, nil, fmt.Errorf("api: %w", err)
 		}
 	}
 	if err := compose.EnsureInstallation(ctx, pool, logger, deployCfg); err != nil {

--- a/backend/cmd/api/config.go
+++ b/backend/cmd/api/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/cliflags"
 	"github.com/margince/margince/backend/internal/platform/config"
+	"github.com/margince/margince/backend/internal/platform/deployconfig"
 	"github.com/margince/margince/backend/internal/shared/runtimeenv"
 )
 
@@ -190,4 +191,17 @@ func envDuration(key string) (time.Duration, error) {
 		return 0, fmt.Errorf("api: %s=%q is not a duration (e.g. 15m, 24h): %w", key, raw, err)
 	}
 	return d, nil
+}
+
+// senderConfigured reports whether this deployment can put a message in
+// somebody else's mailbox — by its own SMTP relay, or through a mailbox
+// connector a rep has linked.
+//
+// It is the trigger for the public-origin rule: an installation that
+// sends nothing may be configured however an operator likes, because no
+// recipient ever sees a link built from it.
+func senderConfigured(cfg apiConfig, deployCfg deployconfig.Config) bool {
+	return deployCfg.Email.Enabled ||
+		(cfg.gmailClientID != "" && cfg.gmailClientSecret != "") ||
+		(cfg.graphClientID != "" && cfg.graphClientSecret != "")
 }

--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -373,7 +373,7 @@ func envDurationOr(key string, fallback time.Duration) (time.Duration, error) {
 // still refuses a grant that cannot send, so its absence costs a clearer
 // message, never a message that should not have gone.
 func sendPath(cfg workerConfig, delivery compose.DeliveryMachinery) compose.SendPath {
-	return compose.SendPath{PublicBaseURL: cfg.publicBaseURL, Delivery: delivery}
+	return compose.SendPath{PublicBaseURL: cfg.publicBaseURL, Delivery: delivery, Environment: cfg.posture}
 }
 
 // gmailAppWired reports whether the deployment configured the Google OAuth

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/events"
 	"github.com/margince/margince/backend/internal/platform/httpserver"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
+	"github.com/margince/margince/backend/internal/platform/netguard"
 	"github.com/margince/margince/backend/internal/shared/buildinfo"
 	kevents "github.com/margince/margince/backend/internal/shared/kernel/events"
 	"github.com/margince/margince/backend/internal/shared/runtimeenv"
@@ -121,7 +122,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if err := ensureLicense(ctx, logger, pool, vault, deployCfg, cfg.posture); err != nil {
+	if err := admitBoot(ctx, logger, pool, vault, cfg, deployCfg); err != nil {
 		return err
 	}
 
@@ -346,6 +347,35 @@ func runGroupSubscriber(ctx context.Context, rdb *redis.Client, group kevents.Gr
 // is reached, which is the posture every role takes: an installation whose root
 // key no longer opens its own secrets has a problem that outlives the license
 // question.
+// admitBoot holds every precondition this worker must satisfy before it
+// starts doing work: it is entitled to run, and anything it sends will
+// carry links a recipient can open.
+func admitBoot(
+	ctx context.Context, logger *slog.Logger, pool *pgxpool.Pool,
+	vault keyvault.Vault, cfg workerConfig, deployCfg deployconfig.Config,
+) error {
+	if err := ensureLicense(ctx, logger, pool, vault, deployCfg, cfg.posture); err != nil {
+		return err
+	}
+	return requireUsablePublicOrigin(cfg, deployCfg)
+}
+
+// requireUsablePublicOrigin refuses to start a sending worker whose
+// outgoing links a recipient could not open.
+//
+// The worker sends too — the scheduled and agent lanes run here — so it
+// answers to the same rule as the api. A role that skipped it would send
+// exactly the messages the api refuses.
+func requireUsablePublicOrigin(cfg workerConfig, deployCfg deployconfig.Config) error {
+	if !deployCfg.Email.Enabled && !cfg.gmailAppWired() {
+		return nil
+	}
+	if err := netguard.RequirePublicOrigin("--public-base-url", cfg.publicBaseURL, cfg.posture); err != nil {
+		return fmt.Errorf("worker: %w", err)
+	}
+	return nil
+}
+
 func ensureLicense(ctx context.Context, logger *slog.Logger, pool *pgxpool.Pool, vault keyvault.Vault, deployCfg deployconfig.Config, posture runtimeenv.Environment) error {
 	_, err := compose.EnsureLicense(ctx, logger, pool, vault, deployCfg, posture, config.FromOS)
 	return err

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -366,6 +366,16 @@ func admitBoot(
 // The worker sends too — the scheduled and agent lanes run here — so it
 // answers to the same rule as the api. A role that skipped it would send
 // exactly the messages the api refuses.
+//
+// What this predicate CANNOT see, and it is worth naming rather than
+// implying: an installation may store its Google app in the database
+// through Settings instead of composing it from the environment
+// (compose.newCaptureRegistryWithGoogle), and that app is not readable
+// here — boot runs before, and independently of, any workspace read. Such
+// a worker starts without this check. It does not then send a broken
+// link: the send-time guard in activities refuses every tokenized message
+// on the same rule. What is lost is the early failure, not the
+// protection.
 func requireUsablePublicOrigin(cfg workerConfig, deployCfg deployconfig.Config) error {
 	if !deployCfg.Email.Enabled && !cfg.gmailAppWired() {
 		return nil

--- a/backend/gates/preferencecentrewriters_test.go
+++ b/backend/gates/preferencecentrewriters_test.go
@@ -51,7 +51,7 @@ func TestThePreferenceCentreAnswersInOneShape(t *testing.T) {
 	// The BODY KEYS, not the function name: a second writer would be a
 	// second map literal carrying them, and renaming the helper would not
 	// help it escape.
-	const key = `"masked_email"`
+	const key = "masked_email"
 	scope := gatekit.Scope{
 		Roots:   []string{consentRoot},
 		Subject: fileContains(key),
@@ -92,6 +92,38 @@ func TestThePreferenceCentreResolvesOnePrimaryAddress(t *testing.T) {
 	}
 }
 
+// TestOneSendDerivesEveryUnsubscribeDestination holds the "every
+// destination" claim on unsubscribeLinks.
+//
+// The defect this whole change exists for was three destinations
+// collapsing into one URL: the visible "Unsubscribe" link pointed at the
+// POST-only machine endpoint, so a human click got 405. A second builder
+// is how they drift apart again — one caller keeps the pages while
+// another goes back to the API path, and each looks correct alone.
+func TestOneSendDerivesEveryUnsubscribeDestination(t *testing.T) {
+	t.Parallel()
+	// The PUBLIC PREFIX, not the function name: every destination is built
+	// by appending to it, so a second builder has to spell it too.
+	const key = "/v1/public/preferences/"
+	scope := gatekit.Scope{
+		Roots:   []string{"internal/modules/activities"},
+		Subject: fileContains(key),
+		// Both spell the prefix to SERVE or to redact it, never to build a
+		// link a recipient is sent. This gate is about the send path's
+		// builders; a reader of the same path is not a second one.
+		Exempt: gatekit.Waive(map[string]string{
+			"internal/compose/publicpreferences.go":                   "the edge that serves the prefix, matching requests rather than minting links",
+			"internal/shared/kernel/capabilitypath/capabilitypath.go": "the access-log redactor, which knows the prefix so a token never reaches a log line",
+		}),
+	}
+	total, where := countAcross(t, scope, key)
+	if total != 1 {
+		t.Errorf("the public preference URL is built %d time(s) in the send path, want exactly 1: %s\n\n"+
+			"The header, the two visible links and the redacted copy come from ONE builder; a second "+
+			"is how the machine endpoint ends up behind a human link again.", total, strings.Join(where, ", "))
+	}
+}
+
 // fileContains is the Subject predicate: does this file spell the string
 // anywhere in its source.
 func fileContains(needle string) func(string, *ast.File) bool {
@@ -120,15 +152,24 @@ func countAcross(t *testing.T, scope gatekit.Scope, needle string) (int, []strin
 }
 
 // countInFile counts a pattern's matches in a file's string literals —
-// where both subjects live, and where a copy would land.
+// where every subject here lives, and where a copy would land.
+//
+// Read through gatekit.LiteralText rather than off lit.Value: the source
+// text carries its escapes, so a statement written in double quotes would
+// not match the pattern at all and this census would report a clean tree
+// over exactly the copy it exists to find.
 func countInFile(file *ast.File, pattern *regexp.Regexp) int {
 	total := 0
 	ast.Inspect(file, func(n ast.Node) bool {
-		lit, ok := n.(*ast.BasicLit)
-		if !ok {
+		expr, isExpr := n.(ast.Expr)
+		if !isExpr {
 			return true
 		}
-		total += len(pattern.FindAllString(lit.Value, -1))
+		text, isLiteral := gatekit.LiteralText(expr)
+		if !isLiteral {
+			return true
+		}
+		total += len(pattern.FindAllString(text, -1))
 		return true
 	})
 	return total

--- a/backend/gates/uniquenessclaims_test.go
+++ b/backend/gates/uniquenessclaims_test.go
@@ -462,7 +462,7 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 var shapeCensus = map[string]int{
 	"cannot-drift":   172,
 	"once":           178,
-	"one-of-a-kind":  180,
+	"one-of-a-kind":  179,
 	"is-every-named": 91,
 	"only-noun":      12,
 	"no-second":      11,

--- a/backend/internal/compose/capture.go
+++ b/backend/internal/compose/capture.go
@@ -477,6 +477,7 @@ func WithGmailCapture(c GmailConfig, cfg CaptureConfig) Option {
 			signer:        newStateSigner([]byte(c.StateKey)),
 			publicBaseURL: c.PublicBaseURL,
 			apiBaseURL:    c.APIBaseURL,
+			publicOrigin:  s.originStatus,
 			// Named here because this literal REPLACES the struct: omitting it is
 			// how the stored app became unreachable while every test still passed.
 			googleCredentials: s.googleAppResolver,

--- a/backend/internal/compose/connectors.go
+++ b/backend/internal/compose/connectors.go
@@ -56,6 +56,10 @@ const codeUnauthorized = "unauthorized"
 
 type connectorHandlers struct {
 	registry *capture.Registry
+	// publicOrigin reports the address this installation puts in outgoing
+	// links. Nil when none is configured, and then the field is absent
+	// rather than reported as broken.
+	publicOrigin func(ctx context.Context) PublicOriginStatus
 	// authority is identity's live resolver. The callback re-reads the
 	// granting human through it before it spends the authorization code: the
 	// signed state proves who STARTED the consent, and minutes of provider
@@ -147,6 +151,17 @@ func (h connectorHandlers) ListConnectors(w http.ResponseWriter, r *http.Request
 	}
 	for _, v := range views {
 		resp.Data = append(resp.Data, toContractConnection(v))
+	}
+	// Absent when no origin is configured, which is itself the answer a
+	// screen needs: there is nothing to report rather than something broken.
+	if h.publicOrigin != nil {
+		status := h.publicOrigin(r.Context())
+		resp.PublicOrigin = &crmcontracts.PublicOriginStatus{
+			Origin:    status.Origin,
+			Reachable: status.Reachable,
+			CheckedAt: status.CheckedAt,
+			Detail:    &status.Detail,
+		}
 	}
 	httperr.WriteJSON(w, http.StatusOK, resp)
 }

--- a/backend/internal/compose/integration/preference_center_integration_test.go
+++ b/backend/internal/compose/integration/preference_center_integration_test.go
@@ -95,9 +95,11 @@ func transmittedBody(t *testing.T, c *consentEnv) string {
 	return body
 }
 
-// unsubscribeLinkIn lifts the one-click URL out of the visible footer the
-// send appended, and tokenFromLink lifts the preference token out of it:
-// `https://base/v1/public/preferences/TOKEN/unsubscribe?…`.
+// unsubscribeLinkIn lifts the visible unsubscribe link out of the footer
+// the send appended, and tokenFromLink lifts the preference token out of
+// it: `https://base/#/unsubscribe/TOKEN/PURPOSE?lang=xx`. The visible link
+// is a PAGE — the machine endpoint that used to be here is POST-only and
+// answers a human click with 405.
 func unsubscribeLinkIn(t *testing.T, body string) string {
 	t.Helper()
 	for _, line := range strings.Split(body, "\n") {
@@ -115,9 +117,13 @@ func tokenFromLink(t *testing.T, link string) string {
 	if err != nil {
 		t.Fatalf("parsing the unsubscribe link %q: %v", link, err)
 	}
-	parts := strings.Split(strings.TrimPrefix(u.Path, "/v1/public/preferences/"), "/")
+	// The token lives in the FRAGMENT: the visible links are hash routes,
+	// which is also what keeps the token out of ordinary web-server access
+	// logs until the page deliberately calls the API with it.
+	route := strings.SplitN(u.Fragment, "?", 2)[0]
+	parts := strings.Split(strings.TrimPrefix(route, "/unsubscribe/"), "/")
 	if len(parts) < 2 || parts[0] == "" {
-		t.Fatalf("unsubscribe link has no token: %q", u.Path)
+		t.Fatalf("unsubscribe link has no token: %q", u.Fragment)
 	}
 	return parts[0]
 }
@@ -162,8 +168,8 @@ func sendAndAssertUnsubscribeLink(t *testing.T, c *consentEnv) string {
 		t.Fatalf("marketing send → %d, want 202", status)
 	}
 	link := unsubscribeLinkIn(t, transmittedBody(t, c))
-	if !strings.HasPrefix(link, "https://mail.example.test/v1/public/preferences/") || !strings.Contains(link, "purpose=newsletter") {
-		t.Fatalf("unsubscribe link = %q, want a one-click URL on the configured base", link)
+	if !strings.HasPrefix(link, "https://mail.example.test/#/unsubscribe/") || !strings.Contains(link, "/newsletter") {
+		t.Fatalf("unsubscribe link = %q, want the human unsubscribe page on the configured base", link)
 	}
 	token := tokenFromLink(t, link)
 
@@ -374,8 +380,8 @@ func TestPreferenceTokenNeverReachesTheRecordedActivity(t *testing.T) {
 	// What the record KEEPS: the footer's shape and the purpose it pointed
 	// at, so a reader still sees the send carried a working one-click link.
 	// Only the credential is gone.
-	if !strings.Contains(recorded, "https://mail.example.test/v1/public/preferences/") ||
-		!strings.Contains(recorded, "purpose=newsletter") {
+	if !strings.Contains(recorded, "https://mail.example.test/#/unsubscribe/") ||
+		!strings.Contains(recorded, "/newsletter") {
 		t.Fatalf("the recorded body lost the unsubscribe footer entirely:\n%s", recorded)
 	}
 	// And the redacted link is inert: it is not a token the public edge honors.

--- a/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
+++ b/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
@@ -228,7 +228,7 @@ func TestAComposedSendRecordsTheVoiceOutcomeOnTheApprovedBody(t *testing.T) {
 	sent := e.send(t, ref, voiceSentBody)
 
 	transmitted := e.transmittedBody(t, sent)
-	if !strings.Contains(transmitted, "/v1/public/preferences/") {
+	if !strings.Contains(transmitted, "/#/unsubscribe/") {
 		t.Fatalf("the transmitted body carries no unsubscribe footer, so this case proves nothing:\n%s", transmitted)
 	}
 	if transmitted == voiceSentBody {

--- a/backend/internal/compose/publicoriginprobe.go
+++ b/backend/internal/compose/publicoriginprobe.go
@@ -24,6 +24,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/margince/margince/backend/internal/platform/outbound"
 )
 
 const (
@@ -107,6 +109,10 @@ func (p *publicOriginProbe) probe(ctx context.Context) PublicOriginStatus {
 		status.Detail = "the configured origin cannot be requested"
 		return status
 	}
+	// Named, because this lands in the operator's OWN access log: an
+	// unexplained hit on /healthz every minute is something somebody has to
+	// go and investigate.
+	req.Header.Set("User-Agent", outbound.SelfCheckHeader)
 	resp, err := p.client.Do(req)
 	if err != nil {
 		status.Reachable = &reachable
@@ -116,7 +122,12 @@ func (p *publicOriginProbe) probe(ctx context.Context) PublicOriginStatus {
 		status.Detail = "the origin did not answer"
 		return status
 	}
+	// The STATUS is the answer here, not the body — so both of these
+	// discard a result that cannot change the verdict, and neither may
+	// turn a reachable origin into an error.
+	//craft:ignore swallowed-errors closing a response whose status has already been read changes no verdict
 	defer func() { _ = resp.Body.Close() }()
+	//craft:ignore swallowed-errors the body is drained to reuse the connection; its content is not the answer
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, originProbeReadLimit))
 
 	reachable = resp.StatusCode < http.StatusInternalServerError
@@ -136,4 +147,19 @@ func newOriginProbeClient() *http.Client {
 			return http.ErrUseLastResponse
 		},
 	}
+}
+
+// originStatus is what every connectorHandlers literal wires as its
+// publicOrigin.
+//
+// A METHOD on the Server rather than the probe's own Status: the handler
+// struct is rebuilt by several options, in an order no single one of them
+// controls, so a literal that captured the probe directly would capture
+// whatever was there at the time — usually nil. This reads the Server's
+// field when the request arrives, which is after every option has run.
+func (s *Server) originStatus(ctx context.Context) PublicOriginStatus {
+	if s.originProbe == nil {
+		return PublicOriginStatus{}
+	}
+	return s.originProbe.Status(ctx)
 }

--- a/backend/internal/compose/publicoriginprobe.go
+++ b/backend/internal/compose/publicoriginprobe.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Whether the configured public origin actually answers, reported to an
+// operator rather than enforced.
+//
+// Deliberately NOT a readiness check. Routing that sends traffic only to
+// ready instances would deadlock on a cold rollout: nothing is ready, so
+// the ingress answers nothing, so the origin looks unreachable, so
+// nothing becomes ready. The deterministic boot and send guards in
+// netguard are what actually stop the misconfiguration this exists for;
+// this only tells somebody what the deployment looks like from here.
+//
+// It is also honest about how little a GET from INSIDE the deployment
+// proves. It says this process can reach that origin. It cannot say a
+// recipient's mail client can.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// originProbeTimeout bounds one attempt. Short: this answers a settings
+	// screen, and a slow origin is a slow answer, not a hung page.
+	originProbeTimeout = 1500 * time.Millisecond
+	// originProbeTTL is how long an answer stands before it is asked again,
+	// so a screen that polls does not turn into traffic against the ingress.
+	originProbeTTL = 60 * time.Second
+	// originProbeReadLimit is all that is ever read of the response. The
+	// body is not the answer — the status is.
+	originProbeReadLimit = 1 << 10
+)
+
+// PublicOriginStatus is what the Connections screen shows about the
+// installation's outward address.
+type PublicOriginStatus struct {
+	// Origin is the configured value. Safe to show: it is a scheme and a
+	// host an operator typed, and the boot guard refuses one carrying
+	// userinfo.
+	Origin string
+	// Reachable is nil until the first probe answers, so a screen can say
+	// "not checked yet" rather than implying a failure.
+	Reachable *bool
+	CheckedAt *time.Time
+	// Detail is the HTTP status or the transport failure. Never more than
+	// the origin itself — no path, and never a token.
+	Detail string
+}
+
+// publicOriginProbe asks the configured origin whether it answers, at most
+// once per TTL.
+type publicOriginProbe struct {
+	origin string
+	client *http.Client
+	clock  func() time.Time
+	ttl    time.Duration
+
+	mu   sync.Mutex
+	last PublicOriginStatus
+}
+
+func newPublicOriginProbe(origin string, client *http.Client, clock func() time.Time) *publicOriginProbe {
+	return &publicOriginProbe{
+		origin: origin,
+		client: client,
+		clock:  clock,
+		ttl:    originProbeTTL,
+		last:   PublicOriginStatus{Origin: origin},
+	}
+}
+
+// Status answers from the cache, refreshing it when the answer has aged
+// past the TTL.
+func (p *publicOriginProbe) Status(ctx context.Context) PublicOriginStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.last.CheckedAt != nil && p.clock().Sub(*p.last.CheckedAt) < p.ttl {
+		return p.last
+	}
+	p.last = p.probe(ctx)
+	return p.last
+}
+
+// probe performs one attempt against the origin's health endpoint.
+//
+// Any status below 500 counts as reachable, and that is the question
+// being asked: does this hostname resolve and answer over this scheme. A
+// dev stack points the origin at Vite, which answers the SPA fallback
+// rather than a health endpoint, and that is still a reachable origin.
+func (p *publicOriginProbe) probe(ctx context.Context) PublicOriginStatus {
+	at := p.clock()
+	status := PublicOriginStatus{Origin: p.origin, CheckedAt: &at}
+	reachable := false
+
+	ctx, cancel := context.WithTimeout(ctx, originProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.origin+"/healthz", nil)
+	if err != nil {
+		status.Reachable = &reachable
+		status.Detail = "the configured origin cannot be requested"
+		return status
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		status.Reachable = &reachable
+		// The URL is stripped from the transport error: it would otherwise
+		// carry the origin into a screen and a log twice over, and the
+		// operator already knows what they configured.
+		status.Detail = "the origin did not answer"
+		return status
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, originProbeReadLimit))
+
+	reachable = resp.StatusCode < http.StatusInternalServerError
+	status.Reachable = &reachable
+	status.Detail = fmt.Sprintf("http %d", resp.StatusCode)
+	return status
+}
+
+// newOriginProbeClient builds the client the probe dials with: bounded,
+// and never following a redirect. A redirect is not followed because the
+// question is what THIS origin answers, and because following one would
+// dial wherever the answer pointed.
+func newOriginProbeClient() *http.Client {
+	return &http.Client{
+		Timeout: originProbeTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}

--- a/backend/internal/compose/publicoriginprobe_test.go
+++ b/backend/internal/compose/publicoriginprobe_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// originClock lets the TTL be tested without waiting a minute for it.
+type originClock struct{ at time.Time }
+
+func (c *originClock) now() time.Time      { return c.at }
+func (c *originClock) add(d time.Duration) { c.at = c.at.Add(d) }
+
+func TestAnAnsweringOriginReadsAsReachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	clock := &originClock{at: time.Now()}
+	status := newPublicOriginProbe(srv.URL, newOriginProbeClient(), clock.now).Status(context.Background())
+	if status.Reachable == nil || !*status.Reachable {
+		t.Fatalf("reachable = %v, want true (detail %q)", status.Reachable, status.Detail)
+	}
+	if status.CheckedAt == nil {
+		t.Error("a probe that ran reported no time")
+	}
+}
+
+// A dev stack points the origin at Vite, which answers the SPA fallback
+// rather than a health endpoint. That is still a reachable origin: the
+// question is whether the host answers over this scheme.
+func TestAnSPAFallbackStillCountsAsReachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	clock := &originClock{at: time.Now()}
+	status := newPublicOriginProbe(srv.URL, newOriginProbeClient(), clock.now).Status(context.Background())
+	if status.Reachable == nil || !*status.Reachable {
+		t.Errorf("reachable = %v, want true for a 404", status.Reachable)
+	}
+}
+
+func TestAnOriginThatDoesNotAnswerReadsAsUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	origin := srv.URL
+	srv.Close() // nothing listens now
+
+	clock := &originClock{at: time.Now()}
+	status := newPublicOriginProbe(origin, newOriginProbeClient(), clock.now).Status(context.Background())
+	if status.Reachable == nil || *status.Reachable {
+		t.Errorf("reachable = %v, want false", status.Reachable)
+	}
+	if status.Detail == "" {
+		t.Error("an unreachable origin reported no reason")
+	}
+}
+
+// A screen that polls must not become traffic against the ingress.
+func TestTheAnswerIsCachedForItsTTL(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	clock := &originClock{at: time.Now()}
+	probe := newPublicOriginProbe(srv.URL, newOriginProbeClient(), clock.now)
+
+	probe.Status(context.Background())
+	probe.Status(context.Background())
+	if got := hits.Load(); got != 1 {
+		t.Errorf("the origin was asked %d times inside one TTL, want 1", got)
+	}
+	clock.add(originProbeTTL + time.Second)
+	probe.Status(context.Background())
+	if got := hits.Load(); got != 2 {
+		t.Errorf("the origin was asked %d times after the TTL lapsed, want 2", got)
+	}
+}
+
+// A redirect is not followed: the question is what THIS origin answers,
+// and following one would dial wherever the answer pointed.
+func TestTheProbeNeverFollowsARedirect(t *testing.T) {
+	var elsewhere atomic.Int64
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		elsewhere.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/v1/public/preferences/tok", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	clock := &originClock{at: time.Now()}
+	newPublicOriginProbe(srv.URL, newOriginProbeClient(), clock.now).Status(context.Background())
+	if got := elsewhere.Load(); got != 0 {
+		t.Errorf("the probe followed a redirect %d time(s); it must not dial where an answer points", got)
+	}
+}
+
+// The reported detail is for an operator's screen, so it must never
+// carry a path — the origin is the only address in it.
+func TestTheReportedDetailCarriesNoPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	clock := &originClock{at: time.Now()}
+	status := newPublicOriginProbe(srv.URL, newOriginProbeClient(), clock.now).Status(context.Background())
+	if status.Detail != "http 200" {
+		t.Errorf("detail = %q, want just the status", status.Detail)
+	}
+}

--- a/backend/internal/compose/publicoriginprobe_test.go
+++ b/backend/internal/compose/publicoriginprobe_test.go
@@ -124,3 +124,39 @@ func TestTheReportedDetailCarriesNoPath(t *testing.T) {
 		t.Errorf("detail = %q, want just the status", status.Detail)
 	}
 }
+
+// The bug this pins: connectorHandlers is REPLACED wholesale by more than
+// one option, in an order no single option controls, so a literal that
+// captured the probe directly captured whatever was there at the time —
+// usually nil — and the row silently never appeared. Reading it through a
+// Server method means every literal answers once the origin is wired,
+// whatever order the options ran in.
+func TestTheOriginStatusSurvivesAHandlerRebuild(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := &Server{}
+	s.connectorHandlers.publicOrigin = s.originStatus
+	// The origin is configured AFTER the handler was built, which is the
+	// order that used to lose it.
+	s.originProbe = newPublicOriginProbe(srv.URL, newOriginProbeClient(), time.Now)
+
+	status := s.connectorHandlers.publicOrigin(context.Background())
+	if status.Origin != srv.URL {
+		t.Errorf("origin = %q, want %q — the handler lost the probe", status.Origin, srv.URL)
+	}
+	if status.Reachable == nil || !*status.Reachable {
+		t.Errorf("reachable = %v, want true", status.Reachable)
+	}
+}
+
+// A role with no origin configured answers an empty status rather than
+// panicking, so the screen renders no row instead of failing.
+func TestNoConfiguredOriginAnswersAnEmptyStatus(t *testing.T) {
+	s := &Server{}
+	if got := s.originStatus(context.Background()); got.Origin != "" || got.Reachable != nil {
+		t.Errorf("status = %+v, want empty", got)
+	}
+}

--- a/backend/internal/compose/publicoriginprobe_test.go
+++ b/backend/internal/compose/publicoriginprobe_test.go
@@ -138,12 +138,12 @@ func TestTheOriginStatusSurvivesAHandlerRebuild(t *testing.T) {
 	defer srv.Close()
 
 	s := &Server{}
-	s.connectorHandlers.publicOrigin = s.originStatus
+	s.publicOrigin = s.originStatus
 	// The origin is configured AFTER the handler was built, which is the
 	// order that used to lose it.
 	s.originProbe = newPublicOriginProbe(srv.URL, newOriginProbeClient(), time.Now)
 
-	status := s.connectorHandlers.publicOrigin(context.Background())
+	status := s.publicOrigin(context.Background())
 	if status.Origin != srv.URL {
 		t.Errorf("origin = %q, want %q — the handler lost the probe", status.Origin, srv.URL)
 	}

--- a/backend/internal/compose/senddeliverability_integration_test.go
+++ b/backend/internal/compose/senddeliverability_integration_test.go
@@ -85,7 +85,7 @@ func TestToolSurfaceSendCarriesTheUnsubscribeSurface(t *testing.T) {
 		t.Fatalf("List-Unsubscribe = %q, want a one-click URL on the configured base (%s…) — an unconfigured store yields the empty string here",
 			staged.ListUnsubscribe, wantPrefix)
 	}
-	if !strings.Contains(staged.Body, "Unsubscribe: "+toolSurfaceBaseURL+"/v1/public/preferences/") {
+	if !strings.Contains(staged.Body, "Unsubscribe: "+toolSurfaceBaseURL+"/#/unsubscribe/") {
 		t.Fatalf("no visible unsubscribe footer on the transmitted body:\n%s", staged.Body)
 	}
 	// The minted identity is qualified by the configured origin, not by the

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -36,6 +36,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/runtimeenv"
 )
 
 // SendPath is the deployment configuration the send path needs and cannot
@@ -50,6 +51,10 @@ type SendPath struct {
 	// means a marketing send refuses (the store's fail-loud branch) rather
 	// than emitting a forgeable link.
 	PublicBaseURL string
+	// Environment decides whether a loopback PublicBaseURL is a working dev
+	// stack or a link the recipient's mail client cannot open. The zero
+	// value is production, which is the direction that fails safe.
+	Environment runtimeenv.Environment
 	// Delivery records an accepted message for transmission, in either shape a
 	// message takes. Nil means the send path refuses rather than log an
 	// activity nothing will carry.
@@ -126,6 +131,7 @@ func (s *Server) applySendPath(pool *pgxpool.Pool) {
 	send := s.send.withPoolDefaults(pool)
 	s.activitiesHandlers = s.activitiesHandlers.
 		WithPublicBaseURL(send.PublicBaseURL).
+		WithRuntimeEnvironment(send.Environment).
 		WithDelivery(send.Delivery).
 		// One machinery, both staging shapes: a nil Delivery converts to a nil
 		// channel stager too, so the reply surface fails closed exactly as the
@@ -227,6 +233,7 @@ func sendStore(pool *pgxpool.Pool, send SendPath) *activities.Store {
 	return activities.NewStore(InstallationDB(pool)).
 		WithUnsubscribe(preferenceLinkAdapter{store: consent.NewStore(InstallationDB(pool))}).
 		WithPublicBaseURL(send.PublicBaseURL).
+		WithRuntimeEnvironment(send.Environment).
 		WithSendAuthority(send.SendAuthority).
 		WithChannelReachability(send.ChannelRecipients).
 		WithRecipientDirectory(recipientDirectory{}).
@@ -236,6 +243,9 @@ func sendStore(pool *pgxpool.Pool, send SendPath) *activities.Store {
 		// because the request arrived on the tool surface. An agent principal
 		// still signs nothing — signedBody decides that, not this wiring.
 		WithSignature(people.NewStore(InstallationDB(pool))).
+		WithBaseLanguage(activities.BaseLanguageFunc(func(ctx context.Context) string {
+			return identity.BaseLanguageForPrompt(ctx, pool)
+		})).
 		WithSenderName(identity.NewServiceFor(InstallationDB(pool))).
 		WithHeldNotifier(send.HeldNotifier).
 		WithDraftOutcome(send.DraftOutcome)

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -132,6 +132,13 @@ func (s *Server) applySendPath(pool *pgxpool.Pool) {
 	s.activitiesHandlers = s.activitiesHandlers.
 		WithPublicBaseURL(send.PublicBaseURL).
 		WithRuntimeEnvironment(send.Environment).
+		// Wired on BOTH transports, which is what this file is for: without
+		// it here, a short message sent over HTTP got an English footer while
+		// the same message sent through the tool surface got the
+		// installation's language.
+		WithBaseLanguage(activities.BaseLanguageFunc(func(ctx context.Context) string {
+			return identity.BaseLanguageForPrompt(ctx, pool)
+		})).
 		WithDelivery(send.Delivery).
 		// One machinery, both staging shapes: a nil Delivery converts to a nil
 		// channel stager too, so the reply surface fails closed exactly as the

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -221,6 +221,12 @@ type Server struct {
 	// threadAudience applies an owner own decision about a thread they imported.
 	threadAudience *ThreadAudienceSetter
 
+	// originProbe answers whether the configured public origin responds.
+	// Nil until WithPublicBaseURL runs, and nil forever in a role with no
+	// origin configured — which the Connections screen renders as an
+	// absent row rather than a failure.
+	originProbe *publicOriginProbe
+
 	// vault is the secret store, injected by WithKeyvault. When configured
 	// it feeds a /readyz probe and backs the capture connector-credential
 	// path; nil means a role that resolves no stored connector credentials.

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -404,6 +404,11 @@ func WithPublicBaseURL(base string) Option {
 		// So does the confirm-details link, which opens one person's own record
 		// to whoever holds it.
 		s.consentHandlers = s.WithConfirmLinkBase(base)
+		// Reported to an operator, never enforced: the boot and send guards
+		// are what refuse an unusable origin, and a readiness check here
+		// would deadlock a rollout on its own ingress.
+		probe := newPublicOriginProbe(base, newOriginProbeClient(), time.Now)
+		s.connectorHandlers.publicOrigin = probe.Status
 		s.rebuildToolRegistry(pool)
 	}
 }

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -409,7 +409,7 @@ func WithPublicBaseURL(base string) Option {
 		// are what refuse an unusable origin, and a readiness check here
 		// would deadlock a rollout on its own ingress.
 		s.originProbe = newPublicOriginProbe(base, newOriginProbeClient(), time.Now)
-		s.connectorHandlers.publicOrigin = s.originStatus
+		s.publicOrigin = s.originStatus
 		s.rebuildToolRegistry(pool)
 	}
 }

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -250,6 +250,7 @@ func WithKeyvault(vault keyvault.Vault) Option {
 				registry:          NewCaptureRegistry(pool, vault, s.captureConfig),
 				authority:         identity.NewService(pool),
 				googleCredentials: s.googleAppResolver,
+				publicOrigin:      s.originStatus,
 			}
 		}
 		// The overlay incumbent connection lifecycle needs the same
@@ -407,8 +408,8 @@ func WithPublicBaseURL(base string) Option {
 		// Reported to an operator, never enforced: the boot and send guards
 		// are what refuse an unusable origin, and a readiness check here
 		// would deadlock a rollout on its own ingress.
-		probe := newPublicOriginProbe(base, newOriginProbeClient(), time.Now)
-		s.connectorHandlers.publicOrigin = probe.Status
+		s.originProbe = newPublicOriginProbe(base, newOriginProbeClient(), time.Now)
+		s.connectorHandlers.publicOrigin = s.originStatus
 		s.rebuildToolRegistry(pool)
 	}
 }

--- a/backend/internal/compose/serveroptions_schema.go
+++ b/backend/internal/compose/serveroptions_schema.go
@@ -98,6 +98,11 @@ func WithResetRuntime(rt ResetRuntime) Option {
 func WithNonProduction(env runtimeenv.Environment) Option {
 	return func(s *Server, _ *pgxpool.Pool) {
 		s.authHandlers = s.WithNonProduction(env.IsNonProduction())
+		// ONE posture, two consumers. The send path needs it for a different
+		// question than /me does — whether a loopback public origin is a
+		// working dev stack or a link the recipient cannot open — and reading
+		// the environment twice is how the two answers start to disagree.
+		s.send.Environment = env
 	}
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15871,6 +15871,12 @@ type CaptureConnectionStatus string
 // CaptureConnectionListResponse defines model for CaptureConnectionListResponse.
 type CaptureConnectionListResponse struct {
 	Data []CaptureConnection `json:"data"`
+
+	// PublicOrigin The address this installation puts in outgoing links, and whether it answered when last asked.
+	// Reported so an operator can SEE the value rather than discover it from a recipient; the boot and
+	// send guards are what actually refuse an unusable one. A probe from inside the deployment says this
+	// process can reach the origin — it cannot say a recipient's mail client can.
+	PublicOrigin *PublicOriginStatus `json:"public_origin,omitempty"`
 }
 
 // CaptureConsent The consent passthrough every capture surface (booking, public forms, imports) must carry
@@ -25337,6 +25343,23 @@ type ProviderRunTrigger string
 // months, so the connection read stays one round trip.
 type ProviderSpend struct {
 	Months []ProviderMonthlySpend `json:"months"`
+}
+
+// PublicOriginStatus The address this installation puts in outgoing links, and whether it answered when last asked.
+// Reported so an operator can SEE the value rather than discover it from a recipient; the boot and
+// send guards are what actually refuse an unusable one. A probe from inside the deployment says this
+// process can reach the origin — it cannot say a recipient's mail client can.
+type PublicOriginStatus struct {
+	CheckedAt *time.Time `json:"checked_at,omitempty"`
+
+	// Detail The HTTP status or the transport failure. Never carries a path or a token.
+	Detail *string `json:"detail,omitempty"`
+
+	// Origin The configured scheme and host.
+	Origin string `json:"origin"`
+
+	// Reachable Null until the first probe answers, so a screen can say "not checked yet" rather than implying a failure.
+	Reachable *bool `json:"reachable,omitempty"`
 }
 
 // PutOnboardingStateRequest defines model for PutOnboardingStateRequest.

--- a/backend/internal/modules/activities/draftoutcome_integration_test.go
+++ b/backend/internal/modules/activities/draftoutcome_integration_test.go
@@ -170,7 +170,7 @@ func TestDraftOutcomeJudgesTheApprovedBodyNotTheTransmittedFooter(t *testing.T) 
 	}
 
 	staged := stager.only(t)
-	if !strings.Contains(staged.Body, "/unsubscribe?purpose=marketing_email") {
+	if !strings.Contains(staged.Body, "/#/unsubscribe/"+testUnsubscribeTok+"/marketing_email") {
 		t.Fatalf("the transmitted body carries no footer, so this case proves nothing:\n%s", staged.Body)
 	}
 	if len(recorder.calls) != 1 {

--- a/backend/internal/modules/activities/email_refusals_integration_test.go
+++ b/backend/internal/modules/activities/email_refusals_integration_test.go
@@ -42,13 +42,15 @@ func TestSendEmailDerivesUnsubscribeHeadersForAMarketingPurpose(t *testing.T) {
 	if staged.ListUnsubscribe != "<"+wantURL+">" {
 		t.Fatalf("staged List-Unsubscribe = %q, want the bracketed one-click URL <%s>", staged.ListUnsubscribe, wantURL)
 	}
-	// Header and footer derive from the SAME token and URL, so a recipient's
-	// visible link can never point somewhere the machine header does not.
-	if !strings.Contains(staged.Body, wantURL) {
-		t.Fatalf("staged body carries no visible unsubscribe link:\n%s", staged.Body)
+	// The VISIBLE links are pages, and deliberately not the URL above: the
+	// machine endpoint is POST-only, so a recipient clicking it in a mail
+	// client gets 405. Same token, same purpose, different shape per caller.
+	wantVisible := testBaseURL + "/#/unsubscribe/" + testUnsubscribeTok + "/marketing_email?lang=en"
+	if !strings.Contains(staged.Body, wantVisible) {
+		t.Fatalf("staged body carries no human unsubscribe page link:\n%s", staged.Body)
 	}
-	if !strings.Contains(staged.Body, testBaseURL+"/v1/public/preferences/"+testUnsubscribeTok+"\n") &&
-		!strings.HasSuffix(staged.Body, testBaseURL+"/v1/public/preferences/"+testUnsubscribeTok) {
+	wantManage := testBaseURL + "/#/preferences/" + testUnsubscribeTok + "?lang=en"
+	if !strings.Contains(staged.Body, wantManage) {
 		t.Fatalf("staged body carries no manage-preferences link:\n%s", staged.Body)
 	}
 	// The timeline records that the send carried a one-click link, and which
@@ -56,7 +58,7 @@ func TestSendEmailDerivesUnsubscribeHeadersForAMarketingPurpose(t *testing.T) {
 	// bearer credential over the recipient's consent record and the activity
 	// row is served back to any seat holding activity:read, so the record and
 	// the transmission deliberately differ by exactly that one segment.
-	recordedURL := testBaseURL + "/v1/public/preferences/" + redactedToken + "/unsubscribe?purpose=marketing_email"
+	recordedURL := testBaseURL + "/#/unsubscribe/" + redactedToken + "/marketing_email?lang=en"
 	if sent.Body == nil || !strings.Contains(*sent.Body, recordedURL) {
 		t.Fatalf("logged activity body lost the unsubscribe footer: %v", sent.Body)
 	}

--- a/backend/internal/modules/activities/footerlanguage.go
+++ b/backend/internal/modules/activities/footerlanguage.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// What language the unsubscribe footer speaks, and whether the links in
+// it can be opened at all.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/platform/netguard"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+	"github.com/margince/margince/backend/internal/shared/runtimeenv"
+)
+
+// BaseLanguageReader answers the installation's configured language.
+// Injected, because it lives in identity and a module never imports a
+// sibling.
+type BaseLanguageReader interface {
+	BaseLanguage(ctx context.Context) string
+}
+
+// BaseLanguageFunc adapts a plain function.
+type BaseLanguageFunc func(ctx context.Context) string
+
+// BaseLanguage satisfies BaseLanguageReader.
+func (f BaseLanguageFunc) BaseLanguage(ctx context.Context) string { return f(ctx) }
+
+// WithBaseLanguage wires the fallback behind the footer's language.
+func (s *Store) WithBaseLanguage(r BaseLanguageReader) *Store {
+	s.baseLanguage = r
+	return s
+}
+
+// WithRuntimeEnvironment tells the send path which posture it runs under,
+// which is what decides whether a loopback public origin is a working dev
+// stack or a message nobody can act on.
+func (s *Store) WithRuntimeEnvironment(env runtimeenv.Environment) *Store {
+	s.env = env
+	return s
+}
+
+// footerLanguage picks the language of the footer from the language of
+// the message it sits under.
+//
+// The ladder is body, then subject, then the installation's own language,
+// then English — the same shape the drafting floor already trusts.
+// textlang.Detect is deliberately biased toward Unknown (it wants three
+// stopword hits and a clear margin), so a two-line note falls through to
+// the tiers below rather than being guessed at.
+//
+// Worth being plain about the limit: this picks the language of the
+// MESSAGE, not the recipient's preference, which nothing in the product
+// records. An English mail to a German reader gets an English footer,
+// which at least matches the message around it — and the page the link
+// opens carries a language switcher, which is the recovery path.
+func (s *Store) footerLanguage(ctx context.Context, body, subject string) textlang.Lang {
+	if lang := textlang.Detect(body); lang != textlang.Unknown {
+		return lang
+	}
+	if lang := textlang.Detect(subject); lang != textlang.Unknown {
+		return lang
+	}
+	if s.baseLanguage != nil {
+		if base := s.baseLanguage.BaseLanguage(ctx); textlang.Known(base) {
+			return textlang.Lang(base)
+		}
+	}
+	return textlang.English
+}
+
+// PublicOriginUnusableError is the refusal when a tokenized send cannot
+// build a link the recipient could open.
+//
+// A MessageFault rather than a field fault: nothing in the request says
+// what the public origin is, so pointing at an argument would hand the
+// caller a task they cannot perform. An operator has to fix the
+// deployment.
+type PublicOriginUnusableError struct {
+	// Reason says what is wrong with the configured origin. It never
+	// carries the origin itself, which may hold credentials.
+	Reason string
+}
+
+func (e *PublicOriginUnusableError) Error() string {
+	return "send: " + e.Reason
+}
+
+// MessageFault names the condition and who must act on it.
+func (e *PublicOriginUnusableError) MessageFault() (string, string) {
+	return "public_origin_unusable", "This message carries an unsubscribe link, and " + e.Reason +
+		" — an administrator must set the installation's public address before it can be sent."
+}
+
+// publicOriginUsable refuses a tokenized send whose links would not work.
+func (s *Store) publicOriginUsable() error {
+	if s.publicBaseURL == "" {
+		// Wording kept deliberately: this is the sentence the send path has
+		// always failed with when no base is configured.
+		return &PublicOriginUnusableError{Reason: "public base URL is not configured"}
+	}
+	if err := netguard.RequirePublicOrigin("the public base URL", s.publicBaseURL, s.env); err != nil {
+		return &PublicOriginUnusableError{Reason: fmt.Sprintf("%v", err)}
+	}
+	return nil
+}
+
+// WithRuntimeEnvironment is the Handlers half of the same wiring: the HTTP
+// transport and the tool surface must agree about the posture, or one of
+// them sends links the other would refuse.
+func (h Handlers) WithRuntimeEnvironment(env runtimeenv.Environment) Handlers {
+	h.store = h.store.WithRuntimeEnvironment(env)
+	return h
+}
+
+// WithBaseLanguage is the Handlers half of the footer's language fallback.
+func (h Handlers) WithBaseLanguage(r BaseLanguageReader) Handlers {
+	h.store = h.store.WithBaseLanguage(r)
+	return h
+}

--- a/backend/internal/modules/activities/sendcore.go
+++ b/backend/internal/modules/activities/sendcore.go
@@ -106,7 +106,7 @@ func (s *Store) PrepareSend(ctx context.Context, origin SendOrigin, in SendEmail
 
 	// Deliverability is derived here, after the gates, so both transports
 	// get it and neither can send marketing mail without it.
-	derived, err := s.deliverability(ctx, signed, in.Recipients, in.ConsentPurpose)
+	derived, err := s.deliverability(ctx, signed, in.Subject, in.Recipients, in.ConsentPurpose)
 	if err != nil {
 		return PreparedSend{}, err
 	}

--- a/backend/internal/modules/activities/signature_test.go
+++ b/backend/internal/modules/activities/signature_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/platform/mailcopy"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -195,8 +196,11 @@ func TestNoMarkupBodyProducesNoMarkupAlternative(t *testing.T) {
 // chose to render.
 func TestBothPartsCarryTheUnsubscribeSurface(t *testing.T) {
 	derived := sendDeliverability{
-		unsubURL:  "https://app.test/v1/public/unsubscribe/tok",
-		manageURL: "https://app.test/v1/public/preferences/tok",
+		links: unsubscribeLinks{
+			unsubscribe: "https://app.test/#/unsubscribe/tok/newsletter?lang=en",
+			manage:      "https://app.test/#/preferences/tok?lang=en",
+		},
+		words: mailcopy.For("en"),
 	}
 	store := (&Store{}).WithSignature(&stubSignature{})
 
@@ -204,7 +208,7 @@ func TestBothPartsCarryTheUnsubscribeSurface(t *testing.T) {
 	if err != nil {
 		t.Fatalf("signing the markup failed: %v", err)
 	}
-	if !strings.Contains(got, derived.unsubURL) || !strings.Contains(got, derived.manageURL) {
+	if !strings.Contains(got, derived.links.unsubscribe) || !strings.Contains(got, derived.links.manage) {
 		t.Fatalf("the markup part carries no unsubscribe surface: %q", got)
 	}
 }

--- a/backend/internal/modules/activities/store.go
+++ b/backend/internal/modules/activities/store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/runtimeenv"
 )
 
 // Store owns this module's tables (data-seam ownership, ADR-0014 Am.1);
@@ -42,6 +43,14 @@ type Store struct {
 	// link resolves to — configured at boot, never taken from the request
 	// (WithPublicBaseURL wires it).
 	publicBaseURL string
+	// baseLanguage is the installation's own language, the tier the footer
+	// falls back to when the message itself is too short to read
+	// (WithBaseLanguage). Nil means English.
+	baseLanguage BaseLanguageReader
+	// env decides whether a loopback public origin is a working dev stack
+	// or a link nobody outside this machine could open. The zero value is
+	// production, which is the safe direction (WithRuntimeEnvironment).
+	env runtimeenv.Environment
 	// signature is the sender's own sign-off, appended to every message they
 	// send; nil means unsigned, which is what every role did before the
 	// signature existed (WithSignature wires it).

--- a/backend/internal/modules/activities/unsubscribe.go
+++ b/backend/internal/modules/activities/unsubscribe.go
@@ -13,10 +13,12 @@ package activities
 
 import (
 	"context"
-	"fmt"
 	"html"
 	"net/url"
 	"strings"
+
+	"github.com/margince/margince/backend/internal/platform/mailcopy"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
 
 // UnsubscribeLinker resolves a recipient address to their preference-center
@@ -122,23 +124,67 @@ type sendDeliverability struct {
 	// recorded is the body the timeline row keeps and every authenticated
 	// read of it serves: the same message with the capability redacted.
 	recorded string
-	// unsubURL and manageURL are the same two links the plain footer carries,
-	// kept so the markup alternative can render them as anchors from the SAME
-	// token. Rebuilding them from a second token would let the two parts of one
-	// message offer different unsubscribe capabilities.
-	unsubURL  string
-	manageURL string
+	// links are the three destinations this send offers, kept so the markup
+	// alternative renders anchors from the SAME token. Rebuilding them from a
+	// second token would let the two parts of one message offer different
+	// unsubscribe capabilities.
+	links unsubscribeLinks
+	// words are the footer's labels in the message's own language.
+	words mailcopy.Copy
+}
+
+// unsubscribeLinks is every destination one send derives from ONE token.
+//
+// Held by: TestOneSendDerivesEveryUnsubscribeDestination (backend/gates/preferencecentrewriters_test.go)
+//
+// Three, not one, because three different callers press them and they need
+// different shapes. Collapsing them is what broke: the visible "Unsubscribe"
+// link pointed at the machine endpoint, which is POST-only by design, so a
+// human clicking it in a mail client got 405 — and the visible "Manage
+// preferences" link pointed at the JSON API, which answered a recipient with
+// a wall of JSON. Built by one function so the three cannot name different
+// tokens, purposes or languages.
+type unsubscribeLinks struct {
+	// oneClick is the RFC 8058 endpoint, for the List-Unsubscribe header and
+	// NOTHING else. A mailbox provider POSTs it without a browser.
+	oneClick string
+	// unsubscribe is the page a person lands on, which asks before it acts:
+	// a GET must never withdraw, because mail scanners and link prefetchers
+	// follow links in a mailbox without a human involved.
+	unsubscribe string
+	// manage is the preference centre, where every purpose can be seen.
+	manage string
+}
+
+// unsubscribeLinksFor builds all three from one token.
+//
+// The two visible links are hash routes: the SPA already serves its public
+// surfaces that way, static hosting needs no server fallback for them, and
+// the token stays out of ordinary web-server access logs until the page
+// deliberately calls the API with it.
+func unsubscribeLinksFor(baseURL, token, purposeKey string, lang textlang.Lang) unsubscribeLinks {
+	purpose := strings.ToLower(strings.TrimSpace(purposeKey))
+	query := "?lang=" + url.QueryEscape(string(lang))
+	return unsubscribeLinks{
+		oneClick: baseURL + "/v1/public/preferences/" + url.PathEscape(token) +
+			"/unsubscribe?purpose=" + url.QueryEscape(purpose),
+		unsubscribe: baseURL + "/#/unsubscribe/" + url.PathEscape(token) + "/" +
+			url.PathEscape(purpose) + query,
+		manage: baseURL + "/#/preferences/" + url.PathEscape(token) + query,
+	}
 }
 
 // htmlFooter renders the unsubscribe links as markup, for the alternative part.
 // Empty when this send carries no unsubscribe surface, which is what a
 // transactional purpose has: nothing to unsubscribe from and no footer.
 func (d sendDeliverability) htmlFooter() string {
-	if d.unsubURL == "" {
+	if d.links.unsubscribe == "" {
 		return ""
 	}
-	return `<hr><p><a href="` + html.EscapeString(d.unsubURL) + `">Unsubscribe</a>` +
-		` · <a href="` + html.EscapeString(d.manageURL) + `">Manage your preferences</a></p>`
+	return `<hr><p><a href="` + html.EscapeString(d.links.unsubscribe) + `">` +
+		html.EscapeString(d.words.UnsubscribeLabel) + `</a>` +
+		` · <a href="` + html.EscapeString(d.links.manage) + `">` +
+		html.EscapeString(d.words.ManagePreferencesLabel) + `</a></p>`
 }
 
 // deliverability derives what a send must carry for a mailbox provider to
@@ -155,7 +201,9 @@ func (d sendDeliverability) htmlFooter() string {
 // recipients is the MERGED addressee list, every To and Cc address, because
 // the refusal above counts who RECEIVES the rendered message rather than how
 // they were addressed.
-func (s *Store) deliverability(ctx context.Context, body string, recipients []string, purposeKey string) (sendDeliverability, error) {
+func (s *Store) deliverability(
+	ctx context.Context, body, subject string, recipients []string, purposeKey string,
+) (sendDeliverability, error) {
 	untokenized := sendDeliverability{transmitted: body, recorded: body}
 	if s.unsubscribe == nil || len(recipients) == 0 {
 		return untokenized, nil
@@ -174,21 +222,26 @@ func (s *Store) deliverability(ctx context.Context, body string, recipients []st
 	if distinctAddresses(recipients) > 1 {
 		return sendDeliverability{}, &SharedUnsubscribeTokenError{}
 	}
-	if s.publicBaseURL == "" {
-		// Fail loudly rather than derive the base from the request: the link
-		// carries the recipient's unsubscribe token, and a marketing send
-		// may not go out without a working, non-forgeable List-Unsubscribe
-		// URL (features/06 §1.2).
-		return sendDeliverability{}, fmt.Errorf("send: public base URL is not configured; a marketing send must carry a working List-Unsubscribe URL")
+	// Fail loudly rather than derive the base from the request: the link
+	// carries the recipient's unsubscribe token, and a marketing send may not
+	// go out without a working, non-forgeable List-Unsubscribe URL
+	// (features/06 §1.2). The guard also refuses an origin a recipient's mail
+	// client cannot reach — a localhost base means "this computer" to whoever
+	// clicks it, which is how a real send went out with links nobody outside
+	// this machine could open.
+	if err := s.publicOriginUsable(); err != nil {
+		return sendDeliverability{}, err
 	}
-	unsubURL := unsubscribeURL(s.publicBaseURL, token, purposeKey)
+	lang := s.footerLanguage(ctx, body, subject)
+	words := mailcopy.For(string(lang))
+	live := unsubscribeLinksFor(s.publicBaseURL, token, purposeKey, lang)
+	redacted := unsubscribeLinksFor(s.publicBaseURL, redactedToken, purposeKey, lang)
 	return sendDeliverability{
-		listUnsubscribe: listUnsubscribeHeader(unsubURL),
-		unsubURL:        unsubURL,
-		manageURL:       s.publicBaseURL + "/v1/public/preferences/" + url.PathEscape(token),
-		transmitted:     appendUnsubscribeFooter(body, s.publicBaseURL, token, unsubURL),
-		recorded: appendUnsubscribeFooter(body, s.publicBaseURL, redactedToken,
-			unsubscribeURL(s.publicBaseURL, redactedToken, purposeKey)),
+		listUnsubscribe: listUnsubscribeHeader(live.oneClick),
+		links:           live,
+		words:           words,
+		transmitted:     appendUnsubscribeFooter(body, live, words),
+		recorded:        appendUnsubscribeFooter(body, redacted, words),
 	}, nil
 }
 
@@ -208,15 +261,6 @@ func distinctAddresses(recipients []string) int {
 	return len(seen)
 }
 
-// unsubscribeURL is the ONE spelling of the public one-click endpoint the
-// header and the body footer both point at: token in the path, the
-// message's purpose in the query so a per-purpose withdrawal targets
-// exactly the list this message belonged to.
-func unsubscribeURL(baseURL, token, purposeKey string) string {
-	return baseURL + "/v1/public/preferences/" + url.PathEscape(token) +
-		"/unsubscribe?purpose=" + url.QueryEscape(strings.ToLower(strings.TrimSpace(purposeKey)))
-}
-
 // listUnsubscribeHeader returns the RFC 8058 List-Unsubscribe value: the
 // bracketed https one-click URL. Its companion List-Unsubscribe-Post value
 // is fixed by the RFC at "List-Unsubscribe=One-Click" and is therefore
@@ -229,8 +273,10 @@ func listUnsubscribeHeader(unsubURL string) string {
 // appendUnsubscribeFooter adds the human-visible unsubscribe + manage-
 // preferences links beneath the message body (AC-D3 "a visible unsubscribe
 // link"), built from the same token as the machine header so the two can
-// never diverge.
-func appendUnsubscribeFooter(body, baseURL, token, unsubURL string) string {
-	manageURL := baseURL + "/v1/public/preferences/" + url.PathEscape(token)
-	return body + "\n\n---\nUnsubscribe: " + unsubURL + "\nManage your preferences: " + manageURL
+// never diverge. Both point at PAGES, never at the API: the machine
+// endpoint is POST-only and answers a human click with 405.
+func appendUnsubscribeFooter(body string, links unsubscribeLinks, words mailcopy.Copy) string {
+	return body + "\n\n---\n" +
+		words.UnsubscribeLabel + ": " + links.unsubscribe + "\n" +
+		words.ManagePreferencesLabel + ": " + links.manage
 }

--- a/backend/internal/modules/activities/unsubscribe_test.go
+++ b/backend/internal/modules/activities/unsubscribe_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// The three destinations one send derives, and the language they speak.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/mailcopy"
+	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
+)
+
+// The header keeps the machine endpoint. A mailbox provider POSTs it
+// without a browser, and moving it would break RFC 8058 one-click.
+func TestTheHeaderKeepsTheOneClickAPIURL(t *testing.T) {
+	links := unsubscribeLinksFor("https://crm.example.com", "tok", "marketing_email", textlang.English)
+	want := "https://crm.example.com/v1/public/preferences/tok/unsubscribe?purpose=marketing_email"
+	if links.oneClick != want {
+		t.Errorf("oneClick = %q, want %q", links.oneClick, want)
+	}
+	if got := listUnsubscribeHeader(links.oneClick); got != "<"+want+">" {
+		t.Errorf("header = %q, want the bracketed one-click URL", got)
+	}
+}
+
+// The two VISIBLE links are pages. This is the defect the whole change is
+// about: a person clicking the footer used to reach a POST-only endpoint
+// (405) and a JSON document.
+func TestTheVisibleLinksArePagesNotTheAPI(t *testing.T) {
+	links := unsubscribeLinksFor("https://crm.example.com", "tok", "business_correspondence", textlang.German)
+	for name, got := range map[string]string{"unsubscribe": links.unsubscribe, "manage": links.manage} {
+		if strings.Contains(got, "/v1/") {
+			t.Errorf("%s = %q — a visible link must not point at the API", name, got)
+		}
+		if !strings.Contains(got, "/#/") {
+			t.Errorf("%s = %q, want a hash route", name, got)
+		}
+		if !strings.HasSuffix(got, "?lang=de") {
+			t.Errorf("%s = %q, want the message's language carried", name, got)
+		}
+	}
+	if !strings.Contains(links.unsubscribe, "/#/unsubscribe/tok/business_correspondence") {
+		t.Errorf("unsubscribe = %q, want token and purpose in the path", links.unsubscribe)
+	}
+	if !strings.Contains(links.manage, "/#/preferences/tok") {
+		t.Errorf("manage = %q, want the preference centre", links.manage)
+	}
+}
+
+// Plain and markup are two renderings of ONE message, so they must offer
+// the same capability. A recipient's ability to unsubscribe must not
+// depend on which alternative their mail client chose to show.
+func TestBothFootersCarryOneTokenPurposeAndLanguage(t *testing.T) {
+	links := unsubscribeLinksFor("https://crm.example.com", "tok", "newsletter", textlang.German)
+	words := mailcopy.For("de")
+	plain := appendUnsubscribeFooter("Guten Tag", links, words)
+	markup := sendDeliverability{links: links, words: words}.htmlFooter()
+
+	for _, want := range []string{links.unsubscribe, links.manage} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("the plain footer is missing %q", want)
+		}
+		if !strings.Contains(markup, want) {
+			t.Errorf("the markup footer is missing %q", want)
+		}
+	}
+	if !strings.Contains(plain, words.UnsubscribeLabel) {
+		t.Errorf("the plain footer does not speak the message's language: %q", plain)
+	}
+}
+
+// The recorded copy keeps the footer's SHAPE and loses only the
+// capability: a reader of the timeline sees that the send carried a
+// working link and which purpose it pointed at, and cannot use it.
+func TestTheRecordedFooterCarriesOnlyTheRedactedToken(t *testing.T) {
+	const live = "pref_secret_value"
+	redacted := unsubscribeLinksFor("https://crm.example.com", redactedToken, "newsletter", textlang.English)
+	recorded := appendUnsubscribeFooter("Body", redacted, mailcopy.For("en"))
+
+	if strings.Contains(recorded, live) {
+		t.Errorf("the recorded body carries the live token: %q", recorded)
+	}
+	if !strings.Contains(recorded, redactedToken) {
+		t.Errorf("the recorded body lost the footer's shape: %q", recorded)
+	}
+	if !strings.Contains(recorded, "/#/unsubscribe/"+redactedToken+"/newsletter") {
+		t.Errorf("the recorded body does not name the purpose: %q", recorded)
+	}
+}
+
+// A purpose or token carrying a separator must not be able to reshape the
+// URL it lands in.
+func TestTokenAndPurposeAreEscaped(t *testing.T) {
+	links := unsubscribeLinksFor("https://crm.example.com", "tok/../evil", "news letter/x", textlang.English)
+	for name, got := range map[string]string{"unsubscribe": links.unsubscribe, "oneClick": links.oneClick} {
+		if strings.Contains(got, "/../") {
+			t.Errorf("%s = %q — a token reshaped the path", name, got)
+		}
+		if strings.Contains(got, "letter/x") {
+			t.Errorf("%s = %q — a purpose reshaped the path", name, got)
+		}
+	}
+}
+
+// A German message gets a German footer. The English footer under German
+// prose is the product speaking two languages in one message.
+func TestAGermanBodyGetsAGermanFooter(t *testing.T) {
+	store := &Store{}
+	const body = "Guten Tag, ich melde mich noch einmal wegen des Angebots und der offenen Fragen dazu."
+	if got := store.footerLanguage(context.Background(), body, "Angebot"); got != textlang.German {
+		t.Errorf("footerLanguage = %q, want de", got)
+	}
+}
+
+// A body too short to read falls through to the subject, then to the
+// installation's own language. textlang.Detect is deliberately biased to
+// Unknown, so this tier is reached often rather than rarely.
+func TestAShortBodyFallsThroughTheLadder(t *testing.T) {
+	store := (&Store{}).WithBaseLanguage(BaseLanguageFunc(func(context.Context) string { return "vi" }))
+	if got := store.footerLanguage(context.Background(), "Danke!", ""); got != textlang.Vietnamese {
+		t.Errorf("footerLanguage = %q, want the installation's vi", got)
+	}
+	const subject = "Ihre Anfrage zu unserem Angebot und den offenen Punkten"
+	if got := store.footerLanguage(context.Background(), "Danke!", subject); got != textlang.German {
+		t.Errorf("footerLanguage = %q, want de from the subject", got)
+	}
+}
+
+// No reader wired, nothing detectable: English rather than a guess.
+func TestAnUnreadableMessageWithNoInstallationLanguageIsEnglish(t *testing.T) {
+	store := &Store{}
+	if got := store.footerLanguage(context.Background(), "ok", ""); got != textlang.English {
+		t.Errorf("footerLanguage = %q, want en", got)
+	}
+}
+
+// The send refuses an origin the recipient could not open. This is the
+// configuration that produced the incident.
+func TestATokenizedSendRefusesAnUnreachableOrigin(t *testing.T) {
+	store := (&Store{}).WithPublicBaseURL("http://localhost:8080")
+	err := store.publicOriginUsable()
+	if err == nil {
+		t.Fatal("a localhost origin was admitted for a tokenized send")
+	}
+	var fault *PublicOriginUnusableError
+	if !asPublicOriginFault(err, &fault) {
+		t.Fatalf("error = %T, want a PublicOriginUnusableError the caller can act on", err)
+	}
+	code, message := fault.MessageFault()
+	if code != "public_origin_unusable" {
+		t.Errorf("code = %q", code)
+	}
+	if strings.Contains(message, "localhost:8080") {
+		t.Errorf("the refusal echoed the configured origin: %q", message)
+	}
+}
+
+// An unconfigured origin keeps the sentence the send path has always used.
+func TestAnUnconfiguredOriginStillSaysSo(t *testing.T) {
+	err := (&Store{}).publicOriginUsable()
+	if err == nil || !strings.Contains(err.Error(), "public base URL is not configured") {
+		t.Errorf("error = %v, want the long-standing wording", err)
+	}
+}
+
+func asPublicOriginFault(err error, target **PublicOriginUnusableError) bool {
+	fault, ok := err.(*PublicOriginUnusableError)
+	if ok {
+		*target = fault
+	}
+	return ok
+}

--- a/backend/internal/modules/consent/oneclickbody.go
+++ b/backend/internal/modules/consent/oneclickbody.go
@@ -71,26 +71,6 @@ func requireOneClickBody(r *http.Request) error {
 		// did not send.
 		return requireEmptyBody(r)
 	}
-	// Some other content type. It is only a refusal if a body actually came
-	// with it: a client that announces JSON and then sends nothing has said
-	// nothing this endpoint disagrees with, and plenty do — the header is
-	// often set by a shared request helper rather than chosen per call.
-	// Refusing those would break the human path to protect a machine one.
-	return refuseIfBodyPresent(r)
-}
-
-// refuseIfBodyPresent admits an empty body under any content type and
-// refuses a non-empty one that is not an RFC 8058 form.
-func refuseIfBodyPresent(r *http.Request) error {
-	n, err := io.Copy(io.Discard, io.LimitReader(r.Body, oneClickBodyLimit+1))
-	if err != nil {
-		slog.DebugContext(r.Context(), "one-click unsubscribe body could not be drained", "error", err)
-		return nil
-	}
-	if n == 0 {
-		return nil
-	}
-	return httperr.Validation("body", "not_one_click", "a one-click unsubscribe carries the RFC 8058 form body")
 }
 
 // readOneClickBody reads the body bounded to the ceiling. It reads one

--- a/backend/internal/modules/consent/oneclickbody.go
+++ b/backend/internal/modules/consent/oneclickbody.go
@@ -71,6 +71,26 @@ func requireOneClickBody(r *http.Request) error {
 		// did not send.
 		return requireEmptyBody(r)
 	}
+	// Some other content type. It is only a refusal if a body actually came
+	// with it: a client that announces JSON and then sends nothing has said
+	// nothing this endpoint disagrees with, and plenty do — the header is
+	// often set by a shared request helper rather than chosen per call.
+	// Refusing those would break the human path to protect a machine one.
+	return refuseIfBodyPresent(r)
+}
+
+// refuseIfBodyPresent admits an empty body under any content type and
+// refuses a non-empty one that is not an RFC 8058 form.
+func refuseIfBodyPresent(r *http.Request) error {
+	n, err := io.Copy(io.Discard, io.LimitReader(r.Body, oneClickBodyLimit+1))
+	if err != nil {
+		slog.DebugContext(r.Context(), "one-click unsubscribe body could not be drained", "error", err)
+		return nil
+	}
+	if n == 0 {
+		return nil
+	}
+	return httperr.Validation("body", "not_one_click", "a one-click unsubscribe carries the RFC 8058 form body")
 }
 
 // readOneClickBody reads the body bounded to the ceiling. It reads one

--- a/backend/internal/modules/consent/oneclickbody_test.go
+++ b/backend/internal/modules/consent/oneclickbody_test.go
@@ -61,6 +61,16 @@ func TestOneClickAcceptsAnEmptyBody(t *testing.T) {
 	}
 }
 
+// A client that announces JSON and sends nothing has said nothing this
+// endpoint disagrees with. Shared request helpers set this header on
+// every call, including bodiless ones, so refusing it would break the
+// product's own unsubscribe page to protect a machine contract.
+func TestOneClickAcceptsAnEmptyBodyUnderAnyContentType(t *testing.T) {
+	if err := requireOneClickBody(oneClickRequest("", "application/json")); err != nil {
+		t.Errorf("refused an empty body announced as JSON: %v", err)
+	}
+}
+
 // A charset parameter is ordinary and must not change the verdict.
 func TestOneClickToleratesAContentTypeParameter(t *testing.T) {
 	if err := requireOneClickBody(
@@ -77,7 +87,7 @@ func TestOneClickRefusesABodyThatIsNotOneClick(t *testing.T) {
 	}{
 		{"a form without the pair", "Something=Else", "application/x-www-form-urlencoded"},
 		{"the wrong value", "List-Unsubscribe=Two-Click", "application/x-www-form-urlencoded"},
-		{"json", `{"List-Unsubscribe":"One-Click"}`, "application/json"},
+		{"a json body", `{"List-Unsubscribe":"One-Click"}`, "application/json"},
 		{"multipart with no boundary", "whatever", "multipart/form-data"},
 		{"no content type, junk body", "hello", ""},
 	}

--- a/backend/internal/platform/mailcopy/catalog.go
+++ b/backend/internal/platform/mailcopy/catalog.go
@@ -32,6 +32,7 @@ func buildCatalog() map[Language]Copy {
 	// One function per message rather than one long one, because the length
 	// cap is a real reading limit here: a translator opens the section they are
 	// working on, and a hundred lines of unrelated copy above it is noise.
+	unsubscribeLines(line)
 	resetLines(line)
 	inviteLines(line)
 	weeklyLines(line)
@@ -44,6 +45,18 @@ func buildCatalog() map[Language]Copy {
 type writeLine = func(field func(*Copy) *string, english, german, vietnamese string)
 
 // resetLines is the password reset a person asked for.
+// unsubscribeLines is the footer beneath an outgoing message.
+func unsubscribeLines(line writeLine) {
+	line(func(c *Copy) *string { return &c.UnsubscribeLabel },
+		"Unsubscribe",
+		"Abmelden",
+		"Hủy đăng ký")
+	line(func(c *Copy) *string { return &c.ManagePreferencesLabel },
+		"Manage your preferences",
+		"E-Mail-Einstellungen verwalten",
+		"Quản lý tùy chọn email")
+}
+
 func resetLines(line writeLine) {
 	line(func(c *Copy) *string { return &c.ResetSubject },
 		"Reset your Margince password",

--- a/backend/internal/platform/mailcopy/mailcopy.go
+++ b/backend/internal/platform/mailcopy/mailcopy.go
@@ -80,6 +80,13 @@ func Known(language string) bool {
 // field of every language: that is what stops a language reaching a mailbox
 // half-written.
 type Copy struct {
+	// The unsubscribe footer under an outgoing message. A German mail with
+	// an English footer is the product speaking two languages in one
+	// message, and the footer is the half a recipient reads when they want
+	// it to stop.
+	UnsubscribeLabel       string
+	ManagePreferencesLabel string
+
 	// The password reset a person asked for.
 	ResetSubject string
 	ResetIntro   string

--- a/backend/internal/platform/netguard/publicorigin.go
+++ b/backend/internal/platform/netguard/publicorigin.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package netguard
+
+// Whether the origin in an outgoing link can be opened by the person who
+// receives it.
+//
+// This is the inverse of the rule a fetch source answers to. A fetch
+// origin may be loopback or private — that is an address THIS process
+// dials. A public origin is an address somebody else's mail client dials,
+// and "localhost" there means their computer, not ours. The product sent
+// a real message whose unsubscribe links pointed at http://localhost:8080;
+// nothing refused it, because nothing had been asked to.
+//
+// The check is syntactic and says so. It refuses the forms that CANNOT
+// work — cleartext, loopback, private and other non-public literals — and
+// admits a hostname without resolving it, because resolving here would
+// make a boot decision depend on DNS at the moment of the check. So it
+// proves an origin is not obviously broken; it never proves one is
+// reachable. The probe on the Connections screen is what reports that.
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/shared/runtimeenv"
+)
+
+// ErrOriginNotPublic is the class: a configured public origin that a
+// recipient could not open.
+var ErrOriginNotPublic = errors.New("public origin is not reachable by a recipient")
+
+// RequirePublicOrigin holds a configured public origin to what a
+// RECIPIENT can open.
+//
+// Shape — scheme, host, no path or userinfo — is somebody else's job:
+// cmd/api's validateBareOrigin already holds it, more strictly than a
+// second copy here would, and this adds only the half that one does not
+// ask. It takes the value as given and judges reachability alone.
+//
+// Under a development or test posture nothing is held, so the dev stack's
+// http://localhost default keeps working. Any other posture — including
+// an unrecognised one, which runtimeenv parses as production — gets the
+// full rule, so the carve-out fails closed.
+func RequirePublicOrigin(label, raw string, env runtimeenv.Environment) error {
+	if strings.TrimSpace(raw) == "" {
+		return fmt.Errorf("%w: %s names no origin", ErrOriginNotPublic, label)
+	}
+	if env == runtimeenv.Development || env == runtimeenv.Test {
+		return nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%w: %s is not a URL", ErrOriginNotPublic, label)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("%w: %s is cleartext (%s); a link in somebody's mailbox must be https",
+			ErrOriginNotPublic, label, parsed.Scheme)
+	}
+	host := parsed.Hostname()
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return fmt.Errorf("%w: %s is %q, which means the RECIPIENT's own computer",
+			ErrOriginNotPublic, label, host)
+	}
+	if ip := net.ParseIP(host); ip != nil && !PublicIP(ip) {
+		return fmt.Errorf("%w: %s is %q, an address that is not reachable from outside this network",
+			ErrOriginNotPublic, label, host)
+	}
+	return nil
+}

--- a/backend/internal/platform/netguard/publicorigin.go
+++ b/backend/internal/platform/netguard/publicorigin.go
@@ -34,39 +34,98 @@ import (
 // recipient could not open.
 var ErrOriginNotPublic = errors.New("public origin is not reachable by a recipient")
 
-// RequirePublicOrigin holds a configured public origin to what a
+// RequirePublicOrigin holds a configured public origin to something a
 // RECIPIENT can open.
 //
-// Shape — scheme, host, no path or userinfo — is somebody else's job:
-// cmd/api's validateBareOrigin already holds it, more strictly than a
-// second copy here would, and this adds only the half that one does not
-// ask. It takes the value as given and judges reachability alone.
+// It asks BOTH halves — that the value is a bare origin at all, and that
+// the origin is publicly reachable — because the sending callers reach
+// only this function. An earlier version delegated the shape half to
+// cmd/api's own validator on the grounds that it was stricter; that
+// validator runs only when the MCP connector is enabled, so a sending
+// deployment with MCP off was left holding nothing, and
+// "https://user:secret@example.com" would have gone into every emailed
+// link.
 //
-// Under a development or test posture nothing is held, so the dev stack's
-// http://localhost default keeps working. Any other posture — including
-// an unrecognised one, which runtimeenv parses as production — gets the
-// full rule, so the carve-out fails closed.
+// Under a development or test posture only the shape is held, so the dev
+// stack's http://localhost default keeps working. Any other posture —
+// including an unrecognised one, which runtimeenv parses as production —
+// gets the full rule, so the carve-out fails closed.
 func RequirePublicOrigin(label, raw string, env runtimeenv.Environment) error {
-	if strings.TrimSpace(raw) == "" {
-		return fmt.Errorf("%w: %s names no origin", ErrOriginNotPublic, label)
+	parsed, err := bareOrigin(label, raw)
+	if err != nil {
+		return err
 	}
 	if env == runtimeenv.Development || env == runtimeenv.Test {
 		return nil
-	}
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return fmt.Errorf("%w: %s is not a URL", ErrOriginNotPublic, label)
 	}
 	if parsed.Scheme != "https" {
 		return fmt.Errorf("%w: %s is cleartext (%s); a link in somebody's mailbox must be https",
 			ErrOriginNotPublic, label, parsed.Scheme)
 	}
-	host := parsed.Hostname()
-	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+	return publiclyReachableHost(label, parsed.Hostname())
+}
+
+// bareOrigin holds the value to a scheme and a host and nothing else.
+//
+// Every refusal here is deliberately silent about the value: an origin
+// carrying userinfo is carrying a credential, and echoing it would copy
+// that credential into the boot log the error lands in.
+func bareOrigin(label, raw string) (*url.URL, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("%w: %s names no origin", ErrOriginNotPublic, label)
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s is not a URL", ErrOriginNotPublic, label)
+	}
+	if parsed.User != nil {
+		return nil, fmt.Errorf("%w: %s carries userinfo, which would be published in every emailed "+
+			"link (value withheld: it may contain a credential)", ErrOriginNotPublic, label)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("%w: %s needs an http or https scheme", ErrOriginNotPublic, label)
+	}
+	// Hostname(), not Host: a Host of ":8443" is a non-empty authority that
+	// names no host at all, and "https:/example.com" parses to an OPAQUE
+	// path with no authority — an https scheme with nothing to dial.
+	if parsed.Hostname() == "" {
+		return nil, fmt.Errorf("%w: %s names no host", ErrOriginNotPublic, label)
+	}
+	// A URL is derived by APPENDING to this value, so anything after the
+	// host swallows what follows it: a fragment makes every appended path
+	// part of the fragment, and a query makes it part of the query.
+	if parsed.Path != "" && parsed.Path != "/" {
+		return nil, fmt.Errorf("%w: %s must be scheme and host only; a path here produces links nothing resolves",
+			ErrOriginNotPublic, label)
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return nil, fmt.Errorf("%w: %s must be scheme and host only, with no query or fragment",
+			ErrOriginNotPublic, label)
+	}
+	return parsed, nil
+}
+
+// publiclyReachableHost refuses the hosts that mean "not from out there".
+func publiclyReachableHost(label, host string) error {
+	// Lowercased and stripped of a trailing root dot before comparing:
+	// "LOCALHOST" and "localhost." are the same name to a resolver, and a
+	// check that missed either would refuse the spelling an operator is
+	// unlikely to type while admitting the ones they might.
+	name := strings.ToLower(strings.TrimSuffix(host, "."))
+	if name == "localhost" || strings.HasSuffix(name, ".localhost") {
 		return fmt.Errorf("%w: %s is %q, which means the RECIPIENT's own computer",
 			ErrOriginNotPublic, label, host)
 	}
-	if ip := net.ParseIP(host); ip != nil && !PublicIP(ip) {
+	// A zone (%eth0) is only meaningful on this machine, so an address
+	// carrying one can never be somebody else's route in. net.ParseIP
+	// rejects the zoned form outright, which would otherwise read as "not
+	// an IP" and fall through as if it were a hostname.
+	addr, zone, hasZone := strings.Cut(name, "%")
+	if hasZone && zone != "" && net.ParseIP(addr) != nil {
+		return fmt.Errorf("%w: %s is %q, an address scoped to one machine's own interface",
+			ErrOriginNotPublic, label, host)
+	}
+	if ip := net.ParseIP(name); ip != nil && !PublicIP(ip) {
 		return fmt.Errorf("%w: %s is %q, an address that is not reachable from outside this network",
 			ErrOriginNotPublic, label, host)
 	}

--- a/backend/internal/platform/netguard/publicorigin_test.go
+++ b/backend/internal/platform/netguard/publicorigin_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package netguard
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/runtimeenv"
+)
+
+// The incident this exists for: a real message went out carrying
+// http://localhost:8080, which on the recipient's machine means their own
+// computer.
+func TestALoopbackOriginIsRefusedInProduction(t *testing.T) {
+	for _, origin := range []string{
+		"http://localhost:8080",
+		"https://localhost",
+		"https://app.localhost",
+		"http://127.0.0.1:5173",
+		"https://[::1]",
+		"https://10.0.0.5",
+		"https://192.168.1.10",
+		"https://169.254.1.1",
+		"https://0.0.0.0",
+	} {
+		t.Run(origin, func(t *testing.T) {
+			err := RequirePublicOrigin("--public-base-url", origin, runtimeenv.Production)
+			if err == nil {
+				t.Fatal("admitted an origin no recipient could open")
+			}
+			if !errors.Is(err, ErrOriginNotPublic) {
+				t.Errorf("error = %v, want it to wrap ErrOriginNotPublic", err)
+			}
+		})
+	}
+}
+
+// Cleartext is refused even on a public name: the link lands in a mailbox
+// and is clicked from networks nobody here controls.
+func TestAPublicOriginMustBeHTTPSInProduction(t *testing.T) {
+	if err := RequirePublicOrigin("--public-base-url", "http://crm.example.com", runtimeenv.Production); err == nil {
+		t.Error("admitted a cleartext public origin")
+	}
+}
+
+func TestAPublicHTTPSOriginIsAdmitted(t *testing.T) {
+	for _, origin := range []string{"https://crm.example.com", "https://crm.example.com:8443", "https://93.184.216.34"} {
+		if err := RequirePublicOrigin("--public-base-url", origin, runtimeenv.Production); err != nil {
+			t.Errorf("RequirePublicOrigin(%q) = %v, want admitted", origin, err)
+		}
+	}
+}
+
+// A hostname is admitted WITHOUT resolving it. Resolving here would make a
+// boot decision depend on DNS at the moment of the check, so the honest
+// scope is "not obviously broken", never "proven reachable".
+func TestAHostnameIsAdmittedWithoutResolving(t *testing.T) {
+	if err := RequirePublicOrigin("--public-base-url",
+		"https://internal-only.invalid", runtimeenv.Production); err != nil {
+		t.Errorf("refused an unresolvable hostname: %v — the check is syntactic by design", err)
+	}
+}
+
+// The dev stack defaults to http://localhost and must keep working.
+func TestDevelopmentAndTestAdmitLocalhost(t *testing.T) {
+	for _, env := range []runtimeenv.Environment{runtimeenv.Development, runtimeenv.Test} {
+		if err := RequirePublicOrigin("--public-base-url", "http://localhost:5173", env); err != nil {
+			t.Errorf("posture %v refused the dev default: %v", env, err)
+		}
+	}
+}
+
+// runtimeenv parses anything it does not recognise as production, and this
+// carve-out must inherit that direction rather than opening on a typo.
+func TestAnUnknownPostureIsTreatedAsProduction(t *testing.T) {
+	if err := RequirePublicOrigin("--public-base-url",
+		"http://localhost:8080", runtimeenv.Parse("staging")); err == nil {
+		t.Error("an unrecognised posture admitted a loopback origin")
+	}
+}
+
+// An empty origin is refused rather than passed through as "nothing to check".
+func TestAnEmptyOriginIsRefused(t *testing.T) {
+	if err := RequirePublicOrigin("--public-base-url", "  ", runtimeenv.Production); err == nil {
+		t.Error("admitted an empty origin")
+	}
+}
+
+// A refusal must not echo an origin that could carry a credential.
+func TestARefusalDoesNotEchoUserinfo(t *testing.T) {
+	err := RequirePublicOrigin("--public-base-url", "http://user:hunter2@localhost", runtimeenv.Production)
+	if err == nil {
+		t.Fatal("admitted a loopback origin carrying userinfo")
+	}
+	if strings.Contains(err.Error(), "hunter2") {
+		t.Errorf("the refusal echoed the credential: %v", err)
+	}
+}

--- a/backend/internal/platform/netguard/publicorigin_test.go
+++ b/backend/internal/platform/netguard/publicorigin_test.go
@@ -89,6 +89,45 @@ func TestAnEmptyOriginIsRefused(t *testing.T) {
 	}
 }
 
+// Every one of these was admitted by a first version of this guard that
+// delegated shape validation to a caller which does not always run.
+func TestAMalformedOriginIsRefusedBySendersOwnGuard(t *testing.T) {
+	cases := map[string]string{
+		"userinfo would be published in every emailed link": "https://user:secret@example.com",
+		"a fragment swallows every appended path":           "https://example.com#dead",
+		"a query swallows every appended path":              "https://example.com?a=b",
+		"a path produces links nothing resolves":            "https://example.com/app",
+		"an https scheme with no authority to dial":         "https:/example.com",
+		"an authority naming no host":                       "https://:8443",
+	}
+	for reason, origin := range cases {
+		t.Run(reason, func(t *testing.T) {
+			if err := RequirePublicOrigin("--public-base-url", origin, runtimeenv.Production); err == nil {
+				t.Errorf("admitted %q — %s", origin, reason)
+			}
+		})
+	}
+}
+
+// The same name in the spellings a resolver treats as equal. A check that
+// missed these refuses what an operator is unlikely to type and admits
+// what they might.
+func TestLocalhostIsRefusedInEverySpelling(t *testing.T) {
+	for _, origin := range []string{
+		"https://LOCALHOST",
+		"https://localhost.",
+		"https://LocalHost.",
+		"https://APP.LOCALHOST",
+		"https://[fe80::1%25eth0]",
+	} {
+		t.Run(origin, func(t *testing.T) {
+			if err := RequirePublicOrigin("--public-base-url", origin, runtimeenv.Production); err == nil {
+				t.Errorf("admitted %q", origin)
+			}
+		})
+	}
+}
+
 // A refusal must not echo an origin that could carry a credential.
 func TestARefusalDoesNotEchoUserinfo(t *testing.T) {
 	err := RequirePublicOrigin("--public-base-url", "http://user:hunter2@localhost", runtimeenv.Production)

--- a/backend/internal/platform/outbound/useragent.go
+++ b/backend/internal/platform/outbound/useragent.go
@@ -46,6 +46,14 @@ const (
 	WebhooksProduct = "margince-webhooks"
 	WebhooksHeader  = WebhooksProduct + "/" + version
 
+	// SelfCheckProduct identifies this installation asking whether its own
+	// configured public address answers. The request goes to the operator's
+	// own ingress, and it is the one call where a name in their log saves
+	// them from investigating an unexplained hit on their health endpoint
+	// every minute.
+	SelfCheckProduct = "margince-selfcheck"
+	SelfCheckHeader  = SelfCheckProduct + "/" + version
+
 	// ClientMetadataProduct identifies the fetch of a client's own metadata
 	// document during OAuth consent. That request goes to a URL the CALLER
 	// supplied, which makes it the one outbound call where the operator on the

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -296,7 +296,6 @@ internal/modules/activities/scheduling.go#var block at var errAvailabilityToNotA
 internal/modules/activities/transcript_integration_test.go#func TestUpdateActivityNormalizesATranscriptBody
 internal/modules/activities/transcriptnorm.go#func transcriptLines
 internal/modules/activities/unsubscribe.go#func listUnsubscribeHeader
-internal/modules/activities/unsubscribe.go#func unsubscribeURL
 internal/modules/activities/unsubscribe.go#method Store.deliverability
 internal/modules/agents/approvals.go#func pinForWrite
 internal/modules/agents/apps/apps.go#const block at const AccountBriefURI

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -205,6 +205,13 @@ const PreferenceCenterScreen = lazy(
     })),
   ),
 );
+const UnsubscribeScreen = lazy(
+  routed(() =>
+    import("./screens/unsubscribe").then((m) => ({
+      default: m.UnsubscribeScreen,
+    })),
+  ),
+);
 const ConfirmDetailsScreen = lazy(
   routed(() =>
     import("./screens/confirm").then((m) => ({
@@ -483,6 +490,12 @@ const SCREEN_VIEWS: Readonly<Record<Screen, (args: ScreenArgs) => ReactNode>> =
     // #/preferences/<token> — anonymous; the token in the path is the
     // whole capability (security: [] in the contract).
     preferences: ({ id }) => <PreferenceCenterScreen token={id} />,
+    // #/unsubscribe/<token>/<purpose> — the page the VISIBLE unsubscribe
+    // link in a message opens. Anonymous, and it never withdraws on arrival:
+    // a mail scanner following the link is not a person pressing a button.
+    unsubscribe: ({ id, id2 }) => (
+      <UnsubscribeScreen token={id} purpose={id2} />
+    ),
     // #/confirm/<token> — anonymous, the sibling of the preference centre. The
     // token is single-use and shows the subject their own record, which is why
     // it is a different credential from the reusable preference link.
@@ -620,6 +633,7 @@ const PUBLIC_SCREENS: ReadonlySet<Screen> = new Set([
   "book",
   "confirm",
   "preferences",
+  "unsubscribe",
   "room",
 ]);
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -12718,6 +12718,23 @@ export interface components {
         };
         CaptureConnectionListResponse: {
             data: components["schemas"]["CaptureConnection"][];
+            public_origin?: components["schemas"]["PublicOriginStatus"];
+        };
+        /**
+         * @description The address this installation puts in outgoing links, and whether it answered when last asked.
+         *     Reported so an operator can SEE the value rather than discover it from a recipient; the boot and
+         *     send guards are what actually refuse an unusable one. A probe from inside the deployment says this
+         *     process can reach the origin — it cannot say a recipient's mail client can.
+         */
+        PublicOriginStatus: {
+            /** @description The configured scheme and host. */
+            origin: string;
+            /** @description Null until the first probe answers, so a screen can say "not checked yet" rather than implying a failure. */
+            reachable?: boolean | null;
+            /** Format: date-time */
+            checked_at?: string | null;
+            /** @description The HTTP status or the transport failure. Never carries a path or a token. */
+            detail?: string | null;
         };
         /**
          * @description Connect a capture source. Providers differ in kind, not in path: an OAuth provider

--- a/frontend/src/app/nav.ts
+++ b/frontend/src/app/nav.ts
@@ -187,6 +187,8 @@ export const RAIL_LESS_SCREENS: ReadonlySet<Screen> = new Set([
   "book",
   "client",
   "preferences",
+  "unsubscribe",
+  "confirm",
   "room",
   "oauth-consent",
 ]);

--- a/frontend/src/app/recordzone.tsx
+++ b/frontend/src/app/recordzone.tsx
@@ -98,7 +98,7 @@ export function renderableRecordZone(configured: string | undefined): string {
  * of the settings query the record zone makes.
  *
  * `enabled` is the session gate. The settings read needs one, and the three
- * public screens (`book`, `preferences`, `room`) render no record dates at all
+ * public screens (`book`, `preferences`, `unsubscribe`, `confirm`, `room`) render no record dates at all
  * — they show a moment the reader relates to their own clock, on
  * `viewerZone()`, which needs no installation.
  *

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -47,6 +47,7 @@ const SCREENS = [
   "client",
   "book",
   "preferences",
+  "unsubscribe",
   "confirm",
   "room",
   "oauth-consent",
@@ -172,6 +173,9 @@ const IDENTITY_DEPTH: Readonly<Record<Screen, number>> = {
   client: WHOLE_ADDRESS,
   book: WHOLE_ADDRESS,
   preferences: WHOLE_ADDRESS,
+  // Token AND purpose name the thing: the same reader may hold links for
+  // two different kinds of mail, and they are two different pages.
+  unsubscribe: WHOLE_ADDRESS,
   confirm: WHOLE_ADDRESS,
   room: WHOLE_ADDRESS,
   "oauth-consent": WHOLE_ADDRESS,

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4890,6 +4890,31 @@ export const de = {
   "prefs.title": "Wähle, was du von uns hörst",
   "prefs.sub":
     "Jeder Zweck steht für sich — hier ist nicht alles oder nichts. Transaktionale Nachrichten lassen sich hier nicht abschalten, weil du sie brauchst; alles andere bestimmst du selbst.",
+  "prefs.unsub.title": "Diese E-Mails nicht mehr erhalten?",
+  "prefs.unsub.lead":
+    "Ein Klick stoppt Nachrichten dieser Art an deine Adresse. Sonst \u00e4ndert sich nichts.",
+  "prefs.unsub.loading":
+    "Deine E-Mail-Einstellungen werden ge\u00f6ffnet \u2026",
+  "prefs.unsub.afterTitle": "Was danach passiert",
+  "prefs.unsub.afterBody":
+    "Wir senden dir keine weiteren E-Mails dieser Art. Sicherheits- und Servicenachrichten, die du f\u00fcr einen von dir angeforderten Vorgang brauchst, bleiben davon unber\u00fchrt.",
+  "prefs.unsub.confirm": "Diese E-Mails abbestellen",
+  "prefs.unsub.busy": "Deine Entscheidung wird gespeichert \u2026",
+  "prefs.unsub.seeAll": "Alle Einstellungen ansehen",
+  "prefs.unsub.privacy":
+    "Kein Login n\u00f6tig. Dieser pers\u00f6nliche Link gilt nur f\u00fcr deine E-Mail-Einstellungen \u2014 bitte teile ihn nicht.",
+  "prefs.unsub.doneTitle": "Abbestellung best\u00e4tigt",
+  "prefs.unsub.doneBody":
+    "Du erh\u00e4ltst {label} nicht mehr von uns. Die \u00c4nderung gilt sofort.",
+  "prefs.unsub.manage": "Einstellungen verwalten",
+  "prefs.unsub.alreadyOff":
+    "Diese E-Mails waren bereits abgeschaltet. Es wurde nichts ge\u00e4ndert.",
+  "prefs.unsub.lockedTitle": "Diese Nachrichten lassen sich nicht abschalten",
+  "prefs.unsub.lockedBody":
+    "Sie geh\u00f6ren zu einem von dir angeforderten Vorgang \u2014 etwa ein neues Passwort oder eine Best\u00e4tigung, um die du gebeten hast.",
+  "prefs.unsub.retry": "Erneut versuchen",
+  "prefs.unsub.unknownPurpose":
+    "Dieser Link nennt keine Art von E-Mail, die wir versenden. \u00d6ffne deine Einstellungen, um alles zu sehen.",
   "prefs.invalidLink":
     "Dieser Link ist nicht mehr gültig. Präferenz-Links laufen ab oder können widerrufen werden — frag in einer aktuellen E-Mail nach einem neuen.",
   "buyer.opening": "Ihr Deal Room wird geöffnet …",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3866,6 +3866,10 @@ export const de = {
   "mailSharing.sharedPosture.warning":
     "Das Postfach von Beschäftigten in ein gemeinsames CRM einzulesen, ist in Deutschland und Österreich Gegenstand einer Betriebsvereinbarung. Wer dies einschaltet, erklärt, dass Ihre Organisation eine solche hat. Margince prüft das nicht.",
   "mailSharing.save": "Speichern",
+  "connectors.originLabel": "Adresse in versendeten Links",
+  "connectors.originReachable": "Antwortet",
+  "connectors.originUnreachable": "Antwortet nicht",
+  "connectors.originUnchecked": "Noch nicht gepr\u00fcft",
   "connectors.sub":
     "Postfächer, die dein CRM automatisch füllen. Trenne eines bei Bedarf — bereits erfasste Datensätze bleiben.",
   "connectors.loading": "Verbindungen werden geladen…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4958,6 +4958,30 @@ export const en = {
   "prefs.title": "Choose what you hear from us",
   "prefs.sub":
     "Each purpose is separate — this isn't all-or-nothing. Transactional messages can't be switched off here, because you need them; everything else is yours to control.",
+  "prefs.unsub.title": "Stop receiving these emails?",
+  "prefs.unsub.lead":
+    "One click stops messages of this kind to your address. Nothing else changes.",
+  "prefs.unsub.loading": "Opening your email preferences\u2026",
+  "prefs.unsub.afterTitle": "What happens next",
+  "prefs.unsub.afterBody":
+    "We stop sending you emails of this kind. Security and service messages you need for something you asked for are not affected.",
+  "prefs.unsub.confirm": "Unsubscribe from these emails",
+  "prefs.unsub.busy": "Recording your choice\u2026",
+  "prefs.unsub.seeAll": "See all preferences",
+  "prefs.unsub.privacy":
+    "No login needed. This personal link only controls your email preferences \u2014 please don't share it.",
+  "prefs.unsub.doneTitle": "Unsubscribed",
+  "prefs.unsub.doneBody":
+    "You won't receive {label} from us again. The change applies immediately.",
+  "prefs.unsub.manage": "Manage preferences",
+  "prefs.unsub.alreadyOff":
+    "These emails were already switched off. Nothing changed.",
+  "prefs.unsub.lockedTitle": "These messages can't be switched off",
+  "prefs.unsub.lockedBody":
+    "They're needed for something you asked for \u2014 a password reset, or a confirmation you requested.",
+  "prefs.unsub.retry": "Try again",
+  "prefs.unsub.unknownPurpose":
+    "This link doesn't name a kind of email we send. Open your preferences to see everything.",
   "prefs.invalidLink":
     "This link is no longer valid. Preference links expire and can be withdrawn — ask for a fresh one from any recent email.",
   "buyer.opening": "Opening your Deal Room…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3902,6 +3902,10 @@ export const en = {
   "mailSharing.sharedPosture.warning":
     "Reading an employee's mailbox into a shared CRM is what a works-council agreement covers in Germany and Austria. Turning this on says your organization holds one. Margince does not check.",
   "mailSharing.save": "Save",
+  "connectors.originLabel": "Address used in emailed links",
+  "connectors.originReachable": "Answering",
+  "connectors.originUnreachable": "Not answering",
+  "connectors.originUnchecked": "Not checked yet",
   "connectors.sub":
     "Mailboxes capturing into your CRM. Disconnect any one when you need to — already-captured records stay.",
   "connectors.loading": "Loading your connections…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3830,6 +3830,11 @@ export const vi = {
   "mailSharing.sharedPosture.warning":
     "Việc đọc hộp thư của nhân viên vào một CRM dùng chung thuộc phạm vi thỏa thuận với hội đồng lao động ở Đức và Áo. Bật mục này nghĩa là tổ chức của bạn đã có thỏa thuận đó. Margince không kiểm tra điều này.",
   "mailSharing.save": "Lưu",
+  "connectors.originLabel":
+    "\u0110\u1ecba ch\u1ec9 d\u00f9ng trong li\u00ean k\u1ebft g\u1eedi qua email",
+  "connectors.originReachable": "C\u00f3 ph\u1ea3n h\u1ed3i",
+  "connectors.originUnreachable": "Kh\u00f4ng ph\u1ea3n h\u1ed3i",
+  "connectors.originUnchecked": "Ch\u01b0a ki\u1ec3m tra",
   "connectors.sub":
     "Các hộp thư đang thu thập vào CRM của bạn. Cần thì ngắt kết nối hộp nào cũng được — bản ghi đã thu thập vẫn giữ nguyên.",
   "connectors.loading": "Đang tải các kết nối…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4850,6 +4850,33 @@ export const vi = {
   "prefs.title": "Chọn những gì bạn nhận từ chúng tôi",
   "prefs.sub":
     "Mỗi mục đích là riêng biệt — không phải chuyện được tất cả hoặc không gì cả. Thư giao dịch không tắt được ở đây, vì bạn cần chúng; mọi thứ còn lại là quyền của bạn.",
+  "prefs.unsub.title": "Ng\u1eebng nh\u1eadn nh\u1eefng email n\u00e0y?",
+  "prefs.unsub.lead":
+    "M\u1ed9t c\u00fa nh\u1ea5p s\u1ebd d\u1eebng c\u00e1c th\u01b0 thu\u1ed9c lo\u1ea1i n\u00e0y g\u1eedi t\u1edbi \u0111\u1ecba ch\u1ec9 c\u1ee7a b\u1ea1n. M\u1ecdi th\u1ee9 kh\u00e1c gi\u1eef nguy\u00ean.",
+  "prefs.unsub.loading":
+    "\u0110ang m\u1edf t\u00f9y ch\u1ecdn email c\u1ee7a b\u1ea1n\u2026",
+  "prefs.unsub.afterTitle": "\u0110i\u1ec1u g\u00ec x\u1ea3y ra ti\u1ebfp theo",
+  "prefs.unsub.afterBody":
+    "Ch\u00fang t\u00f4i s\u1ebd kh\u00f4ng g\u1eedi cho b\u1ea1n email lo\u1ea1i n\u00e0y n\u1eefa. C\u00e1c th\u01b0 v\u1ec1 b\u1ea3o m\u1eadt v\u00e0 d\u1ecbch v\u1ee5 c\u1ea7n cho vi\u1ec7c b\u1ea1n \u0111\u00e3 y\u00eau c\u1ea7u v\u1eabn \u0111\u01b0\u1ee3c gi\u1eef l\u1ea1i.",
+  "prefs.unsub.confirm": "H\u1ee7y nh\u1eadn nh\u1eefng email n\u00e0y",
+  "prefs.unsub.busy":
+    "\u0110ang ghi l\u1ea1i l\u1ef1a ch\u1ecdn c\u1ee7a b\u1ea1n\u2026",
+  "prefs.unsub.seeAll": "Xem t\u1ea5t c\u1ea3 t\u00f9y ch\u1ecdn",
+  "prefs.unsub.privacy":
+    "Kh\u00f4ng c\u1ea7n \u0111\u0103ng nh\u1eadp. Li\u00ean k\u1ebft c\u00e1 nh\u00e2n n\u00e0y ch\u1ec9 \u0111i\u1ec1u khi\u1ec3n t\u00f9y ch\u1ecdn email c\u1ee7a b\u1ea1n \u2014 xin \u0111\u1eebng chia s\u1ebb.",
+  "prefs.unsub.doneTitle": "\u0110\u00e3 h\u1ee7y \u0111\u0103ng k\u00fd",
+  "prefs.unsub.doneBody":
+    "B\u1ea1n s\u1ebd kh\u00f4ng nh\u1eadn {label} t\u1eeb ch\u00fang t\u00f4i n\u1eefa. Thay \u0111\u1ed5i c\u00f3 hi\u1ec7u l\u1ef1c ngay.",
+  "prefs.unsub.manage": "Qu\u1ea3n l\u00fd t\u00f9y ch\u1ecdn",
+  "prefs.unsub.alreadyOff":
+    "Nh\u1eefng email n\u00e0y \u0111\u00e3 t\u1eaft t\u1eeb tr\u01b0\u1edbc. Kh\u00f4ng c\u00f3 g\u00ec thay \u0111\u1ed5i.",
+  "prefs.unsub.lockedTitle":
+    "Kh\u00f4ng th\u1ec3 t\u1eaft nh\u1eefng th\u01b0 n\u00e0y",
+  "prefs.unsub.lockedBody":
+    "Ch\u00fang thu\u1ed9c v\u1ec1 vi\u1ec7c b\u1ea1n \u0111\u00e3 y\u00eau c\u1ea7u \u2014 \u0111\u1eb7t l\u1ea1i m\u1eadt kh\u1ea9u, ho\u1eb7c m\u1ed9t x\u00e1c nh\u1eadn b\u1ea1n \u0111\u00e3 \u0111\u1ec1 ngh\u1ecb.",
+  "prefs.unsub.retry": "Th\u1eed l\u1ea1i",
+  "prefs.unsub.unknownPurpose":
+    "Li\u00ean k\u1ebft n\u00e0y kh\u00f4ng n\u00eau lo\u1ea1i email n\u00e0o ch\u00fang t\u00f4i g\u1eedi. H\u00e3y m\u1edf t\u00f9y ch\u1ecdn \u0111\u1ec3 xem t\u1ea5t c\u1ea3.",
   "prefs.invalidLink":
     "Liên kết này không còn hiệu lực. Liên kết tuỳ chọn sẽ hết hạn và có thể bị thu hồi — hãy lấy một liên kết mới từ bất kỳ email gần đây nào.",
   "buyer.opening": "Đang mở Deal Room của bạn…",

--- a/frontend/src/screens/connectors.test.tsx
+++ b/frontend/src/screens/connectors.test.tsx
@@ -76,6 +76,12 @@ type StubOpts = {
   connect?: { authorize_url?: string } | { status: number };
   /** The messaging-channel roster the Telegram panel reads. */
   channels?: ChannelConnection[];
+  /** The installation's outward address, as GET /connectors reports it. */
+  publicOrigin?: {
+    origin: string;
+    reachable?: boolean | null;
+    detail?: string | null;
+  };
 };
 
 function stubApi(connections: CaptureConnection[], opts: StubOpts = {}) {
@@ -89,7 +95,11 @@ function stubApi(connections: CaptureConnection[], opts: StubOpts = {}) {
         if (opts.listStatus) {
           return jsonResponse({ detail: "boom" }, opts.listStatus);
         }
-        return jsonResponse({ data: connections });
+        return jsonResponse(
+          opts.publicOrigin
+            ? { data: connections, public_origin: opts.publicOrigin }
+            : { data: connections },
+        );
       }
       // Every ConnectorsCard mount now also reads the Telegram channel
       // panel's own list — these tests exercise the mail-connector rows
@@ -724,5 +734,58 @@ describe("the Telegram connector panel", () => {
     // observable proof it bound to that row and not to the first.
     const dialog = screen.getByRole("dialog");
     expect(within(dialog).getByText(/^Pending/)).toBeTruthy();
+  });
+  // The address this installation puts in emailed links, on the card that
+  // already asks whether it can reach the outside world.
+  //
+  // It exists because the value is otherwise invisible: a deployment
+  // configured with a localhost origin sends mail whose unsubscribe links
+  // open nothing, and the only way to find out was for a recipient to
+  // click one.
+  it("shows the address used in emailed links, and that it answers", async () => {
+    stubApi([], {
+      publicOrigin: {
+        origin: "https://crm.example.com",
+        reachable: true,
+        detail: "http 200",
+      },
+    });
+    render(<ConnectorsCard />);
+
+    const row = await screen.findByTestId("public-origin");
+    expect(within(row).getByText("https://crm.example.com")).toBeTruthy();
+    expect(within(row).getByText("Answering")).toBeTruthy();
+  });
+
+  it("says so when the address does not answer", async () => {
+    stubApi([], {
+      publicOrigin: { origin: "https://crm.example.com", reachable: false },
+    });
+    render(<ConnectorsCard />);
+    expect(
+      within(await screen.findByTestId("public-origin")).getByText(
+        "Not answering",
+      ),
+    ).toBeTruthy();
+  });
+
+  // Null is "not asked yet", which must not read as a failure.
+  it("distinguishes an unchecked address from a failing one", async () => {
+    stubApi([], {
+      publicOrigin: { origin: "https://crm.example.com", reachable: null },
+    });
+    render(<ConnectorsCard />);
+    expect(
+      within(await screen.findByTestId("public-origin")).getByText(
+        "Not checked yet",
+      ),
+    ).toBeTruthy();
+  });
+
+  // No origin configured is not a broken origin: the row is absent.
+  it("shows no address row when none is configured", async () => {
+    stubApi([]);
+    render(<ConnectorsCard />);
+    expect(screen.queryByTestId("public-origin")).toBeNull();
   });
 });

--- a/frontend/src/screens/connectors.tsx
+++ b/frontend/src/screens/connectors.tsx
@@ -126,7 +126,14 @@ export type ConnectorsResult = {
   // webhooks_not_configured treatment).
   notConfigured: boolean;
   data: CaptureConnection[];
+  // The address this installation puts in outgoing links, and whether it
+  // answered when last asked. Absent when none is configured — which is
+  // itself the answer, not a failure.
+  publicOrigin?: PublicOriginStatus;
 };
+
+type PublicOriginStatus =
+  components["schemas"]["CaptureConnectionListResponse"]["public_origin"];
 
 // The OAuth return outcome (Task 2): the callback lands back on
 // #/settings/connections/{outcome} — id2 on that route only, never parsed
@@ -928,9 +935,59 @@ export function useConnectors() {
       if (error) {
         throwProblem(error);
       }
-      return { notConfigured: false, data: data.data };
+      return {
+        notConfigured: false,
+        data: data.data,
+        publicOrigin: data.public_origin,
+      };
     },
   });
+}
+
+/**
+ * The address this installation puts in the links it emails, and whether it
+ * answered when last asked.
+ *
+ * It sits on this card because it is the same question the card already
+ * asks — can this installation reach the outside world — and because the
+ * value is otherwise invisible: a deployment configured with a localhost
+ * origin sends mail whose unsubscribe links open nothing, and until now
+ * the only way to find out was for a recipient to click one.
+ *
+ * Reported, never enforced. The boot and send guards are what refuse an
+ * unusable origin; this is so somebody can SEE it. And a probe from inside
+ * the deployment says this process can reach the origin — it cannot say a
+ * recipient's mail client can.
+ */
+function PublicOriginRow({
+  status,
+}: Readonly<{ status?: ConnectorsResult["publicOrigin"] }>) {
+  const t = useT();
+  if (!status) {
+    return null;
+  }
+  const tone =
+    status.reachable === null || status.reachable === undefined
+      ? undefined
+      : status.reachable
+        ? "success"
+        : "warn";
+  const stateLabel =
+    status.reachable === null || status.reachable === undefined
+      ? t("connectors.originUnchecked")
+      : status.reachable
+        ? t("connectors.originReachable")
+        : t("connectors.originUnreachable");
+  return (
+    <SettingList>
+      <SettingRow
+        testId="public-origin"
+        label={t("connectors.originLabel")}
+        description={status.origin}
+        control={<Badge tone={tone}>{stateLabel}</Badge>}
+      />
+    </SettingList>
+  );
 }
 
 // The roster as this card's list of decisions: one row per mailbox, or — when
@@ -1120,6 +1177,7 @@ function MailConnectorsPanel() {
             onDisconnect={setPendingDisconnect}
           />
         )}
+        <PublicOriginRow status={connectors.data?.publicOrigin} />
       </PanelBody>
       <AddConnectionDialog
         open={addOpen && offerAdd}

--- a/frontend/src/screens/preferences.css
+++ b/frontend/src/screens/preferences.css
@@ -170,3 +170,58 @@
   align-items: flex-start;
   gap: var(--space-3);
 }
+
+/* The human unsubscribe page. It shares .pref-page with the preference
+   centre so the two surfaces a recipient reaches from one message look
+   like one product rather than two. */
+.unsub-lead {
+  margin: 0 0 var(--space-5);
+  color: var(--textSecondary);
+}
+
+.unsub-kind {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-4);
+  font-weight: 600;
+}
+
+.unsub-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
+}
+
+.unsub-privacy {
+  margin-top: var(--space-5);
+  color: var(--textTertiary);
+  font-size: var(--fs-sm);
+}
+
+.unsub-done {
+  padding: var(--space-4) 0;
+  text-align: center;
+}
+
+.unsub-done h1 {
+  margin: var(--space-3) 0 var(--space-2);
+}
+
+/* Focused programmatically after the press, so the outcome is announced;
+   the ring is suppressed because the reader did not tab here. */
+.unsub-done h1:focus-visible {
+  outline: none;
+}
+
+.unsub-done-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  color: var(--success);
+  background: var(--successBg);
+}

--- a/frontend/src/screens/preferences.logic.test.ts
+++ b/frontend/src/screens/preferences.logic.test.ts
@@ -18,6 +18,8 @@ const purposes: PurposeView[] = [
     choice: "opted_in",
     can_opt_in: false,
     grant_needs_confirmation: false,
+    choice: "opted_in",
+    can_opt_in: false,
   },
   {
     key: "marketing_email",
@@ -27,6 +29,8 @@ const purposes: PurposeView[] = [
     choice: "opted_in",
     can_opt_in: true,
     grant_needs_confirmation: false,
+    choice: "opted_in",
+    can_opt_in: true,
   },
   {
     key: "events",
@@ -36,6 +40,8 @@ const purposes: PurposeView[] = [
     choice: "opted_out",
     can_opt_in: true,
     grant_needs_confirmation: false,
+    choice: "opted_out",
+    can_opt_in: true,
   },
   {
     key: "research",
@@ -47,6 +53,8 @@ const purposes: PurposeView[] = [
     choice: "no_objection",
     can_opt_in: true,
     grant_needs_confirmation: false,
+    choice: "opted_out",
+    can_opt_in: true,
   },
 ];
 
@@ -64,6 +72,8 @@ const doiPurposes: PurposeView[] = [
     // here either, for the same reason a locked one cannot.
     can_opt_in: false,
     grant_needs_confirmation: true,
+    choice: "opted_out",
+    can_opt_in: false,
   },
   {
     key: "doi_granted",
@@ -73,6 +83,8 @@ const doiPurposes: PurposeView[] = [
     choice: "opted_in",
     can_opt_in: false,
     grant_needs_confirmation: true,
+    choice: "opted_in",
+    can_opt_in: false,
   },
 ];
 

--- a/frontend/src/screens/preferences.logic.test.ts
+++ b/frontend/src/screens/preferences.logic.test.ts
@@ -18,8 +18,6 @@ const purposes: PurposeView[] = [
     choice: "opted_in",
     can_opt_in: false,
     grant_needs_confirmation: false,
-    choice: "opted_in",
-    can_opt_in: false,
   },
   {
     key: "marketing_email",
@@ -29,8 +27,6 @@ const purposes: PurposeView[] = [
     choice: "opted_in",
     can_opt_in: true,
     grant_needs_confirmation: false,
-    choice: "opted_in",
-    can_opt_in: true,
   },
   {
     key: "events",
@@ -40,8 +36,6 @@ const purposes: PurposeView[] = [
     choice: "opted_out",
     can_opt_in: true,
     grant_needs_confirmation: false,
-    choice: "opted_out",
-    can_opt_in: true,
   },
   {
     key: "research",
@@ -53,8 +47,6 @@ const purposes: PurposeView[] = [
     choice: "no_objection",
     can_opt_in: true,
     grant_needs_confirmation: false,
-    choice: "opted_out",
-    can_opt_in: true,
   },
 ];
 
@@ -72,8 +64,6 @@ const doiPurposes: PurposeView[] = [
     // here either, for the same reason a locked one cannot.
     can_opt_in: false,
     grant_needs_confirmation: true,
-    choice: "opted_out",
-    can_opt_in: false,
   },
   {
     key: "doi_granted",
@@ -83,8 +73,6 @@ const doiPurposes: PurposeView[] = [
     choice: "opted_in",
     can_opt_in: false,
     grant_needs_confirmation: true,
-    choice: "opted_in",
-    can_opt_in: false,
   },
 ];
 

--- a/frontend/src/screens/unsubscribe.test.tsx
+++ b/frontend/src/screens/unsubscribe.test.tsx
@@ -1,0 +1,226 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { UnsubscribeScreen } from "./unsubscribe";
+
+// The page the VISIBLE unsubscribe link in a message opens. Like the
+// preference centre next door, this file must NOT seed a workspace slug:
+// the token in the URL is the whole capability, and seeding one would mask
+// a regression where the client starts sending workspace context anyway.
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const CENTER = {
+  masked_email: "m•••••@example.com",
+  workspace_name: "Gradion",
+  refused: [],
+  purposes: [
+    {
+      key: "transactional",
+      label: "Deal & service messages",
+      state: "granted",
+      locked: true,
+      grant_needs_confirmation: false,
+      choice: "no_objection",
+      can_opt_in: false,
+    },
+    {
+      key: "business_correspondence",
+      label: "Direct correspondence",
+      state: "unknown",
+      locked: false,
+      grant_needs_confirmation: false,
+      choice: "no_objection",
+      can_opt_in: true,
+    },
+  ],
+};
+
+type Sent = { key: string; url: string };
+
+function stubEdge(
+  overrides: Record<string, () => Response | Promise<Response>> = {},
+  sent: Sent[] = [],
+) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      sent.push({ key, url: url.pathname + url.search });
+      const override = overrides[key];
+      if (override) return override();
+      if (key === "GET /public/preferences/tok-123")
+        return jsonResponse(CENTER);
+      if (key === "POST /public/preferences/tok-123/unsubscribe") {
+        return jsonResponse({ unsubscribed: ["business_correspondence"] });
+      }
+      return jsonResponse({});
+    }),
+  );
+  return sent;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("UnsubscribeScreen", () => {
+  // The rule the whole page exists for. Mail scanners and link prefetchers
+  // follow links in a mailbox with nobody present, so arriving must never
+  // withdraw anything.
+  it("writes nothing on arrival — only reads", async () => {
+    const sent = stubEdge();
+    render(
+      <UnsubscribeScreen token="tok-123" purpose="business_correspondence" />,
+    );
+
+    expect(
+      await screen.findByRole("button", {
+        name: /unsubscribe from these emails/i,
+      }),
+    ).toBeInTheDocument();
+    expect(sent.every((r) => r.key.startsWith("GET "))).toBe(true);
+  });
+
+  it("names the kind of email the link is about", async () => {
+    stubEdge();
+    render(
+      <UnsubscribeScreen token="tok-123" purpose="business_correspondence" />,
+    );
+    expect(
+      await screen.findByText("Direct correspondence"),
+    ).toBeInTheDocument();
+  });
+
+  it("withdraws only the purpose the link named, on an explicit press", async () => {
+    const sent = stubEdge();
+    render(
+      <UnsubscribeScreen token="tok-123" purpose="business_correspondence" />,
+    );
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: /unsubscribe from these emails/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /unsubscribed/i }),
+      ).toBeInTheDocument(),
+    );
+    const post = sent.find((r) => r.key.startsWith("POST "));
+    expect(post?.url).toContain("purpose=business_correspondence");
+  });
+
+  // The server reports what it CHANGED, so an empty array is a replay
+  // rather than a failure — and the page must say so instead of showing a
+  // fresh confirmation for a no-op.
+  it("reads an empty result as already unsubscribed, not as an error", async () => {
+    stubEdge({
+      "POST /public/preferences/tok-123/unsubscribe": () =>
+        jsonResponse({ unsubscribed: [] }),
+    });
+    render(
+      <UnsubscribeScreen token="tok-123" purpose="business_correspondence" />,
+    );
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: /unsubscribe from these emails/i,
+      }),
+    );
+    expect(
+      await screen.findByRole("heading", { name: /already switched off/i }),
+    ).toBeInTheDocument();
+  });
+
+  // A control that always fails is worse than an absent one.
+  it("offers no button for a purpose that cannot be switched off", async () => {
+    stubEdge();
+    render(<UnsubscribeScreen token="tok-123" purpose="transactional" />);
+    expect(
+      await screen.findByText(/can't be switched off/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /unsubscribe from these emails/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("treats an unknown token as one neutral sentence", async () => {
+    stubEdge({
+      "GET /public/preferences/tok-123": () =>
+        jsonResponse({ title: "not found" }, 404),
+    });
+    render(
+      <UnsubscribeScreen token="tok-123" purpose="business_correspondence" />,
+    );
+    expect(await screen.findByText(/no longer valid/i)).toBeInTheDocument();
+    // Nothing to retry on a dead link: a retry button would invite the
+    // reader to hammer a link that will never work.
+    expect(
+      screen.queryByRole("button", { name: /try again/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("explains a rate limit and offers a retry", async () => {
+    stubEdge({
+      "GET /public/preferences/tok-123": () =>
+        jsonResponse({ title: "slow down" }, 429),
+    });
+    render(
+      <UnsubscribeScreen token="tok-123" purpose="business_correspondence" />,
+    );
+    expect(await screen.findByText(/too many/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
+  });
+
+  // A purpose the catalog does not carry must not read as a broken page.
+  it("sends a reader whose purpose is unknown to their full preferences", async () => {
+    stubEdge();
+    render(<UnsubscribeScreen token="tok-123" purpose="no_such_purpose" />);
+    expect(
+      await screen.findByText(/doesn't name a kind of email/i),
+    ).toBeInTheDocument();
+  });
+
+  it("early-returns honestly when the address carries no purpose", () => {
+    stubEdge();
+    render(<UnsubscribeScreen token="tok-123" />);
+    expect(screen.getByText(/no longer valid/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/unsubscribe.tsx
+++ b/frontend/src/screens/unsubscribe.tsx
@@ -1,0 +1,243 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, Lock, Mail } from "lucide-react";
+import { useRef, useState } from "react";
+import { api } from "../api/client";
+import { Button, Card, PendingBody } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { useT } from "../i18n";
+import { throwProblem } from "./common";
+import {
+  explainPublicError,
+  LinkInvalidError,
+  RateLimitedError,
+} from "./preferences";
+import type { PurposeView } from "./preferences.logic";
+import "./preferences.css";
+
+// The human unsubscribe page: where the VISIBLE "Unsubscribe" link in an
+// outgoing message lands.
+//
+// It exists because that link used to point at the RFC 8058 endpoint,
+// which is POST-only by design — so a person clicking it in their mail
+// client got 405. That endpoint is still the right answer for a mailbox
+// provider, which POSTs it without a browser. A person needs a page.
+//
+// The page does NOT unsubscribe on arrival. Mail scanners and link
+// prefetchers follow links in a mailbox with no human involved, so a GET
+// that withdrew consent would unsubscribe people who never clicked
+// anything. One explicit press does it.
+export function UnsubscribeScreen({
+  token,
+  purpose,
+}: Readonly<{ token?: string; purpose?: string }>) {
+  const t = useT();
+  if (!token || !purpose) {
+    return (
+      <div className="pref-page">
+        <Callout tone="warn">{t("prefs.invalidLink")}</Callout>
+      </div>
+    );
+  }
+  return <UnsubscribeBody token={token} purpose={purpose} />;
+}
+
+function UnsubscribeBody({
+  token,
+  purpose,
+}: Readonly<{ token: string; purpose: string }>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const queryKey = ["preference-center", token];
+  const doneHeading = useRef<HTMLHeadingElement>(null);
+  // null until the press answers. The empty array is NOT the same as null:
+  // it is the server saying nothing moved, which is how a replay is told
+  // apart from a first press.
+  const [stopped, setStopped] = useState<string[] | null>(null);
+
+  const center = useQuery({
+    queryKey,
+    retry: false,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/public/preferences/{token}",
+        { params: { path: { token } } },
+      );
+      if (error) {
+        if (response.status === 404) {
+          throw new LinkInvalidError();
+        }
+        if (response.status === 429) {
+          throw new RateLimitedError();
+        }
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+
+  // The purpose key travels as a mutation VARIABLE rather than through the
+  // closure: a passive effect can re-run this with a stale capture, and the
+  // one thing that must not go stale is which purpose is being withdrawn.
+  const unsubscribe = useMutation({
+    mutationFn: async (purposeKey: string) => {
+      const { data, error, response } = await api.POST(
+        "/public/preferences/{token}/unsubscribe",
+        {
+          params: { path: { token }, query: { purpose: purposeKey } },
+        },
+      );
+      if (error) {
+        if (response.status === 404) {
+          throw new LinkInvalidError();
+        }
+        if (response.status === 429) {
+          throw new RateLimitedError();
+        }
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: (data) => {
+      setStopped(data?.unsubscribed ?? []);
+      queryClient.invalidateQueries({ queryKey });
+      // Focus follows the outcome, so a screen-reader user is told what
+      // happened instead of being left on a button that is now gone.
+      requestAnimationFrame(() => doneHeading.current?.focus());
+    },
+  });
+
+  if (center.isPending) {
+    return (
+      <div className="pref-page">
+        <Card>
+          <PendingBody label={t("prefs.unsub.loading")} lines={4} />
+        </Card>
+      </div>
+    );
+  }
+  if (center.error) {
+    // A dead link is final and offers nothing to retry; a rate limit or a
+    // network failure is a "not now", and a reader who came here to stop
+    // an email deserves a way to try again rather than a dead end.
+    const retryable = !(center.error instanceof LinkInvalidError);
+    return (
+      <div className="pref-page">
+        <Callout
+          tone={center.error instanceof RateLimitedError ? "warn" : "danger"}
+          actions={
+            retryable ? (
+              <Button onClick={() => center.refetch()}>
+                {t("prefs.unsub.retry")}
+              </Button>
+            ) : undefined
+          }
+        >
+          {explainPublicError(center.error, t)}
+        </Callout>
+      </div>
+    );
+  }
+
+  const target = center.data?.purposes.find(
+    (p: PurposeView) => p.key === purpose,
+  );
+  if (!target) {
+    return (
+      <div className="pref-page">
+        <Callout tone="warn">{t("prefs.unsub.unknownPurpose")}</Callout>
+        <ManageLink token={token} label={t("prefs.unsub.seeAll")} />
+      </div>
+    );
+  }
+
+  if (stopped !== null) {
+    return (
+      <div className="pref-page">
+        <Card>
+          <div className="unsub-done">
+            <span className="unsub-done-mark" aria-hidden="true">
+              <Check size={22} />
+            </span>
+            <h1 ref={doneHeading} tabIndex={-1}>
+              {stopped.length > 0
+                ? t("prefs.unsub.doneTitle")
+                : t("prefs.unsub.alreadyOff")}
+            </h1>
+            {stopped.length > 0 && (
+              <p>{t("prefs.unsub.doneBody", { label: target.label })}</p>
+            )}
+          </div>
+        </Card>
+        <ManageLink token={token} label={t("prefs.unsub.manage")} />
+      </div>
+    );
+  }
+
+  // A locked purpose carries no button at all. A control that always fails
+  // is worse than an absent one, and here the honest answer is why.
+  if (target.locked) {
+    return (
+      <div className="pref-page">
+        <h1>{t("prefs.unsub.lockedTitle")}</h1>
+        <Card>
+          <p className="unsub-kind">
+            <Lock size={16} aria-hidden="true" /> {target.label}
+          </p>
+          <p>{t("prefs.unsub.lockedBody")}</p>
+        </Card>
+        <ManageLink token={token} label={t("prefs.unsub.seeAll")} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="pref-page">
+      <h1>{t("prefs.unsub.title")}</h1>
+      <p className="unsub-lead">{t("prefs.unsub.lead")}</p>
+      <Card>
+        <p className="unsub-kind">
+          <Mail size={16} aria-hidden="true" /> {target.label}
+        </p>
+        <Callout tone="info" title={t("prefs.unsub.afterTitle")}>
+          {t("prefs.unsub.afterBody")}
+        </Callout>
+        <div className="unsub-actions">
+          <Button
+            variant="primary"
+            pending={unsubscribe.isPending}
+            busyLabel={t("prefs.unsub.busy")}
+            onClick={() => unsubscribe.mutate(target.key)}
+          >
+            {t("prefs.unsub.confirm")}
+          </Button>
+          <a className="link-button" href={"#/preferences/" + token}>
+            {t("prefs.unsub.seeAll")}
+          </a>
+        </div>
+        {unsubscribe.error ? (
+          <Callout
+            tone={
+              unsubscribe.error instanceof RateLimitedError ? "warn" : "danger"
+            }
+          >
+            {explainPublicError(unsubscribe.error, t)}
+          </Callout>
+        ) : null}
+      </Card>
+      <p className="unsub-privacy">{t("prefs.unsub.privacy")}</p>
+    </div>
+  );
+}
+
+function ManageLink({
+  token,
+  label,
+}: Readonly<{ token: string; label: string }>) {
+  return (
+    <p className="unsub-actions">
+      <a className="link-button" href={"#/preferences/" + token}>
+        {label}
+      </a>
+    </p>
+  );
+}


### PR DESCRIPTION
Second of the changes fixing the broken links in a German sales email. #3415 fixed what the consent API answers; this fixes what the send path puts in the message.

## What was wrong

**Both visible links pointed at the API.** "Unsubscribe" was the RFC 8058 machine endpoint, which is POST-only by design — a person clicking it in their mail client got **405**. "Manage your preferences" was the JSON read, so clicking it showed a wall of JSON. Both are now pages:

| Surface | URL | Who presses it |
|---|---|---|
| `List-Unsubscribe` header | `/v1/public/preferences/{token}/unsubscribe?purpose=` | a mailbox provider, by POST |
| Visible "Unsubscribe" | `/#/unsubscribe/{token}/{purpose}?lang=` | a person, in a browser |
| Visible "Manage preferences" | `/#/preferences/{token}?lang=` | a person, in a browser |

One builder makes all three from one token, so the header, the two visible links and the redacted timeline copy cannot name different tokens or purposes. Collapsing them is what produced the defect, so a gate holds the claim rather than a comment asserting it.

Hash routes because the SPA already serves its public surfaces that way, static hosting needs no server fallback, and the token stays out of ordinary web-server access logs until the page deliberately calls the API with it.

**The footer was hard-coded English under a German message.** It now speaks the language of the message it sits under: body, then subject, then the installation's language, then English — the same ladder the drafting floor already trusts. `textlang.Detect` is deliberately biased toward Unknown, so a short note falls through rather than being guessed at.

Worth being plain about the limit, and it is stated in the code: this picks the language of the **message**, not the recipient's preference, which nothing in the product records. An English mail to a German reader gets an English footer, which at least matches the prose around it. The landing pages carry a language switcher, which is the recovery path.

**Nothing refused an unreachable origin.** The message behind this work went out with `http://localhost:8080` in its links — on the reader's machine, that means their own computer. Both roles now refuse at boot when a real sender is configured, and a tokenized send refuses at send time with a `public_origin_unusable` fault naming what an administrator must fix. A dev or test posture still admits localhost, and an unrecognised posture parses as production, so the carve-out fails closed.

## Verification

Full local gate green with a clean lint cache. Integration lanes green: `activities`, `compose`, `compose/integration`. `craft static` clean.

Two fixture self-checks in existing tests asserted the old URL shape and were updated — both are the "does this case prove anything" guard rather than the assertion under test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the unsubscribe links inside sent emails open human pages instead of API endpoints, in the language of the message they sit under, and refuses to send when the configured public origin is one a recipient couldn't open.

**Bug Fixes**
- The visible "Unsubscribe" link was the POST-only RFC 8058 endpoint (a human click got 405) and "Manage your preferences" served raw JSON; both are now SPA hash routes, so the token stays out of server access logs until the page calls the API.
- The new unsubscribe page does not withdraw on arrival: a mail scanner or prefetcher following the link is not a person pressing a button, so one explicit press does it.
- One builder derives the machine header and both visible links from the same token, with a gate holding the claim.
- Footer language falls back body → subject → installation language → English; it reflects the message's language, not the recipient's preference, which the product never records — the landing pages carry a language switcher as the recovery path.

**Operational behavior**
- API and worker now refuse to boot when a real sender is configured with a non-public `--public-base-url`; tokenized sends refuse at send time with a `public_origin_unusable` fault. Dev and test postures admit localhost, and an unrecognised posture parses as production, so the carve-out fails closed.
- The Connections card now shows the configured public origin and whether it answered when last probed, so an operator can see a bad address instead of learning about it from a recipient.
- The one-click unsubscribe endpoint now accepts an empty body under any content type, because shared request helpers send no body yet announce JSON.

<sup>Written for commit 8afd23ed35839c5f8b60d9eb676d6b0bfca57b53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public unsubscribe page with confirmation, completion, retry, and error states.
  - Email links now open human-friendly unsubscribe and preference pages with localized labels.
  - Connector settings display configured public-origin status and reachability.
- **Bug Fixes**
  - Improved validation of public origins, blocking unsafe or unreachable configurations in production.
  - Added clearer handling for invalid, expired, locked, or repeated unsubscribe requests.
- **Localization**
  - Added unsubscribe and origin-status translations in English, German, and Vietnamese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->