### PR TITLE
A company is reached through the people who were in the room

### DIFF
--- a/backend/gates/accountreachcopies_test.go
+++ b/backend/gates/accountreachcopies_test.go
@@ -34,46 +34,49 @@ import (
 	"testing"
 )
 
-// accountReachArms names the two files that spell the arms, and the constant
-// each spells them into.
-var accountReachArms = []struct {
-	file string
-	// name is the constant each file spells the arms into.
-	name string
-}{
-	{file: "internal/modules/activities/orgscope.go", name: "orgArms"},
-	{file: "internal/modules/search/graphorgreach.go", name: "orgArms"},
+// accountReachFiles are the two files that spell the walk.
+var accountReachFiles = []string{
+	"internal/modules/activities/orgscope.go",
+	"internal/modules/search/graphorgreach.go",
 }
+
+// accountReachArms are the constants each of those files must spell, and spell
+// identically. EVERY constant, not just the first: the arms are split across
+// two of them because one is shared with a producer that stops short of the
+// last arm, and holding only the shared half equal would leave the arm that
+// split them free to drift — which is this gate's whole subject.
+var accountReachArms = []string{"orgArms", "participantEmployerArm"}
 
 func TestTheAccountReachWalkIsOneAnswer(t *testing.T) {
 	t.Parallel()
-	texts := map[string]string{}
-	for _, spelling := range accountReachArms {
-		text, found := constText(t, spelling.file, spelling.name)
-		if !found {
-			t.Fatalf("%s no longer declares %s — the account-reach walk was renamed or moved, and "+
-				"this gate stopped comparing anything rather than failing",
-				spelling.file, spelling.name)
+	for _, arm := range accountReachArms {
+		texts := map[string]string{}
+		for _, file := range accountReachFiles {
+			text, found := constText(t, file, arm)
+			if !found {
+				t.Fatalf("%s no longer declares %s — the account-reach walk was renamed or moved, and "+
+					"this gate stopped comparing anything rather than failing", file, arm)
+			}
+			texts[file] = text
 		}
-		texts[spelling.file] = text
-	}
-	first := accountReachArms[0]
-	for _, other := range accountReachArms[1:] {
-		if normalizeSQL(texts[first.file]) != normalizeSQL(texts[other.file]) {
-			t.Errorf("the account-reach arms differ between %s and %s — one of them has gained or "+
-				"lost a condition, so the account's timeline and its context walk no longer agree "+
-				"about which activities belong to it:\n  %s: %s\n  %s: %s",
-				first.file, other.file,
-				first.file, normalizeSQL(texts[first.file]),
-				other.file, normalizeSQL(texts[other.file]))
+		first := accountReachFiles[0]
+		for _, other := range accountReachFiles[1:] {
+			if normalizeSQL(texts[first]) != normalizeSQL(texts[other]) {
+				t.Errorf("the %s arm differs between %s and %s — one of them has gained or "+
+					"lost a condition, so the account's timeline and its context walk no longer agree "+
+					"about which activities belong to it:\n  %s: %s\n  %s: %s",
+					arm, first, other,
+					first, normalizeSQL(texts[first]),
+					other, normalizeSQL(texts[other]))
+			}
 		}
-	}
-	// Both halves must actually SAY something. Two empty strings compare equal,
-	// and a gate that passes over nothing is the failure mode this whole file
-	// is about.
-	for file, text := range texts {
-		if strings.TrimSpace(text) == "" {
-			t.Errorf("%s spells the arms as an empty string, so the comparison above proved nothing", file)
+		// Both halves must actually SAY something. Two empty strings compare
+		// equal, and a gate that passes over nothing is the failure mode this
+		// whole file is about.
+		for file, text := range texts {
+			if strings.TrimSpace(text) == "" {
+				t.Errorf("%s spells %s as an empty string, so the comparison above proved nothing", file, arm)
+			}
 		}
 	}
 }

--- a/backend/internal/compose/integration/org360/org360_account_timeline_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_account_timeline_integration_test.go
@@ -44,6 +44,31 @@ func accountMailAt(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject string, a
 	return id
 }
 
+// accountMeetingAt seeds a meeting. A meeting carries no direction — nobody
+// sends one — and, since 1788000100, may carry no organization link either:
+// the only way it reaches an account is through the people who were in it.
+func accountMeetingAt(t *testing.T, owner *pgx.Conn, subject string, at time.Time) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(context.Background(), `INSERT INTO activity (id, kind, subject, occurred_at, created_at, source, captured_by)
+		VALUES ($1, 'meeting', $2, $3, $3, 'manual', 'human:x')`,
+		id, subject, at); err != nil {
+		t.Fatalf("seeding meeting %q: %v", subject, err)
+	}
+	return id
+}
+
+// attend puts a person on an event as a PARTICIPANT and nothing else — no
+// activity_link, which is the shape the account walk used to miss entirely.
+func attend(t *testing.T, owner *pgx.Conn, activity, person ids.UUID) {
+	t.Helper()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO activity_participant (activity_id, person_id, role) VALUES ($1, $2, 'attendee')`,
+		activity, person); err != nil {
+		t.Fatalf("seeding participant: %v", err)
+	}
+}
+
 // employ ties a person to an organization as a current employee, in the role
 // the graph draws them in.
 func employ(t *testing.T, e *integration.Env, person, org ids.UUID, title string) {
@@ -168,6 +193,55 @@ func TestAccountTimelineReachesMailThroughItsContactsAndDeals(t *testing.T) {
 	}
 	if !containsActivity(section, viaContact) {
 		t.Errorf("the 360 activities section omits mail filed against a current employee: %v", section)
+	}
+}
+
+// A COMPANY IS REACHED THROUGH THE PEOPLE WHO WERE IN THE ROOM. A meeting may
+// carry no organization link, and capture puts the far side on the invitation
+// rather than in activity_link — so a walk that starts only from the links
+// answers an account's afternoon with nothing in it.
+//
+// The exclusions the linked arm already makes hold here too: a former
+// employee's meeting is not this account's, and neither is one whose only
+// attendee works somewhere else.
+func TestAccountTimelineReachesAMeetingThroughSomebodyInTheRoom(t *testing.T) {
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
+
+	org := e.SeedOrg(t, "Acme", &e.Rep1)
+	other := e.SeedOrg(t, "Globex", &e.Rep1)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+
+	employee := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+	employAt(t, e, employee, org, nil)
+	leaver := e.SeedPerson(t, "Sam Leaver", &e.Rep1)
+	ended := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	employAt(t, e, leaver, org, &ended)
+	stranger := e.SeedPerson(t, "Kim Elsewhere", &e.Rep1)
+	employAt(t, e, stranger, other, nil)
+
+	withEmployee := accountMeetingAt(t, owner, "the quarterly review", org360Clock.Add(-1*time.Hour))
+	attend(t, owner, withEmployee, employee)
+	withLeaver := accountMeetingAt(t, owner, "a call with somebody who has left", org360Clock.Add(-2*time.Hour))
+	attend(t, owner, withLeaver, leaver)
+	withStranger := accountMeetingAt(t, owner, "another account's meeting", org360Clock.Add(-3*time.Hour))
+	attend(t, owner, withStranger, stranger)
+
+	listed, _ := accountTimeline(rep, t, e, org, 25, "")
+	if !containsActivity(listed, withEmployee) {
+		t.Errorf("the account timeline omits a meeting whose only person is on the invitation (%v): %v",
+			withEmployee, listed)
+	}
+	for _, unwanted := range []struct {
+		id   ids.UUID
+		what string
+	}{
+		{withLeaver, "a meeting attended only by somebody who has LEFT the company"},
+		{withStranger, "a meeting attended only by a contact at another account"},
+	} {
+		if containsActivity(listed, unwanted.id) {
+			t.Errorf("the account timeline includes %s (%v): %v", unwanted.what, unwanted.id, listed)
+		}
 	}
 }
 

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -21,12 +21,13 @@ import (
 // OrgLinkedActivityExists is the ONE spelling of "this activity reaches the
 // account", for a query that aliases activity as a.
 //
-// A message or a task belongs to a company through any of three links — its own,
-// its deal's, or the contact it is about — and every reader of the account's
-// timeline needs the same walk: the timeline list itself, the company view's
-// next-steps section, and the two suggestion reads. Spelling it once is what
-// keeps them from drifting apart: a fourth link added to the model reaches every
-// reader, or none of them.
+// A message, a task or a meeting belongs to a company through any of four
+// arms — its own link, its deal's, the contact it is about, or the employer of
+// somebody who was on it — and every reader of the account's timeline needs the
+// same walk: the timeline list itself, the company view's next-steps section,
+// and the two suggestion reads. Spelling it once is what keeps them from
+// drifting apart: an arm added to the model reaches every reader, or none of
+// them.
 //
 // It lives in this module rather than next to the company view because a module
 // may not import compose, and the timeline list is a reader too — the drift this
@@ -80,19 +81,48 @@ const orgArms = `FROM activity_link l
 		    LEFT JOIN relationship r ON r.person_id = l.person_id AND r.kind = 'employment'
 		      AND r.ended_at IS NULL AND r.archived_at IS NULL`
 
+// participantEmployerArm is the READER's fourth arm: the employer of somebody
+// who is on the event as a participant rather than as a link.
+//
+// The three arms above all start from activity_link, and a meeting may not
+// carry a direct organization link at all — a company is not somebody you can
+// meet. So a meeting whose only person is on the invitation reaches no company
+// through them, and the account whose contact sat in the room sees an empty
+// afternoon. search.employerSubjects already walks BOTH person sources for the
+// context prep; this is the same pair for the reach walk, and the two agreeing
+// is the point.
+//
+// Anchored on the activity rather than folded into orgArms, because orgArms is
+// shared with OrgReachSet and this arm deliberately is not — the ruling, and
+// why, is on OrgReachSet.
+//
+// CURRENT employment, exactly as the link arm reads it: a former colleague's
+// company is one they left.
+//
+// The alias is emp rather than r: the row-scope clause a caller composes
+// alongside this one is recognized by its "r." tokens, and a second
+// relationship in scope under that name reads as the first.
+const participantEmployerArm = `EXISTS (
+		    SELECT 1 FROM activity_participant ap
+		      JOIN relationship emp ON emp.person_id = ap.person_id AND emp.kind = 'employment'
+		        AND emp.ended_at IS NULL AND emp.archived_at IS NULL
+		    WHERE ap.activity_id = a.id AND emp.organization_id = %s)`
+
 // activityReachesOrg is the walk as a PREDICATE, for a query that aliases
 // activity as a. operand is what each arm compares its organization id against
 // — a single bind, or ANY(array).
 //
 // It stays an EXISTS rather than a join against OrgReachSet: EXISTS stops at
 // the first arm that matches, and every one of this function's callers is a
-// hot read.
+// hot read. The participant arm is a second EXISTS beside the first for the
+// same reason — it is probed only when the three links found nothing.
 func activityReachesOrg(operand string) string {
-	return sprintf(`EXISTS (
+	linked := sprintf(`EXISTS (
 		    SELECT 1 %s
 		    WHERE l.activity_id = a.id
 		      AND (l.organization_id = %[2]s OR d.organization_id = %[2]s OR r.organization_id = %[2]s))`,
 		orgArms, operand)
+	return "(" + linked + "\n\t\t    OR " + sprintf(participantEmployerArm, operand) + ")"
 }
 
 // OrgReachSet is the same walk as a SET: the body of a derived table producing
@@ -101,7 +131,19 @@ func activityReachesOrg(operand string) string {
 // The predicate above answers "does this activity reach account X" and takes
 // the account as a bind. A producer scanning the whole workspace has the
 // opposite question — it holds an activity and needs the accounts — so it
-// cannot use the predicate at all. Both are the same three arms.
+// cannot use the predicate at all.
+//
+// THREE ARMS, NOT THE PREDICATE'S FOUR. The predicate also reaches through a
+// participant's employer; this set does not, and the difference is the point
+// rather than a lag. This set is what a SIGNAL is filed through, and the note
+// below already draws the line it sits on: a timeline showing something is
+// arguably being helpful, a signal filed against that account is a claim
+// nobody made. Somebody Cc'd on a message is weaker evidence than somebody the
+// message was filed against, and filing against every Cc'd person's employer
+// would put claims on accounts that were never in the conversation.
+//
+// TestTheReachSetDoesNotFileThroughParticipants holds the split, so collapsing
+// it is a decision somebody makes rather than a line they add.
 //
 // DISTINCT collapses an activity that reaches one account through several arms
 // (its own link and its deal's, say) to one row, so a caller counting messages

--- a/backend/internal/modules/activities/orgscope_test.go
+++ b/backend/internal/modules/activities/orgscope_test.go
@@ -66,7 +66,7 @@ func filterFor(ctx context.Context, t *testing.T, entityType string) (join strin
 	return joined, strings.Join(terms, " AND "), args
 }
 
-func TestOrganizationFilterWalksTheAccountsThreeLinks(t *testing.T) {
+func TestOrganizationFilterWalksTheAccountsFourArms(t *testing.T) {
 	join, where, args := filterFor(unscopedCtx(), t, "organization")
 
 	if join != "" {
@@ -76,7 +76,10 @@ func TestOrganizationFilterWalksTheAccountsThreeLinks(t *testing.T) {
 	if !strings.Contains(where, "EXISTS (") {
 		t.Fatalf("organization filter is not an EXISTS: %s", where)
 	}
-	for _, arm := range []string{"l.organization_id = $1", "d.organization_id = $1", "r.organization_id = $1"} {
+	for _, arm := range []string{
+		"l.organization_id = $1", "d.organization_id = $1", "r.organization_id = $1",
+		"emp.organization_id = $1",
+	} {
 		if !strings.Contains(where, arm) {
 			t.Errorf("organization filter misses the %q arm: %s", arm, where)
 		}
@@ -85,10 +88,41 @@ func TestOrganizationFilterWalksTheAccountsThreeLinks(t *testing.T) {
 		!strings.Contains(where, "r.ended_at IS NULL") {
 		t.Errorf("the employment arm must be live employment only: %s", where)
 	}
-	// One bind position, read by all three arms: an account id registered
-	// three times would silently mis-number every later placeholder.
+	// The participant arm reads employment the same way. A former colleague's
+	// company is one they left, whether they were linked or invited.
+	if !strings.Contains(where, "emp.kind = 'employment'") ||
+		!strings.Contains(where, "emp.ended_at IS NULL") {
+		t.Errorf("the participant arm must be live employment only: %s", where)
+	}
+	// Anchored on the activity in hand. Without it the arm asks "is anybody
+	// anywhere a participant who works here", which is true of the whole
+	// workspace at once.
+	if !strings.Contains(where, "ap.activity_id = a.id") {
+		t.Errorf("the participant arm is not anchored on the activity: %s", where)
+	}
+	// One bind position, read by all four arms: an account id registered
+	// four times would silently mis-number every later placeholder.
 	if len(args) != 1 {
 		t.Errorf("organization filter bound %d args, want 1 (the account id): %v", len(args), args)
+	}
+}
+
+// The reader's fourth arm is NOT the producer's. OrgReachSet is what a signal
+// is filed through, and somebody merely Cc'd on a message is weaker evidence
+// than somebody the message was filed against — filing against every Cc'd
+// person's employer would put claims on accounts that were never in the
+// conversation. The split is a ruling, so it is held rather than remembered.
+func TestTheReachSetDoesNotFileThroughParticipants(t *testing.T) {
+	set := OrgReachSet()
+	if strings.Contains(set, "activity_participant") {
+		t.Errorf("OrgReachSet reaches through participants, so a signal is now filed against "+
+			"the employer of everybody copied on a message:\n%s", set)
+	}
+	// And the reader's does, or this test is only describing an absence that
+	// was never a decision.
+	if !strings.Contains(OrgLinkedActivityExists(1), "activity_participant") {
+		t.Error("the timeline predicate no longer reaches through participants either, " +
+			"so the split above holds nothing apart")
 	}
 }
 

--- a/backend/internal/modules/search/graphorgreach.go
+++ b/backend/internal/modules/search/graphorgreach.go
@@ -19,6 +19,21 @@ const orgArms = `FROM activity_link l
 		    LEFT JOIN relationship r ON r.person_id = l.person_id AND r.kind = 'employment'
 		      AND r.ended_at IS NULL AND r.archived_at IS NULL`
 
+// participantEmployerArm is the fourth arm: the employer of somebody who is on
+// the event as a participant rather than as a link. Without it a meeting whose
+// only person is on the invitation reaches no company at all, since a meeting
+// may carry no direct organization link.
+//
+// activities.participantEmployerArm is the same text, held equal to this one by
+// TestTheAccountReachWalkIsOneAnswer. It is a constant of its own rather than
+// part of orgArms because the two modules also share orgArms with a producer
+// that deliberately stops at three arms (activities.OrgReachSet says why).
+const participantEmployerArm = `EXISTS (
+		    SELECT 1 FROM activity_participant ap
+		      JOIN relationship emp ON emp.person_id = ap.person_id AND emp.kind = 'employment'
+		        AND emp.ended_at IS NULL AND emp.archived_at IS NULL
+		    WHERE ap.activity_id = a.id AND emp.organization_id = %s)`
+
 // activityReachesOrg is "this activity belongs to the account", for a query
 // that aliases activity as a.
 //
@@ -30,8 +45,8 @@ const orgArms = `FROM activity_link l
 // with: an account's busiest correspondence carried no organization link at all
 // and this walk never saw it.
 //
-// activities.OrgLinkedActivityExists is the same three arms for the timeline
-// list, the account view and the roll-up. A module never imports a sibling
+// activities.OrgLinkedActivityExists is the same arms for the timeline list,
+// the account view and the roll-up. A module never imports a sibling
 // (ADR-0054), so this is its deliberate copy, held against it by
 // TestTheAccountReachWalkIsOneAnswer rather than by anybody remembering.
 //
@@ -42,9 +57,10 @@ const orgArms = `FROM activity_link l
 // same one.
 func activityReachesOrg(orgPos int) string {
 	operand := fmt.Sprintf("$%d", orgPos)
-	return fmt.Sprintf(`EXISTS (
+	linked := fmt.Sprintf(`EXISTS (
 		    SELECT 1 %s
 		    WHERE l.activity_id = a.id
 		      AND (l.organization_id = %[2]s OR d.organization_id = %[2]s OR r.organization_id = %[2]s))`,
 		orgArms, operand)
+	return "(" + linked + "\n\t\t    OR " + fmt.Sprintf(participantEmployerArm, operand) + ")"
 }


### PR DESCRIPTION
Closes #3130.

The account-reach walk started every arm from `activity_link`, so a person who
is on an event as a **participant** and not as a link carried no company at all.
Since a meeting may hold no direct organization link, a meeting whose only
person is on the invitation reached no account: the timeline list, the company
view, the roll-up and the context walk all answered the afternoon with nothing
in it.

**The reader** now walks a fourth arm — the employer of somebody on the event —
with the same live-employment bound the linked arm reads, and anchored on the
activity so it asks about the event in hand rather than about the workspace.
`search.employerSubjects` already walked both person sources for the context
prep; the two now agree.

**The producer deliberately does not.** `OrgReachSet` is what a signal is filed
through, and the note on it already draws the line: a timeline showing something
is arguably being helpful, a signal filed against that account is a claim nobody
made. Somebody copied on a message is weaker evidence than somebody it was filed
against, and filing against every Cc'd person's employer would put claims on
accounts that were never in the conversation. That split is the decision the
ticket asked for, and it is held by `TestTheReachSetDoesNotFileThroughParticipants`
rather than by the comment — with the copies gate now holding **both** arms equal
across the two modules instead of only the shared one.

## Proof

`TestAccountTimelineReachesAMeetingThroughSomebodyInTheRoom` seeds a meeting
whose only person is on the invitation, plus two controls the arm must still
refuse: an attendee who has left the company, and one who works elsewhere.
Dropping the arm fails it on the meeting; dropping the `ended_at` bound fails it
on the leaver.

`make check-backend` and all 49 integration packages green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization activity searches now include meetings and activities reached through participants’ current employers.
  * Former employees and contacts associated with other organizations are excluded from these results.
  * Account timelines now surface meetings involving current employees of the account.

* **Bug Fixes**
  * Improved consistency between activity filtering and search results when determining organization reachability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->