### PR TITLE
Finish the mailbox privacy UI: the notice, the hold, and the docs that had stopped being true

### DIFF
--- a/backend/internal/modules/knowledge/handbook/capture.md
+++ b/backend/internal/modules/knowledge/handbook/capture.md
@@ -70,6 +70,17 @@ The window can only be **widened** later, never narrowed. And when the progress
 bar fills, the import is finished but the AI work is not — classification runs
 hourly and enrichment daily afterwards.
 
+**Everything it brings in is held to begin with.** A new mailbox is *Held until
+classified*, so a backfill of five years of mail does not put five years of mail
+in front of your colleagues: each thread stays with the people who were on it
+until a classifier judges it ordinary business. That is also true of the records
+the import mints — a contact created from a thread nothing has judged yet is
+yours alone until the verdict clears it.
+
+Which means a backfill is worth watching in two places once it finishes:
+**Senders**, for what was concluded about each address it saw, and your own
+timeline, for the threads still held. Both are under Settings → Connections.
+
 ## What happens to one message
 
 Four stages, in order.
@@ -287,10 +298,41 @@ company."
 what decided each one: a model verdict, a heuristic, or a person. Letting a
 domain back in re-opens the company question rather than merely clearing a flag.
 
-**Email sharing** — on by default. "Captured mail is readable by every colleague
-who can see the contact. On by default — it is what makes the pipeline shared."
-The app warns you honestly if you turn it off: doing so "will make usage of the
-CRM difficult."
+**Who may read mail from this inbox** (Settings → Connections, under each
+mailbox) — the posture that mailbox asks for. Three answers:
+
+- **Held until classified** — the default for every new mailbox. A message stays
+  with the people who were on it until a classifier judges the thread ordinary
+  business; only then can colleagues read it. Nothing is shared before a
+  decision, so a classifier that is down or out of budget leaves mail held
+  rather than open.
+- **Always held** — the same, minus the classifier. You share a thread yourself,
+  one at a time, from its row on the record timeline.
+- **Shared with the team** — a captured message is readable the moment it lands.
+  Off unless an admin allows it for the organization, because reading an
+  employee's mailbox into a shared CRM is what a works-council agreement covers
+  in Germany and Austria. Margince does not verify that one exists.
+
+Changing the posture governs mail captured afterwards. The same dialog offers to
+narrow what is already captured; it only ever narrows, because re-opening what
+was captured under a stricter answer is a separate decision.
+
+**Senders** (Settings → Connections) — every address your mailbox brought in and
+what the classifier concluded about each: a person, a role mailbox, an automated
+tool, a newsletter, an advisor, personal. You can overrule any of them. "This is
+business" readmits a sender; "keep out" destroys what they brought into your
+mailbox and stops the next message. A decision you make is never overwritten by
+a later verdict.
+
+**Private correspondence** (a contact's or company's page) — keep your mail with
+one party to the people on it, without deciding message by message. A domain
+hold covers the whole firm, which is usually what you want for a lawyer or an
+accountant. It binds mail from then on, and lifting it re-opens nothing.
+
+**Email sharing** (Settings → Capture, admin) — the organization-wide floor. On
+by default; turned off, every message captured from then on is held to its
+participants whatever any mailbox asks for. The app warns you honestly that
+doing so "will make usage of the CRM difficult."
 
 ## Whose capture activity you can see
 
@@ -301,3 +343,14 @@ bot, belong to nobody in particular and are shown to people granted that access.
 
 **No permission grant ever reaches a colleague's mailbox.** The organization-wide
 view never returns a member's personal rows.
+
+A held message is not hidden — it is visible as a row with its date and kind,
+and its content withheld. You learn that a conversation happened and nothing
+about it, including why it is held: the reason describes what the message is
+about, so it is withheld with the content. An admin is no exception, and neither
+the audit log nor an export names a held message's subject or attachments.
+
+When a message reached two mailboxes, each owner contributes what their own
+mailbox asks for and the message ends at the strictest of those. Sharing
+releases your own hold only; if a colleague is still holding it, the response
+says how many other seats are, and never who.

--- a/backend/internal/modules/knowledge/handbook/records.md
+++ b/backend/internal/modules/knowledge/handbook/records.md
@@ -263,9 +263,16 @@ A meeting carries a status: **booked, held, no-show, canceled.**
 filed against the wrong record, the fix is **Relink**, not delete.
 
 On top of visibility inherited from linked records, an activity carries an
-audience: everyone in the organization (the default), the participants, or a
-named few. That audience is not overridden by seniority — someone who can see
-every record still does not read a message they were not an audience for.
+audience: everyone in the organization, the participants, or a named few. That
+audience is not overridden by seniority — someone who can see every record still
+does not read a message they were not an audience for.
+
+Where the audience comes from depends on how the row arrived. A note or a call
+you log is shared with the organization unless you say otherwise. **A message
+captured from a mailbox is not**: its audience is derived from what each
+importing mailbox asks for, and a new mailbox holds its mail until a classifier
+judges the thread ordinary. You change a captured message's audience by sharing
+its thread, not by editing the row — the row refuses a direct edit and says so.
 
 ## Putting a change back
 

--- a/docs/explanation/ingress-gate-and-auto-capture.md
+++ b/docs/explanation/ingress-gate-and-auto-capture.md
@@ -52,14 +52,29 @@ Three rules apply everywhere:
 | 3. Tier ladder (T0–T4) | Plain code | — |
 | 4. Verdict engine — claiming, writing, hiding, sweeping | Plain code | — |
 | 4. Verdict engine — **judging one sender** | **AI** | `capture_counterparty_verdict` |
+| 5. Confidentiality engine — **judging one thread** | **AI** | `capture_confidentiality_verdict` |
 | Does this domain deserve a company record? | **AI** | `site_triage` |
 | Attention labels on captured mail (separate feature) | **AI** | `capture_classify` |
 
-A model makes one decision here: *what kind of sender is this?* It is asked once per **sender**, not
-per message, and only for senders plain code could not classify. The answer decides whether a
-**contact** is created. It never decides whether a **message** is kept.
+Two model decisions, and they answer different questions.
 
-If no model is configured, capture works normally. Only the judging step is skipped.
+*What kind of sender is this?* — asked once per **sender**, not per message, and only for senders
+plain code could not classify. The answer decides whether a **contact** is created, and whether that
+contact is the whole workspace's or the importing seat's alone.
+
+*Is this thread ordinary business?* — asked once per **thread per seat**, on the first message. The
+answer decides who may **read** the message, never whether it is kept. A thread it clears is
+readable by colleagues; anything else stays with the people who were on it, with the kind it
+concluded as the reason.
+
+Both run on a local rung by default and neither sends message text off the machine unless an admin
+binds a cloud one. The generated egress table
+([ai-egress.md](../reference/ai-egress.md)) says which, and a gate fails when the two disagree.
+
+**Neither model can widen anything by being unavailable.** With no model configured, capture works
+normally: senders stay unjudged and their records stay owner-scoped, threads stay held, and nothing
+is purged. An outage and a careful classifier look the same from the outside — mail stays with the
+people who were on it — which is the direction an outage has to fail in.
 
 ---
 

