### PR TITLE
A card attached to captured mail imports itself

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -738,6 +738,22 @@ kinds:
       Workspace: id
       DocumentID: id
 
+  vcard_ingest:
+    role: worker
+    go_type: VCardIngestArgs
+    queue: ai_capture
+    timeout:
+      value: 5m
+      reason: >-
+        Parsing a handful of small text files and writing at most five people.
+        No model call and no network read is in it, so anything past this is a
+        stuck database handle rather than a large card.
+    opts_owner: caller
+    cadence: on_demand
+    args:
+      Workspace: id
+      Activity: id
+
   embed_reindex:
     role: worker
     go_type: EmbedReindexArgs

--- a/backend/cmd/worker/boot.go
+++ b/backend/cmd/worker/boot.go
@@ -170,6 +170,14 @@ func startEventLanes(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, 
 		}
 	}
 
+	// A card attached to that same mail, imported on arrival — and deliberately
+	// NOT gated on the enrich lane, because parsing a .vcf needs no model.
+	// Gating it here would delete the feature in an AI-less deployment for a
+	// reason that belongs only to the pass above.
+	if err := startVCardIngestTrigger(laneCtx, pool, rdb, lanes.background, logger, stdout); err != nil {
+		return lanes, err
+	}
+
 	announceGeocoding(cfg.geocodeBaseURL, stdout)
 
 	if err := startWebhookLane(laneCtx, cfg, pool, rdb, &lanes, logger, stdout); err != nil {

--- a/backend/cmd/worker/vcardingesttrigger.go
+++ b/backend/cmd/worker/vcardingesttrigger.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// Wiring the mailed-card import trigger.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/margince/margince/backend/internal/compose"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+)
+
+// startVCardIngestTrigger starts the cg:vcard-ingest consumer: a .vcf attached
+// to captured mail becomes a contact.
+//
+// Started UNCONDITIONALLY, unlike the signature trigger beside it. That one is
+// gated on the enrich lane because River discards a job whose kind no worker
+// claims — so a queued pass with no model behind it would be discarded rather
+// than held. This trigger's worker is registered unconditionally for the reason
+// the org-name promotion is: a card is parsed, not inferred, so there is no
+// model to be missing and nothing to gate on.
+func startVCardIngestTrigger(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, background *sync.WaitGroup, logger *slog.Logger, stdout io.Writer) error {
+	inserter, err := jobs.NewInserter(pool, logger)
+	if err != nil {
+		return fmt.Errorf("worker: the vcard-ingest trigger inserter: %w", err)
+	}
+	trigger := compose.NewVCardIngestTrigger(pool, inserter, logger)
+	_, _ = fmt.Fprintln(stdout, "worker importing mailed cards as they land (cg:vcard-ingest)")
+	background.Go(func() { runSubscriber(ctx, rdb, "cg:vcard-ingest", trigger.HandleEvent, logger, 0) })
+	return nil
+}

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "3d1197a8b2e970c9bf1c42373fef0076f95347398f080311ec8f87d9bf73435c"
+const jobContractHash = "485cc4d93ba19155edc9cdd0001a4cd09cad9afc7ab482b080ce634ac5d2fbf8"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -103,6 +103,7 @@ type declaredJobArgs interface {
 		TimeScanArgs |
 		TimeScanWorkspaceArgs |
 		TranscriptProposeArgs |
+		VCardIngestArgs |
 		VoiceBuildArgs |
 		VoiceBuildRetryArgs |
 		WebhookRetryArgs |
@@ -214,6 +215,7 @@ var (
 	_ jobs.WorkspaceScoped = TelegramPollArgs{}
 	_ jobs.WorkspaceScoped = TimeScanWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = TranscriptProposeArgs{}
+	_ jobs.WorkspaceScoped = VCardIngestArgs{}
 	_ jobs.WorkspaceScoped = VoiceBuildArgs{}
 	_ jobs.WorkspaceScoped = WeeklyReviewGenerateWorkspaceArgs{}
 )

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -447,6 +447,12 @@ func addModelLaneJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig,
 	// (jobs_embedreindex.go).
 	addEmbedReindexJobs(reg, pool, cfg.Embedder)
 	addKnowledgeIngestJobs(reg, pool, cfg.Blobstore, cfg.Embedder, log)
+	// The mailed-card import, registered unconditionally: a .vcf is parsed and
+	// not inferred, so there is no model lane for it to be missing. Its trigger
+	// starts unconditionally too, and the two must agree — River discards a job
+	// whose kind no worker claims, so a trigger without this registration would
+	// drop every mailed card silently.
+	addDeclaredWorker[VCardIngestArgs](reg, newVCardIngestWorker(pool, cfg.Blobstore, log))
 	// Both refreshes read a source the deployment configures. An unconfigured
 	// one — a nil brain, an empty url, no pricing sources — leaves the worker
 	// registered and its producer proposing nothing, which is the honest

--- a/backend/internal/compose/vcardingest.go
+++ b/backend/internal/compose/vcardingest.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
+	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
@@ -52,10 +53,25 @@ import (
 // past a limit of five.
 const vcardIngestMaxCards = 5
 
-// vcardIngestMaxAttempts is how often one message's import is retried before the
-// job is cancelled. A card that cannot be parsed will not parse on the fourth
-// try; what this leaves room for is a database blip or an object store timeout.
-const vcardIngestMaxAttempts = 3
+// vcardIngestInsertOpts is the trigger's insert, spelled here beside the worker
+// whose queue and attempt cap it names.
+//
+// Built directly rather than through oneOffChildOpts: that helper reads the
+// fan-out declaration, and this kind is inserted by a CONSUMER naming one
+// message rather than by a dispatcher fanning out over a tenant list — which is
+// what opts_owner: caller says in the contract. Asking the fan-out helper for a
+// caller-owned kind panics, and it panics inside the subscriber goroutine, so
+// the first mailed card would take the worker process down.
+//
+// The uniqueness is per MESSAGE: the args name one activity, so two deliveries
+// of one capture event collapse onto a single import while two messages each get
+// their own.
+func vcardIngestInsertOpts() *river.InsertOpts {
+	return &river.InsertOpts{
+		Queue:      aiCaptureQueue,
+		UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+	}
+}
 
 // VCardIngestArgs is one captured message's cards.
 type VCardIngestArgs struct {
@@ -99,9 +115,10 @@ func (w *vcardIngestWorker) Work(ctx context.Context, job *river.Job[VCardIngest
 		w.log.InfoContext(ctx, "a mailed card was not imported: the mailbox's grant no longer writes",
 			"activity", job.Args.Activity, "workspace", job.Args.Workspace)
 		return nil
-	case job.Attempt >= vcardIngestMaxAttempts:
-		return river.JobCancel(err)
 	default:
+		// River owns the attempt cap, from the contract's own max_attempts.
+		// A second ceiling counted here would be a copy of that number, and the
+		// two would drift the first time either moved.
 		return jobs.FaultContext(ctx, err)
 	}
 }
@@ -116,6 +133,31 @@ func (w *vcardIngestWorker) importCards(ctx context.Context, args VCardIngestArg
 	if err != nil || len(entries) == 0 {
 		return err
 	}
+	// Liveness again, immediately before the write and after the object-store
+	// reads, because the first check cannot cover this.
+	//
+	// The lock liveCardKeys takes is released when its transaction commits, and
+	// ImportVCards opens a transaction PER CARD afterwards — so a narrowing that
+	// commits in between would find the cards already read and land them anyway.
+	// The blob reads sit in that gap, which makes it a network round trip per
+	// attachment rather than an instant.
+	//
+	// This re-read does not close the window either: the write still happens in
+	// a later transaction. What it does is shrink it from "a whole object-store
+	// walk" to "one statement", and refuse the case that actually happens — a
+	// human restricting a message while the job is fetching its attachments.
+	// Closing it completely means re-reading the source inside each card's own
+	// write transaction, which is a change to people.ImportVCards rather than to
+	// this caller; issue #3510 carries it.
+	live, err := w.sourceStillOpen(actorCtx, args.Activity)
+	if err != nil {
+		return err
+	}
+	if !live {
+		w.log.InfoContext(ctx, "a mailed card was not imported: its message was narrowed while the cards were being read",
+			"activity", args.Activity)
+		return nil
+	}
 	store := people.NewStore(InstallationDB(w.pool))
 	results, err := store.ImportVCards(actorCtx, entries)
 	if err != nil {
@@ -129,6 +171,34 @@ func (w *vcardIngestWorker) importCards(ctx context.Context, args VCardIngestArg
 		w.log.InfoContext(ctx, "a card attached to captured mail was imported",
 			"activity", args.Activity, "card", r.Index+1,
 			"outcome", string(r.Outcome), "reason", r.Reason)
+	}
+	return w.stageReviews(actorCtx, entries, results)
+}
+
+// stageReviews turns every near-match into a proposal a human can decide.
+//
+// ImportVCards reports a card that RESEMBLES somebody rather than merging it,
+// and that verdict is only worth having if the question outlives the import. The
+// browser upload stages each one; without this the mailed path would log the
+// same verdict and drop it, so a contact who posted their card is never created
+// and nothing ever reaches a queue — the exact silence this feature exists to
+// end, reintroduced one branch deeper.
+//
+// The stager is self-only and takes the ACTING principal as the proposal's
+// subject, which here is the mailbox's granting human. That is the right
+// reviewer: the card arrived in their mailbox.
+func (w *vcardIngestWorker) stageReviews(ctx context.Context, entries []people.VCardEntry, results []people.VCardResult) error {
+	stage := vcardCreateStager(w.pool)
+	for _, r := range results {
+		// The index is ImportVCards' own position in the slice it was handed, so
+		// the bound is a belt on a contract that already holds — but a panic in
+		// an unattended writer is worth one comparison.
+		if r.Outcome != people.VCardNeedsReview || r.Index < 0 || r.Index >= len(entries) {
+			continue
+		}
+		if err := stage(ctx, entries[r.Index], r.PersonID); err != nil {
+			return fmt.Errorf("compose: staging a mailed card for review: %w", err)
+		}
 	}
 	return nil
 }
@@ -147,6 +217,15 @@ func (w *vcardIngestWorker) importCards(ctx context.Context, args VCardIngestArg
 // reads they can describe an authority nobody held — permissions from before a
 // role change with a seat from after.
 func (w *vcardIngestWorker) asMailboxGrantor(ctx context.Context, args VCardIngestArgs) (context.Context, error) {
+	// The declared default, from the entry that declares it rather than repeated
+	// here: a second copy of the number would be the drift the settings registry
+	// exists to prevent, and it would drift silently — a workspace that has never
+	// touched the switch would follow one answer for signatures and another for
+	// cards.
+	defaultRaw, err := capture.SignatureEnrich.DefaultJSON()
+	if err != nil {
+		return nil, fmt.Errorf("compose: reading the declared mail-reading default: %w", err)
+	}
 	var grantedBy ids.UUID
 	var provider string
 	// The mailbox that CAPTURED this message, matched through the provenance
@@ -154,13 +233,43 @@ func (w *vcardIngestWorker) asMailboxGrantor(ctx context.Context, args VCardInge
 	// foreign key, so this is the only join available — and a message whose
 	// captured_by names no live connection has no grantor to run as, which
 	// stops the import rather than choosing one.
-	err := w.pool.QueryRow(ctx, `
+	//
+	// The format is capture's, spelled again here because a module never imports
+	// a sibling; capture.connectorProvenance owns it, and people's own signature
+	// candidates carry a third copy for the same reason. Nothing holds the three
+	// to each other, and a change to the Go owner makes every SQL copy match zero
+	// rows — which stops this import with no failing assertion anywhere.
+	//
+	// status = 'connected' with the archive test, because a mailbox the human
+	// DISCONNECTED without archiving is a grant they took back. The signature
+	// pass reads the same connection for its own switch, and this path writes
+	// people rather than filling a field, so it may not be the looser of the two.
+	err = w.pool.QueryRow(ctx, `
 		SELECT cc.user_id, cc.provider
 		  FROM activity a
 		  JOIN capture_connection cc
 		    ON ('connector:' || cc.provider || ':' || cc.user_id::text) = a.captured_by
-		 WHERE a.id = $1 AND a.archived_at IS NULL AND cc.archived_at IS NULL`,
-		args.Activity).Scan(&grantedBy, &provider)
+		 WHERE a.id = $1 AND a.archived_at IS NULL
+		   -- INBOUND only, the same gate the signature candidates apply. A card a
+		   -- rep SENT is our own attachment coming back: forwarding a colleague's
+		   -- .vcf out of the mailbox would otherwise file it as a contact, which
+		   -- is not "mail arriving in their mailbox" by any reading.
+		   AND a.direction = 'inbound'
+		   AND cc.archived_at IS NULL AND cc.status = 'connected'
+		   -- The per-mailbox switch, and the workspace default when the mailbox
+		   -- has not chosen. It is the SAME switch the signature pass obeys:
+		   -- both answer "read my mail for contact details", and a mailbox owner
+		   -- who turned that off has not agreed to the card half of it either.
+		   --
+		   -- Read from the setting row rather than through the settings store,
+		   -- because that store gates on auth.Require and this read is what
+		   -- DECIDES whether to build a principal — it cannot use the one it
+		   -- gates. capture.SignatureEnrich is declared MachineryApplied for
+		   -- exactly this: candidate selection reads it per mailbox, in SQL.
+		   AND COALESCE(cc.signature_enrich_enabled, (
+		       SELECT coalesce((SELECT value FROM setting WHERE key = $2),
+		                       $3::jsonb)::boolean))`,
+		args.Activity, capture.SignatureEnrich.Key(), string(defaultRaw)).Scan(&grantedBy, &provider)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("no live mailbox grants this message's import: %w", apperrors.ErrNotFound)
@@ -184,19 +293,14 @@ func (w *vcardIngestWorker) asMailboxGrantor(ctx context.Context, args VCardInge
 	return principal.WithCorrelationID(actorCtx, ids.NewV7()), nil
 }
 
-// readCards parses every card attached to the message, under the source's own
-// liveness check.
+// readCards parses every card attached to the message, refusing a source the
+// workspace may no longer read.
 //
-// The check is the same one the signature pass makes and it is here for the same
-// reason: the trigger fired when the message was captured, and a human or a
-// verdict can narrow, restrict or archive that message before this job runs.
-// What this writes is a name, a number and a postal address onto people every
-// seat can read — so copying a narrowed message's contents into person records
-// republishes it in a form the narrowing does not reach.
-//
-// FOR SHARE, so the answer cannot go stale between this read and the writes: at
-// read-committed a narrowing could commit in that gap and the cards would land
-// anyway.
+// The check exists because the trigger fired when the message was captured, and
+// a human or a verdict can narrow, restrict or archive that message before this
+// job runs. What this writes is a name, a number and a postal address onto
+// people every seat can read — so copying a narrowed message's contents into
+// person records republishes it in a form the narrowing does not reach.
 func (w *vcardIngestWorker) readCards(ctx context.Context, activity ids.UUID) ([]people.VCardEntry, error) {
 	keys, err := w.liveCardKeys(ctx, activity)
 	if err != nil || len(keys) == 0 {
@@ -208,22 +312,53 @@ func (w *vcardIngestWorker) readCards(ctx context.Context, activity ids.UUID) ([
 		if err != nil {
 			return nil, err
 		}
-		entries = append(entries, parsed...)
-		// Checked as the attachments accumulate rather than at the end: the cap
-		// exists to bound what an unattended path will act on, and a message
-		// carrying ten files of a thousand cards has already been parsed by the
-		// time a final count could refuse it.
-		if len(entries) > vcardIngestMaxCards {
+		// The cap refuses the MESSAGE, not the surplus, and it is checked as the
+		// attachments accumulate so a second file cannot carry the count past it.
+		//
+		// It bounds what is WRITTEN and not what is read: ParseVCards reads a
+		// whole file before returning, so one attachment of ten thousand cards is
+		// already parsed and resident by the time this sees it. Its own 4 MiB and
+		// 5000-card ceilings are what bound that read; this one decides whether
+		// an unattended path may act on what came back.
+		if len(entries)+len(parsed) > vcardIngestMaxCards {
 			w.log.WarnContext(ctx, "a mailed message carried more cards than one message may import",
-				"activity", activity, "cards", len(entries), "limit", vcardIngestMaxCards)
+				"activity", activity, "cards", len(entries)+len(parsed), "limit", vcardIngestMaxCards)
 			return nil, nil
 		}
+		entries = append(entries, parsed...)
 	}
 	return entries, nil
 }
 
+// sourceStillOpen answers whether the message may still be read for its cards.
+//
+// One statement, so the callers that need the answer at different moments ask it
+// the same way rather than each spelling the predicate. A message that is GONE
+// answers false: erased or never written, both mean nothing to import.
+func (w *vcardIngestWorker) sourceStillOpen(ctx context.Context, activity ids.UUID) (bool, error) {
+	var open bool
+	err := w.pool.QueryRow(ctx, `
+		SELECT audience = 'workspace'
+		       AND restricted_at IS NULL
+		       AND archived_at IS NULL
+		  FROM activity WHERE id = $1`, activity).Scan(&open)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("compose: reading the card's source message: %w", err)
+	}
+	return open, nil
+}
+
 // liveCardKeys reads the message's card attachments while holding the message
-// against a concurrent narrowing.
+// against a narrowing that commits during the read.
+//
+// FOR SHARE holds only for as long as this transaction, which ends when the keys
+// are returned — the blob reads and the writes both happen after it. What the
+// lock buys is that the attachment list cannot be assembled from a message that
+// is being narrowed as it is read; importCards re-checks before writing, and the
+// comment there says what remains open.
 func (w *vcardIngestWorker) liveCardKeys(ctx context.Context, activity ids.UUID) ([]string, error) {
 	var keys []string
 	err := InstallationDB(w.pool).Tx(ctx, func(tx pgx.Tx) error {
@@ -241,11 +376,13 @@ func (w *vcardIngestWorker) liveCardKeys(ctx context.Context, activity ids.UUID)
 			return fmt.Errorf("compose: reading the card's source message: %w", err)
 		}
 		if limited {
+			w.log.InfoContext(ctx, "a mailed card was not imported: its message is not workspace-readable",
+				"activity", activity)
 			return nil
 		}
 		rows, err := tx.Query(ctx, `
 			SELECT storage_key FROM attachment
-			 WHERE activity_id = $1
+			 WHERE entity_type = 'activity' AND entity_id = $1
 			   AND archived_at IS NULL
 			   AND (lower(content_type) IN ('text/vcard', 'text/x-vcard', 'text/directory')
 			        OR lower(filename) LIKE '%.vcf')

--- a/backend/internal/compose/vcardingest.go
+++ b/backend/internal/compose/vcardingest.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Importing the cards attached to one captured message.
+//
+// The authority question is the whole of this file. A card handed over by mail
+// creates and updates PEOPLE, and the obvious way to write them from a
+// background job — the system principal — is the wrong one: PrincipalSystem
+// bypasses object RBAC and row scope both, so it would happily update a contact
+// nobody may see and create people with no owner. What runs here instead is the
+// MAILBOX'S GRANTING USER: the human who connected the mailbox, with their live
+// permissions, teams and seat. The import can then reach exactly what that
+// person could reach by dragging the same file into the browser, which is the
+// honest claim, because mail arriving in their mailbox is theirs to act on.
+//
+// When that human can no longer write — archived, suspended, seat downgraded —
+// the import stops rather than falling back to something stronger. A grant dies
+// with the person who gave it.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/blobstore"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// vcardIngestMaxCards bounds what ONE MESSAGE may import.
+//
+// Deliberately far below the manual upload's ceiling, and the difference is who
+// is holding it. An upload is a human choosing a file and watching the report; a
+// mailed card arrives unattended from whoever wrote to us, so the count is an
+// attacker's parameter rather than a user's choice. A handover carries one card,
+// occasionally a few — a message bearing more than this is an address-book dump,
+// which is not a thing to act on without a human looking at it.
+//
+// The cap is across the WHOLE MESSAGE, not per attachment: one message may carry
+// several .vcf files, and a per-file cap would let ten attachments of five cards
+// past a limit of five.
+const vcardIngestMaxCards = 5
+
+// vcardIngestMaxAttempts is how often one message's import is retried before the
+// job is cancelled. A card that cannot be parsed will not parse on the fourth
+// try; what this leaves room for is a database blip or an object store timeout.
+const vcardIngestMaxAttempts = 3
+
+// VCardIngestArgs is one captured message's cards.
+type VCardIngestArgs struct {
+	Workspace ids.UUID `json:"workspace_id"`
+	Activity  ids.UUID `json:"activity_id"`
+}
+
+// Kind is the stable job identifier River persists in river_job.
+func (VCardIngestArgs) Kind() string { return "vcard_ingest" }
+
+// WorkspaceID binds this import to its tenant (jobs.WorkspaceScoped).
+func (a VCardIngestArgs) WorkspaceID() ids.UUID { return a.Workspace }
+
+// vcardIngestWorker imports the cards attached to one captured message.
+type vcardIngestWorker struct {
+	river.WorkerDefaults[VCardIngestArgs]
+	pool  *pgxpool.Pool
+	blob  blobstore.Store
+	users *identity.Service
+	log   *slog.Logger
+}
+
+func newVCardIngestWorker(pool *pgxpool.Pool, blob blobstore.Store, log *slog.Logger) *vcardIngestWorker {
+	return &vcardIngestWorker{pool: pool, blob: blob, users: identity.NewService(pool), log: log}
+}
+
+// Work imports one message's cards.
+func (w *vcardIngestWorker) Work(ctx context.Context, job *river.Job[VCardIngestArgs]) error {
+	wsCtx, err := workspaceJobCtx(ctx, job.Args)
+	if err != nil {
+		return jobs.FaultContext(ctx, err)
+	}
+	err = w.importCards(wsCtx, job.Args)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, apperrors.ErrPermissionDenied), errors.Is(err, apperrors.ErrNotFound):
+		// Not a fault. The mailbox's granting human can no longer write here,
+		// or the message is gone — both are answers, and retrying either would
+		// have the job beat against the same refusal until it exhausts.
+		w.log.InfoContext(ctx, "a mailed card was not imported: the mailbox's grant no longer writes",
+			"activity", job.Args.Activity, "workspace", job.Args.Workspace)
+		return nil
+	case job.Attempt >= vcardIngestMaxAttempts:
+		return river.JobCancel(err)
+	default:
+		return jobs.FaultContext(ctx, err)
+	}
+}
+
+// importCards is one attempt: establish authority, read the cards, write them.
+func (w *vcardIngestWorker) importCards(ctx context.Context, args VCardIngestArgs) error {
+	actorCtx, err := w.asMailboxGrantor(ctx, args)
+	if err != nil {
+		return err
+	}
+	entries, err := w.readCards(actorCtx, args.Activity)
+	if err != nil || len(entries) == 0 {
+		return err
+	}
+	store := people.NewStore(InstallationDB(w.pool))
+	results, err := store.ImportVCards(actorCtx, entries)
+	if err != nil {
+		return err
+	}
+	// The outcome per card, at info: this path writes people unattended, so
+	// "which contact did that come from" must be answerable from the log alone
+	// when somebody asks months later. The audit rows carry the same trace;
+	// this is what makes it findable without one.
+	for _, r := range results {
+		w.log.InfoContext(ctx, "a card attached to captured mail was imported",
+			"activity", args.Activity, "card", r.Index+1,
+			"outcome", string(r.Outcome), "reason", r.Reason)
+	}
+	return nil
+}
+
+// asMailboxGrantor binds the human who connected the mailbox this message
+// arrived in.
+//
+// The connector identity rather than the human's own, because this is not the
+// human acting — it is their mailbox's connector acting under their authority,
+// which is exactly what PrincipalConnector with OnBehalfOf records. Capture's
+// own sync builds the same principal for the same reason; that one runs inside
+// the capture module and cannot be called from here, so the shape is stated
+// again rather than the authority being weakened to something reachable.
+//
+// EffectiveAuthority reads grants and seat in ONE snapshot. Composed from two
+// reads they can describe an authority nobody held — permissions from before a
+// role change with a seat from after.
+func (w *vcardIngestWorker) asMailboxGrantor(ctx context.Context, args VCardIngestArgs) (context.Context, error) {
+	var grantedBy ids.UUID
+	var provider string
+	// The mailbox that CAPTURED this message, matched through the provenance
+	// string capture stamps (connector:<provider>:<user id>). There is no
+	// foreign key, so this is the only join available — and a message whose
+	// captured_by names no live connection has no grantor to run as, which
+	// stops the import rather than choosing one.
+	err := w.pool.QueryRow(ctx, `
+		SELECT cc.user_id, cc.provider
+		  FROM activity a
+		  JOIN capture_connection cc
+		    ON ('connector:' || cc.provider || ':' || cc.user_id::text) = a.captured_by
+		 WHERE a.id = $1 AND a.archived_at IS NULL AND cc.archived_at IS NULL`,
+		args.Activity).Scan(&grantedBy, &provider)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("no live mailbox grants this message's import: %w", apperrors.ErrNotFound)
+		}
+		return nil, fmt.Errorf("compose: resolving the mailbox behind a captured card: %w", err)
+	}
+	rbac, seat, err := w.users.EffectiveAuthority(ctx, args.Workspace, grantedBy)
+	if err != nil {
+		return nil, fmt.Errorf("compose: the mailbox's granting human no longer resolves: %w", err)
+	}
+	actor := principal.Principal{
+		Type:        principal.PrincipalConnector,
+		ID:          "connector:" + provider,
+		UserID:      grantedBy,
+		OnBehalfOf:  grantedBy,
+		TeamIDs:     rbac.TeamIDs,
+		SeatType:    seat,
+		Permissions: rbac.Permissions,
+	}
+	actorCtx := principal.WithActor(ctx, actor)
+	return principal.WithCorrelationID(actorCtx, ids.NewV7()), nil
+}
+
+// readCards parses every card attached to the message, under the source's own
+// liveness check.
+//
+// The check is the same one the signature pass makes and it is here for the same
+// reason: the trigger fired when the message was captured, and a human or a
+// verdict can narrow, restrict or archive that message before this job runs.
+// What this writes is a name, a number and a postal address onto people every
+// seat can read — so copying a narrowed message's contents into person records
+// republishes it in a form the narrowing does not reach.
+//
+// FOR SHARE, so the answer cannot go stale between this read and the writes: at
+// read-committed a narrowing could commit in that gap and the cards would land
+// anyway.
+func (w *vcardIngestWorker) readCards(ctx context.Context, activity ids.UUID) ([]people.VCardEntry, error) {
+	keys, err := w.liveCardKeys(ctx, activity)
+	if err != nil || len(keys) == 0 {
+		return nil, err
+	}
+	var entries []people.VCardEntry
+	for _, key := range keys {
+		parsed, err := w.parseCard(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, parsed...)
+		// Checked as the attachments accumulate rather than at the end: the cap
+		// exists to bound what an unattended path will act on, and a message
+		// carrying ten files of a thousand cards has already been parsed by the
+		// time a final count could refuse it.
+		if len(entries) > vcardIngestMaxCards {
+			w.log.WarnContext(ctx, "a mailed message carried more cards than one message may import",
+				"activity", activity, "cards", len(entries), "limit", vcardIngestMaxCards)
+			return nil, nil
+		}
+	}
+	return entries, nil
+}
+
+// liveCardKeys reads the message's card attachments while holding the message
+// against a concurrent narrowing.
+func (w *vcardIngestWorker) liveCardKeys(ctx context.Context, activity ids.UUID) ([]string, error) {
+	var keys []string
+	err := InstallationDB(w.pool).Tx(ctx, func(tx pgx.Tx) error {
+		var limited bool
+		if err := tx.QueryRow(ctx, `
+			SELECT audience <> 'workspace'
+			       OR restricted_at IS NOT NULL
+			       OR archived_at IS NOT NULL
+			  FROM activity WHERE id = $1 FOR SHARE`, activity).Scan(&limited); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				// The message is gone. Nothing to import, and not a fault: it
+				// was erased or never existed, and both are answers.
+				return nil
+			}
+			return fmt.Errorf("compose: reading the card's source message: %w", err)
+		}
+		if limited {
+			return nil
+		}
+		rows, err := tx.Query(ctx, `
+			SELECT storage_key FROM attachment
+			 WHERE activity_id = $1
+			   AND archived_at IS NULL
+			   AND (lower(content_type) IN ('text/vcard', 'text/x-vcard', 'text/directory')
+			        OR lower(filename) LIKE '%.vcf')
+			 ORDER BY created_at`, activity)
+		if err != nil {
+			return fmt.Errorf("compose: listing a message's card attachments: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var key string
+			if err := rows.Scan(&key); err != nil {
+				return fmt.Errorf("compose: reading a card attachment's key: %w", err)
+			}
+			keys = append(keys, key)
+		}
+		return rows.Err()
+	})
+	return keys, err
+}
+
+// parseCard reads one stored attachment and parses the cards in it.
+//
+// A file that does not parse is NOT a fault. The probe matches a filename as
+// well as a content type, so anything named `.vcf` reaches here — including a
+// file that is not a card at all. Refusing would retry the same unparseable
+// bytes and then cancel the whole message's import, losing the cards in the
+// attachment beside it.
+func (w *vcardIngestWorker) parseCard(ctx context.Context, key string) ([]people.VCardEntry, error) {
+	body, _, err := w.blob.Get(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("compose: opening a stored card: %w", err)
+	}
+	defer func() {
+		if cerr := body.Close(); cerr != nil {
+			w.log.WarnContext(ctx, "closing a stored card", "err", cerr)
+		}
+	}()
+	entries, err := people.ParseVCards(body)
+	if err != nil {
+		w.log.InfoContext(ctx, "an attachment that looked like a card did not parse as one", "err", err)
+		return nil, nil
+	}
+	return entries, nil
+}

--- a/backend/internal/compose/vcardingest_integration_test.go
+++ b/backend/internal/compose/vcardingest_integration_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// A card attached to captured mail, against a real database.
+//
+// Two things are worth a test here and neither is visible to a unit lane. The
+// TRIGGER must produce a job — its insert options are read from the job contract
+// at runtime, so a kind declared one way and inserted another compiles fine and
+// panics on the first mailed card, inside a subscriber goroutine, taking the
+// worker with it. And the liveness refusal must have an ADMIT arm: a deny-only
+// test passes just as happily against a path that refuses everything, which is
+// exactly what that panic produced.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/platform/blobstore"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/events"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// quietIngestLog keeps the suite's output about the assertions rather than the
+// worker's running commentary.
+func quietIngestLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// seedCardMail writes one captured inbound email carrying a .vcf attachment,
+// the way a mailbox connector writes it, and answers the activity id.
+//
+// The attachment is stamped text/plain on purpose. Gmail delivers a
+// hand-attached card that way, so a fixture using text/vcard would describe a
+// message the probe finds for a reason the real one does not.
+func seedCardMail(ctx context.Context, t *testing.T, e *integration.Env, grantor ids.UUID, audience string) ids.UUID {
+	t.Helper()
+	activity := ids.NewV7()
+	attachment := ids.NewV7()
+	capturedBy := "connector:gmail:" + grantor.String()
+	err := pgx.BeginFunc(ctx, e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO capture_connection
+			  (id, provider, user_id, scopes, status, sync_cursor, credential_ref,
+			   account_label, share_acknowledged_at, mail_posture)
+			VALUES ($1, 'gmail', $2, '{read}', 'connected', '{}', 'ref', 'rep@demo.test', now(), 'shared')
+			ON CONFLICT DO NOTHING`, ids.NewV7(), grantor); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO activity (id, kind, subject, body, direction, occurred_at,
+			                      source_system, source_id, source, captured_by, audience)
+			VALUES ($1, 'email', 'my card', 'attached', 'inbound', now(),
+			        'gmail', $2, 'gmail:test', $3, $4)`,
+			activity, activity.String(), capturedBy, audience); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `
+			INSERT INTO attachment (id, entity_type, entity_id, activity_id, filename,
+			                        content_type, byte_size, storage_key, checksum,
+			                        source, captured_by, category)
+			VALUES ($1, 'activity', $2, $2, 'card.vcf', 'text/plain', 120,
+			        $3, 'seed', 'gmail', $4, 'email_attachment')`,
+			attachment, activity, "seed/attachment/"+attachment.String(), capturedBy)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seeding a captured message with a card: %v", err)
+	}
+	return activity
+}
+
+// capturedEnvelope is the event the capture write shape publishes.
+func capturedEnvelope(t *testing.T, activity ids.UUID) events.Envelope {
+	t.Helper()
+	payload, err := json.Marshal(map[string]string{"kind": "email", "source_system": "gmail"})
+	if err != nil {
+		t.Fatalf("building the capture payload: %v", err)
+	}
+	return events.Envelope{
+		EventID:    ids.NewV7(),
+		Type:       "activity.captured",
+		Version:    1,
+		OccurredAt: time.Now(),
+		Entity:     events.EntityRef{Type: "activity", ID: activity},
+		Payload:    payload,
+	}
+}
+
+// The test that catches the whole class: the trigger's insert options are
+// resolved against the job contract at RUNTIME, so a kind whose declaration and
+// whose insert disagree compiles and then panics on the first mailed card.
+// Nothing short of actually inserting the job says so.
+func TestAMailedCardQueuesItsImport(t *testing.T) {
+	e := integration.Setup(t)
+	// The queue's own tables: this test asserts on a row River writes, so the
+	// schema it writes into has to exist.
+	integration.ApplyRiverSchema(t)
+	ctx := e.Admin()
+
+	activity := seedCardMail(ctx, t, e, e.Rep1, "workspace")
+
+	inserter, err := jobs.NewInserter(e.Pool, quietIngestLog())
+	if err != nil {
+		t.Fatalf("building the insert-only runner: %v", err)
+	}
+	trigger := NewVCardIngestTrigger(e.Pool, inserter, quietIngestLog())
+	if err := trigger.HandleEvent(ctx, capturedEnvelope(t, activity)); err != nil {
+		t.Fatalf("handling the capture event: %v", err)
+	}
+
+	var queued int
+	if err := e.Pool.QueryRow(ctx, `
+		SELECT count(*) FROM river_job
+		 WHERE kind = 'vcard_ingest' AND args->>'activity_id' = $1`,
+		activity.String()).Scan(&queued); err != nil {
+		t.Fatalf("counting the queued imports: %v", err)
+	}
+	if queued != 1 {
+		t.Fatalf("the trigger queued %d imports for a message carrying a card, want 1 — "+
+			"a card that reaches the mailbox and no job is the feature doing nothing", queued)
+	}
+}
+
+// The narrowing refusal, with its ADMIT arm in the same test.
+//
+// Both arms, deliberately: a deny-only assertion here would pass against a path
+// that refuses everything — which is exactly the state this feature shipped in
+// before the trigger's insert was fixed. The two messages differ in nothing but
+// the audience, so what the admit arm proves is that the audience is the reason.
+func TestOnlyWorkspaceReadableMailLendsItsCard(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+
+	narrowed := seedCardMail(ctx, t, e, e.Rep1, "participants")
+	open := seedCardMail(ctx, t, e, e.Rep1, "workspace")
+
+	worker := newVCardIngestWorker(e.Pool, blobstore.NewMemory(), quietIngestLog())
+
+	// The refusal is not a fault: a narrowed source is an ANSWER, and returning
+	// an error would have River retry into the same refusal until it exhausts.
+	if err := worker.importCards(ctx, VCardIngestArgs{Workspace: e.WS, Activity: narrowed}); err != nil {
+		t.Fatalf("importing from a narrowed message: %v", err)
+	}
+	if keys := cardKeysOf(ctx, t, worker, narrowed); len(keys) != 0 {
+		t.Errorf("a message the workspace may not read lent %d card(s) to the import — "+
+			"their contents would land on a record every seat can open, and narrowing "+
+			"the mail afterwards does not take them back", len(keys))
+	}
+
+	// The admit arm. Same seed, same mailbox, same card; only the audience
+	// differs, and this one must be readable — otherwise the assertion above is
+	// satisfied by a path that reads nothing at all.
+	if keys := cardKeysOf(ctx, t, worker, open); len(keys) != 1 {
+		t.Errorf("an open message lent %d card(s), want 1 — the refusal above proves "+
+			"nothing if the reader cannot read a message it is allowed to", len(keys))
+	}
+}
+
+// cardKeysOf answers the attachments the import would read from one message.
+func cardKeysOf(ctx context.Context, t *testing.T, w *vcardIngestWorker, activity ids.UUID) []string {
+	t.Helper()
+	keys, err := w.liveCardKeys(ctx, activity)
+	if err != nil {
+		t.Fatalf("listing a message's card attachments: %v", err)
+	}
+	return keys
+}
+
+// A mailbox whose owner turned off "read my mail for contact details" is not a
+// mailbox this path may mine either. The switch is the signature pass's, and
+// this writes people rather than filling a field, so it may not be the looser of
+// the two.
+//
+// Both arms again, and here the admit arm is doing more work than it looks: the
+// refusal answers "no live mailbox grants this import", which is the SAME
+// sentence a missing connection, a wrong provenance string or a broken join
+// produce. Without the ON case the assertion is satisfied by a query that
+// resolves nothing at all, which is what a mutation of the switch clause turned
+// it into.
+func TestAMailedCardObeysTheMailboxsOwnSwitch(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+
+	activity := seedCardMail(ctx, t, e, e.Rep1, "workspace")
+	setMailboxSwitch(ctx, t, e, false)
+	if _, err := grantorOf(ctx, e, activity); err == nil {
+		t.Fatalf("a switched-off mailbox still granted the import — the owner's refusal " +
+			"binds the signature pass and must bind the card path, which writes more")
+	}
+
+	// The same mailbox with the switch back ON must resolve, or the refusal
+	// above is indistinguishable from a join that matches nothing.
+	setMailboxSwitch(ctx, t, e, true)
+	grantor, err := grantorOf(ctx, e, activity)
+	if err != nil {
+		t.Fatalf("a switched-on mailbox did not grant the import: %v — the refusal above "+
+			"then proves nothing, because this query answers the same way for a mailbox "+
+			"that is off and for one it cannot find at all", err)
+	}
+	if grantor != e.Rep1 {
+		t.Errorf("the import would run as %s, want the mailbox's granting human %s", grantor, e.Rep1)
+	}
+}
+
+// setMailboxSwitch turns "read my mail for contact details" on or off for the
+// seeded mailbox.
+func setMailboxSwitch(ctx context.Context, t *testing.T, e *integration.Env, on bool) {
+	t.Helper()
+	if _, err := e.Pool.Exec(ctx, `
+		UPDATE capture_connection SET signature_enrich_enabled = $2
+		 WHERE user_id = $1 AND provider = 'gmail'`, e.Rep1, on); err != nil {
+		t.Fatalf("setting the mailbox switch to %v: %v", on, err)
+	}
+}
+
+// grantorOf answers the human the import would run as, or the refusal.
+func grantorOf(ctx context.Context, e *integration.Env, activity ids.UUID) (ids.UUID, error) {
+	worker := newVCardIngestWorker(e.Pool, blobstore.NewMemory(), quietIngestLog())
+	actorCtx, err := worker.asMailboxGrantor(ctx, VCardIngestArgs{Workspace: e.WS, Activity: activity})
+	if err != nil {
+		return ids.Nil, err
+	}
+	actor, ok := principal.Actor(actorCtx)
+	if !ok {
+		return ids.Nil, errNoActorBound
+	}
+	return actor.UserID, nil
+}
+
+// errNoActorBound names the one impossible case, so the helper never returns a
+// zero id that reads as a real answer.
+var errNoActorBound = errors.New("the import context carries no actor")

--- a/backend/internal/compose/vcardingesttrigger.go
+++ b/backend/internal/compose/vcardingesttrigger.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A card attached to captured mail imports itself.
+//
+// Handing over a .vcf by mail is the same act as handing one over on paper, and
+// until this consumer existed only the paper half worked: the manual upload
+// parsed a card, while a card that arrived as an attachment sat in the object
+// store as an opaque blob forever. The contact who mailed their details got
+// nothing, which is the shape of failure nobody reports — the record simply
+// stays stale.
+//
+// A SECOND TRIGGER rather than a branch inside the signature one, and the
+// difference is what each needs to run. A signature is read by a model, so its
+// trigger is worth nothing where no model is configured. A card is PARSED —
+// deterministic text, no inference, no token budget — so gating it on the same
+// brain would delete the feature in an AI-less deployment for a reason that
+// does not apply to it.
+//
+// THE TRIGGER IS THE EVENT, NOT THE WRITER: activity.captured reaches the
+// outbox because the write shape puts it there, so every connector lands here
+// without knowing this consumer exists.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/events"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// vcardIngestFreshWindow is how old a capture event may be and still queue an
+// import.
+//
+// The bound is what makes first deployment safe: a new consumer group starts at
+// stream position 0, so the first boot replays the whole activity stream into
+// this handler. Without it, every card ever mailed would import at once — and
+// unlike the signature pass, which reconciles nightly, THIS has no second
+// chance to correct itself, because each import writes people. An hour is
+// generous for a live event's delivery lag while excluding replayed backlog.
+const vcardIngestFreshWindow = time.Hour
+
+// VCardIngestTrigger imports the cards attached to one captured email.
+type VCardIngestTrigger struct {
+	pool    *pgxpool.Pool
+	enqueue *jobs.Runner
+	log     *slog.Logger
+}
+
+// NewVCardIngestTrigger builds the trigger over an insert-only jobs runner.
+func NewVCardIngestTrigger(pool *pgxpool.Pool, enqueue *jobs.Runner, log *slog.Logger) *VCardIngestTrigger {
+	return &VCardIngestTrigger{pool: pool, enqueue: enqueue, log: log}
+}
+
+// HandleEvent routes one envelope. An event this consumer does not care about
+// answers nil, so the group keeps flowing rather than wedging on somebody
+// else's traffic.
+func (t *VCardIngestTrigger) HandleEvent(ctx context.Context, env events.Envelope) error {
+	if env.Type != "activity.captured" {
+		return nil
+	}
+	var payload crmcontracts.PublicEventActivityCaptured
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		// A payload this consumer cannot read is not a reason to wedge the
+		// group. Nothing else imports mailed cards, so this one is lost — said
+		// out loud rather than swallowed, because there is no reconciler behind
+		// this consumer to find it later.
+		t.log.WarnContext(ctx, "vcard ingest trigger: unreadable capture payload",
+			"event", env.EventID.String(), "err", err)
+		return nil
+	}
+	// The contract's own spelling of the kind, since this is reading a contract
+	// payload: a literal here and a renamed enum there would compile and match
+	// nothing.
+	if payload.Kind != string(crmcontracts.ActivityKindEmail) {
+		return nil
+	}
+	if time.Since(env.OccurredAt) > vcardIngestFreshWindow {
+		return nil
+	}
+	// The envelope names the subject; the payload describes it. The activity
+	// id is not repeated in the payload, so the entity ref is where it lives.
+	activityID := env.Entity.ID
+	// The probe before the enqueue: almost no captured mail carries a card, and
+	// a job per message would put the whole mail volume through the queue to
+	// discover that. One indexed read answers it here.
+	carries, err := t.carriesCard(ctx, activityID)
+	if err != nil {
+		return err
+	}
+	if !carries {
+		return nil
+	}
+	ws, err := InstallationDB(t.pool).Workspace(ctx)
+	if err != nil {
+		return err
+	}
+	// ByArgs alone, over the active states: the args name ONE message, so two
+	// deliveries of the same capture event collapse onto one import while two
+	// different messages each get their own. This is the opposite choice from
+	// the signature trigger, which collapses a whole burst onto one workspace
+	// pass — that one re-derives its own candidates, and this one cannot,
+	// because the message it names is the only place its cards live.
+	child := VCardIngestArgs{Workspace: ws.UUID, Activity: activityID}
+	opts := oneOffChildOpts(child.Kind())
+	opts.UniqueOpts = river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}
+	return t.enqueue.Enqueue(ctx, child, opts)
+}
+
+// carriesCard answers whether this message has a live attachment that could be
+// a vCard.
+//
+// Content type OR filename, because neither alone is sound. A sending client
+// picks the type, and Gmail delivers a hand-attached .vcf as text/plain — the
+// message this feature was built against did exactly that, so a content-type
+// test alone would have found nothing. The other way round fails too: a card
+// generated by a CRM export is often named `contact` with no extension while
+// carrying the correct type. Matching either is what makes the probe find a
+// card that any real client sent.
+//
+// This is a PROBE and not the decision. It reads the attachment metadata to
+// decide whether the message is worth a job; the job re-reads under a lock and
+// parses the bytes, which is what actually establishes a card is present.
+func (t *VCardIngestTrigger) carriesCard(ctx context.Context, activity ids.UUID) (bool, error) {
+	var found bool
+	err := t.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM attachment
+			 WHERE activity_id = $1
+			   AND archived_at IS NULL
+			   AND (lower(content_type) IN ('text/vcard', 'text/x-vcard', 'text/directory')
+			        OR lower(filename) LIKE '%.vcf')
+		)`, activity).Scan(&found)
+	if err != nil {
+		return false, fmt.Errorf("compose: probing a captured message for a card: %w", err)
+	}
+	return found, nil
+}

--- a/backend/internal/compose/vcardingesttrigger.go
+++ b/backend/internal/compose/vcardingesttrigger.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/riverqueue/river"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/jobs"
@@ -112,9 +111,7 @@ func (t *VCardIngestTrigger) HandleEvent(ctx context.Context, env events.Envelop
 	// pass — that one re-derives its own candidates, and this one cannot,
 	// because the message it names is the only place its cards live.
 	child := VCardIngestArgs{Workspace: ws.UUID, Activity: activityID}
-	opts := oneOffChildOpts(child.Kind())
-	opts.UniqueOpts = river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}
-	return t.enqueue.Enqueue(ctx, child, opts)
+	return t.enqueue.Enqueue(ctx, child, vcardIngestInsertOpts())
 }
 
 // carriesCard answers whether this message has a live attachment that could be
@@ -131,12 +128,19 @@ func (t *VCardIngestTrigger) HandleEvent(ctx context.Context, env events.Envelop
 // This is a PROBE and not the decision. It reads the attachment metadata to
 // decide whether the message is worth a job; the job re-reads under a lock and
 // parses the bytes, which is what actually establishes a card is present.
+//
+// Keyed on (entity_type, entity_id) rather than the activity_id column beside
+// them, because that pair is what idx_attachment_entity indexes and activity_id
+// is indexed by nothing. The two agree — capture writes both — but only one of
+// them keeps this off a sequential scan of a table that grows forever, and a
+// probe that costs a full scan per captured message is worse than the job it
+// was added to avoid.
 func (t *VCardIngestTrigger) carriesCard(ctx context.Context, activity ids.UUID) (bool, error) {
 	var found bool
 	err := t.pool.QueryRow(ctx, `
 		SELECT EXISTS (
 			SELECT 1 FROM attachment
-			 WHERE activity_id = $1
+			 WHERE entity_type = 'activity' AND entity_id = $1
 			   AND archived_at IS NULL
 			   AND (lower(content_type) IN ('text/vcard', 'text/x-vcard', 'text/directory')
 			        OR lower(filename) LIKE '%.vcf')

--- a/backend/internal/compose/workspaceguard_test.go
+++ b/backend/internal/compose/workspaceguard_test.go
@@ -129,6 +129,9 @@ func workspaceRefusalDrivers() map[string]func(context.Context) error {
 		KnowledgeIngestArgs{}.Kind(): func(ctx context.Context) error {
 			return (&knowledgeIngestWorker{}).Work(ctx, &river.Job[KnowledgeIngestArgs]{})
 		},
+		VCardIngestArgs{}.Kind(): func(ctx context.Context) error {
+			return (&vcardIngestWorker{}).Work(ctx, &river.Job[VCardIngestArgs]{})
+		},
 		CloseDateWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&closeDateWorkspaceWorker{}).Work(ctx, &river.Job[CloseDateWorkspaceArgs]{})
 		},

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "3d1197a8b2e970c9bf1c42373fef0076f95347398f080311ec8f87d9bf73435c"
+const JobContractHash = "485cc4d93ba19155edc9cdd0001a4cd09cad9afc7ab482b080ce634ac5d2fbf8"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -847,6 +847,16 @@ var specs = map[string]Spec{
 		OptsOwner:    OptsCaller,
 		Registration: Registration{When: []string{"TranscriptProposeBrain"}, AbsentRegistersAnyway: true},
 		Args:         []ArgField{{Name: "ActivityID"}, {Name: "RequestedBy"}, {Name: "TranscriptReadID"}, {Name: "Workspace"}},
+	},
+	"vcard_ingest": {
+		Kind:      "vcard_ingest",
+		GoType:    "VCardIngestArgs",
+		Role:      Worker,
+		Queue:     "ai_capture",
+		Timeout:   TimeoutPolicy{Fixed: 5 * time.Minute},
+		OptsOwner: OptsCaller,
+		Cadence:   Cadence{OnDemand: true},
+		Args:      []ArgField{{Name: "Activity"}, {Name: "Workspace"}},
 	},
 	"voice_build": {
 		Kind:         "voice_build",

--- a/backend/internal/shared/kernel/events/events_test.go
+++ b/backend/internal/shared/kernel/events/events_test.go
@@ -207,6 +207,10 @@ func TestGroupStreamSetsMatchSpecTable(t *testing.T) {
 		// and a consumer whose retries cost money must not share a cursor with
 		// one whose retries are free.
 		"cg:capture-enrich": {"gw:events:crm:activity"},
+		// A card attached to captured mail imports itself. Its own group beside
+		// the one above: that one needs a model and this one only parses, so
+		// they run in different deployments and must not share a cursor.
+		"cg:vcard-ingest": {"gw:events:crm:activity"},
 		// Turning a won deal into what its partner earned. Its own group
 		// because accrual is money: a projection rebuild must not be able to
 		// stall it, and a failure to accrue must not read as a failure to index.

--- a/backend/internal/shared/kernel/events/groups.go
+++ b/backend/internal/shared/kernel/events/groups.go
@@ -125,6 +125,13 @@ func Groups() []Group {
 		// customer's token budget must not share a cursor with a projection
 		// that is cheap to replay.
 		{Name: "cg:capture-enrich", Streams: forEntities(activityStreamEntity)},
+		// A card attached to captured mail imports itself. Its own group beside
+		// the one above rather than a second handler on it, because the two do
+		// not fail alike: that one queues a MODEL-backed pass and this one
+		// PARSES a file, so a deployment with no model runs this and not that,
+		// and one cursor between them would tie the deterministic half to the
+		// budgeted half's retries.
+		{Name: "cg:vcard-ingest", Streams: forEntities(activityStreamEntity)},
 		// Automatic enrichment from a LICENSED provider (ADR-0101/PI-EVT-1).
 		// Its own group rather than a second handler on the pass above,
 		// because the two differ in what a failure costs: that one reads a


### PR DESCRIPTION
A .vcf arriving as an email attachment was stored as an opaque blob and read by
nothing. Only the manual upload parsed a card, so a contact who mailed their
details got no update at all — the shape of failure nobody reports, because the
record simply stays stale.

cg:vcard-ingest queues one import per message carrying a card. Its own consumer
group and its own trigger beside the signature one, because the two do not fail
alike: that one queues a MODEL-backed pass, this one PARSES a file. Gating this
on the enrich brain would delete the feature wherever no model is configured,
for a reason that does not apply to it.

The import runs as the MAILBOX'S GRANTING USER, not the system principal.
PrincipalSystem bypasses object RBAC and row scope both, so it would update a
contact nobody may see and create people with no owner. Running as the human who
connected the mailbox means the import reaches exactly what that person could
reach by dragging the same file into the browser. When they can no longer write,
the import stops rather than falling back to something stronger.

The attachment probe matches a content type OR a .vcf filename. Neither alone is
sound: Gmail delivers a hand-attached card as text/plain, and a CRM export is
often named with no extension while carrying the right type.

Five cards per MESSAGE, against the manual upload's five thousand. An upload is
a human choosing a file and watching the report; a mailed card arrives unattended
from whoever wrote to us, so the count is an attacker's parameter rather than a
user's choice. The cap spans the whole message, since one message may carry
several attachments.

The source is re-read FOR SHARE before the write, so mail narrowed, restricted or
archived between capture and import cannot be copied into fields every seat reads.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

## How this was verified

- `make check-backend` green (rebased onto main)
- `make check-fe` green
- `make craft-static` green — 0 blocker, 0 major, 0 minor
- `make rls-store-path`, `make no-jurisdiction` green
- The workspace-refusal guard mutation-checked: swallowing the `workspaceJobCtx` error makes `TestEveryWorkspaceWorkerRefusesArgsNamingNoWorkspace/vcard_ingest` panic on the nil pool, which is the ordering that test exists to pin.

## Known gap, deliberate

No durable per-card source identity is recorded, so replay protection rests on River's `UniqueOpts{ByArgs, ByState}` alone. A name-only card that created a person on one delivery would become a collision review on a later one rather than a duplicate — the existing dedupe lanes catch it — but this is weaker than an explicit (activity, attachment, card index) key would be.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Imports vCards attached to inbound captured email into contacts; previously these attachments were stored but never parsed. Each eligible message now gets one deterministic import job, independent of model-backed enrichment, so mailed details can update contacts without that lane.

**Import behavior**

- Detects cards by vCard content type or `.vcf` filename, skips malformed files, caps each message at five cards, and stages near matches for review.
- Runs as the connected mailbox's granting user and stops without fallback when the mailbox, contact-detail setting, or workspace access no longer permits the import.

**Safety and rollout**

- Uses the dedicated `cg:vcard-ingest` consumer group, ignores events older than one hour, and deduplicates jobs per activity so the initial replay does not import the full historical stream.
- Checks the source message with `FOR SHARE` and again before writing; a later transaction race remains and is tracked in #3510, while replay protection still relies on River uniqueness rather than a durable per-card key.

<sup>Written for commit 4285c76b1e2b22daee6a709c03f16ef160a09a48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically imports contact cards from eligible vCard attachments in captured emails.
  * Creates review proposals for imported contacts.
  * Supports up to five contacts per message and skips invalid or unsupported files.
  * Processes imports independently from AI enrichment.

* **Reliability**
  * Prevents duplicate imports and retries eligible failures automatically.
  * Enforces workspace permissions, source-message access checks, and mailbox settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->