### PR TITLE
Two gates read the repository, not the working tree

### DIFF
--- a/backend/gates/docspagelength_test.go
+++ b/backend/gates/docspagelength_test.go
@@ -196,21 +196,67 @@ var documentedTrees = []string{"docs", "user-guide"}
 // tree so a new page is covered the moment it lands.
 func handWrittenDocsPages(t *testing.T) []string {
 	t.Helper()
+	// TRACKED pages, not whatever the working tree carries. A page somebody is
+	// drafting, or one a parallel session left behind, is not documentation
+	// yet — and failing the build on it makes every local run untrustworthy,
+	// which is worse than the budget going unenforced for one uncommitted
+	// file. CI reads the committed tree, so a page over budget is caught at
+	// the moment it becomes one of these pages.
+	// ONE filter, in the walk. It has to be there — a page read before it is
+	// filtered can stop the build on its contents — and a second copy here
+	// would be a filter that cannot disagree with the first only for as long
+	// as nobody edits either.
+	tracked := gitTracked(t, docsTreeRoot)
 	var pages []string
 	for _, tree := range documentedTrees {
-		pages = append(pages, handWrittenPagesUnder(t, tree)...)
+		pages = append(pages, handWrittenPagesUnder(t, tracked, tree)...)
 	}
 	sort.Strings(pages)
 	return pages
 }
 
