### PR TITLE
main is red: an unfindable enrichment fixture, and a generated contract a description behind its source

### DIFF
--- a/backend/internal/compose/integration/persondataenrich_integration_test.go
+++ b/backend/internal/compose/integration/persondataenrich_integration_test.go
@@ -64,6 +64,23 @@ func setupProviderConsumer(t *testing.T, automaticLookup bool) *providerConsumer
 	e := Setup(t)
 	c := &providerConsumerEnv{env: e, enqueued: new(int), personID: seedSubject(t, e)}
 
+	// SOMETHING TO LOOK THEM UP BY. The provider can find a person by their
+	// LinkedIn profile, or by a full name plus an employer, and a subject
+	// satisfying neither is skipped as no_identifiers before any of this
+	// file's subject reaches the queue (#3454). The shared seedSubject writes
+	// a first name and nothing else, which is right for the erasure tests it
+	// was written for and leaves this one's subject unfindable — so the
+	// identifier is added HERE, where the fixture's own claim needs it.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO person_social (person_id, platform, handle)
+			VALUES ($1, 'linkedin', 'https://www.linkedin.com/in/selma-subject')`,
+			c.personID)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	// One PRICED category and one FREE one, and both halves are load-bearing.
 	// An automatic run may take only what the provider gives away, so a
 	// connection selecting nothing free never queues anything — and the two

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -24943,7 +24943,7 @@ type PipelineTrace struct {
 	// Connector The provider id that carried the message, never a display label; resolve it against `GET /channel-providers`. Empty when the trace rows have been swept.
 	Connector *string `json:"connector,omitempty"`
 
-	// PayloadCaptureEnabled The deployment's `capture.trace_payloads` posture. False means no rung carries `counterparty` or `subject` because the operator did not turn payload capture on — as against a rung that simply has none.
+	// PayloadCaptureEnabled The deployment's `capture.trace_payloads` posture, on unless the deployment file turns it off. False means no rung carries `counterparty` or `subject` because the operator turned payload capture off — as against a rung that simply has none.
 	PayloadCaptureEnabled bool `json:"payload_capture_enabled"`
 
 	// RetentionHours How long stored rungs are kept. Derived rungs answer at any age; stored ones report `unknown` past this, which is a different claim from `not_applicable` — the rows are gone, so whether the stage ran can no longer be established.


### PR DESCRIPTION
`main` is red in two ways, both confirmed on a clean `origin/main` checkout.

**The enrichment fixture's subject has nothing to look them up by.**
`TestPersonCreatedQueuesAnEnrichmentRun` and its auto-off sibling fail. #3454
gave the provider lane a fence — a contact satisfying none of the provider's
match rules is skipped as `no_identifiers` rather than sent, because the vendor
rejects such a request and the platform can only read that rejection as a
provider fault. That is the right rule, and this file's own failure message
anticipated the fixture tripping it:

> the run was skipped (no_identifiers) rather than queued — the fixture trips a
> fence it was not meant to

It does. The shared `seedSubject` writes a first name and no surname, no
employer and no profile link — exactly right for the erasure tests it was
written for, and it leaves this file's subject unfindable. The two cases that
assert a run **exists**, which the file names as its own positive control, were
skipped instead of queued. The identifier goes where the claim needs it rather
than into the shared fixture: a LinkedIn profile satisfies the first match rule
on its own, and the erasure tests keep the sparse person they were written
around.

**The generated contract is a description behind its source.** `crm.yaml`'s
wording for `PayloadCaptureEnabled` changed and `api_gen.go` did not, so
`make drift` — which regenerates and then refuses any difference — fails on
every branch, this one included. Regenerated, nothing else.

Whole `internal/compose/integration` package green locally.