### PR TITLE
Two promises due the same day: the older one keeps the card

### DIFF
--- a/backend/internal/compose/person360/momentrules.go
+++ b/backend/internal/compose/person360/momentrules.go
@@ -432,14 +432,17 @@ func nearestOpenTask(page *crmcontracts.Person360) (crmcontracts.Activity, bool)
 }
 
 // openTaskSooner orders two open tasks: a dated one before an undated one,
-// then by due date, then by when it was filed.
+// then by due date, then by when it was filed. Two tasks due the same day
+// fall through to the filing order on purpose: the section lists newest
+// first, and without the fall-through the card switched to whichever task
+// was logged last rather than the one that has waited longest.
 func openTaskSooner(a, b *crmcontracts.Activity) bool {
 	switch {
-	case a.DueAt != nil && b.DueAt != nil:
+	case a.DueAt != nil && b.DueAt != nil && !a.DueAt.Equal(*b.DueAt):
 		return a.DueAt.Before(*b.DueAt)
-	case a.DueAt != nil:
+	case a.DueAt != nil && b.DueAt == nil:
 		return true
-	case b.DueAt != nil:
+	case a.DueAt == nil && b.DueAt != nil:
 		return false
 	default:
 		return a.OccurredAt.Before(b.OccurredAt)

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -480,6 +480,14 @@ func TestAnOpenUndatedTaskIsTheMoment(t *testing.T) {
 		t.Errorf("why_now for a task due later today = %q, want \"Due today.\"", got)
 	}
 
+	// Two tasks due the same day: the one filed first has waited longest and
+	// keeps the card. The section lists newest first, so without this the
+	// card followed whichever task was logged last.
+	page.NextSteps.Data[1].DueAt = ptr(now.Add(2 * time.Hour))
+	if got := deriveMoment(now, page).Headline; got != "You owe them: Send the MCP whitepaper" {
+		t.Errorf("with two tasks due today, headline = %q, want the older one", got)
+	}
+
 	// Done tasks never reach the section, so a page whose section is empty is
 	// the quiet state — and only then may the card say nothing is owed.
 	page.NextSteps.Data = nil


### PR DESCRIPTION
Follow-up to #3537. The open-promise rung ordered dated tasks by due date and stopped there. Two tasks due the same day compared equal, so the first one seen won — and the next-steps section lists newest first, so the card followed whichever task was logged last. Logging a second task on a record flipped the headline away from the one that had waited longest.

Equal due dates now fall through to the filing order (`openTaskSooner` in `momentrules.go`), the same rule the undated tasks already used. Covered in `TestAnOpenUndatedTaskIsTheMoment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the open-promise headline so that when two tasks are due the same day, the one filed first keeps the card. Equal due dates now fall through to the filing order instead of comparing equal, which previously let whichever task was logged last take over the headline.

- Reuses the same fall-through rule undated tasks already use, covered in `TestAnOpenUndatedTaskIsTheMoment`.

<sup>Written for commit 706388e7029d1b4753e97e53156e349cfe2ccce1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task prioritization when multiple tasks share the same due date.
  * The older task is now selected first, including when tasks are due today.
  * Tasks with due dates continue to take precedence over undated tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->