### PR TITLE
A metric whose target is zero is a test

### DIFF
--- a/backend/internal/compose/attention/counts_test.go
+++ b/backend/internal/compose/attention/counts_test.go
@@ -167,7 +167,88 @@ func TestCountsAreOrderedTheSameWayTwice(t *testing.T) {
 // requires categoryOfSource to have said the same thing. A source that changes
 // lane fails here rather than reporting its truncation against the wrong cut.
 func TestTheSourceMapAgreesWithTheClassifiers(t *testing.T) {
-	lanes := []struct {
+	for _, l := range everyLane() {
+		rows := classifyDay(l.day, rankInstant)
+		if len(rows) != 1 {
+			t.Fatalf("%s: the lane classified %d rows, and the fixture holds one", l.source, len(rows))
+		}
+		classified := rows[0].item.Category
+		mapped := categoryOfSource(crmcontracts.WorklistItemSource(l.source))
+		if classified != mapped {
+			t.Fatalf("%s: the classifier files it under %q and the map says %q — a truncation of this source would be reported against the wrong cut",
+				l.source, classified, mapped)
+		}
+	}
+}
+
+// THE HIDDEN-BACKLOG GUARDRAIL: no category holds work while reporting none.
+//
+// The concept names this as a metric whose target is zero incidents, and a
+// metric with a target of zero is a test rather than a number somebody reads
+// once a quarter. It is also the failure this whole accounting exists to
+// prevent: a rep told "no decisions" over a pile of them stops believing the
+// page, and nothing on the screen says the figure was short.
+//
+// Over the same lane corpus the agreement test uses, so a source added
+// tomorrow is covered by being added THERE — one fixture list, two obligations.
+func TestNoCategoryHoldsWorkWhileReportingNone(t *testing.T) {
+	for _, l := range everyLane() {
+		rows := classifyDay(l.day, rankInstant)
+		counts := countsOf(rows, rows, map[crmcontracts.WorklistItemSource]bool{})
+
+		category := rows[0].item.Category
+		for _, count := range counts {
+			if crmcontracts.WorklistItemCategory(count.Category) != category {
+				continue
+			}
+			if count.Considered == 0 {
+				t.Fatalf("%s: category %q holds work and reports none — the page says it is empty",
+					l.source, category)
+			}
+			goto next
+		}
+		t.Fatalf("%s: category %q holds work and is absent from counts entirely",
+			l.source, category)
+	next:
+	}
+}
+
+// A CATEGORY CUT FROM THE PAGE STILL REPORTS WHAT IT HELD.
+//
+// The cut is the ordinary case — twenty-five rows of a larger day — and a
+// category that lost every row to it is exactly when a reader most needs to be
+// told the work is there. Reporting nothing then is the hidden backlog by
+// another route: not a wrong number, an absent one.
+func TestACategoryCutFromThePageStillReportsWhatItHeld(t *testing.T) {
+	for _, l := range everyLane() {
+		rows := classifyDay(l.day, rankInstant)
+		// Considered everything, shown nothing.
+		counts := countsOf(rows, nil, map[crmcontracts.WorklistItemSource]bool{})
+
+		if len(counts) == 0 {
+			t.Fatalf("%s: a page that drew nothing reported no categories at all", l.source)
+		}
+		for _, count := range counts {
+			if count.Considered == 0 {
+				t.Fatalf("%s: category %q reports nothing considered over rows it held",
+					l.source, count.Category)
+			}
+			if count.Shown != 0 {
+				t.Fatalf("%s: category %q claims %d rows on a page that drew none",
+					l.source, count.Category, count.Shown)
+			}
+		}
+	}
+}
+
+// everyLane is one day per source the queue can produce, each holding exactly
+// one row. Shared by every test that needs to reach all of them, so a new
+// source is added once and inherits every obligation.
+func everyLane() []struct {
+	source crmcontracts.AttentionItemSource
+	day    crmcontracts.Attention
+} {
+	return []struct {
 		source crmcontracts.AttentionItemSource
 		day    crmcontracts.Attention
 	}{
@@ -198,19 +279,6 @@ func TestTheSourceMapAgreesWithTheClassifiers(t *testing.T) {
 		{"automation_run", crmcontracts.Attention{AsOf: rankInstant, AutomationHealth: lane(
 			item("x", "automation_run"),
 		)}},
-	}
-
-	for _, l := range lanes {
-		rows := classifyDay(l.day, rankInstant)
-		if len(rows) != 1 {
-			t.Fatalf("%s: the lane classified %d rows, and the fixture holds one", l.source, len(rows))
-		}
-		classified := rows[0].item.Category
-		mapped := categoryOfSource(crmcontracts.WorklistItemSource(l.source))
-		if classified != mapped {
-			t.Fatalf("%s: the classifier files it under %q and the map says %q — a truncation of this source would be reported against the wrong cut",
-				l.source, classified, mapped)
-		}
 	}
 }
 

--- a/backend/internal/compose/attention/counts_test.go
+++ b/backend/internal/compose/attention/counts_test.go
@@ -181,6 +181,70 @@ func TestTheSourceMapAgreesWithTheClassifiers(t *testing.T) {
 	}
 }
 
+// EVERY SOURCE THE CONTRACT DECLARES REACHES THE GUARDRAILS BELOW.
+//
+// everyLane is a hand-written list, and a hand-written census is one that can
+// fail short: it reads a smaller tree, reports PASS, and no assertion notices.
+// Eleven of the contract's twenty sources were in it when this was written, and
+// the nine missing ones included customer_waiting and dedupe_candidate — the
+// two categories a reader is most likely to be lied to about.
+//
+// So the LIST is checked against the contract's own enum. A source added there
+// and not here fails this, and the two guardrails below then cover it by
+// arriving in everyLane at all.
+func TestEverySourceTheContractDeclaresHasALane(t *testing.T) {
+	covered := map[crmcontracts.WorklistItemSource]bool{}
+	for _, l := range everyLane() {
+		covered[crmcontracts.WorklistItemSource(l.source)] = true
+	}
+	for _, source := range everyWorklistSource() {
+		if notADayLane[source] {
+			continue
+		}
+		if !covered[source] {
+			t.Errorf("source %q has no lane, so no guardrail below reaches it — "+
+				"add one to everyLane", source)
+		}
+	}
+}
+
+// notADayLane are the sources classifyDay cannot produce, and why.
+//
+// Each is covered somewhere else or is not a producer at all. Listed rather
+// than skipped silently, so a source added to this set is a decision somebody
+// wrote down.
+var notADayLane = map[crmcontracts.WorklistItemSource]bool{
+	// A GROUP of rows rather than a producer: foldRoutineDecisions makes one
+	// from rows that already have their own lanes, and its category is its
+	// members'.
+	crmcontracts.WorklistItemSourceBatch: true,
+	// Read from its own store rather than from the assembled day: worklist.go
+	// classifies the waiting lane separately, so no Attention field carries
+	// it. Its own suite (waitinglane_integration_test.go) drives it end to end.
+	crmcontracts.WorklistItemSourceCustomerWaiting: true,
+}
+
+// everyWorklistSource is the contract's own source list, derived from the
+// generated Valid() rather than retyped: a list here would be the third copy of
+// a vocabulary that already exists twice.
+func everyWorklistSource() []crmcontracts.WorklistItemSource {
+	all := []crmcontracts.WorklistItemSource{
+		"approval", "dedupe_candidate", "task", "brief_item", "conversation_claim",
+		"customer_waiting", "deal_at_risk", "meeting", "relationship_decay",
+		"failed_approval", "dsr", "sync_health", "capture_health", "ai_work_health",
+		"bounce", "undelivered", "automation_run", "notice", "introduction_request",
+		"batch",
+	}
+	// Held against the generated enum: a value the contract drops fails here
+	// rather than leaving a lane nothing produces.
+	for _, source := range all {
+		if !source.Valid() {
+			panic("worklist source " + string(source) + " is not in the contract")
+		}
+	}
+	return all
+}
+
 // THE HIDDEN-BACKLOG GUARDRAIL: no category holds work while reporting none.
 //
 // The concept names this as a metric whose target is zero incidents, and a
@@ -278,6 +342,27 @@ func everyLane() []struct {
 		)}},
 		{"automation_run", crmcontracts.Attention{AsOf: rankInstant, AutomationHealth: lane(
 			item("x", "automation_run"),
+		)}},
+		{"dedupe_candidate", crmcontracts.Attention{AsOf: rankInstant, NeedsYou: []crmcontracts.AttentionItem{
+			item("x", "dedupe_candidate"),
+		}}},
+		{"brief_item", crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{
+			item("x", "brief_item"),
+		}}},
+		{"sync_health", crmcontracts.Attention{AsOf: rankInstant, SyncHealth: lane(
+			item("x", "sync_health"),
+		)}},
+		{"capture_health", crmcontracts.Attention{AsOf: rankInstant, CaptureHealth: lane(
+			item("x", "capture_health"),
+		)}},
+		{"ai_work_health", crmcontracts.Attention{AsOf: rankInstant, AiWorkHealth: lane(
+			item("x", "ai_work_health"),
+		)}},
+		{"undelivered", crmcontracts.Attention{AsOf: rankInstant, Undelivered: lane(
+			item("x", "undelivered"),
+		)}},
+		{"introduction_request", crmcontracts.Attention{AsOf: rankInstant, Introductions: lane(
+			item("x", "introduction_request"),
 		)}},
 	}
 }

