### PR TITLE
fix(config): the dev seed binds Gemini, not OpenRouter

### DIFF
--- a/config/margince.dev.yaml
+++ b/config/margince.dev.yaml
@@ -44,22 +44,17 @@ seeds:
   ai_routing:
     profile: eu_hosted          # eu_hosted | sovereign | cloud_frontier
     tiers:
-      local_small: { provider: openai_compatible, model: openai/gpt-oss-120b, base_url: https://openrouter.ai/api }
-      cheap_cloud: { provider: openai_compatible, model: openai/gpt-oss-120b, base_url: https://openrouter.ai/api }
-      premium:     { provider: openai_compatible, model: anthropic/claude-haiku-4.5, base_url: https://openrouter.ai/api }
-      frontier:    { provider: openai_compatible, model: anthropic/claude-sonnet-4.5, base_url: https://openrouter.ai/api }
-    # The embed lane rides the SAME broker key as the tiers above, so a dev
-    # stack needs one credential rather than two. It used to bind gemini here,
-    # which meant a fresh clone could not embed anything without a second
-    # provider's key — for nothing else, since every chat tier had already moved
-    # to the broker.
+      local_small: { provider: gemini, model: gemini-3.1-flash-lite }
+      cheap_cloud: { provider: gemini, model: gemini-3.1-flash-lite }
+      premium:     { provider: gemini, model: gemini-3.5-flash }
+      frontier:    { provider: gemini, model: gemini-3.1-pro-preview }
+    # The embed lane rides the SAME provider as the tiers above, so a dev
+    # stack needs one credential (GEMINI_API_KEY) rather than two.
     #
-    # 1024 is mistral-embed-2312's native width, which is what this provider
-    # requires — on openai_compatible the number is a declaration of what the
-    # model emits rather than a request for a width. Why, once:
+    # 1536 is one of gemini-embedding-001's supported output widths; on the
+    # gemini provider the number is a request for that width. Why, once:
     # docs/how-to/connect-a-cloud-model-provider.md §3.
     embeddings:
-      provider: openai_compatible
-      model: mistralai/mistral-embed-2312
-      base_url: https://openrouter.ai/api
-      dimensions: 1024
+      provider: gemini
+      model: gemini-embedding-001
+      dimensions: 1536


### PR DESCRIPTION
## What

`seeds.ai_routing` in `config/margince.dev.yaml` bound every chat tier and the embed lane to OpenRouter. Because the seed re-runs on every `make dev-fresh`, a dev stack silently reverted to OpenRouter even after an operator rebound it to Gemini through Settings → AI.

The seed now binds Gemini everywhere:

- `local_small`, `cheap_cloud`: `gemini-3.1-flash-lite`
- `premium`: `gemini-3.5-flash`
- `frontier`: `gemini-3.1-pro-preview`
- embeddings: `gemini-embedding-001` at 1536 dimensions

## Why the one-credential rationale still holds

The block's comment moved embeddings onto the broker so a fresh clone needs one key. With every lane on Gemini, chat and embeddings ride the same `GEMINI_API_KEY` — still exactly one provider key.

`make check` is green on both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dev seed in `config/margince.dev.yaml` to bind all AI routing to Gemini instead of OpenRouter, so re-running `make dev-fresh` no longer silently reverts manual routing changes made via Settings → AI.

- Chat tiers now map to `gemini-3.1-flash-lite` (`local_small`, `cheap_cloud`), `gemini-3.5-flash` (`premium`), and `gemini-3.1-pro-preview` (`frontier`).
- Embeddings now use `gemini-embedding-001` at 1536 dimensions.
- A single `GEMINI_API_KEY` still covers both chat and embeddings, preserving the one-credential dev setup.

<sup>Written for commit dacf0d1a3e398c7d5c7ec5da1c264b2929d12d41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated development AI routing to use Gemini models for chat and embeddings.
  * Switched development credentials to require `GEMINI_API_KEY`.
  * Updated embedding output dimensions from 1024 to 1536.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->