### PR TITLE
fix(prefs): the staged choices are checkboxes, because that is what they are

### DIFF
--- a/frontend/src/screens/preferences.css
+++ b/frontend/src/screens/preferences.css
@@ -87,43 +87,6 @@
   color: var(--textTertiary);
 }
 
-.pref-toggle {
-  flex: none;
-  width: 40px;
-  height: 22px;
-  border-radius: var(--r-full);
-  border: 1px solid var(--borderStrong);
-  background: var(--bgCard);
-  position: relative;
-  cursor: pointer;
-  padding: 0;
-}
-
-.pref-toggle:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.pref-toggle.on {
-  background: var(--accent);
-  border-color: var(--accent);
-}
-
-.pref-toggle-knob {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 16px;
-  height: 16px;
-  border-radius: var(--r-full);
-  background: var(--bgElevated);
-  transition: transform 0.15s ease;
-}
-
-.pref-toggle.on .pref-toggle-knob {
-  transform: translateX(18px);
-}
-
 .pref-save-bar {
   position: sticky;
   bottom: 16px;
@@ -224,4 +187,11 @@
   border-radius: 50%;
   color: var(--success);
   background: var(--successBg);
+}
+
+/* The row's control sits beside a heading that already names it, so the
+   checkbox carries only a screen-reader label of its own. */
+.pref-check {
+  flex: 0 0 auto;
+  margin-top: var(--space-1);
 }

--- a/frontend/src/screens/preferences.stories.tsx
+++ b/frontend/src/screens/preferences.stories.tsx
@@ -67,7 +67,7 @@ export const Dirty: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(
-      await canvas.findByRole("switch", { name: /product updates/i }),
+      await canvas.findByRole("checkbox", { name: /product updates/i }),
     );
   },
 };
