### PR TITLE
The demo stack can show the network it is built around

### DIFF
--- a/backend/internal/compose/loggedparticipants_integration_test.go
+++ b/backend/internal/compose/loggedparticipants_integration_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose_test
+
+// Who a hand-logged conversation says was in it.
+//
+// A LINK IS NOT A CONVERSATION. The links say which records a message is
+// about; the participants say two people spoke, and everything network-shaped
+// — the interaction and contact edges, the person graph's arms, who-knows, the
+// decay lane — derives from the second. The capture path's stamping has its own
+// suite (participants_integration_test.go); this is the hand-logged half, which
+// is the one every seeded and manually recorded conversation rides.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+type loggedParty struct {
+	role   string
+	user   *ids.UUID
+	person *ids.UUID
+}
+
+// partiesOn reads the participant rows one activity carries, in a stable order.
+func partiesOn(t *testing.T, e *integration.Env, activity ids.UUID) []loggedParty {
+	t.Helper()
+	var out []loggedParty
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(context.Background(), `
+			SELECT role, user_id, person_id FROM activity_participant
+			 WHERE activity_id = $1
+			 ORDER BY role, coalesce(user_id, person_id)`, activity)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var party loggedParty
+			if err := rows.Scan(&party.role, &party.user, &party.person); err != nil {
+				return err
+			}
+			out = append(out, party)
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatalf("reading the parties: %v", err)
+	}
+	return out
+}
+
+// logMail records one hand-logged email against the named people, as the API
+// does: the request shape is the contract's, mapped through the same
+// LogActivityInputFrom every transport uses.
+func logMail(ctx context.Context, t *testing.T, e *integration.Env, kind crmcontracts.CreateActivityRequestKind,
+	direction crmcontracts.CreateActivityRequestDirection, people ...ids.UUID,
+) ids.UUID {
+	t.Helper()
+	subject := "Renewal terms"
+	// Named once, used twice. The contract generates this as an ANONYMOUS struct,
+	// so a caller must spell its shape out — and spelling it out at both the
+	// make and the append is two copies of a shape the generator owns, which
+	// drift apart the day a field is added to it.
+	type mailLink = struct {
+		EntityId   openapi_types.UUID                                `json:"entity_id"` //nolint:staticcheck // mirrors the generated inline struct, whose field is spelled EntityId
+		EntityType crmcontracts.CreateActivityRequestLinksEntityType `json:"entity_type"`
+	}
+	links := make([]mailLink, 0, len(people))
+	for _, person := range people {
+		links = append(links, mailLink{
+			EntityId:   openapi_types.UUID(person),
+			EntityType: crmcontracts.CreateActivityRequestLinksEntityTypePerson,
+		})
+	}
+	in, err := activities.LogActivityInputFrom(crmcontracts.CreateActivityRequest{
+		Kind: kind, Subject: &subject, Direction: &direction, Links: &links, Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	act, _, err := activities.NewStore(e.DB()).LogActivity(ctx, in)
+	if err != nil {
+		t.Fatalf("logging the %s: %v", kind, err)
+	}
+	return ids.UUID(act.Id)
+}
+
+func loggingRep(e *integration.Env) context.Context {
+	return e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"activity": {Create: true, Read: true},
+			"person":   {Read: true},
+		},
+		RowScope: principal.RowScopeAll,
+	})
+}
+
+// EVERY person on the message, not the first. A thread with two contacts on it
+// is where the contact-to-contact edge and the person graph's peer arm come
+// from, and a stamping that took one counterparty would draw neither while
+// every other surface still looked right.
+func TestAHandLoggedMailNamesTheRepAndEveryContactOnIt(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := loggingRep(e)
+	alice := e.SeedPerson(t, "Alice Müller", &e.Rep1)
+	bob := e.SeedPerson(t, "Bob Schmidt", &e.Rep1)
+
+	activity := logMail(ctx, t, e, crmcontracts.CreateActivityRequestKindEmail,
+		crmcontracts.CreateActivityRequestDirectionOutbound, alice, bob)
+
+	parties := partiesOn(t, e, activity)
+	if len(parties) != 3 {
+		t.Fatalf("a mail to two contacts carries %d parties, want 3 (the rep and both of them): %+v",
+			len(parties), parties)
+	}
+	// BOTH, BY NAME. Counting two person rows would pass a stamping that wrote
+	// one contact twice, or one of them and somebody else — and the pair is the
+	// whole reason a thread carries two people.
+	var ours int
+	named := map[ids.UUID]string{}
+	for _, party := range parties {
+		switch {
+		case party.user != nil && *party.user == e.Rep1 && party.role == "from":
+			ours++
+		case party.person != nil:
+			named[*party.person] = party.role
+		}
+	}
+	if ours != 1 {
+		t.Errorf("the rep who logged the mail is not on it as its sender: %+v", parties)
+	}
+	for who, name := range map[ids.UUID]string{alice: "Alice", bob: "Bob"} {
+		role, on := named[who]
+		if !on {
+			t.Errorf("%s is linked to the mail and not on it: %+v", name, parties)
+			continue
+		}
+		if role != "to" {
+			t.Errorf("%s holds role %q on an outbound mail, want to", name, role)
+		}
+	}
+}
+
+// The roles MIRROR the direction, because the fold reads them: our side sends
+// on outbound and receives on inbound, and a stamping that always wrote "from"
+// for the rep would make every conversation look one-directional — which is
+// what the strength score's reciprocity term is computed from.
+func TestAnInboundMailPutsTheContactOnItAsTheSender(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := loggingRep(e)
+	alice := e.SeedPerson(t, "Alice Müller", &e.Rep1)
+
+	activity := logMail(ctx, t, e, crmcontracts.CreateActivityRequestKindEmail,
+		crmcontracts.CreateActivityRequestDirectionInbound, alice)
+
+	// COUNTED, not merely walked. A loop over the rows accepts an empty result,
+	// so a stamping that wrote nothing at all would pass a check about roles
+	// without ever comparing one.
+	parties := partiesOn(t, e, activity)
+	if len(parties) != 2 {
+		t.Fatalf("an inbound mail from one contact carries %d parties, want 2 (them and the rep): %+v",
+			len(parties), parties)
+	}
+	var contact, rep *loggedParty
+	for i := range parties {
+		switch {
+		case parties[i].person != nil && *parties[i].person == alice:
+			contact = &parties[i]
+		case parties[i].user != nil && *parties[i].user == e.Rep1:
+			rep = &parties[i]
+		}
+	}
+	if contact == nil || rep == nil {
+		t.Fatalf("the mail names %+v, want the contact it came from and the rep who logged it", parties)
+	}
+	if contact.role != "from" {
+		t.Errorf("the contact on an INBOUND mail holds role %q, want from — the fold reads the roles, "+
+			"and a conversation stamped one-directional scores as one", contact.role)
+	}
+	if rep.role != "to" {
+		t.Errorf("the rep on an INBOUND mail holds role %q, want to", rep.role)
+	}
+}
+
+// A NOTE IS NOT A CONVERSATION. It is a record of somebody thinking, and
+// counting it would let a rep's own notebook score as a relationship — which
+// is why the interaction kinds are a closed set rather than "anything linked".
+func TestANoteAboutSomebodyNamesNobodyAsHavingSpoken(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := loggingRep(e)
+	alice := e.SeedPerson(t, "Alice Müller", &e.Rep1)
+
+	activity := logMail(ctx, t, e, crmcontracts.CreateActivityRequestKindNote,
+		crmcontracts.CreateActivityRequestDirectionOutbound, alice)
+
+	if parties := partiesOn(t, e, activity); len(parties) != 0 {
+		t.Errorf("a note carries %d participant rows, want none: %+v", len(parties), parties)
+	}
+}

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -235,19 +235,73 @@ iso_in_days() { # iso_in_days <days>
 
 # One activity, created only if a row with that subject is not already there.
 #
-# `ensure` leans on the endpoint answering 409 for a duplicate, and /activities
-# has no natural key to answer it with: a rep may genuinely log the same call
-# twice. So the seed asks first. Without this, every `make seed-dev` adds
-# another copy and the demo Worklist grows a row per run.
-ensure_activity() { # ensure_activity <label> <subject> <json-body>
-  local label="$1" subject="$2" data="$3" status
-  status="$(api GET "/activities?q=$(url_encode "$subject")&limit=50")"
-  [ "$status" = "200" ] || fail "GET /v1/activities returned HTTP $status while checking for $label"
-  if jq -e --arg s "$subject" '.data[]? | select(.subject == $s)' "$workdir/body" >/dev/null; then
+# `ensure_keyed` leans on the endpoint reporting a duplicate rather than writing
+# one — 409 where it refuses the second write, 200 where it answers with the row
+# that stands — and /activities does so only for a row carrying a natural key — a rep may genuinely log the
+# same call twice, so an activity without one is never a duplicate. The seeded
+# conversations supply one (ensure_conversation), which is what makes two
+# overlapping seed runs land one row; everything else here asks first. Without
+# either, every `make seed-dev` adds another copy and the demo Worklist grows a
+# row per run.
+ensure_activity() { # ensure_activity <label> <subject> <source-id> <json-body>
+  local label="$1" subject="$2" key="$3" data="$4" query mine theirs
+  query="/activities?q=$(url_encode "$subject")"
+  # THE SEED'S OWN ROW, matched on the NATURAL KEY rather than on the subject.
+  #
+  # Skipping the POST skips everything the POST does, and the links are the half
+  # that matters: the server stamps participants from them at creation, so a row
+  # this seeder did not write has none, and every network surface built on them
+  # renders empty against a demo stack that reported success. A hand-logged
+  # "Quarterly review with Demo GmbH" is all it takes to hold the subject.
+  #
+  # The KEY is what says the row is this seeder's — the subject is a title
+  # anybody may reuse, and `source: "seed"` is a claim about who wrote a row
+  # rather than about which row it is.
+  #
+  # THROUGH find_first, which follows the pages. A single-page probe answers
+  # from the first hundred rows that match the subject, and an installation
+  # carrying the demo dataset plus a real inbox can hold more — so the seeder
+  # would miss both its own row and somebody else's, and write a second one.
+  mine="$(find_first "$query" '.source_system == "seed" and .source_id == $k' --arg k "$key")"
+  if [ -n "$mine" ]; then
     echo "  OK: $label already present"
     return
   fi
-  ensure "$label" /activities "$data"
+  # A row holding the SUBJECT but not the key is somebody else's — a hand-logged
+  # activity that happens to be titled the same. REFUSED rather than seeded
+  # beside: two activities with one title and nothing to tell them apart is a
+  # demo whose result depends on which row a reader or a verification step
+  # happens to open, and that is worse than a seed that stops and says so.
+  theirs="$(find_first "$query" '.subject == $s' --arg s "$subject")"
+  if [ -n "$theirs" ]; then
+    fail "an activity titled \"$subject\" is already here without the seed key $key — remove or rename it, because seeding beside it would leave two rows nothing can tell apart"
+  fi
+  # KEYED, so the write is idempotent at the database: two seed runs overlapping
+  # both find nothing above and both POST, and the endpoint answers the second
+  # with the row that already stands.
+  ensure_keyed "$label" /activities "$data"
+}
+
+# ensure_keyed is `ensure` for a write carrying a natural key, which one more
+# status means "already there" for.
+#
+# 200 is the endpoint answering idempotently with the row that stands — see
+# LogActivity's `http.StatusOK // idempotent capture replay`. Accepting it in
+# `ensure` itself would be wrong: a 200 from creating a person, an organization
+# or a deal is not a replay, and reading one as "already present" would let a
+# contract regression pass as a seeded fixture nobody wrote.
+ensure_keyed() { # ensure_keyed <label> <path> <json-body>
+  local label="$1" path="$2" data="$3" status
+  status="$(api POST "$path" "$data")"
+  case "$status" in
+    201) echo "  OK: created $label" ;;
+    200 | 409) echo "  OK: $label already present" ;;
+    *)
+      echo "  response body:" >&2
+      cat "$workdir/body" >&2
+      fail "POST /v1$path ($label) returned HTTP $status"
+      ;;
+  esac
 }
 
 ensure() { # ensure <label> <path> <json-body>
@@ -467,8 +521,15 @@ alice_id="$(person_id "Alice Müller" "alice@demo.test")"
 # A task the admin wrote themselves and did not assign. It lands on their own
 # queue because the writer stamps the author as assignee — which is the whole
 # reason "mine" can be exact.
-ensure_activity "task: call Alice back" "Call Alice back about the retrofit" "$(jq -n --arg p "$alice_id" --arg due "$(iso_in_days 0)" \
+#
+# KEYED, like the conversations below. Two seed runs overlapping — a colleague's,
+# a second terminal — both find nothing and both POST, and the demo Worklist then
+# opens on two of every task. The key is what lets /activities answer 409 for the
+# second rather than write a duplicate; the read above it is what keeps a seeder
+# from skipping the links when somebody else's row holds the subject.
+ensure_activity "task: call Alice back" "Call Alice back about the retrofit" "task:call-alice-back" "$(jq -n --arg p "$alice_id" --arg due "$(iso_in_days 0)" \
   '{kind:"task",subject:"Call Alice back about the retrofit",source:"seed",due_at:$due,
+    source_system:"seed",source_id:"task:call-alice-back",
     links:[{entity_type:"person",entity_id:$p}]}')"
 
 # The unanswered inbound that makes a customer WAIT is seeded in seed-dev.sql
