### PR TITLE
A record nothing can look up says so, whatever its old runs claim

### DIFF
--- a/backend/internal/compose/person360/providerpartition_test.go
+++ b/backend/internal/compose/person360/providerpartition_test.go
@@ -52,7 +52,7 @@ func TestEachProviderSectionCarriesOnlyItsOwnPurchases(t *testing.T) {
 	connected := map[string]string{"surfe": "connected", "otherco": "connected"}
 
 	svc := &Service{}
-	profiles, err := svc.profilesFor(namesToShow(connected, nil, claims), connected, nil, claims)
+	profiles, err := svc.profilesFor(namesToShow(connected, nil, claims), connected, nil, claims, lookupableSubject())
 	if err != nil {
 		t.Fatalf("folding the sections: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestSectionsKeepAStableOrderBetweenReads(t *testing.T) {
 	connected := map[string]string{"zeta": "connected", "alpha": "connected", "surfe": "connected"}
 
 	svc := &Service{}
-	profiles, err := svc.profilesFor(namesToShow(connected, nil, nil), connected, nil, nil)
+	profiles, err := svc.profilesFor(namesToShow(connected, nil, nil), connected, nil, nil, lookupableSubject())
 	if err != nil {
 		t.Fatalf("folding the sections: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestAProviderNobodyRunsYetStillGetsItsSection(t *testing.T) {
 	connected := map[string]string{"surfe": "connected"}
 
 	svc := &Service{}
-	profiles, err := svc.profilesFor(namesToShow(connected, nil, nil), connected, nil, nil)
+	profiles, err := svc.profilesFor(namesToShow(connected, nil, nil), connected, nil, nil, lookupableSubject())
 	if err != nil {
 		t.Fatalf("folding the sections: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestAPurchaseSurvivesItsProviderBeingDisconnected(t *testing.T) {
 	connected := map[string]string{"surfe": "connected"}
 
 	svc := &Service{}
-	profiles, err := svc.profilesFor(namesToShow(connected, nil, claims), connected, nil, claims)
+	profiles, err := svc.profilesFor(namesToShow(connected, nil, claims), connected, nil, claims, lookupableSubject())
 	if err != nil {
 		t.Fatalf("folding the sections: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestAnImpairedConnectionSaysWhatIsWrongRatherThanReadingAsStale(t *testing.
 			statuses := map[string]string{"surfe": tc.status}
 
 			svc := &Service{}
-			profiles, err := svc.profilesFor(namesToShow(statuses, nil, claims), statuses, nil, claims)
+			profiles, err := svc.profilesFor(namesToShow(statuses, nil, claims), statuses, nil, claims, lookupableSubject())
 			if err != nil {
 				t.Fatalf("folding the sections: %v", err)
 			}
@@ -396,5 +396,17 @@ func TestTheAskedSetExcludesWhatWasNeverSent(t *testing.T) {
 		if got[i] != name {
 			t.Errorf("position %d is %q, want %q", i, got[i], name)
 		}
+	}
+}
+
+// lookupableSubject is a contact a provider CAN match on, which is what these
+// partition cases are about: they ask which provider's values land in which
+// section, and a subject nothing can look up would answer every one of them
+// with "nothing to look them up by" before the partition was reached.
+func lookupableSubject() provider.PersonIdentifiers {
+	return provider.PersonIdentifiers{
+		FirstName:   "Anna",
+		LastName:    "Muster",
+		CompanyName: "Example GmbH",
 	}
 }

--- a/backend/internal/compose/person360/providerprofile.go
+++ b/backend/internal/compose/person360/providerprofile.go
@@ -24,7 +24,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
-	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
 )
@@ -73,7 +72,15 @@ func (s *Service) providerProfileSection(ctx context.Context, tx pgx.Tx, personI
 	//
 	// The SAME function the queue asks, so the page and the lookup cannot
 	// disagree about whether this person is findable.
-	idents, err := people.SubjectIdentifiers(ctx, tx, personID.String())
+	//
+	// It reads the employer as well as the name, and the employer lives behind
+	// its own grant — every other section here that touches an edge asks
+	// requireRead("relationship") first. A seat without it must not learn from
+	// this sentence that the contact HAS an employer, so it is not read at
+	// all, and the answer falls back to findable: reporting a record as
+	// unlookupable on the strength of a field we were not allowed to see would
+	// invent a fact from an absence.
+	idents, err := s.matchIdentifiers(ctx, tx, personID)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/compose/person360/providerprofile.go
+++ b/backend/internal/compose/person360/providerprofile.go
@@ -24,6 +24,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
 )
@@ -64,7 +65,19 @@ func (s *Service) providerProfileSection(ctx context.Context, tx pgx.Tx, personI
 	// Set even when empty — a pointer to no sections says "nobody is
 	// connected", which is a different fact from the nil the grant check
 	// leaves behind, and `sections_omitted` is what names the second.
-	profiles, err := s.profilesFor(namesToShow(statuses, runs, claims), statuses, runs, claims)
+	// What this record carries that a provider could match on. Resolved once
+	// for the section and asked of each provider's own rules below, because a
+	// failed run means something different depending on the answer: a vendor
+	// that could not place a contact carrying a profile link had a bad day,
+	// and one asked about a contact carrying nothing was never going to.
+	//
+	// The SAME function the queue asks, so the page and the lookup cannot
+	// disagree about whether this person is findable.
+	idents, err := people.SubjectIdentifiers(ctx, tx, personID.String())
+	if err != nil {
+		return err
+	}
+	profiles, err := s.profilesFor(namesToShow(statuses, runs, claims), statuses, runs, claims, idents)
 	if err != nil {
 		return err
 	}
@@ -104,16 +117,6 @@ func (s *Service) connectionStatuses(ctx context.Context, tx pgx.Tx) (map[string
 	return statuses, nil
 }
 
-// impairedStates maps a connection that EXISTS but cannot buy onto the sentence
-// the page shows. Each names the installation's own condition, because that is
-// where the fix is — none of them is a fact about the contact.
-var impairedStates = map[string]crmcontracts.PersonProviderProfileState{
-	"invalid_credentials":  crmcontracts.PersonProviderProfileStateInvalidCredentials,
-	"insufficient_credits": crmcontracts.PersonProviderProfileStateInsufficientCredits,
-	"rate_limited":         crmcontracts.PersonProviderProfileStateRateLimited,
-	"provider_error":       crmcontracts.PersonProviderProfileStateProviderError,
-}
-
 // namesToShow collects the providers the page owes the reader a section for:
 // the connected ones, plus any that already hold a run or a purchase here.
 // Sorted, so the sections keep their order between reads rather than
@@ -146,10 +149,10 @@ func namesToShow(statuses map[string]string, runs []providerRunRow, claims []sto
 // profilesFor builds one snapshot per named provider, each seeing only its own
 // runs and its own claims. The partition is the whole point: a value bought
 // from one vendor must never appear under another's name.
-func (s *Service) profilesFor(names []string, statuses map[string]string, runs []providerRunRow, claims []storedClaim) ([]crmcontracts.PersonProviderProfile, error) {
+func (s *Service) profilesFor(names []string, statuses map[string]string, runs []providerRunRow, claims []storedClaim, idents provider.PersonIdentifiers) ([]crmcontracts.PersonProviderProfile, error) {
 	profiles := make([]crmcontracts.PersonProviderProfile, 0, len(names))
 	for _, name := range names {
-		profile, err := s.profileFor(name, statuses[name], runsOf(name, runs), claimsOf(name, claims))
+		profile, err := s.profileFor(name, statuses[name], runsOf(name, runs), claimsOf(name, claims), idents)
 		if err != nil {
 			return nil, err
 		}
@@ -160,10 +163,10 @@ func (s *Service) profilesFor(names []string, statuses map[string]string, runs [
 
 // profileFor is one provider's section: what it was asked, what it answered,
 // and what it sold us.
-func (s *Service) profileFor(name string, status string, runs []providerRunRow, claims []storedClaim) (crmcontracts.PersonProviderProfile, error) {
+func (s *Service) profileFor(name string, status string, runs []providerRunRow, claims []storedClaim, idents provider.PersonIdentifiers) (crmcontracts.PersonProviderProfile, error) {
 	profile := crmcontracts.PersonProviderProfile{
 		Provider:               crmcontracts.Provider(name),
-		State:                  resolveProviderState(runs, status),
+		State:                  resolveProviderState(runs, status, s.lookupable(name, idents)),
 		CategoriesNotRequested: []string{},
 		Emails:                 []crmcontracts.PersonProviderEmail{},
 		MobilePhones:           []crmcontracts.PersonProviderPhone{},
@@ -368,92 +371,4 @@ func categoriesNotRequested(desc provider.Descriptor, runs []providerRunRow, cla
 	}
 	sort.Strings(out)
 	return out
-}
-
-// resolveProviderState answers the ONE sentence the page shows about this
-// person's enrichment. The three "nothing here" states are three different
-// facts and must never collapse into one: nobody connected a provider, this
-// person is not eligible for one, and nobody has asked yet are different
-// answers to "why is this empty", and only the reader can act on the right
-// one.
-func resolveProviderState(runs []providerRunRow, status string) crmcontracts.PersonProviderProfileState {
-	// A connection that exists but cannot buy says WHY, before anything about
-	// this person's runs. The condition is the installation's — a refused key,
-	// an exhausted wallet — and it outranks the run history because it is what
-	// the next lookup will hit, and the only thing anybody can act on.
-	if impaired, ok := impairedStates[status]; ok {
-		return impaired
-	}
-	if status != "connected" {
-		// Disconnected, and the data this installation already PAID for is
-		// still on the page below — disconnecting stops new egress, it does
-		// not delete what was bought. So the honest word is stale, not
-		// not_connected: telling the reader the platform knows nothing while
-		// showing them a purchased mobile number is the one thing this state
-		// exists to prevent. not_connected is for a page with nothing on it.
-		if len(runs) > 0 {
-			return crmcontracts.PersonProviderProfileStateStale
-		}
-		return crmcontracts.PersonProviderProfileStateNotConnected
-	}
-	if len(runs) == 0 {
-		return crmcontracts.PersonProviderProfileStateNeverRun
-	}
-	latest := runs[0]
-	if latest.state == string(provider.RunCompleted) && latest.claimsUnwritten {
-		// Paid, and the values never reached the record. Its own state
-		// because it is neither a success nor a failure: the customer was
-		// charged and has nothing to show for it, which is a thing somebody
-		// needs to see rather than a completed run with empty fields.
-		return crmcontracts.PersonProviderProfileStateCompletedClaimsUnwritten
-	}
-	if latest.state == string(provider.RunSkipped) {
-		// A skip is a decision, and its REASON is what the reader needs. An
-		// exhausted budget is a fact about the installation's wallet; telling
-		// somebody "this person is not eligible" instead would send them
-		// looking at the contact for a problem that is not there.
-		return skipStates[latest.skipReason]
-	}
-	if mapped, ok := providerRunStates[latest.state]; ok {
-		return mapped
-	}
-	return crmcontracts.PersonProviderProfileStateProviderError
-}
-
-// skipStates says WHY nothing was bought, in the page's vocabulary. The zero
-// value is not_eligible, which is the honest default for the two reasons that
-// really are about the subject; everything else names the installation's own
-// condition instead.
-var skipStates = map[string]crmcontracts.PersonProviderProfileState{
-	"":                            crmcontracts.PersonProviderProfileStateNotEligible,
-	"not_eligible":                crmcontracts.PersonProviderProfileStateNotEligible,
-	"duplicate_subject_candidate": crmcontracts.PersonProviderProfileStateNotEligible,
-	// A consent decision, not an eligibility one. It reads as not_eligible
-	// today because the contract has no suppressed state; the difference is
-	// worth a spec change rather than a wrong word invented here.
-	"suppressed": crmcontracts.PersonProviderProfileStateNotEligible,
-	// Its own state, not a kind of not_eligible: nothing forbids this
-	// purchase. The record carries no profile link and no company, so the
-	// provider has nothing to match on — and the reader's next step is to add
-	// one of those, which is the next step for nothing else in this map.
-	"no_identifiers":   crmcontracts.PersonProviderProfileStateNothingToLookUp,
-	"budget_exhausted": crmcontracts.PersonProviderProfileStateInsufficientCredits,
-	"low_balance":      crmcontracts.PersonProviderProfileStateInsufficientCredits,
-	"rate_limited":     crmcontracts.PersonProviderProfileStateRateLimited,
-	// Nothing was bought because we already hold an answer inside the refresh
-	// window — which is a completed enrichment, not a refusal.
-	"already_fresh": crmcontracts.PersonProviderProfileStateCompleted,
-}
-
-// providerRunStates maps the run machine onto the page's vocabulary. The two
-// are deliberately separate: a run state is what the platform is doing, and
-// this is what the reader is told.
-var providerRunStates = map[string]crmcontracts.PersonProviderProfileState{
-	string(provider.RunQueued):            crmcontracts.PersonProviderProfileStateQueued,
-	string(provider.RunSubmitting):        crmcontracts.PersonProviderProfileStateInProgress,
-	string(provider.RunInProgress):        crmcontracts.PersonProviderProfileStateInProgress,
-	string(provider.RunCompleted):         crmcontracts.PersonProviderProfileStateCompleted,
-	string(provider.RunNoMatch):           crmcontracts.PersonProviderProfileStateNoMatch,
-	string(provider.RunSubmissionUnknown): crmcontracts.PersonProviderProfileStateSubmissionUnknown,
-	string(provider.RunCancelled):         crmcontracts.PersonProviderProfileStateNeverRun,
 }

--- a/backend/internal/compose/person360/providerstalefault_test.go
+++ b/backend/internal/compose/person360/providerstalefault_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package person360
+
+// What a failed run means depends on whether the contact could ever have been
+// found.
+//
+// Before admission checked for identifiers, a contact carrying neither a
+// profile link nor an employer was sent to the provider anyway. The vendor
+// rejected the request and the platform stored that as a provider fault. Those
+// runs are still on record: in one installation, 205 contacts had one as their
+// newest run, and every one of their pages read "The last call to the provider
+// failed. Automatic lookups are paused; a free check that gets through resumes
+// them" — over a connection that was `connected` and working.
+//
+// Both halves of that sentence were false, and the reader could act on
+// neither. What is true is that the record carries nothing to look them up by.
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+func failedRun() []providerRunRow {
+	return []providerRunRow{{
+		state:    string(provider.RunFailed),
+		safeCode: "provider_error",
+	}}
+}
+
+func TestAFailedRunOnAnUnlookupableContactIsNotAProviderFault(t *testing.T) {
+	t.Parallel()
+
+	got := resolveProviderState(failedRun(), "connected", false)
+	if got != crmcontracts.PersonProviderProfileStateNothingToLookUp {
+		t.Errorf("state = %q, want nothing_to_look_up.\n\n"+
+			"A contact with no profile link and no employer cannot be looked up, so a past refusal is not "+
+			"news about the provider — and the provider_error copy tells the reader that automatic lookups "+
+			"are paused and a retry resumes them, when the connection is healthy and a retry can only be "+
+			"skipped again.", got)
+	}
+}
+
+// The same run on a contact the provider CAN match on still reads as a
+// provider fault. Without this case the rule above passes against one that
+// swallows every failure, which would hide the outage it exists to report.
+func TestAFailedRunOnAFindableContactStillReadsAsAProviderFault(t *testing.T) {
+	t.Parallel()
+
+	got := resolveProviderState(failedRun(), "connected", true)
+	if got != crmcontracts.PersonProviderProfileStateProviderError {
+		t.Errorf("state = %q, want provider_error: this contact carries something to match on, so a "+
+			"refusal really is the vendor's and the reader should see it", got)
+	}
+}
+
+// A contact nothing can look up says so even where no run exists at all, which
+// is the case every newly captured calendar contact is in. never_run would
+// invite a press of a button that can only be skipped.
+func TestAnUnlookupableContactSaysSoBeforeAnybodyHasAsked(t *testing.T) {
+	t.Parallel()
+
+	got := resolveProviderState(nil, "connected", false)
+	if got != crmcontracts.PersonProviderProfileStateNothingToLookUp {
+		t.Errorf("state = %q, want nothing_to_look_up: inviting a lookup that admission will decline "+
+			"teaches a reader that the button does nothing", got)
+	}
+}
+
+// The connection's own condition still outranks the record's. A refused key is
+// the installation's problem and the only thing anybody can act on, whatever
+// this one contact carries.
+func TestTheConnectionsOwnFaultOutranksAnUnlookupableRecord(t *testing.T) {
+	t.Parallel()
+
+	for status, want := range map[string]crmcontracts.PersonProviderProfileState{
+		"invalid_credentials":  crmcontracts.PersonProviderProfileStateInvalidCredentials,
+		"insufficient_credits": crmcontracts.PersonProviderProfileStateInsufficientCredits,
+		"rate_limited":         crmcontracts.PersonProviderProfileStateRateLimited,
+	} {
+		if got := resolveProviderState(failedRun(), status, false); got != want {
+			t.Errorf("status %q with an unlookupable contact = %q, want %q: rotating a refused key is "+
+				"what unblocks every contact, and burying that behind one record's missing employer "+
+				"leaves an admin with nothing to fix", status, got, want)
+		}
+	}
+}
+
+// A disconnected provider still reports what was PAID for. Purchases outlive
+// the connection, and telling a reader there is nothing to look up while
+// showing them a bought mobile number is the confusion `stale` exists to stop.
+func TestADisconnectedProviderStillSaysStaleOverAnUnlookupableRecord(t *testing.T) {
+	t.Parallel()
+
+	got := resolveProviderState(failedRun(), "disconnected", false)
+	if got != crmcontracts.PersonProviderProfileStateStale {
+		t.Errorf("state = %q, want stale: this person has runs on record, and what was bought is still "+
+			"on the page below", got)
+	}
+}

--- a/backend/internal/compose/person360/providerstalefault_test.go
+++ b/backend/internal/compose/person360/providerstalefault_test.go
@@ -101,3 +101,49 @@ func TestADisconnectedProviderStillSaysStaleOverAnUnlookupableRecord(t *testing.
 			"on the page below", got)
 	}
 }
+
+// A charge the customer has nothing to show for outranks a missing employer.
+//
+// completed_claims_unwritten means the provider answered, money moved, and the
+// values never reached the record. submission_unknown means the outcome was
+// never learned and the run may have been charged. Both are facts about
+// somebody's money; replacing either with "nothing to look them up by" would
+// hide a paid-for loss behind a tidy explanation about the record.
+func TestAPaidRunIsNotHiddenBehindAMissingIdentifier(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range []struct {
+		name string
+		run  providerRunRow
+		want crmcontracts.PersonProviderProfileState
+	}{
+		{
+			name: "paid and nothing landed",
+			run: providerRunRow{
+				state:           string(provider.RunCompleted),
+				claimsUnwritten: true,
+			},
+			want: crmcontracts.PersonProviderProfileStateCompletedClaimsUnwritten,
+		},
+		{
+			name: "outcome never learned",
+			run:  providerRunRow{state: string(provider.RunSubmissionUnknown)},
+			want: crmcontracts.PersonProviderProfileStateSubmissionUnknown,
+		},
+		{
+			// A purchase that DID land is still on the page below, and saying
+			// the contact cannot be looked up over their own bought values is
+			// the contradiction this whole section exists to avoid.
+			name: "bought and delivered",
+			run:  providerRunRow{state: string(provider.RunCompleted)},
+			want: crmcontracts.PersonProviderProfileStateCompleted,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveProviderState([]providerRunRow{c.run}, "connected", false); got != c.want {
+				t.Errorf("state = %q, want %q — an unlookupable record must not mask what a run cost", got, c.want)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/person360/providerstate.go
+++ b/backend/internal/compose/person360/providerstate.go
@@ -12,7 +12,15 @@ package person360
 // what somebody reads.
 
 import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/provider"
 )
 
@@ -67,22 +75,13 @@ func resolveProviderState(runs []providerRunRow, status string, lookupable bool)
 		}
 		return crmcontracts.PersonProviderProfileStateNotConnected
 	}
-	// Nothing on this record for the provider to match on, so nothing that
-	// happened to a past run is the fact the reader needs. This outranks the
-	// run history for the same reason the connection's own condition does: it
-	// is what the NEXT lookup will hit, and unlike a run it is something the
-	// reader can act on — add a profile link or an employer.
-	//
-	// It is also the only honest reading of the runs already on record. Before
-	// admission checked this, an unlookupable contact was sent anyway and the
-	// vendor rejected the request; the platform stored that as a provider
-	// fault. Those runs are still there, and left to speak they tell every one
-	// of those contacts that the vendor is broken and a retry will fix it.
-	// Neither half is true.
-	if !lookupable {
-		return crmcontracts.PersonProviderProfileStateNothingToLookUp
-	}
 	if len(runs) == 0 {
+		// Nobody has asked, and nothing on this record could be asked WITH.
+		// The reader's next step is to add a profile link or an employer, not
+		// to press a button admission will decline.
+		if !lookupable {
+			return crmcontracts.PersonProviderProfileStateNothingToLookUp
+		}
 		return crmcontracts.PersonProviderProfileStateNeverRun
 	}
 	latest := runs[0]
@@ -100,10 +99,37 @@ func resolveProviderState(runs []providerRunRow, status string, lookupable bool)
 		// looking at the contact for a problem that is not there.
 		return skipStates[latest.skipReason]
 	}
+	// A run that FAILED on a record nothing can match on is a gravestone, not
+	// news about the vendor.
+	//
+	// Before admission checked for identifiers, such a contact was sent
+	// anyway; the provider rejected the request and the platform stored that
+	// as a provider fault. Left to speak, those runs tell the reader the
+	// vendor is broken and a retry will fix it, and neither is true — a retry
+	// is declined before it reaches anybody.
+	//
+	// ONLY the failure states, and only here at the end. A completed run whose
+	// claims never landed means somebody was CHARGED and has nothing to show
+	// for it, and a submission whose outcome was never learned may have been
+	// charged too. Those are material facts about money that outrank a missing
+	// employer, so they are answered above and reach this line only if the run
+	// is neither.
+	if !lookupable && staleFault[latest.state] {
+		return crmcontracts.PersonProviderProfileStateNothingToLookUp
+	}
 	if mapped, ok := providerRunStates[latest.state]; ok {
 		return mapped
 	}
 	return crmcontracts.PersonProviderProfileStateProviderError
+}
+
+// staleFault names the run outcomes that say nothing once the record itself
+// cannot be looked up. A failed or cancelled run bought nothing and charged
+// nothing, so replacing it with the record's own fact costs the reader no
+// information — unlike a completed or unknown one, which may have cost money.
+var staleFault = map[string]bool{
+	string(provider.RunFailed):    true,
+	string(provider.RunCancelled): true,
 }
 
 // skipStates says WHY nothing was bought, in the page's vocabulary. The zero
@@ -142,4 +168,27 @@ var providerRunStates = map[string]crmcontracts.PersonProviderProfileState{
 	string(provider.RunNoMatch):           crmcontracts.PersonProviderProfileStateNoMatch,
 	string(provider.RunSubmissionUnknown): crmcontracts.PersonProviderProfileStateSubmissionUnknown,
 	string(provider.RunCancelled):         crmcontracts.PersonProviderProfileStateNeverRun,
+}
+
+// matchIdentifiers resolves what a provider could match this contact on, under
+// the grants the caller actually holds.
+//
+// The full answer includes the employer, which is a relationship read — and
+// this section is entered on the `person` grant alone. So the edge is read only
+// where the caller may read edges, exactly as every other section here does,
+// and a caller without that grant gets a name-only answer.
+//
+// Erring toward FINDABLE: a name-only answer can only make a contact look less
+// matchable than they are, and the page's own fallback for "findable" is the
+// state it showed before this rule existed. The opposite — telling somebody a
+// record cannot be looked up because we were not allowed to see the field that
+// would have proved otherwise — invents a fact out of a permission.
+func (s *Service) matchIdentifiers(ctx context.Context, tx pgx.Tx, personID ids.PersonID) (provider.PersonIdentifiers, error) {
+	if err := requireRead(ctx, "relationship"); err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return people.SubjectNameOnly(ctx, tx, personID.String())
+		}
+		return provider.PersonIdentifiers{}, err
+	}
+	return people.SubjectIdentifiers(ctx, tx, personID.String())
 }

--- a/backend/internal/compose/person360/providerstate.go
+++ b/backend/internal/compose/person360/providerstate.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package person360
+
+// Which sentence the provider section shows, and why that one.
+//
+// Split from the assembly beside it because they answer different questions:
+// that file gathers what a provider was asked and what it sold us, and this one
+// decides what to TELL the reader about it. The vocabularies are separate on
+// purpose — a run state is what the platform is doing, and a profile state is
+// what somebody reads.
+
+import (
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/ports/provider"
+)
+
+// impairedStates maps a connection that EXISTS but cannot buy onto the sentence
+// the page shows. Each names the installation's own condition, because that is
+// where the fix is — none of them is a fact about the contact.
+var impairedStates = map[string]crmcontracts.PersonProviderProfileState{
+	"invalid_credentials":  crmcontracts.PersonProviderProfileStateInvalidCredentials,
+	"insufficient_credits": crmcontracts.PersonProviderProfileStateInsufficientCredits,
+	"rate_limited":         crmcontracts.PersonProviderProfileStateRateLimited,
+	"provider_error":       crmcontracts.PersonProviderProfileStateProviderError,
+}
+
+// lookupable asks one provider's own rules whether this record carries
+// anything it could match on. A provider this build does not carry answers
+// true: the page must not report a record as unfindable on the authority of a
+// descriptor it cannot read.
+func (s *Service) lookupable(name string, idents provider.PersonIdentifiers) bool {
+	if s.providers == nil {
+		return true
+	}
+	desc, err := s.providers.Descriptor(name)
+	if err != nil {
+		return true
+	}
+	return idents.Matchable(desc.MatchRules)
+}
+
+// resolveProviderState answers the ONE sentence the page shows about this
+// person's enrichment. The "nothing here" states are separate facts and must
+// never collapse into one: nobody connected a provider, this person is not
+// eligible for one, this record carries nothing to look them up by, and nobody
+// has asked yet are different answers to "why is this empty", and only the
+// reader can act on the right one.
+func resolveProviderState(runs []providerRunRow, status string, lookupable bool) crmcontracts.PersonProviderProfileState {
+	// A connection that exists but cannot buy says WHY, before anything about
+	// this person's runs. The condition is the installation's — a refused key,
+	// an exhausted wallet — and it outranks the run history because it is what
+	// the next lookup will hit, and the only thing anybody can act on.
+	if impaired, ok := impairedStates[status]; ok {
+		return impaired
+	}
+	if status != "connected" {
+		// Disconnected, and the data this installation already PAID for is
+		// still on the page below — disconnecting stops new egress, it does
+		// not delete what was bought. So the honest word is stale, not
+		// not_connected: telling the reader the platform knows nothing while
+		// showing them a purchased mobile number is the one thing this state
+		// exists to prevent. not_connected is for a page with nothing on it.
+		if len(runs) > 0 {
+			return crmcontracts.PersonProviderProfileStateStale
+		}
+		return crmcontracts.PersonProviderProfileStateNotConnected
+	}
+	// Nothing on this record for the provider to match on, so nothing that
+	// happened to a past run is the fact the reader needs. This outranks the
+	// run history for the same reason the connection's own condition does: it
+	// is what the NEXT lookup will hit, and unlike a run it is something the
+	// reader can act on — add a profile link or an employer.
+	//
+	// It is also the only honest reading of the runs already on record. Before
+	// admission checked this, an unlookupable contact was sent anyway and the
+	// vendor rejected the request; the platform stored that as a provider
+	// fault. Those runs are still there, and left to speak they tell every one
+	// of those contacts that the vendor is broken and a retry will fix it.
+	// Neither half is true.
+	if !lookupable {
+		return crmcontracts.PersonProviderProfileStateNothingToLookUp
+	}
+	if len(runs) == 0 {
+		return crmcontracts.PersonProviderProfileStateNeverRun
+	}
+	latest := runs[0]
+	if latest.state == string(provider.RunCompleted) && latest.claimsUnwritten {
+		// Paid, and the values never reached the record. Its own state
+		// because it is neither a success nor a failure: the customer was
+		// charged and has nothing to show for it, which is a thing somebody
+		// needs to see rather than a completed run with empty fields.
+		return crmcontracts.PersonProviderProfileStateCompletedClaimsUnwritten
+	}
+	if latest.state == string(provider.RunSkipped) {
+		// A skip is a decision, and its REASON is what the reader needs. An
+		// exhausted budget is a fact about the installation's wallet; telling
+		// somebody "this person is not eligible" instead would send them
+		// looking at the contact for a problem that is not there.
+		return skipStates[latest.skipReason]
+	}
+	if mapped, ok := providerRunStates[latest.state]; ok {
+		return mapped
+	}
+	return crmcontracts.PersonProviderProfileStateProviderError
+}
+
+// skipStates says WHY nothing was bought, in the page's vocabulary. The zero
+// value is not_eligible, which is the honest default for the two reasons that
+// really are about the subject; everything else names the installation's own
+// condition instead.
+var skipStates = map[string]crmcontracts.PersonProviderProfileState{
+	"":                            crmcontracts.PersonProviderProfileStateNotEligible,
+	"not_eligible":                crmcontracts.PersonProviderProfileStateNotEligible,
+	"duplicate_subject_candidate": crmcontracts.PersonProviderProfileStateNotEligible,
+	// A consent decision, not an eligibility one. It reads as not_eligible
+	// today because the contract has no suppressed state; the difference is
+	// worth a spec change rather than a wrong word invented here.
+	"suppressed": crmcontracts.PersonProviderProfileStateNotEligible,
+	// Its own state, not a kind of not_eligible: nothing forbids this
+	// purchase. The record carries no profile link and no company, so the
+	// provider has nothing to match on — and the reader's next step is to add
+	// one of those, which is the next step for nothing else in this map.
+	"no_identifiers":   crmcontracts.PersonProviderProfileStateNothingToLookUp,
+	"budget_exhausted": crmcontracts.PersonProviderProfileStateInsufficientCredits,
+	"low_balance":      crmcontracts.PersonProviderProfileStateInsufficientCredits,
+	"rate_limited":     crmcontracts.PersonProviderProfileStateRateLimited,
+	// Nothing was bought because we already hold an answer inside the refresh
+	// window — which is a completed enrichment, not a refusal.
+	"already_fresh": crmcontracts.PersonProviderProfileStateCompleted,
+}
+
+// providerRunStates maps the run machine onto the page's vocabulary. The two
+// are deliberately separate: a run state is what the platform is doing, and
+// this is what the reader is told.
+var providerRunStates = map[string]crmcontracts.PersonProviderProfileState{
+	string(provider.RunQueued):            crmcontracts.PersonProviderProfileStateQueued,
+	string(provider.RunSubmitting):        crmcontracts.PersonProviderProfileStateInProgress,
+	string(provider.RunInProgress):        crmcontracts.PersonProviderProfileStateInProgress,
+	string(provider.RunCompleted):         crmcontracts.PersonProviderProfileStateCompleted,
+	string(provider.RunNoMatch):           crmcontracts.PersonProviderProfileStateNoMatch,
+	string(provider.RunSubmissionUnknown): crmcontracts.PersonProviderProfileStateSubmissionUnknown,
+	string(provider.RunCancelled):         crmcontracts.PersonProviderProfileStateNeverRun,
+}

--- a/backend/internal/modules/people/enrichment.go
+++ b/backend/internal/modules/people/enrichment.go
@@ -201,11 +201,16 @@ func DuplicateCluster(ctx context.Context, tx pgx.Tx, personID string) ([]string
 	return out, nil
 }
 
-// SubjectIdentifiers resolves the closed set of facts that may leave the
-// installation for one subject (PI-PARAM-11). Nothing else about them can:
-// the provider port names these five fields and the adapter sends what it is
-// given.
-func SubjectIdentifiers(ctx context.Context, tx pgx.Tx, personID string) (provider.PersonIdentifiers, error) {
+// SubjectNameOnly resolves the name half of the same answer, for a caller that
+// may read a person but not their employment edge. The employer is a
+// relationship read and carries its own grant; a caller without it gets what
+// it may see rather than a refusal, because the name alone is still a partial
+// answer to "could a provider match this contact".
+//
+// Split out rather than copied so the full_name fallback below has one
+// spelling: two would drift, and the drift a reader would see is one surface
+// finding a contact by name and another not.
+func SubjectNameOnly(ctx context.Context, tx pgx.Tx, personID string) (provider.PersonIdentifiers, error) {
 	var id provider.PersonIdentifiers
 	var first, last *string
 	var full string
@@ -220,6 +225,18 @@ func SubjectIdentifiers(ctx context.Context, tx pgx.Tx, personID string) (provid
 	id.FirstName, id.LastName = derefOr(first), derefOr(last)
 	if id.FirstName == "" && id.LastName == "" {
 		id.FirstName, id.LastName = splitFullName(full)
+	}
+	return id, nil
+}
+
+// SubjectIdentifiers resolves the closed set of facts that may leave the
+// installation for one subject (PI-PARAM-11). Nothing else about them can:
+// the provider port names these five fields and the adapter sends what it is
+// given.
+func SubjectIdentifiers(ctx context.Context, tx pgx.Tx, personID string) (provider.PersonIdentifiers, error) {
+	id, err := SubjectNameOnly(ctx, tx, personID)
+	if err != nil {
+		return provider.PersonIdentifiers{}, err
 	}
 
 	// The employer, and its primary domain if one is on file. A domain

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7043,7 +7043,7 @@ export const de = {
   "provider.profile.rateLimited":
     "Nicht gekauft: der Anbieter hat uns gebremst.",
   "provider.profile.providerError":
-    "Der letzte Aufruf beim Anbieter ist fehlgeschlagen. Automatische Abfragen pausieren; eine kostenlose Prüfung, die durchkommt, setzt sie fort.",
+    "Die letzte Abfrage für diesen Kontakt kam nicht durch. Versuchen Sie es erneut, oder sehen Sie in den Einstellungen auf der Karte des Anbieters nach, wenn es wieder passiert.",
   "provider.profile.submissionUnknown":
     "Wie diese Abfrage ausgegangen ist, haben wir nie erfahren. Sie kann berechnet worden sein.",
   "provider.profile.claimsUnwritten":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7043,7 +7043,7 @@ export const de = {
   "provider.profile.rateLimited":
     "Nicht gekauft: der Anbieter hat uns gebremst.",
   "provider.profile.providerError":
-    "Die letzte Abfrage für diesen Kontakt kam nicht durch. Versuchen Sie es erneut, oder sehen Sie in den Einstellungen auf der Karte des Anbieters nach, wenn es wieder passiert.",
+    "Die letzte Abfrage kam nicht durch. Versuchen Sie es erneut, oder sehen Sie in den Einstellungen auf der Karte des Anbieters nach, wenn es wieder passiert.",
   "provider.profile.submissionUnknown":
     "Wie diese Abfrage ausgegangen ist, haben wir nie erfahren. Sie kann berechnet worden sein.",
   "provider.profile.claimsUnwritten":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7092,7 +7092,7 @@ export const en = {
   "provider.profile.rateLimited":
     "Not bought: the provider asked us to slow down.",
   "provider.profile.providerError":
-    "The last call to the provider failed. Automatic lookups are paused; a free check that gets through resumes them.",
+    "The last lookup for this contact did not get through. Try again, or check the provider's card in Settings if it keeps happening.",
   "provider.profile.submissionUnknown":
     "We never learned how this lookup ended. It may have been charged for.",
   "provider.profile.claimsUnwritten":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7092,7 +7092,7 @@ export const en = {
   "provider.profile.rateLimited":
     "Not bought: the provider asked us to slow down.",
   "provider.profile.providerError":
-    "The last lookup for this contact did not get through. Try again, or check the provider's card in Settings if it keeps happening.",
+    "The last lookup did not get through. Try again, or check the provider's card in Settings if it keeps happening.",
   "provider.profile.submissionUnknown":
     "We never learned how this lookup ended. It may have been charged for.",
   "provider.profile.claimsUnwritten":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6963,7 +6963,7 @@ export const vi = {
   "provider.profile.rateLimited":
     "Không mua: nhà cung cấp yêu cầu chúng ta chậm lại.",
   "provider.profile.providerError":
-    "Lần gọi gần nhất tới nhà cung cấp đã thất bại. Tra cứu tự động đang tạm dừng; một lượt kiểm tra miễn phí thành công sẽ tiếp tục chúng.",
+    "Lần tra cứu gần nhất cho liên hệ này không thành công. Hãy thử lại, hoặc xem thẻ nhà cung cấp trong Cài đặt nếu vẫn tiếp diễn.",
   "provider.profile.submissionUnknown":
     "Chúng ta không bao giờ biết lượt tra cứu này kết thúc ra sao. Nó có thể đã bị tính phí.",
   "provider.profile.claimsUnwritten":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6963,7 +6963,7 @@ export const vi = {
   "provider.profile.rateLimited":
     "Không mua: nhà cung cấp yêu cầu chúng ta chậm lại.",
   "provider.profile.providerError":
-    "Lần tra cứu gần nhất cho liên hệ này không thành công. Hãy thử lại, hoặc xem thẻ nhà cung cấp trong Cài đặt nếu vẫn tiếp diễn.",
+    "Lần tra cứu gần nhất không thành công. Hãy thử lại, hoặc xem thẻ nhà cung cấp trong Cài đặt nếu vẫn tiếp diễn.",
   "provider.profile.submissionUnknown":
     "Chúng ta không bao giờ biết lượt tra cứu này kết thúc ra sao. Nó có thể đã bị tính phí.",
   "provider.profile.claimsUnwritten":

--- a/frontend/src/screens/provider-status.test.ts
+++ b/frontend/src/screens/provider-status.test.ts
@@ -118,6 +118,23 @@ describe("the provider status vocabulary", () => {
     expect(canEnrichNow("nothing_to_look_up", false)).toBe(true);
   });
 
+  it("does not claim an installation-wide pause on one contact's failed run", () => {
+    // The person page's provider_error is reached two ways: the CONNECTION is
+    // degraded, or this contact's newest run failed under a healthy one. The
+    // copy used to assert the first for both — "Automatic lookups are paused;
+    // a free check that gets through resumes them" — and on a healthy
+    // connection every word of that is false. In one installation 205 contacts
+    // showed it while the connection was `connected` and working, and the
+    // suggested remedy could not fire: those contacts carry nothing to look
+    // them up by, so a free check is skipped rather than passed.
+    //
+    // The installation-wide story belongs to the settings card, which has its
+    // own connection-level sentence for it.
+    const message = en[profileLabel("provider_error")];
+    expect(message).not.toMatch(/paus/i);
+    expect(message).toMatch(/this contact/i);
+  });
+
   it("tells the reader what to add rather than blaming the provider", () => {
     // The defect: a record with no profile link and no company was sent
     // anyway, the vendor rejected the request, and the page reported "the

--- a/frontend/src/screens/provider-status.test.ts
+++ b/frontend/src/screens/provider-status.test.ts
@@ -132,7 +132,11 @@ describe("the provider status vocabulary", () => {
     // own connection-level sentence for it.
     const message = en[profileLabel("provider_error")];
     expect(message).not.toMatch(/paus/i);
-    expect(message).toMatch(/this contact/i);
+    // And it must stay true for BOTH causes: this key is also what a
+    // degraded CONNECTION renders, before any run history is read. Wording
+    // that named this contact's own lookup would be a false claim on every
+    // page during an outage, including contacts nobody ever asked about.
+    expect(message).not.toMatch(/this contact/i);
   });
 
   it("tells the reader what to add rather than blaming the provider", () => {


### PR DESCRIPTION
The rule spares the states that cost money, and takes the grant it reads under

Three defects from review, all reachable.

nothing_to_look_up preempted every run-derived state, including the two that
report a CHARGE. completed_claims_unwritten means the provider answered, money
moved, and the values never reached the record; submission_unknown means the
outcome was never learned and the run may have been billed. Replacing either
with a tidy sentence about a missing employer hides somebody's loss behind an
explanation of the wrong thing. The rule now applies only to failed and
cancelled runs — the two that bought nothing and charged nothing, so answering
with the record's own fact costs the reader no information.

SubjectIdentifiers reads the employment edge, and this section is entered on the
`person` grant alone. Every other section here that touches an edge asks
requireRead("relationship") first; this one did not, so a seat without that
grant could learn from the resulting sentence that the contact HAS an employer.
The edge is now read only where the caller may read edges, and a caller without
the grant gets a name-only answer that errs toward findable — telling somebody a
record cannot be looked up because we were not allowed to see the field that
would have proved otherwise invents a fact out of a permission.
SubjectNameOnly is extracted rather than copied so the full_name fallback keeps
one spelling.

The replacement copy said "the last lookup for this contact", which is false in
the case it was meant to serve. A degraded CONNECTION maps to this same message
key before any run history is read, so during a real outage every contact —
including one nobody ever asked about — would carry a contact-specific claim.
The sentence now describes the lookup without claiming whose.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

A record nothing can look up says so, whatever its old runs claim

205 contacts on one installation showed "The last call to the provider failed.
Automatic lookups are paused; a free check that gets through resumes them" — on
a connection that was `connected` and working. Every word after the first
sentence was false, and the first was misleading.

Those are gravestones. Before admission checked for identifiers, a contact
carrying neither a profile link nor an employer was sent anyway, the vendor
rejected the request, and the platform stored that as a provider fault. The
guard stopped new ones; it did nothing about the runs already on record, and
the page derives its sentence from the newest run. None of the 205 has a
profile link and only four have an employer, so the suggested remedy could
never fire either: a free check on them is skipped, not passed.

So the state asks what the record carries before it asks what happened to a run.
The section resolves the subject's identifiers once — through
people.SubjectIdentifiers, the same function the queue asks, so the page and the
lookup cannot disagree about whether somebody is findable — and each provider
answers with its own MatchRules. A provider this build does not carry answers
"findable", because the page must not call a record unfindable on the authority
of a descriptor it cannot read.

The connection's own condition still outranks it. A refused key or an exhausted
wallet is the installation's problem and the only thing anybody can act on;
burying that behind one contact's missing employer would leave an admin with
nothing to fix. A disconnected provider still reads `stale`, because what was
bought is still on the page.

The provider_error sentence drops the pause it cannot promise. That claim is
true only when the CONNECTION is degraded — admission does refuse automatic
runs then, and a manual one heals it — and the settings card already tells that
story with its own connection-level line. On the person page the sentence now
describes this contact's own lookup and points at the card for the rest.

Verified against the installation's own data: 40 of 40 sampled contacts that
read provider_error now read nothing_to_look_up, with their failed runs still on
record, and 30 of 30 contacts carrying a profile link still read completed.

---

Reported live: every contact read "The last call to the provider failed. Automatic lookups are paused; a free check that gets through resumes them" — on a connection that was `connected` and working. 205 contacts had a stale failed run as their newest, none carried a profile link, and only four had an employer, so the suggested remedy could never fire.

Verified against that installation's own data: 40 of 40 sampled contacts flipped to `nothing_to_look_up` with their failed runs still on record, and 30 of 30 contacts carrying a profile link still read `completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the provider status page so contacts with nothing to look them up by no longer show a false provider fault, and no longer ruins that claim over degraded connections or missing permissions.

- Failed and cancelled runs on contacts no provider could match now read `nothing_to_look_up`, regardless of what the run history says; completed, submission-unknown, and delivered runs still report as before.
- The employer edge is only read when the caller holds the `relationship` grant; callers without it get a name-only answer that errs toward findable.
- Extracts `SubjectNameOnly` from `SubjectIdentifiers` so the full-name fallback has one spelling.
- The `providerError` message copy no longer claims automatic lookups are paused; it now describes the lookup without claiming whose, so it stays true for degraded connections too.
- Moves `resolveProviderState` and its tables into `providerstate.go` to keep the assembly file under the line ceiling.

<sup>Written for commit 662f40b4f7c6ee5e4082173117556df5ad9138e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider status reporting for unavailable, stale, failed, and completed enrichment runs.
  - Correctly handles contacts without lookup identifiers while preserving relevant paid-run and connection statuses.
  - Accounts for relationship-based permissions when determining available contact details.
  - Prevented provider error messages from incorrectly implying an installation-wide pause or blaming the current contact.

- **User Experience**
  - Updated provider error guidance in English, German, and Vietnamese to recommend retrying or checking provider settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->