### PR TITLE
The map drew one lane, and a raw enum reached the strip

### DIFF
--- a/frontend/e2e/person-network.spec.ts
+++ b/frontend/e2e/person-network.spec.ts
@@ -1,0 +1,222 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * The person Network tab against the layout it was rebuilt to.
+ *
+ * It exists for the reason the company-record suite exists: "it looks like the
+ * design" was reported twice from reading the code rather than the page, and
+ * both times the page did not look like it. Shape is asserted first — which
+ * regions exist and in what order — then the two things a screenshot would
+ * catch and a DOM query would not: the lead panel actually reading as the
+ * page's one lead, and the two columns actually being two columns.
+ *
+ * It runs against a LIVE stack (BASE_URL + a real person id with routes),
+ * because a route candidate comes from captured correspondence and a seeded
+ * database has none. Without BASE_URL the suite skips itself loudly rather
+ * than passing on an app it never loaded.
+ */
+
+const BASE_URL = process.env.BASE_URL;
+// A contact somebody here actually corresponds with. Without routes the tab is
+// its empty state, which is a different page and not the one under test.
+const PERSON_ID = process.env.E2E_PERSON_ID;
+
+test.skip(
+  !BASE_URL || !PERSON_ID,
+  "set BASE_URL and E2E_PERSON_ID to run the Network tab layout suite",
+);
+
+async function signIn(page: Page) {
+  await page.goto("/#/login", { waitUntil: "networkidle" });
+  const email = page
+    .locator('input[type="email"], input[name="email"]')
+    .first();
+  if ((await email.count()) === 0) {
+    return;
+  }
+  await email.fill(process.env.E2E_EMAIL ?? "admin@demo.test");
+  await page
+    .locator('input[type="password"], input[name="password"]')
+    .first()
+    .fill(process.env.E2E_PASSWORD ?? "demo-password-123");
+  await page.locator('button[type="submit"]').first().click();
+  await expect(page.locator("nav.rail").first()).toBeVisible();
+}
+
+/**
+ * Open the tab and wait for the graph read to settle.
+ *
+ * The tab is a composite of two independent reads, so `networkidle` can land
+ * while the strip is still drawing. Anchoring on the stat strip means every
+ * assertion below describes a rendered page rather than a racing one.
+ */
+async function openNetwork(page: Page) {
+  await page.goto(`/#/contacts/${PERSON_ID}/network`, {
+    waitUntil: "networkidle",
+  });
+  await expect(page.locator(".stat-strip").first()).toBeVisible();
+}
+
+test.describe("Network tab — page shape", () => {
+  test.beforeEach(async ({ page }) => {
+    await signIn(page);
+    await openNetwork(page);
+  });
+
+  test("leads with the three readings, then the recommended route", async ({
+    page,
+  }) => {
+    const strip = page.locator(".stat-strip").first();
+    await expect(strip).toBeVisible();
+    // Three readings: best path, why now, who owns the next move. Fewer means
+    // a card failed to render rather than that this record lacks the fact.
+    await expect(strip.locator(".stat-card")).toHaveCount(3);
+
+    // The accent panel is the page's ONE lead. A second would ask the reader
+    // which recommendation to believe.
+    await expect(page.locator(".panel-accent")).toHaveCount(1);
+  });
+
+  test("draws the map and no ego ring", async ({ page }) => {
+    await expect(
+      page.locator(".rmap, .relationship-map").first(),
+    ).toBeVisible();
+    // The retired drawing. Its classes surviving would mean the old component
+    // is still mounted somewhere on this page.
+    await expect(page.locator(".pn-ring, .pn-node, .pn-edge")).toHaveCount(0);
+  });
+
+  test("puts the handoff beside the decision, not under it", async ({
+    page,
+  }) => {
+    await expect(page.locator(".pn-work-grid")).toBeVisible();
+    await expect(page.locator(".pn-main-column")).toBeVisible();
+    await expect(page.locator(".pn-side-column")).toBeVisible();
+    // The four-step relay lives in the side column and is an ordered list, so
+    // a screen reader hears "step 2 of 4" rather than a row of circles.
+    await expect(page.locator(".pn-side-column ol.pn-relay li")).toHaveCount(4);
+  });
+
+  /**
+   * All three lanes draw.
+   *
+   * The map's centre column is for ONE hub node and pushes no lane head, so
+   * putting the target's twelve colleagues there drew a 1000px column with two
+   * of the three lanes missing and eleven nodes painted off the canvas. The
+   * DOM said eleven nodes either way — only the lane heads tell the two apart.
+   */
+  test("draws our team, their company and the target", async ({ page }) => {
+    // The centre column takes ONE hub node and pushes no lane head, so the
+    // target belongs there and the company's people belong in a right lane
+    // that DOES get a head. Putting the twelve contacts in the centre drew a
+    // 1000px column, no head for them, and their nodes off the canvas.
+    //
+    // The lane heads are what tell the two arrangements apart: the node count
+    // is identical either way, which is how the first version of this test
+    // passed against the broken layout.
+    const lanes = await page.locator(".rmap text.rmap-lane").allTextContents();
+    expect(lanes).toContain("Unser Team");
+    expect(lanes).toContain("Ihr Unternehmen");
+
+    // Every node the model carries is inside the drawing's own viewBox. A node
+    // painted past it is in the DOM, passes every count, and is invisible.
+    const outside = await page.evaluate(() => {
+      const svg = document.querySelector(".rmap-svg");
+      if (!svg) {
+        return -1;
+      }
+      const vb = svg.getAttribute("viewBox")?.split(" ").map(Number) ?? [];
+      const w = vb[2] ?? 0;
+      return [...svg.querySelectorAll("[data-node-id] rect")].filter((r) => {
+        const x = Number(r.getAttribute("x") ?? 0);
+        const rw = Number(r.getAttribute("width") ?? 0);
+        return x + rw > w + 1;
+      }).length;
+    });
+    expect(outside).toBe(0);
+  });
+
+  test("offers the ask on the lead route", async ({ page }) => {
+    const lead = page.locator(".panel-accent").first();
+    await expect(lead.locator("button")).toHaveCount(1);
+  });
+});
+
+test.describe("Network tab — visual weight", () => {
+  test.beforeEach(async ({ page }) => {
+    await signIn(page);
+    await openNetwork(page);
+  });
+
+  /**
+   * The strip and the lead panel sit ABOVE the map.
+   *
+   * This is the whole complaint the rebuild answered: the answer a rep opens
+   * the tab for used to be three cards down. Order in the DOM is not enough —
+   * a floated or absolutely positioned block can read in source order and
+   * paint anywhere — so this reads the painted geometry.
+   */
+  test("the answer is above the picture", async ({ page }) => {
+    const strip = await page.locator(".stat-strip").first().boundingBox();
+    const lead = await page.locator(".panel-accent").first().boundingBox();
+    const map = await page
+      .locator(".rmap, .relationship-map")
+      .first()
+      .boundingBox();
+    expect(strip).not.toBeNull();
+    expect(lead).not.toBeNull();
+    expect(map).not.toBeNull();
+    if (!strip || !lead || !map) {
+      return;
+    }
+    expect(strip.y).toBeLessThan(lead.y);
+    expect(lead.y).toBeLessThan(map.y);
+  });
+
+  /**
+   * Two columns are actually two columns.
+   *
+   * A grid whose second track collapses still renders both children and passes
+   * every DOM query, while painting one under the other — which is exactly what
+   * "the layout is broken" looks like from a browser.
+   */
+  test("the side column sits beside the main one at desk width", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await expect(page.locator(".pn-work-grid")).toBeVisible();
+    const main = await page.locator(".pn-main-column").boundingBox();
+    const side = await page.locator(".pn-side-column").boundingBox();
+    expect(main).not.toBeNull();
+    expect(side).not.toBeNull();
+    if (!main || !side) {
+      return;
+    }
+    // Side starts after main ends horizontally, and they share a row.
+    expect(side.x).toBeGreaterThan(main.x + main.width - 1);
+    expect(Math.abs(side.y - main.y)).toBeLessThan(40);
+  });
+
+  /** Below the fold breakpoint the two columns stack rather than crush. */
+  test("the columns stack on a narrow window", async ({ page }) => {
+    await page.setViewportSize({ width: 900, height: 900 });
+    await expect(page.locator(".pn-work-grid")).toBeVisible();
+    const main = await page.locator(".pn-main-column").boundingBox();
+    const side = await page.locator(".pn-side-column").boundingBox();
+    if (!main || !side) {
+      return;
+    }
+    expect(side.y).toBeGreaterThan(main.y);
+  });
+
+  /** Nothing may push the page sideways. */
+  test("the page does not scroll horizontally", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/src/screens/personnetwork-panel.test.tsx
+++ b/frontend/src/screens/personnetwork-panel.test.tsx
@@ -306,7 +306,9 @@ describe("PersonNetworkTab", () => {
     });
     renderPanel();
 
-    await user.click(await screen.findByRole("button", { name: "Bo" }));
+    // The map composes a node's name as "label, sublabel, lane", so this
+    // matches the label rather than comparing the whole string.
+    await user.click(await screen.findByRole("button", { name: /Bo/ }));
 
     expect(await screen.findByText("with Cara")).toBeTruthy();
     expect(screen.queryByText("with Bo")).toBeNull();

--- a/frontend/src/screens/personnetwork/index.tsx
+++ b/frontend/src/screens/personnetwork/index.tsx
@@ -112,7 +112,7 @@ export function PersonNetworkTab({
       <DecisionStrip
         lead={read.lead}
         legacyVia={read.legacy?.via_display_name}
-        whyNow={momentWhyNow(view)}
+        whyNow={momentWhyNow(view, t)}
         open={read.open}
       />
 
@@ -157,34 +157,6 @@ export function PersonNetworkTab({
               {null}
             </SurfaceState>
           ) : null}
-
-          <RelationshipMap
-            model={model}
-            focusId={read.focused}
-            onFocus={setFocus}
-            onAction={(nodeId) => {
-              const picked = read.routes.find((r) => r.via_user_id === nodeId);
-              if (picked) {
-                setAsking(picked);
-              }
-            }}
-            completenessText={complete}
-            // The account page's word set, with the one label that names the
-            // subject swapped: this drawing is about a person, not an account.
-            labels={mapLabels(t, locale, t("person.intro.mapRegion"))}
-            // The selected person's own detail, including the one write this
-            // picture offers: recording an observed acquaintance the graph
-            // spotted but nothing has written down yet.
-            panelSlot={
-              read.focused && read.anchor ? (
-                <EdgeDetail
-                  graph={data}
-                  nodeId={read.focused}
-                  anchorId={read.anchor.id}
-                />
-              ) : null
-            }
-          />
         </div>
 
         <aside className="pn-side-column">
@@ -193,6 +165,38 @@ export function PersonNetworkTab({
           {view && <MomentsCard view={view} />}
         </aside>
       </div>
+
+      {/* Full width, below the grid. The drawing is 744px wide and scrolls
+          rather than shrinking, so inside a half-width column it showed its
+          left third and nothing else — one lane, and eleven nodes painted off
+          the visible canvas. */}
+      <RelationshipMap
+        model={model}
+        focusId={read.focused}
+        onFocus={setFocus}
+        onAction={(nodeId) => {
+          const picked = read.routes.find((r) => r.via_user_id === nodeId);
+          if (picked) {
+            setAsking(picked);
+          }
+        }}
+        completenessText={complete}
+        // The account page's word set, with the one label that names the
+        // subject swapped: this drawing is about a person, not an account.
+        labels={mapLabels(t, locale, t("person.intro.mapRegion"))}
+        // The selected person's own detail, including the one write this
+        // picture offers: recording an observed acquaintance the graph
+        // spotted but nothing has written down yet.
+        panelSlot={
+          read.focused && read.anchor ? (
+            <EdgeDetail
+              graph={data}
+              nodeId={read.focused}
+              anchorId={read.anchor.id}
+            />
+          ) : null
+        }
+      />
 
       {asking ? (
         <IntroDrawer

--- a/frontend/src/screens/personnetwork/mapmodel.ts
+++ b/frontend/src/screens/personnetwork/mapmodel.ts
@@ -79,6 +79,14 @@ export function mapModelFromPersonGraph(
     ...(anchor ? [contactNode(anchor, "person")] : []),
   ];
 
+  // Left: our colleagues. Centre: the contact themselves, because THEY are the
+  // hub this whole picture is about. Right: the other people at their company,
+  // who are the routes THROUGH.
+  //
+  // The centre is one node by design — the component stacks it vertically with
+  // a wide gap, so a list there grows the drawing without adding a lane head.
+  // Putting the twelve account contacts in it drew a 1000px column with no
+  // heading and two of the three lanes missing.
   const lanes: MapLane[] = [
     {
       id: "ours",
@@ -87,16 +95,16 @@ export function mapModelFromPersonGraph(
       nodeIds: colleagues.map((n) => n.id),
     },
     {
-      id: "theirs",
-      column: "center",
-      label: copy.theirCompany,
-      nodeIds: account.map((n) => n.id),
-    },
-    {
       id: "target",
-      column: "right",
+      column: "center",
       label: copy.target,
       nodeIds: anchor ? [anchor.id] : [],
+    },
+    {
+      id: "theirs",
+      column: "right",
+      label: copy.theirCompany,
+      nodeIds: account.map((n) => n.id),
     },
   ];
 

--- a/frontend/src/screens/personnetwork/moments.tsx
+++ b/frontend/src/screens/personnetwork/moments.tsx
@@ -26,6 +26,7 @@ type RelationshipMoments = Pick<
  */
 export function momentWhyNow(
   view: RelationshipMoments | undefined,
+  t: ReturnType<typeof useT>,
 ): string | undefined {
   const changes = view?.relationship_changes ?? [];
   // A withheld section is not an empty one. Reading a kind out of a list the
@@ -36,7 +37,10 @@ export function momentWhyNow(
   if (withheld || changes.length === 0) {
     return undefined;
   }
-  return changes[0]?.kind;
+  // The SENTENCE, never the kind. `change.kind` is an API enum, and putting it
+  // on the strip printed "replied_after_gap" where a reader expects words.
+  const head = changes[0];
+  return head ? changeSentence(head, t) : undefined;
 }
 
 /**


### PR DESCRIPTION
Three defects on the Network tab, all visible in a browser and none caught by the tests that shipped with the layout. This also adds the e2e suite that would have caught them.

## The map drew one lane

`RelationshipMap`'s centre column takes a **single hub node** and pushes no lane head — the account page puts one deal there and its people in right-hand lanes. I had inverted it: twelve of the contact's colleagues in the centre, the target alone on the right.

The result was a 1000px column, two of the three lanes missing, and eleven nodes painted off the canvas. The DOM reported all eleven, which is why nothing failed.

The target is the hub this picture is about, so it goes in the centre; their company goes in a right lane that gets a head.

## The map was half a page wide

It also sat inside the main column of the two-column grid. The drawing is 744px and **scrolls rather than shrinking**, so in a ~530px track a reader saw its left third. It is full width below the grid now.

## "Why now" printed an API enum

The strip showed `replied_after_gap` where a sentence belongs. `momentWhyNow` returned `change.kind`; `changeSentence` already existed and handles every kind.

## The suite that catches this next time

`e2e/person-network.spec.ts`, modelled on the company-record suite and written for the same reason: "it looks like the design" was reported twice from reading the code, and both times the page did not look like it.

It asserts shape, then the two things a DOM query cannot see — that the answer is **painted** above the picture (a positioned block can read in source order and paint anywhere), and that the two columns are actually two columns (a collapsed grid track still renders both children and passes every query).

The lane test is mutation-checked. My first version asserted `lanes.length >= 2` and passed against the broken layout, because the node count is identical either way. It now checks the lane heads by name and that no node is painted outside the viewBox — put the twelve contacts back in the centre and it fails.

`make check-fe` green; 9/9 e2e against a live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three visible defects on the Network tab and adds the e2e suite that would have caught them.

**Bug Fixes**
- The relationship map now puts the contact in the centre column and their company in a right lane; before, it placed the contact's colleagues in the centre, drew a 1000px column, and painted eleven nodes off the canvas.
- The map now renders full-width below the two-column grid; before, its 744px drawing showed only its left third inside the half-width column.
- "Why now" now shows the sentence via `changeSentence` instead of the raw API enum (`replied_after_gap`).

**New Features**
- Adds `frontend/e2e/person-network.spec.ts`, which asserts lane heads by name and that no node paints outside the viewBox; the first version passed against the broken layout because the node count is identical either way.
- The suite runs against a live stack via `BASE_URL` and `E2E_PERSON_ID`; without them it skips loudly instead of passing on an app it never loaded.

<sup>Written for commit cb47052d4b67667e04064cea08cc5c92d5a9894f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for the person Network tab, including responsive layouts, relationship-map rendering, navigation actions, and overflow checks.
  * Improved relationship-map organization by placing the primary contact in the center lane and account contacts in the right lane.
  * Moved the relationship map below the work grid for a full-width view.
  * Localized the “why now” relationship-change message.

* **Bug Fixes**
  * Improved account-contact map button recognition for names with additional content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->