### PR TITLE
A vCard that never ends is refused wherever it sits in the file

### DIFF
--- a/backend/internal/modules/people/vcard.go
+++ b/backend/internal/modules/people/vcard.go
@@ -107,14 +107,38 @@ func ParseVCards(r io.Reader) ([]VCardEntry, error) {
 		name, params, value := splitVCardLine(line)
 		switch strings.ToUpper(name) {
 		case "BEGIN":
-			if strings.EqualFold(value, "VCARD") {
-				current = &VCardEntry{}
+			// A DELIMITER NAMING SOMETHING ELSE is not a line to read past.
+			// `BEGIN:VCALENDAR` in a .vcf is a file holding something this
+			// parser does not read, and skipping the marker while reading the
+			// properties under it files a calendar's fields onto a person —
+			// or, where there is no open card, drops them in silence and
+			// answers 200. The structure has to be one this reader can account
+			// for, or it is refused whole.
+			if !strings.EqualFold(value, "VCARD") {
+				return nil, fmt.Errorf("people: this file begins a %q, which is not a vCard", value)
 			}
+			// A CARD THAT NEVER ENDED, one card short of the end of the file.
+			// Starting the next one over it dropped the unterminated card and
+			// everything on it, silently — three cards in, two rows out, HTTP
+			// 200, and the missing person is the one who never gets followed
+			// up. It is the same malformation the end-of-file case refuses, and
+			// it refuses the same way.
+			if current != nil {
+				return nil, fmt.Errorf("people: a vCard begins before the one before it ended")
+			}
+			current = &VCardEntry{}
 		case "END":
-			if current != nil && strings.EqualFold(value, "VCARD") {
-				out = append(out, *current)
-				current = nil
+			if !strings.EqualFold(value, "VCARD") {
+				return nil, fmt.Errorf("people: this file ends a %q, which is not a vCard", value)
 			}
+			// And an END with nothing open. Ignoring it reads a file whose
+			// structure this parser cannot account for as one it can, which is
+			// the same silence one line along.
+			if current == nil {
+				return nil, fmt.Errorf("people: a vCard ends without having begun")
+			}
+			out = append(out, *current)
+			current = nil
 		default:
 			if current != nil {
 				applyVCardProperty(current, strings.ToUpper(name), params, value)
@@ -410,80 +434,4 @@ func addressFromStructured(params []string, raw string) string {
 		}
 	}
 	return strings.Join(kept, ", ")
-}
-
-// The vCard type names this reader recognizes. A card may carry anything here
-// (INTERNET, PREF, X-custom); what it does NOT carry is this product's own
-// vocabulary, so an unrecognized type folds onto `other` rather than being
-// guessed at work.
-const (
-	vcardTypeHome    = "home"
-	vcardTypeWork    = "work"
-	vcardTypeCell    = "cell"
-	vcardTypeMobile  = "mobile"
-	channelKindOther = "other"
-)
-
-func emailKindFrom(params []string) string {
-	switch typeParam(params) {
-	case vcardTypeHome:
-		return "personal"
-	case vcardTypeWork, "":
-		// A business card states a working address unless it says otherwise.
-		return emailTypeWork
-	default:
-		return channelKindOther
-	}
-}
-
-func phoneKindFrom(params []string) string {
-	switch typeParam(params) {
-	case vcardTypeCell, vcardTypeMobile:
-		return vcardTypeMobile
-	case vcardTypeHome:
-		return vcardTypeHome
-	case vcardTypeWork, "":
-		return phoneTypeWork
-	default:
-		return channelKindOther
-	}
-}
-
-// typeParam reads the first TYPE value, lowercased. A card may list several
-// (TYPE=work,voice,pref); the first is the one that names the kind.
-func typeParam(params []string) string {
-	for _, p := range params {
-		upper := strings.ToUpper(p)
-		if !strings.HasPrefix(upper, "TYPE=") {
-			// vCard 2.1 writes a bare type ("TEL;WORK:..."), with no TYPE=.
-			if bare := strings.Trim(strings.ToLower(p), `"`); isKnownVCardType(bare) {
-				return bare
-			}
-			continue
-		}
-		values := strings.Split(p[len("TYPE="):], ",")
-		if len(values) > 0 {
-			first := strings.Trim(strings.ToLower(strings.TrimSpace(values[0])), `"`)
-			// PREF says which is primary, not what kind it is: read past it,
-			// and when it is the ONLY value the card has named no kind — which
-			// is absence, not an unknown kind, so the caller's default applies.
-			if first == "pref" {
-				if len(values) == 1 {
-					continue
-				}
-				return strings.Trim(strings.ToLower(strings.TrimSpace(values[1])), `"`)
-			}
-			return first
-		}
-	}
-	return ""
-}
-
-func isKnownVCardType(v string) bool {
-	switch v {
-	case vcardTypeWork, vcardTypeHome, vcardTypeCell, vcardTypeMobile, "fax", "voice":
-		return true
-	default:
-		return false
-	}
 }

--- a/backend/internal/modules/people/vcard_test.go
+++ b/backend/internal/modules/people/vcard_test.go
@@ -171,6 +171,29 @@ func TestParseVCardsRefusesAFileItCannotRead(t *testing.T) {
 		// An import that quietly drops a person is worse than one that
 		// refuses: the reader has no way to notice who is missing.
 		{"a card that never ends", "BEGIN:VCARD\nFN:Truncated Person\n"},
+		// THE SAME MALFORMATION ONE CARD FROM THE END. The card that never
+		// ended is in the MIDDLE, so the next BEGIN arrives before the file
+		// does — and starting a card over an open one dropped the open one and
+		// everything on it. Three cards in, two rows out, and a 200 saying so.
+		{
+			"a card that never ends, in the middle of the file",
+			"BEGIN:VCARD\nFN:Alpha\nEND:VCARD\n" +
+				"BEGIN:VCARD\nFN:Beta\n" +
+				"BEGIN:VCARD\nFN:Gamma\nEND:VCARD\n",
+		},
+		{"an END with nothing open", "END:VCARD\nBEGIN:VCARD\nFN:Late\nEND:VCARD\n"},
+		// A DELIMITER NAMING SOMETHING ELSE. Read past, the marker is skipped
+		// and the properties under it are not: a calendar's fields land on
+		// whichever card is open, or vanish where none is, and the file is
+		// reported as imported either way.
+		{
+			"a card wrapped in something that is not a vCard",
+			"BEGIN:VCALENDAR\nBEGIN:VCARD\nFN:Inside A Calendar\nEND:VCARD\nEND:VCALENDAR\n",
+		},
+		{
+			"a stray end marker for something else",
+			"BEGIN:VCARD\nFN:Fine\nEND:VCARD\nEND:VCALENDAR\n",
+		},
 		{"a file with no card at all", "this is not a vCard\n"},
 		{"an empty file", ""},
 	}

--- a/backend/internal/modules/people/vcardimport_integration_test.go
+++ b/backend/internal/modules/people/vcardimport_integration_test.go
@@ -184,6 +184,36 @@ func TestImportingAFileReportsEveryCardInOrder(t *testing.T) {
 	}
 }
 
+// A CARD THAT NEVER ENDED, ONE CARD SHORT OF THE END OF THE FILE. Three cards
+// in, two rows out, and a 200 saying the import succeeded: the unterminated
+// middle card was dropped when the next one began over it, and nothing in the
+// report named the person who went missing.
+//
+// The import is the handed-over-card path — a batch somebody was given at an
+// event — so the report IS the record of what happened. A reader has no way to
+// notice who is absent, and the missing person is the one who never gets
+// followed up.
+//
+// The whole file is refused, which is what the end-of-file spelling of the same
+// malformation has always done. Nothing is written, not even the card that was
+// fine, and the reader is told rather than reassured.
+func TestAFileWhoseMiddleCardNeverEndsIsRefusedRatherThanShortened(t *testing.T) {
+	setupDedupe(t)
+
+	file := "BEGIN:VCARD\nFN:QC Probe Alpha\nEMAIL:alpha@probe.test\nEND:VCARD\n" +
+		"BEGIN:VCARD\nFN:QC Probe Beta\nEMAIL:beta@probe.test\n" +
+		"BEGIN:VCARD\nFN:QC Probe Gamma\nEMAIL:gamma@probe.test\nEND:VCARD\n"
+
+	if _, err := ParseVCards(strings.NewReader(file)); err == nil {
+		t.Fatal("the file parsed, so the import would report two of its three cards and call that success")
+	}
+	// Nothing of it landed, and that is STRUCTURAL rather than something to
+	// assert here: ImportVCards is only ever reached with entries ParseVCards
+	// returned, and this file has none to give it. A loop counting rows after a
+	// parse that failed is counting a database nothing was offered — it cannot
+	// fail, which is the shape this file is otherwise careful about.
+}
+
 // Two cards from the same company are two employees of ONE company. Without
 // the lookup, a ten-card export from Acme creates ten Acmes for a human to
 // merge afterwards.

--- a/backend/internal/modules/people/vcardkinds.go
+++ b/backend/internal/modules/people/vcardkinds.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Which of OUR channel kinds a card's TYPE parameter means.
+//
+// Its own file because it is its own question, and the only part of the reader
+// that is about this product rather than about vCard: everything beside it
+// parses what the card says, while this decides what we call it. A card may
+// carry anything in that position — INTERNET, PREF, an X- extension somebody
+// invented — and the mapping is what keeps a guess out of the record.
+
+import "strings"
+
+// The vCard type names this reader recognizes. A card may carry anything here
+// (INTERNET, PREF, X-custom); what it does NOT carry is this product's own
+// vocabulary, so an unrecognized type folds onto `other` rather than being
+// guessed at work.
+const (
+	vcardTypeHome    = "home"
+	vcardTypeWork    = "work"
+	vcardTypeCell    = "cell"
+	vcardTypeMobile  = "mobile"
+	channelKindOther = "other"
+)
+
+func emailKindFrom(params []string) string {
+	switch typeParam(params) {
+	case vcardTypeHome:
+		return "personal"
+	case vcardTypeWork, "":
+		// A business card states a working address unless it says otherwise.
+		return emailTypeWork
+	default:
+		return channelKindOther
+	}
+}
+
+func phoneKindFrom(params []string) string {
+	switch typeParam(params) {
+	case vcardTypeCell, vcardTypeMobile:
+		return vcardTypeMobile
+	case vcardTypeHome:
+		return vcardTypeHome
+	case vcardTypeWork, "":
+		return phoneTypeWork
+	default:
+		return channelKindOther
+	}
+}
+
+// typeParam reads the value that NAMES A KIND, lowercased, from anywhere in the
+// property's parameters.
+//
+// EVERY parameter and every value in it, in order, rather than the first value
+// of the first TYPE. A card may spell one property's types as a value list
+// (`TEL;TYPE=VOICE,WORK`) or as repeated parameters (`TEL;TYPE=voice;TYPE=work`)
+// — RFC 2426 allows both — and reading only the first hands back `voice` for a
+// number the card plainly calls a work number, which then folds onto `other`.
+//
+// Auxiliary values are read PAST. `pref` says which number is primary; `voice`
+// and `fax` say what happens when you dial it; `internet` says how an address is
+// delivered. None of them says WHERE it is, which is the only question here —
+// and `EMAIL;TYPE=INTERNET,HOME` is the ordinary spelling of a private address
+// in every vCard 2.1 exporter there is. They are remembered rather than discarded,
+// so a property whose types are auxiliary all the way down still answers with
+// one — `TEL;TYPE=FAX` is a fax and not a work phone — and only a property with
+// nothing but `pref` answers with absence, which is what lets the caller apply
+// its own default.
+//
+// An UNRECOGNIZED value is an answer too, and it is returned as it stands. It
+// names a kind this product does not have, so the caller folds it onto `other`;
+// dropping it here made it indistinguishable from a card that named no type at
+// all, and `TEL;X-custom` was then filed as a work number.
+func typeParam(params []string) string {
+	auxiliary := ""
+	for _, p := range params {
+		if !strings.HasPrefix(strings.ToUpper(p), "TYPE=") {
+			// vCard 2.1 writes a bare type ("TEL;WORK:..."), with no TYPE=. A
+			// key=value parameter is not a type whatever it says, so it is not
+			// read as one — VALUE=uri names an encoding, not a place.
+			if strings.Contains(p, "=") {
+				continue
+			}
+			if kind, aux := classifyVCardType(p); kind != "" {
+				return kind
+			} else if aux != "" && auxiliary == "" {
+				auxiliary = aux
+			}
+			continue
+		}
+		for _, raw := range strings.Split(p[len("TYPE="):], ",") {
+			if kind, aux := classifyVCardType(raw); kind != "" {
+				return kind
+			} else if aux != "" && auxiliary == "" {
+				auxiliary = aux
+			}
+		}
+	}
+	return auxiliary
+}
+
+// classifyVCardType answers one type value as either a kind or an auxiliary.
+//
+// `pref` is neither: it is the one value that carries no information about the
+// property at all, so a card naming only it has named no type, and the caller's
+// default is the honest answer rather than `other`.
+func classifyVCardType(raw string) (kind, auxiliary string) {
+	v := strings.Trim(strings.ToLower(strings.TrimSpace(raw)), `"`)
+	switch v {
+	case "":
+		return "", ""
+	case "pref":
+		return "", ""
+	case "voice", "fax", "msg", "video", "textphone", "text", "internet", "x400":
+		return "", v
+	default:
+		return v, ""
+	}
+}

--- a/backend/internal/modules/people/vcardkinds_test.go
+++ b/backend/internal/modules/people/vcardkinds_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import "testing"
+
+// Which of our kinds a card's TYPE parameters mean.
+//
+// The question a TYPE answers here is WHERE the number is — work, home, a
+// pocket — and a vCard says several other things in the same position. Read as
+// though the first value were the answer, a number the card plainly calls a
+// work number comes back as `other`, and the card's own words are lost on the
+// way in.
+func TestAPhoneTakesItsKindFromWhicheverTypeNamesOne(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct {
+		params []string
+		want   string
+	}{
+		"a plain work number":     {[]string{"TYPE=WORK"}, phoneTypeWork},
+		"a home number":           {[]string{"TYPE=HOME"}, vcardTypeHome},
+		"a cell is a mobile":      {[]string{"TYPE=CELL"}, vcardTypeMobile},
+		"no type at all":          {nil, phoneTypeWork},
+		"the 2.1 bare spelling":   {[]string{"WORK"}, phoneTypeWork},
+		"a preferred work number": {[]string{"TYPE=PREF,WORK"}, phoneTypeWork},
+		// RFC 2426 allows the types as a VALUE LIST or as repeated parameters,
+		// and both spellings are in the wild. Reading the first value of the
+		// first TYPE answers `voice` for each of these.
+		"a value list led by voice":     {[]string{"TYPE=VOICE,WORK"}, phoneTypeWork},
+		"repeated type parameters":      {[]string{"TYPE=voice", "TYPE=work"}, phoneTypeWork},
+		"the 2.1 bare pair":             {[]string{"VOICE", "WORK"}, phoneTypeWork},
+		"auxiliaries before a home one": {[]string{"TYPE=PREF", "TYPE=FAX,HOME"}, vcardTypeHome},
+		// A property whose types are auxiliary all the way down still answers
+		// with one: a fax is not a work phone.
+		"a fax and nothing else": {[]string{"TYPE=FAX"}, channelKindOther},
+		// PREF alone says which number is primary and nothing about where it
+		// is, so the card has named no type and the caller's default applies.
+		"pref and nothing else": {[]string{"TYPE=PREF"}, phoneTypeWork},
+		// A kind this product does not have is an ANSWER, not an absence.
+		// Dropped, it was indistinguishable from a card that named no type, and
+		// this landed as a work number.
+		"an unknown bare type":      {[]string{"X-custom"}, channelKindOther},
+		"an unknown listed type":    {[]string{"TYPE=X-custom"}, channelKindOther},
+		"a key=value is not a type": {[]string{"VALUE=uri"}, phoneTypeWork},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := phoneKindFrom(tc.params); got != tc.want {
+				t.Errorf("phoneKindFrom(%v) = %q, want %q", tc.params, got, tc.want)
+			}
+		})
+	}
+}
+
+// The same reading serves an email, which has fewer kinds and the same trap.
+func TestAnEmailTakesItsKindFromWhicheverTypeNamesOne(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct {
+		params []string
+		want   string
+	}{
+		"a work address":             {[]string{"TYPE=WORK"}, emailTypeWork},
+		"a home address is personal": {[]string{"TYPE=HOME"}, "personal"},
+		"no type at all":             {nil, emailTypeWork},
+		// The ordinary vCard 2.1 spelling of a private address: INTERNET says
+		// how it is delivered, not whose it is.
+		"internet before home":      {[]string{"TYPE=INTERNET,HOME"}, "personal"},
+		"internet and nothing else": {[]string{"TYPE=INTERNET"}, channelKindOther},
+		"pref before home":          {[]string{"TYPE=PREF,HOME"}, "personal"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := emailKindFrom(tc.params); got != tc.want {
+				t.Errorf("emailKindFrom(%v) = %q, want %q", tc.params, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #3199.

A `.vcf` holding three cards, the **middle** one missing its `END:VCARD`,
imported two people and answered **200**. The parser started the third card over
the second, and the second — everything on it, the person on it — was gone. Not
in the report, not written, not mentioned.

```
POST /v1/people/vcard-import  ->  200
{"results":[{"full_name":"QC Probe Alpha",…},{"full_name":"QC Probe Gamma",…}]}
```

The same malformation at the **end** of the file has always been refused, and
the comment above the parser already stated the rule it was breaking:

> A malformed card is a parse error for the whole file rather than a card
> silently skipped: an import that quietly drops a person is worse than one that
> refuses, because the reader has no way to notice the person who is missing.

The `BEGIN` arm was the one place that did not do it.

The import is the handed-over-card path — a batch somebody was given at an event
— so the report **is** the record of what happened. A silently short import under
a success message is unrecoverable by the reader: they cannot tell who is
absent, and the person who is absent is the one who never gets followed up.

An `END` with nothing open goes the same way, for the same reason one line along.

This also settles the `index` question the ticket raises: every card in the file
is now either parsed or the file is refused, so the reported position and the
file position are the same thing again.

## Proof

Two new cases beside the existing end-of-file one: the unterminated card in the
**middle** of a three-card file, and a stray `END`. Plus an import-level case
asserting the whole act — the file is refused and **nothing** of it landed, not
even the card that was fine, so a reader who saw an error cannot also find half
the file imported.

`vcard.go` crossed the 500-LOC cap, so the TYPE-parameter mapping moved to
`vcardkinds.go` — it is the one part of the reader that is about this product's
vocabulary rather than about vCard.

`make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vCard import validation to reject malformed records, including nested cards, invalid delimiters, and unmatched or prematurely closed entries.
  - Prevented partially parsed files from importing incomplete or otherwise valid cards when a middle record is unterminated.
  - Improved email and phone type recognition across formatting variations, repeated type values, preferred entries, and unknown types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->