### PR TITLE
fix(prefs): the rows say what is true, and an always-on row is on

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4923,6 +4923,8 @@ export const de = {
   "prefs.purpose.marketing_email": "Produktneuigkeiten",
   "prefs.purpose.transactional": "Sicherheit & laufende Vorgänge",
   "prefs.sentVia": "Gesendet über Margince",
+  "prefs.noObjection": "An — du hast dem nicht widersprochen",
+  "prefs.optedOut": "Aus — du hast uns gebeten, damit aufzuhören",
   "prefs.invalidLink":
     "Dieser Link ist nicht mehr gültig. Präferenz-Links laufen ab oder können widerrufen werden — frag in einer aktuellen E-Mail nach einem neuen.",
   "buyer.opening": "Ihr Deal Room wird geöffnet …",
@@ -5020,9 +5022,7 @@ export const de = {
     "Dieses Briefing konnte nicht gelesen werden. Seite neu laden oder neu schreiben.",
   "prefs.rateLimited":
     "Gerade zu viele Versuche von hier aus. Warte eine Minute und lade neu.",
-  "prefs.subscribed": "Abonniert",
-  "prefs.notSubscribed":
-    "Nicht abonniert — du bekommst für diesen Zweck nichts",
+  "prefs.subscribed": "An — du hast danach gefragt",
   "prefs.alwaysOn": "immer an",
   "confirm.title": "Ihre Daten",
   "confirm.intro":
@@ -5050,9 +5050,10 @@ export const de = {
     "Ich habe Ihre Antwort erfasst. Änderungen gehen an eine Person hier zur Übernahme, und dieser Link ist jetzt verbraucht.",
   "confirm.invalidLink":
     "Dieser Link ist nicht mehr gültig. Er wurde möglicherweise schon benutzt oder ist abgelaufen.",
-  "prefs.lockedWhy": "Transaktional — von der Abmeldung ausgenommen.",
+  "prefs.lockedWhy":
+    "Gehört zu etwas, das du angefordert hast, und bleibt deshalb an.",
   "prefs.confirmationNeededWhy":
-    "Um dies zu erhalten, nutzen Sie den Bestätigungslink aus unserer E-Mail. Abbestellen können Sie hier jederzeit.",
+    "Zum Einschalten nutze den Bestätigungslink aus unserer E-Mail. Ausschalten kannst du es hier jederzeit.",
   "prefs.notSaved": "Noch nicht gespeichert.",
   "prefs.savePending": "Ausstehend: {changes}.",
   "prefs.saveProof":
@@ -5069,9 +5070,9 @@ export const de = {
   "prefs.wording.marketing_email":
     "„Schick mir Produkt-Updates und gelegentliche Marketing-E-Mails.“",
   "prefs.wording.events": "„Schick mir Einladungen zu Events und Webinaren.“",
-  "prefs.unsubscribeAll": "Von allem Marketing abmelden",
+  "prefs.unsubscribeAll": "Alles abschalten, was ich abschalten kann",
   "prefs.unsubscribeAllHint":
-    "Lieber alle nicht notwendigen Mails auf einmal stoppen? Transaktionale Nachrichten bekommst du weiterhin.",
+    "Das schaltet jede Zeile oben aus, die ein anklickbares Kästchen hat. Zeilen mit IMMER AN bleiben an — die brauchst du für Dinge, die du selbst angefordert hast.",
   "prefs.oneClickDone":
     "Erledigt — du bekommst keine Marketing-E-Mails mehr von uns. Das gilt sofort für jede Kampagne.",
   "prefs.oneClickAlreadyOff": "Nichts zu tun — das war bereits abgeschaltet.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4990,6 +4990,8 @@ export const en = {
   "prefs.purpose.marketing_email": "Product news",
   "prefs.purpose.transactional": "Security & service messages",
   "prefs.sentVia": "Sent via Margince",
+  "prefs.noObjection": "On — you have not objected to these",
+  "prefs.optedOut": "Off — you asked us to stop these",
   "prefs.invalidLink":
     "This link is no longer valid. Preference links expire and can be withdrawn — ask for a fresh one from any recent email.",
   "buyer.opening": "Opening your Deal Room…",
@@ -5084,9 +5086,7 @@ export const en = {
     "This briefing could not be read. Reload the page, or write it again.",
   "prefs.rateLimited":
     "Too many attempts from here just now. Wait a minute and reload.",
-  "prefs.subscribed": "Subscribed",
-  "prefs.notSubscribed":
-    "Not subscribed — you receive nothing for this purpose",
+  "prefs.subscribed": "On — you asked for these",
   "prefs.alwaysOn": "always on",
   // The public confirm-your-details page. Margince speaks in first person here,
   // as it does in onboarding: short flat sentences, says what it will and will
@@ -5117,9 +5117,9 @@ export const en = {
     "I have recorded your answer. Anything you changed goes to a person here to apply, and this link is now used up.",
   "confirm.invalidLink":
     "This link is no longer valid. It may have been used already, or it may have expired.",
-  "prefs.lockedWhy": "Transactional — exempt from opt-out.",
+  "prefs.lockedWhy": "Needed for something you asked for, so it stays on.",
   "prefs.confirmationNeededWhy":
-    "To start receiving this, use the confirmation link we email you. You can stop it here at any time.",
+    "To switch this on, use the confirmation link in our email. You can switch it off here at any time.",
   "prefs.notSaved": "Not saved yet.",
   "prefs.savePending": "Pending: {changes}.",
   "prefs.saveProof":
@@ -5136,9 +5136,9 @@ export const en = {
   "prefs.wording.marketing_email":
     '"Send me product updates & occasional marketing email."',
   "prefs.wording.events": '"Send me event & webinar invitations."',
-  "prefs.unsubscribeAll": "Unsubscribe from all marketing",
+  "prefs.unsubscribeAll": "Stop everything I can switch off",
   "prefs.unsubscribeAllHint":
-    "Prefer to stop all non-essential mail at once? You'll still get transactional messages.",
+    "This switches off every row above that has a checkbox you can use. Rows marked ALWAYS ON stay on — you need them for things you asked for.",
   "prefs.oneClickDone":
     "Done — you're off our marketing email. It takes effect immediately across every campaign.",
   "prefs.oneClickAlreadyOff": "Nothing to do — these were already off.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4886,6 +4886,8 @@ export const vi = {
   "prefs.purpose.marketing_email": "Tin tức sản phẩm",
   "prefs.purpose.transactional": "Bảo mật và dịch vụ",
   "prefs.sentVia": "Được gửi qua Margince",
+  "prefs.noObjection": "Bật — bạn chưa phản đối",
+  "prefs.optedOut": "Tắt — bạn đã yêu cầu chúng tôi dừng",
   "prefs.invalidLink":
     "Liên kết này không còn hiệu lực. Liên kết tuỳ chọn sẽ hết hạn và có thể bị thu hồi — hãy lấy một liên kết mới từ bất kỳ email gần đây nào.",
   "buyer.opening": "Đang mở Deal Room của bạn…",
@@ -4980,8 +4982,7 @@ export const vi = {
     "Không đọc được bản tóm tắt này. Hãy tải lại trang hoặc viết lại.",
   "prefs.rateLimited":
     "Vừa có quá nhiều lần thử từ đây. Hãy đợi một phút rồi tải lại.",
-  "prefs.subscribed": "Đã đăng ký",
-  "prefs.notSubscribed": "Chưa đăng ký — bạn không nhận gì cho mục đích này",
+  "prefs.subscribed": "Bật — bạn đã yêu cầu",
   "prefs.alwaysOn": "luôn bật",
   "confirm.title": "Thông tin của bạn",
   "confirm.intro":
@@ -5009,9 +5010,9 @@ export const vi = {
     "Tôi đã ghi nhận câu trả lời của bạn. Những thay đổi sẽ được một người ở đây áp dụng, và liên kết này đã được dùng.",
   "confirm.invalidLink":
     "Liên kết này không còn hiệu lực. Có thể nó đã được dùng hoặc đã hết hạn.",
-  "prefs.lockedWhy": "Thư giao dịch — không thuộc diện từ chối nhận.",
+  "prefs.lockedWhy": "Cần cho việc bạn đã yêu cầu, nên vẫn bật.",
   "prefs.confirmationNeededWhy":
-    "Để bắt đầu nhận, hãy dùng liên kết xác nhận trong email của chúng tôi. Bạn có thể dừng nhận tại đây bất cứ lúc nào.",
+    "Để bật, hãy dùng liên kết xác nhận trong email của chúng tôi. Bạn có thể tắt ở đây bất cứ lúc nào.",
   "prefs.notSaved": "Chưa lưu.",
   "prefs.savePending": "Đang chờ: {changes}.",
   "prefs.saveProof":
@@ -5028,9 +5029,9 @@ export const vi = {
   "prefs.wording.marketing_email":
     '"Hãy gửi cho tôi tin cập nhật sản phẩm & email tiếp thị thỉnh thoảng."',
   "prefs.wording.events": '"Hãy gửi cho tôi lời mời sự kiện & webinar."',
-  "prefs.unsubscribeAll": "Huỷ đăng ký mọi thư tiếp thị",
+  "prefs.unsubscribeAll": "Tắt mọi thứ tôi có thể tắt",
   "prefs.unsubscribeAllHint":
-    "Muốn dừng toàn bộ thư không thiết yếu cùng lúc? Bạn vẫn nhận được thư giao dịch.",
+    "Thao tác này tắt mọi hàng phía trên có ô đánh dấu bạn dùng được. Các hàng ghi LUÔN BẬT vẫn bật — bạn cần chúng cho những việc chính bạn đã yêu cầu.",
   "prefs.oneClickDone":
     "Xong — bạn đã ra khỏi danh sách email tiếp thị. Việc này có hiệu lực ngay trên mọi chiến dịch.",
   "prefs.oneClickAlreadyOff": "Không cần làm gì — những mục này vốn đã tắt.",

--- a/frontend/src/screens/preferences.logic.test.ts
+++ b/frontend/src/screens/preferences.logic.test.ts
@@ -4,6 +4,7 @@ import {
   displayOn,
   initialDraft,
   type PurposeView,
+  rowIsOn,
   toChoices,
 } from "./preferences.logic";
 
@@ -78,10 +79,40 @@ const doiPurposes: PurposeView[] = [
 
 describe("display state", () => {
   // Default-deny: no record and a withdrawal both mean "we may not send".
-  it("reads only an explicit grant as subscribed", () => {
-    expect(displayOn("granted")).toBe(true);
-    expect(displayOn("withdrawn")).toBe(false);
-    expect(displayOn("unknown")).toBe(false);
+  // The rule the raw state cannot express. `state: unknown` is off for a
+  // lane somebody must opt INTO and ON for one they may object to, so the
+  // page reads the server's derived choice — reading `state` told a
+  // recipient they were "not subscribed" to ordinary replies, and drew an
+  // always-on row as switched off.
+  it("reads the recipient's decision, not the raw record", () => {
+    const at = (choice: PurposeView["choice"]): PurposeView => ({
+      key: "k",
+      label: "L",
+      state: "unknown",
+      locked: false,
+      grant_needs_confirmation: false,
+      can_opt_in: true,
+      choice,
+    });
+    expect(displayOn(at("opted_in"))).toBe(true);
+    expect(displayOn(at("no_objection"))).toBe(true);
+    expect(displayOn(at("opted_out"))).toBe(false);
+  });
+
+  // A locked row carries an "always on" badge and a disabled control, so
+  // any other value contradicts the badge beside it.
+  it("shows a locked purpose as on whatever the record says", () => {
+    const locked: PurposeView = {
+      key: "transactional",
+      label: "T",
+      state: "unknown",
+      locked: true,
+      grant_needs_confirmation: false,
+      can_opt_in: false,
+      choice: "no_objection",
+    };
+    expect(rowIsOn(locked, {})).toBe(true);
+    expect(rowIsOn(locked, { transactional: false })).toBe(true);
   });
 });
 
@@ -92,7 +123,9 @@ describe("draft diffing", () => {
       transactional: true,
       marketing_email: true,
       events: false,
-      research: false,
+      // no_objection: on, because nobody has objected to it. Reading the
+      // raw "unknown" here is what showed a live lane as switched off.
+      research: true,
     });
     expect(dirtyKeys(purposes, draft)).toEqual([]);
   });

--- a/frontend/src/screens/preferences.logic.ts
+++ b/frontend/src/screens/preferences.logic.ts
@@ -7,16 +7,34 @@ export type PurposeView =
 // key → subscribed. The toggle is binary; the wire state is ternary.
 export type Draft = Record<string, boolean>;
 
-// Default-deny: only an explicit grant is a subscription. "unknown" (no
-// record) and "withdrawn" both mean we may not send, so both read as off.
-export function displayOn(state: PurposeView["state"]): boolean {
-  return state === "granted";
+/**
+ * Whether this row reads as ON.
+ *
+ * It answers from the server's `choice`, never from the raw state, and
+ * the difference is the whole reason that field exists. `state` is
+ * `unknown` both for a marketing lane nobody opted into and for direct
+ * correspondence nobody has objected to — off in the first case, ON in
+ * the second — so a page reading the raw value told a reader they were
+ * "not subscribed" to ordinary replies their sender is entitled to send
+ * under legitimate interest, and showed an always-on lane as switched
+ * off.
+ *
+ * Only an explicit objection is off. That is the shape of the law the
+ * engine applies: consent lanes need a grant (which is what makes their
+ * choice `opted_out` until one exists), while correspondence and
+ * transactional mail run on a basis the recipient may object to rather
+ * than one they must first give.
+ */
+export function displayOn(purpose: PurposeView): boolean {
+  return purpose.choice !== "opted_out";
 }
 
 export function initialDraft(purposes: PurposeView[]): Draft {
   const draft: Draft = {};
   for (const purpose of purposes) {
-    draft[purpose.key] = displayOn(purpose.state);
+    // A locked row is on regardless of what the record says, so the draft
+    // starts where the row is drawn rather than where its raw state sits.
+    draft[purpose.key] = purpose.locked || displayOn(purpose);
   }
   return draft;
 }
@@ -36,7 +54,7 @@ export function dirtyKeys(purposes: PurposeView[], draft: Draft): string[] {
     .filter(
       (purpose) => !(purpose.grant_needs_confirmation && draft[purpose.key]),
     )
-    .filter((purpose) => draft[purpose.key] !== displayOn(purpose.state))
+    .filter((purpose) => draft[purpose.key] !== displayOn(purpose))
     .map((purpose) => purpose.key);
 }
 
@@ -90,4 +108,38 @@ export function labelOf(
 ): string {
   const key = PURPOSE_LABEL_KEYS[purpose.key];
   return key ? t(key) : purpose.label;
+}
+
+/**
+ * The sentence under a row, naming what is true rather than guessing.
+ *
+ * Three states, not two. "Subscribed" and "not subscribed" only describe
+ * a lane somebody opts INTO; applied to direct correspondence they told a
+ * reader they were "not subscribed" to the ordinary replies their sender
+ * is entitled to send, which is both wrong and alarming. A lane running
+ * on no objection says so.
+ */
+export function stateLineKey(purpose: PurposeView, on: boolean): MessageKey {
+  if (!on) {
+    return "prefs.optedOut";
+  }
+  return purpose.choice === "opted_in"
+    ? "prefs.subscribed"
+    : "prefs.noObjection";
+}
+
+/**
+ * Whether a row shows as on, draft included.
+ *
+ * A LOCKED row is on, full stop, and no draft entry can move it. It
+ * carries an "always on" badge and a disabled control, so rendering it
+ * unchecked said the opposite of the badge beside it — and the server
+ * refuses to change it either way, which makes any other value a claim
+ * the product cannot honour.
+ */
+export function rowIsOn(purpose: PurposeView, draft: Draft): boolean {
+  if (purpose.locked) {
+    return true;
+  }
+  return draft[purpose.key] ?? displayOn(purpose);
 }

--- a/frontend/src/screens/preferences.test.tsx
+++ b/frontend/src/screens/preferences.test.tsx
@@ -40,21 +40,41 @@ function render(ui: ReactNode) {
   );
 }
 
+// The fixture answers as the server does: `choice` is what the recipient
+// decided, derived there, and the page renders it rather than guessing
+// from `state`.
 const CENTER = {
+  masked_email: "m•••••@example.com",
+  workspace_name: "Demo Workspace",
+  refused: [],
   purposes: [
     {
       key: "transactional",
       label: "Deal & service messages",
       state: "granted",
       locked: true,
+      grant_needs_confirmation: false,
+      choice: "opted_in",
+      can_opt_in: false,
     },
     {
       key: "marketing_email",
       label: "Product updates",
       state: "granted",
       locked: false,
+      grant_needs_confirmation: false,
+      choice: "opted_in",
+      can_opt_in: true,
     },
-    { key: "events", label: "Events", state: "unknown", locked: false },
+    {
+      key: "events",
+      label: "Events",
+      state: "unknown",
+      locked: false,
+      grant_needs_confirmation: false,
+      choice: "opted_out",
+      can_opt_in: true,
+    },
   ],
 };
 
@@ -141,7 +161,9 @@ describe("PreferenceCenterScreen", () => {
       name: en["prefs.purpose.transactional"],
     });
     expect(toggle).toBeDisabled();
-    expect(screen.getByText(/always on/i)).toBeInTheDocument();
+    // The BADGE specifically: the unsubscribe-all hint below now names
+    // the same words when it explains what it will not touch.
+    expect(screen.getByText(en["prefs.alwaysOn"])).toBeInTheDocument();
   });
 
   it("stages changes — nothing is written until Save", async () => {
@@ -331,7 +353,7 @@ describe("one-click unsubscribe (G-7)", () => {
     });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("button", { name: /unsubscribe from all/i }),
+      await screen.findByRole("button", { name: en["prefs.unsubscribeAll"] }),
     );
     await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
     expect(await screen.findByText(/you're off/i)).toBeInTheDocument();
@@ -352,7 +374,7 @@ describe("one-click unsubscribe (G-7)", () => {
     });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("button", { name: /unsubscribe from all/i }),
+      await screen.findByRole("button", { name: en["prefs.unsubscribeAll"] }),
     );
     expect(await screen.findByText(/already off/i)).toBeInTheDocument();
   });
@@ -368,7 +390,7 @@ describe("one-click unsubscribe (G-7)", () => {
     });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("button", { name: /unsubscribe from all/i }),
+      await screen.findByRole("button", { name: en["prefs.unsubscribeAll"] }),
     );
     expect(await screen.findByText(/too many attempts/i)).toBeInTheDocument();
     expect(
@@ -386,7 +408,7 @@ describe("one-click unsubscribe (G-7)", () => {
     });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("button", { name: /unsubscribe from all/i }),
+      await screen.findByRole("button", { name: en["prefs.unsubscribeAll"] }),
     );
     expect(await screen.findByText(/try again shortly/i)).toBeInTheDocument();
   });
@@ -394,14 +416,30 @@ describe("one-click unsubscribe (G-7)", () => {
   // Re-subscribing must be an explicit opt-in — never a silent re-grant.
   it("stages an undo rather than immediately re-granting", async () => {
     const put = vi.fn(() => jsonResponse(CENTER));
+    // The re-read after the unsubscribe has to AGREE with it: the row the
+    // POST just stopped comes back opted_out, so undoing it is a real
+    // change to stage rather than a no-op the save bar would ignore.
+    const afterUnsubscribe = {
+      ...CENTER,
+      purposes: CENTER.purposes.map((purpose) =>
+        purpose.key === "marketing_email"
+          ? { ...purpose, state: "withdrawn", choice: "opted_out" }
+          : purpose,
+      ),
+    };
+    let stopped = false;
     stubCenter({
-      "POST /public/preferences/tok-123/unsubscribe": () =>
-        jsonResponse({ unsubscribed: ["marketing_email"] }),
+      "GET /public/preferences/tok-123": () =>
+        jsonResponse(stopped ? afterUnsubscribe : CENTER),
+      "POST /public/preferences/tok-123/unsubscribe": () => {
+        stopped = true;
+        return jsonResponse({ unsubscribed: ["marketing_email"] });
+      },
       "PUT /public/preferences/tok-123": put,
     });
     render(<PreferenceCenterScreen token="tok-123" />);
     await userEvent.click(
-      await screen.findByRole("button", { name: /unsubscribe from all/i }),
+      await screen.findByRole("button", { name: en["prefs.unsubscribeAll"] }),
     );
     await userEvent.click(await screen.findByRole("button", { name: /undo/i }));
     expect(put).not.toHaveBeenCalled();

--- a/frontend/src/screens/preferences.tsx
+++ b/frontend/src/screens/preferences.tsx
@@ -16,10 +16,11 @@ import { problemMessageOf, throwProblem } from "./common";
 import {
   type Draft,
   dirtyKeys,
-  displayOn,
   initialDraft,
   labelOf,
   type PurposeView,
+  rowIsOn,
+  stateLineKey,
   toChoices,
 } from "./preferences.logic";
 import { PublicPage } from "./publicpage";
@@ -226,7 +227,14 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
             ...old,
             purposes: old.purposes.map((purpose) =>
               withdrawnKeys.has(purpose.key)
-                ? { ...purpose, state: "withdrawn" as const }
+                ? {
+                    ...purpose,
+                    state: "withdrawn" as const,
+                    // `choice` too, and not only `state`: the row is drawn
+                    // from the choice, so echoing the raw state alone left
+                    // a just-unsubscribed row still showing as on.
+                    choice: "opted_out" as const,
+                  }
                 : purpose,
             ),
           },
@@ -307,7 +315,7 @@ function PreferenceCenterBody({ token }: Readonly<{ token: string }>) {
           <PreferenceRow
             key={purpose.key}
             purpose={purpose}
-            on={draft[purpose.key] ?? displayOn(purpose.state)}
+            on={rowIsOn(purpose, draft)}
             wording={wordingByKey[purpose.key]}
             t={t}
             disabled={writePending}
@@ -432,9 +440,7 @@ function PreferenceRow({
         <p className="t-caption" data-testid={`wording-${purpose.key}`}>
           {wording}
         </p>
-        <p className="t-caption pref-state">
-          {on ? t("prefs.subscribed") : t("prefs.notSubscribed")}
-        </p>
+        <p className="t-caption pref-state">{t(stateLineKey(purpose, on))}</p>
         {purpose.locked && (
           <p className="t-caption pref-locked-why">{t("prefs.lockedWhy")}</p>
         )}


### PR DESCRIPTION
The page still decided each row from the **raw consent state**, ignoring the `choice` field the server derives — which the frontend used exactly zero times. So it repeated the defect that field was added to fix.

## What was wrong

**Direct correspondence showed as "Nicht abonniert".** That lane is not consent-gated: ADR-0098 rules that a reply to somebody you have a business relationship with is not advertising, and `verdict.go` allows it on a qualifying event under legitimate interest. Telling that recipient they were "not subscribed" described a lane they never had to subscribe to — and understated what the sender is entitled to send.

**An always-on row rendered unchecked**, beside its own IMMER AN badge, with a control the server refuses to change in either direction. A locked row is now on unconditionally and no draft can move it.

**The state line had two states where the domain has three.** "Subscribed / not subscribed" cannot express a lane running on no objection:

| | |
|---|---|
| opted in | An — du hast danach gefragt |
| no objection | An — du hast dem nicht widersprochen |
| opted out | Aus — du hast uns gebeten, damit aufzuhören |

**The unsubscribe-all hint named "transaktionale Nachrichten"** without saying which rows those were. It now describes what it will do in terms of what is on screen: every row with a checkbox you can use, and the IMMER AN rows stay.

## A real defect the tests caught

The cache echo after unsubscribe-all wrote `state` but not `choice` — so every row it had just switched off went on rendering as **on**. Pressing the button appeared to do nothing.

## Verification

`make check-fe` green; 17 component tests, 9 logic tests, 49 i18n tests, 8 Playwright cases. Screenshotted from the built bundle against the demo stack: locked row reports `checked: true, disabled: true`.

One test was replaced rather than repaired: `reads only an explicit grant as subscribed` asserted the exact rule that caused this ("unknown is off"). It is now `reads the recipient's decision, not the raw record`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preferences screen so every row reflects the recipient's actual decision, reading the server's derived `choice` field instead of the raw consent state.

- Direct correspondence no longer shows "not subscribed" — with no objection it now shows as on.
- Always-on rows now render checked; locked rows are on unconditionally and no draft can move them.
- The state line now has three states — opted in, no objection, opted out — instead of two.
- The unsubscribe-all hint names the rows it acts on instead of saying "transactional messages".
- The cache echo after unsubscribe-all now updates `choice` too, so rows the button just switched off no longer render as on.
- Replaced the test that asserted "unknown is off" with one reading the recipient's decision.
- Updated de, en, and vi copy for the new row states and hints.

<sup>Written for commit 1d58d75a9e9945310f9d902871a7bb16889ec059. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preference controls now clearly show whether messages are enabled, declined, or enabled by default.
  * Locked communications remain visibly enabled.
  * “Stop everything” now covers all switchable preferences, while required messages remain enabled.
  * Confirmation-based preferences now explain how links change subscription status.

* **Bug Fixes**
  * Unsubscribing now immediately displays the affected preference as disabled.
  * Preference states and undo actions now remain consistent after refreshing.

* **Localization**
  * Updated English, German, and Vietnamese preference-center wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->