### PR TITLE
main is red: three doubles panic on Provider.Read, and an unassigned task is not unassigned

### DIFF
--- a/backend/internal/compose/integration/automation_runs_preview_integration_test.go
+++ b/backend/internal/compose/integration/automation_runs_preview_integration_test.go
@@ -225,7 +225,7 @@ func assertPreviewMeasuresWithoutWriting(t *testing.T, e *apptest.AppEnv, autoID
 	}
 	// The create stamps the admin as owner; the recipe counts leads nobody
 	// owns, so the lead is disowned to be the unrouted one the preview must find.
-	disownOverDB(t, e, "lead", lead.ID)
+	nullOverDB(t, e, "lead", "owner_id", lead.ID)
 
 	var rowsBefore int
 	if err := e.Owner.QueryRow(context.Background(), `

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -27,16 +27,18 @@ import (
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
-// disownOverDB nulls a record's owner at the database. A create over the wire
-// stamps the calling seat as owner when the body names none, so the unowned
-// state these queue tests are about has to be produced after the fact.
-func disownOverDB(t *testing.T, e *apptest.AppEnv, table, id string) {
+// nullOverDB clears one of a record's holder columns at the database. A create
+// over the wire stamps the calling seat into them when the body names nobody —
+// owner_id on every record, assignee_id on a task the seat writes for itself —
+// so the unheld state these queue tests are about has to be produced after the
+// fact.
+func nullOverDB(t *testing.T, e *apptest.AppEnv, table, column, id string) {
 	t.Helper()
 	if err := apptest.InWorkspace(e, t, func(tx pgx.Tx) error {
-		_, err := tx.Exec(t.Context(), `UPDATE `+table+` SET owner_id = NULL WHERE id = $1`, id)
+		_, err := tx.Exec(t.Context(), `UPDATE `+table+` SET `+column+` = NULL WHERE id = $1`, id)
 		return err
 	}); err != nil {
-		t.Fatalf("disown %s %s: %v", table, id, err)
+		t.Fatalf("null %s.%s on %s: %v", table, column, id, err)
 	}
 }
 
@@ -123,7 +125,11 @@ func TestTheActivityListNarrowsByAssigneeOnTheWire(t *testing.T) {
 		"kind": "task", "subject": "Call the buyer", "due_at": "2026-09-01T09:00:00Z", "assignee_id": me.User.ID,
 	})
 	// An unassigned task is the row a dropped filter hands back alongside it.
-	createdRecord(t, e, "/v1/activities", AnyMap{"kind": "task", "subject": "Nobody's"})
+	// It has to be unassigned after the fact: a task written over the wire
+	// without an assignee belongs to its author, so creating one here would
+	// hand the filter a second row it rightly matches.
+	nobodys := createdRecord(t, e, "/v1/activities", AnyMap{"kind": "task", "subject": "Nobody's"})
+	nullOverDB(t, e, "activity", "assignee_id", nobodys)
 
 	onlyRecord(t, e, "/v1/activities?assignee_id="+me.User.ID, mine, "the open task that person holds")
 }
@@ -189,7 +195,7 @@ func TestThePersonListNarrowsToTheUnownedQueueOnTheWire(t *testing.T) {
 
 	createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Owned Person", "owner_id": owner})
 	unowned := createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Unowned Person"})
-	disownOverDB(t, e, "person", unowned)
+	nullOverDB(t, e, "person", "owner_id", unowned)
 
 	// Unassigned is a fact with its own queue, not an absence: a list that
 	// answered every row here would send somebody to claim records that are
@@ -204,7 +210,7 @@ func TestTheLeadListNarrowsToTheUnownedQueueOnTheWire(t *testing.T) {
 
 	createdRecord(t, e, "/v1/leads", AnyMap{"full_name": "Owned Lead", "email": "owned@lead.test", "owner_id": owner})
 	unowned := createdRecord(t, e, "/v1/leads", AnyMap{"full_name": "Unowned Lead", "email": "unowned@lead.test"})
-	disownOverDB(t, e, "lead", unowned)
+	nullOverDB(t, e, "lead", "owner_id", unowned)
 
 	// The same dial the person and company lists answer (DM-VOCAB-OWN-1): a
 	// lead queue nobody has claimed is the first thing a rep asks a lead list.

--- a/backend/internal/modules/automation/effectclaim_integration_test.go
+++ b/backend/internal/modules/automation/effectclaim_integration_test.go
@@ -38,6 +38,10 @@ func (p *countingProvider) Create(_ context.Context, in datasource.CreateInput) 
 	return datasource.EntityRef{Type: in.EntityType, ID: ids.NewV7()}, nil
 }
 
+func (p *countingProvider) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return ownerlessRecord(ref), nil
+}
+
 // leadCreatedEnvelope is one lead.created delivery for a fixed lead.
 func leadCreatedEnvelope(lead ids.UUID) kevents.Envelope {
 	return kevents.Envelope{

--- a/backend/internal/modules/automation/handlers_actions_test.go
+++ b/backend/internal/modules/automation/handlers_actions_test.go
@@ -111,8 +111,24 @@ func (p *fakeUpdateProvider) Update(_ context.Context, in datasource.UpdateInput
 	return in.Ref, p.err
 }
 
-func (p *fakeUpdateProvider) Read(context.Context, datasource.EntityRef) (datasource.Record, error) {
-	panic("fakeUpdateProvider: Read not stubbed for this test")
+func (p *fakeUpdateProvider) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return ownerlessRecord(ref), nil
+}
+
+// ownerlessRecord is what the doubles in this package answer Provider.Read
+// with: the record that was asked for, carrying no fields.
+//
+// No owner is the honest answer. Every case here is about how many tasks a
+// firing mints and what it names them after; the task effect reads the
+// triggering record only to ATTRIBUTE the task, so "nobody owns it" is a
+// complete answer to the only question asked of it.
+//
+// A body rather than the embedded interface's nil: a double that embeds an
+// interface panics on every method it does not write, and a panic is not a
+// loud failure in a test binary — it is the end of the binary. One unmodelled
+// method stopped every other test in this package from running.
+func ownerlessRecord(ref datasource.EntityRef) datasource.Record {
+	return datasource.Record{Ref: ref, Fields: json.RawMessage(`{}`)}
 }
 
 func (p *fakeUpdateProvider) Search(context.Context, datasource.SearchQuery) (datasource.SearchResult, error) {

--- a/backend/internal/modules/automation/handlers_clock_integration_test.go
+++ b/backend/internal/modules/automation/handlers_clock_integration_test.go
@@ -46,8 +46,8 @@ func (p *fakeCreateTaskProvider) Create(_ context.Context, in datasource.CreateI
 	return datasource.EntityRef{Type: in.EntityType, ID: ids.NewV7()}, nil
 }
 
-func (p *fakeCreateTaskProvider) Read(context.Context, datasource.EntityRef) (datasource.Record, error) {
-	panic("fakeCreateTaskProvider: Read not stubbed for this test")
+func (p *fakeCreateTaskProvider) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return ownerlessRecord(ref), nil
 }
 
 func (p *fakeCreateTaskProvider) Search(context.Context, datasource.SearchQuery) (datasource.SearchResult, error) {


### PR DESCRIPTION
`main` was red in three ways. All three are here.

**Three test doubles panic on `Provider.Read`.** The datasource seam gained a
`Read`, and `countingProvider`, `fakeCreateTaskProvider` and `fakeUpdateProvider`
answer it by panicking — so any path that reads back what it just wrote takes
the suite down rather than the double. They answer with the record they were
asked for now.

**An unassigned task is not unassigned.** `TestTheActivityListNarrowsByAssigneeOnTheWire`
seeded a control row it believed no filter would match, then failed because the
list answered two records — which reads exactly like a parameter the handler
drops. The handler carries it fine: a task written over the wire without an
assignee belongs to its author, so the control was assigned to the same person
as the row under test. It is now unassigned at the database after creation,
which is how the sibling owner-queue tests already produce an unheld row — the
one helper that does it takes the column.

The dropped-filter mutation still fails the test, so it goes on proving the
thing it is named for.

`intro_request`'s foreign keys were the fourth failure; #3442 landed the store
and the classification with it, so nothing is owed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automation and integration test coverage for records without assigned owners.
  * Updated preview matching and queue tests to reliably handle cleared owners and assignees.
  * Enhanced test scenarios for activities, people, and leads with unassigned record fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->