### PR TITLE
main is red: the assignee-filter test never disowned its control task

### DIFF
--- a/backend/internal/compose/integration/automation_runs_preview_integration_test.go
+++ b/backend/internal/compose/integration/automation_runs_preview_integration_test.go
@@ -225,7 +225,7 @@ func assertPreviewMeasuresWithoutWriting(t *testing.T, e *apptest.AppEnv, autoID
 	}
 	// The create stamps the admin as owner; the recipe counts leads nobody
 	// owns, so the lead is disowned to be the unrouted one the preview must find.
-	disownOverDB(t, e, "lead", lead.ID)
+	disownOverDB(t, e, "lead", "owner_id", lead.ID)
 
 	var rowsBefore int
 	if err := e.Owner.QueryRow(context.Background(), `

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -30,15 +30,16 @@ import (
 // disownOverDB nulls a record's owner column at the database. A create over
 // the wire stamps the calling seat as owner when the body names none, so the
 // unowned state these queue tests are about has to be produced after the
-// fact. The column varies by table: person and lead use owner_id, activity
-// (a task's self-assignment, taskAssignee in activity.go) uses assignee_id.
+// fact. The package-local Env fixture spells this same idiom inline through
+// e.WsExec instead of sharing this helper — a different fixture type, not a
+// second copy of the invariant.
 func disownOverDB(t *testing.T, e *apptest.AppEnv, table, column, id string) {
 	t.Helper()
 	if err := apptest.InWorkspace(e, t, func(tx pgx.Tx) error {
 		_, err := tx.Exec(t.Context(), `UPDATE `+table+` SET `+column+` = NULL WHERE id = $1`, id)
 		return err
 	}); err != nil {
-		t.Fatalf("disown %s %s: %v", table, id, err)
+		t.Fatalf("disown %s.%s for %s: %v", table, column, id, err)
 	}
 }
 
@@ -113,25 +114,16 @@ func TestTheActivityListNarrowsByAssigneeOnTheWire(t *testing.T) {
 	e := apptest.SetupApp(t)
 	e.BootstrapWorkspace(t)
 
-	var me struct {
-		User struct {
-			ID string `json:"id"`
-		} `json:"user"`
-	}
-	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
-		t.Fatalf("GET /v1/me = %d, want 200", status)
-	}
+	me := callerUserID(t, e)
 	mine := createdRecord(t, e, "/v1/activities", AnyMap{
-		"kind": "task", "subject": "Call the buyer", "due_at": "2026-09-01T09:00:00Z", "assignee_id": me.User.ID,
+		"kind": "task", "subject": "Call the buyer", "due_at": "2026-09-01T09:00:00Z", "assignee_id": me,
 	})
-	// A task posted with no assignee is self-assigned to the caller at write
-	// time (taskAssignee, activity.go) — the unowned state this filter must
-	// exclude has to be produced after the fact, same as the person/lead
-	// queue tests below.
-	nobodys := createdRecord(t, e, "/v1/activities", AnyMap{"kind": "task", "subject": "Nobody's"})
-	disownOverDB(t, e, "activity", "assignee_id", nobodys)
+	// The caller now owns a task it posts unassigned, so this row is
+	// disowned to be the one the filter must not return.
+	unassigned := createdRecord(t, e, "/v1/activities", AnyMap{"kind": "task", "subject": "Nobody's"})
+	disownOverDB(t, e, "activity", "assignee_id", unassigned)
 
-	onlyRecord(t, e, "/v1/activities?assignee_id="+me.User.ID, mine, "the open task that person holds")
+	onlyRecord(t, e, "/v1/activities?assignee_id="+me, mine, "the open task that person holds")
 }
 
 func TestThePipelineListAnswersIncludeArchivedOnTheWire(t *testing.T) {

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -27,13 +27,15 @@ import (
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
-// disownOverDB nulls a record's owner at the database. A create over the wire
-// stamps the calling seat as owner when the body names none, so the unowned
-// state these queue tests are about has to be produced after the fact.
-func disownOverDB(t *testing.T, e *apptest.AppEnv, table, id string) {
+// disownOverDB nulls a record's owner column at the database. A create over
+// the wire stamps the calling seat as owner when the body names none, so the
+// unowned state these queue tests are about has to be produced after the
+// fact. The column varies by table: person and lead use owner_id, activity
+// (a task's self-assignment, taskAssignee in activity.go) uses assignee_id.
+func disownOverDB(t *testing.T, e *apptest.AppEnv, table, column, id string) {
 	t.Helper()
 	if err := apptest.InWorkspace(e, t, func(tx pgx.Tx) error {
-		_, err := tx.Exec(t.Context(), `UPDATE `+table+` SET owner_id = NULL WHERE id = $1`, id)
+		_, err := tx.Exec(t.Context(), `UPDATE `+table+` SET `+column+` = NULL WHERE id = $1`, id)
 		return err
 	}); err != nil {
 		t.Fatalf("disown %s %s: %v", table, id, err)
@@ -122,8 +124,12 @@ func TestTheActivityListNarrowsByAssigneeOnTheWire(t *testing.T) {
 	mine := createdRecord(t, e, "/v1/activities", AnyMap{
 		"kind": "task", "subject": "Call the buyer", "due_at": "2026-09-01T09:00:00Z", "assignee_id": me.User.ID,
 	})
-	// An unassigned task is the row a dropped filter hands back alongside it.
-	createdRecord(t, e, "/v1/activities", AnyMap{"kind": "task", "subject": "Nobody's"})
+	// A task posted with no assignee is self-assigned to the caller at write
+	// time (taskAssignee, activity.go) — the unowned state this filter must
+	// exclude has to be produced after the fact, same as the person/lead
+	// queue tests below.
+	nobodys := createdRecord(t, e, "/v1/activities", AnyMap{"kind": "task", "subject": "Nobody's"})
+	disownOverDB(t, e, "activity", "assignee_id", nobodys)
 
 	onlyRecord(t, e, "/v1/activities?assignee_id="+me.User.ID, mine, "the open task that person holds")
 }
@@ -189,7 +195,7 @@ func TestThePersonListNarrowsToTheUnownedQueueOnTheWire(t *testing.T) {
 
 	createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Owned Person", "owner_id": owner})
 	unowned := createdRecord(t, e, "/v1/people", AnyMap{"full_name": "Unowned Person"})
-	disownOverDB(t, e, "person", unowned)
+	disownOverDB(t, e, "person", "owner_id", unowned)
 
 	// Unassigned is a fact with its own queue, not an absence: a list that
 	// answered every row here would send somebody to claim records that are
@@ -204,7 +210,7 @@ func TestTheLeadListNarrowsToTheUnownedQueueOnTheWire(t *testing.T) {
 
 	createdRecord(t, e, "/v1/leads", AnyMap{"full_name": "Owned Lead", "email": "owned@lead.test", "owner_id": owner})
 	unowned := createdRecord(t, e, "/v1/leads", AnyMap{"full_name": "Unowned Lead", "email": "unowned@lead.test"})
-	disownOverDB(t, e, "lead", unowned)
+	disownOverDB(t, e, "lead", "owner_id", unowned)
 
 	// The same dial the person and company lists answer (DM-VOCAB-OWN-1): a
 	// lead queue nobody has claimed is the first thing a rep asks a lead list.


### PR DESCRIPTION
## What's broken

`main` is red: `TestTheActivityListNarrowsByAssigneeOnTheWire` fails — `GET /v1/activities?assignee_id=...` returns 2 records instead of 1. `main-health` run https://github.com/margince/margince/actions/runs/33462177861 caught it.

## Root cause

Not a filter bug — `openTaskAssigneeClause` and its wiring from the HTTP handler down to the WHERE clause are correct, verified by reading the whole path.

The test's control record ("Nobody's" task, posted with no `assignee_id`) was expected to stay unowned, but `taskAssignee` (`backend/internal/modules/activities/activity.go`) self-assigns any task a human posts with no explicit assignee to the caller — the intended behavior landed by #3431 ("Mine means mine"). So the control task silently became the caller's own task too, and the assignee filter correctly returned both records.

The test file already has a helper, `disownOverDB`, built for exactly this situation (its own doc comment: *"A create over the wire stamps the calling seat as owner when the body names none, so the unowned state these queue tests are about has to be produced after the fact"*), used by the person/lead unowned-queue tests in the same file — this one test just predates it and was never updated.

## Fix

- Generalized `disownOverDB` to take the owner column name as a parameter (`owner_id` for person/lead, `assignee_id` for activity) instead of hardcoding `owner_id`.
- Updated the two existing call sites (person, lead) and one more in `automation_runs_preview_integration_test.go` to pass `"owner_id"` explicitly.
- Called it on the "Nobody's" task in the failing test.

## Verification

- `go build -tags integration ./...`
- `make test-it DIR=backend/internal/compose/integration RUN='TestTheActivityListNarrowsByAssigneeOnTheWire|TestThePersonListNarrowsToTheUnownedQueueOnTheWire|TestTheLeadListNarrowsToTheUnownedQueueOnTheWire'` — all pass
- `craft static` (pre-push hook) — 0 blocker, 0 major, 0 minor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `TestTheActivityListNarrowsByAssigneeOnTheWire` so the assignee filter is asserted against an unowned control task. The task posted without an assignee was self-assigned to the caller at write time, so the filter returned both records; the test now disowns it before asserting. This is a test-only change: `disownOverDB` now accepts the owner column name (`assignee_id` for activities, `owner_id` for people/leads), all call sites pass it explicitly, and the test reuses `callerUserID`.

<sup>Written for commit 600db9e036f6ff2096da28bab1e19f9f32e07053. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test coverage for ownership and assignment workflows across activities, people, and leads.
  * Enhanced validation and diagnostics when records are disowned or ownership fields are cleared.
  * Streamlined test setup by reusing authenticated user context and explicitly handling ownership fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->