### PR TITLE
A uniqueness claim is the same claim however the comment wrapped

### DIFF
--- a/backend/gates/claimedspelling_test.go
+++ b/backend/gates/claimedspelling_test.go
@@ -68,6 +68,7 @@ var sharedSpellings = gatekit.Waive(map[string]string{
 	"internal/modules/ai/feedback.go:fieldSubjectType":           "the second is the same word as a key in the AuditEvent image, where it names a column of the ledger row rather than the request field a refusal points at",
 	"internal/modules/search/queryjoins.go:objectRelationship":   "the second is the relationship TABLE's name in the join spec beside it, not the RBAC object governing it — the two agree today and are free to diverge",
 	"internal/shared/ports/datasource/shapewords.go:objectShape": "the second is the same two words inside a rendered sentence, where they are English rather than the shape word this constant names",
+	"internal/modules/customfields/engine.go:fieldObject":        "the second is the English word in structuralKeywords, which a user's LABEL is smell-tested against — \"add an object for invoices\" is refused as a request to model something new. It is a word somebody typed, not the request field this constant names, and tying the two would make the heuristic's vocabulary follow the wire.",
 })
 
 // claimedConst is one string constant a claim sits on.

--- a/backend/gates/uniquenessclaims_test.go
+++ b/backend/gates/uniquenessclaims_test.go
@@ -460,15 +460,15 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 // a row falling, so the two kinds of progress are told apart by which number
 // moved and whether the tree moved with it.
 var shapeCensus = map[string]int{
-	"cannot-drift":   156,
-	"once":           155,
-	"one-of-a-kind":  154,
+	"cannot-drift":   172,
+	"once":           178,
+	"one-of-a-kind":  180,
 	"is-every-named": 91,
-	"only-noun":      16,
-	"no-second":      10,
-	"never-twice":    6,
+	"only-noun":      12,
+	"no-second":      11,
+	"never-twice":    7,
 	"is-every":       4,
-	"one-truth":      3,
+	"one-truth":      2,
 }
 
 // registeredDebt is the number of unheld claims this tree carries, tracked
@@ -845,6 +845,80 @@ func TestTheBindingIsReadOffTheCommentRatherThanGuessedAt(t *testing.T) {
 	} {
 		if heldBy.MatchString(bad) {
 			t.Errorf("%q was read as a binding and must not be", bad)
+		}
+	}
+}
+
+// A claim is the same claim however the comment was wrapped.
+//
+// The shapes spell their phrases with literal spaces, and a doc comment keeps
+// the newlines it was wrapped at. Without flattening, "the one spelling" is a
+// claim the register holds and the identical claim broken across two lines is
+// invisible — so reflowing a paragraph, which changes no meaning, takes a live
+// claim out of the register with nothing failing to say so.
+//
+// That is under-recognition, the one direction a census must not break: the
+// gate reads a smaller corpus, reports PASS, and no assertion notices.
+//
+// Every wrap point is tried rather than one chosen by hand. A shape is blind
+// if ANY break defeats it, and picking a single space can land on one the
+// pattern happens to tolerate — the derived shape spells its first gap `\s+`
+// and its second as a literal space, so a case broken at the first would have
+// reported it safe.
+func TestAShapeSeesAClaimTheCommentWrapped(t *testing.T) {
+	t.Parallel()
+	claims := map[string]string{
+		"one-of-a-kind": "This is the one spelling of that shape.",
+		"only-noun":     "It is the only reader of this column.",
+		"cannot-drift":  "The two cannot drift apart.",
+		"once":          "The column is spelled once, here.",
+		"no-second":     "There is no second writer of this row.",
+		"one-truth":     "This is the single source of truth for the tier.",
+		"is-every":      "These are EVERY tier the router admits.",
+		"never-twice":   "The value is never duplicated.",
+		namedShape:      "Flush is every Flush there is.",
+	}
+	for shape, sentence := range claims {
+		pattern := claimShapes[shape]
+		if shape == namedShape {
+			pattern = namedExhaustiveness("func Flush")
+		}
+		if pattern == nil {
+			t.Errorf("shape %q has no pattern to test", shape)
+			continue
+		}
+		phrase := pattern.FindString(sentence)
+		if phrase == "" {
+			t.Errorf("shape %q does not read its own case as a claim, so the case proves nothing:\n\t%s",
+				shape, sentence)
+			continue
+		}
+		blindAt := 0
+		for at, char := range phrase {
+			if char != ' ' {
+				continue
+			}
+			// The same sentence, broken inside the phrase where a formatter
+			// would break it.
+			wrapped := strings.Replace(sentence, phrase,
+				phrase[:at]+"\n"+phrase[at+1:], 1)
+			if pattern.FindString(wrapped) == "" {
+				blindAt++
+			}
+			if pattern.FindString(claimWhitespace.ReplaceAllString(wrapped, " ")) == "" {
+				t.Errorf("shape %q does not see its own claim once the wrap is flattened — a reflowed comment leaves the register silently:\n\t%q",
+					shape, wrapped)
+			}
+		}
+		if blindAt == 0 {
+			t.Errorf("shape %q survives every wrap of %q, so this case cannot show what flattening buys — pick a phrase the shape spells with a literal space",
+				shape, phrase)
+		}
+	}
+	for _, shape := range append(sortedShapes(), namedShape) {
+		if _, ok := claims[shape]; !ok {
+			t.Errorf("shape %q has no wrapped case — it could go blind to a reflowed claim "+
+				"and this arm would stay green", shape)
 		}
 	}
 }

