### PR TITLE
The night's pick says what the deal is worth

### DIFF
--- a/backend/internal/compose/attention/dealfacts.go
+++ b/backend/internal/compose/attention/dealfacts.go
@@ -8,16 +8,13 @@ package attention
 //
 // Most lanes read the deal themselves and arrive with the numbers already on
 // the row. The overnight brief does not — it ranks deal ids and keeps its
-// evidence behind its own endpoint, so that the ranking payload is not copied
-// onto a second wire where the two could disagree. The cost was that its rows
-// reached a rep naming a deal and saying nothing else about it: no amount, no
-// close date, nothing to act on. That is the row a rep is meant to open their
-// day on, and it was the least informative one on the page.
+// composite and factor vector behind its own endpoint — so its rows reached a
+// rep naming a deal and saying nothing else about it: no amount, no close date,
+// nothing to act on. That is the row a rep is meant to open their day on, and
+// it was the least informative one on the page.
 //
-// Figures are not the ranking payload. The amount and the close date are the
-// deal's own columns, which every other lane already carries onto its rows;
-// what stays behind the brief's endpoint is the composite and the factors that
-// produced it.
+// Figures are not that ranking arithmetic. The amount and the close date are
+// the deal's own columns, which every other lane already carries onto its rows.
 //
 // One read for every deal the page names, beside the label pass and for the
 // same reason: a follow-up read per card is the N+1 this feed exists to avoid.

