### PR TITLE
The page says how much of the day it is not showing

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -33436,7 +33436,7 @@ components:
         does, widened: a source the caller may not read is named as `withheld`, and one
         that failed to answer is named as `failed`. Both keep the summary from claiming a
         clear day it did not actually see.
-      required: [as_of, queue, summary, sources_unavailable, scope, scope_options, reach]
+      required: [as_of, queue, summary, sources_unavailable, scope, scope_options, reach, counts]
       properties:
         as_of: { type: string, format: date-time, description: 'The instant every source below was read at.' }
         scope:
@@ -33467,6 +33467,14 @@ components:
             How much of each source the queue actually looked at. A source is read up to a
             work bound, so a page can be a page rather than everything there is, and this
             is where the queue says which. Empty only when no source was read at all.
+        counts:
+          type: array
+          items: { $ref: '#/components/schemas/WorklistCount' }
+          description: |
+            The same accounting per KIND of work rather than per producer — what a filter
+            pill counts, and what lets the page say how much it is not showing. Counted
+            before any narrowing, so a filtered page still reports the categories it is
+            not drawing.
 
     WorklistReach:
       type: object
@@ -33503,6 +33511,49 @@ components:
             page that stopped one short of more, and it says the cautious thing rather than
             claiming a source is complete when it is not. The client renders `considered` as
             "200+" rather than "200".
+
+    WorklistCount:
+      type: object
+      description: |
+        What one CATEGORY of work held, and how much of it reached the page.
+
+        The same three figures `WorklistReach` reports per source, asked of the thing a
+        reader actually filters by. A client cannot derive one from the other: which
+        source belongs to which category is decided here, and summing `reach` in the
+        browser would be a second copy of that map, wrong the first time a source moves
+        lane.
+
+        This is what a filter pill draws its number from, and what lets the page say how
+        much it is not showing. Without it the queue was a cut at 25 rows that said
+        nothing about the rest, so a full first page made a real backlog look like zero.
+
+        `considered` counts what this read weighed BEFORE any category narrowing, which
+        is why a page filtered to meetings can still say how many tasks there were. It is
+        not a total when `more_available` is true.
+
+        `shown` counts what the page carries, with a folded group counted as the items it
+        stands for rather than as the single row that stands for them.
+      required: [category, considered, shown, more_available]
+      properties:
+        category:
+          type: string
+          enum: [customer_waiting, deals_at_risk, meetings, tasks, decisions, system]
+          description: 'Which kind of work these numbers are about. The same vocabulary the filter uses.'
+        considered:
+          type: integer
+          minimum: 0
+          description: 'How many items of this kind were read and ranked, before any narrowing.'
+        shown:
+          type: integer
+          minimum: 0
+          description: 'How many of them the page carries, counting a folded group as its members.'
+        more_available:
+          type: boolean
+          description: |
+            True when any source behind this category was read to its work bound, so items
+            MAY exist past what was considered. A category inherits its sources' honesty:
+            reporting "12 decisions" over a pile the read never finished counting is the
+            failure this flag exists to prevent.
 
     WorklistSummary:
       type: object

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -36,6 +36,11 @@ const sourceWaiting = "customer_waiting"
 // out of the queue it was asked for.
 const sourceTask = "task"
 
+// sourceAtRisk names the quiet-deal producer. Three readers spell it — the
+// bounds table, the category map and the classifier — which is two more than a
+// literal survives.
+const sourceAtRisk = "deal_at_risk"
+
 // subjectDeal is the subject type a deal-shaped row names.
 const subjectDeal = "deal"
 

--- a/backend/internal/compose/attention/counts_test.go
+++ b/backend/internal/compose/attention/counts_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // countFor finds one category's figures, failing loudly rather than returning a
@@ -155,5 +156,99 @@ func TestCountsAreOrderedTheSameWayTwice(t *testing.T) {
 		if first.Counts[i].Category != second.Counts[i].Category {
 			t.Fatalf("position %d was %q then %q", i, first.Counts[i].Category, second.Counts[i].Category)
 		}
+	}
+}
+
+// The source-to-category map agrees with the classifiers.
+//
+// The classifiers decide a row's category; countsOf needs the same answer for a
+// bounded source that produced no surviving row. Two spellings of one fact, so
+// this feeds a row from each source through the real classification and
+// requires categoryOfSource to have said the same thing. A source that changes
+// lane fails here rather than reporting its truncation against the wrong cut.
+func TestTheSourceMapAgreesWithTheClassifiers(t *testing.T) {
+	lanes := []struct {
+		source crmcontracts.AttentionItemSource
+		day    crmcontracts.Attention
+	}{
+		{"task", crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			item("x", "task", withDue(rankInstant)),
+		}}},
+		{"deal_at_risk", crmcontracts.Attention{AsOf: rankInstant, AtRisk: lane(
+			item("x", "deal_at_risk", withDeal(1000)),
+		)}},
+		{"meeting", crmcontracts.Attention{AsOf: rankInstant, Meetings: lane(
+			item("x", "meeting", withDue(rankInstant)),
+		)}},
+		{"approval", crmcontracts.Attention{AsOf: rankInstant, NeedsYou: []crmcontracts.AttentionItem{
+			item("x", "approval", withKind("send_email")),
+		}}},
+		{"notice", crmcontracts.Attention{AsOf: rankInstant, Notices: lane(item("x", "notice"))}},
+		{"bounce", crmcontracts.Attention{AsOf: rankInstant, Bounces: lane(item("x", "bounce"))}},
+		{"relationship_decay", crmcontracts.Attention{AsOf: rankInstant, RelationshipDecay: lane(
+			item("x", "relationship_decay"),
+		)}},
+		{"conversation_claim", crmcontracts.Attention{AsOf: rankInstant, Commitments: lane(
+			item("x", "conversation_claim", withDue(rankInstant)),
+		)}},
+		{"dsr", crmcontracts.Attention{AsOf: rankInstant, Dsr: lane(item("x", "dsr", withDue(rankInstant)))}},
+		{"failed_approval", crmcontracts.Attention{AsOf: rankInstant, DidNotRun: lane(
+			item("x", "failed_approval"),
+		)}},
+		{"automation_run", crmcontracts.Attention{AsOf: rankInstant, AutomationHealth: lane(
+			item("x", "automation_run"),
+		)}},
+	}
+
+	for _, l := range lanes {
+		rows := classifyDay(l.day, rankInstant)
+		if len(rows) != 1 {
+			t.Fatalf("%s: the lane classified %d rows, and the fixture holds one", l.source, len(rows))
+		}
+		classified := rows[0].item.Category
+		mapped := categoryOfSource(crmcontracts.WorklistItemSource(l.source))
+		if classified != mapped {
+			t.Fatalf("%s: the classifier files it under %q and the map says %q — a truncation of this source would be reported against the wrong cut",
+				l.source, classified, mapped)
+		}
+	}
+}
+
+// A waiting customer, whose classifier takes a different argument shape.
+func TestTheSourceMapAgreesForAWaitingCustomer(t *testing.T) {
+	row := classifyWaiting(WaitingCustomer{Since: rankInstant}, rankInstant)
+
+	if got := categoryOfSource(sourceWaiting); row.item.Category != got {
+		t.Fatalf("the classifier files a wait under %q and the map says %q", row.item.Category, got)
+	}
+}
+
+// A bounded source whose every row was filtered out still says the read did
+// not finish.
+//
+// The scope filter runs before this snapshot, so a lane can come back full of a
+// colleague's work and leave nothing behind. Counted from rows alone the
+// category vanishes entirely and the page reports nothing was there — which is
+// the false-empty this accounting exists to prevent, reintroduced by the
+// accounting itself.
+func TestABoundedSourceFilteredToNothingStillSaysThereMayBeMore(t *testing.T) {
+	deals := []crmcontracts.AttentionItem{}
+	for i := 0; i < quietDealBound; i++ {
+		row := item("d"+string(rune('a'+i%26)), "deal_at_risk", withDeal(1000))
+		row.Deal.OwnerId = uuidPtr(ids.MustParse("01a05500-0000-7000-8000-0000000000ee"))
+		deals = append(deals, row)
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: &deals}
+
+	// Unassigned drops every row that has an owner, so the lane read fifty and
+	// kept none.
+	out := (&Service{}).worklistFrom(t.Context(), day, scopeUnassigned, "", 25, nil)
+
+	count := countFor(t, out, "deals_at_risk")
+	if count.Considered != 0 {
+		t.Fatalf("considered = %d, and every row was filtered out", count.Considered)
+	}
+	if !count.MoreAvailable {
+		t.Fatal("a lane read to its bound reported a finished read, so the page would say nothing was there")
 	}
 }

