### PR TITLE
The Graph renewal lane is scheduled on the condition its workers register under

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -883,7 +883,7 @@ kinds:
     timeout: 2m
     opts_owner: caller
     cadence: {operator: GraphWatch.Interval, schedule_when_positive: GraphWatch.Interval}
-    registration: {when: [GmailRegistry, GraphWatch.NotificationURL], absent: registers_nothing}
+    registration: {when: [GmailRegistry.OffersGraph, GraphWatch.NotificationURL], absent: registers_nothing}
     fans_out_to: graph_watch_renew_connection
     fan_out_unit: connection
     reason: >-
@@ -900,7 +900,7 @@ kinds:
     timeout: 2m
     max_attempts: 3
     opts_owner: fan_out
-    registration: {when: [GmailRegistry, GraphWatch.NotificationURL], absent: registers_nothing}
+    registration: {when: [GmailRegistry.OffersGraph, GraphWatch.NotificationURL], absent: registers_nothing}
     args:
       Workspace: id
       ConnectionID: id

--- a/backend/cmd/worker/banner_graph_test.go
+++ b/backend/cmd/worker/banner_graph_test.go
@@ -51,3 +51,16 @@ func TestTheBannerNamesTheGraphRenewalOnlyWhenItIsRegistered(t *testing.T) {
 		})
 	}
 }
+
+// THE DEFAULT DEPLOYMENT, which is every installation that never opted into
+// Outlook: no Entra app and no notification URL. The banner says nothing about
+// Graph at all — not "no notification url", which would read as a
+// misconfiguration to an operator who never asked for the lane, and which is
+// the one branch every case above steps over because they all set a client id.
+func TestTheBannerIsSilentAboutGraphOnADeploymentThatNeverAskedForIt(t *testing.T) {
+	t.Parallel()
+	banner := jobRunnerBanner(workerConfig{}, compose.GmailWatchConfig{}, false, compose.ModelPath{}, nil, nil)
+	if strings.Contains(banner, "graph") {
+		t.Errorf("the banner mentions graph on a deployment that configured none of it: %q", banner)
+	}
+}

