### PR TITLE
A card states its own date, and undoing a number moves the row

### DIFF
--- a/backend/internal/modules/people/observedcard.go
+++ b/backend/internal/modules/people/observedcard.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Reading a business card into the shared vocabulary, and applying it.
+//
+// Split from observedcontact.go, which holds the RULE a dated statement obeys.
+// This holds what a CARD specifically states and how its properties map onto
+// that vocabulary — the questions a signature never raises, like which of a
+// card's URLs is a profile and which is a company site.
+
+import (
+	"context"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+// observedCard is one business card, as a dated statement by the person on it.
+type observedCard struct {
+	Entry      VCardEntry
+	Evidence   string
+	SourceRef  string
+	Source     string
+	CapturedBy string
+	// ObservedAt is when the card states it was last revised (its REV), or zero
+	// where it states none this reader trusts — the import then dates it from
+	// its own clock.
+	ObservedAt time.Time
+}
+
+// applyObservedCard writes everything a card states, and reports which fields
+// moved so the caller can audit them.
+//
+// The same writer the signature pass uses, deliberately: a card and a signature
+// are one kind of input — the contact describing themselves — and two writers
+// would let the ARRIVAL ROUTE decide whether a stale number gets corrected.
+//
+// Emails are the exception and stay additive. An address the card omits is not
+// an address retired, and no automatic path may take away a way to reach
+// somebody; the card's own addresses are added on the create path and left
+// alone here.
+func applyObservedCard(ctx context.Context, tx pgx.Tx, personID ids.PersonID, c observedCard) ([]string, error) {
+	var applied []string
+	for _, f := range cardFields(c.Entry) {
+		outcome, err := applyObservedField(ctx, tx, personID, observedField{
+			Field: f.name, Value: f.value, Evidence: c.Evidence, SourceRef: c.SourceRef,
+			Source: c.Source, CapturedBy: c.CapturedBy, ObservedAt: c.ObservedAt,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if outcome == observedApplied {
+			applied = append(applied, f.name)
+		}
+	}
+	// The numbers first, then ONE evidence line for the number that matters.
+	//
+	// One line because the sidecar holds one row per field, and it is written
+	// after the loop because every number on a card shares the card's date —
+	// a second write inside the loop would lose the supersede clause's
+	// strictly-newer test and leave whichever number happened to be first.
+	//
+	// The number that REPLACED one, where the card replaced any: an undo reads
+	// its value out of this row, so a card stating a new home number and a
+	// replacing work number must not point the undo at the home number and
+	// revive something the reader was not looking at.
+	var evidenceFor string
+	for _, phone := range c.Entry.Phones {
+		outcome, err := applyObservedPhone(ctx, tx, personID, observedPhone{
+			Phone: phone.Value, PhoneType: phone.Kind, SourceRef: c.SourceRef,
+			Source: c.Source, CapturedBy: c.CapturedBy, ObservedAt: c.ObservedAt,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if outcome != observedApplied && outcome != observedReplaced {
+			continue
+		}
+		if !slices.Contains(applied, fieldPhone) {
+			applied = append(applied, fieldPhone)
+		}
+		if evidenceFor == "" || outcome == observedReplaced {
+			// NORMALIZED, the way the number list stores it and the way the
+			// signature path writes this line. The raw card spelling would
+			// match no row, and the undo reads this value back to find the
+			// number it is about.
+			parsed, err := values.ParsePhone(phone.Value)
+			if err != nil {
+				continue
+			}
+			evidenceFor = parsed.String()
+		}
+	}
+	if evidenceFor != "" {
+		if _, err := applyObservedField(ctx, tx, personID, observedField{
+			Field: fieldPhone, Value: evidenceFor, Evidence: c.Evidence,
+			SourceRef: c.SourceRef, Source: c.Source, CapturedBy: c.CapturedBy,
+			ObservedAt: c.ObservedAt,
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return applied, nil
+}
+
+// cardField is one of the card's single-answer fields, named in the shared
+// vocabulary.
+type cardField struct{ name, value string }
+
+// cardFields reads a card into that vocabulary, dropping what it does not
+// state.
+//
+// TITLE fills `title` and NOT `role`. They are different claims — a title is
+// what somebody is called, a role is what they do in a deal — and person360
+// attaches role evidence to the employment role, so a card saying "VP Finance"
+// would make an unrelated role like "Decision maker" display with that as its
+// evidence.
+//
+// URL is split rather than filed as linkedin, which is what the old import did
+// to every card: a company website landed under a person's LinkedIn profile and
+// the page then showed it as one. Host, not guesswork.
+func cardFields(entry VCardEntry) []cardField {
+	out := make([]cardField, 0, 5)
+	add := func(name, value string) {
+		if v := strings.TrimSpace(value); v != "" {
+			out = append(out, cardField{name: name, value: v})
+		}
+	}
+	add(fieldTitle, entry.Title)
+	add(fieldOrgName, entry.Organization)
+	add(fieldAddress, entry.Address)
+	if u := strings.TrimSpace(entry.URL); u != "" {
+		if isLinkedinURL(u) {
+			add(fieldLinkedin, u)
+		} else {
+			add(fieldWebsite, u)
+		}
+	}
+	return out
+}
+
+// isLinkedinURL reports whether a URL names a LinkedIn profile, by host rather
+// than by substring: a website whose path merely mentions linkedin is not one.
+//
+// Subdomains count, because LinkedIn's own localized profile links carry them —
+// de.linkedin.com and www.linkedin.com are the same site, and a reader who
+// pasted either meant their profile. Hostname() rather than Host, so an
+// explicit port does not turn a profile into a website.
+func isLinkedinURL(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		// A bare "linkedin.com/in/x" with no scheme parses as a path.
+		host, _, _ = strings.Cut(strings.ToLower(raw), "/")
+		host, _, _ = strings.Cut(host, ":")
+	}
+	return host == "linkedin.com" || strings.HasSuffix(host, ".linkedin.com")
+}

--- a/backend/internal/modules/people/observedcontact.go
+++ b/backend/internal/modules/people/observedcontact.go
@@ -28,9 +28,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -82,6 +79,9 @@ const (
 	// observedConfirmed: the record already carried it, stated at least as
 	// recently. Nothing was written and nothing needs to be.
 	observedConfirmed
+	// observedReplaced: the value landed AND retired an older one, which is
+	// the case an undo exists for.
+	observedReplaced
 )
 
 // applyObservedField writes one dated statement, superseding what is older.
@@ -181,6 +181,9 @@ func observedFieldColumn(field string) (string, bool) {
 // what tells those apart: a column that disagrees with the sidecar was written
 // by somebody else, and it is the value a reader wants back.
 func seedFromColumn(ctx context.Context, tx pgx.Tx, personID ids.PersonID, f observedField) (string, error) {
+	if f.Field == fieldPhone {
+		return seedFromLiveNumber(ctx, tx, personID, f)
+	}
 	column, mirrored := observedFieldColumn(f.Field)
 	if !mirrored {
 		return "", nil
@@ -299,18 +302,9 @@ func applyObservedPhone(ctx context.Context, tx pgx.Tx, personID ids.PersonID, p
 		return observedSkipped, nil
 	}
 
-	// The row of this type this statement replaces, if it is older. Chosen by
-	// id so the archive and the insert name the same row: several live numbers
-	// of one type are permitted, and the primary is the one displayed.
-	var supersededID *ids.UUID
-	if err := tx.QueryRow(ctx, `
-		SELECT id FROM person_phone
-		WHERE person_id = $1 AND phone_type = $2 AND archived_at IS NULL AND observed_at < $3
-		ORDER BY is_primary DESC, position, created_at
-		LIMIT 1`,
-		personID, phoneType, observedAt).Scan(&supersededID); err != nil &&
-		!errors.Is(err, pgx.ErrNoRows) {
-		return observedSkipped, fmt.Errorf("people: looking for the number this replaces: %w", err)
+	supersededID, err := numberThisReplaces(ctx, tx, personID, phoneType, observedAt)
+	if err != nil {
+		return observedSkipped, err
 	}
 
 	if supersededID != nil {
@@ -341,6 +335,12 @@ func applyObservedPhone(ctx context.Context, tx pgx.Tx, personID ids.PersonID, p
 	}
 	if tag.RowsAffected() == 0 {
 		return observedSkipped, nil
+	}
+	if supersededID != nil {
+		// This number took another's place, which is what the undo buffer is
+		// for. The caller records the evidence line against THIS number rather
+		// than against whichever the card happened to list first.
+		return observedReplaced, nil
 	}
 	return observedApplied, nil
 }
@@ -379,132 +379,63 @@ func confirmKnownNumber(ctx context.Context, tx pgx.Tx, personID ids.PersonID, n
 	return observedSkipped, nil
 }
 
-// observedCard is one business card, as a dated statement by the person on it.
-type observedCard struct {
-	Entry      VCardEntry
-	Evidence   string
-	SourceRef  string
-	Source     string
-	CapturedBy string
-	// ObservedAt is when the card was handed over. Zero means now, which is the
-	// honest answer for an import: a .vcf carries no date of its own, and the
-	// moment a human chose to import it is what there is.
-	ObservedAt time.Time
+// seedFromLiveNumber is seedFromColumn's phone arm: the number about to be
+// replaced, read from the list rather than from a column.
+//
+// A phone has no mirror column, so the general path seeds nothing — and a
+// number that only ever lived in person_phone (one typed at create, say) would
+// then be replaced with superseded_value left NULL, which is exactly the state
+// RestoreProfileField reads as "nothing to undo". The undo would be silently
+// unavailable for the commonest phone there is.
+//
+// The PRIMARY of the type being stated, because that is the number a reader is
+// shown and therefore the one they would expect back.
+func seedFromLiveNumber(ctx context.Context, tx pgx.Tx, personID ids.PersonID, f observedField) (string, error) {
+	// The number this one REPLACED, read from the row that says so, and not
+	// from whatever is live now: the numbers are written before this line is,
+	// so by the time it runs the old row is already archived and "live" names
+	// the replacement itself. Falling back to the live primary covers the
+	// signature path, where the line is written first and no supersede has
+	// happened yet.
+	var current *string
+	if err := tx.QueryRow(ctx, `
+		SELECT COALESCE(
+			(SELECT was.phone
+			   FROM person_phone live
+			   JOIN person_phone was ON was.id = live.superseded_phone_id
+			  WHERE live.person_id = $1 AND live.archived_at IS NULL
+			    AND live.phone = $2 AND was.person_id = $1
+			  LIMIT 1),
+			(SELECT phone FROM person_phone
+			  WHERE person_id = $1 AND archived_at IS NULL
+			  ORDER BY is_primary DESC, position, created_at
+			  LIMIT 1))`, personID, f.Value).Scan(&current); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("people: reading the number before it is superseded: %w", err)
+	}
+	if current == nil || *current == f.Value {
+		return "", nil
+	}
+	return *current, nil
 }
 
-// applyObservedCard writes everything a card states, and reports which fields
-// moved so the caller can audit them.
+// numberThisReplaces finds the row of this type a statement supersedes, or nil
+// where it supersedes none.
 //
-// The same writer the signature pass uses, deliberately: a card and a signature
-// are one kind of input — the contact describing themselves — and two writers
-// would let the ARRIVAL ROUTE decide whether a stale number gets corrected.
-//
-// Emails are the exception and stay additive. An address the card omits is not
-// an address retired, and no automatic path may take away a way to reach
-// somebody; the card's own addresses are added on the create path and left
-// alone here.
-func applyObservedCard(ctx context.Context, tx pgx.Tx, personID ids.PersonID, c observedCard) ([]string, error) {
-	var applied []string
-	for _, f := range cardFields(c.Entry) {
-		outcome, err := applyObservedField(ctx, tx, personID, observedField{
-			Field: f.name, Value: f.value, Evidence: c.Evidence, SourceRef: c.SourceRef,
-			Source: c.Source, CapturedBy: c.CapturedBy, ObservedAt: c.ObservedAt,
-		})
-		if err != nil {
-			return nil, err
-		}
-		if outcome == observedApplied {
-			applied = append(applied, f.name)
-		}
+// Chosen by id so the archive and the insert name the same row: several live
+// numbers of one type are permitted, and the primary is the one displayed.
+func numberThisReplaces(ctx context.Context, tx pgx.Tx, personID ids.PersonID, phoneType string, observedAt time.Time) (*ids.UUID, error) {
+	var supersededID *ids.UUID
+	if err := tx.QueryRow(ctx, `
+		SELECT id FROM person_phone
+		WHERE person_id = $1 AND phone_type = $2 AND archived_at IS NULL AND observed_at < $3
+		ORDER BY is_primary DESC, position, created_at
+		LIMIT 1`,
+		personID, phoneType, observedAt).Scan(&supersededID); err != nil &&
+		!errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("people: looking for the number this replaces: %w", err)
 	}
-	wroteEvidence := false
-	for _, phone := range c.Entry.Phones {
-		outcome, err := applyObservedPhone(ctx, tx, personID, observedPhone{
-			Phone: phone.Value, PhoneType: phone.Kind, SourceRef: c.SourceRef,
-			Source: c.Source, CapturedBy: c.CapturedBy, ObservedAt: c.ObservedAt,
-		})
-		if err != nil {
-			return nil, err
-		}
-		if outcome != observedApplied {
-			continue
-		}
-		if !slices.Contains(applied, fieldPhone) {
-			applied = append(applied, fieldPhone)
-		}
-		// The evidence line for the number, written once for the first number
-		// this card LANDS: the sidecar holds one row per field while a card may
-		// state several numbers, so writing it per number would be the same row
-		// overwritten and the undo would offer whichever happened to be last.
-		// The signature pass writes this line too, and it is what gives a
-		// replaced number something to undo.
-		if !wroteEvidence {
-			wroteEvidence = true
-			if _, err := applyObservedField(ctx, tx, personID, observedField{
-				Field: fieldPhone, Value: phone.Value, Evidence: c.Evidence,
-				SourceRef: c.SourceRef, Source: c.Source, CapturedBy: c.CapturedBy,
-				ObservedAt: c.ObservedAt,
-			}); err != nil {
-				return nil, err
-			}
-		}
-	}
-	return applied, nil
-}
-
-// cardField is one of the card's single-answer fields, named in the shared
-// vocabulary.
-type cardField struct{ name, value string }
-
-// cardFields reads a card into that vocabulary, dropping what it does not
-// state.
-//
-// TITLE fills `title` and NOT `role`. They are different claims — a title is
-// what somebody is called, a role is what they do in a deal — and person360
-// attaches role evidence to the employment role, so a card saying "VP Finance"
-// would make an unrelated role like "Decision maker" display with that as its
-// evidence.
-//
-// URL is split rather than filed as linkedin, which is what the old import did
-// to every card: a company website landed under a person's LinkedIn profile and
-// the page then showed it as one. Host, not guesswork.
-func cardFields(entry VCardEntry) []cardField {
-	out := make([]cardField, 0, 5)
-	add := func(name, value string) {
-		if v := strings.TrimSpace(value); v != "" {
-			out = append(out, cardField{name: name, value: v})
-		}
-	}
-	add(fieldTitle, entry.Title)
-	add(fieldOrgName, entry.Organization)
-	add(fieldAddress, entry.Address)
-	if u := strings.TrimSpace(entry.URL); u != "" {
-		if isLinkedinURL(u) {
-			add(fieldLinkedin, u)
-		} else {
-			add(fieldWebsite, u)
-		}
-	}
-	return out
-}
-
-// isLinkedinURL reports whether a URL names a LinkedIn profile, by host rather
-// than by substring: a website whose path merely mentions linkedin is not one.
-//
-// Subdomains count, because LinkedIn's own localized profile links carry them —
-// de.linkedin.com and www.linkedin.com are the same site, and a reader who
-// pasted either meant their profile. Hostname() rather than Host, so an
-// explicit port does not turn a profile into a website.
-func isLinkedinURL(raw string) bool {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return false
-	}
-	host := strings.ToLower(parsed.Hostname())
-	if host == "" {
-		// A bare "linkedin.com/in/x" with no scheme parses as a path.
-		host, _, _ = strings.Cut(strings.ToLower(raw), "/")
-		host, _, _ = strings.Cut(host, ":")
-	}
-	return host == "linkedin.com" || strings.HasSuffix(host, ".linkedin.com")
+	return supersededID, nil
 }

--- a/backend/internal/modules/people/observedcontact.go
+++ b/backend/internal/modules/people/observedcontact.go
@@ -417,6 +417,7 @@ func applyObservedCard(ctx context.Context, tx pgx.Tx, personID ids.PersonID, c 
 			applied = append(applied, f.name)
 		}
 	}
+	wroteEvidence := false
 	for _, phone := range c.Entry.Phones {
 		outcome, err := applyObservedPhone(ctx, tx, personID, observedPhone{
 			Phone: phone.Value, PhoneType: phone.Kind, SourceRef: c.SourceRef,
@@ -425,8 +426,27 @@ func applyObservedCard(ctx context.Context, tx pgx.Tx, personID ids.PersonID, c 
 		if err != nil {
 			return nil, err
 		}
-		if outcome == observedApplied && !slices.Contains(applied, fieldPhone) {
+		if outcome != observedApplied {
+			continue
+		}
+		if !slices.Contains(applied, fieldPhone) {
 			applied = append(applied, fieldPhone)
+		}
+		// The evidence line for the number, written once for the first number
+		// this card LANDS: the sidecar holds one row per field while a card may
+		// state several numbers, so writing it per number would be the same row
+		// overwritten and the undo would offer whichever happened to be last.
+		// The signature pass writes this line too, and it is what gives a
+		// replaced number something to undo.
+		if !wroteEvidence {
+			wroteEvidence = true
+			if _, err := applyObservedField(ctx, tx, personID, observedField{
+				Field: fieldPhone, Value: phone.Value, Evidence: c.Evidence,
+				SourceRef: c.SourceRef, Source: c.Source, CapturedBy: c.CapturedBy,
+				ObservedAt: c.ObservedAt,
+			}); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return applied, nil

--- a/backend/internal/modules/people/profilefieldrestore.go
+++ b/backend/internal/modules/people/profilefieldrestore.go
@@ -100,31 +100,8 @@ func (s *Store) RestoreProfileField(ctx context.Context, personID ids.PersonID, 
 		// mirrored field, so it has to agree too — a title somebody retyped
 		// leaves the sidecar untouched, and restoring on the sidecar alone
 		// would put the old value back under their answer.
-		// A human's CORRECTION blocks the undo, and it has to be asked for
-		// separately: a correction is recorded in the ai_feedback ledger and
-		// touches neither the column nor this row, so the CAS below cannot see
-		// one. Restoring over it would put back a value the reader looked at
-		// and rejected — and would move this row's updated_at, which is the
-		// date their verdict is judged against, retiring the correction as
-		// well as overruling it.
-		//
-		// Matched on the ledger's own key, which is a hash of the claim path:
-		// spelling the path here rather than taking the hash apart is what
-		// keeps the two sides agreeing, and ai.ProfileFieldClaimPath is the one
-		// spelling. The store cannot import that module, so the caller-facing
-		// half lives in the handler's package and this asks the table directly.
-		var corrected bool
-		if err := tx.QueryRow(ctx, `
-			SELECT EXISTS (
-				SELECT 1 FROM ai_feedback
-				 WHERE subject_type = 'person' AND subject_id = $1
-				   AND claim_kind = 'profile_field' AND verdict = 'corrected'
-				   AND claim_key = encode(sha256(('profile_field:' || $2)::bytea), 'hex'))`,
-			personID, field).Scan(&corrected); err != nil {
-			return fmt.Errorf("people: looking for a correction on %s: %w", field, err)
-		}
-		if corrected {
-			return apperrors.ErrConflict
+		if err := refuseIfCorrected(ctx, tx, personID, field); err != nil {
+			return err
 		}
 
 		// The comparison is IN the statement, not before it: reading the column
@@ -236,13 +213,29 @@ func restoreSupersededPhone(ctx context.Context, tx pgx.Tx, personID ids.PersonI
 	normalized := parsed.String()
 
 	var replacementID, supersededID ids.UUID
+	// was.person_id is checked, not assumed from the join. A merge re-homes only
+	// LIVE phone rows, so a replacement can move to the survivor while the
+	// archived row it superseded stays behind on the merged-away person —
+	// following the pointer alone would then archive the survivor's number and
+	// revive one belonging to somebody else. The partial unique index cannot
+	// catch that, because the two rows carry different person_ids.
+	//
+	// NOT EXISTS for the number itself, for the other half of the same gap: a
+	// merge can leave the survivor already holding a live copy of the number
+	// being revived, and nothing on this table forbids one person holding one
+	// number twice.
 	if err := tx.QueryRow(ctx, `
 		SELECT live.id, live.superseded_phone_id
 		  FROM person_phone live
 		  JOIN person_phone was ON was.id = live.superseded_phone_id
 		 WHERE live.person_id = $1 AND live.archived_at IS NULL
 		   AND live.superseded_phone_id IS NOT NULL
+		   AND was.person_id = $1
 		   AND was.phone = $2 AND was.archived_at IS NOT NULL
+		   AND NOT EXISTS (
+			SELECT 1 FROM person_phone dup
+			 WHERE dup.person_id = $1 AND dup.phone = $2
+			   AND dup.archived_at IS NULL)
 		 ORDER BY live.observed_at DESC
 		 LIMIT 1
 		 FOR UPDATE OF live`,
@@ -268,10 +261,48 @@ func restoreSupersededPhone(ctx context.Context, tx pgx.Tx, personID ids.PersonI
 	if tag.RowsAffected() == 0 {
 		return apperrors.ErrConflict
 	}
-	if _, err := tx.Exec(ctx, `
+	revived, err := tx.Exec(ctx, `
 		UPDATE person_phone SET archived_at = NULL
-		 WHERE id = $1 AND archived_at IS NOT NULL`, supersededID); err != nil {
+		 WHERE id = $1 AND archived_at IS NOT NULL AND person_id = $2`,
+		supersededID, personID)
+	if err != nil {
 		return fmt.Errorf("people: bringing the replaced number back: %w", err)
+	}
+	if revived.RowsAffected() == 0 {
+		// The row stopped being ours to revive between the read and here. The
+		// replacement is already retired, so refusing leaves the person one
+		// number short — but the alternative is reviving nothing while
+		// reporting success, and a caller told 204 would never look again.
+		return apperrors.ErrConflict
+	}
+	return nil
+}
+
+// refuseIfCorrected blocks an undo over a field a human has ruled on.
+//
+// A correction is recorded in the ai_feedback ledger and touches neither the
+// column nor the profile-field row, so the CAS the caller makes cannot see one.
+// Restoring over it would put back a value the reader looked at and rejected —
+// and would move the row's updated_at, which is the date their verdict is
+// judged against, retiring the correction as well as overruling it.
+//
+// Matched on the ledger's own key, which is a HASH of the claim path: spelling
+// the path here rather than taking the hash apart is what keeps the two sides
+// agreeing, and a mismatch would fail by matching nothing rather than by
+// failing. TestTheRestoreMatchesTheLedgersOwnClaimKey holds them together.
+func refuseIfCorrected(ctx context.Context, tx pgx.Tx, personID ids.PersonID, field string) error {
+	var corrected bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM ai_feedback
+			 WHERE subject_type = 'person' AND subject_id = $1
+			   AND claim_kind = 'profile_field' AND verdict = 'corrected'
+			   AND claim_key = encode(sha256(('profile_field:' || $2)::bytea), 'hex'))`,
+		personID, field).Scan(&corrected); err != nil {
+		return fmt.Errorf("people: looking for a correction on %s: %w", field, err)
+	}
+	if corrected {
+		return apperrors.ErrConflict
 	}
 	return nil
 }

--- a/backend/internal/modules/people/profilefieldrestore.go
+++ b/backend/internal/modules/people/profilefieldrestore.go
@@ -30,6 +30,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // restoredEvidence is the receipt a restored value carries: the value itself,
@@ -143,6 +144,11 @@ func (s *Store) RestoreProfileField(ctx context.Context, personID ids.PersonID, 
 				return apperrors.ErrConflict
 			}
 		}
+		if field == fieldPhone {
+			if err := restoreSupersededPhone(ctx, tx, personID, superseded); err != nil {
+				return err
+			}
+		}
 
 		// Through the one writer, under the precedence a restore IS: a human
 		// choosing this value over the one that replaced it. Its clause also
@@ -201,4 +207,71 @@ func (h Handlers) RestorePersonProfileField(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// restoreSupersededPhone brings back the number a newer statement replaced.
+//
+// A phone is a LIST, so the sidecar row the restore rewrites is only the
+// EVIDENCE line: leaving it there would tell a reader their old number was
+// back while the record still held the replacement, and they would find out by
+// dialling. The row itself has to move.
+//
+// Identity, not value: person_phone.superseded_phone_id records exactly which
+// row a number replaced, because the table permits several live numbers of one
+// type and "unarchive the old one" names none of them.
+//
+// Both writes are CAS. The replacement is retired only while it is still live
+// and still ours to retire, and the old row is revived only while it is still
+// archived — a number somebody re-added by hand in the meantime is theirs, and
+// reviving a second copy of it would leave the person holding one number twice.
+func restoreSupersededPhone(ctx context.Context, tx pgx.Tx, personID ids.PersonID, want string) error {
+	parsed, err := values.ParsePhone(want)
+	if err != nil {
+		// The buffer holds a value this reader cannot parse back into a number,
+		// so there is nothing to revive. The evidence line is still restored;
+		// the record simply has no row to match it.
+		//nolint:nilerr // an unparseable buffered value is nothing to revive, not a fault
+		return nil
+	}
+	normalized := parsed.String()
+
+	var replacementID, supersededID ids.UUID
+	if err := tx.QueryRow(ctx, `
+		SELECT live.id, live.superseded_phone_id
+		  FROM person_phone live
+		  JOIN person_phone was ON was.id = live.superseded_phone_id
+		 WHERE live.person_id = $1 AND live.archived_at IS NULL
+		   AND live.superseded_phone_id IS NOT NULL
+		   AND was.phone = $2 AND was.archived_at IS NOT NULL
+		 ORDER BY live.observed_at DESC
+		 LIMIT 1
+		 FOR UPDATE OF live`,
+		personID, normalized).Scan(&replacementID, &supersededID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Nothing to move: the replacement is gone, or the number it
+			// replaced is live again already. Not a fault — the evidence line
+			// restores and the record already says what the reader wanted.
+			return nil
+		}
+		return fmt.Errorf("people: looking for the number to bring back: %w", err)
+	}
+
+	// The replacement first. Retiring it before the old row is revived is what
+	// keeps the primary slot free: the partial unique index permits exactly one
+	// live primary per type, and reviving first would collide with it.
+	tag, err := tx.Exec(ctx, `
+		UPDATE person_phone SET archived_at = now()
+		 WHERE id = $1 AND archived_at IS NULL`, replacementID)
+	if err != nil {
+		return fmt.Errorf("people: retiring the replacing number: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return apperrors.ErrConflict
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE person_phone SET archived_at = NULL
+		 WHERE id = $1 AND archived_at IS NOT NULL`, supersededID); err != nil {
+		return fmt.Errorf("people: bringing the replaced number back: %w", err)
+	}
+	return nil
 }

--- a/backend/internal/modules/people/vcard.go
+++ b/backend/internal/modules/people/vcard.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
 
 // VCardEntry is one card, reduced to what a person record holds. Every field is
@@ -39,6 +40,10 @@ type VCardEntry struct {
 	Phones       []VCardChannel
 	URL          string
 	Address      string
+	// Revised is what the card's REV property states: when this card was last
+	// changed. Nil where it states none, and the import then dates the card
+	// from its own clock.
+	Revised *time.Time
 }
 
 // VCardChannel is one address or number with the kind the card gave it.
@@ -246,7 +251,40 @@ func applyVCardProperty(entry *VCardEntry, name string, params []string, raw str
 		if entry.Address == "" {
 			entry.Address = addressFromStructured(params, raw)
 		}
+	case "REV":
+		if entry.Revised == nil {
+			entry.Revised = parseVCardRevision(value)
+		}
 	}
+}
+
+// parseVCardRevision reads REV, the card's own statement of when it was last
+// revised, and nil when it states none or states one this reader cannot parse.
+//
+// It matters because a card carries no other date, and the import needs one:
+// dating a card from the moment the request ran makes a re-upload of the same
+// file a NEWER statement than everything since, so a retry can put back a
+// detail a signature had already corrected. REV is what the card itself says,
+// so importing the same file twice states the same thing twice.
+//
+// RFC 6350 writes REV as an ISO 8601 basic-format timestamp; the extended
+// format and a bare date appear in real files, so all three are read. A card
+// whose REV cannot be read falls back to the import's own clock, which is the
+// behaviour every card had before this.
+func parseVCardRevision(value string) *time.Time {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return nil
+	}
+	for _, layout := range []string{
+		"20060102T150405Z0700", "20060102T150405Z07:00", "20060102T150405",
+		time.RFC3339, "2006-01-02T15:04:05", "20060102", "2006-01-02",
+	} {
+		if at, err := time.Parse(layout, v); err == nil {
+			return &at
+		}
+	}
+	return nil
 }
 
 // decodeVCardValue undoes the two encodings a real-world card carries: the

--- a/backend/internal/modules/people/vcard.go
+++ b/backend/internal/modules/people/vcard.go
@@ -276,9 +276,26 @@ func parseVCardRevision(value string) *time.Time {
 	if v == "" {
 		return nil
 	}
+	// Zoned forms FIRST, and the hour-only offset among them: RFC 6350 admits
+	// -05 as well as -0500, and a card carrying one would otherwise fall
+	// through to the zoneless layouts, be read as UTC, and claim a time hours
+	// from what it says.
 	for _, layout := range []string{
-		"20060102T150405Z0700", "20060102T150405Z07:00", "20060102T150405",
-		time.RFC3339, "2006-01-02T15:04:05", "20060102", "2006-01-02",
+		"20060102T150405Z0700", "20060102T150405Z07:00", "20060102T150405Z07",
+		time.RFC3339, "2006-01-02T15:04:05Z07", "2006-01-02T15:04:05Z0700",
+	} {
+		if at, err := time.Parse(layout, v); err == nil {
+			return &at
+		}
+	}
+	// Zoneless forms are read as UTC, which is a GUESS — the card states a wall
+	// clock and not an instant. It is the safe direction to guess in: UTC is at
+	// or behind every zone east of it, so a card read this way can be older
+	// than it is and lose a comparison it should have won, never newer and win
+	// one it should have lost. A card that loses is a detail not corrected; a
+	// card that wrongly wins overwrites a statement made after it.
+	for _, layout := range []string{
+		"20060102T150405", "2006-01-02T15:04:05", "20060102", "2006-01-02",
 	} {
 		if at, err := time.Parse(layout, v); err == nil {
 			return &at

--- a/backend/internal/modules/people/vcardimport.go
+++ b/backend/internal/modules/people/vcardimport.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -354,8 +355,21 @@ func (s *Store) fillFromVCard(ctx context.Context, tx pgx.Tx, personID ids.Perso
 		Entry: entry, Evidence: evidence, SourceRef: vcardSource,
 		Source: vcardSource, CapturedBy: by,
 	}
+	// A card's REV is written by whoever exported it, so it is attacker-supplied
+	// like every other field on the card — and unlike the others it decides
+	// what this card OUTRANKS. A REV in 2099 would win against every statement
+	// the contact ever makes afterwards, permanently, from one file somebody
+	// mailed in. A future date is therefore not read as a date: the import
+	// falls back to its own clock, which is exactly the answer a card with no
+	// REV already gets.
 	if entry.Revised != nil {
-		card.ObservedAt = *entry.Revised
+		var now time.Time
+		if err := tx.QueryRow(ctx, `SELECT now()`).Scan(&now); err != nil {
+			return fmt.Errorf("people: dating the card against the clock: %w", err)
+		}
+		if !entry.Revised.After(now) {
+			card.ObservedAt = *entry.Revised
+		}
 	}
 	applied, err := applyObservedCard(ctx, tx, personID, card)
 	if err != nil {

--- a/backend/internal/modules/people/vcardimport.go
+++ b/backend/internal/modules/people/vcardimport.go
@@ -344,10 +344,20 @@ func (s *Store) fillFromVCard(ctx context.Context, tx pgx.Tx, personID ids.Perso
 	// snippet is what the card stated, which is what an Art. 15 answer has to
 	// be able to show.
 	evidence := vcardEvidence(entry)
-	applied, err := applyObservedCard(ctx, tx, personID, observedCard{
+	// The card's own REV when it states one, so importing the same file twice
+	// states the same thing twice. Dated from the clock instead, a re-upload
+	// would be a NEWER statement than everything since it — and a reader
+	// re-uploading a file they were unsure landed would put back a detail a
+	// signature had already corrected. A card with no REV still takes the
+	// clock, which is what every card did before.
+	card := observedCard{
 		Entry: entry, Evidence: evidence, SourceRef: vcardSource,
 		Source: vcardSource, CapturedBy: by,
-	})
+	}
+	if entry.Revised != nil {
+		card.ObservedAt = *entry.Revised
+	}
+	applied, err := applyObservedCard(ctx, tx, personID, card)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/modules/people/vcardimport.go
+++ b/backend/internal/modules/people/vcardimport.go
@@ -345,12 +345,15 @@ func (s *Store) fillFromVCard(ctx context.Context, tx pgx.Tx, personID ids.Perso
 	// snippet is what the card stated, which is what an Art. 15 answer has to
 	// be able to show.
 	evidence := vcardEvidence(entry)
-	// The card's own REV when it states one, so importing the same file twice
-	// states the same thing twice. Dated from the clock instead, a re-upload
-	// would be a NEWER statement than everything since it — and a reader
-	// re-uploading a file they were unsure landed would put back a detail a
-	// signature had already corrected. A card with no REV still takes the
-	// clock, which is what every card did before.
+	// The card's own REV when it states one it can be read from, so importing
+	// the same file twice states the same thing twice. Dated from the clock
+	// instead, a re-upload would be a NEWER statement than everything since it,
+	// and a reader re-uploading a file they were unsure landed would put back a
+	// detail a signature had already corrected.
+	//
+	// A card with no REV, an unreadable one, or one dated in the FUTURE takes
+	// the import's own clock — the behaviour every card had before this. The
+	// future case is the security-relevant one and the check below says why.
 	card := observedCard{
 		Entry: entry, Evidence: evidence, SourceRef: vcardSource,
 		Source: vcardSource, CapturedBy: by,

--- a/backend/internal/modules/people/vcardimport_integration_test.go
+++ b/backend/internal/modules/people/vcardimport_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -521,5 +522,58 @@ func TestACardCannotDateItselfIntoTheFuture(t *testing.T) {
 	}
 	if after.Title == nil || *after.Title != "Head of Present" {
 		t.Errorf("title = %v, want the statement made now to win over a card claiming 2099", after.Title)
+	}
+}
+
+// A card listing several numbers points the undo at the one that REPLACED
+// something, not at whichever it happened to list first.
+//
+// The sidecar holds one row per field and the undo reads the value out of it,
+// so a card stating a new mobile and a replacing work number would otherwise
+// point the undo at the mobile — and the reader clicking Undo would revive a
+// number they were not looking at while the mobile stayed put.
+func TestACardWithSeveralNumbersPointsTheUndoAtTheReplacement(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Mila Multi", "mila@multi.example", "Multi AS", "multi.example")
+
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO person_phone (person_id, phone, phone_type, is_primary, position, source, captured_by, observed_at)
+			VALUES ($1, '+49301111111', 'work', true, 0, 'manual', 'human:test', now() - interval '30 days')`,
+			personID)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A HOME number is listed first and replaces nothing, so it would take the
+	// one evidence line the field has. The work number comes second and
+	// replaces what the record holds, which is the number an undo is about.
+	importCards(ctx, t, e,
+		"BEGIN:VCARD\nFN:Mila Multi\nTEL;TYPE=HOME:+49 170 3333333\nTEL;TYPE=WORK:+49 30 2222222\n"+
+			"EMAIL;TYPE=WORK:mila@multi.example\nEND:VCARD\n")
+
+	// The evidence line is what the undo reads, so assert it names the number
+	// that replaced one. Without this the test can pass on the restore alone,
+	// which follows superseded_phone_id and would find the right row even when
+	// the line names the wrong number.
+	if got := profileFieldValue(ctx, t, e, personID, fieldPhone); got != "+49302222222" {
+		t.Errorf("phone evidence line = %q, want the number that REPLACED one — "+
+			"the undo reads its value out of this row", got)
+	}
+	if err := e.store.RestoreProfileField(ctx, personID, fieldPhone); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	live := livePhones(ctx, t, e, personID)
+	if !slices.Contains(live, "+49301111111") {
+		t.Errorf("live numbers = %v after the undo, want the replaced work number back", live)
+	}
+	if !slices.Contains(live, "+491703333333") {
+		t.Errorf("live numbers = %v, want the mobile untouched: the undo was about the work number", live)
+	}
+	if slices.Contains(live, "+49302222222") {
+		t.Errorf("live numbers = %v, want the replacing work number retired", live)
 	}
 }

--- a/backend/internal/modules/people/vcardimport_integration_test.go
+++ b/backend/internal/modules/people/vcardimport_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -360,4 +361,120 @@ func TestTheRestoreMatchesTheLedgersOwnClaimKey(t *testing.T) {
 				field, got, hex.EncodeToString(want[:]))
 		}
 	}
+}
+
+// A card carries its own date, so importing the same file twice states the
+// same thing twice.
+//
+// Without it, a re-upload is dated NOW and outranks everything since — so a
+// reader re-uploading a file they were unsure landed puts back a detail a
+// signature had already corrected. That is the whole defect; the second import
+// asserting nothing new is the fix.
+func TestReimportingACardDoesNotOutrankWhatCameAfterIt(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	card := "BEGIN:VCARD\nFN:Rev Card\nTITLE:VP Finance\nREV:20250101T090000Z\n" +
+		"EMAIL;TYPE=WORK:rev@card.example\nEND:VCARD\n"
+
+	results := importCards(ctx, t, e, card)
+	if len(results) != 1 || results[0].Outcome != VCardCreated {
+		t.Fatalf("outcomes = %+v, want one created", results)
+	}
+	personID := *results[0].PersonID
+
+	// Something states a newer title after the card was written.
+	if !fillFromSignature(ctx, t, e, personID, SignatureField{
+		Name: fieldTitle, Value: "Group CFO", Evidence: "Group CFO", Confidence: 0.9,
+	}) {
+		t.Fatal("the signature wrote nothing, so this test proves nothing about the re-import")
+	}
+
+	// The same file again. Its REV has not moved, so it is not a newer
+	// statement and the title it once carried must not come back.
+	importCards(ctx, t, e, card)
+
+	after, err := e.store.GetPerson(ctx, personID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("re-reading the person: %v", err)
+	}
+	if after.Title == nil || *after.Title != "Group CFO" {
+		t.Errorf("title = %v after re-importing the same card, want the newer %q — "+
+			"a re-upload must not resurrect what a later statement replaced", after.Title, "Group CFO")
+	}
+}
+
+// Undoing a replaced number moves the ROW, not just the evidence line.
+//
+// The sidecar holds one answer per field while the record holds a list, so a
+// restore that rewrote only the sidecar would tell a reader their old number
+// was back while the record still held the replacement — and they would find
+// out by dialling it.
+func TestUndoingAReplacedNumberBringsBackTheRowAReaderDials(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	personID, _ := e.seedEmployedPerson(ctx, t,
+		"Nora Numbers", "nora@numbers.example", "Numbers AS", "numbers.example")
+
+	// The number on the record, stated a month ago.
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO person_phone (person_id, phone, phone_type, is_primary, position, source, captured_by, observed_at)
+			VALUES ($1, '+49301111111', 'work', true, 0, 'manual', 'human:test', now() - interval '30 days')`,
+			personID)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !fillFromSignatureObserved(ctx, t, e, personID, time.Now().Add(-30*24*time.Hour), SignatureField{
+		Name: fieldPhone, Value: "+49301111111", Evidence: "+49 30 1111111", Confidence: 0.9,
+	}) {
+		t.Fatal("seeding the evidence line for the old number wrote nothing")
+	}
+
+	// A newer signature states a different one.
+	if !fillFromSignature(ctx, t, e, personID, SignatureField{
+		Name: fieldPhone, Value: "+49302222222", Evidence: "+49 30 2222222", Confidence: 0.9,
+	}) {
+		t.Fatal("the replacing number wrote nothing, so there is nothing to undo")
+	}
+	if live := livePhones(ctx, t, e, personID); len(live) != 1 || live[0] != "+49302222222" {
+		t.Fatalf("live numbers = %v, want only the replacement before the undo", live)
+	}
+
+	if err := e.store.RestoreProfileField(ctx, personID, fieldPhone); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	live := livePhones(ctx, t, e, personID)
+	if len(live) != 1 || live[0] != "+49301111111" {
+		t.Errorf("live numbers = %v after the undo, want the old number back and the "+
+			"replacement retired — an undo that leaves the record dialling the new one undid nothing", live)
+	}
+}
+
+// livePhones reads the numbers a reader would be offered, in position order.
+func livePhones(ctx context.Context, t *testing.T, e *dedupeEnv, personID ids.PersonID) []string {
+	t.Helper()
+	var out []string
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT phone FROM person_phone
+			 WHERE person_id = $1 AND archived_at IS NULL
+			 ORDER BY position, created_at`, personID)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var phone string
+			if err := rows.Scan(&phone); err != nil {
+				return err
+			}
+			out = append(out, phone)
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatalf("reading the live numbers: %v", err)
+	}
+	return out
 }

--- a/backend/internal/modules/people/vcardimport_integration_test.go
+++ b/backend/internal/modules/people/vcardimport_integration_test.go
@@ -478,3 +478,48 @@ func livePhones(ctx context.Context, t *testing.T, e *dedupeEnv, personID ids.Pe
 	}
 	return out
 }
+
+// A card cannot date itself into the future to win forever.
+//
+// REV is written by whoever exported the card, so it is attacker-supplied like
+// every other field on it — and unlike the others it decides what the card
+// OUTRANKS. A card claiming 2099 would beat every statement the contact makes
+// afterwards, permanently, from one file somebody mailed in.
+func TestACardCannotDateItselfIntoTheFuture(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+
+	// The person exists first, so the card takes the UPDATE path — the one that
+	// applies a card by its own date. A card that CREATES somebody states
+	// nothing this rule has to arbitrate, because there is no earlier answer.
+	incumbent, err := e.store.CreatePerson(ctx, CreatePersonInput{
+		FullName: "Future Card", Source: "manual",
+		Emails: []PersonEmailInput{{Email: "future@card.example", EmailType: emailTypeWork, IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("seeding the incumbent: %v", err)
+	}
+	personID := ids.From[ids.PersonKind](ids.UUID(incumbent.Id))
+
+	results := importCards(ctx, t, e,
+		"BEGIN:VCARD\nFN:Future Card\nTITLE:Time Traveller\nREV:20991231T235959Z\n"+
+			"EMAIL;TYPE=WORK:future@card.example\nEND:VCARD\n")
+	if len(results) != 1 || results[0].Outcome != VCardUpdated {
+		t.Fatalf("outcomes = %+v, want one updated", results)
+	}
+
+	// An ordinary statement made now must still win, which it cannot if the
+	// card's own date was taken at face value.
+	if !fillFromSignature(ctx, t, e, personID, SignatureField{
+		Name: fieldTitle, Value: "Head of Present", Evidence: "Head of Present", Confidence: 0.9,
+	}) {
+		t.Fatal("the signature wrote nothing — a future-dated card is outranking a statement made now")
+	}
+	after, err := e.store.GetPerson(ctx, personID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Title == nil || *after.Title != "Head of Present" {
+		t.Errorf("title = %v, want the statement made now to win over a card claiming 2099", after.Title)
+	}
+}


### PR DESCRIPTION
The last two pieces of the enrichment work. Follows #3427 and #3459.

## What changes for a rep

**Re-importing a .vcf no longer resurrects an old detail.** A card carried no date, so the import dated it "now" on every run — and a reader re-uploading a file they were unsure landed put back a title a later signature had already corrected (#3460). The reader now takes `REV`, the card's own revision timestamp, so importing the same file twice states the same thing twice.

**Undoing a replaced phone number now actually changes the number.** The undo was rewriting the evidence line and leaving the number a reader dials untouched — it reported success and undid nothing, which they would have found out by dialling. It follows `person_phone.superseded_phone_id` to archive the replacement and revive the row it replaced.

## The security-relevant part

`REV` is written by whoever exported the card, so it is attacker-supplied like every other field on it — and unlike the others it decides what the card **outranks**. A card claiming 2099 would beat every statement the contact makes afterwards, permanently, from one file somebody mailed in. A future date is not read as a date; the import falls back to its own clock.

Zoneless `REV` forms are read as UTC, which is a guess. The comment says why it is the safe direction: UTC is at or behind every zone east of it, so a card read this way can only lose a comparison it should have won, never win one it should have lost.

## What review caught

Five majors, two of them cross-person data corruption:

- **The undo could archive one person's number and revive another's.** A merge re-homes only *live* phone rows, so a replacement can move to the survivor while the row it superseded stays on the merged-away person. Following the pointer alone would then leave the survivor holding somebody else's old number — and the partial unique index cannot catch it, because the two rows carry different `person_id`s.
- **It could revive a duplicate**, since nothing on the table forbids one person holding one number twice. Both are checked now, and the revive is a real CAS rather than a comment claiming to be one.
- **A card listing several numbers pointed the undo at the wrong one.** The evidence line is one row per field and the undo reads its value, so a card stating a new home number and a replacing work number would revive something the reader was not looking at.
- **A phone that only ever lived in `person_phone` got no undo buffer at all** — `seedFromColumn` has no mirror column for phone, so the undo was silently unavailable for the commonest phone there is.
- **`REV` missed RFC 6350's hour-only offset** (`-05`), which fell through to the zoneless layouts and was read as UTC, hours from what the card says.

## Verification

`make check-backend` and `make check-fe` green; integration lanes `people` and `compose` green; `craft-static` clean after splitting `observedcard.go` out by concept.

Every guard is mutation-checked. Worth recording that **the multi-number test passed under mutation twice before it held anything** — first because it exercised the create path, which applies no dates at all, and then because it asserted the restore rather than the evidence line the restore reads. Both times the mutation check is what said so.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the last two gaps in the enrichment work: re-importing a `.vcf` card no longer resurrects a detail a later statement corrected, and undoing a replaced phone number now actually brings back the row a reader dials.

- The card import now takes the card's `REV` timestamp, so importing the same file twice states the same thing twice.
- A `REV` in the future falls back to the import clock; parsing accepts RFC 6350's hour-only offset, and zoneless forms read as UTC so a misread card can only lose a comparison, never win one it should have lost.
- The undo follows `person_phone.superseded_phone_id` to retire the replacement and revive the older row, refused when the row belongs to another person or the number is already live.
- The evidence line is written once, for the number that replaced something, so a card with several numbers undoes the right one.
- Phones that only ever lived in `person_phone` now get an undo buffer.

<sup>Written for commit 76db84bb15dbcd35b3aa45a19a6636da1e1e740d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - vCard imports now recognize revision dates across common ISO 8601 formats.
  - Business-card imports map contact details, normalize phone numbers, and classify LinkedIn profiles and websites.
  - Email information remains additive during imports.

- **Bug Fixes**
  - Older or future-dated card imports no longer override newer contact updates.
  - Undoing a phone-number replacement now restores the previously active number.
  - Correct replacement selection is maintained when multiple phone numbers are imported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->