### PR TITLE
A courteous cold pitch is not a prospect

### DIFF
--- a/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/false_spam_01.yaml
+++ b/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/false_spam_01.yaml
@@ -6,13 +6,12 @@ sanitized_by: hand_authored/claude-opus-5
 fixture:
   display_name: Ines Waldherr
   email: i.waldherr@kranzler-druck.example
-  subject: "Re: Angebot Messestand Halle 4"
+  subject: Angebot Messestand Halle 4
   body: |
     Guten Tag,
 
-    vielen Dank fuer Ihre Anfrage von gestern. Anbei unser Angebot fuer den
-    Messestand in Halle 4: Aufbau am 12.03., Abbau am 15.03., inklusive
-    Beleuchtung und Transport.
+    anbei unser Angebot fuer den Messestand in Halle 4: Aufbau am 12.03.,
+    Abbau am 15.03., inklusive Beleuchtung und Transport.
 
     Die Preise verstehen sich netto. Bei Zusage bis Freitag koennen wir den
     Termin fest einplanen.
@@ -24,15 +23,21 @@ expect:
   outcome: accepted
   answer: person
   rubric: >
-    The guard on the direction-of-offer rule. This sender is also offering to
-    sell something, and also signs with a full name and a company — the surface
-    markers spam_01 has. What separates them is that this business ASKED: the
-    subject is a reply, and the body opens by thanking them for yesterday's
-    enquiry. An invited supplier answering a request is the ordinary "person"
-    case, and the sender the CRM most needs as a contact.
-    A verdict of "person" scores high. "spam" scores zero: it would mean the
-    direction-of-offer rule had swallowed every supplier who quotes a price,
-    which is the over-correction this scenario exists to catch.
+    The guard on the direction-of-offer rule, written as the HARD case rather
+    than the easy one. This sender is also offering to sell something and also
+    signs with a full name and a company, so it carries spam_01's surface
+    markers — and it deliberately carries no proof of invitation either: no
+    "Re:", no reference to an earlier enquiry, nothing naming who asked.
+    The model is never told the relationship history. It receives display name,
+    address, subject and body, so a rule phrased as "did this business contact
+    them first?" has to be answered from the message alone. What answers it here
+    is the SHAPE of the mail: a quote for a named job with fixed dates, an
+    itemised scope and a deadline is work already discussed, not an opening
+    pitch. A pitch describes a capability; this describes an agreement.
+    A verdict of "person" scores high. "spam" scores zero, and it is the costly
+    direction: a spam verdict hides the mail and suppresses the sender's whole
+    DOMAIN workspace-wide, so one wrong answer here blocks every future mail
+    from that supplier for every colleague.
     "organization_sender" scores in the middle — a named human signs the mail,
     so it is the wrong reading, but it withholds the record rather than hiding
     the correspondence.

--- a/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/false_spam_01.yaml
+++ b/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/false_spam_01.yaml
@@ -1,0 +1,42 @@
+name: invited_supplier_must_not_be_spam
+task: capture_counterparty_verdict
+site: verdict
+source: hand_authored
+sanitized_by: hand_authored/claude-opus-5
+fixture:
+  display_name: Ines Waldherr
+  email: i.waldherr@kranzler-druck.example
+  subject: "Re: Angebot Messestand Halle 4"
+  body: |
+    Guten Tag,
+
+    vielen Dank fuer Ihre Anfrage von gestern. Anbei unser Angebot fuer den
+    Messestand in Halle 4: Aufbau am 12.03., Abbau am 15.03., inklusive
+    Beleuchtung und Transport.
+
+    Die Preise verstehen sich netto. Bei Zusage bis Freitag koennen wir den
+    Termin fest einplanen.
+
+    Mit freundlichen Gruessen
+    Ines Waldherr
+    Kranzler Druck & Messebau GmbH
+expect:
+  outcome: accepted
+  answer: person
+  rubric: >
+    The guard on the direction-of-offer rule. This sender is also offering to
+    sell something, and also signs with a full name and a company — the surface
+    markers spam_01 has. What separates them is that this business ASKED: the
+    subject is a reply, and the body opens by thanking them for yesterday's
+    enquiry. An invited supplier answering a request is the ordinary "person"
+    case, and the sender the CRM most needs as a contact.
+    A verdict of "person" scores high. "spam" scores zero: it would mean the
+    direction-of-offer rule had swallowed every supplier who quotes a price,
+    which is the over-correction this scenario exists to catch.
+    "organization_sender" scores in the middle — a named human signs the mail,
+    so it is the wrong reading, but it withholds the record rather than hiding
+    the correspondence.
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40

