### PR TITLE
A button that buys two things says "and", not a comma

### DIFF
--- a/backend/internal/compose/providerdescriptorparity_test.go
+++ b/backend/internal/compose/providerdescriptorparity_test.go
@@ -71,6 +71,18 @@ func TestTheOfflineFakeDescribesTheSameProductAsTheLiveAdapter(t *testing.T) {
 			fake.MatchRules, live.MatchRules)
 	}
 
+	// Which purchases are welded together. A pairing the fake declares and the
+	// live adapter does not leaves the lane rehearsing a two-category press
+	// that production sends as one — and the pairing is what stops a lone
+	// mobile request completing empty, so the fake would prove a guard
+	// production has lost. It also sets the price on the button: catalogOf
+	// prices a category together with its prerequisite, so a divergence here
+	// quotes one figure and spends another.
+	if !reflect.DeepEqual(fake.RequiresAnswerTo, live.RequiresAnswerTo) {
+		t.Errorf("prerequisites: fake %+v, live %+v — the pairing rule and the price derived from it are rehearsed against a provider that does not exist",
+			fake.RequiresAnswerTo, live.RequiresAnswerTo)
+	}
+
 	// The one field that may legitimately differ is the disclosure copy: the
 	// fake is not a vendor and links to nothing a customer must read. Every
 	// field that decides BEHAVIOUR is compared above.

--- a/backend/internal/modules/integrations/catalog_test.go
+++ b/backend/internal/modules/integrations/catalog_test.go
@@ -147,3 +147,52 @@ func TestEveryRegisteredAdapterPricesWhatItDeclares(t *testing.T) {
 		})
 	}
 }
+
+// A category the provider only issues alongside another must be priced with
+// it. The buy button asks for both (boughtWith, frontend/src/screens/
+// personprovider.tsx) and quotes ONE figure — this entry's — so an entry
+// carrying only its own price would name a number smaller than the press
+// spends.
+//
+// Derived from the descriptor's own RequiresAnswerTo rather than naming a
+// category: the defect is a property of the pairing rule, so an adapter that
+// declares a new pair is covered the day it lands.
+//
+// Run over the offline fake, which is the only adapter this module may import
+// — a module never imports a sibling, and surfe is one. That costs nothing
+// here: TestTheOfflineFakeDescribesTheSameProductAsTheLiveAdapter
+// (backend/internal/compose/providerdescriptorparity_test.go) compares
+// RequiresAnswerTo and CostTable between the fake and the live adapter, so a
+// fake that passes this and a live adapter that would not cannot both exist.
+func TestAPricedCategoryCarriesItsPrerequisitesPrice(t *testing.T) {
+	desc := NewOfflineProvider(0, func() time.Time { return time.Unix(0, 0).UTC() }).Descriptor()
+	if len(desc.RequiresAnswerTo) == 0 {
+		// Under-recognition is the one way this gate must not break: with no
+		// pairs to walk it would report PASS over a rule nobody checked.
+		t.Fatal("the fake declares no prerequisites, so this gate walked nothing — it mirrors an adapter that has one")
+	}
+	entries := map[string]CategoryCost{}
+	for _, entry := range catalogOf(desc) {
+		entries[entry.Category] = entry
+	}
+	for category, prerequisite := range desc.RequiresAnswerTo {
+		paired, ok := entries[string(category)]
+		if !ok {
+			t.Errorf("category %q has a prerequisite but no catalog entry to price it in", category)
+			continue
+		}
+		if paired.Requires != string(prerequisite) {
+			t.Errorf("%q names prerequisite %q, catalog entry says %q",
+				category, prerequisite, paired.Requires)
+		}
+		// Pool by pool, because a pair spanning two pools is the case here:
+		// summing to one total would pass a price that charged the mobile
+		// pool twice and the email pool not at all.
+		for pool, n := range desc.CostTable[prerequisite] {
+			if paired.Cost[string(pool)] < n {
+				t.Errorf("%q costs %v, which does not cover its prerequisite %q at %d in pool %q — the button would quote less than the press spends",
+					category, paired.Cost, prerequisite, n, pool)
+			}
+		}
+	}
+}