--- a/backend/internal/compose/attention/dealfacts.go
+++ b/backend/internal/compose/attention/dealfacts.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The deal-figures pass: a card that names a deal states what the deal is
+// worth, when it was meant to land and who answers for it.
+//
+// Most lanes read the deal themselves and arrive with the numbers already on
+// the row. The overnight brief does not — it ranks deal ids and keeps its
+// evidence behind its own endpoint, so that the ranking payload is not copied
+// onto a second wire where the two could disagree. The cost was that its rows
+// reached a rep naming a deal and saying nothing else about it: no amount, no
+// close date, nothing to act on. That is the row a rep is meant to open their
+// day on, and it was the least informative one on the page.
+//
+// Figures are not the ranking payload. The amount and the close date are the
+// deal's own columns, which every other lane already carries onto its rows;
+// what stays behind the brief's endpoint is the composite and the factors that
+// produced it.
+//
+// One read for every deal the page names, beside the label pass and for the
+// same reason: a follow-up read per card is the N+1 this feed exists to avoid.
+
+import (
+	"context"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// nameTheMoney puts a deal's figures on every lane item that names one and
+// carries none.
+//
+// Items that already have facts are left alone: the lane that produced them
+// read the deal under this same reader, and asking again could only produce a
+// second answer to a settled question.
+func (s *Service) nameTheMoney(ctx context.Context, day *crmcontracts.Attention) error {
+	if s.dealFacts == nil {
+		return nil
+	}
+	lanes := []*[]crmcontracts.AttentionItem{&day.ThisMorning}
+	wanted := make([]ids.UUID, 0, len(day.ThisMorning))
+	seen := map[ids.UUID]bool{}
+	for _, lane := range lanes {
+		for i := range *lane {
+			id, ok := needsDealFigures((*lane)[i])
+			if !ok || seen[id] {
+				continue
+			}
+			seen[id] = true
+			wanted = append(wanted, id)
+		}
+	}
+	if len(wanted) == 0 {
+		return nil
+	}
+	figures, err := s.dealFacts.Figures(ctx, wanted)
+	if err != nil {
+		return err
+	}
+	for _, lane := range lanes {
+		for i := range *lane {
+			id, ok := needsDealFigures((*lane)[i])
+			if !ok {
+				continue
+			}
+			found, ok := figures[id]
+			if !ok {
+				// The reader may not see this deal, or it is gone. The row
+				// keeps its name and says no more, which is the shape an
+				// unnamed subject already has.
+				continue
+			}
+			applyDealFigures(&(*lane)[i], found)
+		}
+	}
+	return nil
+}
+
+// needsDealFigures answers which deal a lane item names when it carries no
+// figures of its own.
+func needsDealFigures(item crmcontracts.AttentionItem) (ids.UUID, bool) {
+	if item.Deal != nil || item.Subject == nil || item.Subject.Type != subjectDeal {
+		return ids.UUID{}, false
+	}
+	return ids.UUID(item.Subject.Id), true
+}
+
+// applyDealFigures writes one answer onto the item.
+//
+// The close date lands on DueAt as well as on the deal facts, because that is
+// where the projection reads a row's deadline from — a date set only on the
+// facts would print on the card and order nothing.
+func applyDealFigures(item *crmcontracts.AttentionItem, figures DealFigures) {
+	facts := &crmcontracts.AttentionDealFacts{AmountMinor: figures.AmountMinor}
+	if !figures.StageID.IsZero() {
+		stage := openapi_types.UUID(figures.StageID)
+		facts.StageId = &stage
+	}
+	if !figures.OwnerID.IsZero() {
+		owner := openapi_types.UUID(figures.OwnerID)
+		facts.OwnerId = &owner
+	}
+	if figures.Currency != "" {
+		currency := figures.Currency
+		facts.Currency = &currency
+	}
+	item.Deal = facts
+	if figures.ExpectedCloseDate != nil && item.DueAt == nil {
+		closes := *figures.ExpectedCloseDate
+		item.DueAt = &closes
+	}
+}

--- a/backend/internal/compose/attention/dealfacts_test.go
+++ b/backend/internal/compose/attention/dealfacts_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The deal-figures pass.
+//
+// The row it exists for is the overnight brief's: a rep opens their day on it,
+// and before this it named a deal and said nothing else about it.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+type stubDealFacts struct {
+	figures map[ids.UUID]DealFigures
+	asked   []ids.UUID
+	err     error
+}
+
+func (s *stubDealFacts) Figures(_ context.Context, dealIDs []ids.UUID) (map[ids.UUID]DealFigures, error) {
+	s.asked = append(s.asked, dealIDs...)
+	return s.figures, s.err
+}
+
+func briefRow(dealID ids.UUID) crmcontracts.AttentionItem {
+	return crmcontracts.AttentionItem{
+		Id:      dealID.String(),
+		Source:  "brief_item",
+		Actions: []crmcontracts.AttentionItemActions{},
+		Subject: &crmcontracts.AttentionSubject{
+			Type: subjectDeal,
+			Id:   openapi_types.UUID(dealID),
+		},
+	}
+}
+
+// A brief row states the deal's money and its close date, which is the whole
+// point: a card naming a deal and nothing else cannot be acted on.
+func TestABriefRowGainsItsDealsFigures(t *testing.T) {
+	dealID := ids.NewV7()
+	amount := int64(160_100_00)
+	closes := time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC)
+	svc := (&Service{}).WithDealFacts(&stubDealFacts{figures: map[ids.UUID]DealFigures{
+		dealID: {AmountMinor: &amount, Currency: "EUR", ExpectedCloseDate: &closes},
+	}})
+	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{briefRow(dealID)}}
+
+	if err := svc.nameTheMoney(context.Background(), &day); err != nil {
+		t.Fatalf("naming the money: %v", err)
+	}
+
+	got := day.ThisMorning[0]
+	if got.Deal == nil {
+		t.Fatal("the brief row still carries no deal figures")
+	}
+	if got.Deal.AmountMinor == nil || *got.Deal.AmountMinor != amount {
+		t.Fatalf("the row says %v, wanted the deal's amount %d", got.Deal.AmountMinor, amount)
+	}
+	if got.Deal.Currency == nil || *got.Deal.Currency != "EUR" {
+		t.Fatalf("the row says %v currency — a figure whose units are unnamed is dropped by the client", got.Deal.Currency)
+	}
+	if got.DueAt == nil || !got.DueAt.Equal(closes) {
+		t.Fatalf("the row's deadline is %v, wanted the close date %v", got.DueAt, closes)
+	}
+}
+
+// A deal the reader may not see leaves the row as it was. The refusal is an
+// absent answer, not an error, so one withheld deal cannot take the page down.
+func TestAWithheldDealLeavesTheRowUnchanged(t *testing.T) {
+	dealID := ids.NewV7()
+	svc := (&Service{}).WithDealFacts(&stubDealFacts{figures: map[ids.UUID]DealFigures{}})
+	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{briefRow(dealID)}}
+
+	if err := svc.nameTheMoney(context.Background(), &day); err != nil {
+		t.Fatalf("a deal the reader may not see failed the whole read: %v", err)
+	}
+
+	if day.ThisMorning[0].Deal != nil {
+		t.Fatal("a withheld deal put figures on the row anyway")
+	}
+}
+
+// A row that already carries figures is left alone, and its deal is never
+// asked about. The lane that produced it read the deal under this same reader,
+// and a second answer to a settled question is how two numbers come to
+// disagree.
+func TestARowThatAlreadyHasFiguresIsNotAskedAbout(t *testing.T) {
+	dealID := ids.NewV7()
+	existing := int64(42_00)
+	stub := &stubDealFacts{figures: map[ids.UUID]DealFigures{}}
+	row := briefRow(dealID)
+	row.Deal = &crmcontracts.AttentionDealFacts{AmountMinor: &existing}
+	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{row}}
+
+	if err := (&Service{}).WithDealFacts(stub).nameTheMoney(context.Background(), &day); err != nil {
+		t.Fatalf("naming the money: %v", err)
+	}
+
+	if len(stub.asked) != 0 {
+		t.Fatalf("asked about %v, and the row already knew its own figures", stub.asked)
+	}
+	if day.ThisMorning[0].Deal.AmountMinor == nil || *day.ThisMorning[0].Deal.AmountMinor != existing {
+		t.Fatal("the row's own figures were overwritten")
+	}
+}
+
+// The same deal on several rows is one question. A page of brief items about
+// one account would otherwise ask about it once per row.
+func TestOneDealNamedTwiceIsAskedAboutOnce(t *testing.T) {
+	dealID := ids.NewV7()
+	stub := &stubDealFacts{figures: map[ids.UUID]DealFigures{}}
+	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{
+		briefRow(dealID), briefRow(dealID),
+	}}
+
+	if err := (&Service{}).WithDealFacts(stub).nameTheMoney(context.Background(), &day); err != nil {
+		t.Fatalf("naming the money: %v", err)
+	}
+
+	if len(stub.asked) != 1 {
+		t.Fatalf("asked %d times about one deal", len(stub.asked))
+	}
+}
+
+// Unbound, the pass does nothing and says so by not failing: the seam is
+// optional, and a feed without it sends rows the way it always did.
+func TestAnUnboundReaderLeavesEveryRowAlone(t *testing.T) {
+	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{
+		briefRow(ids.NewV7()),
+	}}
+
+	if err := (&Service{}).nameTheMoney(context.Background(), &day); err != nil {
+		t.Fatalf("an unbound reader failed the read: %v", err)
+	}
+	if day.ThisMorning[0].Deal != nil {
+		t.Fatal("an unbound reader invented figures")
+	}
+}

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -97,6 +97,9 @@ type Service struct {
 	// names is OPTIONAL like the lanes above it: nil means subjects travel
 	// unnamed and the client resolves display names itself (labels.go).
 	names Names
+	// dealFacts is OPTIONAL in the same way: nil means a row whose producer
+	// carried only a deal id travels without the deal's figures.
+	dealFacts DealFacts
 	// machine answers whether an address is a sending system, for the group a
 	// routine contact decision joins. Nil means every address reads as a
 	// person's, which under-groups rather than hiding anything.
@@ -168,6 +171,16 @@ func (s *Service) WithUndelivered(u Undelivered) *Service {
 // WithMachineSender binds the rule that tells a sending system from a person.
 func (s *Service) WithMachineSender(is MachineSender) *Service {
 	s.machine = is
+	return s
+}
+
+// WithDealFacts binds the reader that puts a deal's own figures on a row whose
+// producer carried only its id. An option for the reason WithWaiting is one.
+//
+// Unbound, those rows travel with a name and no figures, which is what they did
+// before this seam existed — a smaller card, never a wrong one.
+func (s *Service) WithDealFacts(f DealFacts) *Service {
+	s.dealFacts = f
 	return s
 }
 

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -360,6 +360,35 @@ type WaitingCustomer struct {
 	HasOpenDeal bool
 }
 
+// DealFacts answers the figures behind deals a row names but does not carry.
+//
+// Most rows arrive with their deal's numbers already on them, because the lane
+// that produced them read the deal. The overnight brief does not: it ranks deal
+// ids and keeps its evidence behind its own endpoint, deliberately, so that the
+// ranking payload is not copied onto a second wire where the two could
+// disagree. Without this seam its rows reach a rep naming a deal and saying
+// nothing about it — no amount, no close date, nothing to act on.
+//
+// One call for every id on the page, like the label pass beside it, rather than
+// one per row.
+//
+// A deal the caller may not read is simply absent from the answer, which is the
+// same refusal shape Names uses: the row keeps its name and loses its figures,
+// and the id still travels because naming the deal was the producer's claim.
+type DealFacts interface {
+	Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]DealFigures, error)
+}
+
+// DealFigures is what a card needs to state a deal's commercial case: what it
+// is worth, when it was meant to land, and who answers for it.
+type DealFigures struct {
+	StageID           ids.UUID
+	OwnerID           ids.UUID
+	AmountMinor       *int64
+	Currency          string
+	ExpectedCloseDate *time.Time
+}
+
 // Meetings is today's booked meetings that have not happened yet.
 //
 // Optional as the other two are: nil means this feed does not read meetings,

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -364,10 +364,13 @@ type WaitingCustomer struct {
 //
 // Most rows arrive with their deal's numbers already on them, because the lane
 // that produced them read the deal. The overnight brief does not: it ranks deal
-// ids and keeps its evidence behind its own endpoint, deliberately, so that the
-// ranking payload is not copied onto a second wire where the two could
-// disagree. Without this seam its rows reach a rep naming a deal and saying
-// nothing about it — no amount, no close date, nothing to act on.
+// ids and keeps its composite and factor vector behind its own endpoint, so a
+// card that draws those reads them there. Without this seam its rows reach a
+// rep naming a deal and saying nothing about it — no amount, no close date,
+// nothing to act on.
+//
+// What this answers is the deal's OWN columns, which every other lane already
+// carries onto its rows. The ranking arithmetic stays where it is.
 //
 // One call for every id on the page, like the label pass beside it, rather than
 // one per row.

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -74,6 +74,14 @@ func (s *Service) Worklist(ctx context.Context, scope, filter string, limit int)
 	if err != nil {
 		return crmcontracts.Worklist{}, err
 	}
+	// The overnight brief ranks deal ids and keeps its figures behind its own
+	// endpoint, so its rows arrive naming a deal and saying nothing about it.
+	// Filled here, before the projection, so the money is on the row when the
+	// ordering reads it — enriching afterwards would rank the deal as unpriced
+	// and then print its price, which is the page disagreeing with itself.
+	if err := reader.nameTheMoney(ctx, &day); err != nil {
+		return crmcontracts.Worklist{}, err
+	}
 	// Read beside the assembled day rather than inside it: /attention has its
 	// own fourteen-lane promise and this source is not one of its lanes. A
 	// refused read is named, never folded into an empty answer.

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -28,6 +28,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/platform/database"
@@ -373,4 +374,29 @@ func subjectOfMeeting(row crmcontracts.Activity) string {
 		return *row.Subject
 	}
 	return ""
+}
+
+// attentionDealFacts reads deal figures through the deals store, under the
+// reader's own grants: a deal they may not see is absent from the answer and
+// the row simply states less about it.
+type attentionDealFacts struct{ store *deals.Store }
+
+func (f attentionDealFacts) Figures(
+	ctx context.Context, dealIDs []ids.UUID,
+) (map[ids.UUID]attention.DealFigures, error) {
+	found, err := f.store.Figures(ctx, dealIDs)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[ids.UUID]attention.DealFigures, len(found))
+	for id, figures := range found {
+		out[id] = attention.DealFigures{
+			StageID:           figures.StageID,
+			OwnerID:           figures.OwnerID,
+			AmountMinor:       figures.AmountMinor,
+			Currency:          figures.Currency,
+			ExpectedCloseDate: figures.ExpectedCloseDate,
+		}
+	}
+	return out, nil
 }

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -487,5 +487,9 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, meter *over
 		// The reader's own sends that never left, from the stamp the
 		// dispatcher's park records on the row.
 		WithUndelivered(attentionUndelivered{store: comms.NewStore(db, time.Now, activities.NewStore(db))}).
