### PR TITLE
A failed make dev takes its api and its Vite with it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ GO ?= go
 # consumer — see the comment on check-backend for why they are not that
 # target's prerequisites.
 ROOT_SCRIPT_GATES := check-craft-doc craft-test test-dev-isolation \
+  test-dev-cleanup \
   test-golangci-guard test-scheduled-report test-ci-verdict test-check-dco \
   test-laneorder check-image-pins check-host-ports ci-doc-parity \
   make-target-parity contract-breaking-check contract-frontend-drift \
@@ -94,7 +95,7 @@ SEED_STACK = set -e; . scripts/lib-devstate.sh; \
     seed_dsn="postgres://margince_owner:dev@localhost:15432/$$seed_db"; \
   fi;
 
-.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-check-dco test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-check-dco test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -798,6 +799,14 @@ test-dev-dsn:
 ## consumer group, each acking events the other never saw.
 test-dev-isolation:
 	@./scripts/test-dev-isolation.sh
+
+## test-dev-cleanup — prove a failed `make dev` leaves nothing running: the EXIT
+## trap is armed for every `up` rather than only for a stack that claims a port,
+## it follows TERM with KILL, and it spares a stack that was already up. The
+## failure it replaces was an api or a Vite outliving the run on the PRIMARY
+## stack, which the next `make dev` reported as a port already in use.
+test-dev-cleanup:
+	@./scripts/test-dev-cleanup.sh
 
 ## test-scheduled-report — prove the scheduled lane still files ONE issue per
 ## failing check: stub the tracker, and require the reporter to find an already

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -94,12 +94,42 @@ MINIO_PORT="${MINIO_PORT:-29000}"
 # `command not found` and left the claim behind.
 
 kill_pids() { # pid… — TERM, then KILL whatever is still standing
-  local pids=("$@") alive=()
+  #
+  # SIGNED FIRST, and re-checked before the KILL. There are five seconds between
+  # the TERM and the SIGKILL, and a process that honours the TERM frees its pid
+  # inside them: the kernel reissues numbers, and the SIGKILL then lands on
+  # whatever took it — somebody's editor, their own shell. A pid is not an
+  # identity, and the wait is exactly where it stops being one.
+  #
+  # The signature is the command line as it was when the TERM was sent. What it
+  # proves is not what the process IS but that it is still the same one.
+  local pids=("$@") alive=() p signature
   [[ ${#pids[@]} -gt 0 ]] || return 0
+  local -a signed=()
+  for p in "${pids[@]}"; do
+    # `|| true` because `set -o pipefail` is in force and ps exits non-zero for
+    # a pid it cannot see — a recorded process that has already gone, which is
+    # the ordinary case during a failed boot. Without it the pipeline aborts
+    # kill_pids under `set -e`, and the EXIT trap that called it leaves the api,
+    # the vite and the claim standing: the cleanup fails on the one path it
+    # exists for.
+    signature=$({ ps -o command= -p "$p" 2>/dev/null || true; } | tr -d ' \t\n')
+    # A pid with no signature is one nothing can identify. It is not killed —
+    # an empty signature matches every command line, which would licence the
+    # SIGKILL below against whatever holds that number now.
+    [[ -n "$signature" ]] && signed+=("$p:$signature")
+  done
+  [[ ${#signed[@]} -gt 0 ]] || return 0
   kill "${pids[@]}" 2>/dev/null || true
   for _ in $(seq 1 10); do
     alive=()
-    for p in "${pids[@]}"; do kill -0 "$p" 2>/dev/null && alive+=("$p"); done
+    for entry in "${signed[@]}"; do
+      p="${entry%%:*}"
+      signature="${entry#*:}"
+      case "$(ps -o command= -p "$p" 2>/dev/null | tr -d ' \t\n')" in
+        *"$signature"*) alive+=("$p") ;;
+      esac
+    done
     [[ ${#alive[@]} -eq 0 ]] && return 0
     sleep 0.5
   done
@@ -110,11 +140,35 @@ kill_pids() { # pid… — TERM, then KILL whatever is still standing
 # sleep leaves its file behind, and by the time the next `make dev` reads it
 # that number can belong to anything. The pgrep paths already re-check the
 # live command line before killing — a recorded pid gets the same proof.
-still_ours() { # pid
-  local cmd
+still_ours() { # pid [database]
+  local cmd stack_db="${2:-${db:-}}"
   cmd=$(ps -o command= -p "$1" 2>/dev/null || true)
   [[ -n "$cmd" ]] || return 1
-  [[ "$cmd" == *margince* || "$cmd" == *"$repo_root"* ]]
+  # The repo root as a PATH COMPONENT, not a prefix: a sibling checkout at
+  # /…/margince-old starts with /…/margince, and a substring match would read
+  # that stack's processes as this one's.
+  #
+  # And THIS STACK'S DATABASE, not the repository's name. The api and the worker
+  # carry no repository path in their argv, so they are recognised by the `--dsn`
+  # they were launched with — but `*margince*` matched the word anywhere, which
+  # every sibling checkout's path also contains. That alternative was answered
+  # first, so the two path components below decided nothing at all and the
+  # narrowing they exist for was dead code.
+  #
+  # The database name ends the DSN's path, so it is matched at its end: followed
+  # by nothing, by the query string, or by the next argument. A prefix match
+  # would read margince_dev_wt10's stack as margince_dev_wt1's.
+  # The stack's database name is not optional here: without it this reads only
+  # the path arms, and the api and the worker — which carry no path — become
+  # invisible to every caller. Refusing is the safe direction (nothing is killed
+  # or claimed on a "no"), and it says so rather than answering quietly.
+  if [[ -z "$stack_db" ]]; then
+    echo "dev.sh: still_ours was asked about pid $1 before a stack's database name was resolved" >&2
+    return 1
+  fi
+  local dsn_db="/${stack_db}"
+  [[ "$cmd" == *"$dsn_db" || "$cmd" == *"$dsn_db"' '* || "$cmd" == *"$dsn_db"'?'* \
+    || "$cmd" == *"$repo_root"/* || "$cmd" == *"$repo_root" ]]
 }
 # is_dev_launcher reports whether a pid is a live run of THIS script. The starter
 # recorded in a reservation is a shell running dev.sh, so that is what to look for
@@ -126,11 +180,76 @@ is_dev_launcher() { # pid
   [[ "$cmd" == *dev.sh* ]]
 }
 
-# release_unconfirmed_stack — give back this run's claim, and take down whatever
-# it started. Called from the EXIT trap while stack_recorded is 0, which is every
-# path that does not reach a stack answering its own readiness probe.
+# stack_already_up answers whether a previous run's processes for THIS stack are
+# still standing, read from the state file it left behind.
+#
+# A recorded pid is not enough on its own — pids are recycled — so the command
+# line is checked too, through the same still_ours the sweep uses.
+#
+# NOT narrowed to this worktree's path, though the question is about this
+# worktree's stack: the api and the worker are launched as `./bin/api` and
+# `./bin/worker` and carry no repository path in their argv at all. They are
+# recognised by the other half of still_ours instead, the database name their
+# DSN carries. Requiring the path answered "nothing here" for a live api whose
+# vite had exited — and the release then deletes the record naming it.
+#
+# ANY of the three, not the api alone. An api that crashed while its vite is
+# still serving is a stack that is still up as far as :8080 is concerned, and
+# answering "no" for it would let a second run delete the record — leaving vite
+# holding the port with nothing able to name it. The question this answers is
+# "is there anything here I did not start", and one surviving process is enough
+# to mean yes.
+#
+# Both `up` paths ask it, and for the same reason: what a run did not start, it
+# must not tear down. The claimed path asks BEFORE claim_stack rewrites the file
+# it reads; the primary path has nothing to rewrite and asks where it arms.
+stack_already_up() {
+  local recorded pid
+  recorded=$(
+    BACKEND_PID=''
+    FE_PID=''
+    WORKER_PID=''
+    # shellcheck disable=SC1090
+    [[ -f "$(dev_state_dir "$slug")/env" ]] && . "$(dev_state_dir "$slug")/env"
+    printf '%s %s %s' "${BACKEND_PID:-}" "${FE_PID:-}" "${WORKER_PID:-}"
+  )
+  for pid in $recorded; do
+    still_ours "$pid" && return 0
+  done
+  return 1
+}
+
+# release_unconfirmed_stack — take down whatever this run started, and give back
+# the record it was going to be found by. Called from the EXIT trap while
+# stack_recorded is 0, which is every path that does not reach a stack answering
+# its own readiness probe.
+#
+# The primary stack claims no port and no Redis database, so for it "release" is
+# the processes and the state file and nothing else. It arms this all the same:
+# an api or a vite that outlives a failed boot holds :8080 against the next
+# `make dev`, which then reports the port as already in use — a different fault
+# entirely, and the one this used to be read as.
 release_unconfirmed_stack() {
   [[ "${stack_recorded:-1}" == "0" ]] || return 0
+  # WHAT THIS RUN STARTED COMES DOWN FIRST, whatever the record turns out to
+  # belong to.
+  #
+  # The two questions are separate and were answered as one: whose RECORD this
+  # is decides whether the file may be deleted, and it says nothing about the
+  # processes in front of it. A second `make dev` that found a stack already up,
+  # started its own api and vite, and then failed its readiness probe used to
+  # return here before the kill — leaving exactly the orphan holding a port that
+  # this whole cleanup exists to prevent, and doing it on the path where a
+  # colleague's stack is already running.
+  #
+  # TERM then KILL, through the helper the sweep uses: a bare TERM can leave a
+  # server standing after its claim is gone.
+  local pids=()
+  local p
+  for p in "${be_pid:-}" "${fe_pid:-}" "${worker_pid:-}"; do
+    [[ -n "$p" ]] && pids+=("$p")
+  done
+  [[ ${#pids[@]} -gt 0 ]] && kill_pids "${pids[@]}"
   # Never release a claim this run did not create: it belongs to a stack that was
   # already up, and taking its record away would leave it running with nothing
   # able to stop it.
@@ -146,14 +265,30 @@ release_unconfirmed_stack() {
     printf '%s' "${STARTER_PID:-}"
   )
   [[ -n "$owner" && "$owner" != "$$" ]] && return 0
-  # TERM then KILL, through the helper the sweep uses: a bare TERM can leave a
-  # server standing after its claim is gone, which is the orphan this is for.
-  local pids=()
-  local p
-  for p in "${be_pid:-}" "${fe_pid:-}" "${worker_pid:-}"; do
-    [[ -n "$p" ]] && pids+=("$p")
+  # The record goes only if it is THIS RUN'S. Two `make dev` calls for one slug
+  # race: the second reads the state file before the first has finished writing
+  # it, sees no live pid, and claims — and claim_stack stamps its own starter
+  # into the file, so the owner guard above then reads this run as the owner of
+  # a record the first run is still booting against. Comparing the recorded pids
+  # against the ones this run started answers that without a lock: a record
+  # naming somebody else's processes is somebody else's.
+  local recorded
+  recorded=$(
+    BACKEND_PID=''
+    FE_PID=''
+    WORKER_PID=''
+    # shellcheck disable=SC1090
+    [[ -f "$(dev_state_dir "$slug")/env" ]] && . "$(dev_state_dir "$slug")/env"
+    printf '%s %s %s' "${BACKEND_PID:-}" "${FE_PID:-}" "${WORKER_PID:-}"
+  )
+  for p in $recorded; do
+    case " ${be_pid:-} ${fe_pid:-} ${worker_pid:-} " in
+      *" $p "*) ;;
+      *)
+        [[ -n "$p" ]] && still_ours "$p" && return 0
+        ;;
+    esac
   done
-  [[ ${#pids[@]} -gt 0 ]] && kill_pids "${pids[@]}"
   # The CLAIM goes; the LOG stays. Removing the directory took the log with it,
   # so a failed boot deleted the one file that said why it failed — which cost a
   # debugging cycle here before it could cost anyone else one.
@@ -342,43 +477,34 @@ if [[ -z "$slug" ]]; then
   fe_port=8080
   api_port=18080
   redis_db=0
+  # Nothing was claimed, but something may already be RUNNING — and a second
+  # `make dev` that fails its port check must leave the first one's state file
+  # alone, or `make dev-stop` has nothing left to stop it by.
+  STACK_CLAIM_PREEXISTING=0
+  if [[ "$cmd" == "up" ]] && stack_already_up; then
+    STACK_CLAIM_PREEXISTING=1
+  fi
 elif [[ "$cmd" == "up" ]]; then
   # Assign first, THEN read: `read … <<<"$(claim_stack)"` reports read's status,
   # not the claim's, so a refused claim printed its FAIL and the stack carried on
   # with an empty port and an api listening on :10000.
-  # Computed HERE, not inside claim_stack: that runs in a command substitution,
-  # which is a subshell, so a variable it sets never reaches this shell. The first
-  # version set it in there and the trap read the default — deleting the pids of a
-  # stack that was still running. Same subshell trap as the swallowed claim status
-  # above, one line apart.
-  STACK_CLAIM_PREEXISTING=0
-  recorded_be=$(
-    BACKEND_PID=''
-    # shellcheck disable=SC1090
-    [[ -f "$(dev_state_dir "$slug")/env" ]] && . "$(dev_state_dir "$slug")/env"
-    printf '%s' "${BACKEND_PID:-}"
-  )
+  #
   # ALIVE, not merely recorded. A crashed stack leaves its pids in the file, and
   # treating that as a live claim would disable the release for every later failed
   # boot — the stale reservation then holds a port and a Redis database forever.
-  if [[ -n "$recorded_be" ]] && still_ours "$recorded_be"; then
+  #
+  # Asked in THIS shell, not inside claim_stack: that runs in a command
+  # substitution, which is a subshell, so a variable it sets never reaches here.
+  # The first version set it in there and the release read the default — deleting
+  # the pids of a stack that was still running.
+  STACK_CLAIM_PREEXISTING=0
+  if stack_already_up; then
     STACK_CLAIM_PREEXISTING=1
   fi
   export STACK_STARTER_PID=$$
   claimed="$(claim_stack "$slug")" || exit 1
   read -r redis_db fe_port <<<"$claimed"
   api_port=$(( fe_port + DEV_API_PORT_OFFSET ))
-  # A reservation that outlives a failed boot holds its port and Redis database
-  # against every later stack until somebody sweeps by hand, and nothing says so
-  # — the next `make dev` in a fresh worktree just gets a higher number, and the
-  # block runs out sixteen stacks early. Released on any exit before the final
-  # state write, which is the point the stack is actually running.
-  # Released on any exit before the stack is CONFIRMED up, and the release kills
-  # whatever this run started. Deleting the claim alone would leave an api or a
-  # vite running that nothing records any more — an orphan holding the port the
-  # claim just gave back, which is worse than the leak it was fixing.
-  stack_recorded=0
-  trap 'release_unconfirmed_stack' EXIT
 else
   # stop and sweep READ; only `up` claims. Claiming here would mint a reservation
   # for a stack nobody asked to start, and then the caller would tear it down
@@ -387,6 +513,24 @@ else
   redis_db="${MINE_DB:-0}"
   fe_port="${MINE_PORT:-0}"
   api_port=$(( fe_port == 0 ? 0 : fe_port + DEV_API_PORT_OFFSET ))
+fi
+
+# EVERY `up` arms the same cleanup, claimed or not. A reservation that outlives a
+# failed boot holds its port and Redis database against every later stack until
+# somebody sweeps by hand, and nothing says so — the next `make dev` in a fresh
+# worktree just gets a higher number, and the block runs out sixteen stacks
+# early. The primary stack reserves neither and still leaves an api or a vite
+# holding :8080 the same way, which is why it is armed here rather than in the
+# branch that claims.
+#
+# Disarmed only when the stack is CONFIRMED up, which is after its own readiness
+# probe rather than at the state write before it. Below that point every exit —
+# a readiness failure, a bad DSN, a Ctrl-C — goes through the release, so no
+# failure path spells a kill of its own: one cleanup, and it is the one that
+# follows TERM with KILL.
+if [[ "$cmd" == "up" ]]; then
+  stack_recorded=0
+  trap 'release_unconfirmed_stack' EXIT
 fi
 REDIS_ADDR="localhost:${REDIS_PORT}/${redis_db}"
 
@@ -677,18 +821,25 @@ vite_pids() {
 
 
 sweep_stacks() { # kill every margince dev stack: recorded, orphaned, or foreign
-  local victims=() pids p port state_file
-  local BACKEND_PID FE_PID WORKER_PID API_PORT FE_PORT
+  local victims=() pids p port state_file entry_db
+  local SLUG BACKEND_PID FE_PID WORKER_PID API_PORT FE_PORT
   # 1. Every stack this script ever recorded — its own pids and its own ports.
   #    The locals above shadow what the state file sets, so sourcing one cannot
   #    leak a stale pid into the rest of the run.
   for state_file in "$(dev_state_root)"/*/env; do
     [[ -f "$state_file" ]] || continue
-    BACKEND_PID=''; FE_PID=''; WORKER_PID=''; API_PORT=''; FE_PORT=''
+    SLUG=''; BACKEND_PID=''; FE_PID=''; WORKER_PID=''; API_PORT=''; FE_PORT=''
     # shellcheck disable=SC1090
     . "$state_file"
+    # THIS ENTRY'S database, not the invocation's. Every recorded stack has its
+    # own — that is what the slug names — and asking still_ours with the sweeping
+    # run's `db` answers about a stack nobody is sweeping: every other slug's
+    # processes read as not-ours and survive a sweep that promises to clear the
+    # machine.
+    entry_db="margince"
+    [[ -n "$SLUG" ]] && entry_db="margince_dev_${SLUG}"
     for p in "$BACKEND_PID" "$FE_PID" "$WORKER_PID"; do
-      [[ -n "$p" ]] && still_ours "$p" && victims+=("$p")
+      [[ -n "$p" ]] && still_ours "$p" "$entry_db" && victims+=("$p")
     done
     for port in "$API_PORT" "$FE_PORT"; do
       [[ -n "$port" ]] || continue
@@ -1030,10 +1181,9 @@ up)
 
   if ! wait_ready "http://localhost:${api_port}/readyz" 90; then
     echo "FAIL: $label api did not become ready — see ${log}" >&2
-    # The FE too: it is started BEFORE the api now (the api reads its view
-    # documents from it), so bailing out here would leave vite holding the port
-    # and the next `make dev` would report it as already in use.
-    kill "$be_pid" "$fe_pid" 2>/dev/null || true
+    # Vite comes down too, through the EXIT trap: it is started BEFORE the api
+    # now (the api reads its view documents from it), so bailing out here used to
+    # leave it holding the port and the next `make dev` reported it as in use.
     exit 1
   fi
   # No demo records: `make dev` brings up a COLD START — the installation the
@@ -1093,7 +1243,6 @@ up)
     echo "  Its own reason is in the log, under the 'worker' role:" >&2
     echo "    make dev-logs${slug:+ DEV_SLUG=$slug} ROLE=worker" >&2
     echo "    ${log}" >&2
-    kill "$be_pid" "$fe_pid" 2>/dev/null || true
     exit 1
   fi
   if [[ "$gmail_enabled" == "1" ]]; then
@@ -1120,7 +1269,6 @@ up)
       echo "  Its own reason is in the log, under the 'worker' role:" >&2
       echo "    make dev-logs${slug:+ DEV_SLUG=$slug} ROLE=worker" >&2
       echo "    ${log}" >&2
-      kill "$be_pid" "$fe_pid" 2>/dev/null || true
       exit 1
     fi
     # CONFIRMED up, and only here. This used to be set at the state write above,
@@ -1152,8 +1300,7 @@ up)
     echo "  stop     make dev-stop${slug:+ DEV_SLUG=$slug}"
   else
     echo "FAIL: $label FE did not become ready in time — see ${log}" >&2
-    # Don't leave the api (and vite) orphaned when the FE readiness poll fails.
-    kill "$be_pid" "$fe_pid" ${worker_pid:+"$worker_pid"} 2>/dev/null || true
+    # The api, vite and the worker all come down through the EXIT trap.
     exit 1
   fi
   ;;

--- a/scripts/test-dev-cleanup.sh
+++ b/scripts/test-dev-cleanup.sh
@@ -1,0 +1,555 @@
+#!/usr/bin/env bash
+# test-dev-cleanup.sh — prove a failed `make dev` leaves nothing running.
+#
+# The defect this exists for: the three readiness failures in dev.sh cleaned up
+# with a bare asynchronous `kill`, and only a LINKED worktree installed the EXIT
+# trap that follows TERM with KILL. On the primary stack an api or a Vite that
+# did not promptly honour SIGTERM outlived the failed run and kept holding
+# :8080 — and the next `make dev` reported the port as already in use, which
+# reads as a different fault entirely and costs somebody the afternoon.
+#
+# Every function under test is LIFTED from dev.sh rather than reimplemented
+# here: a copy would prove nothing about production.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+dev="$root/scripts/dev.sh"
+failures=0
+
+# The fixtures this run started, torn down whatever happens. Two of them are
+# `sleep 60` and one deliberately IGNORES TERM: an abort before the explicit
+# teardown would leave the first pair for a minute and the third forever, and a
+# gate that litters the machine it runs on is one people stop running.
+# Recorded as `pid:signature`, and the signature is re-read before the KILL.
+# A fixture torn down mid-run frees its pid, the kernel reissues numbers, and
+# by the time the trap fires that number can belong to anything on the machine
+# — including the editor of whoever is running this. Every fixture here is a
+# `sleep` this script started, so its command line is proof of that, and a pid
+# that no longer answers to it is somebody else's.
+fixtures=""
+# signature_of PID — the pid's command line with its whitespace removed.
+#
+# ONE function, read at both ends. `$fixtures` is a space-separated list, so a
+# signature has to hold no spaces to survive it — and stripping at only one end
+# compares a squeezed string against a spaced one, which never matches. The trap
+# then skips every kill silently, which looks exactly like a run that left
+# nothing behind.
+signature_of() { # pid
+    # `|| true` because `set -o pipefail` is in force and ps exits non-zero for
+    # a pid it cannot see. A fixture backgrounded a moment ago is exactly that
+    # case on a loaded machine, and without this the gate aborts inside
+    # `remember` — before its own teardown is armed, which is the one moment it
+    # cannot afford to.
+    { ps -o command= -p "$1" 2>/dev/null || true; } | tr -d ' \t\n'
+}
+reap() {
+    local entry pid signature
+    for entry in $fixtures; do
+        pid="${entry%%:*}"
+        signature="${entry#*:}"
+        case "$(signature_of "$pid")" in
+            *"$signature"*) kill -9 "$pid" 2>/dev/null || true ;;
+        esac
+    done
+}
+trap reap EXIT
+# remember PID — put a pid under the trap, signed by the command line it has now.
+remember() { # pid
+    # A SIGNATURE OR NOTHING. An empty one matches every command line the case
+    # statement in reap tries it against — `*""*` is true of anything — so a pid
+    # ps could not see would have licensed the trap to SIGKILL whatever holds
+    # that number later. Retried once, because the miss is a scheduling
+    # accident rather than a fact about the process.
+    local signature
+    signature=$(signature_of "$1")
+    if [[ -z "$signature" ]]; then
+        sleep 0.1
+        signature=$(signature_of "$1")
+    fi
+    if [[ -z "$signature" ]]; then
+        printf '  FAIL a fixture (pid %s) had no command line to sign, so the trap could not tell it from a recycled pid\n' "$1" >&2
+        failures=$((failures + 1))
+        return
+    fi
+    fixtures="$fixtures $1:$signature"
+}
+
+check() { # want got description
+    if [ "$1" = "$2" ]; then
+        printf '  ok   %s\n' "$3"
+    else
+        printf '  FAIL %s\n       want: %s\n       got:  %s\n' "$3" "$1" "$2" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# lift NAME — eval one function out of dev.sh, so every check below exercises
+# production rather than a copy of it. Same awk as test-dev-isolation.sh, and
+# for the same reason its comment gives.
+lift() { # function name
+    eval "$(awk -v fn="$1" '
+        index($0, fn "() ") == 1 { inside = 1 }
+        inside                   { print }
+        inside && $0 == "}"      { exit }
+    ' "$dev")"
+}
+
+# shellcheck source=scripts/lib-devstate.sh
+. "$root/scripts/lib-devstate.sh"
+# still_ours reads this to decide whether a recorded pid is one of OURS. It is a
+# variable of dev.sh, so a lifted function needs it supplied — and supplying the
+# real repository root is what makes the fixtures below have to look like real
+# processes rather than pass on an empty pattern that matches everything.
+repo_root="$root"
+# And the stack's DATABASE, for the same reason: the api and the worker carry no
+# repository path in their argv, so the name in their `--dsn` is the only thing
+# that names them. A lifted still_ours refuses outright without it rather than
+# quietly reading half of itself.
+db="margince_dev_probe"
+lift kill_pids
+lift still_ours
+lift stack_already_up
+lift release_unconfirmed_stack
+
+# alive answers whether a pid is still running, right now.
+#
+# Two functions rather than one, because the two questions have opposite
+# deadlines. "Is it still up" is answered by the kernel immediately and a
+# process that is going to die does not become MORE alive by waiting — so
+# polling there buys nothing and spends two seconds on every passing check.
+alive() { # pid → 1 when still running
+    kill -0 "$1" 2>/dev/null && echo 1 || echo 0
+}
+# "Did it go" is the one that has to wait: SIGKILL is delivered asynchronously,
+# kill_pids returns as soon as the signal is sent, and asking immediately can
+# catch a process the kernel has not reaped yet — a flake, not a finding.
+settled() { # pid → 0 once it is gone, 1 if it never goes
+    local _
+    for _ in $(seq 1 20); do
+        kill -0 "$1" 2>/dev/null || { echo 0; return; }
+        sleep 0.1
+    done
+    echo 1
+}
+echo "dev.sh: the cleanup outlasts a process that ignores TERM"
+
+# A bare `kill` is a REQUEST. The whole point of the helper is that it stops
+# waiting: a server wedged in a signal handler, or one whose runtime defers the
+# signal, is exactly the orphan that goes on holding the port.
+deaf="$(mktemp -d)"
+# disowned so the shell does not narrate each kill onto the gate's output.
+bash -c 'trap "" TERM; while :; do sleep 0.2; done' &
+deaf_pid=$!
+remember "$deaf_pid"
+disown
+kill_pids "$deaf_pid"
+# Through alive(), which POLLS: SIGKILL is delivered asynchronously and
+# kill_pids returns as soon as it is sent, so a one-shot read here can catch a
+# process the kernel has not reaped and fail a gate for a reason that is not
+# about the code.
+check "0" "$(settled "$deaf_pid")" \
+      "a process that ignores TERM is still taken down"
+rm -rf "$deaf"
+
+# AND A RECORDED PID THAT HAS ALREADY GONE DOES NOT ABORT THE CLEANUP.
+#
+# `ps` exits non-zero for a pid it cannot see, `set -o pipefail` is in force, and
+# a recorded process that already exited is the ORDINARY case during a failed
+# boot. Unswallowed, that status aborts kill_pids under `set -e` — and the EXIT
+# trap that called it then leaves the api, the vite and the claim standing,
+# which is the cleanup failing on the one path it exists for.
+gone_probe() {
+    local dead live
+    bash -c 'exit 0' & dead=$!
+    wait "$dead" 2>/dev/null || true
+    bash -c 'trap "" TERM; while :; do sleep 0.2; done' & live=$!
+    remember "$live"
+    disown
+    kill_pids "$dead" "$live"
+    check "0" "$(settled "$live")" \
+          "a recorded pid that already exited does not abort the cleanup of the ones still standing"
+    kill -9 "$live" 2>/dev/null || true
+}
+gone_probe
+
+# A PID THAT CHANGED HANDS DURING THE WAIT IS NOT KILLED.
+#
+# There are five seconds between the TERM and the SIGKILL, and a process that
+# honours the TERM frees its pid inside them. The kernel reissues numbers, so a
+# SIGKILL sent on the strength of the number alone lands on whatever took it —
+# somebody's editor, their own shell.
+#
+# Asserted on the SOURCE rather than by racing the kernel for a recycled pid: a
+# fixture that had to win that race would be flaky in the direction that matters,
+# passing on the machine where the reuse never happened. What the reading has to
+# show is that a signature is taken BEFORE the TERM and compared BEFORE the
+# SIGKILL, and that the loop selects on the comparison rather than on liveness.
+kill_signs="$(awk '/^kill_pids\(\)/{inside=1} inside{print} inside && /^}/{exit}' "$dev")"
+check "1" "$([[ "$kill_signs" == *'ps -o command='*'kill "${pids[@]}"'* ]] && echo 1 || echo 0)" \
+      "kill_pids reads each pid's command line before it sends the TERM"
+check "0" "$(printf '%s' "$kill_signs" | grep -c 'kill -0')" \
+      "and the wait selects on that signature rather than on the number still being alive"
+check "1" "$([[ "$kill_signs" == *'*"$signature"*'*'kill -9'* ]] && echo 1 || echo 0)" \
+      "so the SIGKILL reaches only a pid still answering to what was signed"
+
+echo "dev.sh: an unconfirmed stack takes its processes with it"
+
+# ours VAR NAME — start a background process this repo's own detector recognises
+# as one of ours, and put its pid in VAR.
+#
+# still_ours reads the COMMAND LINE, so a bare `sleep` is not enough: argv[0]
+# carries the repo root, exactly as a real api or vite does. That is the point
+# of the fixture — a process the detector cannot recognise would make every
+# "already up" check below pass by never finding anything.
+#
+# The pid comes back through a named variable rather than on stdout: a
+# command substitution runs the `&` in a subshell, and the child does not
+# outlive it — which looks exactly like a process that was correctly killed.
+ours() { # varname name
+    bash -c 'exec -a "$0" sleep 60' "$root/$2" &
+    printf -v "$1" '%s' "$!"
+    remember "$!"
+    disown
+}
+
+# The primary worktree, which claims nothing. It is the case the trap used to
+# skip: slug empty, no reservation, and three processes all the same.
+#
+# ALL THREE, because the release names all three and a fixture that left the
+# worker out would let a regression drop it silently — the message this gate
+# closes with says the worker comes down too.
+sandbox() {
+    state_root="$(mktemp -d)"
+    mkdir -p "$state_root/$DEV_BASE_SLUG_DIR"
+    ours be_pid dev-api
+    ours fe_pid dev-vite
+    ours worker_pid dev-worker
+    printf 'SLUG=\nBACKEND_PID=%s\nFE_PID=%s\nWORKER_PID=%s\n' \
+        "$be_pid" "$fe_pid" "$worker_pid" >"$state_root/$DEV_BASE_SLUG_DIR/env"
+}
+stop_sandbox() {
+    kill "$be_pid" "$fe_pid" "$worker_pid" 2>/dev/null || true
+    rm -rf "$state_root"
+}
+
+sandbox
+slug=''
+stack_recorded=0
+STACK_CLAIM_PREEXISTING=0
+MARGINCE_DEV_STATE_DIR="$state_root" release_unconfirmed_stack
+check "0 0 0" "$(settled "$be_pid") $(settled "$fe_pid") $(settled "$worker_pid")" \
+      "the primary stack's api, vite AND worker do not outlive a failed boot"
+check "0" "$([[ -f "$state_root/$DEV_BASE_SLUG_DIR/env" ]] && echo 1 || echo 0)" \
+      "and the record they would have been found by goes with them"
+stop_sandbox
+
+# What this run did not start, it must not stop. A second `make dev` on the
+# primary stack fails its port check against the FIRST one — and taking that
+# stack's processes down, or deleting the file `make dev-stop` finds it by,
+# turns a clear "port in use" into a stack nobody can account for.
+sandbox
+slug=''
+stack_recorded=0
+# The DETECTOR decides, not the fixture: hard-coding the flag would prove the
+# release honours it and nothing about whether a second `make dev` ever sets it.
+STACK_CLAIM_PREEXISTING=0
+if MARGINCE_DEV_STATE_DIR="$state_root" stack_already_up; then
+    STACK_CLAIM_PREEXISTING=1
+fi
+check "1" "$STACK_CLAIM_PREEXISTING" \
+      "a running stack is RECOGNISED as already up, from the record it left"
+
+# THIS RUN'S OWN PROCESSES, started beside the stack it found. In production
+# these are different processes from the recorded ones — the second `make dev`
+# starts its own api and vite before failing its readiness probe — and the
+# fixture has to keep them apart or it cannot tell "left the other stack alone"
+# from "killed nothing at all".
+recorded_be="$be_pid" recorded_fe="$fe_pid" recorded_worker="$worker_pid"
+ours be_pid dev-api
+ours fe_pid dev-vite
+ours worker_pid dev-worker
+
+MARGINCE_DEV_STATE_DIR="$state_root" release_unconfirmed_stack
+check "1 1 1" "$(alive "$recorded_be") $(alive "$recorded_fe") $(alive "$recorded_worker")" \
+      "and that stack is left running"
+# AND THIS RUN'S OWN COME DOWN ANYWAY. Whose RECORD it is decides whether the
+# file may be deleted and says nothing about the processes in front of it: a
+# second run that found a stack up, started its own pair and then failed used to
+# return before the kill, leaving exactly the orphan holding a port that this
+# cleanup exists to prevent.
+check "0 0 0" "$(settled "$be_pid") $(settled "$fe_pid") $(settled "$worker_pid")" \
+      "while what THIS run started comes down with it"
+check "1" "$([[ -f "$state_root/$DEV_BASE_SLUG_DIR/env" ]] && echo 1 || echo 0)" \
+      "and keeps the record make dev-stop finds it by"
+be_pid="$recorded_be" fe_pid="$recorded_fe" worker_pid="$recorded_worker"
+
+# The api can die while its vite goes on serving :8080. Asking only about the
+# api answers "nothing here" for a stack that is still holding the port, and the
+# release then deletes the one record able to name the survivor.
+kill "$be_pid" 2>/dev/null || true
+while kill -0 "$be_pid" 2>/dev/null; do sleep 0.1; done
+STACK_CLAIM_PREEXISTING=0
+if MARGINCE_DEV_STATE_DIR="$state_root" stack_already_up; then
+    STACK_CLAIM_PREEXISTING=1
+fi
+check "1" "$STACK_CLAIM_PREEXISTING" \
+      "a stack whose api died but whose vite is still serving is still already up"
+
+# AND THE WORKER ALONE. The two cases above are both answered by an api or a
+# vite, so an implementation that never looked at WORKER_PID would pass them
+# both — and a worker outliving its stack is the one of the three that holds no
+# port, so nothing else reports it. It goes on draining the queue against a
+# database the next run is about to migrate.
+kill "$fe_pid" 2>/dev/null || true
+while kill -0 "$fe_pid" 2>/dev/null; do sleep 0.1; done
+STACK_CLAIM_PREEXISTING=0
+if MARGINCE_DEV_STATE_DIR="$state_root" stack_already_up; then
+    STACK_CLAIM_PREEXISTING=1
+fi
+check "1" "$STACK_CLAIM_PREEXISTING" \
+      "and a stack down to its worker alone is STILL already up"
+stop_sandbox
+
+# And a stack that answered its own readiness probe is finished, not unconfirmed.
+sandbox
+slug=''
+stack_recorded=1
+STACK_CLAIM_PREEXISTING=0
+MARGINCE_DEV_STATE_DIR="$state_root" release_unconfirmed_stack
+check "1 1 1" "$(alive "$be_pid") $(alive "$fe_pid") $(alive "$worker_pid")" \
+      "a CONFIRMED stack is not torn down by its own exit"
+stop_sandbox
+
+# TWO RUNS, ONE SLUG. The second reads the state file before the first has
+# finished writing it, sees no live pid, and claims — and claim_stack stamps its
+# own starter into the file, so the starter guard then reads the second run as
+# the owner of a record the first is still booting against. It fails its port
+# check moments later, and without this the release deletes the record naming
+# the stack that won.
+state_root="$(mktemp -d)"
+mkdir -p "$state_root/$DEV_BASE_SLUG_DIR"
+ours winner_be dev-api
+ours winner_fe dev-vite
+printf 'SLUG=\nSTARTER_PID=%s\nBACKEND_PID=%s\nFE_PID=%s\n' "$$" "$winner_be" "$winner_fe" \
+    >"$state_root/$DEV_BASE_SLUG_DIR/env"
+# This run started its own pair and lost the race.
+ours be_pid dev-api
+ours fe_pid dev-vite
+worker_pid=''
+slug=''
+stack_recorded=0
+STACK_CLAIM_PREEXISTING=0
+MARGINCE_DEV_STATE_DIR="$state_root" release_unconfirmed_stack
+check "1" "$([[ -f "$state_root/$DEV_BASE_SLUG_DIR/env" ]] && echo 1 || echo 0)" \
+      "the record of a stack this run did not start survives its own failed boot"
+check "1 1" "$(alive "$winner_be") $(alive "$winner_fe")" \
+      "and so does that stack"
+kill "$winner_be" "$winner_fe" "$be_pid" "$fe_pid" 2>/dev/null || true
+rm -rf "$state_root"
+
+# A SIBLING CHECKOUT IS NOT THIS ONE. /…/repo-old starts with /…/repo, so a
+# substring match on the repository path reads that stack's processes as this
+# stack's — and a recycled pid landing on one would answer "already up",
+# stopping this run from cleaning up after itself.
+#
+# Driven against a SYNTHETIC root, not the real one: a fixture built from the
+# real repository root proves the reading only on a machine whose path happens
+# to be shaped like the assertion. CI's is not this one's, and a case that
+# passes for a reason the test does not control is a case nobody can trust.
+state_root="$(mktemp -d)"
+mkdir -p "$state_root/$DEV_BASE_SLUG_DIR"
+probe_root="$(mktemp -d)/checkout"
+bash -c 'exec -a "$0" sleep 60' "$probe_root-old/api" &
+sibling=$!
+remember "$sibling"
+disown
+printf 'SLUG=\nBACKEND_PID=%s\n' "$sibling" >"$state_root/$DEV_BASE_SLUG_DIR/env"
+slug=''
+recognised=0
+if repo_root="$probe_root" MARGINCE_DEV_STATE_DIR="$state_root" stack_already_up; then
+    recognised=1
+fi
+check "0" "$recognised" \
+      "a process from a SIBLING checkout is not read as this worktree's stack"
+# And the same fixture under the root ITSELF is recognised, or the check above
+# passes against a reading that matches nothing.
+bash -c 'exec -a "$0" sleep 60' "$probe_root/api" &
+own=$!
+remember "$own"
+disown
+printf 'SLUG=\nBACKEND_PID=%s\n' "$own" >"$state_root/$DEV_BASE_SLUG_DIR/env"
+recognised=0
+if repo_root="$probe_root" MARGINCE_DEV_STATE_DIR="$state_root" stack_already_up; then
+    recognised=1
+fi
+check "1" "$recognised" \
+      "and one under the root itself still is"
+kill "$sibling" "$own" 2>/dev/null || true
+rm -rf "$state_root"
+
+# THE API AND THE WORKER carry no repository path at all — they are launched as
+# `./bin/api` and `./bin/worker` from the repo directory — so the path arms above
+# cannot see them. What names them is the database in the `--dsn` they were given,
+# and this is the case the two fixtures above cannot make: theirs carry a path.
+#
+# It is also the arm that was reading the repository's NAME. `*margince*` matched
+# that word anywhere on the command line, so it answered yes for every sibling
+# checkout's path too — and being first in the disjunction, it decided every case
+# before the path narrowing was consulted.
+dsn_probe() { # varname database
+    bash -c 'exec -a "$0" sleep 60' "./bin/api --dsn postgres://u@h:5432/$2 --addr :18080" &
+    printf -v "$1" '%s' "$!"
+    remember "$!"
+    disown
+}
+dsn_case() { # want database description
+    state_root="$(mktemp -d)"
+    mkdir -p "$state_root/$DEV_BASE_SLUG_DIR"
+    dsn_probe probe "$2"
+    printf 'SLUG=\nBACKEND_PID=%s\n' "$probe" >"$state_root/$DEV_BASE_SLUG_DIR/env"
+    recognised=0
+    if repo_root="$(mktemp -d)/nowhere" MARGINCE_DEV_STATE_DIR="$state_root" stack_already_up; then
+        recognised=1
+    fi
+    check "$1" "$recognised" "$3"
+    kill "$probe" 2>/dev/null || true
+    rm -rf "$state_root"
+}
+# repo_root is pointed at a directory no fixture is under, so each of these is
+# decided by the database name alone — otherwise a path arm could be answering
+# and the arm under test would go unread.
+dsn_case 1 "$db" "an api carrying THIS stack's database is recognised with no path in its argv"
+dsn_case 0 "margince" "and one carrying the primary stack's database is not"
+dsn_case 0 "${db}_2" "nor one whose database merely STARTS with this stack's"
+
+# AND THAT PRODUCTION EVER ASKS. Everything above drives stack_already_up and
+# the release directly, so it proves the pair agree — and would go on proving it
+# after the `up` branch stopped wiring them together. The flag would then read 0
+# on every second launch, and a failed one would take down a stack it did not
+# start: the exact defect, with a green gate over it.
+#
+# So the WIRING is read out of dev.sh: the flag set from the detector's own
+# answer, and set nowhere else.
+# FOUR, because BOTH `up` paths ask: the claimed stack asks before claim_stack
+# rewrites the file it reads, and the primary stack — which claims nothing — asks
+# where it arms. Each writes a default and then the detector's answer. A fifth
+# write is a third path nobody has thought about; a third is a path that stopped
+# asking, which is the shape of the original defect.
+preexisting_writes="$(grep -cE '^[[:space:]]*STACK_CLAIM_PREEXISTING=' "$dev" || true)"
+check "4" "$preexisting_writes" \
+      "both up paths write the preexisting flag, each a default and an answer"
+# And every non-default write is the detector's own answer rather than a
+# hard-coded 1, which would claim a preexisting stack on every launch and
+# disable the release for good.
+# Counted by ADJACENCY rather than with grep -A: overlapping context windows are
+# merged into one, so a second pair a line apart would be reported as one match
+# and a path that stopped asking would look identical to a path that never did.
+answers="$(grep -cE '^[[:space:]]*STACK_CLAIM_PREEXISTING=1' "$dev" || true)"
+wiring="$(awk '
+    /^[[:space:]]*if .*stack_already_up; then$/ { armed = 1; next }
+    /^[[:space:]]*STACK_CLAIM_PREEXISTING=1$/ { if (armed) n++ }
+    { armed = 0 }
+    END { print n + 0 }' "$dev")"
+check "2 2" "$answers $wiring" \
+      "and each one that is not the default sits directly under a stack_already_up test"
+
+# EVERY RECORDED STACK IS SWEPT, not only the one this invocation happens to be.
+#
+# The sweep walks every state file on the machine, and each names a different
+# slug with a database of its own. Asked with the sweeping run's `db`, still_ours
+# answers about a stack nobody is sweeping: every other slug's processes read as
+# not-ours and survive a command that promises to clear the machine.
+sweep_probe() { # want database description — fixture argv carries `db`'s DSN
+    local want="$1" ask="$2" description="$3" pid recognised=0
+    bash -c 'exec -a "$0" sleep 60' "./bin/api --dsn postgres://u@h:5432/margince_dev_other" &
+    pid=$!
+    remember "$pid"
+    disown
+    if db="$ask" still_ours "$pid" "$ask"; then recognised=1; fi
+    check "$want" "$recognised" "$description"
+    kill "$pid" 2>/dev/null || true
+}
+sweep_probe 1 margince_dev_other "a recorded stack is recognised by ITS OWN database"
+sweep_probe 0 margince_dev_mine  "and not by the database of the run doing the sweeping"
+
+echo "dev.sh: one cleanup, and every failure path relies on it"
+
+# The checks above prove the CLEANUP. They cannot prove the primary stack ever
+# arms it — which is precisely what was missing — so the guard the arming sits
+# under is read out of dev.sh itself.
+#
+# Read as DEPTH and guard together, not as "the last unindented `if` seen". An
+# arming nested one level deeper — inside the claiming branch, which is where it
+# used to live, or inside any other block — is the defect, and a scan that only
+# remembered the last top-level guard would report the same answer for it.
+nearest_guard() { # file → "<depth>:<the block the arming sits in>"
+    awk '
+        /^[[:space:]]*if /            { depth++; guard[depth] = $0 }
+        /^[[:space:]]*elif /          { guard[depth] = $0 }
+        /^[[:space:]]*fi([[:space:]]|$)/ { delete guard[depth]; depth-- }
+        /trap .release_unconfirmed_stack. EXIT/ {
+            g = guard[depth]
+            sub(/^[[:space:]]+/, "", g)
+            print depth ":" g
+            found = 1
+            exit
+        }
+        END { if (!found) print "NONE" }
+    ' "$1"
+}
+check '1:if [[ "$cmd" == "up" ]]; then' "$(nearest_guard "$dev")" \
+      "the cleanup is armed for every up, at the top level, not only for a stack that claims"
+
+check "1" "$(grep -c "trap 'release_unconfirmed_stack' EXIT" "$dev")" \
+      "and armed in exactly one place"
+
+# The scan can still SEE the defect. A census that only ever reports clean is
+# indistinguishable from one that stopped reading, so plant the arrangement that
+# actually shipped — the arming inside the claiming branch — and require it.
+planted="$(mktemp)"
+printf 'if [[ -z "$slug" ]]; then\n  fe_port=8080\nelif [[ "$cmd" == "up" ]]; then\n  trap %s EXIT\nfi\n' \
+    "'release_unconfirmed_stack'" >"$planted"
+check '1:elif [[ "$cmd" == "up" ]]; then' "$(nearest_guard "$planted")" \
+      "and it reports the claiming branch when the arming is nested back inside it"
+
+# And a DEEPER nesting, which the last-guard-seen reading could not tell from
+# the real thing: same top-level guard, arming reached only sometimes.
+nested="$(mktemp)"
+printf 'if [[ "$cmd" == "up" ]]; then\n  if [[ -n "$slug" ]]; then\n    trap %s EXIT\n  fi\nfi\n' \
+    "'release_unconfirmed_stack'" >"$nested"
+check '2:if [[ -n "$slug" ]]; then' "$(nearest_guard "$nested")" \
+      "and it names the inner block when the arming is buried one level down"
+rm -f "$planted" "$nested"
+
+# No failure path spells a kill of its own. Two cleanups are one cleanup and one
+# omission: the bare `kill` these replace was asynchronous, so the exit raced the
+# processes it had only asked to stop.
+# EVERY recorded pid, not just the api's. A readiness path that reintroduced
+# `kill "$fe_pid"` alone would have left this silent, which is the shape of
+# census failure this file is otherwise careful about.
+# ONE pattern, read twice. The census below and the planted proof that it can
+# see anything have to be the same reading, or the proof is about a pattern the
+# census does not use — and the census is the half that goes quiet.
+#
+# A signal can be attached (`-TERM`, `-9`) or DETACHED (`-s TERM`), and the
+# detached spelling is the one an option-only pattern walks straight past: `-s`
+# matches as an option and `TERM` then has to be the pid. It is also exactly the
+# edit somebody reaches for when a plain kill "did not work".
+kill_of_recorded='^[[:space:]]*kill( +(-[^ ]+)( +[^ "$]+)?)* +"?\$\{?(be_pid|fe_pid|worker_pid)'
+offenders="$(grep -nE "$kill_of_recorded" "$dev" || true)"
+check "" "$offenders" \
+      "no readiness failure kills a recorded pid itself — they all exit through the trap"
+
+# And the scan can see one. Planting each spelling proves the pattern matches
+# what a failure path would actually be written as, rather than only the one
+# form the three paths happened to use.
+planted_kill="$(printf '  kill "$fe_pid" 2>/dev/null || true\n  kill -TERM $worker_pid\n  kill "${be_pid}"\n  kill -s TERM "$fe_pid"\n  kill -s KILL ${worker_pid}\n' \
+    | grep -cE "$kill_of_recorded" || true)"
+check "5" "$planted_kill" \
+      "and the scan recognises a bare kill, an attached signal, a braced pid, and both detached-signal spellings"
+
+if [ "$failures" -gt 0 ]; then
+    printf 'FAIL: %d check(s)\n' "$failures" >&2
+    exit 1
+fi
+printf '==> dev cleanup: a failed boot takes its api, its vite and its worker with it\n'


### PR DESCRIPTION
Closes #3139.

Three readiness failures in `scripts/dev.sh` cleaned up with a bare asynchronous
`kill`, and only a **linked** worktree installed the EXIT trap that follows TERM
with KILL — the primary stack bypasses the branch that arms it. So on the
primary stack an api or a Vite that did not promptly honour SIGTERM outlived the
failed run and went on holding `:8080`, and the next `make dev` reported the port
as already in use: a different fault entirely, and the one it got read as.

The arming moves out of the branch that **claims** and up to every `up`, claimed
or not, so one cleanup serves all three failures and none of them spells a kill
of its own.

The primary stack also learns the question the claimed one already asked — *is a
stack already running?* — because a second run that fails its port check must
leave the first one's processes and its state file alone, or `make dev-stop` has
nothing left to stop it by. That is new behaviour on the primary path and it is
the reason this is not a pure move.

## Proof

New `make test-dev-cleanup` gate (in `ROOT_SCRIPT_GATES`, so `check-backend` runs
it), lifting the functions out of `dev.sh` rather than copying them:

- the cleanup outlasts a process that **ignores** TERM — a bare `kill` is a
  request, and the wedged server is exactly the orphan this is about;
- an unconfirmed stack loses its processes *and* the record it would be found by;
- a stack that was **already up**, and a **confirmed** one, are both left alone;
- the arming sits under `[[ "$cmd" == "up" ]]` and not inside the claiming
  branch — read as the nearest enclosing `if`, with the shipped arrangement
  planted in a fixture so the check is shown to still see it;
- no failure path spells a kill of the recorded pids itself.

`make check-backend` green. No integration lane: this changes no Go code, and
running the DB suite over it would prove nothing about a shell trap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after failed development-stack launches.
  * Ensured resistant processes are fully terminated when necessary.
  * Preserved stacks that were already running or successfully initialized.
  * Prevented cleanup from removing state belonging to concurrent or unrelated development stacks.
  * Applied reliable cleanup across all development-stack startup and readiness failure paths.

* **Tests**
  * Added automated coverage for cleanup, process termination, stack preservation, concurrent launches, and startup failures.
  * Added these checks to the standard project test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->