--- a/docs/explanation/rbac-roles-and-teams.md
+++ b/docs/explanation/rbac-roles-and-teams.md
@@ -128,10 +128,21 @@ An activity has no owner; it inherits visibility from the records it links to (t
 and a link-less note is workspace-shared. On top of that sits a per-activity **audience**
 (`activity.audience`, `activity_audience_member`):
 
-- `workspace` — the default; everyone who can discover the row reads it;
+- `workspace` — everyone who can discover the row reads it;
 - `participants` — the humans on it (the capturing mailbox owner, anyone stamped as a participant
   by seat);
 - `selected` — the participants plus the users and teams a human named.
+
+`workspace` is the default for a row a human logged. For a row a MAILBOX brought in it is derived,
+not defaulted: `activities.RecomputeAudienceTx` takes the strictest contribution across every
+importing seat's `capture_import` row — the mailbox's posture, the thread's verdict, that seat's
+counterparty holds — so a colleague whose mailbox shares cannot publish a message another importer
+is holding, in whatever order the two syncs ran. `activity.audience_reason` names the strictest
+contributor, and is withheld with the content: the reason describes what the message is about.
+
+A direct `PATCH /activities/{id}/audience` on a captured row is refused (`audience_is_derived`) and
+points at `POST /activities/threads/{key}/audience`, which releases the caller's own contribution
+and reports how many other seats still hold the thread — a count, never a name.
 
 `auth.ActivityDiscoverClause` answers "may I learn this row exists" (date, direction, kind, who owns
 it — the last-touch marker); `auth.ActivityContentClause` answers "may I read it" (subject, body,

--- a/docs/handbook/capture.md
+++ b/docs/handbook/capture.md
@@ -70,6 +70,17 @@ The window can only be **widened** later, never narrowed. And when the progress
 bar fills, the import is finished but the AI work is not — classification runs
 hourly and enrichment daily afterwards.
 
+**Everything it brings in is held to begin with.** A new mailbox is *Held until
+classified*, so a backfill of five years of mail does not put five years of mail
+in front of your colleagues: each thread stays with the people who were on it
+until a classifier judges it ordinary business. That is also true of the records
+the import mints — a contact created from a thread nothing has judged yet is
+yours alone until the verdict clears it.
+
+Which means a backfill is worth watching in two places once it finishes:
+**Senders**, for what was concluded about each address it saw, and your own
+timeline, for the threads still held. Both are under Settings → Connections.
+
 ## What happens to one message
 
 Four stages, in order.
@@ -287,10 +298,41 @@ company."
 what decided each one: a model verdict, a heuristic, or a person. Letting a
 domain back in re-opens the company question rather than merely clearing a flag.
 
-**Email sharing** — on by default. "Captured mail is readable by every colleague
-who can see the contact. On by default — it is what makes the pipeline shared."
-The app warns you honestly if you turn it off: doing so "will make usage of the
-CRM difficult."
+**Who may read mail from this inbox** (Settings → Connections, under each
+mailbox) — the posture that mailbox asks for. Three answers:
+
+- **Held until classified** — the default for every new mailbox. A message stays
+  with the people who were on it until a classifier judges the thread ordinary
+  business; only then can colleagues read it. Nothing is shared before a
+  decision, so a classifier that is down or out of budget leaves mail held
+  rather than open.
+- **Always held** — the same, minus the classifier. You share a thread yourself,
+  one at a time, from its row on the record timeline.
+- **Shared with the team** — a captured message is readable the moment it lands.
+  Off unless an admin allows it for the organization, because reading an
+  employee's mailbox into a shared CRM is what a works-council agreement covers
+  in Germany and Austria. Margince does not verify that one exists.
+
+Changing the posture governs mail captured afterwards. The same dialog offers to
+narrow what is already captured; it only ever narrows, because re-opening what
+was captured under a stricter answer is a separate decision.
+
+**Senders** (Settings → Connections) — every address your mailbox brought in and
+what the classifier concluded about each: a person, a role mailbox, an automated
+tool, a newsletter, an advisor, personal. You can overrule any of them. "This is
+business" readmits a sender; "keep out" destroys what they brought into your
+mailbox and stops the next message. A decision you make is never overwritten by
+a later verdict.
+
+**Private correspondence** (a contact's or company's page) — keep your mail with
+one party to the people on it, without deciding message by message. A domain
+hold covers the whole firm, which is usually what you want for a lawyer or an
+accountant. It binds mail from then on, and lifting it re-opens nothing.
+
+**Email sharing** (Settings → Capture, admin) — the organization-wide floor. On
+by default; turned off, every message captured from then on is held to its
+participants whatever any mailbox asks for. The app warns you honestly that
+doing so "will make usage of the CRM difficult."
 
 ## Whose capture activity you can see
 
@@ -301,3 +343,14 @@ bot, belong to nobody in particular and are shown to people granted that access.
 
 **No permission grant ever reaches a colleague's mailbox.** The organization-wide
 view never returns a member's personal rows.
+
+A held message is not hidden — it is visible as a row with its date and kind,
+and its content withheld. You learn that a conversation happened and nothing
+about it, including why it is held: the reason describes what the message is
+about, so it is withheld with the content. An admin is no exception, and neither
+the audit log nor an export names a held message's subject or attachments.
+
+When a message reached two mailboxes, each owner contributes what their own
+mailbox asks for and the message ends at the strictest of those. Sharing
+releases your own hold only; if a colleague is still holding it, the response
+says how many other seats are, and never who.

--- a/docs/handbook/records.md
+++ b/docs/handbook/records.md
@@ -263,9 +263,16 @@ A meeting carries a status: **booked, held, no-show, canceled.**
 filed against the wrong record, the fix is **Relink**, not delete.
 
 On top of visibility inherited from linked records, an activity carries an
-audience: everyone in the organization (the default), the participants, or a
-named few. That audience is not overridden by seniority — someone who can see
-every record still does not read a message they were not an audience for.
+audience: everyone in the organization, the participants, or a named few. That
+audience is not overridden by seniority — someone who can see every record still
+does not read a message they were not an audience for.
+
+Where the audience comes from depends on how the row arrived. A note or a call
+you log is shared with the organization unless you say otherwise. **A message
+captured from a mailbox is not**: its audience is derived from what each
+importing mailbox asks for, and a new mailbox holds its mail until a classifier
+judges the thread ordinary. You change a captured message's audience by sharing
+its thread, not by editing the row — the row refuses a direct edit and says so.
 
 ## Putting a change back
 

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -75,7 +75,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (79)
+## Census (80)
 
 | Gate | Hardness | What it holds |
 |---|---|---|

--- a/frontend/e2e/mailboxprivacy.spec.ts
+++ b/frontend/e2e/mailboxprivacy.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "@playwright/test";
+import { mockApi } from "./seed";
+
+// The mailbox-privacy surfaces, asserted in the language they ship in.
+//
+// Every string here is a claim about who may read somebody's mail, so the words
+// are the product rather than decoration: "held until classified" and "shared
+// with the team" are the difference between a colleague seeing a message and
+// not. A screen whose German drifted would still pass a typecheck and still
+// render, and nobody would notice until a customer read it.
+//
+// The suite runs against the network-edge mock (`mockApi`), so it is hermetic
+// and runs in CI. Point BASE_URL at a live stack to run the same assertions
+// unmocked.
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test("AC-mailbox-1: a mailbox says who may read it, and refuses shared without the opt-in", async ({
+  page,
+}) => {
+  await page.goto("/#/settings/connections");
+  const row = page.getByTestId("connector-gmail-mail-posture");
+  await expect(row).toBeVisible();
+
+  // The stored posture, and the sentence saying what it does.
+  await expect(row).toContainText("Wer E-Mails aus diesem Postfach lesen darf");
+  await expect(row).toContainText("Zurückgehalten bis eingestuft");
+  await expect(row).toContainText(
+    "Eine neue Nachricht bleibt auf die Beteiligten beschränkt",
+  );
+  // The refusal rides on the ROW, not on the option label: a listbox option
+  // ellipsises, and the half that gets cut is the reason a reader needs.
+  await expect(row).toContainText(
+    "muss eine Administratorin für diese Organisation erlauben",
+  );
+
+  await row.getByRole("combobox").click();
+  const shared = page.getByRole("option", { name: "Mit dem Team geteilt" });
+  await expect(shared).toHaveAttribute("aria-disabled", "true");
+  await expect(
+    page.getByRole("option", { name: "Immer zurückgehalten" }),
+  ).not.toHaveAttribute("aria-disabled", "true");
+});
+
+test("AC-mailbox-2: narrowing the posture offers to narrow the history too", async ({
+  page,
+}) => {
+  await page.goto("/#/settings/connections");
+  const row = page.getByTestId("connector-gmail-mail-posture");
+  await row.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Immer zurückgehalten" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toContainText("Und die bereits erfassten E-Mails?");
+  // One question and one modifier, never two rival verbs: the German labels do
+  // not both fit the compact confirm, and a clipped primary button is what the
+  // three-button version shipped as.
+  const alsoHistory = dialog.getByRole("checkbox");
+  await expect(alsoHistory).not.toBeChecked();
+  await alsoHistory.check();
+  await dialog.getByRole("button", { name: "Sichtbarkeit ändern" }).click();
+
+  await expect(row).toContainText("Immer zurückgehalten");
+  await expect(row).toContainText("unabhängig von jeder Einstufung");
+});
+
+test("AC-mailbox-3: the admin opt-in states what turning it on asserts", async ({
+  page,
+}) => {
+  await page.goto("/#/settings/connections");
+  const toggle = page.getByTestId("shared-posture-allowed-toggle");
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute("aria-checked", "false");
+  // The warning belongs to ON. This is the one capture setting whose default
+  // withholds, so it is the one row where the permissive answer is the one that
+  // needs saying out loud.
+  await expect(page.getByText(/Betriebsvereinbarung/)).toHaveCount(0);
+
+  await toggle.click();
+  await expect(page.getByText(/Betriebsvereinbarung/)).toBeVisible();
+  await expect(page.getByText(/Margince prüft das nicht/)).toBeVisible();
+});
+
+test("AC-mailbox-4: the Senders page shows every decision and takes an overrule", async ({
+  page,
+}) => {
+  await page.goto("/#/settings/connections");
+  const senders = page.locator(".panel", { hasText: "Absender" }).first();
+  await expect(senders).toBeVisible();
+  await expect(senders).toContainText("Eine Person");
+  await expect(senders).toContainText("Ein Newsletter");
+  await expect(senders).toContainText("Privat");
+
+  const row = senders.locator("tr", { hasText: "news@substack.com" });
+  await row.getByRole("button", { name: "Geschäftlich" }).click();
+  // An overruled row says whose answer stands, because the reader auditing this
+  // list needs to tell their own decisions from the classifier's.
+  await expect(row).toContainText("von Ihnen entschieden");
+  await expect(row.getByRole("button", { name: "Zurücknehmen" })).toBeVisible();
+});
+
+test("AC-mailbox-5: a sender kept out is told what that destroys", async ({
+  page,
+}) => {
+  await page.goto("/#/settings/connections");
+  const senders = page.locator(".panel", { hasText: "Absender" }).first();
+  await senders
+    .locator("tr", { hasText: "anne@hotmail.com" })
+    .getByRole("button", { name: "Aussperren" })
+    .click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toContainText("dauerhaft aussperren");
+  await expect(dialog).toContainText("vernichtet");
+  // What SURVIVES is the half a reader cannot guess: a colleague's own import
+  // of the same message is theirs, and the purge does not reach it.
+  await expect(dialog).toContainText("bleiben ihr erhalten");
+});
+
+test("AC-mailbox-6: the connect form says what happens before it asks for a password", async ({
+  page,
+}) => {
+  await page.goto("/#/settings/connections");
+  await page.getByRole("button", { name: "Konto verbinden" }).click();
+  await page.getByTestId("connector-add-imap").getByRole("button").click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toContainText("Margince liest dieses Postfach");
+  await expect(dialog).toContainText(
+    "Ein neues Postfach ist standardmäßig zurückgehalten",
+  );
+  // The notice asks for nothing: there is no checkbox and no field the server
+  // records, and a mailbox connects with it unread. An acknowledgement here
+  // would be a consent record nobody gave.
+  await expect(dialog.getByRole("checkbox")).toHaveCount(0);
+});

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -918,6 +918,65 @@ export async function mockApi(
   // vanishing the row or reporting 404 — a 404 means no connection was ever
   // inserted, a different state than "disconnected".
   let connection = { ...overlayConnection };
+  // The mailbox-privacy fixtures, per page for the same reason as the rest:
+  // a posture change, a sender overrule and a hold all have to be readable
+  // back within one test.
+  const captureSettings: Record<string, boolean> = {
+    auto_enrich: true,
+    mail_sharing: true,
+    shared_posture_allowed: false,
+    signature_enrich: true,
+  };
+  const captureConnections = [
+    {
+      id: "conn-gmail",
+      provider: "gmail",
+      status: "connected",
+      account_label: "admin@demo.test",
+      scopes: [],
+      mail_posture: "classified",
+      backfill: { state: "none" },
+    },
+  ];
+  // One of each shape the Senders table draws: an admitted kind, a refused
+  // one, and a personal sender — the three rows that differ on screen.
+  const captureSenders: {
+    address: string;
+    kind?: string;
+    status?: string;
+    decision?: string;
+    overruled_kind?: string;
+    overruled: boolean;
+    record_exists: boolean;
+  }[] = [
+    {
+      address: "jana@commercetools.com",
+      kind: "person",
+      status: "real",
+      overruled: false,
+      record_exists: true,
+    },
+    {
+      address: "news@substack.com",
+      kind: "newsletter",
+      status: "noise",
+      overruled: false,
+      record_exists: false,
+    },
+    {
+      address: "anne@hotmail.com",
+      kind: "personal",
+      status: "noise",
+      overruled: false,
+      record_exists: false,
+    },
+  ];
+  const counterpartyHolds: {
+    id: string;
+    kind: string;
+    value: string;
+    created_at: string;
+  }[] = [];
   // per-page mapping state so a map/unmap actually MOVES something. A generic
   // 200 would let the card report a successful write and then reload the
   // untouched fixture — the workflow would pass having done nothing, which is
@@ -2110,6 +2169,89 @@ export async function mockApi(
     }
     if (path === "/admin/job-health") {
       return json(jobHealth);
+    }
+    // The mailbox-privacy surfaces. Held per page so a spec that flips a
+    // setting or overrules a sender reads back what it wrote: a mock that
+    // answered a fixed fixture would let a write "succeed" and then show the
+    // untouched value, which passes while doing nothing.
+    if (path === "/capture/settings") {
+      if (method === "PATCH") {
+        Object.assign(captureSettings, route.request().postDataJSON());
+      }
+      return json(captureSettings);
+    }
+    if (path === "/capture/senders") {
+      return json({ data: captureSenders });
+    }
+    if (path.startsWith("/capture/senders/") && path.endsWith("/decision")) {
+      const address = decodeURIComponent(
+        path.slice("/capture/senders/".length, -"/decision".length),
+      );
+      const row = captureSenders.find((s) => s.address === address);
+      if (!row) {
+        return route.fulfill({ status: 404 });
+      }
+      if (method === "DELETE") {
+        row.decision = undefined;
+        row.overruled = false;
+        return route.fulfill({ status: 204 });
+      }
+      row.decision = route.request().postDataJSON()?.decision;
+      row.overruled_kind = row.kind;
+      row.overruled = true;
+      return json(row);
+    }
+    if (path === "/capture/counterparty-holds") {
+      if (method === "POST") {
+        const body = route.request().postDataJSON();
+        const hold = {
+          id: `hold-${counterpartyHolds.length + 1}`,
+          kind: body.kind,
+          value: body.value,
+          created_at: "2026-08-01T09:00:00Z",
+        };
+        counterpartyHolds.push(hold);
+        return json(hold, 201);
+      }
+      return json({ data: counterpartyHolds });
+    }
+    if (path.startsWith("/capture/counterparty-holds/")) {
+      const id = path.slice("/capture/counterparty-holds/".length);
+      const at = counterpartyHolds.findIndex((h) => h.id === id);
+      if (at === -1) {
+        return route.fulfill({ status: 404 });
+      }
+      counterpartyHolds.splice(at, 1);
+      return route.fulfill({ status: 204 });
+    }
+    if (path.startsWith("/connectors/") && path.endsWith("/mail-posture")) {
+      const provider = path.slice(
+        "/connectors/".length,
+        -"/mail-posture".length,
+      );
+      const conn = captureConnections.find((c) => c.provider === provider);
+      const posture = route.request().postDataJSON()?.posture;
+      if (!conn) {
+        return route.fulfill({ status: 404 });
+      }
+      // The server's own refusal, which is what the option's disabled state
+      // and the row's second sentence are both about. A mock that accepted it
+      // would let a spec prove the opt-in works while it does not.
+      if (posture === "shared" && !captureSettings.shared_posture_allowed) {
+        return json(
+          {
+            title: "Unprocessable Entity",
+            code: "validation_error",
+            detail: "this workspace does not allow a shared mailbox",
+          },
+          422,
+        );
+      }
+      conn.mail_posture = posture;
+      return json(conn);
+    }
+    if (path === "/connectors") {
+      return json({ data: captureConnections });
     }
     if (path === "/agent-tools") {
       return json({

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3898,6 +3898,31 @@ export const de = {
     "Folgt der Einstellung Ihrer Organisation. Wird sie hier geändert, behält dieses Postfach seine eigene Antwort.",
   "connectors.signatureEnrich.ownAnswer":
     "Eigene Antwort dieses Postfachs — bleibt bestehen, was auch immer Ihre Organisation einstellt.",
+  "hold.sectionTitle": "Private Korrespondenz",
+  "hold.notHeld":
+    "E-Mails mit diesem Kontakt folgen der Einstellung Ihres Postfachs.",
+  "hold.heldByAddress":
+    "Sie behalten E-Mails mit dieser Adresse bei den Beteiligten.",
+  "hold.heldByDomain": "Sie behalten E-Mails mit {domain} bei den Beteiligten.",
+  "hold.holdAddress": "Privat halten",
+  "hold.holdDomain": "Ganz {domain} privat halten",
+  "hold.lift": "Aufheben",
+  "hold.liftingWidensNothing":
+    "Das Aufheben gilt für neue E-Mails. Bereits Zurückgehaltenes bleibt zurückgehalten.",
+  "hold.confirmVerb": "Privat halten",
+  "hold.confirmTitle": "Diese Korrespondenz privat halten?",
+  "hold.confirmAddressBody":
+    "E-Mails mit {address} bleiben bei den Beteiligten. Sie werden weiterhin erfasst und sind für Sie lesbar — Kolleginnen und Kollegen sehen sie nicht.",
+  "hold.confirmDomainBody":
+    "E-Mails mit allen bei {domain}, einschließlich Subdomains, bleiben bei den Beteiligten. Sie werden weiterhin erfasst und sind für Sie lesbar — Kolleginnen und Kollegen sehen sie nicht.",
+  "hold.confirmHistoryNote":
+    "Das gilt ab jetzt. Bereits erfasste E-Mails behalten ihre bisherige Sichtbarkeit.",
+  "captureNotice.whatHappens":
+    "Margince liest dieses Postfach und legt ab, was es findet: die Nachrichten, wer daran beteiligt war, sowie die Kontakte und Firmen hinter den Adressen. Anhänge werden mit ihrer Nachricht gespeichert.",
+  "captureNotice.whoReads":
+    "Ein neues Postfach ist standardmäßig zurückgehalten. Eine Nachricht bleibt bei den Beteiligten, bis eine Einstufung den Verlauf als gewöhnliche geschäftliche Korrespondenz beurteilt — erst dann können Kolleginnen und Kollegen sie lesen. Sie können das Postfach jederzeit so einstellen, dass alles zurückgehalten bleibt.",
+  "captureNotice.yourControl":
+    "Sie entscheiden pro Absender und pro Verlauf unter Einstellungen → Verbindungen: eine Korrespondenz ganz heraushalten, einen Verlauf mit dem Team teilen oder löschen, was ein Absender eingebracht hat. Hier wird um nichts gebeten — so läuft es ab, damit Sie es vor dem Verbinden wissen.",
   "connectors.mailPosture.label": "Wer E-Mails aus diesem Postfach lesen darf",
   "connectors.mailPosture.classified": "Zurückgehalten bis eingestuft",
   "connectors.mailPosture.held": "Immer zurückgehalten",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3934,6 +3934,29 @@ export const en = {
     "Following your organization's setting. Change it here and this mailbox keeps its own answer.",
   "connectors.signatureEnrich.ownAnswer":
     "This mailbox's own answer, kept whatever your organization's setting becomes.",
+  "hold.sectionTitle": "Private correspondence",
+  "hold.notHeld": "Mail with this contact follows your mailbox setting.",
+  "hold.heldByAddress": "You keep mail with this address to the people on it.",
+  "hold.heldByDomain": "You keep mail with {domain} to the people on it.",
+  "hold.holdAddress": "Keep private",
+  "hold.holdDomain": "Keep all of {domain} private",
+  "hold.lift": "Lift",
+  "hold.liftingWidensNothing":
+    "Lifting applies to new mail. What was held stays held.",
+  "hold.confirmVerb": "Keep private",
+  "hold.confirmTitle": "Keep this correspondence private?",
+  "hold.confirmAddressBody":
+    "Mail with {address} stays with the people who were on it. It is still captured and still yours to read — colleagues do not see it.",
+  "hold.confirmDomainBody":
+    "Mail with anyone at {domain}, including subdomains, stays with the people who were on it. It is still captured and still yours to read — colleagues do not see it.",
+  "hold.confirmHistoryNote":
+    "This covers mail from here on. Mail already captured keeps the visibility it has.",
+  "captureNotice.whatHappens":
+    "Margince reads this mailbox and files what it finds: the messages, who was on them, and the contacts and companies behind the addresses. Attachments are stored with their message.",
+  "captureNotice.whoReads":
+    "A new mailbox is held by default. A message stays with the people who were on it until a classifier judges the thread to be ordinary business — only then can colleagues read it. You can set the mailbox to hold everything instead, at any time.",
+  "captureNotice.yourControl":
+    "You decide per sender and per thread, under Settings → Connections: keep a correspondent out entirely, share a thread with the team, or delete what a sender brought in. Nothing here asks you to agree — this is what happens, so you know it before you connect.",
   "connectors.mailPosture.label": "Who may read mail from this inbox",
   "connectors.mailPosture.classified": "Held until classified",
   "connectors.mailPosture.held": "Always held",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3862,6 +3862,31 @@ export const vi = {
     "Đang theo thiết lập của tổ chức. Đổi ở đây thì hộp thư này giữ lựa chọn riêng.",
   "connectors.signatureEnrich.ownAnswer":
     "Lựa chọn riêng của hộp thư này, giữ nguyên dù thiết lập của tổ chức thay đổi.",
+  "hold.sectionTitle": "Trao đổi riêng tư",
+  "hold.notHeld": "Thư với liên hệ này theo thiết lập hộp thư của bạn.",
+  "hold.heldByAddress":
+    "Bạn giữ thư với địa chỉ này chỉ cho những người có trong thư.",
+  "hold.heldByDomain":
+    "Bạn giữ thư với {domain} chỉ cho những người có trong thư.",
+  "hold.holdAddress": "Giữ riêng tư",
+  "hold.holdDomain": "Giữ riêng tư toàn bộ {domain}",
+  "hold.lift": "Bỏ giữ",
+  "hold.liftingWidensNothing":
+    "Việc bỏ giữ áp dụng cho thư mới. Những gì đã giữ vẫn được giữ.",
+  "hold.confirmVerb": "Giữ riêng tư",
+  "hold.confirmTitle": "Giữ riêng tư trao đổi này?",
+  "hold.confirmAddressBody":
+    "Thư với {address} chỉ dành cho những người có trong thư. Thư vẫn được thu thập và bạn vẫn đọc được — đồng nghiệp thì không.",
+  "hold.confirmDomainBody":
+    "Thư với bất kỳ ai tại {domain}, kể cả tên miền phụ, chỉ dành cho những người có trong thư. Thư vẫn được thu thập và bạn vẫn đọc được — đồng nghiệp thì không.",
+  "hold.confirmHistoryNote":
+    "Điều này áp dụng từ nay về sau. Thư đã thu thập giữ nguyên phạm vi hiển thị hiện tại.",
+  "captureNotice.whatHappens":
+    "Margince đọc hộp thư này và lưu lại những gì tìm thấy: các thư, những ai có trong thư, cùng liên hệ và công ty đứng sau các địa chỉ. Tệp đính kèm được lưu cùng thư của nó.",
+  "captureNotice.whoReads":
+    "Hộp thư mới mặc định được giữ lại. Một thư chỉ dành cho những người có trong thư cho đến khi bộ phân loại đánh giá chuỗi thư là công việc thông thường — khi đó đồng nghiệp mới đọc được. Bạn có thể đặt hộp thư giữ lại mọi thứ bất cứ lúc nào.",
+  "captureNotice.yourControl":
+    "Bạn quyết định theo từng người gửi và từng chuỗi thư, tại Cài đặt → Kết nối: chặn hẳn một người liên hệ, chia sẻ chuỗi thư với nhóm, hoặc xóa những gì một người gửi đã mang vào. Ở đây không yêu cầu bạn đồng ý — đây là điều sẽ xảy ra, để bạn biết trước khi kết nối.",
   "connectors.mailPosture.label": "Ai được đọc thư từ hộp thư này",
   "connectors.mailPosture.classified": "Giữ lại cho đến khi phân loại",
   "connectors.mailPosture.held": "Luôn giữ lại",

--- a/frontend/src/screens/capture-notice.stories.tsx
+++ b/frontend/src/screens/capture-notice.stories.tsx
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CaptureNotice } from "./capture-notice";
+import { StoryProviders } from "./story-utils";
+
+// What a person is told before their mailbox is read. One state, because it has
+// one: it takes no props, reads nothing, and says the same thing on every
+// connect surface — which is the point of it being a component rather than
+// three copies of a paragraph.
+//
+// The story exists so the WORDS are reviewable on their own, away from the form
+// that hosts them. This is the sentence the DACH compliance package is about,
+// and it is easier to notice that a claim has stopped being true when it is not
+// buried between a port field and a password.
+
+const meta: Meta<typeof CaptureNotice> = {
+  title: "Settings/You/Connections/Capture notice",
+  component: CaptureNotice,
+};
+export default meta;
+type Story = StoryObj<typeof CaptureNotice>;
+
+export const Default: Story = {
+  render: () => (
+    <StoryProviders>
+      <CaptureNotice />
+    </StoryProviders>
+  ),
+};

--- a/frontend/src/screens/capture-notice.tsx
+++ b/frontend/src/screens/capture-notice.tsx
@@ -1,0 +1,32 @@
+import { Callout } from "../design-system/callout";
+import { useT } from "../i18n";
+
+// What happens to a mailbox's mail, said BEFORE the mailbox is connected.
+//
+// Every connect surface shows the same words: the two OAuth panels, the IMAP
+// panel in onboarding, and the IMAP form in Settings. One component rather than
+// four copies, because this is the sentence the DACH compliance package is
+// about — a person is told what reading their mailbox means before they grant
+// it, and four copies would drift until they disagreed about what was promised.
+//
+// It asks for NOTHING. There is no checkbox, no acknowledgement, and no field
+// the server records: a mailbox connects with the notice unread. That is the
+// product's posture and the handbook says so out loud — Margince tells the
+// person what happens and does not verify that anyone read it. An
+// acknowledgement here would be a consent record nobody actually gave, which is
+// worse than none: `share_acknowledged_at` already carries that lesson, and its
+// column comment says it records a grant time and not a consent.
+//
+// The claim it makes is true because of what ships around it: a new connection
+// is born `classified` (the column default), so nothing this mailbox brings in
+// is readable by a colleague until a classifier has judged the thread ordinary.
+export function CaptureNotice() {
+  const t = useT();
+  return (
+    <Callout tone="info">
+      <p>{t("captureNotice.whatHappens")}</p>
+      <p>{t("captureNotice.whoReads")}</p>
+      <p>{t("captureNotice.yourControl")}</p>
+    </Callout>
+  );
+}

--- a/frontend/src/screens/companyrail.tsx
+++ b/frontend/src/screens/companyrail.tsx
@@ -26,6 +26,7 @@ import { useCompanyReadOnlyReason } from "./companyheader";
 import { DetailsGrid } from "./companyraildetails";
 import { SectionSummary, sectionAnswered } from "./companyrailshared";
 import { TagsSection } from "./companyrailtags";
+import { CounterpartyHoldRow } from "./counterparty-hold";
 import { roleOf } from "./provider-status";
 import { signalKindLabel, signalTone } from "./record360";
 // The row and card shapes this file draws — co-rowlink, co-row-meta, co-card —
@@ -126,9 +127,53 @@ export function CompanyRail({
           <DetailsGrid organization={view?.organization ?? org} />
         </PanelBody>
       </Panel>
+      <CompanyHoldSection organization={view?.organization ?? org} />
       <TagsSection view={view} orgId={orgId} loading={loading} />
     </div>
   );
+}
+
+// Keeping a whole account's correspondence private, from the account page.
+//
+// The account's own domain is what a hold names here — an advisory firm answers
+// from whichever address picked up the file, so the domain is the unit that
+// actually covers the relationship. Drawn only when the account HAS a domain:
+// a hold has to name something, and `website_url` is derived from the primary
+// domain row, so its absence means there is nothing to name.
+function CompanyHoldSection({
+  organization,
+}: Readonly<{ organization: Organization | undefined }>) {
+  const t = useT();
+  const host = hostOf(organization?.website_url);
+  if (!host) {
+    return null;
+  }
+  return (
+    <Panel title={t("hold.sectionTitle")}>
+      <PanelBody>
+        {/* The row takes an ADDRESS and derives the domain from it, which is
+            what every person page hands it. An account has only the domain, so
+            it is handed a bare address at that domain — the same value the
+            row's own domain verb would compute. */}
+        <CounterpartyHoldRow email={`x@${host}`} />
+      </PanelBody>
+    </Panel>
+  );
+}
+
+// The registrable host inside a derived website URL, or nothing when the value
+// is absent or not a URL this can read. Never throws at the caller: an account
+// with an unparseable website simply offers no hold, rather than taking the
+// rail down with it.
+function hostOf(website: string | null | undefined): string | undefined {
+  if (!website) {
+    return undefined;
+  }
+  try {
+    return new URL(website).hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/frontend/src/screens/counterparty-hold.stories.tsx
+++ b/frontend/src/screens/counterparty-hold.stories.tsx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CounterpartyHoldRow } from "./counterparty-hold";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+// The hold control has two states worth a picture, and they are not the same
+// control with a flag: one OFFERS two verbs, the other reports a standing
+// decision and how to undo it. The second also carries the sentence a reader
+// would otherwise learn the hard way — that lifting does not re-open what was
+// already held.
+
+const HELD_DOMAIN = {
+  id: "hold-1",
+  kind: "domain",
+  value: "studiolegal.de",
+  created_at: "2026-08-01T09:00:00Z",
+};
+
+function story(holds: unknown[]) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute({}),
+      "GET /capture/counterparty-holds": () => jsonResponse({ data: holds }),
+    });
+    return (
+      <StoryProviders>
+        <CounterpartyHoldRow email="office@studiolegal.de" />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof CounterpartyHoldRow> = {
+  title: "Records/Rail/Counterparty hold",
+  component: CounterpartyHoldRow,
+};
+export default meta;
+type Story = StoryObj<typeof CounterpartyHoldRow>;
+
+export const NotHeld: Story = { render: story([]) };
+
+// A DOMAIN hold covering this address, which is the one worth having for an
+// advisor: the firm answers from whichever address picked up the file, so the
+// row reports the domain it is actually held by rather than the address asked
+// about.
+export const HeldByDomain: Story = { render: story([HELD_DOMAIN]) };
+
+export const HeldByAddress: Story = {
+  render: story([
+    { ...HELD_DOMAIN, kind: "address", value: "office@studiolegal.de" },
+  ]),
+};

--- a/frontend/src/screens/counterparty-hold.tsx
+++ b/frontend/src/screens/counterparty-hold.tsx
@@ -1,0 +1,206 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { Button } from "../design-system/atoms";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import { useToast } from "../design-system/toast";
+import { useT } from "../i18n";
+import { problemMessageOf, throwProblem } from "./common";
+
+// "My mail with this party is nobody else's."
+//
+// A hold is about the CORRESPONDENT rather than about any one message: holding
+// a lawyer's domain says that whatever passes between you is private, without
+// having to read each message to decide. It belongs on the record page because
+// that is where a person thinks about the correspondent — the Senders page
+// answers "what did the classifier decide", this answers "I have decided, about
+// this one".
+//
+// Per seat, and only ever the caller's own. One rep's lawyer says nothing about
+// another rep's, and a shared list would let anyone keep a colleague's customer
+// out of the CRM by naming their domain. So there is no admin view of this and
+// no id here that reaches another seat's holds.
+//
+// Placing a hold binds mail captured FROM HERE ON. Narrowing the history is a
+// separate press with the count in front of you, and lifting a hold widens
+// NOTHING: mail held while the hold stood was held for a reason that was true at
+// the time, and re-opening a year of correspondence as a side effect of tidying
+// a list is not something anybody asked for.
+
+type Hold = components["schemas"]["CaptureCounterpartyHold"];
+
+function useHolds() {
+  return useQuery({
+    queryKey: ["capture-counterparty-holds"],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/capture/counterparty-holds",
+      );
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+// The hold that covers this address, if the caller placed one. An address hold
+// names it exactly; a domain hold covers every address under it, including a
+// subdomain, the way the server folds one.
+export function holdCovering(
+  holds: readonly Hold[] | undefined,
+  email: string | undefined,
+): Hold | undefined {
+  if (!email) {
+    return undefined;
+  }
+  const address = email.trim().toLowerCase();
+  const domain = address.slice(address.indexOf("@") + 1);
+  return holds?.find((hold) =>
+    hold.kind === "address"
+      ? hold.value === address
+      : domain === hold.value || domain.endsWith(`.${hold.value}`),
+  );
+}
+
+function usePlaceHold() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const t = useT();
+  return useMutation({
+    // Kind and value both arrive as variables: the row a reader pressed belongs
+    // to the committed render (frontend/AGENTS.md, mutation-variable-coverage).
+    mutationFn: async (vars: { kind: "address" | "domain"; value: string }) => {
+      const { error } = await api.POST("/capture/counterparty-holds", {
+        body: { kind: vars.kind, value: vars.value },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["capture-counterparty-holds"],
+      });
+      toast.show(t("settings.saved"));
+    },
+  });
+}
+
+function useLiftHold() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const t = useT();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await api.DELETE("/capture/counterparty-holds/{id}", {
+        params: { path: { id } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["capture-counterparty-holds"],
+      });
+      toast.show(t("settings.saved"));
+    },
+  });
+}
+
+/**
+ * The hold control for one correspondent, for the record rails.
+ *
+ * `email` is the address the record is known by; a record with none cannot be
+ * held by address and the control stands down rather than offering a press that
+ * would have nothing to name.
+ */
+export function CounterpartyHoldRow({
+  email,
+}: Readonly<{ email: string | undefined }>) {
+  const t = useT();
+  const holds = useHolds();
+  const place = usePlaceHold();
+  const lift = useLiftHold();
+  const [asking, setAsking] = useState<"address" | "domain" | null>(null);
+
+  if (!email) {
+    return null;
+  }
+  const address = email.trim().toLowerCase();
+  const domain = address.slice(address.indexOf("@") + 1);
+  const held = holdCovering(holds.data?.data, address);
+
+  if (held) {
+    return (
+      <div className="pe-rail-hold">
+        <p className="t-small">
+          {held.kind === "domain"
+            ? t("hold.heldByDomain", { domain: held.value })
+            : t("hold.heldByAddress")}
+        </p>
+        <Button
+          small
+          variant="ghost"
+          pending={lift.isPending}
+          onClick={() => lift.mutate(held.id)}
+        >
+          {t("hold.lift")}
+        </Button>
+        {/* Said on the way OUT, not behind a confirm on the way in: lifting is
+            the reversible half, and what surprises a reader is that it does not
+            re-open what was already held. */}
+        <p className="t-caption">{t("hold.liftingWidensNothing")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pe-rail-hold">
+      <p className="t-small">{t("hold.notHeld")}</p>
+      <div className="card-actions">
+        <Button small variant="ghost" onClick={() => setAsking("address")}>
+          {t("hold.holdAddress")}
+        </Button>
+        {/* A domain hold is the one worth having for an advisor: a firm answers
+            from whichever address picked up the file. Offered as its own verb
+            rather than a modifier, because the two reach very different sets. */}
+        <Button small variant="ghost" onClick={() => setAsking("domain")}>
+          {t("hold.holdDomain", { domain })}
+        </Button>
+      </div>
+      {place.isError && (
+        <p className="t-caption" role="alert">
+          {problemMessageOf(place.error, t)}
+        </p>
+      )}
+      <ConfirmModal
+        open={asking !== null}
+        onClose={() => setAsking(null)}
+        title={t("hold.confirmTitle")}
+        confirmLabel={t("hold.confirmVerb")}
+        pending={place.isPending}
+        onConfirm={() => {
+          if (asking) {
+            place.mutate(
+              { kind: asking, value: asking === "domain" ? domain : address },
+              { onSuccess: () => setAsking(null) },
+            );
+          }
+        }}
+      >
+        <p>
+          {asking === "domain"
+            ? t("hold.confirmDomainBody", { domain })
+            : t("hold.confirmAddressBody", { address })}
+        </p>
+        {/* The limit, stated where the decision is made rather than discovered
+            afterwards: a hold placed today does not reach back over a year of
+            correspondence by itself. */}
+        <p className="t-caption">{t("hold.confirmHistoryNote")}</p>
+      </ConfirmModal>
+    </div>
+  );
+}

--- a/frontend/src/screens/imap-connect-form.tsx
+++ b/frontend/src/screens/imap-connect-form.tsx
@@ -8,6 +8,7 @@ import { Button, Field, Modal, TextInput } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { CaptureNotice } from "./capture-notice";
 import { problemCodeOf, problemMessageOf, throwProblem } from "./common";
 
 // The IMAP connect flavor (RC-8/Task 6): the credential providers' first-
@@ -157,6 +158,10 @@ export function ImapConnectForm({
           });
         }}
       >
+        {/* Before the fields, not after: a person connecting a mailbox from
+            Settings is told the same thing onboarding tells them, and reading
+            it after typing a password is reading it too late. */}
+        <CaptureNotice />
         <Field label={t("connectors.imapHost")} required>
           {(control) => (
             <TextInput

--- a/frontend/src/screens/onboarding-connect-panels.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.tsx
@@ -11,6 +11,7 @@ import { api } from "../api/client";
 import { Button, Disclosure, Field } from "../design-system/atoms";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { CaptureNotice } from "./capture-notice";
 import { problemMessageOf, throwProblem } from "./common";
 import { imapErrorMessage } from "./imap-connect-form";
 import { OnboardingBackread } from "./onboarding-backread";
@@ -201,6 +202,9 @@ export function OAuthConnectPanel({
           is wrong with the thing they just pressed. A caution about what a
           button does belongs beside the button, never behind a fold. */}
       <p className="t-small ob-google-unverified">{t(copy.unverified)}</p>
+      {/* Last thing read before the grant screen, because after it the mailbox
+          is connected and the telling is too late. */}
+      <CaptureNotice />
       <div className="ob-connect-dialog-actions">
         <Button
           variant="primary"
@@ -557,6 +561,10 @@ export function ImapConnectPanel({
           body={imapErrorMessage(connect.error, t)}
         />
       )}
+
+      {/* Same words as the OAuth panel, and in the same place: the last thing
+          read before the mailbox is connected. */}
+      <CaptureNotice />
 
       <div className="ob-connect-dialog-actions">
         <Button

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -50,6 +50,7 @@ import {
   throwProblem,
   useSorMode,
 } from "./common";
+import { CounterpartyHoldRow } from "./counterparty-hold";
 import { stillHeld, today } from "./employmentcurrency";
 import { interactionIcon } from "./interactionchrome";
 import { consentWord } from "./personstrip";
@@ -151,9 +152,32 @@ export function PersonRail({
         <WhoKnows view={view} firstName={firstName} />
         <SignalsAndRisks view={view} />
         <ConsentAndChannels view={view} guard={guard} />
+        {/* Beside consent, because it is the same subject from the seat's own
+            side: consent says what this contact allows us to send, the hold
+            says what the seat is willing for colleagues to read. */}
+        <PersonHoldSection view={view} />
         <RecentActivity view={view} />
       </Panel>
     </div>
+  );
+}
+
+// --- Keeping this correspondence private -------------------------------
+
+// The hold control, in the rail's own section shape. Drawn for every contact
+// with an address, held or not: a control that appeared only once a hold
+// existed would leave a reader with no way to place the first one.
+function PersonHoldSection({ view }: Readonly<{ view: Person360 }>) {
+  const t = useT();
+  const email = view.person?.emails?.[0]?.email;
+  if (!email) {
+    return null;
+  }
+  return (
+    <section className="pe-rail-section">
+      <h3 className="pe-rail-heading">{t("hold.sectionTitle")}</h3>
+      <CounterpartyHoldRow email={email} />
+    </section>
   );
 }
 


### PR DESCRIPTION
## What this finishes

The last four items of PR 11's acceptance list, plus the PR 12 doc updates that were still open. With this, the mailbox-privacy plan is complete.

### The connect notice

What happens to a mailbox, said **before** it is connected: what is read, that a new mailbox is held by default, and what the person decides afterwards. One component on all three connect surfaces — the OAuth panel, the IMAP panel in onboarding, and the IMAP form in Settings — because four copies of the sentence the DACH package is about would drift until they disagreed about what was promised.

It asks for nothing: no checkbox, no acknowledgement, no field the server records. A mailbox connects with the notice unread. An acknowledgement here would be a consent record nobody gave, which is worse than none — `share_acknowledged_at` already carries that lesson in its column comment.

The plan wanted a posture step here too. `POST /connectors/{provider}/connect` takes no posture, and the plan's own open question 2 names the fallback: `classified` at grant, changed afterwards. That is safe in this direction because a new connection is already born held, so the panel carries the notice and the posture stays where it is set.

### The counterparty hold, on the record pages

The Senders page answers *what did the classifier decide*; this answers *I have decided, about this one*. Both verbs are offered — an address, and the domain, which is the one worth having for an advisor since a firm answers from whichever address picked up the file.

The confirm states the limit where the decision is made rather than after it (a hold binds mail from here on), and lifting says on the way out that it widens nothing. The organization rail carries the same control keyed on the account's own domain, so a hold placed from a contact reads back on the company — verified by doing exactly that.

### e2e that runs in CI

`e2e/mailboxprivacy.spec.ts` asserts the German for six acceptance items against the network-edge mock, so `make frontend-e2e` covers these screens rather than only a stack I happened to have running. `seed.ts` gained the capture routes, held per page: a mock answering a fixed fixture would let a write succeed and then show the untouched value, which passes while doing nothing.

### Four documents that had stopped being true

| Document | The claim |
|---|---|
| `handbook/capture.md` | *"Email sharing — on by default. Captured mail is readable by every colleague who can see the contact."* That is the organization floor, not what a mailbox does |
| `handbook/capture.md` | "Importing your mail history" said nothing about who can read what a backfill brings in |
| `explanation/ingress-gate-and-auto-capture.md` | *"A model makes one decision here… it never decides whether a message is kept."* There are two models now, and the second decides who may **read** a message |
| `handbook/records.md`, `explanation/rbac-roles-and-teams.md` | Both called `workspace` the audience default. True for a row a human logs, false for one a mailbox brought in |

Checked against the code rather than against the plan: both verdict tasks are `ladder: [local_small]` in `ai-tasks.yaml` and the generated egress table agrees, and `audience_is_derived` exists in `activities/audience.go`. The plan also names `docs/explanation/data-enrichment-position.md`, which is not in the tree.

## Acceptance, performed

On a dev stack on its own `DEV_SLUG`, plus the hermetic suite:

| Item | Result |
|---|---|
| Notice renders before the fields, no checkbox | ✅ full German, verified on the running IMAP form |
| Person rail offers both hold verbs | ✅ address and domain, domain interpolated |
| Placing a domain hold | ✅ `POST 201`, row flips to held, `capture_counterparty_hold` has the row |
| Company rail shows the same hold | ✅ reads back the hold placed from the contact page |
| `make frontend-e2e` | ✅ **196 passed**, including the six new assertions |

One thing the browser corrected: the two hold verbs are `.card-actions`, not `.cell-actions`. The rail column is ~250px, so they need to wrap — `.cell-actions` deliberately does not, because it is a table cell's row.

## Still not built, and why

`GET /capture/held-threads` and `GET /ai/health` do not exist, so the held-threads list, the outage banner and the admin AI-health page are not here. Tracked as #3419 and #3420. A page reading an endpoint that does not exist is worse than an absent page, and #3420 matters most: without it a dead classifier and a correctly cautious one look identical from the outside.

## Tests

- `e2e/mailboxprivacy.spec.ts` — six acceptance items in German, hermetic.
- `capture-notice.stories.tsx`, `counterparty-hold.stories.tsx` — the notice's words reviewable on their own, and the hold's three states.

`make check-backend`, `make check-fe` and `make frontend-e2e` are green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes the mailbox privacy UI: a notice on every connect surface that tells people what reading their mailbox means, a per-correspondent hold on record pages, and four documents that claimed behavior the product stopped having.

- The notice renders before the fields on the OAuth panel, the IMAP onboarding panel, and the IMAP Settings form, and asks for nothing — no checkbox, no acknowledgement, no field the server records.
- The counterparty hold on person and company rails offers a hold by address or by domain; the company rail derives the domain from the organization's website, so a hold placed from a contact reads back on the account.
- A hold binds mail from then on, and lifting it does not re-open what was already held.
- The connect flow takes no posture step; a new connection is born held, so the notice ships without extending the connect call.
- `e2e/mailboxprivacy.spec.ts` asserts the German for six acceptance items against the network-edge mock, running in CI via `make frontend-e2e`; `seed.ts` serves the capture routes these tests write through.
- The held-threads list, the outage banner, and the admin AI-health page are not included — their endpoints (`GET /capture/held-threads`, `GET /ai/health`) do not exist yet.

**Docs fixes**

- `capture.md` said captured mail is "readable by every colleague who can see the contact," which is the organization-wide floor; the section now leads with the mailbox's three postures and the admin opt-in sharing requires.
- `records.md` and `rbac-roles-and-teams.md` called `workspace` the audience default; a captured row's audience is derived from each importing seat's contribution, and a direct `PATCH` on it is refused.
- `ingress-gate-and-auto-capture.md` said a model never decides whether a message is kept; there are two models now, and the second decides who may read a thread, both local-only by default.
- The plan names `docs/explanation/data-enrichment-position.md`, which is not in the tree.

<sup>Written for commit 30b69a175be77eb2a8af553f80a3ec0ce4941330. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