@@ -484,9 +545,72 @@ ensure_activity "task: call Alice back" "Call Alice back about the retrofit" "$(
 # by automations running as the system principal, which no seed can impersonate
 # through a public endpoint — and should not, since impersonating one is exactly
 # what captured_by exists to prevent.
-ensure_activity "task: follow up with the lead" "Follow up with the new lead" "$(jq -n --arg p "$alice_id" --arg due "$(iso_in_days 1)" \
+ensure_activity "task: follow up with the lead" "Follow up with the new lead" "task:follow-up-new-lead" "$(jq -n --arg p "$alice_id" --arg due "$(iso_in_days 1)" \
   '{kind:"task",subject:"Follow up with the new lead",source:"seed",due_at:$due,
+    source_system:"seed",source_id:"task:follow-up-new-lead",
     links:[{entity_type:"person",entity_id:$p}]}')"
+
+echo "== seed-dev: demo conversations =="
+# WITHOUT THESE, HALF THE PRODUCT RENDERS ITS EMPTY STATE. The relationship
+# graph, the contact peers, who-knows-this-contact and the decay lane all derive
+# from activity_participant, and nothing else in this seed writes a row of it:
+# links alone do not say two people spoke, and a task or a note is not a
+# conversation. A cold demo stack therefore showed every network surface blank,
+# and reading one meant hand-seeding participant rows first.
+#
+# Logged through the API like everything else here, and that is what makes it
+# work: the server stamps the participants itself from the person links, for an
+# INTERACTION kind only (email, call, meeting). The seeder states the
+# conversation and the server decides who was in it, which is the same rule the
+# capture path follows.
+#
+# Two person links on a thread, not one: a single counterparty draws the
+# colleague-to-contact edge and leaves contact-to-contact and the peer arm
+# empty, which is half the surface this exists to fill.
+ensure_conversation() { # ensure_conversation <slug> <subject> <kind> <direction|-> <days-back> <person-id>…
+  local slug="$1" subject="$2" kind="$3" direction="$4" back="$5"
+  shift 5
+  local links direction_field='{}'
+  links="$(printf '%s\n' "$@" | jq -R '{entity_type:"person",entity_id:.}' | jq -s '.')"
+  # NOBODY SENDS A MEETING. `-` leaves the field off rather than asserting a
+  # direction the event does not have; the server then stamps the roles it
+  # stamps for an undirected interaction, which is what a meeting is.
+  if [ "$direction" != "-" ]; then
+    direction_field="$(jq -n --arg d "$direction" '{direction:$d}')"
+  fi
+  # A NATURAL KEY, so the write is idempotent at the database rather than only
+  # at the read above it. Two seed runs overlapping — a colleague's, a second
+  # terminal — both find nothing and both POST, and without a key the demo stack
+  # ends up with two of every conversation.
+  #
+  # THE SLUG, not the subject. A subject is display copy somebody may reword,
+  # and a reworded one with a fresh key is a second conversation — the duplicate
+  # this key exists to prevent, arriving through the door it was meant to close.
+  ensure_activity "$kind \"$subject\"" "$subject" "$slug" \
+    "$(jq -n --arg s "$subject" --arg k "$kind" --arg at "$(iso_in_days "-$back")" \
+        --arg key "$slug" --argjson l "$links" --argjson dir "$direction_field" \
+        '{kind:$k,subject:$s,occurred_at:$at,source:"seed",
+          source_system:"seed",source_id:$key,links:$l} + $dir')"
+}
+
+bob_id="$(person_id "Bob Schmidt" "bob@demo.test")"
+carol_id="$(person_id "Carol Wagner" "carol@demo.test")"
+[ -n "$bob_id" ] && [ -n "$carol_id" ] \
+  || fail "the demo people this seed just wrote are not readable back — nothing to hang a conversation on"
+
+# Both directions on the same contact, deliberately: the strength score's
+# reciprocity term has nothing to say about a one-way exchange, so a seed that
+# only ever sends draws every edge at the floor and the ranking demonstrates
+# nothing. And they are dated BACK, because a decay lane whose every row arrived
+# this second has nothing decaying in it.
+# ONE contact on the reciprocal pair. Both rows are about Alice — that is what
+# makes them reciprocal — and adding Bob to the outbound one draws a
+# contact-to-contact edge from a conversation that is not about a peer
+# relationship at all. The meeting below is where peers are meant to come from,
+# and a seed that populates that arm twice cannot show either case cleanly.
+ensure_conversation "conversation:renewal-terms-outbound" "Renewal terms for Demo GmbH" email outbound 12 "$alice_id"
+ensure_conversation "conversation:renewal-terms-inbound" "Re: Renewal terms for Demo GmbH" email inbound 9 "$alice_id"
+ensure_conversation "conversation:quarterly-review" "Quarterly review with Demo GmbH" meeting - 40 "$bob_id" "$carol_id"
 
 echo ""
 echo "seed-dev: DONE — log in at $API_BASE with $ADMIN_EMAIL / $ADMIN_PASSWORD"

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -12,9 +12,11 @@
 # Steps:
 #   1. POST /v1/auth/login with the seeded demo admin → 200 + crm_session.
 #   2. GET /v1/people under that session → the three seeded people.
