### PR TITLE
Unanswered is not the same as waiting

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -32971,7 +32971,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [pinned, buyer_wrote_last, waiting_days, overdue, due_today, closing_soon, expected_revenue, material, below_material, quiet_days, no_champion, promised, approved_and_failed, blocks_customer_work, routine, repeated_failure, legal_deadline, meeting_soon]
+          enum: [pinned, buyer_wrote_last, waiting_days, overdue, due_today, closing_soon, expected_revenue, material, below_material, quiet_days, no_champion, promised, approved_and_failed, blocks_customer_work, routine, repeated_failure, legal_deadline, meeting_soon, stale]
           description: 'Which fact this is. The client writes the phrase.'
         value: { $ref: '#/components/schemas/WorklistValue' }
 

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -173,12 +173,41 @@ func classifyDSR(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	}
 }
 
+// waitingStaleDays is when an unanswered message stops being today's work.
+//
+// Past it the wait is still real, but acting on it is no longer urgent in the
+// way the top band means: two weeks of silence has already cost whatever it was
+// going to cost, and a fortnight-old row sitting above a meeting in an hour is
+// the page lying about what matters now. Such a row moves to the review band —
+// still visible, still answerable, no longer claiming the day.
+//
+// Unless money is still on it. An open deal keeps a long wait in execution,
+// because there the silence is the problem rather than a closed chapter.
+const waitingStaleDays = 14
+
+// waitingDaysCeiling bounds what age contributes to the ORDER.
+//
+// Age breaks ties between rows the bands could not separate; it does not earn
+// precedence on its own. Uncapped it does exactly that — every additional day
+// of silence outranks every newer wait forever, so the oldest thread in the
+// workspace leads the page permanently and the queue becomes an archive sorted
+// by how long it has been ignored. That is the live page's own defect: eight
+// half-year-old threads holding the top of a working rep's day.
+//
+// Past the ceiling all waits tie on age and the next tie-break decides, which
+// is the honest answer — at six months versus seven, age has stopped saying
+// anything about what to do first.
+const waitingDaysCeiling = 30
+
 // classifyWaiting: somebody wrote and nobody answered.
 //
 // Level 1, the top band below a pin, and the reason is the concept's own: a
 // customer waiting on a reply is the one thing on this page where the cost of
 // doing nothing falls on somebody else. It outranks a promise, a drifting deal
 // and every decision.
+//
+// That top band is for a LIVE wait. A stale one keeps its row and loses the
+// band, because a queue where nothing ever ages out is one a rep stops reading.
 //
 // The draft verb is offered only when the message can be READ. There is no
 // drafting a reply to words this reader may not see, and a button that opened
@@ -189,17 +218,27 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 	if days < 0 {
 		days = 0
 	}
+	// Stale and unfunded: the row belongs to review, not to today.
+	level := levelWaiting
+	stale := days > waitingStaleDays && !waiting.HasOpenDeal
+	if stale {
+		level = levelRoutine
+	}
+	because := []crmcontracts.WorklistReason{
+		reason("buyer_wrote_last", nil),
+		reason("waiting_days", daysValue(days)),
+	}
+	if stale {
+		because = append(because, reason("stale", nil))
+	}
 	row := crmcontracts.WorklistItem{
 		Id:          waiting.ActivityID.String(),
 		Source:      sourceWaiting,
 		Category:    sourceWaiting,
-		Level:       levelWaiting,
+		Level:       level,
 		Consequence: "buyer_waits",
-		Because: []crmcontracts.WorklistReason{
-			reason("buyer_wrote_last", nil),
-			reason("waiting_days", daysValue(days)),
-		},
-		Actions: []crmcontracts.WorklistItemActions{},
+		Because:     because,
+		Actions:     []crmcontracts.WorklistItemActions{},
 	}
 	// The subject travels because the row exists at all only for a reader the
 	// content gate admitted: a message this reader may not read produces no
@@ -230,7 +269,14 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 		Action:     "draft_reply",
 		ActivityId: openapi_types.UUID(waiting.ActivityID),
 	}
-	return ranked{item: row, waitingDays: days, occurredAt: waiting.Since}
+	// The row SAYS the true age and SORTS on the capped one. A rep reading
+	// "waiting 180 days" is being told something true; the queue placing that
+	// row above everything for the rest of its life is not.
+	ordering := days
+	if ordering > waitingDaysCeiling {
+		ordering = waitingDaysCeiling
+	}
+	return ranked{item: row, waitingDays: ordering, occurredAt: waiting.Since}
 }
 
 // dropDealsAlreadyWaiting removes the at-risk row for a deal somebody is

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -269,14 +269,20 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 		Action:     "draft_reply",
 		ActivityId: openapi_types.UUID(waiting.ActivityID),
 	}
-	// The row SAYS the true age and SORTS on the capped one. A rep reading
-	// "waiting 180 days" is being told something true; the queue placing that
-	// row above everything for the rest of its life is not.
+	// Both ages travel: the true one for everything a reader is shown, the
+	// bounded one for the order. A rep reading "waiting 180 days" is being told
+	// something true; the queue placing that row above everything for the rest
+	// of its life is not.
 	ordering := days
 	if ordering > waitingDaysCeiling {
 		ordering = waitingDaysCeiling
 	}
-	return ranked{item: row, waitingDays: ordering, occurredAt: waiting.Since}
+	return ranked{
+		item:        row,
+		waitingDays: days,
+		waitingRank: ordering,
+		occurredAt:  waiting.Since,
+	}
 }
 
 // dropDealsAlreadyWaiting removes the at-risk row for a deal somebody is

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -339,12 +339,9 @@ type WaitingCustomer struct {
 	PersonID       ids.UUID
 	OrganizationID ids.UUID
 	DealID         ids.UUID
-	// OwnerID is who answers for the linked record. Zero means nobody does, and
-	// that is a routing answer rather than a missing one — an unowned wait
-	// belongs to the unassigned queue, not to whoever happens to read the page.
-	OwnerID ids.UUID
-	// HasOpenDeal reports whether money is still on this thread. It is what
-	// keeps a long wait in execution instead of sending it to review.
+	// HasOpenDeal reports whether money this reader can see is still on this
+	// thread. It is what keeps a long wait in execution instead of sending it
+	// to review.
 	HasOpenDeal bool
 }
 

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -339,6 +339,13 @@ type WaitingCustomer struct {
 	PersonID       ids.UUID
 	OrganizationID ids.UUID
 	DealID         ids.UUID
+	// OwnerID is who answers for the linked record. Zero means nobody does, and
+	// that is a routing answer rather than a missing one — an unowned wait
+	// belongs to the unassigned queue, not to whoever happens to read the page.
+	OwnerID ids.UUID
+	// HasOpenDeal reports whether money is still on this thread. It is what
+	// keeps a long wait in execution instead of sending it to review.
+	HasOpenDeal bool
 }
 
 // Meetings is today's booked meetings that have not happened yet.

