### PR TITLE
A promise is a promise, wherever it was written down

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -24582,7 +24582,7 @@ components:
         `job_change` fires only on a RECORDED employment change, and `public_signal` needs a
         connected data provider. A rule that cannot fire is absent from the page, not an empty
         card.
-      enum: [meeting_prep, re_engaged, job_change, overdue_promise, gone_quiet, open_promise, role_change, public_signal, missing_next_step, thin_relationship, nothing_needed]
+      enum: [meeting_prep, re_engaged, job_change, overdue_promise, overdue_task, gone_quiet, open_promise, role_change, public_signal, missing_next_step, thin_relationship, nothing_needed]
 
     PersonMomentEvidence:
       type: object

--- a/backend/internal/compose/openpromisesection_integration_test.go
+++ b/backend/internal/compose/openpromisesection_integration_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The promise a person page leads with is the FIRST row of its next-steps
+// section, so which row that is has to be decided by the database rather than
+// by re-sorting what the section happened to carry. The section is capped at
+// 25 rows; a rung re-sorting them in memory cannot see the 26th, and the row
+// it cannot see is exactly the one a busy record has waited longest on.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/compose/person360"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/modules/comms"
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestTheOldestPromiseLeadsEvenPastTheSectionCap(t *testing.T) {
+	e := integration.Setup(t)
+	person := seedLinkedPerson(t, e, "vielbeschaeftigt@kunde.example")
+	personID := ids.From[ids.PersonKind](person)
+	now := time.Now()
+
+	// Filed FIRST and due SOONEST, then buried under thirty newer tasks. In
+	// the timeline's order (newest first) this row sits past the section's
+	// 25-row cap, so a page that carried the newest 25 could not name it.
+	oldest := logTaskFor(t, e, person, "Send the signed contract", at(now.Add(24*time.Hour)))
+	for i := range 30 {
+		logTaskFor(t, e, person, "Later chore "+string(rune('a'+i%26)), at(now.Add(time.Duration(200+i)*time.Hour)))
+	}
+
+	svc := person360.NewService(e.Pool, e.People, e.Deals, e.Projects,
+		consent.NewStore(InstallationDB(e.Pool)),
+		comms.NewStore(InstallationDB(e.Pool), time.Now, activities.NewStore(InstallationDB(e.Pool))),
+		ai.NewFeedbackStore(InstallationDB(e.Pool)), time.Now)
+
+	page, err := svc.Assemble(e.Admin(), personID)
+	if err != nil {
+		t.Fatalf("assembling person360: %v", err)
+	}
+	if page.NextSteps == nil || len(page.NextSteps.Data) == 0 {
+		t.Fatal("the next-steps section is empty; the ordering below would prove nothing")
+	}
+	if !page.NextSteps.Page.HasMore {
+		t.Fatalf("the section carries %d of 31 open tasks without saying so — this test needs the "+
+			"cap to bite, and a reader needs to know the list is partial", len(page.NextSteps.Data))
+	}
+	if got := page.NextSteps.Data[0].Id; ids.UUID(got) != oldest {
+		t.Errorf("the section leads with %v, want the soonest-due task %v — the card names the first "+
+			"row, so a section ordered by filing date hands it a chore instead of the contract",
+			got, oldest)
+	}
+	if page.Moment == nil {
+		t.Fatal("no moment on a record that owes a signed contract")
+	}
+	if page.Moment.Headline != "You owe them: Send the signed contract" {
+		t.Errorf("headline = %q, want the soonest-due promise", page.Moment.Headline)
+	}
+}
+
+// at is a due date as the writer wants it. The package's own ptr helper takes
+// an int.
+func at(t time.Time) *time.Time { return &t }
+
+// The card says whose promise it is, and it can only do that if the assignee
+// survives the section's own projection. It did not: the query selected
+// due_at and is_done but not assignee_id, so every assembled task looked
+// unassigned and every reader was told they owed a colleague's work.
+func TestAnAssignedPromiseKeepsItsHolderThroughTheSection(t *testing.T) {
+	e := integration.Setup(t)
+	person := seedLinkedPerson(t, e, "zugewiesen@kunde.example")
+	personID := ids.From[ids.PersonKind](person)
+
+	holder := ids.From[ids.UserKind](e.Rep1)
+	logAssignedTaskFor(t, e, person, "Send the signed contract", holder)
+
+	svc := person360.NewService(e.Pool, e.People, e.Deals, e.Projects,
+		consent.NewStore(InstallationDB(e.Pool)),
+		comms.NewStore(InstallationDB(e.Pool), time.Now, activities.NewStore(InstallationDB(e.Pool))),
+		ai.NewFeedbackStore(InstallationDB(e.Pool)), time.Now)
+
+	page, err := svc.Assemble(e.Admin(), personID)
+	if err != nil {
+		t.Fatalf("assembling person360: %v", err)
+	}
+	if page.NextSteps == nil || len(page.NextSteps.Data) != 1 {
+		t.Fatalf("the section carries %v tasks, want the one just written", page.NextSteps)
+	}
+	if got := page.NextSteps.Data[0].AssigneeId; got == nil {
+		t.Fatal("the task came back unassigned — the card then tells every reader they owe a " +
+			"colleague's promise, and the frontend has nothing to tell them apart with")
+	}
+	if page.Moment == nil || page.Moment.Headline != "Owed to them: Send the signed contract" {
+		t.Errorf("headline = %v, want the promise attributed to the desk that holds it", page.Moment)
+	}
+}
+
+// logAssignedTaskFor writes one open task somebody holds, through the real
+// activity writer.
+func logAssignedTaskFor(t *testing.T, e *integration.Env, person ids.UUID, subject string, assignee ids.UserID) {
+	t.Helper()
+	if _, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+		Kind: "task", Subject: &subject, Source: "manual", AssigneeID: &assignee,
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: person}},
+	}); err != nil {
+		t.Fatalf("logging an assigned task: %v", err)
+	}
+}
+
+// logTaskFor writes one open task filed against a person, through the real
+// activity writer — a hand-inserted row would not exercise the links the
+// section reads through.
+func logTaskFor(t *testing.T, e *integration.Env, person ids.UUID, subject string, due *time.Time) ids.UUID {
+	t.Helper()
+	row, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+		Kind: "task", Subject: &subject, DueAt: due, Source: "manual",
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: person}},
+	})
+	if err != nil {
+		t.Fatalf("logging task %q: %v", subject, err)
+	}
+	return ids.UUID(row.Id)
+}