--- a/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/false_spam_02.yaml
+++ b/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/false_spam_02.yaml
@@ -1,0 +1,46 @@
+name: a_two_sided_thread_is_a_conversation
+task: capture_counterparty_verdict
+site: verdict
+source: hand_authored
+sanitized_by: hand_authored/claude-opus-5
+fixture:
+  display_name: Marta Kovac
+  email: m.kovac@steinbach-tech.example
+  subject: "Re: Lieferzeiten Q4"
+  body: |
+    Guten Tag Herr Weber,
+
+    danke fuer die schnelle Rueckmeldung. Die 6 Wochen passen fuer uns.
+    Ich schicke die Bestellung heute noch raus.
+
+    Viele Gruesse
+    Marta Kovac
+    Steinbach Tech GmbH
+
+    On Mon, Aug 25, 2026, Thomas Weber <t.weber@ourcompany.example> wrote:
+
+    > Hallo Frau Kovac,
+    >
+    > aktuell liegen wir bei 6 Wochen Lieferzeit fuer die Serie 400.
+    > Passt das fuer Ihren Termin?
+    >
+    > Viele Gruesse
+    > Thomas Weber
+expect:
+  outcome: accepted
+  answer: person
+  rubric: >
+    The guard on the quoted-history rule that spam_02 forced. spam_02 says a
+    thread of the sender chasing their own unanswered mail is not a
+    conversation; this is the case that keeps that from swallowing every reply.
+    The quoted block is written by somebody at THIS business, and the sender is
+    answering it: a delivery time was asked and given, accepted, and an order
+    follows. That is the ordinary correspondence a CRM exists to file.
+    A verdict of "person" scores high. "spam" scores zero, and it is the costly
+    direction — a spam verdict suppresses the sender's whole domain
+    workspace-wide, so reading a genuine customer reply as a pitch would hide
+    an active supplier relationship from every colleague.
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40

--- a/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/spam_01.yaml
+++ b/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/spam_01.yaml
@@ -1,0 +1,56 @@
+name: courteous_cold_pitch_is_spam
+task: capture_counterparty_verdict
+site: verdict
+source: hand_authored
+sanitized_by: hand_authored/claude-opus-5
+fixture:
+  display_name: Martin Adeyemi Cole
+  email: info-fbc@meridian.example
+  subject: Business Financing Inquiry
+  body: |
+    Hello,
+
+    I'm reaching out to introduce a potential funding opportunity for
+    businesses seeking capital for growth, expansion, acquisitions,
+    refinancing, or other strategic needs.
+
+    We work closely with private investors to identify suitable
+    business financing opportunities and would be pleased to explore
+    whether funding may be available for your company.
+
+    We also welcome introductions to businesses that may be seeking
+    finance. A 2% referral fee is available for successful
+    introductions that result in completed funding.
+
+    If your company is currently considering funding-or you know of a
+    business that may benefit from financing-I would be delighted to
+    have a brief conversation and discuss the possibilities.
+
+    I look forward to hearing from you.
+
+    Best regards,
+
+    Martin Adeyemi Cole
+    Investment & Management Consultancy Limited
+    25 Little Meadow, Loughton
+    Milton Keynes, MK5 8EH, England
+    Financial Broker | Financial Consultant
+expect:
+  outcome: accepted
+  answer: spam
+  rubric: >
+    Cold outreach carrying every marker of a real person: a full human name, a
+    signature block with a company, a street address and a job title, courteous
+    prose and no bulk-mail furniture at all — no unsubscribe link, no list
+    footer, no promotional formatting. It reads as a named professional writing
+    personally, and that is exactly why it was answered "person" in the field
+    and created a junk contact.
+    What makes it spam is the DIRECTION of the offer: a stranger this business
+    never contacted, pitching their own service, with a referral fee attached.
+    A kind of "spam" scores high. "newsletter" is a near miss — the label is
+    less precise but both resolve to noise, so no record is made either way.
+    "person" scores zero: it is the answer that shipped the defect.
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40