-#   3. Every composed unit's declared channel transport is published by
+#   3. The seeded conversations are readable, and are of a kind the server
+#      stamps participants for — everything network-shaped derives from those.
+#   4. Every composed unit's declared channel transport is published by
 #      GET /v1/channel-providers — the boot step really ran.
-#   4. The frontend production build compiles (pnpm build) — a real
+#   5. The frontend production build compiles (pnpm build) — a real
 #      compile+bundle, not a stale-dist check.
 
 set -euo pipefail
@@ -42,7 +44,7 @@ trap 'rm -rf "$workdir"' EXIT
 # A transport failure (refused, timeout) makes curl print status 000 and
 # exit non-zero; `|| true` keeps set -e from eating the fail() message,
 # and --max-time keeps a stalled API from hanging the proof.
-echo "== verify-boot 1/4: login as the seeded demo admin =="
+echo "== verify-boot 1/5: login as the seeded demo admin =="
 login_status="$(curl -sS --max-time 15 -o "$workdir/login.json" -D "$workdir/headers" -w '%{http_code}' \
   -X POST "$API_BASE/v1/auth/login" \
   -H 'Content-Type: application/json' \
@@ -61,7 +63,7 @@ session="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/
 [ -n "$session" ] || fail "login answered 200 but set no crm_session cookie"
 echo "  OK: logged in as $ADMIN_EMAIL, session captured"
 
