### PR TITLE
A meeting nobody prepared says so

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -34047,7 +34047,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [pinned, buyer_wrote_last, waiting_days, overdue, due_today, closing_soon, expected_revenue, material, below_material, quiet_days, no_champion, promised, approved_and_failed, blocks_customer_work, routine, repeated_failure, legal_deadline, meeting_soon, stale]
+          enum: [pinned, buyer_wrote_last, waiting_days, overdue, due_today, closing_soon, expected_revenue, material, below_material, quiet_days, no_champion, promised, approved_and_failed, blocks_customer_work, routine, repeated_failure, legal_deadline, meeting_soon, meeting_unprepared, stale]
           description: 'Which fact this is. The client writes the phrase.'
         value: { $ref: '#/components/schemas/WorklistValue' }
 

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -128,29 +128,6 @@ func carriedActions(actions []crmcontracts.AttentionItemActions) []crmcontracts.
 	return out
 }
 
-// classifyMeeting: a meeting starting within the horizon is the most urgent
-// thing on the page, because it happens whether or not the reader acts.
-func classifyMeeting(item crmcontracts.AttentionItem, asOf time.Time) ranked {
-	level := levelAgreed
-	reasons := []crmcontracts.WorklistReason{}
-	if item.DueAt != nil && item.DueAt.Sub(asOf) <= meetingHorizon {
-		level = levelWaiting
-		reasons = append(reasons, reason("meeting_soon", nil))
-	}
-	// Nothing written down for it, said only where the lane could actually tell
-	// — an absent kind means the reader may not read the row's content, not
-	// that the meeting is ready. Silence beats a warning nobody can act on.
-	if item.Kind != nil && *item.Kind == meetingKindUnprepared {
-		reasons = append(reasons, reason("meeting_unprepared", nil))
-	}
-	row := base(item, level, "meetings", "meeting_unprepared")
-	// A meeting's start time IS a deadline the reader is racing, so it counts
-	// as work due — unlike a proposal's expiry, which merely lapses.
-	stampDeadline(&row, item.DueAt, asOf)
-	row.Because = reasons
-	return ranked{item: row, deadlineAt: deadlineOf(item.DueAt), occurredAt: occurredOf(item, asOf)}
-}
-
 // classifyCommitment: a promise the rep made. Level 2 whether or not it is
 // overdue — the promise is the fact, and the date only orders it.
 func classifyCommitment(item crmcontracts.AttentionItem, asOf time.Time) ranked {

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -137,6 +137,12 @@ func classifyMeeting(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 		level = levelWaiting
 		reasons = append(reasons, reason("meeting_soon", nil))
 	}
+	// Nothing written down for it, said only where the lane could actually tell
+	// — an absent kind means the reader may not read the row's content, not
+	// that the meeting is ready. Silence beats a warning nobody can act on.
+	if item.Kind != nil && *item.Kind == meetingKindUnprepared {
+		reasons = append(reasons, reason("meeting_unprepared", nil))
+	}
 	row := base(item, level, "meetings", "meeting_unprepared")
 	// A meeting's start time IS a deadline the reader is racing, so it counts
 	// as work due — unlike a proposal's expiry, which merely lapses.

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -422,6 +422,22 @@ type Meeting struct {
 	ID       ids.UUID
 	Subject  string
 	StartsAt time.Time
+
+	// NeedsPrep is true when nothing has been written down for a meeting that
+	// is about to happen: no agenda or notes body, and nobody outside this
+	// organization recorded on it.
+	//
+	// It is a THREE-state answer squeezed into a bool plus its guard below, and
+	// the third state is why: a meeting whose content this reader may not read
+	// arrives with an empty body for a reason that has nothing to do with
+	// preparation. Calling that "needs prep" would tell a rep to prepare a
+	// meeting they cannot see, so the lane leaves PrepKnown false instead and
+	// the surface says nothing rather than something false.
+	NeedsPrep bool
+
+	// PrepKnown reports whether NeedsPrep was answerable at all. False when the
+	// row's content is withheld from this reader.
+	PrepKnown bool
 }
 
 // Notices is the acting person's own unread notices — the durable

--- a/backend/internal/compose/attention/meeting.go
+++ b/backend/internal/compose/attention/meeting.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The meeting concern: how a booked meeting becomes an item, and how that item
+// is ranked. Both halves read the same two facts — when it starts, and whether
+// anybody has written anything down for it — so they live together rather than
+// one file apart, where a change to the hint could stop the ranking reading it.
+
+import (
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// meetingItem renders one appointment still ahead today.
+//
+// The subject IS the sentence a rep recognises — somebody wrote it when the
+// meeting was booked — so it travels as the title, and the start time as
+// `due_at` because that is what a reader is racing. No `overdue` flag: a
+// meeting that has not started cannot be late, and the lane only carries the
+// ones still ahead.
+//
+// It offers NO verb. The pre-meeting brief is its own surface with its own eight
+// cited sections, and a queue that tried to summarise it here would be a second
+// answer to "prepare me for this". `open` is withheld for a narrower reason than
+// it once was: this card's subject is the ACTIVITY, which is a timeline entry
+// rather than a record with a page of its own, so the verb would advertise a
+// destination that does not exist. The two cards whose subject IS a record —
+// the quiet deal and the promise — now send it.
+func meetingItem(meeting Meeting) crmcontracts.AttentionItem {
+	subject := meeting.Subject
+	starts := meeting.StartsAt
+	item := crmcontracts.AttentionItem{
+		Id:      meeting.ID.String(),
+		Source:  crmcontracts.AttentionItemSource("meeting"),
+		Title:   &subject,
+		Subject: subjectOf("activity", meeting.ID),
+		DueAt:   &starts,
+		Actions: []crmcontracts.AttentionItemActions{},
+	}
+	// `kind` is the producer's own sub-type, for the icon and the label and
+	// never for authority — which is exactly what "nobody has written anything
+	// down for this yet" is. Carried here rather than as a field of its own so
+	// the contract gains no vocabulary for a display hint.
+	//
+	// Set only when the answer is KNOWN. A meeting whose content this reader may
+	// not read arrives with an empty body for a reason that is not preparation,
+	// and `meetingPrep` refuses to guess; an absent kind is that refusal
+	// reaching the page, where it draws nothing.
+	if meeting.PrepKnown && meeting.NeedsPrep {
+		kind := meetingKindUnprepared
+		item.Kind = &kind
+	}
+	return item
+}
+
+// meetingKindUnprepared marks a meeting with nothing written down for it.
+//
+// One spelling, written by meetingItem and read by classifyMeeting. A second
+// would be silent: the writer would stamp a word the reader never matches, and
+// the reason would simply stop appearing on rows that had earned it.
+//
+// Held by: TestTheUnpreparedMarkHasOneSpelling
+// (backend/internal/compose/attention/meetingpreplane_test.go)
+const meetingKindUnprepared = "unprepared"
+
+// classifyMeeting: a meeting starting within the horizon is the most urgent
+// thing on the page, because it happens whether or not the reader acts.
+func classifyMeeting(item crmcontracts.AttentionItem, asOf time.Time) ranked {
+	level := levelAgreed
+	reasons := []crmcontracts.WorklistReason{}
+	if item.DueAt != nil && item.DueAt.Sub(asOf) <= meetingHorizon {
+		level = levelWaiting
+		reasons = append(reasons, reason("meeting_soon", nil))
+	}
+	// Nothing written down for it, said only where the lane could actually tell
+	// — an absent kind means the reader may not read the row's content, not
+	// that the meeting is ready. Silence beats a warning nobody can act on.
+	if item.Kind != nil && *item.Kind == meetingKindUnprepared {
+		reasons = append(reasons, reason("meeting_unprepared", nil))
+	}
+	row := base(item, level, "meetings", "meeting_unprepared")
+	// A meeting's start time IS a deadline the reader is racing, so it counts
+	// as work due — unlike a proposal's expiry, which merely lapses.
+	stampDeadline(&row, item.DueAt, asOf)
+	row.Because = reasons
+	return ranked{item: row, deadlineAt: deadlineOf(item.DueAt), occurredAt: occurredOf(item, asOf)}
+}

--- a/backend/internal/compose/attention/meetingpreplane_test.go
+++ b/backend/internal/compose/attention/meetingpreplane_test.go
@@ -91,3 +91,24 @@ func TestAMeetingThisReaderCannotReadClaimsNothingAboutPreparation(t *testing.T)
 		t.Errorf("a withheld meeting published %v — an empty body it may not read is not an unprepared meeting", got)
 	}
 }
