### PR TITLE
A permanent zero gets a reading

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6256,6 +6256,8 @@ export const de = {
   "autonomy.title": "Was sich von selbst erledigt",
   "autonomy.sub":
     "Kleine Korrekturen, die du bisher von Hand bestätigt hast. Schalte eine ein, und sie wird sofort übernommen – die Änderung und ein Rückgängig warten auf deinem Tag.",
+  "autonomy.noneDecidedYet":
+    "Darüber hast du noch nichts entschieden. Was in dieser Liste landet, hängt von den Datensätzen ab, die dir gehören, und von der Arbeit, die dein Team an dich weiterleitet. Ohne beides bleibt sie leer. Die Schalter entscheiden trotzdem, was passiert, sobald etwas auftaucht.",
   "autonomy.noRecord": "Darüber hast du noch nicht entschieden.",
   "autonomy.record":
     "Bisher: {clean} wie vorgeschlagen übernommen, {edited} nach einer Änderung, {rejected} abgelehnt.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6302,6 +6302,8 @@ export const en = {
   "autonomy.title": "What answers itself",
   "autonomy.sub":
     "Small corrections you have been confirming by hand. Switch one on and it applies as soon as it comes up, with the change and an Undo waiting on your day.",
+  "autonomy.noneDecidedYet":
+    "You have not decided any of these yet. What reaches this list depends on the records you own and the work your team routes to you, so a seat with neither stays empty. The switches still decide what happens when something appears.",
   "autonomy.noRecord": "You have not decided one of these yet.",
   "autonomy.record":
     "So far: {clean} approved as proposed, {edited} after an edit, {rejected} turned down.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6198,6 +6198,8 @@ export const vi = {
   "autonomy.title": "Những gì tự xử lý",
   "autonomy.sub":
     "Những chỉnh sửa nhỏ bạn vẫn xác nhận bằng tay. Bật một mục lên và nó sẽ được áp dụng ngay khi xuất hiện, kèm thay đổi và nút Hoàn tác chờ sẵn trong ngày của bạn.",
+  "autonomy.noneDecidedYet":
+    "Bạn chưa quyết định mục nào trong số này. Những gì xuất hiện trong danh sách này phụ thuộc vào các bản ghi bạn sở hữu và công việc nhóm bạn chuyển đến, nên khi không có cả hai thì danh sách vẫn trống. Các công tắc vẫn quyết định điều gì xảy ra khi có việc đến.",
   "autonomy.noRecord": "Bạn chưa quyết định mục nào thuộc loại này.",
   "autonomy.record":
     "Đến nay: {clean} chấp nhận như đề xuất, {edited} sau khi sửa, {rejected} đã từ chối.",

--- a/frontend/src/screens/autonomy-settings.test.tsx
+++ b/frontend/src/screens/autonomy-settings.test.tsx
@@ -110,6 +110,62 @@ describe("AutonomySettingsCard", () => {
     ).not.toBeNull();
   });
 
