### PR TITLE
An anchor reconciles its walk against the folder's own tally

### DIFF
--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -13,7 +13,6 @@ package graph
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -52,6 +51,7 @@ const (
 	paramFilter   = "$filter"
 	paramSelect   = "$select"
 	paramTop      = "$top"
+	paramCount    = "$count"
 
 	// maxMIMELen bounds one message's fetched RFC822 bytes. A message over
 	// this is refused rather than truncated (a truncated MIME blob is not
@@ -120,7 +120,10 @@ type API interface {
 	Profile(ctx context.Context, accessToken string) (email string, err error)
 	// DeltaInit starts a fresh delta over ONE well-known folder, bounded to
 	// messages received on or after the given instant, walks it to completion,
-	// and returns the deltaLink the next Delta resumes from.
+	// and returns the deltaLink the next Delta resumes from. A walk that ends
+	// holding fewer messages than the folder reports for that window is
+	// refused rather than returned: the watermark only moves forward, so a
+	// short anchor would drop what it missed for good.
 	//
 	// Per folder rather than over the whole mailbox: /me/messages/delta would
 	// also yield Drafts, Deleted Items and Junk. A draft was never sent, so
@@ -272,91 +275,6 @@ func (a *httpAPI) Profile(ctx context.Context, accessToken string) (string, erro
 	return out.UserPrincipalName, nil
 }
 
-// receivedAfterFilter renders Graph's only supported delta/list filter:
-// receivedDateTime ge <instant>. The window boundary is a product parameter
-// measured in months, so second-grain UTC rendering loses nothing.
-func receivedAfterFilter(after time.Time) string {
-	return "receivedDateTime ge " + after.UTC().Format(time.RFC3339)
-}
-
-// The two well-known folders a standing sync follows. Named constants because
-// they are Microsoft's own identifiers rather than folder names a person chose,
-// and because which folder a message came from is what attests whether the
-// owner sent it.
-const (
-	folderInbox = "inbox"
-	folderSent  = "sentitems"
-)
-
-// deltaPage is one page of a messages delta. A tombstoned entry
-// carries @removed instead of message fields — nothing to fetch for it.
-type deltaPage struct {
-	Value []struct {
-		ID      string           `json:"id"`
-		Removed *json.RawMessage `json:"@removed"`
-	} `json:"value"`
-	NextLink  string `json:"@odata.nextLink"`  //nolint:tagliatelle // Microsoft's wire format; must match to decode
-	DeltaLink string `json:"@odata.deltaLink"` //nolint:tagliatelle // Microsoft's wire format; must match to decode
-}
-
-func (a *httpAPI) DeltaInit(ctx context.Context, accessToken, folder string, after time.Time) ([]string, string, error) {
-	q := url.Values{paramFilter: {receivedAfterFilter(after)}}
-	// receivedDateTime bounds BOTH folders: Exchange stamps it on a sent
-	// message too, so one filter serves the pair rather than the sent side
-	// needing sentDateTime and a second spelling of "recently".
-	return a.deltaWalk(ctx, accessToken,
-		a.base+"/me/mailFolders/"+url.PathEscape(folder)+"/messages/delta?"+q.Encode())
-}
-
-func (a *httpAPI) Delta(ctx context.Context, accessToken, deltaLink string) ([]string, string, error) {
-	if err := a.sameAPIOrigin(deltaLink); err != nil {
-		return nil, "", err
-	}
-	return a.deltaWalk(ctx, accessToken, deltaLink)
-}
-
-// deltaWalk follows a delta round from startURL through every nextLink until
-// Graph hands back the deltaLink that closes it, collecting the ids of the
-// non-tombstoned messages along the way. A 410 anywhere in the walk means the
-// server no longer honors this delta state (ErrDeltaGone).
-func (a *httpAPI) deltaWalk(ctx context.Context, accessToken, startURL string) ([]string, string, error) {
-	var ids []string
-	next := startURL
-	for {
-		var page deltaPage
-		status, err := a.get(ctx, accessToken, next, nil, &page)
-		if err != nil {
-			if status == http.StatusGone {
-				return nil, "", ErrDeltaGone
-			}
-			return nil, "", err
-		}
-		for _, m := range page.Value {
-			if m.ID != "" && m.Removed == nil {
-				ids = append(ids, m.ID)
-			}
-		}
-		if page.NextLink == "" {
-			if page.DeltaLink == "" {
-				// A closed round with neither a next nor a delta link has lost
-				// the resumable cursor — treat the malformed response as
-				// unreachable rather than reporting success with no watermark.
-				return nil, "", ErrUnreachable
-			}
-			return ids, page.DeltaLink, nil
-		}
-		if err := a.sameAPIOrigin(page.NextLink); err != nil {
-			return nil, "", err
-		}
-		next = page.NextLink
-	}
-}
-
-// sameAPIOrigin refuses any continuation URL that does not live under the
-// configured Graph base. nextLink/deltaLink are server-supplied URLs the
-// client follows bearing the access token — and the deltaLink round-trips
-// through the stored sync cursor — so an off-origin link (tampered cursor,
-// broken provider) must never be fetched.
 func (a *httpAPI) sameAPIOrigin(link string) error {
 	if !strings.HasPrefix(link, a.base+"/") && link != a.base {
 		return fmt.Errorf("graph: continuation link does not point at the graph api")
@@ -409,7 +327,7 @@ func (a *httpAPI) EstimateAfter(ctx context.Context, accessToken string, after t
 	}
 	q := url.Values{
 		paramFilter: {receivedAfterFilter(after)},
-		"$count":    {"true"},
+		paramCount:  {"true"},
 		paramSelect: {"id"},
 		paramTop:    {"1"},
 	}

--- a/backend/internal/modules/capture/graph/client_test.go
+++ b/backend/internal/modules/capture/graph/client_test.go
@@ -77,6 +77,18 @@ func msStub(t *testing.T) *httptest.Server {
 		}
 	})
 
+	mux.HandleFunc("/me/mailFolders/{folder}/messages", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("ConsistencyLevel") != "eventual" {
+			// $count without the header fails on real Graph; the stub makes
+			// that contract visible as a client-side failure.
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		// The two the delta round hands back, so a walk of the whole folder
+		// measures up and the anchor stands.
+		writeJSON(w, map[string]any{"@odata.count": 2, "value": []map[string]any{{"id": "m1"}}})
+	})
+
 	mux.HandleFunc("/me/messages", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("$count") == "true" {
 			if r.Header.Get("ConsistencyLevel") != "eventual" {
@@ -514,4 +526,85 @@ func jsonStub(t *testing.T, body map[string]any) *httptest.Server {
 	}))
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+// anchorStub serves one folder: a single-page delta round holding the given
+// ids, and a $count answering held. It records the filter the count carried.
+func anchorStub(t *testing.T, ids []string, held int) (*httptest.Server, *string) {
+	t.Helper()
+	var countFilter string
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+	mux.HandleFunc("/me/mailFolders/inbox/messages/delta", func(w http.ResponseWriter, _ *http.Request) {
+		value := make([]map[string]any, 0, len(ids))
+		for _, id := range ids {
+			value = append(value, map[string]any{"id": id})
+		}
+		writeJSON(w, map[string]any{
+			"value":            value,
+			"@odata.deltaLink": srv.URL + "/me/mailFolders/inbox/messages/delta?%24deltatoken=d1",
+		})
+	})
+	mux.HandleFunc("/me/mailFolders/inbox/messages", func(w http.ResponseWriter, r *http.Request) {
+		countFilter = r.URL.Query().Get("$filter")
+		writeJSON(w, map[string]any{"@odata.count": held, "value": []map[string]any{}})
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &countFilter
+}
+
+func TestAnAnchorHoldingFewerThanTheFolderReportsIsRefused(t *testing.T) {
+	srv, _ := anchorStub(t, []string{"m1"}, 5)
+	ids, delta, err := NewAPI(srv.Client(), srv.URL).
+		DeltaInit(context.Background(), "at", folderInbox, time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("err = %v, want ErrUnreachable — a round that closed short of the folder's own tally", err)
+	}
+	if ids != nil || delta != "" {
+		t.Errorf("ids = %v, deltaLink = %q, want neither: a watermark stored here would drop the 4 the walk never saw", ids, delta)
+	}
+	if !strings.Contains(err.Error(), "holds 5") {
+		t.Errorf("err = %q, want the tally the walk was measured against", err)
+	}
+}
+
+func TestAnAnchorHoldingMoreThanTheFolderReportsStands(t *testing.T) {
+	// A message arriving mid-walk is inside the walk and outside the closed
+	// window the tally covers. That gap must not read as a short round.
+	srv, _ := anchorStub(t, []string{"m1", "m2", "m3"}, 2)
+	ids, delta, err := NewAPI(srv.Client(), srv.URL).
+		DeltaInit(context.Background(), "at", folderInbox, time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("DeltaInit: %v", err)
+	}
+	if len(ids) != 3 || delta == "" {
+		t.Errorf("ids = %v, deltaLink = %q, want all three and the link that closed the round", ids, delta)
+	}
+}
+
+func TestTheAnchorsTallyCoversTheWindowTheWalkOpenedIn(t *testing.T) {
+	after := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	opened := time.Now().UTC()
+	srv, filter := anchorStub(t, []string{"m1"}, 1)
+	if _, _, err := NewAPI(srv.Client(), srv.URL).
+		DeltaInit(context.Background(), "at", folderInbox, after); err != nil {
+		t.Fatalf("DeltaInit: %v", err)
+	}
+	closed := time.Now().UTC()
+	if !strings.HasPrefix(*filter, "receivedDateTime ge "+after.Format(time.RFC3339)+" and ") {
+		t.Fatalf("count filter = %q, want the anchor's own lower bound", *filter)
+	}
+	_, upper, found := strings.Cut(*filter, " and receivedDateTime lt ")
+	if !found {
+		t.Fatalf("count filter = %q, want a closed upper bound: an open tally would count arrivals the walk could not have seen", *filter)
+	}
+	at, err := time.Parse(time.RFC3339, upper)
+	if err != nil {
+		t.Fatalf("upper bound %q: %v", upper, err)
+	}
+	// Second-grain rendering floors the bound, so allow the second it truncates.
+	if at.Before(opened.Truncate(time.Second)) || at.After(closed) {
+		t.Errorf("upper bound = %s, want the instant the walk opened (between %s and %s)", at, opened, closed)
+	}
 }

--- a/backend/internal/modules/capture/graph/client_test.go
+++ b/backend/internal/modules/capture/graph/client_test.go
@@ -65,13 +65,13 @@ func msStub(t *testing.T) *httptest.Server {
 			// The opening page of a fresh delta round: one page, then the next.
 			if r.URL.Query().Get("$skiptoken") == "p2" {
 				writeJSON(w, map[string]any{
-					"value":            []map[string]any{{"id": "m2"}},
+					"value":            []map[string]any{{"id": "m2", "receivedDateTime": "2026-07-12T00:00:00Z"}},
 					"@odata.deltaLink": srv.URL + "/me/mailFolders/inbox/messages/delta?%24deltatoken=d1",
 				})
 				return
 			}
 			writeJSON(w, map[string]any{
-				"value":           []map[string]any{{"id": "m1"}},
+				"value":           []map[string]any{{"id": "m1", "receivedDateTime": "2026-07-12T00:00:00Z"}},
 				"@odata.nextLink": srv.URL + "/me/mailFolders/inbox/messages/delta?%24skiptoken=p2",
 			})
 		}
@@ -535,12 +535,20 @@ func anchorStub(t *testing.T, ids []string, held int) (*httptest.Server, *string
 	return datedAnchorStub(t, entriesFor(ids), &held)
 }
 
-// entriesFor renders undated delta entries, which is what a round whose every
-// message is a fresh arrival looks like.
+// anchorAfter is the lower bound every anchor test asks for, so the entries a
+// stub hands back and the window they are reconciled against agree.
+var anchorAfter = time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+
+// entriesFor renders delta entries received inside that window, which is what a
+// round over a folder of recent mail looks like. Dated, because the round asks
+// Graph for the field and an entry without it does not count.
 func entriesFor(ids []string) []map[string]any {
 	value := make([]map[string]any, 0, len(ids))
 	for _, id := range ids {
-		value = append(value, map[string]any{"id": id})
+		value = append(value, map[string]any{
+			"id":               id,
+			"receivedDateTime": anchorAfter.Add(time.Hour).Format(time.RFC3339),
+		})
 	}
 	return value
 }
@@ -575,7 +583,7 @@ func datedAnchorStub(t *testing.T, value []map[string]any, held *int) (*httptest
 func TestAnAnchorHoldingFewerThanTheFolderReportsIsRefused(t *testing.T) {
 	srv, _ := anchorStub(t, []string{"m1"}, 5)
 	ids, delta, err := NewAPI(srv.Client(), srv.URL).
-		DeltaInit(context.Background(), "at", folderInbox, time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+		DeltaInit(context.Background(), "at", folderInbox, anchorAfter)
 	if !errors.Is(err, ErrUnreachable) {
 		t.Fatalf("err = %v, want ErrUnreachable — a round that closed short of the folder's own tally", err)
 	}
@@ -592,7 +600,7 @@ func TestAnAnchorHoldingMoreThanTheFolderReportsStands(t *testing.T) {
 	// window the tally covers. That gap must not read as a short round.
 	srv, _ := anchorStub(t, []string{"m1", "m2", "m3"}, 2)
 	ids, delta, err := NewAPI(srv.Client(), srv.URL).
-		DeltaInit(context.Background(), "at", folderInbox, time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+		DeltaInit(context.Background(), "at", folderInbox, anchorAfter)
 	if err != nil {
 		t.Fatalf("DeltaInit: %v", err)
 	}
@@ -602,7 +610,7 @@ func TestAnAnchorHoldingMoreThanTheFolderReportsStands(t *testing.T) {
 }
 
 func TestTheAnchorsTallyCoversTheWindowTheWalkOpenedIn(t *testing.T) {
-	after := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	after := anchorAfter
 	opened := time.Now().UTC()
 	srv, filter := anchorStub(t, []string{"m1"}, 1)
 	if _, _, err := NewAPI(srv.Client(), srv.URL).
@@ -635,7 +643,7 @@ func TestTheAnchorsTallyCoversTheWindowTheWalkOpenedIn(t *testing.T) {
 func TestATallyWithNoCountIsRefusedRatherThanReadAsZero(t *testing.T) {
 	srv, _ := datedAnchorStub(t, entriesFor([]string{"m1"}), nil)
 	_, _, err := NewAPI(srv.Client(), srv.URL).
-		DeltaInit(context.Background(), "at", folderInbox, time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+		DeltaInit(context.Background(), "at", folderInbox, anchorAfter)
 	if !errors.Is(err, ErrUnreachable) {
 		t.Fatalf("err = %v, want ErrUnreachable — a tally read as zero passes every round while "+
 			"measuring nothing, which is this guard wearing the costume of a green check", err)
@@ -649,7 +657,7 @@ func TestATallyWithNoCountIsRefusedRatherThanReadAsZero(t *testing.T) {
 // an old one. Counted, it stands in for an in-window message the round never
 // reached, and the short round passes.
 func TestAnEntryOlderThanTheWindowDoesNotStandInForOneInsideIt(t *testing.T) {
-	after := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	after := anchorAfter
 	held := 2
 	srv, _ := datedAnchorStub(t, []map[string]any{
 		{"id": "in-window", "receivedDateTime": after.Add(time.Hour).Format(time.RFC3339)},
@@ -669,7 +677,7 @@ func TestAnEntryOlderThanTheWindowDoesNotStandInForOneInsideIt(t *testing.T) {
 // AND AN ENTRY THE ROUND NAMED IS STILL FETCHED, whatever window it belongs to:
 // the reconciliation narrows what COUNTS, never what is captured.
 func TestAnEntryOutsideTheWindowIsStillReturnedToBeFetched(t *testing.T) {
-	after := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	after := anchorAfter
 	held := 1
 	srv, _ := datedAnchorStub(t, []map[string]any{
 		{"id": "in-window", "receivedDateTime": after.Add(time.Hour).Format(time.RFC3339)},
@@ -701,7 +709,7 @@ func TestAnOffOriginDeltaLinkIsRefusedRatherThanStored(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	_, delta, err := NewAPI(srv.Client(), srv.URL).
-		DeltaInit(context.Background(), "at", folderInbox, time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+		DeltaInit(context.Background(), "at", folderInbox, anchorAfter)
 	if err == nil {
 		t.Fatalf("DeltaInit accepted an off-origin deltaLink and would have stored %q as the cursor", delta)
 	}
@@ -720,5 +728,87 @@ func TestTheTallysUpperBoundKeepsSubsecondPrecision(t *testing.T) {
 	got := receivedBetweenFilter(after, before)
 	if !strings.HasSuffix(got, "receivedDateTime lt 2026-08-01T09:30:15.123456789Z") {
 		t.Errorf("filter = %q, want the bound at the instant it was taken, subseconds and all", got)
+	}
+}
+
+// AN ENTRY WITH NO INSTANT DOES NOT COUNT TOWARD THE WINDOW.
+//
+// The opening request asks Graph for receivedDateTime, so an entry that carries
+// none is not the ordinary silence of a field nobody asked for: it is an entry
+// that cannot be shown to belong to the window being reconciled, and one that
+// cannot be shown to belong must not stand in for a message the round never
+// reached. The cost is a refusal the next cycle retries; the alternative is a
+// watermark stored over a gap, and the watermark only moves forward.
+func TestAnUndatedEntryDoesNotStandInForOneInsideTheWindow(t *testing.T) {
+	held := 2
+	srv, _ := datedAnchorStub(t, []map[string]any{
+		{"id": "in-window", "receivedDateTime": anchorAfter.Add(time.Hour).Format(time.RFC3339)},
+		{"id": "no-instant"},
+	}, &held)
+
+	_, _, err := NewAPI(srv.Client(), srv.URL).DeltaInit(context.Background(), "at", folderInbox, anchorAfter)
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("err = %v, want ErrUnreachable: one entry belongs to the window, one says nothing, "+
+			"and the folder reports two", err)
+	}
+}
+
+// AND THE ROUND ASKS FOR THE FIELD IT RECONCILES ON. Graph does not promise
+// receivedDateTime on every entry of a delta round; $select is the request that
+// asks, and it rides the deltaLink into every later round of the same stream.
+func TestTheAnchorAsksForTheFieldItReconcilesOn(t *testing.T) {
+	var selected string
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+	mux.HandleFunc("/me/mailFolders/inbox/messages/delta", func(w http.ResponseWriter, r *http.Request) {
+		selected = r.URL.Query().Get("$select")
+		writeJSON(w, map[string]any{
+			"value":            entriesFor([]string{"m1"}),
+			"@odata.deltaLink": srv.URL + "/me/mailFolders/inbox/messages/delta?%24deltatoken=d1",
+		})
+	})
+	mux.HandleFunc("/me/mailFolders/inbox/messages", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"@odata.count": 1, "value": []map[string]any{}})
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	if _, _, err := NewAPI(srv.Client(), srv.URL).
+		DeltaInit(context.Background(), "at", folderInbox, anchorAfter); err != nil {
+		t.Fatalf("DeltaInit: %v", err)
+	}
+	if !strings.Contains(selected, "receivedDateTime") {
+		t.Errorf("$select = %q, want receivedDateTime — without asking, the field the "+
+			"reconciliation reads is one Graph does not promise", selected)
+	}
+	if !strings.Contains(selected, "id") {
+		t.Errorf("$select = %q, want the id too — there is nothing to fetch without it", selected)
+	}
+}
+
+// THE TWO SIDES READ THE LOWER BOUND THE SAME WAY.
+//
+// The filter renders `after` at second grain, so Microsoft counts everything
+// from the top of that second. Comparing against the exact instant instead would
+// drop a message arriving in the fractional remainder from the walk's side while
+// the tally kept it — a complete anchor refused as short, on nothing but a
+// rounding difference between the two questions.
+func TestASubsecondLowerBoundDoesNotRefuseACompleteAnchor(t *testing.T) {
+	// The anchor window is now-minus-a-span, so `after` carries nanoseconds in
+	// every real call; this is the ordinary case, not a contrived one.
+	after := time.Date(2026, 7, 11, 0, 0, 0, 500_000_000, time.UTC)
+	held := 1
+	srv, _ := datedAnchorStub(t, []map[string]any{
+		// Inside the second the filter opens on, before the instant itself.
+		{"id": "arrived-in-the-truncated-remainder", "receivedDateTime": "2026-07-11T00:00:00Z"},
+	}, &held)
+
+	ids, _, err := NewAPI(srv.Client(), srv.URL).DeltaInit(context.Background(), "at", folderInbox, after)
+	if err != nil {
+		t.Fatalf("DeltaInit: %v — Microsoft counted this message and the reconciliation did not, "+
+			"which is a rounding difference reported as a short round", err)
+	}
+	if len(ids) != 1 {
+		t.Errorf("ids = %v, want the one message the round named", ids)
 	}
 }

--- a/backend/internal/modules/capture/graph/client_test.go
+++ b/backend/internal/modules/capture/graph/client_test.go
@@ -532,14 +532,28 @@ func jsonStub(t *testing.T, body map[string]any) *httptest.Server {
 // ids, and a $count answering held. It records the filter the count carried.
 func anchorStub(t *testing.T, ids []string, held int) (*httptest.Server, *string) {
 	t.Helper()
+	return datedAnchorStub(t, entriesFor(ids), &held)
+}
+
+// entriesFor renders undated delta entries, which is what a round whose every
+// message is a fresh arrival looks like.
+func entriesFor(ids []string) []map[string]any {
+	value := make([]map[string]any, 0, len(ids))
+	for _, id := range ids {
+		value = append(value, map[string]any{"id": id})
+	}
+	return value
+}
+
+// datedAnchorStub serves one folder: a single-page delta round holding the given
+// raw entries, and a $count answering held — omitting @odata.count entirely when
+// held is nil. It records the filter the count carried.
+func datedAnchorStub(t *testing.T, value []map[string]any, held *int) (*httptest.Server, *string) {
+	t.Helper()
 	var countFilter string
 	mux := http.NewServeMux()
 	var srv *httptest.Server
 	mux.HandleFunc("/me/mailFolders/inbox/messages/delta", func(w http.ResponseWriter, _ *http.Request) {
-		value := make([]map[string]any, 0, len(ids))
-		for _, id := range ids {
-			value = append(value, map[string]any{"id": id})
-		}
 		writeJSON(w, map[string]any{
 			"value":            value,
 			"@odata.deltaLink": srv.URL + "/me/mailFolders/inbox/messages/delta?%24deltatoken=d1",
@@ -547,7 +561,11 @@ func anchorStub(t *testing.T, ids []string, held int) (*httptest.Server, *string
 	})
 	mux.HandleFunc("/me/mailFolders/inbox/messages", func(w http.ResponseWriter, r *http.Request) {
 		countFilter = r.URL.Query().Get("$filter")
-		writeJSON(w, map[string]any{"@odata.count": held, "value": []map[string]any{}})
+		body := map[string]any{"value": []map[string]any{}}
+		if held != nil {
+			body["@odata.count"] = *held
+		}
+		writeJSON(w, body)
 	})
 	srv = httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
@@ -606,5 +624,101 @@ func TestTheAnchorsTallyCoversTheWindowTheWalkOpenedIn(t *testing.T) {
 	// Second-grain rendering floors the bound, so allow the second it truncates.
 	if at.Before(opened.Truncate(time.Second)) || at.After(closed) {
 		t.Errorf("upper bound = %s, want the instant the walk opened (between %s and %s)", at, opened, closed)
+	}
+}
+
+// A TALLY THAT DID NOT ANSWER is not a tally of zero.
+//
+// A 2xx without @odata.count — the shape a request Graph decides not to count
+// can take — would read as "the folder holds none", and no walk can fall short
+// of none. The reconciliation would pass every round while measuring nothing.
+func TestATallyWithNoCountIsRefusedRatherThanReadAsZero(t *testing.T) {
+	srv, _ := datedAnchorStub(t, entriesFor([]string{"m1"}), nil)
+	_, _, err := NewAPI(srv.Client(), srv.URL).
+		DeltaInit(context.Background(), "at", folderInbox, time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("err = %v, want ErrUnreachable — a tally read as zero passes every round while "+
+			"measuring nothing, which is this guard wearing the costume of a green check", err)
+	}
+}
+
+// AN ENTRY FROM OUTSIDE THE WINDOW DOES NOT COUNT TOWARD IT.
+//
+// A delta tracks a FOLDER, not a query: Microsoft may name a message that falls
+// outside the filter because something about it changed — a read/unread flip on
+// an old one. Counted, it stands in for an in-window message the round never
+// reached, and the short round passes.
+func TestAnEntryOlderThanTheWindowDoesNotStandInForOneInsideIt(t *testing.T) {
+	after := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	held := 2
+	srv, _ := datedAnchorStub(t, []map[string]any{
+		{"id": "in-window", "receivedDateTime": after.Add(time.Hour).Format(time.RFC3339)},
+		{"id": "changed-old-message", "receivedDateTime": after.Add(-30 * 24 * time.Hour).Format(time.RFC3339)},
+	}, &held)
+
+	ids, _, err := NewAPI(srv.Client(), srv.URL).DeltaInit(context.Background(), "at", folderInbox, after)
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("err = %v, want ErrUnreachable: the round holds ONE message from the window and the "+
+			"folder reports two, and an entry from a month earlier is not the missing one", err)
+	}
+	if ids != nil {
+		t.Errorf("ids = %v, want none alongside the refusal", ids)
+	}
+}
+
+// AND AN ENTRY THE ROUND NAMED IS STILL FETCHED, whatever window it belongs to:
+// the reconciliation narrows what COUNTS, never what is captured.
+func TestAnEntryOutsideTheWindowIsStillReturnedToBeFetched(t *testing.T) {
+	after := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	held := 1
+	srv, _ := datedAnchorStub(t, []map[string]any{
+		{"id": "in-window", "receivedDateTime": after.Add(time.Hour).Format(time.RFC3339)},
+		{"id": "changed-old-message", "receivedDateTime": after.Add(-30 * 24 * time.Hour).Format(time.RFC3339)},
+	}, &held)
+
+	ids, _, err := NewAPI(srv.Client(), srv.URL).DeltaInit(context.Background(), "at", folderInbox, after)
+	if err != nil {
+		t.Fatalf("DeltaInit: %v", err)
+	}
+	if strings.Join(ids, ",") != "in-window,changed-old-message" {
+		t.Errorf("ids = %v, want both — a message the round named is a message to fetch", ids)
+	}
+}
+
+// A DELTALINK IS CHECKED FOR ORIGIN LIKE A NEXTLINK, and needs it more: this one
+// is STORED. An off-origin deltaLink becomes the cursor, and every later cycle
+// then refuses it before fetching anything — a refusal that is not the 410 a
+// re-anchor answers, so the mailbox has no way back.
+func TestAnOffOriginDeltaLinkIsRefusedRatherThanStored(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/me/mailFolders/inbox/messages/delta", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"value":            []map[string]any{{"id": "m1"}},
+			"@odata.deltaLink": "https://attacker.example/me/mailFolders/inbox/messages/delta?%24deltatoken=d1",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	_, delta, err := NewAPI(srv.Client(), srv.URL).
+		DeltaInit(context.Background(), "at", folderInbox, time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC))
+	if err == nil {
+		t.Fatalf("DeltaInit accepted an off-origin deltaLink and would have stored %q as the cursor", delta)
+	}
+	if !strings.Contains(err.Error(), "does not point at the graph api") {
+		t.Errorf("err = %v, want the origin refusal", err)
+	}
+}
+
+// THE UPPER BOUND KEEPS ITS SUBSECOND DIGITS. Format truncates, so a
+// second-grain bound moves the window back by up to a second and drops whatever
+// arrived in it out of the tally — quietly, which is the failure this window is
+// for.
+func TestTheTallysUpperBoundKeepsSubsecondPrecision(t *testing.T) {
+	after := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 8, 1, 9, 30, 15, 123456789, time.UTC)
+	got := receivedBetweenFilter(after, before)
+	if !strings.HasSuffix(got, "receivedDateTime lt 2026-08-01T09:30:15.123456789Z") {
+		t.Errorf("filter = %q, want the bound at the instant it was taken, subseconds and all", got)
 	}
 }

--- a/backend/internal/modules/capture/graph/coverage_test.go
+++ b/backend/internal/modules/capture/graph/coverage_test.go
@@ -99,8 +99,15 @@ func fail500(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.Status
 
 // emptyRound is a folder with nothing new in it, for a test that is about the
 // other folder.
-func emptyRound(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, map[string]any{"value": []map[string]any{}, "@odata.deltaLink": "https://graph/none"})
+// The link is built from the request rather than named outright: a deltaLink is
+// STORED and followed on the next cycle, so the client refuses one pointing
+// anywhere but the API it is talking to, and this stub has to be a Graph that
+// behaves.
+func emptyRound(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, map[string]any{
+		"value":            []map[string]any{},
+		"@odata.deltaLink": "http://" + r.Host + r.URL.Path + "?%24deltatoken=none",
+	})
 }
 
 func authViaStub(t *testing.T, c *Connector) []byte {

--- a/backend/internal/modules/capture/graph/coverage_test.go
+++ b/backend/internal/modules/capture/graph/coverage_test.go
@@ -75,6 +75,13 @@ func fullStub(t *testing.T, overrides map[string]http.HandlerFunc) *serveMuxWith
 			"@odata.deltaLink": s.srv.URL + "/me/mailFolders/sentitems/messages/delta?%24deltatoken=s1",
 		})
 	})
+	// The tally an anchor reconciles its walk against. Nothing here carries a
+	// receivedDateTime, so the closed window holds none of it and every canned
+	// round measures up; what the reconciliation refuses is covered against a
+	// stub built for it in client_test.go.
+	reg("/me/mailFolders/{folder}/messages", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"@odata.count": 0, "value": []map[string]any{}})
+	})
 	reg("/me/messages/s1/$value", func(w http.ResponseWriter, _ *http.Request) {
 		//craft:ignore swallowed-errors test stub write; a short write surfaces as the client-side assertion failure
 		_, _ = w.Write(sentMsg("s1@x", "buyer@acme.com"))

--- a/backend/internal/modules/capture/graph/delta.go
+++ b/backend/internal/modules/capture/graph/delta.go
@@ -29,11 +29,17 @@ func receivedAfterFilter(after time.Time) string {
 }
 
 // receivedBetweenFilter closes that window at the top: ge <after> and lt
-// <before>. Second-grain rendering floors the upper bound, which narrows the
-// window rather than widening it — the safe direction for a tally a walk is
-// measured against.
+// <before>.
+//
+// The upper bound keeps its subsecond digits (RFC3339Nano) where the lower one
+// does not need them. The lower bound is a product parameter measured in
+// months; this one is the instant a walk opened, and Format TRUNCATES, so
+// second-grain rendering would move it back by up to a second and drop whatever
+// arrived in that second out of the tally the walk is measured against. Losing
+// it in that direction is losing it quietly, which is the whole failure this
+// window exists to catch.
 func receivedBetweenFilter(after, before time.Time) string {
-	return receivedAfterFilter(after) + " and receivedDateTime lt " + before.UTC().Format(time.RFC3339)
+	return receivedAfterFilter(after) + " and receivedDateTime lt " + before.UTC().Format(time.RFC3339Nano)
 }
 
 // The two well-known folders a standing sync follows. Named constants because
@@ -51,9 +57,55 @@ type deltaPage struct {
 	Value []struct {
 		ID      string           `json:"id"`
 		Removed *json.RawMessage `json:"@removed"`
+		// ReceivedAt is what decides whether an entry belongs to the window a
+		// filtered round asked for. A delta tracks a FOLDER, not a query, so
+		// Microsoft may emit an entry for a message outside the filter when
+		// something about it changed — a read/unread flip on an old message.
+		// Zero where the entry does not say.
+		ReceivedAt time.Time `json:"receivedDateTime"` //nolint:tagliatelle // Microsoft's wire format; must match to decode
 	} `json:"value"`
 	NextLink  string `json:"@odata.nextLink"`  //nolint:tagliatelle // Microsoft's wire format; must match to decode
 	DeltaLink string `json:"@odata.deltaLink"` //nolint:tagliatelle // Microsoft's wire format; must match to decode
+}
+
+// deltaEntry is one message a walk named, with the instant that decides which
+// window it belongs to.
+type deltaEntry struct {
+	id         string
+	receivedAt time.Time
+}
+
+// ids drops the timestamps: every entry a walk named is a message to fetch,
+// whatever window it belongs to.
+func entryIDs(entries []deltaEntry) []string {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.id)
+	}
+	return out
+}
+
+// countWithin counts the DISTINCT entries a walk named that belong to
+// [after, before) — the window a tally covers.
+//
+// An entry that does not carry an instant counts: it cannot be shown to be
+// outside the window, and refusing an anchor over what the response declined to
+// say would be refusing on our own ignorance rather than on evidence. What this
+// does exclude is the entry that says, in Microsoft's own words, that it belongs
+// to some older window — the one that would otherwise pad the walk's side of the
+// reconciliation and let a short round pass.
+func countWithin(entries []deltaEntry, after, before time.Time) int {
+	seen := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		if !e.receivedAt.IsZero() && (e.receivedAt.Before(after) || !e.receivedAt.Before(before)) {
+			continue
+		}
+		seen[e.id] = true
+	}
+	return len(seen)
 }
 
 func (a *httpAPI) DeltaInit(ctx context.Context, accessToken, folder string, after time.Time) ([]string, string, error) {
@@ -62,7 +114,7 @@ func (a *httpAPI) DeltaInit(ctx context.Context, accessToken, folder string, aft
 	// receivedDateTime bounds BOTH folders: Exchange stamps it on a sent
 	// message too, so one filter serves the pair rather than the sent side
 	// needing sentDateTime and a second spelling of "recently".
-	ids, deltaLink, err := a.deltaWalk(ctx, accessToken,
+	entries, deltaLink, err := a.deltaWalk(ctx, accessToken,
 		a.base+"/me/mailFolders/"+url.PathEscape(folder)+"/messages/delta?"+q.Encode())
 	if err != nil {
 		return nil, "", err
@@ -82,12 +134,18 @@ func (a *httpAPI) DeltaInit(ctx context.Context, accessToken, folder string, aft
 	// the counted window yet may be inside the walk, and one deleted mid-walk
 	// leaves both. A walk short of the tally is therefore evidence the round
 	// ended early, never an artifact of the gap between the two calls.
-	if len(ids) < held {
+	// Measured on the entries that BELONG to the counted window, not on
+	// everything the round named: a delta tracks a folder rather than a query,
+	// so an entry for an older message that merely changed would otherwise pad
+	// this side and let a short round pass. Every entry is still returned — a
+	// message named by the round is a message to fetch, whatever window it
+	// belongs to.
+	if walked := countWithin(entries, after, opened); walked < held {
 		return nil, "", fmt.Errorf(
-			"graph: the %s anchor closed after %d message(s) but the folder holds %d since %s: %w",
-			folder, len(ids), held, after.UTC().Format(time.RFC3339), ErrUnreachable)
+			"graph: the %s anchor closed holding %d message(s) from the window but the folder holds %d since %s: %w",
+			folder, walked, held, after.UTC().Format(time.RFC3339), ErrUnreachable)
 	}
-	return ids, deltaLink, nil
+	return entryIDs(entries), deltaLink, nil
 }
 
 // countInFolder reports how many messages one folder holds for a filter, so a
@@ -95,7 +153,14 @@ func (a *httpAPI) DeltaInit(ctx context.Context, accessToken, folder string, aft
 // rather than trusted because its last round closed.
 func (a *httpAPI) countInFolder(ctx context.Context, accessToken, folder, filter string) (int, error) {
 	var out struct {
-		Count int `json:"@odata.count"` //nolint:tagliatelle // Microsoft's wire format; must match to decode
+		// A POINTER, so "Microsoft said none" is distinguishable from "Microsoft
+		// did not answer the question". Read as an int, a 2xx that omits
+		// @odata.count — the shape a request missing ConsistencyLevel can take —
+		// would arrive as a tally of zero, and a tally of zero is one no walk can
+		// ever fall short of. The reconciliation would pass every round while
+		// measuring nothing, which is the failure it exists to catch wearing the
+		// costume of a green check.
+		Count *int `json:"@odata.count"` //nolint:tagliatelle // Microsoft's wire format; must match to decode
 	}
 	q := url.Values{
 		paramFilter: {filter},
@@ -109,22 +174,30 @@ func (a *httpAPI) countInFolder(ctx context.Context, accessToken, folder, filter
 	if _, err := a.get(ctx, accessToken, u, hdr, &out); err != nil {
 		return 0, err
 	}
-	return out.Count, nil
+	if out.Count == nil {
+		return 0, fmt.Errorf(
+			"graph: the %s tally came back without a count: %w", folder, ErrUnreachable)
+	}
+	return *out.Count, nil
 }
 
 func (a *httpAPI) Delta(ctx context.Context, accessToken, deltaLink string) ([]string, string, error) {
 	if err := a.sameAPIOrigin(deltaLink); err != nil {
 		return nil, "", err
 	}
-	return a.deltaWalk(ctx, accessToken, deltaLink)
+	entries, next, err := a.deltaWalk(ctx, accessToken, deltaLink)
+	if err != nil {
+		return nil, "", err
+	}
+	return entryIDs(entries), next, nil
 }
 
 // deltaWalk follows a delta round from startURL through every nextLink until
 // Graph hands back the deltaLink that closes it, collecting the ids of the
 // non-tombstoned messages along the way. A 410 anywhere in the walk means the
 // server no longer honors this delta state (ErrDeltaGone).
-func (a *httpAPI) deltaWalk(ctx context.Context, accessToken, startURL string) ([]string, string, error) {
-	var ids []string
+func (a *httpAPI) deltaWalk(ctx context.Context, accessToken, startURL string) ([]deltaEntry, string, error) {
+	var entries []deltaEntry
 	next := startURL
 	for {
 		var page deltaPage
@@ -137,7 +210,7 @@ func (a *httpAPI) deltaWalk(ctx context.Context, accessToken, startURL string) (
 		}
 		for _, m := range page.Value {
 			if m.ID != "" && m.Removed == nil {
-				ids = append(ids, m.ID)
+				entries = append(entries, deltaEntry{id: m.ID, receivedAt: m.ReceivedAt.UTC()})
 			}
 		}
 		if page.NextLink == "" {
@@ -147,7 +220,16 @@ func (a *httpAPI) deltaWalk(ctx context.Context, accessToken, startURL string) (
 				// unreachable rather than reporting success with no watermark.
 				return nil, "", ErrUnreachable
 			}
-			return ids, page.DeltaLink, nil
+			// The deltaLink gets the same check as a nextLink, and needs it
+			// more: this one is STORED. A nextLink is followed once and the
+			// round ends either way, while an off-origin deltaLink becomes the
+			// cursor, and every later cycle then fails its own origin check
+			// before fetching anything — a mailbox stuck with no way back,
+			// since that refusal is not the 410 a re-anchor answers.
+			if err := a.sameAPIOrigin(page.DeltaLink); err != nil {
+				return nil, "", err
+			}
+			return entries, page.DeltaLink, nil
 		}
 		if err := a.sameAPIOrigin(page.NextLink); err != nil {
 			return nil, "", err

--- a/backend/internal/modules/capture/graph/delta.go
+++ b/backend/internal/modules/capture/graph/delta.go
@@ -25,8 +25,21 @@ import (
 // receivedDateTime ge <instant>. The window boundary is a product parameter
 // measured in months, so second-grain UTC rendering loses nothing.
 func receivedAfterFilter(after time.Time) string {
-	return "receivedDateTime ge " + after.UTC().Format(time.RFC3339)
+	return "receivedDateTime ge " + filterInstant(after).Format(time.RFC3339)
 }
+
+// filterInstant is the lower bound AS MICROSOFT WILL READ IT: second-grain,
+// because that is what RFC3339 rendering leaves of it.
+//
+// Spelled once and shared with the reconciliation, so the two cannot drift. They
+// did: the filter asked Graph for everything from the top of the second while
+// the tally compared against the exact instant, so a message arriving in the
+// fractional remainder counted on Microsoft's side and not on ours — a complete
+// anchor refused as short, every time a mailbox happened to receive one there.
+//
+// Held by: TestASubsecondLowerBoundDoesNotRefuseACompleteAnchor
+// (backend/internal/modules/capture/graph/client_test.go)
+func filterInstant(t time.Time) time.Time { return t.UTC().Truncate(time.Second) }
 
 // receivedBetweenFilter closes that window at the top: ge <after> and lt
 // <before>.
@@ -89,18 +102,24 @@ func entryIDs(entries []deltaEntry) []string {
 }
 
 // countWithin counts the DISTINCT entries a walk named that belong to
-// [after, before) — the window a tally covers.
+// [after, before) — the window a tally covers, with the lower bound read the way
+// Microsoft read it.
 //
-// An entry that does not carry an instant counts: it cannot be shown to be
-// outside the window, and refusing an anchor over what the response declined to
-// say would be refusing on our own ignorance rather than on evidence. What this
-// does exclude is the entry that says, in Microsoft's own words, that it belongs
-// to some older window — the one that would otherwise pad the walk's side of the
-// reconciliation and let a short round pass.
+// An entry that carries no instant does not count. The round ASKS for the field
+// ($select on the opening request), so its absence is not the ordinary silence
+// of a response that was never asked — it is an entry that cannot be shown to
+// belong to the window being reconciled, and one that cannot be shown to belong
+// is exactly what must not stand in for a message the round never reached. The
+// cost of the strict reading is a loud refusal that the next cycle retries; the
+// cost of the lenient one is a watermark stored over a gap, and the watermark
+// only moves forward.
 func countWithin(entries []deltaEntry, after, before time.Time) int {
+	from := filterInstant(after)
 	seen := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		if !e.receivedAt.IsZero() && (e.receivedAt.Before(after) || !e.receivedAt.Before(before)) {
+		// One comparison covers the undated entry too: an absent instant decodes
+		// to the zero time, which precedes every window an anchor can ask for.
+		if e.receivedAt.Before(from) || !e.receivedAt.Before(before) {
 			continue
 		}
 		seen[e.id] = true
@@ -110,7 +129,15 @@ func countWithin(entries []deltaEntry, after, before time.Time) int {
 
 func (a *httpAPI) DeltaInit(ctx context.Context, accessToken, folder string, after time.Time) ([]string, string, error) {
 	opened := time.Now().UTC()
-	q := url.Values{paramFilter: {receivedAfterFilter(after)}}
+	// $select, so the walk is answered in the two fields it reconciles on rather
+	// than in whatever Graph would send by default: receivedDateTime is not
+	// promised on every entry of a delta round, and this is the request that
+	// asks for it. It rides the deltaLink into every later round of the same
+	// stream, so a resume is answered the same way.
+	q := url.Values{
+		paramFilter: {receivedAfterFilter(after)},
+		paramSelect: {"id,receivedDateTime"},
+	}
 	// receivedDateTime bounds BOTH folders: Exchange stamps it on a sent
 	// message too, so one filter serves the pair rather than the sent side
 	// needing sentDateTime and a second spelling of "recently".

--- a/backend/internal/modules/capture/graph/delta.go
+++ b/backend/internal/modules/capture/graph/delta.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package graph
+
+// The messages delta: how a mailbox is read forward. An anchor opens a filtered
+// round over one well-known folder and walks it to a deltaLink; every later
+// cycle resumes from the link the last one stored.
+//
+// The watermark only ever moves forward, so a round that fell short of its own
+// window would drop what it missed for good. That is why an anchor reconciles
+// its walk against the folder's own tally before the link it ends on is allowed
+// to stand as a watermark.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// receivedAfterFilter renders Graph's only supported delta/list filter:
+// receivedDateTime ge <instant>. The window boundary is a product parameter
+// measured in months, so second-grain UTC rendering loses nothing.
+func receivedAfterFilter(after time.Time) string {
+	return "receivedDateTime ge " + after.UTC().Format(time.RFC3339)
+}
+
+// receivedBetweenFilter closes that window at the top: ge <after> and lt
+// <before>. Second-grain rendering floors the upper bound, which narrows the
+// window rather than widening it — the safe direction for a tally a walk is
+// measured against.
+func receivedBetweenFilter(after, before time.Time) string {
+	return receivedAfterFilter(after) + " and receivedDateTime lt " + before.UTC().Format(time.RFC3339)
+}
+
+// The two well-known folders a standing sync follows. Named constants because
+// they are Microsoft's own identifiers rather than folder names a person chose,
+// and because which folder a message came from is what attests whether the
+// owner sent it.
+const (
+	folderInbox = "inbox"
+	folderSent  = "sentitems"
+)
+
+// deltaPage is one page of a messages delta. A tombstoned entry
+// carries @removed instead of message fields — nothing to fetch for it.
+type deltaPage struct {
+	Value []struct {
+		ID      string           `json:"id"`
+		Removed *json.RawMessage `json:"@removed"`
+	} `json:"value"`
+	NextLink  string `json:"@odata.nextLink"`  //nolint:tagliatelle // Microsoft's wire format; must match to decode
+	DeltaLink string `json:"@odata.deltaLink"` //nolint:tagliatelle // Microsoft's wire format; must match to decode
+}
+
+func (a *httpAPI) DeltaInit(ctx context.Context, accessToken, folder string, after time.Time) ([]string, string, error) {
+	opened := time.Now().UTC()
+	q := url.Values{paramFilter: {receivedAfterFilter(after)}}
+	// receivedDateTime bounds BOTH folders: Exchange stamps it on a sent
+	// message too, so one filter serves the pair rather than the sent side
+	// needing sentDateTime and a second spelling of "recently".
+	ids, deltaLink, err := a.deltaWalk(ctx, accessToken,
+		a.base+"/me/mailFolders/"+url.PathEscape(folder)+"/messages/delta?"+q.Encode())
+	if err != nil {
+		return nil, "", err
+	}
+	// A round that ends with a deltaLink says "you are at the end" but a
+	// filtered delta closing early would say exactly the same thing, and the
+	// watermark that follows only ever moves forward — so anything the round
+	// fell short of would never be offered again. Measure the walk against the
+	// folder's own tally before letting the watermark stand.
+	held, err := a.countInFolder(ctx, accessToken, folder, receivedBetweenFilter(after, opened))
+	if err != nil {
+		return nil, "", err
+	}
+	// The tally is taken AFTER the walk over a window closed at the instant the
+	// walk opened, so both ways a mailbox can move meanwhile push the walk's
+	// side up rather than the tally's: a message arriving mid-walk is outside
+	// the counted window yet may be inside the walk, and one deleted mid-walk
+	// leaves both. A walk short of the tally is therefore evidence the round
+	// ended early, never an artifact of the gap between the two calls.
+	if len(ids) < held {
+		return nil, "", fmt.Errorf(
+			"graph: the %s anchor closed after %d message(s) but the folder holds %d since %s: %w",
+			folder, len(ids), held, after.UTC().Format(time.RFC3339), ErrUnreachable)
+	}
+	return ids, deltaLink, nil
+}
+
+// countInFolder reports how many messages one folder holds for a filter, so a
+// walk over that folder can be measured against the provider's own tally
+// rather than trusted because its last round closed.
+func (a *httpAPI) countInFolder(ctx context.Context, accessToken, folder, filter string) (int, error) {
+	var out struct {
+		Count int `json:"@odata.count"` //nolint:tagliatelle // Microsoft's wire format; must match to decode
+	}
+	q := url.Values{
+		paramFilter: {filter},
+		paramCount:  {"true"},
+		paramSelect: {"id"},
+		paramTop:    {"1"},
+	}
+	// $count=true needs the eventual-consistency header on Graph.
+	hdr := http.Header{"ConsistencyLevel": {"eventual"}}
+	u := a.base + "/me/mailFolders/" + url.PathEscape(folder) + "/messages?" + q.Encode()
+	if _, err := a.get(ctx, accessToken, u, hdr, &out); err != nil {
+		return 0, err
+	}
+	return out.Count, nil
+}
+
+func (a *httpAPI) Delta(ctx context.Context, accessToken, deltaLink string) ([]string, string, error) {
+	if err := a.sameAPIOrigin(deltaLink); err != nil {
+		return nil, "", err
+	}
+	return a.deltaWalk(ctx, accessToken, deltaLink)
+}
+
+// deltaWalk follows a delta round from startURL through every nextLink until
+// Graph hands back the deltaLink that closes it, collecting the ids of the
+// non-tombstoned messages along the way. A 410 anywhere in the walk means the
+// server no longer honors this delta state (ErrDeltaGone).
+func (a *httpAPI) deltaWalk(ctx context.Context, accessToken, startURL string) ([]string, string, error) {
+	var ids []string
+	next := startURL
+	for {
+		var page deltaPage
+		status, err := a.get(ctx, accessToken, next, nil, &page)
+		if err != nil {
+			if status == http.StatusGone {
+				return nil, "", ErrDeltaGone
+			}
+			return nil, "", err
+		}
+		for _, m := range page.Value {
+			if m.ID != "" && m.Removed == nil {
+				ids = append(ids, m.ID)
+			}
+		}
+		if page.NextLink == "" {
+			if page.DeltaLink == "" {
+				// A closed round with neither a next nor a delta link has lost
+				// the resumable cursor — treat the malformed response as
+				// unreachable rather than reporting success with no watermark.
+				return nil, "", ErrUnreachable
+			}
+			return ids, page.DeltaLink, nil
+		}
+		if err := a.sameAPIOrigin(page.NextLink); err != nil {
+			return nil, "", err
+		}
+		next = page.NextLink
+	}
+}
+
+// sameAPIOrigin refuses any continuation URL that does not live under the
+// configured Graph base. nextLink/deltaLink are server-supplied URLs the
+// client follows bearing the access token — and the deltaLink round-trips
+// through the stored sync cursor — so an off-origin link (tampered cursor,
+// broken provider) must never be fetched.


### PR DESCRIPTION
Closes #3523.

## What was wrong

`DeltaInit` opened a filtered delta over one well-known folder and `deltaWalk` followed `@odata.nextLink` until Graph handed back an `@odata.deltaLink`. Whatever the walk had collected was captured and the link became the folder's watermark.

Nothing checked that the walk had seen the whole window. A filtered round that closes early is indistinguishable, on the wire, from one that reached the end — both end on a deltaLink. And because the watermark only ever moves forward, anything a short round fell short of would never be offered to a later sync.

## What it does now

`DeltaInit` asks the folder how many messages it holds for the same window and refuses to return a watermark when the walk came up short, with `ErrUnreachable`. The caller already treats that as a cycle that stores nothing and retries, so a silent gap becomes a loud, self-healing one.

The ordering is the part worth reading:

- the tally is taken **after** the walk,
- over a window **closed at the instant the walk opened**.

That way both directions a mailbox can move during a walk push the walk's side up rather than the tally's. A message arriving mid-walk is outside the counted window yet may be inside the walk's result; one deleted mid-walk leaves both. So `walked < tally` is evidence the round ended early, never an artifact of the gap between the two calls. A two-sided equality check would have been the bug here, and one of the tests pins that.

The ticket offered two shapes: partition the window, or reconcile against a `$count`. This is the second, because it holds the invariant for both folders at once without changing what a cycle reads.

## Tests

Three, each mutation-checked:

- a walk holding fewer than the folder reports is refused, with no ids and no link — dropping the guard fails it;
- a walk holding more than the folder reports stands, which is the arrived-mid-walk case — tightening the comparison to `!=` fails it;
- the tally's filter carries a closed upper bound at the instant the walk opened — leaving the window open fails it.

## Note on the file split

The delta half of the client moves to `delta.go`. `client.go` was 542 lines with the addition, over the 500-LOC cap; the split is along the seam the cap asks for rather than a shuffle to get under it.

`make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved synchronization of inbox and sent messages through Microsoft Graph.
  * Added reliable pagination and continuation handling for large message sets.
  * Added recovery support when synchronization links expire.

* **Bug Fixes**
  * Improved reconciliation for empty folders and messages added during synchronization.
  * Preserved message timestamps throughout synchronization.
  * Ensured counts use the correct time window, including subsecond precision.
  * Excluded undated messages from folder reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->