### PR TITLE
The posture is chosen before the history is read

### DIFF
--- a/frontend/src/screens/connect-panels.test.tsx
+++ b/frontend/src/screens/connect-panels.test.tsx
@@ -208,3 +208,98 @@ it("OAuthReturnPanel keeps the generic failure for an unrecognized outcome", asy
     await screen.findByText(/couldn't confirm the connection/i),
   ).toBeTruthy();
 });
+
+// The posture question rides the connect flow because the backread is what
+// reads a year of mail: an answer given on a later screen arrives after every
+// message it was meant to govern.
+describe("the posture step on a fresh connection", () => {
+  const connectedGmail = (posture?: string) => ({
+    id: "g1",
+    provider: "gmail",
+    status: "connected",
+    scopes: ["read"],
+    backfill: { state: "idle" },
+    ...(posture === undefined ? {} : { mail_posture: posture }),
+  });
+
+  it("offers the three postures, refusing shared until an admin allows it", async () => {
+    installFetchStub({
+      "GET /connectors": () => jsonResponse({ data: [connectedGmail()] }),
+      "GET /connectors/gmail/backfill": () => jsonResponse({ state: "idle" }),
+      "GET /capture/settings": () =>
+        jsonResponse({ shared_posture_allowed: false }),
+    });
+    render(<OAuthReturnPanel outcome="ok" onComplete={vi.fn()} />);
+
+    expect(
+      await screen.findByText(en["connectors.mailPosture.label"]),
+    ).toBeTruthy();
+    // The refused option is PRESENT and disabled, never absent: a missing
+    // third answer tells a reader their product has two postures.
+    // The help sentence and the admin refusal share one paragraph, so the
+    // match is on the node that carries both rather than on either alone.
+    expect(
+      await screen.findByText(
+        (_, node) =>
+          node?.tagName === "P" &&
+          (node.textContent ?? "").includes(
+            en["connectors.mailPosture.sharedNeedsAdmin"],
+          ),
+      ),
+    ).toBeTruthy();
+  });
+
+  // The whole point of asking here rather than in Settings.
+  it("saves the posture before the backread offers to read history", async () => {
+    const calls: string[] = [];
+    installFetchStub({
+      "GET /connectors": () => jsonResponse({ data: [connectedGmail()] }),
+      "GET /connectors/gmail/backfill": () => jsonResponse({ state: "idle" }),
+      "GET /capture/settings": () =>
+        jsonResponse({ shared_posture_allowed: false }),
+      // A non-GET handler is handed the PARSED body, never a Request.
+      "PUT /connectors/gmail/mail-posture": (body: unknown) => {
+        calls.push(String((body as { posture: string }).posture));
+        return jsonResponse({});
+      },
+    });
+    render(<OAuthReturnPanel outcome="ok" onComplete={vi.fn()} />);
+
+    await screen.findByText(en["connectors.mailPosture.label"]);
+    // Driven the way the design-system suite drives this control: the popup is
+    // a listbox the keyboard owns, and DOM focus stays on the trigger.
+    const user = userEvent.setup();
+    const trigger = screen.getByRole("combobox");
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    await user.click(
+      await screen.findByRole("option", {
+        name: en["connectors.mailPosture.held"],
+      }),
+    );
+    await waitFor(() => expect(calls).toEqual(["held"]));
+  });
+
+  // A connection is born `classified` from the column default, so the control
+  // reports what the server already wrote rather than a local guess: a reader
+  // who never touches it still leaves with the safe answer.
+  it("shows the posture the server stored, not a client-side default", async () => {
+    installFetchStub({
+      "GET /connectors": () => jsonResponse({ data: [connectedGmail("held")] }),
+      "GET /connectors/gmail/backfill": () => jsonResponse({ state: "idle" }),
+      "GET /capture/settings": () =>
+        jsonResponse({ shared_posture_allowed: true }),
+    });
+    render(<OAuthReturnPanel outcome="ok" onComplete={vi.fn()} />);
+
+    expect(
+      await screen.findByText(
+        (_, node) =>
+          node?.tagName === "P" &&
+          (node.textContent ?? "").includes(
+            en["connectors.mailPosture.help.held"],
+          ),
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/connect-panels.test.tsx
+++ b/frontend/src/screens/connect-panels.test.tsx
@@ -229,7 +229,9 @@ describe("the posture step on a fresh connection", () => {
       "GET /capture/settings": () =>
         jsonResponse({ shared_posture_allowed: false }),
     });
-    render(<OAuthReturnPanel outcome="ok" onComplete={vi.fn()} />);
+    render(
+      <OAuthReturnPanel outcome="ok" provider="gmail" onComplete={vi.fn()} />,
+    );
 
     expect(
       await screen.findByText(en["connectors.mailPosture.label"]),
@@ -263,7 +265,9 @@ describe("the posture step on a fresh connection", () => {
         return jsonResponse({});
       },
     });
-    render(<OAuthReturnPanel outcome="ok" onComplete={vi.fn()} />);
+    render(
+      <OAuthReturnPanel outcome="ok" provider="gmail" onComplete={vi.fn()} />,
+    );
 
     await screen.findByText(en["connectors.mailPosture.label"]);
     // Driven the way the design-system suite drives this control: the popup is
@@ -290,7 +294,9 @@ describe("the posture step on a fresh connection", () => {
       "GET /capture/settings": () =>
         jsonResponse({ shared_posture_allowed: true }),
     });
-    render(<OAuthReturnPanel outcome="ok" onComplete={vi.fn()} />);
+    render(
+      <OAuthReturnPanel outcome="ok" provider="gmail" onComplete={vi.fn()} />,
+    );
 
     expect(
       await screen.findByText(
@@ -301,5 +307,70 @@ describe("the posture step on a fresh connection", () => {
           ),
       ),
     ).toBeTruthy();
+  });
+});
+
+// The three things the review found, each as a case that fails without its fix.
+describe("the posture step and the mail already captured", () => {
+  const gmail = (posture?: string) => ({
+    id: "g1",
+    provider: "gmail",
+    status: "connected",
+    scopes: ["read"],
+    backfill: { state: "idle" },
+    ...(posture === undefined ? {} : { mail_posture: posture }),
+  });
+
+  // A same-account reconnect lands on the row it already had (the grant upserts
+  // on (user_id, provider)), so "nothing is captured yet" is not something this
+  // screen can assume. Narrowing therefore carries the history with it.
+  it("narrows the mail already captured when the posture tightens", async () => {
+    const bodies: { posture: string; apply: boolean }[] = [];
+    installFetchStub({
+      "GET /connectors": () => jsonResponse({ data: [gmail("classified")] }),
+      "GET /connectors/gmail/backfill": () => jsonResponse({ state: "idle" }),
+      "GET /capture/settings": () =>
+        jsonResponse({ shared_posture_allowed: false }),
+      "PUT /connectors/gmail/mail-posture": (body: unknown) => {
+        const b = body as { posture: string; apply_to_history: boolean };
+        bodies.push({ posture: b.posture, apply: b.apply_to_history });
+        return jsonResponse({});
+      },
+    });
+    render(
+      <OAuthReturnPanel outcome="ok" provider="gmail" onComplete={vi.fn()} />,
+    );
+
+    await screen.findByText(en["connectors.mailPosture.label"]);
+    const user = userEvent.setup();
+    const trigger = screen.getByRole("combobox");
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    await user.click(
+      await screen.findByRole("option", {
+        name: en["connectors.mailPosture.held"],
+      }),
+    );
+    await waitFor(() =>
+      expect(bodies).toEqual([{ posture: "held", apply: true }]),
+    );
+  });
+
+  // With no provider on the return, `live` is the roster's FIRST live OAuth
+  // mailbox — a guess. It is good enough to offer a history read, which the
+  // reader can decline, and wrong for a write that changes who may read a
+  // mailbox they did not just connect.
+  it("asks nothing when the return did not name its mailbox", async () => {
+    installFetchStub({
+      "GET /connectors": () => jsonResponse({ data: [gmail("classified")] }),
+      "GET /connectors/gmail/backfill": () => jsonResponse({ state: "idle" }),
+      "GET /capture/settings": () =>
+        jsonResponse({ shared_posture_allowed: false }),
+    });
+    render(<OAuthReturnPanel outcome="ok" onComplete={vi.fn()} />);
+
+    // The panel itself still resolves — this is about the posture control only.
+    expect(await screen.findByText("Live and capturing")).toBeTruthy();
+    expect(screen.queryByText(en["connectors.mailPosture.label"])).toBeNull();
   });
 });

--- a/frontend/src/screens/connect-posture.tsx
+++ b/frontend/src/screens/connect-posture.tsx
@@ -1,0 +1,137 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useId, useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { Select } from "../design-system/select";
+import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { useCaptureSettings } from "./capture-settings";
+import { problemMessageOf, throwProblem } from "./common";
+
+// The posture question, asked while a mailbox is being connected.
+//
+// Settings already carries this decision (connectors.tsx MailPostureRow), and
+// this is deliberately NOT that control moved: the two ask at different moments
+// and owe the reader different things. Settings changes a posture a mailbox has
+// been running under, so it must offer to narrow the mail already captured.
+// Here there is no history — the connection was granted seconds ago and the
+// backread has not run — so there is nothing to apply to, and a control that
+// asked would be offering to narrow an empty set.
+//
+// What they DO share is the vocabulary: the same three postures, the same
+// labels, the same help sentences, the same admin refusal on `shared`. Those
+// live in i18n under connectors.mailPosture.* and are read from there by both,
+// because two spellings of "held until classified" would drift into two
+// different promises about the same column.
+//
+// It changes nothing on its own. A connection is born `classified` from the
+// column default, so a reader who ignores this control entirely gets the safe
+// answer — the same one they would get if this component did not exist. Its
+// whole job is to let somebody say `held` before the backread reads a year of
+// mail, rather than after.
+
+type MailPosture = NonNullable<
+  components["schemas"]["CaptureConnection"]["mail_posture"]
+>;
+
+type Provider = components["schemas"]["CaptureConnection"]["provider"];
+
+function useSetConnectPosture(provider: Provider) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // The posture rides as a variable rather than closed over, for the reason
+    // frontend/AGENTS.md gives: a mutationFn reading rendered state answers
+    // with the previous render's.
+    mutationFn: async (vars: { posture: MailPosture }) => {
+      const { error } = await api.PUT("/connectors/{provider}/mail-posture", {
+        params: { path: { provider } },
+        // Never true here, and not a variable: there is no captured mail to
+        // narrow at connect time. Sending the flag would ask the server to walk
+        // a set that is empty by construction.
+        body: { posture: vars.posture, apply_to_history: false },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["connectors"] });
+    },
+  });
+}
+
+/**
+ * Who may read this mailbox's mail, chosen before its history is read.
+ *
+ * `classified` is preselected because it is what the server already wrote; the
+ * control reports the connection's own value rather than a local default, so a
+ * failed save leaves the screen agreeing with the database instead of showing
+ * an answer nobody stored.
+ */
+export function ConnectPostureStep({
+  provider,
+  posture,
+}: Readonly<{ provider: Provider; posture: MailPosture | undefined }>) {
+  const t = useT();
+  const settings = useCaptureSettings();
+  const save = useSetConnectPosture(provider);
+  // What the server says this connection is, until a save of our own succeeds.
+  // Optimism here would be a lie a reader acts on: the one option that can be
+  // refused (shared, 422 when the workspace has not allowed it) is exactly the
+  // one whose refusal matters.
+  const [saved, setSaved] = useState<MailPosture | null>(null);
+  const labelId = useId();
+  const helpId = useId();
+  const current = saved ?? posture ?? "classified";
+  const sharedAllowed = settings.data?.shared_posture_allowed ?? false;
+
+  return (
+    <div className="form-stack">
+      {/* A visible label rather than an aria-label: the question is one a
+          reader has to READ to answer, and Settings gives it the same words
+          through SettingRow. */}
+      <p className="t-small" id={labelId}>
+        {t("connectors.mailPosture.label")}
+      </p>
+      <Select
+        aria-labelledby={labelId}
+        aria-describedby={helpId}
+        value={current}
+        disabled={save.isPending}
+        onChange={(next) => {
+          const chosen = next as MailPosture;
+          save.mutate(
+            { posture: chosen },
+            { onSuccess: () => setSaved(chosen) },
+          );
+        }}
+        options={[
+          {
+            value: "classified",
+            label: t("connectors.mailPosture.classified"),
+          },
+          { value: "held", label: t("connectors.mailPosture.held") },
+          {
+            value: "shared",
+            label: t("connectors.mailPosture.shared"),
+            // Present and refused rather than absent, for the reason the
+            // Settings row gives: a missing option tells a reader their
+            // product has two postures.
+            disabled: !sharedAllowed,
+          },
+        ]}
+      />
+      <p className="t-small" id={helpId}>
+        {t(`connectors.mailPosture.help.${current}` as MessageKey)}
+        {sharedAllowed
+          ? ""
+          : ` ${t("connectors.mailPosture.sharedNeedsAdmin")}`}
+      </p>
+      {save.isError && (
+        <p className="t-small readfail warn" role="alert">
+          {problemMessageOf(save.error, t)}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/screens/connect-posture.tsx
+++ b/frontend/src/screens/connect-posture.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useId, useState } from "react";
+import { useEffect, useId } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { Select } from "../design-system/select";
@@ -36,19 +36,31 @@ type MailPosture = NonNullable<
 
 type Provider = components["schemas"]["CaptureConnection"]["provider"];
 
+// How strict each posture is. Only a NARROWING has anything to offer history:
+// opening what was captured under a stricter answer is a separate decision the
+// server refuses to make as a side effect of this one.
+const postureRank: Record<MailPosture, number> = {
+  shared: 0,
+  classified: 1,
+  held: 2,
+};
+
 function useSetConnectPosture(provider: Provider) {
   const queryClient = useQueryClient();
   return useMutation({
     // The posture rides as a variable rather than closed over, for the reason
     // frontend/AGENTS.md gives: a mutationFn reading rendered state answers
     // with the previous render's.
-    mutationFn: async (vars: { posture: MailPosture }) => {
+    mutationFn: async (vars: {
+      posture: MailPosture;
+      applyToHistory: boolean;
+    }) => {
       const { error } = await api.PUT("/connectors/{provider}/mail-posture", {
         params: { path: { provider } },
-        // Never true here, and not a variable: there is no captured mail to
-        // narrow at connect time. Sending the flag would ask the server to walk
-        // a set that is empty by construction.
-        body: { posture: vars.posture, apply_to_history: false },
+        body: {
+          posture: vars.posture,
+          apply_to_history: vars.applyToHistory,
+        },
       });
       if (error) {
         throwProblem(error);
@@ -71,18 +83,32 @@ function useSetConnectPosture(provider: Provider) {
 export function ConnectPostureStep({
   provider,
   posture,
-}: Readonly<{ provider: Provider; posture: MailPosture | undefined }>) {
+  onPendingChange,
+}: Readonly<{
+  provider: Provider;
+  posture: MailPosture | undefined;
+  /** Raised while a posture write is in flight, so a caller can hold back the
+   *  controls that read history or leave the flow: a backread that starts
+   *  mid-write imports under whichever answer wins the race. */
+  onPendingChange?: (pending: boolean) => void;
+}>) {
   const t = useT();
   const settings = useCaptureSettings();
   const save = useSetConnectPosture(provider);
-  // What the server says this connection is, until a save of our own succeeds.
-  // Optimism here would be a lie a reader acts on: the one option that can be
-  // refused (shared, 422 when the workspace has not allowed it) is exactly the
-  // one whose refusal matters.
-  const [saved, setSaved] = useState<MailPosture | null>(null);
   const labelId = useId();
   const helpId = useId();
-  const current = saved ?? posture ?? "classified";
+  // The server's answer, always — never a local echo of the last successful
+  // save. A save invalidates the connectors query, so the prop is what comes
+  // back; holding a local copy beside it would keep showing this session's
+  // choice after another session, a reconnect or a later refusal changed the
+  // real value. Optimism is wrong here for the same reason: the one option
+  // that can be refused (shared, 422 without the workspace opt-in) is the one
+  // whose refusal a reader must see.
+  const current = posture ?? "classified";
+
+  useEffect(() => {
+    onPendingChange?.(save.isPending);
+  }, [save.isPending, onPendingChange]);
   const sharedAllowed = settings.data?.shared_posture_allowed ?? false;
 
   return (
@@ -100,10 +126,10 @@ export function ConnectPostureStep({
         disabled={save.isPending}
         onChange={(next) => {
           const chosen = next as MailPosture;
-          save.mutate(
-            { posture: chosen },
-            { onSuccess: () => setSaved(chosen) },
-          );
+          save.mutate({
+            posture: chosen,
+            applyToHistory: postureRank[chosen] > postureRank[current],
+          });
         }}
         options={[
           {

--- a/frontend/src/screens/onboarding-backread.tsx
+++ b/frontend/src/screens/onboarding-backread.tsx
@@ -112,11 +112,16 @@ export type OnboardingBackreadProps = Readonly<{
    *  backread's: the mailbox is connected on every path through this surface,
    *  so declining the history read still finishes with `false`. */
   onFinish: (skipped: boolean) => void;
+  /** Hold the start verb while a decision ABOUT this mailbox is still being
+   *  written — the posture, today. A read that begins first imports under the
+   *  answer the write was about to replace. */
+  disabled?: boolean;
 }>;
 
 export function OnboardingBackread({
   provider,
   initial,
+  disabled,
   onFinish,
 }: OnboardingBackreadProps) {
   const t = useT();
@@ -255,6 +260,7 @@ export function OnboardingBackread({
         }
         previewReady={previewSettled}
         starting={start.isPending}
+        held={disabled}
         startProblem={safeDetail(start.isError, start.error, t)}
         onStart={() => start.mutate(selected)}
         onFinish={onFinish}
@@ -284,6 +290,7 @@ function BackreadSetup({
   previewReady,
   starting,
   startProblem,
+  held,
   onStart,
   onFinish,
 }: Readonly<{
@@ -291,6 +298,10 @@ function BackreadSetup({
   onSelect: (pick: BackreadWindow) => void;
   preview: BackfillPreview | undefined;
   previewProblem: string | null;
+  /** A decision about this mailbox is still being written; the read must not
+   *  begin ahead of it. Separate from `starting`, which also drives the verb's
+   *  own copy — a button reading "starting…" when nothing started is a lie. */
+  held?: boolean;
   /** True once THIS selection's own preview has settled (found or failed).
    *  Start waits for it so a read can never fire against a scope the reader
    *  has not actually seen. */
@@ -324,7 +335,7 @@ function BackreadSetup({
       <div className="ob-backread-acts">
         <Button
           variant="primary"
-          disabled={starting || !previewReady}
+          disabled={starting || !previewReady || held}
           onClick={onStart}
         >
           {t("ob.backread.start")}

--- a/frontend/src/screens/onboarding-connect-panels.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.tsx
@@ -13,6 +13,7 @@ import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { CaptureNotice } from "./capture-notice";
 import { problemMessageOf, throwProblem } from "./common";
+import { ConnectPostureStep } from "./connect-posture";
 import { imapErrorMessage } from "./imap-connect-form";
 import { OnboardingBackread } from "./onboarding-backread";
 
@@ -350,6 +351,14 @@ export function OAuthReturnPanel({
           <span className="trustpill">
             <ShieldCheck aria-hidden /> {t("ob.s4.connectLive")}
           </span>
+          {/* Asked BEFORE the backread, because the backread is what reads a
+              year of mail: a posture chosen after it has already let every
+              captured message in under the previous answer. */}
+
+          <ConnectPostureStep
+            provider={live.provider}
+            posture={live.mail_posture ?? undefined}
+          />
           {/* The mailbox is live, so the step is not finished yet: how far back
               to read it is the next question, and the backread owns the exit
               from here — its own leave controls finish onboarding, whether or
@@ -466,6 +475,14 @@ export function ImapConnectPanel({
           <CheckCircle2 aria-hidden /> {t("ob.s4.capturedTitle")}
         </div>
         <p className="ob-sub">{t("ob.s4.capturedBody")}</p>
+        {/* The same question the OAuth arm asks, in the same place: after the
+            grant, before the reader leaves for the CRM. An IMAP connect reads
+            its first messages on the spot (max_messages above), so a posture
+            chosen on the next screen would arrive after them. */}
+        <ConnectPostureStep
+          provider={connect.data.connection.provider}
+          posture={connect.data.connection.mail_posture ?? undefined}
+        />
         <Button variant="primary" onClick={() => void onComplete(false)}>
           {t("ob.s4.enterCrm")} <ArrowRight aria-hidden />
         </Button>

--- a/frontend/src/screens/onboarding-connect-panels.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.tsx
@@ -278,6 +278,10 @@ export function OAuthReturnPanel({
     },
   });
   const returning = asOAuthProvider(provider);
+  // Raised while the posture write is in flight. The backread is what reads a
+  // year of mail, so starting one before the answer commits imports under
+  // whichever of the two wins.
+  const [postureSaving, setPostureSaving] = useState(false);
   // A segment this build cannot resolve to a provider names no mailbox, and
   // falling back would offer the import for one the human did not just connect.
   // That is precisely the failure the exact match exists to prevent, so it lands
@@ -355,10 +359,19 @@ export function OAuthReturnPanel({
               year of mail: a posture chosen after it has already let every
               captured message in under the previous answer. */}
 
-          <ConnectPostureStep
-            provider={live.provider}
-            posture={live.mail_posture ?? undefined}
-          />
+          {/* Only when the return NAMED its provider. With the segment absent
+              `live` is the roster's first live OAuth mailbox — a good enough
+              guess for the backread, which offers to read a mailbox and can be
+              declined, and the wrong basis for this: writing a posture to a
+              guessed row silently changes who may read a DIFFERENT inbox. The
+              posture is then left to Settings, where the row is named. */}
+          {returning !== null && (
+            <ConnectPostureStep
+              provider={live.provider}
+              posture={live.mail_posture ?? undefined}
+              onPendingChange={setPostureSaving}
+            />
+          )}
           {/* The mailbox is live, so the step is not finished yet: how far back
               to read it is the next question, and the backread owns the exit
               from here — its own leave controls finish onboarding, whether or
@@ -366,6 +379,7 @@ export function OAuthReturnPanel({
           <OnboardingBackread
             provider={live.provider}
             initial={live.backfill}
+            disabled={postureSaving}
             onFinish={(skipped) => void onComplete(skipped)}
           />
         </>
@@ -409,6 +423,10 @@ export function ImapConnectPanel({
 }>) {
   const t = useT();
   const qc = useQueryClient();
+  // This panel's own flag: the OAuth arm above is a different component with a
+  // different lifetime, and sharing one would couple two flows that never run
+  // together.
+  const [postureSaving, setPostureSaving] = useState(false);
   const [host, setHostVal] = useState("imap.gmail.com");
   const [port, setPort] = useState(IMAP_DEFAULT_PORT);
   const [email, setEmail] = useState("");
@@ -476,14 +494,22 @@ export function ImapConnectPanel({
         </div>
         <p className="ob-sub">{t("ob.s4.capturedBody")}</p>
         {/* The same question the OAuth arm asks, in the same place: after the
-            grant, before the reader leaves for the CRM. An IMAP connect reads
-            its first messages on the spot (max_messages above), so a posture
-            chosen on the next screen would arrive after them. */}
+            grant, before the reader leaves for the CRM. The connect stores the
+            credentials; the first window of mail is read afterwards by the
+            standing sync, and the row is due the moment it exists — so this is
+            the last screen on which the answer can still precede the mail. */}
         <ConnectPostureStep
           provider={connect.data.connection.provider}
           posture={connect.data.connection.mail_posture ?? undefined}
+          onPendingChange={setPostureSaving}
         />
-        <Button variant="primary" onClick={() => void onComplete(false)}>
+        <Button
+          variant="primary"
+          // Leaving mid-write lands the reader in the CRM while the answer is
+          // still in flight, with no surface left to show a refusal.
+          disabled={postureSaving}
+          onClick={() => void onComplete(false)}
+        >
           {t("ob.s4.enterCrm")} <ArrowRight aria-hidden />
         </Button>
       </div>


### PR DESCRIPTION
The last unbuilt item of the mailbox-privacy plan's UI. A mailbox owner could change who reads their mail in Settings, but not while connecting it.

## Why the moment matters

A connect is immediately followed by the backread, which reads up to a year of mail. A posture chosen on the next screen arrives after every message it was meant to govern.

## What it is

`ConnectPostureStep` (new, `frontend/src/screens/connect-posture.tsx`), rendered in two places in the onboarding flow: the OAuth return panel between the "live" pill and the backread, and the IMAP panel's success surface.

It shares the vocabulary with Settings' `MailPostureRow` — the same three postures, labels, help sentences and admin refusal on `shared`, read from the same `connectors.mailPosture.*` keys. No new i18n in any of the three locales.

It changes nothing on its own. A connection is born `classified` from the column default, so a reader who ignores the control still gets the safe answer. Its job is to let somebody say `held` **before** the backread rather than after.

The Settings IMAP form is untouched: its only caller is the connectors page, where `MailPostureRow` already renders on the new row as soon as the roster re-reads.

## Review found three real defects

All from one false premise — that a connect surface is looking at a brand-new connection.

**It is not.** `registry_grant.go` upserts on `(user_id, provider)`, so a same-account reconnect lands on a row that has been capturing for months and keeps its posture. The first version sent `apply_to_history: false` as a constant, so choosing `held` narrowed nothing that mailbox had already brought in. A narrowing now carries the history — safe in that direction by contract, since the server never widens through that flag and leaves `selected` rows alone. A widening still sends `false`.

**The control was rendered on a guessed mailbox.** When the OAuth return carries no provider segment, `live` is the roster's *first* live OAuth row. That guess is fine for offering a history read, which a reader can decline; it is wrong for a write that changes who may read an inbox they did not just connect. It now renders only when the return named its provider.

**Nothing sequenced the write against what follows it.** The backread's Start button was live while the PUT was in flight, as was the IMAP arm's "Enter your CRM" — which would carry a reader away from the only surface that could show a refusal. Both are held while the write runs. `OnboardingBackread` gained a `held` prop rather than overloading `starting`, which also drives the verb's copy.

Two smaller ones: local `saved` state shadowed the server's value permanently after one success (deleted — the prop is the answer), and a comment claimed an IMAP connect reads its first messages on the spot when it stores credentials and the standing sync reads the window afterwards.

## Verification

Five tests. The two structural fixes are mutation-checked individually: reverting the history flag fails only the narrowing case, reverting the provider guard fails only the unnamed-mailbox case.

On a stack (`DEV_SLUG=posture`, `:18084`), not only in tests:

| step | result |
|---|---|
| fresh connection | `mail_posture = classified` from the column default |
| `PUT .../mail-posture {held, apply_to_history: false}` | 200, column says `held` |
| `PUT .../mail-posture {held, apply_to_history: true}` | 200, column holds |
| `PUT .../mail-posture {shared}` without the opt-in | 422 naming the works-council agreement, column unchanged |
| `GET /capture/settings` | `shared_posture_allowed: false` — what disables the third option |

`make check-fe` green. No backend changes.

## Left as-is

The mutation is this file's own rather than shared with `MailPostureRow`. The review is right that two writers of one privacy invariant is duplication — but the two now differ in what they send for history, which is exactly the divergence a shared helper would have to parameterise. Folding them together is a refactor of the Settings path, not a change to this one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a posture choice to the mailbox connect flow so an owner can decide who reads their mail before the backread imports up to a year of history. The step appears in both the OAuth return and IMAP success surfaces, using the same terminology and rules as Settings.

- A same-account reconnect now sends `apply_to_history: true` when narrowing, so `held` applies to already-captured mail.
- The step only renders when the OAuth return named its provider, never on a guessed mailbox.
- The backread Start button and the IMAP CRM exit are disabled while a posture write is in flight.
- New tests cover each fix; no backend changes.

<sup>Written for commit b370df3666ebdbff8e369fa38126c221ff8c99ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mailbox posture selection during OAuth and IMAP connection setup.
  * Choose whether incoming mail is classified, held for review, or shared.
  * Shared access remains unavailable until administrator approval.
  * Posture changes can be applied to previously captured mail when access is tightened.
  * Setup navigation and backread actions are paused while posture settings are being saved.
* **Bug Fixes**
  * Improved handling of ambiguous OAuth returns by directing posture management to Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->