--- a/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/spam_02.yaml
+++ b/backend/internal/compose/aicert/corpus/capture_counterparty_verdict/spam_02.yaml
@@ -1,0 +1,68 @@
+name: a_chased_cold_pitch_is_still_spam
+task: capture_counterparty_verdict
+site: verdict
+source: hand_authored
+sanitized_by: hand_authored/claude-opus-5
+fixture:
+  display_name: Robin Marsh
+  email: robin.marsh@harborfin.example
+  subject: "Re: Investors for Sunhold"
+  body: |
+    Hi - the institutional investors, private credit funds and family offices
+    we work with are still deploying into growth equity, private credit and
+    structured capital, and Sunhold is exactly what they have asked us to find.
+
+    A quick chat covers who is active right now and what they typically put to
+    work. If this is a priority for Sunhold, happy to set something up.
+
+    Best,
+    Robin Marsh, Harbor Fin Partners
+    Just say the word and I'll leave it there.
+
+    On Tue, Jun 30, 2026 4:10:14 PM Robin Marsh <robin.marsh@harborfin.example> wrote:
+
+    > Not sure if this sits on your desk, no worries at all. Who should I talk
+    > to about this on your end?
+    >
+    > All the best,
+    > Robin Marsh
+    > Harbor Fin Partners
+    >
+    > On Mon, Jun 29, 2026 4:03:11 PM Robin Marsh <robin.marsh@harborfin.example> wrote:
+    >
+    >> Hello,
+    >>
+    >> We have been mandated to identify companies in your sector for
+    >> institutional partners allocating USD 5 to 100M across growth equity and
+    >> structured capital.
+    >>
+    >> Sunhold came up as a match. Our senior team has advised on over USD 247B
+    >> in deals.
+    >>
+    >> Open to a brief conversation next week?
+    >>
+    >> Best,
+    >> Robin Marsh
+    >> Harbor Fin Partners
+expect:
+  outcome: accepted
+  answer: spam
+  rubric: >
+    The case that defeats the cheap reading of the direction-of-offer rule.
+    spam_01 is a first contact and looks like one. This one carries "Re:" in the
+    subject and two levels of quoted history, so on surface markers it reads as
+    a live conversation — and the rule's own examples name a reply in a thread
+    as evidence of agreed work.
+    What the thread actually shows is one sender writing three times to silence:
+    an opening pitch, a chase asking who to talk to, and a third mail offering to
+    stop. Nobody from this business ever answered. A quoted history is only
+    evidence of a relationship when the OTHER side is in it, and here every
+    quoted block is the same sender.
+    A kind of "spam" scores high. "newsletter" is a near miss: less precise, but
+    it resolves to noise too, so no record is made either way. "person" scores
+    zero — it is the answer that shipped a junk contact, and the reason a
+    self-chased thread must not be read as a conversation.
+  bands:
+    certified_min: 70
+    degraded_min: 50
+    floor: 40

--- a/backend/internal/compose/captureverdictkinds.go
+++ b/backend/internal/compose/captureverdictkinds.go
@@ -97,7 +97,9 @@ For EACH supplied address emit exactly one kind:
     business relationship.
   "transactional" — automated mail from a service: receipts, invoices, notifications, delivery
     reports, calendar or ticketing systems.