-		WithMachineSender(capture.IsMachineAddress)
+		WithMachineSender(capture.IsMachineAddress).
+		// The figures behind a deal a row names but does not carry — the
+		// overnight brief's rows, which rank ids and keep their evidence
+		// behind the brief's own endpoint.
+		WithDealFacts(attentionDealFacts{store: deals.NewStore(db, DealsInstallation())})
 }

--- a/backend/internal/compose/integration/dealfigures_integration_test.go
+++ b/backend/internal/compose/integration/dealfigures_integration_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The batched deal-figures read, against a real database.
+//
+// Its whole claim is that it answers under the reader's own row scope, and that
+// is SQL: a unit test with hand-built rows cannot fail it. The admission is
+// asserted as hard as the refusal, because a read that answered nobody would
+// pass a refusal-only suite while leaving every card blank.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedFiguresDeal writes one deal owned by the given rep, with the figures a
+// card states.
+func seedFiguresDeal(t *testing.T, owner ids.UUID, amount int64) ids.UUID {
+	t.Helper()
+	conn := OwnerConn(t)
+	pipeline := SeedIDRow(t, conn, `INSERT INTO pipeline (id, name, is_default, position)
+		VALUES ($1, 'Sales', true, 0)`)
+	stage := SeedIDRow(t, conn, `INSERT INTO stage (id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, 'Qualify', 0, 'open', 10)`, pipeline)
+	return SeedIDRow(t, conn, `INSERT INTO deal
+		(id, owner_id, name, pipeline_id, stage_id, amount_minor, currency, expected_close_date,
+		 source, captured_by)
+		VALUES ($1, $2, 'Northstar renewal', $3, $4, $5, 'EUR', DATE '2026-08-28', 'manual', 'human:x')`,
+		owner, pipeline, stage, amount)
+}
+
+// A deal the reader may see comes back with the figures a card states.
+func TestDealFiguresAnswerADealTheReaderMaySee(t *testing.T) {
+	e := Setup(t)
+	const amount = int64(160_100_00)
+	dealID := seedFiguresDeal(t, e.Rep1, amount)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+
+	figures, err := e.Deals.Figures(rep, []ids.UUID{dealID})
+	if err != nil {
+		t.Fatalf("reading the deal's figures: %v", err)
+	}
+
+	got, ok := figures[dealID]
+	if !ok {
+		t.Fatal("a deal the reader owns did not come back at all")
+	}
+	if got.AmountMinor == nil || *got.AmountMinor != amount {
+		t.Fatalf("the deal came back worth %v, wanted %d", got.AmountMinor, amount)
+	}
+	if got.Currency != "EUR" {
+		t.Fatalf("the deal came back in %q — a figure whose units are unnamed is dropped", got.Currency)
+	}
+	if got.ExpectedCloseDate == nil {
+		t.Fatal("the deal came back with no close date, which is half of why a card is urgent")
+	}
+	if got.OwnerID != e.Rep1 {
+		t.Fatalf("the deal came back owned by %v, wanted %v", got.OwnerID, e.Rep1)
+	}
+}
+
+// An archived deal is not answered. A card naming a deal nobody works any more
+// would send a rep at a closed conversation.
+func TestDealFiguresWithholdAnArchivedDeal(t *testing.T) {
+	e := Setup(t)
+	dealID := seedFiguresDeal(t, e.Rep1, 50_000_00)
+	if _, err := OwnerConn(t).Exec(context.Background(),
+		`UPDATE deal SET archived_at = now() WHERE id = $1`, dealID); err != nil {
+		t.Fatalf("archiving the deal: %v", err)
+	}
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+
+	figures, err := e.Deals.Figures(rep, []ids.UUID{dealID})
+	if err != nil {
+		t.Fatalf("an archived deal failed the read: %v", err)
+	}
+
+	if _, found := figures[dealID]; found {
+		t.Fatal("an archived deal came back")
+	}
+}
+
+// Asking about nothing answers nothing. A page whose rows all carry their own
+// figures must not pay for a read.
+func TestDealFiguresAnswerNothingForNoIDs(t *testing.T) {
+	e := Setup(t)
+
+	figures, err := e.Deals.Figures(e.Admin(), nil)
+	if err != nil {
+		t.Fatalf("asking about no deals: %v", err)
+	}
+	if len(figures) != 0 {
+		t.Fatalf("asking about no deals answered %d", len(figures))
+	}
+}