--- a/backend/internal/compose/person360/momentpromise.go
+++ b/backend/internal/compose/person360/momentpromise.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package person360
+
+// The two rungs that speak for an open task: one for a promise past its date,
+// one for a promise still ahead or carrying none. They share a card, differ
+// only in where they sit on the ladder, and both attribute the promise from
+// the reader's own seat.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
+	"github.com/margince/margince/backend/internal/shared/kernel/elapsed"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// openPromiseMoment: an open task is filed against them and nobody has done
+// it. Dated or not — the transcript reader files "I'll send you the
+// whitepaper" without a date, and it is owed either way.
+//
+// Below gone_quiet on purpose: a promise with no clock on it can wait for a
+// day, a contact who stopped answering is already costing something. Above
+// role_change and everything under it, because a thing we said we would do
+// outranks a thing we might do next. The overdue rung above reads claims
+// from correspondence; this one reads the task list, so a promise the reader
+// accepted from a transcript reaches the card the moment it becomes a task.
+func openPromiseMoment(ctx context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+	task, ok := nearestOpenTask(page)
+	if !ok {
+		return crmcontracts.PersonMoment{}, false
+	}
+	// A task already past its date is the rung above; this one speaks for the
+	// promises that are undated or still ahead.
+	if deadline.Passed(task.DueAt, now) {
+		return crmcontracts.PersonMoment{}, false
+	}
+	moment := openPromiseFrom(ctx, now, task)
+	return moment, true
+}
+
+// openPromiseFrom is the card both promise rungs show: same headline, same
+// reason, same verb. Only the rung's name and its place on the ladder differ,
+// and neither is a fact about the promise.
+func openPromiseFrom(ctx context.Context, now time.Time, task crmcontracts.Activity) crmcontracts.PersonMoment {
+	// A task filed without a subject is still owed; the card names it as the
+	// task list does rather than printing an empty promise.
+	subject := "an open task"
+	if task.Subject != nil && *task.Subject != "" {
+		subject = *task.Subject
+	}
+	// The evidence is dated by when the promise was filed, not when it falls
+	// due: a task due next month is not "updated today", and the due date is
+	// the reason's to state.
+	observed := task.OccurredAt
+	evidence := []crmcontracts.PersonMomentEvidence{{
+		Type:       crmcontracts.PersonMomentEvidenceTypeTask,
+		Id:         ptr(task.Id),
+		Label:      subject,
+		ObservedAt: &observed,
+	}}
+	// The fingerprint carries WHOSE promise this is, not only which task it
+	// is. A dismissal is keyed on the fingerprint so that the moment comes
+	// back when its evidence moves; handing a colleague's task to the reader
+	// changes the card from "owed to them" to "you owe them", and without the
+	// holder in the fingerprint an old dismissal would keep suppressing it —
+	// hiding the promise at the moment it became theirs to deliver.
+	return crmcontracts.PersonMoment{
+		ClaimKey:            "moment:open_promise",
+		Rule:                crmcontracts.PersonMomentRuleOpenPromise,
+		RuleVersion:         ptr(ruleVersion),
+		EvidenceFingerprint: fingerprintOf(evidence) + heldMarker(ctx, task),
+		Headline:            openPromiseHeadline(ctx, task, subject),
+		WhyNow:              openPromiseWhyNow(now, task),
+		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
+		Evidence:            evidence,
+		FreshnessAt:         &observed,
+		// Writing to them is the one move every promise shares, whether it is
+		// a document to send or a room to book they are waiting to hear about.
+		// The composer opens on the promise itself, so the label says what the
+		// button does rather than presuming the promise is a thing to send.
+		RecommendedAction: crmcontracts.PersonMomentAction{
+			Kind:  crmcontracts.PersonMomentActionKindDraftReply,
+			Label: "Write to them about it",
+			State: crmcontracts.PersonMomentActionStateWillConfirm,
+			Destination: &crmcontracts.PersonMomentDestination{
+				Surface: crmcontracts.PersonMomentDestinationSurfaceComposer,
+				Prefill: prefill(map[string]string{prefillIntent: "deliver_commitment", "subject": subject}),
+			},
+		},
+	}
+}
+
+// openPromiseHeadline names who owes it, from the READER's seat.
+//
+// The comparison is against the reader rather than against nil: the activity
+// writer assigns every human-written task to its author, so "has an assignee"
+// is true of almost every task and would say "owed to them" about the
+// reader's own work. A task held by a colleague still belongs on this card —
+// the record owes it either way — but it is not the reader's to deliver, and
+// a card that says otherwise sends them to do somebody else's job. Unassigned
+// work is the workspace's, and the reader is the workspace.
+func openPromiseHeadline(ctx context.Context, task crmcontracts.Activity, subject string) string {
+	if heldByAnother(ctx, task) {
+		return fmt.Sprintf("Owed to them: %s", subject)
+	}
+	return fmt.Sprintf("You owe them: %s", subject)
+}
+
+// heldMarker distinguishes the two cards one task can produce, so a
+// dismissal of one does not silence the other.
+func heldMarker(ctx context.Context, task crmcontracts.Activity) string {
+	if heldByAnother(ctx, task) {
+		return ":theirs"
+	}
+	return ":ours"
+}
+
+// heldByAnother reports whether a named colleague, and not the reader, holds
+// this task. A call carrying no user (an agent reading through a passport)
+// claims nobody's work as its own.
+func heldByAnother(ctx context.Context, task crmcontracts.Activity) bool {
+	if task.AssigneeId == nil {
+		return false
+	}
+	viewer, ok := principal.Actor(ctx)
+	if !ok || viewer.UserID == (ids.UUID{}) {
+		return true
+	}
+	return ids.UUID(*task.AssigneeId) != viewer.UserID
+}
+
+// nearestOpenTask is the section's FIRST row, and the ordering is the
+// section's own: the next-steps read sorts by due date, then filing order
+// (byUrgency in sectionstimeline.go), so the row a reader sees at the top of
+// their task list is the row the card speaks for. Picking a different one
+// here would put the card and the list beneath it in disagreement, and
+// re-sorting the 25 rows this page carries could not see the 26th anyway.
+func nearestOpenTask(page *crmcontracts.Person360) (crmcontracts.Activity, bool) {
+	if page.NextSteps == nil || len(page.NextSteps.Data) == 0 {
+		return crmcontracts.Activity{}, false
+	}
+	return page.NextSteps.Data[0], true
+}
+
+// openPromiseWhyNow says what the date on the promise is, in the reader's
+// terms: a deadline still ahead, one already behind, or none at all.
+func openPromiseWhyNow(now time.Time, task crmcontracts.Activity) string {
+	if task.DueAt == nil {
+		return fmt.Sprintf("Promised on %s with no date set. It stays open until you do it or close it.", task.OccurredAt.Format("2 Jan"))
+	}
+	if past, ok := deadline.DaysPast(task.DueAt, now); ok {
+		return fmt.Sprintf("Due %d days ago and still open.", past)
+	}
+	// A task logged from the record page carries today's date unless the
+	// writer picks another, so "in 0 days" is the common case, not a corner.
+	if days := elapsed.Days(now, *task.DueAt); days > 0 {
+		return fmt.Sprintf("Due in %d days.", days)
+	}
+	return "Due today."
+}
+
+// overdueTaskMoment: a task we owe them was due and is still open.
+//
+// It sits directly under the overdue-claim rung and ABOVE gone_quiet, which
+// is the whole point of separating it from openPromiseMoment below. The two
+// rungs read one fact — we are late on something we agreed — from the two
+// places a promise gets written down: a claim an extractor read out of an
+// email, and a task a person filed or confirmed. Ranking them apart made the
+// same lateness outrank a silence when it came from mail and lose to one when
+// it came from the task list, which is a rule about provenance rather than
+// about what the reader should do next.
+func overdueTaskMoment(ctx context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+	task, ok := nearestOpenTask(page)
+	if !ok || !deadline.Passed(task.DueAt, now) {
+		return crmcontracts.PersonMoment{}, false
+	}
+	moment := openPromiseFrom(ctx, now, task)
+	moment.ClaimKey = "moment:overdue_task"
+	moment.Rule = crmcontracts.PersonMomentRuleOverdueTask
+	return moment, true
+}

--- a/backend/internal/compose/person360/momentrules.go
+++ b/backend/internal/compose/person360/momentrules.go
@@ -11,6 +11,7 @@ package person360
 // scroll through seven rule bodies to find out.
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -22,7 +23,6 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
-	"github.com/margince/margince/backend/internal/shared/kernel/elapsed"
 	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
