### PR TITLE
A relink stops crediting the colleague whose conversation it no longer is

### DIFF
--- a/backend/gates/projectionedgereaders_test.go
+++ b/backend/gates/projectionedgereaders_test.go
@@ -79,6 +79,7 @@ var projectionMaintenanceSites = gatekit.Waive(map[string]string{
 	"internal/modules/search:recomputePairs":                 "the fold runs under the system principal from the cg:graph-edge consumer; it rewrites the projection from the base tables and returns nothing to a caller",
 	"internal/modules/search:recomputeContactPairs":          "the contact fold, same contract as recomputePairs: system principal, rewrites from base tables, returns nothing",
 	"internal/modules/search:affectedContactPairs":           "resolves which pairs an activity touches for the fold — including stale edges of a relinked participant; the keys never leave the maintenance path",
+	"internal/modules/search:affectedPairs":                  "the colleague half of affectedContactPairs, same contract: names which pairs an activity touches for the fold, stale edges of a relinked participant included, and the keys never leave the maintenance path",
 	"internal/modules/search:contactPairsForPerson":          "resolves a person's pairs for the fold on merge/archive; the keys never leave the maintenance path",
 	"internal/compose/org360:contactRoutes":                  "gated by its one caller: contacts.go asks mayReadRoutes (activity read — the projection derives from activity) before calling, and a refusal omits the routes rather than reaching this read",
 	"internal/compose/org360:readInContactWith":              "gated by its one caller: readOurSide requires person and activity read before calling, and only already-drawn contact ids reach it",

--- a/backend/internal/compose/graphedge_integration_test.go
+++ b/backend/internal/compose/graphedge_integration_test.go
@@ -271,6 +271,45 @@ func TestAnEdgeThatLostItsEvidenceIsDeleted(t *testing.T) {
 	}
 }
 
+// A RELINK is the case the activity's own rows cannot describe. Repointing a
+// participant to another contact removes the row that named the old one, so
+// resolving the affected pairs from the rows alone leaves the old colleague
+// still credited with a conversation that is no longer theirs — until the
+// nightly rebuild, which is a week of recommending an introduction nobody can
+// make.
+func TestARelinkDropsTheEdgeToTheContactTheActivityLeft(t *testing.T) {
+	v := edgeEnv{integration.Setup(t)}
+	now := time.Now().UTC()
+	was := v.person(t, "Dana Mistaken")
+	corrected := v.person(t, "Nils Actually")
+	a1 := v.interaction(t, v.e.Rep1, was, now.AddDate(0, 0, -1), "inbound", "from")
+	v.recompute(t, a1)
+
+	if len(v.edgesFor(t, was)) != 1 {
+		t.Fatal("the edge was not created in the first place")
+	}
+
+	// The relink itself: the participant row is repointed, and the event that
+	// follows names only the activity. Nothing anywhere still says the message
+	// was ever about the first contact.
+	if err := database.WithWorkspaceTx(v.e.Admin(), v.e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE activity_participant SET person_id = $3 WHERE activity_id = $1 AND person_id = $2`,
+			a1, was, corrected)
+		return err
+	}); err != nil {
+		t.Fatalf("relinking the participant: %v", err)
+	}
+	v.recompute(t, a1)
+
+	if edges := v.edgesFor(t, was); len(edges) != 0 {
+		t.Errorf("the edge to the contact the activity LEFT survived the relink: %+v", edges)
+	}
+	if edges := v.edgesFor(t, corrected); len(edges) != 1 {
+		t.Errorf("the contact the activity was relinked TO has %d edges, want 1: %+v", len(edges), edges)
+	}
+}
+
 func TestTheNightlyRebuildAgreesWithTheIncrementalPath(t *testing.T) {
 	v := edgeEnv{integration.Setup(t)}
 	now := time.Now().UTC()

--- a/backend/internal/modules/search/graphedge.go
+++ b/backend/internal/modules/search/graphedge.go
@@ -95,7 +95,7 @@ const interactionRoles = `('from','to','cc','bcc','attendee','organizer')`
 // changed does not know which pairs that touched, so it hands over the
 // activity and this resolves the pairs itself — including, on a relink, the
 // pair the activity used to belong to, which is the pair the caller could not
-// have named.
+// have named and which no longer appears on the activity's own rows.
 //
 // Deleting is as important as writing. A pair whose last qualifying
 // interaction was just archived must lose its row, not keep a stale one: an
@@ -122,38 +122,6 @@ func RecomputeEdgesForActivities(ctx context.Context, tx pgx.Tx, activityIDs []i
 		return err
 	}
 	return recomputePairs(ctx, tx, pairs)
-}
-
-// pair is one (user, person) key.
-type pair struct {
-	user   ids.UUID
-	person ids.UUID
-}
-
-// affectedPairs resolves which edges the named activities can affect: every
-// (user, person) combination appearing on their participant rows, plus every
-// pair that currently has a row citing one of those activities.
-func affectedPairs(ctx context.Context, tx pgx.Tx, activityIDs []ids.UUID) ([]pair, error) {
-	rows, err := tx.Query(ctx, `
-		SELECT DISTINCT u.user_id, p.person_id
-		  FROM activity_participant u
-		  JOIN activity_participant p ON p.activity_id = u.activity_id
-		 WHERE u.activity_id = ANY($1)
-		   AND u.user_id IS NOT NULL
-		   AND p.person_id IS NOT NULL`, activityIDs)
-	if err != nil {
-		return nil, fmt.Errorf("search: resolving the pairs an activity touches: %w", err)
-	}
-	defer rows.Close()
-	var out []pair
-	for rows.Next() {
-		var pr pair
-		if err := rows.Scan(&pr.user, &pr.person); err != nil {
-			return nil, err
-		}
-		out = append(out, pr)
-	}
-	return out, rows.Err()
 }
 
 // RecomputeEdgesForPerson re-folds every edge touching one contact — the

--- a/backend/internal/modules/search/graphedgeaffected.go
+++ b/backend/internal/modules/search/graphedgeaffected.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// Which colleague-to-contact pairs a change can touch.
+//
+// Its own file because it is its own question, and the hard half of it: the
+// fold in graphedge.go recomputes whatever it is given, and everything that can
+// go silently wrong goes wrong HERE, in the naming. A pair this misses keeps a
+// row that its evidence no longer supports, and nothing downstream can notice.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// pair is one (user, person) key.
+type pair struct {
+	user   ids.UUID
+	person ids.UUID
+}
+
+// affectedPairs resolves which edges the named activities can affect: every
+// (user, person) combination appearing on their participant rows, plus every
+// EXISTING edge either end of which is still on those activities.
+//
+// The second arm is the RELINK case, and it is the reason this is not simply a
+// self-join. A relink repoints a participant row before the activity.updated
+// event is consumed, so the pair the activity used to belong to cannot be named
+// from the rows at all — the contact is no longer among them. Its colleague
+// still is, and every edge that colleague holds is refolded from the base
+// tables, at which point the one that lost its evidence is deleted. Without
+// this arm the stale edge stands until the nightly RebuildEdges, which is a
+// colleague being recommended for an introduction they can no longer make.
+//
+// affectedContactPairs closes the same gap the same way for the contact↔contact
+// projection. Both ride this one entry point, so a relink that is honest in one
+// and stale in the other is the disagreement worth not having.
+//
+// It is a WIDER target than the rows alone, and deliberately: over-including a
+// pair costs a refold that writes back what was already there, while omitting
+// one leaves a claim nobody can see is false. The lookup is served by
+// idx_graph_edge_user and idx_graph_edge_person, and recomputePairs folds the
+// whole target set in one statement rather than one per pair.
+func affectedPairs(ctx context.Context, tx pgx.Tx, activityIDs []ids.UUID) ([]pair, error) {
+	rows, err := tx.Query(ctx, `
+		WITH present_users AS (
+		    SELECT DISTINCT user_id
+		      FROM activity_participant
+		     WHERE activity_id = ANY($1) AND user_id IS NOT NULL
+		),
+		present_people AS (
+		    SELECT DISTINCT person_id
+		      FROM activity_participant
+		     WHERE activity_id = ANY($1) AND person_id IS NOT NULL
+		)
+		SELECT DISTINCT u.user_id, p.person_id
+		  FROM activity_participant u
+		  JOIN activity_participant p ON p.activity_id = u.activity_id
+		 WHERE u.activity_id = ANY($1)
+		   AND u.user_id IS NOT NULL
+		   AND p.person_id IS NOT NULL
+		 UNION
+		SELECT e.user_id, e.person_id
+		  FROM graph_interaction_edge e
+		 WHERE e.user_id IN (SELECT user_id FROM present_users)
+		    OR e.person_id IN (SELECT person_id FROM present_people)`, activityIDs)
+	if err != nil {
+		return nil, fmt.Errorf("search: resolving the pairs an activity touches: %w", err)
+	}
+	defer rows.Close()
+	var out []pair
+	for rows.Next() {
+		var pr pair
+		if err := rows.Scan(&pr.user, &pr.person); err != nil {
+			return nil, err
+		}
+		out = append(out, pr)
+	}
+	return out, rows.Err()
+}


### PR DESCRIPTION
Closes #3141.

`RecomputeEdgesForActivities` resolved the affected pairs from the activities'
**current** participant rows, and its comment claimed the relink case with them.
It could not be: a relink repoints the participant row before the
`activity.updated` event is consumed, so the contact the message used to be
about is no longer on the activity and cannot be named from the rows at all. The
stale edge then stood until the nightly `RebuildEdges` — a week of recommending
a colleague for an introduction they can no longer make.

The affected set now unions the existing edges either end of which is still on
the activity, which is what `affectedContactPairs` already does for the
contact↔contact projection and the same gap. The colleague is the end that
survives a relink, so the pair that lost its evidence is named through them,
refolded, and deleted.

It is a **wider** target than the rows alone, and that is the trade: over-
including a pair costs a refold that writes back what was already there, while
omitting one leaves a claim nobody can see is false. `idx_graph_edge_user` and
`idx_graph_edge_person` serve the lookup, and `recomputePairs` folds the whole
target set in one statement rather than one per pair.

## Proof

`TestARelinkDropsTheEdgeToTheContactTheActivityLeft` repoints a participant to
another contact and refolds naming only the activity — the shape the consumer
actually sees. Without the union arm the edge to the contact the activity left
survives, which is what the test reports.

`affectedPairs` moved to its own file: `graphedge.go` was at the 500-LOC cap,
and "which pairs a change can touch" is the half where everything that goes
silently wrong goes wrong. It is ratified in `projectionMaintenanceSites` on the
same terms as its contact sibling — the keys never leave the maintenance path.

`make check-backend` and all 49 integration packages green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected interaction relationships when an activity participant is relinked to a different contact.
  - Removed outdated connections for the former contact and created the correct connection for the replacement.
  - Improved graph relationship maintenance to ensure affected activity connections are fully recalculated and remain accurate.

- **Tests**
  - Added integration coverage for participant relinking scenarios and graph edge updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->