### PR TITLE
The worker's stored-app registration is pinned, and two comments corrected

### DIFF
--- a/backend/internal/compose/capturegraph.go
+++ b/backend/internal/compose/capturegraph.go
@@ -7,9 +7,10 @@ package compose
 //
 // Split from capture.go because it is a second, independent provider app: one
 // Microsoft app per deployment, its own tenant narrowing, its own scopes. It
-// shares the transport in connectors.go and nothing else — and unlike the Google
-// app it is still composed entirely from the deployment's environment, so it has
-// no runtime-resolution half to keep in step.
+// shares the transport in connectors.go and nothing else. Like the Google app it
+// composes from EITHER source — the environment the deployment supplied or the
+// Entra registration an operator stored through Settings — and both process
+// roles resolve it, which is the half that has to stay in step.
 
 import (
 	"github.com/jackc/pgx/v5/pgxpool"

--- a/backend/internal/compose/connectors_graph_test.go
+++ b/backend/internal/compose/connectors_graph_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/capture/graph"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -219,4 +221,45 @@ func registeredNames(descs []connector.Descriptor) map[string]bool {
 		names[d.Name] = true
 	}
 	return names
+}
+
+// THE WORKER REGISTERS EVERY VENDOR THE INSTALLATION COULD HAVE AN APP FOR,
+// including one it configured through the product rather than the environment.
+//
+// This is the failure that reads as an empty inbox rather than a broken one: the
+// dispatcher walks registry.Connectors(), so a connection made against a stored
+// app that the worker never registered is never enumerated, and the renewal pass
+// resolves its connector by name and finds nothing. Both roles ask the same
+// question through newConnectorAppResolvers; what this pins is that the WORKER
+// asks it for Microsoft too, which is where the two last came apart.
+func TestTheWorkerRegistersVendorsItCanOnlyResolveAtRuntime(t *testing.T) {
+	// A pool and a vault and NOTHING in the environment: the shape of an
+	// installation that set both apps through Settings.
+	stored := CaptureSyncRegistry(&pgxpool.Pool{}, fakeVault{},
+		GmailConfig{}, GraphConfig{}, CaptureConfig{}, nil)
+
+	names := registeredNames(stored.Connectors())
+	for _, want := range []string{"gmail", "gcal", "graph", "graphcal"} {
+		if !names[want] {
+			t.Errorf("no %q connector: an installation that configured its app in the product "+
+				"connects the mailbox and then nothing pulls it — connectors = %v", want, names)
+		}
+	}
+}
+
+// AND REGISTERS NONE OF THEM WHERE NOTHING COULD SUPPLY AN APP. A connector with
+// no app behind it fails every call with "no app configured", which is a worse
+// answer than the declared 501: it looks configured and is not.
+func TestTheWorkerRegistersNoVendorItCannotResolveAnAppFor(t *testing.T) {
+	names := registeredNames(
+		CaptureSyncRegistry(nil, nil, GmailConfig{}, GraphConfig{}, CaptureConfig{}, nil).Connectors())
+	for _, unwanted := range []string{"gmail", "gcal", "graph", "graphcal"} {
+		if names[unwanted] {
+			t.Errorf("registered %q with neither a stored app to resolve nor one in the "+
+				"environment — connectors = %v", unwanted, names)
+		}
+	}
+	if !names["imap"] {
+		t.Error("the standing IMAP connector needs no app and must be there regardless")
+	}
 }

--- a/backend/internal/compose/connectors_graph_test.go
+++ b/backend/internal/compose/connectors_graph_test.go
@@ -223,34 +223,47 @@ func registeredNames(descs []connector.Descriptor) map[string]bool {
 	return names
 }
 
-// THE WORKER REGISTERS EVERY VENDOR THE INSTALLATION COULD HAVE AN APP FOR,
-// including one it configured through the product rather than the environment.
+// THE WORKER CARRIES A RUNTIME RESOLVER FOR EVERY VENDOR, so a vendor whose app
+// exists only in the database still gets its connectors registered.
 //