--- a/backend/internal/compose/attention/counts_test.go
+++ b/backend/internal/compose/attention/counts_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// What the page says about the work it is NOT showing.
+//
+// The queue is a cut at 25 rows, and before these figures existed it said
+// nothing about the rest — so a full first page made a real backlog read as
+// zero, and a rep narrowing to one kind of work found rows they had no way to
+// know were there.
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// countFor finds one category's figures, failing loudly rather than returning a
+// zero value: an absent category and a category with nothing in it are
+// different answers, and a helper that conflated them would let a test pass on
+// the first while claiming the second.
+func countFor(t *testing.T, out crmcontracts.Worklist, category string) crmcontracts.WorklistCount {
+	t.Helper()
+	for _, count := range out.Counts {
+		if string(count.Category) == category {
+			return count
+		}
+	}
+	t.Fatalf("the page reported no figures at all for %q", category)
+	return crmcontracts.WorklistCount{}
+}
+
+// The page states how much of each kind of work it holds and how much it is
+// showing. Without this the reader cannot tell a finished queue from a cut one.
+func TestThePageCountsEachKindOfWork(t *testing.T) {
+	tasks := []crmcontracts.AttentionItem{}
+	for i := 0; i < 4; i++ {
+		tasks = append(tasks, item("t"+string(rune('a'+i)), "task", withDue(rankInstant)))
+	}
+	day := crmcontracts.Attention{
+		AsOf:    rankInstant,
+		Planned: tasks,
+		AtRisk:  lane(item("deal", "deal_at_risk", withDeal(50_000_00))),
+	}
+
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, nil)
+
+	if count := countFor(t, got, "tasks"); count.Considered != 4 || count.Shown != 4 {
+		t.Fatalf("tasks: considered %d shown %d, wanted four of each", count.Considered, count.Shown)
+	}
+	if count := countFor(t, got, "deals_at_risk"); count.Considered != 1 {
+		t.Fatalf("deals_at_risk considered %d, wanted the one deal", count.Considered)
+	}
+}
+
+// Work that did not fit the page is COUNTED, which is the whole point: the cut
+// is what the reader could not see, and a page that reported only what it drew
+// would call a backlog empty.
+func TestWorkBelowTheCutIsStillCounted(t *testing.T) {
+	tasks := []crmcontracts.AttentionItem{}
+	for i := 0; i < 9; i++ {
+		tasks = append(tasks, item("t"+string(rune('a'+i)), "task", withDue(rankInstant)))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, Planned: tasks}
+
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 3, nil)
+
+	count := countFor(t, got, "tasks")
+	if count.Shown != 3 {
+		t.Fatalf("shown = %d, and the page carries three", count.Shown)
+	}
+	if count.Considered != 9 {
+		t.Fatalf("considered = %d, and nine were read — the six past the cut are what this figure exists to report",
+			count.Considered)
+	}
+}
+
+// A narrowed page still says what the OTHER kinds held. Counting after the
+// narrowing would answer "no tasks" on a page filtered to deals, when the
+// honest answer is "tasks, not shown".
+func TestANarrowedPageStillCountsTheKindsItIsNotDrawing(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:    rankInstant,
+		Planned: []crmcontracts.AttentionItem{item("task", "task", withDue(rankInstant))},
+		AtRisk:  lane(item("deal", "deal_at_risk", withDeal(50_000_00))),
+	}
+
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "deals_at_risk", 25, nil)
+
+	tasks := countFor(t, got, "tasks")
+	if tasks.Considered != 1 {
+		t.Fatalf("a page filtered to deals reported %d tasks considered, and there was one",
+			tasks.Considered)
+	}
+	if tasks.Shown != 0 {
+		t.Fatalf("a page filtered to deals reported %d tasks shown", tasks.Shown)
+	}
+}
+
+// A folded group is one row standing for many, and the count says how many. A
+// group counted as a single row would report a category as barely present on
+// the page where it is the dominant thing.
+func TestAFoldedGroupCountsTheItemsItStandsFor(t *testing.T) {
+	failures := []crmcontracts.AttentionItem{}
+	for i := 0; i < 6; i++ {
+		row := item("f"+string(rune('a'+i)), "automation_run")
+		cause := "automation_run:one-rule"
+		row.CauseRef = &cause
+		failures = append(failures, row)
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, AutomationHealth: &failures}
+
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 50, nil)
+
+	count := countFor(t, got, "system")
+	if count.Shown != 6 {
+		t.Fatalf("shown = %d, and the folded row stands for six", count.Shown)
+	}
+}
+
+// A category inherits its sources' honesty. Reporting a flat number over a pile
+// the read never finished counting is the failure the flag exists to prevent.
+func TestACategoryWhoseSourceHitItsBoundSaysThereMayBeMore(t *testing.T) {
+	decisions := []crmcontracts.AttentionItem{}
+	for i := 0; i < batchScanDepth; i++ {
+		decisions = append(decisions, item("d"+string(rune(i)), "approval", withKind("send_email")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: decisions}
+
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, nil)
+
+	if count := countFor(t, got, "decisions"); !count.MoreAvailable {
+		t.Fatal("a category read to its bound reported a flat count, so a client would draw it as a total")
+	}
+}
+
+// Two reads of one unchanged day produce the same bytes. Map order is not an
+// order, and a client diffing the payload would see a change that is not one.
+func TestCountsAreOrderedTheSameWayTwice(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:     rankInstant,
+		Planned:  []crmcontracts.AttentionItem{item("task", "task", withDue(rankInstant))},
+		AtRisk:   lane(item("deal", "deal_at_risk", withDeal(50_000_00))),
+		NeedsYou: []crmcontracts.AttentionItem{item("decision", "approval", withKind("send_email"))},
+	}
+
+	first := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, nil)
+	second := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, nil)
+
+	if len(first.Counts) != len(second.Counts) {
+		t.Fatalf("two reads counted %d and %d categories", len(first.Counts), len(second.Counts))
+	}
+	for i := range first.Counts {
+		if first.Counts[i].Category != second.Counts[i].Category {
+			t.Fatalf("position %d was %q then %q", i, first.Counts[i].Category, second.Counts[i].Category)
+		}
+	}
+}

