### PR TITLE
main is red on every open PR: the DCO gate refuses a base branch that moved

### DIFF
--- a/scripts/check-dco.sh
+++ b/scripts/check-dco.sh
@@ -35,8 +35,36 @@ set -eu
 base="${1:?usage: check-dco.sh <base-sha> <head-sha>}"
 head="${2:?usage: check-dco.sh <base-sha> <head-sha>}"
 
-range="${base}..${head}"
 missing=0
+
+# WHAT WAS WRONG WAS THE ASSERTION, NOT THE RANGE.
+#
+# `base..head` is every commit reachable from head and not from base, so when the
+# base branch advances independently it still names exactly the commits this pull
+# request introduces — the base's own new commits are excluded, which is the
+# point. The range never needed changing.
+#
+# The ancestry check did. The caller hands over
+# `github.event.pull_request.base.sha`, the tip of the base branch when the event
+# fired, and a branch tip MOVES: anything merged to main after a pull request
+# branched puts that tip off the head's ancestry, and asserting otherwise failed
+# every open pull request on somebody else's merge.
+#
+# What survives is the question that assertion was reaching for — do these two
+# share any history at all — asked in the form that cannot be answered by a busy
+# afternoon.
+#
+# And it is `base`, not `git merge-base base head`. With criss-cross history
+# there is more than one best common ancestor, merge-base names one of them, and
+# a range starting there can reach a commit the OTHER ancestor already gave the
+# base. This gate would then judge a commit the pull request did not introduce,
+# and refuse it for somebody else's missing trailer.
+if ! git merge-base "$base" "$head" >/dev/null 2>&1; then
+	echo "DCO: ${base} and ${head} share no history, so there is no range of" >&2
+	echo "commits this pull request introduces. Check the base and head it was given." >&2
+	exit 1
+fi
+range="${base}..${head}"
 
 # WHAT THE RANGE COVERS, asserted before it is trusted.
 #
@@ -47,17 +75,15 @@ missing=0
 # the one way a gate must not break: it reads a smaller history, reports PASS,
 # and no assertion fails to say so.
 #
+# Dropping the ancestry assertion above does not retire that guard, it leaves it
+# the whole job: a head already contained in the base yields an empty range, and
+# the count below is the only thing that refuses it.
+#
 # Held HERE rather than at each call site, because the required caller is the
 # one that had no guard: main-health.yml asserted its baseline's ancestry and
 # ci.yml — the job the `ci` fan-in makes required — called this bare. A
 # protection that lives in the advisory lane and not the blocking one protects
 # nothing.
-if ! git merge-base --is-ancestor "$base" "$head"; then
-	echo "DCO: ${base} is not an ancestor of ${head} — the range ${range} does not" >&2
-	echo "cover the commits it is meant to judge, and an empty one would read as a" >&2
-	echo "clean pass having examined nothing." >&2
-	exit 1
-fi
 
 # Merges included: this is what the range HOLDS, not what needs a trailer. A
 # range covering only merge commits is a real thing (a merge queue's own head),

--- a/scripts/test-check-dco.sh
+++ b/scripts/test-check-dco.sh
@@ -236,15 +236,65 @@ case_is "a merge commit needs no sign-off" "$merge_base" "$merged" 0 "are signed
 
 case_is "an empty range is refused, not passed" "$merged" "$merged" 1 "holds no commits"
 
-# A base that RESOLVES and is not behind the head is the dangerous shape, and it
-# is the one `git rev-list` answers silently: not an error, just nothing. The
-# advisory main-health lane asserted this and the required ci.yml job did not,
-# so the protection lived where it could not block a merge.
+# A BASE THAT HAS MOVED ON is the ordinary case, not a fault: main takes another
+# merge while a pull request sits open, and the base sha the caller hands over is
+# that branch's TIP rather than the point the branch was cut from. The RANGE was
+# always right — `base..head` excludes the base's own new commits — and the
+# ancestry assertion was what refused a pull request over somebody else's merge.
 git -C "$repo" checkout -q -b sideways "$base"
 sideways="$(commit_with "a commit on a branch of its own
 
 $signed")"