--- a/backend/internal/compose/attention/reach.go
+++ b/backend/internal/compose/attention/reach.go
@@ -172,7 +172,12 @@ func categoryOfSource(source crmcontracts.WorklistItemSource) crmcontracts.Workl
 		return "meetings"
 	case sourceTask, "conversation_claim":
 		return "tasks"
-	case "approval", "dedupe_candidate":
+	case "approval", "dedupe_candidate", "introduction_request":
+		// An introduction ask is a colleague waiting on this reader to decide,
+		// which classifyIntroduction files under decisions at levelBlocking.
+		// It reached the default and was reported as `system` — so a truncated
+		// introductions lane told the reader their SYSTEM cut was short while
+		// the decisions pill, where the rows actually are, read as complete.
 		return "decisions"
 	default:
 		// Everything the product reports about ITSELF — health, notices,


### PR DESCRIPTION
The concept lists six success metrics. One is different in kind, and it is the
one worth building now.

> hidden-backlog incidents: a category with work but a zero/absent visible count
> (target: zero)

A number somebody reads once a quarter cannot hold that. A test can, and it
fails the moment it stops being true.

It is also the failure the whole `counts[]` accounting exists to prevent: a rep
told "no decisions" over a pile of them stops believing the page, and nothing on
screen says the figure was short.

