### PR TITLE
Two questions an owner and an operator could not ask

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8788,6 +8788,39 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
+  /capture/held-threads:
+    get:
+      tags: [Capture]
+      operationId: listHeldThreads
+      summary: What your mailbox is holding right now.
+      description: |
+        The threads your mailbox is withholding from your colleagues, and why. Pending rows first,
+        because during a classifier outage those are the ones nobody has decided — a thread whose
+        `attempts` stop climbing is a model that stopped answering rather than a thread that is
+        merely slow.
+
+        Release one with `POST /activities/threads/{thread_key}/audience`, which is the same door a
+        record's timeline uses. This endpoint only answers the question that page cannot: what am I
+        holding, across every contact at once.
+
+        A thread the classifier cleared is not here, because it is not held. Everything else is,
+        `unsure` included: a thread the model could not judge withholds exactly like one it judged
+        legal, and an owner who is not shown it cannot release it.
+
+        Your own mailbox and nobody else's. What a person is holding is the most private thing this
+        module knows — the list names threads judged legal, personnel or personal — so there is no
+        id here that reaches a colleague's list and no admin view of one.
+      x-agent-access: human-only
+      security: [ { cookieAuth: [] } ]
+      responses:
+        '200':
+          description: The caller's held threads, pending first.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/HeldThreadListResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
   /capture/senders:
     get:
       tags: [Capture]
@@ -19067,6 +19100,58 @@ components:
             Whether a human vouched for this domain. Only a verified domain — or one the
             installation's own company claims — suppresses storage.
         created_at: { type: string, format: date-time }
+    HeldThreadListResponse:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          items: { $ref: '#/components/schemas/HeldThread' }
+
+    HeldThread:
+      type: object
+      description: One thread your mailbox is withholding, and what is known about why.
+      required: [thread_key, status, pending, attempts]
+      properties:
+        thread_key:
+          type: string
+          description: |
+            The thread this holds, and the key `POST /activities/threads/{thread_key}/audience`
+            takes to release it.
+        status:
+          type: string
+          description: |
+            The ledger's own word: `pending` while no verdict has landed, `held` or `unsure` once
+            one has, `held_by_owner` where you said so yourself.
+        pending:
+          type: boolean
+          description: |
+            No verdict has landed yet. Stated as its own field rather than left to a client
+            comparing `status`, because it decides the order these arrive in and a reader that
+            derived it differently would sort them differently.
+        kind:
+          type: string
+          description: |
+            What the classifier concluded the thread is ABOUT — legal, personnel,
+            financial_corporate, personal, security_incident, explicitly_confidential. Absent while
+            pending, because nothing has concluded anything yet.
+        subject:
+          type: string
+          description: |
+            The subject of the message that opened the thread, so one held thread reads differently
+            from another. Absent when that message was erased while the verdict stood, which the
+            ledger deliberately survives — losing the verdict would re-open a thread a classifier
+            already held.
+        occurred_at:
+          type: string
+          format: date-time
+          description: When that message arrived. Absent for the same reason `subject` can be.
+        attempts:
+          type: integer
+          description: |
+            How many times a verdict has been asked for. This is the outage signal: a pending row
+            whose attempts stop climbing is a model that stopped answering.
+
     CaptureSenderListResponse:
       type: object
       required: [data]

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -19143,7 +19143,7 @@ components:
     HeldThread:
       type: object
       description: One thread your mailbox is withholding, and what is known about why.
-      required: [thread_key, status, pending, attempts]
+      required: [thread_key, status, pending, attempts, has_message]
       properties:
         thread_key:
           type: string
@@ -19167,13 +19167,24 @@ components:
             What the classifier concluded the thread is ABOUT — legal, personnel,
             financial_corporate, personal, security_incident, explicitly_confidential. Absent while
             pending, because nothing has concluded anything yet.
+        has_message:
+          type: boolean
+          description: |
+            The message this thread began with is still readable by you. False where it was erased
+            while the verdict stood — which the ledger deliberately survives, because losing the
+            verdict would re-open a thread a classifier already held — and false where its content
+            is withheld from you.
+
+            Separate from `subject` because absence has two causes that read differently: no
+            message to name, versus a message somebody sent with a blank subject line. It also
+            decides whether releasing is offered at all: the release works on your own messages on
+            the thread, so with none left there is nothing to share.
         subject:
           type: string
           description: |
             The subject of the message that opened the thread, so one held thread reads differently
-            from another. Absent when that message was erased while the verdict stood, which the
-            ledger deliberately survives — losing the verdict would re-open a thread a classifier
-            already held.
+            from another. Absent when there is no message to read one from, and absent when the
+            message carries no subject — `has_message` tells the two apart.
         occurred_at:
           type: string
           format: date-time

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -10115,6 +10115,38 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
 
+  /ai/health:
+    get:
+      tags: [AI]
+      operationId: getAiHealth
+      security: [ { cookieAuth: [] } ]
+      x-agent-access: human-only
+      summary: Whether the model lanes are answering.
+      description: |
+        One row per model tier for the last hour: how many terminal attempts it made, how many
+        failed, the most recent error it reported, and its median latency.
+
+        This exists because an outage is otherwise invisible. Under the capture posture a thread
+        stays held whether the classifier judged it confidential or never answered at all, so a
+        working-and-cautious classifier and a dead one look identical from every other surface —
+        and nobody notices until somebody asks why a thread never opened.
+
+        Read from `ai_call`, which already records every attempt. Nothing is written for this: a
+        health surface with its own bookkeeping would be a second account of what happened, free
+        to disagree with the first. Terminal attempts only, so a failure a retry rescued does not
+        report a lane as failing while every caller of it got an answer.
+
+        An hour, because the question is whether it is answering NOW — a day-long window would
+        call a lane that died forty minutes ago healthy on the strength of this morning.
+      responses:
+        '200':
+          description: One row per tier that made a terminal attempt in the window.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AiHealth' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/PermissionDenied' }
+
   /ai/usage:
     get:
       tags: [AI]
@@ -19625,6 +19657,52 @@ components:
       properties:
         disposition: { type: string, enum: [merge, not_a_duplicate] }
         winner_id: { type: [string, 'null'], format: uuid, description: 'Required for merge: the surviving record — must be one of the pair.' }
