### PR TITLE
A contact with nothing to look them up by is never sent to the provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,8 @@ workspace/
 # each) plus a small verdict file. They are evidence for the run that produced
 # them, not repository content — read them locally, do not carry them in git.
 e2e/llm/records/
+
+# The three binaries `make dev` and the build targets produce. Named here for
+# the reason every other compiled path above is: a build artifact committed
+# once is a stale binary every later reader has to notice is stale.
+/backend/bin/

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -20820,7 +20820,13 @@ components:
       properties:
         state:
           type: string
-          enum: [not_connected, not_eligible, never_run, queued, in_progress, completed, no_match, stale, invalid_credentials, insufficient_credits, rate_limited, provider_error, submission_unknown, completed_claims_unwritten]
+          description: >-
+            Why this provider's section reads the way it does. `nothing_to_look_up` is its own
+            state rather than a kind of `not_eligible`: nothing forbids the purchase, the record
+            simply carries no profile link and no company, so the provider has nothing to match
+            on. The reader's next step is to add one of those, which is the next step for no
+            other state here.
+          enum: [not_connected, not_eligible, nothing_to_look_up, never_run, queued, in_progress, completed, no_match, stale, invalid_credentials, insufficient_credits, rate_limited, provider_error, submission_unknown, completed_claims_unwritten]
         provider:
           description: >-
             Whose snapshot this is. Required: an entry in a list of providers that did not name

--- a/backend/gates/identifierfields_test.go
+++ b/backend/gates/identifierfields_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates_test
+
+// A provider's match rules are checked against IdentifierFields(), so that
+// list has to name every field a person actually carries.
+//
+// The failure this holds is the silent-short kind. If PersonIdentifiers gains
+// a field and IdentifierFields() does not, then two things break in the same
+// direction and neither reports anything: the registry stops rejecting a rule
+// that names the new field, and `present` — which switches on the same closed
+// set — answers false for it, so a rule naming it matches nobody. A provider
+// declaring that rule looks up nobody at all, and refusing to spend money
+// never looks like a fault.
+//
+// So the corpus is derived from the struct by reflection rather than listed
+// here. A list would be the second copy of the thing it is checking.
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+// TestEveryIdentifierFieldIsNamedAndUnderstood pins the count against the
+// struct.
+//
+// The wire spelling is NOT derived from the Go name here. `LinkedInURL` is one
+// word to a reader and three runs of capitals to an algorithm, so a converter
+// would have to be taught the exception — and a gate carrying a special case
+// for its own subject has become a second copy of it. What can be derived
+// without guessing is how MANY fields there are, and the companion test below
+// proves each declared name is one the reader actually understands. Together
+// those close the gap: a new field that nobody named fails the count, and a
+// name that no reader knows fails the second test.
+//
+// Held by: this test (backend/gates/identifierfields_test.go)
+func TestEveryIdentifierFieldIsNamedAndUnderstood(t *testing.T) {
+	t.Parallel()
+
+	declared := map[provider.IdentifierField]bool{}
+	for _, f := range provider.IdentifierFields() {
+		if declared[f] {
+			t.Errorf("IdentifierFields() names %q twice, so the count below can pass while a field is unnamed", f)
+		}
+		declared[f] = true
+	}
+
+	shape := reflect.TypeOf(provider.PersonIdentifiers{})
+	if shape.NumField() == 0 {
+		t.Fatal("PersonIdentifiers has no fields, so this gate would pass over an empty subject")
+	}
+
+	if len(declared) != shape.NumField() {
+		var carried []string
+		for i := range shape.NumField() {
+			carried = append(carried, shape.Field(i).Name)
+		}
+		t.Errorf("PersonIdentifiers carries %d fields (%s) but IdentifierFields() names %d.\n\n"+
+			"A field nobody named cannot be rejected by the registry when a rule misspells it, and a rule "+
+			"that does name it matches nobody — so a provider declaring one looks up no contact at all, "+
+			"with no error anywhere. Add the constant, add it to IdentifierFields(), and teach `present` "+
+			"to read it.",
+			shape.NumField(), strings.Join(carried, ", "), len(declared))
+	}
+}
+
+// A field every real subject carries must actually be readable. The census
+// above compares NAMES; this proves the reader agrees, because a field listed
+// and understood are two different things and only one of them spends money.
+func TestEveryNamedIdentifierIsReadable(t *testing.T) {
+	t.Parallel()
+
+	// Every field set to a non-empty value, so a rule on any single one of
+	// them must be satisfied. A field `present` does not know answers false
+	// here even though the subject carries it.
+	full := provider.PersonIdentifiers{
+		LinkedInURL:   "https://www.linkedin.com/in/someone",
+		FirstName:     "Anna",
+		LastName:      "Muster",
+		CompanyName:   "Example GmbH",
+		CompanyDomain: "example.com",
+	}
+	shape := reflect.TypeOf(full)
+	value := reflect.ValueOf(full)
+	for i := range shape.NumField() {
+		if value.Field(i).String() == "" {
+			t.Fatalf("the fixture leaves PersonIdentifiers.%s empty, so this gate cannot tell a field "+
+				"`present` does not know from one the fixture forgot", shape.Field(i).Name)
+		}
+	}
+
+	for _, f := range provider.IdentifierFields() {
+		rule := []provider.MatchRule{{AllOf: []provider.IdentifierField{f}}}
+		if !full.Matchable(rule) {
+			t.Errorf("a rule requiring only %q is not satisfied by a subject carrying every identifier: "+
+				"`present` does not read that field, so any provider declaring it looks nobody up", f)
+		}
+	}
+}

