### PR TITLE
main is red: a stray content type on an empty one-click body is still absent

### DIFF
--- a/backend/internal/modules/consent/oneclickbody.go
+++ b/backend/internal/modules/consent/oneclickbody.go
@@ -75,8 +75,28 @@ func requireOneClickBody(r *http.Request) error {
 	case "application/x-www-form-urlencoded":
 		return oneClickFromForm(r)
 	default:
-		return httperr.Validation("body", "not_one_click", "a one-click unsubscribe carries the RFC 8058 form body")
+		// A stray content type on a body that turns out to be empty is still
+		// the absent-body case the module comment promises: a caller that
+		// declares a type it never fills must not be refused for content it
+		// did not send.
+		return requireEmptyBody(r)
 	}
+}
+
+// requireEmptyBody admits a body only if it turns out to hold nothing,
+// regardless of what content type declared it.
+func requireEmptyBody(r *http.Request) error {
+	body, err := io.ReadAll(io.LimitReader(r.Body, oneClickBodyLimit+1))
+	if err != nil {
+		return httperr.Validation("body", "not_one_click", "could not read the one-click body")
+	}
+	if len(body) > oneClickBodyLimit {
+		return httperr.Validation("body", "too_large", "a one-click unsubscribe body is a single short field")
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	return httperr.Validation("body", "not_one_click", "a one-click unsubscribe carries the RFC 8058 form body")
 }
 
 // oneClickFromForm reads the URL-encoded spelling.

--- a/backend/internal/modules/consent/oneclickbody.go
+++ b/backend/internal/modules/consent/oneclickbody.go
@@ -46,24 +46,14 @@ const (
 )
 
 // requireOneClickBody admits an empty body, either RFC 8058 encoding of
-// the one-click pair, and nothing else.
+// the one-click pair, and nothing else — regardless of what Content-Type,
+// if any, declared it. A declared type is only ever used to pick which
+// encoding a NON-empty body must match; it never on its own excuses a
+// body that turns out to hold nothing.
 func requireOneClickBody(r *http.Request) error {
 	raw := strings.TrimSpace(r.Header.Get("Content-Type"))
 	if raw == "" {
-		// No content type: only an empty body is meaningful. Read one byte
-		// PAST the ceiling rather than draining to it — a reader stopped at
-		// the limit cannot tell a body that ended from one that went on, so
-		// draining to the cap would accept any size while appearing to
-		// enforce one.
-		n, err := io.Copy(io.Discard, io.LimitReader(r.Body, oneClickBodyLimit+1))
-		if err != nil {
-			slog.DebugContext(r.Context(), "one-click unsubscribe body could not be drained", "error", err)
-			return nil
-		}
-		if n > oneClickBodyLimit {
-			return httperr.Validation("body", "too_large", "a one-click unsubscribe body is a single short field")
-		}
-		return nil
+		return requireEmptyBody(r)
 	}
 	mediaType, params, err := mime.ParseMediaType(raw)
 	if err != nil {
@@ -83,15 +73,29 @@ func requireOneClickBody(r *http.Request) error {
 	}
 }
 
-// requireEmptyBody admits a body only if it turns out to hold nothing,
-// regardless of what content type declared it.
-func requireEmptyBody(r *http.Request) error {
+// readOneClickBody reads the body bounded to the ceiling. It reads one
+// byte PAST the ceiling rather than draining to it — a reader stopped at
+// the limit cannot tell a body that ended from one that went on, so
+// draining to the cap would accept any size while appearing to enforce
+// one. A read failure refuses rather than admits: a transport hiccup is
+// not proof of an absent body, and this endpoint fails closed.
+func readOneClickBody(r *http.Request) ([]byte, error) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, oneClickBodyLimit+1))
 	if err != nil {
-		return httperr.Validation("body", "not_one_click", "could not read the one-click body")
+		return nil, httperr.Validation("body", "not_one_click", "could not read the one-click body")
 	}
 	if len(body) > oneClickBodyLimit {
-		return httperr.Validation("body", "too_large", "a one-click unsubscribe body is a single short field")
+		return nil, httperr.Validation("body", "too_large", "a one-click unsubscribe body is a single short field")
+	}
+	return body, nil
+}
+
+// requireEmptyBody admits a body only if it turns out to hold nothing,
+// regardless of what content type, if any, declared it.
+func requireEmptyBody(r *http.Request) error {
+	body, err := readOneClickBody(r)
+	if err != nil {
+		return err
 	}
 	if len(body) == 0 {
 		return nil
@@ -101,12 +105,9 @@ func requireEmptyBody(r *http.Request) error {
 
 // oneClickFromForm reads the URL-encoded spelling.
 func oneClickFromForm(r *http.Request) error {
-	body, err := io.ReadAll(io.LimitReader(r.Body, oneClickBodyLimit+1))
+	body, err := readOneClickBody(r)
 	if err != nil {
-		return httperr.Validation("body", "not_one_click", "could not read the one-click body")
-	}
-	if len(body) > oneClickBodyLimit {
-		return httperr.Validation("body", "too_large", "a one-click unsubscribe body is a single short field")
+		return err
 	}
 	if len(body) == 0 {
 		return nil

--- a/backend/internal/modules/consent/oneclickbody_test.go
+++ b/backend/internal/modules/consent/oneclickbody_test.go
@@ -79,6 +79,7 @@ func TestOneClickRefusesABodyThatIsNotOneClick(t *testing.T) {
 		{"the wrong value", "List-Unsubscribe=Two-Click", "application/x-www-form-urlencoded"},
 		{"json", `{"List-Unsubscribe":"One-Click"}`, "application/json"},
 		{"multipart with no boundary", "whatever", "multipart/form-data"},
+		{"no content type, junk body", "hello", ""},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -95,5 +96,10 @@ func TestOneClickRefusesAnOversizedBody(t *testing.T) {
 	huge := "List-Unsubscribe=One-Click&pad=" + strings.Repeat("x", oneClickBodyLimit)
 	if err := requireOneClickBody(oneClickRequest(huge, "application/x-www-form-urlencoded")); err == nil {
 		t.Error("admitted an oversized one-click body")
+	}
+	// The same ceiling holds on the stray-content-type path, which reads
+	// the body through the same helper rather than a copy of the check.
+	if err := requireOneClickBody(oneClickRequest(strings.Repeat("x", oneClickBodyLimit+1), "application/json")); err == nil {
+		t.Error("admitted an oversized body behind an unrelated content type")
 	}
 }

--- a/backend/internal/modules/consent/oneclickbody_test.go
+++ b/backend/internal/modules/consent/oneclickbody_test.go
@@ -53,6 +53,12 @@ func TestOneClickAcceptsAnEmptyBody(t *testing.T) {
 	if err := requireOneClickBody(oneClickRequest("", "application/x-www-form-urlencoded")); err != nil {
 		t.Errorf("refused an empty form body: %v", err)
 	}
+	// A caller that declares a content type it never fills — e.g. a client
+	// that always sets Content-Type: application/json — is still an absent
+	// body, not a malformed one.
+	if err := requireOneClickBody(oneClickRequest("", "application/json")); err != nil {
+		t.Errorf("refused an empty body carrying an unrelated content type: %v", err)
+	}
 }
 
 // A charset parameter is ordinary and must not change the verdict.


### PR DESCRIPTION
## What's broken

`main` is red: `TestPreferenceCenterOneClickUnsubscribe` fails with a 422 on the one-click unsubscribe POST. `main-health` run https://github.com/margince/margince/actions/runs/33450789404 caught it after #3417 landed (that PR fixed a different, unrelated red — a frontend type mismatch).

Reproduced on a clean `origin/main` worktree via `make test-it DIR=backend/internal/compose/integration RUN=TestPreferenceCenterOneClickUnsubscribe`.

## Root cause

`requireOneClickBody` (added by #3415) refuses any one-click unsubscribe whose `Content-Type` isn't one of the two RFC 8058 form encodings — even when the body is genuinely empty. That contradicts its own doc comment: *"An ABSENT body is admitted too... Only a body that is present and says something else is refused."*

The integration test's shared `publicCall` helper always sets `Content-Type: application/json`, even when the caller passes a nil body. That's a legitimate client shape (plenty of HTTP clients default a content type regardless of payload), and the handler's own contract says it should be admitted — so the fix is in the handler, not the test helper.

## Fix

`requireOneClickBody`'s default branch (unrecognized media type) now checks whether the body is actually empty before refusing. A stray content type on a genuinely empty body is admitted; a stray content type on real content is still refused (unit test for the JSON-with-real-content case is unchanged and still passes).

## Verification

- `go test ./backend/internal/modules/consent/...` — all pass, plus a new case: empty body + `application/json` content type is admitted
- `make test-it DIR=backend/internal/compose/integration RUN=TestPreferenceCenterOneClickUnsubscribe` — now passes (was 422, now 200)
- `go build ./...`, `go vet ./internal/modules/consent/...`
- `craft static` (pre-push hook) — 0 blocker, 0 major, 0 minor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the one-click unsubscribe handler so an empty request body is accepted regardless of the declared content type, matching the documented absent-body contract. Previously, a stray `Content-Type` on an empty body returned a 422, while a junk body with no content type was admitted. Both the no-`Content-Type` and unrecognized-`Content-Type` paths now share a single bounded read, enforcing the same size limit and failing closed on read errors.

<sup>Written for commit 1a2e2acdfd5894646e64af75e8e28d96c9715beb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved one-click request validation for missing or unsupported content types.
  - Empty request bodies continue to be accepted, while nonempty, oversized, unreadable, or invalid bodies are rejected with validation errors.
  - URL-encoded requests now follow consistent body-size and validation rules.
  - Existing multipart request handling remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->