-echo "== verify-boot 2/4: seeded people are visible =="
+echo "== verify-boot 2/5: seeded people are visible =="
 # The rule the product reads an employment by, spelled the same way
 # scripts/seed-dev.sh writes it: primary, and not ended. `ended_at` is a date and
 # ISO dates compare as strings, so a future end is still current — the reading
@@ -194,7 +196,74 @@ while IFS= read -r body; do
   echo "  OK: '$org_name' stands at '$lifecycle'"
 done <<< "$seeded_org_bodies"
 
-echo "== verify-boot 3/4: every composed unit's transport is registered =="
+echo "== verify-boot 3/5: the seeded conversations are conversations =="
+# A LINK IS NOT A CONVERSATION. Everything network-shaped — the person graph's
+# direct and account arms, contact peers, who-knows-this-contact, the decay lane
+# — derives from activity_participant, and for a long time nothing in the seed
+# wrote a row of it: the demo stack rendered the empty state on all of them, and
+# reading one meant hand-seeding participant rows first.
+#
+# What the seed can guarantee is the KIND. The server stamps the participants
+# itself, but only for an interaction kind — a task is intent and a note is a
+# record of thinking, and neither means two people spoke — so a seed that logged
+# notes would leave every one of those surfaces exactly as empty as before while
+# every other check here still passed.
+#
+# The kind is read BACK from the api rather than off the seeder's own literal:
+# what matters is what the server accepted and stored, not what the script
+# intended to send.
+#
+# The edges themselves are deliberately not asserted here. Folding them is a
+# WORKER's job, consuming activity.captured, and this lane boots the api alone —
+# a check for them could only ever fail. TestAHandLoggedMailNamesTheRepAndEvery
+# ContactOnIt holds the step between the two, where a worker is not needed.
+#
+# The SLUGS are read from the seeder — its first argument, the stable key each
+# conversation is written under — so a conversation added there is checked here
+# without an edit, and a read that finds none says so instead of passing.
+#
+# The slug rather than the subject, and the difference is the point: a subject is
+# display copy anybody may reword or reuse, and the seeder's own row is the one
+# carrying this key. Leading whitespace allowed: a call indented into a loop or a
+# conditional is still a seeded conversation, and a census anchored on column one
+# would stop seeing it without saying so.
+seeded_conversations="$(awk -F'"' '/^[[:space:]]*ensure_conversation[[:space:]]+"/ { print $2 "\t" $4 }' \
+    "$REPO_DIR/scripts/seed-dev.sh")"
+[ -n "$seeded_conversations" ] \
+  || fail "found no 'ensure_conversation \"…\"' calls in scripts/seed-dev.sh — this step would pass by reading nothing"
+
+# The closed set the server stamps participants for, spelled once here and once
+# in relstrength.interactionKinds because neither can call the other.
+while IFS="$(printf '\t')" read -r slug subject; do
+  [ -n "$slug" ] || continue
+  # NARROWED BY THE SUBJECT, SELECTED BY THE KEY, and the two halves are doing
+  # different jobs.
+  #
+  # `q` is a full-text search over subject and body — it does not see
+  # source_id — so the narrowing has to be something the server can search for.
+  # A page-by-page walk of every activity on an installation carrying the demo
+  # dataset is thousands of requests to answer a question the server can answer
+  # in one, which is why there is a narrowing at all.
+  #
+  # The SELECTION is the natural key, because the title alone is satisfied by
+  # any activity carrying it — a hand-logged "Quarterly review with Demo GmbH"
+  # would do — and such a row was created with no links, so the server stamped
+  # no participants for it. Read by title alone, this check and the seeder's own
+  # skip would agree on a demo stack whose network surfaces are empty.
+  logged="$(find_first "/activities?q=$(jq -rn --arg v "$subject" '$v|@uri')" \
+      '.source_system == "seed" and .source_id == $k' --arg k "$slug")"
+  [ -n "$logged" ] \
+    || fail "no activity titled '$subject' carries the seed key '$slug' in GET /v1/activities — the seed is absent or stale (make seed-dev), or something else is holding that title and the seeder seeded beside it"
+  kind="$(printf '%s' "$logged" | jq -r '.kind')"
+  case "$kind" in
+    email|call|meeting) echo "  OK: '$subject' is a seeded $kind" ;;
+    *)
+      fail "seeded conversation '$subject' is a '$kind', which the server stamps no participants for — the demo stack's relationship graph, contact peers, who-knows and decay lane all render empty"
+      ;;
+  esac
+done <<<"$seeded_conversations"
+
+echo "== verify-boot 4/5: every composed unit's transport is registered =="
 # The boot proof for the channel registry, and it belongs HERE rather than in a
 # Go test: registering the vocabulary is a BOOT STEP the api runs, so the only
 # thing that can prove the api runs it is an api that booted. This lane boots
