### PR TITLE
A full enrich pass queues the next slice

### DIFF
--- a/backend/internal/compose/captureenrich.go
+++ b/backend/internal/compose/captureenrich.go
@@ -45,8 +45,9 @@ const (
 	signatureLineCount = 15
 	// enrichConfidenceFloor is the §2.9 acceptance floor.
 	enrichConfidenceFloor = 0.6
-	// enrichPassLimit bounds one pass's candidate set — the nightly cycle
-	// picks up the rest tomorrow.
+	// enrichPassLimit bounds one pass's candidate set. A pass that fills it
+	// queues a continuation rather than leaving the remainder to the nightly
+	// cycle; see RunWorkspace.
 	enrichPassLimit = 100
 )
 
@@ -76,18 +77,42 @@ type CaptureEnricher struct {
 	store *people.Store
 	brain completer
 	log   *slog.Logger
+	// limit is how many candidates one pass takes, and therefore the count at
+	// which it reports a continuation is due. enrichPassLimit in production; a
+	// test sets it small so it can drive that boundary with a handful of
+	// people rather than a hundred.
+	limit int
 }
 
 // NewCaptureEnricher builds the pass over the pool and one model lane.
 func NewCaptureEnricher(pool *pgxpool.Pool, brain completer, log *slog.Logger) *CaptureEnricher {
-	return &CaptureEnricher{pool: pool, store: people.NewStore(InstallationDB(pool)), brain: brain, log: log}
+	return &CaptureEnricher{
+		pool:  pool,
+		store: people.NewStore(InstallationDB(pool)),
+		brain: brain,
+		log:   log,
+		limit: enrichPassLimit,
+	}
 }
 
 // RunWorkspace enriches up to enrichPassLimit candidates in the workspace
 // already bound in ctx. A budget stop ends the pass cleanly; per-person model
 // trouble is logged and the person is retried next cycle (their evidence rows
 // are still absent).