-func handWrittenPagesUnder(t *testing.T, tree string) []string {
+func handWrittenPagesUnder(t *testing.T, tracked map[string]bool, tree string) []string {
+	t.Helper()
+	return handWrittenPagesRootedAt(t, docsTreeRoot, tracked, tree)
+}
+
+// handWrittenPagesRootedAt is the walk itself, over any root.
+//
+// The root is a parameter so a test can drive this over a repository built for
+// the purpose. The branch that matters most here — the one that keeps an
+// untracked draft from being READ — cannot be exercised against the committed
+// tree, because the committed tree holds no untracked files: the real-tree gate
+// passes for that reason rather than because the branch works, and an edit
+// moving the filter back after isGeneratedDoc would go green.
+func handWrittenPagesRootedAt(t *testing.T, treeRoot string, tracked map[string]bool, tree string) []string {
 	t.Helper()
 	var pages []string
+	docsTreeRoot := treeRoot
 	root := filepath.Join(docsTreeRoot, tree)
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		// NOTHING UNTRACKED IS READ AT ALL, which is a step earlier than the
+		// tracked filter below and has to be.
+		//
+		// A file this gate reads before filtering is a file whose contents can
+		// stop the build: isGeneratedDoc scans the page, and a draft with one
+		// very long line fatals the scanner. Filtering afterwards leaves every
+		// local run hostage to what a working tree happens to hold, which is
+		// the complaint this change started from.
+		//
+		// Directories are still descended, because a tracked page can live
+		// under an untracked directory only if git tracks it — and then git
+		// names it here. The symlink refusal below is about the REPOSITORY: a
+		// link somebody committed hides a subtree from the budget, and one
+		// nobody committed hides nothing.
+		rel, relErr := filepath.Rel(docsTreeRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		if !d.IsDir() && !tracked[filepath.ToSlash(rel)] {
+			return nil
 		}
 		// filepath.WalkDir does not follow symlinks, so a symlinked directory
 		// under docs/ would be skipped and its pages never counted — the gate
@@ -228,10 +274,6 @@ func handWrittenPagesUnder(t *testing.T, tree string) []string {
 		}
 		if isGeneratedDoc(t, path) {
 			return nil
-		}
-		rel, relErr := filepath.Rel(docsTreeRoot, path)
-		if relErr != nil {
-			return relErr
 		}
 		pages = append(pages, filepath.ToSlash(rel))
 		return nil
@@ -338,5 +380,37 @@ func TestTheDocsBudgetGateSeesAGeneratedPageAsGenerated(t *testing.T) {
 			t.Errorf("%s: generated=%v, want %v — %s", name, got, tc.want,
 				fmt.Sprintf("the marker is read from the first five lines, case-insensitively"))
 		}
+	}
+}
+
+// AN UNTRACKED PAGE IS NOT READ, which is a step earlier than not being judged.
+//
+// The distinction is the whole complaint this file answers: a page the walk
+// READS can stop the build on its contents, whatever the budget then decides
+// about it. isGeneratedDoc scans the first lines, and a draft with one line past
+// the scanner's buffer fatals it.
+//
+// Driven over a repository built for the purpose. The committed tree holds no
+// untracked files, so the real-tree gate passes whether this branch works or
+// not — an edit moving the filter back after isGeneratedDoc would break nothing
+// there and be found by whoever next ran an install locally.
+//
+// Here it is found immediately, and LOUDLY: the draft's line is past the
+// scanner's buffer, so a walk that reads it fatals rather than merely counting
+// one page too many. That is the same failure the reports described, reproduced
+// on demand instead of waited for.
+func TestAnUntrackedDraftIsNeitherReadNorJudged(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	_, write := initRepo(t, root, map[string]string{"how-to/committed.md": "# committed\n"})
+	// The draft: present, not committed, and carrying a line no scanner will
+	// read. Over the budget as well, so it would fail on length even if it
+	// survived being read.
+	write("how-to/a-draft.md", strings.Repeat("x", 2<<20)+"\n")
+
+	pages := handWrittenPagesRootedAt(t, root, gitTracked(t, root), "how-to")
+	if len(pages) != 1 || pages[0] != "how-to/committed.md" {
+		t.Fatalf("pages = %v, want only the committed one — a draft nobody committed is not "+
+			"documentation yet, and reading it at all is what lets its contents stop the build", pages)
 	}
 }

--- a/backend/gates/gitcontent_test.go
+++ b/backend/gates/gitcontent_test.go
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind shape H3
+
+package gates
+
+// What belongs to the REPOSITORY, as against what happens to be in a working
+// tree.
+//
+// A gate that walks the filesystem judges whatever a checkout carries: a build
+// cache a package manager wrote, a page somebody is drafting, a scratch file
+// from a parallel session. Those are not the repository. Failing on them makes
+// `make check-backend` untrustworthy locally, and the habit of skipping past a
+// failure is the expensive part — the next one looks the same and is real.
+//
+// So the walks ask git. Ignored paths are skipped entirely; where a census must
+// judge only what is committed, it reads the tracked set. Both answers come
+// from one place so the two cannot drift, and both FAIL LOUDLY when git cannot
+// answer rather than judging a smaller tree and reporting the same word for it.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// gitIgnoredPaths answers the absolute paths git ignores under root — build
+// caches, node_modules, a .pnpm-store somebody's install left at the top.
+//
+// Directories, so a walk can skip a whole subtree at its head rather than
+// asking about every file under it.
+func gitIgnoredPaths(t testing.TB, root string) map[string]bool {
+	t.Helper()
+	out := gitPaths(t, root, "ls-files", "--others", "--ignored", "--directory", "--exclude-standard")
+	ignored := map[string]bool{}
+	for _, line := range out {
+		// Compared against filepath.WalkDir paths, which are the host's own
+		// spelling — so back from slashes here rather than on to them.
+		ignored[filepath.Join(root, filepath.FromSlash(line))] = true
+	}
+	return ignored
+}
+
+// gitTracked answers the paths git tracks under root, relative to it. A file
+// that is not in here is not part of the repository yet, whatever a working
+// tree holds.
+func gitTracked(t testing.TB, root string) map[string]bool {
+	t.Helper()
+	tracked := map[string]bool{}
+	for _, line := range gitPaths(t, root, "ls-files") {
+		// SLASHES, because that is what every caller keys on: a page is named
+		// by filepath.ToSlash(rel) so one name reads the same in a message
+		// whatever host printed it. filepath.Clean alone would key this side in
+		// backslashes on Windows, the two would never meet, and the census
+		// would drop every page — which its own emptiness guard would then
+		// report as a repository with no documentation in it.
+		tracked[path.Clean(line)] = true
+	}
+	// A repository with no tracked files is not a repository this gate can
+	// judge, and reading zero is how a census passes over nothing.
+	if len(tracked) == 0 {
+		t.Fatalf("git tracks no file under %s — this census would judge an empty tree "+
+			"and report the same word for it as a full one", root)
+	}
+	return tracked
+}
+
+// gitPaths runs one git query and answers the paths it names, verbatim.
+//
+// `-z` rather than lines, and NO trimming, because a path is not a word. Git
+// quotes any name carrying a non-ASCII byte by default (core.quotepath), and
+// a line-oriented read then keys `"caf\303\251.md"` — a string no walk will
+// ever produce. Trimming loses the other end of the same problem: a file whose
+// name begins or ends with a space is legal on every filesystem this runs on,
+// and its key would name a different file. Both make the census judge less than
+// it thinks while reporting the same word for it. Under `-z` git emits the raw
+// bytes and separates them with NUL, which no path may contain.
+//
+// A git that cannot answer is fatal: every caller is a census, and a census
+// that quietly judges less than it thinks is the failure each of them exists to
+// prevent.
+func gitPaths(t testing.TB, root string, args ...string) []string {
+	t.Helper()
+	cmd := exec.Command("git", append(args, "-z")...)
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		// git's own diagnostic, not just the status. cmd.Output() puts it in
+		// ExitError.Stderr and Error() renders "exit status 128" — which tells
+		// a reader that something failed and nothing about what, on a gate
+		// whose whole posture is to fail loudly. "fatal: not a git repository"
+		// is the sentence they need.
+		var exit *exec.ExitError
+		if errors.As(err, &exit) && len(exit.Stderr) > 0 {
+			err = fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exit.Stderr)))
+		}
+		t.Fatalf("git %s in %s: %v — this gate reads the repository through git, and "+
+			"cannot tell a clean tree from an unreadable one", strings.Join(args, " "), root, err)
+	}
+	var paths []string
+	for _, entry := range strings.Split(string(out), "\x00") {
+		if entry != "" {
+			paths = append(paths, entry)
+		}
+	}
+	return paths
+}
+
+// The two readings, driven over a repository built for the purpose.
+//
+// Built rather than borrowed: whether THIS checkout happens to carry a build
+// cache is a fact about the machine, and a case that passes because somebody
+// ran pnpm install proves nothing on a clean runner. A repository with a known
+// ignore rule and a known tracked file asks the question directly.
+func TestTheRepositoryIsReadThroughGitRatherThanTheWorkingTree(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	run, write := initRepo(t, root, nil)
+
+	write(".gitignore", "/cache/\n")
+	write("kept.md", "# kept\n")
+	// A NESTED page, and one whose name git would quote under a line-oriented
+	// read: `core.quotepath` escapes the non-ASCII bytes, and the key would
+	// then name a file no walk produces. Nested because the separator is the
+	// other half of the same problem — a key spelled with backslashes on one
+	// host and slashes on the other never meets its walk.
+	write("docs/reference/kept.md", "# nested\n")
+	write("docs/reference/caf\u00e9.md", "# accented\n")
+	// The shape the reports were about: a build cache holding a symlink, which
+	// a filesystem walk meets and refuses.
+	write("cache/store/marker", "")
+	if err := os.Symlink(root, filepath.Join(root, "cache", "store", "link")); err != nil {
+		t.Fatalf("planting the symlink a build cache leaves: %v", err)
+	}
+	// And a page somebody is drafting: present, not ignored, not committed.
+	write("draft.md", "# draft\n")
+	run("add", ".gitignore", "kept.md", "docs")
+	run("commit", "-qm", "first")
+
+	tracked := gitTracked(t, root)
+	// Keyed the way every caller names a page: slash-separated, and spelled in
+	// the bytes the filesystem holds. A nested path is where a host's own
+	// separator would show, and an accented one is where git's default quoting
+	// would — either way the key names a file no walk produces, and the census
+	// drops it without a word.
+	for _, page := range []string{"kept.md", "docs/reference/kept.md", "docs/reference/café.md"} {
+		if !tracked[page] {
+			t.Errorf("%q is committed and is not reported as tracked, so the census would judge a "+
+				"smaller tree than the repository holds: %v", page, tracked)
+		}
+	}
+	if tracked["draft.md"] {
+		t.Error("a file nobody has committed is reported as tracked — a page being drafted would " +
+			"fail a budget it is not yet subject to")
+	}
+	if tracked["cache/store/marker"] {
+		t.Error("a file under an ignored directory is reported as tracked")
+	}
+
+	ignored := gitIgnoredPaths(t, root)
+	if !ignored[filepath.Join(root, "cache")] {
+		t.Errorf("the ignored directory is not reported, so a walk would descend into it and "+
+			"meet the symlink inside: %v", ignored)
+	}
+}
+
+// gitFixture answers the two things a purpose-built repository is made of: a
+// way to run git in it, and a way to put a file in it.
+//
+// Shared rather than copied per test, because two copies of a fixture are two
+// fixtures — and the day one of them stops failing loudly on a git error is the
+// day its test starts passing over a repository that was never built.
+// initRepo is gitFixture with the bootstrap done: an initialised repository with
+// an identity to commit under, and whatever first files the caller names already
+// committed.
+//
+// Shared because three tests were each spelling out the same five git calls, and
+// a bootstrap that drifts between copies is three fixtures pretending to be one.
+func initRepo(t *testing.T, root string, committed map[string]string) (run func(...string), write func(rel, body string)) {
+	t.Helper()
+	run, write = gitFixture(t, root)
+	run("init", "-q")
+	run("config", "user.email", "gate@example.test")
+	run("config", "user.name", "Gate")
+	if len(committed) == 0 {
+		return run, write
+	}
+	paths := make([]string, 0, len(committed))
+	for rel, body := range committed {
+		write(rel, body)
+		paths = append(paths, rel)
+	}
+	sort.Strings(paths)
+	run(append([]string{"add"}, paths...)...)
+	run("commit", "-qm", "first")
+	return run, write
+}
+
+func gitFixture(t *testing.T, root string) (run func(...string), write func(rel, body string)) {
+	t.Helper()
+	run = func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+	write = func(rel, body string) {
+		t.Helper()
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return run, write
+}
+
+// THE FAIL-LOUDLY BRANCHES, driven.
+//
+// This file's whole posture is that a git it cannot read is fatal — a census
+// that quietly judges less than it thinks is the failure both its callers exist
+// to prevent. Nothing exercised those branches: a regression making the queries
+// succeed with empty output would have gone green, which is precisely the shape
+// being guarded against.
+//
+// Driven through a recorder rather than a *testing.T, because a Fatalf on the
+// real one ends the test that is trying to observe it.
+func TestAGitThatCannotAnswerIsFatalRatherThanAnEmptyTree(t *testing.T) {
+	t.Parallel()
+	// A directory that is no repository. git exits non-zero and says so.
+	outside := t.TempDir()
+	t.Run("a query git refuses", func(t *testing.T) {
+		t.Parallel()
+		rec := &fatalRecorder{}
+		rec.run(func() { gitPaths(rec, outside, "ls-files") })
+		if !rec.fatal {
+			t.Error("git refused the query and the reading carried on — a census cannot tell a clean " +
+				"tree from an unreadable one, which is the whole of what this file is for")
+		}
+		if !strings.Contains(rec.message, "not a git repository") {
+			t.Errorf("the failure reads %q, which does not carry git's own diagnostic", rec.message)
+		}
+	})
+	t.Run("a repository tracking nothing", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		run, _ := initRepo(t, root, nil)
+		_ = run
+		rec := &fatalRecorder{}
+		rec.run(func() { gitTracked(rec, root) })
+		if !rec.fatal {
+			t.Error("an empty tracked set was returned rather than refused — every caller would then " +
+				"judge nothing and report the same word for it as a full tree")
+		}
+	})
+}
+
+// fatalRecorder is a testing.TB that records a Fatalf instead of ending the
+// test observing it. Only the methods these helpers call do anything; the rest
+// satisfy the interface.
+type fatalRecorder struct {
+	testing.TB
+	fatal   bool
+	message string
+	done    chan struct{}
+}
+
+func (r *fatalRecorder) Helper() {}
+
+func (r *fatalRecorder) Fatalf(format string, args ...any) {
+	r.fatal = true
+	r.message = fmt.Sprintf(format, args...)
+	// The same control flow a real Fatalf has: the caller must not carry on
+	// past it, or this records a failure the helper never actually stopped for.
+	close(r.done)
+	runtime.Goexit()
+}
+
+// run calls fn on a goroutine of its own, so a Goexit from Fatalf ends that
+// goroutine rather than the test.
+func (r *fatalRecorder) run(fn func()) {
+	r.done = make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		fn()
+	}()
+	<-finished
+}