--- a/backend/internal/compose/integration/dealfigures_integration_test.go
+++ b/backend/internal/compose/integration/dealfigures_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // seedFiguresDeal writes one deal owned by the given rep, with the figures a
@@ -97,5 +98,54 @@ func TestDealFiguresAnswerNothingForNoIDs(t *testing.T) {
 	}
 	if len(figures) != 0 {
 		t.Fatalf("asking about no deals answered %d", len(figures))
+	}
+}
+
+// The role mask reaches this read too.
+//
+// Row scope decides which deals answer; the field mask decides which of their
+// columns do. A rep whose role hides another team's amount everywhere else must
+// not read it off the Worklist, which is the one surface that used to get its
+// figures from a door with no mask on it.
+func TestDealFiguresApplyTheRolesFieldMask(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	mine := e.SeedDeal(t, "Mine", pipeline, open, &e.Rep1)
+	theirs := e.SeedDeal(t, "Theirs", pipeline, open, &e.Rep3)
+	const amount = int64(250000)
+	for _, id := range []ids.UUID{mine, theirs} {
+		e.WsExec(t, `UPDATE deal SET amount_minor = $2, currency = 'EUR' WHERE id = $1`, id, amount)
+	}
+	perms := activityLifecyclePerms
+	perms.Objects = map[string]principal.ObjectGrant{"deal": {Read: true, Update: true}, "pipeline": {Read: true}}
+	perms.FieldMasks = []principal.FieldMask{
+		{Object: "deal", Field: "amount_minor", Condition: principal.MaskOutsideWriteAuthority},
+	}
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
+
+	figures, err := e.Deals.Figures(rep, []ids.UUID{mine, theirs})
+	if err != nil {
+		t.Fatalf("reading figures under a mask: %v", err)
+	}
+
+	// The admission half: the mask must not swallow the rep's own money.
+	own, ok := figures[mine]
+	if !ok {
+		t.Fatal("the rep's own deal did not come back at all")
+	}
+	if own.AmountMinor == nil || *own.AmountMinor != amount || own.Currency != "EUR" {
+		t.Fatalf("the rep's own deal came back worth %v %q, wanted %d EUR",
+			own.AmountMinor, own.Currency, amount)
+	}
+	// And the refusal: another team's money is withheld, currency with it.
+	other, ok := figures[theirs]
+	if !ok {
+		t.Fatal("another team's deal vanished — a deal a rep may READ should still name itself")
+	}
+	if other.AmountMinor != nil {
+		t.Fatalf("another team's amount reached the Worklist as %d", *other.AmountMinor)
+	}
+	if other.Currency != "" {
+		t.Fatalf("another team's currency reached the Worklist as %q — a currency alone says the deal is priced and in what units", other.Currency)
 	}
 }

