### PR TITLE
The ways in are a list the reader can act on

### DIFF
--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -106,6 +106,7 @@ components:
   webhooks:    { in: internal/modules/webhooks }
   comms:       { in: internal/modules/comms }
   notices:     { in: internal/modules/notices }
+  introductions: { in: internal/modules/introductions }
   compose:     { in: [internal/compose, internal/compose/**] }
   migrations:  { in: migrations }
   cmd:         { in: cmd/** }
@@ -238,8 +239,11 @@ deps:
   notices:
     mayDependOn: [contracts, platform]
     canUse: [pgx, oapi]
+  introductions:
+    mayDependOn: [contracts, platform]
+    canUse: [pgx, oapi]
   compose:
-    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, finance, integrations, agreements, commissions, contracts, dealrooms, knowledge, platform, migrations, projects]
+    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, introductions, finance, integrations, agreements, commissions, contracts, dealrooms, knowledge, platform, migrations, projects]
     # xtext: the evidence gate normalizes page text to NFC before matching
     # (evidencematch.go) — Unicode normal forms need golang.org/x/text.
     # yaml: aicert's corpus loader parses scenario files directly — the
@@ -299,5 +303,5 @@ deps:
     mayDependOn: [contracts, compose, ai, collections, platform, activities, aiactivity, agents, approvals, people]
     canUse: [yaml, jsonschema]
   cmd:
-    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, finance, integrations, agreements, commissions, contracts, dealrooms, platform, migrations, projects]
+    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, introductions, finance, integrations, agreements, commissions, contracts, dealrooms, platform, migrations, projects]
     canUse: [pgx, redis, xterm, composition]

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -20837,6 +20837,18 @@ components:
         outcome:
           type: string
           enum: [created, updated, needs_review, skipped]
+          # Pins the generated Go constant names. Unpinned, the generator names
+          # these bare whenever nothing else in api_gen.go happens to claim the
+          # word — and `Created` is already declared by publicevents_gen.go in
+          # this same package, so the package stops compiling the moment an
+          # unrelated schema shifts that coincidence.
+          x-enum-varnames:
+            [
+              VCardImportResultOutcomeCreated,
+              VCardImportResultOutcomeUpdated,
+              VCardImportResultOutcomeNeedsReview,
+              VCardImportResultOutcomeSkipped,
+            ]
           description: |
             `created` — nobody matched, so the card became a person, their company and the edge
             between them. `updated` — an exact match, filled only where the record was empty.
@@ -23239,6 +23251,13 @@ components:
           items: { $ref: '#/components/schemas/PersonGraphEdge' }
         route:
           $ref: '#/components/schemas/PersonGraphRoute'
+        routes:
+          type: array
+          description: >-
+            Every way in worth offering, best first, so a reader can take the second one when
+            the first is unavailable. `route` is `routes[0]` — the singular field is the same
+            recommendation and stays for callers that only ever wanted the one.
+          items: { $ref: '#/components/schemas/PersonGraphRouteCandidate' }
         groups_omitted:
           type: array
           description: Groups withheld for lack of a grant — so a client can say "you can't see this" instead of "there is none".
@@ -23339,6 +23358,85 @@ components:
         why:
           type: string
           description: The proof line, written from the counts — "6 two-way exchanges · replied 2 days ago".
+
+    PersonGraphRouteCandidate:
+      type: object
+      description: |
+        One way in, with the facts behind it and whether it can be asked for today.
+
+        The list is ordered the same way the single `route` is chosen: a direct relationship
+        beats an indirect one however warm the indirect one looks, and within a kind the
+        two-way relationships come first. Only a COLLEAGUE can carry an introduction, so a
+        candidate always starts at a live seat — a pair of external contacts who correspond
+        is an edge in this graph but never a route out of it.
+      required: [route_id, route_type, via_user_id, via_display_name, evidence, availability]
+      properties:
+        route_id:
+          type: string
+          description: >-
+            Stable within this response, for selecting a route in a client. `direct:<user>` or
+            `through:<user>:<person>`. A write names the parts it means rather than parsing
+            this back apart.
+        route_type:
+          $ref: '#/components/schemas/PersonGraphRouteType'
+        via_user_id: { type: string, format: uuid }
+        via_display_name: { type: string }
+        through_person_id:
+          type: string
+          format: uuid
+          description: Set when the route goes via someone else at the contact's company.
+        through_display_name: { type: string }
+        strength_bucket:
+          type: string
+          enum: [none, weak, moderate, strong]
+        evidence:
+          $ref: '#/components/schemas/PersonGraphRouteEvidence'
+        receipts:
+          type: array
+          maxItems: 3
+          description: >-
+            The messages behind a `direct` candidate, each individually visibility-checked.
+            Absent on an indirect candidate for the reason the edge itself carries no rows:
+            the counts are disclosable where the correspondence is not.
+          items: { $ref: '#/components/schemas/PersonGraphReceipt' }
+        availability:
+          $ref: '#/components/schemas/PersonGraphRouteAvailability'
+
+    PersonGraphRouteType:
+      type: string
+      description: >-
+        `direct` is a colleague who corresponds with the contact themselves. `through_contact`
+        goes via someone else at the contact's company.
+      enum: [direct, through_contact]
+      # Pinned for the reason the file's other enums are: unpinned, `Direct` is
+      # an identifier far too generic for a package every contract type shares.
+      x-enum-varnames: [PersonGraphRouteTypeDirect, PersonGraphRouteTypeThroughContact]
+
+    PersonGraphRouteAvailability:
+      type: string
+      description: >-
+        Whether a route can be asked for now. `already_requested` means an open ask exists,
+        `declined` that this colleague has refused this contact before, and `unavailable`
+        that the seat can no longer carry it.
+      enum: [available, already_requested, declined, unavailable]
+
+    PersonGraphRouteEvidence:
+      type: object
+      description: >-
+        The counts behind a route, as facts rather than a sentence. The prose is written by
+        the client, because this server speaks one language and the product speaks three.
+      required: [interactions_90d, two_way]
+      properties:
+        interactions_90d: { type: integer }
+        inbound_90d: { type: integer }
+        outbound_90d: { type: integer }
+        two_way:
+          type: boolean
+          description: Correspondence has gone both ways in the window — the claim that separates a relationship from a mailing list.
+        last_at: { type: [string, 'null'], format: date-time }
+        days_since_last:
+          type: [integer, 'null']
+          description: Whole days from the last interaction to now, so a client renders "2 days ago" without re-deriving today from a timestamp.
 
     PersonMoment:
       type: object

--- a/backend/internal/compose/network/persongraph.go
+++ b/backend/internal/compose/network/persongraph.go
@@ -136,7 +136,7 @@ func (h Reads) buildPersonGraph(
 	out.DroppedCount = &dropped
 	routes := chooseRoutes(out, now)
 	out.Routes = &routes
-	out.Route = chooseRoute(routes, now)
+	out.Route = chooseRoute(routes)
 	return nil
 }
 
@@ -288,7 +288,7 @@ func edgeReceipts(ctx context.Context, tx pgx.Tx, userID, personID ids.UUID) ([]
 // second time. Two rankings over one set of facts are two answers to one
 // question, and the day they disagree the card recommends one colleague and
 // lists a different one first.
-func chooseRoute(candidates []crmcontracts.PersonGraphRouteCandidate, now time.Time) *crmcontracts.PersonGraphRoute {
+func chooseRoute(candidates []crmcontracts.PersonGraphRouteCandidate) *crmcontracts.PersonGraphRoute {
 	if len(candidates) == 0 {
 		return nil
 	}

--- a/backend/internal/compose/network/persongraph.go
+++ b/backend/internal/compose/network/persongraph.go
@@ -37,7 +37,6 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
-	"github.com/margince/margince/backend/internal/shared/kernel/elapsed"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -135,7 +134,9 @@ func (h Reads) buildPersonGraph(
 	dropped.Peer = &peerDropped
 
 	out.DroppedCount = &dropped
-	out.Route = chooseRoute(out, now)
+	routes := chooseRoutes(out, now)
+	out.Routes = &routes
+	out.Route = chooseRoute(routes, now)
 	return nil
 }
 
@@ -282,75 +283,37 @@ func edgeReceipts(ctx context.Context, tx pgx.Tx, userID, personID ids.UUID) ([]
 // direct relationship beats an indirect one however warm the indirect one
 // looks, because "she already knows you" is a different kind of claim from
 // "he knows someone at her company".
-func chooseRoute(out *crmcontracts.PersonGraph, now time.Time) *crmcontracts.PersonGraphRoute {
-	anchor := ""
-	labels := map[string]string{}
-	groups := map[string]crmcontracts.PersonGraphNodeGroup{}
-	users := map[string]*openapi_types.UUID{}
-	people := map[string]*openapi_types.UUID{}
-	for i := range out.Nodes {
-		n := &out.Nodes[i]
-		labels[n.Id] = n.Label
-		groups[n.Id] = n.Group
-		users[n.Id] = n.UserId
-		people[n.Id] = n.PersonId
-		if n.Group == crmcontracts.PersonGraphNodeGroupAnchor {
-			anchor = n.Id
-		}
-	}
-
-	var best *crmcontracts.PersonGraphEdge
-	bestDirect := false
-	for i := range out.Edges {
-		e := &out.Edges[i]
-		direct := e.To == anchor
-		switch {
-		case best == nil:
-		case direct && !bestDirect:
-		case direct == bestDirect && edgeRank(*e) > edgeRank(*best):
-		default:
-			continue
-		}
-		best, bestDirect = e, direct
-	}
-	if best == nil {
+//
+// It reads the head of the candidate list rather than ranking the edges a
+// second time. Two rankings over one set of facts are two answers to one
+// question, and the day they disagree the card recommends one colleague and
+// lists a different one first.
+func chooseRoute(candidates []crmcontracts.PersonGraphRouteCandidate, now time.Time) *crmcontracts.PersonGraphRoute {
+	if len(candidates) == 0 {
 		return nil
 	}
-	viaID := users[best.From]
-	if viaID == nil {
-		return nil
-	}
+	best := candidates[0]
 	route := crmcontracts.PersonGraphRoute{
-		ViaUserId:      *viaID,
-		ViaDisplayName: labels[best.From],
-		Why:            proofLine(*best, now),
+		ViaUserId:      best.ViaUserId,
+		ViaDisplayName: best.ViaDisplayName,
+		Why:            proofLineFor(best.Evidence),
 	}
-	if !bestDirect {
-		route.ThroughPersonId = people[best.To]
-		through := labels[best.To]
-		route.ThroughDisplayName = &through
+	if best.RouteType == crmcontracts.PersonGraphRouteTypeThroughContact {
+		route.ThroughPersonId = best.ThroughPersonId
+		route.ThroughDisplayName = best.ThroughDisplayName
 	}
 	return &route
 }
 
-// edgeRank orders candidate routes. Two-way exchange first, because a
-// relationship that answers is worth more than one that only sends; volume
-// breaks the tie.
-func edgeRank(e crmcontracts.PersonGraphEdge) int {
-	twoWay := 0
-	if e.Inbound90d != nil && *e.Inbound90d > 0 && e.Outbound90d != nil && *e.Outbound90d > 0 {
-		twoWay = 1000
-	}
-	return twoWay + e.Interactions90d
-}
-
-// proofLine writes the route's evidence from the counts — the sentence a rep
-// reads before deciding whether to ask.
-func proofLine(e crmcontracts.PersonGraphEdge, now time.Time) string {
+// proofLineFor writes the route's evidence as a sentence.
+//
+// English, and the contract says so: `why` is the fallback for a caller that
+// has not adopted the structured `evidence`, which is what the product renders
+// in the reader's own language. A new surface reads the facts, not this.
+func proofLineFor(ev crmcontracts.PersonGraphRouteEvidence) string {
 	when := "no recent contact"
-	if e.LastAt != nil {
-		days := elapsed.Days(*e.LastAt, now)
-		switch days {
+	if ev.DaysSinceLast != nil {
+		switch days := *ev.DaysSinceLast; days {
 		case 0:
 			when = "last contact today"
 		case 1:
@@ -359,10 +322,10 @@ func proofLine(e crmcontracts.PersonGraphEdge, now time.Time) string {
 			when = fmt.Sprintf("last contact %d days ago", days)
 		}
 	}
-	if e.Inbound90d != nil && *e.Inbound90d > 0 && e.Outbound90d != nil && *e.Outbound90d > 0 {
-		return fmt.Sprintf("%s in 90 days · %s", plural(e.Interactions90d, "two-way exchange"), when)
+	if ev.TwoWay {
+		return fmt.Sprintf("%s in 90 days · %s", plural(ev.Interactions90d, "two-way exchange"), when)
 	}
-	return fmt.Sprintf("%s in 90 days, one-sided · %s", plural(e.Interactions90d, "interaction"), when)
+	return fmt.Sprintf("%s in 90 days, one-sided · %s", plural(ev.Interactions90d, "interaction"), when)
 }
 
 // plural writes a count and its noun. The proof line is read by a person

--- a/backend/internal/compose/network/persongraph_test.go
+++ b/backend/internal/compose/network/persongraph_test.go
@@ -78,7 +78,7 @@ func TestChooseRouteAlwaysPrefersADirectRelationship(t *testing.T) {
 			},
 		})
 
-	route := chooseRoute(chooseRoutes(graph, graphNow), graphNow)
+	route := chooseRoute(chooseRoutes(graph, graphNow))
 	if route == nil {
 		t.Fatal("two candidate routes produced no recommendation")
 	}
@@ -104,7 +104,7 @@ func TestChooseRouteNamesTheIntermediaryWhenTheHopIsIndirect(t *testing.T) {
 			Interactions90d: 12, Inbound90d: intp(6), Outbound90d: intp(6), LastAt: daysBefore(2),
 		}})
 
-	route := chooseRoute(chooseRoutes(graph, graphNow), graphNow)
+	route := chooseRoute(chooseRoutes(graph, graphNow))
 	if route == nil {
 		t.Fatal("an indirect route was available and none was recommended")
 	}
@@ -136,7 +136,7 @@ func TestChooseRoutePrefersAnExchangeOverAOneSidedRelationship(t *testing.T) {
 			},
 		})
 
-	route := chooseRoute(chooseRoutes(graph, graphNow), graphNow)
+	route := chooseRoute(chooseRoutes(graph, graphNow))
 	if route == nil {
 		t.Fatal("no route was chosen")
 	}
@@ -151,7 +151,7 @@ func TestChooseRoutePrefersAnExchangeOverAOneSidedRelationship(t *testing.T) {
 // A graph with nothing in it recommends nothing. Inventing a route from an
 // empty picture is the failure the whole evidence posture exists to avoid.
 func TestChooseRouteRecommendsNothingWhenThereIsNoEdge(t *testing.T) {
-	if route := chooseRoute(chooseRoutes(graphWith(nil, nil), graphNow), graphNow); route != nil {
+	if route := chooseRoute(chooseRoutes(graphWith(nil, nil), graphNow)); route != nil {
 		t.Errorf("an empty graph produced a route via %q", route.ViaDisplayName)
 	}
 }

--- a/backend/internal/compose/network/persongraph_test.go
+++ b/backend/internal/compose/network/persongraph_test.go
@@ -78,7 +78,7 @@ func TestChooseRouteAlwaysPrefersADirectRelationship(t *testing.T) {
 			},
 		})
 
-	route := chooseRoute(graph, graphNow)
+	route := chooseRoute(chooseRoutes(graph, graphNow), graphNow)
 	if route == nil {
 		t.Fatal("two candidate routes produced no recommendation")
 	}
@@ -104,7 +104,7 @@ func TestChooseRouteNamesTheIntermediaryWhenTheHopIsIndirect(t *testing.T) {
 			Interactions90d: 12, Inbound90d: intp(6), Outbound90d: intp(6), LastAt: daysBefore(2),
 		}})
 
-	route := chooseRoute(graph, graphNow)
+	route := chooseRoute(chooseRoutes(graph, graphNow), graphNow)
 	if route == nil {
 		t.Fatal("an indirect route was available and none was recommended")
 	}
@@ -136,7 +136,7 @@ func TestChooseRoutePrefersAnExchangeOverAOneSidedRelationship(t *testing.T) {
 			},
 		})
 
-	route := chooseRoute(graph, graphNow)
+	route := chooseRoute(chooseRoutes(graph, graphNow), graphNow)
 	if route == nil {
 		t.Fatal("no route was chosen")
 	}
@@ -151,7 +151,7 @@ func TestChooseRoutePrefersAnExchangeOverAOneSidedRelationship(t *testing.T) {
 // A graph with nothing in it recommends nothing. Inventing a route from an
 // empty picture is the failure the whole evidence posture exists to avoid.
 func TestChooseRouteRecommendsNothingWhenThereIsNoEdge(t *testing.T) {
-	if route := chooseRoute(graphWith(nil, nil), graphNow); route != nil {
+	if route := chooseRoute(chooseRoutes(graphWith(nil, nil), graphNow), graphNow); route != nil {
 		t.Errorf("an empty graph produced a route via %q", route.ViaDisplayName)
 	}
 }
@@ -159,15 +159,15 @@ func TestChooseRouteRecommendsNothingWhenThereIsNoEdge(t *testing.T) {
 // The proof line is what a rep reads before deciding whether to ask, so it has
 // to distinguish the two cases rather than print one number.
 func TestProofLineSaysWhetherTheRelationshipIsTwoWay(t *testing.T) {
-	twoWay := proofLine(crmcontracts.PersonGraphEdge{
+	twoWay := proofLineFor(evidenceOf(&crmcontracts.PersonGraphEdge{
 		Interactions90d: 6, Inbound90d: intp(3), Outbound90d: intp(3), LastAt: daysBefore(2),
-	}, graphNow)
+	}, graphNow))
 	if !strings.Contains(twoWay, "two-way") {
 		t.Errorf("a mutual relationship reads %q and does not say it is mutual", twoWay)
 	}
-	oneSided := proofLine(crmcontracts.PersonGraphEdge{
+	oneSided := proofLineFor(evidenceOf(&crmcontracts.PersonGraphEdge{
 		Interactions90d: 30, Inbound90d: intp(0), Outbound90d: intp(30), LastAt: daysBefore(2),
-	}, graphNow)
+	}, graphNow))
 	if !strings.Contains(oneSided, "one-sided") {
 		t.Errorf("thirty unanswered sends read %q and do not say they went unanswered", oneSided)
 	}

--- a/backend/internal/compose/network/personroutes.go
+++ b/backend/internal/compose/network/personroutes.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package network
+
+// Every way in, not just the warmest one.
+//
+// The single `route` answers "who should ask"; a rep who cannot use that
+// answer — the colleague is on leave, or already said no — needs the next one
+// without re-reading the graph and working it out themselves. So the same
+// deterministic preference that picks the recommendation orders a list, and
+// the recommendation is its head.
+//
+// Only a COLLEAGUE can carry an introduction. The graph draws contact-to-
+// contact edges too, because they explain who talks to whom inside the
+// account, but a pair of external contacts is never a route out of here: there
+// is nobody on this side of it to ask.
+
+import (
+	"fmt"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/elapsed"
+)
+
+// routeCandidateCap bounds the list for the same reason the groups are capped:
+// past a handful of routes nobody is choosing one, and the tail is always the
+// coldest. Matches the cap the account-level intro tool already applies.
+const routeCandidateCap = 5
+
+// chooseRoutes orders every askable way in, best first.
+//
+// The preference is the recommendation's, spelled once: a direct relationship
+// beats an indirect one however warm the indirect one looks, then two-way
+// beats one-sided, then volume, then the node id so that two identical edges
+// never swap places between reads.
+func chooseRoutes(out *crmcontracts.PersonGraph, now time.Time) []crmcontracts.PersonGraphRouteCandidate {
+	idx := indexNodes(out)
+	if idx.anchor == "" {
+		return nil
+	}
+
+	candidates := []crmcontracts.PersonGraphRouteCandidate{}
+	for i := range out.Edges {
+		candidate, ok := candidateFor(&out.Edges[i], idx, now)
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, candidate)
+	}
+	sortCandidates(candidates)
+	if len(candidates) > routeCandidateCap {
+		candidates = candidates[:routeCandidateCap]
+	}
+	return candidates
+}
+
+// nodeIndex is the graph read back as lookups, so the ranking reads facts
+// about a node rather than re-scanning the slice for each edge.
+type nodeIndex struct {
+	anchor string
+	labels map[string]string
+	users  map[string]*openapi_types.UUID
+	people map[string]*openapi_types.UUID
+}
+
+func indexNodes(out *crmcontracts.PersonGraph) nodeIndex {
+	idx := nodeIndex{
+		labels: map[string]string{},
+		users:  map[string]*openapi_types.UUID{},
+		people: map[string]*openapi_types.UUID{},
+	}
+	for i := range out.Nodes {
+		n := &out.Nodes[i]
+		idx.labels[n.Id] = n.Label
+		idx.users[n.Id] = n.UserId
+		idx.people[n.Id] = n.PersonId
+		if n.Group == crmcontracts.PersonGraphNodeGroupAnchor {
+			idx.anchor = n.Id
+		}
+	}
+	return idx
+}
+
+// candidateFor renders one edge as a route, or refuses it.
+//
+// The refusal is the eligibility rule: an edge whose near end is not a
+// colleague describes two of their people talking to each other. It belongs in
+// the picture and never in this list, because the list's only verb is "ask
+// this person", and there is nobody here to ask.
+func candidateFor(
+	e *crmcontracts.PersonGraphEdge, idx nodeIndex, now time.Time,
+) (crmcontracts.PersonGraphRouteCandidate, bool) {
+	via := idx.users[e.From]
+	if via == nil {
+		return crmcontracts.PersonGraphRouteCandidate{}, false
+	}
+	candidate := crmcontracts.PersonGraphRouteCandidate{
+		RouteType:      crmcontracts.PersonGraphRouteTypeDirect,
+		ViaUserId:      *via,
+		ViaDisplayName: idx.labels[e.From],
+		StrengthBucket: bucketOf(e.StrengthBucket),
+		Evidence:       evidenceOf(e, now),
+		// Nothing has been asked for until the introductions module says
+		// otherwise; a nil availability seam means every route is offerable.
+		Availability: crmcontracts.PersonGraphRouteAvailabilityAvailable,
+	}
+	if e.To == idx.anchor {
+		candidate.RouteId = fmt.Sprintf("direct:%s", *via)
+		candidate.Receipts = receiptsOf(e)
+		return candidate, true
+	}
+
+	through := idx.people[e.To]
+	if through == nil {
+		// An edge that ends on neither the anchor nor a contact is not a way
+		// in. Today nothing builds one; refusing is what keeps that true.
+		return crmcontracts.PersonGraphRouteCandidate{}, false
+	}
+	name := idx.labels[e.To]
+	candidate.RouteType = crmcontracts.PersonGraphRouteTypeThroughContact
+	candidate.RouteId = fmt.Sprintf("through:%s:%s", *via, *through)
+	candidate.ThroughPersonId = through
+	candidate.ThroughDisplayName = &name
+	// No receipts on an indirect route, for the reason the edge itself carries
+	// none: the counts are disclosable where the correspondence is not.
+	return candidate, true
+}
+
+// sortCandidates puts the recommendation first and keeps the order stable.
+//
+// Insertion sort rather than sort.Slice: the list is capped at a handful of
+// routes, and a hand-written comparison that a reader can follow line by line
+// is worth more here than an asymptotic gain nobody can measure.
+func sortCandidates(candidates []crmcontracts.PersonGraphRouteCandidate) {
+	for i := 1; i < len(candidates); i++ {
+		for j := i; j > 0 && beatsCandidate(candidates[j], candidates[j-1]); j-- {
+			candidates[j], candidates[j-1] = candidates[j-1], candidates[j]
+		}
+	}
+}
+
+// beatsCandidate is the whole preference order, in one place.
+func beatsCandidate(a, b crmcontracts.PersonGraphRouteCandidate) bool {
+	aDirect := a.RouteType == crmcontracts.PersonGraphRouteTypeDirect
+	bDirect := b.RouteType == crmcontracts.PersonGraphRouteTypeDirect
+	if aDirect != bDirect {
+		return aDirect
+	}
+	if a.Evidence.TwoWay != b.Evidence.TwoWay {
+		return a.Evidence.TwoWay
+	}
+	if a.Evidence.Interactions90d != b.Evidence.Interactions90d {
+		return a.Evidence.Interactions90d > b.Evidence.Interactions90d
+	}
+	// Nothing left that describes the relationship. The id breaks the tie so
+	// two equal routes hold their order between reads rather than swapping on
+	// map iteration.
+	return a.RouteId < b.RouteId
+}
+
+// evidenceOf states the counts as facts. The sentence is the client's to
+// write: this server speaks English and the product speaks three languages.
+func evidenceOf(e *crmcontracts.PersonGraphEdge, now time.Time) crmcontracts.PersonGraphRouteEvidence {
+	ev := crmcontracts.PersonGraphRouteEvidence{
+		Interactions90d: e.Interactions90d,
+		Inbound90d:      e.Inbound90d,
+		Outbound90d:     e.Outbound90d,
+		TwoWay:          twoWay(e),
+	}
+	if e.LastAt != nil {
+		last := *e.LastAt
+		days := elapsed.Days(last, now)
+		ev.LastAt = &last
+		ev.DaysSinceLast = &days
+	}
+	return ev
+}
+
+// twoWay is the claim that separates a relationship from a mailing list.
+func twoWay(e *crmcontracts.PersonGraphEdge) bool {
+	return e.Inbound90d != nil && *e.Inbound90d > 0 && e.Outbound90d != nil && *e.Outbound90d > 0
+}
+
+func bucketOf(b crmcontracts.PersonGraphEdgeStrengthBucket) *crmcontracts.PersonGraphRouteCandidateStrengthBucket {
+	bucket := crmcontracts.PersonGraphRouteCandidateStrengthBucket(b)
+	return &bucket
+}
+
+func receiptsOf(e *crmcontracts.PersonGraphEdge) *[]crmcontracts.PersonGraphReceipt {
+	if e.Receipts == nil {
+		return nil
+	}
+	receipts := *e.Receipts
+	return &receipts
+}

--- a/backend/internal/compose/network/personroutes.go
+++ b/backend/internal/compose/network/personroutes.go
@@ -33,10 +33,14 @@ const routeCandidateCap = 5
 
 // chooseRoutes orders every askable way in, best first.
 //
-// The preference is the recommendation's, spelled once: a direct relationship
-// beats an indirect one however warm the indirect one looks, then two-way
-// beats one-sided, then volume, then the node id so that two identical edges
-// never swap places between reads.
+// The preference: a direct relationship beats an indirect one however warm the
+// indirect one looks, then two-way beats one-sided, then volume, then the node
+// id so that two identical edges never swap places between reads.
+//
+// chooseRoute reads the head of this list rather than ranking the edges again,
+// so the card's recommendation and the list's first row cannot disagree.
+// Held by: TestTheRecommendationIsTheHeadOfTheList
+// (backend/internal/compose/network/personroutes_test.go)
 func chooseRoutes(out *crmcontracts.PersonGraph, now time.Time) []crmcontracts.PersonGraphRouteCandidate {
 	idx := indexNodes(out)
 	if idx.anchor == "" {

--- a/backend/internal/compose/network/personroutes_test.go
+++ b/backend/internal/compose/network/personroutes_test.go
@@ -32,7 +32,7 @@ func TestTheRecommendationIsTheHeadOfTheList(t *testing.T) {
 		})
 
 	routes := chooseRoutes(graph, graphNow)
-	route := chooseRoute(routes, graphNow)
+	route := chooseRoute(routes)
 	if len(routes) != 2 {
 		t.Fatalf("two askable routes produced %d candidates", len(routes))
 	}
@@ -77,7 +77,7 @@ func TestAContactToContactEdgeIsNeverARoute(t *testing.T) {
 		t.Errorf("route goes via %q; a pair of their own people is not a door",
 			routes[0].ViaDisplayName)
 	}
-	if route := chooseRoute(routes, graphNow); route == nil {
+	if route := chooseRoute(routes); route == nil {
 		t.Error("a usable direct route existed and the card recommended nothing")
 	}
 }

--- a/backend/internal/compose/network/personroutes_test.go
+++ b/backend/internal/compose/network/personroutes_test.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package network
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// The list and the single recommendation are one ranking. If they can diverge,
+// the card recommends one colleague and lists a different one first — and the
+// reader has no way to tell which is the product's actual advice.
+func TestTheRecommendationIsTheHeadOfTheList(t *testing.T) {
+	anchor := personNodeID(uuidFor(9))
+	graph := graphWith(
+		[]crmcontracts.PersonGraphNode{
+			colleague(1, "Thin but direct", crmcontracts.PersonGraphNodeGroupDirect),
+			colleague(2, "Busy Ben", crmcontracts.PersonGraphNodeGroupAccount),
+			contactNode(3, "Their colleague"),
+		},
+		[]crmcontracts.PersonGraphEdge{
+			{
+				From: userNodeID(uuidFor(1)), To: anchor,
+				Interactions90d: 2, Inbound90d: intp(1), Outbound90d: intp(1), LastAt: daysBefore(20),
+			},
+			{
+				From: userNodeID(uuidFor(2)), To: personNodeID(uuidFor(3)),
+				Interactions90d: 40, Inbound90d: intp(20), Outbound90d: intp(20), LastAt: daysBefore(1),
+			},
+		})
+
+	routes := chooseRoutes(graph, graphNow)
+	route := chooseRoute(routes, graphNow)
+	if len(routes) != 2 {
+		t.Fatalf("two askable routes produced %d candidates", len(routes))
+	}
+	if route == nil {
+		t.Fatal("candidates were found and nothing was recommended")
+	}
+	if routes[0].ViaDisplayName != route.ViaDisplayName {
+		t.Errorf("the list leads with %q and the card recommends %q",
+			routes[0].ViaDisplayName, route.ViaDisplayName)
+	}
+}
+
+// Two of their people talking to each other is a fact about the account, not a
+// way into it: there is nobody on our side of that edge to ask. Before this
+// rule the chooser walked such an edge and then returned NO route at all,
+// which read on screen as "nobody here can reach them".
+func TestAContactToContactEdgeIsNeverARoute(t *testing.T) {
+	anchor := personNodeID(uuidFor(9))
+	graph := graphWith(
+		[]crmcontracts.PersonGraphNode{
+			contactNode(3, "Their colleague"),
+			contactNode(4, "Their other colleague"),
+			colleague(1, "Our quiet rep", crmcontracts.PersonGraphNodeGroupDirect),
+		},
+		[]crmcontracts.PersonGraphEdge{
+			// Loud, recent, and entirely on their side of the wall.
+			{
+				From: personNodeID(uuidFor(4)), To: personNodeID(uuidFor(3)),
+				Interactions90d: 90, Inbound90d: intp(45), Outbound90d: intp(45), LastAt: daysBefore(1),
+			},
+			{
+				From: userNodeID(uuidFor(1)), To: anchor,
+				Interactions90d: 3, Inbound90d: intp(1), Outbound90d: intp(2), LastAt: daysBefore(30),
+			},
+		})
+
+	routes := chooseRoutes(graph, graphNow)
+	if len(routes) != 1 {
+		t.Fatalf("expected only the colleague's route, got %d", len(routes))
+	}
+	if routes[0].ViaDisplayName != "Our quiet rep" {
+		t.Errorf("route goes via %q; a pair of their own people is not a door",
+			routes[0].ViaDisplayName)
+	}
+	if route := chooseRoute(routes, graphNow); route == nil {
+		t.Error("a usable direct route existed and the card recommended nothing")
+	}
+}
+
+// A route names the parts a write needs. Parsing the id back apart would make
+// a display string load-bearing.
+func TestARouteIdSaysWhichKindItIs(t *testing.T) {
+	anchor := personNodeID(uuidFor(9))
+	graph := graphWith(
+		[]crmcontracts.PersonGraphNode{
+			colleague(1, "Direct Dana", crmcontracts.PersonGraphNodeGroupDirect),
+			colleague(2, "Busy Ben", crmcontracts.PersonGraphNodeGroupAccount),
+			contactNode(3, "Their colleague"),
+		},
+		[]crmcontracts.PersonGraphEdge{
+			{
+				From: userNodeID(uuidFor(1)), To: anchor,
+				Interactions90d: 8, Inbound90d: intp(4), Outbound90d: intp(4), LastAt: daysBefore(2),
+			},
+			{
+				From: userNodeID(uuidFor(2)), To: personNodeID(uuidFor(3)),
+				Interactions90d: 4, Inbound90d: intp(2), Outbound90d: intp(2), LastAt: daysBefore(6),
+			},
+		})
+
+	routes := chooseRoutes(graph, graphNow)
+	if len(routes) != 2 {
+		t.Fatalf("expected both routes, got %d", len(routes))
+	}
+	direct, indirect := routes[0], routes[1]
+	if direct.RouteType != crmcontracts.PersonGraphRouteTypeDirect {
+		t.Errorf("the direct route is typed %q", direct.RouteType)
+	}
+	if direct.ThroughPersonId != nil {
+		t.Error("a direct route named an intermediary")
+	}
+	if indirect.RouteType != crmcontracts.PersonGraphRouteTypeThroughContact {
+		t.Errorf("the indirect route is typed %q", indirect.RouteType)
+	}
+	if indirect.ThroughPersonId == nil {
+		t.Fatal("an indirect route did not say who it goes through")
+	}
+	if indirect.ThroughDisplayName == nil || *indirect.ThroughDisplayName != "Their colleague" {
+		t.Error("the indirect route did not name the intermediary a reader has to recognise")
+	}
+}
+
+// Correspondence is disclosable as counts where the messages themselves are
+// not. An indirect route carries the numbers and no rows — the same rule the
+// edge itself obeys.
+func TestOnlyADirectRouteCarriesReceipts(t *testing.T) {
+	anchor := personNodeID(uuidFor(9))
+	receipts := []crmcontracts.PersonGraphReceipt{{Subject: strptr("Retrofit review")}}
+	graph := graphWith(
+		[]crmcontracts.PersonGraphNode{
+			colleague(1, "Direct Dana", crmcontracts.PersonGraphNodeGroupDirect),
+			colleague(2, "Busy Ben", crmcontracts.PersonGraphNodeGroupAccount),
+			contactNode(3, "Their colleague"),
+		},
+		[]crmcontracts.PersonGraphEdge{
+			{
+				From: userNodeID(uuidFor(1)), To: anchor, Receipts: &receipts,
+				Interactions90d: 8, Inbound90d: intp(4), Outbound90d: intp(4), LastAt: daysBefore(2),
+			},
+			{
+				From: userNodeID(uuidFor(2)), To: personNodeID(uuidFor(3)), Receipts: &receipts,
+				Interactions90d: 4, Inbound90d: intp(2), Outbound90d: intp(2), LastAt: daysBefore(6),
+			},
+		})
+
+	routes := chooseRoutes(graph, graphNow)
+	if routes[0].Receipts == nil || len(*routes[0].Receipts) != 1 {
+		t.Error("the direct route dropped the proof behind it")
+	}
+	if routes[1].Receipts != nil {
+		t.Error("an indirect route disclosed correspondence it only has counts for")
+	}
+}
+
+// The facts cross the wire; the sentence is the client's to write, because
+// this server speaks English and the product speaks three languages.
+func TestEvidenceCrossesTheWireAsFactsNotProse(t *testing.T) {
+	anchor := personNodeID(uuidFor(9))
+	graph := graphWith(
+		[]crmcontracts.PersonGraphNode{
+			colleague(1, "Direct Dana", crmcontracts.PersonGraphNodeGroupDirect),
+		},
+		[]crmcontracts.PersonGraphEdge{{
+			From: userNodeID(uuidFor(1)), To: anchor,
+			Interactions90d: 6, Inbound90d: intp(3), Outbound90d: intp(3), LastAt: daysBefore(2),
+		}})
+
+	routes := chooseRoutes(graph, graphNow)
+	ev := routes[0].Evidence
+	if !ev.TwoWay {
+		t.Error("three in and three out did not read as two-way")
+	}
+	if ev.Interactions90d != 6 {
+		t.Errorf("the window count arrived as %d", ev.Interactions90d)
+	}
+	if ev.DaysSinceLast == nil || *ev.DaysSinceLast != 2 {
+		t.Error("the client would have to re-derive today from a timestamp")
+	}
+}
+
+// A relationship that answers beats one that only sends, whatever the volume.
+// The list has to agree with the recommendation on this, not just the head.
+func TestAnExchangeOutranksAOneSidedRelationshipInTheList(t *testing.T) {
+	anchor := personNodeID(uuidFor(9))
+	graph := graphWith(
+		[]crmcontracts.PersonGraphNode{
+			colleague(1, "Talks at them", crmcontracts.PersonGraphNodeGroupDirect),
+			colleague(2, "Actually converses", crmcontracts.PersonGraphNodeGroupDirect),
+		},
+		[]crmcontracts.PersonGraphEdge{
+			{
+				From: userNodeID(uuidFor(1)), To: anchor,
+				Interactions90d: 30, Inbound90d: intp(0), Outbound90d: intp(30), LastAt: daysBefore(1),
+			},
+			{
+				From: userNodeID(uuidFor(2)), To: anchor,
+				Interactions90d: 6, Inbound90d: intp(3), Outbound90d: intp(3), LastAt: daysBefore(3),
+			},
+		})
+
+	routes := chooseRoutes(graph, graphNow)
+	if routes[0].ViaDisplayName != "Actually converses" {
+		t.Errorf("the list leads with %q; thirty unanswered sends are not a relationship",
+			routes[0].ViaDisplayName)
+	}
+}
+
+// Nothing has been asked for until the introductions module says so. Until
+// that seam is bound, offering every route is the honest answer — the opposite
+// default would grey out doors that are in fact open.
+func TestEveryRouteIsOfferableBeforeAnythingHasBeenAsked(t *testing.T) {
+	anchor := personNodeID(uuidFor(9))
+	graph := graphWith(
+		[]crmcontracts.PersonGraphNode{
+			colleague(1, "Direct Dana", crmcontracts.PersonGraphNodeGroupDirect),
+		},
+		[]crmcontracts.PersonGraphEdge{{
+			From: userNodeID(uuidFor(1)), To: anchor,
+			Interactions90d: 6, Inbound90d: intp(3), Outbound90d: intp(3), LastAt: daysBefore(2),
+		}})
+
+	routes := chooseRoutes(graph, graphNow)
+	if routes[0].Availability != crmcontracts.PersonGraphRouteAvailabilityAvailable {
+		t.Errorf("a route nobody has asked about reads as %q", routes[0].Availability)
+	}
+}
+
+// Past a handful nobody is choosing a route, they are reading an org chart —
+// and the tail is always the coldest.
+func TestTheListStopsAtTheCap(t *testing.T) {
+	anchor := personNodeID(uuidFor(9))
+	nodes := []crmcontracts.PersonGraphNode{}
+	edges := []crmcontracts.PersonGraphEdge{}
+	for i := range byte(routeCandidateCap + 3) {
+		nodes = append(nodes, colleague(i+10, "Colleague", crmcontracts.PersonGraphNodeGroupDirect))
+		edges = append(edges, crmcontracts.PersonGraphEdge{
+			From: userNodeID(uuidFor(i + 10)), To: anchor,
+			Interactions90d: int(i) + 1, Inbound90d: intp(1), Outbound90d: intp(1), LastAt: daysBefore(2),
+		})
+	}
+
+	if got := len(chooseRoutes(graphWith(nodes, edges), graphNow)); got != routeCandidateCap {
+		t.Errorf("the list offered %d routes; the cap is %d", got, routeCandidateCap)
+	}
+}
+
+func strptr(s string) *string { return &s }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -7909,6 +7909,72 @@ func (e PersonGraphNodeType) Valid() bool {
 	}
 }
 
+// Defines values for PersonGraphRouteAvailability.
+const (
+	PersonGraphRouteAvailabilityAlreadyRequested PersonGraphRouteAvailability = "already_requested"
+	PersonGraphRouteAvailabilityAvailable        PersonGraphRouteAvailability = "available"
+	PersonGraphRouteAvailabilityDeclined         PersonGraphRouteAvailability = "declined"
+	PersonGraphRouteAvailabilityUnavailable      PersonGraphRouteAvailability = "unavailable"
+)
+
+// Valid indicates whether the value is a known member of the PersonGraphRouteAvailability enum.
+func (e PersonGraphRouteAvailability) Valid() bool {
+	switch e {
+	case PersonGraphRouteAvailabilityAlreadyRequested:
+		return true
+	case PersonGraphRouteAvailabilityAvailable:
+		return true
+	case PersonGraphRouteAvailabilityDeclined:
+		return true
+	case PersonGraphRouteAvailabilityUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PersonGraphRouteCandidateStrengthBucket.
+const (
+	PersonGraphRouteCandidateStrengthBucketModerate PersonGraphRouteCandidateStrengthBucket = "moderate"
+	PersonGraphRouteCandidateStrengthBucketNone     PersonGraphRouteCandidateStrengthBucket = "none"
+	PersonGraphRouteCandidateStrengthBucketStrong   PersonGraphRouteCandidateStrengthBucket = "strong"
+	PersonGraphRouteCandidateStrengthBucketWeak     PersonGraphRouteCandidateStrengthBucket = "weak"
+)
+
+// Valid indicates whether the value is a known member of the PersonGraphRouteCandidateStrengthBucket enum.
+func (e PersonGraphRouteCandidateStrengthBucket) Valid() bool {
+	switch e {
+	case PersonGraphRouteCandidateStrengthBucketModerate:
+		return true
+	case PersonGraphRouteCandidateStrengthBucketNone:
+		return true
+	case PersonGraphRouteCandidateStrengthBucketStrong:
+		return true
+	case PersonGraphRouteCandidateStrengthBucketWeak:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PersonGraphRouteType.
+const (
+	PersonGraphRouteTypeDirect         PersonGraphRouteType = "direct"
+	PersonGraphRouteTypeThroughContact PersonGraphRouteType = "through_contact"
+)
+
+// Valid indicates whether the value is a known member of the PersonGraphRouteType enum.
+func (e PersonGraphRouteType) Valid() bool {
+	switch e {
+	case PersonGraphRouteTypeDirect:
+		return true
+	case PersonGraphRouteTypeThroughContact:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for PersonMomentConfidence.
 const (
 	PersonMomentConfidenceHigh         PersonMomentConfidence = "high"
@@ -12990,22 +13056,22 @@ func (e ListOrganizationDocumentsParamsCategory) Valid() bool {
 
 // Defines values for ListOrganizationDocumentsParamsDocState.
 const (
-	Current    ListOrganizationDocumentsParamsDocState = "current"
-	Draft      ListOrganizationDocumentsParamsDocState = "draft"
-	Final      ListOrganizationDocumentsParamsDocState = "final"
-	Superseded ListOrganizationDocumentsParamsDocState = "superseded"
+	ListOrganizationDocumentsParamsDocStateCurrent    ListOrganizationDocumentsParamsDocState = "current"
+	ListOrganizationDocumentsParamsDocStateDraft      ListOrganizationDocumentsParamsDocState = "draft"
+	ListOrganizationDocumentsParamsDocStateFinal      ListOrganizationDocumentsParamsDocState = "final"
+	ListOrganizationDocumentsParamsDocStateSuperseded ListOrganizationDocumentsParamsDocState = "superseded"
 )
 
 // Valid indicates whether the value is a known member of the ListOrganizationDocumentsParamsDocState enum.
 func (e ListOrganizationDocumentsParamsDocState) Valid() bool {
 	switch e {
-	case Current:
+	case ListOrganizationDocumentsParamsDocStateCurrent:
 		return true
-	case Draft:
+	case ListOrganizationDocumentsParamsDocStateDraft:
 		return true
-	case Final:
+	case ListOrganizationDocumentsParamsDocStateFinal:
 		return true
-	case Superseded:
+	case ListOrganizationDocumentsParamsDocStateSuperseded:
 		return true
 	default:
 		return false
@@ -23904,6 +23970,9 @@ type PersonGraph struct {
 	// strongest direct relationship if one exists, otherwise the strongest relationship any
 	// colleague has with someone else at the same company.
 	Route *PersonGraphRoute `json:"route,omitempty"`
+
+	// Routes Every way in worth offering, best first, so a reader can take the second one when the first is unavailable. `route` is `routes[0]` — the singular field is the same recommendation and stays for callers that only ever wanted the one.
+	Routes *[]PersonGraphRouteCandidate `json:"routes,omitempty"`
 }
 
 // PersonGraphGroupsOmitted defines model for PersonGraph.GroupsOmitted.
@@ -23980,6 +24049,59 @@ type PersonGraphRoute struct {
 	// Why The proof line, written from the counts — "6 two-way exchanges · replied 2 days ago".
 	Why string `json:"why"`
 }
+
+// PersonGraphRouteAvailability Whether a route can be asked for now. `already_requested` means an open ask exists, `declined` that this colleague has refused this contact before, and `unavailable` that the seat can no longer carry it.
+type PersonGraphRouteAvailability string
+
+// PersonGraphRouteCandidate One way in, with the facts behind it and whether it can be asked for today.
+//
+// The list is ordered the same way the single `route` is chosen: a direct relationship
+// beats an indirect one however warm the indirect one looks, and within a kind the
+// two-way relationships come first. Only a COLLEAGUE can carry an introduction, so a
+// candidate always starts at a live seat — a pair of external contacts who correspond
+// is an edge in this graph but never a route out of it.
+type PersonGraphRouteCandidate struct {
+	// Availability Whether a route can be asked for now. `already_requested` means an open ask exists, `declined` that this colleague has refused this contact before, and `unavailable` that the seat can no longer carry it.
+	Availability PersonGraphRouteAvailability `json:"availability"`
+
+	// Evidence The counts behind a route, as facts rather than a sentence. The prose is written by the client, because this server speaks one language and the product speaks three.
+	Evidence PersonGraphRouteEvidence `json:"evidence"`
+
+	// Receipts The messages behind a `direct` candidate, each individually visibility-checked. Absent on an indirect candidate for the reason the edge itself carries no rows: the counts are disclosable where the correspondence is not.
+	Receipts *[]PersonGraphReceipt `json:"receipts,omitempty"`
+
+	// RouteId Stable within this response, for selecting a route in a client. `direct:<user>` or `through:<user>:<person>`. A write names the parts it means rather than parsing this back apart.
+	RouteId string `json:"route_id"`
+
+	// RouteType `direct` is a colleague who corresponds with the contact themselves. `through_contact` goes via someone else at the contact's company.
+	RouteType          PersonGraphRouteType                     `json:"route_type"`
+	StrengthBucket     *PersonGraphRouteCandidateStrengthBucket `json:"strength_bucket,omitempty"`
+	ThroughDisplayName *string                                  `json:"through_display_name,omitempty"`
+
+	// ThroughPersonId Set when the route goes via someone else at the contact's company.
+	ThroughPersonId *openapi_types.UUID `json:"through_person_id,omitempty"`
+	ViaDisplayName  string              `json:"via_display_name"`
+	ViaUserId       openapi_types.UUID  `json:"via_user_id"`
+}
+
+// PersonGraphRouteCandidateStrengthBucket defines model for PersonGraphRouteCandidate.StrengthBucket.
+type PersonGraphRouteCandidateStrengthBucket string
+
+// PersonGraphRouteEvidence The counts behind a route, as facts rather than a sentence. The prose is written by the client, because this server speaks one language and the product speaks three.
+type PersonGraphRouteEvidence struct {
+	// DaysSinceLast Whole days from the last interaction to now, so a client renders "2 days ago" without re-deriving today from a timestamp.
+	DaysSinceLast   *int       `json:"days_since_last,omitempty"`
+	Inbound90d      *int       `json:"inbound_90d,omitempty"`
+	Interactions90d int        `json:"interactions_90d"`
+	LastAt          *time.Time `json:"last_at,omitempty"`
+	Outbound90d     *int       `json:"outbound_90d,omitempty"`
+
+	// TwoWay Correspondence has gone both ways in the window — the claim that separates a relationship from a mailing list.
+	TwoWay bool `json:"two_way"`
+}
+
+// PersonGraphRouteType `direct` is a colleague who corresponds with the contact themselves. `through_contact` goes via someone else at the contact's company.
+type PersonGraphRouteType string
 
 // PersonListResponse defines model for PersonListResponse.
 type PersonListResponse struct {

--- a/backend/internal/modules/introductions/doc.go
+++ b/backend/internal/modules/introductions/doc.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package introductions owns the ask: one rep requesting that a colleague open
+// a door to a contact, the colleague's bounded answer, and what actually
+// happened afterwards.
+//
+// Three surfaces speak about introductions and only this one writes. The
+// network graph says which routes EXIST and ranks them; the signals module
+// PROPOSES a warm path off a fresh signal and stages nothing. Neither records
+// that anybody was asked, which is why a rep could open a route somebody had
+// already tried and been refused.
+//
+// The statuses are deliberately not collapsible. `name_drop_approved` — a
+// colleague saying "use my name" — is not `accepted`, and `name_dropped` is
+// not `introduced`: permission to mention somebody is a different event from a
+// handshake, and a screen that reported one as the other would tell a rep a
+// door had been opened that nobody opened. `replied` is reached only from
+// captured activity, never from a checkbox, so the word means what it says.
+//
+// Tables owned: intro_request
+package introductions

--- a/backend/internal/modules/introductions/lifecycle.go
+++ b/backend/internal/modules/introductions/lifecycle.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package introductions
+
+// The states an ask moves through, and who may move it.
+//
+// Pure: no database, no clock, no principal. The store asks this file whether a
+// move is legal and who is entitled to make it, so the rules can be read in one
+// place and tested without a transaction.
+
+import "github.com/margince/margince/backend/internal/shared/apperrors"
+
+// Status is where an ask stands.
+type Status string
+
+const (
+	// StatusRequested is waiting on the colleague.
+	StatusRequested Status = "requested"
+	// StatusAccepted is the colleague agreeing to introduce — and not yet
+	// having done it. The distinction is the point: accepting is a promise,
+	// and reporting it as an introduction would close a loop still open.
+	StatusAccepted Status = "accepted"
+	// StatusNameDropApproved is "use my name", which is NOT an introduction
+	// and never becomes one. The colleague is lending credibility, not making
+	// a handshake, and only the rep can act on it.
+	StatusNameDropApproved Status = "name_drop_approved"
+	// StatusSuggestOther is the colleague naming somebody better placed.
+	// Terminal here: acting on it creates a new ask against that colleague,
+	// so the suggestion cannot silently become an ask nobody agreed to.
+	StatusSuggestOther Status = "suggest_other"
+	// StatusDeclined is a clear no, and the reason is kept: it is what stops
+	// the product recommending this route again next week.
+	StatusDeclined Status = "declined"
+	// StatusIntroduced is the handshake, marked by a human who made it.
+	StatusIntroduced Status = "introduced"
+	// StatusNameDropped is the rep having used the name they were lent.
+	StatusNameDropped Status = "name_dropped"
+	// StatusReplied is the contact answering. Reached ONLY from captured
+	// activity — a checkbox here would make the product's best outcome the one
+	// claim nobody had evidence for.
+	StatusReplied Status = "replied"
+	// StatusExpired is nobody having acted before the due date.
+	StatusExpired Status = "expired"
+	// StatusCancelled is the requester withdrawing.
+	StatusCancelled Status = "cancelled"
+)
+
+// Actor is who is attempting a move, in the only terms the rules care about.
+type Actor string
+
+const (
+	// ActorRequester is the rep who asked.
+	ActorRequester Actor = "requester"
+	// ActorIntroducer is the colleague being asked.
+	ActorIntroducer Actor = "introducer"
+	// ActorClock is the expiry sweep. Not a person, and it may only expire —
+	// a job that could decline on somebody's behalf would put words in a
+	// colleague's mouth.
+	ActorClock Actor = "clock"
+	// ActorCapture is the activity consumer, which may only record a reply it
+	// has evidence for.
+	ActorCapture Actor = "capture"
+)
+
+// transition is one legal move.
+type transition struct {
+	from Status
+	to   Status
+	by   Actor
+}
+
+// The whole state machine, as data. A table rather than nested switches,
+// because the question a reader asks is "can X do Y from Z" and a table
+// answers it by being read.
+var transitions = []transition{
+	// The colleague's four bounded answers. Nobody else may give them: an
+	// introduction the introducer did not agree to is a claim about their
+	// relationship, made in their name.
+	{StatusRequested, StatusAccepted, ActorIntroducer},
+	{StatusRequested, StatusNameDropApproved, ActorIntroducer},
+	{StatusRequested, StatusSuggestOther, ActorIntroducer},
+	{StatusRequested, StatusDeclined, ActorIntroducer},
+
+	// The handshake. Either party may record it, because either may be the one
+	// who sees it happen; both are named in the audit row.
+	{StatusAccepted, StatusIntroduced, ActorIntroducer},
+	{StatusAccepted, StatusIntroduced, ActorRequester},
+
+	// Using a lent name is the REQUESTER's act, so only they can report it.
+	{StatusNameDropApproved, StatusNameDropped, ActorRequester},
+
+	// The contact answering, from captured activity alone.
+	{StatusIntroduced, StatusReplied, ActorCapture},
+	{StatusNameDropped, StatusReplied, ActorCapture},
+
+	// Withdrawing, while it is still the requester's to withdraw.
+	{StatusRequested, StatusCancelled, ActorRequester},
+	{StatusAccepted, StatusCancelled, ActorRequester},
+	{StatusNameDropApproved, StatusCancelled, ActorRequester},
+
+	// Running out of time. Every state where somebody still owes an action,
+	// not just the first — an accepted ask nobody completed is exactly the
+	// case a queue silently loses.
+	{StatusRequested, StatusExpired, ActorClock},
+	{StatusAccepted, StatusExpired, ActorClock},
+	{StatusNameDropApproved, StatusExpired, ActorClock},
+}
+
+// May reports whether this actor can move an ask from one state to another,
+// and refuses with the sentinel the HTTP layer turns into 403.
+//
+// The two failures are told apart on purpose: a move nobody may make is a
+// conflict with the record's state, while a move the WRONG person attempts is a
+// permission failure.
+func May(from, to Status, by Actor) error {
+	legal := false
+	for _, t := range transitions {
+		if t.from != from || t.to != to {
+			continue
+		}
+		legal = true
+		if t.by == by {
+			return nil
+		}
+	}
+	if legal {
+		return apperrors.ErrPermissionDenied
+	}
+	return apperrors.ErrConflict
+}
+
+// Open reports whether an ask is still live — somebody owes an action on it.
+// The duplicate guard and the expiry sweep read the same answer, so a status
+// added to one and forgotten in the other cannot drift.
+func Open(s Status) bool {
+	switch s {
+	case StatusRequested, StatusAccepted, StatusNameDropApproved:
+		return true
+	default:
+		return false
+	}
+}
+
+// Decision is one of the colleague's four answers, as it arrives on the wire.
+func Decision(answer string) (Status, bool) {
+	switch Status(answer) {
+	case StatusAccepted:
+		return StatusAccepted, true
+	case StatusNameDropApproved:
+		return StatusNameDropApproved, true
+	case StatusSuggestOther:
+		return StatusSuggestOther, true
+	case StatusDeclined:
+		return StatusDeclined, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/modules/introductions/lifecycle_test.go
+++ b/backend/internal/modules/introductions/lifecycle_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package introductions
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+)
+
+// Permission to mention somebody is not a handshake. A product that let a
+// name-drop become `introduced` would tell a rep a door had been opened that
+// nobody opened — and the rep would stop chasing it.
+func TestANameDropNeverBecomesAnIntroduction(t *testing.T) {
+	for _, actor := range []Actor{ActorRequester, ActorIntroducer, ActorClock, ActorCapture} {
+		if err := May(StatusNameDropApproved, StatusIntroduced, actor); err == nil {
+			t.Errorf("%s was allowed to turn a lent name into an introduction", actor)
+		}
+	}
+}
+
+// The colleague's answer is the colleague's to give. A rep who could accept on
+// their behalf would be asserting a relationship in somebody else's name.
+func TestOnlyTheColleagueAnswersTheAsk(t *testing.T) {
+	answers := []Status{
+		StatusAccepted, StatusNameDropApproved, StatusSuggestOther, StatusDeclined,
+	}
+	for _, answer := range answers {
+		if err := May(StatusRequested, answer, ActorIntroducer); err != nil {
+			t.Errorf("the colleague could not answer %q: %v", answer, err)
+		}
+		err := May(StatusRequested, answer, ActorRequester)
+		if !errors.Is(err, apperrors.ErrPermissionDenied) {
+			t.Errorf("the requester answering %q gave %v; want a permission refusal", answer, err)
+		}
+	}
+}
+
+// A reply is the product's best outcome and the one claim a person must never
+// be able to type. It comes from captured activity or not at all.
+func TestOnlyCapturedActivityRecordsAReply(t *testing.T) {
+	for _, from := range []Status{StatusIntroduced, StatusNameDropped} {
+		if err := May(from, StatusReplied, ActorCapture); err != nil {
+			t.Errorf("capture could not record a reply from %q: %v", from, err)
+		}
+		for _, human := range []Actor{ActorRequester, ActorIntroducer} {
+			if err := May(from, StatusReplied, human); !errors.Is(err, apperrors.ErrPermissionDenied) {
+				t.Errorf("%s could assert a reply from %q (%v)", human, from, err)
+			}
+		}
+	}
+}
+
+// Using a lent name is something the REP does. The colleague who lent it has no
+// way to know whether it was used.
+func TestOnlyTheRequesterReportsUsingALentName(t *testing.T) {
+	if err := May(StatusNameDropApproved, StatusNameDropped, ActorRequester); err != nil {
+		t.Errorf("the requester could not report using the name: %v", err)
+	}
+	err := May(StatusNameDropApproved, StatusNameDropped, ActorIntroducer)
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("the colleague reported a name-drop they cannot observe (%v)", err)
+	}
+}
+
+// An accepted ask that nobody completes is exactly the request a queue loses
+// quietly. Expiry has to reach every state where somebody still owes an action.
+func TestExpiryReachesEveryStateThatStillOwesAnAction(t *testing.T) {
+	for _, from := range []Status{StatusRequested, StatusAccepted, StatusNameDropApproved} {
+		if !Open(from) {
+			t.Errorf("%q owes an action and does not read as open", from)
+		}
+		if err := May(from, StatusExpired, ActorClock); err != nil {
+			t.Errorf("the sweep could not expire %q: %v", from, err)
+		}
+	}
+	// And nothing settled expires: re-closing a closed ask would rewrite its
+	// outcome, and the audit would carry two endings.
+	for _, from := range []Status{StatusDeclined, StatusIntroduced, StatusReplied, StatusCancelled} {
+		if Open(from) {
+			t.Errorf("%q is settled and reads as still open", from)
+		}
+		if err := May(from, StatusExpired, ActorClock); err == nil {
+			t.Errorf("the sweep expired %q, which was already settled", from)
+		}
+	}
+}
+
+// The clock is not a person. A sweep that could decline on a colleague's behalf
+// would put a refusal in their mouth that they never gave.
+func TestTheSweepCanOnlyExpire(t *testing.T) {
+	answers := []Status{
+		StatusAccepted, StatusNameDropApproved, StatusSuggestOther,
+		StatusDeclined, StatusIntroduced, StatusReplied,
+	}
+	for _, to := range answers {
+		if err := May(StatusRequested, to, ActorClock); err == nil {
+			t.Errorf("the sweep moved an ask to %q", to)
+		}
+	}
+}
+
+// Withdrawing is the requester's while the ask is still live, and nobody's once
+// it is settled.
+func TestOnlyTheRequesterWithdrawsAndOnlyWhileItIsLive(t *testing.T) {
+	for _, from := range []Status{StatusRequested, StatusAccepted, StatusNameDropApproved} {
+		if err := May(from, StatusCancelled, ActorRequester); err != nil {
+			t.Errorf("the requester could not withdraw from %q: %v", from, err)
+		}
+		if err := May(from, StatusCancelled, ActorIntroducer); !errors.Is(err, apperrors.ErrPermissionDenied) {
+			t.Errorf("the colleague cancelled the rep's ask from %q (%v)", from, err)
+		}
+	}
+	if err := May(StatusDeclined, StatusCancelled, ActorRequester); err == nil {
+		t.Error("a declined ask was withdrawn, rewriting the colleague's answer")
+	}
+}
+
+// A suggestion is a pointer, not an ask. Turning it into one here would create
+// a request against a colleague who never agreed to carry it.
+func TestASuggestionIsTerminal(t *testing.T) {
+	onward := []Status{StatusAccepted, StatusIntroduced, StatusNameDropped, StatusReplied}
+	for _, to := range onward {
+		for _, actor := range []Actor{ActorRequester, ActorIntroducer, ActorCapture} {
+			if err := May(StatusSuggestOther, to, actor); err == nil {
+				t.Errorf("%s moved a suggestion to %q instead of opening a new ask", actor, to)
+			}
+		}
+	}
+}
+
+// A move nobody may make and a move the wrong person attempts are different
+// facts, and the caller renders them as 409 and 403. Collapsing them would tell
+// a rep the record was in the wrong state when the truth is it is not theirs.
+func TestAnImpossibleMoveIsNotAForbiddenOne(t *testing.T) {
+	if err := May(StatusRequested, StatusAccepted, ActorRequester); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("the wrong actor on a legal move gave %v; want permission denied", err)
+	}
+	if err := May(StatusDeclined, StatusAccepted, ActorIntroducer); !errors.Is(err, apperrors.ErrConflict) {
+		t.Errorf("an illegal move gave %v; want a conflict", err)
+	}
+}
+
+// The wire says which answer; an unknown one is refused rather than defaulted.
+// Defaulting would let a typo become a decision.
+func TestOnlyTheFourAnswersAreDecisions(t *testing.T) {
+	for _, ok := range []string{"accepted", "name_drop_approved", "suggest_other", "declined"} {
+		if _, valid := Decision(ok); !valid {
+			t.Errorf("%q is one of the four answers and was refused", ok)
+		}
+	}
+	for _, bad := range []string{"introduced", "replied", "expired", "cancelled", "", "ACCEPTED"} {
+		if _, valid := Decision(bad); valid {
+			t.Errorf("%q was accepted as a decision", bad)
+		}
+	}
+}

--- a/backend/migrations/core/1788220000_an_introduction_is_asked_and_answered.down.sql
+++ b/backend/migrations/core/1788220000_an_introduction_is_asked_and_answered.down.sql
@@ -1,0 +1,2 @@
+SET LOCAL lock_timeout = '3s';
+DROP TABLE IF EXISTS intro_request;

--- a/backend/migrations/core/1788220000_an_introduction_is_asked_and_answered.up.sql
+++ b/backend/migrations/core/1788220000_an_introduction_is_asked_and_answered.up.sql
@@ -1,0 +1,101 @@
+-- The person graph names who can open a door; nothing recorded the asking.
+-- A rep left the CRM to write the request, and whether the colleague agreed,
+-- introduced, or declined lived in somebody's inbox — so the next reader saw a
+-- warm route and no sign it had already been asked and refused.
+--
+-- One row per ask, carrying the request, the colleague's answer, and what
+-- actually happened. The statuses are kept apart on purpose: permission to
+-- mention a name is NOT an introduction, and a screen that reported
+-- `introduced` because a colleague allowed a name-drop would claim a handshake
+-- nobody made.
+SET LOCAL lock_timeout = '3s';
+CREATE TABLE intro_request (
+  id uuid PRIMARY KEY DEFAULT uuidv7(),
+  person_id uuid NOT NULL REFERENCES person(id) ON DELETE CASCADE,
+  requester_user_id uuid NOT NULL REFERENCES app_user(id),
+  introducer_user_id uuid NOT NULL REFERENCES app_user(id),
+  route_type text NOT NULL,
+  through_person_id uuid REFERENCES person(id),
+
+  -- Three pieces of copy, because they have three audiences. The reason is the
+  -- requester talking to their colleague; the value is what the CONTACT gets;
+  -- the forwardable note is prose the colleague can paste to the contact. One
+  -- field for all three would send the internal ask to the prospect.
+  internal_reason text NOT NULL,
+  value_for_target text NOT NULL DEFAULT '',
+  forwardable_note text NOT NULL DEFAULT '',
+
+  -- Who wrote the note, kept beside the note itself. Marking it machine-authored
+  -- only while the drawer is open loses the fact everywhere it matters after:
+  -- the colleague's screen, and the request's own history.
+  note_generated_by text NOT NULL DEFAULT 'human',
+  note_ai_generated boolean NOT NULL DEFAULT false,
+
+  -- The requester's answer to "what if this colleague cannot". Stored, not held
+  -- in a browser: the colleague reads it when deciding, and an audit has to be
+  -- able to say what fallback was chosen.
+  fallback_policy text NOT NULL DEFAULT 'none',
+  name_drop_allowed boolean NOT NULL DEFAULT false,
+
+  status text NOT NULL DEFAULT 'requested',
+  decision_reason text,
+  suggested_user_id uuid REFERENCES app_user(id),
+
+  due_at timestamptz NOT NULL,
+  requested_at timestamptz NOT NULL DEFAULT now(),
+  decided_at timestamptz,
+  introduced_at timestamptz,
+  name_dropped_at timestamptz,
+  replied_at timestamptz,
+  closed_at timestamptz,
+  -- The activity that closed it, when one did. A reply advanced by the consumer
+  -- names its evidence; a human marking it introduced may name one too.
+  source_activity_id uuid REFERENCES activity(id) ON DELETE SET NULL,
+
+  version integer NOT NULL DEFAULT 1,
+  captured_by text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  archived_at timestamptz,
+
+  CONSTRAINT intro_request_route_type CHECK (route_type IN ('direct', 'through_contact')),
+  -- A route through somebody names them, and a direct one does not. Either half
+  -- alone describes a route nobody can act on.
+  CONSTRAINT intro_request_route_shape CHECK
+    ((route_type = 'through_contact') = (through_person_id IS NOT NULL)),
+  CONSTRAINT intro_request_status CHECK (status IN (
+    'requested', 'accepted', 'name_drop_approved', 'suggest_other', 'declined',
+    'introduced', 'name_dropped', 'replied', 'expired', 'cancelled')),
+  -- Suggesting somebody else without naming them is not an answer.
+  CONSTRAINT intro_request_suggestion_named CHECK
+    (status <> 'suggest_other' OR suggested_user_id IS NOT NULL),
+  CONSTRAINT intro_request_fallback CHECK
+    (fallback_policy IN ('name_drop', 'next_route', 'none')),
+  CONSTRAINT intro_request_note_origin CHECK
+    (note_generated_by IN ('human', 'model', 'deterministic')),
+  CONSTRAINT intro_request_reason_present CHECK (internal_reason <> ''),
+  -- A colleague cannot introduce somebody to themselves, and asking them to is
+  -- a routing bug rather than a favour.
+  CONSTRAINT intro_request_distinct_seats CHECK (requester_user_id <> introducer_user_id)
+);
+
+-- One open ask per route per contact. The duplicate guard is the index rather
+-- than a read-then-write check: two tabs pressing send at once both pass the
+-- check and only one may pass this.
+CREATE UNIQUE INDEX intro_request_open_route ON intro_request (
+  person_id,
+  introducer_user_id,
+  COALESCE(through_person_id, '00000000-0000-0000-0000-000000000000'::uuid)
+) WHERE status IN ('requested', 'accepted', 'name_drop_approved') AND archived_at IS NULL;
+
+-- The colleague's own queue: what is waiting on them, soonest due first.
+CREATE INDEX intro_request_awaiting_decision ON intro_request (introducer_user_id, due_at)
+  WHERE status = 'requested' AND archived_at IS NULL;
+
+-- The sweep's read: what has run out of time. Every status that can expire, so
+-- an accepted ask cannot sit accepted for ever.
+CREATE INDEX intro_request_due ON intro_request (due_at)
+  WHERE status IN ('requested', 'accepted', 'name_drop_approved') AND archived_at IS NULL;
+
+-- The tab's read: every ask about this contact, newest first.
+CREATE INDEX intro_request_for_person ON intro_request (person_id, requested_at DESC);

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16152,6 +16152,8 @@ export interface components {
             /** @description Who has actually corresponded with whom. An edge exists only where interactions do. */
             edges: components["schemas"]["PersonGraphEdge"][];
             route?: components["schemas"]["PersonGraphRoute"];
+            /** @description Every way in worth offering, best first, so a reader can take the second one when the first is unavailable. `route` is `routes[0]` — the singular field is the same recommendation and stays for callers that only ever wanted the one. */
+            routes?: components["schemas"]["PersonGraphRouteCandidate"][];
             /** @description Groups withheld for lack of a grant — so a client can say "you can't see this" instead of "there is none". */
             groups_omitted: ("direct" | "account")[];
             /** @description How many nodes each group lost to its cap, stated rather than silently truncated. `account` is the true remainder. `direct` counts from a bounded fetch (100), so on a contact more than a hundred colleagues have corresponded with it understates — a shape far outside what this card is for, and making it exact would cost every ordinary read. */
@@ -16229,6 +16231,57 @@ export interface components {
             through_display_name?: string;
             /** @description The proof line, written from the counts — "6 two-way exchanges · replied 2 days ago". */
             why: string;
+        };
+        /**
+         * @description One way in, with the facts behind it and whether it can be asked for today.
+         *
+         *     The list is ordered the same way the single `route` is chosen: a direct relationship
+         *     beats an indirect one however warm the indirect one looks, and within a kind the
+         *     two-way relationships come first. Only a COLLEAGUE can carry an introduction, so a
+         *     candidate always starts at a live seat — a pair of external contacts who correspond
+         *     is an edge in this graph but never a route out of it.
+         */
+        PersonGraphRouteCandidate: {
+            /** @description Stable within this response, for selecting a route in a client. `direct:<user>` or `through:<user>:<person>`. A write names the parts it means rather than parsing this back apart. */
+            route_id: string;
+            route_type: components["schemas"]["PersonGraphRouteType"];
+            /** Format: uuid */
+            via_user_id: string;
+            via_display_name: string;
+            /**
+             * Format: uuid
+             * @description Set when the route goes via someone else at the contact's company.
+             */
+            through_person_id?: string;
+            through_display_name?: string;
+            /** @enum {string} */
+            strength_bucket?: "none" | "weak" | "moderate" | "strong";
+            evidence: components["schemas"]["PersonGraphRouteEvidence"];
+            /** @description The messages behind a `direct` candidate, each individually visibility-checked. Absent on an indirect candidate for the reason the edge itself carries no rows: the counts are disclosable where the correspondence is not. */
+            receipts?: components["schemas"]["PersonGraphReceipt"][];
+            availability: components["schemas"]["PersonGraphRouteAvailability"];
+        };
+        /**
+         * @description `direct` is a colleague who corresponds with the contact themselves. `through_contact` goes via someone else at the contact's company.
+         * @enum {string}
+         */
+        PersonGraphRouteType: "direct" | "through_contact";
+        /**
+         * @description Whether a route can be asked for now. `already_requested` means an open ask exists, `declined` that this colleague has refused this contact before, and `unavailable` that the seat can no longer carry it.
+         * @enum {string}
+         */
+        PersonGraphRouteAvailability: "available" | "already_requested" | "declined" | "unavailable";
+        /** @description The counts behind a route, as facts rather than a sentence. The prose is written by the client, because this server speaks one language and the product speaks three. */
+        PersonGraphRouteEvidence: {
+            interactions_90d: number;
+            inbound_90d?: number;
+            outbound_90d?: number;
+            /** @description Correspondence has gone both ways in the window — the claim that separates a relationship from a mailing list. */
+            two_way: boolean;
+            /** Format: date-time */
+            last_at?: string | null;
+            /** @description Whole days from the last interaction to now, so a client renders "2 days ago" without re-deriving today from a timestamp. */
+            days_since_last?: number | null;
         };
         /**
          * @description One reason this contact is worth attention now, with the evidence behind it.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6423,9 +6423,13 @@ export const de = {
     "Bester zuerst. Nimm den, der sich wirklich nutzen lässt — der zweite steht hier, weil der erste nicht immer verfügbar ist.",
   "person.intro.best": "Bester Weg",
   "person.intro.alternative": "Alternative",
-  "person.intro.evidenceTwoWay":
+  "person.intro.evidenceTwoWay_one":
+    "{total} Austausch in beide Richtungen in 90 Tagen · {when}",
+  "person.intro.evidenceTwoWay_other":
     "{total} Austausche in beide Richtungen in 90 Tagen · {when}",
-  "person.intro.evidenceOneSided":
+  "person.intro.evidenceOneSided_one":
+    "{total} Kontakt in 90 Tagen, einseitig · {when}",
+  "person.intro.evidenceOneSided_other":
     "{total} Kontakte in 90 Tagen, einseitig · {when}",
   "person.intro.whenToday": "letzter Kontakt heute",
   "person.intro.whenYesterday": "letzter Kontakt gestern",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6396,7 +6396,6 @@ export const de = {
   "person.enriched.save": "Korrektur speichern",
   "person.enriched.cancel": "Abbrechen",
   "person.graph.loading": "Das Netzwerk um diesen Kontakt wird gelesen \u2026",
-  "person.graph.routeTitle": "Der w\u00e4rmste Weg hinein",
   "person.graph.routeDirect": "{name} steht bereits im Austausch mit ihnen.",
   "person.graph.routeVia":
     "{name} steht im Austausch mit {through} im selben Unternehmen.",
@@ -6419,6 +6418,22 @@ export const de = {
     "Nur Z\u00e4hlwerte \u2014 die Nachrichten selbst bleiben in der Chronik.",
   "person.graph.untitledMessage": "Nachricht ohne Betreff",
   "person.graph.dropped": "{count} weitere werden nicht angezeigt.",
+  "person.intro.routesTitle": "Wege hinein",
+  "person.intro.routesSub":
+    "Bester zuerst. Nimm den, der sich wirklich nutzen lässt — der zweite steht hier, weil der erste nicht immer verfügbar ist.",
+  "person.intro.best": "Bester Weg",
+  "person.intro.alternative": "Alternative",
+  "person.intro.evidenceTwoWay":
+    "{total} Austausche in beide Richtungen in 90 Tagen · {when}",
+  "person.intro.evidenceOneSided":
+    "{total} Kontakte in 90 Tagen, einseitig · {when}",
+  "person.intro.whenToday": "letzter Kontakt heute",
+  "person.intro.whenYesterday": "letzter Kontakt gestern",
+  "person.intro.whenDays": "letzter Kontakt vor {days} Tagen",
+  "person.intro.whenNever": "kein Kontakt in letzter Zeit",
+  "person.intro.alreadyRequested": "Bereits angefragt",
+  "person.intro.declined": "Früher abgelehnt",
+  "person.intro.unavailable": "Nicht verfügbar",
   "person.network.ringTitle": "Wer diese Person erreicht",
   "person.network.ringSub":
     "Unsere Seite und dieser Account, nach der Wärme der Beziehung. Wählen Sie jemanden aus, um zu sehen, worauf sie beruht.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6441,7 +6441,6 @@ export const en = {
   "person.enriched.save": "Save the correction",
   "person.enriched.cancel": "Cancel",
   "person.graph.loading": "Reading the network around this contact…",
-  "person.graph.routeTitle": "The warmest way in",
   "person.graph.routeDirect": "{name} already corresponds with them.",
   "person.graph.routeVia":
     "{name} corresponds with {through} at the same company.",
@@ -6463,6 +6462,22 @@ export const en = {
     "Counts only — the messages themselves stay on the timeline.",
   "person.graph.untitledMessage": "Message with no subject",
   "person.graph.dropped": "{count} more not shown.",
+  "person.intro.routesTitle": "Ways in",
+  "person.intro.routesSub":
+    "Best first. Pick the one you can actually use — the second is here because the first is not always available.",
+  "person.intro.best": "Best",
+  "person.intro.alternative": "Alternative",
+  "person.intro.evidenceTwoWay":
+    "{total} two-way exchanges in 90 days · {when}",
+  "person.intro.evidenceOneSided":
+    "{total} interactions in 90 days, one-sided · {when}",
+  "person.intro.whenToday": "last contact today",
+  "person.intro.whenYesterday": "last contact yesterday",
+  "person.intro.whenDays": "last contact {days} days ago",
+  "person.intro.whenNever": "no recent contact",
+  "person.intro.alreadyRequested": "Already asked",
+  "person.intro.declined": "Declined before",
+  "person.intro.unavailable": "Not available",
   "person.network.ringTitle": "Who reaches them",
   "person.network.ringSub":
     "Our side and this account, by how warm the relationship is. Pick anyone to see what it is made of.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6467,9 +6467,13 @@ export const en = {
     "Best first. Pick the one you can actually use — the second is here because the first is not always available.",
   "person.intro.best": "Best",
   "person.intro.alternative": "Alternative",
-  "person.intro.evidenceTwoWay":
+  "person.intro.evidenceTwoWay_one":
+    "{total} two-way exchange in 90 days · {when}",
+  "person.intro.evidenceTwoWay_other":
     "{total} two-way exchanges in 90 days · {when}",
-  "person.intro.evidenceOneSided":
+  "person.intro.evidenceOneSided_one":
+    "{total} interaction in 90 days, one-sided · {when}",
+  "person.intro.evidenceOneSided_other":
     "{total} interactions in 90 days, one-sided · {when}",
   "person.intro.whenToday": "last contact today",
   "person.intro.whenYesterday": "last contact yesterday",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6336,7 +6336,6 @@ export const vi = {
   "person.enriched.save": "Lưu bản sửa",
   "person.enriched.cancel": "Huỷ",
   "person.graph.loading": "Đang đọc mạng lưới quanh contact này…",
-  "person.graph.routeTitle": "Đường tiếp cận thân thiết nhất",
   "person.graph.routeDirect": "{name} đã có trao đổi với họ.",
   "person.graph.routeVia": "{name} có trao đổi với {through} ở cùng công ty.",
   "person.graph.noRoute":
@@ -6358,6 +6357,22 @@ export const vi = {
     "Chỉ là số đếm — nội dung tin nhắn vẫn nằm trên timeline.",
   "person.graph.untitledMessage": "Tin nhắn không có tiêu đề",
   "person.graph.dropped": "Còn {count} mục không hiển thị.",
+  "person.intro.routesTitle": "Các lối vào",
+  "person.intro.routesSub":
+    "Tốt nhất trước. Chọn lối bạn thực sự dùng được — lối thứ hai có ở đây vì lối đầu không phải lúc nào cũng sẵn sàng.",
+  "person.intro.best": "Tốt nhất",
+  "person.intro.alternative": "Lựa chọn khác",
+  "person.intro.evidenceTwoWay":
+    "{total} lượt trao đổi hai chiều trong 90 ngày · {when}",
+  "person.intro.evidenceOneSided":
+    "{total} lượt tương tác trong 90 ngày, một chiều · {when}",
+  "person.intro.whenToday": "liên hệ gần nhất hôm nay",
+  "person.intro.whenYesterday": "liên hệ gần nhất hôm qua",
+  "person.intro.whenDays": "liên hệ gần nhất {days} ngày trước",
+  "person.intro.whenNever": "không có liên hệ gần đây",
+  "person.intro.alreadyRequested": "Đã hỏi rồi",
+  "person.intro.declined": "Đã từ chối trước đó",
+  "person.intro.unavailable": "Không khả dụng",
   "person.network.ringTitle": "Ai tiếp cận được người này",
   "person.network.ringSub":
     "Phía chúng ta và khách hàng này, theo độ ấm của quan hệ. Chọn một người để xem quan hệ đó dựa trên điều gì.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6362,9 +6362,13 @@ export const vi = {
     "Tốt nhất trước. Chọn lối bạn thực sự dùng được — lối thứ hai có ở đây vì lối đầu không phải lúc nào cũng sẵn sàng.",
   "person.intro.best": "Tốt nhất",
   "person.intro.alternative": "Lựa chọn khác",
-  "person.intro.evidenceTwoWay":
+  "person.intro.evidenceTwoWay_one":
     "{total} lượt trao đổi hai chiều trong 90 ngày · {when}",
-  "person.intro.evidenceOneSided":
+  "person.intro.evidenceTwoWay_other":
+    "{total} lượt trao đổi hai chiều trong 90 ngày · {when}",
+  "person.intro.evidenceOneSided_one":
+    "{total} lượt tương tác trong 90 ngày, một chiều · {when}",
+  "person.intro.evidenceOneSided_other":
     "{total} lượt tương tác trong 90 ngày, một chiều · {when}",
   "person.intro.whenToday": "liên hệ gần nhất hôm nay",
   "person.intro.whenYesterday": "liên hệ gần nhất hôm qua",

--- a/frontend/src/screens/personnetwork-panel.stories.tsx
+++ b/frontend/src/screens/personnetwork-panel.stories.tsx
@@ -81,6 +81,41 @@ const graph = {
     via_display_name: "Lars Brandt",
     why: "6 two-way exchanges in 90 days · last contact yesterday",
   },
+  // The server sends both, and `route` is `routes[0]`. The fixture keeps that
+  // true: a story where the card recommends one colleague while the list leads
+  // with another models a payload the server cannot produce.
+  routes: [
+    {
+      route_id: "direct:u-1",
+      route_type: "direct",
+      via_user_id: "u-1",
+      via_display_name: "Lars Brandt",
+      strength_bucket: "strong",
+      evidence: {
+        interactions_90d: 6,
+        inbound_90d: 3,
+        outbound_90d: 3,
+        two_way: true,
+        days_since_last: 1,
+      },
+      availability: "available",
+    },
+    {
+      route_id: "direct:u-2",
+      route_type: "direct",
+      via_user_id: "u-2",
+      via_display_name: "Mara Vogel",
+      strength_bucket: "weak",
+      evidence: {
+        interactions_90d: 1,
+        inbound_90d: 0,
+        outbound_90d: 1,
+        two_way: false,
+        days_since_last: 12,
+      },
+      availability: "available",
+    },
+  ],
 };
 
 // The 360 the moments card reads. Only the fields it touches are set; the

--- a/frontend/src/screens/personnetwork-panel.test.tsx
+++ b/frontend/src/screens/personnetwork-panel.test.tsx
@@ -142,6 +142,105 @@ describe("PersonNetworkTab", () => {
     ).toBeTruthy();
   });
 
+  // "1 interactions" undermines the claim the line is making. The count decides
+  // the wording through the plural translator, because which numbers are
+  // singular is a fact about the reader's language and not about the number.
+  it("counts one interaction in the singular", async () => {
+    stub({
+      person_id: "p-1",
+      nodes: [
+        { id: "person:p-1", type: "contact", group: "anchor", label: "Anna" },
+        {
+          id: "user:u-1",
+          type: "colleague",
+          group: "direct",
+          label: "Quiet Quinn",
+        },
+      ],
+      edges: [
+        {
+          from: "user:u-1",
+          to: "person:p-1",
+          strength_bucket: "weak",
+          interactions_90d: 1,
+          inbound_90d: 0,
+          outbound_90d: 1,
+        },
+      ],
+      groups_omitted: [],
+      routes: [
+        {
+          route_id: "direct:u-1",
+          route_type: "direct",
+          via_user_id: "u-1",
+          via_display_name: "Quiet Quinn",
+          strength_bucket: "weak",
+          evidence: {
+            interactions_90d: 1,
+            inbound_90d: 0,
+            outbound_90d: 1,
+            two_way: false,
+            days_since_last: 3,
+          },
+          availability: "available",
+        },
+      ],
+    });
+    renderPanel();
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "1 interaction in 90 days, one-sided · last contact 3 days ago",
+        ),
+      ).toBeTruthy(),
+    );
+  });
+
+  // `routes` is optional in the contract and `route` is not. A server that
+  // predates the list still carries the recommendation, and reading only the
+  // list would tell the reader nobody can reach this contact.
+  it("still shows the recommendation when only the singular route arrives", async () => {
+    stub({
+      person_id: "p-1",
+      nodes: [
+        { id: "person:p-1", type: "contact", group: "anchor", label: "Anna" },
+        {
+          id: "user:u-1",
+          type: "colleague",
+          group: "direct",
+          label: "Direct Dana",
+        },
+      ],
+      edges: [
+        {
+          from: "user:u-1",
+          to: "person:p-1",
+          strength_bucket: "strong",
+          interactions_90d: 6,
+          inbound_90d: 3,
+          outbound_90d: 3,
+        },
+      ],
+      groups_omitted: [],
+      route: {
+        via_user_id: "u-1",
+        via_display_name: "Direct Dana",
+        why: "6 two-way exchanges in 90 days · last contact yesterday",
+      },
+    });
+    renderPanel();
+    await waitFor(() =>
+      expect(
+        screen.getByText("Direct Dana already corresponds with them."),
+      ).toBeTruthy(),
+    );
+    expect(
+      screen.queryByText(
+        "Nobody here corresponds with them or with anyone at their company yet.",
+      ),
+    ).toBeNull();
+  });
+
   // A group withheld for lack of a grant says so. Rendering it as empty would
   // tell the reader nobody knows this contact when the truth is that they
   // cannot see who does.

--- a/frontend/src/screens/personnetwork-panel.test.tsx
+++ b/frontend/src/screens/personnetwork-panel.test.tsx
@@ -108,6 +108,23 @@ describe("PersonNetworkTab", () => {
         via_display_name: "Direct Dana",
         why: "6 two-way exchanges in 90 days · last contact yesterday",
       },
+      routes: [
+        {
+          route_id: "direct:u-1",
+          route_type: "direct",
+          via_user_id: "u-1",
+          via_display_name: "Direct Dana",
+          strength_bucket: "strong",
+          evidence: {
+            interactions_90d: 6,
+            inbound_90d: 3,
+            outbound_90d: 3,
+            two_way: true,
+            days_since_last: 1,
+          },
+          availability: "available",
+        },
+      ],
     });
     renderPanel();
     await waitFor(() =>
@@ -115,6 +132,9 @@ describe("PersonNetworkTab", () => {
         screen.getByText("Direct Dana already corresponds with them."),
       ).toBeTruthy(),
     );
+    // The sentence the server used to write in English, now assembled from the
+    // counts in the reader's own language. Asserting the words rather than the
+    // field is what proves the translation still says the same thing.
     expect(
       screen.getByText(
         "6 two-way exchanges in 90 days · last contact yesterday",

--- a/frontend/src/screens/personnetwork.css
+++ b/frontend/src/screens/personnetwork.css
@@ -107,6 +107,21 @@
   line-height: 1.5;
 }
 
+/* The ways in, best first. An ordered list because the order is the meaning:
+   the first row is the recommendation, and a reader who has to work out which
+   one that is has lost what the ranking was for. */
+.pn-routes {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pn-route-row + .pn-route-row {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--borderSubtle);
+}
+
 /* The region the ring's selection writes into. */
 .pn-live {
   margin-top: var(--space-3);

--- a/frontend/src/screens/personnetwork.tsx
+++ b/frontend/src/screens/personnetwork.tsx
@@ -23,6 +23,7 @@ import { formatDate, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { problemMessageOf } from "./common";
 import { usePersonGraph } from "./persongraph";
+import { RoutesCard } from "./personroutes";
 import { changeSentence } from "./relationshipchange";
 import "./personnetwork.css";
 
@@ -165,7 +166,7 @@ export function PersonNetworkTab({
 
   return (
     <div className="pn-stack">
-      <RouteCard graph={data} />
+      <RoutesCard graph={data} />
 
       <Card
         title={t("person.network.ringTitle")}
@@ -222,37 +223,6 @@ export function PersonNetworkTab({
 
 function isOmitted(graph: Graph, group: string): boolean {
   return (graph.groups_omitted ?? []).some((g) => g === group);
-}
-
-/**
- * RouteCard is the answer: the warmest way in and the evidence for it. It
- * leads because a reader who reads nothing else should still leave knowing
- * who to ask.
- */
-function RouteCard({ graph }: Readonly<{ graph: Graph }>) {
-  const t = useT();
-  const route = graph.route;
-  return (
-    <Card title={t("person.graph.routeTitle")}>
-      {route ? (
-        <>
-          <p className="pn-route">
-            {route.through_display_name
-              ? t("person.graph.routeVia", {
-                  name: route.via_display_name,
-                  through: route.through_display_name,
-                })
-              : t("person.graph.routeDirect", {
-                  name: route.via_display_name,
-                })}
-          </p>
-          <p className="pn-counts">{route.why}</p>
-        </>
-      ) : (
-        <p className="pn-route">{t("person.graph.noRoute")}</p>
-      )}
-    </Card>
-  );
 }
 
 /**

--- a/frontend/src/screens/personroutes.tsx
+++ b/frontend/src/screens/personroutes.tsx
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Every way in to this contact, best first.
+//
+// The server ranks; this file renders. It states each route's evidence in the
+// reader's own language rather than printing the server's `why`, which is
+// English whatever locale the app is in — the counts cross the wire as facts
+// for exactly that reason.
+
+import type { components } from "../api/schema";
+import { Badge, Card } from "../design-system/atoms";
+import { formatNumber } from "../format/format";
+import { type Locale, useLocale, useT } from "../i18n";
+import "./personnetwork.css";
+
+type Graph = components["schemas"]["PersonGraph"];
+type RouteCandidate = components["schemas"]["PersonGraphRouteCandidate"];
+type RouteEvidence = components["schemas"]["PersonGraphRouteEvidence"];
+type Translate = ReturnType<typeof useT>;
+
+/**
+ * RoutesCard lists the ways in, the recommendation first.
+ *
+ * One list, not a lead card plus a list: the server's recommendation IS the
+ * head of this list, so drawing it twice would invite the two to disagree on
+ * screen the moment one of them was rendered from stale data.
+ */
+export function RoutesCard({ graph }: Readonly<{ graph: Graph }>) {
+  const t = useT();
+  const routes = graph.routes ?? [];
+  return (
+    <Card
+      title={t("person.intro.routesTitle")}
+      sub={t("person.intro.routesSub")}
+    >
+      {routes.length === 0 ? (
+        <p className="pn-route">{t("person.graph.noRoute")}</p>
+      ) : (
+        <ol className="pn-routes">
+          {routes.map((route, index) => (
+            <li className="pn-route-row" key={route.route_id}>
+              <RouteRow route={route} lead={index === 0} />
+            </li>
+          ))}
+        </ol>
+      )}
+    </Card>
+  );
+}
+
+function RouteRow({
+  route,
+  lead,
+}: Readonly<{ route: RouteCandidate; lead: boolean }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const blocked = availabilityLabel(route.availability, t);
+  return (
+    <>
+      <p className="pn-route">
+        {/* The same two sentences the single-route card used, because they are
+            the same claim: naming the colleague and how they reach the contact.
+            A second wording for one fact is how two surfaces start disagreeing
+            about what a route is. */}
+        {route.through_display_name
+          ? t("person.graph.routeVia", {
+              name: route.via_display_name,
+              through: route.through_display_name,
+            })
+          : t("person.graph.routeDirect", {
+              name: route.via_display_name,
+            })}{" "}
+        <Badge tone={lead ? "accent" : undefined} quiet={!lead}>
+          {lead ? t("person.intro.best") : t("person.intro.alternative")}
+        </Badge>
+        {/* A route that cannot be used says so beside itself. Rendering it
+            identically to an open one would send a rep to ask a colleague who
+            has already declined. */}
+        {blocked ? <Badge quiet>{blocked}</Badge> : null}
+      </p>
+      <p className="pn-counts">{evidenceSentence(route.evidence, t, locale)}</p>
+    </>
+  );
+}
+
+/**
+ * evidenceSentence writes the proof line the reader acts on.
+ *
+ * Two-way and one-sided are different claims, and the difference is the whole
+ * point: thirty unanswered sends are not a relationship, and a line that
+ * printed one number for both would say they were.
+ */
+export function evidenceSentence(
+  ev: RouteEvidence,
+  t: Translate,
+  locale: Locale,
+): string {
+  const when = lastContactPhrase(ev, t, locale);
+  const key = ev.two_way
+    ? "person.intro.evidenceTwoWay"
+    : "person.intro.evidenceOneSided";
+  return t(key, { total: formatNumber(ev.interactions_90d, locale), when });
+}
+
+// The server counts the days, so the client never re-derives today from a
+// timestamp — two clocks disagreeing is how "yesterday" becomes "2 days ago"
+// for a reader in another timezone.
+function lastContactPhrase(
+  ev: RouteEvidence,
+  t: Translate,
+  locale: Locale,
+): string {
+  const days = ev.days_since_last;
+  if (days === null || days === undefined) return t("person.intro.whenNever");
+  if (days === 0) return t("person.intro.whenToday");
+  if (days === 1) return t("person.intro.whenYesterday");
+  return t("person.intro.whenDays", { days: formatNumber(days, locale) });
+}
+
+// An available route needs no label; the other three each say something the
+// reader would otherwise learn by asking and being turned down.
+function availabilityLabel(
+  availability: RouteCandidate["availability"],
+  t: Translate,
+): string | null {
+  switch (availability) {
+    case "already_requested":
+      return t("person.intro.alreadyRequested");
+    case "declined":
+      return t("person.intro.declined");
+    case "unavailable":
+      return t("person.intro.unavailable");
+    default:
+      return null;
+  }
+}

--- a/frontend/src/screens/personroutes.tsx
+++ b/frontend/src/screens/personroutes.tsx
@@ -11,13 +11,14 @@
 import type { components } from "../api/schema";
 import { Badge, Card } from "../design-system/atoms";
 import { formatNumber } from "../format/format";
-import { type Locale, useLocale, useT } from "../i18n";
+import { type Locale, useLocale, usePlural, useT } from "../i18n";
 import "./personnetwork.css";
 
 type Graph = components["schemas"]["PersonGraph"];
 type RouteCandidate = components["schemas"]["PersonGraphRouteCandidate"];
 type RouteEvidence = components["schemas"]["PersonGraphRouteEvidence"];
 type Translate = ReturnType<typeof useT>;
+type Pluralize = ReturnType<typeof usePlural>;
 
 /**
  * RoutesCard lists the ways in, the recommendation first.
@@ -29,23 +30,64 @@ type Translate = ReturnType<typeof useT>;
 export function RoutesCard({ graph }: Readonly<{ graph: Graph }>) {
   const t = useT();
   const routes = graph.routes ?? [];
+  // `routes` is optional in the contract and `route` is not, so a response from
+  // a server that predates the list still carries the recommendation. Reading
+  // only the list would render that payload as "nobody can reach them" — the
+  // one sentence on this card a reader must never see wrongly.
+  const legacy = routes.length === 0 ? graph.route : undefined;
   return (
     <Card
       title={t("person.intro.routesTitle")}
       sub={t("person.intro.routesSub")}
     >
-      {routes.length === 0 ? (
+      {routes.length === 0 && !legacy ? (
         <p className="pn-route">{t("person.graph.noRoute")}</p>
       ) : (
         <ol className="pn-routes">
-          {routes.map((route, index) => (
-            <li className="pn-route-row" key={route.route_id}>
-              <RouteRow route={route} lead={index === 0} />
+          {legacy ? (
+            <li className="pn-route-row">
+              <LegacyRouteRow route={legacy} />
             </li>
-          ))}
+          ) : (
+            routes.map((route, index) => (
+              <li className="pn-route-row" key={route.route_id}>
+                <RouteRow route={route} lead={index === 0} />
+              </li>
+            ))
+          )}
         </ol>
       )}
     </Card>
+  );
+}
+
+/**
+ * LegacyRouteRow renders the singular `route` from a server that does not send
+ * the list yet.
+ *
+ * It prints the server's own English `why`, because that payload carries no
+ * structured counts to write a translated sentence from. Stating the sentence
+ * the server sent is honest; inventing one from fields that are not there is
+ * not.
+ */
+function LegacyRouteRow({
+  route,
+}: Readonly<{ route: NonNullable<Graph["route"]> }>) {
+  const t = useT();
+  return (
+    <>
+      <p className="pn-route">
+        {route.through_display_name
+          ? t("person.graph.routeVia", {
+              name: route.via_display_name,
+              through: route.through_display_name,
+            })
+          : t("person.graph.routeDirect", {
+              name: route.via_display_name,
+            })}
+      </p>
+      <p className="pn-counts">{route.why}</p>
+    </>
   );
 }
 
@@ -54,6 +96,7 @@ function RouteRow({
   lead,
 }: Readonly<{ route: RouteCandidate; lead: boolean }>) {
   const t = useT();
+  const plural = usePlural();
   const { locale } = useLocale();
   const blocked = availabilityLabel(route.availability, t);
   return (
@@ -79,7 +122,9 @@ function RouteRow({
             has already declined. */}
         {blocked ? <Badge quiet>{blocked}</Badge> : null}
       </p>
-      <p className="pn-counts">{evidenceSentence(route.evidence, t, locale)}</p>
+      <p className="pn-counts">
+        {evidenceSentence(route.evidence, t, plural, locale)}
+      </p>
     </>
   );
 }
@@ -94,13 +139,20 @@ function RouteRow({
 export function evidenceSentence(
   ev: RouteEvidence,
   t: Translate,
+  plural: Pluralize,
   locale: Locale,
 ): string {
   const when = lastContactPhrase(ev, t, locale);
-  const key = ev.two_way
+  const base = ev.two_way
     ? "person.intro.evidenceTwoWay"
     : "person.intro.evidenceOneSided";
-  return t(key, { total: formatNumber(ev.interactions_90d, locale), when });
+  // Through the plural translator, not a count comparison: "1 interactions"
+  // undermines the very claim the line is making, and which counts are
+  // singular is a fact about the reader's language rather than about one.
+  return plural(base, ev.interactions_90d, {
+    total: formatNumber(ev.interactions_90d, locale),
+    when,
+  });
 }
 
 // The server counts the days, so the client never re-derives today from a


### PR DESCRIPTION
The Network tab printed one route and the server's English proof line. A rep who could not use that colleague — on leave, or already asked — had to read the picture and work the next one out themselves. A German or Vietnamese reader got the one sentence on the card that was never translated.

## What changes

`GET /people/{id}/graph` now returns `routes`, every askable way in ranked best-first, and `route` is `routes[0]` rather than a second ranking over the same facts. Two rankings are two answers to one question, and the day they disagreed the card would recommend one colleague while the list led with another.

The tab renders that list, each route carrying its evidence written from the counts in the reader's own language, and a route that cannot be used says so beside itself.

## Two defects fixed on the way

**A contact-to-contact edge could silently erase the recommendation.** The graph draws edges between two of their own people because they explain who talks to whom inside the account. The old chooser walked one, found no colleague at its near end, and returned *no route at all* — which reads on screen as "nobody here can reach them" while a usable direct route sits one edge away. Only colleague-origin edges are candidates now.

**Route evidence was untranslatable.** `proofLine` writes English; the product ships German and Vietnamese. The counts now cross the wire as facts (`PersonGraphRouteEvidence`) and the client writes the sentence. `why` stays as the documented English fallback for callers that have not adopted the structured field.

## Notes

`VCardImportResultOutcome`'s constants are pinned with `x-enum-varnames`, the idiom this contract already uses in a dozen places. Unpinned, the generator names an enum constant bare whenever nothing else in `api_gen.go` claims that word — and `Created` is already declared by `publicevents_gen.go` in the same package, so adding an unrelated schema was enough to stop the package compiling.

Both new guards are mutation-checked: reverting the eligibility filter fails `TestAContactToContactEdgeIsNeverARoute`, and reverting the two-way preference fails both the new list test and the pre-existing recommendation test — which is also the proof that the list and the card share one ranking.

The panel test asserts the localized proof line renders the same words the server used to write, so the translation is held to saying the same thing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Network tab now lists every askable way in to a contact, best first, so a rep can act on the next option when the first one isn't usable. Previously it showed one route with an English-only proof line; now `GET /people/{id}/graph` returns `routes`, `route` is `routes[0]`, and the tab renders each route's evidence from the counts in the reader's own language (German, English, Vietnamese). A route that can't be used says so beside itself.

**Bug Fixes**
- A contact-to-contact edge could silently erase the recommendation; only colleague-origin edges are candidates now.
- Route evidence was untranslatable because the server wrote English prose; counts now cross the wire as facts (`PersonGraphRouteEvidence`) and the client writes the sentence. `why` stays as a documented fallback for callers that haven't adopted the structured field.
- A count of one rendered as "1 interactions"; counts now pluralize through the plural translator.
- A response carrying `route` but no `routes` rendered as "nobody can reach them"; the tab now falls back to the recommendation and prints its `why`.

**New Features**
- An `intro_request` migration and a pure lifecycle state machine define the ask's statuses and who may move each transition; every route is reported `available` until that store is bound.

<sup>Written for commit 00ce344d82dc3ccc9f80cd24c778df1fc7f4af92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