--- a/backend/internal/compose/attention/reach.go
+++ b/backend/internal/compose/attention/reach.go
@@ -103,6 +103,20 @@ func countsOf(
 		seen[category] = row
 		return row
 	}
+	// Seeded from the SOURCES first, the way reach is, and not from the rows.
+	//
+	// A bounded source that contributed no surviving row still truncated its
+	// read, and a count built only from rows cannot know that: the scope filter
+	// runs before this snapshot, so a lane can come back full of a colleague's
+	// work and leave nothing behind. Counting rows alone then reports an exact
+	// figure over a category whose read stopped early — which is the one thing
+	// these numbers exist to prevent.
+	for source, bounded := range bounds {
+		if !bounded {
+			continue
+		}
+		at(categoryOfSource(source)).MoreAvailable = true
+	}
 	for _, row := range considered {
 		count := at(row.item.Category)
 		count.Considered++
@@ -118,7 +132,12 @@ func countsOf(
 		// A folded group is ONE row standing for many, and the reader is being
 		// shown all of them at once. Counting the group as a single shown item
 		// would report a category as barely present on a page where it is the
-		// dominant thing — the same attribution reach makes back to sources.
+		// dominant thing.
+		//
+		// Attributed to the BATCH ROW's own category rather than to each
+		// member's, which reach has to do: a group only ever folds rows that
+		// share a category (batchKeyOf gates on it), so the row's category is
+		// its members'.
 		if row.item.Batch != nil && row.item.Batch.Count > 0 {
 			at(row.item.Category).Shown += row.item.Batch.Count
 			continue
@@ -133,4 +152,34 @@ func countsOf(
 	// of one unchanged day have to produce the same bytes.
 	sort.Slice(out, func(i, j int) bool { return out[i].Category < out[j].Category })
 	return out
+}
+
+// categoryOfSource says which cut of the queue a producer's rows land in.
+//
+// The classifiers decide this per row, and this is the only other place that
+// needs it: to seed a category for a bounded source that contributed no
+// surviving row. Two spellings of one fact, and the test beside it feeds every
+// source through a classifier and requires the same answer, so a source that
+// changes lane fails here rather than reporting its truncation against the
+// wrong cut.
+func categoryOfSource(source crmcontracts.WorklistItemSource) crmcontracts.WorklistItemCategory {
+	switch source {
+	case sourceWaiting:
+		return "customer_waiting"
+	case sourceAtRisk, "brief_item":
+		return "deals_at_risk"
+	case "meeting":
+		return "meetings"
+	case sourceTask, "conversation_claim":
+		return "tasks"
+	case "approval", "dedupe_candidate":
+		return "decisions"
+	default:
+		// Everything the product reports about ITSELF — health, notices,
+		// bounces, undelivered mail, failed approvals, privacy deadlines. The
+		// default rather than a list, because a source added tomorrow is far
+		// more likely to be one of those than a new kind of sales work, and
+		// naming it "system" is the answer that under-claims.
+		return "system"
+	}
 }

--- a/backend/internal/compose/attention/reach.go
+++ b/backend/internal/compose/attention/reach.go
@@ -72,3 +72,65 @@ func reachOf(considered, shown []ranked, bounds map[crmcontracts.WorklistItemSou
 	sort.Slice(out, func(i, j int) bool { return out[i].Source < out[j].Source })
 	return out
 }
+
+// countsOf says, per CATEGORY, how much work the day held and how much of it
+// reached the page.
+//
+// reach answers the same question per source, and a client cannot turn one into
+// the other: the source-to-category map lives here, and summing `reach` in the
+// browser would be a second copy of it that drifts the first time a source
+// changes lane. So the server states both.
+//
+// This is the figure the filter pills draw and the completeness line reads. Its
+// absence is the defect it exists for: the page is a cut at 25 rows and said
+// nothing about what did not fit, so a full first page made a real backlog look
+// like zero. A rep narrowing to Decisions found work they had no way to know
+// was there.
+//
+// `considered` is taken BEFORE the category narrowing, which is what lets a
+// filtered page still report the categories it is not showing. Counting after
+// it would answer "no tasks" on a page filtered to meetings, when the honest
+// answer is "tasks, not shown".
+func countsOf(
+	considered, shown []ranked, bounds map[crmcontracts.WorklistItemSource]bool,
+) []crmcontracts.WorklistCount {
+	seen := map[crmcontracts.WorklistItemCategory]*crmcontracts.WorklistCount{}
+	at := func(category crmcontracts.WorklistItemCategory) *crmcontracts.WorklistCount {
+		if row, ok := seen[category]; ok {
+			return row
+		}
+		row := &crmcontracts.WorklistCount{Category: crmcontracts.WorklistCountCategory(category)}
+		seen[category] = row
+		return row
+	}
+	for _, row := range considered {
+		count := at(row.item.Category)
+		count.Considered++
+		// A category inherits its sources' honesty. Where any source behind it
+		// came back at its bound, the category's own figure is a floor too —
+		// otherwise a page would report "12 decisions" over a pile the read
+		// never finished counting.
+		if bounds[row.item.Source] {
+			count.MoreAvailable = true
+		}
+	}
+	for _, row := range shown {
+		// A folded group is ONE row standing for many, and the reader is being
+		// shown all of them at once. Counting the group as a single shown item
+		// would report a category as barely present on a page where it is the
+		// dominant thing — the same attribution reach makes back to sources.
+		if row.item.Batch != nil && row.item.Batch.Count > 0 {
+			at(row.item.Category).Shown += row.item.Batch.Count
+			continue
+		}
+		at(row.item.Category).Shown++
+	}
+	out := make([]crmcontracts.WorklistCount, 0, len(seen))
+	for _, count := range seen {
+		out = append(out, *count)
+	}
+	// Ordered by category for the reason reach is ordered by source: two reads
+	// of one unchanged day have to produce the same bytes.
+	sort.Slice(out, func(i, j int) bool { return out[i].Category < out[j].Category })
+	return out
+}

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -244,6 +244,10 @@ func (s *Service) worklistFrom(
 		// survived folding and the cut. Both are already in hand, so no figure
 		// here costs a query that could disagree with the page it describes.
 		Reach: reachOf(considered, shown, boundedSources(day)),
+		// The same accounting per kind of work. Both read the same two
+		// snapshots, so the per-source and per-category figures are two views of
+		// one answer rather than two answers.
+		Counts: countsOf(considered, shown, boundedSources(day)),
 	}
 	if filter != "" {
 		narrowed := crmcontracts.WorklistFilter(filter)

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -303,7 +303,7 @@ func boundedSources(day crmcontracts.Attention) map[crmcontracts.WorklistItemSou
 	atCap("bounce", day.Bounces, doneCap)
 	// Each of these carries its own, declared where the lane is read.
 	atCap("task", &day.Planned, plannedCap)
-	atCap("deal_at_risk", day.AtRisk, quietDealBound)
+	atCap(sourceAtRisk, day.AtRisk, quietDealBound)
 	atCap("relationship_decay", day.RelationshipDecay, decayBound)
 	atCap("conversation_claim", day.Commitments, doneCap)
 	// The decision lane is read deeper than the rest, because a batch row

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11743,6 +11743,36 @@ func (e WorklistComparisonComparator) Valid() bool {
 	}
 }
 
+// Defines values for WorklistCountCategory.
+const (
+	WorklistCountCategoryCustomerWaiting WorklistCountCategory = "customer_waiting"
+	WorklistCountCategoryDealsAtRisk     WorklistCountCategory = "deals_at_risk"
+	WorklistCountCategoryDecisions       WorklistCountCategory = "decisions"
+	WorklistCountCategoryMeetings        WorklistCountCategory = "meetings"
+	WorklistCountCategorySystem          WorklistCountCategory = "system"
+	WorklistCountCategoryTasks           WorklistCountCategory = "tasks"
+)
+
+// Valid indicates whether the value is a known member of the WorklistCountCategory enum.
+func (e WorklistCountCategory) Valid() bool {
+	switch e {
+	case WorklistCountCategoryCustomerWaiting:
+		return true
+	case WorklistCountCategoryDealsAtRisk:
+		return true
+	case WorklistCountCategoryDecisions:
+		return true
+	case WorklistCountCategoryMeetings:
+		return true
+	case WorklistCountCategorySystem:
+		return true
+	case WorklistCountCategoryTasks:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorklistItemActions.
 const (
 	WorklistItemActionsAcknowledge WorklistItemActions = "acknowledge"
@@ -28554,6 +28584,12 @@ type Worklist struct {
 	// AsOf The instant every source below was read at.
 	AsOf time.Time `json:"as_of"`
 
+	// Counts The same accounting per KIND of work rather than per producer — what a filter
+	// pill counts, and what lets the page say how much it is not showing. Counted
+	// before any narrowing, so a filtered page still reports the categories it is
+	// not drawing.
+	Counts []WorklistCount `json:"counts"`
+
 	// Filter The narrowing this read applied.
 	Filter *WorklistFilter `json:"filter,omitempty"`
 
@@ -28666,6 +28702,44 @@ type WorklistComparison struct {
 
 // WorklistComparisonComparator What decided it. `order` means every comparator tied and the ids broke it, which the client renders as no reason at all.
 type WorklistComparisonComparator string
+
+// WorklistCount What one CATEGORY of work held, and how much of it reached the page.
+//
+// The same three figures `WorklistReach` reports per source, asked of the thing a
+// reader actually filters by. A client cannot derive one from the other: which
+// source belongs to which category is decided here, and summing `reach` in the
+// browser would be a second copy of that map, wrong the first time a source moves
+// lane.
+//
+// This is what a filter pill draws its number from, and what lets the page say how
+// much it is not showing. Without it the queue was a cut at 25 rows that said
+// nothing about the rest, so a full first page made a real backlog look like zero.
+//
+// `considered` counts what this read weighed BEFORE any category narrowing, which
+// is why a page filtered to meetings can still say how many tasks there were. It is
+// not a total when `more_available` is true.
+//
+// `shown` counts what the page carries, with a folded group counted as the items it
+// stands for rather than as the single row that stands for them.
+type WorklistCount struct {
+	// Category Which kind of work these numbers are about. The same vocabulary the filter uses.
+	Category WorklistCountCategory `json:"category"`
+
+	// Considered How many items of this kind were read and ranked, before any narrowing.
+	Considered int `json:"considered"`
+
+	// MoreAvailable True when any source behind this category was read to its work bound, so items
+	// MAY exist past what was considered. A category inherits its sources' honesty:
+	// reporting "12 decisions" over a pile the read never finished counting is the
+	// failure this flag exists to prevent.
+	MoreAvailable bool `json:"more_available"`
+
+	// Shown How many of them the page carries, counting a folded group as its members.
+	Shown int `json:"shown"`
+}
+
+// WorklistCountCategory Which kind of work these numbers are about. The same vocabulary the filter uses.
+type WorklistCountCategory string
 
 // WorklistDealFacts The deal behind an item, with the facts its card states. `expected_minor_base` is
 // `amount_minor × win_probability`, converted to the installation's base currency —

--- a/frontend/e2e/public-preferences.spec.ts
+++ b/frontend/e2e/public-preferences.spec.ts
@@ -109,11 +109,11 @@ test.describe("the pages a message links to", () => {
     await mockPublicEdge(page, sent);
 
     await page.goto(`/#/unsubscribe/${TOKEN}/${PURPOSE}`);
-    await page
-      .getByRole("button", { name: de["prefs.unsub.confirm"] })
-      .click();
+    await page.getByRole("button", { name: de["prefs.unsub.confirm"] }).click();
 
-    await expect(page.getByRole("heading", { name: de["prefs.unsub.doneTitle"] })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: de["prefs.unsub.doneTitle"] }),
+    ).toBeVisible();
     const post = sent.find((r) => r.method === "POST");
     expect(post?.url).toContain(`purpose=${PURPOSE}`);
   });
@@ -126,18 +126,16 @@ test.describe("the pages a message links to", () => {
     await mockPublicEdge(page, sent);
 
     await page.goto(`/#/unsubscribe/${TOKEN}/${PURPOSE}`);
-    await page
-      .getByRole("button", { name: de["prefs.unsub.confirm"] })
-      .click();
-    await expect(page.getByRole("heading", { name: de["prefs.unsub.doneTitle"] })).toBeVisible();
+    await page.getByRole("button", { name: de["prefs.unsub.confirm"] }).click();
+    await expect(
+      page.getByRole("heading", { name: de["prefs.unsub.doneTitle"] }),
+    ).toBeVisible();
 
     // RELOAD rather than navigate: the address has not changed, so a goto
     // to the same hash leaves the confirmed view standing — which is what
     // a reader pressing the link in the mail a second time actually does.
     await page.reload();
-    await page
-      .getByRole("button", { name: de["prefs.unsub.confirm"] })
-      .click();
+    await page.getByRole("button", { name: de["prefs.unsub.confirm"] }).click();
     await expect(
       page.getByRole("heading", { name: de["prefs.unsub.alreadyOff"] }),
     ).toBeVisible();
@@ -221,7 +219,9 @@ test.describe("the pages a message links to", () => {
     await button.focus();
     await page.keyboard.press("Enter");
 
-    await expect(page.getByRole("heading", { name: de["prefs.unsub.doneTitle"] })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: de["prefs.unsub.doneTitle"] }),
+    ).toBeVisible();
     expect(sent.some((r) => r.method === "POST")).toBe(true);
   });
 });

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -1779,6 +1779,25 @@ export async function mockApi(
         scope_options: ["mine"],
         summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
         sources_unavailable: [],
+        // Both accountings, because the server sends both. A fixture that omits
+        // them models a response the product never produces, and a spec driving
+        // it passes against a page no reader can reach.
+        reach: [
+          {
+            source: "approval",
+            considered: 1,
+            shown: 1,
+            more_available: false,
+          },
+        ],
+        counts: [
+          {
+            category: "decisions",
+            considered: 1,
+            shown: 1,
+            more_available: false,
+          },
+        ],
         queue: [
           {
             id: approval.id,

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -25248,6 +25248,13 @@ export interface components {
              *     is where the queue says which. Empty only when no source was read at all.
              */
             reach: components["schemas"]["WorklistReach"][];
+            /**
+             * @description The same accounting per KIND of work rather than per producer — what a filter
+             *     pill counts, and what lets the page say how much it is not showing. Counted
+             *     before any narrowing, so a filtered page still reports the categories it is
+             *     not drawing.
+             */
+            counts: components["schemas"]["WorklistCount"][];
         };
         /**
          * @description What one source contributed, in numbers that say what they counted.
@@ -25277,6 +25284,44 @@ export interface components {
              *     page that stopped one short of more, and it says the cautious thing rather than
              *     claiming a source is complete when it is not. The client renders `considered` as
              *     "200+" rather than "200".
+             */
+            more_available: boolean;
+        };
+        /**
+         * @description What one CATEGORY of work held, and how much of it reached the page.
+         *
+         *     The same three figures `WorklistReach` reports per source, asked of the thing a
+         *     reader actually filters by. A client cannot derive one from the other: which
+         *     source belongs to which category is decided here, and summing `reach` in the
+         *     browser would be a second copy of that map, wrong the first time a source moves
+         *     lane.
+         *
+         *     This is what a filter pill draws its number from, and what lets the page say how
+         *     much it is not showing. Without it the queue was a cut at 25 rows that said
+         *     nothing about the rest, so a full first page made a real backlog look like zero.
+         *
+         *     `considered` counts what this read weighed BEFORE any category narrowing, which
+         *     is why a page filtered to meetings can still say how many tasks there were. It is
+         *     not a total when `more_available` is true.
+         *
+         *     `shown` counts what the page carries, with a folded group counted as the items it
+         *     stands for rather than as the single row that stands for them.
+         */
+        WorklistCount: {
+            /**
+             * @description Which kind of work these numbers are about. The same vocabulary the filter uses.
+             * @enum {string}
+             */
+            category: "customer_waiting" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system";
+            /** @description How many items of this kind were read and ranked, before any narrowing. */
+            considered: number;
+            /** @description How many of them the page carries, counting a folded group as its members. */
+            shown: number;
+            /**
+             * @description True when any source behind this category was read to its work bound, so items
+             *     MAY exist past what was considered. A category inherits its sources' honesty:
+             *     reporting "12 decisions" over a pile the read never finished counting is the
+             *     failure this flag exists to prevent.
              */
             more_available: boolean;
         };

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7248,6 +7248,9 @@ export const de = {
   "worklist.loading": "Dein Tag wird gelesen…",
   "worklist.queue": "Was als Nächstes zu tun ist",
   "worklist.summary": "{urgent} dringend · {due} fällig · {lower} nachrangig",
+  "worklist.completeness": "{shown} von {considered} angezeigt",
+  "worklist.completeness.bounded":
+    "{shown} von {considered} angezeigt · {sources} Quellen haben mehr",
   "worklist.clear": "Nichts wartet auf dich.",
   "worklist.clearOfWhatWasRead":
     "Unter den Quellen, die geantwortet haben, wartet nichts.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7250,7 +7250,7 @@ export const de = {
   "worklist.summary": "{urgent} dringend · {due} fällig · {lower} nachrangig",
   "worklist.completeness": "{shown} von {considered} angezeigt",
   "worklist.completeness.bounded":
-    "{shown} von {considered} angezeigt · {sources} Quellen haben mehr",
+    "{shown} angezeigt · {sources} Quellen haben mehr",
   "worklist.clear": "Nichts wartet auf dich.",
   "worklist.clearOfWhatWasRead":
     "Unter den Quellen, die geantwortet haben, wartet nichts.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7328,7 +7328,7 @@ export const en = {
   "worklist.summary": "{urgent} urgent · {due} due · {lower} lower-priority",
   "worklist.completeness": "{shown} of {considered} shown",
   "worklist.completeness.bounded":
-    "{shown} of {considered} shown · {sources} sources have more",
+    "{shown} shown · {sources} sources have more",
   "worklist.clear": "Nothing is waiting on you.",
   "worklist.clearOfWhatWasRead":
     "Nothing is waiting among the sources that answered.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7326,6 +7326,9 @@ export const en = {
   "worklist.loading": "Reading your day…",
   "worklist.queue": "What to do next",
   "worklist.summary": "{urgent} urgent · {due} due · {lower} lower-priority",
+  "worklist.completeness": "{shown} of {considered} shown",
+  "worklist.completeness.bounded":
+    "{shown} of {considered} shown · {sources} sources have more",
   "worklist.clear": "Nothing is waiting on you.",
   "worklist.clearOfWhatWasRead":
     "Nothing is waiting among the sources that answered.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7181,6 +7181,9 @@ export const vi = {
   "worklist.queue": "Việc cần làm tiếp theo",
   "worklist.summary":
     "{urgent} khẩn cấp · {due} đến hạn · {lower} ưu tiên thấp",
+  "worklist.completeness": "Hiển thị {shown} trong {considered}",
+  "worklist.completeness.bounded":
+    "Hiển thị {shown} trong {considered} · {sources} nguồn còn nữa",
   "worklist.clear": "Không có gì đang chờ bạn.",
   "worklist.clearOfWhatWasRead":
     "Không có gì đang chờ trong các nguồn đã trả lời.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7182,8 +7182,7 @@ export const vi = {
   "worklist.summary":
     "{urgent} khẩn cấp · {due} đến hạn · {lower} ưu tiên thấp",
   "worklist.completeness": "Hiển thị {shown} trong {considered}",
-  "worklist.completeness.bounded":
-    "Hiển thị {shown} trong {considered} · {sources} nguồn còn nữa",
+  "worklist.completeness.bounded": "Hiển thị {shown} · {sources} nguồn còn nữa",
   "worklist.clear": "Không có gì đang chờ bạn.",
   "worklist.clearOfWhatWasRead":
     "Không có gì đang chờ trong các nguồn đã trả lời.",

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -11,6 +11,7 @@ import { settingsAddress } from "./settings";
 import type {
   Worklist,
   WorklistComparison,
+  WorklistFilter,
   WorklistItem,
   WorklistReason,
   WorklistValue,
@@ -377,4 +378,66 @@ function knownSource(
   source: WorklistItem["source"],
 ): source is keyof typeof KNOWN_SOURCES {
   return source in KNOWN_SOURCES;
+}
+
+// How much of one kind of work the page is carrying, for the pill that narrows
+// to it.
+//
+// A count is drawn only when it is EXACT. `FilterPills` treats an absent count
+// as "no number" rather than as a zero, and that is the honest answer for a
+// category read to its bound: the server knows a floor, not a total, and a
+// floor printed as a count is a wrong number rather than a missing one.
+//
+// The `all` pill counts every category, because "all" is not a category and has
+// no row of its own.
+export function pillCount(
+  day: Worklist,
+  filter: WorklistFilter,
+): number | undefined {
+  if (filter === "all") {
+    return day.counts.some((count) => count.more_available)
+      ? undefined
+      : day.counts.reduce((total, count) => total + count.considered, 0);
+  }
+  const found = day.counts.find((count) => count.category === filter);
+  if (!found || found.more_available) {
+    return undefined;
+  }
+  return found.considered;
+}
+
+// What the page is NOT showing, in one line.
+//
+// The queue is a cut, and before this the reader had no way to tell a finished
+// day from a truncated one — a full first page read as an empty backlog. The
+// line is drawn only when there IS a difference to report: on a day the page
+// carries whole, saying "12 of 12" is noise.
+//
+// A source read to its bound makes the total a floor, and the sentence says so
+// rather than printing a number it cannot stand behind.
+export function completenessText(
+  day: Worklist,
+  t: T,
+  locale: Locale,
+): string | null {
+  const shown = day.counts.reduce((total, count) => total + count.shown, 0);
+  const considered = day.counts.reduce(
+    (total, count) => total + count.considered,
+    0,
+  );
+  const bounded = day.counts.filter((count) => count.more_available).length;
+  if (shown >= considered && bounded === 0) {
+    return null;
+  }
+  if (bounded > 0) {
+    return t("worklist.completeness.bounded", {
+      shown: formatNumber(shown, locale),
+      considered: formatNumber(considered, locale),
+      sources: formatNumber(bounded, locale),
+    });
+  }
+  return t("worklist.completeness", {
+    shown: formatNumber(shown, locale),
+    considered: formatNumber(considered, locale),
+  });
 }

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -413,26 +413,39 @@ export function pillCount(
 // line is drawn only when there IS a difference to report: on a day the page
 // carries whole, saying "12 of 12" is noise.
 //
-// A source read to its bound makes the total a floor, and the sentence says so
-// rather than printing a number it cannot stand behind.
+// It reads only the cut the reader is LOOKING at. `considered` is snapshotted
+// before the category narrowing, so on a filtered page the other categories keep
+// their full figures and contribute nothing shown — summing them all would
+// answer "5 of 35" on a page that is showing every one of the five things the
+// reader asked for, and conflate "you filtered this out" with "this did not
+// fit".
+//
+// Where a source was read to its bound the total is a floor, and the sentence
+// says a source has more rather than printing a number it cannot stand behind.
 export function completenessText(
   day: Worklist,
+  filter: WorklistFilter,
   t: T,
   locale: Locale,
 ): string | null {
-  const shown = day.counts.reduce((total, count) => total + count.shown, 0);
-  const considered = day.counts.reduce(
+  const counted =
+    filter === "all"
+      ? day.counts
+      : day.counts.filter((count) => count.category === filter);
+  const shown = counted.reduce((total, count) => total + count.shown, 0);
+  const considered = counted.reduce(
     (total, count) => total + count.considered,
     0,
   );
-  const bounded = day.counts.filter((count) => count.more_available).length;
+  const bounded = counted.filter((count) => count.more_available).length;
   if (shown >= considered && bounded === 0) {
     return null;
   }
   if (bounded > 0) {
+    // No fraction: the figure it would divide by is a floor, and "200 of 200
+    // shown · 1 source has more" contradicts itself in one sentence.
     return t("worklist.completeness.bounded", {
       shown: formatNumber(shown, locale),
-      considered: formatNumber(considered, locale),
       sources: formatNumber(bounded, locale),
     });
   }

--- a/frontend/src/screens/worklist.counts.test.tsx
+++ b/frontend/src/screens/worklist.counts.test.tsx
@@ -1,0 +1,170 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { WorklistScreen } from "./worklist";
+
+// What the page says about the work it is NOT showing.
+//
+// The queue is a cut, and a cut that says nothing about the rest lets a full
+// first page read as an empty backlog. These are the promises that fixes: a
+// pill states what its cut holds, the line under them states what did not fit,
+// and neither prints a number the server could not stand behind.
+
+type Worklist = components["schemas"]["Worklist"];
+type WorklistCount = components["schemas"]["WorklistCount"];
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function stub(day: Worklist) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      return url.includes("/worklist")
+        ? jsonResponse(day)
+        : jsonResponse({ data: [] });
+    }),
+  );
+}
+
+function day(counts: WorklistCount[], shown = 1): Worklist {
+  return {
+    as_of: "2026-08-31T09:00:00Z",
+    scope: "mine",
+    scope_options: ["mine"],
+    queue: Array.from({ length: shown }, (_, i) => ({
+      id: `row-${i}`,
+      source: "task" as const,
+      category: "tasks" as const,
+      level: 4,
+      consequence: "task_slips" as const,
+      title: `Task ${i}`,
+      because: [],
+      actions: [],
+    })),
+    summary: { urgent: 0, due: 0, lower_priority: 0, total: shown },
+    sources_unavailable: [],
+    reach: [],
+    counts,
+  };
+}
+
+function renderWorklist() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <WorklistScreen />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("what the page says about what it is not showing", () => {
+  it("counts each cut on the pill that opens it", async () => {
+    stub(
+      day([
+        { category: "tasks", considered: 4, shown: 1, more_available: false },
+        {
+          category: "decisions",
+          considered: 12,
+          shown: 0,
+          more_available: false,
+        },
+      ]),
+    );
+    renderWorklist();
+
+    // The number rides inside the button, so it joins the accessible name: a
+    // reader hears "Decisions, 12" rather than meeting a bare figure.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Decisions.*12/ }),
+      ).toBeTruthy();
+    });
+  });
+
+  it("says how much of the day did not fit", async () => {
+    stub(
+      day([
+        { category: "tasks", considered: 9, shown: 1, more_available: false },
+      ]),
+    );
+    renderWorklist();
+
+    // One row drawn out of nine read. Before this line the reader had no way
+    // to tell that page from a finished day.
+    await waitFor(() => {
+      expect(screen.getByText(/1 of 9 shown/)).toBeTruthy();
+    });
+  });
+
+  it("draws no line on a day it is carrying whole", async () => {
+    stub(
+      day([
+        { category: "tasks", considered: 1, shown: 1, more_available: false },
+      ]),
+    );
+    renderWorklist();
+
+    await waitFor(() => {
+      expect(screen.getByText("Task 0")).toBeTruthy();
+    });
+    // Nothing was cut, so there is nothing to report. "1 of 1 shown" is noise.
+    expect(screen.queryByText(/shown/)).toBeNull();
+  });
+
+  it("prints no count for a cut whose source hit its bound", async () => {
+    stub(
+      day([
+        {
+          category: "decisions",
+          considered: 200,
+          shown: 1,
+          more_available: true,
+        },
+      ]),
+    );
+    renderWorklist();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Decisions/ })).toBeTruthy();
+    });
+    // The server knows a floor, not a total. A floor printed as a count is a
+    // wrong number rather than a missing one, so the pill draws none.
+    expect(screen.queryByRole("button", { name: /Decisions.*200/ })).toBeNull();
+  });
+
+  it("says a source has more rather than claiming a total", async () => {
+    stub(
+      day([
+        {
+          category: "decisions",
+          considered: 200,
+          shown: 1,
+          more_available: true,
+        },
+      ]),
+    );
+    renderWorklist();
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 source(s)? ha(s|ve) more/)).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/screens/worklist.counts.test.tsx
+++ b/frontend/src/screens/worklist.counts.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { WorklistScreen } from "./worklist";
+import { completenessText } from "./worklist.copy";
 
 // What the page says about the work it is NOT showing.
 //
@@ -150,6 +151,27 @@ describe("what the page says about what it is not showing", () => {
     expect(screen.queryByRole("button", { name: /Decisions.*200/ })).toBeNull();
   });
 
+  it("does not print a fraction whose denominator is a floor", async () => {
+    stub(
+      day([
+        {
+          category: "decisions",
+          considered: 200,
+          shown: 200,
+          more_available: true,
+        },
+      ]),
+    );
+    renderWorklist();
+
+    await waitFor(() => {
+      expect(screen.getByText(/sources have more/)).toBeTruthy();
+    });
+    // "200 of 200 shown - 1 source has more" contradicts itself in one
+    // sentence: the number it divides by is a floor, not a total.
+    expect(screen.queryByText(/200 of 200/)).toBeNull();
+  });
+
   it("says a source has more rather than claiming a total", async () => {
     stub(
       day([
@@ -166,5 +188,36 @@ describe("what the page says about what it is not showing", () => {
     await waitFor(() => {
       expect(screen.getByText(/1 source(s)? ha(s|ve) more/)).toBeTruthy();
     });
+  });
+
+  // A narrowed page reads only the cut the reader is looking at.
+  //
+  // `considered` is snapshotted before the narrowing, so the other categories
+  // keep their full figures and contribute nothing shown. Summing them all
+  // answers "5 of 35" on a page showing every one of the five things that were
+  // asked for — conflating "you filtered this out" with "this did not fit".
+  it("counts only the cut the reader asked for", () => {
+    const page = day([
+      {
+        category: "deals_at_risk",
+        considered: 5,
+        shown: 5,
+        more_available: false,
+      },
+      { category: "tasks", considered: 30, shown: 0, more_available: false },
+    ]);
+    const t = ((key: string, vars?: Record<string, string>) =>
+      `${key}:${vars?.shown}/${vars?.considered}`) as never;
+
+    const filtered = completenessText(page, "deals_at_risk", t, "en");
+    const unfiltered = completenessText(page, "all", t, "en");
+
+    if (filtered !== null) {
+      throw new Error(
+        `a page showing all five of what was asked for still reported ${filtered}`,
+      );
+    }
+    // Unfiltered, the same day genuinely IS hiding the thirty tasks.
+    expect(unfiltered).toContain("5/35");
   });
 });

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -11,6 +11,14 @@
   margin: 0;
 }
 
+/* What the page is not showing. Quiet on purpose: this is the surface reporting
+   on itself rather than a row of work, and it must not compete with the queue
+   for the reader's eye. */
+.worklist-completeness {
+  color: var(--textSecondary);
+  margin: 0;
+}
+
 .worklist-clear {
   color: var(--textSecondary);
   margin: var(--space-4) 0;

--- a/frontend/src/screens/worklist.stories.tsx
+++ b/frontend/src/screens/worklist.stories.tsx
@@ -35,10 +35,33 @@ export const AFullDay: Story = {
     stubDay({
       as_of: "2026-08-31T09:00:00Z",
       scope: "mine",
-      scope_options: ["mine", "team", "all"],
+      scope_options: ["mine", "unassigned", "team", "all"],
       summary: { urgent: 1, due: 2, lower_priority: 3, total: 5 },
       sources_unavailable: [],
       reach: [],
+      // More work than the page carries, which is the ordinary case and the one
+      // these figures exist for: four decisions sit behind the single row drawn.
+      counts: [
+        {
+          category: "customer_waiting",
+          considered: 1,
+          shown: 1,
+          more_available: false,
+        },
+        {
+          category: "deals_at_risk",
+          considered: 1,
+          shown: 1,
+          more_available: false,
+        },
+        { category: "tasks", considered: 1, shown: 1, more_available: false },
+        {
+          category: "decisions",
+          considered: 5,
+          shown: 1,
+          more_available: false,
+        },
+      ],
       queue: [
         {
           id: "waiting-1",
@@ -121,6 +144,8 @@ export const NothingWaiting: Story = {
       summary: { urgent: 0, due: 0, lower_priority: 0, total: 0 },
       sources_unavailable: [],
       reach: [],
+      // A genuinely clear day: nothing read, nothing counted, nothing hidden.
+      counts: [],
       queue: [],
     });
     return (
@@ -143,6 +168,10 @@ export const PartlyUnread: Story = {
       sources_unavailable: [{ source: "capture_health", reason: "failed" }],
       queue: [],
       reach: [],
+      // Nothing counted, because the source that would have filled the day is
+      // the one that could not be read. The warning says so; the counts do not
+      // pretend otherwise.
+      counts: [],
     });
     return (
       <StoryProviders>

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -64,6 +64,7 @@ function day(over: Partial<Worklist> = {}): Worklist {
     summary: { urgent: 0, due: 0, lower_priority: 0, total: 0 },
     sources_unavailable: [],
     reach: [],
+    counts: [],
     ...over,
   };
 }

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -308,7 +308,7 @@ function WorklistHeader({
   const t = useT();
   const { locale } = useLocale();
   const scopes = day.scope_options;
-  const completeness = completenessText(day, t, locale);
+  const completeness = completenessText(day, filter, t, locale);
   return (
     <div className="worklist-header">
       <p className="t-h2 worklist-lead">

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -10,10 +10,12 @@ import { useLocale, useT } from "../i18n";
 import { ApprovalRow } from "./approvalrow";
 import {
   comparisonText,
+  completenessText,
   consequenceText,
   dealFactsText,
   itemTitle,
   moveHref,
+  pillCount,
   reasonText,
   rowHref,
   sourceUnavailableText,
@@ -306,6 +308,7 @@ function WorklistHeader({
   const t = useT();
   const { locale } = useLocale();
   const scopes = day.scope_options;
+  const completeness = completenessText(day, t, locale);
   return (
     <div className="worklist-header">
       <p className="t-h2 worklist-lead">
@@ -335,11 +338,17 @@ function WorklistHeader({
         pills={FILTERS.map((value) => ({
           value,
           label: t(`worklist.filter.${value}` as const),
+          count: pillCount(day, value),
         }))}
         value={filter}
         onChange={onFilter}
         label={t("worklist.filter.label")}
       />
+      {/* What the page is NOT showing. Drawn only when there is a difference to
+          report: on a day the queue carries whole, "12 of 12" is noise. */}
+      {completeness !== null && (
+        <p className="t-meta worklist-completeness">{completeness}</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #3449 (the counting half).

The Worklist is a cut at twenty-five rows and said nothing about the rest, so a full first page and a real backlog looked identical — and a rep narrowing to Decisions found work they had no way to know was there. That is the trust problem the rest of this queue's work was fixing, still standing.

## What it adds

Per-**category** accounting (`considered` / `shown` / `more_available`) beside the per-source `reach` that already existed. A client cannot derive one from the other: which source belongs to which lane is decided server-side, and summing `reach` in the browser would be a second copy of that map, wrong the first time a source moves.

The frontend draws it as a count on each filter pill and a line saying how much did not fit. Two rules keep it honest, both mutation-checked: a count appears only when it is **exact** (a bounded source knows a floor, and `FilterPills` already treats an absent count as "no number" rather than as zero), and the line appears only when there is something to report (on a day carried whole, "12 of 12" is noise).

## What review caught

Three ways the new figures could state something the server cannot stand behind — the same failure the accounting exists to prevent, reintroduced by the accounting itself:

- **A bounded source filtered to nothing vanished.** The scope filter runs before the snapshot, so a lane can come back full of a colleague's work and keep none. I proved it: fifty at-risk deals read to the bound under `scope=unassigned` produced **zero categories**, so the page reported nothing was there. Categories are now seeded from the bounded sources first, the way `reach` already seeds its own rows.
- **The completeness line summed every category on a filtered page**, announcing "5 of 35 shown" on a page showing all five of the deals the reader asked for.
- **It printed a fraction whose denominator was a floor** — "200 of 200 shown · 1 source has more" contradicts itself in one sentence.

The seeding needs a source-to-category map, which the classifiers already decide per row. Two spellings of one fact, so the test beside it feeds a row from each source through the real classification and requires the same answer. **It caught a wrong guess on its first run:** `relationship_decay` is filed under `system`, not `deals_at_risk`.

## Fixtures

`worklist.stories.tsx` and `frontend/e2e/seed.ts` were sending `reach: []` and no counts at all — a shape the server cannot produce, so a spec driving it passes against a page no reader can reach. Both now send what the product sends.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The worklist now reports per-category counts so readers can see how much of each kind of work the page is not showing. Previously the page was cut at 25 rows with no account of the rest, making a full first page look identical to an empty backlog; the page now draws those counts on filter pills and a completeness line.

## What changed

- Added `counts` to the worklist response, counted before any category narrowing so a filtered page still reports the categories it is not drawing.
- Filter pills show counts only when exact; the completeness line avoids fractions when the denominator is a floor and sums only the active filter's counts.
- Categories are seeded from bounded sources even when filtering leaves zero rows, so a bounded source filtered out still reports `more_available`.
- The source-to-category map is tested against the classifiers.
- Frontend fixtures and the e2e seed now send `reach` and `counts`; the API now requires `counts`.

<sup>Written for commit 3dcb9e605fd52908850a1c4bc1e195bc24ec5178. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worklist filter pills now show accurate item counts.
  * Added completeness messaging showing how many items are displayed versus considered.
  * Indicates when additional items may exist beyond the displayed results.
  * Added localized messaging in English, German, and Vietnamese.
  * Worklist responses now include per-category counts for improved filtering and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->