### PR TITLE
The switch says what it actually governs

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -18923,13 +18923,15 @@ components:
         signature_enrich:
           type: boolean
           description: |
-            The workspace DEFAULT for the nightly pass that lifts stated fields — a title, a phone
-            number, a company — out of the signature of mail a contact sent us. Nothing is inferred:
-            a value the signature does not state is not written.
+            The workspace DEFAULT for reading stated contact details — a title, a phone number, an
+            address, a company — out of mail a contact sent us. It governs both readers: the
+            signature of the message, and a vCard attached to it. Nothing is inferred: a value the
+            mail does not state is not written. Reading happens within minutes of the mail arriving;
+            a daily pass is the backstop.
 
             A mailbox can override it (`CaptureConnection.signature_enrich_enabled`), and one that
             never chose follows this. Distinct from the exclusion list, which keeps whole messages
-            out of capture by address or domain and says nothing about reading a signature.
+            out of capture by address or domain and says nothing about reading contact details.
             Default is ON.
 
             "Workspace" here is the storage tenant, not the word the product shows a reader —
@@ -19226,7 +19228,7 @@ components:
       properties:
         auto_enrich: { type: boolean, description: Toggle captured-organization auto-enrichment. }
         mail_sharing: { type: boolean, description: 'Toggle the workspace mail-sharing posture; affects mail captured from now on.' }
-        signature_enrich: { type: boolean, description: 'Toggle the tenant-wide default for the nightly signature pass. A mailbox that set its own switch keeps it.' }
+        signature_enrich: { type: boolean, description: 'Toggle the tenant-wide default for reading contact details out of captured mail — its signature and any attached vCard. A mailbox that set its own switch keeps it.' }
         shared_posture_allowed: { type: boolean, description: 'Allow a seat to put their mailbox in the `shared` posture. Off by default; see CaptureSettings.shared_posture_allowed for what turning it on asserts.' }
 
     BlockedDomain:
@@ -19336,13 +19338,14 @@ components:
         signature_enrich_enabled:
           type: [boolean, 'null']
           description: |
-            This mailbox's own answer to the nightly signature pass, or null to follow the
-            tenant default (`CaptureSettings.signature_enrich`). Null is a third state and not
-            a missing value: a mailbox that never chose moves with the default, and one that
-            did keeps its answer whatever the default becomes.
+            This mailbox's own answer to reading contact details out of its mail, or null to
+            follow the tenant default (`CaptureSettings.signature_enrich`). Null is a third state
+            and not a missing value: a mailbox that never chose moves with the default, and one
+            that did keeps its answer whatever the default becomes.
 