-  "spam" — unsolicited commercial mail or fraud.
+  "spam" — unsolicited commercial mail or fraud: a sender this business never contacted,
+    pitching their own services, however personally written and however plausible the offer.
+    Cold outreach signed with a real human name is still "spam" — a name is not a relationship.
   "personal" — a private correspondent of the mailbox owner rather than of the business:
     family, friends, a doctor, a school, a landlord, a personal service like a travel agent or
     an expense tool. Their mail is not this company's business at all.
@@ -106,6 +108,11 @@ For EACH supplied address emit exactly one kind:
     belongs to the mailbox owner alone.
 Judge the SENDER, not the tone: a poorly written mail from a real prospect is "person", and a
 polished newsletter from a company they never contacted is "newsletter".
+Judge the DIRECTION of the offer, not its politeness. A "person" wants something this business
+sells, or supplies something this business asked for. A stranger offering to sell this business
+something it never asked about — financing, capital, leads, SEO, staffing, development, an
+introduction for a fee — is "spam", no matter how courteous the mail, how specific the offer, or
+how complete the sender's signature block, address and job title.
 A company NAME in the display name with no human named anywhere is "organization_sender" or
 "role_mailbox", never "person" — do not invent a contact called after a company or a product.
 If this business replied only to decline — "not interested", "please remove me", "unsubscribe" —

--- a/backend/internal/compose/captureverdictkinds.go
+++ b/backend/internal/compose/captureverdictkinds.go
@@ -118,7 +118,11 @@ You are NOT told the relationship history, so decide it from the message. Mail t
 work already agreed is "person": a quote for a named job with dates and scope, an invoice, a
 delivery date, a reply in a thread, an answer to a question. Mail that opens a relationship the
 business never started is "spam": it describes what the sender can do rather than what was
-agreed, and names no job, no date and no prior contact. When the message genuinely leaves this
+agreed, and names no job, no date and no prior contact.
+"Re:" and a quoted history are only evidence of a conversation when THIS BUSINESS is in it.
+Read who wrote the quoted blocks: if every one is the sender chasing their own unanswered mail
+— a pitch, then "did this reach the right person?", then "happy to stop if not" — that is one
+side talking to silence, and it stays "spam" however long the thread grew. When the message genuinely leaves this
 open, prefer "person" and a lower confidence — a wrong "spam" hides a real supplier's mail from
 everyone, where a wrong "person" only leaves a record somebody can delete.
 A company NAME in the display name with no human named anywhere is "organization_sender" or

--- a/backend/internal/compose/captureverdictkinds.go
+++ b/backend/internal/compose/captureverdictkinds.go
@@ -97,9 +97,10 @@ For EACH supplied address emit exactly one kind:
     business relationship.
   "transactional" — automated mail from a service: receipts, invoices, notifications, delivery
     reports, calendar or ticketing systems.
-  "spam" — unsolicited commercial mail or fraud: a sender this business never contacted,
-    pitching their own services, however personally written and however plausible the offer.
-    Cold outreach signed with a real human name is still "spam" — a name is not a relationship.
+  "spam" — unsolicited commercial mail or fraud: a sender pitching their own services to a
+    business that shows no sign of having asked, however personally written and however
+    plausible the offer. Cold outreach signed with a real human name is still "spam" — a name
+    is not a relationship.
   "personal" — a private correspondent of the mailbox owner rather than of the business:
     family, friends, a doctor, a school, a landlord, a personal service like a travel agent or
     an expense tool. Their mail is not this company's business at all.
@@ -109,10 +110,17 @@ For EACH supplied address emit exactly one kind:
 Judge the SENDER, not the tone: a poorly written mail from a real prospect is "person", and a
 polished newsletter from a company they never contacted is "newsletter".
 Judge the DIRECTION of the offer, not its politeness. A "person" wants something this business