+
+// The mark is written in one place and read in another, and nothing but this
+// test makes them agree. A second spelling would not fail a build: the writer
+// would stamp a word the reader never matches, and the reason would quietly
+// stop appearing on the rows that earned it.
+func TestTheUnpreparedMarkHasOneSpelling(t *testing.T) {
+	written := meetingItem(Meeting{
+		ID: ids.NewV7(), Subject: "unprepared", StartsAt: readInstant,
+		NeedsPrep: true, PrepKnown: true,
+	})
+	if written.Kind == nil {
+		t.Fatal("meetingItem stamped no kind on a meeting it knows is unprepared")
+	}
+	row := classifyMeeting(written, readInstant)
+	for _, because := range row.item.Because {
+		if because.Kind == "meeting_unprepared" {
+			return
+		}
+	}
+	t.Errorf("classifyMeeting did not read the mark meetingItem wrote (%q) — the two spellings have drifted", *written.Kind)
+}

--- a/backend/internal/compose/attention/meetingpreplane_test.go
+++ b/backend/internal/compose/attention/meetingpreplane_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// A meeting nobody has prepared says so, and a meeting this reader may not read
+// says nothing at all. The second half is the one worth a test: the row arrives
+// with an empty body either way, and only the lane knows which emptiness it is.
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// meetingPrepReader is a human reading their own day. Without one the queue
+// fails closed and every row disappears, which would make both tests below
+// pass for the wrong reason.
+func meetingPrepReader() context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type:        principal.PrincipalHuman,
+		UserID:      ids.MustParse("01a05500-0000-7000-8000-000000000001"),
+		Permissions: principal.Permissions{RowScope: principal.RowScopeAll},
+	})
+}
+
+func meetingPrepService(rows []Meeting) *Service {
+	return NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
+		stubBriefing{}, nil, nil, nil, &stubMeetings{rows: rows},
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, fixedClock)
+}
+
+// reasonsOn is the reason vocabulary one meeting row published.
+func reasonsOn(t *testing.T, rows []crmcontracts.WorklistItem, subject string) []string {
+	t.Helper()
+	for _, row := range rows {
+		if row.Title == nil || *row.Title != subject {
+			continue
+		}
+		kinds := make([]string, 0, len(row.Because))
+		for _, because := range row.Because {
+			kinds = append(kinds, string(because.Kind))
+		}
+		return kinds
+	}
+	t.Fatalf("no row titled %q on the queue", subject)
+	return nil
+}
+
+func TestAMeetingWithNothingWrittenDownSaysSo(t *testing.T) {
+	soon := readInstant.Add(30 * time.Minute)
+	svc := meetingPrepService([]Meeting{
+		{ID: ids.NewV7(), Subject: "unprepared", StartsAt: soon, NeedsPrep: true, PrepKnown: true},
+		{ID: ids.NewV7(), Subject: "prepared", StartsAt: soon, NeedsPrep: false, PrepKnown: true},
+	})
+
+	day, err := svc.Worklist(meetingPrepReader(), "", "", ids.UUID{}, 25)
+	if err != nil {
+		t.Fatalf("worklist: %v", err)
+	}
+
+	if got := reasonsOn(t, day.Queue, "unprepared"); !slices.Contains(got, "meeting_unprepared") {
+		t.Errorf("a meeting with nothing written down published %v, wanted meeting_unprepared among them", got)
+	}
+	if got := reasonsOn(t, day.Queue, "prepared"); slices.Contains(got, "meeting_unprepared") {
+		t.Errorf("a prepared meeting published %v, which claims it is unprepared", got)
+	}
+}
+
+// The refusal case. A meeting whose content is withheld reaches the lane with
+// PrepKnown false, and the queue must say nothing rather than tell a reader to
+// prepare a meeting they cannot open.
+func TestAMeetingThisReaderCannotReadClaimsNothingAboutPreparation(t *testing.T) {
+	svc := meetingPrepService([]Meeting{{
+		ID: ids.NewV7(), Subject: "withheld", StartsAt: readInstant.Add(30 * time.Minute),
+		NeedsPrep: true, PrepKnown: false,
+	}})
+
+	day, err := svc.Worklist(meetingPrepReader(), "", "", ids.UUID{}, 25)
+	if err != nil {
+		t.Fatalf("worklist: %v", err)
+	}
+
+	if got := reasonsOn(t, day.Queue, "withheld"); slices.Contains(got, "meeting_unprepared") {
+		t.Errorf("a withheld meeting published %v — an empty body it may not read is not an unprepared meeting", got)
+	}
+}

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -374,52 +374,6 @@ func lapsedItem(quiet QuietRelationship) crmcontracts.AttentionItem {
 	}
 }
 