+    AiHealth:
+      type: object
+      required: [window_hours, rungs]
+      properties:
+        window_hours:
+          type: integer
+          description: How far back the counts reach, so a reader knows what "no calls" covers.
+        rungs:
+          type: array
+          items: { $ref: '#/components/schemas/AiRungHealth' }
+
+    AiRungHealth:
+      type: object
+      description: One model tier and what it has been doing.
+      required: [tier, healthy, calls, failures, median_latency_ms]
+      properties:
+        tier:
+          type: string
+          description: The rung's name — `local_small`, `cloud_large` and the rest.
+        healthy:
+          type: boolean
+          description: |
+            The tier answered at least once in the window without every attempt failing. Decided
+            here rather than left to each client: two clients deciding what an all-failed rung
+            means would be two answers, and one surface would call an outage while the other did
+            not.
+        calls:
+          type: integer
+          description: Terminal attempts in the window.
+        failures:
+          type: integer
+          description: How many of them carried an error.
+        last_sentinel:
+          type: string
+          description: |
+            The most recent error this tier reported, absent when it reported none. It is the
+            first clue an operator has: a budget refusal and an unreachable model are both "not
+            answering" and want different fixes.
+        last_call_at:
+          type: string
+          format: date-time
+          description: When this tier last answered anything at all.
+        median_latency_ms:
+          type: integer
+          description: The window's middle latency, which tells a slow lane from a dead one.
+
     AiUsage:
       type: object
       description: 'AI usage + budget (AIRT-WIRE-1): the AIRT-PARAM-33 meter aggregated per day × task × tier, plus the budget band. Token-denominated; cost_est_minor is computed on read from the workspace''s ai_model_rate price sheet as of each call''s day (ADR-0067, price-on-read) — omitted, never a fabricated 0, when a task line''s window carries no priced call.'

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -189,6 +189,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/capture/counterparty-holds":                                 {Op: "listCaptureCounterpartyHolds", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/capture/email-domains":                                      {Op: "listWorkspaceEmailDomains", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/capture/exclusions":                                         {Op: "listCaptureExclusions", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/capture/held-threads":                                       {Op: "listHeldThreads", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/capture/owner-identities":                                   {Op: "listCaptureOwnerIdentities", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/capture/senders":                                            {Op: "listCaptureSenders", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/capture/traces/{id}":                                        {Op: "readCaptureTracePipeline", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -162,6 +162,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/agent-tools":                                                {Op: "listAgentTools", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/calls":                                                   {Op: "listAiCalls", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/calls/{id}":                                              {Op: "getAiCall", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/ai/health":                                                  {Op: "getAiHealth", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/profile":                                                 {Op: "getAiProfile", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/provider-keys":                                           {Op: "listAiProviderKeys", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/routing":                                                 {Op: "getAiRouting", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/handlers_capturesenders.go
+++ b/backend/internal/compose/handlers_capturesenders.go
@@ -65,10 +65,11 @@ func (h captureSenderHandlers) ListHeldThreads(w http.ResponseWriter, r *http.Re
 // sent with a blank subject line.
 func toContractHeldThread(t capture.HeldThread) crmcontracts.HeldThread {
 	out := crmcontracts.HeldThread{
-		ThreadKey: t.ThreadKey,
-		Status:    t.Status,
-		Pending:   t.Pending(),
-		Attempts:  t.Attempts,
+		ThreadKey:  t.ThreadKey,
+		Status:     t.Status,
+		Pending:    t.Pending(),
+		Attempts:   t.Attempts,
+		HasMessage: t.HasActivity,
 	}
 	if t.Kind != "" {
 		out.Kind = &t.Kind

--- a/backend/internal/compose/handlers_capturesenders.go
+++ b/backend/internal/compose/handlers_capturesenders.go
@@ -38,6 +38,48 @@ func (h captureSenderHandlers) ListCaptureSenders(w http.ResponseWriter, r *http
 	httperr.WriteJSON(w, http.StatusOK, out)
 }
 
+// ListHeldThreads answers what the caller's mailbox is withholding.
+//
+// It sits beside the senders list rather than in a file of its own: both are
+// this seat's view of what the capture posture decided on their behalf, both
+// are human-only and owner-scoped, and both are read from the same db.
+func (h captureSenderHandlers) ListHeldThreads(w http.ResponseWriter, r *http.Request) {
+	threads, err := capture.HeldThreadsFor(r.Context(), h.db)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	out := crmcontracts.HeldThreadListResponse{
+		Data: make([]crmcontracts.HeldThread, 0, len(threads)),
+	}
+	for _, t := range threads {
+		out.Data = append(out.Data, toContractHeldThread(t))
+	}
+	httperr.WriteJSON(w, http.StatusOK, out)
+}
+
+// toContractHeldThread maps one held thread onto the wire.
+//
+// The empty strings become absent fields rather than empty ones: a thread whose
+// opening message was erased carries no subject, and "" would read as a message
+// sent with a blank subject line.
+func toContractHeldThread(t capture.HeldThread) crmcontracts.HeldThread {
+	out := crmcontracts.HeldThread{
+		ThreadKey: t.ThreadKey,
+		Status:    t.Status,
+		Pending:   t.Pending(),
+		Attempts:  t.Attempts,
+	}
+	if t.Kind != "" {
+		out.Kind = &t.Kind
+	}
+	if t.Subject != "" {
+		out.Subject = &t.Subject
+	}
+	out.OccurredAt = t.OccurredAt
+	return out
+}
+
 // SetCaptureSenderDecision records the caller's own answer about a sender.
 func (h captureSenderHandlers) SetCaptureSenderDecision(w http.ResponseWriter, r *http.Request, address string) {
 	var req crmcontracts.SetCaptureSenderDecisionJSONRequestBody

--- a/backend/internal/compose/heldthreads_integration_test.go
+++ b/backend/internal/compose/heldthreads_integration_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The held-threads list, and the one property that decides whether it may
+// exist at all: it answers about the caller's own mailbox and about nothing
+// else. The rows name threads a classifier judged legal, personnel or personal,
+// so a list that reached a colleague's would disclose precisely what holding
+// them prevents.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestTheHeldThreadsListIsOneSeatsOwn(t *testing.T) {
+	e := integration.Setup(t)
+	seedVerdict(t, e, e.Rep1, "thread-mine", "held", "legal", 1)
+	seedVerdict(t, e, e.Rep2, "thread-theirs", "held", "personnel", 1)
+
+	mine := heldThreads(t, e, e.Rep1)
+	if len(mine) != 1 {
+		t.Fatalf("Rep1 sees %d threads, want 1", len(mine))
+	}
+	if mine[0].ThreadKey != "thread-mine" {
+		t.Errorf("Rep1 sees %q — a colleague's held thread reached their list, "+
+			"which discloses exactly what holding it prevents", mine[0].ThreadKey)
+	}
+	// The kind is the disclosure that matters most: "personnel" says somebody
+	// is in an HR process, and it must not travel even as a bare word.
+	for _, tr := range mine {
+		if tr.Kind == "personnel" {
+			t.Errorf("Rep1 read a colleague's verdict kind %q", tr.Kind)
+		}
+	}
+}
+
+// A thread the classifier opened is not held, so it is not on a page that
+// answers "what is not visible to my colleagues".
+func TestAClearedThreadIsNotHeld(t *testing.T) {
+	e := integration.Setup(t)
+	seedVerdict(t, e, e.Rep1, "thread-open", "cleared", "ordinary", 1)
+	seedVerdict(t, e, e.Rep1, "thread-shared", "shared_by_owner", "", 1)
+	seedVerdict(t, e, e.Rep1, "thread-unsure", "unsure", "", 2)
+
+	got := heldThreads(t, e, e.Rep1)
+	if len(got) != 1 {
+		t.Fatalf("%d threads held, want 1 — only the unsure one withholds", len(got))
+	}
+	// `unsure` is the case worth pinning: a thread the model could not judge
+	// withholds exactly like one it judged legal, and an owner who is not shown
+	// it cannot release it.
+	if got[0].ThreadKey != "thread-unsure" {
+		t.Errorf("held thread is %q, want thread-unsure", got[0].ThreadKey)
+	}
+}
+
+// Pending first, because during an outage those are the rows nobody has
+// decided — burying them under decided ones is what makes an owner scroll to
+// find the work.
+func TestPendingThreadsComeFirst(t *testing.T) {
+	e := integration.Setup(t)
+	seedVerdict(t, e, e.Rep1, "thread-decided", "held", "legal", 1)
+	seedVerdict(t, e, e.Rep1, "thread-waiting", "pending", "", 3)
+
+	got := heldThreads(t, e, e.Rep1)
+	if len(got) != 2 {
+		t.Fatalf("%d threads, want 2", len(got))
+	}
+	if got[0].ThreadKey != "thread-waiting" {
+		t.Errorf("first row is %q, want thread-waiting — pending rows lead", got[0].ThreadKey)
+	}
+	if !got[0].Pending() {
+		t.Error("the pending row does not report itself pending, so a client cannot style it")
+	}
+	if got[1].Pending() {
+		t.Error("a decided row reports itself pending")
+	}
+	// The outage signal travels: an owner watching attempts stop climbing is
+	// how they tell a stalled model from a slow one.
+	if got[0].Attempts != 3 {
+		t.Errorf("attempts = %d, want 3", got[0].Attempts)
+	}
+}
+
+// The ledger outlives the message it was raised about — first_activity_id is
+// ON DELETE SET NULL, because losing the verdict would re-open a thread a
+// classifier already held. An inner join would drop exactly those rows.
+func TestAThreadWhoseMessageWasErasedIsStillListed(t *testing.T) {
+	e := integration.Setup(t)
+	seedVerdict(t, e, e.Rep1, "thread-orphan", "held", "personal", 1)
+
+	got := heldThreads(t, e, e.Rep1)
+	if len(got) != 1 {
+		t.Fatalf("%d threads, want 1 — a verdict with no activity still holds", len(got))
+	}
+	if got[0].Subject != "" {
+		t.Errorf("subject = %q, want empty — there is no message to read one from", got[0].Subject)
+	}
+	if got[0].Kind != "personal" {
+		t.Errorf("kind = %q, want personal — the verdict survives its evidence", got[0].Kind)
+	}
+}
+
+func heldThreads(t *testing.T, e *integration.Env, user ids.UUID) []capture.HeldThread {
+	t.Helper()
+	got, err := capture.HeldThreadsFor(purgeCtx(e, user), InstallationDB(e.Pool))
+	if err != nil {
+		t.Fatalf("listing held threads: %v", err)
+	}
+	return got
+}
+
+// seedVerdict writes one ledger row directly. The engine that normally writes
+// these needs a model and a whole capture to run; what these cases are about is
+// the READ, and a row is the honest input to that.
+func seedVerdict(t *testing.T, e *integration.Env, user ids.UUID, threadKey, status, kind string, attempts int) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_thread_verdict (thread_key, user_id, status, kind, attempts)
+			VALUES ($1, $2, $3, nullif($4, ''), $5)`,
+			threadKey, user, status, kind, attempts)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a verdict: %v", err)
+	}
+}

--- a/backend/internal/compose/heldthreads_integration_test.go
+++ b/backend/internal/compose/heldthreads_integration_test.go
@@ -98,17 +98,80 @@ func TestPendingThreadsComeFirst(t *testing.T) {
 // classifier already held. An inner join would drop exactly those rows.
 func TestAThreadWhoseMessageWasErasedIsStillListed(t *testing.T) {
 	e := integration.Setup(t)
-	seedVerdict(t, e, e.Rep1, "thread-orphan", "held", "personal", 1)
+	seedVerdictOrphan(t, e, e.Rep1, "thread-orphan", "held", "personal", 1)
 
 	got := heldThreads(t, e, e.Rep1)
 	if len(got) != 1 {
 		t.Fatalf("%d threads, want 1 — a verdict with no activity still holds", len(got))
 	}
-	if got[0].Subject != "" {
-		t.Errorf("subject = %q, want empty — there is no message to read one from", got[0].Subject)
+	if got[0].HasActivity {
+		t.Error("an orphaned verdict reports an activity it does not have — " +
+			"which the card draws as a message with a blank subject line")
 	}
 	if got[0].Kind != "personal" {
 		t.Errorf("kind = %q, want personal — the verdict survives its evidence", got[0].Kind)
+	}
+}
+
+// The subject is activity CONTENT, and it reaches the reader through the same
+// clause every other reader of that table composes.
+//
+// This is the caller's OWN mailbox, so the clause admits them and the subject
+// arrives — which is exactly why the rule is easy to leave out and why nothing
+// on the happy path notices. What it buys is the row the clause refuses: a
+// verdict whose activity the caller may not read the content of is still listed
+// (they are holding it, and must be able to release it) and carries no subject.
+func TestAHeldThreadCarriesItsSubjectOnlyWhenTheReaderMayReadIt(t *testing.T) {
+	e := integration.Setup(t)
+	seedVerdict(t, e, e.Rep1, "thread-mine", "held", "legal", 1)
+
+	got := heldThreads(t, e, e.Rep1)
+	if len(got) != 1 {
+		t.Fatalf("%d threads, want 1", len(got))
+	}
+	if !got[0].HasActivity {
+		t.Fatal("the reader's own message did not reach them — the content clause " +
+			"is refusing a row it should admit")
+	}
+	if got[0].Subject != "Subject of thread-mine" {
+		t.Errorf("subject = %q, want the seeded one", got[0].Subject)
+	}
+}
+
+// A message a colleague imported and holds, whose verdict row is the CALLER's.
+// The ledger row is theirs to see and release; the message's content is not
+// theirs to read, and the two answers are separate.
+func TestAHeldThreadWithholdsAMessageTheReaderIsNotOn(t *testing.T) {
+	e := integration.Setup(t)
+	var activityID ids.UUID
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		activityID = ids.NewV7()
+		// Captured by SOMEBODY ELSE and held to its participants, so the
+		// caller is outside the audience.
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by, audience)
+			VALUES ($1, 'email', 'Entwurf Aufhebungsvertrag', now(), 'gmail', $2, 'participants')`,
+			activityID, "human:"+e.Rep2.String())
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a colleague's message: %v", err)
+	}
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_thread_verdict (thread_key, user_id, status, kind, attempts, first_activity_id)
+			VALUES ('thread-colleagues', $1, 'held', 'personnel', 1, $2)`, e.Rep1, activityID)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the verdict: %v", err)
+	}
+
+	got := heldThreads(t, e, e.Rep1)
+	if len(got) != 1 {
+		t.Fatalf("%d threads, want 1 — the row is the caller's to see", len(got))
+	}
+	if got[0].Subject == "Entwurf Aufhebungsvertrag" {
+		t.Error("a message the caller is not on handed them its subject — " +
+			"the content clause is not composed")
 	}
 }
 
@@ -121,16 +184,48 @@ func heldThreads(t *testing.T, e *integration.Env, user ids.UUID) []capture.Held
 	return got
 }
 
-// seedVerdict writes one ledger row directly. The engine that normally writes
-// these needs a model and a whole capture to run; what these cases are about is
-// the READ, and a row is the honest input to that.
+// seedVerdict writes one ledger row and the message it was raised about. The
+// engine that normally writes these needs a model and a whole capture to run;
+// what these cases are about is the READ, and a row is the honest input to that.
+//
+// The ACTIVITY is not optional here even though the column is. Every case in
+// this file seeded a verdict with a null first_activity_id at first, which left
+// the activity join — and the content clause on it — unexercised by the whole
+// suite: the subject leaked without an audience test and every case stayed
+// green. A fixture that omits the field models a different record.
 func seedVerdict(t *testing.T, e *integration.Env, user ids.UUID, threadKey, status, kind string, attempts int) {
 	t.Helper()
+	seedVerdictWithActivity(t, e, user, threadKey, status, kind, attempts, true)
+}
+
+// seedVerdictOrphan is the verdict whose message was erased while it stood,
+// which is the state ON DELETE SET NULL exists to produce.
+func seedVerdictOrphan(t *testing.T, e *integration.Env, user ids.UUID, threadKey, status, kind string, attempts int) {
+	t.Helper()
+	seedVerdictWithActivity(t, e, user, threadKey, status, kind, attempts, false)
+}
+
+func seedVerdictWithActivity(t *testing.T, e *integration.Env, user ids.UUID,
+	threadKey, status, kind string, attempts int, withActivity bool,
+) {
+	t.Helper()
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(context.Background(), `
-			INSERT INTO capture_thread_verdict (thread_key, user_id, status, kind, attempts)
-			VALUES ($1, $2, $3, nullif($4, ''), $5)`,
-			threadKey, user, status, kind, attempts)
+		ctx := context.Background()
+		var activityID *ids.UUID
+		if withActivity {
+			id := ids.NewV7()
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by, audience)
+				VALUES ($1, 'email', $2, now(), 'gmail', $3, 'participants')`,
+				id, "Subject of "+threadKey, "human:"+user.String()); err != nil {
+				return err
+			}
+			activityID = &id
+		}
+		_, err := tx.Exec(ctx, `
+			INSERT INTO capture_thread_verdict (thread_key, user_id, status, kind, attempts, first_activity_id)
+			VALUES ($1, $2, $3, nullif($4, ''), $5, $6)`,
+			threadKey, user, status, kind, attempts, activityID)
 		return err
 	}); err != nil {
 		t.Fatalf("seeding a verdict: %v", err)

--- a/backend/internal/compose/integration/aihealth_integration_test.go
+++ b/backend/internal/compose/integration/aihealth_integration_test.go
@@ -113,6 +113,117 @@ func TestAiHealthIsRefusedWithoutTheAutomationGrant(t *testing.T) {
 	}
 }
 
+// The case the window bound exists for, and the one the first version of this
+// suite did not reach: a lane that ANSWERED inside the hour and has failed
+// everything since. A rule reading "any success in the window" calls that
+// healthy, which is the outage reported as fine.
+func TestAiHealthReportsALaneThatDiedInsideTheWindow(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	seedRungCall(t, e, "local_small", "", 120, time.Now().Add(-55*time.Minute))
+	seedRungCall(t, e, "local_small", "provider_unavailable", 20, time.Now().Add(-20*time.Minute))
+	seedRungCall(t, e, "local_small", "provider_unavailable", 20, time.Now().Add(-2*time.Minute))
+
+	var got crmcontracts.AiHealth
+	if status := e.Call(t, http.MethodGet, "/v1/ai/health", nil, nil, &got); status != http.StatusOK {
+		t.Fatalf("GET /v1/ai/health = %d, want 200", status)
+	}
+	if len(got.Rungs) != 1 {
+		t.Fatalf("%d rungs, want 1", len(got.Rungs))
+	}
+	if got.Rungs[0].Healthy {
+		t.Error("a lane whose last two calls failed is reported healthy on the " +
+			"strength of one success 55 minutes ago — which is the outage this " +
+			"endpoint exists to catch, reported as fine")
+	}
+	if got.Rungs[0].Calls != 3 || got.Rungs[0].Failures != 2 {
+		t.Errorf("calls/failures = %d/%d, want 3/2", got.Rungs[0].Calls, got.Rungs[0].Failures)
+	}
+}
+
+// metering_failed marks a call the model ANSWERED where only the usage-meter
+// write failed (callstore.go, and callstats.go counts it as served for the same
+// reason). Counting it as a failure reports a working lane as down.
+func TestAiHealthCountsAMeteringFailureAsAnAnswer(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	seedRungCall(t, e, "local_small", "metering_failed", 180, time.Now().Add(-2*time.Minute))
+
+	var got crmcontracts.AiHealth
+	if status := e.Call(t, http.MethodGet, "/v1/ai/health", nil, nil, &got); status != http.StatusOK {
+		t.Fatalf("GET /v1/ai/health = %d, want 200", status)
+	}
+	if len(got.Rungs) != 1 {
+		t.Fatalf("%d rungs, want 1", len(got.Rungs))
+	}
+	if !got.Rungs[0].Healthy {
+		t.Error("a lane whose only fault was the meter write is reported as not answering")
+	}
+	if got.Rungs[0].Failures != 0 {
+		t.Errorf("failures = %d, want 0 — the model answered", got.Rungs[0].Failures)
+	}
+}
+
+// A cache hit never reached the provider, so it says nothing about whether the
+// provider is answering. Counting one as a success is how a dead lane reports
+// healthy on traffic it never sent.
+func TestAiHealthIgnoresACacheHit(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	seedCachedCall(t, e, "local_small", time.Now().Add(-2*time.Minute))
+	seedRungCall(t, e, "local_small", "provider_unavailable", 20, time.Now().Add(-1*time.Minute))
+
+	var got crmcontracts.AiHealth
+	if status := e.Call(t, http.MethodGet, "/v1/ai/health", nil, nil, &got); status != http.StatusOK {
+		t.Fatalf("GET /v1/ai/health = %d, want 200", status)
+	}
+	if len(got.Rungs) != 1 {
+		t.Fatalf("%d rungs, want 1", len(got.Rungs))
+	}
+	if got.Rungs[0].Calls != 1 {
+		t.Errorf("calls = %d, want 1 — a cache hit is not a call to the provider",
+			got.Rungs[0].Calls)
+	}
+	if got.Rungs[0].Healthy {
+		t.Error("a dead lane is reported healthy on the strength of a cached answer")
+	}
+}
+
+// The median is what tells a slow lane from a dead one, so it is worth an
+// assertion of its own rather than being carried untested.
+func TestAiHealthReportsTheMedianLatency(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	for _, ms := range []int{100, 300, 200} {
+		seedRungCall(t, e, "local_small", "", ms, time.Now().Add(-time.Duration(ms)*time.Second))
+	}
+
+	var got crmcontracts.AiHealth
+	if status := e.Call(t, http.MethodGet, "/v1/ai/health", nil, nil, &got); status != http.StatusOK {
+		t.Fatalf("GET /v1/ai/health = %d, want 200", status)
+	}
+	if len(got.Rungs) != 1 {
+		t.Fatalf("%d rungs, want 1", len(got.Rungs))
+	}
+	if got.Rungs[0].MedianLatencyMs != 200 {
+		t.Errorf("median = %d, want 200 — the middle of 100/200/300",
+			got.Rungs[0].MedianLatencyMs)
+	}
+}
+
+func seedCachedCall(t *testing.T, e *apptest.AppEnv, tier string, at time.Time) {
+	t.Helper()
+	if _, err := e.Owner.Exec(context.Background(), `
+		INSERT INTO ai_call (id, task, tier, provider, model_id, request_fingerprint,
+		                     tokens_in, tokens_out, latency_ms, logical_call_id,
+		                     attempt, is_terminal, cache_hit, occurred_at)
+		VALUES ($1, 'capture_confidentiality_verdict', $2, 'test', 'test-model', 'fp',
+		        0, 0, 5, $3, 1, true, true, $4)`,
+		ids.NewV7(), tier, ids.NewV7(), at); err != nil {
+		t.Fatalf("seeding a cached ai_call: %v", err)
+	}
+}
+
 func seedRungCall(t *testing.T, e *apptest.AppEnv, tier, sentinel string, latency int, at time.Time) {
 	t.Helper()
 	seedAttempt(t, e, tier, sentinel, latency, at, ids.NewV7(), 1, true)

--- a/backend/internal/compose/integration/aihealth_integration_test.go
+++ b/backend/internal/compose/integration/aihealth_integration_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Whether the model lanes are answering, read through the wire.
+//
+// The failure this surface exists for: under the capture posture a thread stays
+// held whether the classifier judged it confidential or never answered at all,
+// so an outage and correct cautious behaviour look identical everywhere else.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestAiHealthReportsARungThatStoppedAnswering(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	seedRungCall(t, e, "local_small", "", 120, time.Now().Add(-5*time.Minute))
+	seedRungCall(t, e, "cloud_large", "provider_unavailable", 30, time.Now().Add(-3*time.Minute))
+
+	var got crmcontracts.AiHealth
+	if status := e.Call(t, http.MethodGet, "/v1/ai/health", nil, nil, &got); status != http.StatusOK {
+		t.Fatalf("GET /v1/ai/health = %d, want 200", status)
+	}
+	rungs := map[string]crmcontracts.AiRungHealth{}
+	for _, r := range got.Rungs {
+		rungs[r.Tier] = r
+	}
+	if !rungs["local_small"].Healthy {
+		t.Error("a rung that answered is reported unhealthy")
+	}
+	dead := rungs["cloud_large"]
+	if dead.Healthy {
+		t.Error("a rung whose every attempt failed is reported healthy — " +
+			"which is the state this endpoint exists to make visible")
+	}
+	// The sentinel is the operator's first clue: a budget refusal and an
+	// unreachable model are both "not answering" and want different fixes.
+	if dead.LastSentinel == nil || *dead.LastSentinel != "provider_unavailable" {
+		t.Errorf("last_sentinel = %v, want provider_unavailable", dead.LastSentinel)
+	}
+	if got.WindowHours != 1 {
+		t.Errorf("window_hours = %d, want 1", got.WindowHours)
+	}
+}
+
+// A failure a retry rescued is not a lane that failed. Counting non-terminal
+// attempts would report a rung as failing while every caller of it got an
+// answer, which is a false alarm an operator learns to ignore.
+func TestAiHealthIgnoresAnAttemptARetryRescued(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	logical := ids.NewV7()
+	seedAttempt(t, e, "local_small", "provider_unavailable", 40,
+		time.Now().Add(-4*time.Minute), logical, 1, false)
+	seedAttempt(t, e, "local_small", "", 200,
+		time.Now().Add(-3*time.Minute), logical, 2, true)
+
+	var got crmcontracts.AiHealth
+	if status := e.Call(t, http.MethodGet, "/v1/ai/health", nil, nil, &got); status != http.StatusOK {
+		t.Fatalf("GET /v1/ai/health = %d, want 200", status)
+	}
+	if len(got.Rungs) != 1 {
+		t.Fatalf("%d rungs, want 1", len(got.Rungs))
+	}
+	if got.Rungs[0].Failures != 0 {
+		t.Errorf("failures = %d, want 0 — the retry answered", got.Rungs[0].Failures)
+	}
+	if !got.Rungs[0].Healthy {
+		t.Error("a rung whose retry succeeded is reported unhealthy")
+	}
+}
+
+// An hour, because the question is whether it is answering NOW. A lane that
+// died forty minutes ago must not read as healthy on the strength of a call it
+// made this morning.
+func TestAiHealthReadsOnlyTheLastHour(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	seedRungCall(t, e, "stale_rung", "", 100, time.Now().Add(-3*time.Hour))
+
+	var got crmcontracts.AiHealth
+	if status := e.Call(t, http.MethodGet, "/v1/ai/health", nil, nil, &got); status != http.StatusOK {
+		t.Fatalf("GET /v1/ai/health = %d, want 200", status)
+	}
+	for _, r := range got.Rungs {
+		if r.Tier == "stale_rung" {
+			t.Error("a call from three hours ago is inside a one-hour window")
+		}
+	}
+}
+
+// Operational configuration, not anybody's own data: the same door /ai/usage
+// uses, and a seat without it is refused rather than shown an empty page.
+func TestAiHealthIsRefusedWithoutTheAutomationGrant(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	seedRungCall(t, e, "local_small", "", 100, time.Now().Add(-time.Minute))
+	demoteToRep(t, e)
+
+	if status := e.Call(t, http.MethodGet, "/v1/ai/health", nil, nil, nil); status != http.StatusForbidden {
+		t.Errorf("GET /v1/ai/health as a rep = %d, want 403", status)
+	}
+}
+
+func seedRungCall(t *testing.T, e *apptest.AppEnv, tier, sentinel string, latency int, at time.Time) {
+	t.Helper()
+	seedAttempt(t, e, tier, sentinel, latency, at, ids.NewV7(), 1, true)
+}
+
+func seedAttempt(t *testing.T, e *apptest.AppEnv, tier, sentinel string,
+	latency int, at time.Time, logical ids.UUID, attempt int, terminal bool,
+) {
+	t.Helper()
+	var errSentinel any
+	if sentinel != "" {
+		errSentinel = sentinel
+	}
+	if _, err := e.Owner.Exec(context.Background(), `
+		INSERT INTO ai_call (id, task, tier, provider, model_id, request_fingerprint,
+		                     tokens_in, tokens_out, latency_ms, error_sentinel,
+		                     logical_call_id, attempt, is_terminal, occurred_at)
+		VALUES ($1, 'capture_confidentiality_verdict', $2, 'test', 'test-model', 'fp',
+		        10, 5, $3, $4, $5, $6, $7, $8)`,
+		ids.NewV7(), tier, latency, errSentinel, logical, attempt, terminal, at); err != nil {
+		t.Fatalf("seeding an ai_call: %v", err)
+	}
+}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -411,6 +411,10 @@ func (stubs) PurgeCaptureExclusion(w nethttp.ResponseWriter, r *nethttp.Request,
 	httperr.NotImplemented(w, r, "PurgeCaptureExclusion")
 }
 
+func (stubs) ListHeldThreads(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "ListHeldThreads")
+}
+
 func (stubs) ListCaptureOwnerIdentities(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "ListCaptureOwnerIdentities")
 }

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -135,6 +135,10 @@ func (stubs) RecordAIFeedback(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "RecordAIFeedback")
 }
 
+func (stubs) GetAiHealth(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "GetAiHealth")
+}
+
 func (stubs) GetAiProfile(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetAiProfile")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14420,6 +14420,14 @@ type AiEmbeddingsBinding struct {
 	Provider string `json:"provider"`
 }
 
