### PR TITLE
A mobile number is never bought without the email it depends on

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -20629,6 +20629,14 @@ components:
           type: object
           description: Credits charged per pool, worst case, the fallback included. Empty when free.
           additionalProperties: { type: integer, minimum: 0 }
+        requires:
+          type: [string, 'null']
+          description: >-
+            Another category this one is only looked up alongside, because the provider
+            skips it entirely when that one comes back empty. Surfe's mobile lookup is the
+            case: asked for on its own it makes the vendor hunt for an email nobody bought,
+            fail, and skip the number — returning a run that COMPLETED with nothing in it.
+            A buy button asks for both or neither; the server refuses the lone request.
 
     ProviderLookupBacklog:
       type: object

--- a/backend/internal/compose/handlers_integrations.go
+++ b/backend/internal/compose/handlers_integrations.go
@@ -14,6 +14,7 @@ package compose
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -213,8 +214,21 @@ func writeRunError(w http.ResponseWriter, r *http.Request, err error) {
 		// The caller's mistake, not a provider condition: retrying it
 		// unchanged buys nothing, so it is a 422 rather than a retryable
 		// failure.
+		//
+		// The store's own sentence is passed through rather than replaced.
+		// This sentinel now covers three different mistakes and only one of
+		// them is "the connection does not buy that": the others are a
+		// fallback asked for without its trigger, and a category asked for
+		// without the one it needs an answer from. A reader told the
+		// connection does not buy a category it visibly does buy cannot act
+		// on that, and the mobile case is exactly that shape.
+		//
+		// Safe to surface: every message behind this sentinel names category
+		// keys off the descriptor, which the same caller already reads from
+		// the catalog on the connection. No vendor prose, no identifier,
+		// nothing internal.
 		httperr.Write(w, r, httperr.Validation("categories", "not_permitted",
-			"this connection does not buy that category"))
+			strings.TrimPrefix(err.Error(), "integrations: ")))
 		return
 	}
 	httperr.Write(w, r, err)

--- a/backend/internal/compose/integrationsmapping.go
+++ b/backend/internal/compose/integrationsmapping.go
@@ -278,11 +278,15 @@ func catalogWire(catalog []integrations.CategoryCost) *[]crmcontracts.ProviderCa
 		for pool, n := range entry.Cost {
 			cost[pool] = n
 		}
-		out = append(out, crmcontracts.ProviderCategoryCost{
+		wire := crmcontracts.ProviderCategoryCost{
 			Category: entry.Category,
 			Free:     entry.Free,
 			Cost:     cost,
-		})
+		}
+		if entry.Requires != "" {
+			wire.Requires = &entry.Requires
+		}
+		out = append(out, wire)
 	}
 	return &out
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -25416,6 +25416,9 @@ type ProviderCategoryCost struct {
 
 	// Free Automatic enrichment buys exactly these; everything else waits for a human to press a button.
 	Free bool `json:"free"`
+
+	// Requires Another category this one is only looked up alongside, because the provider skips it entirely when that one comes back empty. Surfe's mobile lookup is the case: asked for on its own it makes the vendor hunt for an email nobody bought, fail, and skip the number — returning a run that COMPLETED with nothing in it. A buy button asks for both or neither; the server refuses the lone request.
+	Requires *string `json:"requires,omitempty"`
 }
 
 // ProviderCategorySelection Resolved per-category choices, keyed by the connected provider's declared category

--- a/backend/internal/modules/integrations/registry.go
+++ b/backend/internal/modules/integrations/registry.go
@@ -72,6 +72,9 @@ func NewRegistry(adapters ...provider.Adapter) (*Registry, error) {
 		if err := matchesOnKnownIdentifiers(d); err != nil {
 			return nil, err
 		}
+		if err := prerequisitesAreFlat(d); err != nil {
+			return nil, err
+		}
 		if d.EgressHost == "" {
 			return nil, fmt.Errorf("integrations: provider %q declared no egress host", d.Name)
 		}
@@ -142,6 +145,39 @@ func matchesOnKnownIdentifiers(d provider.Descriptor) error {
 						"an unknown field is never present, so the rule matches nobody and the lane goes silent",
 					d.Name, i, f)
 			}
+		}
+	}
+	return nil
+}
+
+// prerequisitesAreFlat refuses a descriptor whose RequiresAnswerTo forms a
+// chain or a cycle.
+//
+// Everything that reads this map walks ONE hop: the price of a purchase, the
+// set a button sends, the check that refuses a lone request, the free-set
+// derivation. That is deliberate — no adapter needs more, and a single hop is
+// what a reader can hold. But one hop over a chain is silently wrong in the
+// direction that costs money: with A needing B and B needing C, A's button
+// quotes and sends A+B, and the server then refuses it for missing C. A cycle
+// is worse and simply meaningless — no ordering satisfies "answer first" in
+// both directions.
+//
+// Refused where the author can see it rather than depth-walked. Supporting
+// chains would mean four call sites learning to walk, each with its own
+// termination, to serve a descriptor nobody has written. When one is written,
+// this is the error that says so.
+func prerequisitesAreFlat(d provider.Descriptor) error {
+	for category, prerequisite := range d.RequiresAnswerTo {
+		if category == prerequisite {
+			return fmt.Errorf(
+				"integrations: provider %q declares category %q as its own prerequisite, which no request can satisfy",
+				d.Name, category)
+		}
+		if next, chained := d.RequiresAnswerTo[prerequisite]; chained {
+			return fmt.Errorf(
+				"integrations: provider %q declares %q needing %q, which itself needs %q: every reader of this "+
+					"map walks one hop, so the chain would be priced and requested short and refused by the server",
+				d.Name, category, prerequisite, next)
 		}
 	}
 	return nil

--- a/backend/internal/modules/integrations/registrymatch_test.go
+++ b/backend/internal/modules/integrations/registrymatch_test.go
@@ -95,3 +95,79 @@ func TestAProviderMayDeclareNoMatchRules(t *testing.T) {
 			"provider that does not use it: %v", err)
 	}
 }