--- a/backend/internal/modules/deals/dealfigures.go
+++ b/backend/internal/modules/deals/dealfigures.go
@@ -10,10 +10,13 @@ package deals
 // anything useful about it. Reading them one at a time is a query per card;
 // this is one query per page.
 //
-// Deliberately NOT a general deal read. It answers four columns, masks nothing
-// and joins nothing, because a caller that needs a deal needs GetDeal — which
-// masks references the reader may not see. What is here is what a card states
-// out loud, and every column of it is already on the row this reader may read.
+// Deliberately NOT a general deal read: it answers six columns and joins
+// nothing, because a caller that needs the whole deal needs GetDeal.
+//
+// It does apply the ROLE MASK, which is not part of "the whole deal" — it is
+// the gate that decides whether this reader may see a deal's money at all, and
+// every other deal read applies it. Skipping it here would print on the
+// Worklist the figure the record page withholds.
 
 import (
 	"context"
@@ -27,6 +30,59 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
+
+// maskFigures withholds the figures this reader's ROLE withholds.
+//
+// Row scope decides which deals answer; the field mask decides which of their
+// columns do, and the two are different gates. A role can be authored to hide
+// amount_minor on deals outside the reader's write authority, and every other
+// deal read applies it — the list masks its page, the single get masks its row,
+// the report engine drops masked rows out of its totals so a sum cannot
+// disclose what a row would not. A read that skipped it would print on the
+// Worklist the number the record page refuses to show.
+//
+// The money pair goes together. A withheld amount takes its currency with it,
+// because a currency alone says a deal is priced and in what units, which is
+// half of what the mask was hiding.
+//
+// Unlike a Deal on the wire, DealFigures carries no masked_fields list, so a
+// withheld amount is indistinguishable from an unpriced deal. That is the same
+// answer the card already gives for a deal with no amount, and it is the safe
+// direction: it says less rather than claiming a figure is absent when it is
+// merely withheld.
+func maskFigures(ctx context.Context, tx pgx.Tx, figures map[ids.UUID]DealFigures) error {
+	p, err := storekit.Actor(ctx)
+	if err != nil {
+		return err
+	}
+	// Cheap exit for the common case — no mask on deals at all, which is how
+	// every installation ships until an operator authors one.
+	if len(auth.MaskedFields(p, "deal", false)) == 0 {
+		return nil
+	}
+	dealIDs := make([]ids.UUID, 0, len(figures))
+	for id := range figures {
+		dealIDs = append(dealIDs, id)
+	}
+	writable, err := auth.WritableSubset(ctx, tx, dealTable, dealIDs)
+	if err != nil {
+		return err
+	}
+	for id, row := range figures {
+		for _, field := range auth.MaskedFields(p, "deal", writable[id]) {
+			if field == dealAmountField {
+				row.AmountMinor = nil
+				row.Currency = ""
+			}
+		}
+		figures[id] = row
+	}
+	return nil
+}
+
+// dealAmountField is the masked field this read can actually withhold. The
+// others in dealMaskableFields name columns it does not select.
+const dealAmountField = "amount_minor"
 
 // DealFigures is one deal's commercial face: what it is worth, when it was
 // meant to land, and who answers for it.
@@ -59,7 +115,13 @@ func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]D
 		return out, nil
 	}
 	if len(dealIDs) > figuresScanCap {
-		dealIDs = dealIDs[:figuresScanCap]
+		// Refused rather than silently sliced. No caller can reach this today —
+		// the brief that feeds it is capped far below — so a silent truncation
+		// would be a short answer nothing would ever notice, waiting for the
+		// first caller to grow past it. A caller with more deals than this is
+		// asking a different question and should page.
+		return nil, fmt.Errorf("deals: asked for %d deals' figures, and one read answers %d",
+			len(dealIDs), figuresScanCap)
 	}
 	err := s.Tx(ctx, func(tx pgx.Tx) error {
 		args := []any{}
@@ -105,7 +167,10 @@ func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]D
 			}
 			out[id] = figures
 		}