--- a/backend/gates/uniquenessclaims_test.go
+++ b/backend/gates/uniquenessclaims_test.go
@@ -849,23 +849,70 @@ func TestTheBindingIsReadOffTheCommentRatherThanGuessedAt(t *testing.T) {
 	}
 }
 
-// A claim is the same claim however the comment was wrapped.
+// A claim is the same claim however the comment was wrapped — asserted through
+// the DETECTOR, on real Go source.
 //
 // The shapes spell their phrases with literal spaces, and a doc comment keeps
-// the newlines it was wrapped at. Without flattening, "the one spelling" is a
-// claim the register holds and the identical claim broken across two lines is
-// invisible — so reflowing a paragraph, which changes no meaning, takes a live
-// claim out of the register with nothing failing to say so.
+// the newlines it was wrapped at. Unflattened, "the one spelling" is a claim
+// the register holds and the identical claim broken across two lines is not —
+// so reflowing a paragraph, which changes no meaning, takes a live claim out
+// of the register with nothing failing to say so. That is under-recognition,
+// the one direction a census must not break.
 //
-// That is under-recognition, the one direction a census must not break: the
-// gate reads a smaller corpus, reports PASS, and no assertion notices.
+// It goes through findClaims rather than through the flattening helper because
+// a test that calls the helper itself passes whether or not the detector still
+// uses it. What has to hold is that a WRAPPED comment in a file reaches the
+// register.
 //