@@ -227,7 +296,7 @@ else
   done <<<"$expected_transports"
 fi
 
-echo "== verify-boot 4/4: frontend production build =="
+echo "== verify-boot 5/5: frontend production build =="
 # --ignore-scripts: no lifecycle scripts run at install; esbuild ships
 # prebuilt platform binaries as optional deps, so the build works without
 # its validating postinstall.


### PR DESCRIPTION
Closes #3142.

Every network-shaped surface — the person graph's `direct` and `account` arms,
contact peers, who-knows-this-contact, the decay lane — derives from
`activity_participant`, and nothing in the dev seed wrote a row of it. A link is
not a conversation: the seed said which records an activity was *about* and
never that two people *spoke*, so a cold demo stack rendered the empty state on
all of them, and reading one meant hand-seeding participant rows and touching
the activities over the API to trigger the refold.

Three conversations now, logged through the API like everything else in
`seed-dev.sh`. That is what makes it work rather than a fixture: the server
stamps the participants itself from the person links, for an interaction kind
only, so the seed states the conversation and the product decides who was in it
— the same rule capture follows.

Two of the choices are load-bearing:

- **Two person links on a thread.** One draws the colleague↔contact edge and
  leaves contact↔contact and the peer arm as empty as before.
- **Both directions on one contact.** The strength score's reciprocity term has
  nothing to say about a one-way exchange, so a seed that only ever sends draws
  every edge at the floor and demonstrates no ranking at all.