-		return rows.Err()
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return maskFigures(ctx, tx, out)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("deals: reading the figures behind a page of deals: %w", err)

--- a/backend/internal/modules/deals/dealfigures.go
+++ b/backend/internal/modules/deals/dealfigures.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// The figures a card states about a deal, for several deals at once.
+//
+// A surface that lists deals somebody else ranked — the Worklist, reading the
+// overnight brief — holds ids and needs each deal's money and dates to say
+// anything useful about it. Reading them one at a time is a query per card;
+// this is one query per page.
+//
+// Deliberately NOT a general deal read. It answers four columns, masks nothing
+// and joins nothing, because a caller that needs a deal needs GetDeal — which
+// masks references the reader may not see. What is here is what a card states
+// out loud, and every column of it is already on the row this reader may read.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// DealFigures is one deal's commercial face: what it is worth, when it was
+// meant to land, and who answers for it.
+type DealFigures struct {
+	StageID           ids.UUID
+	OwnerID           ids.UUID
+	AmountMinor       *int64
+	Currency          string
+	ExpectedCloseDate *time.Time
+}
+
+// figuresScanCap bounds one read. A page names as many deals as it has rows,
+// and a caller that hands over more than this is asking a different question
+// than the one this answers.
+const figuresScanCap = 200
+
+// Figures answers the stated figures of the given deals, keyed by id.
+//
+// A deal this reader may not see is ABSENT from the answer rather than an
+// error, which is the refusal shape the label resolver beside it uses: the
+// caller keeps the row and states less about it. Absence and "no such deal" are
+// deliberately the same answer here — both mean this reader has nothing to say
+// about that id, and distinguishing them would tell them a deal exists.
+func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]DealFigures, error) {
+	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	out := map[ids.UUID]DealFigures{}
+	if len(dealIDs) == 0 {
+		return out, nil
+	}
+	if len(dealIDs) > figuresScanCap {
+		dealIDs = dealIDs[:figuresScanCap]
+	}
+	err := s.Tx(ctx, func(tx pgx.Tx) error {
+		args := []any{}
+		arg := func(v any) int { args = append(args, v); return len(args) }
+		idsPos := arg(dealIDs)
+		scope, err := auth.ScopeClauseFor(ctx, dealTable, "d", arg)
+		if err != nil {
+			return err
+		}
+		query := storekit.SQLf(
+			`SELECT d.id, d.stage_id, d.owner_id, d.amount_minor, d.currency, d.expected_close_date
+			   FROM deal d
+			  WHERE d.id = ANY($%d) AND d.archived_at IS NULL`, idsPos)
+		if scope != "" {
+			query += storekit.SQLf(" AND %s", scope)
+		}
+		rows, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var (
+				id     ids.UUID
+				stage  *ids.UUID
+				owner  *ids.UUID
+				amount *int64
+				code   *string
+				closes *time.Time
+			)
+			if err := rows.Scan(&id, &stage, &owner, &amount, &code, &closes); err != nil {
+				return err
+			}
+			figures := DealFigures{AmountMinor: amount, ExpectedCloseDate: closes}
+			if stage != nil {
+				figures.StageID = *stage
+			}
+			if owner != nil {
+				figures.OwnerID = *owner
+			}
+			if code != nil {
+				figures.Currency = *code
+			}
+			out[id] = figures
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("deals: reading the figures behind a page of deals: %w", err)
+	}
+	return out, nil
+}


### PR DESCRIPTION
The row a rep is meant to open their day on was the least informative one on the page. The overnight brief ranks deal ids and keeps its composite and factor vector behind its own endpoint, so its rows reached the Worklist naming a deal and saying nothing else about it: no amount, no close date, nothing to act on. The reported symptom was a headline reading "Die Nacht hat das herausgesucht" — that fallback fires when a row has no title, and these rows had nothing else either.

## What this adds

A batched read of the deal's own columns — amount, currency, close date, stage, owner — bound to the attention feed as an optional seam and filled onto brief rows before the projection. One read per page, beside the label pass and for the same reason: a follow-up read per card is the N+1 this feed exists to avoid.

Filled *before* the projection so the money is on the row when the ordering reads it. Enriching afterwards would rank the deal as unpriced and then print its price, which is the page disagreeing with itself.

Figures are not the ranking arithmetic. The amount and the close date are the deal's own columns, which every other lane already carries onto its rows; the composite stays behind the brief's endpoint.

## What review caught

The read skipped the **role field mask**. Row scope decides which deals answer; the mask decides which of their columns do, and they are different gates. A role authored to hide `amount_minor` outside a rep's write authority is honoured by the single get, the list, and the report engine — and this read handed the raw column back, so the number would have printed on the Worklist for a reader the record page refuses it to. It is applied now, through the same two calls `maskDeals` makes, and an integration test asserts both halves (own deal visible, colleague's withheld) and goes red when the mask call is removed.

