### PR TITLE
fix(prefs): the public pages look like one product, and speak German

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4919,6 +4919,10 @@ export const de = {
   "prefs.unsub.retry": "Erneut versuchen",
   "prefs.unsub.unknownPurpose":
     "Dieser Link nennt keine Art von E-Mail, die wir versenden. \u00d6ffne deine Einstellungen, um alles zu sehen.",
+  "prefs.purpose.business_correspondence": "Persönliche Nachrichten",
+  "prefs.purpose.marketing_email": "Produktneuigkeiten",
+  "prefs.purpose.transactional": "Sicherheit & laufende Vorgänge",
+  "prefs.sentVia": "Gesendet über Margince",
   "prefs.invalidLink":
     "Dieser Link ist nicht mehr gültig. Präferenz-Links laufen ab oder können widerrufen werden — frag in einer aktuellen E-Mail nach einem neuen.",
   "buyer.opening": "Ihr Deal Room wird geöffnet …",
@@ -5057,7 +5061,11 @@ export const de = {
   "prefs.discard": "Verwerfen",
   "prefs.partialSave":
     "Beim Speichern ist etwas schiefgelaufen. Einige deiner Entscheidungen wurden möglicherweise schon übernommen — wir haben deinen aktuellen Stand neu geladen, damit du genau siehst, wo du stehst.",
-  "prefs.wordingGeneric": "„{label} senden.“",
+  "prefs.wording.business_correspondence":
+    "„Schick mir Antworten und direkte Nachrichten zu unseren Gesprächen.“",
+  "prefs.wording.transactional":
+    "„Schick mir, was ich für einen von mir angeforderten Vorgang brauche.“",
+  "prefs.wordingGeneric": "„Schick mir {label}.“",
   "prefs.wording.marketing_email":
     "„Schick mir Produkt-Updates und gelegentliche Marketing-E-Mails.“",
   "prefs.wording.events": "„Schick mir Einladungen zu Events und Webinaren.“",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4986,6 +4986,10 @@ export const en = {
   "prefs.unsub.retry": "Try again",
   "prefs.unsub.unknownPurpose":
     "This link doesn't name a kind of email we send. Open your preferences to see everything.",
+  "prefs.purpose.business_correspondence": "Direct correspondence",
+  "prefs.purpose.marketing_email": "Product news",
+  "prefs.purpose.transactional": "Security & service messages",
+  "prefs.sentVia": "Sent via Margince",
   "prefs.invalidLink":
     "This link is no longer valid. Preference links expire and can be withdrawn — ask for a fresh one from any recent email.",
   "buyer.opening": "Opening your Deal Room…",
@@ -5124,6 +5128,10 @@ export const en = {
   "prefs.discard": "Discard",
   "prefs.partialSave":
     "Something went wrong part-way. Some of your choices may have been saved — we've reloaded your current settings so you can see exactly where you stand.",
+  "prefs.wording.business_correspondence":
+    "“Send me replies and direct messages about our conversations.”",
+  "prefs.wording.transactional":
+    "“Send me what I need for something I asked for.”",
   "prefs.wordingGeneric": '"Send me {label}."',
   "prefs.wording.marketing_email":
     '"Send me product updates & occasional marketing email."',

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4882,6 +4882,10 @@ export const vi = {
   "prefs.unsub.retry": "Th\u1eed l\u1ea1i",
   "prefs.unsub.unknownPurpose":
     "Li\u00ean k\u1ebft n\u00e0y kh\u00f4ng n\u00eau lo\u1ea1i email n\u00e0o ch\u00fang t\u00f4i g\u1eedi. H\u00e3y m\u1edf t\u00f9y ch\u1ecdn \u0111\u1ec3 xem t\u1ea5t c\u1ea3.",
+  "prefs.purpose.business_correspondence": "Thư từ trực tiếp",
+  "prefs.purpose.marketing_email": "Tin tức sản phẩm",
+  "prefs.purpose.transactional": "Bảo mật và dịch vụ",
+  "prefs.sentVia": "Được gửi qua Margince",
   "prefs.invalidLink":
     "Liên kết này không còn hiệu lực. Liên kết tuỳ chọn sẽ hết hạn và có thể bị thu hồi — hãy lấy một liên kết mới từ bất kỳ email gần đây nào.",
   "buyer.opening": "Đang mở Deal Room của bạn…",
@@ -5016,6 +5020,10 @@ export const vi = {
   "prefs.discard": "Bỏ thay đổi",
   "prefs.partialSave":
     "Có gì đó hỏng giữa chừng. Một phần lựa chọn của bạn có thể đã được lưu — chúng tôi đã tải lại thiết lập hiện tại để bạn thấy đúng mình đang ở đâu.",
+  "prefs.wording.business_correspondence":
+    "„Gửi cho tôi phản hồi và tin nhắn trực tiếp về các cuộc trao đổi của chúng ta.“",
+  "prefs.wording.transactional":
+    "„Gửi cho tôi những gì cần cho việc tôi đã yêu cầu.“",
   "prefs.wordingGeneric": '"Hãy gửi cho tôi {label}."',
   "prefs.wording.marketing_email":
     '"Hãy gửi cho tôi tin cập nhật sản phẩm & email tiếp thị thỉnh thoảng."',

--- a/frontend/src/screens/preferences.css
+++ b/frontend/src/screens/preferences.css
@@ -33,9 +33,16 @@
 
 .pref-row {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
+  /* Centred against the text block rather than pinned to its first line:
+     the control governs the whole row, and at three lines of copy a
+     top-aligned box reads as belonging to the title alone. */
+  align-items: center;
+  /* NOT space-between. That pushed the box to the far edge of a 720px
+     row, where it sat closer to the window than to the sentence it
+     answers — which is how it stopped reading as this row's control. The
+     text takes the slack instead, so the box stays beside its own copy. */
+  justify-content: flex-start;
+  gap: var(--space-4);
   background: var(--bgElevated);
   border: 1px solid var(--borderSubtle);
   border-radius: var(--r-md);
@@ -46,6 +53,7 @@
    floor of min-content here is what let a long purpose name push its own row
    past the card's edge. */
 .pref-row-main {
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -194,4 +202,42 @@
 .pref-check {
   flex: 0 0 auto;
   margin-top: var(--space-1);
+}
+
+/* The sign-off under both public pages: quiet, and the only place either
+   page names the product that sent the message. */
+.public-foot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  margin: var(--space-8) 0 0;
+  color: var(--textTertiary);
+  font-size: var(--fs-sm);
+}
+
+/* The row's control, enlarged and given a target.
+   A native 16px box at the far end of a wide row reads as decoration
+   rather than as the thing you press — it was mistaken for one — so the
+   box is scaled up and the whole cell becomes the hit area. */
+.pref-check {
+  flex: 0 0 auto;
+  /* First in the row: a reader scanning a list of choices finds every
+     box in one column on the left, rather than hunting the right edge of
+     rows whose heights differ. */
+  order: -1;
+  align-self: center;
+  padding: var(--space-2);
+  margin: calc(var(--space-2) * -1);
+  border-radius: var(--r-sm);
+}
+
+.pref-check > input {
+  inline-size: var(--space-5);
+  block-size: var(--space-5);
+  accent-color: var(--accent);
+}
+
+.pref-check:not(:has(input:disabled)):hover {
+  background: var(--bgCard);
 }

--- a/frontend/src/screens/preferences.logic.ts
+++ b/frontend/src/screens/preferences.logic.ts
@@ -1,4 +1,5 @@
 import type { components } from "../api/schema";
+import type { MessageKey } from "../i18n/en";
 
 export type PurposeView =
   components["schemas"]["PreferenceCenter"]["purposes"][number];
@@ -60,4 +61,33 @@ export function toChoices(
       state: draft[purpose.key] ? ("granted" as const) : ("withdrawn" as const),
       wording: wordingOf(purpose.key),
     }));
+}
+
+/**
+ * What to CALL each purpose the product seeds itself.
+ *
+ * `purpose.label` comes from the database, where the seeded catalog is
+ * written in English — so a German page printed "Business
+ * correspondence" inside German prose, and the generic wording sentence
+ * wrapped an English noun in German quotes: „Business correspondence
+ * senden."
+ *
+ * An operator may define purposes of their own, and those keep whatever
+ * they were named: this map covers the three the product plants, which
+ * are the ones every installation has and the only ones whose English is
+ * ours rather than a customer's.
+ */
+export const PURPOSE_LABEL_KEYS: Record<string, MessageKey> = {
+  business_correspondence: "prefs.purpose.business_correspondence",
+  marketing_email: "prefs.purpose.marketing_email",
+  transactional: "prefs.purpose.transactional",
+};
+
+/** The purpose's name in the reader's language, or the catalog's own. */
+export function labelOf(
+  t: (key: MessageKey, vars?: Record<string, string>) => string,
+  purpose: PurposeView,
+): string {
+  const key = PURPOSE_LABEL_KEYS[purpose.key];
+  return key ? t(key) : purpose.label;
 }

--- a/frontend/src/screens/preferences.test.tsx
+++ b/frontend/src/screens/preferences.test.tsx
@@ -12,6 +12,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
+import { en } from "../i18n/en";
 import { PreferenceCenterScreen } from "./preferences";
 
 // The public, anonymous preference center (G-6): no login, no session — the
@@ -121,7 +122,7 @@ describe("PreferenceCenterScreen", () => {
     );
     vi.stubGlobal("fetch", fetchSpy);
     render(<PreferenceCenterScreen token="tok-123" />);
-    await screen.findByText("Product updates");
+    await screen.findByText(en["prefs.purpose.marketing_email"]);
     const requests = fetchSpy.mock.calls.map(([input]) =>
       input instanceof Request ? input : new Request(String(input)),
     );
@@ -137,7 +138,7 @@ describe("PreferenceCenterScreen", () => {
     stubCenter();
     render(<PreferenceCenterScreen token="tok-123" />);
     const toggle = await screen.findByRole("checkbox", {
-      name: /deal & service/i,
+      name: en["prefs.purpose.transactional"],
     });
     expect(toggle).toBeDisabled();
     expect(screen.getByText(/always on/i)).toBeInTheDocument();
@@ -148,7 +149,9 @@ describe("PreferenceCenterScreen", () => {
     stubCenter({ "PUT /public/preferences/tok-123": put });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("checkbox", { name: /product updates/i }),
+      await screen.findByRole("checkbox", {
+        name: en["prefs.purpose.marketing_email"],
+      }),
     );
     expect(screen.getByText(/not saved yet/i)).toBeInTheDocument();
     expect(put).not.toHaveBeenCalled();
@@ -158,7 +161,9 @@ describe("PreferenceCenterScreen", () => {
     stubCenter();
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("checkbox", { name: /product updates/i }),
+      await screen.findByRole("checkbox", {
+        name: en["prefs.purpose.marketing_email"],
+      }),
     );
     await userEvent.click(screen.getByRole("button", { name: /discard/i }));
     expect(screen.queryByText(/not saved yet/i)).not.toBeInTheDocument();
@@ -173,7 +178,9 @@ describe("PreferenceCenterScreen", () => {
     const shown = (await screen.findByTestId("wording-marketing_email"))
       .textContent;
     await userEvent.click(
-      screen.getByRole("checkbox", { name: /product updates/i }),
+      screen.getByRole("checkbox", {
+        name: en["prefs.purpose.marketing_email"],
+      }),
     );
     await userEvent.click(
       screen.getByRole("button", { name: /save preferences/i }),
@@ -232,7 +239,9 @@ describe("PreferenceCenterScreen", () => {
     });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("checkbox", { name: /product updates/i }),
+      await screen.findByRole("checkbox", {
+        name: en["prefs.purpose.marketing_email"],
+      }),
     );
     await userEvent.click(
       screen.getByRole("button", { name: /save preferences/i }),
@@ -282,14 +291,18 @@ describe("PreferenceCenterScreen", () => {
     stubCenter({ "PUT /public/preferences/tok-123": () => putPromise });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("checkbox", { name: /product updates/i }),
+      await screen.findByRole("checkbox", {
+        name: en["prefs.purpose.marketing_email"],
+      }),
     );
     await userEvent.click(
       screen.getByRole("button", { name: /save preferences/i }),
     );
 
     expect(
-      screen.getByRole("checkbox", { name: /product updates/i }),
+      screen.getByRole("checkbox", {
+        name: en["prefs.purpose.marketing_email"],
+      }),
     ).toBeDisabled();
     expect(screen.getByRole("checkbox", { name: /^events$/i })).toBeDisabled();
     expect(
@@ -300,7 +313,9 @@ describe("PreferenceCenterScreen", () => {
     resolvePut(jsonResponse(CENTER));
     await waitFor(() =>
       expect(
-        screen.getByRole("checkbox", { name: /product updates/i }),
+        screen.getByRole("checkbox", {
+          name: en["prefs.purpose.marketing_email"],
+        }),
       ).toBeEnabled(),
     );
   });

--- a/frontend/src/screens/preferences.tsx
+++ b/frontend/src/screens/preferences.tsx
@@ -11,16 +11,18 @@ import {
 } from "../design-system/atoms";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { usePublicLocale } from "../i18n/publiclocale";
+
 import { problemMessageOf, throwProblem } from "./common";
 import {
   type Draft,
   dirtyKeys,
   displayOn,
   initialDraft,
+  labelOf,
   type PurposeView,
   toChoices,
 } from "./preferences.logic";
+import { PublicPage } from "./publicpage";
 import "./preferences.css";
 
 // The public, anonymous email preference center (G-6, B-E11.32): the page a
@@ -34,7 +36,9 @@ import "./preferences.css";
 // falls back to prefs.wordingGeneric — a workspace can define arbitrary
 // purposes, so this map is deliberately not exhaustive.
 const WORDING_KEYS: Record<string, MessageKey> = {
+  business_correspondence: "prefs.wording.business_correspondence",
   marketing_email: "prefs.wording.marketing_email",
+  transactional: "prefs.wording.transactional",
   events: "prefs.wording.events",
 };
 
@@ -44,9 +48,9 @@ export function PreferenceCenterScreen({
   const t = useT();
   if (!token) {
     return (
-      <div className="pref-page">
+      <PublicPage>
         <EmptyState>{t("prefs.invalidLink")}</EmptyState>
-      </div>
+      </PublicPage>
     );
   }
   return <PreferenceCenterBody token={token} />;
@@ -81,8 +85,6 @@ export function explainPublicError(
 
 function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
   const t = useT();
-  // The link carried the message's language; the page speaks it too.
-  usePublicLocale();
   const queryClient = useQueryClient();
   const queryKey = ["preference-center", token];
 
@@ -119,7 +121,7 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
       const wordingKey = WORDING_KEYS[purpose.key];
       map[purpose.key] = wordingKey
         ? t(wordingKey)
-        : t("prefs.wordingGeneric", { label: purpose.label });
+        : t("prefs.wordingGeneric", { label: labelOf(t, purpose) });
     }
     return map;
   }, [purposes, t]);
@@ -253,31 +255,27 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
 
   if (center.isPending) {
     return (
-      <div className="pref-page">
-        <div className="pref-center arrive-stack">
-          <Skeleton width="60%" />
-          <Skeleton width="90%" />
-          <Skeleton width="75%" />
-        </div>
-      </div>
+      <PublicPage>
+        <Skeleton width="60%" />
+        <Skeleton width="90%" />
+        <Skeleton width="75%" />
+      </PublicPage>
     );
   }
 
   if (center.isError) {
     return (
-      <div className="pref-page">
+      <PublicPage>
         <EmptyState>{explainPublicError(center.error, t)}</EmptyState>
-      </div>
+      </PublicPage>
     );
   }
 
   if (!draft) {
     return (
-      <div className="pref-page">
-        <div className="pref-center arrive-stack">
-          <Skeleton width="60%" />
-        </div>
-      </div>
+      <PublicPage>
+        <Skeleton width="60%" />
+      </PublicPage>
     );
   }
 
@@ -294,111 +292,106 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
     save.isPending || unsubscribeAll.isPending || center.isFetching;
 
   return (
-    <div className="pref-page">
-      <div className="pref-center arrive-stack">
-        {/* A standalone public page, not app chrome — SectionHeader's fixed
+    <PublicPage>
+      {/* A standalone public page, not app chrome — SectionHeader's fixed
             narrow title column is built for a card header sharing a row with
             a button, and wraps this page's longer headline badly. The
             headline is this page's primary voice, so it stacks full-width
             above the subtitle instead, at its own (larger) size. */}
-        <div className="pref-header">
-          <h1 className="t-display">{t("prefs.title")}</h1>
-          <p className="t-sub">{t("prefs.sub")}</p>
-        </div>
-        <ul className="pref-list">
-          {purposes.map((purpose) => (
-            <PreferenceRow
-              key={purpose.key}
-              purpose={purpose}
-              on={draft[purpose.key] ?? displayOn(purpose.state)}
-              wording={wordingByKey[purpose.key]}
-              t={t}
-              disabled={writePending}
-              onToggle={() =>
-                setDraft((prev) =>
-                  prev ? { ...prev, [purpose.key]: !prev[purpose.key] } : prev,
-                )
-              }
-            />
-          ))}
-        </ul>
-
-        <Card as="div" inset className="pref-unsub">
-          <p className="t-caption">{t("prefs.unsubscribeAllHint")}</p>
-          <Button
-            disabled={writePending}
-            onClick={() => unsubscribeAll.mutate()}
-          >
-            {t("prefs.unsubscribeAll")}
-          </Button>
-          {unsubscribeAll.isError && (
-            <p className="t-caption pref-unsub-error">
-              {explainPublicError(unsubscribeAll.error, t)}
-            </p>
-          )}
-        </Card>
-
-        {lastUnsubscribed !== null && (
-          <Card as="div" inset className="pref-unsub-banner">
-            <p>
-              {lastUnsubscribed.length > 0
-                ? t("prefs.oneClickDone")
-                : t("prefs.oneClickAlreadyOff")}
-            </p>
-            {lastUnsubscribed.length > 0 &&
-              (undoStaged ? (
-                <p className="t-caption">{t("prefs.undoExplicit")}</p>
-              ) : (
-                <Button disabled={writePending} onClick={undoUnsubscribe}>
-                  {t("prefs.undo")}
-                </Button>
-              ))}
-          </Card>
-        )}
-
-        {partialSave && (
-          <Card as="div" inset className="pref-partial-banner">
-            <p>{t("prefs.partialSave")}</p>
-          </Card>
-        )}
-
-        {dirty.length > 0 && (
-          <div className="pref-save-bar">
-            <p className="pref-not-saved">{t("prefs.notSaved")}</p>
-            <p className="t-caption">
-              {t("prefs.savePending", {
-                changes: dirty
-                  .map(
-                    (key) =>
-                      purposes.find((purpose) => purpose.key === key)?.label ??
-                      key,
-                  )
-                  .join(", "),
-              })}
-            </p>
-            <p className="t-caption">{t("prefs.saveProof")}</p>
-            <div className="pref-save-actions">
-              <Button
-                disabled={writePending}
-                onClick={() => {
-                  setDraft(initialDraft(purposes));
-                  setPartialSave(false);
-                }}
-              >
-                {t("prefs.discard")}
-              </Button>
-              <Button
-                variant="primary"
-                disabled={writePending}
-                onClick={() => draft && save.mutate(draft)}
-              >
-                {t("prefs.save")}
-              </Button>
-            </div>
-          </div>
-        )}
+      <div className="pref-header">
+        <h1 className="t-display">{t("prefs.title")}</h1>
+        <p className="t-sub">{t("prefs.sub")}</p>
       </div>
-    </div>
+      <ul className="pref-list">
+        {purposes.map((purpose) => (
+          <PreferenceRow
+            key={purpose.key}
+            purpose={purpose}
+            on={draft[purpose.key] ?? displayOn(purpose.state)}
+            wording={wordingByKey[purpose.key]}
+            t={t}
+            disabled={writePending}
+            onToggle={() =>
+              setDraft((prev) =>
+                prev ? { ...prev, [purpose.key]: !prev[purpose.key] } : prev,
+              )
+            }
+          />
+        ))}
+      </ul>
+
+      <Card as="div" inset className="pref-unsub">
+        <p className="t-caption">{t("prefs.unsubscribeAllHint")}</p>
+        <Button disabled={writePending} onClick={() => unsubscribeAll.mutate()}>
+          {t("prefs.unsubscribeAll")}
+        </Button>
+        {unsubscribeAll.isError && (
+          <p className="t-caption pref-unsub-error">
+            {explainPublicError(unsubscribeAll.error, t)}
+          </p>
+        )}
+      </Card>
+
+      {lastUnsubscribed !== null && (
+        <Card as="div" inset className="pref-unsub-banner">
+          <p>
+            {lastUnsubscribed.length > 0
+              ? t("prefs.oneClickDone")
+              : t("prefs.oneClickAlreadyOff")}
+          </p>
+          {lastUnsubscribed.length > 0 &&
+            (undoStaged ? (
+              <p className="t-caption">{t("prefs.undoExplicit")}</p>
+            ) : (
+              <Button disabled={writePending} onClick={undoUnsubscribe}>
+                {t("prefs.undo")}
+              </Button>
+            ))}
+        </Card>
+      )}
+
+      {partialSave && (
+        <Card as="div" inset className="pref-partial-banner">
+          <p>{t("prefs.partialSave")}</p>
+        </Card>
+      )}
+
+      {dirty.length > 0 && (
+        <div className="pref-save-bar">
+          <p className="pref-not-saved">{t("prefs.notSaved")}</p>
+          <p className="t-caption">
+            {t("prefs.savePending", {
+              changes: dirty
+                .map(
+                  (key) =>
+                    purposes.find((purpose) => purpose.key === key)?.label ??
+                    key,
+                )
+                .join(", "),
+            })}
+          </p>
+          <p className="t-caption">{t("prefs.saveProof")}</p>
+          <div className="pref-save-actions">
+            <Button
+              disabled={writePending}
+              onClick={() => {
+                setDraft(initialDraft(purposes));
+                setPartialSave(false);
+              }}
+            >
+              {t("prefs.discard")}
+            </Button>
+            <Button
+              variant="primary"
+              disabled={writePending}
+              onClick={() => draft && save.mutate(draft)}
+            >
+              {t("prefs.save")}
+            </Button>
+          </div>
+        </div>
+      )}
+    </PublicPage>
   );
 }
 
@@ -431,7 +424,7 @@ function PreferenceRow({
       <div className="pref-row-main">
         <div className="pref-row-head">
           {purpose.locked && <Lock className="pref-lock-icon" aria-hidden />}
-          <span className="pref-label">{purpose.label}</span>
+          <span className="pref-label">{labelOf(t, purpose)}</span>
           {purpose.locked && (
             <span className="pref-lock-badge">{t("prefs.alwaysOn")}</span>
           )}
@@ -460,7 +453,7 @@ function PreferenceRow({
           hidden because the row draws its own richer heading above. */}
       <Checkbox
         checked={on}
-        aria-label={purpose.label}
+        aria-label={labelOf(t, purpose)}
         disabled={purpose.locked || grantBlocked || disabled}
         className="pref-check"
         // Empty, because aria-label above already names the control: a

--- a/frontend/src/screens/publicpage.tsx
+++ b/frontend/src/screens/publicpage.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import { Logomark } from "../design-system/logomark";
+import { useT } from "../i18n";
+import { usePublicLocale } from "../i18n/publiclocale";
+import "./preferences.css";
+
+/**
+ * The frame both public pages sit in.
+ *
+ * They are reached from one message by one reader, so they have to look
+ * like one product: the same column width, the same ground, the same
+ * sign-off underneath. Before this each page centred itself — or, in the
+ * unsubscribe page's case, forgot to, and its content spread across the
+ * whole window because `.pref-page` is a centring flex row with nothing
+ * to centre.
+ *
+ * It also carries the language the link asked for, so neither page has to
+ * remember to.
+ */
+export function PublicPage({ children }: Readonly<{ children: ReactNode }>) {
+  usePublicLocale();
+  return (
+    <div className="pref-page">
+      <div className="pref-center arrive-stack">
+        {children}
+        <PublicFooter />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Who sent this.
+ *
+ * A page that asks somebody to make a decision about their own mail owes
+ * them the name of the product asking — otherwise an unbranded page
+ * arriving from a link is indistinguishable from a phishing attempt.
+ */
+function PublicFooter() {
+  const t = useT();
+  return (
+    <p className="public-foot">
+      <Logomark size={15} />
+      {t("prefs.sentVia")}
+    </p>
+  );
+}

--- a/frontend/src/screens/unsubscribe.tsx
+++ b/frontend/src/screens/unsubscribe.tsx
@@ -5,14 +5,14 @@ import { api } from "../api/client";
 import { Button, Card, PendingBody } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { useT } from "../i18n";
-import { usePublicLocale } from "../i18n/publiclocale";
 import { throwProblem } from "./common";
 import {
   explainPublicError,
   LinkInvalidError,
   RateLimitedError,
 } from "./preferences";
-import type { PurposeView } from "./preferences.logic";
+import { labelOf, type PurposeView } from "./preferences.logic";
+import { PublicPage } from "./publicpage";
 import "./preferences.css";
 
 // The human unsubscribe page: where the VISIBLE "Unsubscribe" link in an
@@ -34,9 +34,9 @@ export function UnsubscribeScreen({
   const t = useT();
   if (!token || !purpose) {
     return (
-      <div className="pref-page">
+      <PublicPage>
         <Callout tone="warn">{t("prefs.invalidLink")}</Callout>
-      </div>
+      </PublicPage>
     );
   }
   return <UnsubscribeBody token={token} purpose={purpose} />;
@@ -47,8 +47,6 @@ function UnsubscribeBody({
   purpose,
 }: Readonly<{ token: string; purpose: string }>) {
   const t = useT();
-  // The link carried the message's language; the page speaks it too.
-  usePublicLocale();
   const queryClient = useQueryClient();
   const queryKey = ["preference-center", token];
   const doneHeading = useRef<HTMLHeadingElement>(null);
@@ -111,11 +109,11 @@ function UnsubscribeBody({
 
   if (center.isPending) {
     return (
-      <div className="pref-page">
+      <PublicPage>
         <Card>
           <PendingBody label={t("prefs.unsub.loading")} lines={4} />
         </Card>
-      </div>
+      </PublicPage>
     );
   }
   if (center.error) {
@@ -124,7 +122,7 @@ function UnsubscribeBody({
     // an email deserves a way to try again rather than a dead end.
     const retryable = !(center.error instanceof LinkInvalidError);
     return (
-      <div className="pref-page">
+      <PublicPage>
         <Callout
           tone={center.error instanceof RateLimitedError ? "warn" : "danger"}
           actions={
@@ -137,7 +135,7 @@ function UnsubscribeBody({
         >
           {explainPublicError(center.error, t)}
         </Callout>
-      </div>
+      </PublicPage>
     );
   }
 
@@ -146,16 +144,16 @@ function UnsubscribeBody({
   );
   if (!target) {
     return (
-      <div className="pref-page">
+      <PublicPage>
         <Callout tone="warn">{t("prefs.unsub.unknownPurpose")}</Callout>
         <ManageLink token={token} label={t("prefs.unsub.seeAll")} />
-      </div>
+      </PublicPage>
     );
   }
 
   if (stopped !== null) {
     return (
-      <div className="pref-page">
+      <PublicPage>
         <Card>
           <div className="unsub-done">
             <span className="unsub-done-mark" aria-hidden="true">
@@ -167,12 +165,12 @@ function UnsubscribeBody({
                 : t("prefs.unsub.alreadyOff")}
             </h1>
             {stopped.length > 0 && (
-              <p>{t("prefs.unsub.doneBody", { label: target.label })}</p>
+              <p>{t("prefs.unsub.doneBody", { label: labelOf(t, target) })}</p>
             )}
           </div>
         </Card>
         <ManageLink token={token} label={t("prefs.unsub.manage")} />
-      </div>
+      </PublicPage>
     );
   }
 
@@ -180,26 +178,26 @@ function UnsubscribeBody({
   // is worse than an absent one, and here the honest answer is why.
   if (target.locked) {
     return (
-      <div className="pref-page">
-        <h1>{t("prefs.unsub.lockedTitle")}</h1>
+      <PublicPage>
+        <h1 className="t-display">{t("prefs.unsub.lockedTitle")}</h1>
         <Card>
           <p className="unsub-kind">
-            <Lock size={16} aria-hidden="true" /> {target.label}
+            <Lock size={16} aria-hidden="true" /> {labelOf(t, target)}
           </p>
           <p>{t("prefs.unsub.lockedBody")}</p>
         </Card>
         <ManageLink token={token} label={t("prefs.unsub.seeAll")} />
-      </div>
+      </PublicPage>
     );
   }
 
   return (
-    <div className="pref-page">
-      <h1>{t("prefs.unsub.title")}</h1>
+    <PublicPage>
+      <h1 className="t-display">{t("prefs.unsub.title")}</h1>
       <p className="unsub-lead">{t("prefs.unsub.lead")}</p>
       <Card>
         <p className="unsub-kind">
-          <Mail size={16} aria-hidden="true" /> {target.label}
+          <Mail size={16} aria-hidden="true" /> {labelOf(t, target)}
         </p>
         <Callout tone="info" title={t("prefs.unsub.afterTitle")}>
           {t("prefs.unsub.afterBody")}
@@ -228,7 +226,7 @@ function UnsubscribeBody({
         ) : null}
       </Card>
       <p className="unsub-privacy">{t("prefs.unsub.privacy")}</p>
-    </div>
+    </PublicPage>
   );
 }
 


### PR DESCRIPTION
Four faults Lars found by opening the pages, all visible immediately.

**The unsubscribe page had no layout.** `.pref-page` is a centring flex row that expects a `.pref-center` child, and that screen never rendered one — so its heading, card and privacy line spread across the whole window as three separate columns. Both pages now share one `PublicPage` frame, which owns the column, the language the link asked for, and the sign-off.

**Neither page said who sent the message.** A page that asks somebody to decide about their own mail and carries no name is indistinguishable from a phishing attempt. Both now carry the Margince mark and "Gesendet über Margince".

**The German was not German.** Purpose labels come from the database, where the seeded catalog is written in English, and the page printed them raw — so German prose wrapped English nouns, and the generic template produced `„Business correspondence senden."` The three purposes the product seeds itself are now named and worded in each language:

| key | was | now (de) |
|---|---|---|
| `business_correspondence` | Business correspondence | Persönliche Nachrichten |
| `marketing_email` | Marketing email | Produktneuigkeiten |
| `transactional` | Transactional email | Sicherheit & laufende Vorgänge |

A purpose an operator defines still keeps whatever they called it — only the ones the product plants are ours to translate.

**The checkbox did not read as a control.** A native 16px box, pushed to the far edge of a 720px row by `justify-content: space-between`, sat closer to the window than to the sentence it answered. It is larger now, leads its row so every box lines up in one column, and takes the whole cell as its target.

## Verification

`make check-fe` green; 75 unit tests and all 8 Playwright cases pass. Both pages screenshotted from the built bundle against the running demo stack — checked the column, the footer, the German and the checkbox column by eye.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the public preference and unsubscribe pages so they look and read like one product, in the reader's language. The unsubscribe page previously had no layout and spread its content across the window, neither page named the sender, German pages mixed English purpose labels into German prose, and the checkbox didn't read as a control.

- Both pages now share a `PublicPage` frame that owns the column width, the link's language, and the Margince sign-off.
- The three seeded purposes are now named and worded in German, English, and Vietnamese; operator-defined purposes keep their own labels.
- The checkbox is larger, leads its row so all boxes line up in one column, and the whole cell is the click target.

<sup>Written for commit 248e8f5b7136d05415559193e9a70e083ab43b70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized preference labels and consent wording for business correspondence, marketing emails, and transactional messages in English, German, and Vietnamese.
  - Added consistent public-page branding, layout, footer, and sender attribution across preference and unsubscribe screens.

- **Improvements**
  - Improved preference controls with larger click areas, clearer positioning, accent colors, and hover feedback.
  - Custom preference purposes continue displaying their configured labels.
  - Improved accessibility by localizing preference and checkbox labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->