### PR TITLE
fix(contract): the generated types carry the description the contract states

### DIFF
--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -24943,7 +24943,7 @@ type PipelineTrace struct {
 	// Connector The provider id that carried the message, never a display label; resolve it against `GET /channel-providers`. Empty when the trace rows have been swept.
 	Connector *string `json:"connector,omitempty"`
 
-	// PayloadCaptureEnabled The deployment's `capture.trace_payloads` posture. False means no rung carries `counterparty` or `subject` because the operator did not turn payload capture on — as against a rung that simply has none.
+	// PayloadCaptureEnabled The deployment's `capture.trace_payloads` posture, on unless the deployment file turns it off. False means no rung carries `counterparty` or `subject` because the operator turned payload capture off — as against a rung that simply has none.
 	PayloadCaptureEnabled bool `json:"payload_capture_enabled"`
 
 	// RetentionHours How long stored rungs are kept. Derived rungs answer at any age; stored ones report `unknown` past this, which is a different claim from `not_applicable` — the rows are gone, so whether the stage ran can no longer be established.


### PR DESCRIPTION
## Main is red, twice

`make drift` fails on a clean `origin/main` worktree:

```
--- a/backend/internal/contracts/api_gen.go
-  // PayloadCaptureEnabled The deployment's `capture.trace_payloads` posture. False means …
+  // PayloadCaptureEnabled The deployment's `capture.trace_payloads` posture, on unless the deployment file turns it off. False means …
```

`crm.yaml`'s description was reworded without regenerating `internal/contracts`, so the `deterministic-gates` lane is red on the tip and every open PR inherits it.

This is **regeneration only** — no contract edit. The generated text is now what `crm.yaml` says.

## Scope note

This PR originally also carried the enrichment-fixture fix for the *other* red-main failure. [#3470](https://github.com/margince/margince/pull/3470) landed the same fix independently and byte-for-byte, so that commit is dropped here rather than duplicated — this PR is now the drift half alone, which nothing else covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)