--- a/backend/internal/compose/person360/providerprofile.go
+++ b/backend/internal/compose/person360/providerprofile.go
@@ -431,7 +431,12 @@ var skipStates = map[string]crmcontracts.PersonProviderProfileState{
 	// A consent decision, not an eligibility one. It reads as not_eligible
 	// today because the contract has no suppressed state; the difference is
 	// worth a spec change rather than a wrong word invented here.
-	"suppressed":       crmcontracts.PersonProviderProfileStateNotEligible,
+	"suppressed": crmcontracts.PersonProviderProfileStateNotEligible,
+	// Its own state, not a kind of not_eligible: nothing forbids this
+	// purchase. The record carries no profile link and no company, so the
+	// provider has nothing to match on — and the reader's next step is to add
+	// one of those, which is the next step for nothing else in this map.
+	"no_identifiers":   crmcontracts.PersonProviderProfileStateNothingToLookUp,
 	"budget_exhausted": crmcontracts.PersonProviderProfileStateInsufficientCredits,
 	"low_balance":      crmcontracts.PersonProviderProfileStateInsufficientCredits,
 	"rate_limited":     crmcontracts.PersonProviderProfileStateRateLimited,

--- a/backend/internal/compose/providerdescriptorparity_test.go
+++ b/backend/internal/compose/providerdescriptorparity_test.go
@@ -19,6 +19,7 @@ package compose
 // is compared without anyone remembering to add it here.
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -54,6 +55,21 @@ func TestTheOfflineFakeDescribesTheSameProductAsTheLiveAdapter(t *testing.T) {
 	assertSamePresets(t, fake.Presets, live.Presets)
 	assertSameCosts(t, fake.CostTable, live.CostTable)
 	assertSameCascades(t, fake.Cascades, live.Cascades)
+
+	// Who each will look up at all. A fake looser than the vendor lets every
+	// dev stack and the whole test lane pass over a contact production rejects
+	// with a 400 — which the platform reads as a provider fault and uses to
+	// mark the connection broken, so the defect surfaces first in front of a
+	// customer. A fake stricter than the vendor is quieter and still wrong: the
+	// lane then rehearses refusals production never issues.
+	if len(live.MatchRules) == 0 {
+		t.Error("the live adapter declares no match rules, so every subject is sent — including the ones " +
+			"the vendor rejects for carrying nothing to match on")
+	}
+	if !reflect.DeepEqual(fake.MatchRules, live.MatchRules) {
+		t.Errorf("match rules: fake %+v, live %+v — the guard is rehearsed against a provider that does not exist",
+			fake.MatchRules, live.MatchRules)
+	}
 
 	// The one field that may legitimately differ is the disclosure copy: the
 	// fake is not a vendor and links to nothing a customer must read. Every

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -8424,6 +8424,7 @@ const (
 	PersonProviderProfileStateNoMatch                  PersonProviderProfileState = "no_match"
 	PersonProviderProfileStateNotConnected             PersonProviderProfileState = "not_connected"
 	PersonProviderProfileStateNotEligible              PersonProviderProfileState = "not_eligible"
+	PersonProviderProfileStateNothingToLookUp          PersonProviderProfileState = "nothing_to_look_up"
 	PersonProviderProfileStateProviderError            PersonProviderProfileState = "provider_error"
 	PersonProviderProfileStateQueued                   PersonProviderProfileState = "queued"
 	PersonProviderProfileStateRateLimited              PersonProviderProfileState = "rate_limited"
@@ -8451,6 +8452,8 @@ func (e PersonProviderProfileState) Valid() bool {
 	case PersonProviderProfileStateNotConnected:
 		return true
 	case PersonProviderProfileStateNotEligible:
+		return true
+	case PersonProviderProfileStateNothingToLookUp:
 		return true
 	case PersonProviderProfileStateProviderError:
 		return true
@@ -24708,14 +24711,16 @@ type PersonProviderProfile struct {
 	// Region Geographic state/province as the provider returned it. Named `region` because
 	// `state` on this schema is the run lifecycle state above; a duplicate key here
 	// silently dropped the lifecycle field until ADR-0101 Decision 6.
-	Region         *string                    `json:"region,omitempty"`
-	RetrievedAt    *time.Time                 `json:"retrieved_at,omitempty"`
-	SafeStatusCode *string                    `json:"safe_status_code,omitempty"`
-	Seniorities    []string                   `json:"seniorities"`
-	State          PersonProviderProfileState `json:"state"`
+	Region         *string    `json:"region,omitempty"`
+	RetrievedAt    *time.Time `json:"retrieved_at,omitempty"`
+	SafeStatusCode *string    `json:"safe_status_code,omitempty"`
+	Seniorities    []string   `json:"seniorities"`
+
+	// State Why this provider's section reads the way it does. `nothing_to_look_up` is its own state rather than a kind of `not_eligible`: nothing forbids the purchase, the record simply carries no profile link and no company, so the provider has nothing to match on. The reader's next step is to add one of those, which is the next step for no other state here.
+	State PersonProviderProfileState `json:"state"`
 }
 
-// PersonProviderProfileState defines model for PersonProviderProfile.State.
+// PersonProviderProfileState Why this provider's section reads the way it does. `nothing_to_look_up` is its own state rather than a kind of `not_eligible`: nothing forbids the purchase, the record simply carries no profile link and no company, so the provider has nothing to match on. The reader's next step is to add one of those, which is the next step for no other state here.
 type PersonProviderProfileState string
 
 // PersonReachability Whether a reply on this channel can currently be delivered (design §6.6) — a live

--- a/backend/internal/modules/integrations/backfill_integration_test.go
+++ b/backend/internal/modules/integrations/backfill_integration_test.go
@@ -306,3 +306,73 @@ func seedCompletedRunWithoutClaims(t *testing.T, e *runsEnv) string {
 	}
 	return runID
 }
+
+// A contact declined for want of identifiers comes back as soon as the record
+// changes, without waiting out the cooldown.
+//
+// The section tells the reader to add a LinkedIn URL or a company. If the
+// sweep then ignored them until tomorrow, the page would be asking somebody to
+// do something and then not looking — which is worse than saying nothing,
+// because they have no way to tell whether it worked.
+//
+// The other refusals keep the full cooldown: a rate limit or a budget refusal
+// says nothing about the RECORD, so editing the record is no reason to retry.
+func TestARecordFixedAfterNoIdentifiersIsPickedUpAtOnce(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	ctx := context.Background()
+
+	unfixed := e.plantSubjectSkippedFor(t, provider.SkipNoIdentifiers)
+	fixed := e.plantSubjectSkippedFor(t, provider.SkipNoIdentifiers)
+	rateLimited := e.plantSubjectSkippedFor(t, provider.SkipRateLimited)
+
+	if selected := e.sweepSelects(t); selected[unfixed] || selected[fixed] || selected[rateLimited] {
+		t.Fatal("a contact declined moments ago was re-selected: without a cooldown of some kind the " +
+			"sweep asks about the same contact every tick")
+	}
+
+	// One record is edited — somebody adds the profile link the page asked
+	// for. person.updated_at moves; the run's created_at does not.
+	if _, err := e.owner.Exec(ctx,
+		`UPDATE person SET updated_at = now() + interval '1 second' WHERE id = $1`, fixed); err != nil {
+		t.Fatal(err)
+	}
+	// And one contact declined for a reason that has nothing to do with the
+	// record is edited too, to prove the rule reads the REASON and not merely
+	// the edit.
+	if _, err := e.owner.Exec(ctx,
+		`UPDATE person SET updated_at = now() + interval '1 second' WHERE id = $1`, rateLimited); err != nil {
+		t.Fatal(err)
+	}
+
+	selected := e.sweepSelects(t)
+	if !selected[fixed] {
+		t.Error("a contact edited after being declined for want of identifiers was NOT re-selected: the " +
+			"page told the reader to add a profile link and then ignored them until tomorrow")
+	}
+	if selected[unfixed] {
+		t.Error("a contact nobody touched was re-selected, so the rule is not reading the edit at all " +
+			"and every unmatchable contact is asked about every tick")
+	}
+	if selected[rateLimited] {
+		t.Error("a contact declined by the RATE LIMIT was re-selected because somebody edited the record; " +
+			"editing a contact does not raise the vendor's ceiling, and this spends against it early")
+	}
+}
+
+// plantSubjectSkippedFor adds a contact whose one run was skipped for the
+// given reason, created now.
+func (e *runsEnv) plantSubjectSkippedFor(t *testing.T, reason provider.SkipReason) ids.PersonID {
+	t.Helper()
+	id := e.plantSubject(t)
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO provider_run
+		       (person_id, subject_kind, provider, trigger, state, skip_reason,
+		        connection_version, connection_epoch, configuration_snapshot,
+		        requested_categories, input_fingerprint, external_correlation_id)
+		VALUES ($1, 'person', $2, 'automatic_backfill', 'skipped', $3, 1, 1, '{}'::jsonb,
+		        ARRAY['linkedin_profile'], $4, gen_random_uuid())`,
+		id, e.provider, string(reason), "fp-"+string(reason)+"-"+id.String()); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}

--- a/backend/internal/modules/integrations/backfillselect.go
+++ b/backend/internal/modules/integrations/backfillselect.go
@@ -31,6 +31,31 @@ import (
 // somebody fixed this morning is picked up tonight.
 const sweepRetryAfter = "1 day"
 
+// coveredByARun says "this contact needs no lookup right now". The sweep takes
+// it to pick what to queue and the countdown takes it to say how many are
+// left, so the number on the settings card is the work the sweep will do.
+//
+// They spelled it separately before and had already drifted: the sweep
+// re-queued a submission_unknown run once the cooldown passed while the count
+// treated it as settled for good, so the card read zero over contacts nobody
+// had looked up.
+//
+// `p` is the person and `r` the run inside the NOT EXISTS.
+//
+// The no_identifiers arm is what makes the page's own advice work. That skip
+// says the record carried no profile link and no company, and the section
+// tells the reader to add one — so holding them back for a full day would be
+// telling somebody to do something and then ignoring it until tomorrow.
+// `p.updated_at > r.created_at` is the cheapest honest test that the record
+// changed since we looked; the identifier check at queue time is what decides
+// whether it changed in a way that helps, so a passing contact that gained
+// only a phone number is skipped again for the price of one row.
+const coveredByARun = `
+	r.state IN ('queued', 'submitting', 'in_progress', 'completed', 'no_match')
+	OR (r.state IN ('skipped', 'failed', 'cancelled', 'submission_unknown')
+	    AND r.created_at > now() - interval '` + sweepRetryAfter + `'
+	    AND NOT (r.skip_reason = 'no_identifiers' AND p.updated_at > r.created_at))`
+
 // uncoveredSubjects names the contacts this tick should queue.
 //
 // Ordered oldest-first so the sweep converges: a contact passed over stays at
@@ -43,20 +68,9 @@ func (s *Store) uncoveredSubjects(ctx context.Context, tx pgx.Tx, name string, l
 		 WHERE p.archived_at IS NULL
 		   AND p.merged_into_id IS NULL
 		   AND NOT EXISTS (
-		       -- Live work, or an answer that settles the question. A completed
-		       -- run answered; a no-match run answered "nobody here", which is
-		       -- an answer and not a reason to ask again tomorrow.
 		       SELECT 1 FROM provider_run r
 		        WHERE r.person_id = p.id AND r.provider = $1
-		          AND (r.state IN ('queued', 'submitting', 'in_progress', 'completed', 'no_match')
-		               -- A refusal, a failure or a submission whose outcome was
-		               -- never learned holds the contact back only for as long
-		               -- as the cooldown. submission_unknown is terminal and
-		               -- nothing ever moves it, so treating it as an answer
-		               -- would exclude the contact for good — and it is not an
-		               -- answer, it is the absence of one.
-		               OR (r.state IN ('skipped', 'failed', 'cancelled', 'submission_unknown')
-		                   AND r.created_at > now() - interval '`+sweepRetryAfter+`')))
+		          AND (`+coveredByARun+`))
 		 ORDER BY p.created_at
 		 LIMIT $2`, name, limit)
 	if err != nil {
@@ -122,10 +136,7 @@ func (s *Store) backlogInTx(ctx context.Context, tx pgx.Tx, name string) (Backlo
 			   AND NOT EXISTS (
 			       SELECT 1 FROM provider_run r
 			        WHERE r.person_id = p.id AND r.provider = $1
-			          AND (r.state IN ('queued', 'submitting', 'in_progress', 'submission_unknown',
-			                           'completed', 'no_match')
-			               OR (r.state IN ('skipped', 'failed', 'cancelled')
-			                   AND r.created_at > now() - interval '`+sweepRetryAfter+`')))`,
+			          AND (`+coveredByARun+`))`,
 		name).Scan(&out.Remaining)
 	if err != nil {
 		return out, fmt.Errorf("integrations: counting the contacts still owed a lookup: %w", err)

--- a/backend/internal/modules/integrations/execute.go
+++ b/backend/internal/modules/integrations/execute.go
@@ -181,6 +181,24 @@ func (s *Store) leaseForSubmit(ctx context.Context, tx pgx.Tx, name, runID strin
 	if err != nil {
 		return none, false, err
 	}
+	// The identifiers are read again HERE, so they are checked again here.
+	// admission asked the same question, but a record can lose a profile link
+	// or an employer between being queued and being sent — an edit, a merge, a
+	// retention pass — and the vendor answers an unmatchable request with a
+	// rejection the platform reads as a provider fault, marking the whole
+	// connection broken. That is the defect this guard exists to stop, and a
+	// check only at queue time leaves the window open.
+	//
+	// Skipped rather than cancelled: `skipped` is excluded from spend exactly
+	// as `cancelled` is, so the hold is released either way, and the reason is
+	// what the person page needs to say what changed.
+	desc, err := s.registry.Descriptor(name)
+	if err != nil {
+		return none, false, err
+	}
+	if !req.Identifiers.Matchable(desc.MatchRules) {
+		return none, false, s.markSkipped(ctx, tx, runID, provider.SkipNoIdentifiers)
+	}
 	cred, err := s.unseal(ctx, tx, conn.credentialRef)
 	if err != nil {
 		return none, false, err

--- a/backend/internal/modules/integrations/execute_integration_test.go
+++ b/backend/internal/modules/integrations/execute_integration_test.go
@@ -616,3 +616,74 @@ func TestAPartialAnswerChargesOnlyForWhatCameBack(t *testing.T) {
 			"contact and charges only for a match, so the hold is released", charged(actual))
 	}
 }
+
+// A subject that loses its identifiers between being queued and being sent is
+// declined at the door, not put to the provider.
+//
+// The window is real: a record can be edited, merged or anonymized while its
+// run sits queued. Admission checked matchability, but the submission re-reads
+// the identifiers from the domain — so a check only at queue time leaves
+// exactly this gap, and what goes through it is the unmatchable request the
+// vendor rejects, which the platform then reads as a provider fault and uses
+// to mark the whole connection broken.
+func TestASubjectThatLosesItsIdentifiersIsNeverSubmitted(t *testing.T) {
+	e := setupRuns(t, runsConfig{})
+	sealCredential(t, e)
+	run := queueFor(t, e, e.mine.String())
+	if run.State != provider.RunQueued {
+		t.Fatalf("run is %s, want queued: the window under test opens only for a run that was admitted", run.State)
+	}
+
+	// The record loses its company between admission and submission.
+	e.store.WithDomain(
+		func(context.Context, pgx.Tx, string) (FenceVerdict, error) {
+			return FenceVerdict{Allowed: true}, nil
+		},
+		nil,
+		func(context.Context, pgx.Tx, string) (provider.PersonIdentifiers, error) {
+			return provider.PersonIdentifiers{FirstName: "Anna", LastName: "Muster"}, nil
+		},
+	)
+
+	before := e.fake.Calls()
+	if err := e.store.ExecuteSubmit(e.ctx, run.ID); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.fake.Calls(); got != before {
+		t.Errorf("the adapter was called %d time(s) for a subject it cannot match on; that request comes "+
+			"back a rejection and marks the connection broken for every other contact", got-before)
+	}
+
+	state, _, inflight := runRow(t, e, run.ID)
+	if state != string(provider.RunSkipped) {
+		t.Fatalf("run is %s, want skipped", state)
+	}
+	if inflight != nil {
+		t.Error("the run is marked in flight, but nothing was ever sent")
+	}
+
+	var reason *string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT skip_reason FROM provider_run WHERE id = $1`, run.ID).Scan(&reason); err != nil {
+		t.Fatal(err)
+	}
+	if reason == nil || *reason != string(provider.SkipNoIdentifiers) {
+		t.Errorf("skip_reason is %v, want no_identifiers: the page reads it to say what the record is "+
+			"missing, and a bare cancellation says nothing anybody can act on", reason)
+	}
+
+	// The hold must not survive. `skipped` is excluded from spend exactly as
+	// `cancelled` is, so a run that bought nothing charges nothing.
+	var spend int
+	if err := e.owner.QueryRow(context.Background(), `
+		SELECT count(*) FROM provider_run_reservation r
+		  JOIN provider_run run ON run.id = r.run_id
+		 WHERE r.run_id = $1 AND run.state <> 'skipped' AND run.state <> 'cancelled'`,
+		run.ID).Scan(&spend); err != nil {
+		t.Fatal(err)
+	}
+	if spend != 0 {
+		t.Errorf("%d reservation(s) still count against the ceiling for a run that never left the "+
+			"building, so the customer's monthly budget is spent on nothing", spend)
+	}
+}

--- a/backend/internal/modules/integrations/offline.go
+++ b/backend/internal/modules/integrations/offline.go
@@ -104,7 +104,24 @@ func (p *OfflineProvider) Descriptor() provider.Descriptor {
 			Cost:     map[provider.Pool]int{"email": 2},
 			Excludes: []provider.Category{"mobile"},
 		}},
-		Identifiers:  []string{"LinkedIn profile URL", "first and last name with company name or domain"},
+		Identifiers: []string{"LinkedIn profile URL", "first and last name with company name or domain"},
+		// The same two rules the real adapter declares, and the same as the
+		// Identifiers sentence above. A fake that accepted subjects the vendor
+		// rejects would let every dev stack and every test pass over the case
+		// this guard exists for.
+		MatchRules: []provider.MatchRule{
+			{AllOf: []provider.IdentifierField{provider.IdentifierLinkedInURL}},
+			{
+				AllOf: []provider.IdentifierField{
+					provider.IdentifierFirstName,
+					provider.IdentifierLastName,
+				},
+				AnyOf: []provider.IdentifierField{
+					provider.IdentifierCompanyName,
+					provider.IdentifierCompanyDomain,
+				},
+			},
+		},
 		EgressHost:   "api.surfe.com",
 		Verification: "credit-balance read",
 		TermsLinks:   []provider.Link{{Label: "Terms", URL: "https://surfe.com/terms"}},

--- a/backend/internal/modules/integrations/registry.go
+++ b/backend/internal/modules/integrations/registry.go
@@ -69,6 +69,9 @@ func NewRegistry(adapters ...provider.Adapter) (*Registry, error) {
 		if err := pricesOnlyDeclaredPools(d); err != nil {
 			return nil, err
 		}
+		if err := matchesOnKnownIdentifiers(d); err != nil {
+			return nil, err
+		}
 		if d.EgressHost == "" {
 			return nil, fmt.Errorf("integrations: provider %q declared no egress host", d.Name)
 		}
@@ -103,6 +106,41 @@ func pricesOnlyDeclaredPools(d provider.Descriptor) error {
 						"a hold taken in an undeclared pool cannot be matched to what the vendor reports spending, and "+
 						"settles as a refund of a charge they kept",
 					d.Name, category, pool)
+			}
+		}
+	}
+	return nil
+}
+
+// matchesOnKnownIdentifiers refuses an adapter whose match rules name a field
+// PersonIdentifiers does not carry.
+//
+// This is the one way the mechanism fails quietly. An unknown field is never
+// present, so a rule carrying a typo can never be satisfied — and a rule that
+// can never be satisfied refuses every subject, which reads as "this provider
+// can look nobody up" and silences the lane completely. Checked at
+// registration, where the author sees the name they mistyped.
+//
+// A rule naming nothing at all goes through the same door: it would likewise
+// match nobody.
+func matchesOnKnownIdentifiers(d provider.Descriptor) error {
+	known := make(map[provider.IdentifierField]bool, len(provider.IdentifierFields()))
+	for _, f := range provider.IdentifierFields() {
+		known[f] = true
+	}
+	for i, rule := range d.MatchRules {
+		if len(rule.AllOf) == 0 && len(rule.AnyOf) == 0 {
+			return fmt.Errorf(
+				"integrations: provider %q declares match rule %d naming no identifier at all: "+
+					"such a rule matches nobody, so every subject would be skipped as unlookupable",
+				d.Name, i)
+		}
+		for _, f := range append(append([]provider.IdentifierField{}, rule.AllOf...), rule.AnyOf...) {
+			if !known[f] {
+				return fmt.Errorf(
+					"integrations: provider %q declares match rule %d on identifier %q, which is not one a person carries: "+
+						"an unknown field is never present, so the rule matches nobody and the lane goes silent",
+					d.Name, i, f)
 			}
 		}
 	}

--- a/backend/internal/modules/integrations/registrymatch_test.go
+++ b/backend/internal/modules/integrations/registrymatch_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package integrations
+
+// A descriptor's match rules are refused at registration when they name a
+// field a person does not carry.
+//
+// This is the one failure mode of the mechanism that is otherwise silent: an
+// unknown field is never present, so a rule carrying a typo is satisfied by
+// nobody. Every subject is then skipped as unlookupable and the provider goes
+// quiet — with no error anywhere, because refusing to spend money never looks
+// like a fault.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+// matchingOn is the shipped fake with its match rules replaced, which is the
+// shape an adapter author reaches by writing a rule by hand.
+type matchingOn struct {
+	provider.Adapter
+	rules []provider.MatchRule
+}
+
+func (m matchingOn) Descriptor() provider.Descriptor {
+	d := m.Adapter.Descriptor()
+	d.MatchRules = m.rules
+	return d
+}
+
+func TestAProviderCannotMatchOnAnIdentifierNobodyCarries(t *testing.T) {
+	t.Parallel()
+
+	// The shipped fake registers as it is, so the case below is not passing
+	// over a descriptor that was refused for some other reason.
+	shipped := NewOfflineProvider(0, time.Now).Descriptor()
+	if len(shipped.MatchRules) == 0 {
+		t.Fatal("the shipped fake declares no match rules, so it models a provider that looks everybody up " +
+			"and no dev stack or test exercises the guard")
+	}
+	if _, err := NewRegistry(NewOfflineProvider(0, time.Now)); err != nil {
+		t.Fatalf("the shipped adapter is refused by its own rule: %v", err)
+	}
+
+	for _, c := range []struct {
+		name  string
+		rules []provider.MatchRule
+		names string
+	}{
+		{
+			name:  "a field that does not exist",
+			rules: []provider.MatchRule{{AllOf: []provider.IdentifierField{"middle_name"}}},
+			names: "middle_name",
+		},
+		{
+			name: "a typo in the any-of half",
+			rules: []provider.MatchRule{{
+				AllOf: []provider.IdentifierField{provider.IdentifierLastName},
+				AnyOf: []provider.IdentifierField{"company_naem"},
+			}},
+			names: "company_naem",
+		},
+		{
+			name:  "a rule naming nothing at all",
+			rules: []provider.MatchRule{{}},
+			names: "matches nobody",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewRegistry(matchingOn{Adapter: NewOfflineProvider(0, time.Now), rules: c.rules})
+			if err == nil {
+				t.Fatal("an adapter whose match rule can never be satisfied registered: every subject is " +
+					"skipped as unlookupable and the provider goes silent with no error to notice")
+			}
+			if !strings.Contains(err.Error(), c.names) {
+				t.Errorf("the refusal does not name what is wrong, so an author cannot act on it: %v", err)
+			}
+		})
+	}
+}
+
+// An adapter declaring no rules at all is allowed: that is how a provider says
+// it can look anybody up, and it is what every adapter written before this
+// mechanism existed declares by omission.
+func TestAProviderMayDeclareNoMatchRules(t *testing.T) {
+	t.Parallel()
+	if _, err := NewRegistry(matchingOn{Adapter: NewOfflineProvider(0, time.Now), rules: nil}); err != nil {
+		t.Errorf("an adapter declaring no match rules was refused, so adding this field broke every "+
+			"provider that does not use it: %v", err)
+	}
+}

--- a/backend/internal/modules/integrations/runs.go
+++ b/backend/internal/modules/integrations/runs.go
@@ -216,6 +216,101 @@ func (s *Store) resolveProvider(ctx context.Context, named string) (string, erro
 	}
 }
 
+// refuseBeforeSpending answers every reason not to spend on this subject, in
+// the order that reads cheapest: the standing and wallet checks first, which
+// need nothing about the person, then the two that need their identifiers.
+//
+// It returns the skip reason to record, or "" to carry on. On the carry-on
+// path it also returns the input fingerprint, computed here because the
+// duplicate fence is defined over it — handing it back rather than recomputing
+// it keeps one answer to "what did we ask about this subject".
+//
+// Separated from queueOne because these refusals share a shape: each is a fact
+// about the subject's standing, the installation's wallet, or what the record
+// carries, and every one must be settled before a single credit is reserved.
+func (s *Store) refuseBeforeSpending(ctx context.Context, tx pgx.Tx, desc provider.Descriptor, conn admittedConnection, in provider.QueueInput, cats []provider.Category) (string, provider.SkipReason, error) {
+	const none = ""
+	refusal, err := s.refuseOnStanding(ctx, tx, conn, in)
+	if err != nil || refusal != "" {
+		return none, refusal, err
+	}
+	return s.refuseOnWhatTheRecordCarries(ctx, tx, desc, in, cats)
+}
+
+// refuseOnStanding answers the refusals that need nothing about the person:
+// whether we may contact them at all, and whether the installation should
+// spend right now.
+func (s *Store) refuseOnStanding(ctx context.Context, tx pgx.Tx, conn admittedConnection, in provider.QueueInput) (provider.SkipReason, error) {
+	// Consent, suppression, objection, erasure. Before anything else, because
+	// a subject we may not contact must not even be looked up.
+	verdict, err := s.fence(ctx, tx, in.PersonID)
+	if err != nil {
+		return "", err
+	}
+	if !verdict.Allowed {
+		return verdict.Reason, nil
+	}
+
+	// The rate ceiling and the freshness window (PI-PARAM-13/14).
+	if conn.dailyLimit != nil {
+		spent, err := s.runsSubmittedToday(ctx, tx, in.Provider)
+		if err != nil {
+			return "", err
+		}
+		if spent >= *conn.dailyLimit {
+			return provider.SkipRateLimited, nil
+		}
+	}
+	if conn.refreshAge != nil && in.Trigger.Automatic() {
+		fresh, err := s.hasFreshRun(ctx, tx, in.PersonID, in.Provider, *conn.refreshAge)
+		if err != nil {
+			return "", err
+		}
+		if fresh {
+			return provider.SkipAlreadyFresh, nil
+		}
+	}
+	return "", nil
+}
+
+// refuseOnWhatTheRecordCarries answers the two refusals that need the
+// subject's identifiers, and returns the fingerprint over them.
+func (s *Store) refuseOnWhatTheRecordCarries(ctx context.Context, tx pgx.Tx, desc provider.Descriptor, in provider.QueueInput, cats []provider.Category) (string, provider.SkipReason, error) {
+	const none = ""
+	idents, err := s.identifiers(ctx, tx, in.PersonID)
+	if err != nil {
+		return none, "", err
+	}
+
+	// Can this provider look the subject up at all? A record carrying neither
+	// a profile link nor a name with a company gives the vendor nothing to
+	// match on, and it answers with a rejection rather than an empty result.
+	// The platform can only read that rejection as a provider fault — which
+	// marks the whole CONNECTION broken, so one unlookupable contact makes
+	// every other lookup look unavailable.
+	//
+	// It applies to a human's request as well as the sweep's: the button
+	// cannot conjure an identifier, and a person who presses it deserves "there
+	// is nothing to look up" rather than a vendor error.
+	if !idents.Matchable(desc.MatchRules) {
+		return none, provider.SkipNoIdentifiers, nil
+	}
+	fingerprint := fingerprintOf(idents, cats)
+
+	// The duplicate fence, automatic runs only. A human asking explicitly
+	// knows something the duplicate signal does not.
+	if in.Trigger.Automatic() && s.cluster != nil {
+		dup, err := s.duplicateAlreadyBought(ctx, tx, in, fingerprint)
+		if err != nil {
+			return none, "", err
+		}
+		if dup {
+			return none, provider.SkipDuplicateSubjectCandidate, nil
+		}
+	}
+	return fingerprint, "", nil
+}
+
 // queueOne is the admission pipeline for one subject. Each refusal writes a
 // skipped run rather than nothing at all: a customer asking "why was this
 // person not enriched" deserves a row that answers, and a silent no-op cannot.
@@ -226,55 +321,15 @@ func (s *Store) queueOne(ctx context.Context, tx pgx.Tx, desc provider.Descripto
 		return provider.Run{}, err
 	}
 
-	// 1. Consent, suppression, objection, erasure. Before anything else,
-	//    because a subject we may not contact must not even be looked up.
-	verdict, err := s.fence(ctx, tx, in.PersonID)
+	// 1-4. Every reason not to spend, in one pass. The fingerprint comes back
+	//      with the verdict because the duplicate fence is defined over it and
+	//      step 5 writes it onto the run.
+	fingerprint, refusal, err := s.refuseBeforeSpending(ctx, tx, desc, conn, in, cats)
 	if err != nil {
 		return provider.Run{}, err
 	}
-	if !verdict.Allowed {
-		return s.insertSkipped(ctx, tx, conn, in, snapshot, cats, verdict.Reason)
-	}
-
-	// 2. The rate ceiling and the freshness window (PI-PARAM-13/14). Both are
-	//    reasons NOT to spend, so both precede the reservation.
-	if conn.dailyLimit != nil {
-		spent, err := s.runsSubmittedToday(ctx, tx, in.Provider)
-		if err != nil {
-			return provider.Run{}, err
-		}
-		if spent >= *conn.dailyLimit {
-			return s.insertSkipped(ctx, tx, conn, in, snapshot, cats, provider.SkipRateLimited)
-		}
-	}
-	if conn.refreshAge != nil && in.Trigger.Automatic() {
-		fresh, err := s.hasFreshRun(ctx, tx, in.PersonID, in.Provider, *conn.refreshAge)
-		if err != nil {
-			return provider.Run{}, err
-		}
-		if fresh {
-			return s.insertSkipped(ctx, tx, conn, in, snapshot, cats, provider.SkipAlreadyFresh)
-		}
-	}
-
-	// 3. The identifiers, and the fingerprint over them. Computed BEFORE the
-	//    duplicate check because that check is defined over the fingerprint.
-	idents, err := s.identifiers(ctx, tx, in.PersonID)
-	if err != nil {
-		return provider.Run{}, err
-	}
-	fingerprint := fingerprintOf(idents, cats)
-
-	// 4. The duplicate fence, automatic runs only. A human asking explicitly
-	//    knows something the duplicate signal does not.
-	if in.Trigger.Automatic() && s.cluster != nil {
-		dup, err := s.duplicateAlreadyBought(ctx, tx, in, fingerprint)
-		if err != nil {
-			return provider.Run{}, err
-		}
-		if dup {
-			return s.insertSkipped(ctx, tx, conn, in, snapshot, cats, provider.SkipDuplicateSubjectCandidate)
-		}
+	if refusal != "" {
+		return s.insertSkipped(ctx, tx, conn, in, snapshot, cats, refusal)
 	}
 
 	// 5. The run row, under the live-run index. A duplicate trigger for the

--- a/backend/internal/modules/integrations/runs_integration_test.go
+++ b/backend/internal/modules/integrations/runs_integration_test.go
@@ -188,9 +188,7 @@ func setupRuns(t *testing.T, cfg runsConfig) *runsEnv {
 		},
 		nil,
 		func(context.Context, pgx.Tx, string) (provider.PersonIdentifiers, error) {
-			return provider.PersonIdentifiers{
-				FirstName: "Anna", LastName: cfg.subjectOf(), CompanyName: "Example",
-			}, nil
+			return cfg.identifiersOf(), nil
 		},
 	)
 	if !cfg.withoutEnqueue {
@@ -228,6 +226,10 @@ type runsConfig struct {
 	// subjectLastName picks the fake's scenario, which it reads out of the
 	// subject's name. Empty means Muster, which succeeds.
 	subjectLastName string
+	// identifiers replaces what the subject seam returns. Set it to model a
+	// record the provider cannot match on; nil means a name with a company,
+	// which every rule the shipped adapters declare is satisfied by.
+	identifiers *provider.PersonIdentifiers
 	// provider names the vendor this environment's connection and adapter are
 	// for. Empty means surfe, which is what almost every test wants; a test
 	// asserting that something is derived FROM the run sets it, because a
@@ -242,6 +244,18 @@ func (c runsConfig) subjectOf() string {
 		return "Muster"
 	}
 	return c.subjectLastName
+}
+
+// identifiersOf is what the subject seam returns. The default carries a name
+// AND a company, which is what the provider's rules require — so a test that
+// does not care about matching gets a subject the lookup can proceed on.
+func (c runsConfig) identifiersOf() provider.PersonIdentifiers {
+	if c.identifiers != nil {
+		return *c.identifiers
+	}
+	return provider.PersonIdentifiers{
+		FirstName: "Anna", LastName: c.subjectOf(), CompanyName: "Example",
+	}
 }
 
 // providerOf is the vendor an environment runs as.
@@ -429,5 +443,86 @@ func TestAQueuedRunAlwaysHasAJob(t *testing.T) {
 	}
 	if e2.enqueued != 1 {
 		t.Errorf("%d jobs enqueued, want 1 — the run and its job commit together or not at all", e2.enqueued)
+	}
+}
+
+// A record the provider cannot match on is declined before anything is spent,
+// and the decline says which fact is missing.
+//
+// The defect this pins: a contact captured from a calendar invite carries a
+// name and an address and nothing else. Sent anyway, the vendor rejects the
+// REQUEST with a 400 — which the platform can only read as a provider fault,
+// so it marks the whole CONNECTION broken. One unlookupable contact then makes
+// every other lookup report "the last call to the provider failed", and the
+// sweep re-breaks it on every tick. In the installation that surfaced this,
+// 214 of 1045 contacts were in exactly this state.
+func TestASubjectWithNothingToMatchOnIsNeverSent(t *testing.T) {
+	e := setupRuns(t, runsConfig{identifiers: &provider.PersonIdentifiers{
+		FirstName: "Lars", LastName: "Jankowfsky",
+	}})
+
+	run, err := e.store.QueueRun(e.ctx, provider.QueueInput{
+		PersonID: e.mine.String(), Provider: "surfe", Trigger: provider.TriggerManual,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != provider.RunSkipped || run.SkipReason != provider.SkipNoIdentifiers {
+		t.Fatalf("run is %s/%s, want skipped/no_identifiers", run.State, run.SkipReason)
+	}
+	if e.enqueued != 0 {
+		t.Errorf("%d jobs enqueued for a subject the provider cannot look up; each one spends a call that "+
+			"comes back a rejection and marks the connection broken", e.enqueued)
+	}
+
+	var held int
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM provider_run_reservation WHERE run_id = $1`, run.ID).Scan(&held); err != nil {
+		t.Fatal(err)
+	}
+	if held != 0 {
+		t.Errorf("%d reservations held for a run that was never sent, so the customer's ceiling is spent "+
+			"on a lookup that never happened", held)
+	}
+}
+
+// The same guard must not refuse a subject the provider CAN place. Without
+// this case the one above passes against a guard that declines everybody,
+// which reads as a working feature and silences the lane completely.
+func TestASubjectWithACompanyIsStillSent(t *testing.T) {
+	e := setupRuns(t, runsConfig{identifiers: &provider.PersonIdentifiers{
+		FirstName: "Anna", LastName: "Muster", CompanyDomain: "example.com",
+	}})
+
+	run, err := e.store.QueueRun(e.ctx, provider.QueueInput{
+		PersonID: e.mine.String(), Provider: "surfe", Trigger: provider.TriggerManual,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != provider.RunQueued {
+		t.Fatalf("run is %s/%s, want queued: a last name with a company domain is one of the two "+
+			"combinations the provider declares it can match on", run.State, run.SkipReason)
+	}
+	if e.enqueued != 1 {
+		t.Errorf("%d jobs enqueued, want 1", e.enqueued)
+	}
+}
+
+// A profile link alone is the other rule, and it carries no name at all.
+func TestAProfileLinkAloneIsEnoughToBeSent(t *testing.T) {
+	e := setupRuns(t, runsConfig{identifiers: &provider.PersonIdentifiers{
+		LinkedInURL: "https://www.linkedin.com/in/someone",
+	}})
+
+	run, err := e.store.QueueRun(e.ctx, provider.QueueInput{
+		PersonID: e.mine.String(), Provider: "surfe", Trigger: provider.TriggerManual,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != provider.RunQueued {
+		t.Fatalf("run is %s/%s, want queued: a profile link is the identifier the provider matches on "+
+			"most directly, and a subject carrying one needs no name", run.State, run.SkipReason)
 	}
 }

--- a/backend/internal/modules/integrations/surfe/surfe.go
+++ b/backend/internal/modules/integrations/surfe/surfe.go
@@ -153,6 +153,7 @@ func (a *Adapter) Descriptor() provider.Descriptor {
 			Excludes: []provider.Category{categoryMobile},
 		}},
 		Identifiers:  []string{"LinkedIn profile URL", "first and last name with company name or domain"},
+		MatchRules:   matchRules(),
 		EgressHost:   egressHost,
 		Verification: "credit-balance read",
 		TermsLinks: []provider.Link{
@@ -191,6 +192,33 @@ func (a *Adapter) Descriptor() provider.Descriptor {
 		// vendor could not place is never asked for a number.
 		RequiresAnswerTo: map[provider.Category]provider.Category{
 			categoryMobile: categoryProfessionalEmail,
+		},
+	}
+}
+
+// matchRules is the Identifiers sentence above, in a form admission can
+// apply. The two must say the same thing: "LinkedIn profile URL, or first and
+// last name with company name or domain".
+//
+// So a name rule requires BOTH names, matching the disclosure exactly. The
+// vendor may well answer a last name alone with a company — the wire field is
+// optional — but nothing here has confirmed that, and guessing LOOSER than the
+// disclosed rule sends the request this whole guard exists to stop. Guessing
+// tighter costs at most a lookup somebody can still start by hand. If the
+// vendor's behaviour is ever confirmed, relax it here and in the sentence
+// together.
+func matchRules() []provider.MatchRule {
+	return []provider.MatchRule{
+		{AllOf: []provider.IdentifierField{provider.IdentifierLinkedInURL}},
+		{
+			AllOf: []provider.IdentifierField{
+				provider.IdentifierFirstName,
+				provider.IdentifierLastName,
+			},
+			AnyOf: []provider.IdentifierField{
+				provider.IdentifierCompanyName,
+				provider.IdentifierCompanyDomain,
+			},
 		},
 	}
 }

--- a/backend/internal/shared/ports/provider/matchable.go
+++ b/backend/internal/shared/ports/provider/matchable.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package provider
+
+// Whether a provider can look somebody up at all, asked before spending a
+// call on them.
+//
+// A vendor matches a person BY something: Surfe by a LinkedIn URL, or by a
+// name together with a company. A subject carrying neither cannot be found,
+// and the vendor says so with a 400 rather than a polite empty answer — one
+// that the platform then has to read as a provider fault, because from the
+// outside a rejected request and a broken key look the same.
+//
+// So the rule is declared here as data and checked before the request leaves.
+// Descriptor.Identifiers is the sentence a customer reads; MatchRules is the
+// same fact in a form the admission pipeline can apply.
+
+// IdentifierField names one member of PersonIdentifiers. It exists so a
+// descriptor can state its matching rule as data rather than as prose.
+type IdentifierField string
+
+// The fields of PersonIdentifiers, spelled the way a rule names them. Every
+// member of the struct has one, and `present` reads each — both held by
+// TestEveryIdentifierFieldIsNamedAndUnderstood
+// (backend/gates/identifierfields_test.go).
+const (
+	IdentifierLinkedInURL   IdentifierField = "linkedin_url"
+	IdentifierFirstName     IdentifierField = "first_name"
+	IdentifierLastName      IdentifierField = "last_name"
+	IdentifierCompanyName   IdentifierField = "company_name"
+	IdentifierCompanyDomain IdentifierField = "company_domain"
+)
+
+// IdentifierFields is every field a rule may name. The registry reads it to
+// reject a descriptor naming something that does not exist, which is the one
+// way this mechanism fails quietly: an unknown field is never present, so a
+// rule carrying a typo can never be satisfied and would refuse every subject.
+//
+// Held by: TestEveryIdentifierFieldIsNamedAndUnderstood
+// (backend/gates/identifierfields_test.go) for the list being complete, and
+// TestAProviderCannotMatchOnAnIdentifierNobodyCarries
+// (backend/internal/modules/integrations/registrymatch_test.go) for the
+// registry actually refusing a rule that names something absent from it.
+func IdentifierFields() []IdentifierField {
+	return []IdentifierField{
+		IdentifierLinkedInURL,
+		IdentifierFirstName,
+		IdentifierLastName,
+		IdentifierCompanyName,
+		IdentifierCompanyDomain,
+	}
+}
+
+// present reports whether one field carries a value.
+func (p PersonIdentifiers) present(f IdentifierField) bool {
+	switch f {
+	case IdentifierLinkedInURL:
+		return p.LinkedInURL != ""
+	case IdentifierFirstName:
+		return p.FirstName != ""
+	case IdentifierLastName:
+		return p.LastName != ""
+	case IdentifierCompanyName:
+		return p.CompanyName != ""
+	case IdentifierCompanyDomain:
+		return p.CompanyDomain != ""
+	}
+	return false
+}
+
+// MatchRule is one combination of identifiers a provider can look somebody up
+// by. Every field in AllOf must carry a value; when AnyOf is set, at least one
+// of those must too. Two fields that are interchangeable — a company by name
+// or by domain — are one rule, not two.
+type MatchRule struct {
+	AllOf []IdentifierField
+	AnyOf []IdentifierField
+}
+
+func (r MatchRule) satisfiedBy(p PersonIdentifiers) bool {
+	for _, f := range r.AllOf {
+		if !p.present(f) {
+			return false
+		}
+	}
+	if len(r.AnyOf) == 0 {
+		return len(r.AllOf) > 0
+	}
+	for _, f := range r.AnyOf {
+		if p.present(f) {
+			return true
+		}
+	}
+	return false
+}
+
+// Matchable reports whether these identifiers satisfy any rule — whether the
+// provider has anything to look the subject up by.
+//
+// No rules means matchable by anything. The platform does not invent a
+// constraint an adapter did not declare: refusing a lookup the vendor would
+// have answered is a worse failure than spending one call to find out.
+func (p PersonIdentifiers) Matchable(rules []MatchRule) bool {
+	if len(rules) == 0 {
+		return true
+	}
+	for _, r := range rules {
+		if r.satisfiedBy(p) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/shared/ports/provider/matchable_test.go
+++ b/backend/internal/shared/ports/provider/matchable_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+// surfeRules is the shape both shipped adapters declare: a profile link on its
+// own, or a last name together with a company named either way.
+func surfeRules() []provider.MatchRule {
+	return []provider.MatchRule{
+		{AllOf: []provider.IdentifierField{provider.IdentifierLinkedInURL}},
+		{
+			AllOf: []provider.IdentifierField{
+				provider.IdentifierFirstName,
+				provider.IdentifierLastName,
+			},
+			AnyOf: []provider.IdentifierField{
+				provider.IdentifierCompanyName,
+				provider.IdentifierCompanyDomain,
+			},
+		},
+	}
+}
+
+func TestMatchableReadsTheDeclaredRules(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		given provider.PersonIdentifiers
+		want  bool
+	}{
+		{
+			name:  "a profile link alone is enough",
+			given: provider.PersonIdentifiers{LinkedInURL: "https://linkedin.com/in/someone"},
+			want:  true,
+		},
+		{
+			name:  "a full name with a company name",
+			given: provider.PersonIdentifiers{FirstName: "Michael", LastName: "Kott", CompanyName: "CM-Equity AG"},
+			want:  true,
+		},
+		{
+			name:  "a full name with a company domain",
+			given: provider.PersonIdentifiers{FirstName: "Michael", LastName: "Kott", CompanyDomain: "cm-equity.de"},
+			want:  true,
+		},
+		{
+			// The disclosure says "first and last name with company", so a
+			// surname alone is not enough. Sending it anyway is the guess this
+			// rule refuses to make on the customer's behalf.
+			name:  "a last name and a company, with no first name",
+			given: provider.PersonIdentifiers{LastName: "Kott", CompanyName: "CM-Equity AG"},
+			want:  false,
+		},
+		{
+			// The case that broke the connection: a calendar-captured contact
+			// carries a name and an address and nothing else.
+			name:  "a full name with no company",
+			given: provider.PersonIdentifiers{FirstName: "Lars", LastName: "Jankowfsky"},
+			want:  false,
+		},
+		{
+			name:  "a company with no name",
+			given: provider.PersonIdentifiers{CompanyName: "CM-Equity AG"},
+			want:  false,
+		},
+		{
+			name:  "nothing at all",
+			given: provider.PersonIdentifiers{},
+			want:  false,
+		},
+		{
+			// A first name is not part of either rule, so adding one to an
+			// otherwise unmatchable subject must not change the answer.
+			name:  "a first name does not rescue a subject without a company",
+			given: provider.PersonIdentifiers{FirstName: "Michael"},
+			want:  false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := c.given.Matchable(surfeRules()); got != c.want {
+				t.Errorf("Matchable = %v, want %v for %+v", got, c.want, c.given)
+			}
+		})
+	}
+}
+
+// An adapter that declares no rule keeps today's behaviour: everything is
+// sent. The platform must not invent a constraint the vendor never stated,
+// because refusing a lookup it would have answered is the worse failure and
+// leaves no trace to notice.
+func TestNoRulesMatchesEverySubject(t *testing.T) {
+	t.Parallel()
+	if !(provider.PersonIdentifiers{}).Matchable(nil) {
+		t.Error("an empty subject was refused by a provider declaring no rules, so an adapter that states " +
+			"no matching constraint silently stops looking anybody up")
+	}
+}
+
+// A rule naming a field nobody carries can never be satisfied. The registry
+// refuses such a descriptor; this pins the behaviour it is refusing, so the
+// two stay one fact.
+func TestAnUnknownFieldMatchesNobody(t *testing.T) {
+	t.Parallel()
+	rules := []provider.MatchRule{{AllOf: []provider.IdentifierField{"middle_name"}}}
+	full := provider.PersonIdentifiers{
+		LinkedInURL: "https://linkedin.com/in/someone",
+		FirstName:   "Michael",
+		LastName:    "Kott",
+		CompanyName: "CM-Equity AG",
+	}
+	if full.Matchable(rules) {
+		t.Error("a rule on an unknown identifier matched a subject carrying every real one, so a typo " +
+			"in a descriptor would widen the rule instead of narrowing it")
+	}
+}

--- a/backend/internal/shared/ports/provider/provider.go
+++ b/backend/internal/shared/ports/provider/provider.go
@@ -130,6 +130,14 @@ type Descriptor struct {
 	// Identifiers names exactly what may leave the installation for this
 	// provider. It is disclosure copy AND the egress contract.
 	Identifiers []string
+	// MatchRules is the same fact as Identifiers in a form admission can
+	// apply: the combinations this provider can find somebody BY. A subject
+	// satisfying none of them is skipped as no_identifiers instead of being
+	// sent, because the vendor rejects such a request and the platform can
+	// only read that rejection as a provider fault.
+	//
+	// Empty means the adapter declares no rule, and every subject is sent.
+	MatchRules []MatchRule
 	// EgressHost is the single allowlisted host this adapter may reach.
 	EgressHost string
 	// Verification names the cheapest read used to validate a credential at

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (55)
+## Parity (56)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -51,6 +51,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `goversionpins_test.go` | H3 | One Go version, pinned in several places, and they have to agree. |
 | `grantrenewalcauses_test.go` | H1 | Every reason a standing grant needs renewing must reach the card that asks for it. |
 | `idempotencymap_test.go` | H3 | The idempotency allowlist as a fitness function: the contract is the authority on which operations promise Idempotency-Key retry safety, and internal/compose's hand-maintained replayableOperations map must mirror it exactly. |
+| `identifierfields_test.go` | H3 | A provider's match rules are checked against IdentifierFields(), so that list has to name every field a person actually carries. |
 | `inboundsigningrecipe_test.go` | H3 | The signing scope is ONE invariant spelled on both sides of a wire. |
 | `issuelabels_test.go` | H3 | The label taxonomy is written down once and read from there. |
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -14294,8 +14294,11 @@ export interface components {
          *     on the page says who was paid for it.
          */
         PersonProviderProfile: {
-            /** @enum {string} */
-            state: "not_connected" | "not_eligible" | "never_run" | "queued" | "in_progress" | "completed" | "no_match" | "stale" | "invalid_credentials" | "insufficient_credits" | "rate_limited" | "provider_error" | "submission_unknown" | "completed_claims_unwritten";
+            /**
+             * @description Why this provider's section reads the way it does. `nothing_to_look_up` is its own state rather than a kind of `not_eligible`: nothing forbids the purchase, the record simply carries no profile link and no company, so the provider has nothing to match on. The reader's next step is to add one of those, which is the next step for no other state here.
+             * @enum {string}
+             */
+            state: "not_connected" | "not_eligible" | "nothing_to_look_up" | "never_run" | "queued" | "in_progress" | "completed" | "no_match" | "stale" | "invalid_credentials" | "insufficient_credits" | "rate_limited" | "provider_error" | "submission_unknown" | "completed_claims_unwritten";
             /** @description Whose snapshot this is. Required: an entry in a list of providers that did not name itself would leave the reader unable to tell who to ask, or who was already paid. */
             provider: components["schemas"]["Provider"];
             /** Format: date-time */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6922,6 +6922,8 @@ export const de = {
     "Es ist kein Datenanbieter verbunden, also wurde nichts gekauft.",
   "provider.profile.notEligible":
     "Für diesen Kontakt nicht zulässig — er hat widersprochen, oder der Datensatz ist archiviert.",
+  "provider.profile.nothingToLookUp":
+    "Es gibt nichts, womit sich dieser Kontakt nachschlagen ließe. Tragen Sie die LinkedIn-URL oder das Unternehmen ein, dann kann die Suche laufen.",
   "provider.profile.neverRun":
     "Diesen Kontakt hat noch niemand nachgeschlagen.",
   "provider.profile.queued": "In der Warteschlange",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6977,6 +6977,8 @@ export const en = {
     "No data provider is connected, so nothing has been bought.",
   "provider.profile.notEligible":
     "This contact is not eligible — they have objected, or the record is archived.",
+  "provider.profile.nothingToLookUp":
+    "There is nothing to look this contact up by. Add their LinkedIn URL, or the company they work for, and the lookup can run.",
   "provider.profile.neverRun": "Nobody has looked this contact up yet.",
   "provider.profile.queued": "Queued",
   "provider.profile.inProgress": "Looking them up…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6848,6 +6848,8 @@ export const vi = {
     "Chưa kết nối nhà cung cấp dữ liệu nào, nên chưa mua gì cả.",
   "provider.profile.notEligible":
     "Liên hệ này không đủ điều kiện — họ đã phản đối, hoặc hồ sơ đã được lưu trữ.",
+  "provider.profile.nothingToLookUp":
+    "Không có thông tin nào để tra cứu liên hệ này. Hãy thêm URL LinkedIn hoặc công ty của họ, rồi việc tra cứu mới chạy được.",
   "provider.profile.neverRun": "Chưa ai tra cứu liên hệ này.",
   "provider.profile.queued": "Trong hàng đợi",
   "provider.profile.inProgress": "Đang tra cứu…",

--- a/frontend/src/screens/provider-status.test.ts
+++ b/frontend/src/screens/provider-status.test.ts
@@ -106,6 +106,31 @@ describe("the provider status vocabulary", () => {
     expect(canEnrichNow("provider_error", false)).toBe(true);
   });
 
+  it("keeps the button where the reader is the one who can fix it", () => {
+    // The section tells somebody to add a LinkedIn URL or a company. Taking
+    // the button away with it would leave them no way to say they had: the
+    // automatic sweep revisits a declined contact only after a day, and only
+    // while automatic lookup is switched on at all.
+    //
+    // Offering it is free — the server re-reads the identifiers and declines
+    // before reserving any credit — so the cost of a wasted press is one
+    // skipped run, against a reader otherwise stuck for a day.
+    expect(canEnrichNow("nothing_to_look_up", false)).toBe(true);
+  });
+
+  it("tells the reader what to add rather than blaming the provider", () => {
+    // The defect: a record with no profile link and no company was sent
+    // anyway, the vendor rejected the request, and the page reported "the
+    // last call to the provider failed" — which names the wrong party and
+    // sits beside a button that can only fail again. The sentence has to name
+    // the missing fact, because supplying it is the only thing that helps.
+    const message = en[profileLabel("nothing_to_look_up")];
+    expect(message).toMatch(/LinkedIn/);
+    expect(message).toMatch(/company/i);
+    // And it must not read as a fault of the provider or of the contact.
+    expect(message).not.toMatch(/failed|error|not eligible/i);
+  });
+
   it("colours a refused key as danger and an unconnected provider as neither", () => {
     // A provider nobody connected is a configuration, not a fault: painting
     // it red tells an operator to fix something that is not broken. A

--- a/frontend/src/screens/provider-status.ts
+++ b/frontend/src/screens/provider-status.ts
@@ -63,14 +63,18 @@ export function connectionLabel(status: ProviderConnectionStatus): MessageKey {
   return CONNECTION_LABEL[status];
 }
 
-// The person page's fourteen states. Three of them mean "nothing here" and
-// they are deliberately three: nobody connected a provider, this person is
-// not eligible for one, and nobody has asked yet are different answers to
-// "why is this empty", and only one of them is something the reader can act
-// on.
+// The person page's fifteen states. Four of them mean "nothing here" and they
+// are deliberately four: nobody connected a provider, this person is not
+// eligible for one, this record carries nothing to look them up by, and nobody
+// has asked yet are different answers to "why is this empty". Two of them are
+// something the reader can act on, and the actions differ.
 const PROFILE_TONE: Record<ProviderProfileState, StatusTone> = {
   not_connected: undefined,
   not_eligible: undefined,
+  // Not a fault and not a refusal: the record is missing something, and
+  // saying so in a warning tone would blame the reader for a gap they can
+  // simply fill.
+  nothing_to_look_up: undefined,
   never_run: undefined,
   queued: undefined,
   in_progress: undefined,
@@ -95,6 +99,7 @@ const PROFILE_TONE: Record<ProviderProfileState, StatusTone> = {
 const PROFILE_LABEL: Record<ProviderProfileState, MessageKey> = {
   not_connected: "provider.profile.notConnected",
   not_eligible: "provider.profile.notEligible",
+  nothing_to_look_up: "provider.profile.nothingToLookUp",
   never_run: "provider.profile.neverRun",
   queued: "provider.profile.queued",
   in_progress: "provider.profile.inProgress",
@@ -159,7 +164,19 @@ export function isRunning(state: ProviderProfileState): boolean {
  *  purchases we retained. The section says so ("the provider is no longer
  *  connected, so this cannot be refreshed"), and the server agrees — a run
  *  needs a connected connection. A button beside that sentence is one the
- *  server was always going to refuse. */
+ *  server was always going to refuse.
+ *
+ *  `nothing_to_look_up` KEEPS its button, unlike the three above, and the
+ *  difference is who can fix the situation. Nobody can conjure a provider
+ *  connection from this page, but the reader can paste a LinkedIn URL into the
+ *  record — and the sentence beside the button asks them to. Withdrawing it
+ *  would leave them told to do something with no way to say they had done it:
+ *  the automatic sweep only revisits a declined contact after a day, and only
+ *  when automatic lookup is on at all.
+ *
+ *  It costs nothing to offer. The server re-reads the record's identifiers and
+ *  declines before any credit is reserved, so a press on a record still
+ *  missing them buys nothing and writes one skipped run. */
 export function canEnrichNow(
   state: ProviderProfileState,
   running: boolean,


### PR DESCRIPTION
A record captured from a calendar invite carries a name and an email address
and nothing else. Surfe matches people by a profile link, or by a name with a
company, so it rejects such a request with a 400 — and the platform can only
read a rejected request as a provider fault, which marks the whole CONNECTION
broken. One unlookupable contact then made every other lookup on the
installation report "the last call to the provider failed", and the catch-up
sweep re-broke it on the next tick. In the installation that surfaced this, 214
of 1045 contacts were in exactly that state, and none of them had a profile
link.

The skip reason for it already existed in the vocabulary, in the contract and
in the run table's CHECK constraint. Nothing ever wrote it.

So the matching rule becomes something admission can apply. A descriptor
declares MatchRules beside the Identifiers sentence it already carried — the
same fact, one in prose for a customer and one in a form the queue can read —
and a subject satisfying none of them is skipped as no_identifiers before any
credit is reserved. Surfe's rule requires both names, exactly as its disclosure
says: the vendor may well answer a surname alone with a company, but nothing
here has confirmed that, and guessing looser than the disclosed rule sends the
request this guard exists to stop.

Both doors, not one. The submission re-reads the subject's identifiers from the
owning domain, so it re-checks them: a record can be edited, merged or
anonymized while its run sits queued, and what went through that window was the
unmatchable request again. Skipped rather than cancelled — `skipped` is
excluded from spend the same way, so the hold is released either way, and the
reason is what the page needs.

A declined contact comes back as soon as the record changes, rather than
waiting out the day-long cooldown. The section tells the reader to add a
LinkedIn URL or a company; holding them until tomorrow would be asking somebody
to do something and then not looking. Other refusals keep the full cooldown,
because a rate limit says nothing about the record. The sweep's predicate and
the backlog count now share one spelling, which also settles a disagreement
they already had: the sweep re-queued a submission_unknown run after the
cooldown while the count called it settled for good, so the card read zero over
contacts nobody had looked up.

The page gets its own state rather than borrowing not_eligible. Nothing forbids
this purchase; the record is missing something, and the next step is the
reader's. The buy button stays for that reason — withdrawing it would leave
them told to fix something with no way to say they had, and it costs nothing
because the server declines before reserving a credit.

Three gates hold the parts that would otherwise fail silently. The registry
refuses a match rule naming a field a person does not carry, because an unknown
field is never present and such a rule matches nobody — a provider that looks
up no one raises no error anywhere. A reflection gate keeps IdentifierFields()
equal to the struct and proves each name is one the reader understands. And the
descriptor parity test that already compared cost tables now compares match
rules, so the offline fake every dev stack and the whole test lane runs against
cannot accept subjects production rejects.

Verified against a running stack: a contact with a name and an email is skipped
no_identifiers by both the create-time lane and the button, the connection stays
`connected` where it used to flip to provider_error, no credit is held, and the
same contact runs the moment an employer is linked.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

---

Found while diagnosing a live report: every lookup on the running stack reported "The last call to the provider failed. Automatic lookups are paused", including on contacts that had never been looked up. 214 of 1045 enriched contacts on that installation carried neither a profile link nor an employer, and each one re-broke the connection on the next sweep tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Contacts with no profile link and no company are now skipped as `no_identifiers` before any credit is reserved, instead of being sent to the provider and rejected with a 400 that the platform read as a provider fault — which marked the whole connection broken and made every other lookup report failure. The connection stays `connected`, the page shows a new `nothing_to_look_up` state telling readers to add a LinkedIn URL or company, and a declined contact is retried as soon as the record changes rather than after the day-long cooldown.

**Bug Fixes**
- Both the queue-time and submit-time lanes re-check the identifiers, so a record edited, merged, or anonymized while its run sits queued is declined at the door.
- The sweep predicate and backlog count now share one spelling, fixing a drift where the card read zero over contacts nobody had looked up.
- Rate-limit and budget refusals keep the full cooldown; the shorter retry applies only to missing identifiers.

**Migration**
- Adapters declare `MatchRules` beside their `Identifiers` prose; empty means everything is sent.
- The registry refuses a match rule naming a field a person does not carry, so typos fail at registration instead of silently matching nobody.
- The descriptor parity test now compares match rules so the offline fake cannot accept subjects production rejects.

<sup>Written for commit bc919094253c5430dccb2dafcd8deac008066cb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying contacts that lack the information required for lookup.
  * Contacts can now be matched using LinkedIn profiles, names with company details, or company domains.
  * Added localized guidance explaining how to provide the information needed for enrichment.

* **Bug Fixes**
  * Contacts missing lookup information are no longer submitted unnecessarily or charged against usage limits.
  * Corrected retry behavior so contacts can be reprocessed promptly after their details are updated.
  * Improved provider matching validation for more reliable enrichment results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->