### PR TITLE
A booking slug admits a write, so the log stops carrying it

### DIFF
--- a/backend/gates/capabilitypathlog_test.go
+++ b/backend/gates/capabilitypathlog_test.go
@@ -216,8 +216,7 @@ func TestEveryPublicRoutePrefixIsJudgedForCredentials(t *testing.T) {
 	// The public prefixes whose segment is NOT a credential, each with why.
 	// A prefix leaves this map only by joining capabilitypath's list.
 	notCredentials := map[string]string{
-		"/v1/public/booking/": "a booking slug is a public identifier the host hands out; the log needs it to say which page was hit",
-		"/v1/public/rooms/":   "the segment is an operation name (peek, exchange, link-request); a deal room presents a Bearer, never a path token",
+		"/v1/public/rooms/": "the segment is an operation name (peek, exchange, link-request); a deal room presents a Bearer, never a path token",
 	}
 
 	redacted := make(map[string]bool)

--- a/backend/internal/shared/kernel/capabilitypath/capabilitypath.go
+++ b/backend/internal/shared/kernel/capabilitypath/capabilitypath.go
@@ -32,11 +32,15 @@ const redacted = "[redacted]"
 // bearer credential rather than an identifier.
 //
 // A route belongs here when possession of the segment grants access. It does
-// NOT belong here merely for being unguessable: the public booking page
-// (/v1/public/booking/) carries a slug the host hands out deliberately, which
-// resolves to free/busy slots and nothing else, and redacting it would cost
-// the access log the only thing naming which booking page was hit while
-// buying nothing.
+// NOT belong here merely for sitting on a public route: the deal room
+// (/v1/public/rooms/) spells an operation name in that position — peek,
+// exchange, link-request — and presents its credential as a Bearer, so the
+// segment names what was asked for rather than who was allowed to ask.
+//
+// Nor does "the holder published it" put a route outside this list. Published
+// to the people a host chooses and written into every log aggregator, support
+// paste and third-party log service are not the same audience, and only the
+// first is a decision the holder made.
 var credentialPrefixes = []string{
 	// The preference centre: the token resolves straight to a
 	// (workspace, person) consent state and can change it.
@@ -45,6 +49,15 @@ var credentialPrefixes = []string{
 	// so a token in a log line is a readable copy of somebody's personal
 	// data sitting in operations.
 	"/v1/public/confirm/",
+	// The public booking page. The slug is the ONLY admission check on a
+	// route that WRITES: an anonymous request holding it creates or matches a
+	// person by email, records a consent grant against them, and books a
+	// meeting on the host's calendar (activities.BookPublicMeeting). That is
+	// the criterion above, whatever the host does with the URL afterwards.
+	//
+	// The cost is real and was weighed: the access log no longer names which
+	// booking page was hit. The booking it produces still does.
+	"/v1/public/booking/",
 }
 
 // Redact replaces the ONE path segment that follows a credential prefix and

--- a/backend/internal/shared/kernel/capabilitypath/capabilitypath_test.go
+++ b/backend/internal/shared/kernel/capabilitypath/capabilitypath_test.go
@@ -47,12 +47,20 @@ func TestRedactHidesTheCredentialAndKeepsTheRoute(t *testing.T) {
 			"/v1/public/preferences/",
 		},
 		{
-			// The booking slug is a public identifier the host hands out, not
-			// a credential. Redacting it would cost the log the one thing
-			// naming which booking page was hit and buy nothing.
-			"a public booking slug is deliberately kept",
+			// The booking slug is the only admission check on a route that
+			// creates a person, records a consent grant and books a meeting.
+			// The host publishing the URL is not the host publishing it to a
+			// log aggregator.
+			"a booking slug admits a write, so it goes too",
 			"/v1/public/booking/acme-discovery-call",
-			"/v1/public/booking/acme-discovery-call",
+			"/v1/public/booking/[redacted]",
+		},
+		{
+			// The availability read hangs off the same slug, and the verb
+			// after it is what makes the line worth keeping.
+			"the availability verb survives the slug",
+			"/v1/public/booking/acme-discovery-call/availability",
+			"/v1/public/booking/[redacted]/availability",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #3131.

`capabilitypath` kept `/v1/public/booking/` out of the redacted set on the
stated ground that the slug *"resolves to free/busy slots and nothing else"*.
It does not. An anonymous request holding the slug and nothing else

- creates or matches a person by email,
- records a consent grant against them,
- books a meeting on the host's calendar

(`activities.BookPublicMeeting`). The slug is the only admission check on that
route.

That is the package's **own** criterion for the list — *possession of the
segment grants access* — so the prefix joins it, and the reason on the exclusion
goes with it. The ticket is right that either answer needed that reason fixed;
it is the half a later reader would have relied on.

## The call, and how to reverse it

The counter-argument is honest: the host publishes this URL deliberately. It
does not survive the audience. Published to the people a host chooses and
written into every log aggregator, support paste and third-party log service are
not the same set, and only the first is a decision the host made.

The cost is real and is now written down rather than assumed away: the access
log no longer names which booking page was hit. The booking it produces still
does.

If you weigh the access log the other way, reverting is one line — drop the
prefix from `credentialPrefixes` and restore the `notCredentials` entry with a
reason that says the slug books.

`make check-backend` and all 49 integration packages green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Booking links are now treated as access credentials, with booking slugs hidden in application logs.
  * Availability-related logs retain the action while redacting sensitive booking slugs.
* **Bug Fixes**
  * Public booking requests can use their secure booking links to create or match contacts, record consent, and schedule meetings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->