+
+// requiresChain is the shipped fake with a prerequisite graph replaced, which
+// is the shape an adapter author reaches by declaring one by hand.
+type requiresChain struct {
+	provider.Adapter
+	requires map[provider.Category]provider.Category
+}
+
+func (r requiresChain) Descriptor() provider.Descriptor {
+	d := r.Adapter.Descriptor()
+	d.RequiresAnswerTo = r.requires
+	return d
+}
+
+// A prerequisite chain or cycle is refused where the author declares it.
+//
+// Every reader of RequiresAnswerTo walks ONE hop: the price of a purchase, the
+// set the button sends, the check that refuses a lone request, the free-set
+// derivation. Over a chain that is wrong in the direction that costs money —
+// A's button quotes and sends A+B, and the server refuses it for missing C —
+// and a cycle has no ordering that satisfies "answer first" at all.
+func TestAPrerequisiteChainIsRefusedAtRegistration(t *testing.T) {
+	t.Parallel()
+
+	// The shipped fake registers as it is, so the cases below are not passing
+	// over a descriptor refused for some other reason.
+	shipped := NewOfflineProvider(0, time.Now).Descriptor()
+	if len(shipped.RequiresAnswerTo) == 0 {
+		t.Fatal("the shipped fake declares no prerequisite, so no dev stack or test exercises this rule")
+	}
+	if _, err := NewRegistry(NewOfflineProvider(0, time.Now)); err != nil {
+		t.Fatalf("the shipped adapter is refused by its own rule: %v", err)
+	}
+
+	for _, c := range []struct {
+		name     string
+		requires map[provider.Category]provider.Category
+		names    string
+	}{
+		{
+			name: "a chain",
+			requires: map[provider.Category]provider.Category{
+				"mobile":             "professional_email",
+				"professional_email": "linkedin_profile",
+			},
+			names: "linkedin_profile",
+		},
+		{
+			name: "a two-step cycle",
+			requires: map[provider.Category]provider.Category{
+				"mobile":             "professional_email",
+				"professional_email": "mobile",
+			},
+			names: "professional_email",
+		},
+		{
+			name:     "a category needing itself",
+			requires: map[provider.Category]provider.Category{"mobile": "mobile"},
+			names:    "its own prerequisite",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewRegistry(requiresChain{
+				Adapter: NewOfflineProvider(0, time.Now), requires: c.requires,
+			})
+			if err == nil {
+				t.Fatal("an adapter declaring a prerequisite graph deeper than one hop registered: every " +
+					"reader walks one hop, so its purchases are priced and requested short")
+			}
+			if !strings.Contains(err.Error(), c.names) {
+				t.Errorf("the refusal does not name what is wrong, so an author cannot act on it: %v", err)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/integrations/runcategories.go
+++ b/backend/internal/modules/integrations/runcategories.go
@@ -14,6 +14,7 @@ package integrations
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
 )
@@ -64,7 +65,45 @@ func runCategories(desc provider.Descriptor, conn admittedConnection, in provide
 	if err := requireCascadeTriggers(desc, asked); err != nil {
 		return nil, err
 	}
+	if err := requirePrerequisites(desc, asked); err != nil {
+		return nil, err
+	}
 	return out, nil
+}
+
+// requirePrerequisites refuses a category asked for without the one that has
+// to come back with something first.
+//
+// Surfe's mobile lookup is the worked case, and it is the one that shipped
+// broken. The adapter always sends skipMobileEnrichmentIfNoEmailFound, so a
+// request naming mobile and nothing else makes the vendor hunt for an email it
+// was never asked to buy, fail to find one, and skip the number entirely. The
+// run comes back COMPLETED and empty. Nothing along the way looks wrong — no
+// refusal, no error, a successful run — and the page reports that the contact
+// was found while the field stays blank.
+//
+// Refused rather than silently widened, for the reason requireCascadeTriggers
+// gives above: adding professional_email would buy a category the caller did
+// not ask for and charge them for it. They name both, or neither.
+//
+// The map is walked in sorted order so a request breaking two of these rules
+// names the same one every time. An error that varies between identical calls
+// reads as intermittent to whoever is looking at it.
+func requirePrerequisites(desc provider.Descriptor, asked map[provider.Category]bool) error {
+	categories := make([]string, 0, len(desc.RequiresAnswerTo))
+	for category := range desc.RequiresAnswerTo {
+		categories = append(categories, string(category))
+	}
+	sort.Strings(categories)
+	for _, name := range categories {
+		category := provider.Category(name)
+		prerequisite := desc.RequiresAnswerTo[category]
+		if asked[category] && !asked[prerequisite] {
+			return fmt.Errorf("%w: %q is only looked up when %q comes back with something, so it cannot be bought without it",
+				ErrCategoryNotPermitted, category, prerequisite)
+		}
+	}
+	return nil
 }
 
 // requireCascadeTriggers refuses a fallback asked for without the category it

--- a/backend/internal/modules/integrations/runcategories.go
+++ b/backend/internal/modules/integrations/runcategories.go
@@ -47,7 +47,31 @@ func runCategories(desc provider.Descriptor, conn admittedConnection, in provide
 	}
 	requested := in.Categories
 	if len(requested) == 0 {
-		return permitted, nil
+		// The caller named nothing, so the connection's own selection is the
+		// request — and it has to survive the same two rules, because an admin
+		// choosing categories on a settings card is not asked to know which of
+		// them the provider only issues alongside another.
+		//
+		// DROPPED rather than refused, unlike the named path below. Nobody made
+		// a mistake here: the caller asked for "whatever this connection buys",
+		// and answering that with a 422 about a category they never typed would
+		// make the plain lookup button unusable on a connection an admin is
+		// perfectly entitled to configure. What is dropped could not have been
+		// answered anyway — a mobile lookup with no email to anchor it comes
+		// back empty and is charged for.
+		issuable := askable(desc, permitted)
+		if len(issuable) == 0 {
+			// Everything the connection selects depends on something it does
+			// not. Dispatching the empty remainder would send a request naming
+			// no categories, which the provider answers with a refusal — and a
+			// refusal flips the connection's status, breaking every later
+			// lookup over one configuration choice. The same reason the
+			// automatic path above refuses rather than sending nothing.
+			return nil, fmt.Errorf(
+				"%w: every category this connection selects is one the provider only issues alongside another it does not select",
+				ErrCategoryNotPermitted)
+		}
+		return issuable, nil
 	}
 	allowed := make(map[provider.Category]bool, len(permitted))
 	for _, c := range permitted {
@@ -69,6 +93,41 @@ func runCategories(desc provider.Descriptor, conn admittedConnection, in provide
 		return nil, err
 	}
 	return out, nil
+}
+
+// askable drops from a set the categories the provider would not issue for it:
+// a fallback whose trigger is absent, and one whose prerequisite is absent.
+//
+// The set is otherwise kept in order and whole. Dropping is right only where
+// nobody chose the combination — see the caller — and it is the same question
+// requireCascadeTriggers and requirePrerequisites ask, answered by removal
+// instead of refusal.
+func askable(desc provider.Descriptor, categories []provider.Category) []provider.Category {
+	present := make(map[provider.Category]bool, len(categories))
+	for _, c := range categories {
+		present[c] = true
+	}
+	drop := map[provider.Category]bool{}
+	for _, cascade := range desc.Cascades {
+		if present[cascade.Category] && !present[cascade.After] {
+			drop[cascade.Category] = true
+		}
+	}
+	for category, prerequisite := range desc.RequiresAnswerTo {
+		if present[category] && !present[prerequisite] {
+			drop[category] = true
+		}
+	}
+	if len(drop) == 0 {
+		return categories
+	}
+	out := make([]provider.Category, 0, len(categories))
+	for _, c := range categories {
+		if !drop[c] {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // requirePrerequisites refuses a category asked for without the one that has

--- a/backend/internal/modules/integrations/runcategories.go
+++ b/backend/internal/modules/integrations/runcategories.go
@@ -149,7 +149,13 @@ func intersect(permitted, allowed []provider.Category) []provider.Category {
 // swallows it exactly as it swallows a trigger the policy does not admit.
 var ErrNothingFreeToBuy = errors.New("integrations: this connection buys nothing an automatic run may take")
 
-// ErrCategoryNotPermitted reports that a run asked for a category the
-// connection does not carry. A caller's mistake, not a provider condition: the
-// HTTP surface answers 422, because retrying it unchanged buys nothing.
-var ErrCategoryNotPermitted = errors.New("integrations: this connection does not buy that category")
+// ErrCategoryNotPermitted reports that a run asked for a combination it may
+// not buy: a category the connection does not carry, a fallback without its
+// trigger, or one that needs an answer from another first. A caller's mistake,
+// not a provider condition, so the HTTP surface answers 422 — retrying it
+// unchanged buys nothing.
+//
+// The sentinel says only that the purchase is refused; each wrapping message
+// says WHICH of the three it was, and the handler passes that through. Stating
+// one of the three here would contradict the other two in the same sentence.
+var ErrCategoryNotPermitted = errors.New("integrations: that is not a purchase this run can make")

--- a/backend/internal/modules/integrations/runcategories_test.go
+++ b/backend/internal/modules/integrations/runcategories_test.go
@@ -12,6 +12,7 @@ package integrations
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
@@ -157,5 +158,78 @@ func TestAFallbackCannotBeBoughtWithoutTheCategoryItFollows(t *testing.T) {
 	// the one outcome this must not allow.
 	if !errors.Is(err, ErrCategoryNotPermitted) {
 		t.Errorf("err = %v, want the fallback refused without its trigger", err)
+	}
+}
+
+// A category the provider only looks up when something else came back cannot
+// be bought on its own.
+//
+// The defect this pins is the one a customer actually hit. Surfe's adapter
+// always sends skipMobileEnrichmentIfNoEmailFound, so a request naming mobile
+// alone makes the vendor hunt for an email nobody bought, fail, and skip the
+// number. The run returns COMPLETED with no claims: no refusal, no error, a
+// successful run — and the page reports the contact as found while the mobile
+// field stays empty. Two of these were bought for one contact on consecutive
+// days and neither could ever have produced a number.
+func TestACategoryNeedingAnAnswerFirstCannotBeBoughtAlone(t *testing.T) {
+	desc := pricedDescriptor()
+	desc.RequiresAnswerTo = map[provider.Category]provider.Category{
+		"mobile": "professional_email",
+	}
+	conn := connectionBuying("professional_email", "mobile")
+
+	_, err := runCategories(desc, conn, provider.QueueInput{
+		Trigger:    provider.TriggerManual,
+		Categories: []provider.Category{"mobile"},
+	})
+
+	if !errors.Is(err, ErrCategoryNotPermitted) {
+		t.Fatalf("err = %v, want mobile refused without the email it depends on", err)
+	}
+	// The message has to name BOTH halves: a reader told only that mobile was
+	// refused cannot tell what to add.
+	if msg := err.Error(); !strings.Contains(msg, "mobile") || !strings.Contains(msg, "professional_email") {
+		t.Errorf("the refusal does not name both categories, so nobody can act on it: %v", err)
+	}
+}
+
+// The same pair bought TOGETHER goes through. Without this case the rule above
+// passes against a guard that refuses mobile outright, which would take the
+// working purchase away with the broken one.
+func TestTheDependentPairIsBoughtTogether(t *testing.T) {
+	desc := pricedDescriptor()
+	desc.RequiresAnswerTo = map[provider.Category]provider.Category{
+		"mobile": "professional_email",
+	}
+	conn := connectionBuying("professional_email", "mobile")
+
+	got, err := runCategories(desc, conn, provider.QueueInput{
+		Trigger:    provider.TriggerManual,
+		Categories: []provider.Category{"professional_email", "mobile"},
+	})
+	if err != nil {
+		t.Fatalf("naming both categories was refused: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("got %v, want both categories — the run must ask for the pair it priced", got)
+	}
+}
+
+// A provider declaring no prerequisite is unaffected. The rule reads the
+// descriptor, so an adapter that never fills the map keeps today's behaviour
+// rather than acquiring a constraint its vendor does not have.
+func TestAProviderWithoutPrerequisitesBuysWhatItLikes(t *testing.T) {
+	desc := pricedDescriptor()
+	conn := connectionBuying("mobile")
+
+	got, err := runCategories(desc, conn, provider.QueueInput{
+		Trigger:    provider.TriggerManual,
+		Categories: []provider.Category{"mobile"},
+	})
+	if err != nil {
+		t.Fatalf("a provider declaring no prerequisite refused a lone category: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("got %v, want just the one category asked for", got)
 	}
 }

--- a/backend/internal/modules/integrations/runcategories_test.go
+++ b/backend/internal/modules/integrations/runcategories_test.go
@@ -233,3 +233,68 @@ func TestAProviderWithoutPrerequisitesBuysWhatItLikes(t *testing.T) {
 		t.Errorf("got %v, want just the one category asked for", got)
 	}
 }
+
+// A run naming NO categories takes the connection's selection — and that
+// selection has to survive the same rules, because an admin ticking boxes on a
+// settings card is not asked to know which the provider only issues alongside
+// another.
+//
+// The defect: the guard above sat behind an early return for the empty request,
+// so a connection selecting only the mobile queued exactly the broken
+// mobile-only run through the API's own documented default.
+func TestTheConnectionsOwnSelectionIsNarrowedToWhatCanBeAsked(t *testing.T) {
+	desc := pricedDescriptor()
+	desc.RequiresAnswerTo = map[provider.Category]provider.Category{
+		"mobile": "professional_email",
+	}
+	// The admin ticked the mobile and the free ones, and left the work email
+	// off — a configuration nothing forbids.
+	conn := connectionBuying("linkedin_profile", "mobile")
+
+	got, err := runCategories(desc, conn, provider.QueueInput{Trigger: provider.TriggerManual})
+	if err != nil {
+		t.Fatalf("a plain lookup was refused over a category nobody typed: %v", err)
+	}
+	for _, c := range got {
+		if c == "mobile" {
+			t.Errorf("got %v — the mobile is still asked for without the email it needs, which is the "+
+				"request that comes back completed and empty", got)
+		}
+	}
+	if len(got) != 1 || got[0] != "linkedin_profile" {
+		t.Errorf("got %v, want just linkedin_profile: what the provider CAN answer must survive", got)
+	}
+}
+
+// Dropping must not empty the request. A connection whose every selection
+// depends on something it does not select is refused, because a request naming
+// no categories is one the provider answers with a refusal — and that flips the
+// connection's status, breaking every later lookup over one configuration.
+func TestAConnectionWhoseWholeSelectionIsUnaskableIsRefused(t *testing.T) {
+	desc := pricedDescriptor()
+	desc.RequiresAnswerTo = map[provider.Category]provider.Category{
+		"mobile": "professional_email",
+	}
+	conn := connectionBuying("mobile")
+
+	_, err := runCategories(desc, conn, provider.QueueInput{Trigger: provider.TriggerManual})
+	if !errors.Is(err, ErrCategoryNotPermitted) {
+		t.Fatalf("err = %v, want a refusal: dispatching the empty remainder sends a request naming no "+
+			"categories, and the refusal that comes back marks the connection broken", err)
+	}
+}
+
+// A selection with no dependencies at all is returned untouched, so the
+// narrowing above cannot quietly shrink an ordinary connection.
+func TestAnUnencumberedSelectionIsReturnedWhole(t *testing.T) {
+	desc := pricedDescriptor()
+	conn := connectionBuying("linkedin_profile", "professional_email", "mobile")
+
+	got, err := runCategories(desc, conn, provider.QueueInput{Trigger: provider.TriggerManual})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Errorf("got %v, want all three — a provider declaring no prerequisites loses nothing", got)
+	}
+}

--- a/backend/internal/modules/integrations/store.go
+++ b/backend/internal/modules/integrations/store.go
@@ -124,17 +124,21 @@ func NewStore(db *database.DB, vault keyvault.Vault, reg *Registry, now func() t
 	return &Store{db: db, vault: vault, registry: reg, now: now}, nil
 }
 
-// Connection is one provider's connection as the surfaces read it. It carries
-// no credential material and no vault reference — only whether a key is
-// present at all.
 // CategoryCost is one category's price, as the settings card and a buy button
 // read it.
 type CategoryCost struct {
 	Category string
 	Free     bool
 	Cost     map[string]int
+	// Requires names another category this one is only looked up alongside,
+	// empty when there is none. A buy button asks for both or neither, and
+	// Cost above is already the price of the pair.
+	Requires string
 }
 
+// Connection is one provider's connection as the surfaces read it. It carries
+// no credential material and no vault reference — only whether a key is
+// present at all.
 type Connection struct {
 	Provider string
 	// Catalog is what this provider sells, with what each entry costs.
@@ -371,25 +375,35 @@ func catalogOf(d provider.Descriptor) []CategoryCost {
 			Category: string(category),
 			Free:     free[category],
 			Cost:     priced,
+			Requires: string(d.RequiresAnswerTo[category]),
 		})
 	}
 	return out
 }
 
 // pricedWith is the category set whose worst case is the true price of asking
-// for one category: itself, plus the trigger of any cascade it is the fallback
-// for.
+// for one category: itself, the trigger of any cascade it is the fallback for,
+// and the category it needs an answer from.
 //
-// ONE hop. No adapter declares a cascade whose trigger is itself a fallback,
-// and a chain would need this to walk it — said here rather than built for,
-// because the descriptor that needed it would also be the one to prove what
-// walking should cost.
+// The prerequisite is priced in for the same reason as the cascade trigger,
+// and here it is not even conditional: the run cannot be bought without it
+// (requirePrerequisites refuses the lone request), so a button pricing mobile
+// on its own would state one figure and spend two. Price and request name the
+// same set, or the number on the button is a lie.
+//
+// ONE hop each. No adapter declares a cascade whose trigger is itself a
+// fallback, nor a prerequisite carrying its own — said here rather than built
+// for, because the descriptor that needed it would also be the one to prove
+// what walking should cost.
 func pricedWith(d provider.Descriptor, category provider.Category) []provider.Category {
 	out := []provider.Category{category}
 	for _, cascade := range d.Cascades {
 		if cascade.Category == category {
 			out = append(out, cascade.After)
 		}
+	}
+	if prerequisite, ok := d.RequiresAnswerTo[category]; ok {
+		out = append(out, prerequisite)
 	}
 	return out
 }

--- a/backend/internal/shared/ports/provider/worstcase.go
+++ b/backend/internal/shared/ports/provider/worstcase.go
@@ -130,6 +130,13 @@ func PoolsInLockOrder(cost map[Pool]int) []Pool {
 // A cascade's cost counts. A category that is free to request but triggers a
 // charged fallback is not free, and calling it so would put a spend behind a
 // switch labelled "costs nothing".
+//
+// A prerequisite's cost counts for the same reason, and more directly: a
+// category the provider only issues alongside another cannot be requested
+// without it at all, so its true price includes that one. Free without this,
+// such a category would be bought automatically for every new contact and
+// charge the prerequisite's pool each time — a spend nobody authorized,
+// against a switch that promised none.
 func (d Descriptor) Free() []Category {
 	charged := map[Category]bool{}
 	for category, pools := range d.CostTable {
@@ -144,6 +151,11 @@ func (d Descriptor) Free() []Category {
 			if n > 0 {
 				charged[cascade.Category] = true
 			}
+		}
+	}
+	for category, prerequisite := range d.RequiresAnswerTo {
+		if charged[prerequisite] {
+			charged[category] = true
 		}
 	}
 	free := []Category{}

--- a/backend/internal/shared/ports/provider/worstcase_test.go
+++ b/backend/internal/shared/ports/provider/worstcase_test.go
@@ -60,3 +60,54 @@ func TestFreeKeepsTheDescriptorsOwnOrder(t *testing.T) {
 		}
 	}
 }
+
+// A category the provider only issues alongside a PRICED one is not free.
+//
+// The free set is what automatic enrichment spends on nobody's say-so, for
+// every new contact. A category counted free here but carrying a priced
+// prerequisite would be requested automatically and charge that prerequisite's
+// pool every time — a spend nobody authorized, behind a switch that promised
+// none. The cascade arm already reasons this way; this is the same argument
+// about the other dependency the descriptor can declare.
+func TestACategoryNeedingAPricedAnswerIsNotFree(t *testing.T) {
+	t.Parallel()
+	d := provider.Descriptor{
+		Categories: []provider.Category{"work_email", "verified_role"},
+		CostTable: map[provider.Category]map[provider.Pool]int{
+			"work_email":    {"email": 1},
+			"verified_role": {},
+		},
+		RequiresAnswerTo: map[provider.Category]provider.Category{
+			"verified_role": "work_email",
+		},
+	}
+
+	for _, c := range d.Free() {
+		if c == "verified_role" {
+			t.Error("a category that cannot be requested without a priced one is advertised as free, so " +
+				"automatic enrichment buys it for every contact and charges the other one's pool each time")
+		}
+	}
+}
+
+// The prerequisite being free leaves the dependent free too, so the rule above
+// does not simply mark everything with a dependency as priced.
+func TestACategoryNeedingAFreeAnswerStaysFree(t *testing.T) {
+	t.Parallel()
+	d := provider.Descriptor{
+		Categories: []provider.Category{"profile", "role"},
+		CostTable: map[provider.Category]map[provider.Pool]int{
+			"profile": {},
+			"role":    {},
+		},
+		RequiresAnswerTo: map[provider.Category]provider.Category{"role": "profile"},
+	}
+
+	free := map[provider.Category]bool{}
+	for _, c := range d.Free() {
+		free[c] = true
+	}
+	if !free["role"] || !free["profile"] {
+		t.Errorf("free = %v, want both: a dependency on something that costs nothing costs nothing", d.Free())
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -14160,6 +14160,8 @@ export interface components {
             cost: {
                 [key: string]: number;
             };
+            /** @description Another category this one is only looked up alongside, because the provider skips it entirely when that one comes back empty. Surfe's mobile lookup is the case: asked for on its own it makes the vendor hunt for an email nobody bought, fail, and skip the number — returning a run that COMPLETED with nothing in it. A buy button asks for both or neither; the server refuses the lone request. */
+            requires?: string | null;
         };
         /** @description How much of the installation is still waiting to be looked up once, and whether the sweep is moving. A count without the paused flag reads as progress that has stalled; the two together say whether waiting is the right thing to do. */
         ProviderLookupBacklog: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7026,7 +7026,8 @@ export const de = {
   "provider.profile.departments": "Bereiche",
   "provider.profile.seniorities": "Ebene",
   "provider.profile.notRequested": "Nie angefragt: {categories}.",
-  "provider.profile.buy": "{category} kaufen · {credits} Credit",
+  "provider.profile.buy_one": "{category} kaufen · {credits} Credit",
+  "provider.profile.buy_other": "{category} kaufen · {credits} Credits",
   "provider.freeTier.hint":
     "LinkedIn-Profil, aktuelle Rolle und Werdegang kosten keine Credits. Am besten anlassen: jeder neue Kontakt bekommt sie, ohne dass jemand entscheiden muss.",
   "provider.pricedTier.hint":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7081,7 +7081,8 @@ export const en = {
   // exactly like one that returned all six, and nothing on the page said when
   // the answer arrived.
   // The price rides the button because the decision IS the spend.
-  "provider.profile.buy": "Buy {category} · {credits} credit",
+  "provider.profile.buy_one": "Buy {category} · {credits} credit",
+  "provider.profile.buy_other": "Buy {category} · {credits} credits",
   "provider.freeTier.hint":
     "LinkedIn profile, current role and work history cost no credits. Leave this on: every new contact gets them without anybody deciding.",
   "provider.pricedTier.hint":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6947,7 +6947,8 @@ export const vi = {
   "provider.profile.departments": "Bộ phận",
   "provider.profile.seniorities": "Cấp bậc",
   "provider.profile.notRequested": "Chưa bao giờ hỏi tới: {categories}.",
-  "provider.profile.buy": "Mua {category} · {credits} tín dụng",
+  "provider.profile.buy_one": "Mua {category} · {credits} tín dụng",
+  "provider.profile.buy_other": "Mua {category} · {credits} tín dụng",
   "provider.freeTier.hint":
     "Hồ sơ LinkedIn, vai trò hiện tại và quá trình làm việc không tốn tín dụng. Nên bật: mọi liên hệ mới đều có chúng mà không ai phải quyết định.",
   "provider.pricedTier.hint":

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -422,7 +422,18 @@ describe("the details that cost credits", () => {
     },
   ];
 
-  function mountWithCatalog(profile: Profile, run: () => Response) {
+  function mountWithCatalog(
+    profile: Profile,
+    run: () => Response,
+    // Which categories the admin has switched on. The default is all three,
+    // which is what almost every case wants; a case about the SELECTION says
+    // so here rather than building a second stub beside this one.
+    categories: Record<string, boolean> = {
+      linkedin_profile: true,
+      professional_email: true,
+      mobile: true,
+    },
+  ) {
     const posted: unknown[] = [];
     installFetchStub({
       "GET /me": meRoute({ person: ["read", "update"] }),
@@ -434,13 +445,7 @@ describe("the details that cost credits", () => {
               status: "connected",
               credential_present: true,
               catalog,
-              configuration: {
-                categories: {
-                  linkedin_profile: true,
-                  professional_email: true,
-                  mobile: true,
-                },
-              },
+              configuration: { categories },
               credits: { pools: {} },
               version: 1,
               created_at: "2026-08-20T09:00:00Z",

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -407,10 +407,19 @@ describe("a lookup that came back mostly empty", () => {
 });
 
 describe("the details that cost credits", () => {
+  // Surfe's real shape: the mobile lookup is only issued when a work email
+  // comes back, so its price is the PAIR and `requires` names the other half.
+  // A fixture pricing it alone would model a provider that does not exist and
+  // would let the button send the request the server now refuses.
   const catalog = [
     { category: "linkedin_profile", free: true, cost: {} },
     { category: "professional_email", free: false, cost: { email: 1 } },
-    { category: "mobile", free: false, cost: { mobile: 1 } },
+    {
+      category: "mobile",
+      free: false,
+      cost: { mobile: 1, email: 1 },
+      requires: "professional_email",
+    },
   ];
 
   function mountWithCatalog(profile: Profile, run: () => Response) {
@@ -500,9 +509,13 @@ describe("the details that cost credits", () => {
     expect(
       await screen.findByRole("button", { name: /Buy work email · 1 credit/ }),
     ).toBeDefined();
+    // The mobile button names BOTH halves and the price of both. The provider
+    // will not look for a number without an email to anchor it, so a button
+    // offering "mobile, 1 credit" would promise a purchase that cannot happen
+    // and understate what it spends.
     expect(
       await screen.findByRole("button", {
-        name: /Buy mobile number · 1 credit/,
+        name: /Buy work email, mobile number · 2 credits/,
       }),
     ).toBeDefined();
 
@@ -518,8 +531,11 @@ describe("the details that cost credits", () => {
       queuedRun,
     );
 
+    // Anchored on the price, because the mobile button names the work email
+    // too — it cannot be bought without one — and a loose /Buy work email/
+    // matches both.
     await user.click(
-      await screen.findByRole("button", { name: /Buy work email/ }),
+      await screen.findByRole("button", { name: /Buy work email · 1 credit/ }),
     );
 
     // One category, named. A press that sent the connection's whole selection
@@ -528,6 +544,31 @@ describe("the details that cost credits", () => {
     expect(posted[0]).toEqual({
       provider: "surfe",
       categories: ["professional_email"],
+    });
+  });
+
+  it("buys the email with the mobile, because the provider will not look for one without it", async () => {
+    const user = userEvent.setup();
+    const posted = mountWithCatalog(
+      { ...neverRun(), state: "completed" },
+      queuedRun,
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: /Buy work email, mobile number · 2 credits/,
+      }),
+    );
+
+    // BOTH categories, and the email first. Surfe always sends
+    // skipMobileEnrichmentIfNoEmailFound, so a request naming the mobile alone
+    // makes it hunt for an email nobody bought, fail, and skip the number —
+    // returning a run that COMPLETED with nothing in it. The server refuses
+    // that request now; this is what stops the button making it.
+    await expect.poll(() => posted.length).toBe(1);
+    expect(posted[0]).toEqual({
+      provider: "surfe",
+      categories: ["professional_email", "mobile"],
     });
   });
 

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -17,7 +17,7 @@ import {
   providerBrandName,
 } from "../design-system/provider-mark";
 import { formatDateAbbrev, formatNumber } from "../format/format";
-import { type Locale, useLocale, useT } from "../i18n";
+import { type Locale, useLocale, usePlural, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
 import { categoryNames } from "./provider-categories";
 import {
@@ -287,6 +287,7 @@ function BuyPriced({
   running: boolean;
 }>) {
   const t = useT();
+  const plural = usePlural();
   const { locale } = useLocale();
   const connections = useProviderConnections();
   const connection = connections.data?.connections.find(
@@ -316,18 +317,35 @@ function BuyPriced({
             enrich.mutate({
               personId,
               provider: profile.provider,
-              categories: [entry.category],
+              categories: boughtWith(entry),
             })
           }
         >
-          {t("provider.profile.buy", {
-            category: categoryNames([entry.category], t),
+          {plural("provider.profile.buy", creditsOf(entry), {
+            category: categoryNames(boughtWith(entry), t),
             credits: formatNumber(creditsOf(entry), locale),
           })}
         </Button>
       ))}
     </div>
   );
+}
+
+/** What one press actually asks for: the category, and the one it can only be
+ *  looked up alongside.
+ *
+ *  Surfe's mobile lookup is the case. Asked for on its own, the provider hunts
+ *  for an email nobody bought, fails, and skips the number — returning a run
+ *  that COMPLETED with nothing in it, which the page then reports as a
+ *  successful lookup over an empty field. The server refuses the lone request
+ *  now; this is what stops the button making it.
+ *
+ *  `entry.cost` is already the price of the pair, so the figure beside this
+ *  needs no adjusting — the two are derived from one descriptor rule. */
+function boughtWith(
+  entry: components["schemas"]["ProviderCategoryCost"],
+): string[] {
+  return entry.requires ? [entry.requires, entry.category] : [entry.category];
 }
 
 /** The credits one category costs, summed across pools. A category priced in

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -293,12 +293,20 @@ function BuyPriced({
   const connection = connections.data?.connections.find(
     (c) => c.provider === profile.provider,
   );
-  // Only what this connection actually carries: a category an admin switched
-  // off is not one to offer, and the server would refuse it anyway.
+  // Only what this connection actually carries, asked of EVERY category the
+  // press would send — not just the one on the button.
+  //
+  // A category with a prerequisite sends both, so a connection with the mobile
+  // switched on and the work email switched off would otherwise show a
+  // two-credit button whose request the server refuses every time. The comment
+  // that used to sit here said "the server would refuse it anyway"; that only
+  // stays true if this asks about the same set the press does.
+  const enabled = (category: string) =>
+    connection?.configuration.categories?.[category] ?? false;
   const buyable = (connection?.catalog ?? []).filter(
     (entry) =>
       !entry.free &&
-      (connection?.configuration.categories?.[entry.category] ?? false) &&
+      boughtWith(entry).every(enabled) &&
       !alreadyHeld(profile, entry.category),
   );
   if (buyable.length === 0 || !canEnrichNow(profile.state, running)) {


### PR DESCRIPTION
The rule holds on the paths the first cut missed

Four gaps, all found by review, all reachable.

A manual run naming NO categories returned the connection's selection before
either dependency check ran. A connection with the mobile switched on then
queued the exact broken mobile-only request through the API's own default path
— reproduced live. The selection is now narrowed to what the provider would
actually issue: dropped rather than refused, because nobody typed the offending
category and a 422 about it would make the plain lookup button unusable on a
configuration an admin is entitled to choose. A selection that narrows to
nothing IS refused, for the reason the automatic path already refuses: an empty
request is one the provider answers with a refusal, and that flips the
connection's status for every later lookup.

The buy row checked only the button's own category while the press sends its
prerequisite too, so a connection with the mobile on and the work email off
showed a two-credit button whose request the server refuses every time. It now
asks about the whole set the press would send.

Free() counted a cascade's cost but not a prerequisite's. A free category
needing a priced one read as free — and automatic enrichment buys everything
free, for every new contact, so it would have charged the prerequisite's pool
each time behind a switch that promises no spend. No shipped adapter declares
that shape; the next one would have.

Prerequisite chains and cycles are refused at registration. Every reader walks
one hop, which is right for what adapters declare and silently short over a
chain: A's button would quote and send A+B and the server would refuse it for
missing C. Refused where the author can see it rather than teaching four call
sites to walk a graph nobody has written.

No frontend test for the buy-row fix. Three attempts passed with the guard
removed — the panel renders no buy row in that fixture for reasons of its own,
so the absence they assert is not the rule. Shipping a test that passes either
way is worse than shipping none; the behaviour is verified against a running
server instead, and the gap is stated here rather than papered over.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

The refusal says which of the three purchases it refused

writeRunError replaced every ErrCategoryNotPermitted with one sentence: "this
connection does not buy that category". That was true when the sentinel had one
meaning. It now has three — a category the connection does not carry, a
fallback without its trigger, a category needing an answer from another — and
for two of them the sentence is false. A reader told the connection does not
buy mobile, on a connection whose own catalog lists mobile, has nothing to act
on.

So the store's own message is passed through. Each one names the category keys
the same caller already reads off the catalog: no vendor prose, no identifier,
nothing internal.

The sentinel's own text moves with it. It said one of the three, which
contradicted the other two in the same line — the live 422 read "this
connection does not buy that category: mobile is only looked up when
professional_email comes back". It now says only that the purchase was refused,
and the wrapping message says which.

---

Found from a live report: a contact was bought a mobile number twice on consecutive days and got nothing both times, while the page said "Found". Across 1045 contacts, no `mobile_phones` or `professional_emails` claim had ever been stored. Verified on a running stack: the pair now completes and `+49…` lands on the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A mobile number is no longer bought without the email it depends on, closing every path that could queue a lookup the provider always answers empty. A real contact was bought a mobile number twice on consecutive days and got nothing both times while the page said "Found."

**Bug Fixes**
- The buy button now sends the prerequisite email with the mobile and prices the pair; the server refuses the lone request.
- Manual runs naming no categories now drop selections the provider will not issue, and refuse when nothing is left.
- Automatic enrichment no longer treats a category with a priced prerequisite as free, so it cannot spend the prerequisite's pool behind a free switch.
- Prerequisite chains and cycles are refused at adapter registration, since every reader walks one hop.
- Refusal messages now name which purchase was refused instead of a generic sentence.

<sup>Written for commit ec6e28107bbb453c4a1687f9dc6813b34a048d35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for category prerequisites, ensuring related categories are requested and purchased together.
  * Catalogs now display prerequisite relationships and combined pricing.
  * Provider purchases show all required categories and use correct singular/plural credit labels.

* **Bug Fixes**
  * Prevented invalid prerequisite chains and unsupported standalone requests.
  * Improved automatic category selection by excluding categories that cannot be requested safely.
  * Error messages now provide clearer, sanitized details when a category is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->