### PR TITLE
A manager can open the queue the exception named

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -9350,6 +9350,33 @@ paths:
           in: query
           schema: { type: integer, minimum: 1, maximum: 100, default: 25 }
           description: 'How many ranked items to return.'
+        - name: owner
+          in: query
+          schema: { type: string, format: uuid }
+          description: |
+            Whose queue to answer, when it is somebody else's. A manager reading a team
+            exception is told which rep it belongs to, and the next question is always
+            "show me their day" — without this they can only widen to `team`, which
+            answers about everybody when they asked about one person.
+
+            Refused with 403 rather than quietly narrowed when the reader's own row scope
+            does not reach past themselves. A narrowing here would be worse than
+            elsewhere: the answer would look like the named rep's day while being the
+            reader's own.
+
+            It narrows the shared, record-bearing work — their tasks and their deals. It
+            does NOT reach their mailbox, their notices or their promises: those sources
+            are bound to the acting user inside the modules that own them, exactly as
+            they are under `team` and `all`. Reading somebody's queue is not reading
+            their inbox.
+
+            Naming yourself is the same question the default answers, and needs no wider
+            tier.
+
+            Sending it together with a `scope` other than `mine` is refused with 422. They
+            are two answers to one question and nothing defines which wins; letting the
+            owner take it silently would echo back the scope that had been ignored, so one
+            rep's work would arrive labelled `"scope": "unassigned"`.
       responses:
         '200':
           description: The ranked day.

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -30,6 +30,12 @@ import (
 // compile.
 const sourceWaiting = "customer_waiting"
 
+// sourceTask names the open-task producer. Named for the reason sourceWaiting
+// is: the owner filter asks whether a row came from the lane that narrowed to
+// one person in its own query, and a typo there would silently drop every task
+// out of the queue it was asked for.
+const sourceTask = "task"
+
 // subjectDeal is the subject type a deal-shaped row names.
 const subjectDeal = "deal"
 

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // needsYouPage is how many decisions one read carries.
@@ -118,6 +119,20 @@ type Service struct {
 	// anybody's, the reader's, nobody's — where a mailbox or a notice is
 	// per-reader by construction and has only one.
 	taskScope TaskScope
+	// taskOwner is whose queue TasksOwnedBy means. Zero for every other scope,
+	// and never read by them.
+	taskOwner ids.UUID
+}
+
+// forOwner returns a copy that reads one named person's queue. Same
+// copy-per-read reason as forReader: a service is shared by every request, and
+// an owner set on it would follow one manager's question onto another reader's
+// page.
+func (s *Service) forOwner(owner ids.UUID) *Service {
+	narrowed := *s
+	narrowed.taskScope = TasksOwnedBy
+	narrowed.taskOwner = owner
+	return &narrowed
 }
 
 // forReader returns a copy of this service that reads only the acting reader's
@@ -394,7 +409,7 @@ func endOfDay(asOf time.Time) time.Time {
 
 // planned is today's agreed work, overdue first.
 func (s *Service) planned(ctx context.Context, asOf time.Time, scope TaskScope) ([]crmcontracts.AttentionItem, error) {
-	open, err := s.tasks.OpenForViewer(ctx, endOfDay(asOf), plannedCap, scope)
+	open, err := s.tasks.OpenForViewer(ctx, endOfDay(asOf), plannedCap, scope, s.taskOwner)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -81,13 +81,17 @@ type stubTasks struct {
 	until *time.Time
 	// scope records WHOSE tasks the lane asked for, so a test can prove the
 	// narrowing reaches the QUERY rather than trusting that a filter ran
-	// afterwards.
+	// afterwards. owner records WHICH person, where the scope names one.
 	scope TaskScope
+	owner ids.UUID
 }
 
-func (s *stubTasks) OpenForViewer(_ context.Context, until time.Time, _ int, scope TaskScope) ([]Task, error) {
+func (s *stubTasks) OpenForViewer(
+	_ context.Context, until time.Time, _ int, scope TaskScope, owner ids.UUID,
+) ([]Task, error) {
 	s.until = &until
 	s.scope = scope
+	s.owner = owner
 	return s.rows, s.err
 }
 

--- a/backend/internal/compose/attention/handlers.go
+++ b/backend/internal/compose/attention/handlers.go
@@ -8,6 +8,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // Handlers is the feed's HTTP surface: one read, no verbs.
@@ -67,7 +68,23 @@ func (h Handlers) GetWorklist(w http.ResponseWriter, r *http.Request, params crm
 		}
 		scope = string(*params.Scope)
 	}
-	out, err := h.svc.Worklist(r.Context(), scope, filter, limit)
+	// The generated type already refused anything that is not a uuid, so an
+	// unparseable owner never reaches the resolver.
+	var owner ids.UUID
+	if params.Owner != nil {
+		// A named owner and a wider scope are two answers to one question, and
+		// nothing defines which wins. Letting the owner take it silently left
+		// the response echoing the scope that had been ignored — one rep's work
+		// labelled `"scope": "unassigned"`, which is the most misleading
+		// direction available. Refused, so the caller says which they meant.
+		if scope != "" && scope != scopeMine {
+			httperr.Write(w, r, httperr.Validation("owner", "conflicts_with_scope",
+				"asking for one person's queue and for a wider scope are different questions; send one"))
+			return
+		}
+		owner = ids.UUID(*params.Owner)
+	}
+	out, err := h.svc.Worklist(r.Context(), scope, filter, owner, limit)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -113,6 +113,10 @@ const (
 	TasksMine
 	// TasksUnassigned is the open tasks assigned to nobody.
 	TasksUnassigned
+	// TasksOwnedBy is the open tasks assigned to one NAMED person — a manager
+	// opening the queue of the rep an exception named. The name rides beside
+	// the scope, because a scope value cannot carry one.
+	TasksOwnedBy
 )
 
 // Tasks is the open-task read, through the activities module.
@@ -122,7 +126,7 @@ const (
 // rows out of a page of twelve and leave the reader's own overdue task
 // unreachable behind them.
 type Tasks interface {
-	OpenForViewer(ctx context.Context, until time.Time, limit int, scope TaskScope) ([]Task, error)
+	OpenForViewer(ctx context.Context, until time.Time, limit int, scope TaskScope, owner ids.UUID) ([]Task, error)
 }
 
 // Task is one piece of agreed work.

--- a/backend/internal/compose/attention/scope.go
+++ b/backend/internal/compose/attention/scope.go
@@ -83,6 +83,49 @@ func resolveScope(ctx context.Context, asked string) (string, error) {
 	return "", apperrors.ErrPermissionDenied
 }
 
+// resolveOwner answers whose queue this read is FOR, or refuses.
+//
+// A manager looking at a team exception needs to open the rep's own day — the
+// exception says whose it is, and the next question is always "show me their
+// queue". Without this they can only widen to `team`, which answers a question
+// about everybody when they asked about one person.
+//
+// The rule is the one resolveScope keeps: an ask the reader's row scope does
+// not reach is a 403, never a quiet narrowing. Narrowing here would be worse
+// than elsewhere, because the answer would look like the named rep's day while
+// being the reader's own.
+//
+// Reading somebody's queue is not reading their inbox. The per-user sources —
+// a mailbox, a notice, a promise — stay bound to the acting user inside the
+// modules that own them, exactly as they do under `team` and `all`, so what
+// this reaches is the shared record-bearing work assigned to that person. The
+// contract says so where the parameter is declared.
+func resolveOwner(ctx context.Context, asked ids.UUID) (ids.UUID, error) {
+	if asked.IsZero() {
+		return ids.UUID{}, nil
+	}
+	owner := asked
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		return ids.UUID{}, apperrors.ErrPermissionDenied
+	}
+	// Their own id needs no wider tier: "mine, spelled out" is the same
+	// question the default answers.
+	if owner == actor.UserID {
+		return owner, nil
+	}
+	// Somebody else's queue is a team-or-wider question. The tier is the whole
+	// test: whether that person is on the reader's team is a fact the row scope
+	// already decides for every record this read returns, and re-deriving it
+	// here would be a second answer to it.
+	switch actor.Permissions.RowScope {
+	case principal.RowScopeTeam, principal.RowScopeAll:
+		return owner, nil
+	default:
+		return ids.UUID{}, apperrors.ErrPermissionDenied
+	}
+}
+
 // mineOnly reports whether this read keeps only the reader's own work.
 //
 // WHAT A WIDER SCOPE CAN AND CANNOT DO, because the difference is not obvious
@@ -142,4 +185,94 @@ func waitingIsMine(waiting WaitingCustomer, ownedDeals map[ids.UUID]bool) bool {
 		return true
 	}
 	return ownedDeals[waiting.DealID]
+}
+
+// keepReadersOwn drops the rows belonging to somebody else.
+//
+// It runs over the CANDIDATES, before the page is cut, so a reader asking for
+// twenty-five of their own rows gets twenty-five where they exist. Narrowing
+// after the cut returned a short page while the reader's own work sat just
+// past it.
+//
+// It fails CLOSED. A call with no human behind it has no "own work" to answer
+// for, and a queue that handed such a caller every row it had read would be
+// widening a scope named `mine` — the opposite of what it says. An agent that
+// needs the day reads it under a scope it can actually hold.
+//
+// The narrowing itself is a display cut, not the security boundary: the lanes
+// are already row-scoped, so this changes what a wide-scoped reader is SHOWN
+// by default rather than what any store was asked. Pushing the filter into
+// each producer is the better shape and needs each to take an owner.
+func keepReadersOwn(ctx context.Context, rows []ranked) []ranked {
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID.IsZero() {
+		return nil
+	}
+	kept := make([]ranked, 0, len(rows))
+	for _, row := range rows {
+		if ownedByReader(row.item, actor) {
+			kept = append(kept, row)
+		}
+	}
+	return kept
+}
+
+// keepOwnedBy keeps only the rows POSITIVELY attributable to one named person.
+//
+// The opposite default from keepReadersOwn, and the difference is the whole
+// rule. That one keeps a row it cannot judge because the lane already bound it
+// to the acting reader: a notice addressed to them, their own mailbox, their
+// own promise. Under a named owner those same lanes are still bound to the
+// ACTING reader, so keeping what cannot be judged hands a manager their own
+// notices and meetings with somebody else's name on the page.
+//
+// Nothing crosses a scope boundary either way — every row here was already
+// readable. What is at stake is whether the answer is true: a page headed
+// "Lena's day" that is mostly the reader's own day is a worse failure than an
+// empty one, because nothing on it says so.
+//
+// So a row survives when it names this owner's deal, or when it came from the
+// task lane, which narrowed to them in its own query. Everything else is the
+// reader's, and this is not their page.
+//
+// That is also the honest limit of the scope, and the contract states it where
+// the parameter is declared: a manager opening a rep's queue sees the rep's
+// deals and tasks, never their mailbox.
+func keepOwnedBy(rows []ranked, owner ids.UUID) []ranked {
+	kept := make([]ranked, 0, len(rows))
+	for _, row := range rows {
+		if row.item.Source == sourceTask {
+			kept = append(kept, row)
+			continue
+		}
+		if row.item.Deal != nil && row.item.Deal.OwnerId != nil &&
+			ids.UUID(*row.item.Deal.OwnerId) == owner {
+			kept = append(kept, row)
+		}
+	}
+	return kept
+}
+
+// keepUnowned keeps the rows that answer to nobody.
+//
+// The counterpart to keepReadersOwn, over the same evidence: a deal-bearing row
+// with an owner belongs to that person and not to this queue. A row with no
+// owner to check stays, which is what the scope is for.
+func keepUnowned(rows []ranked) []ranked {
+	kept := make([]ranked, 0, len(rows))
+	for _, row := range rows {
+		if row.item.Deal == nil || row.item.Deal.OwnerId == nil {
+			kept = append(kept, row)
+		}
+	}
+	return kept
+}
+
+// scopeOptions puts the resolver's answer on the wire.
+func scopeOptions(options []string) []crmcontracts.WorklistScopeOptions {
+	out := make([]crmcontracts.WorklistScopeOptions, 0, len(options))
+	for _, option := range options {
+		out = append(out, crmcontracts.WorklistScopeOptions(option))
+	}
+	return out
 }

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
@@ -225,4 +226,92 @@ func TestTheLaneFeedStillReadsEveryVisibleTask(t *testing.T) {
 	if tasks.mineOnly() {
 		t.Fatal("the lane feed narrowed to the reader, changing a surface this did not set out to change")
 	}
+}
+
+// Opening somebody else's queue is a team-or-wider question.
+//
+// Both halves, because either alone proves nothing: a resolver that refused
+// everybody would pass the refusal test while making the feature dead, and one
+// that admitted everybody would pass the admission test while handing a rep
+// their colleague's day.
+func TestOpeningAnothersQueueNeedsATierThatReachesThem(t *testing.T) {
+	colleague := ids.MustParse("01a05500-0000-7000-8000-0000000000bb")
+
+	for _, tier := range []principal.RowScope{principal.RowScopeTeam, principal.RowScopeAll} {
+		got, err := resolveOwner(readerAt(tier), colleague)
+		if err != nil {
+			t.Fatalf("row scope %q was refused a colleague's queue: %v", tier, err)
+		}
+		if got != colleague {
+			t.Fatalf("row scope %q was given %v, wanted the named colleague", tier, got)
+		}
+	}
+
+	if _, err := resolveOwner(readerAt(principal.RowScopeOwn), colleague); err == nil {
+		t.Fatal("a reader whose scope reaches only themselves opened a colleague's queue")
+	}
+}
+
+// Naming yourself is the question the default already answers, so every tier
+// may ask it. A rep following a link that spells out their own id must not be
+// refused their own day.
+func TestNamingYourselfNeedsNoWiderTier(t *testing.T) {
+	me := ids.MustParse("01a05500-0000-7000-8000-000000000001")
+
+	got, err := resolveOwner(readerAt(principal.RowScopeOwn), me)
+	if err != nil {
+		t.Fatalf("a reader was refused their OWN queue: %v", err)
+	}
+	if got != me {
+		t.Fatalf("asking for their own queue answered %v", got)
+	}
+}
+
+// No ask is no narrowing. The parameter is optional, and its absence must not
+// read as "nobody's queue" and empty the page.
+func TestNoOwnerAskNarrowsNothing(t *testing.T) {
+	got, err := resolveOwner(readerAt(principal.RowScopeAll), ids.UUID{})
+	if err != nil {
+		t.Fatalf("omitting the owner was refused: %v", err)
+	}
+	if !got.IsZero() {
+		t.Fatalf("omitting the owner narrowed to %v", got)
+	}
+}
+
+// A named rep's queue carries THEIR work, not the reader's.
+//
+// The per-user lanes — notices, meetings, a mailbox, a promise — stay bound to
+// the ACTING reader whatever owner is asked for, because that is where the
+// modules that own them bind. So a filter that kept every row it could not
+// judge handed a manager their own day with somebody else's name at the top of
+// it. Nothing crossed a scope boundary; the page simply was not true.
+func TestOpeningAnothersQueueCarriesTheirWorkAndNotTheReadersOwn(t *testing.T) {
+	lena := ids.MustParse("01a05500-0000-7000-8000-0000000000bb")
+	lenasDeal := item("lenas-deal", "deal_at_risk", withDeal(90_000_00))
+	lenasDeal.Deal.OwnerId = uuidPtr(lena)
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		// The reader's own: a notice addressed to them, and a meeting they can
+		// see. Neither carries a deal, so neither can be judged by ownership.
+		Notices:  lane(item("my-notice", "notice")),
+		Meetings: lane(item("my-meeting", "meeting", withDue(rankInstant.Add(time.Hour)))),
+		AtRisk:   lane(lenasDeal),
+	}
+	reader := &Service{taskOwner: lena, taskScope: TasksOwnedBy}
+
+	out := reader.worklistFrom(context.Background(), day, scopeMine, "", 25, nil)
+
+	var ids []string
+	for _, row := range out.Queue {
+		ids = append(ids, row.Id)
+	}
+	if len(out.Queue) != 1 || out.Queue[0].Id != "lenas-deal" {
+		t.Fatalf("Lena's queue came back as %v, wanted only the deal she owns", ids)
+	}
+}
+
+func uuidPtr(id ids.UUID) *openapi_types.UUID {
+	out := openapi_types.UUID(id)
+	return &out
 }

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -49,11 +49,18 @@ const worklistMaxPage = 100
 // The filter narrows what is CARRIED, never what is read: a source is read,
 // classified and then dropped, so the summary's figures describe the same day
 // whichever filter is applied.
-func (s *Service) Worklist(ctx context.Context, scope, filter string, limit int) (crmcontracts.Worklist, error) {
+func (s *Service) Worklist(
+	ctx context.Context, scope, filter string, owner ids.UUID, limit int,
+) (crmcontracts.Worklist, error) {
 	// Resolved BEFORE the day is read: a reader asking for a scope they do not
 	// hold gets a refusal rather than a page assembled and then narrowed, and
 	// the read they were never entitled to make is not made.
 	resolved, err := resolveScope(ctx, scope)
+	if err != nil {
+		return crmcontracts.Worklist{}, err
+	}
+	// Same rule, same moment: whose queue this is, refused rather than narrowed.
+	namedOwner, err := resolveOwner(ctx, owner)
 	if err != nil {
 		return crmcontracts.Worklist{}, err
 	}
@@ -65,6 +72,11 @@ func (s *Service) Worklist(ctx context.Context, scope, filter string, limit int)
 	// taken from a page of ten would report ten over a hundred and fifty.
 	reader := s.countingDecisions()
 	switch {
+	// A named owner outranks the scope word: "their queue" is a narrower
+	// question than any of mine/team/all, and answering the wider one would
+	// hand back a page that looks like the rep's day and is not.
+	case !namedOwner.IsZero():
+		reader = reader.forOwner(namedOwner)
 	case mineOnly(resolved):
 		reader = reader.forReader()
 	case resolved == scopeUnassigned:
@@ -93,60 +105,6 @@ func (s *Service) Worklist(ctx context.Context, scope, filter string, limit int)
 	out.Scope = crmcontracts.WorklistScope(resolved)
 	out.ScopeOptions = scopeOptions(scopeOptionsFor(ctx))
 	return out, nil
-}
-
-// keepReadersOwn drops the rows belonging to somebody else.
-//
-// It runs over the CANDIDATES, before the page is cut, so a reader asking for
-// twenty-five of their own rows gets twenty-five where they exist. Narrowing
-// after the cut returned a short page while the reader's own work sat just
-// past it.
-//
-// It fails CLOSED. A call with no human behind it has no "own work" to answer
-// for, and a queue that handed such a caller every row it had read would be
-// widening a scope named `mine` — the opposite of what it says. An agent that
-// needs the day reads it under a scope it can actually hold.
-//
-// The narrowing itself is a display cut, not the security boundary: the lanes
-// are already row-scoped, so this changes what a wide-scoped reader is SHOWN
-// by default rather than what any store was asked. Pushing the filter into
-// each producer is the better shape and needs each to take an owner.
-func keepReadersOwn(ctx context.Context, rows []ranked) []ranked {
-	actor, ok := principal.Actor(ctx)
-	if !ok || actor.UserID.IsZero() {
-		return nil
-	}
-	kept := make([]ranked, 0, len(rows))
-	for _, row := range rows {
-		if ownedByReader(row.item, actor) {
-			kept = append(kept, row)
-		}
-	}
-	return kept
-}
-
-// keepUnowned keeps the rows that answer to nobody.
-//
-// The counterpart to keepReadersOwn, over the same evidence: a deal-bearing row
-// with an owner belongs to that person and not to this queue. A row with no
-// owner to check stays, which is what the scope is for.
-func keepUnowned(rows []ranked) []ranked {
-	kept := make([]ranked, 0, len(rows))
-	for _, row := range rows {
-		if row.item.Deal == nil || row.item.Deal.OwnerId == nil {
-			kept = append(kept, row)
-		}
-	}
-	return kept
-}
-
-// scopeOptions puts the resolver's answer on the wire.
-func scopeOptions(options []string) []crmcontracts.WorklistScopeOptions {
-	out := make([]crmcontracts.WorklistScopeOptions, 0, len(options))
-	for _, option := range options {
-		out = append(out, crmcontracts.WorklistScopeOptions(option))
-	}
-	return out
 }
 
 // worklistFrom projects an already-assembled day, so a test can drive the
@@ -237,6 +195,12 @@ func (s *Service) worklistFrom(
 	rows = dropDealsAlreadyWaiting(rows)
 
 	switch {
+	// Whose queue this is, applied to the rows the same way the lane applied it
+	// to the query. A deal-bearing row belonging to somebody else is not part
+	// of this person's day, and leaving it in would make a manager's answer to
+	// "show me Lena's queue" quietly include rows that are not hers.
+	case !s.taskOwner.IsZero():
+		rows = keepOwnedBy(rows, s.taskOwner)
 	case mineOnly(scope):
 		rows = keepReadersOwn(ctx, rows)
 	case scope == scopeUnassigned:

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -400,3 +400,73 @@ func (f attentionDealFacts) Figures(
 	}
 	return out, nil
 }
+
+// attentionTasks reads open tasks through the activities store. A task is an
+// activity of kind `task`, so this is the same read the task queue makes.
+type attentionTasks struct{ store *activities.Store }
+
+func (t attentionTasks) OpenForViewer(
+	ctx context.Context, until time.Time, limit int, scope attention.TaskScope, owner ids.UUID,
+) ([]attention.Task, error) {
+	// The store answers "open and due by then" itself, so the limit bounds the
+	// rows that QUALIFY. This used to read ten times the lane and narrow
+	// afterwards, which put the bound on the wrong set: a pile of completed
+	// tasks filled the scan, the overdue promise underneath never reached the
+	// reader, and the day rendered clear while the work was still there.
+	in := activities.ListActivitiesInput{OpenAndDueBy: &until, Limit: &limit}
+	// Narrowed in the QUERY, so the store's own bound applies to the rows that
+	// qualify. Filtering the answer instead would let a colleague's twelve
+	// tasks fill the page and hide the reader's own overdue one behind them.
+	switch scope {
+	case attention.TasksMine:
+		actor, ok := principal.Actor(ctx)
+		if !ok || actor.UserID.IsZero() {
+			// No human, no "own work" to answer for. Reading every task and
+			// calling the result theirs is the widening this narrowing exists
+			// to prevent.
+			return nil, nil
+		}
+		// Exactly theirs. A task they wrote themselves carries their name from
+		// the moment it is written, so this needs no unassigned arm — and the
+		// arm it used to have is what put an automation's follow-up on every
+		// colleague's queue.
+		assignee := ids.From[ids.UserKind](actor.UserID)
+		in.OwnQueueOf = &assignee
+	case attention.TasksUnassigned:
+		in.UnassignedQueue = true
+	case attention.TasksOwnedBy:
+		// One named person's open work. The scope resolver already refused a
+		// reader whose tier does not reach past themselves, and the store's own
+		// row-scope gate still applies underneath — this narrows, never widens.
+		named := ids.From[ids.UserKind](owner)
+		in.OwnQueueOf = &named
+	case attention.TasksVisible:
+		// Every open task the reader may see; the row-scope gate in the store
+		// is the only narrowing.
+	}
+	rows, _, err := t.store.ListActivities(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	open := make([]attention.Task, 0, len(rows))
+	for _, row := range rows {
+		// The filter above answers only dated rows, so this skip is unreachable
+		// today. It is here because the alternative to a skip is a nil deref
+		// that panics the WHOLE day's page, and the guarantee lives in a WHERE
+		// clause one package away — too far for the next reader of this loop to
+		// see it.
+		if row.DueAt == nil {
+			continue
+		}
+		due := *row.DueAt
+		linkType, linkID := primaryLink(row)
+		open = append(open, attention.Task{
+			ID:       ids.UUID(row.Id),
+			Subject:  subjectOfActivity(row),
+			DueAt:    &due,
+			LinkType: linkType,
+			LinkID:   linkID,
+		})
+	}
+	return open, nil
+}

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -38,7 +38,6 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
-	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // attentionApprovals reads the staged queue through the engine every approval
@@ -128,70 +127,6 @@ func (d attentionDuplicates) Describe(
 
 func (d attentionDuplicates) CountOpen(ctx context.Context) (int, error) {
 	return d.store.CountOpenDedupeCandidates(ctx)
-}
-
-// attentionTasks reads open tasks through the activities store. A task is an
-// activity of kind `task`, so this is the same read the task queue makes.
-type attentionTasks struct{ store *activities.Store }
-
-func (t attentionTasks) OpenForViewer(
-	ctx context.Context, until time.Time, limit int, scope attention.TaskScope,
-) ([]attention.Task, error) {
-	// The store answers "open and due by then" itself, so the limit bounds the
-	// rows that QUALIFY. This used to read ten times the lane and narrow
-	// afterwards, which put the bound on the wrong set: a pile of completed
-	// tasks filled the scan, the overdue promise underneath never reached the
-	// reader, and the day rendered clear while the work was still there.
-	in := activities.ListActivitiesInput{OpenAndDueBy: &until, Limit: &limit}
-	// Narrowed in the QUERY, so the store's own bound applies to the rows that
-	// qualify. Filtering the answer instead would let a colleague's twelve
-	// tasks fill the page and hide the reader's own overdue one behind them.
-	switch scope {
-	case attention.TasksMine:
-		actor, ok := principal.Actor(ctx)
-		if !ok || actor.UserID.IsZero() {
-			// No human, no "own work" to answer for. Reading every task and
-			// calling the result theirs is the widening this narrowing exists
-			// to prevent.
-			return nil, nil
-		}
-		// Exactly theirs. A task they wrote themselves carries their name from
-		// the moment it is written, so this needs no unassigned arm — and the
-		// arm it used to have is what put an automation's follow-up on every
-		// colleague's queue.
-		assignee := ids.From[ids.UserKind](actor.UserID)
-		in.OwnQueueOf = &assignee
-	case attention.TasksUnassigned:
-		in.UnassignedQueue = true
-	case attention.TasksVisible:
-		// Every open task the reader may see; the row-scope gate in the store
-		// is the only narrowing.
-	}
-	rows, _, err := t.store.ListActivities(ctx, in)
-	if err != nil {
-		return nil, err
-	}
-	open := make([]attention.Task, 0, len(rows))
-	for _, row := range rows {
-		// The filter above answers only dated rows, so this skip is unreachable
-		// today. It is here because the alternative to a skip is a nil deref
-		// that panics the WHOLE day's page, and the guarantee lives in a WHERE
-		// clause one package away — too far for the next reader of this loop to
-		// see it.
-		if row.DueAt == nil {
-			continue
-		}
-		due := *row.DueAt
-		linkType, linkID := primaryLink(row)
-		open = append(open, attention.Task{
-			ID:       ids.UUID(row.Id),
-			Subject:  subjectOfActivity(row),
-			DueAt:    &due,
-			LinkType: linkType,
-			LinkID:   linkID,
-		})
-	}
-	return open, nil
 }
 
 // subjectOfActivity is the line a task shows. An activity always carries one

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -33415,6 +33415,31 @@ type GetWorklistParams struct {
 
 	// Limit How many ranked items to return.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Owner Whose queue to answer, when it is somebody else's. A manager reading a team
+	// exception is told which rep it belongs to, and the next question is always
+	// "show me their day" — without this they can only widen to `team`, which
+	// answers about everybody when they asked about one person.
+	//
+	// Refused with 403 rather than quietly narrowed when the reader's own row scope
+	// does not reach past themselves. A narrowing here would be worse than
+	// elsewhere: the answer would look like the named rep's day while being the
+	// reader's own.
+	//
+	// It narrows the shared, record-bearing work — their tasks and their deals. It
+	// does NOT reach their mailbox, their notices or their promises: those sources
+	// are bound to the acting user inside the modules that own them, exactly as
+	// they are under `team` and `all`. Reading somebody's queue is not reading
+	// their inbox.
+	//
+	// Naming yourself is the same question the default answers, and needs no wider
+	// tier.
+	//
+	// Sending it together with a `scope` other than `mine` is refused with 422. They
+	// are two answers to one question and nothing defines which wins; letting the
+	// owner take it silently would echo back the scope that had been ignored, so one
+	// rep's work would arrive labelled `"scope": "unassigned"`.
+	Owner *openapi_types.UUID `form:"owner,omitempty" json:"owner,omitempty"`
 }
 
 // GetWorklistParamsScope defines parameters for GetWorklist.
@@ -70150,6 +70175,19 @@ func (siw *ServerInterfaceWrapper) GetWorklist(w http.ResponseWriter, r *http.Re
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "owner" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "owner", r.URL.Query(), &params.Owner, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "owner"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "owner", Err: err})
 		}
 		return
 	}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -36421,6 +36421,32 @@ export interface operations {
                 filter?: "all" | "customer_waiting" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system";
                 /** @description How many ranked items to return. */
                 limit?: number;
+                /**
+                 * @description Whose queue to answer, when it is somebody else's. A manager reading a team
+                 *     exception is told which rep it belongs to, and the next question is always
+                 *     "show me their day" — without this they can only widen to `team`, which
+                 *     answers about everybody when they asked about one person.
+                 *
+                 *     Refused with 403 rather than quietly narrowed when the reader's own row scope
+                 *     does not reach past themselves. A narrowing here would be worse than
+                 *     elsewhere: the answer would look like the named rep's day while being the
+                 *     reader's own.
+                 *
+                 *     It narrows the shared, record-bearing work — their tasks and their deals. It
+                 *     does NOT reach their mailbox, their notices or their promises: those sources
+                 *     are bound to the acting user inside the modules that own them, exactly as
+                 *     they are under `team` and `all`. Reading somebody's queue is not reading
+                 *     their inbox.
+                 *
+                 *     Naming yourself is the same question the default answers, and needs no wider
+                 *     tier.
+                 *
+                 *     Sending it together with a `scope` other than `mine` is refused with 422. They
+                 *     are two answers to one question and nothing defines which wins; letting the
+                 *     owner take it silently would echo back the scope that had been ignored, so one
+                 *     rep's work would arrive labelled `"scope": "unassigned"`.
+                 */
+                owner?: string;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
A team exception says whose work it is, and the next question is always "show me their day". Until now a manager could only widen to `team`, which answers about everybody when they asked about one person — so the answer to a question about Lena was a page mostly not about Lena.

`GET /v1/worklist?owner=<uuid>` answers it, under the rule `resolveScope` already keeps: an ask the reader's row scope does not reach is a 403, never a quiet narrowing. Narrowing would be worse here than anywhere else, because the page would look like the named rep's day while being the reader's own. Naming yourself needs no wider tier.

**What it reaches:** the shared, record-bearing work — their tasks, their deals. It does **not** reach their mailbox, notices or promises; those bind to the acting user inside the modules that own them, exactly as under `team` and `all`. Reading somebody's queue is not reading their inbox.

## What review caught

The row filter kept every row it *could not* judge, copying the rule from `keepReadersOwn`. That rule is right there — the lane already bound those rows to the reader — and exactly backwards here: the per-user lanes stay bound to the **acting reader** whatever owner is asked for, so a manager asking for Lena's queue got their own notices and meetings back with her name on the page. No scope boundary was crossed; the page simply was not true, and my comment argued the point in the wrong direction.

The filter now keeps only rows positively attributable to the owner. A test drives the projection with a reader's own notice and meeting alongside the named rep's deal and asserts only the deal survives; the mutation that restores the old default reproduces the defect exactly.

Also fixed: `scope` was silently ignored when `owner` was present while the response echoed the ignored value, so one rep's work could arrive labelled `"scope": "unassigned"` — the combination is now a 422, since nothing defines which wins. And the owner threads through as a typed UUID rather than a string round-trip, removing an unreachable parse branch.

The reviewer confirmed no privilege escalation, no existence oracle, and that the per-user lanes genuinely do not widen. Both halves of the tier test are mutation-checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `owner` query parameter to `GET /v1/worklist` so a manager can open a specific rep's queue instead of widening to `team`. Previously the only way to answer “show me their day” was to widen to `team`, which returned everybody's work; now a manager can name the rep. Access is refused with 403 when the reader's row scope does not reach that person, and naming yourself is allowed for all tiers. The owner filter applies to tasks in the query and deals over the rows; mailbox, notices, and promises stay bound to the acting user, so a manager sees the rep's tasks and deals but never their inbox.

**Behavior and validation**
- `owner` together with a `scope` other than `mine` is a 422; previously the scope was silently ignored and the response echoed the ignored value.
- The row filter now keeps only rows positively attributable to the owner, instead of keeping every row it could not judge (which showed the reader's own notices and meetings on the rep's page).
- The owner is passed as a typed UUID through the task lane, narrowing the store query to that person.
- Added mutation-checked tests covering the 403 boundary and the row projection.

<sup>Written for commit b31af0e91acc4f271ee6dc54fdfac2e6f36cfd07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional owner filter for viewing another representative’s work queue.
  - Supports viewing personal, colleague, unassigned, and all visible task queues.
  - Preserves correct task ownership and excludes unrelated reader-specific items.
- **Bug Fixes**
  - Added authorization checks for owner-specific queue access.
  - Invalid owner and scope combinations now return a clear validation error.
  - Improved filtering of planned tasks and worklist results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->