`days_ago` spells the dates on GNU **and** BSD `date`, because a stack seeded
entirely at `now` shows a decay lane with nothing decaying in it.

## Proof

The step between the seed and the edges had no test at all — the capture path's
stamping suite never covered the hand-logged half — so it has one now:
a hand-logged mail names the rep **and every contact on it**, with the roles its
direction implies, and a note names nobody. That is the invariant this seed
rides.

`verify-boot` asks what the seed can guarantee at boot: the **kind** the server
accepted, read back from the api. A seed that logged notes would stamp no
participants and leave every surface exactly as empty as before, while every
other check there still passed. The subjects are read out of the seeder, so a
fourth conversation is checked without an edit, and a read that finds none fails
instead of passing.

It deliberately does **not** assert the edges themselves. Folding them is a
worker's job, consuming `activity.captured`, and the live-boot lane starts the
api alone — a check for them could only ever fail. (The first push of this
branch did assert them, and that is exactly how it failed.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development environments now include sample conversations with historical emails and meetings.
  * Sample conversation data can be safely recreated without duplicates.

* **Bug Fixes**
  * Email interactions correctly identify participants and sender/recipient roles.
  * Notes no longer create conversation participants.

* **Tests**
  * Boot verification now checks seeded conversations and supported interaction types.
  * Added coverage for participant handling across manually logged activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->