### PR TITLE
An open promise is the moment, dated or not

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -24422,7 +24422,7 @@ components:
         `job_change` fires only on a RECORDED employment change, and `public_signal` needs a
         connected data provider. A rule that cannot fire is absent from the page, not an empty
         card.
-      enum: [meeting_prep, re_engaged, job_change, overdue_promise, gone_quiet, role_change, public_signal, missing_next_step, thin_relationship, nothing_needed]
+      enum: [meeting_prep, re_engaged, job_change, overdue_promise, gone_quiet, open_promise, role_change, public_signal, missing_next_step, thin_relationship, nothing_needed]
 
     PersonMomentEvidence:
       type: object

--- a/backend/internal/compose/person360/momentrules.go
+++ b/backend/internal/compose/person360/momentrules.go
@@ -22,6 +22,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
+	"github.com/margince/margince/backend/internal/shared/kernel/elapsed"
 	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
@@ -341,3 +342,123 @@ func entityType(v crmcontracts.PersonMomentDestinationEntityType) *crmcontracts.
 
 // prefill lifts the string map the contract carries as an optional object.
 func prefill(v map[string]string) *map[string]string { return &v }
+
+// openPromiseMoment: an open task is filed against them and nobody has done
+// it. Dated or not — the transcript reader files "I'll send you the
+// whitepaper" without a date, and it is owed either way.
+//
+// Below gone_quiet on purpose: a promise with no clock on it can wait for a
+// day, a contact who stopped answering is already costing something. Above
+// role_change and everything under it, because a thing we said we would do
+// outranks a thing we might do next. The overdue rung above reads claims
+// from correspondence; this one reads the task list, so a promise the reader
+// accepted from a transcript reaches the card the moment it becomes a task.
+func openPromiseMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+	task, ok := nearestOpenTask(page)
+	if !ok {
+		return crmcontracts.PersonMoment{}, false
+	}
+	// A task filed without a subject is still owed; the card names it as the
+	// task list does rather than printing an empty promise.
+	subject := "an open task"
+	if task.Subject != nil && *task.Subject != "" {
+		subject = *task.Subject
+	}
+	// The evidence is dated by when the promise was filed, not when it falls
+	// due: a task due next month is not "updated today", and the due date is
+	// the reason's to state.
+	observed := task.OccurredAt
+	evidence := []crmcontracts.PersonMomentEvidence{{
+		Type:       crmcontracts.PersonMomentEvidenceTypeTask,
+		Id:         ptr(task.Id),
+		Label:      subject,
+		ObservedAt: &observed,
+	}}
+	return crmcontracts.PersonMoment{
+		ClaimKey:            "moment:open_promise",
+		Rule:                crmcontracts.PersonMomentRuleOpenPromise,
+		RuleVersion:         ptr(ruleVersion),
+		EvidenceFingerprint: fingerprintOf(evidence),
+		Headline:            openPromiseHeadline(task, subject),
+		WhyNow:              openPromiseWhyNow(now, task),
+		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
+		Evidence:            evidence,
+		FreshnessAt:         &observed,
+		// Writing to them is the one move every promise shares, whether it is
+		// a document to send or a room to book they are waiting to hear about.
+		// The composer opens on the promise itself, so the label says what the
+		// button does rather than presuming the promise is a thing to send.
+		RecommendedAction: crmcontracts.PersonMomentAction{
+			Kind:  crmcontracts.PersonMomentActionKindDraftReply,
+			Label: "Write to them about it",
+			State: crmcontracts.PersonMomentActionStateWillConfirm,
+			Destination: &crmcontracts.PersonMomentDestination{
+				Surface: crmcontracts.PersonMomentDestinationSurfaceComposer,
+				Prefill: prefill(map[string]string{prefillIntent: "deliver_commitment", "subject": subject}),
+			},
+		},
+	}, true
+}
+
+// openPromiseHeadline names who owes it. A task with an assignee is that
+// person's, and the card is read by the whole workspace — "you owe them" to a
+// reader whose colleague holds the task attributes a promise to the wrong
+// desk. Unassigned, it is the workspace's, and the reader is the workspace.
+func openPromiseHeadline(task crmcontracts.Activity, subject string) string {
+	if task.AssigneeId != nil {
+		return fmt.Sprintf("Owed to them: %s", subject)
+	}
+	return fmt.Sprintf("You owe them: %s", subject)
+}
+
+// nearestOpenTask picks the one open task the card speaks for: the earliest
+// due date first, and among undated ones the oldest filed. One promise on the
+// card, not a list — the task list below it is where the rest live.
+func nearestOpenTask(page *crmcontracts.Person360) (crmcontracts.Activity, bool) {
+	if page.NextSteps == nil {
+		return crmcontracts.Activity{}, false
+	}
+	var pick *crmcontracts.Activity
+	for i := range page.NextSteps.Data {
+		task := &page.NextSteps.Data[i]
+		if pick == nil || openTaskSooner(task, pick) {
+			pick = task
+		}
+	}
+	if pick == nil {
+		return crmcontracts.Activity{}, false
+	}
+	return *pick, true
+}
+
+// openTaskSooner orders two open tasks: a dated one before an undated one,
+// then by due date, then by when it was filed.
+func openTaskSooner(a, b *crmcontracts.Activity) bool {
+	switch {
+	case a.DueAt != nil && b.DueAt != nil:
+		return a.DueAt.Before(*b.DueAt)
+	case a.DueAt != nil:
+		return true
+	case b.DueAt != nil:
+		return false
+	default:
+		return a.OccurredAt.Before(b.OccurredAt)
+	}
+}
+
+// openPromiseWhyNow says what the date on the promise is, in the reader's
+// terms: a deadline still ahead, one already behind, or none at all.
+func openPromiseWhyNow(now time.Time, task crmcontracts.Activity) string {
+	if task.DueAt == nil {
+		return fmt.Sprintf("Promised on %s with no date set. It stays open until you do it or close it.", task.OccurredAt.Format("2 Jan"))
+	}
+	if past, ok := deadline.DaysPast(task.DueAt, now); ok {
+		return fmt.Sprintf("Due %d days ago and still open.", past)
+	}
+	// A task logged from the record page carries today's date unless the
+	// writer picks another, so "in 0 days" is the common case, not a corner.
+	if days := elapsed.Days(now, *task.DueAt); days > 0 {
+		return fmt.Sprintf("Due in %d days.", days)
+	}
+	return "Due today."
+}

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -190,6 +190,7 @@ var momentLadder = []func(time.Time, *crmcontracts.Person360) (crmcontracts.Pers
 	reEngagedMoment,        // 2. new inbound after a material quiet period
 	overduePromiseMoment,   // 4. an open commitment of ours is overdue
 	goneQuietMoment,        // 5. outbound unanswered past the configured rule
+	openPromiseMoment,      // 5b. an open task we owe them, dated or not
 	roleChangeMoment,       // 6. a new deal role or material relationship change
 	missingNextStepMoment,  // 8. an open deal with no next step involving them
 	thinRelationshipMoment, // 9. no captured interaction or network
@@ -204,6 +205,7 @@ var momentLadderNames = []string{
 	"re_engaged",
 	"overdue_promise",
 	"gone_quiet",
+	"open_promise",
 	"role_change",
 	"missing_next_step",
 	"thin_relationship",

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -185,6 +185,17 @@ func TestEveryOfferedActionEitherGoesSomewhereOrSaysWhyItCannot(t *testing.T) {
 				DueAt:            ptr(at(6)),
 			}},
 		},