--- a/backend/internal/compose/attention/rank.go
+++ b/backend/internal/compose/attention/rank.go
@@ -79,9 +79,20 @@ type ranked struct {
 	// units compare a yen to a euro and get it wrong.
 	expectedBase int64
 	hasExpected  bool
-	waitingDays  int
-	strength     int
-	occurredAt   time.Time
+	// waitingDays is the TRUE age of a wait, in days, and it is what a reader is
+	// ever shown — both in the row's own reasons and in the comparison naming
+	// why it sits above the next one.
+	//
+	// waitingRank is the same age bounded by the ordering ceiling, and it is
+	// what decides the order. The two are separate fields because they are read
+	// by different callers for different purposes, and a single field serving
+	// both published the bounded number as though it were the real one: a row
+	// saying "waiting 180 days" while its own explanation compared 30 against
+	// 20, which is a reason nobody can check.
+	waitingDays int
+	waitingRank int
+	strength    int
+	occurredAt  time.Time
 	// foldedFrom names the sources of the rows this one stands for, once per
 	// member. A folded group is shown INSTEAD of its members, so a count of
 	// what the reader can see has to attribute it back to them — otherwise
@@ -148,8 +159,8 @@ func less(a, b ranked) bool {
 	if decided, order := byExpected(a, b); decided {
 		return order
 	}
-	if a.waitingDays != b.waitingDays {
-		return a.waitingDays > b.waitingDays
+	if a.waitingRank != b.waitingRank {
+		return a.waitingRank > b.waitingRank
 	}
 	if a.strength != b.strength {
 		return a.strength > b.strength
@@ -244,7 +255,16 @@ func compare(a, b ranked) crmcontracts.WorklistComparison {
 			Theirs:     moneyValue(b),
 		}
 	}
-	if a.waitingDays != b.waitingDays {
+	// Decided on the ORDERING age, because that is what less() compared — naming
+	// a comparator that did not decide is the failure this function exists to
+	// avoid. Reported as the TRUE age, because that is the number the row itself
+	// says and the one a reader can check.
+	//
+	// Where the ceiling clipped a side, the two sides can order differently from
+	// how they read: 180 and 40 days both rank as 30, tie, and the next
+	// comparator decides. Then this arm never fires, so no row ever claims an
+	// age decided it when the ages had stopped mattering.
+	if a.waitingRank != b.waitingRank {
 		return crmcontracts.WorklistComparison{
 			Comparator: crmcontracts.WorklistComparisonComparatorWaitingDays,
 			Mine:       daysValue(a.waitingDays),

--- a/backend/internal/compose/attention/rank_test.go
+++ b/backend/internal/compose/attention/rank_test.go
@@ -52,8 +52,15 @@ func expected(minor int64) func(*ranked) {
 	}
 }
 
+// quiet builds a wait of the given age the way classifyWaiting does: the true
+// age for what a reader is shown, the bounded age for the order. Setting only
+// one would model a row production never produces, and the ordering tests would
+// then pass against a shape that cannot occur.
 func quiet(days int) func(*ranked) {
-	return func(r *ranked) { r.waitingDays = days }
+	return func(r *ranked) {
+		r.waitingDays = days
+		r.waitingRank = min(days, waitingDaysCeiling)
+	}
 }
 
 func idsOf(items []crmcontracts.WorklistItem) []string {

--- a/backend/internal/compose/attention/waitingfreshness_test.go
+++ b/backend/internal/compose/attention/waitingfreshness_test.go
@@ -95,12 +95,44 @@ func TestAgeStopsRaisingUrgencyAtTheCeiling(t *testing.T) {
 		HasOpenDeal: true,
 	}, rankInstant)
 
-	if older.waitingDays != newer.waitingDays {
+	if older.waitingRank != newer.waitingRank {
 		t.Fatalf("waits of %d and %d ordering days past the ceiling did not tie",
-			older.waitingDays, newer.waitingDays)
+			older.waitingRank, newer.waitingRank)
 	}
-	if older.waitingDays != waitingDaysCeiling {
-		t.Fatalf("the ordering age was %d, wanted the ceiling %d", older.waitingDays, waitingDaysCeiling)
+	if older.waitingRank != waitingDaysCeiling {
+		t.Fatalf("the ordering age was %d, wanted the ceiling %d", older.waitingRank, waitingDaysCeiling)
+	}
+	// And the two still SAY different ages, because they waited different
+	// lengths of time. Bounding the order must not reach the reader.
+	if older.waitingDays == newer.waitingDays {
+		t.Fatalf("both rows reported %d days, so the bound reached what the reader is told",
+			older.waitingDays)
+	}
+}
+
+// The comparison a reader is shown reports the TRUE ages. A row saying "waiting
+// 183 days" whose own explanation compares 30 against 20 is a reason nobody can
+// check — the failure the comparator exists to avoid, reintroduced by bounding
+// the field it reads.
+func TestTheComparisonReportsTheAgeTheRowClaims(t *testing.T) {
+	older := classifyWaiting(WaitingCustomer{
+		ActivityID:  ids.MustParse("01a05500-0000-7000-8000-0000000000f1"),
+		Since:       rankInstant.Add(-183 * 24 * time.Hour),
+		HasOpenDeal: true,
+	}, rankInstant)
+	newer := classifyWaiting(WaitingCustomer{
+		ActivityID:  ids.MustParse("01a05500-0000-7000-8000-0000000000f2"),
+		Since:       rankInstant.Add(-20 * 24 * time.Hour),
+		HasOpenDeal: true,
+	}, rankInstant)
+
+	got := compare(older, newer)
+
+	if got.Comparator != crmcontracts.WorklistComparisonComparatorWaitingDays {
+		t.Fatalf("the ages decided this pair, and the comparison named %q", got.Comparator)
+	}
+	if got.Mine == nil || got.Mine.Days == nil || *got.Mine.Days != 183 {
+		t.Fatalf("the comparison reported %v days, and the row says it waited 183", got.Mine)
 	}
 }
 

--- a/backend/internal/compose/attention/waitingfreshness_test.go
+++ b/backend/internal/compose/attention/waitingfreshness_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// What a wait is worth as it ages.
+//
+// The live page put eight half-year-old threads at the top of a working rep's
+// day, because age raised urgency forever and nothing ever aged out. These are
+// the rules that ended that, each with the case that would bring it back.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// A fortnight of silence with no money behind it is not today's work. The row
+// stays — somebody did write — but it stops claiming the top band.
+func TestAStaleUnfundedWaitLeavesTheTopBand(t *testing.T) {
+	waiting := WaitingCustomer{
+		ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000c1"),
+		Subject:    "Re: the brochure",
+		Since:      rankInstant.Add(-40 * 24 * time.Hour),
+	}
+
+	row := classifyWaiting(waiting, rankInstant)
+
+	if row.item.Level == levelWaiting {
+		t.Fatal("a forty-day unanswered thread still led the day as a live wait")
+	}
+	if row.item.Source != sourceWaiting {
+		t.Fatalf("the row changed source to %q — it is still somebody waiting", row.item.Source)
+	}
+	var said bool
+	for _, because := range row.item.Because {
+		if because.Kind == "stale" {
+			said = true
+		}
+	}
+	if !said {
+		t.Fatal("the row was demoted without saying why, which reads as a ranking bug to whoever finds it")
+	}
+}
+
+// Money keeps a long wait in the day. Where a deal is open the silence IS the
+// problem, and demoting it would hide the case the rep most needs.
+func TestAnOpenDealKeepsALongWaitInTheTopBand(t *testing.T) {
+	waiting := WaitingCustomer{
+		ActivityID:  ids.MustParse("01a05500-0000-7000-8000-0000000000c2"),
+		Subject:     "Re: the contract",
+		Since:       rankInstant.Add(-40 * 24 * time.Hour),
+		HasOpenDeal: true,
+	}
+
+	row := classifyWaiting(waiting, rankInstant)
+
+	if row.item.Level != levelWaiting {
+		t.Fatalf("a forty-day wait on an OPEN deal was demoted to level %d", row.item.Level)
+	}
+}
+
+// The boundary itself, from both sides. A rule stated in days is wrong by a day
+// exactly as often as it is right, and only the pair catches it.
+func TestTheStaleBoundaryIsWhereItSaysItIs(t *testing.T) {
+	at := func(days int) ranked {
+		return classifyWaiting(WaitingCustomer{
+			ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000c3"),
+			Since:      rankInstant.Add(-time.Duration(days) * 24 * time.Hour),
+		}, rankInstant)
+	}
+
+	if got := at(waitingStaleDays); got.item.Level != levelWaiting {
+		t.Fatalf("a wait of exactly %d days was already stale (level %d)", waitingStaleDays, got.item.Level)
+	}
+	if got := at(waitingStaleDays + 1); got.item.Level == levelWaiting {
+		t.Fatalf("a wait of %d days was still live", waitingStaleDays+1)
+	}
+}
+
+// Age stops buying precedence at the ceiling. Two ancient waits tie, and what
+// separates them is the next tie-break — not which was ignored longer.
+func TestAgeStopsRaisingUrgencyAtTheCeiling(t *testing.T) {
+	older := classifyWaiting(WaitingCustomer{
+		ActivityID:  ids.MustParse("01a05500-0000-7000-8000-0000000000d1"),
+		Since:       rankInstant.Add(-time.Duration(waitingDaysCeiling+150) * 24 * time.Hour),
+		HasOpenDeal: true,
+	}, rankInstant)
+	newer := classifyWaiting(WaitingCustomer{
+		ActivityID:  ids.MustParse("01a05500-0000-7000-8000-0000000000d2"),
+		Since:       rankInstant.Add(-time.Duration(waitingDaysCeiling+10) * 24 * time.Hour),
+		HasOpenDeal: true,
+	}, rankInstant)
+
+	if older.waitingDays != newer.waitingDays {
+		t.Fatalf("waits of %d and %d ordering days past the ceiling did not tie",
+			older.waitingDays, newer.waitingDays)
+	}
+	if older.waitingDays != waitingDaysCeiling {
+		t.Fatalf("the ordering age was %d, wanted the ceiling %d", older.waitingDays, waitingDaysCeiling)
+	}
+}
+
+// The row still tells the truth about its age. Capping the SORT must not cap
+// what the reader is told, or the page says a customer has waited a month when
+// they have waited half a year.
+func TestTheRowStillReportsTheRealWait(t *testing.T) {
+	const realDays = waitingDaysCeiling + 153
+
+	row := classifyWaiting(WaitingCustomer{
+		ActivityID:  ids.MustParse("01a05500-0000-7000-8000-0000000000d3"),
+		Since:       rankInstant.Add(-realDays * 24 * time.Hour),
+		HasOpenDeal: true,
+	}, rankInstant)
+
+	var reported *crmcontracts.WorklistValue
+	for _, because := range row.item.Because {
+		if because.Kind == "waiting_days" {
+			reported = because.Value
+		}
+	}
+	if reported == nil || reported.Days == nil {
+		t.Fatal("the row never said how long they had waited")
+	}
+	if *reported.Days != realDays {
+		t.Fatalf("the row reported %d days of waiting, and they have waited %d",
+			*reported.Days, realDays)
+	}
+}
+
+// The defect this whole change exists to end: an ancient thread outranking a
+// deal that closes today, purely because nobody had answered it for longer.
+func TestAnAncientWaitNoLongerOutranksTodaysDeal(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("closing", "deal_at_risk", withDeal(80_000_00))),
+	}
+	waiting := []WaitingCustomer{{
+		ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000e1"),
+		Subject:    "Re: your enquiry",
+		Since:      rankInstant.Add(-182 * 24 * time.Hour),
+	}}
+
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waiting)
+
+	if out.Queue[0].Source == sourceWaiting {
+		t.Fatal("a 182-day unanswered thread still led the day over a deal at risk")
+	}
+}

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -408,7 +408,7 @@ func TestAWaitingCustomerLeadsTheDay(t *testing.T) {
 	waiting := []WaitingCustomer{{
 		ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000aaaa"),
 		Subject:    "Re: pricing",
-		Since:      rankInstant.Add(-83 * 24 * time.Hour),
+		Since:      rankInstant.Add(-2 * 24 * time.Hour),
 	}}
 
 	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waiting)
@@ -447,10 +447,14 @@ func TestAWaitingDealDoesNotAlsoAppearAsDrifting(t *testing.T) {
 
 // The longer somebody has waited, the higher they sit — among people who are
 // all waiting, the forgotten one is the one at risk.
+//
+// Both waits are inside the ordering ceiling. Past it every wait ties on age by
+// design, so a fixture that straddled the cap would be asserting the tie-break
+// below age while claiming to test age.
 func TestTheLongestWaitLeadsAmongWaitingCustomers(t *testing.T) {
 	waiting := []WaitingCustomer{
 		{ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000000a"), Since: rankInstant.Add(-2 * 24 * time.Hour)},
-		{ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000000b"), Since: rankInstant.Add(-83 * 24 * time.Hour)},
+		{ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000000b"), Since: rankInstant.Add(-9 * 24 * time.Hour)},
 	}
 
 	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waiting)
@@ -664,11 +668,14 @@ func TestABatchNamesSomeOfWhatItHolds(t *testing.T) {
 // longest-waiting few lead; the rest are demoted, never dropped.
 func TestOneKindOfWorkCannotTakeTheWholePage(t *testing.T) {
 	waiting := []WaitingCustomer{}
+	// Every wait is LIVE — hours apart, none old enough to go stale. Crowding
+	// and staleness both move a row down the page, and a fixture that aged past
+	// the stale line would pass this test while proving the other rule.
 	for i := 0; i < 30; i++ {
 		waiting = append(waiting, WaitingCustomer{
 			ActivityID: ids.NewV7(),
 			Subject:    "Thread " + string(rune('a'+i%26)) + string(rune('0'+i/26)),
-			Since:      rankInstant.Add(-time.Duration(30-i) * 24 * time.Hour),
+			Since:      rankInstant.Add(-time.Duration(30-i) * time.Hour),
 		})
 	}
 	day := crmcontracts.Attention{

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -264,6 +264,8 @@ func (w attentionWaiting) Unanswered(ctx context.Context, asOf time.Time) ([]att
 			PersonID:       row.PersonID,
 			OrganizationID: row.OrganizationID,
 			DealID:         row.DealID,
+			OwnerID:        row.OwnerID,
+			HasOpenDeal:    row.HasOpenDeal,
 		})
 	}
 	return out, nil

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -264,7 +264,6 @@ func (w attentionWaiting) Unanswered(ctx context.Context, asOf time.Time) ([]att
 			PersonID:       row.PersonID,
 			OrganizationID: row.OrganizationID,
 			DealID:         row.DealID,
-			OwnerID:        row.OwnerID,
 			HasOpenDeal:    row.HasOpenDeal,
 		})
 	}

--- a/backend/internal/compose/integration/waitinglane_integration_test.go
+++ b/backend/internal/compose/integration/waitinglane_integration_test.go
@@ -189,17 +189,41 @@ func TestAWaitOlderThanTheHorizonIsNotReported(t *testing.T) {
 	}
 }
 
-// The wait carries whoever answers for the record, so "mine" can mean mine.
-// Without this the queue has no owner to compare against and falls back to
-// showing unowned work to everybody.
-func TestAWaitCarriesTheOwnerOfItsRecord(t *testing.T) {
+// Money outlives the horizon. A wait past ninety days with an open deal on it
+// still reaches the reader, because the caller's staleness rule promises to keep
+// exactly that case and a horizon that removed it first would leave that promise
+// with nothing to act on.
+func TestAnOldWaitWithAnOpenDealSurvivesTheHorizon(t *testing.T) {
 	e := Setup(t)
 	person := seedWaitingPerson(t, e)
-	if _, err := OwnerConn(t).Exec(context.Background(),
-		`UPDATE person SET owner_id = $1 WHERE id = $2`, e.AdminUser, person); err != nil {
-		t.Fatalf("giving the person an owner: %v", err)
+	deal := seedWaitingDeal(t, "open")
+	seedWaitingMessageLinked(t, e, "thread-old-funded", "inbound", "Still open",
+		waitingInstant.Add(-200*24*time.Hour), person)
+	linkActivityToDeal(t, "Still open", deal)
+
+	waiting, err := activities.NewStore(e.DB()).WaitingReplies(e.Admin(), waitingInstant)
+	if err != nil {
+		t.Fatalf("reading who is waiting: %v", err)
 	}
-	seedWaitingMessageLinked(t, e, "thread-owned", "inbound", "Owned thread",
+
+	if !containsSubject(waiting, "Still open") {
+		t.Fatal("a 200-day wait on an OPEN deal was dropped by the horizon")
+	}
+}
+
+// A thread with an open deal on it says so, and one without says so too.
+//
+// Both halves in one test because the flag only means something as a pair: a
+// query that answered true for everything would pass the first half alone, and
+// that is the answer that keeps every ancient thread in the day forever.
+func TestAWaitReportsWhetherAnOpenDealIsOnIt(t *testing.T) {
+	e := Setup(t)
+	person := seedWaitingPerson(t, e)
+	deal := seedWaitingDeal(t, "open")
+	seedWaitingMessageLinked(t, e, "thread-funded", "inbound", "Funded thread",
+		waitingInstant.Add(-2*24*time.Hour), person)
+	linkActivityToDeal(t, "Funded thread", deal)
+	seedWaitingMessageLinked(t, e, "thread-unfunded", "inbound", "Unfunded thread",
 		waitingInstant.Add(-2*24*time.Hour), person)
 
 	waiting, err := activities.NewStore(e.DB()).WaitingReplies(e.Admin(), waitingInstant)
@@ -207,42 +231,70 @@ func TestAWaitCarriesTheOwnerOfItsRecord(t *testing.T) {
 		t.Fatalf("reading who is waiting: %v", err)
 	}
 
-	for _, row := range waiting {
-		if row.Subject != "Owned thread" {
-			continue
-		}
-		if row.OwnerID != ids.UUID(e.AdminUser) {
-			t.Fatalf("the wait came back owned by %v, wanted the person's owner %v",
-				row.OwnerID, e.AdminUser)
-		}
-		return
-	}
-	t.Fatal("the owned thread never reached the reader at all")
+	assertOpenDeal(t, waiting, "Funded thread", true)
+	assertOpenDeal(t, waiting, "Unfunded thread", false)
 }
 
-// An unowned record yields an unowned wait. Zero is the routing answer that
-// sends it to the unassigned queue; guessing an owner here is what put every
-// colleague's mail on everybody's page.
-func TestAWaitOnAnUnownedRecordHasNoOwner(t *testing.T) {
+// A deal that is WON is not money still on the thread. Without the status
+// predicate every closed deal would keep its thread in the day forever.
+func TestAClosedDealIsNotAnOpenOne(t *testing.T) {
 	e := Setup(t)
-	seedWaitingMessage(t, e, "thread-unowned", "inbound", "Unowned thread",
-		waitingInstant.Add(-2*24*time.Hour))
+	person := seedWaitingPerson(t, e)
+	deal := seedWaitingDeal(t, "won")
+	seedWaitingMessageLinked(t, e, "thread-won", "inbound", "Won thread",
+		waitingInstant.Add(-2*24*time.Hour), person)
+	linkActivityToDeal(t, "Won thread", deal)
 
 	waiting, err := activities.NewStore(e.DB()).WaitingReplies(e.Admin(), waitingInstant)
 	if err != nil {
 		t.Fatalf("reading who is waiting: %v", err)
 	}
 
-	for _, row := range waiting {
-		if row.Subject != "Unowned thread" {
+	assertOpenDeal(t, waiting, "Won thread", false)
+}
+
+// seedWaitingDeal creates one deal in the given status, with the pipeline and
+// stage every deal needs. A closed deal carries a closed_at, which its own CHECK
+// constraint requires.
+func seedWaitingDeal(t *testing.T, status string) ids.UUID {
+	t.Helper()
+	owner := OwnerConn(t)
+	pipeline := SeedIDRow(t, owner, `INSERT INTO pipeline (id, name, is_default, position)
+		VALUES ($1, 'Sales', true, 0)`)
+	stage := SeedIDRow(t, owner, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, pipeline)
+	var closedAt any
+	if status != "open" {
+		closedAt = waitingInstant.Add(-24 * time.Hour)
+	}
+	return SeedIDRow(t, owner, `INSERT INTO deal (id, name, pipeline_id, stage_id, status, closed_at, source, captured_by)
+		VALUES ($1, 'A deal', $2, $3, $4, $5, 'manual', 'human:x')`,
+		pipeline, stage, status, closedAt)
+}
+
+// linkActivityToDeal files an already-seeded message under a deal as well.
+func linkActivityToDeal(t *testing.T, subject string, deal ids.UUID) {
+	t.Helper()
+	if _, err := OwnerConn(t).Exec(context.Background(), `
+		INSERT INTO activity_link (activity_id, entity_type, deal_id)
+		SELECT id, 'deal', $1 FROM activity WHERE subject = $2`,
+		deal, subject); err != nil {
+		t.Fatalf("filing %q under a deal: %v", subject, err)
+	}
+}
+
+func assertOpenDeal(t *testing.T, rows []activities.WaitingReply, subject string, want bool) {
+	t.Helper()
+	for _, row := range rows {
+		if row.Subject != subject {
 			continue
 		}
-		if !row.OwnerID.IsZero() {
-			t.Fatalf("an unowned record produced owner %v", row.OwnerID)
+		if row.HasOpenDeal != want {
+			t.Fatalf("%q reported HasOpenDeal=%v, wanted %v", subject, row.HasOpenDeal, want)
 		}
 		return
 	}
-	t.Fatal("the unowned thread never reached the reader at all")
+	t.Fatalf("%q never reached the reader at all", subject)
 }
 
 func containsSubject(rows []activities.WaitingReply, subject string) bool {

--- a/backend/internal/compose/integration/waitinglane_integration_test.go
+++ b/backend/internal/compose/integration/waitinglane_integration_test.go
@@ -26,7 +26,36 @@ var waitingInstant = time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC)
 
 // seedMessage writes one captured message through the owner connection, the
 // way capture would leave it: a thread key, an audience, a direction.
+//
+// It also files the message under a PERSON, because that is what makes it sales
+// mail. The lane requires a link to a record the workspace sells to, so a
+// message seeded without one is a rep's private correspondence and correctly
+// never appears — every case in this file that is about something else has to
+// clear that bar first or it would pass for the wrong reason.
 func seedWaitingMessage(t *testing.T, e *Env, thread, direction, subject string, at time.Time) {
+	t.Helper()
+	seedWaitingMessageLinked(t, e, thread, direction, subject, at, seedWaitingPerson(t, e))
+}
+
+// seedWaitingPerson creates one person for a message to be filed under.
+func seedWaitingPerson(t *testing.T, e *Env) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := OwnerConn(t).Exec(context.Background(), `
+		INSERT INTO person (id, full_name, source, captured_by, version, created_at, updated_at)
+		VALUES ($1, 'Waiting Customer', 'system', $2, 1, now(), now())`,
+		id, "human:"+e.AdminUser.String()); err != nil {
+		t.Fatalf("seeding the person a thread is filed under: %v", err)
+	}
+	return id
+}
+
+// seedWaitingMessageLinked writes the message and files it under one person.
+// Pass a zero person to seed mail linked to NOTHING, which is how the personal
+// -mail case is built.
+func seedWaitingMessageLinked(
+	t *testing.T, e *Env, thread, direction, subject string, at time.Time, person ids.UUID,
+) {
 	t.Helper()
 	id := ids.NewV7()
 	owner := OwnerConn(t)
@@ -37,6 +66,14 @@ func seedWaitingMessage(t *testing.T, e *Env, thread, direction, subject string,
 		VALUES ($1, 'email', $2, $3, $4, false, 'system', $5, 1, now(), now(), false, $6, 'workspace')`,
 		id, direction, subject, at, "human:"+e.AdminUser.String(), thread); err != nil {
 		t.Fatalf("seeding a %s message: %v", direction, err)
+	}
+	if person.IsZero() {
+		return
+	}
+	if _, err := owner.Exec(context.Background(), `
+		INSERT INTO activity_link (activity_id, entity_type, person_id)
+		VALUES ($1, 'person', $2)`, id, person); err != nil {
+		t.Fatalf("filing the message under a person: %v", err)
 	}
 }
 
@@ -109,6 +146,103 @@ func TestAFutureDatedMessageDoesNotSuppressTheWaitingOne(t *testing.T) {
 	if !containsSubject(waiting, "Waiting now") {
 		t.Fatal("a message dated a year ahead silenced a thread that is waiting today")
 	}
+}
+
+// Mail linked to nothing is not sales work. This is the reported defect in its
+// simplest form: a rep's dentist wrote, nobody replied, and the queue called it
+// a customer waiting because unanswered was the only test it applied.
+func TestMailLinkedToNothingIsNotWaitingWork(t *testing.T) {
+	e := Setup(t)
+	seedWaitingMessageLinked(t, e, "thread-personal", "inbound", "Your appointment",
+		waitingInstant.Add(-3*24*time.Hour), ids.UUID{})
+
+	waiting, err := activities.NewStore(e.DB()).WaitingReplies(e.Admin(), waitingInstant)
+	if err != nil {
+		t.Fatalf("reading who is waiting: %v", err)
+	}
+
+	if containsSubject(waiting, "Your appointment") {
+		t.Fatal("mail filed under no record at all was reported as a customer waiting")
+	}
+}
+
+// Past the horizon a wait is history. The bands decide what is urgent among
+// what survives; this decides what is still a wait at all.
+func TestAWaitOlderThanTheHorizonIsNotReported(t *testing.T) {
+	e := Setup(t)
+	seedWaitingMessage(t, e, "thread-ancient", "inbound", "Six months ago",
+		waitingInstant.Add(-200*24*time.Hour))
+	seedWaitingMessage(t, e, "thread-recent", "inbound", "Last week",
+		waitingInstant.Add(-7*24*time.Hour))
+
+	waiting, err := activities.NewStore(e.DB()).WaitingReplies(e.Admin(), waitingInstant)
+	if err != nil {
+		t.Fatalf("reading who is waiting: %v", err)
+	}
+
+	if containsSubject(waiting, "Six months ago") {
+		t.Fatal("a two-hundred-day-old thread was still reported as a wait")
+	}
+	// The admission half: the horizon must not have swallowed everything.
+	if !containsSubject(waiting, "Last week") {
+		t.Fatal("the horizon removed a week-old wait, which is ordinary work")
+	}
+}
+
+// The wait carries whoever answers for the record, so "mine" can mean mine.
+// Without this the queue has no owner to compare against and falls back to
+// showing unowned work to everybody.
+func TestAWaitCarriesTheOwnerOfItsRecord(t *testing.T) {
+	e := Setup(t)
+	person := seedWaitingPerson(t, e)
+	if _, err := OwnerConn(t).Exec(context.Background(),
+		`UPDATE person SET owner_id = $1 WHERE id = $2`, e.AdminUser, person); err != nil {
+		t.Fatalf("giving the person an owner: %v", err)
+	}
+	seedWaitingMessageLinked(t, e, "thread-owned", "inbound", "Owned thread",
+		waitingInstant.Add(-2*24*time.Hour), person)
+
+	waiting, err := activities.NewStore(e.DB()).WaitingReplies(e.Admin(), waitingInstant)
+	if err != nil {
+		t.Fatalf("reading who is waiting: %v", err)
+	}
+
+	for _, row := range waiting {
+		if row.Subject != "Owned thread" {
+			continue
+		}
+		if row.OwnerID != ids.UUID(e.AdminUser) {
+			t.Fatalf("the wait came back owned by %v, wanted the person's owner %v",
+				row.OwnerID, e.AdminUser)
+		}
+		return
+	}
+	t.Fatal("the owned thread never reached the reader at all")
+}
+
+// An unowned record yields an unowned wait. Zero is the routing answer that
+// sends it to the unassigned queue; guessing an owner here is what put every
+// colleague's mail on everybody's page.
+func TestAWaitOnAnUnownedRecordHasNoOwner(t *testing.T) {
+	e := Setup(t)
+	seedWaitingMessage(t, e, "thread-unowned", "inbound", "Unowned thread",
+		waitingInstant.Add(-2*24*time.Hour))
+
+	waiting, err := activities.NewStore(e.DB()).WaitingReplies(e.Admin(), waitingInstant)
+	if err != nil {
+		t.Fatalf("reading who is waiting: %v", err)
+	}
+
+	for _, row := range waiting {
+		if row.Subject != "Unowned thread" {
+			continue
+		}
+		if !row.OwnerID.IsZero() {
+			t.Fatalf("an unowned record produced owner %v", row.OwnerID)
+		}
+		return
+	}
+	t.Fatal("the unowned thread never reached the reader at all")
 }
 
 func containsSubject(rows []activities.WaitingReply, subject string) bool {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11837,6 +11837,7 @@ const (
 	WorklistReasonKindQuietDays          WorklistReasonKind = "quiet_days"
 	WorklistReasonKindRepeatedFailure    WorklistReasonKind = "repeated_failure"
 	WorklistReasonKindRoutine            WorklistReasonKind = "routine"
+	WorklistReasonKindStale              WorklistReasonKind = "stale"
 	WorklistReasonKindWaitingDays        WorklistReasonKind = "waiting_days"
 )
 
@@ -11876,6 +11877,8 @@ func (e WorklistReasonKind) Valid() bool {
 	case WorklistReasonKindRepeatedFailure:
 		return true
 	case WorklistReasonKindRoutine:
+		return true
+	case WorklistReasonKindStale:
 		return true
 	case WorklistReasonKindWaitingDays:
 		return true

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -46,14 +46,43 @@ type WaitingReply struct {
 	PersonID       ids.UUID
 	OrganizationID ids.UUID
 	DealID         ids.UUID
+	// OwnerID is who answers for the linked record, by the precedence the query
+	// declares. Zero means nobody does — which routes the wait to the unassigned
+	// queue rather than to whoever happens to be reading.
+	OwnerID ids.UUID
+	// HasOpenDeal reports whether an open deal is on this thread. It is what
+	// lets a caller keep an old wait that still has money behind it, and drop
+	// one that does not.
+	HasOpenDeal bool
 }
 
 // waitingScanCap bounds the work one read does. Beyond this the answer is
 // "there are more", never a silent truncation reported as a total.
 const waitingScanCap = 200
 
+// waitingHorizonDays is how far back a wait can reach and still be work.
+//
+// Past this, an unanswered message is history rather than an obligation: the
+// conversation it belonged to has ended one way or another, and nobody is
+// sitting at the other end of it. The horizon is coarse on purpose — the bands
+// that separate an urgent wait from a stale one are the caller's, and they
+// judge what survives this.
+//
+// Applied BEFORE the cap for the same reason the machine rule is, and the
+// reason is worth restating because it is the whole shape of this query: a
+// filter after LIMIT lets two hundred rows nobody wants fill the scan and push
+// a real customer past it, and the page then says nobody is waiting.
+const waitingHorizonDays = 90
+
 // waitingRepliesSQL finds, per thread, the newest inbound with no later
-// outbound in the same thread.
+// outbound in the same thread — where the thread is a SALES conversation the
+// workspace is answerable for, recent enough to still be one.
+//
+// Every eligibility rule is applied before ORDER BY and LIMIT, so the cap falls
+// on qualified rows only. A rule applied after the cap reads as a working
+// filter and fails as a silent one: the scan fills with rows the rule would
+// have removed, the customer behind them never arrives, and the page reports an
+// empty queue with nothing to say it was truncated.
 //
 // NOT EXISTS rather than a window function or a join: it expresses the question
 // directly — "nobody wrote back after this" — and it stops at the first later
@@ -102,7 +131,31 @@ const waitingRepliesSQL = `
 	                '00000000-0000-0000-0000-000000000000'::uuid),
 	       COALESCE((array_agg(wl.deal_id ORDER BY wl.deal_id::text)
 	                 FILTER (WHERE wl.deal_id IS NOT NULL))[1],
-	                '00000000-0000-0000-0000-000000000000'::uuid)
+	                '00000000-0000-0000-0000-000000000000'::uuid),
+	       -- Who answers for this wait, by ONE declared precedence:
+	       -- deal, then lead, then person, then organization.
+	       --
+	       -- Nearest-to-the-money first. A thread filed under both a deal and
+	       -- the person on it belongs to whoever owns the deal, because that is
+	       -- who the reply changes an outcome for. Without a stated order the
+	       -- answer would follow whichever link happened to sort first, and one
+	       -- message would change hands between reads.
+	       --
+	       -- Absent is a real answer, not a missing one: nobody owns it, and the
+	       -- caller routes it to the unassigned queue rather than to everyone.
+	       COALESCE(
+	         (array_agg(dealOwner.owner_id ORDER BY dealOwner.id::text)
+	          FILTER (WHERE dealOwner.owner_id IS NOT NULL))[1],
+	         (array_agg(leadOwner.owner_id ORDER BY leadOwner.id::text)
+	          FILTER (WHERE leadOwner.owner_id IS NOT NULL))[1],
+	         (array_agg(personOwner.owner_id ORDER BY personOwner.id::text)
+	          FILTER (WHERE personOwner.owner_id IS NOT NULL))[1],
+	         (array_agg(orgOwner.owner_id ORDER BY orgOwner.id::text)
+	          FILTER (WHERE orgOwner.owner_id IS NOT NULL))[1],
+	         '00000000-0000-0000-0000-000000000000'::uuid),
+	       -- Whether an OPEN deal is on this thread, which is what lets the
+	       -- caller keep an old wait that still has money on it.
+	       bool_or(dealOwner.id IS NOT NULL)
 	  FROM activity a
 	  LEFT JOIN activity_link wl ON wl.activity_id = a.id AND (%[3]s)
 	  -- Who wrote. The sender participant is where capture records the address,
@@ -110,12 +163,59 @@ const waitingRepliesSQL = `
 	  -- from a notification service.
 	  LEFT JOIN activity_participant sender
 	         ON sender.activity_id = a.id AND sender.role = 'from'
+	  -- The owner joins walk the links WITHOUT the visibility clause the wl
+	  -- join carries. Who answers for a record is a fact about the record; if it
+	  -- were read through what this reader may see, a message would look
+	  -- unowned to one colleague and owned to another, and "mine" would mean a
+	  -- different set of rows per reader for the same underlying truth.
+	  --
+	  -- Only the id and the owner leave these joins. No name, no amount, no
+	  -- subject — nothing a reader could not otherwise reach — so this widens
+	  -- what the query KNOWS without widening what it discloses.
+	  LEFT JOIN activity_link ownerLink ON ownerLink.activity_id = a.id
+	  LEFT JOIN deal dealOwner ON dealOwner.id = ownerLink.deal_id
+	                          AND dealOwner.status = 'open'
+	                          AND dealOwner.archived_at IS NULL
+	  LEFT JOIN lead leadOwner ON leadOwner.id = ownerLink.lead_id
+	                          AND leadOwner.status IN ('new', 'contacted', 'engaged')
+	                          AND leadOwner.archived_at IS NULL
+	  LEFT JOIN person personOwner ON personOwner.id = ownerLink.person_id
+	                              AND personOwner.archived_at IS NULL
+	  LEFT JOIN organization orgOwner ON orgOwner.id = ownerLink.organization_id
+	                                 AND orgOwner.archived_at IS NULL
 	 WHERE a.kind IN ('email', 'message')
 	   AND a.direction = 'inbound'
 	   AND a.archived_at IS NULL
 	   AND a.occurred_at <= $%[1]d
 	   AND %[2]s
 	   AND a.thread_key IS NOT NULL
+	   -- Old enough and it is history, not work. Before the cap, like every
+	   -- other exclusion here.
+	   AND a.occurred_at >= $%[1]d - make_interval(days => %[5]d)
+	   -- A SALES link, or it is not this queue's business.
+	   --
+	   -- The rule that was missing: this read used to answer "somebody wrote and
+	   -- nobody replied", which is true of a rep's dentist. Unanswered is a fact
+	   -- about a mailbox; waiting is a fact about a customer, and only a link to
+	   -- a record the workspace sells to tells the two apart.
+	   --
+	   -- Its own EXISTS rather than a predicate on the wl join above, because
+	   -- that join is filtered by what the reader may SEE. Qualifying through it
+	   -- would make eligibility depend on the reader, so the same message would
+	   -- be work for one colleague and personal mail for another.
+	   AND EXISTS (
+	         SELECT 1 FROM activity_link sales
+	          WHERE sales.activity_id = a.id
+	            AND (sales.person_id IS NOT NULL
+	              OR sales.organization_id IS NOT NULL
+	              OR EXISTS (SELECT 1 FROM deal d
+	                          WHERE d.id = sales.deal_id
+	                            AND d.status = 'open'
+	                            AND d.archived_at IS NULL)
+	              OR EXISTS (SELECT 1 FROM lead ld
+	                          WHERE ld.id = sales.lead_id
+	                            AND ld.status IN ('new', 'contacted', 'engaged')
+	                            AND ld.archived_at IS NULL)))
 	   -- The obvious machines, excluded BEFORE the cap. Filtering them after
 	   -- LIMIT lets two hundred notification threads fill the scan and push a
 	   -- real customer past it, and the page then says nobody is waiting —
@@ -204,7 +304,8 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 			linkVisible = scopeUnbounded
 		}
 		rows, err := tx.Query(ctx,
-			fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, waitingScanCap), args...)
+			fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, waitingScanCap,
+				waitingHorizonDays), args...)
 		if err != nil {
 			return err
 		}
@@ -213,7 +314,8 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 		for rows.Next() {
 			var row WaitingReply
 			if err := rows.Scan(&row.ActivityID, &row.Subject, &row.Sender, &row.OccurredAt,
-				&row.PersonID, &row.OrganizationID, &row.DealID); err != nil {
+				&row.PersonID, &row.OrganizationID, &row.DealID,
+				&row.OwnerID, &row.HasOpenDeal); err != nil {
 				return err
 			}
 			waiting = append(waiting, row)

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -46,13 +46,14 @@ type WaitingReply struct {
 	PersonID       ids.UUID
 	OrganizationID ids.UUID
 	DealID         ids.UUID
-	// OwnerID is who answers for the linked record, by the precedence the query
-	// declares. Zero means nobody does — which routes the wait to the unassigned
-	// queue rather than to whoever happens to be reading.
-	OwnerID ids.UUID
 	// HasOpenDeal reports whether an open deal is on this thread. It is what
 	// lets a caller keep an old wait that still has money behind it, and drop
 	// one that does not.
+	//
+	// Read through the SAME visibility-gated links as the record ids above, so
+	// it means "an open deal this reader can see" rather than "an open deal
+	// exists". The looser reading would let somebody learn a deal is there by
+	// watching a row they can see decline to go stale.
 	HasOpenDeal bool
 }
 
@@ -68,11 +69,37 @@ const waitingScanCap = 200
 // that separate an urgent wait from a stale one are the caller's, and they
 // judge what survives this.
 //
+// A thread with an open deal on it is exempt. That is the one case where a long
+// silence still costs money, and the caller says the same thing in its own
+// staleness rule; a horizon that outranked it would leave that rule with
+// nothing to act on.
+//
 // Applied BEFORE the cap for the same reason the machine rule is, and the
 // reason is worth restating because it is the whole shape of this query: a
 // filter after LIMIT lets two hundred rows nobody wants fill the scan and push
 // a real customer past it, and the page then says nobody is waiting.
 const waitingHorizonDays = 90
+
+// What "still live" means, per record type, as one spelling each.
+//
+// Both predicates take a table alias, because every reader needs them under a
+// different one. They exist as constants because this file needed each rule
+// twice and lasttouch.go states the same two in its own dispatch: four copies
+// of "a deal is open" in one package is four places to edit when archiving
+// changes, and nothing fails when the fourth is missed.
+//
+// The lead list is the WORKING part of the lifecycle. A promoted or
+// disqualified lead is finished business, and a wait on one is history rather
+// than work.
+const (
+	openDealPredicate    = `%[1]s.status = 'open' AND %[1]s.archived_at IS NULL`
+	workingLeadPredicate = `%[1]s.status IN ('new', 'contacted', 'engaged') AND %[1]s.archived_at IS NULL`
+)
+
+// liveRecord renders one of the predicates above under a caller's alias.
+func liveRecord(predicate, alias string) string {
+	return fmt.Sprintf(predicate, alias)
+}
 
 // waitingRepliesSQL finds, per thread, the newest inbound with no later
 // outbound in the same thread — where the thread is a SALES conversation the
@@ -132,30 +159,14 @@ const waitingRepliesSQL = `
 	       COALESCE((array_agg(wl.deal_id ORDER BY wl.deal_id::text)
 	                 FILTER (WHERE wl.deal_id IS NOT NULL))[1],
 	                '00000000-0000-0000-0000-000000000000'::uuid),
-	       -- Who answers for this wait, by ONE declared precedence:
-	       -- deal, then lead, then person, then organization.
+	       -- Whether an open deal this reader can SEE is on this thread, which
+	       -- is what lets a long wait with money on it stay in the day.
 	       --
-	       -- Nearest-to-the-money first. A thread filed under both a deal and
-	       -- the person on it belongs to whoever owns the deal, because that is
-	       -- who the reply changes an outcome for. Without a stated order the
-	       -- answer would follow whichever link happened to sort first, and one
-	       -- message would change hands between reads.
-	       --
-	       -- Absent is a real answer, not a missing one: nobody owns it, and the
-	       -- caller routes it to the unassigned queue rather than to everyone.
-	       COALESCE(
-	         (array_agg(dealOwner.owner_id ORDER BY dealOwner.id::text)
-	          FILTER (WHERE dealOwner.owner_id IS NOT NULL))[1],
-	         (array_agg(leadOwner.owner_id ORDER BY leadOwner.id::text)
-	          FILTER (WHERE leadOwner.owner_id IS NOT NULL))[1],
-	         (array_agg(personOwner.owner_id ORDER BY personOwner.id::text)
-	          FILTER (WHERE personOwner.owner_id IS NOT NULL))[1],
-	         (array_agg(orgOwner.owner_id ORDER BY orgOwner.id::text)
-	          FILTER (WHERE orgOwner.owner_id IS NOT NULL))[1],
-	         '00000000-0000-0000-0000-000000000000'::uuid),
-	       -- Whether an OPEN deal is on this thread, which is what lets the
-	       -- caller keep an old wait that still has money on it.
-	       bool_or(dealOwner.id IS NOT NULL)
+	       -- Off the visibility-gated join, like every record id above it. Read
+	       -- off an ungated one it would answer "a deal exists" rather than "you
+	       -- can see a deal", and a reader would learn the first by watching a
+	       -- row they can see decline to go stale.
+	       bool_or(openDeal.id IS NOT NULL)
 	  FROM activity a
 	  LEFT JOIN activity_link wl ON wl.activity_id = a.id AND (%[3]s)
 	  -- Who wrote. The sender participant is where capture records the address,
@@ -163,35 +174,29 @@ const waitingRepliesSQL = `
 	  -- from a notification service.
 	  LEFT JOIN activity_participant sender
 	         ON sender.activity_id = a.id AND sender.role = 'from'
-	  -- The owner joins walk the links WITHOUT the visibility clause the wl
-	  -- join carries. Who answers for a record is a fact about the record; if it
-	  -- were read through what this reader may see, a message would look
-	  -- unowned to one colleague and owned to another, and "mine" would mean a
-	  -- different set of rows per reader for the same underlying truth.
-	  --
-	  -- Only the id and the owner leave these joins. No name, no amount, no
-	  -- subject — nothing a reader could not otherwise reach — so this widens
-	  -- what the query KNOWS without widening what it discloses.
-	  LEFT JOIN activity_link ownerLink ON ownerLink.activity_id = a.id
-	  LEFT JOIN deal dealOwner ON dealOwner.id = ownerLink.deal_id
-	                          AND dealOwner.status = 'open'
-	                          AND dealOwner.archived_at IS NULL
-	  LEFT JOIN lead leadOwner ON leadOwner.id = ownerLink.lead_id
-	                          AND leadOwner.status IN ('new', 'contacted', 'engaged')
-	                          AND leadOwner.archived_at IS NULL
-	  LEFT JOIN person personOwner ON personOwner.id = ownerLink.person_id
-	                              AND personOwner.archived_at IS NULL
-	  LEFT JOIN organization orgOwner ON orgOwner.id = ownerLink.organization_id
-	                                 AND orgOwner.archived_at IS NULL
+	  LEFT JOIN deal openDeal ON openDeal.id = wl.deal_id
+	                         AND %[8]s
 	 WHERE a.kind IN ('email', 'message')
 	   AND a.direction = 'inbound'
 	   AND a.archived_at IS NULL
 	   AND a.occurred_at <= $%[1]d
 	   AND %[2]s
 	   AND a.thread_key IS NOT NULL
-	   -- Old enough and it is history, not work. Before the cap, like every
-	   -- other exclusion here.
-	   AND a.occurred_at >= $%[1]d - make_interval(days => %[5]d)
+	   -- Old enough and it is history, not work — UNLESS an open deal is on it.
+	   --
+	   -- The horizon and the caller's staleness rule have to agree about money,
+	   -- or the looser of the two is decoration. The caller keeps a long wait
+	   -- that still has a deal behind it, on the ground that there the silence
+	   -- IS the problem; a horizon that removed those rows first would make that
+	   -- branch unreachable and the rep would never see the one case where a
+	   -- half-year of quiet costs something.
+	   --
+	   -- Before the cap, like every other exclusion here.
+	   AND (a.occurred_at >= $%[1]d - make_interval(days => %[5]d)
+	     OR EXISTS (
+	          SELECT 1 FROM activity_link funded
+	          JOIN deal fd ON fd.id = funded.deal_id AND %[9]s
+	           WHERE funded.activity_id = a.id))
 	   -- A SALES link, or it is not this queue's business.
 	   --
 	   -- The rule that was missing: this read used to answer "somebody wrote and
@@ -209,13 +214,9 @@ const waitingRepliesSQL = `
 	            AND (sales.person_id IS NOT NULL
 	              OR sales.organization_id IS NOT NULL
 	              OR EXISTS (SELECT 1 FROM deal d
-	                          WHERE d.id = sales.deal_id
-	                            AND d.status = 'open'
-	                            AND d.archived_at IS NULL)
+	                          WHERE d.id = sales.deal_id AND %[6]s)
 	              OR EXISTS (SELECT 1 FROM lead ld
-	                          WHERE ld.id = sales.lead_id
-	                            AND ld.status IN ('new', 'contacted', 'engaged')
-	                            AND ld.archived_at IS NULL)))
+	                          WHERE ld.id = sales.lead_id AND %[7]s)))
 	   -- The obvious machines, excluded BEFORE the cap. Filtering them after
 	   -- LIMIT lets two hundred notification threads fill the scan and push a
 	   -- real customer past it, and the page then says nobody is waiting —
@@ -253,7 +254,19 @@ const waitingRepliesSQL = `
 	            AND newer.occurred_at <= $%[1]d
 	            AND (newer.occurred_at, newer.id) > (a.occurred_at, a.id))
 	 GROUP BY a.id, a.subject, a.occurred_at
-	 ORDER BY a.occurred_at ASC
+	 -- NEWEST first, which is the opposite of how the rows are then shown.
+	 --
+	 -- The cap has to spend its budget on the rows most likely to matter, and
+	 -- those are the recent ones: a wait inside a day is urgent, and one past a
+	 -- fortnight without an open deal is demoted by the caller the moment it
+	 -- arrives. Taking the OLDEST two hundred spent the entire scan on rows
+	 -- headed for the bottom of the page and cut the urgent ones before anybody
+	 -- saw them — the queue would report nobody waiting on the day it was most
+	 -- wrong.
+	 --
+	 -- The caller sorts oldest-first for display, so what a reader sees is
+	 -- unchanged. This decides only WHICH waits survive the bound.
+	 ORDER BY a.occurred_at DESC
 	 LIMIT %[4]d`
 
 // WaitingReplies answers who is waiting on this reader for a reply.
@@ -305,7 +318,11 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 		}
 		rows, err := tx.Query(ctx,
 			fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, waitingScanCap,
-				waitingHorizonDays), args...)
+				waitingHorizonDays,
+				liveRecord(openDealPredicate, "d"),
+				liveRecord(workingLeadPredicate, "ld"),
+				liveRecord(openDealPredicate, "openDeal"),
+				liveRecord(openDealPredicate, "fd")), args...)
 		if err != nil {
 			return err
 		}
@@ -315,7 +332,7 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 			var row WaitingReply
 			if err := rows.Scan(&row.ActivityID, &row.Subject, &row.Sender, &row.OccurredAt,
 				&row.PersonID, &row.OrganizationID, &row.DealID,
-				&row.OwnerID, &row.HasOpenDeal); err != nil {
+				&row.HasOpenDeal); err != nil {
 				return err
 			}
 			waiting = append(waiting, row)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24970,7 +24970,7 @@ export interface components {
              * @description Which fact this is. The client writes the phrase.
              * @enum {string}
              */
-            kind: "pinned" | "buyer_wrote_last" | "waiting_days" | "overdue" | "due_today" | "closing_soon" | "expected_revenue" | "material" | "below_material" | "quiet_days" | "no_champion" | "promised" | "approved_and_failed" | "blocks_customer_work" | "routine" | "repeated_failure" | "legal_deadline" | "meeting_soon";
+            kind: "pinned" | "buyer_wrote_last" | "waiting_days" | "overdue" | "due_today" | "closing_soon" | "expected_revenue" | "material" | "below_material" | "quiet_days" | "no_champion" | "promised" | "approved_and_failed" | "blocks_customer_work" | "routine" | "repeated_failure" | "legal_deadline" | "meeting_soon" | "stale";
             value?: components["schemas"]["WorklistValue"];
         };
         /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7094,6 +7094,7 @@ export const de = {
   "worklist.because.repeated_failure": "dasselbe schlägt immer wieder fehl",
   "worklist.because.legal_deadline": "eine gesetzliche Frist läuft",
   "worklist.because.meeting_soon": "beginnt gleich",
+  "worklist.because.stale": "wartet schon lange",
   "worklist.above.pin": "Über dem Nächsten, weil du es angeheftet hast.",
   "worklist.above.level": "Über dem Nächsten, weil es dringlichere Arbeit ist.",
   "worklist.above.deadline": "Über dem Nächsten wegen des Datums.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7181,6 +7181,7 @@ export const en = {
   "worklist.because.repeated_failure": "the same thing keeps failing",
   "worklist.because.legal_deadline": "a legal deadline is running",
   "worklist.because.meeting_soon": "starting shortly",
+  "worklist.because.stale": "waiting a long time",
   "worklist.above.pin": "Above the next because you pinned it.",
   "worklist.above.level":
     "Above the next because it is a more pressing kind of work.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7029,6 +7029,7 @@ export const vi = {
   "worklist.because.repeated_failure": "cùng một lỗi lặp lại nhiều lần",
   "worklist.because.legal_deadline": "thời hạn pháp lý đang chạy",
   "worklist.because.meeting_soon": "sắp bắt đầu",
+  "worklist.because.stale": "đã chờ rất lâu",
   "worklist.above.pin": "Trên mục kế vì bạn đã ghim.",
   "worklist.above.level": "Trên mục kế vì đây là loại việc gấp hơn.",
   "worklist.above.deadline": "Trên mục kế nhờ ngày hạn.",

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -142,6 +142,7 @@ const KNOWN_REASONS = {
   repeated_failure: true,
   legal_deadline: true,
   meeting_soon: true,
+  stale: true,
 } as const;
 
 type KnownReason = keyof typeof KNOWN_REASONS;


### PR DESCRIPTION
The Worklist opened on eight half-year-old email threads. Every one was genuinely unanswered, and none of them was work: the read asked only whether somebody wrote last and nobody replied, which is equally true of a rep's dentist.

## What decides a wait now

Three rules, all inside `waitingRepliesSQL` and all before its two-hundred-row cap:

- **A sales link.** A thread reaching an open deal, a live lead, a person or an organization is the workspace's business; one reaching no record at all is the rep's own mail. The test runs in its own `EXISTS` rather than through the visibility-filtered join beside it, so eligibility cannot come to depend on who is reading.
- **Recency.** Ninety days, unless an open deal is on the thread — that is the one case where a long silence still costs money, and the caller's staleness rule promises to keep it.
- **The cap keeps the newest.** The scan used to take the two hundred oldest, which is exactly the rows the new staleness rule demotes; together they would have spent the whole budget on rows headed for the bottom and cut the urgent ones before anybody saw them. Display order is unchanged — the caller re-sorts oldest-first.

A rule applied after the cap reads as a working filter and fails as a silent one, which is why they all sit before it. The machine-sender rule was already placed this way for that reason.

## And age stops buying precedence

Past a fortnight without an open deal a wait leaves the top band for review — it keeps its row, loses the day. Past thirty days age stops ordering at all: uncapped, every further day of silence outranked every newer wait forever, which is how eight forgotten threads came to lead a working rep's morning.

The row still reports the true age, and so does the comparison explaining why it sits where it does. The ordering age is a separate field, because a row saying "waiting 183 days" whose own explanation compares 30 against 20 is a reason nobody can check.

## Review findings fixed in the branch

A security and a craftsmanship pass found four defects, each a rule that was right alone and wrong beside its neighbour — the cap/staleness conflict and the horizon/funded conflict above, the comparator reporting the bounded age, and `HasOpenDeal` reading off links without the reader's visibility clause (a reader could learn an invisible deal existed by watching a row decline to go stale). All four are fixed here.

Owner resolution was plumbed end to end and read by nothing, with a comment claiming a routing behaviour no caller performs. It is dropped; it can arrive with the queue that consumes it.

## Tests

Nine integration cases against a real database, each pairing a refusal with an admission. Three existing unit tests had fixtures that encoded the old defect — an 83-day wait leading the day, 83 days outranking 2, thirty waits aged past the new stale line. Their assertions were right and are kept; the fixtures are now live waits, so each proves its own rule instead of the one next to it. Both new guards were mutation-checked one at a time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unanswered was treated as waiting, so a rep's forgotten personal thread could lead the worklist. The lane now qualifies waits by sales link and recency, and age stops buying precedence beyond set limits.

**Eligibility**
- A wait must link to a person, organization, live lead, or open deal; mail linked to nothing is the rep's own correspondence and is never reported.
- The sales-link test runs in its own `EXISTS`, outside the reader-visibility join, so eligibility cannot depend on who is reading.
- Threads older than 90 days are dropped unless an open deal is on them; the 200-row cap now keeps the newest waits, and the caller still shows them oldest-first.

**Freshness and ordering**
- Unfunded waits older than 14 days move to the review band and gain a `stale` reason; an open deal keeps a long wait in the top band.
- Ordering age caps at 30 days, while rows and their comparisons still report the true age.
- `HasOpenDeal` reads through the reader's visibility-gated links, so a reader cannot infer a hidden deal from a row not going stale.
- The owner-resolution plumbing was removed; it returns with the queue that consumes it.
- Nine integration cases cover the new boundaries, and three fixtures that encoded the old behavior now use live waits.

<sup>Written for commit ba2497b8b949943fca4d7911e714143ed7831019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