--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -265,11 +265,11 @@ func registerDeepReadFlags(fs *flag.FlagSet, cfg *workerConfig) error {
 // and compose reads a non-positive interval as "no cadence given" and
 // registers no schedule at all — a role that meant to sweep silently never
 // would. Both readings are wrong for an operator's dial. These are strictly
-// scheduling PERIODS. Two duration flags are deliberately NOT in this set:
-// gmail-watch-renew-within is a renewal THRESHOLD (a lead time —
-// time.Now().Add(within) in DueWatches), so zero validly means "renew
-// missing or already-expired watches" and is checked separately (negative
-// only); and the deep-read / backfill caps are counts with a documented
+// scheduling PERIODS. The renewal THRESHOLDS are deliberately NOT in this set:
+// gmail-watch-renew-within and graph-watch-renew-within are lead times —
+// time.Now().Add(within) in DueWatches — so zero validly means "renew
+// missing or already-expired watches" and both are checked separately
+// (negative only); and the deep-read / backfill caps are counts with a documented
 // zero-means-default meaning, validated above. Zero and negative here are
 // boot errors, never silent defaults.
 func validateSchedulerIntervals(cfg workerConfig) error {

--- a/backend/internal/compose/graphpush.go
+++ b/backend/internal/compose/graphpush.go
@@ -186,6 +186,12 @@ func bumpGraphMailboxes(
 	if err != nil {
 		return err
 	}
+	// Every hit is attempted before any failure is reported. One delivery names
+	// many mailboxes across many workspaces, and returning at the first enqueue
+	// fault would leave the rest of the batch unsynced until the redelivery —
+	// which arrives with the SAME set, so a mailbox that keeps landing behind a
+	// consistently failing one would never be reached at all.
+	var faults error
 	for _, d := range hits {
 		if err := inserter.Enqueue(ctx, CaptureSyncArgs{
 			Workspace:    d.Workspace.UUID,
@@ -199,8 +205,12 @@ func bumpGraphMailboxes(
 			UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
 		}); err != nil {
 			log.ErrorContext(ctx, "graph push: enqueueing sync", "connection", d.ID.String(), "err", err)
-			return err
+			faults = errors.Join(faults, err)
 		}
 	}
-	return nil
+	// Joined, not swallowed: the handler answers Transient on any fault, so
+	// Microsoft redelivers and the mailboxes that DID enqueue are protected
+	// from a second sync by the uniqueness window rather than by this returning
+	// early.
+	return faults
 }

--- a/backend/internal/compose/jobcensusconfig.go
+++ b/backend/internal/compose/jobcensusconfig.go
@@ -65,14 +65,6 @@ func everyDeclaredDependencySupplied(cfg JobRunnerConfig) error {
 		strings.Join(slices.Sorted(maps.Keys(unmet)), "\n  "))
 }
 
-// censusJobConfig is the maximally-configured role: every credential
-// custodian, connector registry, model lane and operator dial the declaration
-// names, so that every kind the contract declares is one this assembly wires.
-//
-// It is not a deployment anyone runs. A real role supplies what it can reach,
-// and which kinds that leaves wired is the whole subject of the registration
-// postures; this one exists so the census reads the contract's full extent
-// rather than one deployment's slice of it.
 // censusCaptureRegistry is a registry holding the connectors the census needs a
 // job to be able to look up. Only Graph today: it is the one watch pass that
 // asks, because it is the one whose worker role registers its connector from
@@ -83,6 +75,14 @@ func censusCaptureRegistry() *capture.Registry {
 	return reg
 }
 
+// censusJobConfig is the maximally-configured role: every credential
+// custodian, connector registry, model lane and operator dial the declaration
+// names, so that every kind the contract declares is one this assembly wires.
+//
+// It is not a deployment anyone runs. A real role supplies what it can reach,
+// and which kinds that leaves wired is the whole subject of the registration
+// postures; this one exists so the census reads the contract's full extent
+// rather than one deployment's slice of it.
 func censusJobConfig() JobRunnerConfig {
 	seam := censusSeam{}
 	return JobRunnerConfig{

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "b3ca6c28bcfe1f1769cbf17311159a17711b6899f40d4fb10e7a0ec4df9ea854"
+const jobContractHash = "cc0508aa4201841e43826e2e824e02354b75b567add7d526a6757bf30d1f5d01"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -102,8 +102,19 @@ func addGraphWatchJobs(reg *jobRegistry, cfg JobRunnerConfig, log *slog.Logger) 
 // EXPORTED so the boot banner can ask the same question rather than restate it.
 // A banner naming a lane that did not come up is worse than no banner: it is the
 // one place an operator looks to check.
+//
+// ASKED OF THE DECLARATION, not of the fields directly. The periodic schedule
+// gates on api/jobs.yaml's registration.when through the same `registers`, so a
+// condition spelled only here would be one the scheduler does not know about —
+// and it enqueues under its own answer. That divergence does not fail loudly:
+// the rows are inserted, no worker claims them, and the lane looks idle rather
+// than broken.
 func GraphWatchWillRun(reg *capture.Registry, cfg GraphWatchConfig) bool {
-	return reg != nil && cfg.NotificationURL != "" && registryOffers(reg, providerGraph)
+	spec, declared := jobs.SpecFor(graphWatchKind)
+	if !declared {
+		panic("compose: api/jobs.yaml does not declare " + graphWatchKind)
+	}
+	return registers(JobRunnerConfig{GmailRegistry: reg, GraphWatch: cfg}, spec.Registration)
 }
 
 // registryOffers reports whether reg holds a connector for provider.
@@ -430,7 +441,13 @@ func renewOneWatch(
 type GraphWatchArgs struct{}
 
 // Kind is the stable job identifier River persists in river_job.
-func (GraphWatchArgs) Kind() string { return "graph_watch_renew" }
+func (GraphWatchArgs) Kind() string { return graphWatchKind }
+
+// graphWatchKind is the kind string, named so the registration can be read from
+// api/jobs.yaml without constructing the args — a dispatcher literal outside
+// periodicFor is what jobdispatcherenqueue_test refuses, and rightly: building
+// one to ask a question looks exactly like building one to enqueue it.
+const graphWatchKind = "graph_watch_renew"
 
 // FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
 // tenant work of its own (jobs.FleetWide).

--- a/backend/internal/compose/jobs_databasesweeps.go
+++ b/backend/internal/compose/jobs_databasesweeps.go
@@ -11,15 +11,25 @@ import (
 	"github.com/margince/margince/backend/internal/modules/identity"
 )
 
-// addDatabaseOnlySweepJobs registers the periodic passes that need nothing but
-// the database: the deals close-date hygiene, the follow-up reconcile, the
-// automation clock scan, and the idempotency-key retention sweep.
+// addDatabaseOnlySweepJobs registers every periodic pass that needs nothing but
+// the database.
 //
-// It takes no JobRunnerConfig, and that is the group rather than an economy of
-// arguments — there is no lane, credential or registry any of these could be
-// gated on, so every role that runs jobs runs all four. Each is a dispatcher
-// plus a workspace worker: only the dispatcher is ticked (the schedules in
-// wireJobs), and the workspace worker is enqueued by it, never scheduled.
+// It takes no JobRunnerConfig, and that is what the group IS rather than an
+// economy of arguments — there is no lane, credential or registry any of these
+// could be gated on, so every role that runs jobs runs all of them.
+//
+// Two shapes are here, and the difference decides what gets scheduled:
+//
+//   - Dispatcher plus workspace worker — close-date hygiene, the follow-up
+//     reconcile, the automation clock scan, idempotency-key retention. Only the
+//     dispatcher is ticked (the schedules in wireJobs); the workspace worker is
+//     enqueued by it and never scheduled.
+//   - Installation-wide, with no workspace fan-out — agent-task retention,
+//     approval expiry, intro expiry, approval auto-apply. One row does the whole
+//     installation, so there is no child kind to enqueue.
+//
+// It also pulls in the AI-activity and brief-generate groups, which are their
+// own functions because they are longer, not because they are gated differently.
 func addDatabaseOnlySweepJobs(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Logger) {
 	addDeclaredWorker[CloseDateSweepArgs](reg, &closeDateSweepWorker{pool: pool})
 	addDeclaredWorker[CloseDateWorkspaceArgs](reg, &closeDateWorkspaceWorker{corrector: NewCloseDateCorrector(pool, log)})

--- a/backend/internal/compose/jobs_databasesweeps.go
+++ b/backend/internal/compose/jobs_databasesweeps.go
@@ -28,8 +28,11 @@ import (
 //     approval expiry, intro expiry, approval auto-apply. One row does the whole
 //     installation, so there is no child kind to enqueue.
 //
-// It also pulls in the AI-activity and brief-generate groups, which are their
-// own functions because they are longer, not because they are gated differently.
+// It also pulls in the AI-activity and brief-generate groups. Those are their
+// own functions because their WORKERS need collaborators the rest of this group
+// does not — a projection store, and the brief engine plus the identity service
+// — not because they are gated differently: the gating is the same nothing, and
+// that is why they belong here rather than behind a condition of their own.
 func addDatabaseOnlySweepJobs(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Logger) {
 	addDeclaredWorker[CloseDateSweepArgs](reg, &closeDateSweepWorker{pool: pool})
 	addDeclaredWorker[CloseDateWorkspaceArgs](reg, &closeDateWorkspaceWorker{corrector: NewCloseDateCorrector(pool, log)})

--- a/backend/internal/compose/jobschedule.go
+++ b/backend/internal/compose/jobschedule.go
@@ -124,13 +124,19 @@ func operatorInterval(cfg JobRunnerConfig, kind, path string) time.Duration {
 // other direction — a declared path with no entry — is a fitness test.
 func configDependencies(cfg JobRunnerConfig) map[string]bool {
 	return map[string]bool{
-		"AgentScheduler.Service":     cfg.AgentScheduler.Service != nil,
-		"ChannelVault":               cfg.ChannelVault != nil,
-		"ClassifyBrain":              cfg.ClassifyBrain != nil,
-		"DeepReadBrain":              cfg.DeepReadBrain != nil,
-		"Embedder":                   cfg.Embedder != nil,
-		"EnrichBrain":                cfg.EnrichBrain != nil,
-		"GmailRegistry":              cfg.GmailRegistry != nil,
+		"AgentScheduler.Service": cfg.AgentScheduler.Service != nil,
+		"ChannelVault":           cfg.ChannelVault != nil,
+		"ClassifyBrain":          cfg.ClassifyBrain != nil,
+		"DeepReadBrain":          cfg.DeepReadBrain != nil,
+		"Embedder":               cfg.Embedder != nil,
+		"EnrichBrain":            cfg.EnrichBrain != nil,
+		"GmailRegistry":          cfg.GmailRegistry != nil,
+		// The registry OFFERING graph, not merely existing. The Gmail registry
+		// is the same object for both vendors, so "a registry is present" is
+		// true on a worker that has Gmail credentials and no Microsoft ones —
+		// and scheduling under that while the workers gate on the connector
+		// leaves rows nothing can claim.
+		"GmailRegistry.OffersGraph":  cfg.GmailRegistry != nil && registryOffers(cfg.GmailRegistry, providerGraph),
 		"GmailWatch.Topic":           cfg.GmailWatch.Topic != "",
 		"GraphWatch.NotificationURL": cfg.GraphWatch.NotificationURL != "",
 		"OverlayVault":               cfg.OverlayVault != nil,

--- a/backend/internal/modules/capture/graph/subscription.go
+++ b/backend/internal/modules/capture/graph/subscription.go
@@ -246,18 +246,44 @@ func (a *httpAPI) findSubscription(ctx context.Context, accessToken, notificatio
 	return "", errSubscriptionListUnbounded
 }
 
+// isSubscriptionID reports whether id can be spliced into a URL path as ONE
+// segment naming a subscription.
+//
+// The test is that the id is ALREADY its own escaping, plus the two dot
+// segments that survive escaping untouched. Anything needing an escape — a
+// separator, a query or fragment marker, a space, a stray percent — is not an
+// identifier Microsoft minted, and `.` and `..` are path instructions wearing an
+// id's clothes.
+//
+// Stated as what an id IS rather than as a list of traversal spellings: a
+// blacklist is a list somebody has to keep complete, against an input whose
+// whole point is that it was chosen by the far end.
+func isSubscriptionID(id string) bool {
+	return id != "" && id != "." && id != ".." && url.PathEscape(id) == id
+}
+
 // errSubscriptionListUnbounded is a subscription listing that would not end.
 var errSubscriptionListUnbounded = fmt.Errorf(
 	"graph: the subscription listing did not end within %d pages: %w", maxSubscriptionPages, ErrUnreachable,
 )
 
 func (a *httpAPI) renewSubscription(ctx context.Context, accessToken, id string, deadline time.Time) (Subscription, error) {
+	// REFUSED, not merely escaped. The id arrives as a decoded field of a
+	// provider response, and one carrying a path segment would aim this
+	// authenticated PATCH — the user's own delegated token on it — at another
+	// resource. url.PathEscape alone does not settle that: it escapes the
+	// separators and leaves `..` intact, so a server that decodes %2F before
+	// resolving the path still walks out of the collection. Rejecting the id
+	// does not depend on how the far end normalizes.
+	if !isSubscriptionID(id) {
+		// GONE, not unreachable: the subscription this names cannot be
+		// addressed, so from the round's seat there is nothing to renew — and
+		// the round answers that by creating one, which is the safe direction.
+		// Failing instead would leave the mailbox on the poll for as long as
+		// the provider kept answering with an id like this.
+		return Subscription{}, errSubscriptionGone
+	}
 	var out subscription
-	// Escaped even though Microsoft mints it: it arrives as a decoded field of a
-	// provider response, and an id carrying a path segment or a query would aim
-	// this authenticated PATCH — the user's own delegated token on it — at a
-	// different resource. Only identifiers are ever formatted into a URL here,
-	// and never unescaped.
 	status, err := a.writeJSON(ctx, http.MethodPatch,
 		a.base+subscriptionsPath+"/"+url.PathEscape(id), accessToken,
 		subscriptionRequest{Expiration: deadline}, &out)

--- a/backend/internal/modules/capture/graph/subscription_test.go
+++ b/backend/internal/modules/capture/graph/subscription_test.go
@@ -126,7 +126,22 @@ func TestARoundRenewsTheSubscriptionItAlreadyHasRatherThanAddingOne(t *testing.T
 }
 
 // A URL that is not ours is somebody else's subscription, including one left by
-// a rotated operator token: it is replaced, not extended.
+// a rotated operator token: a new one is created beside it rather than the old
+// one being re-pointed.
+//
+// The old one is NOT deleted — nothing here can prove it is ours to delete —
+// so a rotation does leave a duplicate delivering to an endpoint that now
+// refuses it. That is bounded and self-healing: exactly one, because the next
+// round matches the new URL exactly, and Microsoft drops a subscription whose
+// endpoint keeps failing.
+//
+// The alternative is matching on the resource and re-pointing whatever watches
+// `/me/messages`. It is rejected deliberately. Graph lists subscriptions per
+// APP, so two deployments sharing one Entra registration — a staging and a
+// production, the ordinary case — see each other's, and re-pointing would take
+// the other's notifications and give back nothing. The token in the URL is what
+// tells those two apart, which is the whole reason it is there. A bounded
+// duplicate beats an unbounded hijack.
 func TestASubscriptionForADifferentURLIsNotAdopted(t *testing.T) {
 	var created, renewed int
 	srv := subscriptionStub(t, subscriptionStubState{

--- a/backend/internal/modules/capture/graph/subscription_test.go
+++ b/backend/internal/modules/capture/graph/subscription_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -295,8 +294,12 @@ func TestARenewalCannotBeAimedByAProviderSuppliedID(t *testing.T) {
 			NotificationURL: "https://api.example/webhooks/graph?token=t",
 		}}})
 	})
+	// The RAW path, as it went over the wire. r.URL.Path is the decoded view,
+	// which is the wrong thing to assert on twice over: it would read
+	// `/subscriptions/../../me/messages` as though the escaping had failed, and
+	// it hides that the bytes sent never left the collection.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		patched = r.URL.Path
+		patched = r.URL.EscapedPath()
 		writeJSON(w, map[string]any{
 			"id": "sub-1", "expirationDateTime": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
 		})
@@ -304,12 +307,37 @@ func TestARenewalCannotBeAimedByAProviderSuppliedID(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
+	// The round SUCCEEDS: refusing the id is not refusing the mailbox. It falls
+	// through to creating a subscription, which is the safe direction — a
+	// duplicate notification costs one redundant sync, where declining to renew
+	// costs the mailbox its push.
 	if _, err := NewAPI(srv.Client(), srv.URL).EnsureSubscription(context.Background(), "at",
 		"https://api.example/webhooks/graph?token=t", owner, time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("EnsureSubscription: %v", err)
 	}
-	if !strings.HasPrefix(patched, subscriptionsPath+"/") {
-		t.Errorf("the renewal reached %q — a provider-supplied id steered it out of the subscription collection", patched)
+	// Nothing was PATCHed at all: the id is refused before a request is built,
+	// so this does not rest on how the far end normalizes what it received.
+	if patched != "" {
+		t.Errorf("a renewal was sent to %q for a provider-supplied id that is not a subscription id", patched)
+	}
+}
+
+// The refusal itself, at the seam, so the case above cannot pass by accident of
+// routing. Every spelling here is one a server that decodes before resolving
+// would walk out of the subscription collection on, whatever url.PathEscape did
+// to the separators.
+func TestOnlyASubscriptionIDCanAddressARenewal(t *testing.T) {
+	for _, id := range []string{
+		"", "../../me/messages", "..", "a/b", `a\b`, "sub 1", "sub?x=1", "sub#f", "%2e%2e",
+	} {
+		if isSubscriptionID(id) {
+			t.Errorf("%q was accepted as a subscription id", id)
+		}
+	}
+	// And a real one still is, or the refusal above would be refusing every
+	// renewal this client ever makes.
+	if !isSubscriptionID("0fc1b2a3-3d4e-5f60-8a1b-2c3d4e5f6071") {
+		t.Error("a GUID Microsoft would mint was refused as a subscription id")
 	}
 }
 

--- a/backend/internal/modules/capture/graph/transport.go
+++ b/backend/internal/modules/capture/graph/transport.go
@@ -134,7 +134,14 @@ func (a *httpAPI) get(ctx context.Context, accessToken, fullURL string, hdr http
 }
 
 // writeJSON performs a JSON-bodied request (POST or PATCH) and decodes the
-// response into out, which may be nil for a call that answers with nothing.
+// response into out.
+//
+// out is never nil: both writes this client makes read the subscription back,
+// and a nil-output fast path would have to decide what an unread body means.
+// Skipping the read error there reports an oversized or failed response as a
+// success; honouring it reports a write the server ACCEPTED as failed, and the
+// caller creates a second subscription on the retry. Neither is right, so the
+// branch does not exist.
 //
 // Beside get rather than inside each caller: the Authorization header, the
 // bounded read, the status classification and the "a truncated prefix is not a
@@ -166,9 +173,6 @@ func (a *httpAPI) writeJSON(ctx context.Context, method, fullURL, accessToken st
 	body, readErr := readBounded(resp)
 	if err := classifyStatus(resp, a.requestOp(fullURL), body); err != nil {
 		return resp.StatusCode, err
-	}
-	if out == nil {
-		return resp.StatusCode, nil
 	}
 	if readErr != nil {
 		return resp.StatusCode, fmt.Errorf("graph: reading response: %w", ErrUnreachable)

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "b3ca6c28bcfe1f1769cbf17311159a17711b6899f40d4fb10e7a0ec4df9ea854"
+const JobContractHash = "cc0508aa4201841e43826e2e824e02354b75b567add7d526a6757bf30d1f5d01"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -529,7 +529,7 @@ var specs = map[string]Spec{
 		FanOutTo:     "graph_watch_renew_connection",
 		OptsOwner:    OptsCaller,
 		Cadence:      Cadence{OperatorField: "GraphWatch.Interval", ScheduleWhenPositive: "GraphWatch.Interval"},
-		Registration: Registration{When: []string{"GmailRegistry", "GraphWatch.NotificationURL"}},
+		Registration: Registration{When: []string{"GmailRegistry.OffersGraph", "GraphWatch.NotificationURL"}},
 	},
 	"graph_watch_renew_connection": {
 		Kind:         "graph_watch_renew_connection",
@@ -539,7 +539,7 @@ var specs = map[string]Spec{
 		Timeout:      TimeoutPolicy{Fixed: 2 * time.Minute},
 		MaxAttempts:  3,
 		OptsOwner:    OptsFanOut,
-		Registration: Registration{When: []string{"GmailRegistry", "GraphWatch.NotificationURL"}},
+		Registration: Registration{When: []string{"GmailRegistry.OffersGraph", "GraphWatch.NotificationURL"}},
 		Args:         []ArgField{{Name: "ConnectionID"}, {Name: "Workspace"}},
 	},
 	"idempotency_retention": {


### PR DESCRIPTION
Review findings on https://github.com/margince/margince/pull/3469 that arrived after its checks went green and it auto-merged. The work is unchanged from what was answered there; this is the same diff on `main`.

## The one that is a live bug

The periodic schedule and the workers gated on different conditions. `periodicFor` reads `api/jobs.yaml`'s `registration.when`, which named `GmailRegistry` and `GraphWatch.NotificationURL`; `GraphWatchWillRun` gated on those AND the registry actually offering a graph connector.

A worker role holding Gmail credentials and no Microsoft ones satisfies the first pair and not the second. The rows are inserted, no worker claims them, and nothing fails — the lane reads as idle rather than broken, which is the shape of defect that survives longest.

The connector condition is now a declared dependency (`GmailRegistry.OffersGraph`), and `GraphWatchWillRun` asks the declaration through the same `registers` the scheduler uses, so the two cannot diverge again.

## A provider-supplied id is refused, not escaped

`url.PathEscape` escapes the separators and leaves `..` intact. The mutation run prints what actually went over the wire:

```
a renewal was sent to "/subscriptions/..%2F..%2Fme%2Fmessages"
```

A server that decodes `%2F` before resolving the path walks straight out of the subscription collection, carrying the user's own delegated token. `isSubscriptionID` now requires the id to be its own escaping and not a dot segment, and an id that fails reads as `errSubscriptionGone` — so the round creates a subscription instead of failing, which is the direction that keeps the mailbox on push.

The old test asserted `r.URL.Path`, the DECODED view, which cannot see any of this.

## A wide delivery reaches every mailbox it names

An enqueue fault returned before the rest of the batch was scheduled. One delivery names many mailboxes across many workspaces and the redelivery arrives with the same set, so a mailbox landing behind a consistently failing one would never be reached. Every hit is attempted, faults are joined, and the handler still answers `Transient`.

## `writeJSON`'s nil-output branch is gone

It had no caller and could not have had a right answer: skipping the read error reports an oversized response as success; honouring it reports a write the server ACCEPTED as failed, and the retry creates a second subscription. The doc says why it is not coming back.

## Comments that had drifted

The database-only sweep group registers installation-wide kinds and two sub-groups as well as dispatcher pairs. The renewal-threshold exclusion covers both vendors' flags. `censusJobConfig`'s doc had been separated from it by a helper. And the subscription comment claimed a rotated token's subscription is "replaced" — it is not, a new one is created beside it and the old is left to lapse.

That last one is a decision, so it is now written down as one: matching on the resource instead is rejected because Graph lists subscriptions per APP, so two deployments sharing one Entra registration would take each other's notifications. A bounded, self-healing duplicate beats an unbounded hijack.

## Coverage

The banner's silent case — no Entra app and no URL, which is every installation that never opted into Outlook — was the one branch no case reached.

## Verification

`make check-backend` green. The traversal refusal is mutation-checked: relaxing `isSubscriptionID` to `id != ""` fails the test with the escaped path above.