-sells, or supplies something this business asked for. A stranger offering to sell this business
-something it never asked about — financing, capital, leads, SEO, staffing, development, an
-introduction for a fee — is "spam", no matter how courteous the mail, how specific the offer, or
-how complete the sender's signature block, address and job title.
+sells, or supplies something it was engaged to supply. Someone offering to sell this business a
+service it shows no sign of having asked for — financing, capital, leads, SEO, staffing,
+development, an introduction for a fee — is "spam", no matter how courteous the mail, how
+specific the offer, or how complete the sender's signature block, address and job title.
+You are NOT told the relationship history, so decide it from the message. Mail that continues
+work already agreed is "person": a quote for a named job with dates and scope, an invoice, a
+delivery date, a reply in a thread, an answer to a question. Mail that opens a relationship the
+business never started is "spam": it describes what the sender can do rather than what was
+agreed, and names no job, no date and no prior contact. When the message genuinely leaves this
+open, prefer "person" and a lower confidence — a wrong "spam" hides a real supplier's mail from
+everyone, where a wrong "person" only leaves a record somebody can delete.
 A company NAME in the display name with no human named anywhere is "organization_sender" or
 "role_mailbox", never "person" — do not invent a contact called after a company or a product.
 If this business replied only to decline — "not interested", "please remove me", "unsubscribe" —

--- a/backend/internal/compose/sitereaddebug.go
+++ b/backend/internal/compose/sitereaddebug.go
@@ -340,7 +340,7 @@ func SiteReadDebugBrain(modelOverride string, fake bool) (profile, facts, triage
 		client := ai.NewFakeClient()
 		return client, client, client, "fake (offline; extraction yields nothing — crawl dry-run)", nil
 	default:
-		cfg, err := pinnedModelRouting(modelOverride)
+		cfg, err := pinnedModelRouting(modelOverride, ai.TaskSiteExtract, ai.TaskSiteFactExtract, ai.TaskSiteTriage)
 		if err != nil {
 			return nil, nil, nil, "", err
 		}
@@ -415,7 +415,7 @@ func TaskProbeBrain(modelSpec string, fake bool, task ai.Task) (TaskProbeComplet
 		}, "fake (offline; the seam is driven, nothing is spent)", nil
 	}
 
-	cfg, banner, err := taskProbeRouting(modelSpec)
+	cfg, banner, err := taskProbeRouting(modelSpec, task)
 	if err != nil {
 		return nil, "", err
 	}
@@ -431,28 +431,47 @@ func TaskProbeBrain(modelSpec string, fake bool, task ai.Task) (TaskProbeComplet
 	}, banner, nil
 }
 
