### PR TITLE
The demo database has work for the Worklist to show

### DIFF
--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -220,6 +220,36 @@ sign_in_as_admin
 
 # Demo records ride the same natural-key dedupe the product uses: a 201
 # created it, a 409 means an earlier run did — anything else is a defect.
+# A moment N days from now, in the format the API takes. Negative for the past.
+# Relative rather than fixed, so a seed run next month produces a wait of two
+# days rather than one of six weeks — a fixture that ages is a fixture that
+# stops demonstrating what it was written for.
+iso_in_days() { # iso_in_days <days>
+  # The sign is explicit because BSD date's -v needs one and GNU date's -d
+  # tolerates it, so one spelling works on a developer's laptop and in CI.
+  local offset="$1"
+  case "$offset" in -*) : ;; *) offset="+$offset" ;; esac
+  date -u -v"${offset}d" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -d "${offset} days" +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# One activity, created only if a row with that subject is not already there.
+#
+# `ensure` leans on the endpoint answering 409 for a duplicate, and /activities
+# has no natural key to answer it with: a rep may genuinely log the same call
+# twice. So the seed asks first. Without this, every `make seed-dev` adds
+# another copy and the demo Worklist grows a row per run.
+ensure_activity() { # ensure_activity <label> <subject> <json-body>
+  local label="$1" subject="$2" data="$3" status
+  status="$(api GET "/activities?q=$(url_encode "$subject")&limit=50")"
+  [ "$status" = "200" ] || fail "GET /v1/activities returned HTTP $status while checking for $label"
+  if jq -e --arg s "$subject" '.data[]? | select(.subject == $s)' "$workdir/body" >/dev/null; then
+    echo "  OK: $label already present"
+    return
+  fi
+  ensure "$label" /activities "$data"
+}
+
 ensure() { # ensure <label> <path> <json-body>
   local label="$1" path="$2" data="$3" status
   status="$(api POST "$path" "$data")"
@@ -419,6 +449,44 @@ ensure_deal() { # ensure_deal <name> <stage-id> <amount-minor>
 
 ensure_deal "Acme Expansion" "$stage_id_qualified" 2500000
 ensure_deal "Globex Renewal" "$stage_id_proposal" 1200000
+
+# The Worklist needs WORK to show, and nothing above produces any: people,
+# organizations and deals are records, and the queue ranks obligations. A demo
+# database with none of those renders the surface as an honest empty page, which
+# is the one state a demo must not open on — and it is why two shipped changes
+# to that queue could not be demonstrated at all.
+#
+# Through the real endpoints, like everything else here. Rows written straight
+# to the table would be rows the product never produces, and a demo built on
+# those teaches whoever reads it something false about the software.
+echo "== seed-dev: work for the Worklist =="
+
+alice_id="$(person_id "Alice Müller" "alice@demo.test")"
+[ -n "$alice_id" ] || fail "Alice Müller is missing, so there is nobody for the demo mail to be from"
+
+# A task the admin wrote themselves and did not assign. It lands on their own
+# queue because the writer stamps the author as assignee — which is the whole
+# reason "mine" can be exact.
+ensure_activity "task: call Alice back" "Call Alice back about the retrofit" "$(jq -n --arg p "$alice_id" --arg due "$(iso_in_days 0)" \
+  '{kind:"task",subject:"Call Alice back about the retrofit",source:"seed",due_at:$due,
+    links:[{entity_type:"person",entity_id:$p}]}')"
+
+# The unanswered inbound that makes a customer WAIT is seeded in seed-dev.sql
+# instead. A waiting row needs a thread_key, and that column is capture's to
+# stamp: the create endpoint refuses it, correctly, because a client naming its
+# own thread could silence an unrelated conversation. So the one fixture this
+# API cannot produce is written where the file for exactly that lives.
+
+# A second task, so the queue has more than one row of agreed work.
+#
+# It is OWNED, like the one above and for the same reason: a human writing a
+# task through the API is stamped as its assignee. The unassigned queue is fed
+# by automations running as the system principal, which no seed can impersonate
+# through a public endpoint — and should not, since impersonating one is exactly
+# what captured_by exists to prevent.
+ensure_activity "task: follow up with the lead" "Follow up with the new lead" "$(jq -n --arg p "$alice_id" --arg due "$(iso_in_days 1)" \
+  '{kind:"task",subject:"Follow up with the new lead",source:"seed",due_at:$due,
+    links:[{entity_type:"person",entity_id:$p}]}')"
 
 echo ""
 echo "seed-dev: DONE — log in at $API_BASE with $ADMIN_EMAIL / $ADMIN_PASSWORD"

--- a/scripts/seed-dev.sql
+++ b/scripts/seed-dev.sql
@@ -282,4 +282,60 @@ BEGIN
   RAISE NOTICE 'seed-dev.sql: offline_demo finance connection + customer links seeded; the sweep fills the ledger';
 END $$;
 