-// Every wrap point is tried rather than one chosen by hand. A shape is blind
-// if ANY break defeats it, and picking a single space can land on one the
-// pattern happens to tolerate — the derived shape spells its first gap `\s+`
-// and its second as a literal space, so a case broken at the first would have
-// reported it safe.
-func TestAShapeSeesAClaimTheCommentWrapped(t *testing.T) {
+// And the paragraph case is here for the opposite error: a blank line
+// separates two sentences, and running them together manufactures a claim
+// nobody wrote, which puts innocent prose in a closed register.
+func TestTheDetectorReadsAClaimTheCommentWrapped(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	source := `package fixture
+
+// wrappedClaim is the one
+// spelling of that shape, so nothing else may name it.
+const wrappedClaim = "a"
+
+// splitAcrossParagraphs ends a paragraph with the one
+//
+// writer of this row is somebody else entirely.
+const splitAcrossParagraphs = "b"
+`
+	if err := os.WriteFile(filepath.Join(dir, "fixture.go"), []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	claims, err := findClaims(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for _, c := range claims {
+		seen[c.decl] = true
+	}
+
+	if !seen["const wrappedClaim"] {
+		t.Error("a claim broken across two lines did not reach the detector — reflowing a " +
+			"paragraph would take it out of the register with nothing failing to say so")
+	}
+	if seen["const splitAcrossParagraphs"] {
+		t.Error("two paragraphs were run together into a claim nobody wrote — a blank line " +
+			"separates sentences and joining them puts innocent prose in a closed register")
+	}
+}
+
+// Every shape is blind to a wrap somewhere, and flattening is what covers it.
+//
+// Per shape rather than the one fixture above, so a shape widened tomorrow has
+// to answer here too. Every wrap point is tried rather than one chosen by
+// hand: a shape is blind if ANY break defeats it, and picking a single space
+// can land on one the pattern happens to tolerate — the derived shape spells
+// its first gap `\s+` and its second as a literal space, so a case broken at
+// the first would have reported it safe.
+func TestEveryShapeIsBlindToSomeWrapTheDetectorFlattens(t *testing.T) {
 	t.Parallel()
 	claims := map[string]string{
 		"one-of-a-kind": "This is the one spelling of that shape.",
@@ -893,25 +940,19 @@ func TestAShapeSeesAClaimTheCommentWrapped(t *testing.T) {
 				shape, sentence)
 			continue
 		}
-		blindAt := 0
+		blind := 0
 		for at, char := range phrase {
 			if char != ' ' {
 				continue
 			}
-			// The same sentence, broken inside the phrase where a formatter
-			// would break it.
 			wrapped := strings.Replace(sentence, phrase,
 				phrase[:at]+"\n"+phrase[at+1:], 1)
 			if pattern.FindString(wrapped) == "" {
-				blindAt++
-			}
-			if pattern.FindString(claimWhitespace.ReplaceAllString(wrapped, " ")) == "" {
-				t.Errorf("shape %q does not see its own claim once the wrap is flattened — a reflowed comment leaves the register silently:\n\t%q",
-					shape, wrapped)
+				blind++
 			}
 		}
-		if blindAt == 0 {
-			t.Errorf("shape %q survives every wrap of %q, so this case cannot show what flattening buys — pick a phrase the shape spells with a literal space",
+		if blind == 0 {
+			t.Errorf("shape %q survives every wrap of %q, so it shows nothing about what flattening buys — pick a phrase the shape spells with a literal space",
 				shape, phrase)
 		}
 	}

--- a/backend/gates/uniquenessclaimsdetector_test.go
+++ b/backend/gates/uniquenessclaimsdetector_test.go
@@ -231,6 +231,10 @@ func intensifier(word string) bool {
 // legal Go identifier and a legal thing to write, and `go test` will never run
 // it — so a claim could name a "gate" that compiles, exists, and can never
 // execute. The signature is checked too, below.
+// claimWhitespace is every run of space the comment's own wrapping produced.
+// Collapsed to one space so a phrase reads the same however it was broken.
+var claimWhitespace = regexp.MustCompile(`\s+`)
+
 var heldBy = regexp.MustCompile(`Held by:\s*(Test[A-Z_][A-Za-z0-9_]*)\s*\(([^)]+)\)`)
 
 // goTestFunc finds the declarations a `Held by:` may name.
@@ -372,7 +376,15 @@ func findClaims(root string) ([]claim, error) {
 			if doc == nil {
 				return
 			}
-			text := doc.Text()
+			// Flattened before matching. doc.Text() keeps the newlines the
+			// comment was WRAPPED at, and every pattern below spells its
+			// phrase with literal spaces — so "the one spelling" is a claim
+			// this sees and the same claim broken across two lines is not.
+			//
+			// That is the one direction a census must not break: reflowing a
+			// paragraph changes no meaning, and it would have taken a live
+			// claim out of the register with nothing failing to say so.
+			text := claimWhitespace.ReplaceAllString(doc.Text(), " ")
 			shapes := sortedShapes()
 			patterns := make(map[string]*regexp.Regexp, len(claimShapes)+1)
 			for name, pattern := range claimShapes {

--- a/backend/gates/uniquenessclaimsdetector_test.go
+++ b/backend/gates/uniquenessclaimsdetector_test.go
@@ -231,9 +231,29 @@ func intensifier(word string) bool {
 // legal Go identifier and a legal thing to write, and `go test` will never run
 // it — so a claim could name a "gate" that compiles, exists, and can never
 // execute. The signature is checked too, below.
-// claimWhitespace is every run of space the comment's own wrapping produced.
-// Collapsed to one space so a phrase reads the same however it was broken.
-var claimWhitespace = regexp.MustCompile(`\s+`)
+// claimWrap is the whitespace a comment's own line WRAPPING produced: a run of
+// space that crosses at most one newline. Collapsed to a single space so a
+// phrase reads the same however it was broken.
+//
+// A blank line is deliberately not matched. It separates two paragraphs, and
+// joining them would run the last words of one into the first words of the
+// next — "… the one" then "writer of …" becomes a claim nobody wrote, which is
+// over-recognition in a register whose whole value is that its number means
+// something.
+var claimWrap = regexp.MustCompile(`[^\S\n]*\n[^\S\n]*|[^\S\n]+`)
+
+// flattenWraps rejoins each PARAGRAPH onto one line, leaving the blank lines
+// between them where they are.
+func flattenWraps(text string) string {
+	paragraphs := claimParagraph.Split(text, -1)
+	for i, paragraph := range paragraphs {
+		paragraphs[i] = strings.TrimSpace(claimWrap.ReplaceAllString(paragraph, " "))
+	}
+	return strings.Join(paragraphs, "\n\n")
+}
+
+// claimParagraph is a blank line — the boundary flattenWraps will not cross.
+var claimParagraph = regexp.MustCompile(`\n[^\S\n]*\n`)
 
 var heldBy = regexp.MustCompile(`Held by:\s*(Test[A-Z_][A-Za-z0-9_]*)\s*\(([^)]+)\)`)
 
@@ -384,7 +404,7 @@ func findClaims(root string) ([]claim, error) {
 			// That is the one direction a census must not break: reflowing a
 			// paragraph changes no meaning, and it would have taken a live
 			// claim out of the register with nothing failing to say so.
-			text := claimWhitespace.ReplaceAllString(doc.Text(), " ")
+			text := flattenWraps(doc.Text())
 			shapes := sortedShapes()
 			patterns := make(map[string]*regexp.Regexp, len(claimShapes)+1)
 			for name, pattern := range claimShapes {

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -165,7 +165,7 @@ func ensureRelationshipAnchorWritable(
 // an anchor whatever the kind, and stating it per-kind is what let
 // project_stakeholder through the same door this paragraph closed.
 var relationshipKinds = map[string]bool{
-	employmentKind: true, "deal_stakeholder": true, "project_stakeholder": true,
+	employmentKind: true, "deal_stakeholder": true, ProjectStakeholderKind: true,
 	"partner_of": true, "referred_by": true, "co_sell_with": true,
 	worksWithKind: true,
 }

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -32,8 +32,11 @@
 #
 # Sorted, one key per line: <path>#<declaration>.
 
+../cli/craft/gate/anthropic.go#func NewAnthropicClient
+../cli/craft/main.go#func pinnedModel
 ../desktop/launcher/console.go#func say
 ../desktop/launcher/main.go#type stack
+../desktop/launcher/postgres.go#type cluster.connArgs
 cmd/api/configitems.go#const oauthAccessTokenTTLEnv
 cmd/api/resetruntime.go#func newResetLane
 cmd/worker/boot.go#func workerModelPathSpec
@@ -46,6 +49,7 @@ gates/edgereaders_test.go#const edgeTable
 gates/edgereaders_test.go#var edgeReaderScope
 gates/enumsync_test.go#func recordChecks
 gates/envcontract_test.go#func liveEnvVars
+gates/extensioncapabilitycensus_test.go#var surfaceConstants
 gates/fieldnames_test.go#const internalTree
 gates/geocodestaleness_test.go#var addressColumns
 gates/jobargscontent_test.go#func declaredArgsRationales
@@ -55,6 +59,8 @@ gates/manifestdigest_test.go#func committedManifests
 gates/manifestdigest_test.go#var manifestDigestEncoding
 gates/modulepoolsharing_test.go#var poolConstructors
 gates/netguardparity_test.go#func TestPublishedReservedNetsMatchTheGuard
+gates/outboundanonymity_test.go#func isDefaultClient
+gates/preferencecentrewriters_test.go#func TestThePreferenceCentreResolvesOnePrimaryAddress
 gates/replayscope_test.go#var replayScopeConsts
 gates/restrictedreaders_test.go#var activityReaderScope
 gates/tableownership_test.go#var tableOwners
@@ -66,11 +72,13 @@ internal/compose/agentcommand_integration_test.go#func archivableRecordTypes
 internal/compose/agentgatecanon.go#const keyBindsTheRetry
 internal/compose/agentgatestaging.go#func resolveStagedTarget
 internal/compose/agentsplit.go#const block at const opAddListMember
+internal/compose/agenttasks.go#const taskColumns
 internal/compose/aicert/record.go#type Record.Scenarios
 internal/compose/aicert/reportcmd/report.go#var reportColumns
 internal/compose/aicert/run.go#type runCalls
 internal/compose/aicert/scenario.go#const sourceHandAuthored
 internal/compose/approval_kinds_test.go#var exportedApprovalKinds
+internal/compose/attentionseam.go#const approvalStatusApproved
 internal/compose/backfilltransport.go#func backfillStatusPayload
 internal/compose/backfilltransport.go#func writeBackfillJSON
 internal/compose/bodyceilingcensus_test.go#var httpMethods
@@ -95,22 +103,27 @@ internal/compose/commsjobs.go#type deliveryDispatcher
 internal/compose/commsjobs.go#type mailboxSenders
 internal/compose/commsjobs.go#type seatResolver
 internal/compose/commsjobs_test.go#func TestSendEmailJobDeclaresAUsableLadder
+internal/compose/costestimate/estimator.go#func expectedUnits
 internal/compose/costestimate/rules.go#type unitRule
 internal/compose/csvfields.go#const fieldFullName
+internal/compose/datareset.go#type resetDataResponse
 internal/compose/datasweep.go#const credentialHandleSuffix
 internal/compose/dbhandle.go#func ProjectsStore
 internal/compose/dealstatus/grounding.go#func knownIDs
 internal/compose/deepread_integration_test.go#func TestDeepReadAttributesItsWritesToTheRequesterTheRowNames
+internal/compose/deepreadprincipal.go#func withClaimedRequester
 internal/compose/deploymentsecretseal.go#func resolveSecret
 internal/compose/deploymentsecretseal.go#method vaultBinding.open
 internal/compose/dispatch.go#func fanOutChildren
 internal/compose/dispatcher.go#func overlayModeOf
+internal/compose/documentextract.go#func documentFieldOrder
 internal/compose/documentextract.go#func toModelField
 internal/compose/draftcheck/draftcheck.go#func allDirectedRelationshipPhrases
 internal/compose/export.go#func exportableColumns
 internal/compose/extensions.go#func preflightRetentionClasses
 internal/compose/extensions.go#var composedExtensions
 internal/compose/extensions.go#var composedSubscriptions
+internal/compose/extensions.go#var composedVerbs
 internal/compose/extensiontools.go#method extensionTool.OwningUnit
 internal/compose/extjobs.go#var composedJobs
 internal/compose/extjobs_integration_test.go#func TestAHumanSeatIsNotAcceptedAsAJobPrincipal
@@ -128,6 +141,7 @@ internal/compose/flipclaim.go#func flipLockKey
 internal/compose/flipsource.go#const block at const flipObjectOrganization
 internal/compose/flipstages.go#const block at const stageSemanticOpen
 internal/compose/gmailpush.go#func handleGmailPush
+internal/compose/handlers_extensions.go#method extensionsHandlers.ListExtensions
 internal/compose/heldrelease_integration_test.go#const draftRecipient
 internal/compose/idempotency.go#const replayWindow
 internal/compose/installation.go#func seedRoutingBinding
@@ -140,6 +154,7 @@ internal/compose/integration/channels/telegram_fixture_integration_test.go#type 
 internal/compose/integration/channels/telegram_fixture_integration_test.go#type fakeTelegramAPI.sent
 internal/compose/integration/channels/telegram_identity_integration_test.go#func TestErasedSubjectsNextMessageIsAcceptedAndPersistsNothing
 internal/compose/integration/collections/linkedleaves_integration_test.go#method fixture.customerAndSupplier
+internal/compose/integration/declaredfilters_integration_test.go#func TestTheLeadListNarrowsToOneTeamAndToTheUnownedQueue
 internal/compose/integration/deploymentsecretseal_integration_test.go#func TestARotatedDeclarationIsResealed
 internal/compose/integration/deploymentsecretseal_integration_test.go#func TestAnUnopenableVaultNamesItselfRatherThanReportingNoLicense
 internal/compose/integration/employment_dedupe_integration_test.go#func TestAnEmploymentPastItsLastDayStopsCountingAtTheAccount
@@ -153,6 +168,7 @@ internal/compose/integration/queryplan_integration_test.go#var queryObjects
 internal/compose/integration/recordhistory_http_integration_test.go#const recordHistoryFixtureRows
 internal/compose/integration/requiredbodyids_http_integration_test.go#func requiredIDCases
 internal/compose/integration/scheduledsend_integration_test.go#method preflightEnv.seedConsentedRecipient
+internal/compose/integration/searchenv.go#var searchObjects
 internal/compose/integration/seatmatrix_integration_test.go#func seededRoles
 internal/compose/integration/workflow_replay_integration_test.go#const block at const routeLeadHandler
 internal/compose/integration/writeauthorityreview_integration_test.go#func TestAReadShareOfADealCannotRewriteItsContracts
@@ -189,6 +205,7 @@ internal/compose/org360/pipelineread.go#type pipeline.Stalled
 internal/compose/org360/sections.go#func edgeScope
 internal/compose/org360/suggestionreads.go#func newestMessage
 internal/compose/org360/suggestions.go#func candidateSuggestions
+internal/compose/org360/suggestions.go#func ptrString
 internal/compose/orgbrief/ask.go#const askSystem
 internal/compose/orgbrief/ask.go#var askInstruction
 internal/compose/orgbrief/ask_test.go#func declaredQuestions
@@ -198,6 +215,7 @@ internal/compose/orgdossier/doc.go#package orgdossier
 internal/compose/orgdossier/input.go#func KnownRecords
 internal/compose/orgdossier/service.go#var knownNature
 internal/compose/orgnamepromotion_integration_test.go#func seedDossierName
+internal/compose/orgrollupread.go#type fxConverter
 internal/compose/overlay.go#const incumbentHubSpot
 internal/compose/overlayincumbent_refusing_integration_test.go#func refusals
 internal/compose/overlayread.go#const block at const paramSort
@@ -218,6 +236,7 @@ internal/compose/project360/sectionswork.go#var entityTypeProject
 internal/compose/queryseam.go#func queryRunner
 internal/compose/replydraft.go#type replyDrafter.envelope
 internal/compose/replydraftmodel.go#method replyDrafter.completeChecked
+internal/compose/report.go#const block at const colOwnerID
 internal/compose/report.go#method reportSpec.fromClause
 internal/compose/reportcatalog.go#func catalogFilterNames
 internal/compose/reporterrors.go#const block at const slotGroupBy
@@ -227,6 +246,7 @@ internal/compose/routeshadow_test.go#func pathParameters
 internal/compose/sendpath.go#func consentGateFor
 internal/compose/sendpath.go#func registerLateApprovalEffects
 internal/compose/sendpreflight_test.go#func sendCapableCases
+internal/compose/sendvoiceoutcome_integration_test.go#type witnessDraftOutcome
 internal/compose/serverassembly.go#func NewCollectionsStore
 internal/compose/serveroptions.go#func WithMCPResource
 internal/compose/serveroptions_schema.go#func WithDataResetAvailable
@@ -246,15 +266,18 @@ internal/compose/telegrampollscope.go#func telegramRawSourceID
 internal/compose/transcriptproposetransport.go#func TranscriptReadOnLanding
 internal/modules/activities/activity.go#const block at const fieldKind
 internal/modules/activities/activitylinks.go#func insertActivityLinks
+internal/modules/activities/activityread.go#func scanActivity
 internal/modules/activities/attachment.go#func resolveAttachmentParent
 internal/modules/activities/channelsend.go#method outboundChannelMessage.activity
 internal/modules/activities/email.go#const sourceManual
 internal/modules/activities/handlers_email.go#func DeterministicEmailDraft
 internal/modules/activities/handlers_email.go#func IsMailThread
 internal/modules/activities/handlers_email.go#func writeSendOutcome
+internal/modules/activities/handlers_email.go#method Handlers.SendAccountEmail
 internal/modules/activities/lasttouch.go#method Store.LastTouchBefore
 internal/modules/activities/linktarget.go#var linkIDCoalesce
 internal/modules/activities/mapping.go#const fieldBody
+internal/modules/activities/messageidentity.go#const sourceIDImage
 internal/modules/activities/messageidentity.go#func copyEchoLinks
 internal/modules/activities/messageidentity_absorb_integration_test.go#func TestAbsorbLeavesTheEchosProjectLinkBehindWhenTheSurvivorHasOne
 internal/modules/activities/orgscope.go#func ActivityWithinProject
@@ -271,6 +294,7 @@ internal/modules/activities/scheduledsendstore.go#const scheduledSendStatusExpr
 internal/modules/activities/scheduling.go#const block at const businessDayStartHour
 internal/modules/activities/scheduling.go#var block at var errAvailabilityToNotAfterFrom
 internal/modules/activities/transcript_integration_test.go#func TestUpdateActivityNormalizesATranscriptBody
+internal/modules/activities/transcriptnorm.go#func transcriptLines
 internal/modules/activities/unsubscribe.go#func listUnsubscribeHeader
 internal/modules/activities/unsubscribe.go#func unsubscribeURL
 internal/modules/activities/unsubscribe.go#method Store.deliverability
@@ -289,6 +313,7 @@ internal/modules/agents/conformance_test.go#func TestReadOnlyIsDerivedFromTheEnf
 internal/modules/agents/dispatch.go#const block at const jsonRPCVersion
 internal/modules/agents/dispatch.go#type rpcErrorData
 internal/modules/agents/modern.go#const block at const codeParseError
+internal/modules/agents/modern.go#const block at const metaProtocolVersion
 internal/modules/agents/modern.go#func supportedProtocolVersions
 internal/modules/agents/modernextensions.go#func declaresExtension
 internal/modules/agents/outputshapes.go#const block at const schemaObject
@@ -318,9 +343,11 @@ internal/modules/ai/railemit_test.go#func TestADegradedCallSaysWhyEvenWithNoSent
 internal/modules/ai/routing.go#method RoutingConfig.BoundModelIDsByProvider
 internal/modules/ai/selectbrain.go#var knownProviders
 internal/modules/ai/sovereignendpoint_test.go#func TestABracketedIPv6EndpointIsAccepted
+internal/modules/ai/voice_sendoutcome_integration_test.go#func TestRecordSendOutcomeCannotReachAnotherWorkspacesSignal
 internal/modules/ai/voicecorpus.go#const CorpusMeterVersion
 internal/modules/aiactivity/handler.go#var eventType
 internal/modules/aiactivity/store.go#method Change.args
+internal/modules/approvals/authority.go#const objectActivity
 internal/modules/approvals/decide.go#method Service.runDecisionEffect
 internal/modules/approvals/evidence.go#func validateEvidence
 internal/modules/approvals/expiresweep.go#method Service.ExpireDue
@@ -329,6 +356,7 @@ internal/modules/approvals/inbox.go#func approvalWhere
 internal/modules/approvals/stageagentcall.go#method Service.StageAgentCall
 internal/modules/approvals/staging.go#func withCanonicalIdentity
 internal/modules/approvals/targetvisibility.go#func targetDecidable
+internal/modules/automation/automations_catalog_renewal.go#func RenewalReminderObjects
 internal/modules/automation/automations_preview.go#const previewBaseWhereNotArchived
 internal/modules/automation/engine.go#const systemSource
 internal/modules/automation/handlers_clock.go#func renewalAnchor
@@ -345,22 +373,27 @@ internal/modules/capture/channelsend.go#method Registry.liveChannelBindings
 internal/modules/capture/freemaildomain.go#const block at const auditKeyDomain
 internal/modules/capture/gmail/send.go#method Connector.stampedIdentity
 internal/modules/capture/lifecycleaudit.go#func connectionAuditImage
+internal/modules/capture/mailmap/htmltext.go#func linkText
 internal/modules/capture/mailmap/mailmap.go#method Message.Addresses
 internal/modules/capture/mailmap/mailmap.go#type Message.addresses
 internal/modules/capture/oauthflow/oauthflow.go#package oauthflow
 internal/modules/capture/offlinedemo/locale.go#const block at const threadKickoff
 internal/modules/capture/offlinedemo/locale.go#type templateWords
 internal/modules/capture/pending.go#func normalizeEmail
+internal/modules/capture/rawcapture.go#func InsertRawCaptureTx
 internal/modules/capture/registry_connections.go#const sendableConnection
 internal/modules/capture/sink.go#const fieldError
 internal/modules/capture/sinkchannel.go#func admitCounterpartyShape
+internal/modules/capture/sinkraw.go#const RawCaptureBase64Encoding
 internal/modules/capture/telegram/api.go#func classify
 internal/modules/capture/telegram/api.go#method httpAPI.callWith
 internal/modules/capture/telegram/connector.go#const CapturedByTelegram
 internal/modules/capture/telegram/send.go#const ProviderName
 internal/modules/capture/telegram/sendfiles.go#func declaredType
 internal/modules/capture/telegram/sendfiles.go#func partName
+internal/modules/capture/traceladder.go#func holdsSharedChannelGrant
 internal/modules/capture/traceladder.go#type TraceLadder
+internal/modules/collections/handlers.go#func NewHandlers
 internal/modules/collections/savedviews.go#const block at const viewFilterKey
 internal/modules/collections/vocab.go#const projectEntity
 internal/modules/collections/vocab.go#const tagFilterField
@@ -386,11 +419,13 @@ internal/modules/contracts/store.go#const contractColumns
 internal/modules/contracts/visibility.go#func VisibleClause
 internal/modules/customfields/create.go#func marshalOptions
 internal/modules/customfields/create.go#func unmarshalOptions
+internal/modules/customfields/engine.go#const codeUnsupportedObject
 internal/modules/customfields/engine.go#func quoteIdentifier
 internal/modules/customfields/engine.go#type FieldSpec
 internal/modules/customfields/engine.go#var FieldObjects
 internal/modules/customfields/privilege_boundary_test.go#func isStorekitAuditCall
 internal/modules/customfields/service.go#const catalogColumns
+internal/modules/dealrooms/document_read.go#const inTheDealsFilesArea
 internal/modules/dealrooms/document_read.go#func documentIDOf
 internal/modules/dealrooms/errors.go#const block at const codeTooLong
 internal/modules/dealrooms/errors.go#const codeRequired
@@ -405,6 +440,8 @@ internal/modules/deals/store.go#const block at const listCreatedAtColumn
 internal/modules/finance/audit.go#const block at const entityInvoice
 internal/modules/identity/authority.go#func RBACObjectGrantable
 internal/modules/identity/handlers_roster.go#func rosterUserMapping
+internal/modules/identity/installation.go#func slugify
+internal/modules/identity/installationsettings.go#method InstallationSettingsStore.UpdateInstallation
 internal/modules/identity/internal/policy/composable_test.go#func reset
 internal/modules/identity/nonproduction.go#method Handlers.WithDataResetAvailable
 internal/modules/identity/oauth_audience.go#func audienceMatches
@@ -423,6 +460,7 @@ internal/modules/identity/passport.go#func auditPassportRevoked
 internal/modules/identity/passport.go#func mintPassport
 internal/modules/identity/passport.go#var passportScopeVocabulary
 internal/modules/identity/passwordlink.go#func passwordLink
+internal/modules/identity/rbacobjects.go#func RegisterRbacObjects
 internal/modules/identity/roles.go#method Service.ListRoles
 internal/modules/identity/seatusage.go#const fullSeatsInUseQuery
 internal/modules/identity/service.go#func passwordLengthError
@@ -444,11 +482,14 @@ internal/modules/overlay/hubspot/mapping_hs.go#const industryField
 internal/modules/overlay/hubspot/mapping_hs.go#const unmappedPolicyFlag
 internal/modules/overlay/incumbent.go#const block at const IncumbentClassContacts
 internal/modules/overlay/mirrorstore.go#const ingestSQL
+internal/modules/overlay/mirrorstore.go#method MirrorStore.Ingest
 internal/modules/overlay/provider_writeback_integration_test.go#const writebackOwner
 internal/modules/overlay/reconcilefloor.go#func reconcileFloor
 internal/modules/overlay/teardown.go#func RevertToNative
 internal/modules/overlay/usermapadmin.go#func auditRevokedMappings
+internal/modules/overlay/usermapadmin.go#method MirrorStore.SetManualUserMap
 internal/modules/overlay/usermapservice.go#func requireUserMapAdmin
+internal/modules/people/company.go#const block at const fieldOfferSummary
 internal/modules/people/companysitereadcomparison.go#func PrintedSiteReadValue
 internal/modules/people/domainadmission.go#func reopenAdmittedDomainTx
 internal/modules/people/employmentedge.go#const relationshipOriginCapture
@@ -457,6 +498,7 @@ internal/modules/people/geocode.go#var organizationAddressColumns
 internal/modules/people/handlers_projectstakeholder.go#const block at const ProjectStakeholderKind
 internal/modules/people/lead_list.go#const block at const leadNameColumn
 internal/modules/people/lead_read.go#const liveOnlyClause
+internal/modules/people/leadmanualsignal.go#func manualSignalImage
 internal/modules/people/leadstatus.go#method LeadStatus.Open
 internal/modules/people/linkedinmatch.go#method Store.MatchLinkedInConnections
 internal/modules/people/linkedinmatch.go#var suggestNameEmployerMatchSQL
@@ -465,7 +507,10 @@ internal/modules/people/linkedinrenormalize.go#func matchRank
 internal/modules/people/linkedinrenormalize.go#var matchRankOrder
 internal/modules/people/listfilters.go#const block at const filterOwnerID
 internal/modules/people/listpage.go#func aiWrittenClause
+internal/modules/people/merge.go#const targetIDField
 internal/modules/people/organization_profile_field_write.go#const block at const auditKeyValue
+internal/modules/people/partner.go#method Store.MarginTierOf
+internal/modules/people/personarchive.go#func archivePersonRows
 internal/modules/people/projectstakeholder.go#method Store.PersonNames
 internal/modules/people/provider.go#func pageOf
 internal/modules/people/relationship_conflict_test.go#func TestRelationshipUniquenessRefusalKeepsBothTheSentinelAndTheConstraint
@@ -475,7 +520,11 @@ internal/modules/people/resolvecreate.go#type OrgSpec
 internal/modules/people/resolvecreate.go#type PersonSpec
 internal/modules/people/store.go#type Store.consumerMail
 internal/modules/people/strength.go#func personScopePredicate
+internal/modules/privacy/auditfilter_test.go#func TestEveryPublishedAuditFilterReachesTheStore
 internal/modules/privacy/auditlog.go#const auditContentStateKey
+internal/modules/privacy/auditlog.go#func ScrubNewerThanRowSQL
+internal/modules/privacy/erasure.go#const block at const evidenceKeyCause
+internal/modules/privacy/erasure_approvals.go#const subjectApprovalMatch
 internal/modules/privacy/fieldhistory.go#const entityTypeActivity
 internal/modules/privacy/handlers_restriction.go#type qualifyingRecordWire
 internal/modules/privacy/legalholdarms_test.go#func activityHoldSelectors
@@ -494,6 +543,7 @@ internal/modules/projects/keymint.go#const projectKeyField
 internal/modules/projects/keymint.go#func mintProjectKey
 internal/modules/projects/listfilters.go#const block at const filterKey
 internal/modules/projects/project.go#const projectObject
+internal/modules/search/binding.go#const systemPrincipalID
 internal/modules/search/binding.go#func releaseReembeddingTx
 internal/modules/search/binding.go#method Store.SeedBinding
 internal/modules/search/embedgen.go#const block at const entityPerson
@@ -518,6 +568,7 @@ internal/modules/signals/signal.go#func OfOrganizationWhere
 internal/modules/signals/warmroom.go#func RankRouteIn
 internal/modules/signals/warmroom.go#func RouteInEdges
 internal/modules/webhooks/store.go#const fieldEventTypes
+internal/platform/agentquota/counter.go#func CounterFor
 internal/platform/agentquota/meter_test.go#var governedCounters
 internal/platform/auth/capturePrivacyCoverage_test.go#func TestEveryTableThatCanHoldAnOwnerRowIsOwnerPrivate
 internal/platform/auth/edgeread.go#const relationshipObject
@@ -529,9 +580,12 @@ internal/platform/auth/linkscope.go#const block at const tablePerson
 internal/platform/auth/rbac.go#func UpsertAction
 internal/platform/auth/rbac.go#func refuseBuyer
 internal/platform/auth/rowscope.go#var ownerPrivateTables
+internal/platform/auth/writescope.go#const grantAccessWrite
 internal/platform/cliflags/cliflags.go#method Env.Items
 internal/platform/database/statementbudget.go#func BoundStatement
+internal/platform/database/storekit/claim.go#func ClaimOwnership
 internal/platform/database/storekit/customcolumns.go#func quoteColumnIdentifier
+internal/platform/database/storekit/patch.go#func PlainDate
 internal/platform/database/storekit/predicate.go#func ReferenceTargets
 internal/platform/database/storekit/query.go#method Query.CountMatching
 internal/platform/database/storekit/sqlstate.go#const block at const pgUniqueViolation
@@ -541,11 +595,14 @@ internal/platform/database/storekit/storekit.go#package storekit
 internal/platform/events/dedupe.go#const DedupeKeyPrefix
 internal/platform/events/relay.go#func ClientOptions
 internal/platform/extsecrets/store.go#package extsecrets
+internal/platform/extsecrets/store_integration_test.go#func TestSecretsUserScopeRefusesAnUnknownUser
 internal/platform/httperr/decoderefusal.go#func fieldDecodeRefusal
 internal/platform/httperr/decoderefusal_test.go#var block at var intoAdvanceDeal
 internal/platform/httperr/decoderefusal_test.go#var decodeRefusalCases
 internal/platform/httperr/faulttest/faulttest.go#package faulttest
 internal/platform/httperr/httperr.go#func Classify
+internal/platform/httperr/httperr.go#type DetailedError.Fields
+internal/platform/httperr/wire.go#const codeBodyTooLarge
 internal/platform/jobs/composed.go#var composed
 internal/platform/jobs/fault.go#func faultFor
 internal/platform/jobs/fault.go#func faultLogAttrs
@@ -556,6 +613,8 @@ internal/platform/jobs/faultreschedule_test.go#var transientClass
 internal/platform/jobs/spec.go#func DeclaredQueues
 internal/platform/jobs/stats.go#const sweepTagPredicate
 internal/platform/jobs/stats.go#type StateRow.Untenanted
+internal/platform/settings/entry.go#const CodeInvalidValue
+internal/platform/settings/store.go#type Store
 internal/platform/testdb/dropschema.go#const unreferencedTables
 internal/platform/testdb/redis.go#func RedisDB
 internal/platform/testdb/reset.go#const resetTables
@@ -563,6 +622,7 @@ internal/platform/testdb/river.go#func EnsureRiverSchema
 internal/shared/buildinfo/buildinfo.go#var ReleaseVersion
 internal/shared/gatekit/scope.go#method Scope.normalizedRoots
 internal/shared/kernel/draftfloor/envelope.go#func langOrDefault
+internal/shared/kernel/events/catalog.go#const streamOverlay
 internal/shared/kernel/pipelinetrace/registry.go#func FunnelStages
 internal/shared/kernel/principal/principal.go#const HumanIDPrefix
 internal/shared/kernel/promptfence/promptfence.go#func FromMarker
@@ -610,8 +670,10 @@ tools/gen-composition/astreader_subscriptions.go#method unitReader.readSubscript
 tools/gen-composition/astreader_subscriptions_test.go#func TestSubscriptionRulesAreThePublishedOnes
 tools/gen-composition/astreader_test.go#func TestPackageInitIsRejected
 tools/gen-composition/astreadertools.go#method unitReader.readHandle
+tools/gen-composition/contracts.go#const apiLayer
 tools/gen-composition/emit.go#func composedWork
 tools/gen-composition/emit.go#type composition.Files
+tools/gen-composition/extfrontend_test.go#func TestCollectUnitFrontendRefusesAnEntryPointOutsideTheLayer
 tools/gen-composition/extmigrations.go#func derivedIdentifier
 tools/gen-composition/extverbs.go#const extensionRoutePrefix
 tools/gen-composition/extverbs.go#func operationHash


### PR DESCRIPTION
Closes #3084.

## The defect

The detector read each doc comment with `doc.Text()`, which keeps the newlines the comment was wrapped at, and every shape spells its phrase with literal spaces. So `the one spelling` was a claim the register held, and

```go
// … — the one
// spelling of that shape, so …
```

was the same claim, invisible to it.

Reflowing a paragraph changes no meaning and would take a live claim out of the register with nothing failing to say so — under-recognition, the one direction `AGENTS.md` says a census must not break.

## What it costs, and why that is the sanctioned path

Flattening makes **62** claims visible that were always in the tree. The register grows to hold them and `shapeCensus` agrees to the growth, which is the file's own rule, stated in its doc:

> **CLOSED TO NEW CLAIMS, NOT TO A BETTER DETECTOR.** A shape that learns to see a wording it used to miss finds claims that were already there, and the register grows to hold them; "closed" would otherwise mean the detector may never improve, which is the opposite of the point.

The per-shape counts move in **both** directions, which surprised me and is worth knowing: a declaration is attributed to the first shape that matches it, so flattening does not only add claims — it re-attributes some between shapes (`once` fell by two while `one-of-a-kind` rose by five). Counts are set to what the detector attributes rather than to the arithmetic of the newly-listed set.

## Two of the 62 were judged rather than registered

The claimed-spelling gate reads the same corpus, so widening the detector immediately gave it two findings — which is the gate working:

- `people/relationship.go` — `relationshipKinds` spelled `"project_stakeholder"` raw beside `employmentKind` and `worksWithKind`, which are already constants. It now uses `ProjectStakeholderKind`. That is the claim being honoured, not worked around.
- `customfields/engine.go:fieldObject` — ratified in `sharedSpellings`, because the other `"object"` is the English word in `structuralKeywords`, which a user's **label** is smell-tested against ("add an object for invoices" is refused as a request to model something new). Tying the two would make a heuristic's vocabulary follow a wire field name.

## The regression test

`TestAShapeSeesAClaimTheCommentWrapped` gives every shape a sentence it matches and then breaks the matched phrase at **every** internal space, asserting that some break defeats the unflattened pattern and that flattening restores all of them.

Trying every wrap point rather than one is not thoroughness for its own sake: my first attempt broke at the first space and reported the derived `is-every-named` shape safe. It is not — it spells its first gap `\s+` and its second as a literal space, so it is blind at exactly one of its two joints.

## Verification

- `make check-backend`, `make craft-static`, full `./gates`
- `make -C backend test-integration` — 48 packages, 0 skips
- Reverting the flattening fails two arms with their own messages: `62 register entry/entries no longer describe an unheld claim` and the per-shape census disagreeing. The register and the census are load-bearing from both directions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of uniqueness claims when documentation comments contain line breaks or irregular whitespace.
  - Corrected relationship-kind handling for project stakeholders.

- **Tests**
  - Added coverage confirming claims remain detectable across wrapped comments.
  - Updated detector shape expectations and spelling validation.

- **Documentation**
  - Registered additional uniqueness claims.
  - Updated the gate inventory count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->