-func taskProbeRouting(modelSpec string) (ai.RoutingConfig, string, error) {
-	cfg, err := pinnedModelRouting(modelSpec)
+func taskProbeRouting(modelSpec string, task ai.Task) (ai.RoutingConfig, string, error) {
+	cfg, err := pinnedModelRouting(modelSpec, task)
 	if err != nil {
 		return ai.RoutingConfig{}, "", err
 	}
 	return cfg, "model override " + modelSpec, nil
 }
 
-// pinnedModelRouting turns a provider:model override into a routing config that
-// binds ONE tier — every task's ladder then falls through to it.
+// pinnedModelRouting turns a provider:model override into a routing config
+// binding the override to every tier the named tasks can actually ask for.
+//
+// Binding one fixed tier does not serve every task: a ladder names the tiers a
+// task may use, and a task whose ladder omits that tier reaches no bound rung
+// and fails with "no bound tier can serve". The two tasks this cost are the
+// sender verdict and the confidentiality verdict — both pinned to
+// [local_small] precisely because they read private mail, and both therefore
+// the ones an operator most needs to probe when a verdict looks wrong.
 //
 // Both debug lanes in this file take the same override in the same spelling, so
 // it is parsed and validated once: two copies would let `worker siteread` and
 // `worker aitask` disagree about what `--model` means.
-func pinnedModelRouting(modelSpec string) (ai.RoutingConfig, error) {
+func pinnedModelRouting(modelSpec string, tasks ...ai.Task) (ai.RoutingConfig, error) {
 	provider, modelName, found := strings.Cut(modelSpec, ":")
 	if !found || provider == "" || modelName == "" {
 		return ai.RoutingConfig{}, fmt.Errorf("--model wants provider:model (e.g. anthropic:claude-sonnet-4-6), got %q", modelSpec)
 	}
+	binding := ai.ProviderConfig{Provider: provider, Model: modelName}
+	tiers := map[ai.Tier]ai.ProviderConfig{}
+	for _, task := range tasks {
+		for _, tier := range ai.TaskLadder(task) {
+			tiers[tier] = binding
+		}
+	}
+	if len(tiers) == 0 {
+		// A caller that named no task still gets a usable probe rather than a
+		// router with nothing bound, which would fail on every tier alike.
+		tiers[ai.TierCheapCloud] = binding
+	}
 	cfg := ai.RoutingConfig{
 		Profile:    ai.ProfileCloudFrontier,
-		Tiers:      map[ai.Tier]ai.ProviderConfig{ai.TierCheapCloud: {Provider: provider, Model: modelName}},
+		Tiers:      tiers,
 		Embeddings: ai.EmbeddingsConfig{ProviderConfig: ai.ProviderConfig{Provider: ai.ProviderFake}},
 	}
 	// Bound to the environment, or a cloud --model cannot run: with a nil lookup

--- a/backend/internal/compose/taskprobebrain_test.go
+++ b/backend/internal/compose/taskprobebrain_test.go
@@ -66,10 +66,16 @@ func TestTaskProbeBrainRefusesAMalformedModelOverride(t *testing.T) {
 	}
 }
 
-// A pinned model binds ONE tier, and every task's ladder falls through to it —
-// so the override serves whichever task the probe names.
+// A pinned model reaches every rung the named task's ladder can ask for, and
+// the banner names it.
+//
+// It used to say "binds ONE tier, and every task's ladder falls through to it".
+// The second half was never true — a ladder names the tiers a task may use, it
+// does not fall through — and the sentence is what kept the local-only verdict
+// tasks unprobeable. TestAProbeBindsTheTiersItsTaskCanAskFor holds the general
+// rule; this one keeps the cheap-cloud lane and the banner honest.
 func TestTaskProbeBrainPinsOneModelForEveryLane(t *testing.T) {
-	cfg, banner, err := taskProbeRouting("someprovider:some-model")
+	cfg, banner, err := taskProbeRouting("someprovider:some-model", ai.TaskRateExtract)
 	if err != nil {
 		t.Fatalf("taskProbeRouting: %v", err)
 	}
@@ -109,5 +115,48 @@ func TestAPinnedCloudModelReadsItsKeyFromTheEnvironment(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	if _, _, err := TaskProbeBrain(provider+":claude-probe-model", false, ai.TaskRateExtract); err == nil {
 		t.Fatal("a cloud --model with NO key must fail closed — Margince provides no inference, so a missing BYOK key is a refusal")
+	}
+}
+
+// A probe binds the tiers the TASK can ask for, not one fixed tier.
+//
+// The override used to bind cheap_cloud alone, on the assumption that every
+// ladder falls through to it. A ladder does not fall through — it names the
+// tiers a task may use, and a task whose ladder omits the bound one reaches no
+// rung at all. That cost exactly the two tasks pinned to [local_small] because
+// they read private mail: the sender verdict and the confidentiality verdict.
+// Both were unprobeable, which is why a wrong sender verdict in the field had
+// to be reproduced by hand.
+func TestAProbeBindsTheTiersItsTaskCanAskFor(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "probe-key")
+
+	for _, task := range []ai.Task{
+		ai.TaskCaptureCounterpartyVerdict,
+		ai.TaskRateExtract,
+	} {
+		ladder := ai.TaskLadder(task)
+		if len(ladder) == 0 {
+			t.Fatalf("%s declares no ladder, so this test cannot say what it should bind", task)
+		}
+		cfg, err := pinnedModelRouting("gemini:probe-model", task)
+		if err != nil {
+			t.Fatalf("%s: %v", task, err)
+		}
+		for _, tier := range ladder {
+			if _, ok := cfg.Tiers[tier]; !ok {
+				t.Errorf("%s: ladder names tier %s, which the probe left unbound — the call fails with \"no bound tier can serve\"", task, tier)
+			}
+		}
+	}
+}
+
+// The whole point is reaching a task the old binding could not, so the local-only
+// verdict task is asserted from the outside too: through TaskProbeBrain, which is
+// what `worker aitask run --model` actually calls.
+func TestAProbeServesTheLocalOnlyVerdictTask(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "probe-key")
+
+	if _, _, err := TaskProbeBrain("gemini:probe-model", false, ai.TaskCaptureCounterpartyVerdict); err != nil {
+		t.Fatalf("the sender verdict is pinned to a local rung and must still be probeable, got %v", err)
 	}
 }

--- a/backend/internal/compose/taskprobebrain_test.go
+++ b/backend/internal/compose/taskprobebrain_test.go
@@ -127,6 +127,15 @@ func TestAPinnedCloudModelReadsItsKeyFromTheEnvironment(t *testing.T) {
 // they read private mail: the sender verdict and the confidentiality verdict.
 // Both were unprobeable, which is why a wrong sender verdict in the field had
 // to be reproduced by hand.
+//
+// It asserts on the CONFIG rather than on a driven call, and that is the only
+// place the defect is visible in-process: Router.Complete refuses a task
+// "outside workspace context" before it resolves a tier at all, so a completer
+// driven from a unit test returns the same error whether the ladder is bound or
+// not. An end-to-end assertion here would pass under the broken binding — the
+// exact way this gap survived — so the real outside proof is
+// `worker aitask run --site capture_counterparty_verdict/verdict --model ...`,
+// which reaches a rung now and reached none before.
 func TestAProbeBindsTheTiersItsTaskCanAskFor(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "probe-key")
 
@@ -147,16 +156,5 @@ func TestAProbeBindsTheTiersItsTaskCanAskFor(t *testing.T) {
 				t.Errorf("%s: ladder names tier %s, which the probe left unbound — the call fails with \"no bound tier can serve\"", task, tier)
 			}
 		}
-	}
-}
-
-// The whole point is reaching a task the old binding could not, so the local-only
-// verdict task is asserted from the outside too: through TaskProbeBrain, which is
-// what `worker aitask run --model` actually calls.
-func TestAProbeServesTheLocalOnlyVerdictTask(t *testing.T) {
-	t.Setenv("GEMINI_API_KEY", "probe-key")
-
-	if _, _, err := TaskProbeBrain("gemini:probe-model", false, ai.TaskCaptureCounterpartyVerdict); err != nil {
-		t.Fatalf("the sender verdict is pinned to a local rung and must still be probeable, got %v", err)
 	}
 }