@@ -35,7 +35,7 @@ import (
 // for a signal the system does not produce is a contract question, tracked
 // separately; what must not happen meanwhile is the page telling a rep that
 // somebody's seat moved on the strength of a reply.
-func roleChangeMoment(_ time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+func roleChangeMoment(_ context.Context, _ time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
 	change, ok := findChange(page, relstrength.ChangeRepliedAfterGap)
 	if !ok {
 		return crmcontracts.PersonMoment{}, false
@@ -84,7 +84,7 @@ func withheld(page *crmcontracts.Person360, sections ...crmcontracts.Person360Se
 
 // missingNextStepMoment: there is an open deal and nothing scheduled with the
 // person who sits on it. The gap is the finding.
-func missingNextStepMoment(_ time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+func missingNextStepMoment(_ context.Context, _ time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
 	// "Nothing is scheduled" is only true if this reader could see the schedule.
 	if withheld(page, crmcontracts.Person360SectionsOmittedNextMeeting,
 		crmcontracts.Person360SectionsOmittedNextSteps,
@@ -130,7 +130,7 @@ func missingNextStepMoment(_ time.Time, page *crmcontracts.Person360) (crmcontra
 // and because saying it too eagerly on a record whose activity section was
 // simply withheld would be a lie. Both inputs must be READ and empty, not
 // absent.
-func thinRelationshipMoment(_ time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+func thinRelationshipMoment(_ context.Context, _ time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
 	if page.Activities == nil || page.Network == nil {
 		// A section the caller may not read contributes no moment. Absent is
 		// not the same as empty, and only one of them is a fact about the
@@ -342,126 +342,3 @@ func entityType(v crmcontracts.PersonMomentDestinationEntityType) *crmcontracts.
 
 // prefill lifts the string map the contract carries as an optional object.
 func prefill(v map[string]string) *map[string]string { return &v }
-
-// openPromiseMoment: an open task is filed against them and nobody has done
-// it. Dated or not — the transcript reader files "I'll send you the
-// whitepaper" without a date, and it is owed either way.
-//
-// Below gone_quiet on purpose: a promise with no clock on it can wait for a
-// day, a contact who stopped answering is already costing something. Above
-// role_change and everything under it, because a thing we said we would do
-// outranks a thing we might do next. The overdue rung above reads claims
-// from correspondence; this one reads the task list, so a promise the reader
-// accepted from a transcript reaches the card the moment it becomes a task.
-func openPromiseMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
-	task, ok := nearestOpenTask(page)
-	if !ok {
-		return crmcontracts.PersonMoment{}, false
-	}
-	// A task filed without a subject is still owed; the card names it as the
-	// task list does rather than printing an empty promise.
-	subject := "an open task"
-	if task.Subject != nil && *task.Subject != "" {
-		subject = *task.Subject
-	}
-	// The evidence is dated by when the promise was filed, not when it falls
-	// due: a task due next month is not "updated today", and the due date is
-	// the reason's to state.
-	observed := task.OccurredAt
-	evidence := []crmcontracts.PersonMomentEvidence{{
-		Type:       crmcontracts.PersonMomentEvidenceTypeTask,
-		Id:         ptr(task.Id),
-		Label:      subject,
-		ObservedAt: &observed,
-	}}
-	return crmcontracts.PersonMoment{
-		ClaimKey:            "moment:open_promise",
-		Rule:                crmcontracts.PersonMomentRuleOpenPromise,
-		RuleVersion:         ptr(ruleVersion),
-		EvidenceFingerprint: fingerprintOf(evidence),
-		Headline:            openPromiseHeadline(task, subject),
-		WhyNow:              openPromiseWhyNow(now, task),
-		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
-		Evidence:            evidence,
-		FreshnessAt:         &observed,
-		// Writing to them is the one move every promise shares, whether it is
-		// a document to send or a room to book they are waiting to hear about.
-		// The composer opens on the promise itself, so the label says what the
-		// button does rather than presuming the promise is a thing to send.
-		RecommendedAction: crmcontracts.PersonMomentAction{
-			Kind:  crmcontracts.PersonMomentActionKindDraftReply,
-			Label: "Write to them about it",
-			State: crmcontracts.PersonMomentActionStateWillConfirm,
-			Destination: &crmcontracts.PersonMomentDestination{
-				Surface: crmcontracts.PersonMomentDestinationSurfaceComposer,
-				Prefill: prefill(map[string]string{prefillIntent: "deliver_commitment", "subject": subject}),
-			},
-		},
-	}, true
-}
-
-// openPromiseHeadline names who owes it. A task with an assignee is that
-// person's, and the card is read by the whole workspace — "you owe them" to a
-// reader whose colleague holds the task attributes a promise to the wrong
-// desk. Unassigned, it is the workspace's, and the reader is the workspace.
-func openPromiseHeadline(task crmcontracts.Activity, subject string) string {
-	if task.AssigneeId != nil {
-		return fmt.Sprintf("Owed to them: %s", subject)
-	}
-	return fmt.Sprintf("You owe them: %s", subject)
-}
-
-// nearestOpenTask picks the one open task the card speaks for: the earliest
-// due date first, and among undated ones the oldest filed. One promise on the
-// card, not a list — the task list below it is where the rest live.
-func nearestOpenTask(page *crmcontracts.Person360) (crmcontracts.Activity, bool) {
-	if page.NextSteps == nil {
-		return crmcontracts.Activity{}, false
-	}
-	var pick *crmcontracts.Activity
-	for i := range page.NextSteps.Data {
-		task := &page.NextSteps.Data[i]
-		if pick == nil || openTaskSooner(task, pick) {
-			pick = task
-		}
-	}
-	if pick == nil {
-		return crmcontracts.Activity{}, false
-	}
-	return *pick, true
-}
-
-// openTaskSooner orders two open tasks: a dated one before an undated one,
-// then by due date, then by when it was filed. Two tasks due the same day
-// fall through to the filing order on purpose: the section lists newest
-// first, and without the fall-through the card switched to whichever task
-// was logged last rather than the one that has waited longest.
-func openTaskSooner(a, b *crmcontracts.Activity) bool {
-	switch {
-	case a.DueAt != nil && b.DueAt != nil && !a.DueAt.Equal(*b.DueAt):
-		return a.DueAt.Before(*b.DueAt)
-	case a.DueAt != nil && b.DueAt == nil:
-		return true
-	case a.DueAt == nil && b.DueAt != nil:
-		return false
-	default:
-		return a.OccurredAt.Before(b.OccurredAt)
-	}
-}
-
-// openPromiseWhyNow says what the date on the promise is, in the reader's
-// terms: a deadline still ahead, one already behind, or none at all.
-func openPromiseWhyNow(now time.Time, task crmcontracts.Activity) string {
-	if task.DueAt == nil {
-		return fmt.Sprintf("Promised on %s with no date set. It stays open until you do it or close it.", task.OccurredAt.Format("2 Jan"))
-	}
-	if past, ok := deadline.DaysPast(task.DueAt, now); ok {
-		return fmt.Sprintf("Due %d days ago and still open.", past)
-	}
-	// A task logged from the record page carries today's date unless the
-	// writer picks another, so "in 0 days" is the common case, not a corner.
-	if days := elapsed.Days(now, *task.DueAt); days > 0 {
-		return fmt.Sprintf("Due in %d days.", days)
-	}
-	return "Due today."
-}

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -55,7 +55,7 @@ import (
 // ruleVersion stamps the ladder that selected a moment. It changes whenever a
 // rung's condition or order changes, so the same evidence rendering differently
 // across two clients is visible rather than silent.
-const ruleVersion = "person-moment-ladder-v1"
+const ruleVersion = "person-moment-ladder-v2"
 
 // meetingHorizonHours is how far ahead a meeting is worth preparing for
 // (ADR-0096 D2 rung 1). Three days, not the week the earlier ladder used: a
@@ -82,7 +82,7 @@ const prefillIntent = "intent"
 //
 // It runs LAST among the sections so it can read what the others gathered.
 func (s *Service) momentsSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now time.Time, out *crmcontracts.Person360) error {
-	moment := deriveMoment(now, out)
+	moment := deriveMoment(ctx, now, out)
 	dismissed, err := s.momentDismissed(ctx, tx, personID, moment)
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ func (s *Service) momentsSection(ctx context.Context, tx pgx.Tx, personID ids.Pe
 		// Dismissed against THIS evidence. The quiet success state is what the
 		// reader asked for by dismissing, and it is a moment of its own rather
 		// than an empty card.
-		moment = nothingNeededMoment(now, out)
+		moment = nothingNeededMoment(ctx, now, out)
 	}
 	withholdLogActivity(ctx, &moment)
 	out.Moment = &moment
@@ -168,15 +168,15 @@ func (s *Service) momentDismissed(ctx context.Context, tx pgx.Tx, personID ids.P
 // Rungs 3 (job change) and 7 (public signal) are absent by design — both need
 // inputs this build does not have, and a rule that cannot fire belongs nowhere
 // on the page.
-func deriveMoment(now time.Time, page *crmcontracts.Person360) crmcontracts.PersonMoment {
+func deriveMoment(ctx context.Context, now time.Time, page *crmcontracts.Person360) crmcontracts.PersonMoment {
 	for _, rung := range momentLadder {
-		if moment, ok := rung(now, page); ok {
+		if moment, ok := rung(ctx, now, page); ok {
 			return moment
 		}
 	}
 	// 10. Nothing needs you today. A quiet success state, not a blank card:
 	// "there is nothing here" is an answer, and the reader came for an answer.
-	return nothingNeededMoment(now, page)
+	return nothingNeededMoment(ctx, now, page)
 }
 
 // momentLadder is the ladder itself, named so a test can walk every rung.
@@ -185,12 +185,13 @@ func deriveMoment(now time.Time, page *crmcontracts.Person360) crmcontracts.Pers
 // constructing a page that makes it win, and the rungs below it then never run
 // at all - which is how three dead buttons sat on untested rungs while a test
 // claiming to be a general rule covered two.
-var momentLadder = []func(time.Time, *crmcontracts.Person360) (crmcontracts.PersonMoment, bool){
+var momentLadder = []func(context.Context, time.Time, *crmcontracts.Person360) (crmcontracts.PersonMoment, bool){
 	meetingPrepMoment,      // 1. a meeting within 72 hours
 	reEngagedMoment,        // 2. new inbound after a material quiet period
 	overduePromiseMoment,   // 4. an open commitment of ours is overdue
+	overdueTaskMoment,      // 4b. an open task of ours whose date has passed
 	goneQuietMoment,        // 5. outbound unanswered past the configured rule
-	openPromiseMoment,      // 5b. an open task we owe them, dated or not
+	openPromiseMoment,      // 5b. an open task we owe them, undated or ahead
 	roleChangeMoment,       // 6. a new deal role or material relationship change
 	missingNextStepMoment,  // 8. an open deal with no next step involving them
 	thinRelationshipMoment, // 9. no captured interaction or network
@@ -204,6 +205,7 @@ var momentLadderNames = []string{
 	"meeting_prep",
 	"re_engaged",
 	"overdue_promise",
+	"overdue_task",
 	"gone_quiet",
 	"open_promise",
 	"role_change",
@@ -213,7 +215,7 @@ var momentLadderNames = []string{
 
 // meetingPrepMoment: a meeting is close enough that preparing for it is the
 // most valuable thing the reader could do.
-func meetingPrepMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+func meetingPrepMoment(_ context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
 	if page.NextMeeting == nil {
 		return crmcontracts.PersonMoment{}, false
 	}
@@ -266,7 +268,7 @@ func meetingPrepMoment(now time.Time, page *crmcontracts.Person360) (crmcontract
 
 // reEngagedMoment: they came back. The strongest reason captured data alone can
 // produce, and the one most likely to be acted on the same hour.
-func reEngagedMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+func reEngagedMoment(_ context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
 	if page.LastInboundAt == nil {
 		return crmcontracts.PersonMoment{}, false
 	}
@@ -313,7 +315,7 @@ func reEngagedMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.
 // Ours outranks theirs on purpose. A promise we owe is entirely within the
 // reader's control, and it is the one they would be most embarrassed to
 // discover from the other side.
-func overduePromiseMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+func overduePromiseMoment(_ context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
 	claim, ok := oldestOverdueCommitment(now, page)
 	if !ok {
 		return crmcontracts.PersonMoment{}, false
@@ -353,7 +355,7 @@ func overduePromiseMoment(now time.Time, page *crmcontracts.Person360) (crmcontr
 // The moment names the rule in its own text. A reader who disagrees with the
 // verdict can see what produced it, which is the difference between a system
 // that judges and one that explains.
-func goneQuietMoment(now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+func goneQuietMoment(_ context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
 	if page.LastOutboundAt == nil {
 		return crmcontracts.PersonMoment{}, false
 	}
@@ -441,7 +443,7 @@ func logInteraction() crmcontracts.PersonMomentAction {
 // It is a moment rather than an absence because the reader opened the page to
 // be told what to do, and "nothing" is a legitimate answer that an empty card
 // fails to give.
-func nothingNeededMoment(now time.Time, page *crmcontracts.Person360) crmcontracts.PersonMoment {
+func nothingNeededMoment(_ context.Context, now time.Time, page *crmcontracts.Person360) crmcontracts.PersonMoment {
 	why := "No meeting is close, nothing is owed, and nobody is waiting on a reply."
 	// Every rung above this one either fired or found nothing, and "found
 	// nothing" includes "was not allowed to look". Saying nobody is waiting on

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -4,6 +4,7 @@
 package person360
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -63,7 +64,7 @@ func TestTheLadderSelectsExactlyOneMoment(t *testing.T) {
 			SourceQuote:      "I'll get you the model by Friday",
 		}},
 	}
-	got := deriveMoment(now, page)
+	got := deriveMoment(readerCtx(), now, page)
 	if got.Rule != crmcontracts.PersonMomentRuleMeetingPrep {
 		t.Fatalf("meeting prep outranks every rung below it, got %q", got.Rule)
 	}
@@ -78,7 +79,7 @@ func TestAMeetingBeyondSeventyTwoHoursDoesNotWin(t *testing.T) {
 		LastInboundAt:  &replied,
 		LastOutboundAt: ptr(at(40)),
 	}
-	got := deriveMoment(now, page)
+	got := deriveMoment(readerCtx(), now, page)
 	if got.Rule != crmcontracts.PersonMomentRuleReEngaged {
 		t.Fatalf("a meeting four days out should not beat a fresh reply, got %q", got.Rule)
 	}
@@ -95,7 +96,7 @@ func TestAnAnsweredConversationIsNotGoneQuiet(t *testing.T) {
 			Colleagues []crmcontracts.PersonNetworkColleague `json:"colleagues"`
 		}{},
 	}
-	got := deriveMoment(now, page)
+	got := deriveMoment(readerCtx(), now, page)
 	if got.Rule == crmcontracts.PersonMomentRuleGoneQuiet {
 		t.Fatal("they answered after our last message; silence is not the story")
 	}
@@ -109,7 +110,7 @@ func TestGoneQuietNamesTheRuleItFiredOn(t *testing.T) {
 		LastOutboundAt: ptr(at(9)),
 		LastInboundAt:  ptr(at(16)),
 	}
-	got := deriveMoment(now, page)
+	got := deriveMoment(readerCtx(), now, page)
 	if got.Rule != crmcontracts.PersonMomentRuleGoneQuiet {
 		t.Fatalf("nine days unanswered past a seven-day rule is gone quiet, got %q", got.Rule)
 	}
@@ -196,11 +197,22 @@ func TestEveryOfferedActionEitherGoesSomewhereOrSaysWhyItCannot(t *testing.T) {
 				Subject: ptr("Send the MCP whitepaper"), OccurredAt: at(1),
 			}}},
 		},
+		// Rung 4b wants an open task whose date has passed — the same lateness
+		// the claim rung above reads, from the task list instead.
+		"overdue task": {
+			NextSteps: &struct {
+				Data []crmcontracts.Activity `json:"data"`
+				Page crmcontracts.PageInfo   `json:"page"`
+			}{Data: []crmcontracts.Activity{{
+				Id: openapi_types.UUID(ids.NewV7()), Kind: "task",
+				Subject: ptr("Send the signed contract"), OccurredAt: at(72), DueAt: ptr(at(30)),
+			}}},
+		},
 		"nothing needed": {},
 	}
 	for name, page := range pages {
 		t.Run(name, func(t *testing.T) {
-			assertActionsAreHonest(t, deriveMoment(now, page))
+			assertActionsAreHonest(t, deriveMoment(readerCtx(), now, page))
 		})
 	}
 
@@ -215,7 +227,7 @@ func TestEveryOfferedActionEitherGoesSomewhereOrSaysWhyItCannot(t *testing.T) {
 		fired := make(map[int]bool, len(momentLadder))
 		for _, page := range pages {
 			for i, rung := range momentLadder {
-				moment, ok := rung(now, page)
+				moment, ok := rung(readerCtx(), now, page)
 				if !ok {
 					continue
 				}
@@ -295,7 +307,7 @@ func TestAQuietRecordStillGetsAnAnswer(t *testing.T) {
 			Colleagues []crmcontracts.PersonNetworkColleague `json:"colleagues"`
 		}{Colleagues: []crmcontracts.PersonNetworkColleague{{}}},
 	}
-	got := deriveMoment(now, page)
+	got := deriveMoment(readerCtx(), now, page)
 	if got.Rule != crmcontracts.PersonMomentRuleNothingNeeded {
 		t.Fatalf("a record with nothing pending gets the quiet success state, got %q", got.Rule)
 	}
@@ -305,7 +317,7 @@ func TestAQuietRecordStillGetsAnAnswer(t *testing.T) {
 // same as empty, and only one of them is a fact about the relationship.
 func TestAWithheldSectionDoesNotProduceAThinRelationshipClaim(t *testing.T) {
 	page := &crmcontracts.Person360{}
-	got := deriveMoment(now, page)
+	got := deriveMoment(readerCtx(), now, page)
 	if got.Rule == crmcontracts.PersonMomentRuleThinRelationship {
 		t.Fatal("activities and network were withheld, not empty; the page must not call the relationship thin")
 	}
@@ -359,7 +371,7 @@ func TestARuleDoesNotClaimAbsenceForASectionItCouldNotRead(t *testing.T) {
 	// An open deal with no visible schedule. Allowed to look, the page says
 	// nothing is scheduled; forbidden to look, it must not.
 	visible := &crmcontracts.Person360{Commercial: deal}
-	if got := deriveMoment(now, visible).Rule; got != crmcontracts.PersonMomentRuleMissingNextStep {
+	if got := deriveMoment(readerCtx(), time.Now(), visible).Rule; got != crmcontracts.PersonMomentRuleMissingNextStep {
 		t.Fatalf("with the schedule readable and empty, the gap IS the finding, got %q", got)
 	}
 
@@ -369,7 +381,7 @@ func TestARuleDoesNotClaimAbsenceForASectionItCouldNotRead(t *testing.T) {
 			crmcontracts.Person360SectionsOmittedNextMeeting,
 		},
 	}
-	if got := deriveMoment(now, withheldSchedule).Rule; got == crmcontracts.PersonMomentRuleMissingNextStep {
+	if got := deriveMoment(readerCtx(), time.Now(), withheldSchedule).Rule; got == crmcontracts.PersonMomentRuleMissingNextStep {
 		t.Error("the schedule was withheld, so 'nothing is scheduled' is not something this page knows")
 	}
 }
@@ -377,12 +389,12 @@ func TestARuleDoesNotClaimAbsenceForASectionItCouldNotRead(t *testing.T) {
 // And the quiet fall-through says so too, rather than reporting a withheld
 // timeline as a clean bill of health.
 func TestNothingNeededAdmitsWhenItCouldNotSeeEverything(t *testing.T) {
-	full := deriveMoment(now, &crmcontracts.Person360{})
+	full := deriveMoment(readerCtx(), time.Now(), &crmcontracts.Person360{})
 	if full.Rule != crmcontracts.PersonMomentRuleNothingNeeded {
 		t.Fatalf("an empty readable page is the quiet state, got %q", full.Rule)
 	}
 
-	partial := deriveMoment(now, &crmcontracts.Person360{
+	partial := deriveMoment(readerCtx(), time.Now(), &crmcontracts.Person360{
 		SectionsOmitted: []crmcontracts.Person360SectionsOmitted{
 			crmcontracts.Person360SectionsOmittedActivities,
 		},
@@ -400,13 +412,13 @@ func TestNothingNeededAdmitsWhenItCouldNotSeeEverything(t *testing.T) {
 // save without it. So the action a reader cannot complete is handed to them
 // blocked, with the reason, rather than as a live button that fails on save.
 func TestLogActivityIsWithheldFromACallerWithoutTheCreateGrant(t *testing.T) {
-	quiet := nothingNeededMoment(time.Now(), &crmcontracts.Person360{})
+	quiet := nothingNeededMoment(readerCtx(), time.Now(), &crmcontracts.Person360{})
 	if quiet.RecommendedAction.Kind != crmcontracts.PersonMomentActionKindLogActivity {
 		t.Fatalf("the quiet moment's action is %q, want log_activity — this test needs that rung", quiet.RecommendedAction.Kind)
 	}
 
 	reader := quiet
-	withholdLogActivity(as(map[string]principal.ObjectGrant{"person": {Read: true}}), &reader)
+	withholdLogActivity((as(map[string]principal.ObjectGrant{"person": {Read: true}})), &reader)
 	if reader.RecommendedAction.State != crmcontracts.PersonMomentActionStateBlocked {
 		t.Errorf("state = %q for a caller without activity.create, want blocked", reader.RecommendedAction.State)
 	}
@@ -418,7 +430,7 @@ func TestLogActivityIsWithheldFromACallerWithoutTheCreateGrant(t *testing.T) {
 	}
 
 	writer := quiet
-	withholdLogActivity(as(map[string]principal.ObjectGrant{"person": {Read: true}, "activity": {Create: true}}), &writer)
+	withholdLogActivity((as(map[string]principal.ObjectGrant{"person": {Read: true}, "activity": {Create: true}})), &writer)
 	if writer.RecommendedAction.State != crmcontracts.PersonMomentActionStateAvailable || writer.RecommendedAction.Destination == nil {
 		t.Errorf("a caller holding activity.create got %q with destination %v, want the action untouched", writer.RecommendedAction.State, writer.RecommendedAction.Destination)
 	}
@@ -427,24 +439,29 @@ func TestLogActivityIsWithheldFromACallerWithoutTheCreateGrant(t *testing.T) {
 // An open task with no date is still a promise. The transcript reader files
 // "I'll send you the whitepaper" without one, and the card used to fall past
 // every rung to "nothing is owed" while that task sat directly beneath it.
+//
+// The page arrives ordered by the next-steps read (byUrgency): soonest
+// deadline first, then oldest. The card speaks for the first row, so these
+// pages are built in that order rather than the timeline's.
 func TestAnOpenUndatedTaskIsTheMoment(t *testing.T) {
 	now := time.Now()
+	filed := now.Add(-48 * time.Hour)
 	page := &crmcontracts.Person360{
 		NextSteps: &struct {
 			Data []crmcontracts.Activity `json:"data"`
 			Page crmcontracts.PageInfo   `json:"page"`
 		}{Data: []crmcontracts.Activity{
+			{Id: openapi_types.UUID(ids.NewV7()), Kind: "task", Subject: ptr("Send the MCP whitepaper"), OccurredAt: filed},
 			{Id: openapi_types.UUID(ids.NewV7()), Kind: "task", Subject: ptr("Book the workshop room"), OccurredAt: now.Add(-2 * time.Hour)},
-			{Id: openapi_types.UUID(ids.NewV7()), Kind: "task", Subject: ptr("Send the MCP whitepaper"), OccurredAt: now.Add(-48 * time.Hour)},
 		}},
 	}
 
-	moment := deriveMoment(now, page)
+	moment := deriveMoment(readerCtx(), now, page)
 	if moment.Rule != crmcontracts.PersonMomentRuleOpenPromise {
 		t.Fatalf("rule = %q, want open_promise — an open task is owed, dated or not", moment.Rule)
 	}
 	if moment.Headline != "You owe them: Send the MCP whitepaper" {
-		t.Errorf("headline = %q, want the OLDEST undated task named", moment.Headline)
+		t.Errorf("headline = %q, want the section's first task named", moment.Headline)
 	}
 	if !strings.Contains(moment.WhyNow, "no date set") {
 		t.Errorf("why_now = %q, want it to say the promise carries no date", moment.WhyNow)
@@ -452,46 +469,120 @@ func TestAnOpenUndatedTaskIsTheMoment(t *testing.T) {
 	if got := (*moment.RecommendedAction.Destination.Prefill)["subject"]; got != "Send the MCP whitepaper" {
 		t.Errorf("composer subject = %q, want the promise itself", got)
 	}
-	if moment.FreshnessAt == nil || !moment.FreshnessAt.Equal(now.Add(-48*time.Hour)) {
+	if moment.FreshnessAt == nil || !moment.FreshnessAt.Equal(filed) {
 		t.Errorf("freshness = %v, want the day the promise was filed", moment.FreshnessAt)
 	}
 
 	// A task somebody specific holds is owed by that desk, not by whoever is
 	// reading the card.
-	assigned := page.NextSteps.Data[1]
-	assigned.AssigneeId = ptr(openapi_types.UUID(ids.NewV7()))
-	page.NextSteps.Data[1] = assigned
-	if got := deriveMoment(now, page).Headline; got != "Owed to them: Send the MCP whitepaper" {
+	page.NextSteps.Data[0].AssigneeId = ptr(openapi_types.UUID(ids.NewV7()))
+	if got := deriveMoment(readerCtx(), now, page).Headline; got != "Owed to them: Send the MCP whitepaper" {
 		t.Errorf("headline for an assigned task = %q, want it attributed to its holder", got)
 	}
-	page.NextSteps.Data[1].AssigneeId = nil
+	page.NextSteps.Data[0].AssigneeId = nil
 
-	// A dated task outranks an undated one, however old the undated one is.
-	dated := page.NextSteps.Data[0]
-	dated.DueAt = ptr(now.Add(72 * time.Hour))
-	page.NextSteps.Data[0] = dated
-	if got := deriveMoment(now, page).Headline; got != "You owe them: Book the workshop room" {
-		t.Errorf("with a dated task present, headline = %q, want the dated one", got)
-	}
-	// A task logged from the record page is due at the end of today, and the
-	// card says so in words rather than counting zero days.
+	// A task due later today reads as due today rather than counting zero days.
 	page.NextSteps.Data[0].DueAt = ptr(now.Add(2 * time.Hour))
-	if got := deriveMoment(now, page).WhyNow; got != "Due today." {
+	if got := deriveMoment(readerCtx(), now, page).WhyNow; got != "Due today." {
 		t.Errorf("why_now for a task due later today = %q, want \"Due today.\"", got)
-	}
-
-	// Two tasks due the same day: the one filed first has waited longest and
-	// keeps the card. The section lists newest first, so without this the
-	// card followed whichever task was logged last.
-	page.NextSteps.Data[1].DueAt = ptr(now.Add(2 * time.Hour))
-	if got := deriveMoment(now, page).Headline; got != "You owe them: Send the MCP whitepaper" {
-		t.Errorf("with two tasks due today, headline = %q, want the older one", got)
 	}
 
 	// Done tasks never reach the section, so a page whose section is empty is
 	// the quiet state — and only then may the card say nothing is owed.
 	page.NextSteps.Data = nil
-	if got := deriveMoment(now, page).Rule; got != crmcontracts.PersonMomentRuleNothingNeeded {
+	if got := deriveMoment(readerCtx(), now, page).Rule; got != crmcontracts.PersonMomentRuleNothingNeeded {
 		t.Errorf("with no open task, rule = %q, want nothing_needed", got)
+	}
+}
+
+// A promise past its date outranks a silence, and it must do so whichever
+// place the promise was written down. Ranking the task rung below gone_quiet
+// made the same lateness win from an email and lose from the task list, which
+// is a rule about where a fact was recorded rather than about what the reader
+// should do next.
+func TestAnOverdueTaskOutranksASilence(t *testing.T) {
+	now := time.Now()
+	quiet := func() *crmcontracts.Person360 {
+		return &crmcontracts.Person360{
+			LastOutboundAt: ptr(now.Add(-9 * 24 * time.Hour)),
+			LastInboundAt:  ptr(now.Add(-16 * 24 * time.Hour)),
+		}
+	}
+	task := func(due time.Time) []crmcontracts.Activity {
+		return []crmcontracts.Activity{{
+			Id: openapi_types.UUID(ids.NewV7()), Kind: "task",
+			Subject: ptr("Send the signed contract"), OccurredAt: now.Add(-72 * time.Hour), DueAt: ptr(due),
+		}}
+	}
+
+	// The silence alone is the moment, so the two cases below are a change of
+	// rung rather than a page that only ever had one answer.
+	if got := deriveMoment(readerCtx(), now, quiet()).Rule; got != crmcontracts.PersonMomentRuleGoneQuiet {
+		t.Fatalf("with no task, rule = %q, want gone_quiet — this test needs the silence to fire", got)
+	}
+
+	late := quiet()
+	late.NextSteps = &struct {
+		Data []crmcontracts.Activity `json:"data"`
+		Page crmcontracts.PageInfo   `json:"page"`
+	}{Data: task(now.Add(-30 * time.Hour))}
+	moment := deriveMoment(readerCtx(), now, late)
+	if moment.Rule != crmcontracts.PersonMomentRuleOverdueTask {
+		t.Errorf("rule = %q, want overdue_task — a promise we are late on outranks their silence", moment.Rule)
+	}
+	if moment.Headline != "You owe them: Send the signed contract" {
+		t.Errorf("headline = %q, want the overdue promise named", moment.Headline)
+	}
+	if !strings.Contains(moment.WhyNow, "still open") {
+		t.Errorf("why_now = %q, want it to say the date has passed", moment.WhyNow)
+	}
+
+	// Not yet due, so the silence keeps the card and the promise waits below it.
+	ahead := quiet()
+	ahead.NextSteps = &struct {
+		Data []crmcontracts.Activity `json:"data"`
+		Page crmcontracts.PageInfo   `json:"page"`
+	}{Data: task(now.Add(48 * time.Hour))}
+	if got := deriveMoment(readerCtx(), now, ahead).Rule; got != crmcontracts.PersonMomentRuleGoneQuiet {
+		t.Errorf("rule = %q for a promise still ahead of its date, want gone_quiet", got)
+	}
+}
+
+// readerCtx is a human reading their own workspace: the seat every ladder
+// case below is judged from, since who the reader is decides whether an
+// assigned promise is theirs to deliver.
+func readerCtx() context.Context {
+	return as(map[string]principal.ObjectGrant{"person": {Read: true}, "activity": {Create: true}})
+}
+
+// A dismissal is keyed on the moment's fingerprint, so the fingerprint has to
+// change when the card does. Handing a colleague's task to the reader turns
+// "owed to them" into "you owe them"; sharing one fingerprint would let the
+// earlier dismissal suppress the new card, hiding the promise at the moment
+// it became the reader's to deliver.
+func TestReassigningAPromiseRearmsItsDismissal(t *testing.T) {
+	now := time.Now()
+	task := crmcontracts.Activity{
+		Id: openapi_types.UUID(ids.NewV7()), Kind: "task",
+		Subject: ptr("Send the signed contract"), OccurredAt: now.Add(-24 * time.Hour),
+	}
+	page := &crmcontracts.Person360{
+		NextSteps: &struct {
+			Data []crmcontracts.Activity `json:"data"`
+			Page crmcontracts.PageInfo   `json:"page"`
+		}{Data: []crmcontracts.Activity{task}},
+	}
+
+	ours := deriveMoment(readerCtx(), now, page)
+
+	page.NextSteps.Data[0].AssigneeId = ptr(openapi_types.UUID(ids.NewV7()))
+	theirs := deriveMoment(readerCtx(), now, page)
+
+	if theirs.Headline == ours.Headline {
+		t.Fatalf("both readings say %q; this test needs the card to change", ours.Headline)
+	}
+	if theirs.EvidenceFingerprint == ours.EvidenceFingerprint {
+		t.Error("the fingerprint is unchanged across a reassignment, so a dismissal of one card " +
+			"silences the other — the promise disappears exactly when it changes hands")
 	}
 }

--- a/backend/internal/compose/person360/sectionstimeline.go
+++ b/backend/internal/compose/person360/sectionstimeline.go
@@ -96,7 +96,7 @@ func (s *Service) activitiesSection(ctx context.Context, tx pgx.Tx, personID ids
 	if err := requireRead(ctx, "activity"); err != nil {
 		return err
 	}
-	rows, hasMore, err := s.readActivities(ctx, tx, personID, opts, "")
+	rows, hasMore, err := s.readActivities(ctx, tx, personID, opts, "", byRecency)
 	if err != nil {
 		return err
 	}
@@ -114,16 +114,38 @@ func (s *Service) nextStepsSection(ctx context.Context, tx pgx.Tx, personID ids.
 		return err
 	}
 	rows, hasMore, err := s.readActivities(ctx, tx, personID, opts,
-		`AND a.kind = 'task' AND coalesce(a.is_done, false) = false`)
+		`AND a.kind = 'task' AND coalesce(a.is_done, false) = false`, byUrgency)
 	if err != nil {
 		return err
 	}
 	out.NextSteps = &struct {
 		Data []crmcontracts.Activity `json:"data"`
 		Page crmcontracts.PageInfo   `json:"page"`
-	}{Data: rows, Page: sectionPage(rows, hasMore)}
+	}{Data: rows, Page: crmcontracts.PageInfo{HasMore: hasMore}}
 	return nil
 }
+
+// How a section's rows are ordered, and why the two differ.
+//
+// byRecency is the timeline's order and the one GET /activities pages by, so
+// a section using it can hand out a keyset cursor that continues the same
+// list. byUrgency is what a TASK list is for: the soonest deadline first,
+// undated work after it, and the oldest of those ahead of the newest — the
+// order a reader would put their own to-do list in. The undated tail is where
+// a transcript's "I'll send it later" lands, and filing order is the only
+// thing that separates two of those.
+//
+// A section ordered by urgency carries NO cursor: the activities list has no
+// such order to continue into, so a cursor minted here would be read against
+// (occurred_at, id) and page into the middle of a different list. It bounds
+// at sectionCap and says has_more instead, which is what every other summary
+// section does when it runs out of room.
+type sectionOrder string
+
+const (
+	byRecency sectionOrder = "a.occurred_at DESC, a.id DESC"
+	byUrgency sectionOrder = "a.due_at ASC NULLS LAST, a.occurred_at ASC, a.id ASC"
+)
 
 // sectionPage is the section's edge in the activities list's own cursor
 // vocabulary: the same (occurred_at, id) keyset GET /activities orders by, so
@@ -155,7 +177,7 @@ func sectionPage(rows []crmcontracts.Activity, hasMore bool) crmcontracts.PageIn
 // TestThePerson360TimelineNamesTheTransportThatCarriedAMessage and
 // TestThePerson360TimelineCarriesTheVersionAWriteNeeds are the guards that
 // say so out loud.
-func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.PersonID, opts AssembleOptions, extra string) ([]crmcontracts.Activity, bool, error) {
+func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.PersonID, opts AssembleOptions, extra string, order sectionOrder) ([]crmcontracts.Activity, bool, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	personPos := arg(personID)
@@ -173,16 +195,16 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 	}
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT a.id, a.kind, a.channel_provider, a.subject, a.body, a.direction,
-		       a.occurred_at, a.due_at, a.is_done, a.source, a.captured_by, a.created_at,
+		       a.occurred_at, a.due_at, a.is_done, a.assignee_id, a.source, a.captured_by, a.created_at,
 		       a.thread_key, a.bulk_mail_attested, a.audience, a.audience_reason,
 		       a.version, (%s) AS content_available,
 		       EXISTS (SELECT 1 FROM activity_link fl
 		                WHERE fl.activity_id = a.id AND fl.person_id = $%d) AS filed_here
 		FROM activity a
 		WHERE a.archived_at IS NULL AND %s AND (%s)%s %s
-		ORDER BY a.occurred_at DESC, a.id DESC
+		ORDER BY %s
 		LIMIT %d`,
-		contentArm, personPos, fmt.Sprintf(personReachesActivity, personPos), scope, projectScope(opts, arg), extra, sectionCap+1), args...)
+		contentArm, personPos, fmt.Sprintf(personReachesActivity, personPos), scope, projectScope(opts, arg), extra, order, sectionCap+1), args...)
 	if err != nil {
 		return nil, false, err
 	}
@@ -196,7 +218,7 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 		var contentAvailable, bulkMailAttested, filedHere bool
 		var threadKey, audienceReason *string
 		if err := rows.Scan(&id, &a.Kind, &a.ChannelProvider, &a.Subject, &a.Body,
-			&a.Direction, &a.OccurredAt, &a.DueAt, &a.IsDone, &a.Source, &a.CapturedBy,
+			&a.Direction, &a.OccurredAt, &a.DueAt, &a.IsDone, &a.AssigneeId, &a.Source, &a.CapturedBy,
 			&a.CreatedAt, &threadKey, &bulkMailAttested, &audience, &audienceReason,
 			&version, &contentAvailable, &filedHere); err != nil {
 			return nil, false, err

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -8293,6 +8293,7 @@ const (
 	PersonMomentRuleNothingNeeded    PersonMomentRule = "nothing_needed"
 	PersonMomentRuleOpenPromise      PersonMomentRule = "open_promise"
 	PersonMomentRuleOverduePromise   PersonMomentRule = "overdue_promise"
+	PersonMomentRuleOverdueTask      PersonMomentRule = "overdue_task"
 	PersonMomentRulePublicSignal     PersonMomentRule = "public_signal"
 	PersonMomentRuleReEngaged        PersonMomentRule = "re_engaged"
 	PersonMomentRuleRoleChange       PersonMomentRule = "role_change"
@@ -8315,6 +8316,8 @@ func (e PersonMomentRule) Valid() bool {
 	case PersonMomentRuleOpenPromise:
 		return true
 	case PersonMomentRuleOverduePromise:
+		return true
+	case PersonMomentRuleOverdueTask:
 		return true
 	case PersonMomentRulePublicSignal:
 		return true

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -17063,7 +17063,7 @@ export interface components {
          *     card.
          * @enum {string}
          */
-        PersonMomentRule: "meeting_prep" | "re_engaged" | "job_change" | "overdue_promise" | "gone_quiet" | "open_promise" | "role_change" | "public_signal" | "missing_next_step" | "thin_relationship" | "nothing_needed";
+        PersonMomentRule: "meeting_prep" | "re_engaged" | "job_change" | "overdue_promise" | "overdue_task" | "gone_quiet" | "open_promise" | "role_change" | "public_signal" | "missing_next_step" | "thin_relationship" | "nothing_needed";
         /** @description One thing that actually happened, which the reader can open. */
         PersonMomentEvidence: {
             /** @enum {string} */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6772,6 +6772,7 @@ export const de = {
   "person.moment.rule.re_engaged": "Sie haben sich gemeldet",
   "person.moment.rule.job_change": "Neue Stelle",
   "person.moment.rule.overdue_promise": "Zusage überfällig",
+  "person.moment.rule.overdue_task": "Versprechen überfällig",
   "person.moment.rule.gone_quiet": "Still geworden",
   "person.moment.rule.open_promise": "Offenes Versprechen",
   "person.moment.rule.role_change": "Rolle geändert",
@@ -6824,6 +6825,7 @@ export const de = {
   "person.loops.dueInDays": "in {count} Tagen",
   "person.loops.waiting": "wartet",
   "person.loops.open": "offen",
+  "person.loops.atLeast": "mindestens {count}",
 
   "person.memory.title": "Gesprächsgedächtnis",
   "person.memory.empty": "Auf diesem Kanal wurde noch nichts erfasst.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6820,6 +6820,7 @@ export const en = {
   "person.moment.rule.re_engaged": "They came back",
   "person.moment.rule.job_change": "They moved on",
   "person.moment.rule.overdue_promise": "Promise overdue",
+  "person.moment.rule.overdue_task": "Promise overdue",
   "person.moment.rule.gone_quiet": "Gone quiet",
   "person.moment.rule.open_promise": "You owe them",
   "person.moment.rule.role_change": "Role changed",
@@ -6871,6 +6872,7 @@ export const en = {
   "person.loops.dueInDays": "in {count} days",
   "person.loops.waiting": "waiting",
   "person.loops.open": "open",
+  "person.loops.atLeast": "at least {count}",
 
   "person.memory.title": "Conversation memory",
   "person.memory.empty": "Nothing captured on this channel yet.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6698,6 +6698,7 @@ export const vi = {
   "person.moment.rule.re_engaged": "Họ đã quay lại",
   "person.moment.rule.job_change": "Đã đổi việc",
   "person.moment.rule.overdue_promise": "Lời hứa quá hạn",
+  "person.moment.rule.overdue_task": "Lời hứa quá hạn",
   "person.moment.rule.gone_quiet": "Đã im lặng",
   "person.moment.rule.open_promise": "Lời hứa còn mở",
   "person.moment.rule.role_change": "Đã đổi vai trò",
@@ -6749,6 +6750,7 @@ export const vi = {
   "person.loops.dueInDays": "trong {count} ngày",
   "person.loops.waiting": "đang chờ",
   "person.loops.open": "đang mở",
+  "person.loops.atLeast": "ít nhất {count}",
 
   "person.memory.title": "Ký ức trò chuyện",
   "person.memory.empty": "Chưa ghi nhận gì trên kênh này.",

--- a/frontend/src/screens/personcards.loops.test.tsx
+++ b/frontend/src/screens/personcards.loops.test.tsx
@@ -1,9 +1,9 @@
 /** @vitest-environment jsdom */
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
-import { LocaleProvider } from "../i18n";
 import { PersonCommitmentsCard } from "./personcards";
+import { installFetchStub, meRoute, StoryProviders } from "./story-utils";
 
 type Person360 = components["schemas"]["Person360"];
 type ConversationClaim = components["schemas"]["ConversationClaim"];
@@ -26,6 +26,14 @@ const CAPTURED: Pick<
   created_at: "2026-06-01T08:00:00Z",
   updated_at: "2026-08-01T08:00:00Z",
 };
+
+// The reader every case renders as. useViewerId reads it off the shared /me
+// cache, and whose task a row is decides how the row is prefixed.
+const VIEWER = "00000000-0000-4000-8000-000000000001";
+
+beforeEach(() => {
+  installFetchStub({ "GET /me": meRoute({ activity: ["read"] }) });
+});
 
 // The reading moment every case below is an offset from. Fixed, because a
 // suite that reads the machine's calendar changes its verdict in December.
@@ -60,9 +68,9 @@ function at(offsetMs: number): string {
 
 function renderDue(dueAt: string | null) {
   render(
-    <LocaleProvider initial="en">
+    <StoryProviders>
       <PersonCommitmentsCard view={viewWithDue(dueAt)} firstName="Dana" />
-    </LocaleProvider>,
+    </StoryProviders>,
   );
 }
 
@@ -120,5 +128,128 @@ describe("the commitments card's due status", () => {
   it("shows the open badge when there is no due date at all", () => {
     renderDue(null);
     expect(screen.getByText("open")).toBeTruthy();
+  });
+});
+
+// A task IS a promise. The card read extracted claims alone, so a record whose
+// only open promise was a task — which is what an accepted transcript proposal
+// becomes — said "nothing has been promised" under a headline naming it.
+describe("open tasks are commitments too", () => {
+  function viewWithTask(dueAt: string | null): Person360 {
+    return {
+      as_of: NOW,
+      person: { id: "p-1", full_name: "Dana Buyer", ...CAPTURED },
+      sections_omitted: [],
+      next_steps: {
+        data: [
+          {
+            id: "t-1",
+            kind: "task",
+            subject: "Send the MCP whitepaper",
+            occurred_at: NOW,
+            is_done: false,
+            due_at: dueAt,
+            ...CAPTURED,
+          },
+        ],
+        page: { has_more: false },
+      },
+    };
+  }
+
+  it("lists an undated task as ours and open", () => {
+    render(
+      <StoryProviders>
+        <PersonCommitmentsCard view={viewWithTask(null)} firstName="Dana" />
+      </StoryProviders>,
+    );
+
+    expect(
+      screen.getAllByText(/Send the MCP whitepaper/).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("open")).toBeDefined();
+    expect(screen.queryByText(/Nothing has been promised/)).toBeNull();
+  });
+
+  it("reads an overdue task against the clock, like a claim", () => {
+    vi.setSystemTime(new Date(Date.parse(NOW)));
+    render(
+      <StoryProviders>
+        <PersonCommitmentsCard
+          view={viewWithTask(at(-25 * HOUR))}
+          firstName="Dana"
+        />
+      </StoryProviders>,
+    );
+
+    expect(screen.getByText("overdue 1 days")).toBeDefined();
+  });
+
+  it('keeps "You" on a task the reader holds themselves', async () => {
+    // The writer assigns every human-written task to its author, so this is
+    // the ordinary case, not a corner: a rule reading "assigned" as "somebody
+    // else's" would strip the prefix from nearly every task on the page.
+    const view = viewWithTask(null);
+    // biome-ignore lint/style/noNonNullAssertion: the fixture above builds it.
+    view.next_steps!.data[0].assignee_id = VIEWER;
+    render(
+      <StoryProviders>
+        <PersonCommitmentsCard view={view} firstName="Dana" />
+      </StoryProviders>,
+    );
+
+    // The reader's identity arrives with /me, so the prefix appears on the
+    // render after it resolves.
+    await waitFor(() =>
+      expect(
+        screen.getAllByText(/You: Send the MCP whitepaper/).length,
+      ).toBeGreaterThan(0),
+    );
+  });
+
+  it("does not tell the reader they owe a colleague's task", () => {
+    const view = viewWithTask(null);
+    // biome-ignore lint/style/noNonNullAssertion: the fixture above builds it.
+    view.next_steps!.data[0].assignee_id = "u-someone-else";
+    render(
+      <StoryProviders>
+        <PersonCommitmentsCard view={view} firstName="Dana" />
+      </StoryProviders>,
+    );
+
+    expect(screen.queryByText(/You: Send the MCP whitepaper/)).toBeNull();
+    expect(
+      screen.getAllByText(/Send the MCP whitepaper/).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("names a task whose subject it may not see", () => {
+    const view = viewWithTask(null);
+    // biome-ignore lint/style/noNonNullAssertion: the fixture above builds it.
+    view.next_steps!.data[0].subject = null;
+    render(
+      <StoryProviders>
+        <PersonCommitmentsCard view={view} firstName="Dana" />
+      </StoryProviders>,
+    );
+
+    expect(screen.getAllByText(/an open task/).length).toBeGreaterThan(0);
+  });
+
+  it("still says nothing is promised when there is neither claim nor task", () => {
+    render(
+      <StoryProviders>
+        <PersonCommitmentsCard
+          view={{
+            as_of: NOW,
+            person: { id: "p-1", full_name: "Dana Buyer", ...CAPTURED },
+            sections_omitted: [],
+          }}
+          firstName="Dana"
+        />
+      </StoryProviders>,
+    );
+
+    expect(screen.getByText(/Nothing has been promised/)).toBeDefined();
   });
 });

--- a/frontend/src/screens/personcards.tsx
+++ b/frontend/src/screens/personcards.tsx
@@ -13,6 +13,7 @@ import {
 import { daysPast } from "../format/lateness";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { useViewerId } from "./common";
 import { interactionIcon, useInteractionLabel } from "./interactionchrome";
 
 // The overview's four cards (concept §5.6–5.9). Each one is a read of what the
@@ -21,7 +22,6 @@ import { interactionIcon, useInteractionLabel } from "./interactionchrome";
 
 type Person360 = components["schemas"]["Person360"];
 type PersonBrief = components["schemas"]["PersonBrief"];
-type ConversationClaim = components["schemas"]["ConversationClaim"];
 type Activity = components["schemas"]["Activity"];
 type BriefEvidence = components["schemas"]["OrganizationBriefEvidence"];
 
@@ -37,6 +37,7 @@ export function PersonBriefCard({
   view: Person360;
 }>) {
   const t = useT();
+  const viewerId = useViewerId();
   const { locale } = useLocale();
   const firstName = view.person.full_name.split(" ")[0];
   // The timeline the page already read, by id. A citation is resolved from it
@@ -102,7 +103,7 @@ export function PersonBriefCard({
           <h3 className="pe-brief-label t-caption">
             {t("person.loops.title")}
           </h3>
-          <p className="pe-brief-line">{commitmentsLine(view, t)}</p>
+          <p className="pe-brief-line">{commitmentsLine(view, viewerId, t)}</p>
         </div>
         <div className="pe-brief-block">
           <h3 className="pe-brief-label t-caption">
@@ -380,25 +381,113 @@ const LOOPS: ReadonlyArray<{ kind: string; prefixKey: MessageKey | null }> = [
 // card's row list runs, so an empty band block and an empty panel are always
 // the same fact rather than two independent reads of the claims.
 export function hasCommitments(view: Person360): boolean {
-  const claims = view.claims ?? [];
-  return LOOPS.some((loop) =>
-    claims.some(
-      (claim) => claim.kind === loop.kind && claim.status !== "dismissed",
-    ),
-  );
+  // The band asks only WHETHER there is anything to show, which does not
+  // depend on who is reading.
+  return openLoops(view, undefined).length > 0;
 }
 
-function commitmentsLine(view: Person360, t: ReturnType<typeof useT>): string {
+// Everything this record owes, from BOTH places a promise is written down: a
+// claim an extractor read out of a conversation, and a task somebody filed.
+// The card once read claims alone, so a record whose only open promise was a
+// task — which is what an accepted transcript proposal becomes — said "nothing
+// has been promised" directly under a headline naming the promise.
+//
+// Tasks lead: one was typed or confirmed by a person, a claim was inferred.
+// The task list arrives ordered by urgency (the next-steps read), and that
+// order is kept.
+function openLoops(
+  view: Person360,
+  viewerId: string | undefined,
+): readonly OpenLoop[] {
   const claims = view.claims ?? [];
-  const openCount = LOOPS.flatMap((loop) =>
-    claims.filter(
-      (claim) => claim.kind === loop.kind && claim.status !== "dismissed",
-    ),
-  ).length;
+  const tasks = (view.next_steps?.data ?? []).map(
+    (task): OpenLoop => ({
+      key: task.id,
+      // A task can arrive without a subject — one filed without one, and one
+      // whose content this reader may not see, which the server nulls. Both
+      // are still owed, and the card names them the way the backend's own
+      // card does rather than printing a bare "You:".
+      body: task.subject ?? "an open task",
+      // "You" only when the task is not somebody else's. The activity writer
+      // assigns every human-written task to its author, so "has an assignee"
+      // is true of nearly all of them and would drop the prefix from the
+      // reader's own work; the comparison that matters is against the reader.
+      // While /me is in flight the id is unknown, and an unattributed row is
+      // the honest reading — better than telling someone they owe a
+      // colleague's promise.
+      prefixKey: heldByReader(task.assignee_id, viewerId)
+        ? "person.loops.ours"
+        : null,
+      dueAt: task.due_at ?? null,
+      done: task.is_done === true,
+      theirs: false,
+    }),
+  );
+  const fromClaims = LOOPS.flatMap((loop) =>
+    claims
+      .filter(
+        (claim) => claim.kind === loop.kind && claim.status !== "dismissed",
+      )
+      .map(
+        (claim): OpenLoop => ({
+          key: claim.id,
+          body: claim.body,
+          prefixKey: loop.prefixKey,
+          dueAt: claim.due_at ?? null,
+          done: claim.status === "done",
+          theirs: loop.kind === "commitment_theirs",
+        }),
+      ),
+  );
+  return [...tasks, ...fromClaims];
+}
+
+// One line of the card, whatever it was read from: a claim carries its kind
+// in a prefix, a task is always ours.
+type OpenLoop = {
+  key: string;
+  body: string;
+  // The word before the promise. Null means the contact's own name, which no
+  // catalog can carry.
+  prefixKey: MessageKey | null;
+  dueAt: string | null;
+  done: boolean;
+  // Whether the OTHER side owes it, which decides the badge when no date is set.
+  theirs: boolean;
+};
+
+// Whether this task is the reader's to deliver. Unassigned work is the
+// workspace's, and the reader is the workspace.
+function heldByReader(
+  assigneeId: string | null | undefined,
+  viewerId: string | undefined,
+): boolean {
+  if (!assigneeId) {
+    return true;
+  }
+  return viewerId !== undefined && assigneeId === viewerId;
+}
+
+function commitmentsLine(
+  view: Person360,
+  viewerId: string | undefined,
+  t: ReturnType<typeof useT>,
+): string {
+  const openCount = openLoops(view, viewerId).length;
   if (openCount === 0) {
     return t("person.loops.empty");
   }
-  return `${openCount} ${t("person.loops.open")}`;
+  // The sections this counts are summaries the server caps, so the number is a
+  // floor whenever one of them ran out of room. Printing it flat said "25
+  // open" on a record holding thirty-one, and the six it did not mention are
+  // exactly the ones nobody is looking at.
+  const count = `${openCount} ${t("person.loops.open")}`;
+  return truncated(view) ? t("person.loops.atLeast", { count }) : count;
+}
+
+// Whether either section this card reads has more rows than it carried.
+function truncated(view: Person360): boolean {
+  return view.next_steps?.page.has_more === true;
 }
 
 export function PersonCommitmentsCard({
@@ -406,14 +495,7 @@ export function PersonCommitmentsCard({
   firstName,
 }: Readonly<{ view: Person360; firstName: string }>) {
   const t = useT();
-  const claims = view.claims ?? [];
-  const rows = LOOPS.flatMap((loop) =>
-    claims
-      .filter(
-        (claim) => claim.kind === loop.kind && claim.status !== "dismissed",
-      )
-      .map((claim) => ({ claim, loop })),
-  );
+  const rows = openLoops(view, useViewerId());
   return (
     <Panel title={t("person.loops.title")}>
       {rows.length === 0 && (
@@ -423,8 +505,8 @@ export function PersonCommitmentsCard({
           <p className="pe-prose">{t("person.loops.empty")}</p>
         </PanelBody>
       )}
-      {rows.map(({ claim, loop }) => (
-        <PanelRow className="pe-loop" key={claim.id}>
+      {rows.map((loop) => (
+        <PanelRow className="pe-loop" key={loop.key}>
           {/* A read of the claim's done state, never a write: disabled so a
               click can't nudge the tick, and the accessible name lives here
               (sr-only) because the visible body sits in its own cell so the
@@ -433,17 +515,17 @@ export function PersonCommitmentsCard({
             label={
               <span className="sr-only">
                 {loopPrefix(loop, firstName, t)}
-                {claim.body}
+                {loop.body}
               </span>
             }
-            checked={claim.status === "done"}
+            checked={loop.done}
             disabled
           />
           <span className="pe-loop-body">
             {loopPrefix(loop, firstName, t)}
-            {claim.body}
+            {loop.body}
           </span>
-          <LoopStatus claim={claim} />
+          <LoopStatus loop={loop} />
         </PanelRow>
       ))}
     </Panel>
@@ -451,22 +533,24 @@ export function PersonCommitmentsCard({
 }
 
 function loopPrefix(
-  loop: { kind: string; prefixKey: MessageKey | null },
+  loop: OpenLoop,
   firstName: string,
   t: ReturnType<typeof useT>,
 ): string {
-  if (loop.kind === "commitment_theirs") {
+  if (loop.theirs) {
     return `${firstName}: `;
   }
+  // No prefix at all for a task somebody else holds: the card does not know
+  // their name, and naming the wrong desk is worse than naming none.
   return loop.prefixKey ? `${t(loop.prefixKey)}: ` : "";
 }
 
-function LoopStatus({ claim }: Readonly<{ claim: ConversationClaim }>) {
+function LoopStatus({ loop }: Readonly<{ loop: OpenLoop }>) {
   const t = useT();
   const { locale } = useLocale();
-  // An unreadable due instant names no deadline, so the claim reads as one with
+  // An unreadable due instant names no deadline, so the row reads as one with
   // no date rather than as a promise due at some NaN o'clock.
-  const dueMs = claim.due_at ? Date.parse(claim.due_at) : Number.NaN;
+  const dueMs = loop.dueAt ? Date.parse(loop.dueAt) : Number.NaN;
   if (!Number.isNaN(dueMs)) {
     // The verdict comes from the instant and the count only picks the wording:
     // a promise 23 hours past due is late by no whole days and still late, and
@@ -489,7 +573,7 @@ function LoopStatus({ claim }: Readonly<{ claim: ConversationClaim }>) {
       </span>
     );
   }
-  if (claim.kind === "commitment_theirs") {
+  if (loop.theirs) {
     return <Badge tone="accent">{t("person.loops.waiting")}</Badge>;
   }
   return <Badge>{t("person.loops.open")}</Badge>;

--- a/frontend/src/screens/persontoday.tsx
+++ b/frontend/src/screens/persontoday.tsx
@@ -41,6 +41,7 @@ const MOMENT_RULE_LABEL = {
   re_engaged: "person.moment.rule.re_engaged",
   job_change: "person.moment.rule.job_change",
   overdue_promise: "person.moment.rule.overdue_promise",
+  overdue_task: "person.moment.rule.overdue_task",
   gone_quiet: "person.moment.rule.gone_quiet",
   open_promise: "person.moment.rule.open_promise",
   role_change: "person.moment.rule.role_change",
@@ -64,10 +65,22 @@ const MOMENT_EVIDENCE_LABEL = {
 // something nobody has judged. Everything else is a live thread — a fact about
 // the relationship that wants a move rather than a verdict on it.
 function standingTone(rule: PersonMoment["rule"]): StandingTone {
-  if (rule === "gone_quiet" || rule === "overdue_promise") {
+  if (isLate(rule)) {
     return "warn";
   }
   return rule === "nothing_needed" ? "calm" : "accent";
+}
+
+// The three rules that mean somebody is being kept waiting. A promise past
+// its date is late whether it was read out of an email or filed as a task, so
+// both rungs colour the card the same; a promise not yet due is a live thread,
+// not a warning.
+function isLate(rule: PersonMoment["rule"]): boolean {
+  return (
+    rule === "gone_quiet" ||
+    rule === "overdue_promise" ||
+    rule === "overdue_task"
+  );
 }
 
 export function PersonToday({
@@ -85,8 +98,7 @@ export function PersonToday({
   // The amber treatment is the finding itself — a relationship that stopped,
   // or a promise that is late — so it colours the card rather than a badge
   // inside it.
-  const warn =
-    moment.rule === "gone_quiet" || moment.rule === "overdue_promise";
+  const warn = isLate(moment.rule);
   const secondary = moment.secondary_actions ?? [];
   // What the moment rests on, in the shape every claim on a record states it:
   // the label a reader can act on, and the kind of record it was read from.


### PR DESCRIPTION
Three things the person page got wrong about what a record owes. Closes #3541.

**1. The card could not see past the first 25 tasks.** It names the first row of the next-steps section, but that section was ordered newest-first and capped at 25 rows, so a busy record's oldest, soonest-due promise was invisible to it. The section now reads by urgency — `due_at ASC NULLS LAST, occurred_at ASC` — and carries no cursor, because the activities list has no such order to page into (`sectionstimeline.go`). The rung simply takes row one, so the card and the task list beneath it always agree. Proved against real Postgres in `openpromisesection_integration_test.go`: 31 tasks through the real writer, the soonest-due one filed first and buried past the cap, still leads. Mutation-checked — reverting the ORDER BY fails it.

**2. "Commitments & open loops" ignored tasks.** It read extracted claims only, so a record whose one open promise was a task — what an accepted transcript proposal becomes — said "nothing has been promised or asked" under a headline naming that promise. It now lists open tasks beside claims, ours first, each read against the clock the same way (`personcards.tsx`).

**3. An overdue task lost to a silence; an overdue claim did not.** Same lateness, opposite ranking, decided by which source recorded it. New rung `overdue_task` sits beside `overdue_promise` above `gone_quiet`; undated or still-ahead promises keep the rung below it. Both rungs build the same card through `openPromiseFrom`.

Gates: backend, frontend (5624 unit tests), the full compose integration lane, craft static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes how the person page reads what a record owes, so open tasks and extracted promises are now ranked and shown by the same rules. Closes #3541.

**Bug Fixes**
- Next-steps orders by urgency (`due_at ASC NULLS LAST, occurred_at ASC`) and carries no cursor, so the card names the soonest-due promise even when more than 25 tasks are open.
- Commitments card now lists open tasks before claims, reads each row's due date the same way, and says "at least N open" when a section is truncated.
- `overdue_task` sits beside `overdue_promise` above `gone_quiet`; undated or still-ahead promises keep the rung below the silence.
- Section now projects `assignee_id`, so both cards attribute a promise from the reader's seat: a colleague's task reads "Owed to them", not "You owe them".

<sup>Written for commit b566a16dff998bfe3f94170a46e3ebc17285dc72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added overdue tasks as a distinct moment, prioritized ahead of “gone quiet” alerts.
  * Open tasks now appear alongside commitments with due dates, completion controls, ownership, and overdue warnings.
  * Improved Next Steps ordering to show the most urgent tasks first, including tasks beyond the initial list.
  * Added English, German, and Vietnamese labels for overdue tasks and minimum-count indicators.

* **Bug Fixes**
  * Corrected task selection, commitment counts, and assignee display when open tasks and commitments are combined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->