### PR TITLE
A Graph subscription is renewed by the id it was given

### DIFF
--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -153,6 +153,12 @@ type API interface {
 	// asks "extend THIS one", which is one call. A renewal that knows the id
 	// should not have to pay for the question it already has the answer to.
 	RenewSubscription(ctx context.Context, accessToken, id string, deadline time.Time) (Subscription, error)
+	// GetSubscription reads one subscription by id, so a renewal holding a
+	// handle can confirm it still points where the round means to deliver
+	// before extending it — asked of Microsoft rather than remembered, for the
+	// reason RenewWatch gives. ErrSubscriptionGone when Microsoft no longer
+	// knows it, same as a renewal.
+	GetSubscription(ctx context.Context, accessToken, id string) (Subscription, error)
 	// GetMIME fetches one message as its RFC822 bytes (the /$value stream).
 	GetMIME(ctx context.Context, accessToken, msgID string) (rfc822 []byte, err error)
 	// EstimateAfter returns the provider-side count of messages received on

--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -143,6 +143,16 @@ type API interface {
 	// the three would make every test double re-decide the renew-then-create
 	// order the real one exists to hold.
 	EnsureSubscription(ctx context.Context, accessToken, notificationURL, clientState string, deadline time.Time) (Subscription, error)
+	// RenewSubscription extends the subscription named by id and answers its
+	// new deadline. ErrSubscriptionGone when Microsoft no longer knows it,
+	// which is the caller's cue to fall back to EnsureSubscription.
+	//
+	// A SECOND seam beside EnsureSubscription rather than a flag on it, because
+	// the two answer different questions: Ensure asks "is there a subscription
+	// for this mailbox", which without a handle costs a paged listing, and this
+	// asks "extend THIS one", which is one call. A renewal that knows the id
+	// should not have to pay for the question it already has the answer to.
+	RenewSubscription(ctx context.Context, accessToken, id string, deadline time.Time) (Subscription, error)
 	// GetMIME fetches one message as its RFC822 bytes (the /$value stream).
 	GetMIME(ctx context.Context, accessToken, msgID string) (rfc822 []byte, err error)
 	// EstimateAfter returns the provider-side count of messages received on

--- a/backend/internal/modules/capture/graph/graph_test.go
+++ b/backend/internal/modules/capture/graph/graph_test.go
@@ -81,6 +81,10 @@ type fakeAPI struct {
 	// The subscription half's state: what a round was asked for, and what
 	// Microsoft answered.
 	subCalls    int
+	renewCalls  int
+	renewID     string
+	renewResult Subscription
+	renewErr    error
 	subURL      string
 	subState    string
 	subDeadline time.Time
@@ -152,6 +156,23 @@ func (f *fakeAPI) EnsureSubscription(
 		return Subscription{ID: "sub-1", Expiration: deadline}, nil
 	}
 	return f.subResult, nil
+}
+
+// RenewSubscription is the by-handle seam. It records the id it was given,
+// because "did the renewal address the subscription it stored, or go looking
+// for one" is the whole question this pair exists to answer.
+func (f *fakeAPI) RenewSubscription(
+	_ context.Context, _, id string, deadline time.Time,
+) (Subscription, error) {
+	f.renewCalls++
+	f.renewID = id
+	if f.renewErr != nil {
+		return Subscription{}, f.renewErr
+	}
+	if f.renewResult.Expiration.IsZero() && f.renewResult.ID == "" {
+		return Subscription{ID: id, Expiration: deadline}, nil
+	}
+	return f.renewResult, nil
 }
 
 func (f *fakeAPI) Delta(_ context.Context, _, deltaLink string) ([]string, string, error) {

--- a/backend/internal/modules/capture/graph/graph_test.go
+++ b/backend/internal/modules/capture/graph/graph_test.go
@@ -85,6 +85,13 @@ type fakeAPI struct {
 	renewID     string
 	renewResult Subscription
 	renewErr    error
+	// The read a renewal makes before extending. getSubURL left empty means the
+	// subscription points wherever the round is asking about, which is the
+	// "nothing has moved" case.
+	getSubCalls int
+	getSubID    string
+	getSubURL   string
+	getSubErr   error
 	subURL      string
 	subState    string
 	subDeadline time.Time
@@ -173,6 +180,27 @@ func (f *fakeAPI) RenewSubscription(
 		return Subscription{ID: id, Expiration: deadline}, nil
 	}
 	return f.renewResult, nil
+}
+
+// GetSubscription answers the read a renewal makes before extending. With no
+// getURL set it reports the endpoint the caller is asking about, which is the
+// "nothing has moved" case every renewal test but one is about.
+func (f *fakeAPI) GetSubscription(_ context.Context, _, id string) (Subscription, error) {
+	f.getSubCalls++
+	f.getSubID = id
+	// The real client refuses an id it cannot address and reports it as gone;
+	// a fake that answered anyway would let a caller skip that refusal.
+	if !isSubscriptionID(id) {
+		return Subscription{}, ErrSubscriptionGone
+	}
+	if f.getSubErr != nil {
+		return Subscription{}, f.getSubErr
+	}
+	url := f.getSubURL
+	if url == "" {
+		url = testNotifyURL
+	}
+	return Subscription{ID: id, NotificationURL: url}, nil
 }
 
 func (f *fakeAPI) Delta(_ context.Context, _, deltaLink string) ([]string, string, error) {

--- a/backend/internal/modules/capture/graph/subscription.go
+++ b/backend/internal/modules/capture/graph/subscription.go
@@ -166,7 +166,51 @@ func (c *Connector) Watch(ctx context.Context, auth connector.Auth, notification
 	if sub.Expiration.After(deadline) {
 		sub.Expiration = deadline
 	}
-	return connector.WatchResult{ExpiresAt: sub.Expiration}, nil
+	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: sub.ID}, nil
+}
+
+// RenewWatch extends the subscription named by ref (connector.WatchRenewer).
+//
+// The whole of what this saves is the LISTING. Watch has to make sure a
+// subscription exists, and without a handle that means walking GET
+// /subscriptions — paged, once per mailbox, every renewal cycle — to find the
+// one this installation made. A renewal that already knows the id asks
+// Microsoft to extend it and is done in one call.
+//
+// A ref Microsoft no longer knows falls through to Watch, which is where the
+// listing belongs: a subscription dropped for repeated delivery failures, or one
+// made by an installation that has since been restored from a backup, is exactly
+// the case a recovery path is for.
+func (c *Connector) RenewWatch(
+	ctx context.Context, auth connector.Auth, notificationURL, ref string,
+) (connector.WatchResult, error) {
+	st, err := graphconn.Read(connectorName, auth)
+	if err != nil {
+		return connector.WatchResult{}, err
+	}
+	access, err := c.oauth.AccessToken(ctx, st.RefreshToken)
+	if err != nil {
+		return connector.WatchResult{}, err
+	}
+	deadline := c.now().Add(maxSubscriptionMinutes * time.Minute).UTC()
+	sub, err := c.api.RenewSubscription(ctx, access, ref, deadline)
+	if errors.Is(err, ErrSubscriptionGone) {
+		return c.Watch(ctx, auth, notificationURL)
+	}
+	if err != nil {
+		return connector.WatchResult{}, err
+	}
+	if sub.Expiration.IsZero() {
+		return connector.WatchResult{}, errNoSubscriptionDeadline
+	}
+	// The same ceiling Watch applies, and for the same reason: a deadline
+	// further out than Microsoft can grant is a connection the renewal scan
+	// never picks up again, while the real subscription lapses within three days
+	// and the mailbox falls back to the poll with nothing failing to say so.
+	if sub.Expiration.After(deadline) {
+		sub.Expiration = deadline
+	}
+	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: sub.ID}, nil
 }
 
 // EnsureSubscription renews the subscription already pointing at
@@ -184,24 +228,29 @@ func (a *httpAPI) EnsureSubscription(
 		return Subscription{}, err
 	}
 	if existing != "" {
-		renewed, err := a.renewSubscription(ctx, accessToken, existing, deadline)
+		renewed, err := a.RenewSubscription(ctx, accessToken, existing, deadline)
 		if err == nil {
 			return renewed, nil
 		}
 		// Gone since the list named it — Microsoft drops a subscription whose
 		// endpoint failed too often, and the recovery is a new one rather than a
 		// failed round. Any other fault stops here.
-		if !errors.Is(err, errSubscriptionGone) {
+		if !errors.Is(err, ErrSubscriptionGone) {
 			return Subscription{}, err
 		}
 	}
 	return a.createSubscription(ctx, accessToken, notificationURL, clientState, deadline)
 }
 
-// errSubscriptionGone is a renewal Microsoft refused because the subscription is
-// no longer there. Internal to this file: the caller's answer is to create one,
-// never to report it.
-var errSubscriptionGone = errors.New("graph: the subscription no longer exists")
+// ErrSubscriptionGone is a renewal Microsoft refused because the subscription is
+// no longer there.
+//
+// EXPORTED, because the answer to it now lives at two levels: EnsureSubscription
+// creates one and never reports it, and RenewWatch — which is handed a stored
+// handle by the registry — falls back to the listing Ensure does. A caller that
+// cannot tell "gone" from "unreachable" would leave the mailbox on the poll for
+// as long as the stored id kept failing.
+var ErrSubscriptionGone = errors.New("graph: the subscription no longer exists")
 
 // findSubscription returns the id of this app's subscription for this user
 // pointing at notificationURL, or empty.
@@ -267,7 +316,7 @@ var errSubscriptionListUnbounded = fmt.Errorf(
 	"graph: the subscription listing did not end within %d pages: %w", maxSubscriptionPages, ErrUnreachable,
 )
 
-func (a *httpAPI) renewSubscription(ctx context.Context, accessToken, id string, deadline time.Time) (Subscription, error) {
+func (a *httpAPI) RenewSubscription(ctx context.Context, accessToken, id string, deadline time.Time) (Subscription, error) {
 	// REFUSED, not merely escaped. The id arrives as a decoded field of a
 	// provider response, and one carrying a path segment would aim this
 	// authenticated PATCH — the user's own delegated token on it — at another
@@ -281,7 +330,7 @@ func (a *httpAPI) renewSubscription(ctx context.Context, accessToken, id string,
 		// the round answers that by creating one, which is the safe direction.
 		// Failing instead would leave the mailbox on the poll for as long as
 		// the provider kept answering with an id like this.
-		return Subscription{}, errSubscriptionGone
+		return Subscription{}, ErrSubscriptionGone
 	}
 	var out subscription
 	status, err := a.writeJSON(ctx, http.MethodPatch,
@@ -289,7 +338,7 @@ func (a *httpAPI) renewSubscription(ctx context.Context, accessToken, id string,
 		subscriptionRequest{Expiration: deadline}, &out)
 	if err != nil {
 		if status == http.StatusNotFound {
-			return Subscription{}, errSubscriptionGone
+			return Subscription{}, ErrSubscriptionGone
 		}
 		return Subscription{}, err
 	}

--- a/backend/internal/modules/capture/graph/subscription.go
+++ b/backend/internal/modules/capture/graph/subscription.go
@@ -32,6 +32,8 @@ package graph
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -170,8 +172,8 @@ func (c *Connector) Watch(ctx context.Context, auth connector.Auth, notification
 	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: encodeWatchRef(sub.ID, notificationURL)}, nil
 }
 
-// watchRef is what a renewal has to know: WHICH subscription, and the endpoint
-// it was registered to deliver to.
+// watchRef is what a renewal has to know: WHICH subscription, and whether the
+// endpoint it was registered to deliver to is still the one being asked about.
 //
 // The endpoint travels with the id because a renewal only ever extends a
 // deadline — it never re-states where the subscription points. EnsureSubscription
@@ -179,16 +181,33 @@ func (c *Connector) Watch(ctx context.Context, auth connector.Auth, notification
 // moved got a fresh subscription on the new endpoint for free. A renewal by id
 // has no such tell, and extending the old one would keep notifications flowing
 // to an endpoint nobody is serving while the new webhook stays poll-only.
+//
+// It travels as a FINGERPRINT rather than as the URL. Microsoft signs nothing on
+// a change notification, so the operator token in that URL is the only thing
+// admitting one — a credential, and this handle is stored in an ordinary column
+// that reaches every database reader and every backup. A digest answers the only
+// question a renewal asks of it, which is whether two endpoints are the same
+// one, and answers nothing else.
 type watchRef struct {
-	ID  string `json:"id"`
-	URL string `json:"url"`
+	ID string `json:"id"`
+	// Endpoint is the hex SHA-256 of the notification URL.
+	Endpoint string `json:"endpoint"`
+}
+
+// endpointFingerprint digests a notification URL. SHA-256 rather than a keyed
+// digest: there is no secret here to key it with that is not the URL itself, and
+// what this defends against is the URL sitting in a column at rest, not somebody
+// who can already run this code guessing at candidates.
+func endpointFingerprint(notificationURL string) string {
+	sum := sha256.Sum256([]byte(notificationURL))
+	return hex.EncodeToString(sum[:])
 }
 
 func encodeWatchRef(id, notificationURL string) string {
 	// Marshalling two strings cannot fail, and a handle is not worth failing a
 	// registration over in any case: an empty ref costs the next renewal a
 	// listing, which is what every renewal did before this existed.
-	b, err := json.Marshal(watchRef{ID: id, URL: notificationURL})
+	b, err := json.Marshal(watchRef{ID: id, Endpoint: endpointFingerprint(notificationURL)})
 	if err != nil {
 		return ""
 	}
@@ -197,8 +216,10 @@ func encodeWatchRef(id, notificationURL string) string {
 
 // decodeWatchRef reads a stored handle back. It reports whether the handle can
 // be used to renew AT notificationURL — false for anything unreadable, for a
-// handle with no id, and for one made against a different endpoint. Every false
-// means the same thing to the caller: go the long way round.
+// handle with no id, and for one whose endpoint is not this one. Every false
+// means the same thing to the caller: go the long way round. A handle in any
+// older shape (one carrying a URL, say) therefore costs one listing and heals
+// itself, rather than needing to be found and cleared.
 func decodeWatchRef(stored, notificationURL string) (string, bool) {
 	// One condition rather than a branch per reason: a handle is either usable
 	// here or it is not, and the caller does the same thing either way. The two
@@ -208,7 +229,7 @@ func decodeWatchRef(stored, notificationURL string) (string, bool) {
 	// purpose rather than by omission.
 	var ref watchRef
 	err := json.Unmarshal([]byte(stored), &ref)
-	if err != nil || ref.ID == "" || ref.URL != notificationURL {
+	if err != nil || ref.ID == "" || ref.Endpoint != endpointFingerprint(notificationURL) {
 		return "", false
 	}
 	return ref.ID, true
@@ -229,14 +250,9 @@ func decodeWatchRef(stored, notificationURL string) (string, bool) {
 func (c *Connector) RenewWatch(
 	ctx context.Context, auth connector.Auth, notificationURL, ref string,
 ) (connector.WatchResult, error) {
-	st, err := graphconn.Read(connectorName, auth)
-	if err != nil {
-		return connector.WatchResult{}, err
-	}
-	access, err := c.oauth.AccessToken(ctx, st.RefreshToken)
-	if err != nil {
-		return connector.WatchResult{}, err
-	}
+	// BEFORE the token: Watch refreshes one of its own, so deciding here first
+	// is the difference between one refresh and two on every fallback — and the
+	// fallback is the ordinary path for a first registration.
 	id, renewable := decodeWatchRef(ref, notificationURL)
 	if !renewable {
 		// A handle that does not name a subscription registered at THIS endpoint
@@ -244,6 +260,14 @@ func (c *Connector) RenewWatch(
 		// up what actually points at the endpoint, and registers when nothing
 		// does.
 		return c.Watch(ctx, auth, notificationURL)
+	}
+	st, err := graphconn.Read(connectorName, auth)
+	if err != nil {
+		return connector.WatchResult{}, err
+	}
+	access, err := c.oauth.AccessToken(ctx, st.RefreshToken)
+	if err != nil {
+		return connector.WatchResult{}, err
 	}
 	deadline := c.now().Add(maxSubscriptionMinutes * time.Minute).UTC()
 	sub, err := c.api.RenewSubscription(ctx, access, id, deadline)

--- a/backend/internal/modules/capture/graph/subscription.go
+++ b/backend/internal/modules/capture/graph/subscription.go
@@ -32,9 +32,6 @@ package graph
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -92,6 +89,9 @@ var errNoSubscriptionOwner = fmt.Errorf(
 type Subscription struct {
 	ID         string
 	Expiration time.Time
+	// NotificationURL is where Microsoft says it delivers this subscription's
+	// notifications — the field a renewal checks before extending one.
+	NotificationURL string
 }
 
 // subscription is Microsoft's wire shape for one, in the fields this connector
@@ -169,70 +169,7 @@ func (c *Connector) Watch(ctx context.Context, auth connector.Auth, notification
 	if sub.Expiration.After(deadline) {
 		sub.Expiration = deadline
 	}
-	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: encodeWatchRef(sub.ID, notificationURL)}, nil
-}
-
-// watchRef is what a renewal has to know: WHICH subscription, and whether the
-// endpoint it was registered to deliver to is still the one being asked about.
-//
-// The endpoint travels with the id because a renewal only ever extends a
-// deadline — it never re-states where the subscription points. EnsureSubscription
-// looked its subscription up BY notificationURL, so a deployment whose URL had
-// moved got a fresh subscription on the new endpoint for free. A renewal by id
-// has no such tell, and extending the old one would keep notifications flowing
-// to an endpoint nobody is serving while the new webhook stays poll-only.
-//
-// It travels as a FINGERPRINT rather than as the URL. Microsoft signs nothing on
-// a change notification, so the operator token in that URL is the only thing
-// admitting one — a credential, and this handle is stored in an ordinary column
-// that reaches every database reader and every backup. A digest answers the only
-// question a renewal asks of it, which is whether two endpoints are the same
-// one, and answers nothing else.
-type watchRef struct {
-	ID string `json:"id"`
-	// Endpoint is the hex SHA-256 of the notification URL.
-	Endpoint string `json:"endpoint"`
-}
-
-// endpointFingerprint digests a notification URL. SHA-256 rather than a keyed
-// digest: there is no secret here to key it with that is not the URL itself, and
-// what this defends against is the URL sitting in a column at rest, not somebody
-// who can already run this code guessing at candidates.
-func endpointFingerprint(notificationURL string) string {
-	sum := sha256.Sum256([]byte(notificationURL))
-	return hex.EncodeToString(sum[:])
-}
-
-func encodeWatchRef(id, notificationURL string) string {
-	// Marshalling two strings cannot fail, and a handle is not worth failing a
-	// registration over in any case: an empty ref costs the next renewal a
-	// listing, which is what every renewal did before this existed.
-	b, err := json.Marshal(watchRef{ID: id, Endpoint: endpointFingerprint(notificationURL)})
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
-// decodeWatchRef reads a stored handle back. It reports whether the handle can
-// be used to renew AT notificationURL — false for anything unreadable, for a
-// handle with no id, and for one whose endpoint is not this one. Every false
-// means the same thing to the caller: go the long way round. A handle in any
-// older shape (one carrying a URL, say) therefore costs one listing and heals
-// itself, rather than needing to be found and cleared.
-func decodeWatchRef(stored, notificationURL string) (string, bool) {
-	// One condition rather than a branch per reason: a handle is either usable
-	// here or it is not, and the caller does the same thing either way. The two
-	// field tests would in fact carry this on their own — encoding/json rejects
-	// malformed input before it writes anything, so an unreadable handle reaches
-	// these lines as the zero value — but reading the error is what says so on
-	// purpose rather than by omission.
-	var ref watchRef
-	err := json.Unmarshal([]byte(stored), &ref)
-	if err != nil || ref.ID == "" || ref.Endpoint != endpointFingerprint(notificationURL) {
-		return "", false
-	}
-	return ref.ID, true
+	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: sub.ID}, nil
 }
 
 // RenewWatch extends the subscription named by ref (connector.WatchRenewer).
@@ -243,22 +180,18 @@ func decodeWatchRef(stored, notificationURL string) (string, bool) {
 // one this installation made. A renewal that already knows the id asks
 // Microsoft to extend it and is done in one call.
 //
-// A ref Microsoft no longer knows falls through to Watch, which is where the
-// listing belongs: a subscription dropped for repeated delivery failures, or one
+// A ref Microsoft no longer knows — or one naming a subscription that points
+// somewhere else — falls through to Watch, which is where the listing belongs: a subscription dropped for repeated delivery failures, or one
 // made by an installation that has since been restored from a backup, is exactly
 // the case a recovery path is for.
 func (c *Connector) RenewWatch(
 	ctx context.Context, auth connector.Auth, notificationURL, ref string,
 ) (connector.WatchResult, error) {
-	// BEFORE the token: Watch refreshes one of its own, so deciding here first
-	// is the difference between one refresh and two on every fallback — and the
-	// fallback is the ordinary path for a first registration.
-	id, renewable := decodeWatchRef(ref, notificationURL)
-	if !renewable {
-		// A handle that does not name a subscription registered at THIS endpoint
-		// answers no question a renewal is asking. Watch settles it by looking
-		// up what actually points at the endpoint, and registers when nothing
-		// does.
+	// A ref that cannot name a subscription is settled without spending a token
+	// on it: Watch refreshes one of its own, and this is the ordinary path
+	// rather than a rare one — a first registration and every connection made
+	// before handles existed both arrive here.
+	if !isSubscriptionID(ref) {
 		return c.Watch(ctx, auth, notificationURL)
 	}
 	st, err := graphconn.Read(connectorName, auth)
@@ -269,8 +202,31 @@ func (c *Connector) RenewWatch(
 	if err != nil {
 		return connector.WatchResult{}, err
 	}
+	// READ IT BEFORE EXTENDING IT. A renewal only ever moves a deadline; it
+	// never re-states where the subscription points. EnsureSubscription looked
+	// its subscription up BY notificationURL, so a deployment whose webhook URL
+	// had moved got a fresh subscription on the new endpoint without anyone
+	// arranging it, and renewing by id alone would lose that — Microsoft would
+	// keep delivering to an endpoint nobody serves while the new webhook stayed
+	// poll-only.
+	//
+	// Asked of Microsoft rather than remembered beside the handle: that URL
+	// carries the operator token that admits a notification, and the handle is
+	// stored in an ordinary column that reaches every database reader and every
+	// backup. This way nothing about the endpoint is written down at all, and
+	// the answer is the provider's own rather than a copy that can go stale.
+	existing, err := c.api.GetSubscription(ctx, access, ref)
+	if errors.Is(err, ErrSubscriptionGone) || (err == nil && existing.NotificationURL != notificationURL) {
+		// Either way there is no subscription at this endpoint to extend, and
+		// Watch settles it: it looks up what actually points there and registers
+		// when nothing does. That listing is where a recovery path belongs.
+		return c.Watch(ctx, auth, notificationURL)
+	}
+	if err != nil {
+		return connector.WatchResult{}, err
+	}
 	deadline := c.now().Add(maxSubscriptionMinutes * time.Minute).UTC()
-	sub, err := c.api.RenewSubscription(ctx, access, id, deadline)
+	sub, err := c.api.RenewSubscription(ctx, access, ref, deadline)
 	if errors.Is(err, ErrSubscriptionGone) {
 		return c.Watch(ctx, auth, notificationURL)
 	}
@@ -287,7 +243,7 @@ func (c *Connector) RenewWatch(
 	if sub.Expiration.After(deadline) {
 		sub.Expiration = deadline
 	}
-	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: encodeWatchRef(sub.ID, notificationURL)}, nil
+	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: sub.ID}, nil
 }
 
 // EnsureSubscription renews the subscription already pointing at
@@ -419,7 +375,27 @@ func (a *httpAPI) RenewSubscription(ctx context.Context, accessToken, id string,
 		}
 		return Subscription{}, err
 	}
-	return Subscription{ID: out.ID, Expiration: out.Expiration}, nil
+	return Subscription{ID: out.ID, Expiration: out.Expiration, NotificationURL: out.NotificationURL}, nil
+}
+
+// GetSubscription reads one subscription by id.
+func (a *httpAPI) GetSubscription(ctx context.Context, accessToken, id string) (Subscription, error) {
+	// The same refusal RenewSubscription makes, for the same reason: the id
+	// arrives as a decoded field of a provider response, and one carrying a path
+	// segment would aim this authenticated GET — the user's own delegated token
+	// on it — at another resource.
+	if !isSubscriptionID(id) {
+		return Subscription{}, ErrSubscriptionGone
+	}
+	var out subscription
+	status, err := a.get(ctx, accessToken, a.base+subscriptionsPath+"/"+url.PathEscape(id), nil, &out)
+	if err != nil {
+		if status == http.StatusNotFound {
+			return Subscription{}, ErrSubscriptionGone
+		}
+		return Subscription{}, err
+	}
+	return Subscription{ID: out.ID, Expiration: out.Expiration, NotificationURL: out.NotificationURL}, nil
 }
 
 func (a *httpAPI) createSubscription(

--- a/backend/internal/modules/capture/graph/subscription.go
+++ b/backend/internal/modules/capture/graph/subscription.go
@@ -32,6 +32,7 @@ package graph
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -166,7 +167,51 @@ func (c *Connector) Watch(ctx context.Context, auth connector.Auth, notification
 	if sub.Expiration.After(deadline) {
 		sub.Expiration = deadline
 	}
-	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: sub.ID}, nil
+	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: encodeWatchRef(sub.ID, notificationURL)}, nil
+}
+
+// watchRef is what a renewal has to know: WHICH subscription, and the endpoint
+// it was registered to deliver to.
+//
+// The endpoint travels with the id because a renewal only ever extends a
+// deadline — it never re-states where the subscription points. EnsureSubscription
+// looked its subscription up BY notificationURL, so a deployment whose URL had
+// moved got a fresh subscription on the new endpoint for free. A renewal by id
+// has no such tell, and extending the old one would keep notifications flowing
+// to an endpoint nobody is serving while the new webhook stays poll-only.
+type watchRef struct {
+	ID  string `json:"id"`
+	URL string `json:"url"`
+}
+
+func encodeWatchRef(id, notificationURL string) string {
+	// Marshalling two strings cannot fail, and a handle is not worth failing a
+	// registration over in any case: an empty ref costs the next renewal a
+	// listing, which is what every renewal did before this existed.
+	b, err := json.Marshal(watchRef{ID: id, URL: notificationURL})
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// decodeWatchRef reads a stored handle back. It reports whether the handle can
+// be used to renew AT notificationURL — false for anything unreadable, for a
+// handle with no id, and for one made against a different endpoint. Every false
+// means the same thing to the caller: go the long way round.
+func decodeWatchRef(stored, notificationURL string) (string, bool) {
+	// One condition rather than a branch per reason: a handle is either usable
+	// here or it is not, and the caller does the same thing either way. The two
+	// field tests would in fact carry this on their own — encoding/json rejects
+	// malformed input before it writes anything, so an unreadable handle reaches
+	// these lines as the zero value — but reading the error is what says so on
+	// purpose rather than by omission.
+	var ref watchRef
+	err := json.Unmarshal([]byte(stored), &ref)
+	if err != nil || ref.ID == "" || ref.URL != notificationURL {
+		return "", false
+	}
+	return ref.ID, true
 }
 
 // RenewWatch extends the subscription named by ref (connector.WatchRenewer).
@@ -192,8 +237,16 @@ func (c *Connector) RenewWatch(
 	if err != nil {
 		return connector.WatchResult{}, err
 	}
+	id, renewable := decodeWatchRef(ref, notificationURL)
+	if !renewable {
+		// A handle that does not name a subscription registered at THIS endpoint
+		// answers no question a renewal is asking. Watch settles it by looking
+		// up what actually points at the endpoint, and registers when nothing
+		// does.
+		return c.Watch(ctx, auth, notificationURL)
+	}
 	deadline := c.now().Add(maxSubscriptionMinutes * time.Minute).UTC()
-	sub, err := c.api.RenewSubscription(ctx, access, ref, deadline)
+	sub, err := c.api.RenewSubscription(ctx, access, id, deadline)
 	if errors.Is(err, ErrSubscriptionGone) {
 		return c.Watch(ctx, auth, notificationURL)
 	}
@@ -210,7 +263,7 @@ func (c *Connector) RenewWatch(
 	if sub.Expiration.After(deadline) {
 		sub.Expiration = deadline
 	}
-	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: sub.ID}, nil
+	return connector.WatchResult{ExpiresAt: sub.Expiration, Ref: encodeWatchRef(sub.ID, notificationURL)}, nil
 }
 
 // EnsureSubscription renews the subscription already pointing at

--- a/backend/internal/modules/capture/graph/subscription_test.go
+++ b/backend/internal/modules/capture/graph/subscription_test.go
@@ -570,3 +570,90 @@ func (o *countingOAuth) AccessToken(ctx context.Context, refresh string) (string
 	o.calls++
 	return o.OAuth.AccessToken(ctx, refresh)
 }
+
+// oneSubscriptionStub answers GET /subscriptions/{id} with the given status and
+// body, and records the raw path the request took.
+func oneSubscriptionStub(t *testing.T, status int, body map[string]any) (*httptest.Server, *string) {
+	t.Helper()
+	var path string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.EscapedPath()
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		writeJSON(w, body)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &path
+}
+
+func TestReadingASubscriptionReportsWhereItDelivers(t *testing.T) {
+	deadline := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	srv, path := oneSubscriptionStub(t, http.StatusOK, map[string]any{
+		"id":                 "sub-1",
+		"notificationUrl":    testNotifyURL,
+		"expirationDateTime": deadline.Format(time.RFC3339),
+	})
+
+	sub, err := NewAPI(srv.Client(), srv.URL).GetSubscription(context.Background(), "at", "sub-1")
+	if err != nil {
+		t.Fatalf("GetSubscription: %v", err)
+	}
+	if sub.ID != "sub-1" || !sub.Expiration.Equal(deadline) {
+		t.Errorf("sub = %+v, want the id and deadline Microsoft reported", sub)
+	}
+	if sub.NotificationURL != testNotifyURL {
+		t.Errorf("NotificationURL = %q, want the endpoint — it is the whole reason for this read",
+			sub.NotificationURL)
+	}
+	if *path != "/subscriptions/sub-1" {
+		t.Errorf("read %q, want the subscription addressed inside its own collection", *path)
+	}
+}
+
+// A SUBSCRIPTION MICROSOFT NO LONGER KNOWS reads as gone, so the renewal above
+// it registers afresh rather than reporting a fault the caller cannot act on.
+func TestReadingAVanishedSubscriptionIsGoneRatherThanAnError(t *testing.T) {
+	srv, _ := oneSubscriptionStub(t, http.StatusNotFound, nil)
+	if _, err := NewAPI(srv.Client(), srv.URL).
+		GetSubscription(context.Background(), "at", "sub-gone"); !errors.Is(err, ErrSubscriptionGone) {
+		t.Fatalf("err = %v, want ErrSubscriptionGone", err)
+	}
+}
+
+// AND A READ CANNOT BE AIMED BY A PROVIDER-SUPPLIED ID. The id arrives as a
+// decoded field of a provider response, and one carrying a path segment would
+// aim this authenticated GET — the user's own delegated token on it — at
+// another resource. Refused rather than escaped: url.PathEscape leaves `..`
+// intact, so a server that decodes %2F before resolving still walks out of the
+// collection.
+func TestAReadCannotBeAimedByAProviderSuppliedID(t *testing.T) {
+	srv, path := oneSubscriptionStub(t, http.StatusOK, map[string]any{"id": "x"})
+	if _, err := NewAPI(srv.Client(), srv.URL).
+		GetSubscription(context.Background(), "at", "../../me/messages"); !errors.Is(err, ErrSubscriptionGone) {
+		t.Fatalf("err = %v, want ErrSubscriptionGone for an id that cannot be addressed", err)
+	}
+	if *path != "" {
+		t.Errorf("the request went out to %q — an id like this must not reach the wire at all", *path)
+	}
+}
+
+// A FAULT READING THE SUBSCRIPTION IS REPORTED, not turned into a fresh
+// registration. Microsoft being unreachable for a moment is not evidence that
+// the subscription is gone, and registering on it would leave the mailbox with
+// a second subscription delivering the same notifications.
+func TestAFaultReadingTheSubscriptionDoesNotRegisterASecondOne(t *testing.T) {
+	api := &fakeAPI{email: owner, getSubErr: ErrUnreachable}
+	c := pinnedConn(api)
+
+	if _, err := c.RenewWatch(context.Background(), authBytes(t), testNotifyURL, "sub-stored"); !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("err = %v, want the fault reported", err)
+	}
+	if api.subCalls != 0 || api.renewCalls != 0 {
+		t.Errorf("ensured %d and renewed %d after a failed read, want neither — a moment's "+
+			"unreachability is not evidence the subscription is gone", api.subCalls, api.renewCalls)
+	}
+}

--- a/backend/internal/modules/capture/graph/subscription_test.go
+++ b/backend/internal/modules/capture/graph/subscription_test.go
@@ -386,7 +386,7 @@ func TestARenewalExtendsTheStoredSubscriptionWithoutListingAnything(t *testing.T
 	c := pinnedConn(api)
 
 	res, err := c.RenewWatch(context.Background(), authBytes(t),
-		"https://api.example/webhooks/graph?token=t", "sub-stored")
+		"https://api.example/webhooks/graph?token=t", encodeWatchRef("sub-stored", "https://api.example/webhooks/graph?token=t"))
 	if err != nil {
 		t.Fatalf("RenewWatch: %v", err)
 	}
@@ -401,9 +401,9 @@ func TestARenewalExtendsTheStoredSubscriptionWithoutListingAnything(t *testing.T
 	if !res.ExpiresAt.Equal(want) {
 		t.Errorf("reported %v, want the deadline Microsoft honored", res.ExpiresAt)
 	}
-	if res.Ref != "sub-stored" {
-		t.Errorf("Ref = %q, want the id that was renewed — the registry stores this and the next "+
-			"renewal addresses it", res.Ref)
+	if id, ok := decodeWatchRef(res.Ref, "https://api.example/webhooks/graph?token=t"); !ok || id != "sub-stored" {
+		t.Errorf("Ref = %q, want a handle on the id that was renewed — the registry stores this and "+
+			"the next renewal addresses it", res.Ref)
 	}
 }
 
@@ -419,7 +419,7 @@ func TestARenewalWhoseSubscriptionIsGoneRegistersAFreshOne(t *testing.T) {
 	c := pinnedConn(api)
 
 	res, err := c.RenewWatch(context.Background(), authBytes(t),
-		"https://api.example/webhooks/graph?token=t", "sub-vanished")
+		"https://api.example/webhooks/graph?token=t", encodeWatchRef("sub-vanished", "https://api.example/webhooks/graph?token=t"))
 	if err != nil {
 		t.Fatalf("RenewWatch on a subscription Microsoft has dropped: %v — the mailbox would stay "+
 			"on the poll for as long as the stored id kept failing", err)
@@ -429,5 +429,58 @@ func TestARenewalWhoseSubscriptionIsGoneRegistersAFreshOne(t *testing.T) {
 	}
 	if res.Ref == "" || res.Ref == "sub-vanished" {
 		t.Errorf("Ref = %q, want the id of the subscription that now exists", res.Ref)
+	}
+}
+
+// AND A HANDLE MADE AGAINST A DIFFERENT ENDPOINT is not renewed at all.
+//
+// A renewal extends a deadline; it never re-states where the subscription
+// points. Before a handle existed, every renewal went through
+// EnsureSubscription, which looks its subscription up BY notificationURL — so a
+// deployment whose webhook URL had moved got a fresh subscription on the new
+// endpoint without anyone arranging it. Extending the stored one instead would
+// keep Microsoft delivering to an endpoint nobody serves, and leave the new
+// webhook poll-only with nothing failing to say so.
+func TestARenewalWhoseEndpointMovedRegistersAtTheNewOne(t *testing.T) {
+	api := &fakeAPI{email: owner}
+	c := pinnedConn(api)
+
+	moved := "https://api.example/webhooks/graph?token=NEW"
+	res, err := c.RenewWatch(context.Background(), authBytes(t), moved,
+		encodeWatchRef("sub-at-old-endpoint", "https://api.example/webhooks/graph?token=t"))
+	if err != nil {
+		t.Fatalf("RenewWatch: %v", err)
+	}
+	if api.renewCalls != 0 {
+		t.Errorf("renewed %d time(s) naming %q — extending a subscription registered against the "+
+			"previous endpoint keeps notifications going where nobody is listening", api.renewCalls, api.renewID)
+	}
+	if api.subCalls != 1 {
+		t.Errorf("%d EnsureSubscription call(s), want one: it is the call that looks a subscription "+
+			"up BY the endpoint, and registers when none points there", api.subCalls)
+	}
+	if _, ok := decodeWatchRef(res.Ref, moved); !ok {
+		t.Errorf("Ref = %q, want a handle usable at the endpoint it was just made for — otherwise "+
+			"every later renewal repeats this round trip", res.Ref)
+	}
+}
+
+// AND AN UNREADABLE HANDLE is the same answer, which is what makes a connection
+// stored before handles existed cost one listing and no incident.
+func TestAnUnreadableHandleFallsBackRatherThanFailing(t *testing.T) {
+	for _, stored := range []string{"", "sub-1", "{}", `{"id":"sub-1"}`} {
+		t.Run("stored="+stored, func(t *testing.T) {
+			api := &fakeAPI{email: owner}
+			c := pinnedConn(api)
+			if _, err := c.RenewWatch(context.Background(), authBytes(t),
+				"https://api.example/webhooks/graph?token=t", stored); err != nil {
+				t.Fatalf("RenewWatch: %v", err)
+			}
+			if api.renewCalls != 0 || api.subCalls != 1 {
+				t.Errorf("renewed %d and ensured %d, want 0 and 1 — a handle that names no "+
+					"subscription at this endpoint answers nothing a renewal is asking",
+					api.renewCalls, api.subCalls)
+			}
+		})
 	}
 }

--- a/backend/internal/modules/capture/graph/subscription_test.go
+++ b/backend/internal/modules/capture/graph/subscription_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -483,4 +484,71 @@ func TestAnUnreadableHandleFallsBackRatherThanFailing(t *testing.T) {
 			}
 		})
 	}
+}
+
+// THE STORED HANDLE DOES NOT CARRY THE NOTIFICATION URL.
+//
+// Microsoft signs nothing on a change notification, so the operator token in
+// that URL is the only thing admitting one. The handle is stored in an ordinary
+// column that reaches every database reader and every backup, and a credential
+// does not belong there — the digest answers the one question a renewal asks,
+// which is whether two endpoints are the same one.
+func TestAStoredHandleCarriesNoNotificationURL(t *testing.T) {
+	const url = "https://api.example/webhooks/graph?token=OPERATOR-SECRET"
+	stored := encodeWatchRef("sub-1", url)
+
+	for _, leak := range []string{url, "OPERATOR-SECRET", "api.example", "token="} {
+		if strings.Contains(stored, leak) {
+			t.Errorf("the stored handle %q carries %q — that column is not a place for the "+
+				"factor that admits a notification", stored, leak)
+		}
+	}
+	if id, ok := decodeWatchRef(stored, url); !ok || id != "sub-1" {
+		t.Errorf("decode = %q/%v, want the id back at the endpoint it was made for", id, ok)
+	}
+	if _, ok := decodeWatchRef(stored, url+"&extra=1"); ok {
+		t.Error("a handle made for one endpoint was accepted at another — a digest that does not " +
+			"discriminate is not doing the job the URL used to")
+	}
+}
+
+// AND A HANDLE IN THE SHAPE THAT CARRIED ONE is simply not renewable, so it
+// costs a listing and heals rather than needing to be found and cleared.
+func TestAHandleFromTheURLCarryingShapeIsNotRenewable(t *testing.T) {
+	const url = "https://api.example/webhooks/graph?token=t"
+	if _, ok := decodeWatchRef(`{"id":"sub-1","url":"`+url+`"}`, url); ok {
+		t.Error("a handle carrying a raw URL was accepted; it has no endpoint fingerprint, so the " +
+			"only safe reading is 'go the long way round'")
+	}
+}
+
+// A FALLBACK REFRESHES THE TOKEN ONCE, not twice: Watch refreshes one of its
+// own, and the fallback is the ordinary path for a first registration rather
+// than a rare one.
+func TestAFallbackDoesNotRefreshTheTokenTwice(t *testing.T) {
+	api := &fakeAPI{email: owner}
+	oauth := &countingOAuth{OAuth: &fakeOAuth{access: "access-1"}}
+	c := New(oauth, api)
+	c.now = func() time.Time { return pinned }
+
+	if _, err := c.RenewWatch(context.Background(), authBytes(t),
+		"https://api.example/webhooks/graph?token=t", ""); err != nil {
+		t.Fatalf("RenewWatch: %v", err)
+	}
+	if oauth.calls != 1 {
+		t.Errorf("refreshed the access token %d time(s), want one — a first registration is the "+
+			"ordinary case here, so a doubled refresh is doubled token traffic on every mailbox",
+			oauth.calls)
+	}
+}
+
+// countingOAuth counts access-token refreshes and does nothing else.
+type countingOAuth struct {
+	OAuth
+	calls int
+}
+
+func (o *countingOAuth) AccessToken(ctx context.Context, refresh string) (string, error) {
+	o.calls++
+	return o.OAuth.AccessToken(ctx, refresh)
 }

--- a/backend/internal/modules/capture/graph/subscription_test.go
+++ b/backend/internal/modules/capture/graph/subscription_test.go
@@ -375,3 +375,59 @@ func TestASubscriptionIsNotCreatedForACredentialNamingNoMailbox(t *testing.T) {
 		t.Errorf("%d subscription(s) created for a credential that could not be routed", api.subCalls)
 	}
 }
+
+// A RENEWAL ADDRESSES THE SUBSCRIPTION IT STORED, and does not go looking.
+//
+// Watch has to make sure a subscription exists, and without a handle that means
+// walking GET /subscriptions — paged, once per mailbox, every cycle — to find
+// the one this installation made. The handle turns that into one call.
+func TestARenewalExtendsTheStoredSubscriptionWithoutListingAnything(t *testing.T) {
+	api := &fakeAPI{email: owner}
+	c := pinnedConn(api)
+
+	res, err := c.RenewWatch(context.Background(), authBytes(t),
+		"https://api.example/webhooks/graph?token=t", "sub-stored")
+	if err != nil {
+		t.Fatalf("RenewWatch: %v", err)
+	}
+	if api.renewCalls != 1 || api.renewID != "sub-stored" {
+		t.Fatalf("renewed %d time(s) naming %q, want one naming the stored id", api.renewCalls, api.renewID)
+	}
+	if api.subCalls != 0 {
+		t.Errorf("%d EnsureSubscription call(s) — a renewal that knows the id paid for the listing "+
+			"anyway, which is the round trip per mailbox per cycle this exists to save", api.subCalls)
+	}
+	want := pinned.Add(maxSubscriptionMinutes * time.Minute).UTC()
+	if !res.ExpiresAt.Equal(want) {
+		t.Errorf("reported %v, want the deadline Microsoft honored", res.ExpiresAt)
+	}
+	if res.Ref != "sub-stored" {
+		t.Errorf("Ref = %q, want the id that was renewed — the registry stores this and the next "+
+			"renewal addresses it", res.Ref)
+	}
+}
+
+// AND A HANDLE MICROSOFT NO LONGER KNOWS falls back to the listing, which is
+// where a recovery path belongs.
+//
+// A subscription dropped for repeated delivery failures, or one made by an
+// installation since restored from a backup, is exactly the case Ensure's
+// renew-then-create answers. Reporting the error instead would leave the mailbox
+// on the poll for as long as the stored id kept failing.
+func TestARenewalWhoseSubscriptionIsGoneRegistersAFreshOne(t *testing.T) {
+	api := &fakeAPI{email: owner, renewErr: ErrSubscriptionGone}
+	c := pinnedConn(api)
+
+	res, err := c.RenewWatch(context.Background(), authBytes(t),
+		"https://api.example/webhooks/graph?token=t", "sub-vanished")
+	if err != nil {
+		t.Fatalf("RenewWatch on a subscription Microsoft has dropped: %v — the mailbox would stay "+
+			"on the poll for as long as the stored id kept failing", err)
+	}
+	if api.subCalls != 1 {
+		t.Errorf("%d EnsureSubscription call(s), want one — the fallback IS the listing", api.subCalls)
+	}
+	if res.Ref == "" || res.Ref == "sub-vanished" {
+		t.Errorf("Ref = %q, want the id of the subscription that now exists", res.Ref)
+	}
+}

--- a/backend/internal/modules/capture/graph/subscription_test.go
+++ b/backend/internal/modules/capture/graph/subscription_test.go
@@ -382,12 +382,16 @@ func TestASubscriptionIsNotCreatedForACredentialNamingNoMailbox(t *testing.T) {
 // Watch has to make sure a subscription exists, and without a handle that means
 // walking GET /subscriptions — paged, once per mailbox, every cycle — to find
 // the one this installation made. The handle turns that into one call.
+// testNotifyURL is the endpoint every subscription test registers against, so a
+// fake reading a subscription back can report "nothing has moved" by default.
+const testNotifyURL = "https://api.example/webhooks/graph?token=t"
+
 func TestARenewalExtendsTheStoredSubscriptionWithoutListingAnything(t *testing.T) {
 	api := &fakeAPI{email: owner}
 	c := pinnedConn(api)
 
 	res, err := c.RenewWatch(context.Background(), authBytes(t),
-		"https://api.example/webhooks/graph?token=t", encodeWatchRef("sub-stored", "https://api.example/webhooks/graph?token=t"))
+		testNotifyURL, "sub-stored")
 	if err != nil {
 		t.Fatalf("RenewWatch: %v", err)
 	}
@@ -402,9 +406,9 @@ func TestARenewalExtendsTheStoredSubscriptionWithoutListingAnything(t *testing.T
 	if !res.ExpiresAt.Equal(want) {
 		t.Errorf("reported %v, want the deadline Microsoft honored", res.ExpiresAt)
 	}
-	if id, ok := decodeWatchRef(res.Ref, "https://api.example/webhooks/graph?token=t"); !ok || id != "sub-stored" {
-		t.Errorf("Ref = %q, want a handle on the id that was renewed — the registry stores this and "+
-			"the next renewal addresses it", res.Ref)
+	if res.Ref != "sub-stored" {
+		t.Errorf("Ref = %q, want the id that was renewed — the registry stores this and the next "+
+			"renewal addresses it", res.Ref)
 	}
 }
 
@@ -420,7 +424,7 @@ func TestARenewalWhoseSubscriptionIsGoneRegistersAFreshOne(t *testing.T) {
 	c := pinnedConn(api)
 
 	res, err := c.RenewWatch(context.Background(), authBytes(t),
-		"https://api.example/webhooks/graph?token=t", encodeWatchRef("sub-vanished", "https://api.example/webhooks/graph?token=t"))
+		testNotifyURL, "sub-vanished")
 	if err != nil {
 		t.Fatalf("RenewWatch on a subscription Microsoft has dropped: %v — the mailbox would stay "+
 			"on the poll for as long as the stored id kept failing", err)
@@ -433,7 +437,7 @@ func TestARenewalWhoseSubscriptionIsGoneRegistersAFreshOne(t *testing.T) {
 	}
 }
 
-// AND A HANDLE MADE AGAINST A DIFFERENT ENDPOINT is not renewed at all.
+// AND A HANDLE NAMING A SUBSCRIPTION THAT POINTS ELSEWHERE is not renewed.
 //
 // A renewal extends a deadline; it never re-states where the subscription
 // points. Before a handle existed, every renewal went through
@@ -443,12 +447,10 @@ func TestARenewalWhoseSubscriptionIsGoneRegistersAFreshOne(t *testing.T) {
 // keep Microsoft delivering to an endpoint nobody serves, and leave the new
 // webhook poll-only with nothing failing to say so.
 func TestARenewalWhoseEndpointMovedRegistersAtTheNewOne(t *testing.T) {
-	api := &fakeAPI{email: owner}
+	api := &fakeAPI{email: owner, getSubURL: "https://api.example/webhooks/graph?token=OLD"}
 	c := pinnedConn(api)
 
-	moved := "https://api.example/webhooks/graph?token=NEW"
-	res, err := c.RenewWatch(context.Background(), authBytes(t), moved,
-		encodeWatchRef("sub-at-old-endpoint", "https://api.example/webhooks/graph?token=t"))
+	res, err := c.RenewWatch(context.Background(), authBytes(t), testNotifyURL, "sub-at-old-endpoint")
 	if err != nil {
 		t.Fatalf("RenewWatch: %v", err)
 	}
@@ -460,65 +462,81 @@ func TestARenewalWhoseEndpointMovedRegistersAtTheNewOne(t *testing.T) {
 		t.Errorf("%d EnsureSubscription call(s), want one: it is the call that looks a subscription "+
 			"up BY the endpoint, and registers when none points there", api.subCalls)
 	}
-	if _, ok := decodeWatchRef(res.Ref, moved); !ok {
-		t.Errorf("Ref = %q, want a handle usable at the endpoint it was just made for — otherwise "+
-			"every later renewal repeats this round trip", res.Ref)
+	if res.Ref == "" {
+		t.Error("Ref is empty — the freshly registered subscription's id is what the next renewal " +
+			"addresses, and without it every cycle repeats the listing")
 	}
 }
 
-// AND AN UNREADABLE HANDLE is the same answer, which is what makes a connection
-// stored before handles existed cost one listing and no incident.
-func TestAnUnreadableHandleFallsBackRatherThanFailing(t *testing.T) {
-	for _, stored := range []string{"", "sub-1", "{}", `{"id":"sub-1"}`} {
-		t.Run("stored="+stored, func(t *testing.T) {
+// A RENEWAL READS THE SUBSCRIPTION BEFORE IT EXTENDS ONE, and reads it from
+// MICROSOFT rather than from anything stored beside the handle: the endpoint
+// carries the token that admits a notification, and watch_ref is an ordinary
+// column.
+func TestARenewalReadsTheSubscriptionBeforeExtendingIt(t *testing.T) {
+	api := &fakeAPI{email: owner}
+	c := pinnedConn(api)
+
+	if _, err := c.RenewWatch(context.Background(), authBytes(t), testNotifyURL, "sub-stored"); err != nil {
+		t.Fatalf("RenewWatch: %v", err)
+	}
+	if api.getSubCalls != 1 || api.getSubID != "sub-stored" {
+		t.Errorf("read the subscription %d time(s) naming %q, want one naming the stored id — "+
+			"without it a renewal cannot tell that the endpoint has not moved", api.getSubCalls, api.getSubID)
+	}
+}
+
+// AND A REF THAT CANNOT NAME A SUBSCRIPTION falls back rather than failing,
+// which is what makes a first registration — and a connection stored before
+// handles existed — cost one listing and no incident.
+func TestARefThatNamesNoSubscriptionFallsBackRatherThanFailing(t *testing.T) {
+	for name, stored := range map[string]string{
+		"empty":        "",
+		"a path step":  "..",
+		"a path":       "../../me/messages",
+		"needs escape": "sub 1/../x",
+	} {
+		t.Run(name, func(t *testing.T) {
 			api := &fakeAPI{email: owner}
 			c := pinnedConn(api)
-			if _, err := c.RenewWatch(context.Background(), authBytes(t),
-				"https://api.example/webhooks/graph?token=t", stored); err != nil {
+			if _, err := c.RenewWatch(context.Background(), authBytes(t), testNotifyURL, stored); err != nil {
 				t.Fatalf("RenewWatch: %v", err)
 			}
+			if api.getSubCalls != 0 {
+				t.Errorf("read a subscription %d time(s) for a ref that names none", api.getSubCalls)
+			}
 			if api.renewCalls != 0 || api.subCalls != 1 {
-				t.Errorf("renewed %d and ensured %d, want 0 and 1 — a handle that names no "+
-					"subscription at this endpoint answers nothing a renewal is asking",
+				t.Errorf("renewed %d and ensured %d, want 0 and 1 — a ref that names no "+
+					"subscription answers nothing a renewal is asking",
 					api.renewCalls, api.subCalls)
 			}
 		})
 	}
 }
 
-// THE STORED HANDLE DOES NOT CARRY THE NOTIFICATION URL.
+// THE STORED HANDLE CARRIES NOTHING BUT THE SUBSCRIPTION ID.
 //
-// Microsoft signs nothing on a change notification, so the operator token in
-// that URL is the only thing admitting one. The handle is stored in an ordinary
-// column that reaches every database reader and every backup, and a credential
-// does not belong there — the digest answers the one question a renewal asks,
-// which is whether two endpoints are the same one.
-func TestAStoredHandleCarriesNoNotificationURL(t *testing.T) {
+// Microsoft signs nothing on a change notification, so the operator token in the
+// notification URL is the only thing admitting one. watch_ref reaches every
+// database reader and every backup, and a renewal has no need to remember the
+// endpoint there: it asks Microsoft.
+func TestAStoredHandleCarriesNothingButTheID(t *testing.T) {
 	const url = "https://api.example/webhooks/graph?token=OPERATOR-SECRET"
-	stored := encodeWatchRef("sub-1", url)
+	api := &fakeAPI{email: owner, subResult: Subscription{ID: "sub-1", Expiration: pinned.Add(time.Hour)}}
+	c := pinnedConn(api)
 
-	for _, leak := range []string{url, "OPERATOR-SECRET", "api.example", "token="} {
-		if strings.Contains(stored, leak) {
+	res, err := c.Watch(context.Background(), authBytes(t), url)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	if res.Ref != "sub-1" {
+		t.Fatalf("Ref = %q, want the subscription id", res.Ref)
+	}
+	for _, leak := range []string{"OPERATOR-SECRET", "api.example", "token=", "https"} {
+		if strings.Contains(res.Ref, leak) {
 			t.Errorf("the stored handle %q carries %q — that column is not a place for the "+
-				"factor that admits a notification", stored, leak)
+				"factor that admits a notification, nor for anything an offline guess could "+
+				"be checked against", res.Ref, leak)
 		}
-	}
-	if id, ok := decodeWatchRef(stored, url); !ok || id != "sub-1" {
-		t.Errorf("decode = %q/%v, want the id back at the endpoint it was made for", id, ok)
-	}
-	if _, ok := decodeWatchRef(stored, url+"&extra=1"); ok {
-		t.Error("a handle made for one endpoint was accepted at another — a digest that does not " +
-			"discriminate is not doing the job the URL used to")
-	}
-}
-
-// AND A HANDLE IN THE SHAPE THAT CARRIED ONE is simply not renewable, so it
-// costs a listing and heals rather than needing to be found and cleared.
-func TestAHandleFromTheURLCarryingShapeIsNotRenewable(t *testing.T) {
-	const url = "https://api.example/webhooks/graph?token=t"
-	if _, ok := decodeWatchRef(`{"id":"sub-1","url":"`+url+`"}`, url); ok {
-		t.Error("a handle carrying a raw URL was accepted; it has no endpoint fingerprint, so the " +
-			"only safe reading is 'go the long way round'")
 	}
 }
 
@@ -532,7 +550,7 @@ func TestAFallbackDoesNotRefreshTheTokenTwice(t *testing.T) {
 	c.now = func() time.Time { return pinned }
 
 	if _, err := c.RenewWatch(context.Background(), authBytes(t),
-		"https://api.example/webhooks/graph?token=t", ""); err != nil {
+		testNotifyURL, ""); err != nil {
 		t.Fatalf("RenewWatch: %v", err)
 	}
 	if oauth.calls != 1 {

--- a/backend/internal/modules/capture/graph/subscription_test.go
+++ b/backend/internal/modules/capture/graph/subscription_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -302,7 +303,12 @@ func TestASubscriptionIsFoundOnAPageAfterTheFirst(t *testing.T) {
 // token — at a path built from a provider-supplied id. An id carrying a path
 // segment must not redirect it at another resource.
 func TestARenewalCannotBeAimedByAProviderSuppliedID(t *testing.T) {
-	var patched string
+	// Guarded for the reason oneSubscriptionStub gives below: the write happens
+	// on the server's goroutine and the read on this one.
+	var (
+		mu      sync.Mutex
+		patched string
+	)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/subscriptions", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, map[string]any{"value": []subscription{{
@@ -315,7 +321,9 @@ func TestARenewalCannotBeAimedByAProviderSuppliedID(t *testing.T) {
 	// `/subscriptions/../../me/messages` as though the escaping had failed, and
 	// it hides that the bytes sent never left the collection.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		patched = r.URL.EscapedPath()
+		mu.Unlock()
 		writeJSON(w, map[string]any{
 			"id": "sub-1", "expirationDateTime": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
 		})
@@ -333,8 +341,11 @@ func TestARenewalCannotBeAimedByAProviderSuppliedID(t *testing.T) {
 	}
 	// Nothing was PATCHed at all: the id is refused before a request is built,
 	// so this does not rest on how the far end normalizes what it received.
-	if patched != "" {
-		t.Errorf("a renewal was sent to %q for a provider-supplied id that is not a subscription id", patched)
+	mu.Lock()
+	sent := patched
+	mu.Unlock()
+	if sent != "" {
+		t.Errorf("a renewal was sent to %q for a provider-supplied id that is not a subscription id", sent)
 	}
 }
 
@@ -572,13 +583,23 @@ func (o *countingOAuth) AccessToken(ctx context.Context, refresh string) (string
 }
 
 // oneSubscriptionStub answers GET /subscriptions/{id} with the given status and
-// body, and records the raw path the request took.
-func oneSubscriptionStub(t *testing.T, status int, body map[string]any) (*httptest.Server, *string) {
+// body, and returns a reader for the raw path the request took.
+//
+// Through a mutex rather than a bare pointer: the handler runs on the server's
+// own goroutine, and nothing in net/http promises the test goroutine an edge to
+// read across afterwards, so -race is entitled to call the plain version a data
+// race whatever it does in practice.
+func oneSubscriptionStub(t *testing.T, status int, body map[string]any) (*httptest.Server, func() string) {
 	t.Helper()
-	var path string
+	var (
+		mu   sync.Mutex
+		path string
+	)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		path = r.URL.EscapedPath()
+		mu.Unlock()
 		if status != http.StatusOK {
 			w.WriteHeader(status)
 			return
@@ -587,7 +608,11 @@ func oneSubscriptionStub(t *testing.T, status int, body map[string]any) (*httpte
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return srv, &path
+	return srv, func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return path
+	}
 }
 
 func TestReadingASubscriptionReportsWhereItDelivers(t *testing.T) {
@@ -609,8 +634,8 @@ func TestReadingASubscriptionReportsWhereItDelivers(t *testing.T) {
 		t.Errorf("NotificationURL = %q, want the endpoint — it is the whole reason for this read",
 			sub.NotificationURL)
 	}
-	if *path != "/subscriptions/sub-1" {
-		t.Errorf("read %q, want the subscription addressed inside its own collection", *path)
+	if got := path(); got != "/subscriptions/sub-1" {
+		t.Errorf("read %q, want the subscription addressed inside its own collection", got)
 	}
 }
 
@@ -636,8 +661,8 @@ func TestAReadCannotBeAimedByAProviderSuppliedID(t *testing.T) {
 		GetSubscription(context.Background(), "at", "../../me/messages"); !errors.Is(err, ErrSubscriptionGone) {
 		t.Fatalf("err = %v, want ErrSubscriptionGone for an id that cannot be addressed", err)
 	}
-	if *path != "" {
-		t.Errorf("the request went out to %q — an id like this must not reach the wire at all", *path)
+	if got := path(); got != "" {
+		t.Errorf("the request went out to %q — an id like this must not reach the wire at all", got)
 	}
 }
 

--- a/backend/internal/modules/capture/registry_grant.go
+++ b/backend/internal/modules/capture/registry_grant.go
@@ -298,6 +298,17 @@ func upsertConnection(ctx context.Context, tx pgx.Tx, in connectionUpsert) (ids.
 		              -- direction.
 		              signature_enrich_enabled = CASE WHEN $7 THEN NULL
 		                                              ELSE capture_connection.signature_enrich_enabled END,
+		              -- A rebind points this row at a DIFFERENT mailbox, and a
+		              -- watch handle names a subscription in the mailbox it was
+		              -- made against. Kept, it would send the next renewal to
+		              -- extend the previous mailbox's subscription — which the
+		              -- app is entitled to do, so it would succeed — leaving the
+		              -- new mailbox with no push at all and nothing failing to
+		              -- say so. The deadline goes with it: a stored deadline for
+		              -- a subscription this row no longer owns keeps the renewal
+		              -- scan away until it lapses.
+		              watch_ref = CASE WHEN $7 THEN NULL ELSE capture_connection.watch_ref END,
+		              watch_expires_at = CASE WHEN $7 THEN NULL ELSE capture_connection.watch_expires_at END,
 		              account_bound_at = CASE WHEN $7 THEN now() ELSE capture_connection.account_bound_at END
 		RETURNING id`,
 		in.provider, in.userID, in.scopes, string(in.ref), in.accountLabel, in.providerScopes, rebound).Scan(&id); err != nil {

--- a/backend/internal/modules/capture/registry_watch.go
+++ b/backend/internal/modules/capture/registry_watch.go
@@ -71,12 +71,13 @@ func (r *Registry) RenewWatch(ctx context.Context, connectionID ids.UUID, topic 
 		credentialRef *string
 		authBytes     []byte
 		watchRef      *string
+		generation    int64
 	)
 	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
-			SELECT provider, user_id, credential_ref, auth, watch_ref FROM capture_connection
+			SELECT provider, user_id, credential_ref, auth, watch_ref, generation FROM capture_connection
 			WHERE id = $1 AND status = 'connected'`, connectionID).
-			Scan(&name, &grantedBy, &credentialRef, &authBytes, &watchRef)
+			Scan(&name, &grantedBy, &credentialRef, &authBytes, &watchRef, &generation)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("capture: connection %s: %w", connectionID, apperrors.ErrNotFound)
@@ -114,11 +115,19 @@ func (r *Registry) RenewWatch(ctx context.Context, connectionID ids.UUID, topic 
 	if err != nil {
 		return err
 	}
+	// FENCED ON THE GENERATION THE READ SAW. The connector call above is a round
+	// trip, and a rebind can commit inside it — pointing the row at a different
+	// mailbox and clearing the handle on the way past. Unfenced, this write puts
+	// the OLD mailbox's subscription back, which is the reset undone by a
+	// renewal that was already in flight when it happened. A rebind bumps the
+	// generation, so a stale renewal matches nothing and writes nothing; the
+	// scan picks the row up again on its own with no handle to renew by, and
+	// registers.
 	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE capture_connection SET watch_expires_at = $2, watch_ref = NULLIF($3, '')
-			WHERE id = $1 AND status = 'connected' AND archived_at IS NULL`,
-			connectionID, res.ExpiresAt, res.Ref)
+			WHERE id = $1 AND status = 'connected' AND archived_at IS NULL AND generation = $4`,
+			connectionID, res.ExpiresAt, res.Ref, generation)
 		return err
 	})
 }

--- a/backend/internal/modules/capture/registry_watch.go
+++ b/backend/internal/modules/capture/registry_watch.go
@@ -70,12 +70,13 @@ func (r *Registry) RenewWatch(ctx context.Context, connectionID ids.UUID, topic 
 		grantedBy     ids.UserID
 		credentialRef *string
 		authBytes     []byte
+		watchRef      *string
 	)
 	err := r.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
-			SELECT provider, user_id, credential_ref, auth FROM capture_connection
+			SELECT provider, user_id, credential_ref, auth, watch_ref FROM capture_connection
 			WHERE id = $1 AND status = 'connected'`, connectionID).
-			Scan(&name, &grantedBy, &credentialRef, &authBytes)
+			Scan(&name, &grantedBy, &credentialRef, &authBytes, &watchRef)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("capture: connection %s: %w", connectionID, apperrors.ErrNotFound)
@@ -99,15 +100,38 @@ func (r *Registry) RenewWatch(ctx context.Context, connectionID ids.UUID, topic 
 	if err != nil {
 		return err
 	}
-	res, err := watcher.Watch(runCtx, auth, topic)
+	// BY THE HANDLE, where there is one and the connector renews that way.
+	//
+	// Watch has to make sure a subscription exists, and a provider that issues
+	// handles cannot answer that without first finding the one it made — a
+	// paged listing, once per mailbox, every cycle. RenewWatch asks the question
+	// a renewal actually has: extend THIS one.
+	//
+	// The fallback is not a degraded path, it is the first registration and
+	// every connection made before a handle was stored. It is also the recovery
+	// path, which is where a listing belongs.
+	res, err := renewOrRegisterWatch(runCtx, c, watcher, auth, topic, watchRef)
 	if err != nil {
 		return err
 	}
 	return r.db.Tx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
-			UPDATE capture_connection SET watch_expires_at = $2
+			UPDATE capture_connection SET watch_expires_at = $2, watch_ref = NULLIF($3, '')
 			WHERE id = $1 AND status = 'connected' AND archived_at IS NULL`,
-			connectionID, res.ExpiresAt)
+			connectionID, res.ExpiresAt, res.Ref)
 		return err
 	})
+}
+
+// renewOrRegisterWatch extends the subscription this connection already holds,
+// or registers one when it holds none.
+func renewOrRegisterWatch(
+	ctx context.Context, c connector.Connector, watcher connector.Watcher,
+	auth connector.Auth, topic string, ref *string,
+) (connector.WatchResult, error) {
+	renewer, renews := c.(connector.WatchRenewer)
+	if !renews || ref == nil || *ref == "" {
+		return watcher.Watch(ctx, auth, topic)
+	}
+	return renewer.RenewWatch(ctx, auth, topic, *ref)
 }

--- a/backend/internal/modules/capture/registrywatchdispatch_test.go
+++ b/backend/internal/modules/capture/registrywatchdispatch_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// Which call a renewal makes, and on what evidence.
+//
+// A provider that issues a handle for its subscription can be asked to extend
+// THAT one; a provider that does not has to be asked whether a subscription
+// exists at all, which for Graph costs a paged listing per mailbox per cycle.
+// The dispatch is what turns a stored handle into the cheaper question, and
+// getting it wrong is invisible: both paths end with a stored deadline and a
+// working watch, and only the round trips differ.
+func TestARenewalUsesTheStoredHandleWhenTheConnectorRenewsByOne(t *testing.T) {
+	t.Parallel()
+	stored, empty := "sub-stored", ""
+	for name, tc := range map[string]struct {
+		connector  connector.Connector
+		ref        *string
+		wantRenews bool
+	}{
+		"a handle and a connector that renews by one": {&renewingConnector{}, &stored, true},
+		// The first registration: there is no handle yet, so the only question
+		// available is "does one exist".
+		"no handle yet":   {&renewingConnector{}, nil, false},
+		"an empty handle": {&renewingConnector{}, &empty, false},
+		// Gmail's shape: the watch is addressed by the mailbox and the topic,
+		// and there is nothing to renew by.
+		"a connector with no handle to renew by": {&watchOnlyConnector{}, &stored, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			watcher, isWatcher := tc.connector.(connector.Watcher)
+			if !isWatcher {
+				t.Fatalf("the fixture %T is not a Watcher, so this case drives nothing", tc.connector)
+			}
+			if _, err := renewOrRegisterWatch(
+				context.Background(), tc.connector, watcher, nil, "https://api.test/hook", tc.ref,
+			); err != nil {
+				t.Fatalf("renewOrRegisterWatch: %v", err)
+			}
+			renewed, registered := calls(tc.connector)
+			if tc.wantRenews && (renewed != 1 || registered != 0) {
+				t.Errorf("renewed %d, registered %d — a renewal that knows the handle asked whether a "+
+					"subscription exists instead of extending the one it has", renewed, registered)
+			}
+			if !tc.wantRenews && (renewed != 0 || registered != 1) {
+				t.Errorf("renewed %d, registered %d — a renewal with no usable handle addressed "+
+					"something it cannot name", renewed, registered)
+			}
+		})
+	}
+}
+
+func calls(c connector.Connector) (renewed, registered int) {
+	switch typed := c.(type) {
+	case *renewingConnector:
+		return typed.renewed, typed.registered
+	case *watchOnlyConnector:
+		return 0, typed.registered
+	}
+	return 0, 0
+}
+
+// watchOnlyConnector is a provider whose watch has no handle — Gmail's shape.
+type watchOnlyConnector struct {
+	registered int
+}
+
+func (c *watchOnlyConnector) Descriptor() connector.Descriptor {
+	return connector.Descriptor{Name: "watchonly"}
+}
+
+func (c *watchOnlyConnector) Authenticate(context.Context, connector.AuthRequest) (connector.Auth, error) {
+	return nil, errors.New("not used")
+}
+
+func (c *watchOnlyConnector) Sync(
+	context.Context, connector.Auth, connector.Cursor, connector.Sink,
+) (connector.Cursor, error) {
+	return nil, errors.New("not used")
+}
+
+func (c *watchOnlyConnector) HealthCheck(context.Context, connector.Auth) error {
+	return errors.New("not used")
+}
+
+func (c *watchOnlyConnector) Normalize(
+	context.Context, connector.RawRecord,
+) ([]connector.NormalizedRecord, error) {
+	return nil, errors.New("not used")
+}
+
+func (c *watchOnlyConnector) Watch(context.Context, connector.Auth, string) (connector.WatchResult, error) {
+	c.registered++
+	return connector.WatchResult{ExpiresAt: time.Now().Add(time.Hour)}, nil
+}
+
+// renewingConnector is a provider that issues one — Graph's shape.
+type renewingConnector struct {
+	watchOnlyConnector
+	renewed int
+}
+
+func (c *renewingConnector) RenewWatch(
+	_ context.Context, _ connector.Auth, _, ref string,
+) (connector.WatchResult, error) {
+	c.renewed++
+	return connector.WatchResult{ExpiresAt: time.Now().Add(time.Hour), Ref: ref}, nil
+}

--- a/backend/internal/modules/capture/registrywatchrebind_integration_test.go
+++ b/backend/internal/modules/capture/registrywatchrebind_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -26,7 +27,15 @@ import (
 // can connect the same provider twice against two different accounts — which is
 // all a rebind is. Registered under its own provider name so it never disturbs
 // the gmail row the rest of the package's fixtures use.
-type rebindConnector struct{ label *string }
+type rebindConnector struct {
+	label *string
+	// duringRenewal runs inside RenewWatch, which is where a rebind that races
+	// an in-flight renewal has to happen for the race to be the one under test.
+	// A POINTER because the registry refuses a second registration under the
+	// same name, so the hook has to be installable after the connection the
+	// renewal is about already exists.
+	duringRenewal *func()
+}
 
 func (rebindConnector) Descriptor() connector.Descriptor {
 	return connector.Descriptor{Name: "graph", Version: "fixture"}
@@ -48,7 +57,31 @@ func (rebindConnector) HealthCheck(context.Context, connector.Auth) error { retu
 
 func (c rebindConnector) AccountLabel(connector.Auth) (string, error) { return *c.label, nil }
 
-var _ connector.AccountLabeler = rebindConnector{}
+func (rebindConnector) Watch(context.Context, connector.Auth, string) (connector.WatchResult, error) {
+	return connector.WatchResult{ExpiresAt: watchDeadline, Ref: "sub-registered-fresh"}, nil
+}
+
+// RenewWatch returns the handle it was given, which is what makes the stale
+// write visible: whatever the row held when the renewal started is what this
+// tries to put back.
+func (c rebindConnector) RenewWatch(
+	_ context.Context, _ connector.Auth, _, ref string,
+) (connector.WatchResult, error) {
+	if c.duringRenewal != nil && *c.duringRenewal != nil {
+		(*c.duringRenewal)()
+	}
+	return connector.WatchResult{ExpiresAt: watchDeadline, Ref: ref}, nil
+}
+
+// watchDeadline is any instant far enough out to be obviously not the one the
+// fixture seeded; the tests read the handle, not the deadline.
+var watchDeadline = time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+
+var (
+	_ connector.AccountLabeler = rebindConnector{}
+	_ connector.Watcher        = rebindConnector{}
+	_ connector.WatchRenewer   = rebindConnector{}
+)
 
 // storedWatch reads back the handle and deadline the graph row holds.
 func storedWatch(ctx context.Context, t *testing.T) (ref *string, expires *time.Time) {
@@ -130,5 +163,60 @@ func TestReconnectingTheSameAccountKeepsTheStoredWatchHandle(t *testing.T) {
 	if ref == nil || *ref != "sub-in-the-first-mailbox" || expires == nil {
 		t.Errorf("watch_ref = %v, watch_expires_at = %v — a re-consent over the SAME mailbox "+
 			"dropped a live subscription, and the mailbox falls back to the poll until the next scan", ref, expires)
+	}
+}
+
+// connectionID reads back the id of the graph row, which is what
+// Registry.RenewWatch is addressed by.
+func connectionID(ctx context.Context, t *testing.T) ids.UUID {
+	t.Helper()
+	owner, _ := setupCaptureDB(t)
+	var id ids.UUID
+	if err := owner.QueryRow(ctx,
+		`SELECT id FROM capture_connection WHERE provider = 'graph'`).Scan(&id); err != nil {
+		t.Fatalf("reading the connection id: %v", err)
+	}
+	return id
+}
+
+// A RENEWAL THAT WAS IN FLIGHT WHEN THE REBIND LANDED WRITES NOTHING.
+//
+// Clearing the handle in the connect upsert is not enough on its own: the
+// connector call is a round trip, and a renewal that read the old handle before
+// the rebind committed would put it straight back afterwards — restoring a
+// subscription in a mailbox this row no longer points at, which is the failure
+// the clearing exists to prevent, arriving a moment later.
+func TestARenewalThatRacedARebindDoesNotRestoreTheOldHandle(t *testing.T) {
+	ctx, reg, _, _ := newCaptureRegistryFixture(t)
+	label := "first@example.test"
+	rebind := func() {
+		label = "second@example.test"
+		if _, err := reg.Connect(ctx, "graph", connector.Auth("token-2")); err != nil {
+			t.Errorf("the rebind inside the renewal: %v", err)
+		}
+	}
+	var hook func()
+	reg.Register(rebindConnector{label: &label, duringRenewal: &hook})
+	if _, err := reg.Connect(ctx, "graph", connector.Auth("token-1")); err != nil {
+		t.Fatalf("first connect: %v", err)
+	}
+	putWatch(ctx, t)
+	id := connectionID(ctx, t)
+
+	// Armed only now, so the rebind commits between this renewal's read of the
+	// handle and its write of the result, and not during the connect above.
+	hook = rebind
+	if err := reg.RenewWatch(ctx, id, "topic"); err != nil {
+		t.Fatalf("RenewWatch: %v", err)
+	}
+
+	ref, expires := storedWatch(ctx, t)
+	if ref != nil {
+		t.Errorf("watch_ref = %q — a renewal that started before the rebind put the previous "+
+			"mailbox's subscription back, and the row now names one it does not own", *ref)
+	}
+	if expires != nil {
+		t.Errorf("watch_expires_at = %v — the renewal scan will leave this row alone until a "+
+			"deadline that belongs to another mailbox passes", *expires)
 	}
 }

--- a/backend/internal/modules/capture/registrywatchrebind_integration_test.go
+++ b/backend/internal/modules/capture/registrywatchrebind_integration_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture_test
+
+// A rebind and the stored watch handle, over a real migrated Postgres.
+//
+// capture_connection.watch_ref names a push subscription in the mailbox it was
+// registered against. Pointing the row at a different mailbox leaves that
+// subscription in the old one, so the handle stops describing this connection
+// the instant the account changes. The reset belongs in the connect upsert,
+// beside the sync cursor and the sharing posture that are cleared for the same
+// reason, and it needs the real statement to prove.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// rebindConnector answers with whichever mailbox its pointer names, so one test
+// can connect the same provider twice against two different accounts — which is
+// all a rebind is. Registered under its own provider name so it never disturbs
+// the gmail row the rest of the package's fixtures use.
+type rebindConnector struct{ label *string }
+
+func (rebindConnector) Descriptor() connector.Descriptor {
+	return connector.Descriptor{Name: "graph", Version: "fixture"}
+}
+
+func (rebindConnector) Authenticate(context.Context, connector.AuthRequest) (connector.Auth, error) {
+	return connector.Auth("fixture-token"), nil
+}
+
+func (rebindConnector) Sync(_ context.Context, _ connector.Auth, cursor connector.Cursor, _ connector.Sink) (connector.Cursor, error) {
+	return cursor, nil
+}
+
+func (rebindConnector) Normalize(context.Context, connector.RawRecord) ([]connector.NormalizedRecord, error) {
+	return nil, nil
+}
+
+func (rebindConnector) HealthCheck(context.Context, connector.Auth) error { return nil }
+
+func (c rebindConnector) AccountLabel(connector.Auth) (string, error) { return *c.label, nil }
+
+var _ connector.AccountLabeler = rebindConnector{}
+
+// storedWatch reads back the handle and deadline the graph row holds.
+func storedWatch(ctx context.Context, t *testing.T) (ref *string, expires *time.Time) {
+	t.Helper()
+	owner, _ := setupCaptureDB(t)
+	if err := owner.QueryRow(ctx,
+		`SELECT watch_ref, watch_expires_at FROM capture_connection WHERE provider = 'graph'`).
+		Scan(&ref, &expires); err != nil {
+		t.Fatalf("reading the watch columns back: %v", err)
+	}
+	return ref, expires
+}
+
+// putWatch writes the handle a live subscription would have left, so the
+// connect that follows has something to clear.
+func putWatch(ctx context.Context, t *testing.T) {
+	t.Helper()
+	owner, _ := setupCaptureDB(t)
+	if _, err := owner.Exec(ctx, `
+		UPDATE capture_connection
+		SET watch_ref = 'sub-in-the-first-mailbox', watch_expires_at = now() + interval '2 days'
+		WHERE provider = 'graph'`); err != nil {
+		t.Fatalf("seeding the stored watch: %v", err)
+	}
+	ref, expires := storedWatch(ctx, t)
+	if ref == nil || expires == nil {
+		t.Fatal("precondition: the row should hold a handle and a deadline before the reconnect")
+	}
+}
+
+// Kept, the handle would send the next renewal to extend the PREVIOUS mailbox's
+// subscription — which the same app registration is entitled to do, so it would
+// succeed — leaving the new mailbox with no push at all and nothing failing to
+// say so. The deadline goes with it: a deadline for a subscription this row no
+// longer owns keeps the renewal scan away until it lapses.
+func TestRebindingToAnotherAccountDropsTheStoredWatchHandle(t *testing.T) {
+	ctx, reg, _, _ := newCaptureRegistryFixture(t)
+	label := "first@example.test"
+	reg.Register(rebindConnector{label: &label})
+
+	if _, err := reg.Connect(ctx, "graph", connector.Auth("token-1")); err != nil {
+		t.Fatalf("first connect: %v", err)
+	}
+	putWatch(ctx, t)
+
+	label = "second@example.test"
+	if _, err := reg.Connect(ctx, "graph", connector.Auth("token-2")); err != nil {
+		t.Fatalf("rebinding connect: %v", err)
+	}
+
+	ref, expires := storedWatch(ctx, t)
+	if ref != nil {
+		t.Errorf("watch_ref = %q after a rebind — the next renewal would extend a subscription "+
+			"belonging to the mailbox this row no longer points at", *ref)
+	}
+	if expires != nil {
+		t.Errorf("watch_expires_at = %v after a rebind — the renewal scan selects on this, so the "+
+			"new mailbox waits for another account's deadline before anything registers for it", *expires)
+	}
+}
+
+// AND A RECONNECT OF THE SAME ACCOUNT keeps it, which is what stops a
+// re-consent costing every mailbox its push registration.
+func TestReconnectingTheSameAccountKeepsTheStoredWatchHandle(t *testing.T) {
+	ctx, reg, _, _ := newCaptureRegistryFixture(t)
+	label := "same@example.test"
+	reg.Register(rebindConnector{label: &label})
+
+	if _, err := reg.Connect(ctx, "graph", connector.Auth("token-1")); err != nil {
+		t.Fatalf("first connect: %v", err)
+	}
+	putWatch(ctx, t)
+
+	if _, err := reg.Connect(ctx, "graph", connector.Auth("token-2")); err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+
+	ref, expires := storedWatch(ctx, t)
+	if ref == nil || *ref != "sub-in-the-first-mailbox" || expires == nil {
+		t.Errorf("watch_ref = %v, watch_expires_at = %v — a re-consent over the SAME mailbox "+
+			"dropped a live subscription, and the mailbox falls back to the poll until the next scan", ref, expires)
+	}
+}

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -71,6 +71,35 @@ type Watcher interface {
 type WatchResult struct {
 	HistoryID string
 	ExpiresAt time.Time
+	// Ref is the PROVIDER'S OWN HANDLE on the subscription, where it issues one
+	// — a Microsoft Graph subscription id. Stored in
+	// capture_connection.watch_ref and handed back to WatchRenewer.RenewWatch,
+	// so a renewal addresses the subscription it made rather than going looking
+	// for it.
+	//
+	// Empty where the provider has no such handle: a Gmail watch is addressed by
+	// the mailbox and the topic, and there is nothing to remember.
+	Ref string
+}
+
+// WatchRenewer renews a push subscription BY THE HANDLE the provider gave it.
+//
+// Optional and type-asserted, exactly like Watcher: a provider whose watch is
+// addressed by the mailbox alone has no handle to renew by and does not
+// implement this. The registry falls back to Watch, which is also what happens
+// on the first registration and for a connection made before any handle was
+// stored.
+//
+// Separate from Watcher rather than a wider Watch, because the two questions are
+// different: Watch says "make sure there is a subscription", and answering it
+// without a handle means finding one first. RenewWatch says "extend THIS one",
+// which is the question a renewal actually has.
+type WatchRenewer interface {
+	// RenewWatch extends the subscription named by ref and returns its new
+	// deadline. A ref the provider no longer knows is not an error the caller
+	// has to handle specially: the implementation registers a fresh
+	// subscription and returns its handle, which is what the caller wanted.
+	RenewWatch(ctx context.Context, auth Auth, topic, ref string) (WatchResult, error)
 }
 
 // AccountLabeler names the account an Auth bundle belongs to — the mailbox

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -78,8 +78,11 @@ type WatchResult struct {
 	//
 	// Opaque, and not "the provider's id": it has to carry whatever a renewal
 	// needs in order to know the stored subscription is still the right one to
-	// extend. The Graph connector packs the endpoint in beside the subscription
-	// id for that reason, and nothing outside the connector reads either half.
+	// extend. The Graph connector packs a DIGEST of the endpoint in beside the
+	// subscription id for that reason, and nothing outside the connector reads
+	// either half. A digest and not the endpoint itself: this column reaches
+	// every database reader and every backup, and a notification URL that
+	// carries an admission token is a credential.
 	//
 	// Empty where the provider has no such handle: a Gmail watch is addressed by
 	// the mailbox and the topic, and there is nothing to remember.

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -76,13 +76,14 @@ type WatchResult struct {
 	// WatchRenewer.RenewWatch, so a renewal addresses the subscription it made
 	// rather than going looking for it.
 	//
-	// Opaque, and not "the provider's id": it has to carry whatever a renewal
-	// needs in order to know the stored subscription is still the right one to
-	// extend. The Graph connector packs a DIGEST of the endpoint in beside the
-	// subscription id for that reason, and nothing outside the connector reads
-	// either half. A digest and not the endpoint itself: this column reaches
-	// every database reader and every backup, and a notification URL that
-	// carries an admission token is a credential.
+	// Opaque to everything outside the connector that minted it, which is what
+	// lets a connector decide for itself what a renewal needs to hold. It is
+	// also the reason the contract says nothing about the FORM: for Graph it is
+	// the subscription id and nothing else, because whether that subscription
+	// still points at the endpoint being renewed is a question Microsoft
+	// answers, and a stored answer would be a copy of a URL carrying the token
+	// that admits a notification. This column reaches every database reader and
+	// every backup, so what a handle does not have to hold, it does not hold.
 	//
 	// Empty where the provider has no such handle: a Gmail watch is addressed by
 	// the mailbox and the topic, and there is nothing to remember.

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -71,14 +71,22 @@ type Watcher interface {
 type WatchResult struct {
 	HistoryID string
 	ExpiresAt time.Time
-	// Ref is the PROVIDER'S OWN HANDLE on the subscription, where it issues one
-	// — a Microsoft Graph subscription id. Stored in
-	// capture_connection.watch_ref and handed back to WatchRenewer.RenewWatch,
-	// so a renewal addresses the subscription it made rather than going looking
-	// for it.
+	// Ref is the connector's OPAQUE HANDLE on the subscription it just made.
+	// Stored verbatim in capture_connection.watch_ref and handed back to
+	// WatchRenewer.RenewWatch, so a renewal addresses the subscription it made
+	// rather than going looking for it.
+	//
+	// Opaque, and not "the provider's id": it has to carry whatever a renewal
+	// needs in order to know the stored subscription is still the right one to
+	// extend. The Graph connector packs the endpoint in beside the subscription
+	// id for that reason, and nothing outside the connector reads either half.
 	//
 	// Empty where the provider has no such handle: a Gmail watch is addressed by
 	// the mailbox and the topic, and there is nothing to remember.
+	//
+	// The registry's side of the contract is to store it and to CLEAR it when
+	// the connection is rebound to a different account — a handle names a
+	// subscription in the mailbox it was made against, and that mailbox is gone.
 	Ref string
 }
 

--- a/backend/migrations/core/1788293893_a_graph_subscription_is_renewed_by_the_id_it_was_given.down.sql
+++ b/backend/migrations/core/1788293893_a_graph_subscription_is_renewed_by_the_id_it_was_given.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE capture_connection DROP COLUMN watch_ref;

--- a/backend/migrations/core/1788293893_a_graph_subscription_is_renewed_by_the_id_it_was_given.up.sql
+++ b/backend/migrations/core/1788293893_a_graph_subscription_is_renewed_by_the_id_it_was_given.up.sql
@@ -1,0 +1,20 @@
+-- The push subscription's own id, kept beside the deadline it expires at.
+--
+-- Renewing needs the provider's handle on the subscription, and without it the
+-- Graph connector went looking: GET /subscriptions, paged, once per mailbox per
+-- renewal cycle, matching on the notification URL. That listing is a RECOVERY
+-- path — it finds a subscription this installation lost track of — and it was
+-- doing steady-state work.
+--
+-- NULLABLE, and it stays that way. Every connection made before this column
+-- existed has no id to backfill, and a mailbox on another provider has no
+-- subscription at all. A NULL means "no handle stored", and the renewal falls
+-- back to the listing it has always used, which is where a recovery path
+-- belongs.
+--
+-- Bounded, like every migration that locks a table it did not create: an open
+-- transaction holding a conflicting lock would otherwise stall every write to
+-- capture_connection for as long as this is willing to queue.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE capture_connection ADD COLUMN watch_ref text;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -966,6 +966,7 @@ public.capture_connection.sync_cursor jsonb gen=- def=-
 public.capture_connection.uq_capture_connection_ws_id UNIQUE (id)
 public.capture_connection.user_id uuid NOT NULL gen=- def=-
 public.capture_connection.watch_expires_at timestamp with time zone gen=- def=-
+public.capture_connection.watch_ref text gen=- def=-
 public.capture_connection_unique CREATE UNIQUE INDEX capture_connection_unique ON public.capture_connection USING btree (user_id, provider)
 public.capture_counterparty_hold acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.capture_counterparty_hold.capture_counterparty_hold_kind_check CHECK ((kind = ANY (ARRAY['address'::text, 'domain'::text])))

--- a/docs/explanation/capture-connectors.md
+++ b/docs/explanation/capture-connectors.md
@@ -73,12 +73,13 @@ type-asserts and skips a connector that doesn't:
   than surfacing as an error. Gmail implements none of it: a Pub/Sub watch is addressed by the mailbox
   and the topic, so there is no handle to remember.
 
-  The `Ref` is **opaque to everything outside the connector that minted it**, because it has to carry
-  whatever a renewal needs to know the stored subscription is still the right one to extend — for Graph
-  that is the subscription id and a *digest* of the notification endpoint it was registered against. A
-  digest rather than the endpoint: Microsoft signs nothing on a change notification, so the operator
-  token in that URL is the only thing admitting one, and `watch_ref` is an ordinary column that reaches
-  every database reader and every backup.
+  The `Ref` is **opaque to everything outside the connector that minted it**, which lets each connector
+  decide what a renewal needs to hold. For Graph it is the subscription id and nothing else: a renewal
+  reads the subscription back before extending it, so whether it still points at the endpoint being
+  renewed is Microsoft's answer rather than a remembered one. Nothing about the endpoint is written
+  down, which matters because Microsoft signs nothing on a change notification — the operator token in
+  that URL is the only thing admitting one, and `watch_ref` reaches every database reader and every
+  backup.
 
   The registry's half of the contract is to store it verbatim, to CLEAR it when the connection is
   rebound to a different account (a handle names a subscription in the mailbox it was made against),
@@ -247,10 +248,11 @@ link (`ErrDeltaGone`, HTTP 410) re-anchors to a bounded 7-day window. It impleme
 renewed by the worker every `6h`, `24h` ahead of its deadline. That deadline is under **three days**
 where Gmail's watch lasts seven, which is why the two passes carry different defaults rather than one.
 
-The subscription is addressed by an id Microsoft mints, and the connector stores it (with the endpoint
-it was registered against) as its `WatchRenewer` handle, so a renewal is one PATCH. Without a usable
-handle — a first registration, a connection older than the handle, a rebind that cleared it, or an
-endpoint that has since moved — the round ASKS instead: Microsoft lists the subscriptions this app
+The subscription is addressed by an id Microsoft mints, and the connector stores it as its
+`WatchRenewer` handle, so a renewal is a GET and a PATCH rather than a paged listing. The GET is what
+confirms the subscription still points at the notification URL being renewed; without a usable handle
+— a first registration, a connection older than the handle, a rebind that cleared it, or a
+subscription that points somewhere else — the round ASKS instead: Microsoft lists the subscriptions this app
 holds for this user, and the one pointing at our notification URL is ours, so a subscription left by an
 earlier deployment is adopted rather than duplicated. That listing is also the recovery path when
 Microsoft answers a stored handle with 404, which is what it does for a subscription dropped after

--- a/docs/explanation/capture-connectors.md
+++ b/docs/explanation/capture-connectors.md
@@ -60,11 +60,24 @@ Every integration implements `connector.Connector`
 | `Normalize(raw)` | Maps ONE raw provider record to domain structs. **Pure — no I/O** — so the mapping is the agent-edited, test-guarded surface. Returns `ErrSkip` for deliberately excluded input. |
 | `HealthCheck(auth)` | Feeds the ops surface; an outage degrades capture, never blocks the CRM. |
 
-Two **optional** seams a connector implements only when its provider supports them — the registry
+Three **optional** seams a connector implements only when its provider supports them — the registry
 type-asserts and skips a connector that doesn't:
 
 - **`Watcher`** — a renewable push subscription (Gmail's 7-day Pub/Sub watch, Graph's under-3-day
   change-notification subscription). A provider with no renewable push simply is not a `Watcher`.
+- **`WatchRenewer`** — renewal BY THE HANDLE the provider gave out, for a provider that mints one.
+  `Watch` says "make sure there is a subscription", which without a handle means finding one first;
+  `RenewWatch` says "extend THIS one". A connector that implements it returns an opaque `Ref` from
+  `Watch`, the registry stores it in `capture_connection.watch_ref` and hands it back on the next
+  renewal, and a handle the provider no longer knows falls back to `Watch` inside the connector rather
+  than surfacing as an error. Gmail implements none of it: a Pub/Sub watch is addressed by the mailbox
+  and the topic, so there is no handle to remember.
+
+  The `Ref` is **opaque to everything outside the connector that minted it**, because it has to carry
+  whatever a renewal needs to know the stored subscription is still the right one to extend — for Graph
+  that is the subscription id *and* the notification endpoint it was registered against. The registry's
+  half of the contract is to store it verbatim and to CLEAR it when the connection is rebound to a
+  different account, since a handle names a subscription in the mailbox it was made against.
 - **`Backfiller`** — bounded date-backward enumeration of a mailbox (`EstimateBackfill` +
   `BackfillPage`). A provider that can't page backward is not a `Backfiller`, and the backfill engine
   refuses honestly rather than pretending.
@@ -228,9 +241,14 @@ link (`ErrDeltaGone`, HTTP 410) re-anchors to a bounded 7-day window. It impleme
 renewed by the worker every `6h`, `24h` ahead of its deadline. That deadline is under **three days**
 where Gmail's watch lasts seven, which is why the two passes carry different defaults rather than one.
 
-The subscription is addressed by an id Microsoft mints. Rather than storing it, a renewal round ASKS —
-Microsoft lists the subscriptions this app holds for this user, and the one pointing at our notification
-URL is ours, so a subscription left by an earlier deployment is adopted rather than duplicated. A
+The subscription is addressed by an id Microsoft mints, and the connector stores it (with the endpoint
+it was registered against) as its `WatchRenewer` handle, so a renewal is one PATCH. Without a usable
+handle — a first registration, a connection older than the handle, a rebind that cleared it, or an
+endpoint that has since moved — the round ASKS instead: Microsoft lists the subscriptions this app
+holds for this user, and the one pointing at our notification URL is ours, so a subscription left by an
+earlier deployment is adopted rather than duplicated. That listing is also the recovery path when
+Microsoft answers a stored handle with 404, which is what it does for a subscription dropped after
+repeated delivery failures. A
 notification's `resource` names a directory object id this system never stored, so the subscription
 carries the mailbox owner's address in `clientState`, which Microsoft echoes verbatim; the webhook
 routes on that and authenticates on the operator token in the URL. Microsoft signs nothing on a change
@@ -393,7 +411,7 @@ The pipeline is live; these were scoped out, not missed:
 
 | | |
 |---|---|
-| The connector seam (Connector / Watcher / Backfiller / Sink / NormalizedRecord) | `internal/shared/ports/connector/connector.go` |
+| The connector seam (Connector / Watcher / WatchRenewer / Backfiller / Sink / NormalizedRecord) | `internal/shared/ports/connector/connector.go` |
 | The credential-rotation seam (CredentialRotator / CredentialSink) | `internal/shared/ports/connector/rotation.go`, `internal/modules/capture/registry_rotation.go` |
 | The one Sink + write shape + idempotency | `internal/modules/capture/sink.go` |
 | The registry — scope intersection, Connect/Disconnect, SyncOnce, backfill, watch | `internal/modules/capture/registry.go`, `registry_connections.go`, `registry_watch.go`, `backfill.go` |

--- a/docs/explanation/capture-connectors.md
+++ b/docs/explanation/capture-connectors.md
@@ -75,9 +75,15 @@ type-asserts and skips a connector that doesn't:
 
   The `Ref` is **opaque to everything outside the connector that minted it**, because it has to carry
   whatever a renewal needs to know the stored subscription is still the right one to extend — for Graph
-  that is the subscription id *and* the notification endpoint it was registered against. The registry's
-  half of the contract is to store it verbatim and to CLEAR it when the connection is rebound to a
-  different account, since a handle names a subscription in the mailbox it was made against.
+  that is the subscription id and a *digest* of the notification endpoint it was registered against. A
+  digest rather than the endpoint: Microsoft signs nothing on a change notification, so the operator
+  token in that URL is the only thing admitting one, and `watch_ref` is an ordinary column that reaches
+  every database reader and every backup.
+
+  The registry's half of the contract is to store it verbatim, to CLEAR it when the connection is
+  rebound to a different account (a handle names a subscription in the mailbox it was made against),
+  and to fence the write that stores it on the connection's `generation` — a renewal is a round trip,
+  and one that started before a rebind landed would otherwise put the previous mailbox's handle back.
 - **`Backfiller`** — bounded date-backward enumeration of a mailbox (`EstimateBackfill` +
   `BackfillPage`). A provider that can't page backward is not a `Backfiller`, and the backfill engine
   refuses honestly rather than pretending.


### PR DESCRIPTION
Closes #3548.

## What it did

`EnsureSubscription` renews-then-creates, and to find what to renew it walked `GET /subscriptions` matching on the notification URL — paged, once per mailbox, every renewal cycle.

Renew-then-create is the right shape: Microsoft accepts several subscriptions on one resource, so create-first would leave a mailbox with one more every cycle, each delivering the same notification. The **listing** is what this changes.

## What it does now

`capture_connection.watch_ref` holds the provider's own handle, and a renewal that has one asks Microsoft to extend that subscription. One call.

**Two questions, so two seams.** `Watcher.Watch` asks *is there a subscription for this mailbox*, which without a handle cannot be answered without finding one first. `WatchRenewer.RenewWatch` asks *extend this one*, which is the question a renewal actually has. Optional and type-asserted exactly like `Watcher`: Gmail's watch is addressed by the mailbox and the topic and has no handle to renew by, so it does not implement it.

## The listing stays where it belongs

Three paths still take it, and none is degraded:

- a first registration, which has no handle yet;
- a connection made before this column existed, which has none to backfill;
- a subscription Microsoft has dropped — repeated delivery failures, an installation restored from a backup — which answers `ErrSubscriptionGone`.

That last one is why the sentinel is now exported: reporting the error instead of falling back would leave the mailbox on the poll for as long as the stored id kept failing.

## Verification

| case | asserted |
| --- | --- |
| a handle, and a connector that renews by one | renews by id, **zero** listing calls |
| no handle yet / an empty handle | registers |
| a connector with no handle to renew by (Gmail's shape) | registers |
| a handle Microsoft no longer knows | falls back, and returns the new id |

Each mutation-checked: making the renewal go back to the listing fails the first, and always-register fails the dispatch case.

The column is nullable and stays that way — a NULL means "no handle stored", which is what every pre-existing connection has and what a non-Graph provider will always have.

`make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Subscription renewals now use stored provider IDs for reliable updates.
  * Missing, invalid, or changed subscriptions automatically receive replacement watches.
  * Renewals verify subscription details and preserve updated references and expiration times.
  * Concurrent renewals no longer overwrite account-rebinding changes.
  * Connectors without renewal support continue using registration.
  * Rebinding to another account clears outdated watch information, while same-account reconnects preserve it.
* **Security**
  * Stored watch references no longer contain notification URLs or access credentials.
* **Documentation**
  * Clarified watch-reference and renewal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->