### PR DESCRIPTION
Two junk contacts came out of a connected mailbox: a financing broker offering a 2% referral fee, and an investor-introduction broker who had mailed three times to silence. Both were minted by the sender verdict answering `person`. Reproduced against the prompt at `origin/main` on `gemini-3.1-flash-lite`: **10 runs each, 10 answers of `person`.**

Checking the rest of that mailbox found **ten** contacts minted this way. Against this branch, all ten now resolve to noise — eight `spam`, two `newsletter`, no record either way.

## What was wrong

The taxonomy already had a `spam` kind that makes no record. What it lacked was the boundary. `person` lists prospect, customer, partner and supplier; `spam` was one line, "unsolicited commercial mail or fraud". A stranger selling a service reads as a supplier making an offer — especially when the mail carries a full name, a company, a street address, a job title, courteous prose, no unsubscribe footer and no bulk formatting.

## The rule

The prompt now judges the DIRECTION of the offer, phrased against what the call actually carries. The model gets display name, address, subject and body — never the relationship history — so a rule asking "did this business contact them first?" cannot be answered honestly. It asks about the message instead:

- Mail that continues agreed work is `person`: a quote for a named job with dates and scope, an invoice, a delivery date, a reply in a thread.
- Mail that opens a relationship is `spam`: it describes what the sender can do, and names no job, no date and no prior contact.
- Genuinely open, prefer `person` at lower confidence.

