### PR TITLE
The person page logs an interaction

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -24475,8 +24475,9 @@ components:
           description: >-
             `composer` — the outbound draft drawer. `meeting_brief` — the pre-meeting dossier.
             `research` — the deep-research drawer. `record` — another record page. `task` — the
-            task sheet.
-          enum: [composer, meeting_brief, research, record, task]
+            task sheet. `activity_log` — the log-activity form, for writing down a note or a
+            meeting that happened off-system.
+          enum: [composer, meeting_brief, research, record, task, activity_log]
         entity_type:
           type: [string, 'null']
           enum: [person, organization, deal, activity, null]

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -46,6 +46,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/elapsed"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -90,12 +91,37 @@ func (s *Service) momentsSection(ctx context.Context, tx pgx.Tx, personID ids.Pe
 		// Dismissed against THIS evidence. The quiet success state is what the
 		// reader asked for by dismissing, and it is a moment of its own rather
 		// than an empty card.
-		quiet := nothingNeededMoment(now, out)
-		out.Moment = &quiet
-		return nil
+		moment = nothingNeededMoment(now, out)
 	}
+	withholdLogActivity(ctx, &moment)
 	out.Moment = &moment
 	return nil
+}
+
+// withholdLogActivity turns a log-activity action the caller may not perform
+// into a blocked one that says so. The ladder derives its actions from the
+// page alone and knows nothing about the caller; the store behind the form
+// requires `activity.create`, so an action offered as available to a reader
+// without that grant is a button that opens a form whose save is refused.
+func withholdLogActivity(ctx context.Context, moment *crmcontracts.PersonMoment) {
+	if auth.Require(ctx, "activity", principal.ActionCreate) == nil {
+		return
+	}
+	reason := "You do not have permission to log activities"
+	withhold := func(action *crmcontracts.PersonMomentAction) {
+		if action.Kind != crmcontracts.PersonMomentActionKindLogActivity {
+			return
+		}
+		action.State = crmcontracts.PersonMomentActionStateBlocked
+		action.BlockedReason = &reason
+		action.Destination = nil
+	}
+	withhold(&moment.RecommendedAction)
+	if moment.SecondaryActions != nil {
+		for i := range *moment.SecondaryActions {
+			withhold(&(*moment.SecondaryActions)[i])
+		}
+	}
 }
 
 // momentDismissed asks whether this viewer has already put this moment away
@@ -393,21 +419,17 @@ func askColleague() crmcontracts.PersonMomentAction {
 }
 
 // logInteraction offers the one thing worth doing on a record with nothing
-// pending: write down something that happened off-system.
-//
-// Blocked for the same reason as askColleague, and it was found by the test
-// that pins that rule rather than by a report — which is the argument for
-// having written the rule instead of the one fix. The screen for it exists
-// (frontend logactivity.tsx, the contract's logActivity POST), but the person
-// page does not route to it and the destination vocabulary has no surface
-// naming it, so an available action here is a button that does nothing.
+// pending: write down something that happened off-system. It opens the
+// log-activity form the person page mounts, the same form the deal and lead
+// pages keep in their rail.
 func logInteraction() crmcontracts.PersonMomentAction {
-	reason := "Logging an interaction from this card is not available yet"
 	return crmcontracts.PersonMomentAction{
-		Kind:          crmcontracts.PersonMomentActionKindLogActivity,
-		Label:         "Log an interaction",
-		State:         crmcontracts.PersonMomentActionStateBlocked,
-		BlockedReason: &reason,
+		Kind:  crmcontracts.PersonMomentActionKindLogActivity,
+		Label: "Log an interaction",
+		State: crmcontracts.PersonMomentActionStateAvailable,
+		Destination: &crmcontracts.PersonMomentDestination{
+			Surface: crmcontracts.PersonMomentDestinationSurfaceActivityLog,
+		},
 	}
 }
 

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -12,6 +12,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
@@ -234,6 +235,7 @@ var dispatchedByThePersonPage = map[crmcontracts.PersonMomentDestinationSurface]
 	crmcontracts.PersonMomentDestinationSurfaceResearch:     true,
 	crmcontracts.PersonMomentDestinationSurfaceMeetingBrief: true,
 	crmcontracts.PersonMomentDestinationSurfaceRecord:       true,
