### PR TITLE
main is red: the meeting arm's file never reached the merge

### DIFF
--- a/backend/internal/modules/people/meetingcohort.go
+++ b/backend/internal/modules/people/meetingcohort.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Filing a meeting under a person who was IN it.
+//
+// The arm the cohort repair could not be, in its own file: linkCapturedCohort
+// keys on counterparty_email and a meeting has none, so this one reads the
+// participant rows instead.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// maxMeetingLinksPerActivity mirrors activities.maxActivityLinks: an activity
+// may be filed under at most 25 records. Spelled again rather than imported
+// because a module never imports a sibling — capture.maxDerivedMeetingLinks is
+// the third spelling, for the same reason and against the same number.
+const maxMeetingLinksPerActivity = 25
+
+// linkAttendedMeetings files a meeting under a person who was IN it.
+//
+// This is the arm linkCapturedCohort cannot be. That one keys on
+// counterparty_email, which is how mail names its other party — and a meeting
+// has no counterparty at all, because attendance is a LIST and the calendar
+// mapper leaves the field unset. Keying the repair on a column meetings never
+// carry is why every synced meeting in a workspace could sit unlinked while the
+// sweep reported nothing owed.
+//
+// So this arm reads what a meeting DOES carry: the participant rows.
+// capture.linkResolvedMeetingParticipants does exactly this at capture time, for
+// an attendee who was already a contact. Here it is for the other ordering — the
+// meeting synced first and the person arrived later — and it is the same three
+// rules, because a repair that filed a meeting the capture path would have
+// refused is not a repair.
+//
+// It must run AFTER promoteParticipantsToPerson in the same transaction. The
+// promotion is what turns this person's address-only attendee row into a
+// person-resolved one, and this arm reads person-resolved rows. Reversed, a
+// meeting whose attendee was only ever an address is offered to no arm at all.
+//
+// PERSON links only, never the company: a meeting may not link straight to an
+// organization, and the account reaches it through the attendee's employment.
+//
+// The ATTENDEE's own merge redirect is resolved, not just the person the repair
+// was asked about. A participant row written before the merge repointed them
+// still names the retired id; matching on it alone would miss that meeting
+// forever, while the selector offered the retired id and the liveness join then
+// dropped it — the meeting stays unlinked and the sweep reports a drained
+// backlog. capture.meetingParticipantsWithPeople resolves it the same way, for
+// the same reason.
+//
+// An archived meeting is left alone. Linking one would file a record a reader
+// cannot open, and emit an activity.updated for it.
+//
+// The 25-link ceiling is activities.maxActivityLinks — an activity may be filed
+// under at most 25 records, whatever wrote them. It is re-spelled rather than
+// imported because a module never imports a sibling; what must not drift is the
+// NUMBER. A meeting already at the cap is left alone rather than failed: the
+// cohort scan carries this same guard, so a row this refuses is not offered
+// again on every pass, and the sweep still drains.
+func linkAttendedMeetings(ctx context.Context, tx pgx.Tx, personID ids.PersonID) ([]ids.UUID, error) {
+	rows, err := tx.Query(ctx, `
+		INSERT INTO activity_link (activity_id, entity_type, person_id)
+		SELECT a.id, 'person', $1
+		  FROM activity a
+		 WHERE a.kind = 'meeting'
+		   AND a.captured_by LIKE 'connector:%'
+		   AND a.restricted_at IS NULL
+		   AND a.archived_at IS NULL
+		   AND EXISTS (
+		       SELECT 1 FROM activity_participant ap
+		         JOIN person att ON att.id = ap.person_id
+		        WHERE ap.activity_id = a.id
+		          AND coalesce(att.merged_into_id, att.id) = $1)
+		   AND NOT EXISTS (
+		       SELECT 1 FROM activity_link l
+		        WHERE l.activity_id = a.id AND l.person_id = $1)
+		   AND (SELECT count(*) FROM activity_link cap
+		         WHERE cap.activity_id = a.id) < $3
+		 ORDER BY a.occurred_at DESC, a.id
+		 LIMIT $2
+		ON CONFLICT DO NOTHING
+		RETURNING activity_id`, personID, cohortRepairBatch, maxMeetingLinksPerActivity)
+	if err != nil {
+		return nil, fmt.Errorf("people: filing a person's attended meetings: %w", err)
+	}
+	defer rows.Close()
+	var linked []ids.UUID
+	for rows.Next() {
+		var id ids.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("people: filing a person's attended meetings: %w", err)
+		}
+		linked = append(linked, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("people: filing a person's attended meetings: %w", err)
+	}
+	return linked, nil
+}


### PR DESCRIPTION
`go build ./...` fails on origin/main. cohortpromote.go calls
linkAttendedMeetings and maxMeetingLinksPerActivity; neither exists anywhere in
the tree.

The cause is visible in the merged PR's own history. Its last commit was a
refactor moving the arm out of cohortpromote.go into a file of its own — 88
lines removed, and no file added in the same commit, so the new file existed
only in that session's working tree. The squash took the deletion and there was
nothing to take on the other side. The three integration tests for the arm
landed and have had nothing to run against since.

Restored as the file that commit meant to add. The function, its doc comment
and the constant are byte-identical to the last commit that carried them, which
is the version Codex reviewed and the version the tests were written for — this
recovers reviewed code rather than reimplementing it from the PR description.

The eight cohort integration tests pass, including the three meeting cases that
could not compile before.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken build on `main` by restoring the missing `backend/internal/modules/people/meetingcohort.go` file that defines `linkAttendedMeetings` and `maxMeetingLinksPerActivity`. The file was accidentally dropped in a prior refactor, leaving `go build ./...` failing. Restores the file as it existed in the last reviewed and tested commit, so the three meeting integration tests now compile and pass.

<sup>Written for commit 48710ba742cd708cb060885877f5d3696f9b22d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically links eligible attended meetings to the associated person’s activity history.
  * Recognizes merged identities while avoiding duplicate links and meetings already linked directly to an organization.
  * Limits automatic linking to a maximum of 25 activities per person.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->