### PR TITLE
Mine means mine

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -9147,7 +9147,7 @@ paths:
       parameters:
         - name: scope
           in: query
-          schema: { type: string, enum: [mine, team, all] }
+          schema: { type: string, enum: [mine, unassigned, team, all] }
           description: |
             Whose work to answer for. Omitted means `mine`, which is the default for
             every reader: an admin account can read every deal in the installation, and a
@@ -9157,6 +9157,13 @@ paths:
             A scope the reader's own row scope does not reach is refused with 403 rather
             than quietly narrowed — answering a question about the team with facts about
             one person, with no way for the reader to tell, is the worse failure.
+
+            `unassigned` is the open work nobody answers for, and every reader may ask for
+            it at any tier: nothing in it belongs to a colleague, which is what unassigned
+            means. It exists because `mine` is exact — a task with no assignee is no
+            longer folded into every reader's own queue, so it needs a queue of its own or
+            the product would have stopped mentioning it. Tasks only: a message has no
+            assignee, so unanswered mail stays reachable from `mine`, `team` and `all`.
 
             WHAT A WIDER SCOPE REACHES. The record-bearing sources widen: tasks, deals
             going quiet, meetings and duplicate pairs are read under the caller's row
@@ -32905,11 +32912,11 @@ components:
         as_of: { type: string, format: date-time, description: 'The instant every source below was read at.' }
         scope:
           type: string
-          enum: [mine, team, all]
+          enum: [mine, unassigned, team, all]
           description: 'Whose work this read answered for.'
         scope_options:
           type: array
-          items: { type: string, enum: [mine, team, all] }
+          items: { type: string, enum: [mine, unassigned, team, all] }
           description: |
             The scopes this reader may ask for, narrowest first — derived from their own
             row scope. A client draws a control only when there is more than one, so a

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -112,9 +112,10 @@ type Service struct {
 	// behaviour; the ranked queue's default scope sets it), because the same
 	// service answers both surfaces.
 	mineOnly bool
-	// tasks read at this scope. Separate from mineOnly because the task lane is
-	// the one producer with a third answer: unowned work, which is nobody's
-	// rather than everybody's.
+	// tasks read at this scope. Separate from mineOnly because a task carries an
+	// assignee and so has a third answer available to it — unowned work, which
+	// is nobody's rather than everybody's — where a mailbox or a notice is
+	// per-reader by construction and has only two.
 	taskScope TaskScope
 }
 

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -107,15 +107,13 @@ type Service struct {
 	// a hundred and fifty is a wrong number rather than a bounded one.
 	decisionDepth int
 	now           Clock
-	// mineOnly narrows the producers that can be narrowed to the acting
-	// reader's own work. Set per read (Assemble keeps the lane feed's
-	// behaviour; the ranked queue's default scope sets it), because the same
-	// service answers both surfaces.
-	mineOnly bool
-	// tasks read at this scope. Separate from mineOnly because a task carries an
-	// assignee and so has a third answer available to it — unowned work, which
-	// is nobody's rather than everybody's — where a mailbox or a notice is
-	// per-reader by construction and has only two.
+	// taskScope narrows the task lane to whose work this read answers for. Set
+	// per read (Assemble keeps the lane feed's behaviour; the ranked queue's
+	// resolved scope sets it), because the same service answers both surfaces.
+	//
+	// A task carries an assignee and so has three answers available to it —
+	// anybody's, the reader's, nobody's — where a mailbox or a notice is
+	// per-reader by construction and has only one.
 	taskScope TaskScope
 }
 