+-- 4. The one piece of Worklist work no endpoint can write: a customer waiting.
+--
+-- A waiting row is the newest inbound of a thread with no later outbound, and
+-- "thread" means thread_key — which the create endpoint refuses on purpose. A
+-- client naming its own thread could silence an unrelated conversation, so
+-- capture stamps it and nothing else may. That leaves this fixture with no API
+-- to go through, which is what this file is for.
+--
+-- Everything else the Worklist shows is seeded through the real endpoints in
+-- seed-dev.sh, where it belongs.
+--
+-- Dated relative to now, so a seed run next month still demonstrates a two-day
+-- wait rather than a stale one past the freshness horizon.
+DO $$
+DECLARE
+  person_row uuid;
+  activity_row uuid;
+  capturer text;
+BEGIN
+  SELECT id INTO person_row FROM person
+   WHERE full_name = 'Alice Müller' AND archived_at IS NULL
+   ORDER BY created_at LIMIT 1;
+  IF person_row IS NULL THEN
+    RAISE NOTICE 'seed-dev.sql: no Alice Müller yet — run the API seed first; skipping the waiting customer';
+    RETURN;
+  END IF;
+  -- Idempotent on the thread key, like every other block here.
+  IF EXISTS (SELECT 1 FROM activity WHERE thread_key = 'seed-retrofit-pricing') THEN
+    RAISE NOTICE 'seed-dev.sql: the waiting customer is already seeded';
+    RETURN;
+  END IF;
+  SELECT 'human:' || id INTO capturer FROM app_user
+   WHERE email = 'admin@demo.test' LIMIT 1;
+
+  activity_row := uuidv7();
+  INSERT INTO activity (id, kind, direction, subject, body, occurred_at, is_done,
+                        source, captured_by, version, created_at, updated_at,
+                        counterparty_outbound_attested, thread_key, audience)
+  VALUES (activity_row, 'email', 'inbound',
+          'Re: pricing for the retrofit',
+          'Could you confirm the implementation cost before Friday?',
+          now() - interval '2 days', false, 'system',
+          coalesce(capturer, 'system:seed'), 1, now(), now(), false,
+          'seed-retrofit-pricing', 'workspace');
+  -- Filed under a person, which is what makes it SALES mail rather than a rep's
+  -- own correspondence: the lane requires a link to a record the workspace
+  -- sells to.
+  INSERT INTO activity_link (activity_id, entity_type, person_id)
+  VALUES (activity_row, 'person', person_row);
+  -- Who wrote, so the lane can tell a person from a notification service.
+  INSERT INTO activity_participant (activity_id, role, address, person_id)
+  VALUES (activity_row, 'from', 'alice@demo.test', person_row);
+
+  RAISE NOTICE 'seed-dev.sql: a customer is waiting on the Worklist';
+END $$;
+
 COMMIT;


### PR DESCRIPTION
The Worklist opened on an empty page in the demo. Nothing seeded any work — people, organizations and deals are records, and the queue ranks obligations. That is an honest empty page and the one state a demo must not open on, and it is why two shipped changes to that queue could not be demonstrated at all last week.

Three rows now, through the real endpoints wherever an endpoint exists: two tasks and a customer waiting on a reply. The queue opens the way the design says it should, with the wait leading and the agreed work beneath it.

**The waiting mail goes through `seed-dev.sql` instead.** A waiting row is the newest inbound of a *thread* with no later outbound, and `thread_key` is capture's to stamp — the create endpoint refuses it, correctly, because a client naming its own thread could silence an unrelated conversation. That leaves the fixture with no API to go through, which is exactly what the SQL companion is for.

## Two things running it taught me

Both were assumptions I had written into comments before testing, and the running product contradicted both:

- **A seeded task is owned.** A human writing one through the API is stamped as its assignee, so a seed cannot produce the unassigned case — that belongs to automations running as the system principal, which no seed may impersonate through a public endpoint. My first comment claimed the opposite.
- **`/activities` has no natural key**, because a rep may genuinely log the same call twice, so `ensure` cannot dedupe it and every `make seed-dev` added another copy. Verified by seeing the duplicate, then fixed by asking first. Two consecutive runs now leave one row each.

Dates are relative, so a run next month still demonstrates a two-day wait rather than one already past the freshness horizon.

Verified on a live stack: the seed runs clean twice, and `GET /v1/worklist` returns the waiting customer first with the counts beside it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The demo Worklist opened on an empty page because nothing seeded work into it. Now seeds three rows — two tasks and a waiting customer — so the queue opens with the wait leading and the agreed work beneath it.

**Waiting mail**
- Seeds through `scripts/seed-dev.sql` instead of the API because the create endpoint refuses client-supplied `thread_key`.
- Dates are relative, so a run next month still demonstrates a two-day wait.

**Seed details**
- Tasks go through the real endpoints and are owned by the writing admin; the unassigned case is not seedable through the API.
- `ensure_activity` checks for an existing subject first because `/activities` has no natural key for dedupe.

<sup>Written for commit 3845efa25b82a1ba4efd86a7dbe7d05a43786e77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development data seeding with realistic, date-based activities.
  * Added a waiting-customer email fixture linked to Alice Müller.
  * Seeding is now idempotent, preventing duplicate activities and email threads.
  * Seed data is created only when the required contact and user records are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->