--- a/backend/gates/uniquenessclaimscorpus_test.go
+++ b/backend/gates/uniquenessclaimscorpus_test.go
@@ -135,25 +135,14 @@ func TestTheSweptCorpusIsEveryModuleThatCouldCarryAClaim(t *testing.T) {
 	perRoot := map[string]int{}
 	var unswept []string
 	modules := 0
-	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() {
-			if unauthoredDir(entry.Name()) {
-				return fs.SkipDir
-			}
-			return nil
-		}
-		// A symlink is neither a directory nor a file to this walk, and the
-		// claim sweep does not follow one either — so sources behind one are
-		// unswept AND invisible to this arm. The tree carries none today;
-		// refusing the first is cheaper than discovering it as a blind spot.
-		if entry.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("%s is a symlink: neither walk follows one, so anything behind it "+
-				"is outside the sweep and outside this check of the sweep", path)
-		}
-		if entry.Name() != "go.mod" {
+	// What git IGNORES is not this repository's source, and a checkout carries
+	// plenty of it: a package manager's cache, an install somebody ran at the
+	// top of the tree. Skipping it at the head of the subtree is also what
+	// keeps the symlink refusal below meaningful — the symlinks in a pnpm store
+	// are not blind spots in the sweep, they are not in the sweep's subject.
+	ignored := gitIgnoredPaths(t, repoRoot)
+	err := walkSweptTree(repoRoot, ignored, func(path string) error {
+		if filepath.Base(path) != "go.mod" {
 			return nil
 		}
 		module, relErr := filepath.Rel(repoRoot, filepath.Dir(path))
@@ -323,5 +312,116 @@ func TestTheTwoDoorsAreJudgedRatherThanTrusted(t *testing.T) {
 	if declares {
 		t.Error("a DIRECTORY named go.mod read as a module declaration — the subtree behind it " +
 			"would be skipped as answering for itself while nothing registers it as a module")
+	}
+}
+
+// walkSweptTree walks root the way the corpus sweep does: past what git
+// ignores, and refusing a symlink it meets.
+//
+// Its own function so a test can drive it over a repository built for the
+// purpose. The two halves are one claim — the skip is what makes the refusal
+// mean something — and neither can be exercised against the committed tree,
+// which carries no symlinks and, on a clean checkout, nothing ignored either.
+// A regression removing the skip would leave the sweep refusing on the first
+// symlink in somebody's package store, which is the flake this exists to stop.
+func walkSweptTree(root string, ignored map[string]bool, visit func(path string) error) error {
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if unauthoredDir(entry.Name()) || ignored[path] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if ignored[path] {
+			return nil
+		}
+		// A symlink is neither a directory nor a file to this walk, and the
+		// claim sweep does not follow one either — so sources behind one are
+		// unswept AND invisible to this arm. The tree carries none today;
+		// refusing the first is cheaper than discovering it as a blind spot.
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s is a symlink: neither walk follows one, so anything behind it "+
+				"is outside the sweep and outside this check of the sweep", path)
+		}
+		return visit(path)
+	})
+}
+
+// THE SYMLINK IN THE PACKAGE STORE, which is where this whole change started.
+//
+// A pnpm install at the top of the tree leaves .pnpm-store full of symlinks, git
+// ignores it, and the sweep met one and refused — failing `make check-backend`
+// on a file that is neither in the repository nor in anybody's diff.
+//
+// Driven over a purpose-built repository, because the committed tree has no
+// symlinks and a clean checkout has nothing ignored: the real-tree sweep passes
+// whether the skip works or not, and a regression removing it would go green on
+// every check until somebody ran an install.
+func TestTheSweepSkipsAnIgnoredStoreRatherThanRefusingTheSymlinksInIt(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	_, write := initRepo(t, root, map[string]string{
+		".gitignore": "/cache/\n",
+		"go.mod":     "module probe\n",
+	})
+
+	// The store: ignored, and holding the shape that broke the sweep.
+	write("cache/store/marker", "")
+	if err := os.Symlink(root, filepath.Join(root, "cache", "store", "link")); err != nil {
+		t.Fatalf("planting the symlink a package store leaves: %v", err)
+	}
+
+	var visited []string
+	if err := walkSweptTree(root, gitIgnoredPaths(t, root), func(path string) error {
+		visited = append(visited, filepath.ToSlash(path))
+		return nil
+	}); err != nil {
+		t.Fatalf("the sweep refused an ignored store: %v — a package manager's cache is not this "+
+			"repository's source, and meeting a symlink in one fails a build over nothing", err)
+	}
+	for _, path := range visited {
+		if strings.Contains(path, "/cache/") {
+			t.Errorf("the sweep walked into an ignored store: %s", path)
+		}
+	}
+	// And it visited the repository's OWN source, or the case above passes
+	// against a walk that reached nothing worth reaching. Named rather than
+	// counted: `len(visited) > 0` says a walk produced paths and nothing about
+	// which, and the only path this fixture guarantees is the one it committed.
+	if !slices.Contains(visited, filepath.ToSlash(filepath.Join(root, "go.mod"))) {
+		t.Fatalf("the sweep did not reach the repository's own go.mod, so skipping the store proves "+
+			"nothing about the skip: %v", visited)
+	}
+}
+
+// AND THE REFUSAL ITSELF, which the case above cannot reach.
+//
+// There the skip fires first, by design — that is what it is for. So the arm it
+// protects goes unexercised, and the committed tree carries no symlink either:
+// a regression in the refusal would be invisible in both places, which is this
+// repository's own "a guard the tree happens not to reach is a guard with no
+// test".
+//
+// A symlink OUTSIDE anything ignored is a real blind spot: neither this walk nor
+// the claim sweep follows one, so whatever is behind it is unswept and unseen.
+func TestTheSweepRefusesASymlinkNothingIgnores(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	initRepo(t, root, map[string]string{"go.mod": "module probe\n"})
+
+	if err := os.Symlink(root, filepath.Join(root, "elsewhere")); err != nil {
+		t.Fatalf("planting the symlink: %v", err)
+	}
+
+	err := walkSweptTree(root, gitIgnoredPaths(t, root), func(string) error { return nil })
+	if err == nil {
+		t.Fatal("the sweep walked past a symlink nothing ignores — anything behind it is outside " +
+			"the claim sweep and outside this check of it, which is a blind spot rather than a skip")
+	}
+	if !strings.Contains(err.Error(), "is a symlink") {
+		t.Errorf("the sweep failed with %v, which does not say what it met", err)
 	}
 }

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -186,7 +186,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthorityreach_test.go` | H2 | Every write of a shareable record reaches a write-authority probe. |
 | `writeshape_test.go` | H2 | The write-shape obligation as a fitness function: every mutation that writes an audit row commits a paired outbox event on the same static call path (data-model §11, events.md §4.2 — spelled once in storekit), across modules AND the composition layer. |
 
-## Shape (20)
+## Shape (21)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -196,6 +196,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `extensionsqlscope_test.go` | H1 | A unit's SQL addresses the unit's own tables. |
 | `fieldnames_test.go` | H2 | A field name published to a caller has to BE a field name. |
 | `geocodestaleness_test.go` | H1 | The staleness rule lives in the SCHEMA, and this holds it there. |
+| `gitcontent_test.go` | H3 | What belongs to the REPOSITORY, as against what happens to be in a working tree. |
 | `jobfault_test.go` | H2 | Every River worker returns through jobs.Fault. |
 | `jobfleetwide_test.go` | H2 | A FleetWide declaration is a promise: this job enumerates and enqueues, and does no tenant write of its own (jobs.FleetWide). |
 | `jobwirekey_test.go` | H2 | One workspace arg, one spelling, and only where it means something. |


### PR DESCRIPTION
Closes #3220.

`make check-backend` failed in a working checkout while passing on a clean `origin/main`, on two files that are neither in the repository nor in anybody's diff:

- the uniqueness-claims corpus walk met a symlink inside `.pnpm-store`, the gitignored package store a root `pnpm install` leaves behind, and refused it. Rightly so in itself: a corpus that can silently shrink is exactly what that gate exists to catch.
- the docs page-length budget read an untracked page a parallel session had left in `docs/`, and failed the build for everyone sharing the checkout.

Both walked the filesystem, which judges whatever a checkout happens to carry: a build cache, a page somebody is drafting, a scratch file. That makes a local run untrustworthy, and the habit of shrugging past a red build is the expensive part, because the next failure looks the same and is real.

## What changed

Both now ask git.

- The corpus skips ignored paths at the head of the subtree. That also makes its symlink refusal mean what it says: the links inside a package store are not blind spots in the sweep, they are not the sweep's subject.
- The docs budget judges **tracked** pages. A page nobody has committed is not documentation yet, and CI reads the committed tree, so the page is caught the moment it becomes one.

Both readings live in one new file so they cannot drift apart, and both **fail** when git cannot answer rather than quietly judging a smaller tree and reporting the same word for it.

## Confidence

Each half was mutation-checked against the shape that was reported:

- planting `.pnpm-store/v11/projects/abc123` as a symlink reproduced the original refusal once the ignore-skip was removed;
- planting a 1301-line untracked `docs/explanation/…md` failed the docs gate once the tracked filter was removed.

The new self-test is driven over a repository built for the purpose rather than over this one. Whether a checkout holds a build cache is a fact about the machine, and a case that passes because somebody ran `pnpm install` proves nothing on a clean runner.

`make check-backend` green locally, `./gates` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation and coverage checks now evaluate only Git-tracked files, excluding uncommitted drafts and other working-tree content.
  * Ignored files and directories are reliably excluded, including cache contents and untracked symlinked paths.
  * Tracked symlinks retain their existing validation behavior.

* **Tests**
  * Added coverage for Git-based repository reading, ignored paths, nested files, and non-ASCII filenames.

* **Documentation**
  * Updated the gate inventory with new repository-content validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->