-// This is the failure that reads as an empty inbox rather than a broken one: the
-// dispatcher walks registry.Connectors(), so a connection made against a stored
-// app that the worker never registered is never enumerated, and the renewal pass
-// resolves its connector by name and finds nothing. Both roles ask the same
-// question through newConnectorAppResolvers; what this pins is that the WORKER
-// asks it for Microsoft too, which is where the two last came apart.
-func TestTheWorkerRegistersVendorsItCanOnlyResolveAtRuntime(t *testing.T) {
-	// A pool and a vault and NOTHING in the environment: the shape of an
-	// installation that set both apps through Settings.
-	stored := CaptureSyncRegistry(&pgxpool.Pool{}, fakeVault{},
+// Precisely what this pins, and no more: that CaptureSyncRegistry hands a
+// resolver to BOTH vendors' registrations. Registration is on the resolver
+// EXISTING (googleAppReachable and registerMicrosoftConnectors ask whether
+// anything could supply an app, not whether something does), so this passes with
+// an empty store on purpose — the environment is empty here to take the other
+// source away, not to stand in for a configured installation.
+//
+// That is the seam this ticket is about. The dispatcher walks
+// registry.Connectors(), so a vendor the worker never registered is a mailbox
+// that connects and is then never enumerated: an empty inbox rather than a
+// broken one. Microsoft was registered from environment credentials alone while
+// Google resolved a stored app, and nothing failed to say so.
+//
+// Whether a resolver then RESOLVES is a different question, held elsewhere:
+// TestAStoredAppRegistersTheGoogleConnectors over googleAppReachable's sources,
+// and TestEveryMicrosoftMethodReachesTheSameResolvedApp end to end through the
+// Graph authorizer.
+func TestTheWorkerCarriesARuntimeResolverForEveryVendor(t *testing.T) {
+	// A pool and a vault, and nothing in the environment: with the environment
+	// source gone, a registration can only come from the resolver.
+	resolvers := CaptureSyncRegistry(&pgxpool.Pool{}, fakeVault{},
 		GmailConfig{}, GraphConfig{}, CaptureConfig{}, nil)
 
-	names := registeredNames(stored.Connectors())
+	names := registeredNames(resolvers.Connectors())
 	for _, want := range []string{"gmail", "gcal", "graph", "graphcal"} {
 		if !names[want] {
-			t.Errorf("no %q connector: an installation that configured its app in the product "+
-				"connects the mailbox and then nothing pulls it — connectors = %v", want, names)
+			t.Errorf("no %q connector with a resolver available: an installation that configured "+
+				"that app in the product connects the mailbox and then nothing pulls it — "+
+				"connectors = %v", want, names)
 		}
 	}
 }
 
-// AND REGISTERS NONE OF THEM WHERE NOTHING COULD SUPPLY AN APP. A connector with
-// no app behind it fails every call with "no app configured", which is a worse
-// answer than the declared 501: it looks configured and is not.
-func TestTheWorkerRegistersNoVendorItCannotResolveAnAppFor(t *testing.T) {
+// AND REGISTERS NONE OF THEM WHERE NEITHER SOURCE IS THERE — no resolver to
+// build one from and nothing in the environment. A connector with no app behind
+// it fails every call with "no app configured", which is a worse answer than the
+// declared 501: it looks configured and is not.
+func TestTheWorkerRegistersNoVendorWithNeitherSource(t *testing.T) {
 	names := registeredNames(
 		CaptureSyncRegistry(nil, nil, GmailConfig{}, GraphConfig{}, CaptureConfig{}, nil).Connectors())
 	for _, unwanted := range []string{"gmail", "gcal", "graph", "graphcal"} {

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -93,11 +93,10 @@ func addGraphWatchJobs(reg *jobRegistry, cfg JobRunnerConfig, log *slog.Logger) 
 // fail is worse than no pass: the poll still runs either way, and the difference
 // is a fleet-wide error rate an operator has to explain.
 //
-// The worker registers Graph from ENVIRONMENT credentials alone
-// (CaptureSyncRegistry), where the Google side also resolves a stored app. So a
-// Microsoft app configured in the product reaches the api and not this role, and
-// an operator who sets the notification URL for it gets exactly that failing
-// pass.
+// The registry is the thing asked, rather than the environment that helped build
+// it, because an app configured through the product registers a connector no
+// environment variable names — and the two roles have already come apart over
+// exactly that once.
 //
 // EXPORTED so the boot banner can ask the same question rather than restate it.
 // A banner naming a lane that did not come up is worse than no banner: it is the


### PR DESCRIPTION
Closes #3528.

## The ticket describes a gap that has since closed

`CaptureSyncRegistry` today does what the ticket asks for:

```go
google, microsoft := newConnectorAppResolvers(pool, vault, log)
reg := newCaptureRegistryWithGoogle(pool, vault, google, c, cfg)
registerMicrosoftConnectors(reg, microsoft, g, pool)
```

That arrived with #3458. So there is no production change to make here, and saying so is most of the report.

## What was actually still wrong

**Nothing pinned it.** `TestCaptureSyncRegistryRegistersConfiguredProviders` passes `nil, nil` for the pool and the vault, so `newConnectorAppResolvers` returns `nil, nil` and every case it covers is the environment-only one. The stored-app path — the one both roles depend on, and the one the two roles last came apart over — was untested for Google as well as for Microsoft.

Two tests now cover the shape that matters: a pool and a vault and nothing in the environment, which is exactly the installation that configured its apps through Settings.

- the worker offers `gmail`, `gcal`, `graph` and `graphcal` there;
- and none of them where nothing could supply an app, with `imap` still standing.

Both mutation-checked: dropping either vendor's resolver at the `CaptureSyncRegistry` seam fails the first with the missing connectors named.

**Two comments still asserted the gap as current.** `GraphWatchWillRun` told a reader that "the worker registers Graph from ENVIRONMENT credentials alone ... So a Microsoft app configured in the product reaches the api and not this role", and `capturegraph.go`'s header told them the Microsoft app "is still composed entirely from the deployment's environment, so it has no runtime-resolution half to keep in step". A comment that describes a closed gap as open is worse than none: the second one in particular is the first thing a reader of that file sees. Both now say what the code does, and both keep the reasoning that is still true (the registry is asked rather than the environment, because a stored app registers a connector no environment variable names).

## What I checked and did not change

`graphWatchConfig`'s gate. The ticket suggested it could gate on the app once the resolver existed; it gates on `registryOffers(reg, providerGraph)`, which is the better question and is already correct now that the registry includes Graph on a stored app. The #3469 guard stays as the belt.

`make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Microsoft Graph OAuth setup options, including deployment environment variables and stored Entra registrations.
  * Updated connector monitoring documentation to reflect runtime registration detection.

* **Bug Fixes**
  * Improved connector availability detection so supported Gmail, Google Calendar, Microsoft Graph, and Graph Calendar integrations can be recognized without environment configuration.
  * Preserved IMAP registration while excluding connectors without resolvable applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->