### PR TITLE
A verdict states the bar it was measured against

### DIFF
--- a/backend/internal/compose/attention/waitingfreshness_test.go
+++ b/backend/internal/compose/attention/waitingfreshness_test.go
@@ -182,3 +182,44 @@ func TestAnAncientWaitNoLongerOutranksTodaysDeal(t *testing.T) {
 		t.Fatal("a 182-day unanswered thread still led the day over a deal at risk")
 	}
 }
+
+// The page states the bar a deal had to clear.
+//
+// Every "material" and "below material" reason is a verdict, and a verdict
+// whose threshold is withheld cannot be checked: a reader sees that a deal was
+// called big and has no way to ask compared to what. The contract has promised
+// this figure since the queue shipped.
+func TestTheSummaryStatesTheMaterialBar(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		AtRisk: lane(
+			item("small", "deal_at_risk", withDeal(10_000_00)),
+			item("big", "deal_at_risk", withDeal(200_000_00)),
+		),
+	}
+
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, nil)
+
+	if out.Summary.MaterialThresholdMinor == nil {
+		t.Fatal("a day with priced deals stated no material bar, so every material reason on it is unverifiable")
+	}
+	// The LOWER median of the two, which is the smaller — the rule the bar's
+	// own doc states, asserted here so a change to it fails a test rather than
+	// silently moving what counts as a big deal.
+	if *out.Summary.MaterialThresholdMinor != 10_000_00 {
+		t.Fatalf("the bar was %d, wanted the lower median 1000000", *out.Summary.MaterialThresholdMinor)
+	}
+}
+
+// A pipeline with no priced deals states no bar rather than zero. Zero would
+// say every deal is material, which is the opposite of what an absent median
+// means.
+func TestADayWithNoPricedDealsStatesNoBar(t *testing.T) {
+	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: lane(item("unpriced", "deal_at_risk"))}
+
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, nil)
+
+	if out.Summary.MaterialThresholdMinor != nil {
+		t.Fatalf("a pipeline with no prices stated a bar of %d", *out.Summary.MaterialThresholdMinor)
+	}
+}

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -268,9 +268,13 @@ func (s *Service) worklistFrom(
 	shown := page(rows, limit)
 	ordered := rankAll(shown)
 	out := crmcontracts.Worklist{
-		AsOf:               day.AsOf,
-		Queue:              ordered,
-		Summary:            summarize(ordered),
+		AsOf:  day.AsOf,
+		Queue: ordered,
+		// The bar is re-derived rather than threaded out of classifyDay: it is a
+		// pure function of the same day this call already holds, so the two
+		// cannot disagree, and threading it would change a signature twenty-odd
+		// callers spell.
+		Summary:            summarize(ordered, materialBarOf(day)),
 		SourcesUnavailable: unavailable(day),
 		// `considered` is every candidate this read weighed, `shown` what
 		// survived folding and the cut. Both are already in hand, so no figure
@@ -397,8 +401,24 @@ func keepCategory(rows []ranked, want crmcontracts.WorklistItemCategory) []ranke
 //
 // Held by: TestTheSummaryCountsTheSameItemsTheQueueCarries
 // (backend/internal/compose/attention/worklist_test.go).
-func summarize(items []crmcontracts.WorklistItem) crmcontracts.WorklistSummary {
+func summarize(items []crmcontracts.WorklistItem, bar materialBar) crmcontracts.WorklistSummary {
 	summary := crmcontracts.WorklistSummary{Total: len(items)}
+	// Why a deal ranked where it did, in the figure the ranking actually used.
+	// The contract has promised this since the queue shipped and the projection
+	// never sent it, so every "material" and "below material" reason on the page
+	// was a verdict with its threshold withheld: a reader could see that a deal
+	// had been called big, and had no way to ask compared to what.
+	//
+	// base_currency stays absent, and that is not an oversight. The bar is the
+	// median of raw amount_minor values — expectedRevenue converts nothing, and
+	// says so — so on a mixed-currency pipeline the figure is not in any one
+	// currency. Naming one would assert a conversion that did not happen, which
+	// is worse than sending a number the client formats cautiously. It becomes
+	// answerable when the feed reads the FX seam.
+	if bar.known {
+		minor := bar.minor
+		summary.MaterialThresholdMinor = &minor
+	}
 	for _, item := range items {
 		switch {
 		case item.Level <= levelPromise:

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -151,7 +151,7 @@ func TestTheSummaryCountsTheSameItemsTheQueueCarries(t *testing.T) {
 	}
 
 	ordered := rankAll(classifyDay(day, rankInstant))
-	summary := summarize(ordered)
+	summary := summarize(ordered, materialBar{})
 
 	if summary.Total != len(ordered) {
 		t.Fatalf("summary totals %d over a queue of %d", summary.Total, len(ordered))
@@ -223,7 +223,7 @@ func TestADecisionsExpiryIsNotCountedAsWorkDue(t *testing.T) {
 		Planned: []crmcontracts.AttentionItem{item("real-task", "task", withDue(rankInstant.Add(-time.Hour)))},
 	}
 
-	summary := summarize(rankAll(classifyDay(day, rankInstant)))
+	summary := summarize(rankAll(classifyDay(day, rankInstant)), materialBarOf(day))
 
 	if summary.Due != 1 {
 		t.Fatalf("counted %d due, wanted only the task — a proposal's expiry is not the reader's deadline", summary.Due)
@@ -365,7 +365,7 @@ func TestOnlyAnArrivedDateCountsAsDue(t *testing.T) {
 		},
 	}
 
-	summary := summarize(rankAll(classifyDay(day, rankInstant)))
+	summary := summarize(rankAll(classifyDay(day, rankInstant)), materialBarOf(day))
 
 	if summary.Due != 1 {
 		t.Fatalf("counted %d due, wanted only the one whose date has passed", summary.Due)


### PR DESCRIPTION
Every deal on the queue carries a "material" or "below material" reason, and the figure those verdicts were measured against was never sent. A reader could see that a deal had been called big and had no way to ask compared to what.

`material_threshold_minor` has been in the contract since the queue shipped, with a description explaining exactly what it is for ("Sent so the client can say WHY a deal ranked where it did"). The projection simply never populated it. It does now — the same median the ranking itself used.

**`base_currency` stays absent, deliberately.** The bar is the median of raw `amount_minor` values; `expectedRevenue` converts nothing and documents that. On a mixed-currency pipeline the figure is therefore not in any one currency, and naming one would assert a conversion that did not happen. The comment says so where the field is filled. It becomes answerable when this feed reads the FX seam.

A pipeline with no priced deals states no bar rather than zero — zero would say every deal is material, which is the opposite of what an absent median means. Both cases are tested, and the threshold's guard is mutation-checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populates `material_threshold_minor` on the worklist summary so every material or below-material verdict is answerable against the figure the ranking used.

- The bar is re-derived from the same day the projection already holds, so ranking and summary cannot disagree.
- `base_currency` stays absent on purpose: the bar is the median of raw `amount_minor` values, and on a mixed-currency pipeline no single currency applies without a fake conversion.
- A pipeline with no priced deals sends no bar rather than zero — zero would make every deal material.
- Both cases are covered by new tests.

<sup>Written for commit 4ddc4c905fec844e9e18ec3ed52a9eab1591f361. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worklist summaries now show a material-deal threshold based on priced deals.
  * Thresholds are displayed when pricing information is available in a consistent currency.
  * Summaries omit the threshold when no priced deals are available or values use mixed currencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->