--- a/backend/internal/modules/integrations/catalog_test.go
+++ b/backend/internal/modules/integrations/catalog_test.go
@@ -10,6 +10,7 @@ package integrations
 // cost table they are computed from.
 
 import (
+	"maps"
 	"testing"
 	"time"
 
@@ -185,14 +186,35 @@ func TestAPricedCategoryCarriesItsPrerequisitesPrice(t *testing.T) {
 			t.Errorf("%q names prerequisite %q, catalog entry says %q",
 				category, prerequisite, paired.Requires)
 		}
-		// Pool by pool, because a pair spanning two pools is the case here:
-		// summing to one total would pass a price that charged the mobile
-		// pool twice and the email pool not at all.
-		for pool, n := range desc.CostTable[prerequisite] {
-			if paired.Cost[string(pool)] < n {
-				t.Errorf("%q costs %v, which does not cover its prerequisite %q at %d in pool %q — the button would quote less than the press spends",
-					category, paired.Cost, prerequisite, n, pool)
+		// The exact price of the pair, pool by pool.
+		//
+		// Pool by pool because a pair spanning two pools is the case here: one
+		// summed total would pass a price that charged the mobile pool twice
+		// and the email pool not at all.
+		//
+		// Exact rather than "at least the prerequisite's share": a floor is
+		// satisfied by 1 >= 1 the moment a pair shares a pool with its
+		// prerequisite, so a catalog that had dropped one half's cost would
+		// still pass while the button quoted half what the press spends. No
+		// shipped pair shares a pool today, which is exactly why the weaker
+		// check looked green — the first pair that does would be the one it
+		// could not see.
+		want := map[string]int{}
+		for _, priced := range []provider.Category{category, prerequisite} {
+			for pool, n := range desc.CostTable[priced] {
+				want[string(pool)] += n
 			}
+		}
+		// catalogOf drops a pool costing nothing, so the expectation must too
+		// or every comparison fails on a zero neither side charges.
+		for pool, n := range want {
+			if n == 0 {
+				delete(want, pool)
+			}
+		}
+		if !maps.Equal(paired.Cost, want) {
+			t.Errorf("%q costs %v, want %v — its own price plus prerequisite %q's, which is what one press spends",
+				category, paired.Cost, want, prerequisite)
 		}
 	}
 }

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -518,9 +518,13 @@ describe("the details that cost credits", () => {
     // will not look for a number without an email to anchor it, so a button
     // offering "mobile, 1 credit" would promise a purchase that cannot happen
     // and understate what it spends.
+    //
+    // Joined by "and", not a comma: a comma read as a list of things the press
+    // might pick from, and a rep who took it for the work-email button bought
+    // a mobile number he had not asked for.
     expect(
       await screen.findByRole("button", {
-        name: /Buy work email, mobile number · 2 credits/,
+        name: /Buy work email and mobile number · 2 credits/,
       }),
     ).toBeDefined();
 
@@ -561,7 +565,7 @@ describe("the details that cost credits", () => {
 
     await user.click(
       await screen.findByRole("button", {
-        name: /Buy work email, mobile number · 2 credits/,
+        name: /Buy work email and mobile number · 2 credits/,
       }),
     );
 

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -19,7 +19,7 @@ import {
 import { formatDateAbbrev, formatNumber } from "../format/format";
 import { type Locale, useLocale, usePlural, useT } from "../i18n";
 import { problemMessageOf, throwProblem } from "./common";
-import { categoryNames } from "./provider-categories";
+import { categoryNames, categoryNamesTogether } from "./provider-categories";
 import {
   canEnrichNow,
   profileLabel,
@@ -330,7 +330,7 @@ function BuyPriced({
           }
         >
           {plural("provider.profile.buy", creditsOf(entry), {
-            category: categoryNames(boughtWith(entry), t),
+            category: categoryNamesTogether(boughtWith(entry), t, locale),
             credits: formatNumber(creditsOf(entry), locale),
           })}
         </Button>
@@ -349,7 +349,16 @@ function BuyPriced({
  *  now; this is what stops the button making it.
  *
  *  `entry.cost` is already the price of the pair, so the figure beside this
- *  needs no adjusting — the two are derived from one descriptor rule. */
+ *  needs no adjusting: the server prices a category together with the one it
+ *  requires (`pricedWith`, backend/internal/modules/integrations/store.go),
+ *  so cost and request are derived from one descriptor rule. Held by
+ *  TestAPricedCategoryCarriesItsPrerequisitesPrice
+ *  (backend/internal/modules/integrations/catalog_test.go), which fails if a
+ *  catalog entry ever quotes a lone price for a paired purchase.
+ *
+ *  The button names both, joined by the locale's conjunction rather than a
+ *  comma — a comma reads as a list to pick from, and a rep who read one as the
+ *  work-email button bought a mobile number he had not asked for. */
 function boughtWith(
   entry: components["schemas"]["ProviderCategoryCost"],
 ): string[] {

--- a/frontend/src/screens/provider-categories.test.ts
+++ b/frontend/src/screens/provider-categories.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { MessageKey } from "../i18n/en";
+import { categoryNames, categoryNamesTogether } from "./provider-categories";
+
+// Two ways to name several categories, and the difference is what a reader
+// does with them. A list is what a run asked for; a conjunction is what one
+// press buys as one purchase. The buy button used the list, and a rep read
+// "Buy work email, mobile number · 2 credits" as the work-email button — then
+// got a mobile number he had not meant to ask for.
+
+// The real message keys, so a renamed key surfaces here rather than passing on
+// a stub that agrees with itself.
+const NAMES: Partial<Record<MessageKey, string>> = {
+  "provider.category.professionalEmail": "work email",
+  "provider.category.mobile": "mobile number",
+};
+
+const t = (key: MessageKey): string => NAMES[key] ?? key;
+
+const PAIR = ["professional_email", "mobile"];
+
+describe("naming the categories one press buys", () => {
+  it("joins them with the locale's conjunction, not a comma", () => {
+    const label = categoryNamesTogether(PAIR, t, "en");
+    expect(label).toBe("work email and mobile number");
+    // Its own expectation, because a comma is precisely the spelling that
+    // misread as a list: a change back to join(", ") must fail here rather
+    // than merely look different.
+    expect(label).not.toContain(",");
+  });
+
+  it("uses the reader's own language, not an English 'and' translated", () => {
+    expect(categoryNamesTogether(PAIR, t, "de")).toBe(
+      "work email und mobile number",
+    );
+    expect(categoryNamesTogether(PAIR, t, "vi")).toBe(
+      "work email và mobile number",
+    );
+  });
+
+  it("says just the one name when a press buys one thing", () => {
+    expect(categoryNamesTogether(["professional_email"], t, "en")).toBe(
+      "work email",
+    );
+  });
+
+  it("leaves the list spelling alone, because a list is not a purchase", () => {
+    // categoryNames still serves "what came back empty" and "what we never
+    // asked for", where the items are separate facts rather than one buy.
+    expect(categoryNames(PAIR, t)).toBe("work email, mobile number");
+  });
+});

--- a/frontend/src/screens/provider-categories.ts
+++ b/frontend/src/screens/provider-categories.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
+import { INTL_LOCALE } from "../format/format";
+import type { Locale } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
 /** The categories a provider names, as words a reader knows.
@@ -36,10 +38,37 @@ export function categoryName(
   return label ? t(label) : category;
 }
 
-/** Several categories, as one comma-joined phrase. */
+/** Several categories, as one comma-joined phrase. For a LIST of categories —
+ *  what a run asked for, what came back empty. */
 export function categoryNames(
   categories: readonly string[],
   t: (key: MessageKey) => string,
 ): string {
   return categories.map((category) => categoryName(category, t)).join(", ");
+}
+
+/** Several categories a single press buys TOGETHER, joined by the locale's own
+ *  conjunction: "work email and mobile number".
+ *
+ *  A comma is what categoryNames gives, and on a button it reads as a list the
+ *  press might pick from rather than a pair it buys as one. A reader who
+ *  scanned "Buy work email, mobile number · 2 credits" as the work-email
+ *  button and got a mobile number too is the case this exists for — the price
+ *  beside it was already the pair's, so nobody was overcharged, but nobody was
+ *  told either.
+ *
+ *  Intl.ListFormat rather than a conjunction per language: German's "und" and
+ *  Vietnamese's "và" are the platform's to know, and an i18n key would ask a
+ *  translator to re-derive what the runtime already has right.
+ */
+export function categoryNamesTogether(
+  categories: readonly string[],
+  t: (key: MessageKey) => string,
+  locale: Locale,
+): string {
+  const names = categories.map((category) => categoryName(category, t));
+  return new Intl.ListFormat(INTL_LOCALE[locale], {
+    style: "long",
+    type: "conjunction",
+  }).format(names);
 }


### PR DESCRIPTION
Buying a mobile number always buys the work email with it: Surfe sends
skipMobileEnrichmentIfNoEmailFound on every request, so a lone mobile
lookup finds nothing and returns a run that completed empty. The button
has asked for both since that guard landed, and priced both — catalogOf
prices a category together with its prerequisite.

It named both too, joined by a comma: "Buy work email, mobile number ·
2 credits". A rep read that as the work-email button, pressed it, and
got a mobile number he had not meant to buy. He was not overcharged —
the 2 was the true price of the pair — but nothing on screen told him
the press was one purchase rather than a list.

Join them with the locale's own conjunction instead, through
Intl.ListFormat: "work email and mobile number", "und" in German, "và"
in Vietnamese. categoryNames keeps the comma for the two places that
render a genuine LIST — what a run asked for, what came back empty —
because those items are separate facts rather than one buy.

Two gaps found while proving it:

- The catalog's pairing price had no test. catalogOf could have quoted
  a lone price for a paired purchase and every suite stayed green.
  TestAPricedCategoryCarriesItsPrerequisitesPrice compares pool by
  pool, and fails when the corpus is empty rather than reporting PASS
  over a rule it never walked.
- The fake-vs-live parity test compared CostTable, Cascades and
  MatchRules but not RequiresAnswerTo, while its comment claimed every
  field deciding behaviour was covered. A fake declaring the pairing
  and a live adapter dropping it would have left the whole lane
  rehearsing a guard production had lost.

Mutation-checked one clause at a time: dropping the prerequisite from
pricedWith, dropping Requires from the catalog entry, dropping the
pairing from the fake, and reverting the conjunction to join(", ") each
fail exactly one thing and name it.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

## Verified

- `make check-backend` green
- `make check-fe` green
- `make craft-static` clean (0 blocker, 0 major, 0 minor)
- Mutation-checked four guards, one clause at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the buy button to join the two purchased categories with the locale's conjunction ("and", "und", "và") via `Intl.ListFormat` instead of a comma, so a paired purchase reads as one press rather than a list to pick from. The quoted price already covered the pair, so no cost changes.

**Tests**
- Adds a catalog test proving a paired category's entry prices the pair exactly: the full expected cost map (its own price plus its prerequisite's, pool by pool) must match, and the test fails loudly if no pairing exists to walk.
- Extends the fake-vs-live parity test to compare `RequiresAnswerTo`, which previously went untested despite the comment claiming all behavior-deciding fields were covered.

<sup>Written for commit d2a9dcd113553017195106f23f6a81af1c9b44ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated provider category labels with natural, locale-aware conjunctions in English, German, and Vietnamese.
  - Improved purchase button wording for combined work email and mobile number offerings.
  - Clarified prerequisite category pricing, including combined category and prerequisite charges.

- **Quality**
  - Added coverage for localized category naming, purchase labels, prerequisite handling, and pricing consistency across provider offerings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->