### PR TITLE
A send goes out through the mailbox the sender actually has

### DIFF
--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -203,6 +203,16 @@ func (p *preflightEnv) dispatchOnce(t *testing.T, deliveryID ids.UUID, stampAs s
 	return outcome, captured, gmailConnector
 }
 
+// drivenProvider is the connector this suite actually drives, read from its own
+// descriptor.
+//
+// NOT activities.DefaultSendProvider, which is what a store composed with no
+// send authority falls back to. The two carry the same value today and mean
+// different things: a test resting on the fallback would go on passing after
+// this suite was pointed at another vendor, asserting about a provider it no
+// longer drives.
+var drivenProvider = gmail.New(nil, nil).Descriptor().Name
+
 // connectorCtx is the principal the capture registry builds for a sync: the
 // connector identity acting under the granting human's permissions.
 func (p *preflightEnv) connectorCtx(t *testing.T) context.Context {
@@ -210,7 +220,7 @@ func (p *preflightEnv) connectorCtx(t *testing.T) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), p.workspaceID(t))
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	return principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalConnector, ID: "connector:" + activities.SendProvider,
+		Type: principal.PrincipalConnector, ID: "connector:" + drivenProvider,
 		Scopes: principal.NewScopeSet(principal.ScopeRead),
 		Permissions: principal.Permissions{
 			Objects:  map[string]principal.ObjectGrant{"activity": {Create: true, Read: true}},
@@ -230,12 +240,29 @@ func TestCapturedCopyOfASentEmailCollapsesOntoTheSameActivity(t *testing.T) {
 	rfc822, capturingConnector := p.transmit(t, deliveryID, "")
 
 	// BOTH halves of the natural key come from the capture side, never from the
-	// send side. source_system is the connector's own declared name — two
-	// independent constants (gmail.connectorName and activities.SendProvider)
-	// spell it today, and nothing but this comparison holds them equal. Feeding
-	// the send-side literal in here would assert the assumption and stay green
+	// send side. source_system is the connector's own declared name, and nothing
+	// but the comparison below holds it equal to what the send wrote. Feeding
+	// the send-side value in here would assert the assumption and stay green
 	// while every outbound email landed twice.
 	sourceSystem := capturingConnector.Descriptor().Name
+
+	// What the SEND actually resolved, read off the row it wrote.
+	//
+	// Not activities.DefaultSendProvider, which is only what a store with no
+	// send authority falls back to, and not drivenProvider either: the send
+	// path now resolves a provider PER SEND from the sender's own mailbox, so
+	// the only honest send-side value is the one that send arrived at. A
+	// constant here would go on matching after this suite was pointed at
+	// another vendor, and it is this very test — the one proving a sent mail
+	// does not land twice — that would be asserting about a provider nobody
+	// drove.
+	var sentSourceSystem string
+	if err := apptest.InWorkspace(p.AppEnv, t, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT source_system FROM activity WHERE id = $1`, sentActivity).Scan(&sentSourceSystem)
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// The key comes out of the bytes, through the connector's own mapping —
 	// mailmap.Parse + ToRecord is precisely what the Gmail connector runs on
@@ -245,9 +272,11 @@ func TestCapturedCopyOfASentEmailCollapsesOntoTheSameActivity(t *testing.T) {
 		t.Fatalf("the message the connector produced does not parse:\n%s\n%v", rfc822, err)
 	}
 	echo := msg.AttestSentByOwner(true).ToRecord(sourceSystem, rfc822)
-	if echo.NaturalKey.SourceSystem != activities.SendProvider {
-		t.Fatalf("capture keys this message under source_system %q but the send path writes %q — the two constants have drifted apart",
-			echo.NaturalKey.SourceSystem, activities.SendProvider)
+	// This comparison is the point: it holds the capture side and the send side
+	// equal, each read from where it is actually decided.
+	if echo.NaturalKey.SourceSystem != sentSourceSystem {
+		t.Fatalf("capture keys this message under source_system %q but the send wrote %q — the two sides have drifted apart",
+			echo.NaturalKey.SourceSystem, sentSourceSystem)
 	}
 	if echo.NaturalKey.SourceID != messageID {
 		t.Fatalf("the captured copy keys on %q but the send wrote %q — every outbound email would land twice",

--- a/backend/internal/compose/sendpreflight.go
+++ b/backend/internal/compose/sendpreflight.go
@@ -110,6 +110,36 @@ func installSendPreflight(s *Server, pool *pgxpool.Pool) {
 	})(s, pool)
 }
 
+// SendableMailProvider names the mailbox this user's next send goes out
+// through: the first mail provider they hold a transmitting grant for.
+//
+// DERIVED from comms' own census rather than from a list here, so a vendor
+// added there is one this can already choose — and asked through SendCapable,
+// so "can this user send through it" is the same question in both directions
+// rather than two that could disagree.
+//
+// FIRST, in the census's own order, and that order is alphabetical rather than
+// meaningful. It matters only to somebody holding two sendable mailboxes at
+// once, which nothing in the product asks them to do and no surface lets them
+// choose between; until one does, a stable answer beats an arbitrary-looking
+// one that changes between sends. A rep with one mailbox — every rep today —
+// gets theirs.
+//
+// Empty means none of them can transmit, which the caller turns into the
+// refusal naming what to fix.
+func (m mailboxAuthority) SendableMailProvider(ctx context.Context) (string, error) {
+	for _, provider := range comms.MailSendProviders() {
+		capable, err := m.SendCapable(ctx, provider)
+		if err != nil {
+			return "", err
+		}
+		if capable {
+			return provider, nil
+		}
+	}
+	return "", nil
+}
+
 func (m mailboxAuthority) SendCapable(ctx context.Context, provider string) (bool, error) {
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.UserID.IsZero() {

--- a/backend/internal/compose/sendpreflight_test.go
+++ b/backend/internal/compose/sendpreflight_test.go
@@ -22,8 +22,11 @@ import (
 
 type stubGrants struct {
 	granted []string
-	err     error
-	calls   int
+	// grantedFor answers per provider, for the cases about choosing between two
+	// mailboxes. nil falls back to `granted` for all of them.
+	grantedFor map[string][]string
+	err        error
+	calls      int
 	// channelBound is what the WORKSPACE lookup answers, and channelCalls counts
 	// it separately: the two lookups read different tables, and a pre-flight
 	// that asked the wrong one is exactly the defect that refused every channel
@@ -33,8 +36,14 @@ type stubGrants struct {
 	channelCalls int
 }
 
-func (s *stubGrants) GrantedScopesFor(context.Context, ids.UserID, string) ([]string, error) {
+func (s *stubGrants) GrantedScopesFor(_ context.Context, _ ids.UserID, provider string) ([]string, error) {
 	s.calls++
+	// Per provider when the case says so, which is what a choice BETWEEN
+	// mailboxes needs; `granted` answers for every provider otherwise, which is
+	// what every single-mailbox case wants.
+	if s.grantedFor != nil {
+		return s.grantedFor[provider], s.err
+	}
 	return s.granted, s.err
 }
 
@@ -239,5 +248,78 @@ func TestSendCapableAsksTheUnitRatherThanTheWorkspaceBotTable(t *testing.T) {
 				t.Errorf("the workspace bot table was read %d time(s) for a unit transport; a unit never writes it, and asking it is what refused every unit reply", grants.channelCalls)
 			}
 		})
+	}
+}
+
+// Which mailbox a send goes out through — the question this pre-flight was
+// extended to answer, and the one a hard-coded provider got wrong for every rep
+// whose only mailbox is the other vendor.
+func TestSendableMailProviderNamesAMailboxTheSenderCanActuallySendFrom(t *testing.T) {
+	human := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:x", UserID: ids.NewV7(),
+	})
+	// The scope each vendor's send rides, read from comms rather than spelled
+	// here: a test naming its own would go on passing after the real one moved.
+	sendable := func(providers ...string) map[string][]string {
+		out := map[string][]string{}
+		for _, p := range providers {
+			scope, _ := comms.SendScopeFor(p)
+			out[p] = []string{scope}
+		}
+		return out
+	}
+	mail := comms.MailSendProviders()
+	if len(mail) < 2 {
+		t.Fatalf("comms names %d mail provider(s); this test is about choosing between them", len(mail))
+	}
+	first, second := mail[0], mail[len(mail)-1]
+
+	for name, tc := range map[string]struct {
+		grantedFor map[string][]string
+		want       string
+	}{
+		// A rep whose only mailbox is the SECOND vendor is the case a constant
+		// refused: it named the first and reported them unable to send.
+		"only the second vendor": {sendable(second), second},
+		"only the first vendor":  {sendable(first), first},
+		// Holding both is not something any surface asks for, and the answer is
+		// the census's own order — stable beats arbitrary-looking.
+		"both":    {sendable(mail...), first},
+		"neither": {map[string][]string{}, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			authority := mailboxAuthority{
+				grants:            &stubGrants{grantedFor: tc.grantedFor},
+				mailAppConfigured: func(string) bool { return true },
+			}
+			got, err := authority.SendableMailProvider(human)
+			if err != nil {
+				t.Fatalf("SendableMailProvider: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("SendableMailProvider = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A lookup fault is not "this user cannot send": answering empty would refuse
+// the send by name over a database blip, sending a rep to reconnect a mailbox
+// that was never the problem.
+func TestSendableMailProviderReportsALookupFaultRatherThanNoMailbox(t *testing.T) {
+	human := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:x", UserID: ids.NewV7(),
+	})
+	wantErr := errors.New("the grant table is unreachable")
+	authority := mailboxAuthority{
+		grants:            &stubGrants{err: wantErr},
+		mailAppConfigured: func(string) bool { return true },
+	}
+	got, err := authority.SendableMailProvider(human)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("SendableMailProvider error = %v, want the lookup fault", err)
+	}
+	if got != "" {
+		t.Errorf("SendableMailProvider = %q on a fault, want none", got)
 	}
 }

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -25,17 +25,22 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
-// SendProvider names the channel V1 transmits through. It is both the
-// delivery's provider and the activity's source_system, deliberately the
-// same literal: the provider files its own copy of every sent message back
-// into the mailbox, and that copy is only recognised as this activity when
-// the natural key it carries — (source_system, source_id) — is the one the
-// send wrote.
+// DefaultSendProvider is what a store with NO send authority wired sends
+// through — the historical answer, kept because the pre-flight is advisory and
+// an absent one must not change which mailbox a send uses.
 //
-// Exported because the composition root's mailbox pre-flight has to ask about
-// the connection this path will actually transmit through; a second literal
-// there could name a provider the send path never uses.
-const SendProvider = "gmail"
+// It is not the answer for a composed installation. There, the provider is
+// RESOLVED per send (sendableMailProvider): a mail send carries no `from`, so
+// something has to choose, and a constant refused every rep whose only mailbox
+// was the other vendor's.
+//
+// Whichever way it is arrived at, the SAME value is the delivery's provider and
+// the activity's source_system — the provider files its own copy of every sent
+// message back into the mailbox, and that copy is only recognised as this
+// activity when the natural key it carries, (source_system, source_id), is the
+// one the send wrote. Two answers here would be a duplicate timeline row for
+// every message anybody sends.
+const DefaultSendProvider = "gmail"
 
 // sourceManual is the provenance every send this system composes carries: a
 // human typed it here, whichever transport carried it out. Spelled once because
@@ -155,9 +160,12 @@ func MintMessageID(domain string) string {
 // record and a person they may not read. Every guard is fail-closed; only
 // their order carries this rule, which is why they are one function and not
 // scattered through the send.
-func (s *Store) refuseUnsendable(ctx context.Context, in SendEmailInput, gate ConsentGate, stager DeliveryStager) error {
+// It RETURNS the provider it resolved, so the send that follows uses the very
+// mailbox this guard cleared. Asking twice would be two round-trips and two
+// answers, and the second could differ from the one that was judged.
+func (s *Store) refuseUnsendable(ctx context.Context, in SendEmailInput, gate ConsentGate, stager DeliveryStager) (string, error) {
 	if err := auth.Require(ctx, "activity", principal.ActionCreate); err != nil {
-		return err
+		return "", err
 	}
 	// Guard the To: LINE, not the merged list, because they are not the same
 	// thing and only the first one goes on the wire. Recipients is To+Cc
@@ -180,31 +188,57 @@ func (s *Store) refuseUnsendable(ctx context.Context, in SendEmailInput, gate Co
 	// loosening this in Go while the contract still refuses it would make the
 	// two disagree about what a valid send is.
 	if len(toRecipients(in.Recipients, in.Cc, in.Bcc)) == 0 {
-		return &NoRecipientsError{}
+		return "", &NoRecipientsError{}
 	}
 	// The composition guards report a deployment defect, and a caller who may
 	// not send has no business learning which parts of this installation's
 	// send path are wired — hence their position, not their existence.
 	if gate == nil {
-		return fmt.Errorf("send path has no consent authority wired: %w", apperrors.ErrConsentNotGranted)
+		return "", fmt.Errorf("send path has no consent authority wired: %w", apperrors.ErrConsentNotGranted)
 	}
 	if stager == nil {
 		// A send nothing will ever transmit must refuse, not leave a timeline
 		// entry claiming a message went out.
-		return errNoDeliveryStager
+		return "", errNoDeliveryStager
 	}
 	// The mailbox pre-flight is the SENDER's own authority and precedes the
 	// consent gate for the same reason authorization does: a user who holds no
 	// send grant must get the refusal they can act on, not a verdict about the
 	// recipients' consent state.
-	capable, err := s.canSend(ctx, SendProvider)
+	//
+	// It asks WHICH mailbox rather than asking about a fixed one. A mail send
+	// carries no `from`, so something has to choose; a constant was an honest
+	// answer only while one provider could send, and refused a rep whose only
+	// mailbox is the other.
+	provider, err := s.sendableMailProvider(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
-	if !capable {
-		return &MailboxNotSendCapableError{}
+	if err := gate.RequireGrantedForEmails(ctx, in.Recipients, in.ConsentPurpose); err != nil {
+		return "", err
 	}
-	return gate.RequireGrantedForEmails(ctx, in.Recipients, in.ConsentPurpose)
+	return provider, nil
+}
+
+// sendableMailProvider names the mailbox this send will go out through, or
+// refuses with the error the caller can act on.
+//
+// An unwired authority answers with the historical default rather than
+// refusing: the pre-flight is advisory by contract (see SendAuthority), and a
+// store composed without one must accept the send exactly as it did before this
+// question existed.
+func (s *Store) sendableMailProvider(ctx context.Context) (string, error) {
+	if s.sendAuthority == nil {
+		return DefaultSendProvider, nil
+	}
+	provider, err := s.sendAuthority.SendableMailProvider(ctx)
+	if err != nil {
+		return "", err
+	}
+	if provider == "" {
+		return "", &MailboxNotSendCapableError{}
+	}
+	return provider, nil
 }
 
 // messageIDDomain is the right-hand side of every minted Message-ID: the

--- a/backend/internal/modules/activities/email_test.go
+++ b/backend/internal/modules/activities/email_test.go
@@ -11,12 +11,14 @@ package activities
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // stubUnsubscribeLinker stands in for the consent module's preference-token
@@ -39,11 +41,28 @@ type stubSendAuthority struct {
 	capable bool
 	err     error
 	asked   []string
+	// mailProvider is the mailbox this stub says a mail send goes out through;
+	// empty falls back to the one a capable authority would name, so a fixture
+	// that only cares about capability need not spell it.
+	mailProvider string
 }
 
 func (m *stubSendAuthority) SendCapable(_ context.Context, provider string) (bool, error) {
 	m.asked = append(m.asked, provider)
 	return m.capable, m.err
+}
+
+func (m *stubSendAuthority) SendableMailProvider(context.Context) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	if !m.capable {
+		return "", nil
+	}
+	if m.mailProvider != "" {
+		return m.mailProvider, nil
+	}
+	return DefaultSendProvider, nil
 }
 
 // draftOutcomeCall is what the send path handed the learning loop: the
@@ -221,4 +240,61 @@ func TestTheFloorGreetsTheRecipientOrNobody(t *testing.T) {
 func firstLineOf(body string) string {
 	line, _, _ := strings.Cut(body, "\n")
 	return line
+}
+
+// THE DEFECT THIS SEAM EXISTS FOR.
+//
+// A mail send carries no `from`, so something chooses the mailbox. While Gmail
+// was the only provider that could transmit, a constant was an honest answer.
+// It stopped being one when Outlook could: the delivery named a connector the
+// sender had no grant on, and the connector that could have carried the message
+// was never reached.
+func TestASendGoesOutThroughTheMailboxItResolved(t *testing.T) {
+	for name, provider := range map[string]string{
+		"a Gmail mailbox":    "gmail",
+		"an Outlook mailbox": "graph",
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := outboundMessage{
+				in:        SendEmailInput{Subject: "Following up"},
+				messageID: "outbound-1@margince.test",
+				provider:  provider,
+				to:        []string{"client@acme.test"},
+			}
+			// BOTH, and the same value: the delivery names the connector that
+			// transmits, and the activity's source_system is the natural key the
+			// provider's own echo carries. Two answers here would file a
+			// duplicate timeline row for every message anybody sends.
+			if got := m.delivery(ids.NewV7(), threading{}).Provider; got != provider {
+				t.Errorf("delivery provider = %q, want %q — handed to a connector this sender has no grant on", got, provider)
+			}
+			act := m.activity(threading{})
+			if act.SourceSystem == nil || *act.SourceSystem != provider {
+				t.Errorf("activity source_system = %v, want %q — the echo would key onto nothing and land as a second row", act.SourceSystem, provider)
+			}
+		})
+	}
+}
+
+// What the guard does with each answer.
+func TestTheMailboxResolutionRefusesOnlyWhenNothingCanTransmit(t *testing.T) {
+	store := &Store{}
+
+	// No authority wired: the pre-flight is advisory, so an absent one must not
+	// change which mailbox a send uses.
+	if got, err := store.sendableMailProvider(context.Background()); err != nil || got != DefaultSendProvider {
+		t.Errorf("unwired authority = (%q, %v), want the historical default", got, err)
+	}
+
+	sending := store.WithSendAuthority(&stubSendAuthority{capable: true, mailProvider: "graph"})
+	if got, err := sending.sendableMailProvider(context.Background()); err != nil || got != "graph" {
+		t.Errorf("resolved = (%q, %v), want the mailbox the authority named", got, err)
+	}
+
+	none := store.WithSendAuthority(&stubSendAuthority{capable: false})
+	_, err := none.sendableMailProvider(context.Background())
+	var refusal *MailboxNotSendCapableError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("no transmitting mailbox = %v, want the refusal naming what to fix", err)
+	}
 }

--- a/backend/internal/modules/activities/outboundmessage.go
+++ b/backend/internal/modules/activities/outboundmessage.go
@@ -44,6 +44,11 @@ type outboundMessage struct {
 	listUnsubscribe string
 	to              []string
 	links           []ActivityLinkInput
+	// provider is the mailbox this send goes out through, resolved once per
+	// send. It is used twice below — the activity's source_system and the
+	// delivery's provider — and the two must be the same value or the captured
+	// echo keys onto nothing and lands as a second timeline row.
+	provider string
 }
 
 // htmlAlternativeNote marks a timeline row whose message also went out as
@@ -54,7 +59,7 @@ const htmlAlternativeNote = "This message was also sent as HTML."
 
 // activity is the timeline row the send commits.
 func (m outboundMessage) activity(chain threading) LogActivityInput {
-	direction, sourceSystem := "outbound", SendProvider
+	direction, sourceSystem := "outbound", m.provider
 	recorded := m.recordedBody
 	if m.htmlBody != "" {
 		// The timeline keeps the PLAIN alternative, and says so when a markup
@@ -93,7 +98,7 @@ func (m outboundMessage) activity(chain threading) LogActivityInput {
 func (m outboundMessage) delivery(activityID ids.UUID, chain threading) DeliveryRequest {
 	return DeliveryRequest{
 		ActivityID:      ids.From[ids.ActivityKind](activityID),
-		Provider:        SendProvider,
+		Provider:        m.provider,
 		MessageID:       m.messageID,
 		Recipients:      m.to,
 		Cc:              m.in.Cc,

--- a/backend/internal/modules/activities/sendauthority.go
+++ b/backend/internal/modules/activities/sendauthority.go
@@ -31,6 +31,23 @@ type SendAuthority interface {
 	// SendCapable reports whether a send through provider, by the principal on
 	// ctx, has a credential behind it that can transmit — not merely read.
 	SendCapable(ctx context.Context, provider string) (bool, error)
+
+	// SendableMailProvider names the mail provider this user's next send should
+	// go out through, or "" when none of their mailboxes can transmit.
+	//
+	// It exists because a MAIL send has no `from` argument — the contract takes
+	// recipients and a body, never a mailbox — so something has to choose, and
+	// for as long as Gmail was the only mail provider that could send, a
+	// constant was an honest answer. It stopped being one the day Outlook could:
+	// a rep whose only mailbox is Microsoft was refused by a pre-flight asking
+	// about a Google connection they never made.
+	//
+	// The answer is one provider and it is used TWICE — the delivery's provider
+	// and the activity's source_system — which is why this returns rather than
+	// being asked twice. The provider files its own copy of every sent message
+	// back into the mailbox, and that copy is only recognised as this activity
+	// when the natural key it carries is the one the send wrote.
+	SendableMailProvider(ctx context.Context) (string, error)
 }
 
 // MailboxNotSendCapableError refuses a MAIL send this installation already knows

--- a/backend/internal/modules/activities/sendcore.go
+++ b/backend/internal/modules/activities/sendcore.go
@@ -83,7 +83,8 @@ func (s *Store) PrepareSend(ctx context.Context, origin SendOrigin, in SendEmail
 	if err != nil {
 		return PreparedSend{}, err
 	}
-	if err := s.refuseUnsendable(ctx, in, gate, stager); err != nil {
+	provider, err := s.refuseUnsendable(ctx, in, gate, stager)
+	if err != nil {
 		return PreparedSend{}, err
 	}
 
@@ -163,6 +164,7 @@ func (s *Store) PrepareSend(ctx context.Context, origin SendOrigin, in SendEmail
 			listUnsubscribe: derived.listUnsubscribe,
 			to:              toRecipients(in.Recipients, in.Cc, in.Bcc),
 			links:           links,
+			provider:        provider,
 		},
 	}, nil
 }

--- a/backend/internal/modules/capture/gmail/send.go
+++ b/backend/internal/modules/capture/gmail/send.go
@@ -36,7 +36,15 @@ const SendScope = "https://www.googleapis.com/auth/gmail.send"
 // Reconnecting is the fix, so the caller parks rather than retries.
 var ErrSendScopeMissing = fmt.Errorf("gmail: this connection was not granted the send scope: %w", connector.ErrAuthRejected)
 
-var _ connector.EmailSender = (*Connector)(nil)
+var (
+	_ connector.EmailSender = (*Connector)(nil)
+	// Asserted as well as implemented, the way the Outlook connector does.
+	// CarriageOf reaches Carriage through a type assertion, so a rename here
+	// would stop this connector declaring carriage at all — and a message with
+	// files staged against a connector that carries nothing PARKS. The compiler
+	// is the only thing that can notice.
+	_ connector.AttachmentCarrier = (*Connector)(nil)
+)
 
 // maxSendableFiles is the most files this connector will put in one message.
 //


### PR DESCRIPTION
Found by reviewing the merged Microsoft work against Google, looking for what the feature tests could not see.

## Outlook sending was implemented and unreachable

A mail send carries no `from` — the contract takes recipients and a body, never a mailbox — so something has to choose which connection transmits. `activities.SendProvider` was that choice:

```go
const SendProvider = "gmail"
```

It was an honest answer for exactly as long as Gmail was the only mail provider that could send. It stopped being one when Outlook could.

A rep whose only mailbox is Microsoft was refused by a pre-flight asking whether their **Google** connection could transmit (`canSend(ctx, SendProvider)` → `MailboxNotSendCapableError`), and the connector that would have carried the message was never reached: `SenderFor` resolves `capture_connection` on `(user_id, provider)`, and the provider it was handed was always `"gmail"`.

**Nothing above it was wrong.** `SendCapable` was already per-provider, `comms.SendScopeFor` had learned `Mail.Send`, `mailAppConfigured` had a graph arm, and the connector implements `EmailSender` and `AttachmentCarrier`. One literal at the bottom decided the whole thing — and it was the only mail-delivery provider assignment in the tree:

```
$ grep -rn "Provider:" internal/modules/activities/ internal/modules/comms/ | grep -i "SendProvider\|\"gmail\"\|\"graph\""
internal/modules/activities/outboundmessage.go:96:  Provider: SendProvider,
```

(Channel sends take a provider as a parameter. Mail sends did not.)

## The fix

The provider is **resolved per send**, from the census `comms` already keeps (`MailSendProviders`), asked through the existing `SendCapable` — so a vendor added there is one this can already choose, and "can this user send through it" stays one question rather than two that could disagree.

The resolved value is used **twice**, and that is the part worth guarding: the delivery's provider and the activity's `source_system` must be the *same* value, because the mailbox files its own copy of every sent message back and that copy is only recognised as this activity when the natural key matches. Two answers there would be a duplicate timeline row for every message anybody sends. Mutating either back to the constant fails `TestASendGoesOutThroughTheMailboxItResolved` with exactly the messages that describe the bug.

A rep holding two sendable mailboxes gets the census's own (alphabetical) order. That matters only to somebody nothing in the product asks to do that, and no surface lets them choose between; until one does, a stable answer beats one that changes between sends.

A store with **no** authority wired keeps the historical default — the pre-flight is advisory by contract, and an absent one must not change which mailbox a send uses.

## Also

The Gmail connector implements `Carriage()` without asserting `connector.AttachmentCarrier`, where the Outlook one asserts it. `CarriageOf` reaches it through a type assertion, so a rename would have stopped Gmail declaring carriage at all — and a message with files staged against a connector that carries nothing **parks**. The compiler is the only thing that can notice, so it now does.

## Verification

`make check-fe` and `make craft-static` green; `make check-backend` green apart from a docs-budget gate tripping on **gitignored** local `docs/superpowers/plans/*` files that CI never sees. The send integration lane passes. `TestTheActivityListNarrowsByAssigneeOnTheWire` fails identically on clean `main` — that is [#3379](https://github.com/margince/margince/issues/3379), not this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail delivery now dynamically selects the first available sending provider.
  * Messages and delivery activity consistently use the provider selected for each send.
  * Mailbox checks clearly report when no sending provider is available.

* **Bug Fixes**
  * Improved provider-specific delivery metadata and activity tracking.
  * Preserved the default provider when no provider-selection authority is configured.

* **Tests**
  * Added coverage for Gmail, Outlook, provider resolution, and unavailable mailbox scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->