+// AiHealth defines model for AiHealth.
+type AiHealth struct {
+	Rungs []AiRungHealth `json:"rungs"`
+
+	// WindowHours How far back the counts reach, so a reader knows what "no calls" covers.
+	WindowHours int `json:"window_hours"`
+}
+
 // AiModelRate One effective-dated model price. The four buckets are USD per 1M tokens as decimal strings (the server stores µUSD integers). Transparency-only — never gates routing.
 type AiModelRate struct {
 	CacheReadPerMtok  string             `json:"cache_read_per_mtok"`
@@ -14559,6 +14567,35 @@ type AiRunSummary struct {
 
 // AiRunSummaryCurrency defines model for AiRunSummary.Currency.
 type AiRunSummaryCurrency string
+
+// AiRungHealth One model tier and what it has been doing.
+type AiRungHealth struct {
+	// Calls Terminal attempts in the window.
+	Calls int `json:"calls"`
+
+	// Failures How many of them carried an error.
+	Failures int `json:"failures"`
+
+	// Healthy The tier answered at least once in the window without every attempt failing. Decided
+	// here rather than left to each client: two clients deciding what an all-failed rung
+	// means would be two answers, and one surface would call an outage while the other did
+	// not.
+	Healthy bool `json:"healthy"`
+
+	// LastCallAt When this tier last answered anything at all.
+	LastCallAt *time.Time `json:"last_call_at,omitempty"`
+
+	// LastSentinel The most recent error this tier reported, absent when it reported none. It is the
+	// first clue an operator has: a budget refusal and an unreachable model are both "not
+	// answering" and want different fixes.
+	LastSentinel *string `json:"last_sentinel,omitempty"`
+
+	// MedianLatencyMs The window's middle latency, which tells a slow lane from a dead one.
+	MedianLatencyMs int `json:"median_latency_ms"`
+
+	// Tier The rung's name — `local_small`, `cloud_large` and the rest.
+	Tier string `json:"tier"`
+}
 
 // AiTierBinding defines model for AiTierBinding.
 type AiTierBinding struct {
@@ -41995,6 +42032,9 @@ type ServerInterface interface {
 	// Record a human's verdict on a claim the system derived — the correction the next re-derivation must respect.
 	// (POST /ai/feedback)
 	RecordAIFeedback(w http.ResponseWriter, r *http.Request)
+	// Whether the model lanes are answering.
+	// (GET /ai/health)
+	GetAiHealth(w http.ResponseWriter, r *http.Request)
 	// Authenticated AI configuration posture for transparent human-facing workspaces.
 	// (GET /ai/profile)
 	GetAiProfile(w http.ResponseWriter, r *http.Request)
@@ -43702,6 +43742,12 @@ func (_ Unimplemented) GetAiCall(w http.ResponseWriter, r *http.Request, id Id) 
 // Record a human's verdict on a claim the system derived — the correction the next re-derivation must respect.
 // (POST /ai/feedback)
 func (_ Unimplemented) RecordAIFeedback(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Whether the model lanes are answering.
+// (GET /ai/health)
+func (_ Unimplemented) GetAiHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -48152,6 +48198,26 @@ func (siw *ServerInterfaceWrapper) RecordAIFeedback(w http.ResponseWriter, r *ht
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.RecordAIFeedback(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAiHealth operation middleware
+func (siw *ServerInterfaceWrapper) GetAiHealth(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAiHealth(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -70632,6 +70698,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/ai/feedback", wrapper.RecordAIFeedback)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/ai/health", wrapper.GetAiHealth)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/ai/profile", wrapper.GetAiProfile)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19659,6 +19659,45 @@ type HealthDimension struct {
 // HealthDimensionRating Three values, not a scale. A dimension that cannot be computed is ABSENT rather than rated `unknown`: absence is a fact about the reading, where a rating is a claim about the account.
 type HealthDimensionRating string
 
+// HeldThread One thread your mailbox is withholding, and what is known about why.
+type HeldThread struct {
+	// Attempts How many times a verdict has been asked for. This is the outage signal: a pending row
+	// whose attempts stop climbing is a model that stopped answering.
+	Attempts int `json:"attempts"`
+
+	// Kind What the classifier concluded the thread is ABOUT — legal, personnel,
+	// financial_corporate, personal, security_incident, explicitly_confidential. Absent while
+	// pending, because nothing has concluded anything yet.
+	Kind *string `json:"kind,omitempty"`
+
+	// OccurredAt When that message arrived. Absent for the same reason `subject` can be.
+	OccurredAt *time.Time `json:"occurred_at,omitempty"`
+
+	// Pending No verdict has landed yet. Stated as its own field rather than left to a client
+	// comparing `status`, because it decides the order these arrive in and a reader that
+	// derived it differently would sort them differently.
+	Pending bool `json:"pending"`
+
+	// Status The ledger's own word: `pending` while no verdict has landed, `held` or `unsure` once
+	// one has, `held_by_owner` where you said so yourself.
+	Status string `json:"status"`
+
+	// Subject The subject of the message that opened the thread, so one held thread reads differently
+	// from another. Absent when that message was erased while the verdict stood, which the
+	// ledger deliberately survives — losing the verdict would re-open a thread a classifier
+	// already held.
+	Subject *string `json:"subject,omitempty"`
+
+	// ThreadKey The thread this holds, and the key `POST /activities/threads/{thread_key}/audience`
+	// takes to release it.
+	ThreadKey string `json:"thread_key"`
+}
+
+// HeldThreadListResponse defines model for HeldThreadListResponse.
+type HeldThreadListResponse struct {
+	Data []HeldThread `json:"data"`
+}
+
 // HistoryEdge Set when this history entry changed a LINK between two records rather than a field
 // of this one, and null on every ordinary row.
 //
@@ -42163,6 +42202,9 @@ type ServerInterface interface {
 	// Destroy the mail one of your own rules matched.
 	// (POST /capture/exclusions/{id}/purge)
 	PurgeCaptureExclusion(w http.ResponseWriter, r *http.Request, id Id, params PurgeCaptureExclusionParams)
+	// What your mailbox is holding right now.
+	// (GET /capture/held-threads)
+	ListHeldThreads(w http.ResponseWriter, r *http.Request)
 	// The caller's own other email addresses.
 	// (GET /capture/owner-identities)
 	ListCaptureOwnerIdentities(w http.ResponseWriter, r *http.Request)
@@ -44074,6 +44116,12 @@ func (_ Unimplemented) DeleteCaptureExclusion(w http.ResponseWriter, r *http.Req
 // Destroy the mail one of your own rules matched.
 // (POST /capture/exclusions/{id}/purge)
 func (_ Unimplemented) PurgeCaptureExclusion(w http.ResponseWriter, r *http.Request, id Id, params PurgeCaptureExclusionParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// What your mailbox is holding right now.
+// (GET /capture/held-threads)
+func (_ Unimplemented) ListHeldThreads(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -50490,6 +50538,26 @@ func (siw *ServerInterfaceWrapper) PurgeCaptureExclusion(w http.ResponseWriter, 
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PurgeCaptureExclusion(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListHeldThreads operation middleware
+func (siw *ServerInterfaceWrapper) ListHeldThreads(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListHeldThreads(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -70771,6 +70839,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/capture/exclusions/{id}/purge", wrapper.PurgeCaptureExclusion)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/capture/held-threads", wrapper.ListHeldThreads)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/capture/owner-identities", wrapper.ListCaptureOwnerIdentities)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19702,6 +19702,17 @@ type HeldThread struct {
 	// whose attempts stop climbing is a model that stopped answering.
 	Attempts int `json:"attempts"`
 
+	// HasMessage The message this thread began with is still readable by you. False where it was erased
+	// while the verdict stood — which the ledger deliberately survives, because losing the
+	// verdict would re-open a thread a classifier already held — and false where its content
+	// is withheld from you.
+	//
+	// Separate from `subject` because absence has two causes that read differently: no
+	// message to name, versus a message somebody sent with a blank subject line. It also
+	// decides whether releasing is offered at all: the release works on your own messages on
+	// the thread, so with none left there is nothing to share.
+	HasMessage bool `json:"has_message"`
+
 	// Kind What the classifier concluded the thread is ABOUT — legal, personnel,
 	// financial_corporate, personal, security_incident, explicitly_confidential. Absent while
 	// pending, because nothing has concluded anything yet.
@@ -19720,9 +19731,8 @@ type HeldThread struct {
 	Status string `json:"status"`
 
 	// Subject The subject of the message that opened the thread, so one held thread reads differently
-	// from another. Absent when that message was erased while the verdict stood, which the
-	// ledger deliberately survives — losing the verdict would re-open a thread a classifier
-	// already held.
+	// from another. Absent when there is no message to read one from, and absent when the
+	// message carries no subject — `has_message` tells the two apart.
 	Subject *string `json:"subject,omitempty"`
 
 	// ThreadKey The thread this holds, and the key `POST /activities/threads/{thread_key}/audience`

--- a/backend/internal/modules/ai/handlers_usage.go
+++ b/backend/internal/modules/ai/handlers_usage.go
@@ -122,3 +122,43 @@ func wireAiUsage(days []DayUsage, budget BudgetStatus) crmcontracts.AiUsage {
 	out.Budget.Currency = &currency
 	return out
 }
+
+// GetAiHealth implements (GET /ai/health).
+//
+// Beside the usage handler because both are the same operator's view of the
+// model lanes — what they cost, and whether they are answering — and both are
+// admitted through the same automation-config grant.
+func (h Handlers) GetAiHealth(w http.ResponseWriter, r *http.Request) {
+	rungs, err := h.meter.RungHealthReport(r.Context())
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	out := crmcontracts.AiHealth{
+		WindowHours: int(HealthWindow / time.Hour),
+		Rungs:       make([]crmcontracts.AiRungHealth, 0, len(rungs)),
+	}
+	for _, rung := range rungs {
+		out.Rungs = append(out.Rungs, toContractRungHealth(rung))
+	}
+	httperr.WriteJSON(w, http.StatusOK, out)
+}
+
+// toContractRungHealth maps one rung onto the wire.
+//
+// The empty sentinel becomes an absent field rather than an empty string: a
+// rung that reported no error is not a rung whose error was blank.
+func toContractRungHealth(r RungHealth) crmcontracts.AiRungHealth {
+	out := crmcontracts.AiRungHealth{
+		Tier:            r.Tier,
+		Healthy:         r.Healthy(),
+		Calls:           r.Calls,
+		Failures:        r.Failures,
+		MedianLatencyMs: r.MedianLatencyMs,
+	}
+	if r.LastSentinel != "" {
+		out.LastSentinel = &r.LastSentinel
+	}
+	out.LastCallAt = r.LastCallAt
+	return out
+}

--- a/backend/internal/modules/ai/health.go
+++ b/backend/internal/modules/ai/health.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// Whether the model lanes are answering, per rung.
+//
+// The failure this exists for: a classifier that stopped answering and one that
+// is working and merely cautious look identical from every other surface. Under
+// the capture posture a thread stays held either way, so nobody notices an
+// outage until somebody asks why a thread never opened — and by then the answer
+// is a week of held mail.
+//
+// Read from ai_call, which already records every attempt with its tier, its
+// latency and its sentinel. Nothing new is written for this: a health surface
+// that needed its own bookkeeping would be a second account of what happened,
+// free to disagree with the first.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// HealthWindow is how far back a rung's health is read.
+//
+// An hour, because the question is "is it answering NOW" and a day-long window
+// would report a lane that died forty minutes ago as healthy on the strength of
+// this morning. Long enough that a lane nobody happened to call in the last ten
+// minutes does not read as broken.
+const HealthWindow = time.Hour
+
+// RungHealth is one model tier and what it has been doing.
+type RungHealth struct {
+	// Tier is the rung's name — local_small, cloud_large and the rest.
+	Tier string
+	// Calls and Failures count the window. A rung with calls and no failures
+	// is answering; one with failures and no successes is not.
+	Calls    int
+	Failures int
+	// LastSentinel is the most recent error this rung reported, empty when it
+	// reported none. It is the operator's first clue: a budget refusal and an
+	// unreachable model are both "not answering" and want different fixes.
+	LastSentinel string
+	// LastCallAt is when this rung last answered anything at all.
+	LastCallAt *time.Time
+	// MedianLatencyMs is the window's middle latency, which distinguishes a
+	// lane that is slow from one that is down.
+	MedianLatencyMs int
+}
+
+// Healthy reports that this rung answered at least once in the window without
+// every attempt failing.
+//
+// Stated here rather than left to each reader: a client comparing counts itself
+// would have to decide what an all-failed rung means, and two clients deciding
+// differently is how one surface calls an outage while the other does not.
+func (r RungHealth) Healthy() bool { return r.Calls > 0 && r.Failures < r.Calls }
+
+// RungHealthReport reads what every model tier has been doing for the last
+// hour.
+//
+// Admin-gated through the automation-config write grant, the same door
+// UsageReport uses and for the same reason: the closed RBAC object set carries
+// no AI-runtime entry, and this is operational configuration rather than
+// anybody's own data.
+func (m *Meter) RungHealthReport(ctx context.Context) ([]RungHealth, error) {
+	if err := auth.Require(ctx, "automation", principal.ActionUpdate); err != nil {
+		return nil, err
+	}
+	since := m.now().Add(-HealthWindow)
+	var out []RungHealth
+	err := m.db.Tx(ctx, func(tx pgx.Tx) error {
+		// TERMINAL attempts only. A retried call writes a row per attempt, and
+		// counting the failed ones that a retry then rescued would report a
+		// lane as failing while every caller of it got an answer.
+		rows, err := tx.Query(ctx, `
+			SELECT tier,
+			       count(*)                                        AS calls,
+			       count(*) FILTER (WHERE error_sentinel IS NOT NULL) AS failures,
+			       coalesce(max(occurred_at) FILTER (WHERE error_sentinel IS NOT NULL
+			                                          AND error_sentinel <> ''), NULL) AS last_failure,
+			       coalesce((array_agg(error_sentinel ORDER BY occurred_at DESC)
+			                 FILTER (WHERE error_sentinel IS NOT NULL
+			                          AND error_sentinel <> ''))[1], '') AS last_sentinel,
+			       max(occurred_at)                                AS last_call_at,
+			       coalesce(percentile_disc(0.5) WITHIN GROUP (ORDER BY latency_ms), 0) AS median_latency
+			  FROM ai_call
+			 WHERE occurred_at >= $1
+			   AND is_terminal
+			   AND tier <> ''
+			 GROUP BY tier
+			 ORDER BY tier`, since)
+		if err != nil {
+			return fmt.Errorf("ai: reading rung health: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var h RungHealth
+			var lastFailure *time.Time
+			var median int64
+			if err := rows.Scan(&h.Tier, &h.Calls, &h.Failures, &lastFailure,
+				&h.LastSentinel, &h.LastCallAt, &median); err != nil {
+				return fmt.Errorf("ai: reading rung health: %w", err)
+			}
+			h.MedianLatencyMs = int(median)
+			out = append(out, h)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/modules/ai/health.go
+++ b/backend/internal/modules/ai/health.go
@@ -39,10 +39,17 @@ const HealthWindow = time.Hour
 type RungHealth struct {
 	// Tier is the rung's name — local_small, cloud_large and the rest.
 	Tier string
-	// Calls and Failures count the window. A rung with calls and no failures
-	// is answering; one with failures and no successes is not.
+	// Calls and Failures count the window.
 	Calls    int
 	Failures int
+	// LastOutcomeFailed is what actually decides health: whether the MOST
+	// RECENT terminal attempt on this rung carried an error.
+	//
+	// A count cannot answer it. A lane that answered once at the top of the
+	// hour and has failed every call since has more successes than zero, and a
+	// rule reading "any success in the window" calls that healthy — which is
+	// precisely the lane this endpoint exists to catch, reported as fine.
+	LastOutcomeFailed bool
 	// LastSentinel is the most recent error this rung reported, empty when it
 	// reported none. It is the operator's first clue: a budget refusal and an
 	// unreachable model are both "not answering" and want different fixes.
@@ -54,13 +61,21 @@ type RungHealth struct {
 	MedianLatencyMs int
 }
 
-// Healthy reports that this rung answered at least once in the window without
-// every attempt failing.
+// Healthy reports that this rung's most recent terminal attempt answered.
 //
-// Stated here rather than left to each reader: a client comparing counts itself
-// would have to decide what an all-failed rung means, and two clients deciding
-// differently is how one surface calls an outage while the other does not.
-func (r RungHealth) Healthy() bool { return r.Calls > 0 && r.Failures < r.Calls }
+// The LATEST outcome, not a ratio over the window. A lane that answered at the
+// top of the hour and has failed everything since is down now, and that is the
+// only tense this question has — an operator reads this page to decide whether
+// to act, and "it worked 59 minutes ago" is not a reason not to.
+//
+// A rung with no calls at all is not healthy and not unhealthy; it is silent,
+// and Calls == 0 is what says so. Reporting silence as either would make an
+// unused installation look broken or a dead one look fine.
+//
+// Decided here rather than left to each reader: two clients deciding what an
+// all-failed rung means is how one surface calls an outage while the other does
+// not.
+func (r RungHealth) Healthy() bool { return r.Calls > 0 && !r.LastOutcomeFailed }
 
 // RungHealthReport reads what every model tier has been doing for the last
 // hour.
@@ -76,24 +91,42 @@ func (m *Meter) RungHealthReport(ctx context.Context) ([]RungHealth, error) {
 	since := m.now().Add(-HealthWindow)
 	var out []RungHealth
 	err := m.db.Tx(ctx, func(tx pgx.Tx) error {
-		// TERMINAL attempts only. A retried call writes a row per attempt, and
-		// counting the failed ones that a retry then rescued would report a
-		// lane as failing while every caller of it got an answer.
+		// TERMINAL attempts only, and cache hits excluded. A retried call
+		// writes a row per attempt, and counting the failed ones a retry then
+		// rescued would report a lane as failing while every caller of it got
+		// an answer. A cache hit never reached the provider at all, so it says
+		// nothing about whether the provider is answering — counting one as a
+		// success is how a dead lane reports healthy.
+		//
+		// `metering_failed` is a SUCCESS here. It marks a call the model
+		// answered where only the usage-meter write failed (callstore.go), and
+		// callstats.go already treats it as served for exactly that reason.
+		// Counting it as a failure would report a working lane as down.
 		rows, err := tx.Query(ctx, `
+			WITH terminal AS (
+			  SELECT tier, occurred_at, latency_ms,
+			         (error_sentinel IS NOT NULL
+			          AND error_sentinel <> ''
+			          AND error_sentinel <> 'metering_failed') AS failed,
+			         coalesce(error_sentinel, '') AS sentinel
+			    FROM ai_call
+			   WHERE occurred_at >= $1
+			     AND is_terminal
+			     AND NOT cache_hit
+			     AND tier <> ''
+			)
 			SELECT tier,
-			       count(*)                                        AS calls,
-			       count(*) FILTER (WHERE error_sentinel IS NOT NULL) AS failures,
-			       coalesce(max(occurred_at) FILTER (WHERE error_sentinel IS NOT NULL
-			                                          AND error_sentinel <> ''), NULL) AS last_failure,
-			       coalesce((array_agg(error_sentinel ORDER BY occurred_at DESC)
-			                 FILTER (WHERE error_sentinel IS NOT NULL
-			                          AND error_sentinel <> ''))[1], '') AS last_sentinel,
-			       max(occurred_at)                                AS last_call_at,
-			       coalesce(percentile_disc(0.5) WITHIN GROUP (ORDER BY latency_ms), 0) AS median_latency
-			  FROM ai_call
-			 WHERE occurred_at >= $1
-			   AND is_terminal
-			   AND tier <> ''
+			       count(*)                                   AS calls,
+			       count(*) FILTER (WHERE failed)             AS failures,
+			       coalesce((array_agg(sentinel ORDER BY occurred_at DESC)
+			                 FILTER (WHERE failed))[1], '')   AS last_sentinel,
+			       max(occurred_at)                           AS last_call_at,
+			       coalesce(percentile_disc(0.5) WITHIN GROUP (ORDER BY latency_ms), 0) AS median_latency,
+			       -- The LATEST attempt's own outcome, which is what decides
+			       -- health. array_agg over the same ordering the sentinel
+			       -- uses, so both describe the same most-recent row.
+			       coalesce((array_agg(failed ORDER BY occurred_at DESC))[1], false) AS last_failed
+			  FROM terminal
 			 GROUP BY tier
 			 ORDER BY tier`, since)
 		if err != nil {
@@ -102,10 +135,9 @@ func (m *Meter) RungHealthReport(ctx context.Context) ([]RungHealth, error) {
 		defer rows.Close()
 		for rows.Next() {
 			var h RungHealth
-			var lastFailure *time.Time
 			var median int64
-			if err := rows.Scan(&h.Tier, &h.Calls, &h.Failures, &lastFailure,
-				&h.LastSentinel, &h.LastCallAt, &median); err != nil {
+			if err := rows.Scan(&h.Tier, &h.Calls, &h.Failures,
+				&h.LastSentinel, &h.LastCallAt, &median, &h.LastOutcomeFailed); err != nil {
 				return fmt.Errorf("ai: reading rung health: %w", err)
 			}
 			h.MedianLatencyMs = int(median)

--- a/backend/internal/modules/ai/health.go
+++ b/backend/internal/modules/ai/health.go
@@ -45,10 +45,10 @@ type RungHealth struct {
 	// LastOutcomeFailed is what actually decides health: whether the MOST
 	// RECENT terminal attempt on this rung carried an error.
 	//
-	// A count cannot answer it. A lane that answered once at the top of the
-	// hour and has failed every call since has more successes than zero, and a
-	// rule reading "any success in the window" calls that healthy — which is
-	// precisely the lane this endpoint exists to catch, reported as fine.
+	// A count cannot answer it. A lane with a single success at the top of the
+	// hour that has failed every call since still has more successes than zero,
+	// and a rule reading "any success in the window" calls that healthy — which
+	// is precisely the lane this endpoint exists to catch, reported as fine.
 	LastOutcomeFailed bool
 	// LastSentinel is the most recent error this rung reported, empty when it
 	// reported none. It is the operator's first clue: a budget refusal and an
@@ -63,8 +63,8 @@ type RungHealth struct {
 
 // Healthy reports that this rung's most recent terminal attempt answered.
 //
-// The LATEST outcome, not a ratio over the window. A lane that answered at the
-// top of the hour and has failed everything since is down now, and that is the
+// The LATEST outcome, not a ratio over the window. A lane whose last success
+// was at the top of the hour and has failed everything since is down now, and that is the
 // only tense this question has — an operator reads this page to decide whether
 // to act, and "it worked 59 minutes ago" is not a reason not to.
 //

--- a/backend/internal/modules/capture/heldthreadslist.go
+++ b/backend/internal/modules/capture/heldthreadslist.go
@@ -40,11 +40,15 @@ type HeldThread struct {
 	// personnel, financial_corporate and the rest — empty while pending.
 	Kind string
 	// Subject and OccurredAt come from the message that opened the thread, so
-	// a reader can tell one held thread from another. Both absent when that
-	// activity was erased while the verdict stood, which is a state the ledger
-	// deliberately survives.
+	// a reader can tell one held thread from another.
 	Subject    string
 	OccurredAt *time.Time
+	// HasActivity separates "no message to read a subject from" — erased while
+	// the verdict stood, which the ledger deliberately survives — from a
+	// message somebody sent with a blank subject line. Collapsing the two would
+	// tell a reader their evidence was destroyed when it is sitting there
+	// unnamed.
+	HasActivity bool
 	// Attempts is how many times a verdict has been asked for. It is the
 	// outage signal: a pending row whose attempts stop climbing is a model
 	// that stopped answering, not a thread that is merely slow.
@@ -74,44 +78,69 @@ func HeldThreadsFor(ctx context.Context, db *database.DB) ([]HeldThread, error) 
 	if !ok || actor.UserID == ids.Nil {
 		return nil, apperrors.ErrPermissionDenied
 	}
+	// The arguments the clause and the query share, numbered together: the
+	// content clause mints its own placeholders and they must not collide with
+	// the seat's.
+	args := []any{actor.UserID}
+	arg := func(v any) int {
+		args = append(args, v)
+		return len(args)
+	}
+	// The subject is activity CONTENT, so it is read through the same clause
+	// every other reader of that table composes. This is the caller's own
+	// mailbox, so the clause admits them — but writing the read unconditionally
+	// would leave a projection of activity text that no audience rule governs,
+	// which is the shape audiencereaders_test refuses. A held thread the caller
+	// may not read the content of still appears, with no subject.
+	content, err := auth.ActivityContentClause(ctx, "a", arg)
+	if err != nil {
+		return nil, err
+	}
 	var out []HeldThread
-	err := db.Tx(ctx, func(tx pgx.Tx) error {
+	err = db.Tx(ctx, func(tx pgx.Tx) error {
 		// The activity join is a LEFT one and the ledger is the driving table:
 		// a verdict outlives the message it was raised about (first_activity_id
 		// is ON DELETE SET NULL, so an erasure inside the window nulls it
 		// rather than dropping the row), and an inner join would silently drop
 		// exactly the threads whose evidence is gone while the hold stands.
 		//
-		// The subject is read through the same content rule the timeline uses.
-		// This is the owner's own mailbox so the rule admits them, but writing
-		// it as an unconditional read would leave a projection of activity text
-		// that no audience clause governs — the shape audiencereaders_test
-		// exists to refuse.
+		// The content clause rides the JOIN rather than the WHERE for the same
+		// reason: in the WHERE it would turn the outer join into an inner one
+		// and drop every row whose activity is absent or withheld.
 		rows, err := tx.Query(ctx, `
 			SELECT v.thread_key,
 			       v.status,
 			       coalesce(v.kind, '')    AS kind,
-			       coalesce(a.subject, '') AS subject,
+			       a.subject,
 			       a.occurred_at,
 			       v.attempts
 			  FROM capture_thread_verdict v
 			  LEFT JOIN activity a
 			    ON a.id = v.first_activity_id
 			   AND a.archived_at IS NULL
+			   AND `+content+`
 			 WHERE v.user_id = $1
 			   AND v.status NOT IN ('cleared', 'shared_by_owner')
 			 ORDER BY (v.status = 'pending') DESC,
 			          a.occurred_at DESC NULLS LAST,
-			          v.created_at DESC`, actor.UserID)
+			          v.created_at DESC`, args...)
 		if err != nil {
 			return fmt.Errorf("capture: listing a seat's held threads: %w", err)
 		}
 		defer rows.Close()
 		for rows.Next() {
 			var t HeldThread
+			var subject *string
 			if err := rows.Scan(&t.ThreadKey, &t.Status, &t.Kind,
-				&t.Subject, &t.OccurredAt, &t.Attempts); err != nil {
+				&subject, &t.OccurredAt, &t.Attempts); err != nil {
 				return fmt.Errorf("capture: listing a seat's held threads: %w", err)
+			}
+			// NULL is "no message to read one from"; an empty string is a
+			// message somebody sent with a blank subject line. The two read
+			// differently on screen, so they stay different here.
+			t.HasActivity = subject != nil
+			if subject != nil {
+				t.Subject = *subject
 			}
 			out = append(out, t)
 		}

--- a/backend/internal/modules/capture/heldthreadslist.go
+++ b/backend/internal/modules/capture/heldthreadslist.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// What one seat's mailbox is holding right now, in one list.
+//
+// An owner could already open or hold a thread from a record's timeline, one
+// thread at a time. What they could not do is ask "what am I holding" — and
+// during a classifier outage that is the only question worth asking, because
+// every new thread lands pending and stays there until the model answers.
+//
+// One seat's own threads and nobody else's. What a person's mailbox is holding
+// is the most private thing this module knows: the list names threads a
+// classifier judged legal, personnel or personal, so a colleague's view of it
+// would disclose exactly what holding them exists to prevent. There is no id
+// here that reaches another seat's list and no admin view of one.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// HeldThread is one thread this seat is holding, and why.
+type HeldThread struct {
+	ThreadKey string
+	// Status is the ledger's own word: pending while no verdict has landed,
+	// held or unsure once one has, held_by_owner where the owner said so.
+	Status string
+	// Kind is what the classifier concluded the thread is ABOUT — legal,
+	// personnel, financial_corporate and the rest — empty while pending.
+	Kind string
+	// Subject and OccurredAt come from the message that opened the thread, so
+	// a reader can tell one held thread from another. Both absent when that
+	// activity was erased while the verdict stood, which is a state the ledger
+	// deliberately survives.
+	Subject    string
+	OccurredAt *time.Time
+	// Attempts is how many times a verdict has been asked for. It is the
+	// outage signal: a pending row whose attempts stop climbing is a model
+	// that stopped answering, not a thread that is merely slow.
+	Attempts int
+}
+
+// Pending reports that no verdict has landed yet, which is the row an owner
+// acts on during an outage.
+func (t HeldThread) Pending() bool { return t.Status == "pending" }
+
+// HeldThreadsFor lists what the calling seat's mailbox is holding.
+//
+// PENDING FIRST, then by recency. The order is the feature: during an outage
+// the pending rows are the ones nobody has decided, and burying them under
+// decided ones sorted by date is what makes an owner scroll to find the work.
+//
+// `cleared` and `shared_by_owner` are absent because they are not held — the
+// list answers "what is not visible to my colleagues", and a thread the
+// classifier opened is visible. Every other status withholds, including
+// `unsure`: a thread the model could not judge is held exactly like one it
+// judged legal, and an owner who is not shown it cannot release it.
+func HeldThreadsFor(ctx context.Context, db *database.DB) ([]HeldThread, error) {
+	if err := auth.RequireHuman(ctx); err != nil {
+		return nil, err
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID == ids.Nil {
+		return nil, apperrors.ErrPermissionDenied
+	}
+	var out []HeldThread
+	err := db.Tx(ctx, func(tx pgx.Tx) error {
+		// The activity join is a LEFT one and the ledger is the driving table:
+		// a verdict outlives the message it was raised about (first_activity_id
+		// is ON DELETE SET NULL, so an erasure inside the window nulls it
+		// rather than dropping the row), and an inner join would silently drop
+		// exactly the threads whose evidence is gone while the hold stands.
+		//
+		// The subject is read through the same content rule the timeline uses.
+		// This is the owner's own mailbox so the rule admits them, but writing
+		// it as an unconditional read would leave a projection of activity text
+		// that no audience clause governs — the shape audiencereaders_test
+		// exists to refuse.
+		rows, err := tx.Query(ctx, `
+			SELECT v.thread_key,
+			       v.status,
+			       coalesce(v.kind, '')    AS kind,
+			       coalesce(a.subject, '') AS subject,
+			       a.occurred_at,
+			       v.attempts
+			  FROM capture_thread_verdict v
+			  LEFT JOIN activity a
+			    ON a.id = v.first_activity_id
+			   AND a.archived_at IS NULL
+			 WHERE v.user_id = $1
+			   AND v.status NOT IN ('cleared', 'shared_by_owner')
+			 ORDER BY (v.status = 'pending') DESC,
+			          a.occurred_at DESC NULLS LAST,
+			          v.created_at DESC`, actor.UserID)
+		if err != nil {
+			return fmt.Errorf("capture: listing a seat's held threads: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var t HeldThread
+			if err := rows.Scan(&t.ThreadKey, &t.Status, &t.Kind,
+				&t.Subject, &t.OccurredAt, &t.Attempts); err != nil {
+				return fmt.Errorf("capture: listing a seat's held threads: %w", err)
+			}
+			out = append(out, t)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/migrations/core/1788242480_a_seat_reads_its_own_held_threads.down.sql
+++ b/backend/migrations/core/1788242480_a_seat_reads_its_own_held_threads.down.sql
@@ -1,0 +1,6 @@
+-- The drop takes the same write-blocking lock the build did, so it is bounded
+-- the same way: a rollback that queues behind an open transaction holds every
+-- capture out of the ledger for as long as it is willing to wait.
+SET LOCAL lock_timeout = '3s';
+
+DROP INDEX IF EXISTS capture_thread_verdict_held_by_seat_idx;

--- a/backend/migrations/core/1788242480_a_seat_reads_its_own_held_threads.up.sql
+++ b/backend/migrations/core/1788242480_a_seat_reads_its_own_held_threads.up.sql
@@ -1,0 +1,23 @@
+-- The held-threads list asks one question: which threads is THIS seat holding.
+--
+-- The table's existing indexes answer neither half of it. capture_thread_verdict
+-- is unique on (thread_key, user_id), which leads with the thread and so cannot
+-- serve a scan by seat; and the due-work index leads with next_attempt_at and is
+-- partial on pending rows, which is the opposite selection. Without this the
+-- read scans the workspace-wide ledger and sorts, on a table that grows one row
+-- per thread per seat for the life of the thread.
+--
+-- Partial on exactly what the list selects. A cleared thread is not held and is
+-- never on this page, and the ledger keeps those rows forever — they are the
+-- majority in a healthy installation, and an unfiltered index would carry all
+-- of them to answer a question that excludes them.
+-- The build blocks writes to capture_thread_verdict, which the capture sink
+-- writes on every message it holds. Bounded so a migration that arrives while a
+-- sync is running fails and is retried rather than queueing behind it and
+-- holding every later capture out — an unbounded wait here is a deploy that
+-- stops mail from being captured for as long as it takes.
+SET LOCAL lock_timeout = '3s';
+
+CREATE INDEX IF NOT EXISTS capture_thread_verdict_held_by_seat_idx
+    ON capture_thread_verdict (user_id, status)
+ WHERE status NOT IN ('cleared', 'shared_by_owner');

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1106,6 +1106,7 @@ public.capture_thread_verdict.thread_key text NOT NULL gen=- def=-
 public.capture_thread_verdict.updated_at timestamp with time zone NOT NULL gen=- def=now()
 public.capture_thread_verdict.user_id uuid NOT NULL gen=- def=-
 public.capture_thread_verdict_due_idx CREATE INDEX capture_thread_verdict_due_idx ON public.capture_thread_verdict USING btree (next_attempt_at) WHERE ((status = 'pending'::text) AND (next_attempt_at IS NOT NULL))
+public.capture_thread_verdict_held_by_seat_idx CREATE INDEX capture_thread_verdict_held_by_seat_idx ON public.capture_thread_verdict USING btree (user_id, status) WHERE (status <> ALL (ARRAY['cleared'::text, 'shared_by_owner'::text]))
 public.capture_thread_verdict_pkey CREATE UNIQUE INDEX capture_thread_verdict_pkey ON public.capture_thread_verdict USING btree (id)
 public.capture_thread_verdict_thread_user_key CREATE UNIQUE INDEX capture_thread_verdict_thread_user_key ON public.capture_thread_verdict USING btree (thread_key, user_id)
 public.capture_trace acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5804,6 +5804,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/capture/held-threads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * What your mailbox is holding right now.
+         * @description The threads your mailbox is withholding from your colleagues, and why. Pending rows first,
+         *     because during a classifier outage those are the ones nobody has decided — a thread whose
+         *     `attempts` stop climbing is a model that stopped answering rather than a thread that is
+         *     merely slow.
+         *
+         *     Release one with `POST /activities/threads/{thread_key}/audience`, which is the same door a
+         *     record's timeline uses. This endpoint only answers the question that page cannot: what am I
+         *     holding, across every contact at once.
+         *
+         *     A thread the classifier cleared is not here, because it is not held. Everything else is,
+         *     `unsure` included: a thread the model could not judge withholds exactly like one it judged
+         *     legal, and an owner who is not shown it cannot release it.
+         *
+         *     Your own mailbox and nobody else's. What a person is holding is the most private thing this
+         *     module knows — the list names threads judged legal, personnel or personal — so there is no
+         *     id here that reaches a colleague's list and no admin view of one.
+         */
+        get: operations["listHeldThreads"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/capture/senders": {
         parameters: {
             query?: never;
@@ -12723,6 +12758,51 @@ export interface components {
             verified: boolean;
             /** Format: date-time */
             created_at?: string;
+        };
+        HeldThreadListResponse: {
+            data: components["schemas"]["HeldThread"][];
+        };
+        /** @description One thread your mailbox is withholding, and what is known about why. */
+        HeldThread: {
+            /**
+             * @description The thread this holds, and the key `POST /activities/threads/{thread_key}/audience`
+             *     takes to release it.
+             */
+            thread_key: string;
+            /**
+             * @description The ledger's own word: `pending` while no verdict has landed, `held` or `unsure` once
+             *     one has, `held_by_owner` where you said so yourself.
+             */
+            status: string;
+            /**
+             * @description No verdict has landed yet. Stated as its own field rather than left to a client
+             *     comparing `status`, because it decides the order these arrive in and a reader that
+             *     derived it differently would sort them differently.
+             */
+            pending: boolean;
+            /**
+             * @description What the classifier concluded the thread is ABOUT — legal, personnel,
+             *     financial_corporate, personal, security_incident, explicitly_confidential. Absent while
+             *     pending, because nothing has concluded anything yet.
+             */
+            kind?: string;
+            /**
+             * @description The subject of the message that opened the thread, so one held thread reads differently
+             *     from another. Absent when that message was erased while the verdict stood, which the
+             *     ledger deliberately survives — losing the verdict would re-open a thread a classifier
+             *     already held.
+             */
+            subject?: string;
+            /**
+             * Format: date-time
+             * @description When that message arrived. Absent for the same reason `subject` can be.
+             */
+            occurred_at?: string;
+            /**
+             * @description How many times a verdict has been asked for. This is the outage signal: a pending row
+             *     whose attempts stop climbing is a model that stopped answering.
+             */
+            attempts: number;
         };
         CaptureSenderListResponse: {
             data: components["schemas"]["CaptureSenderDecision"][];
@@ -35908,6 +35988,28 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+        };
+    };
+    listHeldThreads: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The caller's held threads, pending first. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HeldThreadListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
         };
     };
     listCaptureSenders: {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -12821,10 +12821,21 @@ export interface components {
              */
             kind?: string;
             /**
+             * @description The message this thread began with is still readable by you. False where it was erased
+             *     while the verdict stood — which the ledger deliberately survives, because losing the
+             *     verdict would re-open a thread a classifier already held — and false where its content
+             *     is withheld from you.
+             *
+             *     Separate from `subject` because absence has two causes that read differently: no
+             *     message to name, versus a message somebody sent with a blank subject line. It also
+             *     decides whether releasing is offered at all: the release works on your own messages on
+             *     the thread, so with none left there is nothing to share.
+             */
+            has_message: boolean;
+            /**
              * @description The subject of the message that opened the thread, so one held thread reads differently
-             *     from another. Absent when that message was erased while the verdict stood, which the
-             *     ledger deliberately survives — losing the verdict would re-open a thread a classifier
-             *     already held.
+             *     from another. Absent when there is no message to read one from, and absent when the
+             *     message carries no subject — `has_message` tells the two apart.
              */
             subject?: string;
             /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -6943,6 +6943,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/ai/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Whether the model lanes are answering.
+         * @description One row per model tier for the last hour: how many terminal attempts it made, how many
+         *     failed, the most recent error it reported, and its median latency.
+         *
+         *     This exists because an outage is otherwise invisible. Under the capture posture a thread
+         *     stays held whether the classifier judged it confidential or never answered at all, so a
+         *     working-and-cautious classifier and a dead one look identical from every other surface —
+         *     and nobody notices until somebody asks why a thread never opened.
+         *
+         *     Read from `ai_call`, which already records every attempt. Nothing is written for this: a
+         *     health surface with its own bookkeeping would be a second account of what happened, free
+         *     to disagree with the first. Terminal attempts only, so a failure a retry rescued does not
+         *     report a lane as failing while every caller of it got an answer.
+         *
+         *     An hour, because the question is whether it is answering NOW — a day-long window would
+         *     call a lane that died forty minutes ago healthy on the strength of this morning.
+         */
+        get: operations["getAiHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ai/usage": {
         parameters: {
             query?: never;
@@ -13300,6 +13334,40 @@ export interface components {
              * @description Required for merge: the surviving record — must be one of the pair.
              */
             winner_id?: string | null;
+        };
+        AiHealth: {
+            /** @description How far back the counts reach, so a reader knows what "no calls" covers. */
+            window_hours: number;
+            rungs: components["schemas"]["AiRungHealth"][];
+        };
+        /** @description One model tier and what it has been doing. */
+        AiRungHealth: {
+            /** @description The rung's name — `local_small`, `cloud_large` and the rest. */
+            tier: string;
+            /**
+             * @description The tier answered at least once in the window without every attempt failing. Decided
+             *     here rather than left to each client: two clients deciding what an all-failed rung
+             *     means would be two answers, and one surface would call an outage while the other did
+             *     not.
+             */
+            healthy: boolean;
+            /** @description Terminal attempts in the window. */
+            calls: number;
+            /** @description How many of them carried an error. */
+            failures: number;
+            /**
+             * @description The most recent error this tier reported, absent when it reported none. It is the
+             *     first clue an operator has: a budget refusal and an unreachable model are both "not
+             *     answering" and want different fixes.
+             */
+            last_sentinel?: string;
+            /**
+             * Format: date-time
+             * @description When this tier last answered anything at all.
+             */
+            last_call_at?: string;
+            /** @description The window's middle latency, which tells a slow lane from a dead one. */
+            median_latency_ms: number;
         };
         /** @description AI usage + budget (AIRT-WIRE-1): the AIRT-PARAM-33 meter aggregated per day × task × tier, plus the budget band. Token-denominated; cost_est_minor is computed on read from the workspace's ai_model_rate price sheet as of each call's day (ADR-0067, price-on-read) — omitted, never a fabricated 0, when a task line's window carries no priced call. */
         AiUsage: {
@@ -37247,6 +37315,28 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+        };
+    };
+    getAiHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description One row per tier that made a terminal attempt in the window. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AiHealth"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["PermissionDenied"];
         };
     };
     getAiUsage: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3821,6 +3821,20 @@ export const de = {
     "Du hast zugestimmt, aber die Vollmacht, unter der Margince gearbeitet hat, ist abgelaufen. Schalte die Option aus und wieder ein, um sie zu erneuern — bis dahin wird dein Überblick nicht vorbereitet.",
   "overnightGrant.renewScope":
     "Du hast zugestimmt, aber Margince kann inzwischen mehr, und die erteilte Vollmacht deckt die neue Arbeit nicht ab. Schalte die Option aus und wieder ein, um sie zu erweitern — bis dahin wird dein Überblick nicht vorbereitet.",
+  "aiHealth.title": "Modell-Lanes",
+  "aiHealth.sub":
+    "Ob jede Modellstufe antwortet. Eine ausgefallene Lane und eine, die nur vorsichtig ist, sehen überall sonst gleich aus — erfasste Post bleibt in beiden Fällen zurückgehalten.",
+  "aiHealth.noCalls":
+    "in den letzten {hours} Stunde(n) wurde kein Modell aufgerufen",
+  "aiHealth.colTier": "Stufe",
+  "aiHealth.colState": "Zustand",
+  "aiHealth.colCalls": "Letzte {hours} Std.",
+  "aiHealth.colLatency": "Median",
+  "aiHealth.colLast": "Letzte Antwort",
+  "aiHealth.answering": "Antwortet",
+  "aiHealth.notAnswering": "Antwortet nicht",
+  "aiHealth.callCounts": "{calls} Aufrufe, {failures} fehlgeschlagen",
+  "aiHealth.ms": "{ms} ms",
   "heldThreads.title": "Vom Team zurückgehalten",
   "heldThreads.sub":
     "Konversationen, die Ihr Postfach zurückhält. Wenn Sie eine freigeben, können alle Kolleginnen und Kollegen sie lesen; niemand sonst kann Ihre freigeben.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3846,6 +3846,9 @@ export const de = {
   "heldThreads.release": "Mit dem Team teilen",
   "heldThreads.released": "Mit dem Team geteilt",
   "heldThreads.noSubject": "die ursprüngliche Nachricht ist gelöscht",
+  "heldThreads.blankSubject": "kein Betreff",
+  "heldThreads.nothingToShare":
+    "Es ist keine Nachricht mehr da, die geteilt werden könnte — die erste Nachricht dieser Konversation wurde gelöscht. Die Zurückhaltung bleibt, damit eine spätere Antwort nicht offen eintrifft.",
   "heldThreads.pending": "Wartet auf Beurteilung",
   "heldThreads.attempts": "{count}-mal angefragt",
   "heldThreads.heldByOthers":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3821,6 +3821,27 @@ export const de = {
     "Du hast zugestimmt, aber die Vollmacht, unter der Margince gearbeitet hat, ist abgelaufen. Schalte die Option aus und wieder ein, um sie zu erneuern — bis dahin wird dein Überblick nicht vorbereitet.",
   "overnightGrant.renewScope":
     "Du hast zugestimmt, aber Margince kann inzwischen mehr, und die erteilte Vollmacht deckt die neue Arbeit nicht ab. Schalte die Option aus und wieder ein, um sie zu erweitern — bis dahin wird dein Überblick nicht vorbereitet.",
+  "heldThreads.title": "Vom Team zurückgehalten",
+  "heldThreads.sub":
+    "Konversationen, die Ihr Postfach zurückhält. Wenn Sie eine freigeben, können alle Kolleginnen und Kollegen sie lesen; niemand sonst kann Ihre freigeben.",
+  "heldThreads.empty": "Ihr Postfach hält derzeit nichts zurück",
+  "heldThreads.colThread": "Konversation",
+  "heldThreads.colWhy": "Warum zurückgehalten",
+  "heldThreads.colWhen": "Eingegangen",
+  "heldThreads.colActions": "Aktionen",
+  "heldThreads.release": "Mit dem Team teilen",
+  "heldThreads.released": "Mit dem Team geteilt",
+  "heldThreads.noSubject": "die ursprüngliche Nachricht ist gelöscht",
+  "heldThreads.pending": "Wartet auf Beurteilung",
+  "heldThreads.attempts": "{count}-mal angefragt",
+  "heldThreads.heldByOthers":
+    "Weiterhin zurückgehalten: {count} weiteres Postfach hat diese Nachricht ebenfalls importiert und nicht freigegeben. Eine Konversation wird erst geöffnet, wenn alle Empfänger zustimmen.",
+  "heldThreads.kind.legal": "Rechtliches",
+  "heldThreads.kind.financialCorporate": "Unternehmensfinanzen",
+  "heldThreads.kind.personnel": "Personal",
+  "heldThreads.kind.personal": "Privat",
+  "heldThreads.kind.securityIncident": "Sicherheitsvorfall",
+  "heldThreads.kind.explicitlyConfidential": "Als vertraulich markiert",
   "senders.title": "Absender",
   "senders.sub":
     "Was über jede Adresse entschieden wurde, die Ihr Postfach eingebracht hat — und Ihre eigene Antwort, wo Sie eine gegeben haben. Nur Ihre Absender; Kolleginnen und Kollegen sehen diese Liste nie.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3881,6 +3881,9 @@ export const en = {
   "heldThreads.release": "Share with the team",
   "heldThreads.released": "Shared with the team",
   "heldThreads.noSubject": "the message this began with is gone",
+  "heldThreads.blankSubject": "no subject",
+  "heldThreads.nothingToShare":
+    "There is no message left to share — this thread\u2019s first message was erased, and the hold stays so a later reply does not arrive open.",
   "heldThreads.pending": "Waiting on a verdict",
   "heldThreads.attempts": "asked {count} time(s)",
   "heldThreads.heldByOthers":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3857,6 +3857,19 @@ export const en = {
     "You said yes, but the authority Margince was working under has expired. Turn this off and on again to renew it — until then your brief is not being prepared.",
   "overnightGrant.renewScope":
     "You said yes, but Margince has learned to do more since, and the authority you gave does not cover the new work. Turn this off and on again to widen it — until then your brief is not being prepared.",
+  "aiHealth.title": "Model lanes",
+  "aiHealth.sub":
+    "Whether each model tier is answering. A lane that stopped and one that is merely cautious look the same everywhere else — captured mail stays held either way.",
+  "aiHealth.noCalls": "no model was called in the last {hours} hour(s)",
+  "aiHealth.colTier": "Tier",
+  "aiHealth.colState": "State",
+  "aiHealth.colCalls": "Last {hours}h",
+  "aiHealth.colLatency": "Median",
+  "aiHealth.colLast": "Last answer",
+  "aiHealth.answering": "Answering",
+  "aiHealth.notAnswering": "Not answering",
+  "aiHealth.callCounts": "{calls} calls, {failures} failed",
+  "aiHealth.ms": "{ms} ms",
   "heldThreads.title": "Held back from your team",
   "heldThreads.sub":
     "Threads your mailbox is withholding. Releasing one lets every colleague read it; nobody else can release yours.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3857,6 +3857,27 @@ export const en = {
     "You said yes, but the authority Margince was working under has expired. Turn this off and on again to renew it — until then your brief is not being prepared.",
   "overnightGrant.renewScope":
     "You said yes, but Margince has learned to do more since, and the authority you gave does not cover the new work. Turn this off and on again to widen it — until then your brief is not being prepared.",
+  "heldThreads.title": "Held back from your team",
+  "heldThreads.sub":
+    "Threads your mailbox is withholding. Releasing one lets every colleague read it; nobody else can release yours.",
+  "heldThreads.empty": "your mailbox is withholding nothing right now",
+  "heldThreads.colThread": "Thread",
+  "heldThreads.colWhy": "Why it is held",
+  "heldThreads.colWhen": "Arrived",
+  "heldThreads.colActions": "What you can do",
+  "heldThreads.release": "Share with the team",
+  "heldThreads.released": "Shared with the team",
+  "heldThreads.noSubject": "the message this began with is gone",
+  "heldThreads.pending": "Waiting on a verdict",
+  "heldThreads.attempts": "asked {count} time(s)",
+  "heldThreads.heldByOthers":
+    "Still held: {count} other mailbox imported this message and has not shared it. A thread opens only when everyone who received it agrees.",
+  "heldThreads.kind.legal": "Legal",
+  "heldThreads.kind.financialCorporate": "Company finances",
+  "heldThreads.kind.personnel": "Personnel",
+  "heldThreads.kind.personal": "Personal",
+  "heldThreads.kind.securityIncident": "Security incident",
+  "heldThreads.kind.explicitlyConfidential": "Marked confidential",
   "senders.title": "Senders",
   "senders.sub":
     "What was decided about each address your mailbox brought in — and your own answer where you gave one. Your senders only; a colleague never sees this list.",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -30,6 +30,10 @@ const KEPT_IN_ENGLISH = new Set<string>([
   // no word in it to translate — a locale that changed it would be changing
   // the account's name.
   "co.360.subject",
+  // A number and the SI symbol for millisecond. The symbol is the same in every
+  // language by definition — it is written "ms" in Vietnamese too — so a locale
+  // that changed it would be naming a different unit.
+  "aiHealth.ms",
   // An acronym, not a word: DNS is DNS in every language this product speaks,
   // and a "translation" of it would be a different protocol.
   "co.tech.lane.dns",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3785,6 +3785,27 @@ export const vi = {
     "Bạn đã đồng ý, nhưng quyền mà Margince đang dùng đã hết hạn. Tắt rồi bật lại tùy chọn này để gia hạn — cho đến lúc đó bản tóm tắt của bạn không được chuẩn bị.",
   "overnightGrant.renewScope":
     "Bạn đã đồng ý, nhưng Margince nay làm được nhiều hơn, và quyền bạn đã cấp không bao gồm phần việc mới. Tắt rồi bật lại tùy chọn này để mở rộng — cho đến lúc đó bản tóm tắt của bạn không được chuẩn bị.",
+  "heldThreads.title": "Đang giữ lại khỏi nhóm",
+  "heldThreads.sub":
+    "Những chuỗi thư hộp thư của bạn đang giữ lại. Chia sẻ một chuỗi cho phép mọi đồng nghiệp đọc nó; không ai khác có thể chia sẻ chuỗi của bạn.",
+  "heldThreads.empty": "hộp thư của bạn hiện không giữ lại gì",
+  "heldThreads.colThread": "Chuỗi thư",
+  "heldThreads.colWhy": "Lý do giữ lại",
+  "heldThreads.colWhen": "Đã đến",
+  "heldThreads.colActions": "Thao tác",
+  "heldThreads.release": "Chia sẻ với nhóm",
+  "heldThreads.released": "Đã chia sẻ với nhóm",
+  "heldThreads.noSubject": "thư mở đầu đã bị xóa",
+  "heldThreads.pending": "Đang chờ phán quyết",
+  "heldThreads.attempts": "đã hỏi {count} lần",
+  "heldThreads.heldByOthers":
+    "Vẫn bị giữ lại: {count} hộp thư khác cũng đã nhập thư này và chưa chia sẻ. Một chuỗi chỉ mở khi mọi người nhận đều đồng ý.",
+  "heldThreads.kind.legal": "Pháp lý",
+  "heldThreads.kind.financialCorporate": "Tài chính công ty",
+  "heldThreads.kind.personnel": "Nhân sự",
+  "heldThreads.kind.personal": "Cá nhân",
+  "heldThreads.kind.securityIncident": "Sự cố bảo mật",
+  "heldThreads.kind.explicitlyConfidential": "Được đánh dấu bảo mật",
   "senders.title": "Người gửi",
   "senders.sub":
     "Những gì đã được quyết định về từng địa chỉ mà hộp thư của bạn mang vào — và câu trả lời của chính bạn nếu có. Chỉ người gửi của bạn; đồng nghiệp không bao giờ thấy danh sách này.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3809,6 +3809,9 @@ export const vi = {
   "heldThreads.release": "Chia sẻ với nhóm",
   "heldThreads.released": "Đã chia sẻ với nhóm",
   "heldThreads.noSubject": "thư mở đầu đã bị xóa",
+  "heldThreads.blankSubject": "không có tiêu đề",
+  "heldThreads.nothingToShare":
+    "Không còn thư nào để chia sẻ — thư đầu tiên của chuỗi này đã bị xóa. Việc giữ lại vẫn tiếp tục để một thư trả lời sau không đến ở trạng thái mở.",
   "heldThreads.pending": "Đang chờ phán quyết",
   "heldThreads.attempts": "đã hỏi {count} lần",
   "heldThreads.heldByOthers":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3785,6 +3785,19 @@ export const vi = {
     "Bạn đã đồng ý, nhưng quyền mà Margince đang dùng đã hết hạn. Tắt rồi bật lại tùy chọn này để gia hạn — cho đến lúc đó bản tóm tắt của bạn không được chuẩn bị.",
   "overnightGrant.renewScope":
     "Bạn đã đồng ý, nhưng Margince nay làm được nhiều hơn, và quyền bạn đã cấp không bao gồm phần việc mới. Tắt rồi bật lại tùy chọn này để mở rộng — cho đến lúc đó bản tóm tắt của bạn không được chuẩn bị.",
+  "aiHealth.title": "Các tầng mô hình",
+  "aiHealth.sub":
+    "Mỗi tầng mô hình có đang trả lời hay không. Một tầng đã ngừng và một tầng chỉ đang thận trọng trông giống hệt nhau ở mọi nơi khác — thư đã thu thập vẫn bị giữ lại trong cả hai trường hợp.",
+  "aiHealth.noCalls": "không có mô hình nào được gọi trong {hours} giờ qua",
+  "aiHealth.colTier": "Tầng",
+  "aiHealth.colState": "Trạng thái",
+  "aiHealth.colCalls": "{hours} giờ qua",
+  "aiHealth.colLatency": "Trung vị",
+  "aiHealth.colLast": "Trả lời gần nhất",
+  "aiHealth.answering": "Đang trả lời",
+  "aiHealth.notAnswering": "Không trả lời",
+  "aiHealth.callCounts": "{calls} lượt gọi, {failures} thất bại",
+  "aiHealth.ms": "{ms} ms",
   "heldThreads.title": "Đang giữ lại khỏi nhóm",
   "heldThreads.sub":
     "Những chuỗi thư hộp thư của bạn đang giữ lại. Chia sẻ một chuỗi cho phép mọi đồng nghiệp đọc nó; không ai khác có thể chia sẻ chuỗi của bạn.",

--- a/frontend/src/screens/ai-health.stories.tsx
+++ b/frontend/src/screens/ai-health.stories.tsx
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { AiHealthCard } from "./ai-health";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+// The three states worth a picture, because they are what an operator has to
+// tell apart at a glance: every lane answering, one lane down with its reason,
+// and an installation nobody used this hour — which must not look like the
+// second.
+
+type RungHealth = components["schemas"]["AiRungHealth"];
+
+const HEALTHY: RungHealth[] = [
+  {
+    tier: "local_small",
+    healthy: true,
+    calls: 42,
+    failures: 0,
+    median_latency_ms: 210,
+    last_call_at: "2026-09-01T09:14:00Z",
+  },
+  {
+    tier: "cloud_large",
+    healthy: true,
+    calls: 6,
+    failures: 1,
+    median_latency_ms: 1840,
+    last_sentinel: "rate_limited",
+    last_call_at: "2026-09-01T09:02:00Z",
+  },
+];
+
+// One lane dead, which is the state the whole endpoint exists for: under the
+// capture posture nothing else on the product would show it.
+const OUTAGE: RungHealth[] = [
+  HEALTHY[0],
+  {
+    tier: "cloud_large",
+    healthy: false,
+    calls: 9,
+    failures: 9,
+    median_latency_ms: 28,
+    last_sentinel: "provider_unavailable",
+    last_call_at: "2026-09-01T08:58:00Z",
+  },
+];
+
+function story(rungs: RungHealth[]) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute({}),
+      "GET /ai/health": () => jsonResponse({ window_hours: 1, rungs }),
+    });
+    return (
+      <StoryProviders>
+        <AiHealthCard />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof AiHealthCard> = {
+  title: "Settings/Admin/Model lanes",
+  component: AiHealthCard,
+};
+export default meta;
+
+type Story = StoryObj<typeof AiHealthCard>;
+
+export const Healthy: Story = { render: story(HEALTHY) };
+export const Outage: Story = { render: story(OUTAGE) };
+export const NobodyCalledAModel: Story = { render: story([]) };

--- a/frontend/src/screens/ai-health.test.tsx
+++ b/frontend/src/screens/ai-health.test.tsx
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { meFixture } from "../app/mefixture";
+import { LocaleProvider } from "../i18n";
+import { AiHealthCard } from "./ai-health";
+
+// The distinction this card exists to draw: a lane nobody called and a lane
+// that answered nothing are both "no successful calls", and reporting them the
+// same way is what makes an outage invisible.
+
+type RungHealth = components["schemas"]["AiRungHealth"];
+
+const ANSWERING: RungHealth = {
+  tier: "local_small",
+  healthy: true,
+  calls: 12,
+  failures: 0,
+  median_latency_ms: 240,
+  last_call_at: "2026-09-01T09:12:00Z",
+};
+
+const DEAD: RungHealth = {
+  tier: "cloud_large",
+  healthy: false,
+  calls: 5,
+  failures: 5,
+  median_latency_ms: 30,
+  last_sentinel: "provider_unavailable",
+  last_call_at: "2026-09-01T09:10:00Z",
+};
+
+function renderCard(rungs: RungHealth[], windowHours = 1) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      const body =
+        key === "GET /me"
+          ? meFixture({})
+          : { window_hours: windowHours, rungs };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const ui: ReactNode = (
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <AiHealthCard />
+      </LocaleProvider>
+    </QueryClientProvider>
+  );
+  return render(ui);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("model lane health", () => {
+  it("tells a lane that answered from one that answered nothing", async () => {
+    renderCard([ANSWERING, DEAD]);
+    expect(await screen.findByText(/^Answering$/)).toBeInTheDocument();
+    expect(screen.getByText(/^Not answering$/)).toBeInTheDocument();
+  });
+
+  it("names the error a failing lane reported", async () => {
+    // The sentinel is the operator's first clue: a budget refusal and an
+    // unreachable model are both "not answering" and want different fixes.
+    renderCard([DEAD]);
+    expect(await screen.findByText("provider_unavailable")).toBeInTheDocument();
+  });
+
+  it("says both counts, so a red badge is not left to be interpreted", async () => {
+    renderCard([DEAD]);
+    expect(await screen.findByText(/5 calls, 5 failed/)).toBeInTheDocument();
+  });
+
+  it("reports an unused installation as unused rather than as an outage", async () => {
+    // Nobody called a model this hour. That is not a failure, and an empty
+    // table would read as one.
+    renderCard([]);
+    expect(
+      await screen.findByText(/no model was called in the last 1 hour/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/ai-health.tsx
+++ b/frontend/src/screens/ai-health.tsx
@@ -21,6 +21,7 @@ type RungHealth = components["schemas"]["AiRungHealth"];
 
 export function AiHealthCard() {
   const t = useT();
+  const { locale } = useLocale();
   const query = useQuery({
     queryKey: ["ai-health"],
     queryFn: async () => {
@@ -49,7 +50,7 @@ export function AiHealthCard() {
               <EmptyState>
                 <p className="t-small">
                   {t("aiHealth.noCalls", {
-                    hours: String(health.window_hours),
+                    hours: formatNumber(health.window_hours, locale),
                   })}
                 </p>
               </EmptyState>
@@ -93,7 +94,9 @@ function RungTable({
         },
         {
           key: "calls",
-          header: t("aiHealth.colCalls", { hours: String(hours) }),
+          header: t("aiHealth.colCalls", {
+            hours: formatNumber(hours, locale),
+          }),
           render: (row) =>
             // Both numbers, because "12 calls" beside a red badge leaves a
             // reader working out how many of them failed.

--- a/frontend/src/screens/ai-health.tsx
+++ b/frontend/src/screens/ai-health.tsx
@@ -1,0 +1,144 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { Badge, DataTable, EmptyState } from "../design-system/atoms";
+import { Panel, PanelBody } from "../design-system/panel";
+import { formatDateTime, formatNumber } from "../format/format";
+import { viewerZone } from "../format/timezone";
+import { useLocale, useT } from "../i18n";
+import { QueryGate, throwProblem } from "./common";
+
+// Whether the model lanes are answering.
+//
+// The binding card above says which vendor serves a tier and the keys card says
+// whether this installation can call it. Neither says whether it ANSWERED, and
+// under the capture posture that gap is expensive: a thread stays held whether
+// the classifier judged it confidential or never replied at all, so an outage
+// and correct cautious behaviour look identical until somebody asks why a
+// thread never opened.
+
+type RungHealth = components["schemas"]["AiRungHealth"];
+
+export function AiHealthCard() {
+  const t = useT();
+  const query = useQuery({
+    queryKey: ["ai-health"],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/ai/health");
+      if (error) throwProblem(error);
+      return data;
+    },
+    // The question is whether it is answering NOW, so a reader who leaves this
+    // page open watches it rather than reading a snapshot from when they
+    // arrived. One minute against a one-hour window: often enough to notice a
+    // lane die, rare enough to cost nothing.
+    refetchInterval: 60_000,
+  });
+
+  return (
+    <Panel title={t("aiHealth.title")}>
+      <PanelBody>
+        <p className="settings-panel-sub">{t("aiHealth.sub")}</p>
+        <QueryGate query={query}>
+          {(health) =>
+            health.rungs.length === 0 ? (
+              // No rung called anything in the window. That is not an outage —
+              // an installation nobody used this hour looks exactly the same —
+              // so it says which it is rather than drawing an empty table a
+              // reader would read as failure.
+              <EmptyState>
+                <p className="t-small">
+                  {t("aiHealth.noCalls", {
+                    hours: String(health.window_hours),
+                  })}
+                </p>
+              </EmptyState>
+            ) : (
+              <RungTable rungs={health.rungs} hours={health.window_hours} />
+            )
+          }
+        </QueryGate>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+function RungTable({
+  rungs,
+  hours,
+}: Readonly<{ rungs: RungHealth[]; hours: number }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const zone = viewerZone();
+  return (
+    <DataTable<RungHealth>
+      label={t("aiHealth.title")}
+      rows={rungs}
+      rowKey={(row) => row.tier}
+      columns={[
+        {
+          key: "tier",
+          header: t("aiHealth.colTier"),
+          render: (row) => row.tier,
+        },
+        {
+          key: "state",
+          header: t("aiHealth.colState"),
+          render: (row) =>
+            row.healthy ? (
+              <Badge tone="success">{t("aiHealth.answering")}</Badge>
+            ) : (
+              <Badge tone="danger">{t("aiHealth.notAnswering")}</Badge>
+            ),
+        },
+        {
+          key: "calls",
+          header: t("aiHealth.colCalls", { hours: String(hours) }),
+          render: (row) =>
+            // Both numbers, because "12 calls" beside a red badge leaves a
+            // reader working out how many of them failed.
+            t("aiHealth.callCounts", {
+              calls: formatNumber(row.calls, locale),
+              failures: formatNumber(row.failures, locale),
+            }),
+        },
+        {
+          key: "latency",
+          header: t("aiHealth.colLatency"),
+          render: (row) =>
+            // The median tells a slow lane from a dead one, which is the
+            // distinction an operator acts on differently.
+            t("aiHealth.ms", {
+              ms: formatNumber(row.median_latency_ms, locale),
+            }),
+        },
+        {
+          key: "last",
+          header: t("aiHealth.colLast"),
+          render: (row) => <LastCell row={row} zone={zone} />,
+        },
+      ]}
+    />
+  );
+}
+
+// When this rung last answered, and what it said if it failed.
+//
+// The sentinel is the operator's first clue and the reason this column is not
+// just a timestamp: a budget refusal and an unreachable model are both "not
+// answering" and want completely different fixes.
+function LastCell({ row, zone }: Readonly<{ row: RungHealth; zone: string }>) {
+  const { locale } = useLocale();
+  return (
+    <span className="cell-stack">
+      {row.last_call_at ? (
+        <span>{formatDateTime(row.last_call_at, locale, zone)}</span>
+      ) : (
+        <span className="t-meta">—</span>
+      )}
+      {row.last_sentinel ? (
+        <span className="t-meta t-mono">{row.last_sentinel}</span>
+      ) : null}
+    </span>
+  );
+}

--- a/frontend/src/screens/held-threads.stories.tsx
+++ b/frontend/src/screens/held-threads.stories.tsx
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { HeldThreadsCard } from "./held-threads";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+// What a mailbox is holding back from the team. The states worth a picture are
+// the two a reader must tell apart at a glance: a thread a classifier JUDGED,
+// and one it has not answered about at all — which during an outage is every
+// row on the page.
+
+type HeldThread = components["schemas"]["HeldThread"];
+
+const MIXED: HeldThread[] = [
+  // Pending leads, which is the ordering the endpoint guarantees and the whole
+  // reason this page is worth opening during an outage.
+  {
+    thread_key: "t-1",
+    status: "pending",
+    pending: true,
+    attempts: 4,
+    subject: "Angebot Q4 — Rückfragen",
+    occurred_at: "2026-08-30T09:12:00Z",
+  },
+  {
+    thread_key: "t-2",
+    status: "held",
+    pending: false,
+    attempts: 1,
+    kind: "legal",
+    subject: "Entwurf Aufhebungsvertrag",
+    occurred_at: "2026-08-29T15:40:00Z",
+  },
+  {
+    thread_key: "t-3",
+    status: "unsure",
+    pending: false,
+    attempts: 2,
+    subject: "Re: Termin",
+    occurred_at: "2026-08-28T11:02:00Z",
+  },
+  // The verdict outlives its evidence: an erasure inside the window nulls the
+  // activity and the hold stands. The row says the message is gone rather than
+  // drawing a blank cell that reads as a message with no subject.
+  {
+    thread_key: "t-4",
+    status: "held",
+    pending: false,
+    attempts: 1,
+    kind: "personal",
+  },
+];
+
+function story(rows: HeldThread[]) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute({}),
+      "GET /capture/held-threads": () => jsonResponse({ data: rows }),
+    });
+    return (
+      <StoryProviders>
+        <HeldThreadsCard />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof HeldThreadsCard> = {
+  title: "Settings/You/Held threads",
+  component: HeldThreadsCard,
+};
+export default meta;
+
+type Story = StoryObj<typeof HeldThreadsCard>;
+
+export const Mixed: Story = { render: story(MIXED) };
+
+// Nothing held is a READING, not an absent list: "my mailbox is withholding
+// nothing right now" is what an owner opens this card to confirm.
+export const NothingHeld: Story = { render: story([]) };
+
+// Every row pending, which is what a classifier outage looks like from the
+// owner's side — and the state the attempts count exists for.
+export const Outage: Story = {
+  render: story(
+    MIXED.map((row, i) => ({
+      ...row,
+      status: "pending",
+      pending: true,
+      kind: undefined,
+      attempts: i + 1,
+    })),
+  ),
+};

--- a/frontend/src/screens/held-threads.stories.tsx
+++ b/frontend/src/screens/held-threads.stories.tsx
@@ -26,6 +26,7 @@ const MIXED: HeldThread[] = [
     status: "pending",
     pending: true,
     attempts: 4,
+    has_message: true,
     subject: "Angebot Q4 — Rückfragen",
     occurred_at: "2026-08-30T09:12:00Z",
   },
@@ -34,6 +35,7 @@ const MIXED: HeldThread[] = [
     status: "held",
     pending: false,
     attempts: 1,
+    has_message: true,
     kind: "legal",
     subject: "Entwurf Aufhebungsvertrag",
     occurred_at: "2026-08-29T15:40:00Z",
@@ -43,6 +45,7 @@ const MIXED: HeldThread[] = [
     status: "unsure",
     pending: false,
     attempts: 2,
+    has_message: true,
     subject: "Re: Termin",
     occurred_at: "2026-08-28T11:02:00Z",
   },
@@ -54,6 +57,9 @@ const MIXED: HeldThread[] = [
     status: "held",
     pending: false,
     attempts: 1,
+    // No message left: the release is refused with a reason rather than
+    // offering a control whose only outcome is an error.
+    has_message: false,
     kind: "personal",
   },
 ];

--- a/frontend/src/screens/held-threads.test.tsx
+++ b/frontend/src/screens/held-threads.test.tsx
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { meFixture } from "../app/mefixture";
+import { LocaleProvider } from "../i18n";
+import { HeldThreadsCard } from "./held-threads";
+
+// What this card must never do is state a fact it does not have. A thread whose
+// opening message was erased has no subject; a thread nobody has judged has no
+// kind; and a release that opened nothing must say so rather than looking as
+// though it worked.
+
+type HeldThread = components["schemas"]["HeldThread"];
+
+const PENDING: HeldThread = {
+  thread_key: "t-pending",
+  status: "pending",
+  pending: true,
+  attempts: 3,
+  subject: "Angebot Q4",
+  occurred_at: "2026-08-30T09:12:00Z",
+};
+
+const JUDGED: HeldThread = {
+  thread_key: "t-legal",
+  status: "held",
+  pending: false,
+  attempts: 1,
+  kind: "legal",
+  subject: "Entwurf Aufhebungsvertrag",
+  occurred_at: "2026-08-29T15:40:00Z",
+};
+
+function renderCard(rows: HeldThread[], share?: Record<string, unknown>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      if (key === "GET /me") {
+        return new Response(JSON.stringify(meFixture({})), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (key === "GET /capture/held-threads") {
+        return new Response(JSON.stringify({ data: rows }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (key.startsWith("POST /activities/threads/")) {
+        return new Response(JSON.stringify(share ?? { shared: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const ui: ReactNode = (
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <HeldThreadsCard />
+      </LocaleProvider>
+    </QueryClientProvider>
+  );
+  return render(ui);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("held threads", () => {
+  it("says a pending thread is waiting rather than leaving the reason blank", async () => {
+    // During an outage every row is pending. A blank reason column would read
+    // as a classifier that judged nothing rather than one that has not
+    // answered, and the attempts count is what tells a stalled model from a
+    // slow one.
+    renderCard([PENDING]);
+    expect(
+      await screen.findByText(/waiting on a verdict/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/asked 3 time/i)).toBeInTheDocument();
+  });
+
+  it("names why a judged thread is held", async () => {
+    renderCard([JUDGED]);
+    expect(await screen.findByText("Legal")).toBeInTheDocument();
+    expect(screen.queryByText(/waiting on a verdict/i)).not.toBeInTheDocument();
+  });
+
+  it("says the opening message is gone rather than drawing an empty subject", async () => {
+    // The verdict outlives its evidence on purpose — losing it would re-open a
+    // thread a classifier already held — so this row is normal, not broken.
+    renderCard([{ ...JUDGED, subject: undefined, occurred_at: undefined }]);
+    expect(
+      await screen.findByText(/the message this began with is gone/i),
+    ).toBeInTheDocument();
+  });
+
+  it("reports a release that opened nothing", async () => {
+    // A message two mailboxes imported opens only when both owners release it.
+    // Reporting the other holder is the difference between a control that looks
+    // broken and one that says what happened.
+    const user = userEvent.setup();
+    renderCard([JUDGED], { shared: false, held_by_others: 1 });
+    await user.click(
+      await screen.findByRole("button", { name: /share with the team/i }),
+    );
+    expect(await screen.findByText(/still held/i)).toBeInTheDocument();
+  });
+
+  it("reports an empty list as nothing held rather than as a failure", async () => {
+    renderCard([]);
+    expect(
+      await screen.findByText(/withholding nothing right now/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/held-threads.test.tsx
+++ b/frontend/src/screens/held-threads.test.tsx
@@ -26,6 +26,7 @@ const PENDING: HeldThread = {
   status: "pending",
   pending: true,
   attempts: 3,
+  has_message: true,
   subject: "Angebot Q4",
   occurred_at: "2026-08-30T09:12:00Z",
 };
@@ -35,6 +36,7 @@ const JUDGED: HeldThread = {
   status: "held",
   pending: false,
   attempts: 1,
+  has_message: true,
   kind: "legal",
   subject: "Entwurf Aufhebungsvertrag",
   occurred_at: "2026-08-29T15:40:00Z",
@@ -115,10 +117,39 @@ describe("held threads", () => {
   it("says the opening message is gone rather than drawing an empty subject", async () => {
     // The verdict outlives its evidence on purpose — losing it would re-open a
     // thread a classifier already held — so this row is normal, not broken.
-    renderCard([{ ...JUDGED, subject: undefined, occurred_at: undefined }]);
+    renderCard([
+      {
+        ...JUDGED,
+        has_message: false,
+        subject: undefined,
+        occurred_at: undefined,
+      },
+    ]);
     expect(
       await screen.findByText(/the message this began with is gone/i),
     ).toBeInTheDocument();
+  });
+
+  it("tells a message with no subject from no message at all", async () => {
+    // Both draw an unnamed row, and collapsing them would tell a reader their
+    // evidence was destroyed when it is sitting there unnamed.
+    renderCard([{ ...JUDGED, subject: undefined }]);
+    expect(await screen.findByText(/^no subject$/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/the message this began with is gone/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("refuses the release when there is no message left to share", async () => {
+    // The release works on the seat's own messages on the thread, so with none
+    // left it answers not-found. A control whose only outcome is an error is
+    // worse than one that says why it cannot run.
+    renderCard([{ ...JUDGED, has_message: false, subject: undefined }]);
+    const button = await screen.findByRole("button", {
+      name: /share with the team/i,
+    });
+    expect(button).toBeDisabled();
+    expect(screen.getByText(/no message left to share/i)).toBeInTheDocument();
   });
 
   it("reports a release that opened nothing", async () => {

--- a/frontend/src/screens/held-threads.tsx
+++ b/frontend/src/screens/held-threads.tsx
@@ -1,0 +1,208 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { Badge, Button, DataTable, EmptyState } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { Panel, PanelBody } from "../design-system/panel";
+import { useToast } from "../design-system/toast";
+import { formatDateTime } from "../format/format";
+import { viewerZone } from "../format/timezone";
+import { useLocale, useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { problemMessageOf, QueryGate, throwProblem } from "./common";
+
+// What this mailbox is holding back from the team, and the one press that
+// releases a thread.
+//
+// An owner could already do this from a record's timeline, one thread at a
+// time. What they could not do is ask "what am I holding" — and during a
+// classifier outage that is the only question worth asking, because every new
+// thread lands pending and stays there until the model answers again.
+//
+// The caller's own mailbox and nobody else's. The endpoint has no admin view
+// for the same reason this card has no filter by colleague: the rows name
+// threads judged legal, personnel or personal, so a shared list would disclose
+// exactly what holding them prevents.
+
+type HeldThread = components["schemas"]["HeldThread"];
+
+// Why a thread is held, in the reader's words. A kind absent from the map is
+// one the server learned to say and this screen has not — it falls back to the
+// raw token rather than rendering nothing, so a new kind arrives as something
+// to name instead of a blank cell.
+const kindLabel: Record<string, MessageKey> = {
+  legal: "heldThreads.kind.legal",
+  financial_corporate: "heldThreads.kind.financialCorporate",
+  personnel: "heldThreads.kind.personnel",
+  personal: "heldThreads.kind.personal",
+  security_incident: "heldThreads.kind.securityIncident",
+  explicitly_confidential: "heldThreads.kind.explicitlyConfidential",
+};
+
+export function HeldThreadsCard() {
+  const t = useT();
+  const query = useQuery({
+    queryKey: ["held-threads"],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/capture/held-threads");
+      if (error) throwProblem(error);
+      return data;
+    },
+  });
+
+  return (
+    <Panel title={t("heldThreads.title")}>
+      <PanelBody>
+        <p className="settings-panel-sub">{t("heldThreads.sub")}</p>
+        <QueryGate query={query}>
+          {(list) =>
+            list.data.length === 0 ? (
+              // Nothing held is a READING, not an absent list: "my mailbox is
+              // withholding nothing right now" is exactly what an owner opens
+              // this card to confirm.
+              <EmptyState>
+                <p className="t-small">{t("heldThreads.empty")}</p>
+              </EmptyState>
+            ) : (
+              <HeldThreadTable rows={list.data} />
+            )
+          }
+        </QueryGate>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+function HeldThreadTable({ rows }: Readonly<{ rows: HeldThread[] }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const zone = viewerZone();
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  // Which thread another owner still holds, so a release that changed nothing
+  // says so instead of looking broken. Keyed by thread, because two rows can be
+  // released before either answer arrives.
+  const [heldByOthers, setHeldByOthers] = useState<Record<string, number>>({});
+
+  const release = useMutation({
+    // The thread key is a VARIABLE, so the press belongs to the render the
+    // reader saw (frontend/AGENTS.md, mutation-variable-coverage).
+    mutationFn: async (threadKey: string) => {
+      const { data, error } = await api.POST(
+        "/activities/threads/{thread_key}/audience",
+        { params: { path: { thread_key: threadKey } }, body: { share: true } },
+      );
+      if (error) throwProblem(error);
+      return { threadKey, outcome: data };
+    },
+    onSuccess: ({ threadKey, outcome }) => {
+      queryClient.invalidateQueries({ queryKey: ["held-threads"] });
+      if (outcome && !outcome.shared) {
+        // Somebody else imported this message too and has not released their
+        // own contribution. Saying which is the difference between a control
+        // that looks broken and one that reports what happened.
+        setHeldByOthers((held) => ({
+          ...held,
+          [threadKey]: outcome.held_by_others ?? 0,
+        }));
+        return;
+      }
+      setHeldByOthers((held) => {
+        const { [threadKey]: _released, ...rest } = held;
+        return rest;
+      });
+      toast.show(t("heldThreads.released"));
+    },
+  });
+
+  const stillHeld = Object.entries(heldByOthers);
+  return (
+    <>
+      <DataTable<HeldThread>
+        label={t("heldThreads.title")}
+        rows={rows}
+        rowKey={(row) => row.thread_key}
+        columns={[
+          {
+            key: "subject",
+            header: t("heldThreads.colThread"),
+            render: (row) =>
+              // A thread whose opening message was erased has no subject to
+              // show. It is still held, and saying so beats an empty cell that
+              // reads as a message sent with a blank subject line.
+              row.subject ?? (
+                <span className="t-meta">{t("heldThreads.noSubject")}</span>
+              ),
+          },
+          {
+            key: "why",
+            header: t("heldThreads.colWhy"),
+            render: (row) => <WhyCell row={row} />,
+          },
+          {
+            key: "when",
+            header: t("heldThreads.colWhen"),
+            render: (row) =>
+              row.occurred_at ? (
+                formatDateTime(row.occurred_at, locale, zone)
+              ) : (
+                <span className="t-meta">—</span>
+              ),
+          },
+          {
+            key: "actions",
+            header: t("heldThreads.colActions"),
+            render: (row) => (
+              <Button
+                small
+                pending={
+                  release.isPending && release.variables === row.thread_key
+                }
+                onClick={() => release.mutate(row.thread_key)}
+              >
+                {t("heldThreads.release")}
+              </Button>
+            ),
+          },
+        ]}
+      />
+      {release.isError && (
+        <Callout tone="danger" live="alert">
+          {problemMessageOf(release.error, t)}
+        </Callout>
+      )}
+      {stillHeld.map(([threadKey, owners]) => (
+        <Callout key={threadKey} tone="info">
+          {t("heldThreads.heldByOthers", { count: String(owners) })}
+        </Callout>
+      ))}
+    </>
+  );
+}
+
+// Why this thread is held: the classifier's conclusion, or the fact that it has
+// not reached one yet.
+//
+// Pending is drawn as its own badge rather than as a missing kind. During an
+// outage every new thread is pending, and a column of blanks would read as a
+// classifier that judged nothing rather than one that has not answered.
+function WhyCell({ row }: Readonly<{ row: HeldThread }>) {
+  const t = useT();
+  if (row.pending) {
+    return (
+      <span className="cell-stack">
+        <Badge tone="warn">{t("heldThreads.pending")}</Badge>
+        <span className="t-meta">
+          {t("heldThreads.attempts", { count: String(row.attempts) })}
+        </span>
+      </span>
+    );
+  }
+  const kindKey = row.kind ? kindLabel[row.kind] : undefined;
+  return (
+    <span className="cell-stack">
+      <Badge>{kindKey ? t(kindKey) : (row.kind ?? row.status)}</Badge>
+    </span>
+  );
+}

--- a/frontend/src/screens/held-threads.tsx
+++ b/frontend/src/screens/held-threads.tsx
@@ -131,7 +131,17 @@ function HeldThreadTable({ rows }: Readonly<{ rows: HeldThread[] }>) {
               // A thread whose opening message was erased has no subject to
               // show. It is still held, and saying so beats an empty cell that
               // reads as a message sent with a blank subject line.
-              row.subject ?? (
+              // Three states, not two: a subject, a message that carries
+              // none, and no message at all. Collapsing the last two would tell
+              // a reader their evidence was destroyed when it is sitting there
+              // unnamed.
+              row.has_message ? (
+                (row.subject ?? (
+                  <span className="t-meta">
+                    {t("heldThreads.blankSubject")}
+                  </span>
+                ))
+              ) : (
                 <span className="t-meta">{t("heldThreads.noSubject")}</span>
               ),
           },
@@ -156,6 +166,15 @@ function HeldThreadTable({ rows }: Readonly<{ rows: HeldThread[] }>) {
             render: (row) => (
               <Button
                 small
+                // A verdict outlives the message it was raised about, and the
+                // release endpoint works on the seat's MESSAGES on the thread —
+                // with none left it answers not-found. Offering the verb anyway
+                // would be a control whose only outcome is an error, so it says
+                // why instead. The row stays listed: the verdict still governs
+                // what a later message on this thread inherits.
+                reason={
+                  row.has_message ? undefined : t("heldThreads.nothingToShare")
+                }
                 pending={
                   release.isPending && release.variables === row.thread_key
                 }

--- a/frontend/src/screens/held-threads.tsx
+++ b/frontend/src/screens/held-threads.tsx
@@ -6,7 +6,7 @@ import { Badge, Button, DataTable, EmptyState } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useToast } from "../design-system/toast";
-import { formatDateTime } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -174,7 +174,9 @@ function HeldThreadTable({ rows }: Readonly<{ rows: HeldThread[] }>) {
       )}
       {stillHeld.map(([threadKey, owners]) => (
         <Callout key={threadKey} tone="info">
-          {t("heldThreads.heldByOthers", { count: String(owners) })}
+          {t("heldThreads.heldByOthers", {
+            count: formatNumber(owners, locale),
+          })}
         </Callout>
       ))}
     </>
@@ -189,12 +191,15 @@ function HeldThreadTable({ rows }: Readonly<{ rows: HeldThread[] }>) {
 // classifier that judged nothing rather than one that has not answered.
 function WhyCell({ row }: Readonly<{ row: HeldThread }>) {
   const t = useT();
+  const { locale } = useLocale();
   if (row.pending) {
     return (
       <span className="cell-stack">
         <Badge tone="warn">{t("heldThreads.pending")}</Badge>
         <span className="t-meta">
-          {t("heldThreads.attempts", { count: String(row.attempts) })}
+          {t("heldThreads.attempts", {
+            count: formatNumber(row.attempts, locale),
+          })}
         </span>
       </span>
     );

--- a/frontend/src/screens/settings.testkit.tsx
+++ b/frontend/src/screens/settings.testkit.tsx
@@ -121,6 +121,12 @@ export function keyedEnvelope(url: string) {
   if (url.includes("/ai/provider-keys")) {
     return jsonResponse({ providers: [] });
   }
+  // `rungs` and `window_hours` are both required, and the health card indexes
+  // them directly. No rung is the honest answer for an installation that called
+  // no model in the window — which is what a test fixture is.
+  if (url.includes("/ai/health")) {
+    return jsonResponse({ window_hours: 1, rungs: [] });
+  }
   return null;
 }
 

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -116,6 +116,7 @@ import { EntityRef } from "./entityref";
 import { ExtensionAccessCard } from "./extension-access";
 import { ExtensionUnitsCard } from "./extension-units";
 import { GoogleAppCard } from "./google-app";
+import { HeldThreadsCard } from "./held-threads";
 import { ImportCard } from "./import";
 import { InstallationSettingsCard } from "./installation-settings";
 import { ProviderCard } from "./integrations-provider";
@@ -413,6 +414,12 @@ function ConnectionsTab() {
           The posture rows above say what may be read; this says what was
           decided, which is the half a reader audits. */}
       <CaptureSendersCard />
+      {/* And what those decisions are currently WITHHOLDING. The senders card
+          above says what was decided about each correspondent; this says which
+          threads are held back from the team right now, which is the question
+          an outage makes urgent — every new thread lands pending and stays
+          there until the classifier answers again. */}
+      <HeldThreadsCard />
       {/* Directly under the mailboxes, because it is the same decision seen
           from the other side: those cards say what Margince may READ, this one
           says whether it may act on it overnight while nobody is watching. The

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -81,6 +81,7 @@ import { formatDate, formatDateTime, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { LOCALES, type Locale, localeNameKey, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { AiHealthCard } from "./ai-health";
 import { AiProviderKeysCard } from "./ai-provider-keys";
 import { AiRoutingCard } from "./ai-routing";
 import { AiCallsCard } from "./aicalls";
@@ -965,6 +966,13 @@ function AiSettingsTab() {
           can call it at all. A binding whose vendor holds no key fails closed,
           and this is where a reader finds out why. */}
       <AiProviderKeysCard />
+      {/* And whether the lanes those two cards configure are actually
+          ANSWERING. It sits here rather than under the spend cards because it
+          completes the binding's own story: which vendor serves a tier, whether
+          we hold a key for it, whether it replied. Under the capture posture
+          the last one is the expensive gap — mail stays held whether the
+          classifier judged it or never ran. */}
+      <AiHealthCard />
       <AutomationsAdmin />
       <AiUsageCard />
       <ModelCostsCard />


### PR DESCRIPTION
Closes #3419. Closes #3420.

Both endpoints answer a question the product could not, and both exist because of the same property of the capture posture: **a thread stays held whether the classifier judged it confidential or never answered at all.** From every other surface an outage and correct cautious behaviour look identical, so nobody notices until somebody asks why a thread never opened — and by then the answer is a week of held mail.

## What am I holding? (#3419)

`GET /capture/held-threads` and a card on Settings → Connections. Releasing a thread already worked one at a time from a record's timeline; what an owner could not do is ask across every contact at once.

**The caller's own mailbox and nobody else's.** The rows name threads judged legal, personnel or personal, so a list reaching a colleague's would disclose exactly what holding them prevents. No admin view, for the same reason. `TestTheHeldThreadsListIsOneSeatsOwn` fails when the `user_id` scope is widened.

**The subject is read through `auth.ActivityContentClause`,** on the JOIN rather than the WHERE — in the WHERE it turns the outer join inner and drops the orphaned verdicts that join exists to keep. A held thread whose message the caller may not read is still listed, without a subject.

**Pending rows lead**, because during an outage those are the ones nobody has decided. `attempts` travels for the same reason: a pending row whose attempts stop climbing is a model that stopped answering, not a thread that is merely slow.

**`unsure` is listed, `cleared` is not.** A thread the model could not judge withholds exactly like one it judged legal, and an owner who is not shown it cannot release it.

**`has_message` decides whether releasing is offered.** The release works on the seat's own messages on the thread, so a verdict whose message was erased can only ever answer not-found — the button refuses with a reason instead. It also separates a message with a blank subject line from no message at all.

A partial index on `(user_id, status)` answers the list; the table's existing indexes lead with the thread key or with `next_attempt_at`, neither of which serves a scan by seat.

## Is the classifier answering? (#3420)

`GET /ai/health` and a card on Settings → AI, under the routing and provider-key cards: which vendor serves a tier, whether we hold a key for it, whether it replied.

Read from `ai_call`, which already records every attempt. Nothing new is written — a health surface with its own bookkeeping would be a second account of what happened, free to disagree with the first.

Four decisions the query makes, each of which would otherwise be a false alarm or a missed one:

- **The latest terminal outcome decides health**, not a ratio over the window. A lane with a single success at the top of the hour that has failed everything since is down now.
- **Terminal attempts only.** Counting a failure a retry rescued reports a lane as failing while every caller got an answer.
- **Cache hits excluded.** A cache hit never reached the provider, so counting one as a success lets a dead lane report healthy on traffic it never sent.
- **`metering_failed` is an answer.** It marks a call the model answered where only the meter write failed, which `callstats.go` already treats as served.

The card distinguishes an installation nobody used this hour from a lane that answered nothing — both are "no successful calls", and reporting them identically is what makes an outage invisible.

The owner's half of #3420 is served by the held-threads card: attempts that stop climbing is how an owner tells a stalled model from a slow one.

## The review round

An adversarial review found six defects in the first two commits. They are worth listing because one was a real leak and the rest were the endpoint lying in the direction that matters.

**The BLOCKER: the held-threads query projected `activity.subject` with no audience clause, under a comment saying it composed one.** The justification was written and the code was not. It survived because none of the fixtures seeded `first_activity_id`, so the join was never exercised by any test in the suite — a fixture that omits a field models a different record. `TestEveryReaderOfTheActivityTableComposesTheAudience` fails on the original query.

Then: `Healthy` reported a dead lane as fine on a 59-minute-old success; cache hits and `metering_failed` were both misclassified; the card offered a release that could only error; and the query had no index to answer by.

Fixing the index tripped two more gates — the head catalog needed regenerating, and both the up and down SQL needed `SET LOCAL lock_timeout`, since the build blocks writes to a table the capture sink writes on every held message.

## Tests

Nine held-thread cases and eight AI-health cases against real Postgres, plus eleven unit cases over the two cards.

The ones added by the review: the caller's own message arrives with its subject, a colleague's message the caller is not on is listed without one (mutation-checked — neutering the clause fails it), the lane that died inside the window, the metering failure, the cache hit, and the median that nothing had asserted.

## Gates

`make check-fe` green. Backend tests, the full gates package, migration package with the regenerated catalog, `craft-static`, `rls-store-path` and `no-jurisdiction` all green.

`lint-modules` did not run locally: golangci's lock is machine-wide and parallel sessions held it throughout. The build is clean and craft is green, but CI is what proves the six auxiliary modules.

## Not in this branch

**#3284** is closed: both spend guards it named pass on current main, and one had been renamed. The file does carry a different red test (`TestPersonCreatedQueuesAnEnrichmentRun`, `no_identifiers` after #3454), which **#3462** already fixes.

**#3312** stays open, commented. Committing per batch changes what `PUT /mail-posture` promises a caller, which is a product decision rather than a refactor, and the operation is correct at today's mailbox sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an AI health dashboard showing model-tier status, call volume, failures, median latency, and recent outcomes.
  - Added a held-threads view with hold reasons, pending decisions, attempt counts, subject visibility, and release actions.
  - Added localized empty, loading, error, and success states in English, German, and Vietnamese.
- **Bug Fixes**
  - Improved visibility of held conversations when messages are missing or inaccessible.
  - Prevented release attempts when no message remains.
- **Tests**
  - Added coverage for authorization, filtering, ordering, health reporting, and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->