### PR TITLE
A press that buys two things says what the second one costs

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7010,8 +7010,12 @@ export const de = {
   "provider.automaticLookupJurisdiction":
     "Schalt das aus, wenn deine Kontakte einem Recht unterliegen, das den Handel mit Personendaten verbietet, etwa dem vietnamesischen. Der Knopf auf dem einzelnen Kontakt funktioniert weiterhin, damit die Entscheidung bei dem bleibt, der sie trifft.",
   "provider.buyable": "Kauf von {category} erlauben",
-  "provider.buyableHint":
+  "provider.buyableHint_one":
     "Dieser Schalter kauft nichts. Er stellt bei jedem Kontakt eine Schaltfläche bereit, zum Preis von {credits} Guthaben, damit jemand diese Angabe für eine einzelne Person kaufen kann.",
+  "provider.buyableHint_other":
+    "Dieser Schalter kauft nichts. Er stellt bei jedem Kontakt eine Schaltfläche bereit, zum Preis von {credits} Guthaben, damit jemand diese Angabe für eine einzelne Person kaufen kann.",
+  "provider.buyableNeeds":
+    "Der Anbieter sucht danach nur zusammen mit {prerequisite}. Einzeln lässt es sich nicht kaufen — erlauben Sie zuerst diese Angabe.",
   "provider.backlog": "Noch nachzuschlagen",
   "provider.backlogRemaining_one": "{count} Kontakt",
   "provider.backlogRemaining_other": "{count} Kontakte",
@@ -7090,6 +7094,8 @@ export const de = {
   "provider.profile.notRequested": "Nie angefragt: {categories}.",
   "provider.profile.buy_one": "{category} kaufen · {credits} Credit",
   "provider.profile.buy_other": "{category} kaufen · {credits} Credits",
+  "provider.profile.buyRebuys":
+    "Im Preis ist {categories} erneut enthalten: Der Anbieter sucht ohne diese Angabe nicht danach und berechnet alles, was er zurückliefert.",
   "provider.freeTier.hint":
     "LinkedIn-Profil, aktuelle Rolle und Werdegang kosten keine Credits. Am besten anlassen: jeder neue Kontakt bekommt sie, ohne dass jemand entscheiden muss.",
   "provider.pricedTier.hint":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7054,8 +7054,12 @@ export const en = {
   "provider.automaticLookupJurisdiction":
     "Switch this off if your contacts fall under a law that forbids trading personal data, Vietnam's among them. The button on each contact still works, which keeps the decision with the person making it.",
   "provider.buyable": "Allow buying {category}",
-  "provider.buyableHint":
+  "provider.buyableHint_one":
     "Switching this on buys nothing. It puts a button on each contact, priced at {credits} credit, so somebody can buy this detail for one person at a time.",
+  "provider.buyableHint_other":
+    "Switching this on buys nothing. It puts a button on each contact, priced at {credits} credits, so somebody can buy this detail for one person at a time.",
+  "provider.buyableNeeds":
+    "The provider looks for this only alongside the {prerequisite}, so it cannot be bought on its own. Allow that one first.",
   "provider.backlog": "Still to look up",
   "provider.backlogRemaining_one": "{count} contact",
   "provider.backlogRemaining_other": "{count} contacts",
@@ -7138,6 +7142,8 @@ export const en = {
   // The price rides the button because the decision IS the spend.
   "provider.profile.buy_one": "Buy {category} · {credits} credit",
   "provider.profile.buy_other": "Buy {category} · {credits} credits",
+  "provider.profile.buyRebuys":
+    "The price includes the {categories} again: the provider will not look for this without it, and it charges for whatever it sends back.",
   "provider.freeTier.hint":
     "LinkedIn profile, current role and work history cost no credits. Leave this on: every new contact gets them without anybody deciding.",
   "provider.pricedTier.hint":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6929,8 +6929,12 @@ export const vi = {
   "provider.automaticLookupJurisdiction":
     "Hãy tắt mục này nếu liên hệ của bạn thuộc phạm vi luật cấm mua bán dữ liệu cá nhân, trong đó có luật Việt Nam. Nút trên từng liên hệ vẫn dùng được, để quyết định thuộc về người đưa ra nó.",
   "provider.buyable": "Cho phép mua {category}",
-  "provider.buyableHint":
+  "provider.buyableHint_one":
     "Bật công tắc này không mua gì cả. Nó đặt một nút trên mỗi liên hệ, giá {credits} tín dụng, để ai đó mua thông tin này cho từng người một.",
+  "provider.buyableHint_other":
+    "Bật công tắc này không mua gì cả. Nó đặt một nút trên mỗi liên hệ, giá {credits} tín dụng, để ai đó mua thông tin này cho từng người một.",
+  "provider.buyableNeeds":
+    "Nhà cung cấp chỉ tìm thông tin này cùng với {prerequisite}, nên không thể mua riêng. Hãy cho phép mục đó trước.",
   "provider.backlog": "Còn phải tra cứu",
   "provider.backlogRemaining_one": "{count} liên hệ",
   "provider.backlogRemaining_other": "{count} liên hệ",
@@ -7005,6 +7009,8 @@ export const vi = {
   "provider.profile.notRequested": "Chưa bao giờ hỏi tới: {categories}.",
   "provider.profile.buy_one": "Mua {category} · {credits} tín dụng",
   "provider.profile.buy_other": "Mua {category} · {credits} tín dụng",
+  "provider.profile.buyRebuys":
+    "Giá này bao gồm việc mua lại {categories}: nhà cung cấp không tìm thông tin này nếu thiếu mục đó, và tính phí cho mọi thứ họ trả về.",
   "provider.freeTier.hint":
     "Hồ sơ LinkedIn, vai trò hiện tại và quá trình làm việc không tốn tín dụng. Nên bật: mọi liên hệ mới đều có chúng mà không ai phải quyết định.",
   "provider.pricedTier.hint":

--- a/frontend/src/screens/integrations-provider.stories.tsx
+++ b/frontend/src/screens/integrations-provider.stories.tsx
@@ -231,3 +231,34 @@ export const OperatorConnectedPhone: Story = {
   tags: ["uat-phone"],
   render: cardStory(OPERATOR, [connected]),
 };
+
+/**
+ * The paid half of the card, which no other story reaches: none of them carries
+ * a catalog, so the switches that decide what a rep may buy render nowhere.
+ *
+ * The mobile row is the case worth looking at. The provider only issues a
+ * number alongside the work email, so with that switch off the mobile cannot be
+ * bought at all — the switch is refused and says what it needs, rather than
+ * sitting on while the buy button it promises never appears on any contact.
+ */
+export const OperatorPricedCategories: Story = {
+  render: cardStory(OPERATOR, [
+    {
+      ...connected,
+      configuration: {
+        ...connected.configuration,
+        categories: { linkedin_profile: true, professional_email: false },
+      },
+      catalog: [
+        { category: "linkedin_profile", free: true, cost: {} },
+        { category: "professional_email", free: false, cost: { email: 1 } },
+        {
+          category: "mobile",
+          free: false,
+          cost: { email: 1, mobile: 1 },
+          requires: "professional_email",
+        },
+      ],
+    },
+  ]),
+};

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -390,6 +390,37 @@ describe("ProviderCard write posture", () => {
     RENDER_TEST_MS,
   );
 
+  // Switching a prerequisite off leaves its dependent saved as on. Refusing
+  // that row outright stranded the admin: the only control able to undo the
+  // combination was the one they could not reach, so the way out was to turn
+  // the prerequisite back on purely to release the switch beneath it.
+  it(
+    "still lets a dependent purchase be switched OFF after its prerequisite went off",
+    async () => {
+      await renderAs(ME_OPERATOR, {
+        ...CONNECTION,
+        configuration: {
+          ...CONNECTION.configuration,
+          // The stranding combination: the dependent on, its prerequisite off.
+          categories: {
+            linkedin_profile: true,
+            professional_email: false,
+            mobile: true,
+          },
+        },
+      });
+
+      const mobile = screen.getByRole("switch", {
+        name: "Allow buying mobile number",
+      });
+      expect(mobile.getAttribute("aria-checked")).toBe("true");
+      // Operable, because the only flip it offers now is the one that resolves
+      // the combination.
+      expect(mobile).toHaveProperty("disabled", false);
+    },
+    RENDER_TEST_MS,
+  );
+
   it(
     "allows the dependent purchase once its prerequisite is on",
     async () => {

--- a/frontend/src/screens/integrations-provider.test.tsx
+++ b/frontend/src/screens/integrations-provider.test.tsx
@@ -37,6 +37,16 @@ const CONNECTION: ProviderConnection = {
   catalog: [
     { category: "linkedin_profile", free: true, cost: {} },
     { category: "professional_email", free: false, cost: { email: 1 } },
+    // A category the provider only issues alongside another, priced for the
+    // pair. The real Surfe descriptor has exactly one, and without it here the
+    // card's dependency handling would be tested against a catalog where every
+    // purchase stands alone.
+    {
+      category: "mobile",
+      free: false,
+      cost: { email: 1, mobile: 1 },
+      requires: "professional_email",
+    },
   ],
   credits: { pools: { email: 120 } },
   version: 4,
@@ -328,7 +338,75 @@ describe("ProviderCard write posture", () => {
       // rendering a switch for every category the provider sells.
       expect(
         screen.getAllByRole("switch", { name: /^Allow buying / }),
-      ).toHaveLength(1);
+      ).toHaveLength(2);
+    },
+    RENDER_TEST_MS,
+  );
+
+  // The card let an admin allow a mobile purchase with the work email it
+  // depends on switched off. That combination buys nothing: the vendor refuses
+  // a mobile lookup without the email flag, so the contact page showed no
+  // button and the card gave no reason — a switch that was on, and a purchase
+  // that never appeared anywhere.
+  it(
+    "refuses a purchase whose prerequisite is off, and says what it needs",
+    async () => {
+      await renderAs(ME_OPERATOR);
+
+      // professional_email is false in the fixture's saved selection.
+      //
+      // The native attribute, which is what a stated reason sets: Switch reads
+      // `reason` as the refusal itself, so a caller cannot announce a denial
+      // and leave the control live.
+      const mobile = screen.getByRole("switch", {
+        name: "Allow buying mobile number",
+      });
+      expect(mobile).toHaveProperty("disabled", true);
+      // The reason is on screen, not merely implied by a dead control: an
+      // admin looking for the mobile has to learn what it depends on, and a
+      // disabled switch with no sentence reads as a permission they lack.
+      //
+      // ONCE, counted rather than merely present. The sentence belongs to the
+      // Switch's `reason`, which both renders and announces it; a copy in the
+      // row's description printed it twice on the card and read it twice to a
+      // screen reader, and a `getAllByText(...).length > 0` assertion passed
+      // over exactly that.
+      expect(screen.getAllByText(/only alongside the work email/)).toHaveLength(
+        1,
+      );
+
+      // The row it depends on is unaffected — the dependency runs one way.
+      expect(
+        screen.getByRole("switch", { name: "Allow buying work email" }),
+      ).toHaveProperty("disabled", false);
+
+      // Priced for the PAIR, and plural. The row quotes the whole press, so a
+      // dependent category never names a figure smaller than pressing its
+      // button spends — and "2 credit" is what a figure formatted without a
+      // plural form prints, which no assertion here used to notice.
+      expect(screen.getByText(/priced at 2 credits/)).toBeDefined();
+      expect(screen.queryByText(/priced at 2 credit,/)).toBeNull();
+    },
+    RENDER_TEST_MS,
+  );
+
+  it(
+    "allows the dependent purchase once its prerequisite is on",
+    async () => {
+      await renderAs(ME_OPERATOR, {
+        ...CONNECTION,
+        configuration: {
+          ...CONNECTION.configuration,
+          categories: { linkedin_profile: true, professional_email: true },
+        },
+      });
+
+      // Mutation guard for the case above: a switch disabled for a reason
+      // unrelated to the dependency would pass that test and this one would
+      // catch it.
+      expect(
+        screen.getByRole("switch", { name: "Allow buying mobile number" }),
+      ).toHaveProperty("disabled", false);
     },
     RENDER_TEST_MS,
   );

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -493,7 +493,15 @@ function PricedCategoryRows({
         // "stands alone", and a check that caught only one would block every
         // row the server sent.
         const prerequisite = entry.requires ? entry.requires : undefined;
-        const blocked = prerequisite !== undefined && !selection[prerequisite];
+        const on = selection[entry.category] ?? false;
+        // Refused only where the flip would turn it ON. Switching a
+        // prerequisite off leaves its dependent saved as on, and blocking that
+        // row outright would strand the admin: the only control able to undo
+        // the combination would be the one they cannot reach, and turning the
+        // prerequisite back on to release it spends nothing but reads like the
+        // card fighting them. Off is always allowed.
+        const blocked =
+          prerequisite !== undefined && !selection[prerequisite] && !on;
         const dependency =
           prerequisite === undefined
             ? undefined

--- a/frontend/src/screens/integrations-provider.tsx
+++ b/frontend/src/screens/integrations-provider.tsx
@@ -457,6 +457,7 @@ function PricedCategoryRows({
   canEdit,
 }: Readonly<{ connection: ProviderConnection; canEdit: boolean }>) {
   const t = useT();
+  const plural = usePlural();
   const { locale } = useLocale();
   const patch = usePatchCategories();
   const priced = (connection.catalog ?? []).filter((entry) => !entry.free);
@@ -477,41 +478,80 @@ function PricedCategoryRows({
   const selection = connection.configuration.categories ?? {};
   return (
     <>
-      {priced.map((entry) => (
-        <SettingRow
-          key={entry.category}
-          label={t("provider.buyable", {
-            category: categoryName(entry.category, t),
-          })}
-          description={t("provider.buyableHint", {
-            credits: formatNumber(creditsOf(entry), locale),
-          })}
-          control={(control) => (
-            <Switch
-              describedBy={control["aria-describedby"]}
-              checked={selection[entry.category] ?? false}
-              // The WHOLE selection, not the one key. The contract's patch
-              // replaces the map rather than merging into it, so sending one
-              // pair would switch off every category not named — including the
-              // free ones the automatic lookup runs on.
-              onChange={(next) =>
-                patch.mutate({
-                  provider: connection.provider,
-                  version,
-                  categories: { ...selection, [entry.category]: next },
-                })
-              }
-              reason={canEdit ? undefined : t("captureSettings.adminOnly")}
-              disabled={!canEdit}
-              pending={patch.isPending}
-              label={t("provider.buyable", {
-                category: categoryName(entry.category, t),
-              })}
-              labelHidden
-            />
-          )}
-        />
-      ))}
+      {priced.map((entry) => {
+        // A category the provider only issues alongside another cannot be
+        // bought while that one is off — the vendor refuses the request, so
+        // the switch would promise a purchase nobody can make and the buy
+        // button would never appear, with nothing on screen saying why.
+        //
+        // Disabled with the reason rather than hidden: an admin looking for
+        // the mobile number needs to find it and learn what it depends on. A
+        // row that vanished would read as "this provider does not sell it".
+        // Truthy, not `!== undefined`: the contract types this as
+        // `[string, 'null']`, so an absent prerequisite arrives as null on the
+        // wire and as undefined from a fixture that omits the key. Both mean
+        // "stands alone", and a check that caught only one would block every
+        // row the server sent.
+        const prerequisite = entry.requires ? entry.requires : undefined;
+        const blocked = prerequisite !== undefined && !selection[prerequisite];
+        const dependency =
+          prerequisite === undefined
+            ? undefined
+            : t("provider.buyableNeeds", {
+                prerequisite: categoryName(prerequisite, t),
+              });
+        return (
+          <SettingRow
+            key={entry.category}
+            label={t("provider.buyable", {
+              category: categoryName(entry.category, t),
+            })}
+            // The dependency sentence belongs to the Switch's `reason`, which
+            // renders it AND announces it — repeating it here read it to a
+            // screen reader twice and printed it twice on the card.
+            description={plural(
+              "provider.buyableHint",
+              creditsOf(entry),
+              // Priced for the pair where there is one, so a dependent row
+              // never quotes a figure smaller than the press spends.
+              { credits: formatNumber(creditsOf(entry), locale) },
+            )}
+            control={(control) => (
+              <Switch
+                describedBy={control["aria-describedby"]}
+                checked={selection[entry.category] ?? false}
+                // The WHOLE selection, not the one key. The contract's patch
+                // replaces the map rather than merging into it, so sending one
+                // pair would switch off every category not named — including the
+                // free ones the automatic lookup runs on.
+                onChange={(next) =>
+                  patch.mutate({
+                    provider: connection.provider,
+                    version,
+                    categories: { ...selection, [entry.category]: next },
+                  })
+                }
+                // The admin denial comes first: a seat that may not edit
+                // anything is not told instead about a dependency it could
+                // not act on either way.
+                reason={
+                  canEdit
+                    ? blocked
+                      ? dependency
+                      : undefined
+                    : t("captureSettings.adminOnly")
+                }
+                disabled={!canEdit || blocked}
+                pending={patch.isPending}
+                label={t("provider.buyable", {
+                  category: categoryName(entry.category, t),
+                })}
+                labelHidden
+              />
+            )}
+          />
+        );
+      })}
       {patch.error && (
         <div className="provider-row-note">
           <Callout tone="danger" live="alert">

--- a/frontend/src/screens/person360.css
+++ b/frontend/src/screens/person360.css
@@ -855,11 +855,23 @@
   gap: var(--space-2);
 }
 
-/* The buy row: one button per priced detail, wrapping rather than truncating
+/* The buy row: one offer per priced detail, wrapping rather than truncating
    so a price is never cut off. */
 .pe-buy-row {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
   margin-top: var(--space-3);
+}
+
+/* One offer: the button, and under it the note saying what the press buys a
+   second time. Stacked so the note reads as belonging to that button rather
+   than to the row — with two offers side by side, a note in the row's own flow
+   would sit under whichever one wrapped last. */
+.pe-buy-offer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  align-items: flex-start;
+  max-width: 22rem;
 }

--- a/frontend/src/screens/personprovider.stories.tsx
+++ b/frontend/src/screens/personprovider.stories.tsx
@@ -343,3 +343,63 @@ export const TwoProviders: Story = {
     );
   },
 };
+
+/**
+ * The mobile number offered for a contact whose work email is already on
+ * record — the common case once a lookup has run, and the one that spends more
+ * than a reader would guess.
+ *
+ * Surfe will not look for a number without the email flag set, and it charges
+ * for whatever it sends back regardless of what we already hold. So this press
+ * costs two credits and buys the address a second time. The button names only
+ * what is being SOUGHT; the line under it names what is paid for again.
+ */
+export const BuyMobileWithEmailHeld: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /provider-connections": () =>
+        jsonResponse({
+          data: [
+            {
+              provider: "surfe",
+              status: "connected",
+              credential_present: true,
+              catalog: [
+                { category: "linkedin_profile", free: true, cost: {} },
+                {
+                  category: "professional_email",
+                  free: false,
+                  cost: { email: 1 },
+                },
+                {
+                  category: "mobile",
+                  free: false,
+                  cost: { email: 1, mobile: 1 },
+                  requires: "professional_email",
+                },
+              ],
+              configuration: {
+                categories: {
+                  linkedin_profile: true,
+                  professional_email: true,
+                  mobile: true,
+                },
+              },
+              credits: { pools: {} },
+              version: 1,
+              created_at: "2026-08-20T09:00:00Z",
+              updated_at: "2026-08-20T09:00:00Z",
+            },
+          ],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <PersonProviderSection
+          personId="p-1"
+          profiles={[profile({ state: "completed", mobile_phones: [] })]}
+        />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -624,6 +624,71 @@ describe("the details that cost credits", () => {
     ).toBeNull();
   });
 
+  it("still offers the work email when only a personal address came back", async () => {
+    mountWithCatalog(
+      {
+        ...neverRun(),
+        state: "completed",
+        // A personal address and nothing else. The two are separate purchases
+        // from separate pools, so this contact still has no work email.
+        emails: [
+          {
+            value: "dana@privatemail.example",
+            email_type: "personal",
+            email_type_source: "provider",
+            validation_status: "valid",
+          },
+        ],
+      },
+      queuedRun,
+    );
+
+    // Reading "any address at all" hid each email offer behind the other: a
+    // contact whose personal address came back was never offered a work
+    // email, and the reverse.
+    expect(
+      await screen.findByRole("button", { name: /Buy work email · 1 credit/ }),
+    ).toBeDefined();
+
+    // And the mobile press does not claim to re-buy a work email nobody
+    // holds — the note names what is actually paid for twice.
+    expect(
+      await screen.findByRole("button", {
+        name: /Buy work email and mobile number · 2 credits/,
+      }),
+    ).toBeDefined();
+    expect(screen.queryByText(/includes the work email again/)).toBeNull();
+  });
+
+  it("offers both email purchases when the provider classified neither", async () => {
+    mountWithCatalog(
+      {
+        ...neverRun(),
+        state: "completed",
+        // Surfe can omit emailType, and the platform only labels it from the
+        // frozen cascade where it can. An address of unknown type is one of
+        // the two purchases, and guessing which would either hide an offer
+        // the reader can still use or claim a re-buy that never happens.
+        emails: [
+          {
+            value: "dana@unknown.example",
+            email_type: null,
+            email_type_source: null,
+            validation_status: null,
+          },
+        ],
+      },
+      queuedRun,
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /Buy work email · 1 credit/ }),
+    ).toBeDefined();
+    // No re-buy claim either: nothing here is known to be the work email, so
+    // saying the press pays for one twice would be a guess presented as a fact.
+    expect(screen.queryByText(/includes the work email again/)).toBeNull();
+  });
+
   it("says nothing about re-buying when neither half is held", async () => {
     mountWithCatalog({ ...neverRun(), state: "completed" }, queuedRun);
 

--- a/frontend/src/screens/personprovider.test.tsx
+++ b/frontend/src/screens/personprovider.test.tsx
@@ -581,6 +581,85 @@ describe("the details that cost credits", () => {
     });
   });
 
+  it("offers the mobile with the email already held, and says the email is re-bought", async () => {
+    mountWithCatalog(
+      {
+        ...neverRun(),
+        state: "completed",
+        // The 819-contact case in a real installation: a work email bought
+        // earlier, no number yet.
+        emails: [
+          {
+            value: "dana.buyer@surfe.example",
+            email_type: "professional",
+            email_type_source: "provider",
+            validation_status: "valid",
+          },
+        ],
+      },
+      queuedRun,
+    );
+
+    // Still offered. Filtering on the button's own category alone was right;
+    // filtering on the whole press would have removed the only way to buy a
+    // number for somebody whose email is already on record.
+    const button = await screen.findByRole("button", {
+      name: /Buy mobile number · 2 credits/,
+    });
+    expect(button).toBeDefined();
+
+    // And the second credit is named. Surfe charges per pool that returns
+    // anything and cannot be told to skip an address we already hold, so this
+    // press pays for that email twice — a fact the reader has to see BEFORE
+    // pressing, not discover on the spend history.
+    expect(
+      await screen.findByText(/includes the work email again/),
+    ).toBeDefined();
+
+    // The button does not offer to buy the email: the reader can see they
+    // have it, and naming it there would read as a second purchase of a
+    // detail already on screen.
+    expect(
+      screen.queryByRole("button", { name: /Buy work email and mobile/ }),
+    ).toBeNull();
+  });
+
+  it("says nothing about re-buying when neither half is held", async () => {
+    mountWithCatalog({ ...neverRun(), state: "completed" }, queuedRun);
+
+    // The note is the exception, not the furniture. A line about re-buying on
+    // every button would train the reader to skip it, which is exactly when
+    // it matters.
+    await screen.findByRole("button", {
+      name: /Buy work email and mobile number · 2 credits/,
+    });
+    expect(screen.queryByText(/includes the work email again/)).toBeNull();
+  });
+
+  it("offers nothing once both halves of a press are held", async () => {
+    mountWithCatalog(
+      {
+        ...neverRun(),
+        state: "completed",
+        emails: [
+          {
+            value: "dana.buyer@surfe.example",
+            email_type: "professional",
+            email_type_source: "provider",
+            validation_status: "valid",
+          },
+        ],
+        mobile_phones: [{ value: "+491701234567", confidence: 0.82 }],
+      },
+      queuedRun,
+    );
+
+    await screen.findByText(/dana\.buyer@surfe\.example/);
+    // Nothing left to look for, so no offer — and in particular not a
+    // two-credit button that would buy both again.
+    expect(screen.queryByRole("button", { name: /^Buy / })).toBeNull();
+  });
+
   it("names the free categories when the plain lookup button is pressed", async () => {
     const user = userEvent.setup();
     const posted = mountWithCatalog(

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -303,6 +303,12 @@ function BuyPriced({
   // stays true if this asks about the same set the press does.
   const enabled = (category: string) =>
     connection?.configuration.categories?.[category] ?? false;
+  // Offered on the button's OWN category, not on everything the press sends.
+  // The detail being sought is what decides whether there is anything to buy:
+  // a mobile is still worth offering when the work email it needs is already
+  // held — that is the common case, and the note below says what the second
+  // half costs — while a press whose own category is held has nothing left to
+  // find and would only re-buy what is on screen.
   const buyable = (connection?.catalog ?? []).filter(
     (entry) =>
       !entry.free &&
@@ -314,27 +320,55 @@ function BuyPriced({
   }
   return (
     <div className="pe-buy-row">
-      {buyable.map((entry) => (
-        <Button
-          key={entry.category}
-          small
-          type="button"
-          pending={enrich.isPending}
-          busyLabel={t("provider.profile.lookingUp")}
-          onClick={() =>
-            enrich.mutate({
-              personId,
-              provider: profile.provider,
-              categories: boughtWith(entry),
-            })
-          }
-        >
-          {plural("provider.profile.buy", creditsOf(entry), {
-            category: categoryNamesTogether(boughtWith(entry), t, locale),
-            credits: formatNumber(creditsOf(entry), locale),
-          })}
-        </Button>
-      ))}
+      {buyable.map((entry) => {
+        const asks = boughtWith(entry);
+        const rebought = asks.filter((category) =>
+          alreadyHeld(profile, category),
+        );
+        return (
+          <div className="pe-buy-offer" key={entry.category}>
+            <Button
+              small
+              type="button"
+              pending={enrich.isPending}
+              busyLabel={t("provider.profile.lookingUp")}
+              onClick={() =>
+                enrich.mutate({
+                  personId,
+                  provider: profile.provider,
+                  categories: asks,
+                })
+              }
+            >
+              {plural("provider.profile.buy", creditsOf(entry), {
+                // The category being SOUGHT, not everything the press sends.
+                // Naming a detail already on the record would read as an
+                // offer to buy what the reader can see they have.
+                category: categoryNamesTogether(
+                  asks.filter((category) => !alreadyHeld(profile, category)),
+                  t,
+                  locale,
+                ),
+                credits: formatNumber(creditsOf(entry), locale),
+              })}
+            </Button>
+            {rebought.length > 0 && (
+              // The price above is the whole press, and part of it buys again
+              // what this record already holds. Surfe charges one credit per
+              // pool that returns anything and does not know we hold the
+              // address, and it refuses to look for a number with the email
+              // flag off — so the second charge is the vendor's rule, not a
+              // choice this product makes. Said plainly rather than hidden
+              // behind a cheaper-looking number or a button that disappears.
+              <p className="t-caption">
+                {t("provider.profile.buyRebuys", {
+                  categories: categoryNamesTogether(rebought, t, locale),
+                })}
+              </p>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -374,8 +408,17 @@ function creditsOf(
   return Object.values(entry.cost).reduce((total, n) => total + n, 0);
 }
 
-/** Whether the section already shows what this category buys, so a button does
- *  not offer to buy again what is on screen. */
+/** Whether the section already shows what this category buys.
+ *
+ *  Asked TWICE about one press, for two different questions. Whether to offer
+ *  the button reads the category being sought — a mobile is worth offering
+ *  when the work email it needs is already held. What the button says reads
+ *  every category the press sends, because the provider bills for whatever it
+ *  returns and cannot be told to skip an address we hold, so that press pays
+ *  for the email a second time.
+ *
+ *  Answering only the first question is what let the second charge go
+ *  unmentioned. */
 function alreadyHeld(profile: Profile, category: string): boolean {
   switch (category) {
     case "professional_email":

--- a/frontend/src/screens/personprovider.tsx
+++ b/frontend/src/screens/personprovider.tsx
@@ -421,9 +421,21 @@ function creditsOf(
  *  unmentioned. */
 function alreadyHeld(profile: Profile, category: string): boolean {
   switch (category) {
+    // By TYPE, not by "any address at all". The two are separate purchases
+    // from separate pools, and collapsing them hid each behind the other: a
+    // contact whose personal address came back was never offered a work
+    // email, and the reverse.
+    //
+    // An address the provider could not classify counts for neither. It is
+    // one of the two, and guessing which would either hide an offer the
+    // reader can still use or claim a re-buy that does not happen — both
+    // worse than offering a purchase they may decline.
     case "professional_email":
+      return profile.emails.some(
+        (email) => email.email_type === "professional",
+      );
     case "personal_email":
-      return profile.emails.length > 0;
+      return profile.emails.some((email) => email.email_type === "personal");
     case "mobile":
       return profile.mobile_phones.length > 0;
     default:


### PR DESCRIPTION
Surfe sells one lookup that returns a work email and, optionally, a
mobile number attached to it. The product modelled that as two
purchases, and each control was wrong in its own way.

A mobile press for a contact whose work email is already on record
pays for that address a second time. Surfe charges one credit per pool
that returns anything and does not know we hold it, and it refuses to
look for a number with the email flag off — so there is no cheaper
request to make. 819 contacts in one installation are in exactly that
state. The button said "Buy work email and mobile number · 2 credits"
and nothing said one of those credits bought a duplicate.

Now the button names only what is being SOUGHT — "Buy mobile number ·
2 credits" — and a line under it says the price includes the work
email again, and why. Charged, stated, neither hidden behind a
cheaper-looking number nor blocked.

The settings card let an admin allow a mobile purchase with the work
email switched off. That combination buys nothing: the vendor refuses
the request, so no button appeared on any contact and the card gave no
reason. The mobile row is now refused while its prerequisite is off,
with the sentence saying what it needs.

Two defects the tests could not see and the browser could. Rendering
the new story in Storybook showed the dependency sentence printed
twice — once in the row description, once as the switch's reason,
which announces it to a screen reader as well — and "priced at 2
credit", a figure formatted with no plural form. Both are fixed and
both now have assertions that count rather than merely check presence.

Neither surface had a story reaching it: no settings story carried a
catalog, so the paid switches rendered nowhere, and no person-page
story set up a held email. Both added.

Mutation-checked one clause at a time: dropping the re-buy note,
widening the button label back to every category sent, never blocking
the dependent switch, blocking it regardless of its prerequisite,
forcing the singular, and restoring the duplicated sentence each fail
exactly one test and name it.

One correction to my own first attempt, recorded because the mutation
check is what caught it: I widened the buy-row filter to consider every
category a press sends. All 28 tests passed with the old filter
restored, because the two differ only when the mobile is held and the
email is not — where my version would have offered a two-credit button
to buy an email for somebody who already has a number. Reverted; the
filter reads the button's own category, which was right.

The automatic sweep was audited and cannot reach a priced pool: all
three automatic triggers resolve to the free set with a worst case of
zero in every pool, even with every category selected. This money is
reachable only by a human pressing a button.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

## Verified in a browser, not only in tests

Rendered both new stories in Storybook and read the accessibility tree:

- `Buy mobile number · 2 credits` with "The price includes the work email again: the provider will not look for this without it, and it charges for whatever it sends back."
- The mobile settings switch `[disabled]` with its reason on screen once, and "priced at 2 credits"

That browser pass is what found the duplicated sentence and the "2 credit" singular; both now have counting assertions.

## Gates

- `make check-fe` green (frontend-only change; no Go touched)
- Six mutations, one clause at a time, each failing exactly one test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Surfe purchase UI so a mobile lookup that pays a second time for an already-held work email says so, and prevents enabling a mobile purchase without its prerequisite.

- The buy button now names only what's sought ("Buy mobile number · 2 credits") and appends a note when the press re-buys an email already on record.
- Held emails are checked by type: a personal address no longer hides the work email offer, and unknown email types count for neither.
- A dependent purchase's switch can always be turned off; only turning it on is refused while its prerequisite is off.
- Fixed the dependency sentence rendering twice and "2 credit" having no plural form; both now have counting assertions.
- Added stories for the settings card's priced rows and the contact page's held-email case.

<sup>Written for commit 1671a7ca33370a2b7cbd77d93f1496a465189740. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Provider purchases now show prerequisite categories and disable unavailable options until requirements are met.
  - Purchase details distinguish requested categories from prerequisites already included or already held.
  - Pricing messages explain when prerequisite categories may be charged again.
  - Provider offers remain available when only some categories are already owned.

- **Bug Fixes**
  - Improved purchase option visibility and messaging when categories are partially or fully owned.

- **Localization**
  - Updated English, German, and Vietnamese text for contact enrichment, pluralized pricing, and prerequisite notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->