## Two obligations, one corpus

- Every category holding work reports a non-zero figure.
- A category cut entirely from the page still reports what it held — the same
  defect by another route: not a wrong number, an absent one, and exactly the
  case a reader most needs when a category loses every row to the 25-row cut.

Both run over the lane list `TestTheSourceMapAgreesWithTheClassifiers` already
had, lifted into `everyLane()`. **One fixture list, three obligations**: a source
added tomorrow is added once and inherits all of them, rather than being covered
by whichever test its author happened to remember.

Both mutation-checked. Dropping a category from the count fails the first with
"category system holds work and reports none". Seeding the counts from the
*shown* rows rather than the *considered* ones — report the page and call it the
day — fails the second.

## The other five, and why they are not here

**Already answerable.** The disposition rates the concept asks for —
`Not sales` / `Not mine` / immediate dismiss — are countable from `audit_log`
today, because the write shape put them there when PR 2 landed:

```
SELECT after->>'disposition', count(*) FROM audit_log
 WHERE entity_type = 'activity' AND after ? 'disposition' GROUP BY 1;
```

Building a second surface for a figure the audit trail already carries would be
two answers to one question.

**Needs an authority decision, not a catalog entry.** The reports engine
(`reportspecs.go`) is the right home for the rest — a typed query plan with
per-cell derivation, where "a new report is a new entry here and nothing else".
But no report reads `audit_log` today, and it carries its own scope
(`scopeAudit` in `export.go`). Deciding who may read audit rows through the
report engine is a product question I should not answer alone.

**Blocked.** "Median time to first response" and "share of material at-risk
deals" both need money compared across deals, and issue #3552 is that
`expectedBase` is not the base-currency figure its own documentation claims —
the Worklist already ranks a yen against a euro. A metric built on that would
inherit it silently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encodes the "hidden-backlog incidents" metric as two guardrail tests so a category holding work can never report an empty count, and a category cut from the page still reports what it held.

- Lifts the lane fixture into `everyLane()`, now checked against the contract's own enum so a source added to the contract but not the fixture fails the census. Widening coverage caught `introduction_request` reported as `system` while the classifier files it under `decisions`; the map now agrees.
- Defers the other five success metrics: disposition rates are already answerable from `audit_log`, while the rest need the reports engine to read audit rows or a converted currency figure blocked by issue #3552.

<sup>Written for commit d9c393d15128e1415681a40d0024eac4c45b0a16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