-// meetingItem renders one appointment still ahead today.
-//
-// The subject IS the sentence a rep recognises — somebody wrote it when the
-// meeting was booked — so it travels as the title, and the start time as
-// `due_at` because that is what a reader is racing. No `overdue` flag: a
-// meeting that has not started cannot be late, and the lane only carries the
-// ones still ahead.
-//
-// It offers NO verb. The pre-meeting brief is its own surface with its own eight
-// cited sections, and a queue that tried to summarise it here would be a second
-// answer to "prepare me for this". `open` is withheld for a narrower reason than
-// it once was: this card's subject is the ACTIVITY, which is a timeline entry
-// rather than a record with a page of its own, so the verb would advertise a
-// destination that does not exist. The two cards whose subject IS a record —
-// the quiet deal and the promise — now send it.
-func meetingItem(meeting Meeting) crmcontracts.AttentionItem {
-	subject := meeting.Subject
-	starts := meeting.StartsAt
-	item := crmcontracts.AttentionItem{
-		Id:      meeting.ID.String(),
-		Source:  crmcontracts.AttentionItemSource("meeting"),
-		Title:   &subject,
-		Subject: subjectOf("activity", meeting.ID),
-		DueAt:   &starts,
-		Actions: []crmcontracts.AttentionItemActions{},
-	}
-	// `kind` is the producer's own sub-type, for the icon and the label and
-	// never for authority — which is exactly what "nobody has written anything
-	// down for this yet" is. Carried here rather than as a field of its own so
-	// the contract gains no vocabulary for a display hint.
-	//
-	// Set only when the answer is KNOWN. A meeting whose content this reader may
-	// not read arrives with an empty body for a reason that is not preparation,
-	// and `meetingPrep` refuses to guess; an absent kind is that refusal
-	// reaching the page, where it draws nothing.
-	if meeting.PrepKnown && meeting.NeedsPrep {
-		kind := meetingKindUnprepared
-		item.Kind = &kind
-	}
-	return item
-}
-
-// meetingKindUnprepared marks a meeting with nothing written down for it.
-// Spelled once here and read by classifyMeeting, so the two cannot drift.
-const meetingKindUnprepared = "unprepared"
-
 // receiptItem renders one thing the system did on its own.
 //
 // It offers no decision: a receipt reports a finished act, and asking the reader

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -392,7 +392,7 @@ func lapsedItem(quiet QuietRelationship) crmcontracts.AttentionItem {
 func meetingItem(meeting Meeting) crmcontracts.AttentionItem {
 	subject := meeting.Subject
 	starts := meeting.StartsAt
-	return crmcontracts.AttentionItem{
+	item := crmcontracts.AttentionItem{
 		Id:      meeting.ID.String(),
 		Source:  crmcontracts.AttentionItemSource("meeting"),
 		Title:   &subject,
@@ -400,7 +400,25 @@ func meetingItem(meeting Meeting) crmcontracts.AttentionItem {
 		DueAt:   &starts,
 		Actions: []crmcontracts.AttentionItemActions{},
 	}
+	// `kind` is the producer's own sub-type, for the icon and the label and
+	// never for authority — which is exactly what "nobody has written anything
+	// down for this yet" is. Carried here rather than as a field of its own so
+	// the contract gains no vocabulary for a display hint.
+	//
+	// Set only when the answer is KNOWN. A meeting whose content this reader may
+	// not read arrives with an empty body for a reason that is not preparation,
+	// and `meetingPrep` refuses to guess; an absent kind is that refusal
+	// reaching the page, where it draws nothing.
+	if meeting.PrepKnown && meeting.NeedsPrep {
+		kind := meetingKindUnprepared
+		item.Kind = &kind
+	}
+	return item
 }
+
+// meetingKindUnprepared marks a meeting with nothing written down for it.
+// Spelled once here and read by classifyMeeting, so the two cannot drift.
+const meetingKindUnprepared = "unprepared"
 
 // receiptItem renders one thing the system did on its own.
 //

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -18,6 +18,7 @@ package compose
 import (
 	"context"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -341,8 +342,10 @@ func (m attentionMeetings) Today(
 		if !meetingStillWorthPreparing(row) {
 			continue
 		}
+		needsPrep, known := meetingPrep(row)
 		ahead = append(ahead, attention.Meeting{
 			ID: ids.UUID(row.Id), Subject: subjectOfMeeting(row), StartsAt: row.OccurredAt,
+			NeedsPrep: needsPrep, PrepKnown: known,
 		})
 	}
 	// Soonest first: the lane is a countdown, and the store returns activities
@@ -360,6 +363,32 @@ func (m attentionMeetings) Today(
 // installations whose calendars are connected.
 func meetingStillWorthPreparing(row crmcontracts.Activity) bool {
 	return row.MeetingStatus == nil || *row.MeetingStatus == crmcontracts.ActivityMeetingStatusBooked
+}
+
+// meetingPrep answers whether a meeting has anything written down for it, and
+// whether that question could be answered at all.
+//
+// The signals are the two the row already carries: a body (the agenda or the
+// notes somebody typed) and a link to a record outside this organization (the
+// customer the meeting is with). A meeting with neither is one nobody has
+// prepared.
+//
+// It refuses to answer for a WITHHELD row, and that refusal is the point. A
+// reader outside the activity's audience receives the row with its body nulled
+// — content_state says so — so reading "no body" as "no agenda" would report
+// every colleague's meeting as unprepared, to a reader who cannot open it to
+// find out. Absent beats wrong: the caller draws nothing.
+func meetingPrep(row crmcontracts.Activity) (needsPrep bool, known bool) {
+	if row.ContentState != nil && *row.ContentState != crmcontracts.ActivityContentStateAvailable {
+		return false, false
+	}
+	if row.Body != nil && strings.TrimSpace(*row.Body) != "" {
+		return false, true
+	}
+	if row.Links != nil && len(*row.Links) > 0 {
+		return false, true
+	}
+	return true, true
 }
 
 // subjectOfMeeting is the line a meeting shows, or NOTHING.

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -17,15 +17,12 @@ package compose
 
 import (
 	"context"
-	"sort"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/compose/attention"
-	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/modules/capture"
@@ -310,99 +307,6 @@ func keepWaitingCustomers(rows []activities.WaitingReply) []activities.WaitingRe
 		kept = append(kept, row)
 	}
 	return kept
-}
-
-// attentionMeetings reads today's remaining meetings through the activities
-// store — the same gated list every other activity surface reads.
-//
-// The WINDOW is applied in SQL, not here. An earlier cut read ten times the
-// lane and narrowed the time range in Go, which is lossy in the one direction
-// that hides itself: a day with more than the scan's worth of later activity
-// pushes a real meeting off the page, and the lane draws a free afternoon over
-// a booked one. ListActivitiesInput carries OccurredAfter/OccurredBefore and
-// the store applies both as predicates, so the bound is the day rather than a
-// guess about how busy the day might be.
-//
-// The STATUS filter stays in Go: the store has no dial for it, and the set it
-// removes is bounded by the window the database already applied.
-type attentionMeetings struct{ store *activities.Store }
-
-func (m attentionMeetings) Today(
-	ctx context.Context, from, until time.Time, limit int,
-) ([]attention.Meeting, error) {
-	kind := string(crmcontracts.ActivityKindMeeting)
-	rows, _, err := m.store.ListActivities(ctx, activities.ListActivitiesInput{
-		Kind: &kind, OccurredAfter: &from, OccurredBefore: &until, Limit: &limit,
-	})
-	if err != nil {
-		return nil, err
-	}
-	ahead := make([]attention.Meeting, 0, len(rows))
-	for _, row := range rows {
-		if !meetingStillWorthPreparing(row) {
-			continue
-		}
-		needsPrep, known := meetingPrep(row)
-		ahead = append(ahead, attention.Meeting{
-			ID: ids.UUID(row.Id), Subject: subjectOfMeeting(row), StartsAt: row.OccurredAt,
-			NeedsPrep: needsPrep, PrepKnown: known,
-		})
-	}
-	// Soonest first: the lane is a countdown, and the store returns activities
-	// newest-first, which is the opposite order for a day still ahead.
-	sort.SliceStable(ahead, func(i, j int) bool { return ahead[i].StartsAt.Before(ahead[j].StartsAt) })
-	return ahead, nil
-}
-
-// meetingStillWorthPreparing keeps the meetings a rep can still do something
-// about: booked, rather than held, cancelled or a no-show. The time window is
-// the database's to apply.
-//
-// A meeting with no status is treated as booked. Capture writes calendar events
-// without one, and dropping them would empty this lane on exactly the
-// installations whose calendars are connected.
-func meetingStillWorthPreparing(row crmcontracts.Activity) bool {
-	return row.MeetingStatus == nil || *row.MeetingStatus == crmcontracts.ActivityMeetingStatusBooked
-}
-
-// meetingPrep answers whether a meeting has anything written down for it, and
-// whether that question could be answered at all.
-//
-// The signals are the two the row already carries: a body (the agenda or the
-// notes somebody typed) and a link to a record outside this organization (the
-// customer the meeting is with). A meeting with neither is one nobody has
-// prepared.
-//
-// It refuses to answer for a WITHHELD row, and that refusal is the point. A
-// reader outside the activity's audience receives the row with its body nulled
-// — content_state says so — so reading "no body" as "no agenda" would report
-// every colleague's meeting as unprepared, to a reader who cannot open it to
-// find out. Absent beats wrong: the caller draws nothing.
-func meetingPrep(row crmcontracts.Activity) (needsPrep bool, known bool) {
-	if row.ContentState != nil && *row.ContentState != crmcontracts.ActivityContentStateAvailable {
-		return false, false
-	}
-	if row.Body != nil && strings.TrimSpace(*row.Body) != "" {
-		return false, true
-	}
-	if row.Links != nil && len(*row.Links) > 0 {
-		return false, true
-	}
-	return true, true
-}
-
-// subjectOfMeeting is the line a meeting shows, or NOTHING.
-//
-// A calendar event with a blank title is a real thing a provider hands over,
-// and the empty answer is the honest one: the product ships three languages, so
-// a placeholder composed here reaches a German reader in English — and
-// "(untitled meeting)" is a parenthetical stand-in rather than a sentence
-// anybody wrote. The client writes "A meeting" in the reader's own words.
-func subjectOfMeeting(row crmcontracts.Activity) string {
-	if row.Subject != nil {
-		return *row.Subject
-	}
-	return ""
 }
 
 // attentionDealFacts reads deal figures through the deals store, under the

--- a/backend/internal/compose/attentionmeetingseam.go
+++ b/backend/internal/compose/attentionmeetingseam.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The meetings lane's seam over the activities store, and the two questions it
+// answers about a booked meeting: what to call it, and whether anybody has
+// prepared it.
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/attention"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// attentionMeetings reads today's remaining meetings through the activities
+// store — the same gated list every other activity surface reads.
+//
+// The WINDOW is applied in SQL, not here. An earlier cut read ten times the
+// lane and narrowed the time range in Go, which is lossy in the one direction
+// that hides itself: a day with more than the scan's worth of later activity
+// pushes a real meeting off the page, and the lane draws a free afternoon over
+// a booked one. ListActivitiesInput carries OccurredAfter/OccurredBefore and
+// the store applies both as predicates, so the bound is the day rather than a
+// guess about how busy the day might be.
+//
+// The STATUS filter stays in Go: the store has no dial for it, and the set it
+// removes is bounded by the window the database already applied.
+type attentionMeetings struct{ store *activities.Store }
+
+func (m attentionMeetings) Today(
+	ctx context.Context, from, until time.Time, limit int,
+) ([]attention.Meeting, error) {
+	kind := string(crmcontracts.ActivityKindMeeting)
+	rows, _, err := m.store.ListActivities(ctx, activities.ListActivitiesInput{
+		Kind: &kind, OccurredAfter: &from, OccurredBefore: &until, Limit: &limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ahead := make([]attention.Meeting, 0, len(rows))
+	for _, row := range rows {
+		if !meetingStillWorthPreparing(row) {
+			continue
+		}
+		needsPrep, known := meetingPrep(row)
+		ahead = append(ahead, attention.Meeting{
+			ID: ids.UUID(row.Id), Subject: subjectOfMeeting(row), StartsAt: row.OccurredAt,
+			NeedsPrep: needsPrep, PrepKnown: known,
+		})
+	}
+	// Soonest first: the lane is a countdown, and the store returns activities
+	// newest-first, which is the opposite order for a day still ahead.
+	sort.SliceStable(ahead, func(i, j int) bool { return ahead[i].StartsAt.Before(ahead[j].StartsAt) })
+	return ahead, nil
+}
+
+// meetingStillWorthPreparing keeps the meetings a rep can still do something
+// about: booked, rather than held, cancelled or a no-show. The time window is
+// the database's to apply.
+//
+// A meeting with no status is treated as booked. Capture writes calendar events
+// without one, and dropping them would empty this lane on exactly the
+// installations whose calendars are connected.
+func meetingStillWorthPreparing(row crmcontracts.Activity) bool {
+	return row.MeetingStatus == nil || *row.MeetingStatus == crmcontracts.ActivityMeetingStatusBooked
+}
+
+// meetingPrep answers whether a meeting has anything written down for it, and
+// whether that question could be answered at all.
+//
+// The signals are the two the row already carries: a body (the agenda or the
+// notes somebody typed) and a link to a record outside this organization (the
+// customer the meeting is with). A meeting with neither is one nobody has
+// prepared.
+//
+// It refuses to answer for a WITHHELD row, and that refusal is the point. A
+// reader outside the activity's audience receives the row with its body nulled
+// — content_state says so — so reading "no body" as "no agenda" would report
+// every colleague's meeting as unprepared, to a reader who cannot open it to
+// find out. Absent beats wrong: the caller draws nothing.
+func meetingPrep(row crmcontracts.Activity) (needsPrep bool, known bool) {
+	if row.ContentState != nil && *row.ContentState != crmcontracts.ActivityContentStateAvailable {
+		return false, false
+	}
+	if row.Body != nil && strings.TrimSpace(*row.Body) != "" {
+		return false, true
+	}
+	if row.Links != nil && len(*row.Links) > 0 {
+		return false, true
+	}
+	return true, true
+}
+
+// subjectOfMeeting is the line a meeting shows, or NOTHING.
+//
+// A calendar event with a blank title is a real thing a provider hands over,
+// and the empty answer is the honest one: the product ships three languages, so
+// a placeholder composed here reaches a German reader in English — and
+// "(untitled meeting)" is a parenthetical stand-in rather than a sentence
+// anybody wrote. The client writes "A meeting" in the reader's own words.
+func subjectOfMeeting(row crmcontracts.Activity) string {
+	if row.Subject != nil {
+		return *row.Subject
+	}
+	return ""
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -12094,6 +12094,7 @@ const (
 	WorklistReasonKindLegalDeadline      WorklistReasonKind = "legal_deadline"
 	WorklistReasonKindMaterial           WorklistReasonKind = "material"
 	WorklistReasonKindMeetingSoon        WorklistReasonKind = "meeting_soon"
+	WorklistReasonKindMeetingUnprepared  WorklistReasonKind = "meeting_unprepared"
 	WorklistReasonKindNoChampion         WorklistReasonKind = "no_champion"
 	WorklistReasonKindOverdue            WorklistReasonKind = "overdue"
 	WorklistReasonKindPinned             WorklistReasonKind = "pinned"
@@ -12127,6 +12128,8 @@ func (e WorklistReasonKind) Valid() bool {
 	case WorklistReasonKindMaterial:
 		return true
 	case WorklistReasonKindMeetingSoon:
+		return true
+	case WorklistReasonKindMeetingUnprepared:
 		return true
 	case WorklistReasonKindNoChampion:
 		return true

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -25737,7 +25737,7 @@ export interface components {
              * @description Which fact this is. The client writes the phrase.
              * @enum {string}
              */
-            kind: "pinned" | "buyer_wrote_last" | "waiting_days" | "overdue" | "due_today" | "closing_soon" | "expected_revenue" | "material" | "below_material" | "quiet_days" | "no_champion" | "promised" | "approved_and_failed" | "blocks_customer_work" | "routine" | "repeated_failure" | "legal_deadline" | "meeting_soon" | "stale";
+            kind: "pinned" | "buyer_wrote_last" | "waiting_days" | "overdue" | "due_today" | "closing_soon" | "expected_revenue" | "material" | "below_material" | "quiet_days" | "no_champion" | "promised" | "approved_and_failed" | "blocks_customer_work" | "routine" | "repeated_failure" | "legal_deadline" | "meeting_soon" | "meeting_unprepared" | "stale";
             value?: components["schemas"]["WorklistValue"];
         };
         /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7416,6 +7416,7 @@ export const de = {
   "worklist.because.repeated_failure": "dasselbe schlägt immer wieder fehl",
   "worklist.because.legal_deadline": "eine gesetzliche Frist läuft",
   "worklist.because.meeting_soon": "beginnt gleich",
+  "worklist.because.meeting_unprepared": "nichts vorbereitet",
   "worklist.because.stale": "wartet schon lange",
   "worklist.above.pin": "Über dem Nächsten, weil du es angeheftet hast.",
   "worklist.above.level": "Über dem Nächsten, weil es dringlichere Arbeit ist.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7488,6 +7488,7 @@ export const en = {
   "worklist.because.repeated_failure": "the same thing keeps failing",
   "worklist.because.legal_deadline": "a legal deadline is running",
   "worklist.because.meeting_soon": "starting shortly",
+  "worklist.because.meeting_unprepared": "nothing prepared",
   "worklist.because.stale": "waiting a long time",
   "worklist.above.pin": "Above the next because you pinned it.",
   "worklist.above.level":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7341,6 +7341,7 @@ export const vi = {
   "worklist.because.repeated_failure": "cùng một lỗi lặp lại nhiều lần",
   "worklist.because.legal_deadline": "thời hạn pháp lý đang chạy",
   "worklist.because.meeting_soon": "sắp bắt đầu",
+  "worklist.because.meeting_unprepared": "chưa chuẩn bị gì",
   "worklist.because.stale": "đã chờ rất lâu",
   "worklist.above.pin": "Trên mục kế vì bạn đã ghim.",
   "worklist.above.level": "Trên mục kế vì đây là loại việc gấp hơn.",

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -159,6 +159,7 @@ const KNOWN_REASONS = {
   repeated_failure: true,
   legal_deadline: true,
   meeting_soon: true,
+  meeting_unprepared: true,
   stale: true,
 } as const;
 


### PR DESCRIPTION
The Worklist's meetings lane read the full activity row and kept three fields, so the queue could say a meeting was starting and never that nothing had been written down for it. The consequence line already claimed `meeting_unprepared` for every meeting on the page, prepared or not — a verdict the row carried no evidence for.

The lane now derives it from what it already reads: a body somebody typed, or a link to the record the meeting is with. Neither means nobody has prepared it.

**It refuses to answer for a withheld row, and that refusal is the point.** A reader outside the activity's audience receives the row with its body nulled — `content_state` says so — so reading "no body" as "no agenda" would report every colleague's meeting as unprepared, to a reader who cannot open it to find out. `PrepKnown` carries that refusal and the page draws nothing. Absent beats wrong.

The mark rides the item's `kind`, which the contract defines as the producer's own sub-type "for the icon and the label, never for authority" — which is what a display hint is.

## Along the way

Adding the field pushed three files past the 500-line cap, so the meeting concern moved out whole into `attention/meeting.go` and `attentionmeetingseam.go`. How a booked meeting becomes an item and how that item is ranked read the same two facts; splitting them apart would let the hint and its reader drift.

The uniqueness-claims gate then caught a comment asserting the mark "cannot drift" with no test holding it. `TestTheUnpreparedMarkHasOneSpelling` is that test — a second spelling would not fail a build, the writer would stamp a word the reader never matches and the reason would quietly stop appearing on rows that earned it.

## Tests

- `TestAMeetingWithNothingWrittenDownSaysSo` — the reason appears for an unprepared meeting and not for a prepared one.
- `TestAMeetingThisReaderCannotReadClaimsNothingAboutPreparation` — the withheld case. Mutation-checked: dropping the `PrepKnown` guard makes it fail.
- `TestTheUnpreparedMarkHasOneSpelling` — mutation-checked: changing either spelling makes it fail.

`make check-backend`, `make check-fe`, `make craft-static` all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The meetings lane now marks a meeting unprepared only when nothing is written down for it — no agenda or notes body, no link to the record it's with — instead of tagging every meeting on the page. Meetings this reader can't open say nothing rather than wrong, since an empty body from a read restriction isn't evidence of a missing agenda.

**Refactors**
- The meeting concern moved into `attention/meeting.go` and `attentionmeetingseam.go` to stay under the 500-line cap.
- `TestTheUnpreparedMarkHasOneSpelling` pins the single spelling of the `unprepared` mark so writer and reader cannot drift.

<sup>Written for commit f73fafeeb89346b0aaa8124fa04d71beecf8d72f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added meeting items to the worklist, prioritized by start time.
  * Meetings can now be marked as needing preparation when that status is known.
  * Added support for the “nothing prepared” meeting reason.
* **Localization**
  * Added English, German, and Vietnamese translations for the new meeting-preparation message.
* **Bug Fixes**
  * Prevented preparation claims when meeting content is unavailable.
  * Preserved meeting subjects, including blank subjects, as provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->