+	crmcontracts.PersonMomentDestinationSurfaceActivityLog:  true,
 }
 
 // assertActionsAreHonest holds the rule for one moment: available means
@@ -379,5 +381,34 @@ func TestNothingNeededAdmitsWhenItCouldNotSeeEverything(t *testing.T) {
 	}
 	if !strings.Contains(partial.WhyNow, "not yours to see") {
 		t.Errorf("and it must say WHY the picture is partial, got %q", partial.WhyNow)
+	}
+}
+
+// The ladder offers "log an interaction" from the page alone; whether the
+// reader may actually log one is the caller's grant, and the store refuses a
+// save without it. So the action a reader cannot complete is handed to them
+// blocked, with the reason, rather than as a live button that fails on save.
+func TestLogActivityIsWithheldFromACallerWithoutTheCreateGrant(t *testing.T) {
+	quiet := nothingNeededMoment(time.Now(), &crmcontracts.Person360{})
+	if quiet.RecommendedAction.Kind != crmcontracts.PersonMomentActionKindLogActivity {
+		t.Fatalf("the quiet moment's action is %q, want log_activity — this test needs that rung", quiet.RecommendedAction.Kind)
+	}
+
+	reader := quiet
+	withholdLogActivity(as(map[string]principal.ObjectGrant{"person": {Read: true}}), &reader)
+	if reader.RecommendedAction.State != crmcontracts.PersonMomentActionStateBlocked {
+		t.Errorf("state = %q for a caller without activity.create, want blocked", reader.RecommendedAction.State)
+	}
+	if reader.RecommendedAction.BlockedReason == nil || *reader.RecommendedAction.BlockedReason == "" {
+		t.Error("a withheld action carries no reason, so the reader is refused without being told why")
+	}
+	if reader.RecommendedAction.Destination != nil {
+		t.Error("a withheld action still names a destination, which the client would treat as reachable")
+	}
+
+	writer := quiet
+	withholdLogActivity(as(map[string]principal.ObjectGrant{"person": {Read: true}, "activity": {Create: true}}), &writer)
+	if writer.RecommendedAction.State != crmcontracts.PersonMomentActionStateAvailable || writer.RecommendedAction.Destination == nil {
+		t.Errorf("a caller holding activity.create got %q with destination %v, want the action untouched", writer.RecommendedAction.State, writer.RecommendedAction.Destination)
 	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -8217,6 +8217,7 @@ func (e PersonMomentDestinationEntityType) Valid() bool {
 
 // Defines values for PersonMomentDestinationSurface.
 const (
+	PersonMomentDestinationSurfaceActivityLog  PersonMomentDestinationSurface = "activity_log"
 	PersonMomentDestinationSurfaceComposer     PersonMomentDestinationSurface = "composer"
 	PersonMomentDestinationSurfaceMeetingBrief PersonMomentDestinationSurface = "meeting_brief"
 	PersonMomentDestinationSurfaceRecord       PersonMomentDestinationSurface = "record"
@@ -8227,6 +8228,8 @@ const (
 // Valid indicates whether the value is a known member of the PersonMomentDestinationSurface enum.
 func (e PersonMomentDestinationSurface) Valid() bool {
 	switch e {
+	case PersonMomentDestinationSurfaceActivityLog:
+		return true
 	case PersonMomentDestinationSurfaceComposer:
 		return true
 	case PersonMomentDestinationSurfaceMeetingBrief:
@@ -24756,14 +24759,14 @@ type PersonMomentDestination struct {
 	// Prefill What the surface opens with — a draft intent, a subject, a task title. Strings only: a prefill is what a human is about to edit, never a structure the client must interpret.
 	Prefill *map[string]string `json:"prefill,omitempty"`
 
-	// Surface `composer` — the outbound draft drawer. `meeting_brief` — the pre-meeting dossier. `research` — the deep-research drawer. `record` — another record page. `task` — the task sheet.
+	// Surface `composer` — the outbound draft drawer. `meeting_brief` — the pre-meeting dossier. `research` — the deep-research drawer. `record` — another record page. `task` — the task sheet. `activity_log` — the log-activity form, for writing down a note or a meeting that happened off-system.
 	Surface PersonMomentDestinationSurface `json:"surface"`
 }
 
 // PersonMomentDestinationEntityType defines model for PersonMomentDestination.EntityType.
 type PersonMomentDestinationEntityType string
 
-// PersonMomentDestinationSurface `composer` — the outbound draft drawer. `meeting_brief` — the pre-meeting dossier. `research` — the deep-research drawer. `record` — another record page. `task` — the task sheet.
+// PersonMomentDestinationSurface `composer` — the outbound draft drawer. `meeting_brief` — the pre-meeting dossier. `research` — the deep-research drawer. `record` — another record page. `task` — the task sheet. `activity_log` — the log-activity form, for writing down a note or a meeting that happened off-system.
 type PersonMomentDestinationSurface string
 
 // PersonMomentEvidence One thing that actually happened, which the reader can open.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -17038,10 +17038,10 @@ export interface components {
          */
         PersonMomentDestination: {
             /**
-             * @description `composer` — the outbound draft drawer. `meeting_brief` — the pre-meeting dossier. `research` — the deep-research drawer. `record` — another record page. `task` — the task sheet.
+             * @description `composer` — the outbound draft drawer. `meeting_brief` — the pre-meeting dossier. `research` — the deep-research drawer. `record` — another record page. `task` — the task sheet. `activity_log` — the log-activity form, for writing down a note or a meeting that happened off-system.
              * @enum {string}
              */
-            surface: "composer" | "meeting_brief" | "research" | "record" | "task";
+            surface: "composer" | "meeting_brief" | "research" | "record" | "task" | "activity_log";
             /** @enum {string|null} */
             entity_type?: "person" | "organization" | "deal" | "activity" | null;
             /** Format: uuid */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6729,6 +6729,8 @@ export const de = {
   "person.action.meetings": "Termine ansehen",
   "person.action.addTask": "Aufgabe",
   "person.action.research": "Recherche",
+  "person.action.logRefused":
+    "Sie haben keine Berechtigung, Aktivitäten zu diesem Kontakt zu erfassen.",
 
   "person.strip.lastInbound": "Zuletzt eingehend",
   "person.strip.lastOutbound": "Zuletzt ausgehend",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6782,6 +6782,8 @@ export const en = {
   "person.action.meetings": "See meetings",
   "person.action.addTask": "Add task",
   "person.action.research": "Research",
+  "person.action.logRefused":
+    "You do not have permission to log activities on this record.",
 
   "person.strip.lastInbound": "Last inbound",
   "person.strip.lastOutbound": "Last outbound",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6660,6 +6660,8 @@ export const vi = {
   "person.action.meetings": "Xem lịch hẹn",
   "person.action.addTask": "Thêm việc",
   "person.action.research": "Nghiên cứu",
+  "person.action.logRefused":
+    "Bạn không có quyền ghi nhận hoạt động cho hồ sơ này.",
 
   "person.strip.lastInbound": "Nhận gần nhất",
   "person.strip.lastOutbound": "Gửi gần nhất",

--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -15,6 +15,7 @@ import {
   installFetchStub,
   jsonResponse,
   meRoute,
+  type RouteMap,
   StoryProviders,
 } from "./story-utils";
 
@@ -107,9 +108,20 @@ function mount(
   tab: (typeof PERSON_TABS)[number],
   page: Person360 = view,
   guardEntries: readonly PersonConsentGuardEntry[] = [],
+  // Routes a test adds for the write it makes; the reads every mount needs
+  // stay here.
+  extraRoutes: RouteMap = {},
+  // What the caller may do. Logging needs `activity.create`, which the store
+  // behind the form requires, so a spec that logs must hold it here or it
+  // passes under an authorization production refuses.
+  allow: Parameters<typeof meRoute>[0] = {
+    person: ["read", "update"],
+    activity: ["create"],
+  },
 ) {
   installFetchStub({
-    "GET /me": meRoute({ person: ["read", "update"] }),
+    ...extraRoutes,
+    "GET /me": meRoute(allow, { seat: "full" }),
     "GET /people/p-1/360": () => jsonResponse(page),
     "GET /people/p-1/brief": () =>
       jsonResponse({ person_id: "p-1", sentences: [], generated_by: "rules" }),
@@ -545,5 +557,99 @@ describe("the contact's LinkedIn on the header", () => {
     expect(link.getAttribute("href")).toBe(
       "https://de.linkedin.com/in/dana-buyer",
     );
+  });
+});
+
+// The one thing a CRM must let a rep do on a person is write down what
+// happened. Two ways in, one form: the header verb that is always there, and
+// the moment card's action when its rung decides logging is the next step.
+describe("logging an activity", () => {
+  // The "nothing needed" rung, whose one action is to log an interaction.
+  const quietDayMoment: Person360["moment"] = {
+    claim_key: "moment:nothing_needed",
+    evidence_fingerprint: "quiet",
+    rule: "nothing_needed",
+    headline: "Nothing needs you today",
+    why_now:
+      "No meeting is close, nothing is owed, and nobody is waiting on a reply.",
+    confidence: "observed_fact",
+    evidence: [],
+    recommended_action: {
+      kind: "log_activity",
+      label: "Log an interaction",
+      state: "available",
+      destination: { surface: "activity_log" },
+    },
+  };
+
+  it("opens the log form from the header, whatever the moment card offers", async () => {
+    const user = userEvent.setup();
+    mount("overview");
+
+    // Disabled until the caller's grants have arrived, and the header is
+    // rebuilt when they do — so the button is looked up fresh each time
+    // rather than held from before the grant landed.
+    const logButton = async () =>
+      within(await recordHeader()).getByRole("button", {
+        name: "Log activity",
+      });
+    await waitFor(async () =>
+      expect(await logButton()).toHaveProperty("disabled", false),
+    );
+    await user.click(await logButton());
+
+    expect(
+      await screen.findByRole("dialog", { name: "Log activity" }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the verb on the page but refuses it without the create grant", async () => {
+    // The store refuses a save without `activity.create`, so the button must
+    // not open a form it cannot complete — and it stays visible, because a
+    // reader who cannot tell "not mine to do" from "no such button" learns
+    // nothing from an absence.
+    mount("overview", view, [], {}, { person: ["read", "update"] });
+
+    const header = await recordHeader();
+    const button = within(header).getByRole("button", {
+      name: /Log activity/,
+    });
+    expect(button).toHaveProperty("disabled", true);
+    expect(
+      within(header).getByText(
+        "You do not have permission to log activities on this record.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("logs a meeting on this person from the moment card's action", async () => {
+    const user = userEvent.setup();
+    const posted: unknown[] = [];
+    mount("overview", { ...view, moment: quietDayMoment }, [], {
+      "POST /activities": (body) => {
+        posted.push(body);
+        return jsonResponse({}, 201);
+      },
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Log an interaction" }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "Log activity" });
+    await user.click(within(dialog).getByRole("combobox", { name: "Type" }));
+    await user.click(await screen.findByRole("option", { name: "Meeting" }));
+    await user.type(
+      within(dialog).getByRole("textbox", { name: "Subject" }),
+      "Coffee at the fair",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "Log" }));
+
+    await waitFor(() => expect(posted).toHaveLength(1));
+    expect(posted[0]).toMatchObject({
+      kind: "meeting",
+      subject: "Coffee at the fair",
+      meeting_status: "held",
+      links: [{ entity_type: "person", entity_id: "p-1" }],
+    });
   });
 });

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   CalendarDays,
   CheckSquare,
+  FileText,
   Link as LinkIcon,
   Mail,
   MapPin,
@@ -12,6 +13,7 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { useCanWrite } from "../app/capability";
 import { PageAside, PageAsideToggle } from "../app/pageaside";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
@@ -26,6 +28,7 @@ import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { throwProblem } from "./common";
 import { ConsentSection } from "./consent";
+import { LogActivityAction } from "./logactivity";
 import {
   hasCommercial,
   hasCommitments,
@@ -312,6 +315,9 @@ export function PersonPageV2({
           navigate({ screen: "deals", id: destination.entity_id });
         }
         return;
+      case "activity_log":
+        setDrawer("activity_log");
+        return;
       default:
         // `task` has no surface on this page yet. Doing nothing is the honest
         // outcome; inventing a navigation would take the reader somewhere they
@@ -336,6 +342,7 @@ export function PersonPageV2({
               personId={id}
               onWrite={() => openComposer("")}
               onResearch={() => setDrawer("research")}
+              onLogActivity={() => setDrawer("activity_log")}
             />
             <PageAsideToggle />
           </>
@@ -448,6 +455,16 @@ export function PersonPageV2({
           onClose={() => setDrawer(null)}
           projects={liveProjects(view.data.projects)}
         />
+        {/* Mounted only while open, so the form starts fresh each time and the
+            day it offers is today's, not the day the drawer was first built. */}
+        {drawer === "activity_log" && (
+          <LogActivityAction
+            entityType="person"
+            entityId={id}
+            openOnMount
+            onClose={() => setDrawer(null)}
+          />
+        )}
       </RecordView>
     </div>
   );
@@ -464,6 +481,7 @@ export function PersonPageV2({
 type Drawer =
   | "composer"
   | "research"
+  | "activity_log"
   | { kind: "meeting"; activityId: string }
   | null;
 
@@ -617,6 +635,7 @@ function PersonActions({
   personId,
   onWrite,
   onResearch,
+  onLogActivity,
 }: Readonly<{
   view: Person360;
   consentAllows: boolean;
@@ -624,8 +643,14 @@ function PersonActions({
   personId: string;
   onWrite: () => void;
   onResearch: () => void;
+  onLogActivity: () => void;
 }>): ReactNode {
   const t = useT();
+  // useCanWrite, not useCan: the form issues a POST, and a read seat is
+  // refused before RBAC is consulted. The button stays on the page and says
+  // why it will not press, so a reader can tell "not mine to do" from "this
+  // build has no such button".
+  const canLog = useCanWrite("activity", "create");
   // The transports the composer would offer, read here so the button NAMES
   // what pressing it does. The same reachability the drawer resolves: a label
   // computed from anything else is a promise the composer then breaks.
@@ -669,6 +694,16 @@ function PersonActions({
       <Button onClick={() => navigate({ screen: "worklist" })}>
         <CheckSquare size={15} aria-hidden="true" />{" "}
         {t("person.action.addTask")}
+      </Button>
+      {/* A CRM a rep cannot write a meeting into is a CRM that only reads.
+          This is the standing way in; the moment card offers the same form
+          when its rung decides logging is the thing to do next. */}
+      <Button
+        disabled={!canLog}
+        reason={canLog ? undefined : t("person.action.logRefused")}
+        onClick={onLogActivity}
+      >
+        <FileText size={15} aria-hidden="true" /> {t("log.title")}
       </Button>
       {/* A real menu. This was a button labelled "More actions" that navigated
           to the timeline tab — the same place the Call button went — so the one


### PR DESCRIPTION
The new person page had no way to write down a meeting, a call or a note. Its "Log an interaction" moment action shipped blocked ("not available yet") because the page did not route to the log-activity form, and the standing composer the old person detail carried was never mounted on the page that replaced it. A rep on a contact could read everything and log nothing.

Now the page mounts the same `LogActivityAction` the company header uses:

- A **Log activity** button beside **Add task** in the person header opens the form (note / task / meeting, with the transcript option).
- The moment card's **Log an interaction** action opens the same form, through a new `activity_log` destination surface in `crm.yaml` (contracts regenerated on both sides).
- `logInteraction()` in `compose/person360/moments.go` is offered as available with that destination, and `dispatchedByThePersonPage` in its test admits the surface, so the ladder's honesty rule (available means reachable) still holds.

Verified in the browser on an isolated dev stack: both buttons open the dialog, choosing Meeting and pressing Log answers `201 POST /v1/activities` and the entry appears on the timeline.

Specs: `personpage.test.tsx` covers the header button opening the dialog and a meeting logged from the moment action reaching `POST /activities` linked to the person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the person page to log a meeting, call, or note so a rep can write down what happened instead of only reading. Both the header's **Log activity** button and the moment card's **Log an interaction** action now open the same log-activity form.

- Adds `activity_log` as a destination surface in `crm.yaml` and regenerates the backend and frontend contracts.
- Callers without the `activity.create` grant get the moment action blocked with a reason, and the header button disabled with the same reason.
- Extends the honesty test so every available action stays reachable.
- Adds tests for the header button opening the dialog, the withheld action, and logging a meeting that posts `POST /activities` linked to the person.

<sup>Written for commit cbf90e8d2fa7235fff3082a3f3cef9f9c96c5f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Log Activity** action to person pages.
  * Open the activity log from the page header or directly from moment cards.
  * Record off-system notes and meetings with the relevant person context.
  * Added support for activity logging as a CRM destination.
* **Bug Fixes**
  * Activity-log actions now correctly reflect activity-creation permissions.
  * Unauthorized actions are disabled with a clear explanation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->