@@ -108,7 +108,7 @@ export const PartialSave: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(
-      await canvas.findByRole("switch", { name: /product updates/i }),
+      await canvas.findByRole("checkbox", { name: /product updates/i }),
     );
     await userEvent.click(
       canvas.getByRole("button", { name: /save preferences/i }),

--- a/frontend/src/screens/preferences.test.tsx
+++ b/frontend/src/screens/preferences.test.tsx
@@ -136,7 +136,7 @@ describe("PreferenceCenterScreen", () => {
   it("locks transactional and explains why instead of silently ignoring the click", async () => {
     stubCenter();
     render(<PreferenceCenterScreen token="tok-123" />);
-    const toggle = await screen.findByRole("switch", {
+    const toggle = await screen.findByRole("checkbox", {
       name: /deal & service/i,
     });
     expect(toggle).toBeDisabled();
@@ -148,7 +148,7 @@ describe("PreferenceCenterScreen", () => {
     stubCenter({ "PUT /public/preferences/tok-123": put });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("switch", { name: /product updates/i }),
+      await screen.findByRole("checkbox", { name: /product updates/i }),
     );
     expect(screen.getByText(/not saved yet/i)).toBeInTheDocument();
     expect(put).not.toHaveBeenCalled();
@@ -158,7 +158,7 @@ describe("PreferenceCenterScreen", () => {
     stubCenter();
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("switch", { name: /product updates/i }),
+      await screen.findByRole("checkbox", { name: /product updates/i }),
     );
     await userEvent.click(screen.getByRole("button", { name: /discard/i }));
     expect(screen.queryByText(/not saved yet/i)).not.toBeInTheDocument();
@@ -173,7 +173,7 @@ describe("PreferenceCenterScreen", () => {
     const shown = (await screen.findByTestId("wording-marketing_email"))
       .textContent;
     await userEvent.click(
-      screen.getByRole("switch", { name: /product updates/i }),
+      screen.getByRole("checkbox", { name: /product updates/i }),
     );
     await userEvent.click(
       screen.getByRole("button", { name: /save preferences/i }),
@@ -195,7 +195,7 @@ describe("PreferenceCenterScreen", () => {
     render(<PreferenceCenterScreen token="tok-123" />);
     const shown = (await screen.findByTestId("wording-events")).textContent;
     await userEvent.click(
-      await screen.findByRole("switch", { name: /^events$/i }),
+      await screen.findByRole("checkbox", { name: /^events$/i }),
     );
     await userEvent.click(
       screen.getByRole("button", { name: /save preferences/i }),
@@ -232,7 +232,7 @@ describe("PreferenceCenterScreen", () => {
     });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("switch", { name: /product updates/i }),
+      await screen.findByRole("checkbox", { name: /product updates/i }),
     );
     await userEvent.click(
       screen.getByRole("button", { name: /save preferences/i }),
@@ -282,16 +282,16 @@ describe("PreferenceCenterScreen", () => {
     stubCenter({ "PUT /public/preferences/tok-123": () => putPromise });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("switch", { name: /product updates/i }),
+      await screen.findByRole("checkbox", { name: /product updates/i }),
     );
     await userEvent.click(
       screen.getByRole("button", { name: /save preferences/i }),
     );
 
     expect(
-      screen.getByRole("switch", { name: /product updates/i }),
+      screen.getByRole("checkbox", { name: /product updates/i }),
     ).toBeDisabled();
-    expect(screen.getByRole("switch", { name: /^events$/i })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: /^events$/i })).toBeDisabled();
     expect(
       screen.getByRole("button", { name: /save preferences/i }),
     ).toBeDisabled();
@@ -300,7 +300,7 @@ describe("PreferenceCenterScreen", () => {
     resolvePut(jsonResponse(CENTER));
     await waitFor(() =>
       expect(
-        screen.getByRole("switch", { name: /product updates/i }),
+        screen.getByRole("checkbox", { name: /product updates/i }),
       ).toBeEnabled(),
     );
   });
@@ -392,5 +392,16 @@ describe("one-click unsubscribe (G-7)", () => {
     expect(put).not.toHaveBeenCalled();
     expect(screen.getByText(/not saved yet/i)).toBeInTheDocument();
     expect(screen.getByText(/explicit opt-in/i)).toBeInTheDocument();
+  });
+  // A Switch IS the write; a Checkbox states an intent something later
+  // submits. This page stages every change and commits them from the save
+  // bar, so role="switch" would tell a screen-reader user their choice had
+  // already taken effect while it was still only staged.
+  it("offers checkboxes, not switches, because the change is staged", async () => {
+    stubCenter();
+    render(<PreferenceCenterScreen token="tok-123" />);
+
+    expect((await screen.findAllByRole("checkbox")).length).toBeGreaterThan(0);
+    expect(screen.queryAllByRole("switch")).toHaveLength(0);
   });
 });

--- a/frontend/src/screens/preferences.tsx
+++ b/frontend/src/screens/preferences.tsx
@@ -2,7 +2,13 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Lock } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { api } from "../api/client";
-import { Button, Card, EmptyState, Skeleton } from "../design-system/atoms";
+import {
+  Button,
+  Card,
+  Checkbox,
+  EmptyState,
+  Skeleton,
+} from "../design-system/atoms";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
@@ -442,17 +448,25 @@ function PreferenceRow({
           </p>
         )}
       </div>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={on}
+      {/* A Checkbox, not a Switch, and the difference is not cosmetic: a
+          Switch IS the write, while a Checkbox states an intent something
+          later submits (design-system/README.md). This page stages every
+          change and commits them from the save bar below, so announcing
+          role="switch" would tell a screen-reader user their choice had
+          already taken effect when it has not. The visible label is
+          hidden because the row draws its own richer heading above. */}
+      <Checkbox
+        checked={on}
         aria-label={purpose.label}
         disabled={purpose.locked || grantBlocked || disabled}
-        className={`pref-toggle${on ? " on" : ""}`}
-        onClick={onToggle}
-      >
-        <span className="pref-toggle-knob" aria-hidden />
-      </button>
+        className="pref-check"
+        // Empty, because aria-label above already names the control: a
+        // second copy of the purpose name would put the same words on the
+        // page twice for a sighted reader and read them twice to everyone
+        // else.
+        label=""
+        onChange={onToggle}
+      />
     </li>
   );
 }


### PR DESCRIPTION
The preference centre drew a hand-rolled control announcing `role="switch"`, but a switch **is** the write and this page writes nothing when you flip one — every change is staged and committed from the save bar below.

So the control told a screen-reader user their choice had already taken effect while it was still only staged. That is the exact lie the design system's Switch-versus-Checkbox rule exists to prevent (`design-system/README.md`): *a Checkbox states an intent that something later submits, a Switch is the action.*

They are `Checkbox` now, from the design system rather than hand-rolled. A test fails if a `switch` ever reappears on this page.

The checkbox's own visible label is empty: the row already draws a richer heading and the control carries an `aria-label`, so a second copy of the purpose name put the same words on screen twice and read them twice to everyone else.

## Verification

`make check-fe` green. 17 preference-centre tests pass, including the new one pinning the decision. Checked in the running app against a real token: three checkboxes, zero switches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hand-rolled `role="switch"` controls in the preference centre with the design system's `Checkbox`, so screen-reader users are no longer told their choice took effect while it is still only staged until the save bar is clicked.

- The checkbox's visible label is empty; the row's heading and the control's `aria-label` already name it, avoiding duplicate text.
- A test now fails if a `switch` reappears on this page.

<sup>Written for commit 25f72f984202956c4b2be05eee0b8811fd2e87d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated preference controls to use accessible checkboxes instead of switches.
  - Improved checkbox sizing and alignment for a more consistent appearance.
  - Preserved disabled states and accessible labels while saving preference changes.

- **Bug Fixes**
  - Improved preference-control behavior and accessibility during pending saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->