### PR TITLE
The export owes the value a newer statement replaced

### DIFF
--- a/backend/internal/modules/privacy/sar_integration_test.go
+++ b/backend/internal/modules/privacy/sar_integration_test.go
@@ -19,6 +19,8 @@ package privacy
 import (
 	"context"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,7 +39,11 @@ type sarIdentifierEnv struct {
 	// db is pinned to the workspace this fixture created: the handle is where
 	// "which tenant am I" lives now (ADR-0091 §9 step 3), and this env builds
 	// its workspace by raw SQL rather than through the installation resolver.
-	db     *database.DB
+	db *database.DB
+	// owner is the migration-role connection the fixture seeded through, kept
+	// so a test can add to the subject's history or read the live table
+	// definition. Held open for the test's lifetime by the cleanup below.
+	owner  *pgx.Conn
 	person ids.PersonID
 }
 
@@ -102,6 +108,7 @@ func setupSARIdentifiers(t *testing.T) *sarIdentifierEnv {
 	return &sarIdentifierEnv{
 		ctx:    exportContext(ws, user),
 		db:     database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)),
+		owner:  owner,
 		person: person,
 	}
 }
@@ -110,6 +117,11 @@ func setupSARIdentifiers(t *testing.T) *sarIdentifierEnv {
 // kind. The two values in a pair differ because the live-row uniqueness indexes
 // are partial on archived_at IS NULL — reusing one value would leave the export
 // unable to say which row it named.
+//
+// Every value is scoped to the subject through ident(). The dedupe indexes on
+// these tables are workspace-wide, not per-person, so a fixed literal binds the
+// fixture to being the only one in the database — the second test to seed a
+// subject fails on the first test's address rather than on anything it asserts.
 func seedIdentifierPairs(ctx context.Context, t *testing.T, owner *pgx.Conn, person ids.PersonID) {
 	t.Helper()
 	for _, insert := range []struct {
@@ -119,18 +131,18 @@ func seedIdentifierPairs(ctx context.Context, t *testing.T, owner *pgx.Conn, per
 		{
 			`INSERT INTO person_email (person_id, email, source, captured_by, archived_at)
 		  VALUES ($1, $2, 'manual', 'user:test', NULL), ($1, $3, 'manual', 'user:test', $4)`,
-			liveEmail, retiredEmail,
+			ident(person, liveEmail), ident(person, retiredEmail),
 		},
 		{
 			`INSERT INTO person_phone (person_id, phone, source, captured_by, archived_at)
 		  VALUES ($1, $2, 'manual', 'user:test', NULL), ($1, $3, 'manual', 'user:test', $4)`,
-			livePhone, retiredPhone,
+			ident(person, livePhone), ident(person, retiredPhone),
 		},
 		{
 			`INSERT INTO person_channel_identity (person_id, provider, channel_user_id, username, source, captured_by, archived_at)
 		  VALUES ($1, 'telegram', $2, 'sara', 'connector:telegram', 'connector:telegram', NULL),
 		         ($1, 'telegram', $3, 'sara_old', 'connector:telegram', 'connector:telegram', $4)`,
-			liveAccount, retiredAccount,
+			ident(person, liveAccount), ident(person, retiredAccount),
 		},
 	} {
 		if _, err := owner.Exec(ctx, insert.statement, person, insert.live, insert.retired, retiredAt); err != nil {
@@ -157,7 +169,8 @@ func exportContext(ws, user ids.UUID) context.Context {
 	})
 }
 
-// The subject's identifiers, one live and one retired per kind.
+// The subject's identifiers, one live and one retired per kind. These are the
+// SHAPES; ident() below binds each to a particular subject.
 const (
 	liveEmail      = "sara.live@sar.test"
 	retiredEmail   = "sara.retired@sar.test"
@@ -166,6 +179,36 @@ const (
 	liveAccount    = "770000001"
 	retiredAccount = "770000002"
 )
+
+// ident scopes one identifier to one subject, keeping the shape each column
+// expects: an address stays an address and a number stays digits, because the
+// dedupe indexes and the column checks are real constraints on these tables.
+//
+// The discriminator is the subject's own id, so two fixtures in one database
+// can hold "the same" identifier without colliding on the workspace-wide
+// dedupe indexes. The shape's OWN trailing digits are kept and the
+// discriminator goes in the middle — dropping them would fold a fixture's live
+// and retired values onto one string, and the pair exists precisely to be
+// told apart.
+func ident(person ids.PersonID, shape string) string {
+	// The TAIL of the id, not its head. These are UUIDv7s, whose leading hex
+	// is a millisecond clock — two fixtures built in the same millisecond
+	// share that prefix and would collide on exactly the index this exists to
+	// avoid. The tail is the random half.
+	full := person.String()
+	tag := full[len(full)-8:]
+	if local, domain, ok := strings.Cut(shape, "@"); ok {
+		return local + "+" + tag + "@" + domain
+	}
+	var digits strings.Builder
+	for _, r := range tag {
+		digits.WriteString(strconv.Itoa(int(r) % 10))
+	}
+	// Keep the last four of the shape, which is where liveX and retiredX
+	// differ, and splice the subject's digits in front of them.
+	keep := len(shape) - 4
+	return shape[:keep] + digits.String() + shape[keep:]
+}
 
 // TestTheSARExportDistinguishesARetiredBindingFromALiveOne walks all three
 // identifier sections, because the obligation is the same in each: the section
@@ -185,9 +228,9 @@ func TestTheSARExportDistinguishesARetiredBindingFromALiveOne(t *testing.T) {
 		live    string
 		retired string
 	}{
-		{"emails", pkg.Emails, "email", liveEmail, retiredEmail},
-		{"phones", pkg.Phones, "phone", livePhone, retiredPhone},
-		{"channel identities", pkg.ChannelIdentities, "channel_user_id", liveAccount, retiredAccount},
+		{"emails", pkg.Emails, "email", ident(e.person, liveEmail), ident(e.person, retiredEmail)},
+		{"phones", pkg.Phones, "phone", ident(e.person, livePhone), ident(e.person, retiredPhone)},
+		{"channel identities", pkg.ChannelIdentities, "channel_user_id", ident(e.person, liveAccount), ident(e.person, retiredAccount)},
 	} {
 		t.Run(section.name, func(t *testing.T) {
 			byIdentifier := map[string]map[string]any{}

--- a/backend/internal/modules/privacy/sarobservation_integration_test.go
+++ b/backend/internal/modules/privacy/sarobservation_integration_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package privacy
+
+// The Art. 15 export over the columns that record what a value REPLACED.
+//
+// A newer dated statement by the contact — a mail signature, a business card —
+// overwrites what the record held and keeps the old value on the row. That
+// makes the row hold two assertions about the subject, plus the date the record
+// believes each was stated. Exporting only the current one hands the subject a
+// package that is true and incomplete: it says their title is X, while the
+// installation also holds that it said Y until a message dated Z replaced it.
+//
+// The census at the bottom is the part that survives the next schema change. A
+// column added to either table and left out of the SELECT is invisible in
+// production and in every behavioural test above it, because the export simply
+// never mentions it — nothing fails, and the subject is quietly owed something.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The subject's superseded history. The replaced values differ from the live
+// ones so an assertion can name which of the two it found.
+const (
+	livedTitle    = "Head of Partnerships"
+	replacedTitle = "Partnerships Lead"
+	replacedPhone = "+493033333333"
+)
+
+// observedAt and replacedObservedAt are the dates the RECORD believes the
+// subject stated each value — fixed literals, because the assertions ask only
+// whether the date reached the export.
+var (
+	observedAt         = time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	replacedObservedAt = time.Date(2025, 6, 1, 9, 0, 0, 0, time.UTC)
+)
+
+// seedSupersededHistory gives the subject a profile field that replaced an
+// earlier answer, and a phone row that replaced an earlier number.
+//
+// The phone pair is seeded as two rows joined by superseded_phone_id, which is
+// how the writer records a replacement: the old row is archived rather than
+// deleted, and the new one points back at it.
+func seedSupersededHistory(ctx context.Context, t *testing.T, owner *pgx.Conn, person ids.PersonID) {
+	t.Helper()
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO person_profile_field
+		  (person_id, field, value, evidence_snippet, source_ref, source, captured_by,
+		   observed_at, superseded_value, superseded_captured_by, superseded_observed_at)
+		VALUES ($1, 'title', $2, 'signature block', 'activity:test', 'signature', 'agent:enrich',
+		        $3, $4, 'user:test', $5)`,
+		person, livedTitle, observedAt, replacedTitle, replacedObservedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	var replaced ids.UUID
+	if err := owner.QueryRow(ctx, `
+		INSERT INTO person_phone (person_id, phone, source, captured_by, observed_at, archived_at)
+		VALUES ($1, $2, 'manual', 'user:test', $3, $4)
+		RETURNING id`,
+		person, ident(person, replacedPhone), replacedObservedAt, retiredAt).Scan(&replaced); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := owner.Exec(ctx, `
+		UPDATE person_phone SET superseded_phone_id = $1, observed_at = $2
+		 WHERE person_id = $3 AND phone = $4`,
+		replaced, observedAt, person, ident(person, livePhone)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestTheExportCarriesTheValueANewerStatementReplaced asserts the profile-field
+// section hands over both assertions and both dates.
+func TestTheExportCarriesTheValueANewerStatementReplaced(t *testing.T) {
+	e := setupSARIdentifiers(t)
+	seedSupersededHistory(e.ctx, t, e.owner, e.person)
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	var title map[string]any
+	for _, row := range pkg.EnrichedFields {
+		if row["field"] == "title" {
+			title = row
+		}
+	}
+	if title == nil {
+		t.Fatalf("the enriched title is missing from the export: %v", pkg.EnrichedFields)
+	}
+
+	if got := title["value"]; got != livedTitle {
+		t.Errorf("current value = %v, want %q", got, livedTitle)
+	}
+	// The replaced value is the assertion the export used to drop. A subject
+	// reading only the current one cannot tell that this installation also
+	// holds what it said before, or that a colleague was the one who said it.
+	if got := title["superseded_value"]; got != replacedTitle {
+		t.Errorf("superseded_value = %v, want %q — Art. 15 owes the value still held on the row", got, replacedTitle)
+	}
+	if got := title["superseded_captured_by"]; got != "user:test" {
+		t.Errorf("superseded_captured_by = %v, want the colleague who wrote the replaced value", got)
+	}
+	for _, field := range []struct {
+		key  string
+		want time.Time
+	}{
+		{"observed_at", observedAt},
+		{"superseded_observed_at", replacedObservedAt},
+	} {
+		stamp, ok := title[field.key].(time.Time)
+		if !ok {
+			t.Errorf("%s is absent from the export: %v", field.key, title)
+			continue
+		}
+		if !stamp.Equal(field.want) {
+			t.Errorf("%s = %v, want %v", field.key, stamp, field.want)
+		}
+	}
+}
+
+// TestTheExportNamesTheNumberANewerOneReplaced asserts the phone section
+// resolves superseded_phone_id to the number it points at.
+//
+// The column holds a row id. Exporting it raw would satisfy a census and tell
+// the subject nothing, so the obligation is the NUMBER.
+func TestTheExportNamesTheNumberANewerOneReplaced(t *testing.T) {
+	e := setupSARIdentifiers(t)
+	seedSupersededHistory(e.ctx, t, e.owner, e.person)
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	var live map[string]any
+	for _, row := range pkg.Phones {
+		if row["phone"] == ident(e.person, livePhone) {
+			live = row
+		}
+	}
+	if live == nil {
+		t.Fatalf("the live phone is missing from the export: %v", pkg.Phones)
+	}
+	if got := live["replaced_phone"]; got != ident(e.person, replacedPhone) {
+		t.Errorf("replaced_phone = %v, want %q — a row id would name nothing the subject can read", got, replacedPhone)
+	}
+	stamp, ok := live["replaced_observed_at"].(time.Time)
+	if !ok {
+		t.Fatalf("replaced_observed_at is absent: %v", live)
+	}
+	if !stamp.Equal(replacedObservedAt) {
+		t.Errorf("replaced_observed_at = %v, want %v", stamp, replacedObservedAt)
+	}
+}
+
+// A phone row that replaced nothing must export the pair as absent rather than
+// borrowing another row's. The LEFT JOIN is what makes that true, and a plain
+// JOIN — the easy edit — would silently drop every number that replaced nothing,
+// which is most of them.
+func TestAPhoneThatReplacedNothingStillReachesTheExport(t *testing.T) {
+	e := setupSARIdentifiers(t)
+	seedSupersededHistory(e.ctx, t, e.owner, e.person)
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	var replaced map[string]any
+	for _, row := range pkg.Phones {
+		if row["phone"] == ident(e.person, replacedPhone) {
+			replaced = row
+		}
+	}
+	if replaced == nil {
+		t.Fatalf("the replaced phone is itself missing from the export — Art. 15 owes what is held: %v", pkg.Phones)
+	}
+	if got := replaced["replaced_phone"]; got != nil {
+		t.Errorf("replaced_phone = %v on a row that replaced nothing, want nil", got)
+	}
+}
+
+// TestEveryHeldColumnReachesTheExport is the census. It reads the live table
+// definition and fails on a column no section projects.
+//
+// Derived from the database rather than from a list kept here, because a list
+// is updated by whoever remembers it exists. The excused set is small and each
+// entry says why it is not the subject's data; adding to it is a decision a
+// reader can see, which is the whole difference between an omission and a
+// judgement.
+func TestEveryHeldColumnReachesTheExport(t *testing.T) {
+	e := setupSARIdentifiers(t)
+	seedSupersededHistory(e.ctx, t, e.owner, e.person)
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	for _, subject := range []struct {
+		table   string
+		rows    []map[string]any
+		excused map[string]string
+	}{
+		{
+			table: "person_profile_field",
+			rows:  pkg.EnrichedFields,
+			excused: map[string]string{
+				"id":         "the row's own key, not a fact about the subject",
+				"person_id":  "the subject this whole package is about",
+				"created_at": "updated_at is the one the section reports",
+				"version":    "optimistic-locking counter; says how often the row was written, not what it says",
+			},
+		},
+		{
+			table: "person_phone",
+			rows:  pkg.Phones,
+			excused: map[string]string{
+				"id":                  "the row's own key, not a fact about the subject",
+				"person_id":           "the subject this whole package is about",
+				"created_at":          "bookkeeping; observed_at is what the record believes",
+				"updated_at":          "bookkeeping; observed_at is what the record believes",
+				"superseded_phone_id": "exported resolved, as replaced_phone",
+				"source":              "how it was captured, reported by the provenance section",
+				"captured_by":         "who captured it, reported by the provenance section",
+				"is_primary":          "a display choice this installation made, not the subject's data",
+				"position":            "the order the numbers are listed in, a display choice",
+				"version":             "optimistic-locking counter; says how often the row was written, not what it says",
+			},
+		},
+	} {
+		t.Run(subject.table, func(t *testing.T) {
+			rows, err := e.owner.Query(e.ctx, `
+				SELECT column_name FROM information_schema.columns
+				 WHERE table_schema = 'public' AND table_name = $1`, subject.table)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+
+			var columns []string
+			for rows.Next() {
+				var column string
+				if err := rows.Scan(&column); err != nil {
+					t.Fatal(err)
+				}
+				columns = append(columns, column)
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatal(err)
+			}
+			// A census that reads no columns reports PASS while proving
+			// nothing, which is the one way this test could fail short.
+			if len(columns) == 0 {
+				t.Fatalf("read no columns for %s — the census has nothing to check", subject.table)
+			}
+			if len(subject.rows) == 0 {
+				t.Fatalf("the export carries no %s rows, so no column can be seen in one", subject.table)
+			}
+
+			exported := subject.rows[0]
+			for _, column := range columns {
+				if reason, ok := subject.excused[column]; ok {
+					if reason == "" {
+						t.Errorf("%s.%s is excused without a reason", subject.table, column)
+					}
+					continue
+				}
+				if _, ok := exported[column]; !ok {
+					t.Errorf("%s.%s is held about the subject but reaches no export section — "+
+						"add it to the SELECT, or excuse it with the reason it is not their data",
+						subject.table, column)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/modules/privacy/sarobservation_integration_test.go
+++ b/backend/internal/modules/privacy/sarobservation_integration_test.go
@@ -192,6 +192,69 @@ func TestAPhoneThatReplacedNothingStillReachesTheExport(t *testing.T) {
 	}
 }
 
+// TestTheExportNeverNamesAStrangersReplacedNumber is the merge case.
+//
+// A merge re-homes only LIVE phone rows, so the survivor ends up carrying a
+// live row that still points at the merged-away person's ARCHIVED one. The
+// pointer therefore crosses subjects in ordinary use, and an export that
+// followed it would hand this subject a number belonging to somebody else —
+// the single worst thing a privacy export can do.
+func TestTheExportNeverNamesAStrangersReplacedNumber(t *testing.T) {
+	e := setupSARIdentifiers(t)
+
+	// A second person, holding the number, whose live row is then re-homed to
+	// our subject exactly as relinkDemotingPrimary does it: the archived
+	// predecessor stays behind.
+	stranger := ids.New[ids.PersonKind]()
+	if _, err := e.owner.Exec(e.ctx, `
+		INSERT INTO person (id, full_name, source, captured_by)
+		VALUES ($1, 'Merged Away', 'manual', 'user:test')`, stranger); err != nil {
+		t.Fatal(err)
+	}
+	var strangersOld ids.UUID
+	if err := e.owner.QueryRow(e.ctx, `
+		INSERT INTO person_phone (person_id, phone, source, captured_by, observed_at, archived_at)
+		VALUES ($1, $2, 'manual', 'user:test', $3, $4)
+		RETURNING id`,
+		stranger, ident(stranger, replacedPhone), replacedObservedAt, retiredAt).Scan(&strangersOld); err != nil {
+		t.Fatal(err)
+	}
+	// The survivor's live row points at it, which is what the merge leaves.
+	if _, err := e.owner.Exec(e.ctx, `
+		UPDATE person_phone SET superseded_phone_id = $1
+		 WHERE person_id = $2 AND phone = $3`,
+		strangersOld, e.person, ident(e.person, livePhone)); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := AssembleSAR(e.ctx, e.db, e.person)
+	if err != nil {
+		t.Fatalf("AssembleSAR: %v", err)
+	}
+
+	strangersNumber := ident(stranger, replacedPhone)
+	for _, row := range pkg.Phones {
+		if row["replaced_phone"] == strangersNumber {
+			t.Fatalf("the export named a number held by another person as this subject's "+
+				"replaced number: %v", row)
+		}
+	}
+	// And the row itself still reaches the export: the pointer is left
+	// unresolved, not dropped along with the number that carries it.
+	var live map[string]any
+	for _, row := range pkg.Phones {
+		if row["phone"] == ident(e.person, livePhone) {
+			live = row
+		}
+	}
+	if live == nil {
+		t.Fatalf("the subject's own live phone vanished with the unresolvable pointer: %v", pkg.Phones)
+	}
+	if got := live["replaced_phone"]; got != nil {
+		t.Errorf("replaced_phone = %v, want nil for a pointer that crosses subjects", got)
+	}
+}
+
 // TestEveryHeldColumnReachesTheExport is the census. It reads the live table
 // definition and fails on a column no section projects.
 //
@@ -233,8 +296,6 @@ func TestEveryHeldColumnReachesTheExport(t *testing.T) {
 				"created_at":          "bookkeeping; observed_at is what the record believes",
 				"updated_at":          "bookkeeping; observed_at is what the record believes",
 				"superseded_phone_id": "exported resolved, as replaced_phone",
-				"source":              "how it was captured, reported by the provenance section",
-				"captured_by":         "who captured it, reported by the provenance section",
 				"is_primary":          "a display choice this installation made, not the subject's data",
 				"position":            "the order the numbers are listed in, a display choice",
 				"version":             "optimistic-locking counter; says how often the row was written, not what it says",

--- a/backend/internal/modules/privacy/sarsections.go
+++ b/backend/internal/modules/privacy/sarsections.go
@@ -39,7 +39,17 @@ func sarIdentitySections(pkg *SARPackage) []sarSection {
 		// subject cannot tell a retirement that happened from one that did not —
 		// in the very package they would check it in.
 		{&pkg.Emails, `SELECT email, email_type, is_primary, archived_at FROM person_email WHERE person_id = $1`, nil},
-		{&pkg.Phones, `SELECT phone, phone_type, archived_at FROM person_phone WHERE person_id = $1`, nil},
+		// The number this row replaced is exported as the NUMBER, not as the
+		// superseded_phone_id the column holds: a bare row id tells the subject
+		// nothing, and the point of the export is what is known about them. The
+		// join is left, because the replaced row is deleted outright by erasure
+		// while this one survives archived, and a subject whose old number has
+		// already gone should still receive the row that replaced it.
+		{&pkg.Phones, `SELECT p.phone, p.phone_type, p.archived_at, p.observed_at,
+		          prev.phone AS replaced_phone, prev.observed_at AS replaced_observed_at
+		   FROM person_phone p
+		   LEFT JOIN person_phone prev ON prev.id = p.superseded_phone_id
+		  WHERE p.person_id = $1`, nil},
 		{&pkg.ChannelIdentities, `SELECT provider, channel_user_id, username, blocked_at, source, created_at, archived_at
 		   FROM person_channel_identity WHERE person_id = $1`, nil},
 		{&pkg.InteractionParticipation, `SELECT ap.activity_id, ap.role, ap.address, ap.created_at,
@@ -248,8 +258,18 @@ func sarProvenanceSections(pkg *SARPackage) []sarSection {
 		// enriched value and the correction — which travels beside it in
 		// Corrections below, as its own section. Merging them here would hand
 		// the subject one value and conceal that the override exists at all.
+		// observed_at and the superseded_* trio are exported beside the value
+		// they belong to. They are held personal data in their own right: the
+		// superseded value is a second thing this installation says about the
+		// subject — often the one a colleague typed — and observed_at is the
+		// date the record believes the subject stated it. Exporting the current
+		// value alone would tell the subject their title is X while the row
+		// also holds that it used to say Y until a message dated Z replaced it,
+		// which is precisely the sort of held-but-unstated fact Art. 15 owes.
 		{&pkg.EnrichedFields, `SELECT ppf.field, ppf.value, ppf.evidence_snippet, ppf.source_ref,
-		          ppf.confidence, ppf.source, ppf.captured_by, ppf.updated_at
+		          ppf.confidence, ppf.source, ppf.captured_by, ppf.updated_at,
+		          ppf.observed_at, ppf.superseded_value, ppf.superseded_captured_by,
+		          ppf.superseded_observed_at
 		   FROM person_profile_field ppf
 		   WHERE ppf.person_id = $1`, nil},
 		// claim_key is exported as it stands: it is a hash of the claim's

--- a/backend/internal/modules/privacy/sarsections.go
+++ b/backend/internal/modules/privacy/sarsections.go
@@ -41,14 +41,26 @@ func sarIdentitySections(pkg *SARPackage) []sarSection {
 		{&pkg.Emails, `SELECT email, email_type, is_primary, archived_at FROM person_email WHERE person_id = $1`, nil},
 		// The number this row replaced is exported as the NUMBER, not as the
 		// superseded_phone_id the column holds: a bare row id tells the subject
-		// nothing, and the point of the export is what is known about them. The
-		// join is left, because the replaced row is deleted outright by erasure
-		// while this one survives archived, and a subject whose old number has
-		// already gone should still receive the row that replaced it.
+		// nothing, and the point of the export is what is known about them.
+		//
+		// The join is LEFT because the replaced row is deleted outright by
+		// erasure while this one survives archived, and a subject whose old
+		// number has already gone should still receive the row that replaced
+		// it. A plain JOIN would also drop every number that replaced nothing,
+		// which is most of them.
+		//
+		// prev.person_id = p.person_id is the tenant predicate this join cannot
+		// do without. A merge re-homes only LIVE phone rows, so the survivor
+		// can carry a live row still pointing at the merged-away person's
+		// ARCHIVED one — and without this clause the survivor's export hands
+		// out a number belonging to somebody else. The pointer is left
+		// unresolved in that case rather than followed.
 		{&pkg.Phones, `SELECT p.phone, p.phone_type, p.archived_at, p.observed_at,
+		          p.source, p.captured_by,
 		          prev.phone AS replaced_phone, prev.observed_at AS replaced_observed_at
 		   FROM person_phone p
-		   LEFT JOIN person_phone prev ON prev.id = p.superseded_phone_id
+		   LEFT JOIN person_phone prev
+		          ON prev.id = p.superseded_phone_id AND prev.person_id = p.person_id
 		  WHERE p.person_id = $1`, nil},
 		{&pkg.ChannelIdentities, `SELECT provider, channel_user_id, username, blocked_at, source, created_at, archived_at
 		   FROM person_channel_identity WHERE person_id = $1`, nil},


### PR DESCRIPTION
A contact's own dated statement — a mail signature, a business card — replaces
what the record held and keeps the old value on the row. That makes
`person_profile_field` and `person_phone` hold two assertions about the subject
plus the date each was stated, and the Art. 15 export was still selecting only
the current one.

The subject received a package saying their title is X, while the installation
also held that it said Y until a message dated Z replaced it, and that a
colleague wrote Y. Erasure needed nothing: it deletes both tables outright.

## What changed

- `person_profile_field`: `observed_at` and the `superseded_*` trio now reach the export.
- `person_phone`: `observed_at`, plus `superseded_phone_id` resolved to the number it names as `replaced_phone`. A bare row id would satisfy a census and tell the subject nothing.
- `person_phone.source` / `captured_by` are exported too — see below.

## The cross-subject leak this went through

The first version of the self-join carried no person predicate. That pointer
crosses subjects in ordinary use: a merge re-homes only LIVE phone rows
(`mergerelink.go`), so the survivor keeps a live row pointing at the
merged-away person's ARCHIVED one, and the survivor's export handed out a
stranger's number. `prev.person_id = p.person_id` closes it; the pointer is
left unresolved rather than followed.

Found by review, not by the tests — the fixture seeded both rows under one
person, so it could not see it. `TestTheExportNeverNamesAStrangersReplacedNumber`
now seeds the merge shape and fails without the predicate.

## The census

`TestEveryHeldColumnReachesTheExport` reads the live table definition and fails
on any column no section projects. A column added and left out of the SELECT is
invisible in production and in every behavioural test, because the export never
mentions it: nothing fails, and the subject is quietly owed something.

It earned its place immediately — it caught `version` and `position`, and the
review then caught that two of its excuses were false. `source` and
`captured_by` were excused as "reported by the provenance section", which reads
`field_provenance` rows and never these columns. They are exported now. A wrong
excuse is worse than a missing column, because it answers the question for the
next reader.

## Verification

`make check-backend` green, `make craft-static` 0/0/0, full
`make test-it DIR=backend/internal/modules/privacy` green. Both the tenant
predicate and the LEFT JOIN were mutation-checked: removing either makes a test
fail, naming the leaked number and the dropped rows respectively.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports the value a newer dated statement replaced from `person_profile_field` and `person_phone`, so the Art. 15 package shows both assertions the installation holds about the subject instead of only the current one.

**Bug Fixes**
- Resolves `superseded_phone_id` to the actual number as `replaced_phone`; exporting the raw row id would tell the subject nothing.
- Adds `prev.person_id = p.person_id` to the phone self-join so a merge re-homing a live row never hands the survivor a stranger's replaced number.
- Exports `source` and `captured_by` from `person_phone`, which the provenance section never covered.

**Refactors**
- Adds a census test that reads the live table definition and fails on any column no export section projects, so a new column cannot silently miss the export.
- Scopes test fixture identifiers per subject so parallel tests cannot collide on workspace-wide dedupe indexes.

<sup>Written for commit b3bf811547991311f3f08debabdec43b609c09e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Privacy exports now include replaced phone details when available.
  * Exported profile fields now show observation and superseded-value information.
  * Phone records remain included even when no replacement record exists.

* **Bug Fixes**
  * Prevented privacy exports from referencing replacement data belonging to another person.
  * Improved handling of historical profile and phone values in exported records.

* **Tests**
  * Added comprehensive coverage for historical values, replacement references, metadata, and export completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->