@@ -125,7 +123,6 @@ type Service struct {
 // reader's page.
 func (s *Service) forReader() *Service {
 	narrowed := *s
-	narrowed.mineOnly = true
 	narrowed.taskScope = TasksMine
 	return &narrowed
 }

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -112,6 +112,10 @@ type Service struct {
 	// behaviour; the ranked queue's default scope sets it), because the same
 	// service answers both surfaces.
 	mineOnly bool
+	// tasks read at this scope. Separate from mineOnly because the task lane is
+	// the one producer with a third answer: unowned work, which is nobody's
+	// rather than everybody's.
+	taskScope TaskScope
 }
 
 // forReader returns a copy of this service that reads only the acting reader's
@@ -121,6 +125,15 @@ type Service struct {
 func (s *Service) forReader() *Service {
 	narrowed := *s
 	narrowed.mineOnly = true
+	narrowed.taskScope = TasksMine
+	return &narrowed
+}
+
+// forUnowned returns a copy that reads the work nobody answers for. Same
+// copy-per-read reason as forReader.
+func (s *Service) forUnowned() *Service {
+	narrowed := *s
+	narrowed.taskScope = TasksUnassigned
 	return &narrowed
 }
 
@@ -212,7 +225,7 @@ func (s *Service) Assemble(ctx context.Context) (crmcontracts.Attention, error) 
 		return crmcontracts.Attention{}, err
 	}
 
-	planned, err := s.planned(ctx, asOf, s.mineOnly)
+	planned, err := s.planned(ctx, asOf, s.taskScope)
 	omitted, err = fill(omitted, "planned", err, func() {
 		out.Planned = planned
 		out.Counts.Planned = len(planned)
@@ -369,8 +382,8 @@ func endOfDay(asOf time.Time) time.Time {
 }
 
 // planned is today's agreed work, overdue first.
-func (s *Service) planned(ctx context.Context, asOf time.Time, mineOnly bool) ([]crmcontracts.AttentionItem, error) {
-	open, err := s.tasks.OpenForViewer(ctx, endOfDay(asOf), plannedCap, mineOnly)
+func (s *Service) planned(ctx context.Context, asOf time.Time, scope TaskScope) ([]crmcontracts.AttentionItem, error) {
+	open, err := s.tasks.OpenForViewer(ctx, endOfDay(asOf), plannedCap, scope)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -79,17 +79,20 @@ type stubTasks struct {
 	// boundary rather than assume it. A pointer receiver only where it is
 	// read back; the value form stays valid for every test that ignores it.
 	until *time.Time
-	// mineOnly records whether the lane asked for the reader's own tasks, so a
-	// test can prove the narrowing reaches the QUERY rather than trusting that
-	// a filter ran afterwards.
-	mineOnly bool
+	// scope records WHOSE tasks the lane asked for, so a test can prove the
+	// narrowing reaches the QUERY rather than trusting that a filter ran
+	// afterwards.
+	scope TaskScope
 }
 
-func (s *stubTasks) OpenForViewer(_ context.Context, until time.Time, _ int, mineOnly bool) ([]Task, error) {
+func (s *stubTasks) OpenForViewer(_ context.Context, until time.Time, _ int, scope TaskScope) ([]Task, error) {
 	s.until = &until
-	s.mineOnly = mineOnly
+	s.scope = scope
 	return s.rows, s.err
 }
+
+// mineOnly is what most callers actually ask of the recorded scope.
+func (s *stubTasks) mineOnly() bool { return s.scope == TasksMine }
 
 type stubReceipts struct {
 	rows []Receipt

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -99,15 +99,29 @@ type RecordFace struct {
 	RelatedCount *int
 }
 
+// TaskScope says whose open tasks a read answers.
+//
+// Three answers, not a boolean, because "nobody's" is a real one: unowned work
+// has to be reachable without arriving in every reader's own queue.
+type TaskScope int
+
+const (
+	// TasksVisible is every open task the reader may see.
+	TasksVisible TaskScope = iota
+	// TasksMine is the open tasks assigned to the reader, and no others.
+	TasksMine
+	// TasksUnassigned is the open tasks assigned to nobody.
+	TasksUnassigned
+)
+
 // Tasks is the open-task read, through the activities module.
 //
-// mineOnly asks the store for the READER'S OWN open tasks rather than every
-// task they may see. It belongs in the query and not in a filter afterwards:
-// the store bounds what it returns, so narrowing later would cut a colleague's
-// twelve rows out of a page of twelve and leave the reader's own overdue task
+// The scope belongs in the QUERY and not in a filter afterwards: the store
+// bounds what it returns, so narrowing later would cut a colleague's twelve
+// rows out of a page of twelve and leave the reader's own overdue task
 // unreachable behind them.
 type Tasks interface {
-	OpenForViewer(ctx context.Context, until time.Time, limit int, mineOnly bool) ([]Task, error)
+	OpenForViewer(ctx context.Context, until time.Time, limit int, scope TaskScope) ([]Task, error)
 }
 
 // Task is one piece of agreed work.

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -106,7 +106,8 @@ type RecordFace struct {
 type TaskScope int
 
 const (
-	// TasksVisible is every open task the reader may see.
+	// TasksVisible adds no narrowing of its own: the store's row-scope gate
+	// decides what comes back.
 	TasksVisible TaskScope = iota
 	// TasksMine is the open tasks assigned to the reader, and no others.
 	TasksMine

--- a/backend/internal/compose/attention/scope.go
+++ b/backend/internal/compose/attention/scope.go
@@ -28,8 +28,14 @@ import (
 // The scopes a reader may ask the queue for.
 const (
 	scopeMine = "mine"
-	scopeTeam = "team"
-	scopeAll  = "all"
+	// scopeUnassigned is the work nobody answers for.
+	//
+	// Its own scope because "mine" stopped carrying it. Unowned work is real and
+	// somebody has to pick it up, but it arrives in a queue a reader opens on
+	// purpose rather than in the one that claims to be theirs.
+	scopeUnassigned = "unassigned"
+	scopeTeam       = "team"
+	scopeAll        = "all"
 )
 
 // scopeOptionsFor answers which scopes this reader may ask for, narrowest
@@ -39,8 +45,13 @@ const (
 // the tier is a fact about the principal, and asking the database whether a
 // colleague's deal is visible would be re-deriving per row what the policy
 // already decided once (P11).
+// Unassigned is offered to EVERY reader, at every tier. It is the other half of
+// making "mine" exact: work that belongs to nobody stopped appearing in each
+// reader's own queue, so it has to be reachable from every one of them or the
+// change would have hidden it. Nothing in it is a colleague's — that is what
+// unassigned means — so no tier gates it.
 func scopeOptionsFor(ctx context.Context) []string {
-	options := []string{scopeMine}
+	options := []string{scopeMine, scopeUnassigned}
 	actor, ok := principal.Actor(ctx)
 	if !ok {
 		return options
@@ -114,9 +125,18 @@ func ownedByReader(item crmcontracts.WorklistItem, reader principal.Principal) b
 //
 // A message has no owner column, so the question is answered by the RECORD it
 // is filed under: a thread about a colleague's deal is that colleague's to
-// answer. A message filed under nothing names nobody, and stays — an unowned
-// customer writing in is everybody's, and dropping it would leave nobody
-// looking at it.
+// answer.
+//
+// A message filed under nothing names nobody, and stays — an unowned customer
+// writing in is everybody's, and dropping it would leave nobody looking at it.
+//
+// That reading is the one this queue is otherwise moving away from, and it
+// survives here for a reason worth stating: ownedDeals is built from the
+// at-risk lane alone, so a deal the reader owns which is perfectly healthy is
+// absent from it and reads as unowned. Judging a wait exactly against that set
+// would drop the reader's own waiting customer whenever their deal was doing
+// well. Making it exact needs the owner on the row itself, which is the read
+// the waiting query does not yet carry.
 func waitingIsMine(waiting WaitingCustomer, ownedDeals map[ids.UUID]bool) bool {
 	if waiting.DealID.IsZero() {
 		return true

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -45,10 +45,13 @@ func TestEveryReaderDefaultsToTheirOwnWork(t *testing.T) {
 // A reader is offered exactly the scopes their row scope reaches, so a client
 // never draws a control that would 403 when pressed.
 func TestTheOfferedScopesMatchTheReadersOwnReach(t *testing.T) {
+	// Unassigned is offered at EVERY tier: nothing in it belongs to a
+	// colleague, and it is where ownerless work lives now that "mine" no longer
+	// folds it into each reader's own queue.
 	cases := map[principal.RowScope][]string{
-		principal.RowScopeOwn:  {scopeMine},
-		principal.RowScopeTeam: {scopeMine, scopeTeam},
-		principal.RowScopeAll:  {scopeMine, scopeTeam, scopeAll},
+		principal.RowScopeOwn:  {scopeMine, scopeUnassigned},
+		principal.RowScopeTeam: {scopeMine, scopeUnassigned, scopeTeam},
+		principal.RowScopeAll:  {scopeMine, scopeUnassigned, scopeTeam, scopeAll},
 	}
 	for tier, want := range cases {
 		got := scopeOptionsFor(readerAt(tier))
@@ -201,7 +204,7 @@ func TestTheReadersOwnScopeReachesTheTaskQuery(t *testing.T) {
 		t.Fatalf("assembling the day: %v", err)
 	}
 
-	if !tasks.mineOnly {
+	if !tasks.mineOnly() {
 		t.Fatal("the task lane was asked for every visible task on a read scoped to the reader")
 	}
 }
@@ -219,7 +222,7 @@ func TestTheLaneFeedStillReadsEveryVisibleTask(t *testing.T) {
 		t.Fatalf("assembling the day: %v", err)
 	}
 
-	if tasks.mineOnly {
+	if tasks.mineOnly() {
 		t.Fatal("the lane feed narrowed to the reader, changing a surface this did not set out to change")
 	}
 }

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -64,8 +64,11 @@ func (s *Service) Worklist(ctx context.Context, scope, filter string, limit int)
 	// Deeper than the lane feed reads: a batch row counts a pile, and a count
 	// taken from a page of ten would report ten over a hundred and fifty.
 	reader := s.countingDecisions()
-	if mineOnly(resolved) {
+	switch {
+	case mineOnly(resolved):
 		reader = reader.forReader()
+	case resolved == scopeUnassigned:
+		reader = reader.forUnowned()
 	}
 	day, err := reader.Assemble(ctx)
 	if err != nil {
@@ -108,6 +111,21 @@ func keepReadersOwn(ctx context.Context, rows []ranked) []ranked {
 	kept := make([]ranked, 0, len(rows))
 	for _, row := range rows {
 		if ownedByReader(row.item, actor) {
+			kept = append(kept, row)
+		}
+	}
+	return kept
+}
+
+// keepUnowned keeps the rows that answer to nobody.
+//
+// The counterpart to keepReadersOwn, over the same evidence: a deal-bearing row
+// with an owner belongs to that person and not to this queue. A row with no
+// owner to check stays, which is what the scope is for.
+func keepUnowned(rows []ranked) []ranked {
+	kept := make([]ranked, 0, len(rows))
+	for _, row := range rows {
+		if row.item.Deal == nil || row.item.Deal.OwnerId == nil {
 			kept = append(kept, row)
 		}
 	}
@@ -180,6 +198,14 @@ func (s *Service) worklistFrom(
 		if mineOnly(scope) && !waitingIsMine(customer, owned) {
 			continue
 		}
+		// The unassigned queue is about work with no ASSIGNEE, and a message has
+		// no assignee column — waitingIsMine reads the record it is filed under,
+		// which cannot tell "nobody owns this" from "the owner's deal is
+		// healthy". Rather than guess, this scope carries no waiting rows and
+		// every one of them stays reachable from mine, team and all.
+		if scope == scopeUnassigned {
+			continue
+		}
 		mine = append(mine, customer)
 	}
 	sort.SliceStable(mine, func(i, j int) bool { return mine[i].Since.Before(mine[j].Since) })
@@ -202,8 +228,11 @@ func (s *Service) worklistFrom(
 	// appear as drifting.
 	rows = dropDealsAlreadyWaiting(rows)
 
-	if mineOnly(scope) {
+	switch {
+	case mineOnly(scope):
 		rows = keepReadersOwn(ctx, rows)
+	case scope == scopeUnassigned:
+		rows = keepUnowned(rows)
 	}
 	// Held before the category narrowing, so a filtered-out source still
 	// reports what it had. Counting after it erased those sources from reach

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -135,7 +135,7 @@ func (d attentionDuplicates) CountOpen(ctx context.Context) (int, error) {
 type attentionTasks struct{ store *activities.Store }
 
 func (t attentionTasks) OpenForViewer(
-	ctx context.Context, until time.Time, limit int, mineOnly bool,
+	ctx context.Context, until time.Time, limit int, scope attention.TaskScope,
 ) ([]attention.Task, error) {
 	// The store answers "open and due by then" itself, so the limit bounds the
 	// rows that QUALIFY. This used to read ten times the lane and narrow
@@ -146,7 +146,8 @@ func (t attentionTasks) OpenForViewer(
 	// Narrowed in the QUERY, so the store's own bound applies to the rows that
 	// qualify. Filtering the answer instead would let a colleague's twelve
 	// tasks fill the page and hide the reader's own overdue one behind them.
-	if mineOnly {
+	switch scope {
+	case attention.TasksMine:
 		actor, ok := principal.Actor(ctx)
 		if !ok || actor.UserID.IsZero() {
 			// No human, no "own work" to answer for. Reading every task and
@@ -154,10 +155,17 @@ func (t attentionTasks) OpenForViewer(
 			// to prevent.
 			return nil, nil
 		}
-		// Mine, or nobody's: a task the reader wrote themselves without an
-		// assignee is still theirs to do.
+		// Exactly theirs. A task they wrote themselves carries their name from
+		// the moment it is written, so this needs no unassigned arm — and the
+		// arm it used to have is what put an automation's follow-up on every
+		// colleague's queue.
 		assignee := ids.From[ids.UserKind](actor.UserID)
 		in.OwnQueueOf = &assignee
+	case attention.TasksUnassigned:
+		in.UnassignedQueue = true
+	case attention.TasksVisible:
+		// Every open task the reader may see; the row-scope gate in the store
+		// is the only narrowing.
 	}
 	rows, _, err := t.store.ListActivities(ctx, in)
 	if err != nil {

--- a/backend/internal/compose/integration/taskownership_integration_test.go
+++ b/backend/internal/compose/integration/taskownership_integration_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Who owns a task, written by the real writer and read back off the row.
+//
+// The unit test beside taskAssignee proves the decision; this proves the
+// decision reaches the column. Without it the helper could be disconnected from
+// the insert and every unit test would stay green while the queue quietly went
+// back to showing one rep's work to everybody.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// storedAssignee reads the assignee off the row itself, not off the response,
+// so the test cannot pass on a value the writer merely echoed back.
+func storedAssignee(t *testing.T, id string) *ids.UUID {
+	t.Helper()
+	var assignee *ids.UUID
+	if err := OwnerConn(t).QueryRow(context.Background(),
+		`SELECT assignee_id FROM activity WHERE id = $1`, id).Scan(&assignee); err != nil {
+		t.Fatalf("reading the task's assignee: %v", err)
+	}
+	return assignee
+}
+
+// A rep writing themselves a task owns it, without naming themselves. This is
+// the case that lets "mine" be exact: the queue stopped folding in every
+// ownerless row, so the row a rep wrote has to arrive owned.
+func TestASelfWrittenTaskIsStoredAgainstItsAuthor(t *testing.T) {
+	e := Setup(t)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	person := e.SeedPerson(t, "A Contact", &e.Rep1)
+
+	task, _, err := e.Activities.LogActivity(rep, activities.LogActivityInput{
+		Kind: "task", Subject: strPtr("Call them back"), Source: "manual",
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: person}},
+	})
+	if err != nil {
+		t.Fatalf("logging the task: %v", err)
+	}
+
+	stored := storedAssignee(t, task.Id.String())
+	if stored == nil {
+		t.Fatal("a task the rep wrote for themselves was stored belonging to nobody")
+	}
+	if *stored != e.Rep1 {
+		t.Fatalf("the task was stored against %v, wanted its author %v", *stored, e.Rep1)
+	}
+}
+
+// A note is not a task, and the column stays empty. The activity table's own
+// CHECK keeps assignee_id NULL on every other kind, so stamping one would fail
+// the write rather than merely look wrong.
+func TestANoteIsStoredWithNoAssignee(t *testing.T) {
+	e := Setup(t)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	person := e.SeedPerson(t, "A Contact", &e.Rep1)
+
+	note, _, err := e.Activities.LogActivity(rep, activities.LogActivityInput{
+		Kind: "note", Subject: strPtr("They mentioned a rollout"), Source: "manual",
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: person}},
+	})
+	if err != nil {
+		t.Fatalf("logging the note: %v", err)
+	}
+
+	if stored := storedAssignee(t, note.Id.String()); stored != nil {
+		t.Fatalf("a note was stored against %v", *stored)
+	}
+}

--- a/backend/internal/compose/workflows.go
+++ b/backend/internal/compose/workflows.go
@@ -91,6 +91,9 @@ func workflowEngineWithDrafter(db *database.DB, drafter activities.EmailDrafter)
 	for _, handler := range activities.FollowUpWorkflows(activityStore) {
 		engine.RegisterSystemWorkflow(handler)
 	}
+	for _, handler := range activities.OwnershipWorkflows(activityStore) {
+		engine.RegisterSystemWorkflow(handler)
+	}
 	return engine
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11511,9 +11511,10 @@ func (e WorklistFilter) Valid() bool {
 
 // Defines values for WorklistScope.
 const (
-	WorklistScopeAll  WorklistScope = "all"
-	WorklistScopeMine WorklistScope = "mine"
-	WorklistScopeTeam WorklistScope = "team"
+	WorklistScopeAll        WorklistScope = "all"
+	WorklistScopeMine       WorklistScope = "mine"
+	WorklistScopeTeam       WorklistScope = "team"
+	WorklistScopeUnassigned WorklistScope = "unassigned"
 )
 
 // Valid indicates whether the value is a known member of the WorklistScope enum.
@@ -11525,6 +11526,8 @@ func (e WorklistScope) Valid() bool {
 		return true
 	case WorklistScopeTeam:
 		return true
+	case WorklistScopeUnassigned:
+		return true
 	default:
 		return false
 	}
@@ -11532,9 +11535,10 @@ func (e WorklistScope) Valid() bool {
 
 // Defines values for WorklistScopeOptions.
 const (
-	WorklistScopeOptionsAll  WorklistScopeOptions = "all"
-	WorklistScopeOptionsMine WorklistScopeOptions = "mine"
-	WorklistScopeOptionsTeam WorklistScopeOptions = "team"
+	WorklistScopeOptionsAll        WorklistScopeOptions = "all"
+	WorklistScopeOptionsMine       WorklistScopeOptions = "mine"
+	WorklistScopeOptionsTeam       WorklistScopeOptions = "team"
+	WorklistScopeOptionsUnassigned WorklistScopeOptions = "unassigned"
 )
 
 // Valid indicates whether the value is a known member of the WorklistScopeOptions enum.
@@ -11545,6 +11549,8 @@ func (e WorklistScopeOptions) Valid() bool {
 	case WorklistScopeOptionsMine:
 		return true
 	case WorklistScopeOptionsTeam:
+		return true
+	case WorklistScopeOptionsUnassigned:
 		return true
 	default:
 		return false
@@ -13509,9 +13515,10 @@ func (e ListSignalsParamsResolutionState) Valid() bool {
 
 // Defines values for GetWorklistParamsScope.
 const (
-	GetWorklistParamsScopeAll  GetWorklistParamsScope = "all"
-	GetWorklistParamsScopeMine GetWorklistParamsScope = "mine"
-	GetWorklistParamsScopeTeam GetWorklistParamsScope = "team"
+	GetWorklistParamsScopeAll        GetWorklistParamsScope = "all"
+	GetWorklistParamsScopeMine       GetWorklistParamsScope = "mine"
+	GetWorklistParamsScopeTeam       GetWorklistParamsScope = "team"
+	GetWorklistParamsScopeUnassigned GetWorklistParamsScope = "unassigned"
 )
 
 // Valid indicates whether the value is a known member of the GetWorklistParamsScope enum.
@@ -13522,6 +13529,8 @@ func (e GetWorklistParamsScope) Valid() bool {
 	case GetWorklistParamsScopeMine:
 		return true
 	case GetWorklistParamsScopeTeam:
+		return true
+	case GetWorklistParamsScopeUnassigned:
 		return true
 	default:
 		return false
@@ -33070,6 +33079,13 @@ type GetWorklistParams struct {
 	// A scope the reader's own row scope does not reach is refused with 403 rather
 	// than quietly narrowed — answering a question about the team with facts about
 	// one person, with no way for the reader to tell, is the worse failure.
+	//
+	// `unassigned` is the open work nobody answers for, and every reader may ask for
+	// it at any tier: nothing in it belongs to a colleague, which is what unassigned
+	// means. It exists because `mine` is exact — a task with no assignee is no
+	// longer folded into every reader's own queue, so it needs a queue of its own or
+	// the product would have stopped mentioning it. Tasks only: a message has no
+	// assignee, so unanswered mail stays reachable from `mine`, `team` and `all`.
 	//
 	// WHAT A WIDER SCOPE REACHES. The record-bearing sources widen: tasks, deals
 	// going quiet, meetings and duplicate pairs are read under the caller's row

--- a/backend/internal/modules/activities/activity.go
+++ b/backend/internal/modules/activities/activity.go
@@ -136,6 +136,34 @@ func (s *Store) logActivityAndReadTranscript(
 	return out, created, s.readTranscriptOnLanding(ctx, tx, out, created)
 }
 
+// taskAssignee decides who a new task belongs to.
+//
+// A task somebody writes for themselves and does not assign is THEIRS. The
+// column used to keep the NULL and the "my work" queue compensated by treating
+// every unassigned task as the reader's own, which put each automation-created
+// follow-up on every colleague's queue at once — the lead was owned, the task
+// it minted was not, and "mine" quietly meant "mine plus everybody's".
+//
+// Owning it at the point of writing is the half of that fix which keeps the
+// self-written task where its author expects it, so the queue can go back to
+// meaning exactly what it says.
+//
+// Only for a HUMAN creating a TASK. A system principal writing on nobody's
+// behalf leaves the column NULL, which is what routes automation work to the
+// unassigned queue instead of to whoever the workflow ran as; and a caller who
+// named an assignee is obeyed.
+func taskAssignee(ctx context.Context, in LogActivityInput) *ids.UserID {
+	if in.AssigneeID != nil || in.Kind != "task" {
+		return in.AssigneeID
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Type != principal.PrincipalHuman || actor.UserID == ids.Nil {
+		return nil
+	}
+	owner := ids.From[ids.UserKind](actor.UserID)
+	return &owner
+}
+
 // logActivityInTx is LogActivity's transactional body, shared by the
 // store-opened (LogActivity) and caller-opened (LogActivityTx) entry
 // points.
@@ -148,6 +176,7 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 	if in.OccurredAt != nil {
 		occurredAt = in.OccurredAt.UTC()
 	}
+	assignee := taskAssignee(ctx, in)
 
 	replay, err := replayedActivity(ctx, tx, in)
 	if err != nil {
@@ -167,7 +196,7 @@ func logActivityInTx(ctx context.Context, tx pgx.Tx, in LogActivityInput) (crmco
 		// NULLIF on channel_provider: the column FKs into channel_provider, and
 		// '' names no provider, so anything without a transport stores NULL.
 		id, in.Kind, in.ChannelProvider, in.Subject, in.Body, occurredAt, in.Direction, in.MeetingStatus,
-		in.DueAt, in.RemindAt, in.AssigneeID, in.HostUserID, in.SourceSystem, in.SourceID, in.Source, by,
+		in.DueAt, in.RemindAt, assignee, in.HostUserID, in.SourceSystem, in.SourceID, in.Source, by,
 		in.ThreadKey, in.CounterpartyEmail, in.CounterpartyOutboundAttested)
 	if err != nil {
 		if storekit.IsUniqueViolation(err) {

--- a/backend/internal/modules/activities/activityread.go
+++ b/backend/internal/modules/activities/activityread.go
@@ -73,15 +73,18 @@ type ListActivitiesInput struct {
 	// that question rather than a second dial — see openTaskAssigneeClause.
 	AssigneeID *ids.UserID
 
-	// OwnQueueOf narrows to the work one person is answerable for: assigned to
-	// them, or assigned to NOBODY. Distinct from AssigneeID, which means exact
-	// assignment and is what the task screen filters by.
-	//
-	// The unassigned arm is the difference that matters. A rep who writes
-	// themselves a task without filling in an assignee still owns it, and a
-	// "my work" queue that dropped it would hide the reader's own to-do from
-	// them — which is worse than showing one row too many.
+	// OwnQueueOf narrows to the open work one person is answerable for.
+	// Distinct from AssigneeID, which means exact assignment on any kind and is
+	// what the task screen filters by; this one is the day's queue and carries
+	// open-ness with it.
 	OwnQueueOf *ids.UserID
+	// UnassignedQueue narrows to the open tasks nobody answers for.
+	//
+	// A scope of its own rather than an arm of OwnQueueOf: unowned work is
+	// somebody's to pick up, and a reader chooses to look at it. Folded into a
+	// personal queue it arrives as though already theirs, which is how one
+	// automation's follow-up came to sit on every colleague's page.
+	UnassignedQueue bool
 	// WithinProjectID narrows to one body of work, EXCLUDING what belongs to
 	// another project and keeping what belongs to none.
 	//

--- a/backend/internal/modules/activities/followupownership.go
+++ b/backend/internal/modules/activities/followupownership.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
@@ -151,10 +152,13 @@ func (s *Store) AlignSystemTaskAssigneeToLead(ctx context.Context, leadID ids.Le
 	}
 	moved := 0
 	for _, task := range wrong {
-		if err := s.assignSystemTask(ctx, task.id, task.version, owner); err != nil {
+		reassigned, err := s.assignSystemTask(ctx, task.id, task.version, owner)
+		if err != nil {
 			return 0, fmt.Errorf("assigning system task %s: %w", task.id, err)
 		}
-		moved++
+		if reassigned {
+			moved++
+		}
 	}
 	return moved, nil
 }
@@ -184,32 +188,63 @@ func (s *Store) leadOwner(ctx context.Context, leadID ids.LeadID) (ids.UserID, b
 	return *owner, true, nil
 }
 
-// assignSystemTask points one selected task at the owner.
+// assignmentAttempts bounds the re-read below, for the reason completionAttempts
+// bounds its own: each attempt is a lost race with a different writer, and more
+// than a couple means a row somebody is editing continuously.
+const assignmentAttempts = 3
+
+// assignSystemTask points one selected task at the owner, answering whether
+// THIS call moved it.
 //
-// Version skew is not retried the way a completion is. A task somebody moved
-// underneath this call was moved by a writer with a live opinion about who owns
-// it — a human reassigning it by hand, or a later firing of this same handler
-// reading a newer owner — and overwriting that with an owner read before their
-// change is how an automation takes work back off the person it was just given
-// to. The next lead.updated reconciles again if the disagreement is real.
+// Version skew is a RE-READ, not a skip — the same conclusion completeSystemTask
+// reached over the same select-then-write shape. Every update to an activity
+// bumps its version, so skew here usually means somebody edited the subject or
+// the due date, not that anybody expressed an opinion about who owns it.
+// Skipping on that would leave the task pointing at nobody with no promise of
+// another firing: lead.updated fires when the LEAD changes, and the task's own
+// edits do not produce one.
+//
+// A task that has come to disagree with the lead about its owner is left alone.
+// That is the case where somebody did decide, and re-reading the lead's owner
+// over their decision is how an automation takes work back off the person it
+// was just handed to.
 func (s *Store) assignSystemTask(
 	ctx context.Context, id ids.ActivityID, version int64, owner ids.UserID,
-) error {
-	_, err := s.UpdateActivity(ctx, id, UpdateActivityInput{
-		AssigneeID: &owner,
-		IfVersion:  &version,
-	})
-	switch {
-	case err == nil:
-		return nil
-	case errors.Is(err, apperrors.ErrNotFound):
-		// Archived between the selection and the write. No task to move, and
-		// failing here would strand every other task this call selected.
-		return nil
-	case errors.Is(err, apperrors.ErrVersionSkew):
-		// Somebody with a newer opinion got there first. See above.
-		return nil
-	default:
-		return err
+) (bool, error) {
+	for attempt := 0; attempt < assignmentAttempts; attempt++ {
+		_, err := s.UpdateActivity(ctx, id, UpdateActivityInput{
+			AssigneeID: &owner,
+			IfVersion:  &version,
+		})
+		switch {
+		case err == nil:
+			return true, nil
+		case errors.Is(err, apperrors.ErrNotFound):
+			// Either the task was archived between the selection and the write,
+			// or the owner is no longer an active seat (UpdateActivity checks
+			// the assignee exists). Both mean there is nothing to do here, and
+			// failing would strand every other task this call selected.
+			return false, nil
+		case !errors.Is(err, apperrors.ErrVersionSkew):
+			return false, err
+		}
+		current, err := s.GetActivity(ctx, id, storekit.LiveOnly)
+		if err != nil {
+			if errors.Is(err, apperrors.ErrNotFound) {
+				return false, nil
+			}
+			return false, err
+		}
+		if current.AssigneeId != nil && ids.UUID(*current.AssigneeId) != owner.UUID {
+			// Somebody assigned it to a different person while this call was in
+			// flight. Their decision is newer than the one this call is
+			// carrying, so it stands.
+			return false, nil
+		}
+		if current.Version == nil {
+			return false, nil
+		}
+		version = *current.Version
 	}
+	return false, nil
 }

--- a/backend/internal/modules/activities/followupownership.go
+++ b/backend/internal/modules/activities/followupownership.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// A system follow-up belongs to whoever owns the record it was minted for.
+//
+// Two workflows answer one lead.created with no ordering between them: one
+// routes the lead to a rep, the other mints its follow-up task. When the mint
+// runs first the task is written before there is an owner to write, and it
+// would stay unowned forever — the lead has a rep, their follow-up does not,
+// and it waits in the unassigned queue nobody opened.
+//
+// So the task follows the record. This reconciles from the lead's CURRENT
+// owner rather than applying a change described in an event, which is what
+// makes it safe to run twice, out of order, or after a reassignment: whatever
+// the lead says now is what its open system tasks say when this finishes.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+	"github.com/margince/margince/backend/internal/shared/ports/workflow"
+)
+
+// OwnershipWorkflows returns the system handler that keeps a system-minted
+// follow-up assigned to whoever owns the lead it belongs to. compose registers
+// it beside FollowUpWorkflows.
+func OwnershipWorkflows(store *Store) []workflow.Handler {
+	return []workflow.Handler{followUpOwnerReconcile{store: store}}
+}
+
+// followUpOwnerReconcile answers lead.updated by making the lead's open system
+// tasks agree with its owner.
+type followUpOwnerReconcile struct{ store *Store }
+
+func (followUpOwnerReconcile) Spec() workflow.Spec {
+	return workflow.Spec{
+		Name:    "follow_up_owner_reconcile",
+		Trigger: workflow.Trigger{EventType: "lead.updated"},
+		Tier:    mcp.TierAutoExecute,
+	}
+}
+
+// Match fires on every lead.updated. The event does not say which column
+// moved, and testing the payload for an owner change would miss the case this
+// exists for: the mint losing the race arrives as an update carrying no owner
+// change at all, because the owner was already there.
+func (followUpOwnerReconcile) Match(_ context.Context, _ workflow.Event) (bool, error) {
+	return true, nil
+}
+
+func (followUpOwnerReconcile) Plan(_ context.Context, ev workflow.Event) (workflow.Effect, error) {
+	// Which tasks, and to whom, is Apply's query — the envelope carries no
+	// links, so Plan states the invariant the way the auto-resolve sibling's
+	// Plan does.
+	args, err := json.Marshal(map[string]any{"assignee_id": "the lead's owner"})
+	if err != nil {
+		return workflow.Effect{}, fmt.Errorf("activities: encoding the reassignment effect: %w", err)
+	}
+	return workflow.Effect{Actions: []workflow.Action{{
+		Kind: workflow.ActionUpdateRecord, Target: ev.Entity, Args: args,
+	}}}, nil
+}
+
+func (w followUpOwnerReconcile) Apply(
+	ctx context.Context, ev workflow.Event, eff workflow.Effect, _ *workflow.ApprovalToken,
+) (workflow.RunResult, error) {
+	moved, err := w.store.AlignSystemTaskAssigneeToLead(ctx, ids.From[ids.LeadKind](ev.Entity.ID))
+	if err != nil {
+		return workflow.RunResult{}, fmt.Errorf("aligning follow-ups on lead %s: %w", ev.Entity.ID, err)
+	}
+	if moved == 0 {
+		return workflow.RunResult{}, nil
+	}
+	return workflow.RunResult{Applied: eff.Actions}, nil
+}
+
+func (followUpOwnerReconcile) IdempotencyKey(ev workflow.Event) string {
+	// The event id, not the lead: a reassignment an hour later is a different
+	// firing that must run again, and keying on the lead would swallow it.
+	return "follow_up_owner_reconcile:" + ev.ID.String()
+}
+
+// AlignSystemTaskAssigneeToLead points every open system-minted task on the
+// lead at the lead's current owner, and answers how many it moved.
+//
+// Reconciliation, not a delta: it reads the owner NOW and writes what disagrees
+// with it. That is what makes the two race orders converge, and it is also what
+// makes a later reassignment carry its tasks along — the same call answers both
+// without knowing which one it is handling.
+//
+// A lead with no owner leaves its tasks alone rather than clearing them. Nobody
+// asked for the work to be taken off a rep, and an unowned lead is ordinarily a
+// lead whose routing has not run yet.
+//
+// "System-minted" is source AND captured_by together, the same pair
+// CompleteOpenSystemTasksForLead uses and for the same reason: source rides the
+// create wire verbatim and any caller can spell it, while captured_by is
+// stamped from the authenticated principal. A planted source alone reaches
+// nothing here.
+//
+// Each move goes through UpdateActivity — the module's own write path — so it
+// carries the audit row and the activity.updated event a human reassignment
+// carries. A bulk UPDATE would move the work and leave no history of who now
+// owns it.
+func (s *Store) AlignSystemTaskAssigneeToLead(ctx context.Context, leadID ids.LeadID) (int, error) {
+	owner, ok, err := s.leadOwner(ctx, leadID)
+	if err != nil || !ok {
+		return 0, err
+	}
+	type misassigned struct {
+		id      ids.ActivityID
+		version int64
+	}
+	var wrong []misassigned
+	err = s.tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT a.id, a.version FROM activity a
+			JOIN activity_link l ON l.activity_id = a.id
+			WHERE l.lead_id = $1 AND a.kind = $2 AND a.source = $3
+			  AND (a.captured_by = $4 OR a.captured_by LIKE $5)
+			  AND a.is_done = false AND a.archived_at IS NULL
+			  AND a.assignee_id IS DISTINCT FROM $6
+			ORDER BY a.id`,
+			leadID, string(crmcontracts.ActivityKindTask), systemSource,
+			systemCapturedBy, systemCapturedByPattern, owner)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var task misassigned
+			if err := rows.Scan(&task.id, &task.version); err != nil {
+				return err
+			}
+			wrong = append(wrong, task)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return 0, err
+	}
+	moved := 0
+	for _, task := range wrong {
+		if err := s.assignSystemTask(ctx, task.id, task.version, owner); err != nil {
+			return 0, fmt.Errorf("assigning system task %s: %w", task.id, err)
+		}
+		moved++
+	}
+	return moved, nil
+}
+
+// leadOwner reads who answers for the lead, reporting whether anybody does.
+//
+// A direct read of the lead table rather than a call into people: a module
+// never imports a sibling, and this is one column of one row. The write that
+// follows is on this module's own table.
+func (s *Store) leadOwner(ctx context.Context, leadID ids.LeadID) (ids.UserID, bool, error) {
+	var owner *ids.UserID
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT owner_id FROM lead WHERE id = $1 AND archived_at IS NULL`, leadID).Scan(&owner)
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// The lead went between the event and this read. Nothing to align,
+			// and nothing here went wrong.
+			return ids.UserID{}, false, nil
+		}
+		return ids.UserID{}, false, err
+	}
+	if owner == nil {
+		return ids.UserID{}, false, nil
+	}
+	return *owner, true, nil
+}
+
+// assignSystemTask points one selected task at the owner.
+//
+// Version skew is not retried the way a completion is. A task somebody moved
+// underneath this call was moved by a writer with a live opinion about who owns
+// it — a human reassigning it by hand, or a later firing of this same handler
+// reading a newer owner — and overwriting that with an owner read before their
+// change is how an automation takes work back off the person it was just given
+// to. The next lead.updated reconciles again if the disagreement is real.
+func (s *Store) assignSystemTask(
+	ctx context.Context, id ids.ActivityID, version int64, owner ids.UserID,
+) error {
+	_, err := s.UpdateActivity(ctx, id, UpdateActivityInput{
+		AssigneeID: &owner,
+		IfVersion:  &version,
+	})
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, apperrors.ErrNotFound):
+		// Archived between the selection and the write. No task to move, and
+		// failing here would strand every other task this call selected.
+		return nil
+	case errors.Is(err, apperrors.ErrVersionSkew):
+		// Somebody with a newer opinion got there first. See above.
+		return nil
+	default:
+		return err
+	}
+}

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -217,18 +217,34 @@ func openTaskAssigneeClause(assignee *ids.UserID, arg func(any) int) string {
 }
 
 // ownQueueClause narrows to the open tasks one person is answerable for:
-// assigned to them, or assigned to NOBODY.
+// assigned to them, and to nobody else.
 //
-// The unassigned arm is the difference from openTaskAssigneeClause, and it is
-// the point. A rep who writes themselves a task without filling in an assignee
-// still owns it, and a "my work" queue that dropped it would hide the reader's
-// own to-do from them — worse than carrying one row too many.
+// It used to admit unassigned tasks too, on the ground that a rep who writes
+// themselves a task without filling in an assignee still owns it. That reading
+// was true of the case it named and wrong about every other: an automation
+// mints a follow-up with no assignee, and "or nobody" put that one task on
+// every colleague's queue at once — a manager opening "mine" found a rep's
+// lead work waiting for them, which is the report this rule comes from.
+//
+// The self-written task is kept where it belongs by owning it at the point of
+// writing instead (taskAssignee, activity.go), so this clause can mean exactly
+// what it says. Work that genuinely belongs to nobody is answered by
+// unassignedQueueClause, which is a queue somebody chooses to open rather than
+// one that arrives in everybody's.
 func ownQueueClause(reader *ids.UserID, arg func(any) int) string {
 	if reader == nil {
 		return ""
 	}
-	return sprintf("(a.assignee_id = $%d OR a.assignee_id IS NULL) AND a.kind = 'task' AND NOT a.is_done",
-		arg(*reader))
+	return sprintf("a.assignee_id = $%d AND a.kind = 'task' AND NOT a.is_done", arg(*reader))
+}
+
+// unassignedQueueClause is the open tasks nobody answers for.
+//
+// Its own scope rather than a corner of somebody's queue: unowned work is real
+// and has to be visible, but it is picked up deliberately. Arriving unbidden in
+// every reader's "mine" is what taught reps that the queue was not theirs.
+func unassignedQueueClause() string {
+	return "a.assignee_id IS NULL AND a.kind = 'task' AND NOT a.is_done"
 }
 
 // listActivitiesFilter builds the timeline query's join, WHERE terms and
@@ -274,6 +290,9 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 	}
 	if clause := ownQueueClause(in.OwnQueueOf, arg); clause != "" {
 		where = append(where, clause)
+	}
+	if in.UnassignedQueue {
+		where = append(where, unassignedQueueClause())
 	}
 	if clause := openTaskAssigneeClause(in.AssigneeID, arg); clause != "" {
 		where = append(where, clause)

--- a/backend/internal/modules/activities/orgscope_test.go
+++ b/backend/internal/modules/activities/orgscope_test.go
@@ -149,21 +149,40 @@ func TestAnUnknownEntityTypeIsRefusedRatherThanBuiltIntoSQL(t *testing.T) {
 	}
 }
 
-// A "my work" queue is mine OR nobody's. A rep who writes themselves a task
-// without filling in an assignee still owns it, and dropping it would hide the
-// reader's own to-do from them.
-func TestTheOwnQueueClauseAdmitsUnassignedWork(t *testing.T) {
+// A "my work" queue is MINE, and nobody else's.
+//
+// It used to admit unassigned work too, so a task a rep wrote themselves
+// without an assignee still reached them. That kept one case and broke the
+// queue for every other: an automation's follow-up carries no assignee either,
+// and every colleague found it in their own day at once. The self-written task
+// is answered by owning it as it is written (taskAssignee), not by widening
+// what "mine" means.
+func TestTheOwnQueueClauseIsExactlyTheReaders(t *testing.T) {
 	args := []any{}
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	reader := ids.From[ids.UserKind](ids.MustParse("01a05500-0000-7000-8000-000000000001"))
 
 	clause := ownQueueClause(&reader, arg)
 
-	if !strings.Contains(clause, "a.assignee_id IS NULL") {
-		t.Fatalf("the own-queue clause %q drops unassigned work", clause)
+	if strings.Contains(clause, "IS NULL") {
+		t.Fatalf("the own-queue clause %q still admits work nobody owns", clause)
 	}
 	if !strings.Contains(clause, "a.assignee_id = $1") {
 		t.Fatalf("the own-queue clause %q does not bind the reader", clause)
+	}
+}
+
+// And ownerless work is still reachable, through a clause of its own. Making
+// "mine" exact without this would not have moved that work — it would have
+// hidden it.
+func TestTheUnassignedQueueClauseAnswersOwnerlessWork(t *testing.T) {
+	clause := unassignedQueueClause()
+
+	if !strings.Contains(clause, "a.assignee_id IS NULL") {
+		t.Fatalf("the unassigned clause %q does not select ownerless work", clause)
+	}
+	if !strings.Contains(clause, "NOT a.is_done") {
+		t.Fatalf("the unassigned clause %q carries finished work", clause)
 	}
 }
 

--- a/backend/internal/modules/activities/taskassignee_test.go
+++ b/backend/internal/modules/activities/taskassignee_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Who a new task belongs to.
+//
+// "Mine" became exact, which is only safe because a task somebody writes for
+// themselves is owned as it is written. These are the cases that hold that up:
+// lose the first and a rep's own to-do vanishes from their day, lose the second
+// and every automation's work lands on whoever the job ran as.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func humanWriting(user ids.UUID) context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type:   principal.PrincipalHuman,
+		ID:     "human:" + user.String(),
+		UserID: user,
+	})
+}
+
+// A rep who writes themselves a task owns it, without naming themselves.
+func TestASelfWrittenTaskBelongsToItsAuthor(t *testing.T) {
+	author := ids.NewV7()
+
+	got := taskAssignee(humanWriting(author), LogActivityInput{Kind: "task"})
+
+	if got == nil {
+		t.Fatal("a task a rep wrote for themselves came out belonging to nobody")
+	}
+	if got.UUID != author {
+		t.Fatalf("the task belongs to %v, wanted its author %v", got.UUID, author)
+	}
+}
+
+// A named assignee is obeyed. Handing a task to a colleague must not silently
+// become keeping it.
+func TestANamedAssigneeIsKept(t *testing.T) {
+	author, colleague := ids.NewV7(), ids.From[ids.UserKind](ids.NewV7())
+
+	got := taskAssignee(humanWriting(author), LogActivityInput{Kind: "task", AssigneeID: &colleague})
+
+	if got == nil || got.UUID != colleague.UUID {
+		t.Fatalf("the task went to %v, wanted the named colleague %v", got, colleague)
+	}
+}
+
+// A system principal owns nothing. An automation's follow-up belongs to the
+// record it was minted for, or to nobody until routing says otherwise — never
+// to the job that happened to run.
+func TestASystemWrittenTaskBelongsToNobody(t *testing.T) {
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalSystem,
+		ID:   "system:time-scan",
+	})
+
+	if got := taskAssignee(ctx, LogActivityInput{Kind: "task"}); got != nil {
+		t.Fatalf("a system-written task was assigned to %v", got)
+	}
+}
+
+// Only tasks. An email or a note has no assignee, and stamping one would put a
+// column on a row whose CHECK constraint refuses it.
+func TestOnlyATaskGetsAnAssignee(t *testing.T) {
+	author := ids.NewV7()
+
+	for _, kind := range []string{"email", "call", "note", "meeting"} {
+		if got := taskAssignee(humanWriting(author), LogActivityInput{Kind: kind}); got != nil {
+			t.Fatalf("a %s was assigned to %v", kind, got)
+		}
+	}
+}

--- a/backend/internal/modules/automation/handlers_clock.go
+++ b/backend/internal/modules/automation/handlers_clock.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 	"github.com/margince/margince/backend/internal/shared/ports/workflow"
@@ -152,14 +153,34 @@ func activityStaleMatch(ev workflow.Event, days clockDaysExtractor) (bool, error
 // so an editor-facing schema change lands once, not in three hand-copied
 // maps that could drift.
 func taskCreateEffect(ev workflow.Event, subject string, dueAt time.Time) (workflow.Effect, error) {
-	args, err := json.Marshal(map[string]any{
+	return taskCreateEffectFor(ev, subject, dueAt, nil)
+}
+
+// taskCreateEffectFor is taskCreateEffect with an owner.
+//
+// A task minted for a record somebody already answers for belongs to that
+// person. Left unowned it lands in the unassigned queue — the right home for
+// work nobody owns, and the wrong answer when the owner is named on the record
+// that fired: a routed lead mints a follow-up, the follow-up carries no
+// assignee, and the rep whose lead it is never sees it in their own queue.
+//
+// A nil owner is the honest answer for a record nobody owns yet, and it stays
+// nil rather than falling back to whoever the workflow happened to run as.
+func taskCreateEffectFor(
+	ev workflow.Event, subject string, dueAt time.Time, owner *ids.UUID,
+) (workflow.Effect, error) {
+	fields := map[string]any{
 		fieldKind: "task",
 		"subject": subject,
 		"due_at":  dueAt,
 		"links": []map[string]any{{
 			"entity_type": string(ev.Entity.Type), "entity_id": ev.Entity.ID,
 		}},
-	})
+	}
+	if owner != nil {
+		fields["assignee_id"] = *owner
+	}
+	args, err := json.Marshal(fields)
 	if err != nil {
 		return workflow.Effect{}, fmt.Errorf("automation: encoding the task: %w", err)
 	}

--- a/backend/internal/modules/automation/handlers_clock.go
+++ b/backend/internal/modules/automation/handlers_clock.go
@@ -19,8 +19,8 @@ package automation
 // ActivityScan read (activities/lasttouch.go's source='system'
 // exclusion applies to both alike) and differ only in which params key
 // names their own cadence and what their own reminder says — the shared
-// anchor helpers below (touchAnchor, activityStaleMatch,
-// anchorReminderTaskEffect, anchorIdempotencyKey) exist so that
+// anchor helpers (touchAnchor, activityStaleMatch and anchorIdempotencyKey
+// below, anchorReminderTaskEffect in taskeffect.go) exist so that
 // difference is the ONLY thing their Match/Plan/IdempotencyKey bodies
 // spell out. renewal_reminder rides a different anchor (a custom
 // renewal-date field's value, not a last-touch timestamp) and its own
@@ -34,7 +34,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 	"github.com/margince/margince/backend/internal/shared/ports/workflow"
@@ -144,59 +143,6 @@ func activityStaleMatch(ev workflow.Event, days clockDaysExtractor) (bool, error
 	return anchor.Before(cutoff), nil
 }
 
-// taskCreateEffect is the ONE create_task effect shape every task-minting
-// starter plans — the clock reminders here AND the event starters in
-// handlers_event.go (stage_change_create_task, route_lead). A task of
-// the given subject, due at dueAt, linked to whatever entity actually
-// fired. Sharing the builder keeps the effect's JSON keys
-// (task/subject/due_at/links/entity_type/entity_id) in exactly one place,
-// so an editor-facing schema change lands once, not in three hand-copied
-// maps that could drift.
-func taskCreateEffect(ev workflow.Event, subject string, dueAt time.Time) (workflow.Effect, error) {
-	return taskCreateEffectFor(ev, subject, dueAt, nil)
-}
-
-// taskCreateEffectFor is taskCreateEffect with an owner.
-//
-// A task minted for a record somebody already answers for belongs to that
-// person. Left unowned it lands in the unassigned queue — the right home for
-// work nobody owns, and the wrong answer when the owner is named on the record
-// that fired: a routed lead mints a follow-up, the follow-up carries no
-// assignee, and the rep whose lead it is never sees it in their own queue.
-//
-// A nil owner is the honest answer for a record nobody owns yet, and it stays
-// nil rather than falling back to whoever the workflow happened to run as.
-func taskCreateEffectFor(
-	ev workflow.Event, subject string, dueAt time.Time, owner *ids.UUID,
-) (workflow.Effect, error) {
-	fields := map[string]any{
-		fieldKind: "task",
-		"subject": subject,
-		"due_at":  dueAt,
-		"links": []map[string]any{{
-			"entity_type": string(ev.Entity.Type), "entity_id": ev.Entity.ID,
-		}},
-	}
-	if owner != nil {
-		fields["assignee_id"] = *owner
-	}
-	args, err := json.Marshal(fields)
-	if err != nil {
-		return workflow.Effect{}, fmt.Errorf("automation: encoding the task: %w", err)
-	}
-	return workflow.Effect{Actions: []workflow.Action{{
-		Kind: workflow.ActionCreateTask, Target: ev.Entity, Args: args,
-	}}}, nil
-}
-
-// anchorReminderTaskEffect is the clock handlers' view of taskCreateEffect:
-// a reminder due AT the anchor moment (ev.OccurredAt), anchored on the
-// fired entity, with the caller's own wording — no_activity_reminder,
-// check_in_cadence, and renewal_reminder all plan through it.
-func anchorReminderTaskEffect(ev workflow.Event, subject string) (workflow.Effect, error) {
-	return taskCreateEffect(ev, subject, ev.OccurredAt)
-}
-
 // anchorIdempotencyKey is the load-bearing occurrence key (Task 12) every
 // anchor-derived clock handler derives its dedupe key from: keyed on the
 // ENTITY plus the ANCHOR, never ev.ID — a fresh time-scan pass mints a
@@ -259,13 +205,13 @@ func (noActivityReminder) Match(_ context.Context, ev workflow.Event) (bool, err
 // Plan mints one create_task reminder anchored on the stale entity,
 // naming the anchor in the subject so the reminder is never a mystery
 // number (P6).
-func (noActivityReminder) Plan(_ context.Context, ev workflow.Event) (workflow.Effect, error) {
+func (w noActivityReminder) Plan(ctx context.Context, ev workflow.Event) (workflow.Effect, error) {
 	anchor, err := touchAnchor(ev)
 	if err != nil {
 		return workflow.Effect{}, err
 	}
 	subject := fmt.Sprintf("Check in — no activity since %s", anchor.Format(time.DateOnly))
-	return anchorReminderTaskEffect(ev, subject)
+	return anchorReminderTaskEffect(ctx, w.ex, ev, subject)
 }
 
 func (w noActivityReminder) Apply(ctx context.Context, _ workflow.Event, eff workflow.Effect, _ *workflow.ApprovalToken) (workflow.RunResult, error) {
@@ -342,13 +288,13 @@ func (checkInCadence) Match(_ context.Context, ev workflow.Event) (bool, error) 
 	return activityStaleMatch(ev, checkInCadenceDays)
 }
 
-func (checkInCadence) Plan(_ context.Context, ev workflow.Event) (workflow.Effect, error) {
+func (w checkInCadence) Plan(ctx context.Context, ev workflow.Event) (workflow.Effect, error) {
 	anchor, err := touchAnchor(ev)
 	if err != nil {
 		return workflow.Effect{}, err
 	}
 	subject := fmt.Sprintf("Time for a check-in — last touched %s", anchor.Format(time.DateOnly))
-	return anchorReminderTaskEffect(ev, subject)
+	return anchorReminderTaskEffect(ctx, w.ex, ev, subject)
 }
 
 func (w checkInCadence) Apply(ctx context.Context, _ workflow.Event, eff workflow.Effect, _ *workflow.ApprovalToken) (workflow.RunResult, error) {
@@ -479,13 +425,13 @@ func (renewalReminder) Match(_ context.Context, ev workflow.Event) (bool, error)
 	return !anchor.Before(today) && !anchor.After(horizon), nil
 }
 
-func (renewalReminder) Plan(_ context.Context, ev workflow.Event) (workflow.Effect, error) {
+func (w renewalReminder) Plan(ctx context.Context, ev workflow.Event) (workflow.Effect, error) {
 	anchor, err := renewalAnchor(ev)
 	if err != nil {
 		return workflow.Effect{}, err
 	}
 	subject := fmt.Sprintf("Renewal coming up — %s", anchor.Format(time.DateOnly))
-	return anchorReminderTaskEffect(ev, subject)
+	return anchorReminderTaskEffect(ctx, w.ex, ev, subject)
 }
 
 func (w renewalReminder) Apply(ctx context.Context, _ workflow.Event, eff workflow.Effect, _ *workflow.ApprovalToken) (workflow.RunResult, error) {

--- a/backend/internal/modules/automation/handlers_event.go
+++ b/backend/internal/modules/automation/handlers_event.go
@@ -150,13 +150,38 @@ func (routeLeadCreateTask) Match(_ context.Context, _ workflow.Event) (bool, err
 	return true, nil
 }
 
-func (w routeLeadCreateTask) Plan(_ context.Context, ev workflow.Event) (workflow.Effect, error) {
+// Plan mints the follow-up ASSIGNED to whoever answers for the lead.
+//
+// The owner is read off the lead through the same provider stage_change_notify
+// reads its deal through, rather than imported from the people module: this
+// module reaches no sibling, and the record is already in front of it.
+//
+// A lead nobody owns yet mints an unassigned task, which is the honest answer —
+// it lands in the unassigned queue for somebody to pick up. Owner routing is a
+// separate workflow on the same event with no ordering guarantee between them,
+// so the two orders differ in WHERE the task first appears and never in whether
+// it appears at all.
+func (w routeLeadCreateTask) Plan(ctx context.Context, ev workflow.Event) (workflow.Effect, error) {
 	dueInDays, err := DueInDays(ev.Params, defaultRouteLeadDueInDays)
 	if err != nil {
 		return workflow.Effect{}, err
 	}
-	return taskCreateEffect(ev, "Follow up with the new lead",
-		ev.OccurredAt.AddDate(0, 0, dueInDays))
+	rec, err := w.ex.Provider.Read(ctx, ev.Entity)
+	if err != nil {
+		return workflow.Effect{}, fmt.Errorf("automation: reading the new lead: %w", err)
+	}
+	var lead leadOwnerFields
+	if err := json.Unmarshal(rec.Fields, &lead); err != nil {
+		return workflow.Effect{}, fmt.Errorf("automation: decoding the lead's owner: %w", err)
+	}
+	return taskCreateEffectFor(ev, "Follow up with the new lead",
+		ev.OccurredAt.AddDate(0, 0, dueInDays), lead.OwnerID)
+}
+
+// leadOwnerFields is the one column route_lead needs off the new lead's record.
+// A local shape for the same reason dealOwnerFields is one.
+type leadOwnerFields struct {
+	OwnerID *ids.UUID `json:"owner_id"`
 }
 
 func (w routeLeadCreateTask) Apply(ctx context.Context, _ workflow.Event, eff workflow.Effect, _ *workflow.ApprovalToken) (workflow.RunResult, error) {

--- a/backend/internal/modules/automation/handlers_event.go
+++ b/backend/internal/modules/automation/handlers_event.go
@@ -92,7 +92,7 @@ func (stageChangeCreateTask) Match(_ context.Context, ev workflow.Event) (bool, 
 // task effects handlers plan — named once so the string doesn't drift.
 const fieldKind = "kind"
 
-func (w stageChangeCreateTask) Plan(_ context.Context, ev workflow.Event) (workflow.Effect, error) {
+func (w stageChangeCreateTask) Plan(ctx context.Context, ev workflow.Event) (workflow.Effect, error) {
 	dueInDays, err := DueInDays(ev.Params, 2)
 	if err != nil {
 		return workflow.Effect{}, err
@@ -100,8 +100,9 @@ func (w stageChangeCreateTask) Plan(_ context.Context, ev workflow.Event) (workf
 	// The fired entity IS the deal (this handler triggers only on
 	// deal.stage_changed), so taskCreateEffect's string(ev.Entity.Type)
 	// resolves to "deal" — the same value this map hardcoded before the
-	// shared builder existed.
-	return taskCreateEffect(ev, "Plan the next step after the stage change",
+	// shared builder existed. The deal's owner is who the next step belongs
+	// to; without them the task reaches nobody's own queue.
+	return ownedTaskEffect(ctx, w.ex, ev, "Plan the next step after the stage change",
 		ev.OccurredAt.AddDate(0, 0, dueInDays))
 }
 
@@ -166,22 +167,8 @@ func (w routeLeadCreateTask) Plan(ctx context.Context, ev workflow.Event) (workf
 	if err != nil {
 		return workflow.Effect{}, err
 	}
-	rec, err := w.ex.Provider.Read(ctx, ev.Entity)
-	if err != nil {
-		return workflow.Effect{}, fmt.Errorf("automation: reading the new lead: %w", err)
-	}
-	var lead leadOwnerFields
-	if err := json.Unmarshal(rec.Fields, &lead); err != nil {
-		return workflow.Effect{}, fmt.Errorf("automation: decoding the lead's owner: %w", err)
-	}
-	return taskCreateEffectFor(ev, "Follow up with the new lead",
-		ev.OccurredAt.AddDate(0, 0, dueInDays), lead.OwnerID)
-}
-
-// leadOwnerFields is the one column route_lead needs off the new lead's record.
-// A local shape for the same reason dealOwnerFields is one.
-type leadOwnerFields struct {
-	OwnerID *ids.UUID `json:"owner_id"`
+	return ownedTaskEffect(ctx, w.ex, ev, "Follow up with the new lead",
+		ev.OccurredAt.AddDate(0, 0, dueInDays))
 }
 
 func (w routeLeadCreateTask) Apply(ctx context.Context, _ workflow.Event, eff workflow.Effect, _ *workflow.ApprovalToken) (workflow.RunResult, error) {

--- a/backend/internal/modules/automation/handlers_event_route_lead_test.go
+++ b/backend/internal/modules/automation/handlers_event_route_lead_test.go
@@ -31,8 +31,15 @@ func (p *fakeCreateRecorder) Create(_ context.Context, in datasource.CreateInput
 	return datasource.EntityRef{}, p.err
 }
 
-func (p *fakeCreateRecorder) Read(context.Context, datasource.EntityRef) (datasource.Record, error) {
-	panic("fakeCreateRecorder: Read not stubbed for this test")
+// Read answers a lead nobody owns. Plan reads the record to decide who the
+// follow-up belongs to, so a recorder that refused the read would fail every
+// test of the create path for a reason about the fixture.
+func (p *fakeCreateRecorder) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	fields, err := json.Marshal(leadOwnerFields{})
+	if err != nil {
+		return datasource.Record{}, err
+	}
+	return datasource.Record{Ref: ref, Fields: fields}, nil
 }
 
 func (p *fakeCreateRecorder) Search(context.Context, datasource.SearchQuery) (datasource.SearchResult, error) {
@@ -131,7 +138,7 @@ func TestRouteLeadPlanEmitsOneCreateTaskOnTheLead(t *testing.T) {
 		OccurredAt: occurredAt,
 	}
 
-	eff, err := routeLeadCreateTask{}.Plan(context.Background(), ev)
+	eff, err := routeLeadPlanner(t, leadID, nil).Plan(context.Background(), ev)
 	if err != nil {
 		t.Fatalf("Plan err = %v, want nil", err)
 	}
@@ -183,7 +190,7 @@ func TestRouteLeadPlanHonorsTheInstancesOwnDueInDays(t *testing.T) {
 		OccurredAt: occurredAt,
 		Params:     json.RawMessage(`{"due_in_days": 5}`),
 	}
-	eff, err := routeLeadCreateTask{}.Plan(context.Background(), ev)
+	eff, err := routeLeadPlanner(t, ev.Entity.ID, nil).Plan(context.Background(), ev)
 	if err != nil {
 		t.Fatalf("Plan err = %v, want nil", err)
 	}
@@ -259,5 +266,71 @@ func TestRouteLeadIdempotencyKeyIsStablePerEvent(t *testing.T) {
 	other := routeLeadCreateTask{}.IdempotencyKey(workflow.Event{ID: ids.NewV7()})
 	if key1 == other {
 		t.Error("IdempotencyKey did not vary across distinct events — replays of different events would collide")
+	}
+}
+
+// routeLeadPlanner builds the handler over a lead record the given owner owns,
+// which is what Plan reads to decide who the follow-up belongs to. A nil owner
+// models a lead routing has not reached yet.
+func routeLeadPlanner(t *testing.T, leadID ids.UUID, owner *ids.UUID) routeLeadCreateTask {
+	t.Helper()
+	fields, err := json.Marshal(leadOwnerFields{OwnerID: owner})
+	if err != nil {
+		t.Fatalf("marshal the lead fixture: %v", err)
+	}
+	return routeLeadCreateTask{ex: Executors{Provider: &fakeReadProvider{record: datasource.Record{
+		Ref:    datasource.EntityRef{Type: datasource.EntityLead, ID: leadID},
+		Fields: fields,
+	}}}}
+}
+
+// The follow-up a routed lead mints belongs to the rep the lead was routed to.
+//
+// Without this the task is created with no assignee, and the queue that used to
+// treat unassigned work as everybody's put one rep's lead follow-up in front of
+// every colleague at once.
+func TestRouteLeadAssignsTheFollowUpToTheLeadsOwner(t *testing.T) {
+	leadID := ids.NewV7()
+	owner := ids.NewV7()
+	ev := workflow.Event{
+		Entity:     datasource.EntityRef{Type: datasource.EntityLead, ID: leadID},
+		OccurredAt: time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC),
+	}
+
+	eff, err := routeLeadPlanner(t, leadID, &owner).Plan(context.Background(), ev)
+	if err != nil {
+		t.Fatalf("Plan err = %v, want nil", err)
+	}
+	var args struct {
+		AssigneeID string `json:"assignee_id"`
+	}
+	if err := json.Unmarshal(eff.Actions[0].Args, &args); err != nil {
+		t.Fatalf("action.Args do not decode: %v", err)
+	}
+	if args.AssigneeID != owner.String() {
+		t.Fatalf("the follow-up was assigned to %q, wanted the lead's owner %v", args.AssigneeID, owner)
+	}
+}
+
+// A lead nobody owns mints a task nobody owns. Falling back to whoever the
+// workflow ran as would hand the work to the system principal and hide it from
+// the unassigned queue that exists to surface it.
+func TestRouteLeadLeavesAnUnownedLeadsFollowUpUnassigned(t *testing.T) {
+	leadID := ids.NewV7()
+	ev := workflow.Event{
+		Entity:     datasource.EntityRef{Type: datasource.EntityLead, ID: leadID},
+		OccurredAt: time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC),
+	}
+
+	eff, err := routeLeadPlanner(t, leadID, nil).Plan(context.Background(), ev)
+	if err != nil {
+		t.Fatalf("Plan err = %v, want nil", err)
+	}
+	var args map[string]any
+	if err := json.Unmarshal(eff.Actions[0].Args, &args); err != nil {
+		t.Fatalf("action.Args do not decode: %v", err)
+	}
+	if _, named := args["assignee_id"]; named {
+		t.Fatalf("an unowned lead named an assignee: %v", args["assignee_id"])
 	}
 }

--- a/backend/internal/modules/automation/handlers_event_route_lead_test.go
+++ b/backend/internal/modules/automation/handlers_event_route_lead_test.go
@@ -35,7 +35,7 @@ func (p *fakeCreateRecorder) Create(_ context.Context, in datasource.CreateInput
 // follow-up belongs to, so a recorder that refused the read would fail every
 // test of the create path for a reason about the fixture.
 func (p *fakeCreateRecorder) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
-	fields, err := json.Marshal(leadOwnerFields{})
+	fields, err := json.Marshal(map[string]any{})
 	if err != nil {
 		return datasource.Record{}, err
 	}
@@ -274,7 +274,7 @@ func TestRouteLeadIdempotencyKeyIsStablePerEvent(t *testing.T) {
 // models a lead routing has not reached yet.
 func routeLeadPlanner(t *testing.T, leadID ids.UUID, owner *ids.UUID) routeLeadCreateTask {
 	t.Helper()
-	fields, err := json.Marshal(leadOwnerFields{OwnerID: owner})
+	fields, err := json.Marshal(map[string]any{"owner_id": owner})
 	if err != nil {
 		t.Fatalf("marshal the lead fixture: %v", err)
 	}
@@ -332,5 +332,44 @@ func TestRouteLeadLeavesAnUnownedLeadsFollowUpUnassigned(t *testing.T) {
 	}
 	if _, named := args["assignee_id"]; named {
 		t.Fatalf("an unowned lead named an assignee: %v", args["assignee_id"])
+	}
+}
+
+// Every automation-minted task inherits the owner of the record that fired, not
+// just route_lead's.
+//
+// A task with no assignee reaches no rep's own queue. Before "mine" became
+// exact these rows were visible to everybody, which hid the omission; now an
+// unowned reminder about a deal somebody owns waits in a queue nobody opened,
+// so the rule has to hold for every handler that mints one.
+func TestAStageChangeTaskInheritsTheDealsOwner(t *testing.T) {
+	dealID := ids.NewV7()
+	owner := ids.NewV7()
+	fields, err := json.Marshal(map[string]any{"owner_id": owner})
+	if err != nil {
+		t.Fatalf("marshal the deal fixture: %v", err)
+	}
+	w := stageChangeCreateTask{ex: Executors{Provider: &fakeReadProvider{record: datasource.Record{
+		Ref:    datasource.EntityRef{Type: datasource.EntityDeal, ID: dealID},
+		Fields: fields,
+	}}}}
+	ev := workflow.Event{
+		Entity:     datasource.EntityRef{Type: datasource.EntityDeal, ID: dealID},
+		OccurredAt: time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC),
+		Payload:    json.RawMessage(`{"to_semantic":"open"}`),
+	}
+
+	eff, err := w.Plan(context.Background(), ev)
+	if err != nil {
+		t.Fatalf("Plan err = %v, want nil", err)
+	}
+	var args struct {
+		AssigneeID string `json:"assignee_id"`
+	}
+	if err := json.Unmarshal(eff.Actions[0].Args, &args); err != nil {
+		t.Fatalf("action.Args do not decode: %v", err)
+	}
+	if args.AssigneeID != owner.String() {
+		t.Fatalf("the stage-change task went to %q, wanted the deal's owner %v", args.AssigneeID, owner)
 	}
 }

--- a/backend/internal/modules/automation/taskeffect.go
+++ b/backend/internal/modules/automation/taskeffect.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package automation
+
+// The create_task effect, in one place.
+//
+// Every task-minting starter plans through here — the clock reminders in
+// handlers_clock.go and the event starters in handlers_event.go alike — so the
+// effect's JSON keys and the rule about who a minted task belongs to are each
+// spelled once. Split out of handlers_clock.go because they were never clock
+// machinery: both files call them, and only one of them owned them.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/workflow"
+)
+
+// taskCreateEffectFor is the create_task effect shape every task-minting
+// starter plans — the clock reminders in handlers_clock.go and the event
+// starters in handlers_event.go alike. A task of the given subject, due at
+// dueAt, linked to whatever entity fired, belonging to the given owner.
+//
+// Sharing the builder keeps the effect's JSON keys
+// (kind/subject/due_at/assignee_id/links) in one place, so an editor-facing
+// schema change lands once rather than in several hand-copied maps.
+//
+// A nil owner is the honest answer for a record nobody owns yet: the task is
+// created unassigned and waits in the unassigned queue. It never falls back to
+// whoever the workflow happened to run as, which would file the work under a
+// system principal and hide it from everybody.
+func taskCreateEffectFor(
+	ev workflow.Event, subject string, dueAt time.Time, owner *ids.UUID,
+) (workflow.Effect, error) {
+	fields := map[string]any{
+		fieldKind: "task",
+		"subject": subject,
+		"due_at":  dueAt,
+		"links": []map[string]any{{
+			"entity_type": string(ev.Entity.Type), "entity_id": ev.Entity.ID,
+		}},
+	}
+	if owner != nil {
+		fields["assignee_id"] = *owner
+	}
+	args, err := json.Marshal(fields)
+	if err != nil {
+		return workflow.Effect{}, fmt.Errorf("automation: encoding the task: %w", err)
+	}
+	return workflow.Effect{Actions: []workflow.Action{{
+		Kind: workflow.ActionCreateTask, Target: ev.Entity, Args: args,
+	}}}, nil
+}
+
+// anchorReminderTaskEffect is the clock handlers' view of taskCreateEffect:
+// a reminder due AT the anchor moment (ev.OccurredAt), anchored on the
+// fired entity, with the caller's own wording — no_activity_reminder,
+// check_in_cadence, and renewal_reminder all plan through it.
+func anchorReminderTaskEffect(
+	ctx context.Context, ex Executors, ev workflow.Event, subject string,
+) (workflow.Effect, error) {
+	return ownedTaskEffect(ctx, ex, ev, subject, ev.OccurredAt)
+}
+
+// ownedTaskEffect mints a task belonging to whoever owns the record that fired.
+//
+// Every automation-minted task goes through here, because leaving one of them
+// unowned is not a smaller version of the same bug — it is the whole bug. A task
+// with no assignee reaches no rep's own queue and waits in the unassigned one
+// nobody opened, so a reminder about a deal somebody owns quietly stops being
+// their reminder.
+//
+// A record with no owner mints an unassigned task, which is honest: there is
+// nobody to give it to, and the unassigned queue is where it belongs until
+// somebody claims the record.
+//
+// A record this read cannot reach mints an unassigned task too, rather than
+// failing the run. The reminder is the point; losing it entirely because its
+// owner could not be looked up trades a misfiled task for no task at all.
+func ownedTaskEffect(
+	ctx context.Context, ex Executors, ev workflow.Event, subject string, dueAt time.Time,
+) (workflow.Effect, error) {
+	return taskCreateEffectFor(ev, subject, dueAt, recordOwner(ctx, ex, ev))
+}
+
+// recordOwner reads who answers for the record that fired, or nil.
+//
+// One shape for every record type the task-minting handlers fire on: deal,
+// lead, person and organization all spell their owner `owner_id`, so one decode
+// answers all four and a per-type switch would be four spellings of one fact.
+func recordOwner(ctx context.Context, ex Executors, ev workflow.Event) *ids.UUID {
+	if ex.Provider == nil {
+		return nil
+	}
+	rec, err := ex.Provider.Read(ctx, ev.Entity)
+	if err != nil {
+		return nil
+	}
+	var owned struct {
+		OwnerID *ids.UUID `json:"owner_id"`
+	}
+	if err := json.Unmarshal(rec.Fields, &owned); err != nil {
+		return nil
+	}
+	return owned.OwnerID
+}

--- a/backend/internal/modules/introductions/lifecycle.go
+++ b/backend/internal/modules/introductions/lifecycle.go
@@ -131,8 +131,8 @@ func May(from, to Status, by Actor) error {
 }
 
 // Open reports whether an ask is still live — somebody owes an action on it.
-// The duplicate guard and the expiry sweep read the same answer, so a status
-// added to one and forgotten in the other cannot drift.
+// The duplicate guard and the expiry sweep both ask this function rather than
+// listing the live statuses themselves, so a new status is added here once.
 func Open(s Status) bool {
 	switch s {
 	case StatusRequested, StatusAccepted, StatusNameDropApproved:

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24858,13 +24858,13 @@ export interface components {
              * @description Whose work this read answered for.
              * @enum {string}
              */
-            scope: "mine" | "team" | "all";
+            scope: "mine" | "unassigned" | "team" | "all";
             /**
              * @description The scopes this reader may ask for, narrowest first — derived from their own
              *     row scope. A client draws a control only when there is more than one, so a
              *     rep who can only see their own work is never offered a switch that would 403.
              */
-            scope_options: ("mine" | "team" | "all")[];
+            scope_options: ("mine" | "unassigned" | "team" | "all")[];
             /**
              * @description The narrowing this read applied.
              * @enum {string}
@@ -35924,6 +35924,13 @@ export interface operations {
                  *     than quietly narrowed — answering a question about the team with facts about
                  *     one person, with no way for the reader to tell, is the worse failure.
                  *
+                 *     `unassigned` is the open work nobody answers for, and every reader may ask for
+                 *     it at any tier: nothing in it belongs to a colleague, which is what unassigned
+                 *     means. It exists because `mine` is exact — a task with no assignee is no
+                 *     longer folded into every reader's own queue, so it needs a queue of its own or
+                 *     the product would have stopped mentioning it. Tasks only: a message has no
+                 *     assignee, so unanswered mail stays reachable from `mine`, `team` and `all`.
+                 *
                  *     WHAT A WIDER SCOPE REACHES. The record-bearing sources widen: tasks, deals
                  *     going quiet, meetings and duplicate pairs are read under the caller's row
                  *     scope, so `team` and `all` return what that tier reaches and `mine` narrows
@@ -35933,7 +35940,7 @@ export interface operations {
                  *     means "every shared record I may see, plus my own personal queue" — not a
                  *     licence to read a colleague's inbox.
                  */
-                scope?: "mine" | "team" | "all";
+                scope?: "mine" | "unassigned" | "team" | "all";
                 /** @description Narrow the queue to one kind of work. Omitted means everything, which is the default view. */
                 filter?: "all" | "customer_waiting" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system";
                 /** @description How many ranked items to return. */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7161,6 +7161,7 @@ export const de = {
   "worklist.overdue": "Überfällig",
   "worklist.scope.label": "Wessen Arbeit",
   "worklist.scope.mine": "Meine",
+  "worklist.scope.unassigned": "Ohne Zuständigkeit",
   "worklist.scope.team": "Mein Team",
   "worklist.scope.all": "Alle",
   "worklist.filter.label": "Art der Arbeit",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7244,6 +7244,7 @@ export const en = {
   "worklist.overdue": "Overdue",
   "worklist.scope.label": "Whose work",
   "worklist.scope.mine": "Mine",
+  "worklist.scope.unassigned": "Unassigned",
   "worklist.scope.team": "My team",
   "worklist.scope.all": "All",
   "worklist.filter.label": "Kind of work",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7095,6 +7095,7 @@ export const vi = {
   "worklist.overdue": "Quá hạn",
   "worklist.scope.label": "Công việc của ai",
   "worklist.scope.mine": "Của tôi",
+  "worklist.scope.unassigned": "Chưa có người phụ trách",
   "worklist.scope.team": "Nhóm của tôi",
   "worklist.scope.all": "Tất cả",
   "worklist.filter.label": "Loại công việc",

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -325,6 +325,7 @@ function WorklistHeader({
           label={t("worklist.scope.label")}
           labels={{
             mine: t("worklist.scope.mine"),
+            unassigned: t("worklist.scope.unassigned"),
             team: t("worklist.scope.team"),
             all: t("worklist.scope.all"),
           }}


### PR DESCRIPTION
A manager opened their Worklist and found a rep's lead work waiting in it. The lead was routed to Lena; the follow-up task it minted carried no assignee; and the "my work" query admitted `assignee_id IS NULL`. That one task therefore appeared in every colleague's day at once, each of them believing it was theirs.

## Mine is exact, and unowned work gets a home

The NULL arm was deliberate and defended a real case: a rep who writes themselves a task without filling in an assignee still owns it. That case is now answered where it belongs — a task a human writes is stamped with its author as it is written — so the query can mean what it says.

Work that genuinely belongs to nobody gets its own scope. Making "mine" exact without it would not have moved that work, it would have hidden it, so `unassigned` is offered to every reader at every tier: nothing in it is a colleague's, which is what unassigned means.

## Every automation task inherits its record's owner

The first cut of this fixed `route_lead` and left four other handlers minting unowned tasks. Before "mine" became exact those rows were visible to everybody, which hid the omission; after it they reach nobody's queue. The rule now lives in the shared effect builder, so `stage_change_create_task`, `no_activity_reminder`, `check_in_cadence` and `renewal_reminder` inherit it too.

Owner routing is a separate workflow on the same event with no ordering between them, so a new system handler reconciles on `lead.updated`: it reads the lead's **current** owner and points its open system tasks at it. Reconciliation rather than a delta, which is what makes both race orders converge and carries a later reassignment along for free.

## What review caught

Five defects, all fixed in the branch. The four unowned handlers above; a frontend that did not compile (the scope control's labels are typed from the contract enum, and `fe-build` is the check that says so — I had not run it); version skew swallowed where the sibling handler re-reads, which could strand a task pointing at nobody; a reconcile that counted skipped tasks as moved; and a dead field.

## Waiting rows are deliberately untouched

A message has no assignee, and the only ownership evidence available comes from the at-risk lane, so a healthy owned deal reads as unowned. Judging against that would drop a rep's own waiting customer whenever their deal was doing well. Making it exact needs the owner on the row, which is a later change; the comment says so where the rule is.

## Also

`origin/main` was red on its own uniqueness gate when this rebased — two PRs raced, one broadening the detector and one adding a comment it catches. One sentence in `introductions/lifecycle.go`, fixed here rather than filed.

Tests: the unit test for the new stamp passes with the wiring removed, because it calls the decision directly. The integration test beside it reads `assignee_id` off the row after a real `LogActivity` and fails when the two are disconnected — that is the one holding this up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Worklist's "mine" scope exact so automation-created tasks no longer appear in every colleague's queue, and adds a new `unassigned` scope for work that belongs to nobody.

**New Features**
- `unassigned` lists open tasks with no assignee and is offered to every reader at every tier.
- Waiting rows stay out of it: a message has no assignee, and the record's health cannot be read from the at-risk lane alone.

**Bug Fixes**
- "mine" now returns exactly the reader's assigned open tasks; ownerless rows no longer fold into it.
- A task a human writes without naming an assignee is stamped with its author at creation.
- All automation-minted tasks now inherit the owner of the record that fired.
- A new system handler repoints open follow-ups to the lead's current owner on `lead.updated`, so routing and minting resolve in either order.

<sup>Written for commit 1c1a3db25d1b147208cfcc69df79e241592cd7d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Unassigned** worklist scope for viewing open tasks without an owner.
  * Personal worklists now show only tasks assigned to the current user.
  * Human-created tasks default to their author when no assignee is selected.
  * Automated follow-up tasks inherit the related lead or deal owner when available.
  * Added localized labels for the new scope in English, German, and Vietnamese.

* **Bug Fixes**
  * Updated follow-up ownership when lead ownership changes.
  * Preserved explicitly assigned tasks and correctly handled unowned records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->