### PR TITLE
feat(prefs): a public page speaks the language of the message that linked to it

### DIFF
--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -77,7 +77,14 @@ export const LOCALES = ["en", "de", "vi"] as const satisfies readonly Locale[];
 
 export const DEFAULT_LOCALE: Locale = "en";
 
-function isLocale(value: string): value is Locale {
+/**
+ * Whether a string names a language this product speaks.
+ *
+ * Exported for the public pages: an email's `?lang=` is text a link
+ * carried, so it is validated here rather than trusted, and the same
+ * predicate that admits a stored pick admits that one.
+ */
+export function isLocale(value: string): value is Locale {
   return LOCALES.some((locale) => locale === value);
 }
 

--- a/frontend/src/i18n/publiclocale.test.tsx
+++ b/frontend/src/i18n/publiclocale.test.tsx
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { LocaleProvider, useT } from ".";
+import { usePublicLocale } from "./publiclocale";
+
+// The language a public page speaks, taken from the link that opened it.
+
+function Page() {
+  usePublicLocale();
+  return <p>{useT()("prefs.title")}</p>;
+}
+
+function renderAt(hash: string) {
+  globalThis.location.hash = hash;
+  return render(
+    <LocaleProvider>
+      <Page />
+    </LocaleProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  globalThis.location.hash = "";
+  globalThis.localStorage.clear();
+});
+
+describe("the language a public link carries", () => {
+  it("speaks the language the link named", async () => {
+    renderAt("#/preferences/tok?lang=de");
+    expect(
+      await screen.findByText("Wähle, was du von uns hörst"),
+    ).toBeDefined();
+  });
+
+  // ?lang is what the MESSAGE happened to be written in, not a choice this
+  // reader made — so it must not become their stored pick and follow them
+  // onto every other screen.
+  it("does not store the link's language as the reader's own choice", async () => {
+    renderAt("#/preferences/tok?lang=de");
+    await screen.findByText("Wähle, was du von uns hörst");
+    expect(globalThis.localStorage.getItem("margince.locale")).toBeNull();
+  });
+
+  it("ignores a language this product does not speak", async () => {
+    globalThis.localStorage.setItem("margince.locale", "de");
+    renderAt("#/preferences/tok?lang=klingon");
+    // The stored pick still decides, rather than the page falling back to
+    // English because the link said something unrecognised.
+    expect(
+      await screen.findByText("Wähle, was du von uns hörst"),
+    ).toBeDefined();
+  });
+
+  it("leaves the stored pick alone when the link names no language", async () => {
+    globalThis.localStorage.setItem("margince.locale", "de");
+    renderAt("#/preferences/tok");
+    expect(
+      await screen.findByText("Wähle, was du von uns hörst"),
+    ).toBeDefined();
+    expect(globalThis.localStorage.getItem("margince.locale")).toBe("de");
+  });
+});

--- a/frontend/src/i18n/publiclocale.ts
+++ b/frontend/src/i18n/publiclocale.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { parseParams } from "../app/urlstate";
+import { isLocale, useLocale } from ".";
+
+/**
+ * Take the language from the link a reader followed.
+ *
+ * A message goes out in one language and its footer links carry that
+ * language, so the page they open should speak it too — a German mail
+ * whose unsubscribe page answers in English has changed language halfway
+ * through one conversation.
+ *
+ * It ADOPTS rather than sets: `?lang=` is what the message happened to be
+ * written in, not a choice this reader made, so it must not be written
+ * back as their stored pick. Someone who then uses the switcher IS
+ * choosing, and that path persists.
+ *
+ * An absent or unrecognised value does nothing at all, leaving the stored
+ * pick and then the browser to decide, which is what a public page falls
+ * back to anyway.
+ */
+export function usePublicLocale(): void {
+  const { adoptLocale } = useLocale();
+  useEffect(() => {
+    const asked = parseParams(globalThis.location.hash).get("lang");
+    if (asked !== undefined && isLocale(asked)) {
+      adoptLocale(asked);
+    }
+  }, [adoptLocale]);
+}

--- a/frontend/src/screens/preferences.tsx
+++ b/frontend/src/screens/preferences.tsx
@@ -11,6 +11,7 @@ import {
 } from "../design-system/atoms";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { usePublicLocale } from "../i18n/publiclocale";
 import { problemMessageOf, throwProblem } from "./common";
 import {
   type Draft,
@@ -80,6 +81,8 @@ export function explainPublicError(
 
 function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
   const t = useT();
+  // The link carried the message's language; the page speaks it too.
+  usePublicLocale();
   const queryClient = useQueryClient();
   const queryKey = ["preference-center", token];
 

--- a/frontend/src/screens/unsubscribe.tsx
+++ b/frontend/src/screens/unsubscribe.tsx
@@ -5,6 +5,7 @@ import { api } from "../api/client";
 import { Button, Card, PendingBody } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { useT } from "../i18n";
+import { usePublicLocale } from "../i18n/publiclocale";
 import { throwProblem } from "./common";
 import {
   explainPublicError,
@@ -46,6 +47,8 @@ function UnsubscribeBody({
   purpose,
 }: Readonly<{ token: string; purpose: string }>) {
   const t = useT();
+  // The link carried the message's language; the page speaks it too.
+  usePublicLocale();
   const queryClient = useQueryClient();
   const queryKey = ["preference-center", token];
   const doneHeading = useRef<HTMLHeadingElement>(null);


### PR DESCRIPTION
The send path already puts the message's language in its footer links (`?lang=de`), but the pages ignored it — so a German mail whose unsubscribe page answered in English changed language halfway through one conversation.

`usePublicLocale` reads that parameter on both public pages.

It **adopts** the language rather than setting it, which is a distinction the i18n provider already draws: `?lang` is what the message happened to be written in, not a choice this reader made, so it must not become their stored pick and follow them onto every other screen. Somebody who later uses a switcher *is* choosing, and that path still persists. A test fails if the link's language is ever written to storage, and reverting `adoptLocale` to `setLocale` fails exactly that test.

An absent or unrecognised value does nothing, leaving the stored pick and then the browser to decide — which is what a public page falls back to anyway.

## Verification

`make check-fe` green; 4 new tests. Checked in the running app with a browser that prefers English:

| Address | Renders | Stored |
|---|---|---|
| `?lang=de` | Wähle, was du von uns hörst | none |
| `?lang=en` | Choose what you hear from us | none |
| no parameter | Choose what you hear from us | none |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Public pages now speak the language of the message that linked to them by reading the `?lang=` parameter, fixing the issue where a German email could lead to an English page. The language is adopted without persisting it; only an explicit language switcher selection is stored, and unknown or missing values fall back to the stored preference or browser default.

- Adds `usePublicLocale` hook, used by both the unsubscribe and preference center pages.
- Tests ensure the link's language is never written to storage and invalid values are ignored.

<sup>Written for commit cd86655a8ebef85b493a78604e712c3f2da1c335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public preference and unsubscribe links now open in the language specified by the link.
  * Supported language parameters are applied without changing the user’s saved language preference.
  * Invalid, missing, or unsupported language parameters fall back to the saved language.

* **Tests**
  * Added coverage for supported, unsupported, and absent language parameters in public links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->