+		// Rung 5b wants an open task filed against them, and it must fire with
+		// no date on it — that is what the transcript reader files.
+		"open promise": {
+			NextSteps: &struct {
+				Data []crmcontracts.Activity `json:"data"`
+				Page crmcontracts.PageInfo   `json:"page"`
+			}{Data: []crmcontracts.Activity{{
+				Id: openapi_types.UUID(ids.NewV7()), Kind: "task",
+				Subject: ptr("Send the MCP whitepaper"), OccurredAt: at(1),
+			}}},
+		},
 		"nothing needed": {},
 	}
 	for name, page := range pages {
@@ -410,5 +421,69 @@ func TestLogActivityIsWithheldFromACallerWithoutTheCreateGrant(t *testing.T) {
 	withholdLogActivity(as(map[string]principal.ObjectGrant{"person": {Read: true}, "activity": {Create: true}}), &writer)
 	if writer.RecommendedAction.State != crmcontracts.PersonMomentActionStateAvailable || writer.RecommendedAction.Destination == nil {
 		t.Errorf("a caller holding activity.create got %q with destination %v, want the action untouched", writer.RecommendedAction.State, writer.RecommendedAction.Destination)
+	}
+}
+
+// An open task with no date is still a promise. The transcript reader files
+// "I'll send you the whitepaper" without one, and the card used to fall past
+// every rung to "nothing is owed" while that task sat directly beneath it.
+func TestAnOpenUndatedTaskIsTheMoment(t *testing.T) {
+	now := time.Now()
+	page := &crmcontracts.Person360{
+		NextSteps: &struct {
+			Data []crmcontracts.Activity `json:"data"`
+			Page crmcontracts.PageInfo   `json:"page"`
+		}{Data: []crmcontracts.Activity{
+			{Id: openapi_types.UUID(ids.NewV7()), Kind: "task", Subject: ptr("Book the workshop room"), OccurredAt: now.Add(-2 * time.Hour)},
+			{Id: openapi_types.UUID(ids.NewV7()), Kind: "task", Subject: ptr("Send the MCP whitepaper"), OccurredAt: now.Add(-48 * time.Hour)},
+		}},
+	}
+
+	moment := deriveMoment(now, page)
+	if moment.Rule != crmcontracts.PersonMomentRuleOpenPromise {
+		t.Fatalf("rule = %q, want open_promise — an open task is owed, dated or not", moment.Rule)
+	}
+	if moment.Headline != "You owe them: Send the MCP whitepaper" {
+		t.Errorf("headline = %q, want the OLDEST undated task named", moment.Headline)
+	}
+	if !strings.Contains(moment.WhyNow, "no date set") {
+		t.Errorf("why_now = %q, want it to say the promise carries no date", moment.WhyNow)
+	}
+	if got := (*moment.RecommendedAction.Destination.Prefill)["subject"]; got != "Send the MCP whitepaper" {
+		t.Errorf("composer subject = %q, want the promise itself", got)
+	}
+	if moment.FreshnessAt == nil || !moment.FreshnessAt.Equal(now.Add(-48*time.Hour)) {
+		t.Errorf("freshness = %v, want the day the promise was filed", moment.FreshnessAt)
+	}
+
+	// A task somebody specific holds is owed by that desk, not by whoever is
+	// reading the card.
+	assigned := page.NextSteps.Data[1]
+	assigned.AssigneeId = ptr(openapi_types.UUID(ids.NewV7()))
+	page.NextSteps.Data[1] = assigned
+	if got := deriveMoment(now, page).Headline; got != "Owed to them: Send the MCP whitepaper" {
+		t.Errorf("headline for an assigned task = %q, want it attributed to its holder", got)
+	}
+	page.NextSteps.Data[1].AssigneeId = nil
+
+	// A dated task outranks an undated one, however old the undated one is.
+	dated := page.NextSteps.Data[0]
+	dated.DueAt = ptr(now.Add(72 * time.Hour))
+	page.NextSteps.Data[0] = dated
+	if got := deriveMoment(now, page).Headline; got != "You owe them: Book the workshop room" {
+		t.Errorf("with a dated task present, headline = %q, want the dated one", got)
+	}
+	// A task logged from the record page is due at the end of today, and the
+	// card says so in words rather than counting zero days.
+	page.NextSteps.Data[0].DueAt = ptr(now.Add(2 * time.Hour))
+	if got := deriveMoment(now, page).WhyNow; got != "Due today." {
+		t.Errorf("why_now for a task due later today = %q, want \"Due today.\"", got)
+	}
+
+	// Done tasks never reach the section, so a page whose section is empty is
+	// the quiet state — and only then may the card say nothing is owed.
+	page.NextSteps.Data = nil
+	if got := deriveMoment(now, page).Rule; got != crmcontracts.PersonMomentRuleNothingNeeded {
+		t.Errorf("with no open task, rule = %q, want nothing_needed", got)
 	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -8273,6 +8273,7 @@ const (
 	PersonMomentRuleMeetingPrep      PersonMomentRule = "meeting_prep"
 	PersonMomentRuleMissingNextStep  PersonMomentRule = "missing_next_step"
 	PersonMomentRuleNothingNeeded    PersonMomentRule = "nothing_needed"
+	PersonMomentRuleOpenPromise      PersonMomentRule = "open_promise"
 	PersonMomentRuleOverduePromise   PersonMomentRule = "overdue_promise"
 	PersonMomentRulePublicSignal     PersonMomentRule = "public_signal"
 	PersonMomentRuleReEngaged        PersonMomentRule = "re_engaged"
@@ -8292,6 +8293,8 @@ func (e PersonMomentRule) Valid() bool {
 	case PersonMomentRuleMissingNextStep:
 		return true
 	case PersonMomentRuleNothingNeeded:
+		return true
+	case PersonMomentRuleOpenPromise:
 		return true
 	case PersonMomentRuleOverduePromise:
 		return true

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16997,7 +16997,7 @@ export interface components {
          *     card.
          * @enum {string}
          */
-        PersonMomentRule: "meeting_prep" | "re_engaged" | "job_change" | "overdue_promise" | "gone_quiet" | "role_change" | "public_signal" | "missing_next_step" | "thin_relationship" | "nothing_needed";
+        PersonMomentRule: "meeting_prep" | "re_engaged" | "job_change" | "overdue_promise" | "gone_quiet" | "open_promise" | "role_change" | "public_signal" | "missing_next_step" | "thin_relationship" | "nothing_needed";
         /** @description One thing that actually happened, which the reader can open. */
         PersonMomentEvidence: {
             /** @enum {string} */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6748,6 +6748,7 @@ export const de = {
   "person.moment.rule.job_change": "Neue Stelle",
   "person.moment.rule.overdue_promise": "Zusage überfällig",
   "person.moment.rule.gone_quiet": "Still geworden",
+  "person.moment.rule.open_promise": "Offenes Versprechen",
   "person.moment.rule.role_change": "Rolle geändert",
   "person.moment.rule.public_signal": "Öffentlich gesagt",
   "person.moment.rule.missing_next_step": "Nichts geplant",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6799,6 +6799,7 @@ export const en = {
   "person.moment.rule.job_change": "They moved on",
   "person.moment.rule.overdue_promise": "Promise overdue",
   "person.moment.rule.gone_quiet": "Gone quiet",
+  "person.moment.rule.open_promise": "You owe them",
   "person.moment.rule.role_change": "Role changed",
   "person.moment.rule.public_signal": "Said in public",
   "person.moment.rule.missing_next_step": "Nothing scheduled",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6677,6 +6677,7 @@ export const vi = {
   "person.moment.rule.job_change": "Đã đổi việc",
   "person.moment.rule.overdue_promise": "Lời hứa quá hạn",
   "person.moment.rule.gone_quiet": "Đã im lặng",
+  "person.moment.rule.open_promise": "Lời hứa còn mở",
   "person.moment.rule.role_change": "Đã đổi vai trò",
   "person.moment.rule.public_signal": "Nói công khai",
   "person.moment.rule.missing_next_step": "Chưa có lịch",

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -103,7 +103,14 @@ function composerIntentOf(
   t: ReturnType<typeof useT>,
 ): string {
   const key = COMPOSER_INTENT_KEYS[prefill?.intent ?? ""];
-  return key ? t(key) : "";
+  if (!key) {
+    return "";
+  }
+  // The promise itself rides in `subject`. Without it, a rung firing on one of
+  // several open commitments asks the composer to deliver "what we promised"
+  // and leaves the drafter to guess which.
+  const subject = prefill?.subject?.trim();
+  return subject ? `${t(key)}: ${subject}` : t(key);
 }
 
 /**

--- a/frontend/src/screens/persontoday.tsx
+++ b/frontend/src/screens/persontoday.tsx
@@ -42,6 +42,7 @@ const MOMENT_RULE_LABEL = {
   job_change: "person.moment.rule.job_change",
   overdue_promise: "person.moment.rule.overdue_promise",
   gone_quiet: "person.moment.rule.gone_quiet",
+  open_promise: "person.moment.rule.open_promise",
   role_change: "person.moment.rule.role_change",
   public_signal: "person.moment.rule.public_signal",
   missing_next_step: "person.moment.rule.missing_next_step",


### PR DESCRIPTION
A task filed against a person and not yet done fell past every rung of the person-page ladder. The overdue rung reads commitments extracted from correspondence and fires only once their date has passed; the missing-next-step rung is silent precisely because a next step exists. So a promise accepted from a transcript — "I'll send you the whitepaper", no date — landed on "Nothing needs you today … nothing is owed", printed directly above the task that contradicted it.

A new rung, `open_promise`, sits below `gone_quiet` and above `role_change` ([moments.go](backend/internal/compose/person360/moments.go), [momentrules.go](backend/internal/compose/person360/momentrules.go)). It reads the page's next-steps section, picks one task — the earliest due date first, then the oldest undated one — and names it: "You owe them: Send the MCP whitepaper", with the reason saying whether a date is set, ahead or behind. The action opens the composer with the `deliver_commitment` prefill, exactly as the overdue rung does. The quiet state is now only reachable when the task list is genuinely empty, so its sentence is true.

Contract: `PersonMomentRule` gains `open_promise` (both generators run). Frontend: the rule's badge label in en/de/vi and the typed label map in `persontoday.tsx`.

Tests: `TestAnOpenUndatedTaskIsTheMoment` (undated task wins, dated outranks undated, empty section falls to nothing_needed) and a new page in the ladder honesty test so the rung's action is checked for reachability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `open_promise` moment for unfinished tasks, including undated promises, so person pages no longer show `nothing_needed` while work remains. It selects the most relevant task and opens a prefilled composer for delivering it.

- Runs below `gone_quiet` and above `role_change`.
- Chooses the earliest due task, or the oldest undated task; assigned tasks are labeled “Owed to them.”
- Explains whether the task is due today, upcoming, overdue, or undated, and includes its subject in the composer intent.
- Adds the rule to the API contract, generated frontend types, English, German, and Vietnamese labels, and tests.

<sup>Written for commit a3df1bb5c985551b9be207b2ef55273b243a81e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “You owe them” relationship moments for open commitments.
  - Highlights the earliest outstanding task, including due, overdue, or undated timing.
  - Provides a confirmation-gated action with a prefilled subject to help deliver on the commitment.
  - Added English, German, and Vietnamese translations.

- **Bug Fixes**
  - Undated tasks are now considered, with the oldest selected when appropriate.
  - Dated tasks take precedence over undated tasks.
  - The moment no longer appears when no outstanding tasks remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->