### PR TITLE
main is red: the gate inventory census count drifted

### DIFF
--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -75,7 +75,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (79)
+## Census (80)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
## What's broken

`main` is red: `TestTheGateInventoryPageIsCurrent` fails. `main-health` run https://github.com/margince/margince/actions/runs/33453517191 caught it (after PR #3422 fixed a different, unrelated red).

## Root cause

`docs/reference/gate-inventory.md`'s "Census (79)" heading had drifted one behind the actual `//gate:kind` census count (80) in the tree — a recent PR added a gate without regenerating the inventory page in the same commit, per the doc's own instruction.

## Fix

Regenerated the page:

```
go test ./gates -run GateInventory -update-gate-inventory
```

Only the census count line changes.

## Verification

- `go test ./gates -run TestTheGateInventoryPageIsCurrent -v` — passes
- `go test -count=1 ./gates` — passes (the only remaining local failure, `TestTheSweptCorpusIsEveryModuleThatCouldCarryAClaim` on `.tmp/_archive/...`, is pre-existing local scratch debris outside git, unrelated to this change and not present in CI's clean clone)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the gate inventory census count drift that broke `TestTheGateInventoryPageIsCurrent` on `main`. The `Census (79)` heading in `docs/reference/gate-inventory.md` was one behind the actual `//gate:kind` count (80); regenerated the page with `go test ./gates -run GateInventory -update-gate-inventory`, changing only the count line. The test now passes.

<sup>Written for commit 7975b25cd9d9151f4acbb4f9643d8ab266c12581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the gate inventory census to reflect 80 entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->