### PR TITLE
The repair sweep can actually publish

### DIFF
--- a/backend/internal/compose/integration/linkreconcile_integration_test.go
+++ b/backend/internal/compose/integration/linkreconcile_integration_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The repair sweep, driven through the WORKER rather than the store.
+//
+// The store-level tests call the repair on a context the test built, so they
+// proved the SQL and nothing about the context the job actually runs under. That
+// gap shipped: the worker bound a workspace and a principal but no correlation
+// id, storekit.EmitEvent refuses to publish without one, and every contact
+// failed on its own event. The sweep retried three times, was discarded, and the
+// backlog it exists to clear sat untouched — looking exactly like a job that had
+// not run yet.
+//
+// So this drives the real worker over a real database, and asserts the repair
+// LANDED. A test that only checked the job returned nil would have passed while
+// the rows stayed broken.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/riverqueue/river"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// sweepPersonPerms may create the contact this fixture strands mail under.
+var sweepPersonPerms = principal.Permissions{
+	Objects:  map[string]principal.ObjectGrant{"person": {Create: true, Read: true}},
+	RowScope: principal.RowScopeAll,
+}
+
+func TestTheRepairSweepActuallyRepairsWhenDrivenAsTheJob(t *testing.T) {
+	e := Setup(t)
+	store := people.NewStore(e.DB())
+
+	// A contact, and mail captured under their address that no link reaches —
+	// the shape a backfill leaves when the person arrives mid-run.
+	person, err := store.EnsurePersonByEmail(e.As(e.Rep1, []ids.UUID{e.Team1}, sweepPersonPerms),
+		"Stranded Sender", "stranded@sweep.test", "manual")
+	if err != nil {
+		t.Fatalf("seeding the contact: %v", err)
+	}
+	activity := ids.NewV7()
+	e.WsExec(t, `
+		INSERT INTO activity (id, kind, subject, direction, counterparty_email,
+		                      source_system, source_id, source, captured_by)
+		VALUES ($1, 'email', 'hello', 'inbound', 'stranded@sweep.test',
+		        'gmail', $2, 'gmail:seed', 'connector:gmail')`, activity, activity.String())
+	e.WsExec(t, `
+		INSERT INTO activity_participant (id, activity_id, address, role)
+		VALUES ($1, $2, 'stranded@sweep.test', 'from')`, ids.NewV7(), activity)
+
+	// Drive the worker exactly as River does.
+	worker := compose.NewLinkReconcileWorkspaceWorkerForTest(e.Pool, store)
+	if err := worker.Work(context.Background(), &river.Job[compose.LinkReconcileWorkspaceArgs]{
+		Args: compose.LinkReconcileWorkspaceArgs{Workspace: e.WS},
+	}); err != nil {
+		t.Fatalf("the sweep failed: %v", err)
+	}
+
+	linked := e.WsCount(t, `SELECT count(*) FROM activity_link
+	                         WHERE activity_id = $1 AND entity_type = 'person' AND person_id = $2`,
+		activity, person) > 0
+	named := e.WsCount(t, `SELECT count(*) FROM activity_participant
+	                        WHERE activity_id = $1 AND person_id = $2`, activity, person) > 0
+	if !linked || !named {
+		t.Errorf("after the sweep: linked=%v named=%v, want both — the job returning cleanly is not "+
+			"the repair landing, and that difference is what let a sweep that repaired nothing look healthy",
+			linked, named)
+	}
+}

--- a/backend/internal/compose/linkreconcile.go
+++ b/backend/internal/compose/linkreconcile.go
@@ -172,6 +172,12 @@ func (w *linkReconcileWorker) attachDomainBacklogs(sweepCtx context.Context, ws 
 // actor for both.
 func (w *linkReconcileWorker) systemContext(ctx context.Context, ws ids.UUID) context.Context {
 	ctx = principal.WithWorkspaceID(ctx, ws)
+	// The correlation id is not decoration: storekit.EmitEvent REFUSES to
+	// publish without one, so a pass that omitted it repaired nothing at all —
+	// every contact failed on its own event, the whole sweep retried three
+	// times and was discarded, and the backlog it exists to clear sat there
+	// looking as though the job had simply not run yet.
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalSystem,
 		ID:   linkReconcileActor,
@@ -181,3 +187,17 @@ func (w *linkReconcileWorker) systemContext(ctx context.Context, ws ids.UUID) co
 // linkReconcileActor names the sweep in the trail, so a link that appeared with
 // nobody clicking is attributable to the pass that wrote it.
 const linkReconcileActor = "link-reconcile"
+
+// NewLinkReconcileWorkspaceWorkerForTest builds the workspace pass for an
+// integration test that drives it the way River does.
+//
+// It exists because the store-level tests build their OWN context, so they
+// prove the repair's SQL and nothing about the context this job runs under —
+// and that is exactly where a defect hid: a missing correlation id made every
+// publish refuse, so the sweep repaired nothing while looking like a job that
+// had simply not run yet.
+func NewLinkReconcileWorkspaceWorkerForTest(pool *pgxpool.Pool, store *people.Store) *linkReconcileWorkspaceWorker {
+	return &linkReconcileWorkspaceWorker{
+		linkReconcileWorker: newLinkReconcileWorker(pool, store, slog.Default()),
+	}
+}


### PR DESCRIPTION
The sweep merged in #3435 **repaired nothing**. Found by checking the dev database after merging, which is the only reason it did not sit there silently.

`link_reconcile_workspace` bound a workspace and a principal and no correlation id. `storekit.EmitEvent` refuses to publish without one, so every contact failed on its own event, the pass retried three times and was discarded, and the backlog it exists to clear stayed exactly where it was — looking like a job that simply had not run yet.

On Lars's database: 43 contacts owed a repair, 0 repaired, `state = discarded` at attempt 3/3.

```
repairing 01a04fcc-8b00-…: people: publishing a cohort repair:
  store: no correlation id bound to context
```

One line, and the sibling sweep next door (`linkedInRematchWorker.systemContext`) already binds one.

## Why the tests missed it

The store-level tests call the repair on a context the **test** builds, so they proved the SQL and nothing about the context the **job** runs under. That is precisely where the defect lived.

The new test drives the real worker the way River does and asserts the rows changed — not that the call returned nil. A job returning cleanly is not the repair landing, and the whole of this bug is that difference. Mutation-checked: remove the correlation id and the test reproduces the production failure, message for message.

`make check` green, lint 0 issues, `craft static --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the repair sweep so it repairs contacts instead of silently failing. The sweep now binds a correlation id to its worker context; `storekit.EmitEvent` refuses to publish without one, so every contact was previously failing on its own event and the pass was discarded after three retries, leaving the backlog untouched.

**Bug Fixes**
- Binds `principal.WithCorrelationID` in `systemContext`, matching the sibling `linkedInRematchWorker.systemContext`.
- Adds an integration test that drives the real worker and asserts the repair rows changed; the store-level tests built their own context, so they proved the SQL but not the job's context.

<sup>Written for commit c9489a0205f2a50dad4cfeb1a35722ae1b661d8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link reconciliation so stranded contact activity is correctly connected to the associated person.
  * Ensured repair events receive a unique correlation identifier for more reliable tracking.
* **Tests**
  * Added integration coverage verifying that activity links and participant associations are repaired successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->