-            False means no mail from this mailbox is ever SELECTED for enrichment — the pass
-            never reads it, rather than reading it and discarding the result.
+            False means no mail from this mailbox is ever SELECTED — neither its signatures are
+            read nor its attached vCards imported. The passes never reach it, rather than
+            reading it and discarding the result.
         mail_posture:
           type: string
           enum: [shared, classified, held]

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -16300,13 +16300,14 @@ type CaptureConnection struct {
 	// Scopes The granted provider scopes.
 	Scopes []string `json:"scopes"`
 
-	// SignatureEnrichEnabled This mailbox's own answer to the nightly signature pass, or null to follow the
-	// tenant default (`CaptureSettings.signature_enrich`). Null is a third state and not
-	// a missing value: a mailbox that never chose moves with the default, and one that
-	// did keeps its answer whatever the default becomes.
+	// SignatureEnrichEnabled This mailbox's own answer to reading contact details out of its mail, or null to
+	// follow the tenant default (`CaptureSettings.signature_enrich`). Null is a third state
+	// and not a missing value: a mailbox that never chose moves with the default, and one
+	// that did keeps its answer whatever the default becomes.
 	//
-	// False means no mail from this mailbox is ever SELECTED for enrichment — the pass
-	// never reads it, rather than reading it and discarding the result.
+	// False means no mail from this mailbox is ever SELECTED — neither its signatures are
+	// read nor its attached vCards imported. The passes never reach it, rather than
+	// reading it and discarding the result.
 	SignatureEnrichEnabled *bool `json:"signature_enrich_enabled,omitempty"`
 
 	// Status Connection state; `reauth_required` when the stored token expired/was revoked upstream.
@@ -16523,13 +16524,15 @@ type CaptureSettings struct {
 	// mail already captured. It governs what a seat may newly ask for.
 	SharedPostureAllowed bool `json:"shared_posture_allowed"`
 
-	// SignatureEnrich The workspace DEFAULT for the nightly pass that lifts stated fields — a title, a phone
-	// number, a company — out of the signature of mail a contact sent us. Nothing is inferred:
-	// a value the signature does not state is not written.
+	// SignatureEnrich The workspace DEFAULT for reading stated contact details — a title, a phone number, an
+	// address, a company — out of mail a contact sent us. It governs both readers: the
+	// signature of the message, and a vCard attached to it. Nothing is inferred: a value the
+	// mail does not state is not written. Reading happens within minutes of the mail arriving;
+	// a daily pass is the backstop.
 	//
 	// A mailbox can override it (`CaptureConnection.signature_enrich_enabled`), and one that
 	// never chose follows this. Distinct from the exclusion list, which keeps whole messages
-	// out of capture by address or domain and says nothing about reading a signature.
+	// out of capture by address or domain and says nothing about reading contact details.
 	// Default is ON.
 	//
 	// "Workspace" here is the storage tenant, not the word the product shows a reader —
@@ -28011,7 +28014,7 @@ type UpdateCaptureSettingsRequest struct {
 	// SharedPostureAllowed Allow a seat to put their mailbox in the `shared` posture. Off by default; see CaptureSettings.shared_posture_allowed for what turning it on asserts.
 	SharedPostureAllowed *bool `json:"shared_posture_allowed,omitempty"`
 
-	// SignatureEnrich Toggle the tenant-wide default for the nightly signature pass. A mailbox that set its own switch keeps it.
+	// SignatureEnrich Toggle the tenant-wide default for reading contact details out of captured mail — its signature and any attached vCard. A mailbox that set its own switch keeps it.
 	SignatureEnrich *bool `json:"signature_enrich,omitempty"`
 }
 

--- a/backend/internal/modules/capture/settingsentry.go
+++ b/backend/internal/modules/capture/settingsentry.go
@@ -85,9 +85,18 @@ var SharedPostureAllowed = settings.Define[bool](
 	nil, // every bool is a valid posture; a validator here would be ceremony
 ).MachineryApplied() // SetMailPosture reads it inside the write it gates
 
-// SignatureEnrich is the workspace DEFAULT for the nightly pass that lifts
-// stated fields out of an email signature — a title, a phone number, the
-// company somebody types under their own name.
+// SignatureEnrich is the workspace DEFAULT for reading contact details out of
+// captured mail — a title, a phone number, an address, the company somebody
+// types under their own name.
+//
+// It governs BOTH readers, which is why its name is narrower than its subject:
+// the signature pass, and the ingest of a vCard attached to a message
+// (compose/vcardingest.go reads this same key). One switch, because somebody
+// turning it off means "do not take contact details off my mail", and a card
+// attached to that mail is the same answer to the same question.
+//
+// No longer nightly. The pass runs within minutes of a message arriving; the
+// nightly cycle is the backstop now, not the trigger.
 //
 // It is the default rather than the answer: `capture_connection.signature_enrich_enabled`
 // overrides it per mailbox, and a mailbox that never chose follows this. That
@@ -97,7 +106,7 @@ var SharedPostureAllowed = settings.Define[bool](
 //
 // Distinct from the exclusion list, which is a different lever entirely: that
 // keeps whole MESSAGES out of capture by address or domain, and says nothing
-// about whether captured mail may be read for a signature.
+// about whether captured mail may be read for contact details.
 //
 // Default true: the pass reads only what a person put under their own name in
 // mail they sent us, which is the least-surprising enrichment in the product.

--- a/backend/internal/modules/capture/settingsentry.go
+++ b/backend/internal/modules/capture/settingsentry.go
@@ -95,8 +95,8 @@ var SharedPostureAllowed = settings.Define[bool](
 // turning it off means "do not take contact details off my mail", and a card
 // attached to that mail is the same answer to the same question.
 //
-// No longer nightly. The pass runs within minutes of a message arriving; the
-// nightly cycle is the backstop now, not the trigger.
+// The pass runs within minutes of a message arriving; the daily cycle is the
+// backstop rather than the trigger.
 //
 // It is the default rather than the answer: `capture_connection.signature_enrich_enabled`
 // overrides it per mailbox, and a mailbox that never chose follows this. That

--- a/docs/explanation/capture-connectors.md
+++ b/docs/explanation/capture-connectors.md
@@ -304,6 +304,12 @@ Capture spans both process roles ([the four `cmd/<role>` binaries](architecture.
   watch-renewal scan (`6h`), and the nightly capture suite (classify hourly, enrich + digest daily). The Surface-B agent
   runner shares the worker process but is a *separate* scheduler — it does not run capture.
 
+  The enrich pass has a second door: `activity.captured` queues it for the workspace that
+  received the mail, so contact details land within minutes rather than overnight. A pass that
+  fills its candidate limit and moved somebody queues the next slice itself. The daily run is
+  the backstop for whatever those miss — a mailbox that was switched off, a model that was
+  unavailable, a message the freshness window had already passed.
+
 Gmail/Graph OAuth needs its config on **both** roles (the api connects, the worker syncs). The full
 flag/env table is [reference/configuration.md → Capture connector OAuth](../reference/configuration.md).
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -12570,13 +12570,15 @@ export interface components {
              */
             auto_enrich: boolean;
             /**
-             * @description The workspace DEFAULT for the nightly pass that lifts stated fields — a title, a phone
-             *     number, a company — out of the signature of mail a contact sent us. Nothing is inferred:
-             *     a value the signature does not state is not written.
+             * @description The workspace DEFAULT for reading stated contact details — a title, a phone number, an
+             *     address, a company — out of mail a contact sent us. It governs both readers: the
+             *     signature of the message, and a vCard attached to it. Nothing is inferred: a value the
+             *     mail does not state is not written. Reading happens within minutes of the mail arriving;
+             *     a daily pass is the backstop.
              *
              *     A mailbox can override it (`CaptureConnection.signature_enrich_enabled`), and one that
              *     never chose follows this. Distinct from the exclusion list, which keeps whole messages
-             *     out of capture by address or domain and says nothing about reading a signature.
+             *     out of capture by address or domain and says nothing about reading contact details.
              *     Default is ON.
              *
              *     "Workspace" here is the storage tenant, not the word the product shows a reader —
@@ -12741,7 +12743,7 @@ export interface components {
             auto_enrich?: boolean;
             /** @description Toggle the workspace mail-sharing posture; affects mail captured from now on. */
             mail_sharing?: boolean;
-            /** @description Toggle the tenant-wide default for the nightly signature pass. A mailbox that set its own switch keeps it. */
+            /** @description Toggle the tenant-wide default for reading contact details out of captured mail — its signature and any attached vCard. A mailbox that set its own switch keeps it. */
             signature_enrich?: boolean;
             /** @description Allow a seat to put their mailbox in the `shared` posture. Off by default; see CaptureSettings.shared_posture_allowed for what turning it on asserts. */
             shared_posture_allowed?: boolean;
@@ -12871,13 +12873,14 @@ export interface components {
             /** @description Summary of the connection's backfill run; state `none` when never run. */
             backfill?: components["schemas"]["BackfillStatus"];
             /**
-             * @description This mailbox's own answer to the nightly signature pass, or null to follow the
-             *     tenant default (`CaptureSettings.signature_enrich`). Null is a third state and not
-             *     a missing value: a mailbox that never chose moves with the default, and one that
-             *     did keeps its answer whatever the default becomes.
+             * @description This mailbox's own answer to reading contact details out of its mail, or null to
+             *     follow the tenant default (`CaptureSettings.signature_enrich`). Null is a third state
+             *     and not a missing value: a mailbox that never chose moves with the default, and one
+             *     that did keeps its answer whatever the default becomes.
              *
-             *     False means no mail from this mailbox is ever SELECTED for enrichment — the pass
-             *     never reads it, rather than reading it and discarding the result.
+             *     False means no mail from this mailbox is ever SELECTED — neither its signatures are
+             *     read nor its attached vCards imported. The passes never reach it, rather than
+             *     reading it and discarding the result.
              */
             signature_enrich_enabled?: boolean | null;
             /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3934,7 +3934,7 @@ export const de = {
     "Die Mail-Erfassung ist in dieser Installation nicht konfiguriert.",
   "connectors.reconnect": "Neu verbinden",
   "connectors.disconnect": "Trennen",
-  "connectors.signatureEnrich.label": "Signaturen aus diesem Postfach lesen",
+  "connectors.signatureEnrich.label": "Kontaktdaten aus diesem Postfach lesen",
   "connectors.signatureEnrich.followingDefault":
     "Folgt der Einstellung Ihrer Organisation. Wird sie hier geändert, behält dieses Postfach seine eigene Antwort.",
   "connectors.signatureEnrich.ownAnswer":
@@ -6295,10 +6295,9 @@ export const de = {
     "Erfasste Unternehmen automatisch anreichern",
   "captureSettings.autoEnrich.help":
     "Wenn aktiviert, erhält jedes aus erfassten E-Mails erstellte Unternehmen automatisch ein Web-Dossier — seine Website wird gelesen und sein Profil ausgefüllt. Läuft unter einem Tageslimit.",
-  "captureSettings.signatureEnrich.label":
-    "Signaturen für Kontaktdaten auswerten",
+  "captureSettings.signatureEnrich.label": "Kontaktdaten aus E-Mails auswerten",
   "captureSettings.signatureEnrich.help":
-    "Wenn aktiv, übernimmt ein nächtlicher Durchlauf, was ein Kontakt in seiner eigenen Signatur angibt — Position, Telefonnummer, Firma. Nichts wird erschlossen: Was die Signatur nicht nennt, wird nicht geschrieben. Das ist die Voreinstellung der Organisation; ein Postfach mit eigener Einstellung behält sie.",
+    "Wenn aktiv, übernimmt Margince, was ein Kontakt in E-Mails an Sie unter seinem eigenen Namen angibt — in der Signatur und auf einer angehängten Visitenkarte. Position, Telefonnummer, Adresse, Firma. Das geschieht innerhalb von Minuten nach Eingang der E-Mail. Nichts wird erschlossen: Was die E-Mail nicht nennt, wird nicht geschrieben. Das ist die Voreinstellung der Organisation; ein Postfach mit eigener Einstellung behält sie.",
   "captureSettings.adminOnly":
     "Nur ein Administrator oder Ops kann dies ändern.",
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3969,7 +3969,7 @@ export const en = {
     "Mail capture isn't configured in this deployment.",
   "connectors.reconnect": "Reconnect",
   "connectors.disconnect": "Disconnect",
-  "connectors.signatureEnrich.label": "Read signatures from this mailbox",
+  "connectors.signatureEnrich.label": "Read contact details from this mailbox",
   "connectors.signatureEnrich.followingDefault":
     "Following your organization's setting. Change it here and this mailbox keeps its own answer.",
   "connectors.signatureEnrich.ownAnswer":
@@ -6339,10 +6339,9 @@ export const en = {
   "captureSettings.autoEnrich.label": "Auto-enrich captured companies",
   "captureSettings.autoEnrich.help":
     "When on, each new company created from captured mail gets an automatic web dossier — its site is read and its profile filled in. Runs under a daily limit.",
-  "captureSettings.signatureEnrich.label":
-    "Read signatures for contact details",
+  "captureSettings.signatureEnrich.label": "Read contact details from mail",
   "captureSettings.signatureEnrich.help":
-    "When on, a nightly pass lifts what a contact states under their own name in mail they sent you — a title, a phone number, a company. Nothing is inferred: a detail the signature does not state is not written. This is the organization's default; a mailbox that set its own switch keeps it.",
+    "When on, Margince reads what a contact states under their own name in mail they sent you — in a signature, and on a business card attached to it. A title, a phone number, an address, a company. It happens within minutes of the mail arriving. Nothing is inferred: a detail the mail does not state is not written. This is the organization's default; a mailbox that set its own switch keeps it.",
   "captureSettings.adminOnly": "Only an admin or ops can change this.",
 
   "ownDomains.companyTitle": "Company domains",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3898,7 +3898,7 @@ export const vi = {
     "Việc thu thập thư chưa được cấu hình trên bản triển khai này.",
   "connectors.reconnect": "Kết nối lại",
   "connectors.disconnect": "Ngắt kết nối",
-  "connectors.signatureEnrich.label": "Đọc chữ ký từ hộp thư này",
+  "connectors.signatureEnrich.label": "Đọc thông tin liên hệ từ hộp thư này",
   "connectors.signatureEnrich.followingDefault":
     "Đang theo thiết lập của tổ chức. Đổi ở đây thì hộp thư này giữ lựa chọn riêng.",
   "connectors.signatureEnrich.ownAnswer":
@@ -6236,10 +6236,9 @@ export const vi = {
     "Tự động bổ sung thông tin cho công ty đã thu thập",
   "captureSettings.autoEnrich.help":
     "Khi bật, mỗi công ty mới tạo từ thư đã thu thập sẽ được lập hồ sơ web tự động — website của công ty được đọc và hồ sơ được điền. Chạy trong một giới hạn theo ngày.",
-  "captureSettings.signatureEnrich.label":
-    "Đọc chữ ký để lấy thông tin liên hệ",
+  "captureSettings.signatureEnrich.label": "Đọc thông tin liên hệ từ thư",
   "captureSettings.signatureEnrich.help":
-    "Khi bật, một lượt chạy hằng đêm lấy những gì người liên hệ tự ghi trong chữ ký của họ — chức danh, số điện thoại, công ty. Không suy đoán: điều chữ ký không nói thì không được ghi. Đây là mặc định của tổ chức; hộp thư đã tự chọn thì giữ lựa chọn đó.",
+    "Khi bật, Margince lấy những gì người liên hệ tự ghi dưới tên mình trong thư gửi cho bạn — trong chữ ký, và trên danh thiếp đính kèm. Chức danh, số điện thoại, địa chỉ, công ty. Việc này diễn ra trong vài phút sau khi thư đến. Không suy đoán: điều thư không nói thì không được ghi. Đây là mặc định của tổ chức; hộp thư đã tự chọn thì giữ lựa chọn đó.",
   "captureSettings.adminOnly":
     "Chỉ quản trị viên hoặc vận hành mới đổi được mục này.",
 


### PR DESCRIPTION
`capture.signature_enrich` gates two readers — the signature pass and the ingest
of a vCard attached to a message — but every word around it still said
"signatures", and said a nightly pass did the reading.

Both halves were wrong in front of the person deciding. Somebody reading "Read
signatures for contact details" and switching it off has also switched off
business-card ingest without being told. Somebody leaving it on is told their
contact's new phone number lands overnight, when it lands in minutes.

## What changed

- The settings help and label, the per-mailbox toggle label, in **en, de and vi**.
- The Go doc comment on `SignatureEnrich`: which two readers share the key, and why one switch is right.
- **Three `crm.yaml` descriptions**, regenerated through both generators.
- `capture-connectors.md` gains the enrich pass's second door — the event trigger and the self-queued continuation — with the daily run named as the backstop it now is.

## The half I missed first

Review caught that I had fixed four spellings of this invariant and left three,
in the public contract. `CaptureConnection.signature_enrich_enabled` was the
worst: it said false means mail is never selected for enrichment, without
mentioning it also refuses card import. Someone reading the contract to decide
what turning it off costs them got half the answer.

That is AGENTS.md's "fix the invariant, not the call site", and I had done
exactly the thing it warns about.

## Verified against code, not assumed

The reviewer checked each claim rather than taking the copy's word:
`vcardingest.go:208`/`:255` do read this key, and a false answer refuses the
import before any principal is built. "Within minutes" holds via
`cg:capture-enrich` on `activity.captured`. The three locales carry the same six
elements with no divergence.

`make check-backend`, `make check-fe` (5621 tests) and `make craft-static`
all green. No E2E spec asserts either changed string.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects all copy around `capture.signature_enrich` to state that the switch governs both the signature pass and vCard ingest, and that reading happens within minutes, not overnight. Previously, the UI and API text said "signatures" and "nightly", so turning the switch off disabled business-card import without saying so, and the timing claim was wrong.

- Settings labels, help text, and the per-mailbox toggle now say "contact details" and name the attached vCard in English, German, and Vietnamese.
- The `CaptureConnection.signature_enrich_enabled` contract now states false also refuses card import.
- `capture-connectors.md` documents the event-triggered enrich path with the daily run as backstop.

<sup>Written for commit 7465ec3c8050109735c614ab2a26327a5922b432. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Contact details can now be enriched from email signatures and attached business cards.
  - Enrichment begins within minutes of receiving a message, with a daily fallback for missed processing.
  - Mailbox opt-outs prevent messages from being selected for capture or enrichment.

- **Documentation**
  - Updated CRM settings, connector guidance, and localized help text to reflect the expanded enrichment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->