### PR TITLE
main is red: the AI settings page has no health card to answer

### DIFF
--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -422,6 +422,35 @@ export const aiProviderKeys = {
   ],
 };
 
+// Whether the model lanes are answering (the AI settings health card). Two
+// rungs rather than none: an empty `rungs` draws the "nobody called anything"
+// empty state, and the table — the part with the latency, the failure count and
+// the sentinel — would then never be rendered by any sweep that visits this
+// page. One healthy lane and one that is failing, so both badges are painted
+// and the axe pass measures the tones it actually ships.
+export const aiHealth = {
+  window_hours: 1,
+  rungs: [
+    {
+      tier: "cheap_cloud",
+      healthy: true,
+      calls: 412,
+      failures: 3,
+      last_call_at: "2026-07-13T09:41:00Z",
+      median_latency_ms: 640,
+    },
+    {
+      tier: "premium",
+      healthy: false,
+      calls: 7,
+      failures: 7,
+      last_sentinel: "provider_quota",
+      last_call_at: "2026-07-13T09:12:00Z",
+      median_latency_ms: 2_180,
+    },
+  ],
+};
+
 export const aiUsage = {
   days: [
     {
@@ -2176,6 +2205,9 @@ export async function mockApi(
     }
     if (path === "/installation/license") {
       return json(installationLicense);
+    }
+    if (path === "/ai/health") {
+      return json(aiHealth);
     }
     if (path === "/ai/usage") {
       return json(aiUsage);


### PR DESCRIPTION
Five UAT criteria fail on `main`, all of them on `#/settings/ai` and none of them about what they assert:

| criterion | what it reported |
| --- | --- |
| AC-automations-1, AC-automations-2 | the automations region is not there |
| §3.8 390px, axe light, axe dark | `nav.rail` is not there |

## What is actually happening

The rail is gone because the app error boundary is standing where the shell should be.

`/ai/health` is a new read on that page ([#3476](https://github.com/margince/margince/pull/3476)) and the seed mocks do not answer it. The catch-all hands back the list envelope, the health card reads `rungs.length` off an object that has no `rungs`, and the throw takes the whole page down. The automations editor goes with it, because the two share a page.

```
TypeError: Cannot read properties of undefined (reading 'length')
```

The two automations criteria then report the region as missing, which is true and is not the fault they were written to find.

## The fixture

Two rungs rather than none. An empty `rungs` draws the "nobody called anything in the window" empty state, and the table beside it — the latency, the failure count, the sentinel, and both badge tones — would then be rendered by no sweep at all. That table is the half the axe pass exists to measure, so the fixture gives it one healthy lane and one that is failing.

## Two things worth saying out loud

**The harness did its job.** Three of the five failures are `expectShellRendered`, the assertion whose entire purpose is to notice a page that did not render. It fired the first time this happened.

**It fired before the merge, too.** `uat` was already `failure` on #3476's own head commit when that PR was merged. This PR fixes the page; it does not fix that.

**This is the fifth time** the list catch-all has reached a card that wanted an entity. `seed.ts` carries a comment about it at four other endpoints, each added the same way after the same kind of red build.

## Verification

Full Playwright suite locally: 204 passed, 23 skipped, 0 failed. `make check-fe` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test data for healthy and failing AI model health metrics.
  * Added a simulated AI health endpoint for testing health-status scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->