### PR TITLE
A Team Lead reads their team

### DIFF
--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -105,6 +105,12 @@ type Service struct {
 	// routine contact decision joins. Nil means every address reads as a
 	// person's, which under-groups rather than hiding anything.
 	machine MachineSender
+	// teammates answers whether a team-scoped reader may open a named person's
+	// queue. Unlike the lanes above it, nil does NOT mean "absent lane": it
+	// means the question has no answer, and resolveOwner refuses rather than
+	// admits. A lane whose absence widened a scope would be a security hole
+	// wearing the shape of a missing feature.
+	teammates Teammates
 	// decisionDepth is how many staged decisions a read takes. The lane feed's
 	// page is a prefetch for a surface that answers one at a time; the ranked
 	// queue takes a census, because a batch row that says "10" over a pile of
@@ -196,6 +202,18 @@ func (s *Service) WithMachineSender(is MachineSender) *Service {
 // before this seam existed — a smaller card, never a wrong one.
 func (s *Service) WithDealFacts(f DealFacts) *Service {
 	s.dealFacts = f
+	return s
+}
+
+// WithTeammates binds the membership question a team-scoped reader's named-owner
+// ask is decided by. An option for the reason WithWaiting is one.
+//
+// Unbound, a team-scoped reader naming somebody else is REFUSED — the opposite
+// of how the optional lanes above degrade, and deliberately so: those answer
+// "this installation has no such lane", while this one answers "may I", and an
+// unanswerable may-I is a no.
+func (s *Service) WithTeammates(t Teammates) *Service {
+	s.teammates = t
 	return s
 }
 

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -129,6 +129,19 @@ type Tasks interface {
 	OpenForViewer(ctx context.Context, until time.Time, limit int, scope TaskScope, owner ids.UUID) ([]Task, error)
 }
 
+// Teammates answers whether a named user is on a team with the reader.
+//
+// The reader is the authenticated caller and is not passed: the module behind
+// this takes it from the principal, so the question can only ever be asked
+// about an edge the asker is themselves an end of.
+//
+// Asked only when a TEAM-scoped reader names somebody else's queue. An
+// unbounded reader reaches every row and needs no such question; an own-scoped
+// reader is refused before it is asked.
+type Teammates interface {
+	SharesLiveTeamWithCaller(ctx context.Context, other ids.UUID) (bool, error)
+}
+
 // Task is one piece of agreed work.
 type Task struct {
 	ID      ids.UUID

--- a/backend/internal/compose/attention/scope.go
+++ b/backend/internal/compose/attention/scope.go
@@ -100,7 +100,7 @@ func resolveScope(ctx context.Context, asked string) (string, error) {
 // modules that own them, exactly as they do under `team` and `all`, so what
 // this reaches is the shared record-bearing work assigned to that person. The
 // contract says so where the parameter is declared.
-func resolveOwner(ctx context.Context, asked ids.UUID) (ids.UUID, error) {
+func (s *Service) resolveOwner(ctx context.Context, asked ids.UUID) (ids.UUID, error) {
 	if asked.IsZero() {
 		return ids.UUID{}, nil
 	}
@@ -114,12 +114,31 @@ func resolveOwner(ctx context.Context, asked ids.UUID) (ids.UUID, error) {
 	if owner == actor.UserID {
 		return owner, nil
 	}
-	// Somebody else's queue is a team-or-wider question. The tier is the whole
-	// test: whether that person is on the reader's team is a fact the row scope
-	// already decides for every record this read returns, and re-deriving it
-	// here would be a second answer to it.
+	// An unbounded reader reaches every row, so for them the tier IS the whole
+	// test and naming anyone is answerable.
+	//
+	// A TEAM-scoped reader is different, and the difference is not academic. Row
+	// scope narrows the deal-bearing rows correctly, but the task lane's gate is
+	// a link walk: auth.ActivityDiscoverClause coalesces the empty link set to
+	// TRUE, so a task carrying no record link is discoverable by anyone. Naming
+	// an out-of-team colleague would return exactly those rows, under a page
+	// headed with that colleague's name. So membership is asked here, where the
+	// question is "may I open this person's queue" rather than "may I read this
+	// row".
 	switch actor.Permissions.RowScope {
-	case principal.RowScopeTeam, principal.RowScopeAll:
+	case principal.RowScopeAll:
+		return owner, nil
+	case principal.RowScopeTeam:
+		if s.teammates == nil {
+			return ids.UUID{}, apperrors.ErrPermissionDenied
+		}
+		shares, err := s.teammates.SharesLiveTeamWithCaller(ctx, owner)
+		if err != nil {
+			return ids.UUID{}, err
+		}
+		if !shares {
+			return ids.UUID{}, apperrors.ErrPermissionDenied
+		}
 		return owner, nil
 	default:
 		return ids.UUID{}, apperrors.ErrPermissionDenied

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -236,9 +236,10 @@ func TestTheLaneFeedStillReadsEveryVisibleTask(t *testing.T) {
 // their colleague's day.
 func TestOpeningAnothersQueueNeedsATierThatReachesThem(t *testing.T) {
 	colleague := ids.MustParse("01a05500-0000-7000-8000-0000000000bb")
+	svc := &Service{teammates: teammatesSaying(true)}
 
 	for _, tier := range []principal.RowScope{principal.RowScopeTeam, principal.RowScopeAll} {
-		got, err := resolveOwner(readerAt(tier), colleague)
+		got, err := svc.resolveOwner(readerAt(tier), colleague)
 		if err != nil {
 			t.Fatalf("row scope %q was refused a colleague's queue: %v", tier, err)
 		}
@@ -247,8 +248,64 @@ func TestOpeningAnothersQueueNeedsATierThatReachesThem(t *testing.T) {
 		}
 	}
 
-	if _, err := resolveOwner(readerAt(principal.RowScopeOwn), colleague); err == nil {
+	if _, err := svc.resolveOwner(readerAt(principal.RowScopeOwn), colleague); err == nil {
 		t.Fatal("a reader whose scope reaches only themselves opened a colleague's queue")
+	}
+}
+
+// A team-scoped reader reaches their own team, and stops there.
+//
+// The tier alone is not the test for this reader class. Row scope narrows the
+// deal-bearing rows, but a task carrying no record link is discoverable by
+// anyone (auth.ActivityDiscoverClause coalesces the empty link set to TRUE), so
+// naming an out-of-team colleague would answer with exactly those rows under
+// that colleague's name.
+func TestATeamScopedReaderReachesOnlyTheirOwnTeam(t *testing.T) {
+	colleague := ids.MustParse("01a05500-0000-7000-8000-0000000000bb")
+
+	shared := &Service{teammates: teammatesSaying(true)}
+	got, err := shared.resolveOwner(readerAt(principal.RowScopeTeam), colleague)
+	if err != nil {
+		t.Fatalf("a team-scoped reader was refused a teammate's queue: %v", err)
+	}
+	if got != colleague {
+		t.Fatalf("a teammate's queue answered %v, wanted the named colleague", got)
+	}
+
+	stranger := &Service{teammates: teammatesSaying(false)}
+	if _, err := stranger.resolveOwner(readerAt(principal.RowScopeTeam), colleague); err == nil {
+		t.Fatal("a team-scoped reader opened the queue of somebody on no team of theirs")
+	}
+}
+
+// An unanswerable may-I is a no.
+//
+// Every other optional lane renders absent when unbound, which is why this one
+// needs saying: a membership lane that degraded the same way would widen the
+// scope it exists to bound, and would look like a missing feature while doing
+// it.
+func TestAnUnboundMembershipLaneRefusesRatherThanAdmits(t *testing.T) {
+	colleague := ids.MustParse("01a05500-0000-7000-8000-0000000000bb")
+
+	unbound := &Service{}
+	if _, err := unbound.resolveOwner(readerAt(principal.RowScopeTeam), colleague); err == nil {
+		t.Fatal("a team-scoped reader opened a colleague's queue with no membership lane to ask")
+	}
+
+	// The unbounded reader is unaffected: they reach every row, so the lane was
+	// never part of their answer.
+	if _, err := unbound.resolveOwner(readerAt(principal.RowScopeAll), colleague); err != nil {
+		t.Fatalf("an unbounded reader was refused for want of a lane they do not need: %v", err)
+	}
+}
+
+// A membership read that fails is not a membership read that said no.
+func TestAFailedMembershipReadRefusesAndReportsTheFailure(t *testing.T) {
+	colleague := ids.MustParse("01a05500-0000-7000-8000-0000000000bb")
+	svc := &Service{teammates: teammatesFailing{}}
+
+	if _, err := svc.resolveOwner(readerAt(principal.RowScopeTeam), colleague); err == nil {
+		t.Fatal("a failed membership read admitted the reader")
 	}
 }
 
@@ -258,7 +315,7 @@ func TestOpeningAnothersQueueNeedsATierThatReachesThem(t *testing.T) {
 func TestNamingYourselfNeedsNoWiderTier(t *testing.T) {
 	me := ids.MustParse("01a05500-0000-7000-8000-000000000001")
 
-	got, err := resolveOwner(readerAt(principal.RowScopeOwn), me)
+	got, err := (&Service{}).resolveOwner(readerAt(principal.RowScopeOwn), me)
 	if err != nil {
 		t.Fatalf("a reader was refused their OWN queue: %v", err)
 	}
@@ -270,7 +327,7 @@ func TestNamingYourselfNeedsNoWiderTier(t *testing.T) {
 // No ask is no narrowing. The parameter is optional, and its absence must not
 // read as "nobody's queue" and empty the page.
 func TestNoOwnerAskNarrowsNothing(t *testing.T) {
-	got, err := resolveOwner(readerAt(principal.RowScopeAll), ids.UUID{})
+	got, err := (&Service{}).resolveOwner(readerAt(principal.RowScopeAll), ids.UUID{})
 	if err != nil {
 		t.Fatalf("omitting the owner was refused: %v", err)
 	}
@@ -314,4 +371,20 @@ func TestOpeningAnothersQueueCarriesTheirWorkAndNotTheReadersOwn(t *testing.T) {
 func uuidPtr(id ids.UUID) *openapi_types.UUID {
 	out := openapi_types.UUID(id)
 	return &out
+}
+
+// teammatesSaying answers every membership question the same way, which is what
+// the resolver's own branches need: whether it ASKS, and what it does with each
+// answer.
+type teammatesSaying bool
+
+func (t teammatesSaying) SharesLiveTeamWithCaller(context.Context, ids.UUID) (bool, error) {
+	return bool(t), nil
+}
+
+// teammatesFailing is the membership read that could not answer.
+type teammatesFailing struct{}
+
+func (teammatesFailing) SharesLiveTeamWithCaller(context.Context, ids.UUID) (bool, error) {
+	return false, errors.New("reading team membership")
 }

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -60,7 +60,7 @@ func (s *Service) Worklist(
 		return crmcontracts.Worklist{}, err
 	}
 	// Same rule, same moment: whose queue this is, refused rather than narrowed.
-	namedOwner, err := resolveOwner(ctx, owner)
+	namedOwner, err := s.resolveOwner(ctx, owner)
 	if err != nil {
 		return crmcontracts.Worklist{}, err
 	}

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -29,6 +29,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/platform/database"
@@ -399,6 +400,20 @@ func (f attentionDealFacts) Figures(
 		}
 	}
 	return out, nil
+}
+
+// attentionTeammates answers the membership question through the identity
+// module, which owns team_membership. The typed ids stay inside that module;
+// the projection speaks raw uuids, exactly as the row-scope seams do.
+type attentionTeammates struct{ svc *identity.Service }
+
+// newAttentionTeammates builds the membership lane over the identity module.
+func newAttentionTeammates(pool *pgxpool.Pool) attentionTeammates {
+	return attentionTeammates{svc: identity.NewService(pool)}
+}
+
+func (t attentionTeammates) SharesLiveTeamWithCaller(ctx context.Context, other ids.UUID) (bool, error) {
+	return t.svc.SharesLiveTeamWithCaller(ctx, ids.From[ids.UserKind](other))
 }
 
 // attentionTasks reads open tasks through the activities store. A task is an

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -426,5 +426,10 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, meter *over
 		// The figures behind a deal a row names but does not carry — the
 		// overnight brief's rows, which rank ids and keep their evidence
 		// behind the brief's own endpoint.
-		WithDealFacts(attentionDealFacts{store: deals.NewStore(db, DealsInstallation())})
+		WithDealFacts(attentionDealFacts{store: deals.NewStore(db, DealsInstallation())}).
+		// Whether a team-scoped reader may open a named person's queue. Bound
+		// unconditionally: unbound, that reader is refused, so a seam that
+		// dropped this would present as a Team Lead unable to open their own
+		// rep's day rather than as one able to open a stranger's.
+		WithTeammates(newAttentionTeammates(pool))
 }

--- a/backend/internal/modules/identity/internal/policy/defaults.go
+++ b/backend/internal/modules/identity/internal/policy/defaults.go
@@ -98,16 +98,17 @@ var defaults = map[string]Document{
 	},
 	"manager": {
 		Objects: managerObjects,
-		// Own scope, not team: membership of a team is not by itself permission
-		// to rewrite a teammate's records. Writing somebody else's customer
-		// record takes an explicit share — a record_grant naming the user or
-		// one of their teams — or an unbounded seat.
+		// Team scope: a Team Lead manages their team, so they read and work the
+		// records of everyone sharing a live team with them without a share
+		// being arranged first. This is the manager grid above, bounded to the
+		// team rather than the organization — `management` is the same grid
+		// unbounded.
 		//
-		// The team ARM survives in the write predicate and is not dead: a
-		// record_grant may name a team, and an operator may still author a
-		// custom role at team scope. What changed is only what the seeded
-		// roles claim by default.
-		RowScope: principal.RowScopeOwn,
+		// Membership resolves through team_membership and live teams only, so a
+		// Team Lead who belongs to no team reaches exactly their own rows. A
+		// record_grant naming a user or a team stays the mechanism for sharing
+		// ACROSS teams, and for every seat that is not this one.
+		RowScope: principal.RowScopeTeam,
 	},
 	"rep": {
 		// Reps create and work records but never delete them — except

--- a/backend/internal/modules/identity/rbacmatrix_test.go
+++ b/backend/internal/modules/identity/rbacmatrix_test.go
@@ -164,16 +164,19 @@ CRU- is create, read and update but never delete, and ---- is no access at all.
 **Row scope is a second, independent question,** and it belongs to the role
 rather than to a cell, so it is listed once per role below. The letters say what
 a role may do to a *kind* of record; row scope says *which* records of that kind
-it may touch in the first place:
+it may WRITE:
 
 - **own** — only records the user owns.
-- **team** — records the user owns, records owned by a teammate, and records
-  that have no owner.
+- **team** — records the user owns and records owned by a teammate, resolved
+  through live team membership.
 - **all** — every record in the workspace.
 
-Both questions have to pass. A rep holding CRU- on deals still only reaches
-their own team's deals; a read-only auditor holding R--- reaches every deal in
-the workspace but changes none of them.
+Both questions have to pass, and they do not bind equally. Row scope narrows
+WRITES; a customer record — person, organization, lead, deal, project — is read
+by every seat that holds its read grant, whatever their scope. So a rep holding
+CRU- on deals reads the whole workspace's deals and may update only the ones
+their scope reaches, while a read-only auditor holding R--- reads them all and
+changes none.
 
 `
 

--- a/backend/internal/modules/identity/teammembership_integration_test.go
+++ b/backend/internal/modules/identity/teammembership_integration_test.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package identity
+
+// Whether a named person is on a team with the CALLER, against real rows.
+//
+// This answer gates a Team Lead opening somebody else's queue, so each arm is
+// held separately: sharing a team admits, sharing none refuses, and an archived
+// team admits nobody — matching how row scope resolves membership, because an
+// answer wider than that predicate would grant a reach the rows then deny.
+//
+// The caller is taken from the principal rather than passed, so a test drives
+// it by acting AS the person asking, which is also how the product reaches it.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestATeammateSharesALiveTeamAndAStrangerDoesNot(t *testing.T) {
+	e := setupRevocationEnv(t, "team-membership")
+	ctx := context.Background()
+
+	sales, err := e.svc.CreateTeam(e.wsCtx(e.admin), e.admin, "DACH Sales")
+	if err != nil {
+		t.Fatalf("creating the team: %v", err)
+	}
+	support, err := e.svc.CreateTeam(e.wsCtx(e.admin), e.admin, "Support")
+	if err != nil {
+		t.Fatalf("creating the second team: %v", err)
+	}
+
+	teammate := inviteMember(ctx, t, e, "teammate@acme.test", "Team Mate")
+	stranger := inviteMember(ctx, t, e, "stranger@acme.test", "Strange R")
+
+	for _, member := range []ids.UUID{e.admin.UserID.UUID, teammate.UUID} {
+		if err := e.svc.SetTeamMember(e.wsCtx(e.admin), e.admin, sales.ID, member, true); err != nil {
+			t.Fatalf("adding %s to DACH Sales: %v", member, err)
+		}
+	}
+	// The stranger is in a team of their OWN, not in no team at all: a refusal
+	// that only holds for the teamless would miss the case this gate exists for.
+	if err := e.svc.SetTeamMember(e.wsCtx(e.admin), e.admin, support.ID, stranger.UUID, true); err != nil {
+		t.Fatalf("adding the stranger to Support: %v", err)
+	}
+
+	shares, err := e.svc.SharesLiveTeamWithCaller(e.wsCtx(e.admin), teammate)
+	if err != nil {
+		t.Fatalf("asking about a teammate: %v", err)
+	}
+	if !shares {
+		t.Fatal("two members of DACH Sales did not read as teammates")
+	}
+
+	shares, err = e.svc.SharesLiveTeamWithCaller(e.wsCtx(e.admin), stranger)
+	if err != nil {
+		t.Fatalf("asking about somebody on another team: %v", err)
+	}
+	if shares {
+		t.Fatal("a member of Support read as a teammate of DACH Sales")
+	}
+}
+
+// An archived team grants nothing, matching the row-scope predicate. The
+// memberships survive the archive so a restore brings them back, which is
+// exactly why this needs asserting rather than assuming.
+func TestAnArchivedTeamMakesNobodyTeammates(t *testing.T) {
+	e := setupRevocationEnv(t, "team-membership-archived")
+	ctx := context.Background()
+
+	sales, err := e.svc.CreateTeam(e.wsCtx(e.admin), e.admin, "DACH Sales")
+	if err != nil {
+		t.Fatalf("creating the team: %v", err)
+	}
+	teammate := inviteMember(ctx, t, e, "teammate@acme.test", "Team Mate")
+	for _, member := range []ids.UUID{e.admin.UserID.UUID, teammate.UUID} {
+		if err := e.svc.SetTeamMember(e.wsCtx(e.admin), e.admin, sales.ID, member, true); err != nil {
+			t.Fatalf("adding %s to DACH Sales: %v", member, err)
+		}
+	}
+
+	// Teammates BEFORE the archive, so the assertion after it is a change and
+	// not a query that never matched.
+	shares, err := e.svc.SharesLiveTeamWithCaller(e.wsCtx(e.admin), teammate)
+	if err != nil {
+		t.Fatalf("asking about a teammate: %v", err)
+	}
+	if !shares {
+		t.Fatal("two members of a live team did not read as teammates")
+	}
+
+	archived := true
+	if _, err := e.svc.UpdateTeam(e.wsCtx(e.admin), e.admin, sales.ID, UpdateTeamInput{Archived: &archived}); err != nil {
+		t.Fatalf("archiving the team: %v", err)
+	}
+
+	shares, err = e.svc.SharesLiveTeamWithCaller(e.wsCtx(e.admin), teammate)
+	if err != nil {
+		t.Fatalf("asking after the archive: %v", err)
+	}
+	if shares {
+		t.Fatal("an archived team still made two people teammates")
+	}
+}
+
+// A caller is their own teammate. A reader naming their own id follows the same
+// path as any other ask, and refusing them their own queue would be a bug the
+// two-person cases above cannot see.
+func TestACallerIsTheirOwnTeammate(t *testing.T) {
+	e := setupRevocationEnv(t, "team-membership-self")
+
+	// No team anywhere: the answer must not depend on membership rows existing.
+	shares, err := e.svc.SharesLiveTeamWithCaller(e.wsCtx(e.admin), e.admin.UserID)
+	if err != nil {
+		t.Fatalf("asking about themselves: %v", err)
+	}
+	if !shares {
+		t.Fatal("a caller did not read as their own teammate")
+	}
+}
+
+// A caller with no human behind it is refused rather than answered.
+//
+// "false" would read as a fact about the organization chart — that these two
+// are not teammates — where the truth is that the asker has no place on it. The
+// refusal keeps an agent seat or a background pass from probing the chart.
+func TestACallerWithNoHumanBehindItIsRefused(t *testing.T) {
+	e := setupRevocationEnv(t, "team-membership-nonhuman")
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws.UUID)
+
+	// An agent seat is refused with the permission sentinel, which is the answer
+	// a caller acts on: it is a decision about authority rather than a
+	// malformed request.
+	agent := principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:probe", UserID: e.admin.UserID.UUID,
+	})
+	shares, err := e.svc.SharesLiveTeamWithCaller(agent, e.admin.UserID)
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("an agent seat asking about the chart got %v, wanted the permission sentinel", err)
+	}
+	if shares {
+		t.Fatal("a refused agent seat was still told the two are teammates")
+	}
+
+	// No actor at all is refused too. The sentinel differs — there is no
+	// principal to make a decision about — and what matters is that it errors
+	// rather than answering.
+	shares, err = e.svc.SharesLiveTeamWithCaller(ctx, e.admin.UserID)
+	if err == nil {
+		t.Fatal("a call with no actor at all was answered rather than refused")
+	}
+	if shares {
+		t.Fatal("a refused call was still told the two are teammates")
+	}
+}
+
+// inviteMember resolves a second seat through the real invite → redeem path, so
+// the row under test is one the product writes rather than one the test does.
+func inviteMember(ctx context.Context, t *testing.T, e *revocationEnv, email, name string) ids.UserID {
+	t.Helper()
+	created, rawToken, err := e.svc.InviteUser(e.wsCtx(e.admin), e.admin, InviteUserInput{
+		Email: email, DisplayName: name, Role: "rep",
+	})
+	if err != nil {
+		t.Fatalf("inviting %s: %v", email, err)
+	}
+	redeem := principal.WithCorrelationID(principal.WithWorkspaceID(ctx, e.ws.UUID), ids.NewV7())
+	if err := e.svc.RedeemPasswordReset(redeem, rawToken, "a member password!"); err != nil {
+		t.Fatalf("redeeming the invite for %s: %v", email, err)
+	}
+	return created
+}

--- a/backend/internal/modules/identity/teams.go
+++ b/backend/internal/modules/identity/teams.go
@@ -22,9 +22,11 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
@@ -216,6 +218,53 @@ func (s *Service) recordTeamChange(ctx context.Context, tx pgx.Tx, actor Identit
 		payload.UserId = &u
 	}
 	return storekit.EmitEvent(ctx, tx, auditID, teamID, payload)
+}
+
+// SharesLiveTeamWithCaller reports whether the named user is on a team with the
+// AUTHENTICATED caller.
+//
+// The caller's own id comes from the principal rather than from an argument, so
+// this cannot be asked about two other people. That is the gate: the answer
+// discloses one edge of the organization chart, and the only edge a reader is
+// entitled to probe is one they are themselves an end of. A caller with no
+// human behind it is refused — an agent or a system pass has no teammates, and
+// answering "false" would read as a fact rather than as an absence.
+//
+// Live teams only, matching how row scope resolves membership: an archived team
+// keeps its rows so a restore brings them back, but while archived it grants
+// nothing, and an answer of true here would hand a reader authority the
+// row-scope predicate does not agree with.
+//
+// The parent_team_id hierarchy is NOT walked, again matching row scope. A lead
+// of a parent team reaches a child team's members by belonging to the child
+// team too. Walking it here alone would make this answer wider than the
+// predicate that decides what the reader then reads.
+func (s *Service) SharesLiveTeamWithCaller(ctx context.Context, other ids.UserID) (bool, error) {
+	// Refuses an agent seat and a Deal Room buyer. It admits the system and
+	// connector principals, which is why the seated-identity check follows: a
+	// background pass has no place on the chart to answer from.
+	if err := auth.RequireHuman(ctx); err != nil {
+		return false, err
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Type != principal.PrincipalHuman || actor.UserID.IsZero() {
+		return false, apperrors.ErrPermissionDenied
+	}
+	me := ids.From[ids.UserKind](actor.UserID)
+	// Asking about themselves needs no query: a reader is their own teammate,
+	// and the caller need not special-case it.
+	if me == other {
+		return true, nil
+	}
+	var shares bool
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT EXISTS (
+		         SELECT 1 FROM team_membership ma
+		           JOIN team_membership mb ON mb.team_id = ma.team_id AND mb.user_id = $2
+		           JOIN team t ON t.id = ma.team_id AND t.archived_at IS NULL
+		          WHERE ma.user_id = $1)`, me, other).Scan(&shares)
+	})
+	return shares, err
 }
 
 // validTeamName trims and bounds a team name.

--- a/backend/migrations/core/1788244324_a_team_lead_reads_their_team.down.sql
+++ b/backend/migrations/core/1788244324_a_team_lead_reads_their_team.down.sql
@@ -1,0 +1,21 @@
+-- Put the seeded manager role back to own scope — but only where THIS
+-- migration is what widened it.
+--
+-- row_scope_set_by is the provenance the up migration wrote. Without it this
+-- rollback could not tell a role it moved to team scope from one an operator
+-- had already chosen to put there, because afterwards the two documents look
+-- the same. Narrowing the second kind would withdraw write authority the
+-- operator granted deliberately, and nothing would say it had happened.
+--
+-- So an installation where the up migration matched nothing — an operator had
+-- already moved the seeded role off `own` — passes through this untouched.
+--
+-- The marker goes with the scope, so the pair is reversible in both directions:
+-- reapplying the up migration afterwards finds `own` again and widens again.
+UPDATE role
+   SET permissions = jsonb_set(permissions, '{row_scope}', '"own"'::jsonb, true)
+                     - 'row_scope_set_by'
+ WHERE key = 'manager'
+   AND is_system
+   AND permissions ->> 'row_scope' = 'team'
+   AND permissions ->> 'row_scope_set_by' = '1788244324';

--- a/backend/migrations/core/1788244324_a_team_lead_reads_their_team.up.sql
+++ b/backend/migrations/core/1788244324_a_team_lead_reads_their_team.up.sql
@@ -1,0 +1,35 @@
+-- The seeded manager (Team Lead) role moves from own scope to team scope.
+--
+-- Reach the installations that already exist. seedSystemRoles writes each role
+-- document once at workspace creation and never re-syncs, so a change to the
+-- compiled defaults alone would take effect on a FRESH database and nowhere
+-- else — every deployed installation would keep own scope permanently, and the
+-- two would diverge with nothing to show it.
+--
+-- This is a WIDENING: a Team Lead gains the manager grid over the records of
+-- everyone sharing a live team with them, where before they reached only their
+-- own. The product ruling is that a Team Lead manages their team, so they read
+-- and work their team's records without an explicit share being arranged first.
+-- A record_grant naming a team keeps working and is now redundant for this
+-- seat; it stays the mechanism for every other case.
+--
+-- Guarded three ways, each for its own reason:
+--   is_system     — an operator's custom role that happens to be keyed
+--                   'manager' is theirs, not ours to rewrite.
+--   row_scope=own — idempotent, and it leaves alone an operator who has
+--                   already chosen a different scope for the seeded role.
+--   the key       — 'rep' stays own-scoped; only the Team Lead's default moved.
+--
+-- row_scope_set_by records that THIS migration made the change, so the down
+-- migration can tell a role it widened from one an operator had already put at
+-- team scope themselves. Matching on the current value alone cannot: both look
+-- identical afterwards, and a rollback would narrow a setting it never made.
+-- The marker is removed by the down migration, so a rolled-back-then-reapplied
+-- installation is in the same state as one that only ever ran the up.
+UPDATE role
+   SET permissions = jsonb_set(
+         jsonb_set(permissions, '{row_scope}', '"team"'::jsonb, true),
+         '{row_scope_set_by}', '"1788244324"'::jsonb, true)
+ WHERE key = 'manager'
+   AND is_system
+   AND permissions ->> 'row_scope' = 'own';

--- a/backend/migrations/testdata/rbac_seeded_defaults.json
+++ b/backend/migrations/testdata/rbac_seeded_defaults.json
@@ -768,7 +768,7 @@
         "update": false
       }
     },
-    "row_scope": "own"
+    "row_scope": "team"
   },
   "ops": {
     "objects": {

--- a/docs/explanation/rbac-roles-and-teams.md
+++ b/docs/explanation/rbac-roles-and-teams.md
@@ -47,16 +47,19 @@ same values by a test and so cannot drift from them. The shape:
 |---|---|---|
 | `admin` | Full CRUD on everything (config included). | `all` |
 | `ops` | Same CRUD reach as admin — the operations counterpart. | `all` |
-| `manager` | CRUD on records; **read-only** on most config (pipeline, automation, custom_field, quota); **no access at all** to the admin-only sheets (`fx_rate`, `ai_model_rate`, `embedding_reindex`, `import_run`). | `own` |
+| `manager` | CRUD on records; **read-only** on most config (pipeline, automation, custom_field, quota); **no access at all** to the admin-only sheets (`fx_rate`, `ai_model_rate`, `embedding_reindex`, `import_run`). | `team` |
 | `rep` | Create/read/update records (delete only where it's routine, e.g. disqualify a lead); **read-only** on config. | `own` |
 | `read_only` | Reads every record kind and every config surface a rep can see; writes nothing except its own saved views. The four admin-only sheets (`fx_rate`, `ai_model_rate`, `embedding_reindex`, `import_run`) are closed to it entirely — not even read. | `all` |
 
 Two things surprise people:
 
-- **`read_only` is `row_scope: all`, `rep`/`manager` are `row_scope: own`.** Scope and object reach
+- **`read_only` is `row_scope: all`, and `rep` is `row_scope: own`.** Scope and object reach
   are orthogonal — a read-only auditor is *meant* to see the whole workspace and write none of it,
   while a rep reads every record and writes only their own. On the five customer-record tables the
   read tier is not what scope decides at all (see *Reads* below); scope decides writes.
+- **`manager` is `row_scope: team`, and it is the only seeded role that is.** A Team Lead writes
+  their teammates' records as well as their own, resolved through live team membership. The seat
+  above it, `management`, is the same object grid at `all` — the sales leader over every row.
 - **Config objects (pipeline, custom_field, automation, quota) are read-only below admin/ops.** This
   is why a `rep` gets `pipeline.read: permission denied`-adjacent behaviour only when they have **no
   role at all** — with the `rep` role they *can* read pipelines; they just can't edit them.
@@ -105,14 +108,18 @@ Row scope decides **who may change** an identity row: the write-authority probe
 rep who can read a colleague's deal and tries to edit it gets **403**, not 404 — the row is visibly
 theirs to read, so there is nothing left for a 404 to hide.
 
-**Team membership grants nothing by itself.** The seeded `rep` and `manager` are `own`-scoped, so a
+**Team membership grants nothing to a `rep`.** The seeded `rep` is `own`-scoped, so for them a
 colleague's record takes an explicit share — a `record_grant` naming the user or one of their teams —
-or an unbounded seat. This is the change from the earlier model, where being in somebody's team was
-standing write access to everything they owned.
+or an unbounded seat. Being in somebody's team is not by itself permission to rewrite their records.
 
-The team arm survives in the predicate and is not dead code. A record grant may name a **team**, so
-sharing with a group is one act rather than one per member, and an operator may still author a custom
-role at `team` scope. What changed is only what the seeded roles claim by default.
+**For a `manager` it grants exactly one thing: their teammates.** A Team Lead is `team`-scoped, so the
+owner predicate resolves to themselves plus everyone sharing a live team with them. That is the seat's
+purpose — a lead who cannot work their team's records is a lead in name only — and it is bounded by
+membership rather than by the org chart: an archived team grants nothing, and `parent_team_id` is not
+walked, so leading a parent team reaches a child team's members only by belonging to that team too.
+
+A record grant may still name a **team**, so sharing with a group is one act rather than one per
+member, and it stays the mechanism for reaching ACROSS teams and for every seat that is not this one.
 
 An **ownerless** row (`owner_id IS NULL`) is nobody's to change until somebody claims it
 (`EnsureClaimable`, `POST /v1/records/{record_type}/{id}/claim`); claiming makes the claimer the
@@ -157,9 +164,9 @@ that had no seat to attribute. Such a row is readable by everyone and writable b
 seat claims it, which is the opposite of what this paragraph used to say: an ownerless customer
 record every seat could rewrite is how two teams edit one company past each other.
 
-The seeded `rep` and `manager` are `row_scope: own`, and `read_only`, `ops`, `admin` and
-`management` are `all`. No seeded role is `team`-scoped; that tier is available to custom roles and
-is what a team-subject record grant resolves against.
+The seeded `rep` is `row_scope: own`, `manager` is `team`, and `read_only`, `ops`, `admin` and
+`management` are `all`. The `team` tier is also what a team-subject record grant resolves against,
+and a custom role may claim it.
 
 ## Field masks — one column of a readable row
 

--- a/docs/reference/rbac-matrix.md
+++ b/docs/reference/rbac-matrix.md
@@ -34,16 +34,19 @@ CRU- is create, read and update but never delete, and ---- is no access at all.
 **Row scope is a second, independent question,** and it belongs to the role
 rather than to a cell, so it is listed once per role below. The letters say what
 a role may do to a *kind* of record; row scope says *which* records of that kind
-it may touch in the first place:
+it may WRITE:
 
 - **own** — only records the user owns.
-- **team** — records the user owns, records owned by a teammate, and records
-  that have no owner.
+- **team** — records the user owns and records owned by a teammate, resolved
+  through live team membership.
 - **all** — every record in the workspace.
 
-Both questions have to pass. A rep holding CRU- on deals still only reaches
-their own team's deals; a read-only auditor holding R--- reaches every deal in
-the workspace but changes none of them.
+Both questions have to pass, and they do not bind equally. Row scope narrows
+WRITES; a customer record — person, organization, lead, deal, project — is read
+by every seat that holds its read grant, whatever their scope. So a rep holding
+CRU- on deals reads the whole workspace's deals and may update only the ones
+their scope reaches, while a read-only auditor holding R--- reads them all and
+changes none.
 
 ## The six roles a workspace starts with
 
@@ -51,7 +54,7 @@ the workspace but changes none of them.
 |---|---|---|
 | `admin` | Admin | all |
 | `management` | Management | all |
-| `manager` | Team Lead | own |
+| `manager` | Team Lead | team |
 | `rep` | User | own |
 | `read_only` | Read-only | all |
 | `ops` | Ops / Integrations | all |


### PR DESCRIPTION
The seeded `manager` role (display name "Team Lead") moves from row scope `own`
to row scope `team`. A Team Lead now reads and works the records of everyone
sharing a live team with them.

Until now the role carried the manager grid over their own rows only, which left
"Team Lead" a name without reach: they could not select `scope=team` on the
Worklist, and could not open a colleague's queue at all. The seats that could
were `admin`, `management`, `read_only` and `ops` — none of them per-team.

**This reverses an earlier deliberate decision.** Migration
`1787449829_seeded_roles_own_scope` moved `manager` from team to own, on the
stated ground that "membership of a team is not by itself permission to rewrite
a teammate's records". The product ruling is now that a Team Lead manages their
team, so they reach their team's records without a share being arranged first. A
`record_grant` naming a user or a team stays the mechanism for sharing across
teams, and for every other seat.

The migration reaches deployed installations, not only fresh ones.
`seedSystemRoles` writes each role document once at workspace creation and never
re-syncs, so changing the compiled default alone would leave every existing
installation on own scope permanently.

## The security seam this opens, closed in the same change

`?owner=<uuid>` on the Worklist decided admission from the reader's tier alone.
The reasoning recorded in `resolveOwner` was that row scope already decides what
the reader may see, so re-deriving membership would be a second answer to it.

That holds for an unbounded reader. It does not hold for a team-scoped one. The
task lane's gate is a link walk, and `auth.ActivityDiscoverClause` coalesces the
empty link set to `TRUE`, so a task carrying **no record link is discoverable by
anyone**. A team-scoped reader naming an out-of-team colleague would have got
exactly those rows, on a page headed with that colleague's name.

Nothing could reach that before this change, because no seeded role was
team-scoped. This migration is what makes it reachable, so the fix lands with it.

`identity.SharesLiveTeamWithCaller` answers the membership question. The caller
comes from the principal rather than from an argument, so it cannot be asked
about two other people — the answer discloses one edge of the organization
chart, and a reader may probe only an edge they are an end of. An agent seat and
a call with no human behind it are refused rather than answered `false`, which
would read as a fact about the chart. Live teams only and no `parent_team_id`
walk, both matching how row scope resolves membership: an answer wider than that
predicate would grant a reach the rows then deny.

The attention lane fails **closed**. Every other optional lane renders absent
when unbound; this one refuses, because a membership lane that degraded the same
way would widen the scope it exists to bound while looking like a missing
feature.

## Verified against the running product

A Team Lead and an outsider created through the real invite and set-password
endpoints, then driven through the API:

| Reader | `scope_options` | Teammate's queue | Stranger's queue |
|---|---|---|---|
| Team Lead (`manager`) | `mine, unassigned, team` | 200 | 403 |
| Rep (`rep`) | `mine, unassigned` | 403 | 403 |

Before the change the same Team Lead was offered `mine, unassigned` and got 403
for both. The rep is unaffected, which is the point: the widening reached one
role.

## Tests

- `identity`: teammate admits, stranger on another team refuses (a team of their
  own, not no team — a refusal that only held for the teamless would miss the
  case this exists for), archived team admits nobody, caller is their own
  teammate, agent seat and actorless call refused.
- `attention`: team reader with a shared team admits, without one refuses,
  unbound lane refuses while an unbounded reader is unaffected, failed
  membership read refuses.
- Each new guard mutation-checked one at a time — reverted alone, confirmed its
  own test fails.

`make check-backend` green; `make test-it` green for `identity`, `compose` and
`migrations` (which exercises apply/reverse/reapply, so the down migration runs).
`make craft-static`, `make rls-store-path`, `make no-jurisdiction` clean.

## Also in this diff

`docs/reference/rbac-matrix.md` regenerates, and one sentence of its prose is
corrected in the generator: it claimed a rep "only reaches their own team's
deals", which stopped being true when reps became own-scoped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The seeded `manager` role (Team Lead) moves from `own` to `team` row scope, so a Team Lead now reads and works the records of everyone sharing a live team with them. A migration updates existing installations, since seeded roles are written once at workspace creation and never re-synced.

**Security seam closed in the same change**

- A team-scoped reader naming an out-of-team colleague's queue is now refused, because unlinked tasks are discoverable by anyone through the task lane's link-walk gate.
- `identity.SharesLiveTeamWithCaller` answers membership from the principal, not an argument, so the question can only be asked about an edge the asker is an end of; agent seats and actorless calls are refused rather than answered.
- Membership covers live teams only and does not walk `parent_team_id`, matching how row scope resolves membership.
- The attention lane fails closed when unbound, instead of degrading into a wider scope.

**Migration**

- `1788244324_a_team_lead_reads_their_team` only touches seeded `manager` roles still at `own` scope, leaving operators' custom edits alone.
- The up migration tags widened roles with a `row_scope_set_by` marker; the down migration keys on it and removes it, so a rollback only narrows roles this migration widened.

<sup>Written for commit 4417447634eea1156c9dd9bf3453b2563f6974e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team-scoped access now recognizes live team membership when opening named teammates’ queues.
  * Managers can access records belonging to members of their live team.
  * Cross-team, archived-team, unauthenticated, and non-human access remains restricted.
* **Bug Fixes**
  * Named-user access now correctly enforces team membership instead of treating unavailable membership data as an empty result.
* **Documentation**
  * Updated RBAC guidance to clarify team scope, read access, write access, and manager behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->