+  // A PERMANENT ZERO DESERVES A READING. The card is shown to every seat on
+  // purpose — approvals are structural, so there is no role list to gate on —
+  // which leaves a seat nothing is routed to looking at switches that will
+  // never have anything to switch. "You have not decided one of these yet" is
+  // true of one kind; it says nothing about why there is none of any kind.
+  //
+  // DECIDED, not "received": a seat may have work waiting on it right now, and
+  // this card cannot see the queue.
+  it("says why the record is empty when this seat has decided none of them", async () => {
+    vi.stubGlobal(
+      "fetch",
+      backendFor([
+        row("close_date_correction", "manual"),
+        row("stage_correction", "manual"),
+      ]).fetchMock,
+    );
+    render(<AutonomySettingsCard />);
+
+    expect(
+      await screen.findByText(/have not decided any of these yet/i),
+    ).not.toBeNull();
+  });
+
+  // And it goes away the moment one HAS. A note that stands beside a real track
+  // record tells a working seat their queue is empty while they read its
+  // history.
+  it("says nothing of the sort once the seat has decided one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      backendFor([
+        row("close_date_correction", "manual", 3),
+        row("stage_correction", "manual"),
+      ]).fetchMock,
+    );
+    render(<AutonomySettingsCard />);
+
+    expect(await screen.findByText(/3 approved as proposed/i)).not.toBeNull();
+    expect(screen.queryByText(/have not decided any of these yet/i)).toBeNull();
+  });
+
+  // AND NOT WHEN THERE IS NOTHING TO HAVE DECIDED. "You have not decided any of
+  // these yet" is a sentence about a set, and with no eligible kinds there is no
+  // set — it reads as a queue the seat is behind on rather than an installation
+  // that routes them nothing.
+  it("says nothing of the sort when there is no kind to decide", async () => {
+    vi.stubGlobal("fetch", backendFor([]).fetchMock);
+    render(<AutonomySettingsCard />);
+
+    // Awaited on the EMPTY STATE, which only the settled query can draw. The
+    // card's own sub-copy renders before the fetch resolves, so waiting on that
+    // would read the absence below off a card that had not loaded yet — an
+    // assertion no implementation could fail.
+    expect(await screen.findByText(/nothing here yet/i)).not.toBeNull();
+    expect(screen.queryByText(/have not decided any of these yet/i)).toBeNull();
+  });
+
   it("shows the track record under a kind the reader has decided", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/src/screens/autonomy-settings.tsx
+++ b/frontend/src/screens/autonomy-settings.tsx
@@ -75,6 +75,41 @@ function useUpdateAutonomy() {
 // Absent rather than a row of zeroes: "you have approved 0 of these unchanged"
 // invites the reader to weigh evidence that does not exist, where saying nothing
 // leaves the switch to be judged on the description above it.
+// noneDecidedYet reports whether this seat has decided none of these, of any
+// kind.
+//
+// DECIDED, not "received": the card reads a decision history, and a seat may
+// well have work waiting on it right now. Saying nothing has arrived would be a
+// claim about the queue that this card cannot see.
+//
+// The card is shown to every seat on purpose: approvals are STRUCTURAL, so
+// there is no role list a client could gate on, and the nearest available gate
+// — does this seat own any records — would make the card appear and disappear
+// under a rep as their book of business changes.
+//
+// What that leaves is a permanent zero for a seat nothing is ever routed to,
+// and a zero with no reading is merely accurate rather than honest. The
+// per-switch line already says there is no record; what it cannot say, being
+// about one kind, is WHY there is none of ANY kind and whether there ever will
+// be. That belongs once at the card, where it is about the seat.
+//
+// AN EMPTY LIST IS NOT A ZERO — and it never reaches here, because the gate
+// above answers it with the empty state instead. `every` is true of nothing, so
+// a seat with no eligible kind at all would otherwise be told it had decided
+// none of them: a sentence about a set that does not exist, standing on a card
+// with no switches under it.
+//
+// Guarded THERE rather than with a `rows.length > 0` here. Both read correctly,
+// and only one of them can be tested: with the empty state drawn, this function
+// is never called with an empty list, so a length check beside it is a claim no
+// case can fail — and an untestable guard is how a reader learns to trust the
+// wrong one of two.
+function noneDecidedYet(rows: readonly KindAutonomy[]): boolean {
+  return rows.every(
+    (row) => row.approved_clean + row.approved_edited + row.rejected === 0,
+  );
+}
+
 function decidedSoFar(
   row: KindAutonomy,
   t: Translator,
@@ -145,34 +180,47 @@ export function AutonomySettingsCard() {
     <Panel title={t("autonomy.title")}>
       <PanelBody className="form-stack">
         <p className="settings-panel-sub">{t("autonomy.sub")}</p>
-        <QueryGate query={query}>
+        {/* An empty list is its own answer, and it is not a blank card: this
+            installation routes this seat nothing of any kind, so there is no
+            switch to offer and no track record to be behind on. Saying so here
+            is also what keeps noneDecidedYet from having to speak for a set
+            that does not exist. */}
+        <QueryGate
+          query={query}
+          empty={(settings) => settings.data.length === 0}
+        >
           {(settings) => (
-            <SettingList>
-              {settings.data.map((row) => (
-                <SettingRow
-                  key={row.kind}
-                  label={kindLabel(row.kind, t)}
-                  description={[
-                    kindHelp(row.kind, t),
-                    decidedSoFar(row, t, locale),
-                  ]
-                    .filter(Boolean)
-                    .join(" ")}
-                  control={
-                    <Switch
-                      testId={`autonomy-toggle-${row.kind}`}
-                      label={kindLabel(row.kind, t)}
-                      labelHidden
-                      checked={row.mode === "auto"}
-                      disabled={update.isPending}
-                      onChange={(next) =>
-                        update.mutate({ kind: row.kind, auto: next })
-                      }
-                    />
-                  }
-                />
-              ))}
-            </SettingList>
+            <>
+              {noneDecidedYet(settings.data) && (
+                <Callout tone="info">{t("autonomy.noneDecidedYet")}</Callout>
+              )}
+              <SettingList>
+                {settings.data.map((row) => (
+                  <SettingRow
+                    key={row.kind}
+                    label={kindLabel(row.kind, t)}
+                    description={[
+                      kindHelp(row.kind, t),
+                      decidedSoFar(row, t, locale),
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                    control={
+                      <Switch
+                        testId={`autonomy-toggle-${row.kind}`}
+                        label={kindLabel(row.kind, t)}
+                        labelHidden
+                        checked={row.mode === "auto"}
+                        disabled={update.isPending}
+                        onChange={(next) =>
+                          update.mutate({ kind: row.kind, auto: next })
+                        }
+                      />
+                    }
+                  />
+                ))}
+              </SettingList>
+            </>
           )}
         </QueryGate>
         {update.isError && (


### PR DESCRIPTION
Closes #3202.

The autonomy card is shown to every seat on purpose — the reasoning is on
#3194: approvals are structural, so there is no role list a client could gate
on, and the nearest available gate ("does this seat own any records") would make
the card appear and disappear under a rep as their book of business changes.

That leaves a seat nothing is ever routed to looking at switches that will never
have anything to switch, under a line saying *"You have not decided one of these
yet."* True of one kind, and silent about why there is none of **any** kind or
whether there ever will be. Accurate rather than honest — which is the part
#3194 explicitly did not defend.

So the card says it once, where it is about the **seat** rather than about a
kind: what reaches this list depends on the records you own and the work your
team routes to you, and the switches still decide what happens when something
does.

The per-switch line stays exactly as it was. It answers a different question,
and this one cannot be asked per switch.

## Both directions

It goes away the moment one kind has been decided, or it would tell a working
seat their queue is empty while they read its own history. Both cases have a
test; removing the note fails the first and nothing else.

`make check-fe` green. Copy in all three locales, no dash (VOICE-RULE-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational empty-state message when no autonomy decisions are available.
  * The message explains that displayed work depends on assigned records and delegated tasks.
  * Added English, German, and Vietnamese translations.

* **Bug Fixes**
  * Empty-state messaging now disappears once approval history is available.

* **Tests**
  * Added coverage for displaying and hiding the empty approval state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->