-case_is "a base that is not an ancestor is refused" "$sideways" "$merged" 1 "not an ancestor"
+case_is "a base that has moved on is judged, not refused" "$sideways" "$merged" 0 "are signed off"
+
+# And the same shape with the pull request's OWN commit unsigned still fails, so
+# the case above is the gate reading the right range rather than reading none.
+git -C "$repo" checkout -q -b sideways-unsigned "$base"
+unsigned_head="$(commit_with "a commit with no trailer at all")"
+git -C "$repo" checkout -q sideways
+case_is "and an unsigned commit past a moved base is still named" "$sideways" "$unsigned_head" 1 "$unsigned_head"
+
+# CRISS-CROSS, which is what makes `base..head` the right range rather than
+# merely a simpler one.
+#
+# Two branches off one root, each merged into the other: the pair then has TWO
+# best common ancestors, and `git merge-base` names one of them. A range starting
+# there reaches the commit the OTHER ancestor already gave the base — so a gate
+# reading from the merge base judges a commit this pull request did not
+# introduce, and refuses it for a trailer that is somebody else's to add.
+#
+# `base..head` excludes it by construction, which is the whole reason the range
+# is anchored on the base.
+#
+# BOTH sides unsigned, and that is what makes the case deterministic: `git
+# merge-base` names whichever of the two bests it likes, so a fixture with one
+# unsigned side passes or fails on that choice. With both, whichever it names,
+# the OTHER is in the merge-base range and in neither pull request.
+git -C "$repo" checkout -q -b cross-left "$base"
+left="$(commit_with "the left side with no trailer at all")"
+git -C "$repo" checkout -q -b cross-right "$base"
+right="$(commit_with "the right side with no trailer at all")"
+git -C "$repo" checkout -q -b cross-base "$left"
+git -C "$repo" merge -q --no-ff --no-verify -m "Merge right into base
+
+$signed" cross-right
+cross_base="$(git -C "$repo" rev-parse HEAD)"
+git -C "$repo" checkout -q -b cross-head "$right"
+git -C "$repo" merge -q --no-ff --no-verify -m "Merge left into head
+
+$signed" cross-left
+git -C "$repo" commit -q --allow-empty -m "the pull request's own commit
+
+$signed"
+cross_head="$(git -C "$repo" rev-parse HEAD)"
+case_is "a commit the base already has is not judged, however the ancestors cross" \
+    "$cross_base" "$cross_head" 0 "are signed off"
+
+# Histories that share nothing at all cannot be ranged over, and saying so beats
+# reading whatever `A..B` happens to mean for them.
+unrelated="$(git -C "$repo" mktree </dev/null)"
+orphan="$(git -C "$repo" commit-tree "$unrelated" -m "an orphan")"
+case_is "histories that share nothing are refused" "$orphan" "$merged" 1 "share no history"
 
 # And the success line carries its own DENOMINATOR, which is what makes a run
 # that read nothing unable to look like one that read everything.


### PR DESCRIPTION
Every open pull request fails the required `dco` check as soon as anything else merges to main, for a reason that has nothing to do with sign-off:

```
DCO: 0402172fa44cdd1873fa80249773759a7421193e is not an ancestor of cfaf88cac38e51a70e99379c6d3751696887c3ae
 — the range does not cover the commits it is meant to judge, and an empty one
 would read as a clean pass having examined nothing.
```

I hit this on nine PRs in one afternoon. Rebasing clears it until the next merge, which is not a fix, it is a race.

## Why

`ci.yml` passes `github.event.pull_request.base.sha` — the base branch's **tip** when the event fired, not the point the branch was cut from. Anything merged to main after a PR branches puts that tip off the head's ancestry, and `git merge-base --is-ancestor base head` is then false.

The **range** was never the problem. `base..head` is every commit reachable from head and not from base, so it already named exactly the commits the PR introduces; the base's own new commits are excluded, which is the point. Only the assertion was wrong.

The assertion itself was added for a good reason (#2781): `git rev-list A..B` answers silently for a base that is not behind the head, the loops run zero times, and the gate prints the same clean pass it prints for a fully signed branch. That failure mode is real and is still closed here — by the count, which is what refuses an empty range.

## The change

The ancestry assertion becomes the question it was reaching for: do these two share any history at all. That cannot be answered "no" by a busy afternoon on main, and it still refuses a pair with nothing in common.

**Deliberately not** a merge-base range. Reviewers raised the criss-cross case and it is real: with two best common ancestors `git merge-base` names one, and a range starting there reaches a commit the *other* ancestor already gave the base. The gate would then refuse a PR for somebody else's missing trailer. Anchoring on `base` excludes it by construction.

## Nothing is loosened

| case | outcome |
| --- | --- |
| histories that share nothing | refused |
| a head the base already contains | refused, the range holds no commits |
| an unsigned commit past a moved base | still named, by sha |
| a commit the base already has, ancestors crossed | not judged |

The last one has both sides of the cross unsigned on purpose. With only one, the case is decided by which of the two bests `git merge-base` happens to name — mine named the unsigned one, and the case went green over a genuinely broken reading.

Mutation-checked in both directions: restoring the ancestry assertion fails the moved-base case, and anchoring the range on `git merge-base` fails the criss-cross case.

`make check-backend` green, `scripts/test-check-dco.sh` green (12 cases).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contribution compliance checks when the base branch advances or histories diverge.
  * Ensured only commits introduced by the requested change are evaluated, including unsigned commits.
  * Added rejection for histories without a shared starting point.
* **Tests**
  * Expanded coverage for advanced branches, merged histories, and unrelated repositories.
  * Added validation for commits already present in the base branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->