Also from that pass: the oversize guard sliced silently where no caller could reach it, so it refuses instead; and `MaskedFields` takes an RBAC object where I had passed the table constant — equal strings today, and a gate exists because the compiler cannot tell them apart.

## Tests

Four integration cases against a real database, each pairing an admission with a refusal. Five unit cases for the fill pass: figures land, a withheld deal leaves the row alone rather than failing the read, a row that already has facts is never asked about, one deal named twice is one question, and an unbound seam invents nothing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives the overnight brief's rows on the Worklist the deal's own figures, so the row a rep opens their day on states amount, currency, close date, stage, and owner instead of a bare deal name.

- One batched read per page fills brief rows before the projection, so ordering ranks the deal as priced.
- Rows that already carry figures are left alone, and a deal the reader cannot see leaves the row unchanged rather than failing the read.
- The read applies the same role field mask as other deal reads: amounts outside a rep's write authority are withheld, currency with them.
- The oversize guard now refuses instead of silently truncating, and `MaskedFields` is called with an RBAC object rather than the table constant.

<sup>Written for commit 22583a0d652cad18b1d73b6660195085cdfc6b39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attention items now display deal amount, currency, stage, owner, and expected close date when available.
  * Deal details are loaded efficiently across multiple attention items, including duplicate deal references.
* **Privacy & Permissions**
  * Deal information respects access permissions and role-based visibility rules.
  * Restricted or unavailable deals remain unchanged without disrupting the worklist.
* **Reliability**
  * Existing deal details are preserved, and missing optional information is handled gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->