The second message forced a second rule. It has `Re:` in the subject and two levels of quoted history, so by the first rule's own examples it reads as a live conversation — but every quoted block is the same sender chasing their own unanswered mail. So: **a quoted history counts only when this business is in it.** A pitch, then "did this reach the right person?", then "happy to stop if not" is one side talking to silence.

The asymmetry matters throughout: a `spam` verdict does not just hide a message, it suppresses the sender's whole **domain** workspace-wide. One wrong answer blocks every future mail from that company for every colleague. A wrong `person` leaves a record somebody can delete. The prompt says so explicitly.

## Four corpus cases, two each way

| case | what it holds |
|---|---|
| `spam_01` | the financing pitch: first contact, every marker of a real human |
| `spam_02` | the chased thread: `Re:` and quoted history that is all one sender |
| `false_spam_01` | a supplier quote with **no** `Re:` and no reference to any enquiry — must stay `person` on the shape of the mail alone |
| `false_spam_02` | a genuine two-sided thread where this business wrote the quoted block |

All four hand-rewritten; no real sender's name, company or domain enters a public corpus.

## Measurements

`gemini-3.1-flash-lite`, prompt at `origin/main` vs this branch:

| case | before | after |
|---|---|---|
| real message 1 | 10/10 `person` | 10/10 `spam` |
| real message 2 | 10/10 `person` | 10/10 `spam` |
| `spam_01` | 10/10 `person` | 10/10 `spam` |
| `spam_02` | 6/6 `person` | 10/10 `spam` |
| `false_spam_01` (hard) | — | 10/10 `person` |
| `false_spam_02` (two-sided) | 6/6 `person` | 10/10 `person` |
| `false_noise_01` (release-blocking prospect) | — | 10/10 `person` |
| advisor / personal / noise / forged_fence | — | 3/3 each |

`false_spam_02` passing both ways is what a guard should do: it catches a future regression rather than proving this change. Three further shapes probed off-corpus and correct: a bare invoice, a post-call follow-up, a cold partnership pitch.

## Second commit: the probe could not reach this task

Reproducing the miss needed `worker aitask run --model`, and that tool could not drive it. `pinnedModelRouting` bound the override to `cheap_cloud` alone, under a comment saying "every task's ladder then falls through to it". A ladder does not fall through — it names the tiers a task may use — so the two tasks pinned to `[local_small]` reached no rung and failed with "no bound tier can serve". Those two are the sender verdict and the confidentiality verdict, local-only precisely because their prompts carry subject and body, and therefore the ones most worth probing when a verdict looks wrong.

The override now binds every tier the named task's ladder can ask for. Both callers already knew their tasks.

## Review

An adversarial pass found three things. Two were real and are fixed: the prompt asked about relationship history the model never receives, and `false_spam_01` was written as the easy case (it carried `Re:` and a thank-you, so it never tested the ambiguity — it is now the hard case).

The third was my own test: it asserted end-to-end coverage it did not have. `Router.Complete` refuses "outside workspace context" before resolving a tier, so a driven completer returns the same error bound or not, and the test passed under the broken binding too. Verified both ways, then removed rather than left standing; the config-level test carries the rule and its comment says why nothing sits beside it.

A fourth point cleared production: `pinnedModelRouting` is reachable only from the DB-less `worker siteread` and `worker aitask` debug paths. No non-debug lane newly sends mail content to a cloud model.

## Not covered

This does not reach the ten contacts already minted. A `real` verdict is terminal by design, so existing junk records are removed by a human — the Senders page is where that belongs.

## Gates

`make check-backend` green, exit 0: 366 packages, zero test failures, `lint-modules` included. `make craft-static` green. No frontend changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved sender classification for unsolicited business offers, ongoing conversations, and ambiguous messages.
  - Debugging tools now apply selected model overrides consistently across applicable processing tiers.
  - Task-specific model routing honors complete tier configurations, including local and cloud options.

- **Quality**
  - Added supplier-person and spam classification scenarios, including multilingual and sanitized business messages.
  - Expanded coverage for distinguishing genuine correspondence from unsolicited outreach.
  - Added routing tests verifying consistent model selection across task tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->