-func (e *CaptureEnricher) RunWorkspace(ctx context.Context) error {
+//
+// It reports whether the candidate set FILLED the limit, which is the caller's
+// signal that more people are due right now. Two things make that worth acting
+// on rather than leaving to the nightly pass. A mailbox sync lands hundreds of
+// messages at once, so the 101st contact would wait until tonight for details a
+// rep is about to read. And the trigger's own uniqueness means mail arriving
+// mid-pass dedupes against a pass that has already listed its candidates —
+// so without a continuation that message waits for the nightly run too,
+// whatever the queue depth.
+//
+// A full set is not proof that anyone is left: the last pass may have finished
+// exactly at the limit. The continuation costs one job that lists no candidates
+// and stops, which is the cheap side of the trade.
+func (e *CaptureEnricher) RunWorkspace(ctx context.Context) (filled bool, err error) {
 	// The store's apply writes audit + outbox rows, so the pass binds
 	// the system actor and an operation scope like every worker job.
 	wsCtx := principal.WithCorrelationID(principal.WithActor(ctx, principal.Principal{
@@ -100,11 +125,11 @@ func (e *CaptureEnricher) RunWorkspace(ctx context.Context) error {
 	// answers to the same question.
 	defaultEnrich, err := settings.Get(wsCtx, NewSettingsStore(e.pool), capture.SignatureEnrich)
 	if err != nil {
-		return fmt.Errorf("reading the signature-enrichment setting: %w", err)
+		return false, fmt.Errorf("reading the signature-enrichment setting: %w", err)
 	}
-	candidates, err := e.store.SignatureCandidates(wsCtx, enrichPassLimit, defaultEnrich)
+	candidates, err := e.store.SignatureCandidates(wsCtx, e.limit, defaultEnrich)
 	if err != nil {
-		return err
+		return false, err
 	}
 	// A candidate that fails is logged, not returned, and that survives the
 	// fan-out deliberately: the retry is durable in the DATA rather than in
@@ -116,13 +141,16 @@ func (e *CaptureEnricher) RunWorkspace(ctx context.Context) error {
 		if err := e.enrichOne(wsCtx, cand); err != nil {
 			if isBudgetStop(err) {
 				e.log.InfoContext(wsCtx, "signature enrich: budget exhausted, stopping the pass")
-				return nil
+				// No continuation: the budget is what stopped this pass, and a
+				// follow-on would hit the same wall immediately. The nightly
+				// cycle is the right owner of work the budget deferred.
+				return false, nil
 			}
 			e.log.WarnContext(wsCtx, "signature enrich: candidate failed",
 				"person", cand.PersonID.String(), "err", err)
 		}
 	}
-	return nil
+	return len(candidates) == e.limit, nil
 }
 
 func isBudgetStop(err error) bool { return errors.Is(err, ai.ErrBudgetDeferred) }

--- a/backend/internal/compose/captureenrich.go
+++ b/backend/internal/compose/captureenrich.go
@@ -100,14 +100,17 @@ func NewCaptureEnricher(pool *pgxpool.Pool, brain completer, log *slog.Logger) *
 // trouble is logged and the person is retried next cycle (their evidence rows
 // are still absent).
 //
-// It reports whether the candidate set FILLED the limit, which is the caller's
-// signal that more people are due right now. Two things make that worth acting
-// on rather than leaving to the nightly pass. A mailbox sync lands hundreds of
-// messages at once, so the 101st contact would wait until tonight for details a
-// rep is about to read. And the trigger's own uniqueness means mail arriving
-// mid-pass dedupes against a pass that has already listed its candidates —
-// so without a continuation that message waits for the nightly run too,
-// whatever the queue depth.
+// It reports whether the pass filled its limit AND moved at least one person,
+// which is the caller's signal that more people are due right now. Two things
+// make that worth acting on rather than leaving to the nightly pass. A mailbox
+// sync lands hundreds of messages at once, so the 101st contact would wait
+// until tonight for details a rep is about to read. And the trigger's own
+// uniqueness means mail arriving mid-pass dedupes against a pass that has
+// already listed its candidates — so without a continuation that message waits
+// for the nightly run too, whatever the queue depth.
+//
+// Both halves are load-bearing; see the return statement for why progress
+// alone bounds the chain.
 //
 // A full set is not proof that anyone is left: the last pass may have finished
 // exactly at the limit. The continuation costs one job that lists no candidates
@@ -137,6 +140,7 @@ func (e *CaptureEnricher) RunWorkspace(ctx context.Context) (filled bool, err er
 	// rows, so SignatureCandidates re-selects them on the next pass. Failing
 	// the workspace row for one unparseable reply would retry the whole
 	// candidate set to re-reach the same person.
+	var advanced int
 	for _, cand := range candidates {
 		if err := e.enrichOne(wsCtx, cand); err != nil {
 			if isBudgetStop(err) {
@@ -148,9 +152,26 @@ func (e *CaptureEnricher) RunWorkspace(ctx context.Context) (filled bool, err er
 			}
 			e.log.WarnContext(wsCtx, "signature enrich: candidate failed",
 				"person", cand.PersonID.String(), "err", err)
+			continue
 		}
+		advanced++
 	}
-	return len(candidates) == e.limit, nil
+	// A continuation needs BOTH a full set and somebody moved off it.
+	//
+	// The full set alone would chain forever. A failed candidate writes no
+	// watermark on purpose — the comment above says why — so it stays the
+	// newest mail and fills the next pass too. Queueing on the count alone,
+	// a hundred candidates whose model call keeps failing would re-select
+	// themselves, enqueue another job, and do it again: an unbroken chain of
+	// jobs that each succeed, spend the model budget, and starve every older
+	// person behind them. River's attempt cap cannot stop it, because no job
+	// in the chain ever fails.
+	//
+	// Requiring progress bounds the chain by the work actually done. A pass
+	// that moved nobody is the end of it, and the nightly cycle owns the
+	// candidates it could not read — which is where they lived before this
+	// continuation existed.
+	return advanced > 0 && len(candidates) == e.limit, nil
 }
 
 func isBudgetStop(err error) bool { return errors.Is(err, ai.ErrBudgetDeferred) }

--- a/backend/internal/compose/captureenrich_integration_test.go
+++ b/backend/internal/compose/captureenrich_integration_test.go
@@ -397,3 +397,41 @@ type budgetStoppedBrain struct{}
 func (b *budgetStoppedBrain) Complete(context.Context, model.Request) (model.Response, error) {
 	return model.Response{}, ai.ErrBudgetDeferred
 }
+
+// TestAPassThatMovedNobodyAsksForNoContinuation is the runaway bound.
+//
+// A candidate whose model call fails writes no watermark, deliberately, so it
+// stays the newest mail and fills the next pass too. If a full set alone
+// queued a continuation, a hundred permanently failing candidates would
+// re-select themselves and enqueue another job forever — every job succeeding,
+// every one spending the model budget, and River's attempt cap unable to see
+// it because nothing ever fails.
+func TestAPassThatMovedNobodyAsksForNoContinuation(t *testing.T) {
+	e := integration.Setup(t)
+	body := "Hi,\n\nsounds good.\n\nBest,\nBob Person\nCTO\nAcme GmbH"
+	for i := range 2 {
+		seedEnrichPerson(t, e, fmt.Sprintf("stuck%d@acme.example", i), body)
+	}
+
+	// Output the pass cannot parse: the candidate fails, is logged, and keeps
+	// its place at the head of the queue.
+	enricher := NewCaptureEnricher(e.Pool, &unparseableBrain{}, slog.New(slog.DiscardHandler))
+	enricher.limit = 2
+
+	filled, err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if filled {
+		t.Error("a pass that enriched nobody asked for a continuation — " +
+			"the same candidates would fill the next pass and chain forever")
+	}
+}
+
+// unparseableBrain answers with text the verdict parser rejects, which fails
+// the candidate without failing the pass.
+type unparseableBrain struct{}
+
+func (b *unparseableBrain) Complete(context.Context, model.Request) (model.Response, error) {
+	return model.Response{Text: "not json"}, nil
+}

--- a/backend/internal/compose/captureenrich_integration_test.go
+++ b/backend/internal/compose/captureenrich_integration_test.go
@@ -6,13 +6,16 @@
 package compose
 
 // The signature-enrich pass over a real Postgres: an evidence-grounded
-// title and phone land fill-only-empty with their PO-DDL-12 evidence rows;
-// a fabricated snippet is dropped by the code-side gate; an occupied field
-// is never touched; and a person once enriched leaves the candidate set.
+// title and phone land with their PO-DDL-12 evidence rows; a fabricated
+// snippet is dropped by the code-side gate; a human's correction is never
+// overwritten; a person once enriched leaves the candidate set; and a pass
+// that filled its limit says so, so the worker can queue the next slice
+// instead of leaving it until tonight.
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -89,7 +92,7 @@ func TestSignatureEnrichPass(t *testing.T) {
 		{"field": "linkedin", "value": "linkedin.com/in/bob", "evidence_snippet": "linkedin.com/in/bob", "confidence": 0.9},
 	}}
 	enricher := NewCaptureEnricher(e.Pool, brain, slog.New(slog.DiscardHandler))
-	if err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
+	if _, err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -130,7 +133,7 @@ func TestSignatureEnrichPass(t *testing.T) {
 		// select them again — and asking would show the model the identical
 		// window and get the identical answer, nightly, forever.
 		before := brain.calls
-		if err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
+		if _, err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
 			t.Fatalf("Run: %v", err)
 		}
 		if brain.calls != before {
@@ -157,7 +160,7 @@ func TestSignatureEnrichPass(t *testing.T) {
 			t.Fatal(err)
 		}
 		before := brain.calls
-		if err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
+		if _, err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
 			t.Fatalf("Run: %v", err)
 		}
 		if brain.calls == before {
@@ -179,7 +182,7 @@ func TestSignatureEnrichPass(t *testing.T) {
 		// She is still a candidate — the org_name her signature may state is
 		// unanswered — so the pass reads her mail and the model returns the
 		// same title it returns for everyone. The human's answer survives it.
-		if err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
+		if _, err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
 			t.Fatalf("Run: %v", err)
 		}
 		var title string
@@ -222,7 +225,7 @@ func TestSignatureEnrichAbsorbsModelFailures(t *testing.T) {
 	t.Run("garbage output fails the candidate, not the pass", func(t *testing.T) {
 		brain := &faultyEnrichBrain{garbage: true}
 		enricher := NewCaptureEnricher(e.Pool, brain, slog.New(slog.DiscardHandler))
-		if err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
+		if _, err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
 			t.Fatalf("a per-candidate model failure must not fail the pass: %v", err)
 		}
 		if brain.calls == 0 {
@@ -237,7 +240,7 @@ func TestSignatureEnrichAbsorbsModelFailures(t *testing.T) {
 	t.Run("a budget stop ends the pass cleanly", func(t *testing.T) {
 		brain := &faultyEnrichBrain{err: ai.ErrBudgetDeferred}
 		enricher := NewCaptureEnricher(e.Pool, brain, slog.New(slog.DiscardHandler))
-		if err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
+		if _, err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
 			t.Fatalf("a budget stop must not be an error: %v", err)
 		}
 		if brain.calls != 1 {
@@ -295,7 +298,7 @@ func TestASignatureDoesNotOverwriteACorrectedField(t *testing.T) {
 		{"field": "title", "value": "CTO", "evidence_snippet": "CTO", "confidence": 0.9},
 	}}
 	enricher := NewCaptureEnricher(e.Pool, brain, slog.New(slog.DiscardHandler))
-	if err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
+	if _, err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS)); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -318,4 +321,79 @@ func TestASignatureDoesNotOverwriteACorrectedField(t *testing.T) {
 	if titleRows != 0 {
 		t.Errorf("%d title evidence rows, want 0: the pass wrote over a human's ruling", titleRows)
 	}
+}
+
+// TestAFullPassAsksForAContinuation drives the boundary the continuation turns
+// on: a pass whose candidate set filled the limit reports that more people are
+// due, and one that came back short does not.
+//
+// The limit is set to 2 rather than seeding a hundred people. What is under
+// test is the comparison against the pass's own limit, and that comparison is
+// the same one at 2 as at 100.
+func TestAFullPassAsksForAContinuation(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		people     int
+		wantFilled bool
+	}{
+		// One short of the limit: nobody is waiting, and a continuation would
+		// be a job that lists no candidates.
+		{"a short pass is finished", 1, false},
+		// Exactly the limit. There may be a hundred more behind these two, and
+		// before the continuation they waited for the nightly pass.
+		{"a full pass has more to do", 2, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := integration.Setup(t)
+			body := "Hi,\n\nsounds good.\n\nBest,\nBob Person\nCTO\nAcme GmbH"
+			for i := range tc.people {
+				seedEnrichPerson(t, e, fmt.Sprintf("full%d@acme.example", i), body)
+			}
+
+			brain := &signatureScriptBrain{fields: []map[string]any{
+				{"field": "title", "value": "CTO", "evidence_snippet": "CTO", "confidence": 0.9},
+			}}
+			enricher := NewCaptureEnricher(e.Pool, brain, slog.New(slog.DiscardHandler))
+			enricher.limit = 2
+
+			filled, err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS))
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if filled != tc.wantFilled {
+				t.Errorf("filled = %v, want %v for %d candidates against a limit of 2",
+					filled, tc.wantFilled, tc.people)
+			}
+		})
+	}
+}
+
+// A budget stop reports no continuation. The pass stopped because the model
+// budget ran out, so a follow-on would hit the same wall at once — and the
+// candidate set was full, which is the signal that would otherwise fire.
+func TestABudgetStopAsksForNoContinuation(t *testing.T) {
+	e := integration.Setup(t)
+	body := "Hi,\n\nsounds good.\n\nBest,\nBob Person\nCTO\nAcme GmbH"
+	for i := range 2 {
+		seedEnrichPerson(t, e, fmt.Sprintf("budget%d@acme.example", i), body)
+	}
+
+	enricher := NewCaptureEnricher(e.Pool, &budgetStoppedBrain{}, slog.New(slog.DiscardHandler))
+	enricher.limit = 2
+
+	filled, err := enricher.RunWorkspace(principal.WithWorkspaceID(context.Background(), e.WS))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if filled {
+		t.Error("a budget-stopped pass asked for a continuation, which would spend a job to hit the same wall")
+	}
+}
+
+// budgetStoppedBrain is the model lane refusing on budget, which is the one
+// error RunWorkspace treats as ending the pass rather than skipping a person.
+type budgetStoppedBrain struct{}
+
+func (b *budgetStoppedBrain) Complete(context.Context, model.Request) (model.Response, error) {
+	return model.Response{}, ai.ErrBudgetDeferred
 }

--- a/backend/internal/compose/capturejobs.go
+++ b/backend/internal/compose/capturejobs.go
@@ -109,6 +109,7 @@ func (a CaptureEnrichWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace 
 // signature line.
 type captureEnrichWorkspaceWorker struct {
 	enricher *CaptureEnricher
+	log      *slog.Logger
 }
 
 func (w *captureEnrichWorkspaceWorker) Work(ctx context.Context, job *river.Job[CaptureEnrichWorkspaceArgs]) error {
@@ -116,7 +117,40 @@ func (w *captureEnrichWorkspaceWorker) Work(ctx context.Context, job *river.Job[
 	if err != nil {
 		return jobs.FaultContext(ctx, err)
 	}
-	return jobs.FaultContext(ctx, w.enricher.RunWorkspace(wsCtx))
+	filled, err := w.enricher.RunWorkspace(wsCtx)
+	if err != nil {
+		return jobs.FaultContext(ctx, err)
+	}
+	if filled {
+		w.enqueueContinuation(wsCtx, job.Args)
+	}
+	return nil
+}
+
+// enqueueContinuation queues the next slice of a workspace whose pass filled
+// its limit.
+//
+// Best-effort, like the backfill's digest above and for the same reason: the
+// work is already done and committed, and the nightly pass still reconciles
+// whatever this fails to queue. Failing the job instead would re-run a pass
+// that has already spent its model budget on the candidates it handled.
+//
+// The insert carries NO uniqueness. This runs inside the pass it continues, so
+// the ByArgs/active-state uniqueness the trigger uses would dedupe the
+// continuation against its own still-running parent and drop it silently —
+// which is precisely the case this exists to fix.
+func (w *captureEnrichWorkspaceWorker) enqueueContinuation(ctx context.Context, args CaptureEnrichWorkspaceArgs) {
+	client, err := river.ClientFromContextSafely[pgx.Tx](ctx)
+	if err != nil {
+		w.log.WarnContext(ctx, "signature enrich: no River client in context, so the continuation was not enqueued",
+			"workspace", args.Workspace.String(), "err", err)
+		return
+	}
+	if _, err := client.Insert(ctx, CaptureEnrichWorkspaceArgs{Workspace: args.Workspace},
+		oneOffChildOpts(CaptureEnrichWorkspaceArgs{}.Kind())); err != nil {
+		w.log.WarnContext(ctx, "signature enrich: continuation enqueue failed",
+			"workspace", args.Workspace.String(), "err", err)
+	}
 }
 
 // OrgNamePromotionArgs runs one org-name promotion pass (PO-F-2a).

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -112,6 +112,7 @@ func addCapturePipelineJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerC
 		addDeclaredWorker[CaptureEnrichArgs](reg, &captureEnrichWorker{pool: pool})
 		addDeclaredWorker[CaptureEnrichWorkspaceArgs](reg, &captureEnrichWorkspaceWorker{
 			enricher: NewCaptureEnricher(pool, cfg.EnrichBrain, log),
+			log:      log,
 		})
 	}
 


### PR DESCRIPTION
The signature pass takes 100 candidates and left the rest to the nightly cycle.
Two things made that wrong now that the pass runs within minutes of a message
arriving rather than once a night.

A mailbox sync lands hundreds of messages at once, so the 101st contact waited
until tonight for details a rep is about to read. And the trigger's own
uniqueness means mail arriving mid-pass dedupes against a pass that has already
listed its candidates — that message waited for the nightly run too, at any
queue depth. `captureenrichtrigger.go` already named this as the hole it
accepted.

## What changed

`RunWorkspace` reports whether the pass filled its limit **and moved at least
one person**; the worker queues a continuation on that signal.

The continuation insert carries no uniqueness on purpose. It runs inside the
pass it continues, so the ByArgs active-state uniqueness would dedupe it
against its own still-running parent and drop it silently — the exact case this
fixes. It is best-effort like the backfill's digest enqueue: the work is
already committed, and failing the job would re-run a pass that has spent its
model budget.

## The runaway this went through

The first version queued on a full candidate set alone. A candidate whose model
call fails writes no watermark — deliberately, so the next pass retries it — so
it stays the newest mail and fills the next pass too. A hundred permanently
failing candidates would re-select themselves and enqueue another job forever:
every job succeeding, every one spending the model budget, older people starved
behind them, and River's attempt cap blind to it because nothing ever fails.

Requiring progress bounds the chain by work done. Found by review;
`TestAPassThatMovedNobodyAsksForNoContinuation` now holds it.

## Verification

`make check-backend` green, `make craft-static` 0/0/0, full
`make test-it DIR=backend/internal/compose` green (145s).

Four branches mutation-checked, each failing a test when reverted: never
signalling, always signalling, a budget stop that signals, and a full page with
no progress that signals.

## Deferred

#3538 — two concurrent passes can read the same candidate page and each pay for
it. Pre-existing (the nightly dispatcher has the same property); the fix is a
workspace lease, which reaches past this diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The signature-enrich pass now queues a continuation when it fills its 100-candidate limit and moves at least one person, so contacts no longer wait for the nightly cycle. Previously the 101st candidate — and mail arriving mid-pass, which deduped against the already-listed set — waited until the night run.

**Continuation behavior**
- Budget stops queue no continuation; a follow-on would immediately hit the same wall.
- The continuation insert is best-effort and carries no uniqueness — uniqueness would dedupe it against its still-running parent.
- The pass limit is now a field so tests can drive the boundary with two people instead of a hundred.

**Runaway guard**
- Queueing on a full set alone would chain forever when candidates keep failing model calls.
- Requiring progress bounds the chain by work done instead of queue depth.

<sup>Written for commit 1a5a3f95bde1dc471ebbb6e2adde75b07ae25d38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enrichment processing so continuation work is requested only when a full batch makes progress.
  * Prevented unnecessary continuation attempts when candidates fail, processing stops due to limits, or no records are updated.
  * Preserved retryability for unsuccessful candidates.
  * Enrichment errors continue to be reported, while non-critical continuation scheduling failures are handled gracefully.

* **Tests**
  * Added coverage for successful, budget-limited, and zero-progress enrichment passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->