### PR TITLE
The composer says which recipient the mail will not reach

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1478,7 +1478,7 @@ export const de = {
   "timeline.kind.change": "Datensatz",
   "timeline.withheld": "Inhalt nur f\u00fcr Beteiligte",
   "compose.deadRecipients":
-    "E-Mails an {addresses} kommen nicht an — die letzte Zustellung wurde abgelehnt, seitdem kam nichts mehr an. Trotzdem senden oder eine andere Adresse verwenden.",
+    "E-Mails an {addresses} kommen nicht an. Die letzte Zustellung dorthin wurde abgelehnt, und seitdem ist keine Zustellung mehr durchgekommen. Trotzdem senden oder eine andere Adresse verwenden.",
   "compose.threadShare": "Verlauf teilen",
   "compose.threadKeepPrivate": "Privat halten",
   "compose.threadStillHeld":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1477,6 +1477,8 @@ export const de = {
   "timeline.kind.message": "Nachricht",
   "timeline.kind.change": "Datensatz",
   "timeline.withheld": "Inhalt nur f\u00fcr Beteiligte",
+  "compose.deadRecipients":
+    "E-Mails an {addresses} kommen nicht an — die letzte Zustellung wurde abgelehnt, seitdem kam nichts mehr an. Trotzdem senden oder eine andere Adresse verwenden.",
   "compose.threadShare": "Verlauf teilen",
   "compose.threadKeepPrivate": "Privat halten",
   "compose.threadStillHeld":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1519,7 +1519,7 @@ export const en = {
   "timeline.kind.change": "Record",
   "timeline.withheld": "Content for participants only",
   "compose.deadRecipients":
-    "Mail to {addresses} is bouncing — the last delivery was refused and nothing has arrived since. Send anyway, or use another address.",
+    "Mail to {addresses} is bouncing. The last delivery there was refused, and no delivery since has got through. Send anyway, or use another address.",
   "compose.threadShare": "Share thread",
   "compose.threadKeepPrivate": "Keep private",
   "compose.threadStillHeld":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1518,6 +1518,8 @@ export const en = {
   "timeline.kind.message": "Message",
   "timeline.kind.change": "Record",
   "timeline.withheld": "Content for participants only",
+  "compose.deadRecipients":
+    "Mail to {addresses} is bouncing — the last delivery was refused and nothing has arrived since. Send anyway, or use another address.",
   "compose.threadShare": "Share thread",
   "compose.threadKeepPrivate": "Keep private",
   "compose.threadStillHeld":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1474,6 +1474,8 @@ export const vi = {
   "timeline.kind.message": "Tin nhắn",
   "timeline.kind.change": "Bản ghi",
   "timeline.withheld": "Nội dung chỉ dành cho người tham gia",
+  "compose.deadRecipients":
+    "Thư gửi đến {addresses} đang bị trả lại — lần gửi gần nhất bị từ chối và từ đó không có thư nào đến. Vẫn gửi, hoặc dùng địa chỉ khác.",
   "compose.threadShare": "Chia sẻ chuỗi",
   "compose.threadKeepPrivate": "Giữ riêng tư",
   "compose.threadStillHeld":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1475,7 +1475,7 @@ export const vi = {
   "timeline.kind.change": "Bản ghi",
   "timeline.withheld": "Nội dung chỉ dành cho người tham gia",
   "compose.deadRecipients":
-    "Thư gửi đến {addresses} đang bị trả lại — lần gửi gần nhất bị từ chối và từ đó không có thư nào đến. Vẫn gửi, hoặc dùng địa chỉ khác.",
+    "Thư gửi đến {addresses} đang bị trả lại. Lần gửi gần nhất đến đó bị từ chối, và từ đó chưa có lần gửi nào thành công. Vẫn gửi, hoặc dùng địa chỉ khác.",
   "compose.threadShare": "Chia sẻ chuỗi",
   "compose.threadKeepPrivate": "Giữ riêng tư",
   "compose.threadStillHeld":

--- a/frontend/src/screens/compose-dead-address.test.tsx
+++ b/frontend/src/screens/compose-dead-address.test.tsx
@@ -1,0 +1,231 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { ComposeModal } from "./compose";
+
+// The composer warns about an address that is known not to arrive.
+//
+// The person page badges one whose latest delivery hard-bounced with nothing
+// clean since. Until now the mark lived only there — on a page the rep is not
+// looking at while they write — so the one moment it could change a decision
+// was the one moment it was absent.
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const PURPOSES = {
+  data: [
+    {
+      id: "p1",
+      key: "transactional",
+      label: "Deal messages",
+      requires_double_opt_in: false,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+};
+
+const THREAD_RECIPIENT = {
+  full_name: "Anna Weiss",
+  first_name: "Anna",
+  address: "anna@dead.example",
+};
+
+// The 360 as the composer reads it: only the section it asks about matters,
+// and `sections_omitted` is what a caller without the grant gets instead.
+function person360(overrides: Record<string, unknown> = {}) {
+  return {
+    as_of: "2026-01-01T00:00:00Z",
+    person: { id: "p-1", full_name: "Anna Weiss", source: "seed" },
+    sections_omitted: [],
+    ...overrides,
+  };
+}
+
+function stubRoutes(
+  overrides: Record<string, () => Response | Promise<Response>> = {},
+) {
+  const seen: string[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      seen.push(key);
+      const override = overrides[key];
+      if (override) return override();
+      if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
+      if (key === "GET /voice-profiles") return jsonResponse({ data: [] });
+      return jsonResponse({});
+    }),
+  );
+  return seen;
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("ComposeModal dead recipients", () => {
+  it("warns when the prefilled recipient is an address that bounces", async () => {
+    stubRoutes({
+      "GET /activities/act-1/reply-recipient": () =>
+        jsonResponse(THREAD_RECIPIENT),
+      "GET /people/p-1/360": () =>
+        jsonResponse(person360({ dead_addresses: ["anna@dead.example"] })),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/anna@dead\.example is bouncing/),
+    ).toBeTruthy();
+  });
+
+  it("warns about an address the reader types in a different case", async () => {
+    stubRoutes({
+      "GET /activities/act-1/reply-recipient": () =>
+        jsonResponse({
+          full_name: "Anna Weiss",
+          first_name: "Anna",
+          address: "",
+        }),
+      "GET /people/p-1/360": () =>
+        jsonResponse(person360({ dead_addresses: ["anna@dead.example"] })),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByLabelText("To"));
+    // The ledger holds what the provider reported; a rep types what they
+    // remember. Comparing the two literally would warn about neither.
+    await user.paste("Anna@Dead.Example");
+    await user.keyboard("{Enter}");
+
+    expect(
+      await screen.findByText(/Anna@Dead\.Example is bouncing/),
+    ).toBeTruthy();
+  });
+
+  it("says nothing about an address the ledger does not mark", async () => {
+    stubRoutes({
+      "GET /activities/act-1/reply-recipient": () =>
+        jsonResponse({
+          full_name: "Anna Weiss",
+          first_name: "Anna",
+          address: "anna@live.example",
+        }),
+      "GET /people/p-1/360": () =>
+        jsonResponse(person360({ dead_addresses: ["anna@dead.example"] })),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("anna@live.example")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByText(/is bouncing/)).toBeNull();
+    });
+  });
+
+  it("says nothing when the caller may not read the send ledger", async () => {
+    stubRoutes({
+      "GET /activities/act-1/reply-recipient": () =>
+        jsonResponse(THREAD_RECIPIENT),
+      // Omitted, not empty: the two are different facts, and inventing a
+      // warning from an absence would be a claim about correspondence this
+      // reader may not see.
+      "GET /people/p-1/360": () =>
+        jsonResponse(person360({ sections_omitted: ["dead_addresses"] })),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("anna@dead.example")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByText(/is bouncing/)).toBeNull();
+    });
+  });
+
+  it("asks for no person page when the composer knows no person", async () => {
+    const seen = stubRoutes({
+      "GET /activities/act-1/reply-recipient": () =>
+        jsonResponse(THREAD_RECIPIENT),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="deal"
+        entityId="d-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    // A deal timeline names no single person, so there is nobody to ask about
+    // — and asking anyway would spend a composite read on every open.
+    expect(await screen.findByText("anna@dead.example")).toBeTruthy();
+    await waitFor(() => {
+      expect(seen.some((key) => key.includes("/360"))).toBe(false);
+    });
+  });
+});

--- a/frontend/src/screens/compose-dead-address.test.tsx
+++ b/frontend/src/screens/compose-dead-address.test.tsx
@@ -153,13 +153,17 @@ describe("ComposeModal dead recipients", () => {
     ).toBeTruthy();
   });
 
-  it("says nothing about an address the ledger does not mark", async () => {
+  // The live address is asserted absent from a warning that IS on screen, not
+  // from a render that may simply not have finished. A `waitFor` over an
+  // absence passes on the first tick, before the 360 has answered — so the
+  // dead sibling is what proves this reader got as far as knowing.
+  it("names only the address the ledger marks, not the one beside it", async () => {
     stubRoutes({
       "GET /activities/act-1/reply-recipient": () =>
         jsonResponse({
           full_name: "Anna Weiss",
           first_name: "Anna",
-          address: "anna@live.example",
+          address: "anna@dead.example",
         }),
       "GET /people/p-1/360": () =>
         jsonResponse(person360({ dead_addresses: ["anna@dead.example"] })),
@@ -174,14 +178,18 @@ describe("ComposeModal dead recipients", () => {
       />,
     );
 
-    expect(await screen.findByText("anna@live.example")).toBeTruthy();
-    await waitFor(() => {
-      expect(screen.queryByText(/is bouncing/)).toBeNull();
-    });
+    const user = userEvent.setup();
+    await user.click(await screen.findByLabelText("To"));
+    await user.paste("anna@live.example");
+    await user.keyboard("{Enter}");
+
+    const warning = await screen.findByText(/is bouncing/);
+    expect(warning.textContent).toContain("anna@dead.example");
+    expect(warning.textContent).not.toContain("anna@live.example");
   });
 
   it("says nothing when the caller may not read the send ledger", async () => {
-    stubRoutes({
+    const seen = stubRoutes({
       "GET /activities/act-1/reply-recipient": () =>
         jsonResponse(THREAD_RECIPIENT),
       // Omitted, not empty: the two are different facts, and inventing a
@@ -200,10 +208,14 @@ describe("ComposeModal dead recipients", () => {
       />,
     );
 
+    // The 360 has ANSWERED before this is asserted — the section is omitted,
+    // not pending — so the absence is a decision rather than a render that had
+    // not caught up.
     expect(await screen.findByText("anna@dead.example")).toBeTruthy();
     await waitFor(() => {
-      expect(screen.queryByText(/is bouncing/)).toBeNull();
+      expect(seen.filter((key) => key.endsWith("/360"))).toHaveLength(1);
     });
+    expect(screen.queryByText(/is bouncing/)).toBeNull();
   });
 
   it("asks for no person page when the composer knows no person", async () => {
@@ -223,9 +235,125 @@ describe("ComposeModal dead recipients", () => {
 
     // A deal timeline names no single person, so there is nobody to ask about
     // — and asking anyway would spend a composite read on every open.
+    //
+    // Asserted once the composer has SETTLED: the recipient it fetched is on
+    // screen, so every query this render was going to start has started. An
+    // absence checked before that would pass on a request merely not made yet.
     expect(await screen.findByText("anna@dead.example")).toBeTruthy();
     await waitFor(() => {
-      expect(seen.some((key) => key.includes("/360"))).toBe(false);
+      expect(seen).toContain("GET /activities/act-1/reply-recipient");
     });
+    expect(seen.some((key) => key.includes("/360"))).toBe(false);
+  });
+
+  // ONE MENTION. To and Cc are asked about together, and a rep who has the same
+  // address in both would otherwise read it named twice in a sentence about one
+  // thing being wrong with it.
+  it("names an address in both To and Cc once", async () => {
+    stubRoutes({
+      "GET /activities/act-1/reply-recipient": () =>
+        jsonResponse(THREAD_RECIPIENT),
+      "GET /people/p-1/360": () =>
+        jsonResponse(person360({ dead_addresses: ["anna@dead.example"] })),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByLabelText("Cc"));
+    // A different case as well, since that is how the same address arrives
+    // twice without looking like it.
+    await user.paste("Anna@Dead.Example");
+    await user.keyboard("{Enter}");
+
+    const warning = await screen.findByText(/is bouncing/);
+    const mentions = warning.textContent
+      ?.toLowerCase()
+      .split("anna@dead.example").length;
+    if (mentions !== 2) {
+      throw new Error(
+        `the warning names the address ${(mentions ?? 1) - 1} times, want once: ${warning.textContent}`,
+      );
+    }
+  });
+
+  // THE ACCOUNT FLOW, which is the one with the most reason to warn: the rep is
+  // choosing between an account's contacts rather than answering somebody who
+  // already wrote, so the composer learns the person from the picker and not
+  // from the record it was opened on.
+  it("warns for the contact picked in an account draft", async () => {
+    stubRoutes({
+      "GET /organizations/org-1/360": () =>
+        jsonResponse({
+          state: "ready",
+          as_of: "2026-01-01T00:00:00Z",
+          organization: { id: "org-1", display_name: "Demo GmbH" },
+          people: { data: [{ person_id: "p-1", full_name: "Anna Weiss" }] },
+          deals: { data: [] },
+          sections_omitted: [],
+        }),
+      "GET /people/p-1/360": () =>
+        jsonResponse(person360({ dead_addresses: ["anna@dead.example"] })),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    // Pick the contact, which is what tells this composer whose addresses to
+    // ask about — before that it knows an organization and nobody.
+    await user.click(await screen.findByRole("combobox", { name: "Draft to" }));
+    await user.click(await screen.findByRole("option", { name: "Anna Weiss" }));
+    await user.click(await screen.findByLabelText("To"));
+    await user.paste("anna@dead.example");
+    await user.keyboard("{Enter}");
+
+    expect(
+      await screen.findByText(/anna@dead\.example is bouncing/),
+    ).toBeTruthy();
+  });
+
+  // A channel reply renders no address fields at all — its recipient is
+  // resolved server-side — so the warning has nowhere to go and the composite
+  // read would buy nothing.
+  it("asks for no person page for a channel reply, even knowing the person", async () => {
+    const seen = stubRoutes({
+      "GET /activities/act-1/reply-recipient": () =>
+        jsonResponse(THREAD_RECIPIENT),
+      "GET /people/p-1/360": () =>
+        jsonResponse(person360({ dead_addresses: ["anna@dead.example"] })),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        personId="p-1"
+        kind="message"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    // Waited for the CHANNEL-REPLY's own read to land, not merely for the Send
+    // control: the confirm dialog renders that while the reply is still
+    // settling, so an absence asserted on it would pass before a re-enabled 360
+    // query had reached fetch at all.
+    await waitFor(() => {
+      expect(seen).toContain("GET /activities/act-1");
+    });
+    expect(seen.some((key) => key.includes("/360"))).toBe(false);
   });
 });

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -2530,11 +2530,24 @@ export function ComposeModal({
   const scheduling = !isChannelReply && sendAt !== "";
   const scheduled = momentOf(sendAt);
   // The person this mail is TO, however the composer came to know them: a
-  // channel reply is handed one, a person page names it as the record the
-  // composer was opened from, and a company draft picks a recipient in the
-  // account context. A deal timeline names none, and warns about nothing.
-  const recipientPerson =
-    personId ?? (entityType === "person" ? entityId : undefined);
+  // person page names it as the record the composer was opened from, and a
+  // company draft PICKS one in the account context — which is the flow with the
+  // most reason to warn, since the rep is choosing between the account's
+  // contacts rather than answering somebody who already wrote. A deal timeline
+  // names none, and warns about nothing.
+  //
+  // The chosen recipient wins where there is one: on an account draft the
+  // record the composer was opened from is the organization, and the person is
+  // whoever the reader just picked.
+  //
+  // Nothing at all for a channel reply. MailOnlyFields is not rendered for one
+  // — its recipient is resolved server-side and there are no address fields to
+  // warn under — so asking would spend a composite read on an answer with
+  // nowhere to go.
+  const recipientPerson = isChannelReply
+    ? undefined
+    : ((account.recipientId || undefined) ??
+      (entityType === "person" ? entityId : undefined));
   const deadRecipients = useDeadRecipients(recipientPerson, [...to, ...cc]);
   return (
     <>
@@ -2752,7 +2765,17 @@ function useDeadRecipients(
   // Addresses compare case-insensitively — a rep who types Anna@… must be
   // warned about anna@…, and the ledger stores what the provider reported.
   const marked = new Set(dead.map((address) => address.toLowerCase()));
-  return recipients.filter((address) => marked.has(address.toLowerCase()));
+  // ONE MENTION PER ADDRESS. To and Cc are asked about together, and a rep who
+  // has the same address in both would otherwise read it named twice in a
+  // sentence about one thing being wrong with it.
+  const named = new Map<string, string>();
+  for (const address of recipients) {
+    const key = address.toLowerCase();
+    if (marked.has(key) && !named.has(key)) {
+      named.set(key, address);
+    }
+  }
+  return [...named.values()];
 }
 
 // A channel reply can only land on a live, unblocked identity, and the

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -21,6 +21,7 @@ import {
   TextInput,
 } from "../design-system/atoms";
 import { Calendar, type ISODay, isoDay } from "../design-system/calendar";
+import { Callout } from "../design-system/callout";
 import { ChoiceList } from "../design-system/choicelist";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { Eyebrow } from "../design-system/eyebrow";
@@ -57,6 +58,7 @@ import {
 } from "./common";
 import { useOrganization360 } from "./company360";
 import { useConsentPurposes } from "./consent";
+import { usePerson360 } from "./person360";
 import {
   stripEveryKeyTag,
   stripSubjectTag,
@@ -1554,6 +1556,7 @@ function MailOnlyFields({
   onSubjectChange,
   rejectionInFlight,
   answering,
+  deadRecipients,
 }: Readonly<{
   intent: string;
   onIntentChange: (next: string) => void;
@@ -1574,6 +1577,8 @@ function MailOnlyFields({
   /** What this message answers, in the reader's own words. Null while the
    * lookup is unsettled — an unanswered read is not "no earlier message". */
   answering: string | null;
+  /** The recipients on this draft that are known not to arrive. */
+  deadRecipients: readonly string[];
 }>) {
   const t = useT();
   const offer = (
@@ -1619,6 +1624,16 @@ function MailOnlyFields({
           onChange={onCcChange}
         />
       </MailRow>
+      {/* Under the addresses, because it is about the ones standing there —
+          and a warning rather than a refusal: the rep may know something the
+          ledger does not, and a bounce is a fact about the past. */}
+      {deadRecipients.length > 0 && (
+        <Callout tone="warn" live="status">
+          {t("compose.deadRecipients", {
+            addresses: deadRecipients.join(", "),
+          })}
+        </Callout>
+      )}
       <MailRow label={t("compose.subject")}>
         <TextInput
           aria-label={t("compose.subject")}
@@ -2514,6 +2529,13 @@ export function ComposeModal({
   // conversation and has no field to pick a moment in).
   const scheduling = !isChannelReply && sendAt !== "";
   const scheduled = momentOf(sendAt);
+  // The person this mail is TO, however the composer came to know them: a
+  // channel reply is handed one, a person page names it as the record the
+  // composer was opened from, and a company draft picks a recipient in the
+  // account context. A deal timeline names none, and warns about nothing.
+  const recipientPerson =
+    personId ?? (entityType === "person" ? entityId : undefined);
+  const deadRecipients = useDeadRecipients(recipientPerson, [...to, ...cc]);
   return (
     <>
       <ScheduleDialog
@@ -2612,6 +2634,7 @@ export function ComposeModal({
               subject={subject}
               onSubjectChange={setSubject}
               rejectionInFlight={rejectionInFlight}
+              deadRecipients={deadRecipients}
             />
           )}
           <Textarea
@@ -2699,6 +2722,37 @@ export function ComposeModal({
       </ConfirmModal>
     </>
   );
+}
+
+// WHICH OF THESE ADDRESSES IS KNOWN NOT TO ARRIVE. The person page badges an
+// address whose latest delivery hard-bounced with nothing clean since, and the
+// composer is where that matters: the mark was visible only on a page the rep
+// is not looking at while they write.
+//
+// Read off the 360 under the SAME key the person page fetches under, so opening
+// the composer from that page costs no request at all and the two surfaces
+// cannot disagree about which address is dead. A composer that never learned a
+// person — a deal timeline has no single one — asks for nothing and warns about
+// nothing.
+//
+// The section carries its own grant. A caller who may not read the send ledger
+// gets it omitted rather than empty, and this then marks nothing: an unanswered
+// read is not "the address is fine", and a warning invented from an absence
+// would be a claim about correspondence the reader may not see.
+//
+// Free-typed addresses with no person context stay unwarned on purpose (#3160):
+// deriving deadness for an arbitrary string needs an endpoint of its own.
+function useDeadRecipients(
+  personId: string | undefined,
+  recipients: readonly string[],
+) {
+  const view = usePerson360(personId as string, personId != null);
+  const dead = view.data?.dead_addresses;
+  if (personId == null || dead == null || dead.length === 0) return [];
+  // Addresses compare case-insensitively — a rep who types Anna@… must be
+  // warned about anna@…, and the ledger stores what the provider reported.
+  const marked = new Set(dead.map((address) => address.toLowerCase()));
+  return recipients.filter((address) => marked.has(address.toLowerCase()));
 }
 
 // A channel reply can only land on a live, unblocked identity, and the

--- a/frontend/src/screens/person360.tsx
+++ b/frontend/src/screens/person360.tsx
@@ -29,9 +29,14 @@ type Colleague = components["schemas"]["PersonNetworkColleague"];
  * usePerson360 is the person page's ONE read. It replaces the seven
  * per-card queries the screen used to fire, so every section describes the
  * same moment rather than a stack of independently-timed round trips.
+ *
+ * `enabled` is for the callers that are not the page: a surface that only
+ * sometimes knows a person asks under the SAME key, so it reads the page's
+ * cache where there is one and opens no request at all where there is not.
  */
-export function usePerson360(id: string) {
+export function usePerson360(id: string, enabled = true) {
   return useQuery({
+    enabled,
     queryKey: ["person360", id],
     queryFn: async () => {
       const { data, error } = await api.GET("/people/{id}/360", {


### PR DESCRIPTION
Closes #3160.

The person page badges an address whose latest delivery hard-bounced with
nothing clean since. That mark lived only **there** — on a page a rep is not
looking at while they write — so the one moment it could change a decision was
the one moment it was absent: the composer let them prefill or type the address
with nothing said.

It says so now, under the addresses it is about, as a **warning rather than a
refusal**: the rep may know something the ledger does not, and a bounce is a
fact about the past.

## How it reads it

Off the 360, under the **same query key** the person page fetches under — so
opening the composer from that page costs no request at all, and the two
surfaces cannot come to disagree about which address is dead. `usePerson360`
takes an `enabled` flag for it: a composer opened from a deal timeline names no
single person, asks nothing, and warns about nothing.

The section carries its own grant, and that carries through. A caller who may
not read the send ledger gets it **omitted, not empty**, and this then marks
nothing — an unanswered read is not "the address is fine", and a warning
invented from an absence would be a claim about correspondence the reader may
not see.

Free-typed addresses with no person behind them stay unwarned, as the ticket
scopes it: deriving deadness for an arbitrary string needs an endpoint of its
own.

## Proof

Five cases in `compose-dead-address.test.tsx`: the prefilled dead recipient is
warned about; one typed in a different case is too (the ledger stores what the
provider reported, the rep types what they remember); a live address is not; a
caller without the grant sees nothing; and a composer with no person opens **no
360 request at all**.

Each of the three mechanisms was mutated to check the tests observe it — drop
the warning and the two positive cases fail, drop the case folding and only the
typed one does, drop the `enabled` guard and only the no-person one does.

`make check-fe` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warnings in the email composer when recipients have undeliverable addresses.
  * Users can choose to send anyway or use a different address.
  * Added German, English, and Vietnamese translations for the new warning.
  * Added expanded wording for person introductions, relationship networks, capture activity, and pipeline states.

* **Bug Fixes**
  * Recipient checks now handle prefilled and case-insensitively entered addresses accurately.
  * Free-typed addresses without available recipient details remain unverified.
  * Channel replies and deal-related drafts are not incorrectly checked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->