### PR TITLE
An attachment's filename follows the mail's audience

### DIFF
--- a/backend/internal/modules/privacy/auditaudienceboundary.go
+++ b/backend/internal/modules/privacy/auditaudienceboundary.go
@@ -42,16 +42,31 @@ var auditGovernedTypes = []string{
 //
 // The four collateral routes, each verified against the baseline schema:
 //
-//   - attachment is polymorphic AND carries activity_id. The capture path writes
-//     both (capturedfiles.go); a manual upload writes only the pair
-//     (attachmentupload.go). Reading either column is what covers both writers.
-//     Reading one alone leaves the other writer's rows unresolved, and an
-//     unresolved row is withheld — no disclosure, so no disclosure test can see
-//     it, while every manually uploaded file's image collapses to the withheld
-//     marker even for a reader the thread is open to.
-//     TestAnUploadedFileOnAnOpenThreadKeepsItsName is the case that fails.
+//   - attachment hangs off SEVEN parent types, not one: person, organization,
+//     deal, lead, activity, project and relationship, by its own CHECK. Only the
+//     activity parent has an audience, so the route reads the polymorphic
+//     (entity_type, entity_id) pair and resolves nothing for the other six.
+//     TestADocumentOnAPersonKeepsItsName is the case that fails.
+//
+//     Which is why the route answers TWO questions rather than one. "No activity
+//     resolved" has two meanings and they take opposite answers: a document
+//     filed on a person is not governed at all and must reach a compliance
+//     reader whole, while an unreleased account-origin scheduled send IS
+//     governed and simply cannot be checked — that one is withheld. The
+//     `governed` column is what tells them apart, so neither has to be inferred
+//     from a NULL.
+//
+//     The nullable activity_id column is deliberately NOT read. It duplicates
+//     the pair for capture-path rows, and no FK or CHECK ties the two together,
+//     so a schema-valid row naming a held activity in the pair and an open one
+//     in activity_id would resolve the open one and release the image. The
+//     authoritative parent is the pair; a second, unconstrained answer to the
+//     same question is one a reader can be pointed at.
+//
 //   - attachment_extraction reaches its activity through attachment, two hops.
+//
 //   - transcript_read carries activity_id NOT NULL.
+//
 //   - scheduled_send carries activity_id once released and anchor_activity_id for
 //     a reply; an origin_kind='account' send that has not been released has
 //     NEITHER, by its own CHECK constraint. Those rows resolve to NULL and are
@@ -61,12 +76,10 @@ const auditActivityRouteSQL = `
 		  SELECT CASE a.entity_type
 		           WHEN 'activity' THEN a.entity_id
 		           WHEN 'attachment' THEN (
-		             SELECT coalesce(att.activity_id,
-		                             CASE WHEN att.entity_type = 'activity' THEN att.entity_id END)
+		             SELECT CASE WHEN att.entity_type = 'activity' THEN att.entity_id END
 		               FROM attachment att WHERE att.id = a.entity_id)
 		           WHEN 'attachment_extraction' THEN (
-		             SELECT coalesce(att.activity_id,
-		                             CASE WHEN att.entity_type = 'activity' THEN att.entity_id END)
+		             SELECT CASE WHEN att.entity_type = 'activity' THEN att.entity_id END
 		               FROM attachment_extraction ext
 		               JOIN attachment att ON att.id = ext.attachment_id
 		              WHERE ext.id = a.entity_id)
@@ -75,7 +88,18 @@ const auditActivityRouteSQL = `
 		           WHEN 'scheduled_send' THEN (
 		             SELECT coalesce(ss.activity_id, ss.anchor_activity_id)
 		               FROM scheduled_send ss WHERE ss.id = a.entity_id)
-		         END AS activity_id`
+		         END AS activity_id,
+		         CASE a.entity_type
+		           WHEN 'attachment' THEN (
+		             SELECT att.entity_type = 'activity'
+		               FROM attachment att WHERE att.id = a.entity_id)
+		           WHEN 'attachment_extraction' THEN (
+		             SELECT att.entity_type = 'activity'
+		               FROM attachment_extraction ext
+		               JOIN attachment att ON att.id = ext.attachment_id
+		              WHERE ext.id = a.entity_id)
+		           ELSE true
+		         END AS governed`
 
 // auditActivityJoin reaches the activity an audit row's image describes, and
 // only for rows that describe one.
@@ -177,12 +201,26 @@ var auditCollateralGovernanceKeys = map[string]map[string]func(json.RawMessage) 
 		"entity_type": anyValue, "entity_id": anyValue,
 		"category": anyValue, "byte_size": anyValue, "source_system": anyValue,
 		"doc_state": anyValue, "pinned": anyValue, "supersedes_id": anyValue,
+		// dealdocuments.go's hide/unhide image.
+		"deal_id": anyValue, "hidden_from_deal": anyValue,
 	},
 	"attachment_extraction": {
 		"attachment_id": anyValue, "requested_by": anyValue,
+		// extractionclaim.go's finish image. `grounded` counts the FIELDS the
+		// reading proposed, not the document's words.
+		"status": anyValue, "grounded": anyValue,
 	},
 	"transcript_read": {
-		"activity_id": anyValue, "requested_by": anyValue, "line_count": anyValue,
+		"activity_id": anyValue, "requested_by": anyValue,
+		// transcriptread.go's finish image. `status` is the job's own progress.
+		"status": anyValue,
+		// line_count and proposals are ABSENT, and that is the finding this set
+		// exists to record: both measure the transcript itself. A line count is
+		// how long the held conversation was, and it survives the transcript's
+		// erasure — purgeTranscriptReadings deletes the routing row without a
+		// tombstone, so the route resolves NULL and the same redactor runs. A
+		// measurement of content is content when the content is what the
+		// audience withholds.
 	},
 	// Spelled as literals, not as activities.FieldScheduledAt/TZ: privacy is a
 	// sibling module and the layout forbids the import. The two spellings are

--- a/backend/internal/modules/privacy/auditaudienceboundary.go
+++ b/backend/internal/modules/privacy/auditaudienceboundary.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package privacy
+
+// Which audit rows answer to an activity's audience, and what survives when one
+// is withheld.
+//
+// An audit image describing an activity carries that activity's content — the
+// subject verbatim, an attachment's user-supplied filename, a scheduled send's
+// subject line. The compliance log is admin-only and deliberately crosses row
+// scope, so the audience is the only rule left standing over those images, and
+// it is applied here rather than in the read: auditlog.go asks the question,
+// this file defines what it is asking about.
+//
+// Three lists have to agree — the governed types, the route that resolves each
+// one's activity, and the per-type key sets — and auditgovernedtypes_test.go is
+// what fails when they drift.
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// auditGovernedTypes are the entity types whose audit image answers to an
+// activity's audience: the activity itself, plus the four collateral records
+// that hang off one and carry its content into their own images.
+//
+// It is the corpus auditActivityRouteSQL resolves and the key set
+// auditImageGovernanceKeys is defined over, so a type present in one and absent
+// from the other is what auditgovernedtypes_test.go fails on.
+var auditGovernedTypes = []string{
+	entityTypeActivity, "attachment", "attachment_extraction", "transcript_read", "scheduled_send",
+}
+
+// auditActivityRouteSQL resolves the activity an audit row's image describes,
+// for every type in auditGovernedTypes, as ONE expression.
+//
+// One expression rather than one join per type because the audience arm is a
+// correlated subquery over workspace membership: rendering it five times would
+// evaluate it five times per row and register its parameters five times over.
+//
+// The four collateral routes, each verified against the baseline schema:
+//
+//   - attachment is polymorphic AND carries activity_id. The capture path writes
+//     both (capturedfiles.go); a manual upload writes only the pair
+//     (attachmentupload.go). Reading either column is what covers both writers.
+//     Reading one alone leaves the other writer's rows unresolved, and an
+//     unresolved row is withheld — no disclosure, so no disclosure test can see
+//     it, while every manually uploaded file's image collapses to the withheld
+//     marker even for a reader the thread is open to.
+//     TestAnUploadedFileOnAnOpenThreadKeepsItsName is the case that fails.
+//   - attachment_extraction reaches its activity through attachment, two hops.
+//   - transcript_read carries activity_id NOT NULL.
+//   - scheduled_send carries activity_id once released and anchor_activity_id for
+//     a reply; an origin_kind='account' send that has not been released has
+//     NEITHER, by its own CHECK constraint. Those rows resolve to NULL and are
+//     withheld, which is the correct answer rather than a gap: no activity's
+//     audience can admit an image whose activity does not exist.
+const auditActivityRouteSQL = `
+		  SELECT CASE a.entity_type
+		           WHEN 'activity' THEN a.entity_id
+		           WHEN 'attachment' THEN (
+		             SELECT coalesce(att.activity_id,
+		                             CASE WHEN att.entity_type = 'activity' THEN att.entity_id END)
+		               FROM attachment att WHERE att.id = a.entity_id)
+		           WHEN 'attachment_extraction' THEN (
+		             SELECT coalesce(att.activity_id,
+		                             CASE WHEN att.entity_type = 'activity' THEN att.entity_id END)
+		               FROM attachment_extraction ext
+		               JOIN attachment att ON att.id = ext.attachment_id
+		              WHERE ext.id = a.entity_id)
+		           WHEN 'transcript_read' THEN (
+		             SELECT tr.activity_id FROM transcript_read tr WHERE tr.id = a.entity_id)
+		           WHEN 'scheduled_send' THEN (
+		             SELECT coalesce(ss.activity_id, ss.anchor_activity_id)
+		               FROM scheduled_send ss WHERE ss.id = a.entity_id)
+		         END AS activity_id`
+
+// auditActivityJoin reaches the activity an audit row's image describes, and
+// only for rows that describe one.
+//
+// The route resolves first and the activity is joined on its result, so
+// entity_id is never matched against activity.id directly: entity_id is a bare
+// uuid across every entity type, and a direct match is what would let a person's
+// id collide with an activity's and withhold an image that has no audience to
+// answer to.
+const auditActivityJoin = `
+		LEFT JOIN LATERAL (` + auditActivityRouteSQL + `) aud_route ON true
+		LEFT JOIN activity ` + auditActivityAlias + `
+		  ON ` + auditActivityAlias + `.id = aud_route.activity_id`
+
+// auditImageGovernanceKeys are the keys an activity's audit image may carry
+// that describe the MUTATION rather than the activity's content — who the
+// audience became, which record a relink pointed at, which fields moved.
+//
+// The audience governs an activity's CONTENT. It has no claim over the record
+// of an administrative act performed on that activity, and withholding one
+// destroys governance data rather than protecting anything: the row recording
+// "this conversation was limited to its participants, naming 3 members" carries
+// nothing a reader outside the audience is not entitled to, and is precisely
+// what a compliance reader is looking for.
+//
+// The map is an ALLOWLIST and the redaction is fail-closed: a key that is not
+// here is dropped, so a new writer that starts recording content into an audit
+// image cannot leak it by default.
+//
+// SCOPE: this map is the ACTIVITY's key set. The four collateral types have
+// their own, in auditCollateralGovernanceKeys, because a shared map would have
+// to be the union of five vocabularies and would then admit each type's keys on
+// every other type — the direction that quietly re-widens an allowlist.
+//
+// Each entry carries a predicate on the VALUE, because a key alone is not a
+// safety property. `body` is the case that forced it: the writer reduces it to a
+// presence flag and says so in a comment, but nothing bound the READER to that —
+// one plausible edit turning `delta["body"] = true` into the body itself would
+// have handed an out-of-audience admin the confidential text of a limited
+// conversation through this endpoint, passing every gate in the tree.
+//
+// `body` is the only entry actually constrained. The rest are anyValue, so the
+// "a writer starts nesting content under this key" scenario applies unchanged
+// to `kind`, `source_system` or a timestamp: those are judged safe by what the
+// activity read surface answers for them, which is a claim about today's
+// writers rather than a guard. Tightening one is a one-line predicate.
+//
+// TestRedactionKeepsGovernanceAndDropsContent pins both directions, including
+// a `body` carrying something other than a boolean.
+var auditImageGovernanceKeys = map[string]func(json.RawMessage) bool{
+	"audience": anyValue, "member_count": anyValue,
+	"entity_type": anyValue, "entity_id": anyValue, "replaced": anyValue,
+	"merged_into_id": anyValue,
+	// Mirrors what the activity READ surface keeps on a withheld row
+	// (activityread.go): kind, direction, occurred_at and source_system are
+	// markers it answers; subject, body and SOURCE_ID are what it nils. source_id
+	// is deliberately absent here for that reason — it identifies the message at
+	// the provider, the capture sink writes it onto the audit image, and admitting
+	// it would have this endpoint answer what the record's own read refuses.
+	"kind": anyValue, "direction": anyValue, "source_system": anyValue,
+	"occurred_at": anyValue, "due_at": anyValue, "remind_at": anyValue,
+	"assignee_id": anyValue, "is_done": anyValue,
+	// Presence only, and enforced HERE rather than trusted from the writer.
+	"body": isJSONBool,
+}
+
+// auditCollateralGovernanceKeys are the keys each collateral type's image may
+// carry to a reader outside the activity's audience.
+//
+// Per type rather than one shared set, and derived from what each writer
+// actually records rather than from what sounded safe:
+//
+//   - attachment: capturedfiles.go writes {entity_type, entity_id, category,
+//     byte_size, source_system}; documents.go writes a metadata patch over
+//     {category, title, doc_state, pinned, supersedes_id}. FILENAME is never
+//     admitted — it is user-supplied and is the leak this PR closes — and
+//     neither is TITLE, which is a human-authored name for a document on a
+//     limited thread and is content by the same argument.
+//   - attachment_extraction: extractionread.go writes {attachment_id,
+//     requested_by}, both of which are the governance record itself. Withholding
+//     them wholly would destroy "who asked to read this file", which is exactly
+//     what a compliance reader came for.
+//   - transcript_read: transcriptread.go writes {activity_id, requested_by,
+//     line_count}. line_count measures the transcript rather than quoting it.
+//   - scheduled_send: scheduledsend.go writes {scheduled_at, scheduled_tz,
+//     SUBJECT}; scheduledsendfire.go writes {activity_id, delivery_id} on
+//     release and {reason} on a hold. Subject is the message's own subject line,
+//     verbatim — content, and absent here for the same reason the activity map
+//     drops it. `reason` is a fixed hold vocabulary the fire path chooses, not
+//     free text from a user.
+//
+// Fail-closed like the activity map: a key absent here is dropped, so a writer
+// that starts recording content into one of these images cannot leak it by
+// default. A type absent from this map has NO governance keys and is withheld
+// whole, which auditgovernedtypes_test.go turns into a failing test rather than
+// a silent loss of governance data.
+var auditCollateralGovernanceKeys = map[string]map[string]func(json.RawMessage) bool{
+	"attachment": {
+		"entity_type": anyValue, "entity_id": anyValue,
+		"category": anyValue, "byte_size": anyValue, "source_system": anyValue,
+		"doc_state": anyValue, "pinned": anyValue, "supersedes_id": anyValue,
+	},
+	"attachment_extraction": {
+		"attachment_id": anyValue, "requested_by": anyValue,
+	},
+	"transcript_read": {
+		"activity_id": anyValue, "requested_by": anyValue, "line_count": anyValue,
+	},
+	// Spelled as literals, not as activities.FieldScheduledAt/TZ: privacy is a
+	// sibling module and the layout forbids the import. The two spellings are
+	// held together by auditgovernedtypes_test.go rather than by the compiler.
+	"scheduled_send": {
+		"scheduled_at": anyValue, "scheduled_tz": anyValue,
+		"activity_id": anyValue, "delivery_id": anyValue, "reason": anyValue,
+	},
+}
+
+// governanceKeysFor answers which keys survive redaction for one entity type.
+//
+// The activity's own set and the collateral sets are looked up through one
+// function so a caller cannot reach for the wrong map, and a type in neither
+// returns nil — every key dropped — rather than falling back to a permissive
+// default.
+func governanceKeysFor(entityType string) map[string]func(json.RawMessage) bool {
+	if entityType == entityTypeActivity {
+		return auditImageGovernanceKeys
+	}
+	return auditCollateralGovernanceKeys[entityType]
+}
+
+// anyValue admits a key whose every possible value is metadata about the
+// mutation. Named rather than written as an inline closure so the exceptions —
+// today just `body` — stand out at a glance in the map above.
+func anyValue(json.RawMessage) bool { return true }
+
+// isJSONBool admits only a literal JSON `true` or `false`.
+//
+// The null check is not redundant: json.Unmarshal into a bool accepts JSON null
+// and leaves the bool at its zero value, so a bare Unmarshal admits
+// `"body": null` — the one shape where a non-boolean body would survive
+// redaction, and survive it with no marker to say anything was examined.
+func isJSONBool(raw json.RawMessage) bool {
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return false
+	}
+	var flag bool
+	return json.Unmarshal(raw, &flag) == nil
+}

--- a/backend/internal/modules/privacy/auditgovernedtypes_test.go
+++ b/backend/internal/modules/privacy/auditgovernedtypes_test.go
@@ -69,7 +69,13 @@ func TestNoGovernanceKeySetAdmitsAKnownContentKey(t *testing.T) {
 	// may appear in any key set, on any type. `body` is the documented exception
 	// on the activity: the writer reduces it to a presence flag and
 	// isJSONBool re-checks that here rather than trusting it.
-	content := []string{"subject", "filename", "title", "source_id", "snippet", "text"}
+	// line_count and proposals are here because a MEASUREMENT of content is
+	// content when the content is what the audience withholds: both say how
+	// long the held conversation was.
+	content := []string{
+		"subject", "filename", "title", "source_id", "snippet", "text",
+		"line_count", "proposals",
+	}
 	for _, entityType := range auditGovernedTypes {
 		keys := governanceKeysFor(entityType)
 		for _, key := range content {

--- a/backend/internal/modules/privacy/auditgovernedtypes_test.go
+++ b/backend/internal/modules/privacy/auditgovernedtypes_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package privacy
+
+// The three lists that have to agree about which audit rows answer to an
+// activity's audience.
+//
+// auditGovernedTypes decides which rows are JOINED and tested. The route SQL
+// decides which of them can actually resolve an activity. The governance maps
+// decide what survives redaction once a row is withheld. A type present in one
+// and missing from another does not fail to compile and does not fail any
+// existing test: it either withholds an image that had governance data in it,
+// or — the direction that matters — leaves a content-carrying image readable to
+// a reader outside the audience. Both are silent.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEveryGovernedTypeIsRoutedAndHasKeys(t *testing.T) {
+	for _, entityType := range auditGovernedTypes {
+		t.Run(entityType, func(t *testing.T) {
+			// The route is a CASE over entity_type spelled as SQL literals, so
+			// the check is that this type has an arm. Without one the CASE falls
+			// to NULL, the activity never joins, and the row is withheld whole —
+			// safe, but it destroys the governance record with no failing test.
+			if !strings.Contains(auditActivityRouteSQL, "'"+entityType+"'") {
+				t.Errorf("%q is governed but auditActivityRouteSQL has no arm for it, so its "+
+					"activity never resolves and its image is withheld whole", entityType)
+			}
+			if len(governanceKeysFor(entityType)) == 0 {
+				t.Errorf("%q is governed but has no governance keys, so a withheld image loses "+
+					"every key including the ones recording who acted", entityType)
+			}
+		})
+	}
+}
+
+func TestTheRouteCarriesNoTypeThatIsNotGoverned(t *testing.T) {
+	// The other direction. A type routed but absent from auditGovernedTypes
+	// resolves an activity that the content_readable predicate then never
+	// consults — the join runs, the answer is discarded, and the image is
+	// disclosed. That is the leak this PR closes, in the shape it would come
+	// back.
+	governed := make(map[string]bool, len(auditGovernedTypes))
+	for _, entityType := range auditGovernedTypes {
+		governed[entityType] = true
+	}
+	for _, line := range strings.Split(auditActivityRouteSQL, "\n") {
+		_, rest, found := strings.Cut(line, "WHEN '")
+		if !found {
+			continue
+		}
+		entityType, _, ok := strings.Cut(rest, "'")
+		if !ok {
+			t.Fatalf("a WHEN arm with no closing quote — the route is malformed: %q", line)
+		}
+		if !governed[entityType] {
+			t.Errorf("auditActivityRouteSQL routes %q but auditGovernedTypes omits it, so its "+
+				"audience is resolved and then ignored", entityType)
+		}
+	}
+}
+
+func TestNoGovernanceKeySetAdmitsAKnownContentKey(t *testing.T) {
+	// The keys every writer in this tree uses for the message's own words. None
+	// may appear in any key set, on any type. `body` is the documented exception
+	// on the activity: the writer reduces it to a presence flag and
+	// isJSONBool re-checks that here rather than trusting it.
+	content := []string{"subject", "filename", "title", "source_id", "snippet", "text"}
+	for _, entityType := range auditGovernedTypes {
+		keys := governanceKeysFor(entityType)
+		for _, key := range content {
+			if _, admitted := keys[key]; admitted {
+				t.Errorf("%q admits %q, which carries the message's own words to a reader "+
+					"outside its audience", entityType, key)
+			}
+		}
+	}
+}

--- a/backend/internal/modules/privacy/auditlog.go
+++ b/backend/internal/modules/privacy/auditlog.go
@@ -12,7 +12,6 @@ package privacy
 // that would misread as "nothing happened".
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -98,87 +97,6 @@ type AuditPage struct {
 // audience the row's author set can be asked about it. It is deliberately not
 // `a` or one of the app_user aliases already in the statement.
 const auditActivityAlias = "aud_activity"
-
-// auditActivityJoin reaches the activity an audit row describes, and only for
-// rows that describe one. entity_id is a bare uuid across every entity type, so
-// the entity_type test is what stops a person's id colliding with an activity's
-// and withholding an image that has no audience to answer to.
-const auditActivityJoin = `
-		LEFT JOIN activity ` + auditActivityAlias + `
-		  ON a.entity_type = 'activity' AND ` + auditActivityAlias + `.id = a.entity_id`
-
-// auditImageGovernanceKeys are the keys an activity's audit image may carry
-// that describe the MUTATION rather than the activity's content — who the
-// audience became, which record a relink pointed at, which fields moved.
-//
-// The audience governs an activity's CONTENT. It has no claim over the record
-// of an administrative act performed on that activity, and withholding one
-// destroys governance data rather than protecting anything: the row recording
-// "this conversation was limited to its participants, naming 3 members" carries
-// nothing a reader outside the audience is not entitled to, and is precisely
-// what a compliance reader is looking for.
-//
-// The map is an ALLOWLIST and the redaction is fail-closed: a key that is not
-// here is dropped, so a new writer that starts recording content into an audit
-// image cannot leak it by default.
-//
-// ⚠️ SCOPE, narrower than "the audience is honoured on this endpoint": this map
-// is consulted only for an audit row whose entity_type is `activity`. Other
-// entity types that hang off an activity — `attachment`, whose image carries
-// the user-supplied filename, plus `attachment_extraction`, `transcript_read`
-// and `scheduled_send` — are not joined to their activity and are not
-// redacted, so a reader outside the audience receives those images whole.
-//
-// Each entry carries a predicate on the VALUE, because a key alone is not a
-// safety property. `body` is the case that forced it: the writer reduces it to a
-// presence flag and says so in a comment, but nothing bound the READER to that —
-// one plausible edit turning `delta["body"] = true` into the body itself would
-// have handed an out-of-audience admin the confidential text of a limited
-// conversation through this endpoint, passing every gate in the tree.
-//
-// `body` is the only entry actually constrained. The rest are anyValue, so the
-// "a writer starts nesting content under this key" scenario applies unchanged
-// to `kind`, `source_system` or a timestamp: those are judged safe by what the
-// activity read surface answers for them, which is a claim about today's
-// writers rather than a guard. Tightening one is a one-line predicate.
-//
-// TestRedactionKeepsGovernanceAndDropsContent pins both directions, including
-// a `body` carrying something other than a boolean.
-var auditImageGovernanceKeys = map[string]func(json.RawMessage) bool{
-	"audience": anyValue, "member_count": anyValue,
-	"entity_type": anyValue, "entity_id": anyValue, "replaced": anyValue,
-	"merged_into_id": anyValue,
-	// Mirrors what the activity READ surface keeps on a withheld row
-	// (activityread.go): kind, direction, occurred_at and source_system are
-	// markers it answers; subject, body and SOURCE_ID are what it nils. source_id
-	// is deliberately absent here for that reason — it identifies the message at
-	// the provider, the capture sink writes it onto the audit image, and admitting
-	// it would have this endpoint answer what the record's own read refuses.
-	"kind": anyValue, "direction": anyValue, "source_system": anyValue,
-	"occurred_at": anyValue, "due_at": anyValue, "remind_at": anyValue,
-	"assignee_id": anyValue, "is_done": anyValue,
-	// Presence only, and enforced HERE rather than trusted from the writer.
-	"body": isJSONBool,
-}
-
-// anyValue admits a key whose every possible value is metadata about the
-// mutation. Named rather than written as an inline closure so the exceptions —
-// today just `body` — stand out at a glance in the map above.
-func anyValue(json.RawMessage) bool { return true }
-
-// isJSONBool admits only a literal JSON `true` or `false`.
-//
-// The null check is not redundant: json.Unmarshal into a bool accepts JSON null
-// and leaves the bool at its zero value, so a bare Unmarshal admits
-// `"body": null` — the one shape where a non-boolean body would survive
-// redaction, and survive it with no marker to say anything was examined.
-func isJSONBool(raw json.RawMessage) bool {
-	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
-		return false
-	}
-	var flag bool
-	return json.Unmarshal(raw, &flag) == nil
-}
 
 // UnscrubbedImageSQL renders the erasure boundary as a predicate over one
 // audit_log row, aliased for the query using it.
@@ -274,8 +192,9 @@ func scanAuditEntry(rows pgx.Rows) (AuditEntry, error) {
 // policy fired, which rule admitted it — not the record content the audience
 // governs.
 func withholdAuditImage(e *AuditEntry) {
-	e.Before = redactAuditImage(e.Before)
-	e.After = redactAuditImage(e.After)
+	keys := governanceKeysFor(e.EntityType)
+	e.Before = redactAuditImage(e.Before, keys)
+	e.After = redactAuditImage(e.After, keys)
 }
 
 // redactAuditImage keeps the governance keys of one image and marks the rest
@@ -286,7 +205,7 @@ func withholdAuditImage(e *AuditEntry) {
 // ledger never asked. An UNREADABLE one is withheld whole — it cannot be
 // redacted key by key, and passing it through would be the disclosure. The two
 // are different answers and must not be collapsed into one word.
-func redactAuditImage(raw []byte) []byte {
+func redactAuditImage(raw []byte, governance map[string]func(json.RawMessage) bool) []byte {
 	if len(raw) == 0 {
 		return raw
 	}
@@ -299,7 +218,7 @@ func redactAuditImage(raw []byte) []byte {
 	kept := make(map[string]json.RawMessage, len(fields))
 	withheld := false
 	for key, value := range fields {
-		if admits, ok := auditImageGovernanceKeys[key]; ok && admits(value) {
+		if admits, ok := governance[key]; ok && admits(value) {
 			kept[key] = value
 			continue
 		}
@@ -369,13 +288,20 @@ func ListAuditLog(ctx context.Context, db *database.DB, f AuditFilter) (AuditPag
 	// holes in it is its own defect: the row, its actor, its action and its
 	// timestamp are all still answered, and only the IMAGE is withheld.
 	//
-	// A non-activity row has no audience to answer to and is untouched. An
-	// activity row whose record is GONE is withheld, not passed through: the
-	// join failing is not evidence that the caller may read the image, and a
-	// predicate spelled `id IS NULL OR audience` would answer "readable" for
-	// exactly the rows whose audience can no longer be checked. Nothing purges
-	// activity rows today, so this is the latent direction — but it is the
-	// direction that re-opens the disclosure silently, and no test would notice.
+	// A row of no governed type has no audience to answer to and is untouched.
+	// A governed row whose activity does not resolve is withheld, not passed
+	// through: the route returning NULL is not evidence that the caller may read
+	// the image, and a predicate spelled `id IS NULL OR audience` would answer
+	// "readable" for exactly the rows whose audience can no longer be checked.
+	// That direction re-opens the disclosure silently and no test would notice,
+	// and it is reachable today — an unreleased account-origin scheduled_send has
+	// no activity at all.
+	//
+	// The four collateral types are governed for the same reason the activity is:
+	// their images carry its content. An attachment's image carries the
+	// user-supplied filename, which is why a `Kuendigung.pdf` on a limited thread
+	// was legible to every admin before this predicate read auditGovernedTypes
+	// rather than the single literal 'activity'.
 	audience, err := auth.ActivityAudienceArm(ctx, auditActivityAlias, argN)
 	if err != nil {
 		return AuditPage{}, err
@@ -388,7 +314,7 @@ func ListAuditLog(ctx context.Context, db *database.DB, f AuditFilter) (AuditPag
 			        a.action, a.entity_type, a.entity_id, a.before, a.after, a.authorization_rule,
 			        a.evidence, a.occurred_at,
 			        actor_user.display_name, obo.display_name,
-			        (a.entity_type <> 'activity'
+			        (NOT (a.entity_type = ANY(`+arg(auditGovernedTypes)+`))
 			          OR (`+auditActivityAlias+`.id IS NOT NULL AND (`+audience+`))) AS content_readable,
 			        `+UnscrubbedImageSQL("a", arg(ScrubVerbs()))+` AS images_readable
 			 FROM audit_log a`+auditActorNameJoins+auditActivityJoin+`

--- a/backend/internal/modules/privacy/auditlog.go
+++ b/backend/internal/modules/privacy/auditlog.go
@@ -288,14 +288,19 @@ func ListAuditLog(ctx context.Context, db *database.DB, f AuditFilter) (AuditPag
 	// holes in it is its own defect: the row, its actor, its action and its
 	// timestamp are all still answered, and only the IMAGE is withheld.
 	//
-	// A row of no governed type has no audience to answer to and is untouched.
-	// A governed row whose activity does not resolve is withheld, not passed
-	// through: the route returning NULL is not evidence that the caller may read
-	// the image, and a predicate spelled `id IS NULL OR audience` would answer
-	// "readable" for exactly the rows whose audience can no longer be checked.
-	// That direction re-opens the disclosure silently and no test would notice,
-	// and it is reachable today — an unreleased account-origin scheduled_send has
-	// no activity at all.
+	// Two conditions, not one. The TYPE says whether this kind of row can carry
+	// an activity's content; the route's `governed` column says whether THIS row
+	// actually hangs off an activity, which for an attachment depends on its
+	// polymorphic parent. A contract filed on a deal is an attachment and is not
+	// governed by anybody's audience, and withholding its filename would destroy
+	// audit data to protect an audience that does not exist.
+	//
+	// A row that IS governed and whose activity does not resolve is withheld, not
+	// passed through: an unresolvable route is not evidence that the caller may
+	// read the image, and a predicate answering "readable" for exactly the rows
+	// whose audience cannot be checked re-opens the disclosure silently. That is
+	// reachable today — an unreleased account-origin scheduled_send has no
+	// activity at all, by its own CHECK constraint.
 	//
 	// The four collateral types are governed for the same reason the activity is:
 	// their images carry its content. An attachment's image carries the
@@ -314,7 +319,7 @@ func ListAuditLog(ctx context.Context, db *database.DB, f AuditFilter) (AuditPag
 			        a.action, a.entity_type, a.entity_id, a.before, a.after, a.authorization_rule,
 			        a.evidence, a.occurred_at,
 			        actor_user.display_name, obo.display_name,
-			        (NOT (a.entity_type = ANY(`+arg(auditGovernedTypes)+`))
+			        (NOT (a.entity_type = ANY(`+arg(auditGovernedTypes)+`) AND aud_route.governed)
 			          OR (`+auditActivityAlias+`.id IS NOT NULL AND (`+audience+`))) AS content_readable,
 			        `+UnscrubbedImageSQL("a", arg(ScrubVerbs()))+` AS images_readable
 			 FROM audit_log a`+auditActorNameJoins+auditActivityJoin+`

--- a/backend/internal/modules/privacy/auditlogaudience_integration_test.go
+++ b/backend/internal/modules/privacy/auditlogaudience_integration_test.go
@@ -255,6 +255,132 @@ func TestAnUploadedFileOnAnOpenThreadKeepsItsName(t *testing.T) {
 	}
 }
 
+// TestADocumentOnAPersonKeepsItsName holds the other six parent types.
+//
+// An attachment hangs off person, organization, deal, lead, activity, project or
+// relationship. Only the activity parent has an audience, so treating every
+// attachment row as governed would withhold the filename of a contract filed on
+// a deal from the compliance log — audit data destroyed to protect an audience
+// that does not exist. The route resolves nothing for those six, and a row that
+// resolves nothing is not governed.
+func TestADocumentOnAPersonKeepsItsName(t *testing.T) {
+	e := setupAuditBoundary(t)
+	attachment := e.seedID(t, `
+		INSERT INTO attachment (id, entity_type, entity_id, filename,
+		                        storage_key, source, captured_by)
+		VALUES ($1, 'person', $2, 'Kuendigung.pdf', 'blob/p', 'upload',
+		        'human:'||$3::text)`, e.person, e.other)
+	e.seedCollateralAudit(t, "attachment", attachment)
+
+	entityType, limit := "attachment", 50
+	page, err := ListAuditLog(e.ctx, e.db,
+		AuditFilter{EntityType: &entityType, EntityID: &attachment, Limit: &limit})
+	if err != nil {
+		t.Fatalf("ListAuditLog: %v", err)
+	}
+	found := false
+	for _, entry := range page.Entries {
+		if entry.Action != "create" {
+			continue
+		}
+		found = true
+		if !strings.Contains(string(entry.After), "Kuendigung") {
+			t.Errorf("a document filed on a person was redacted; there is no activity audience "+
+				"to enforce, so this is audit data destroyed for nothing: %s", entry.After)
+		}
+	}
+	if !found {
+		t.Fatal("the attachment's create row is absent from the page, so this proved nothing")
+	}
+}
+
+// TestEachRouteResolvesItsOwnActivity is the test the disclosure cases cannot
+// be: a route that returns NULL, or resolves the WRONG activity, withholds — and
+// withholding is what every "was content disclosed?" assertion reads as correct.
+//
+// So each route is exercised from an activity the reader MAY read. A working
+// route resolves that activity, the audience admits it, and nothing is redacted.
+// A broken one resolves NULL and the content vanishes.
+func TestEachRouteResolvesItsOwnActivity(t *testing.T) {
+	for _, tc := range []struct {
+		entityType string
+		seed       func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID
+	}{{
+		entityType: "attachment",
+		seed: func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID {
+			return e.seedID(t, `
+				INSERT INTO attachment (id, entity_type, entity_id, activity_id, filename,
+				                        storage_key, source, captured_by)
+				VALUES ($1, 'activity', $2, $2, 'Kuendigung.pdf', 'blob/r1', 'gmail',
+				        'connector:gmail:'||$3::text)`, activity, e.other)
+		},
+	}, {
+		entityType: "attachment_extraction",
+		seed: func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID {
+			attachment := e.seedID(t, `
+				INSERT INTO attachment (id, entity_type, entity_id, activity_id, filename,
+				                        storage_key, source, captured_by)
+				VALUES ($1, 'activity', $2, $2, 'Kuendigung.pdf', 'blob/r2', 'gmail',
+				        'connector:gmail:'||$3::text)`, activity, e.other)
+			return e.seedID(t, `
+				INSERT INTO attachment_extraction (id, attachment_id, requested_by)
+				VALUES ($1, $2, 'human:'||$3::text)`, attachment, e.other)
+		},
+	}, {
+		entityType: "transcript_read",
+		seed: func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID {
+			return e.seedID(t, `
+				INSERT INTO transcript_read (id, activity_id, requested_by)
+				VALUES ($1, $2, 'human:'||$3::text)`, activity, e.other)
+		},
+	}, {
+		entityType: "scheduled_send",
+		seed: func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID {
+			return e.seedID(t, `
+				INSERT INTO scheduled_send (id, anchor_activity_id, origin_kind, status,
+				                            scheduled_at, scheduled_tz, payload,
+				                            scheduled_by, principal_kind)
+				VALUES ($1, $2, 'reply', 'scheduled', now(), 'Europe/Berlin',
+				        '{"subject":"Re: Aufhebungsvertrag"}'::jsonb, $3, 'human')`, activity, e.other)
+		},
+	}} {
+		t.Run(tc.entityType, func(t *testing.T) {
+			e := setupAuditBoundary(t)
+			// Workspace, not participants: the audience admits the reader, so
+			// anything redacted here was redacted because the ROUTE failed.
+			activity := e.seedID(t, `
+				INSERT INTO activity (id, kind, audience, source, captured_by, occurred_at)
+				VALUES ($1, 'email', 'workspace', 'gmail', 'connector:gmail:'||$2::text, $3)`,
+				e.other, boundaryEarlier)
+			id := tc.seed(t, e, activity)
+			e.seedCollateralAudit(t, tc.entityType, id)
+
+			limit := 50
+			page, err := ListAuditLog(e.ctx, e.db,
+				AuditFilter{EntityType: &tc.entityType, EntityID: &id, Limit: &limit})
+			if err != nil {
+				t.Fatalf("ListAuditLog: %v", err)
+			}
+			found := false
+			for _, entry := range page.Entries {
+				if entry.Action != "create" {
+					continue
+				}
+				found = true
+				if !strings.Contains(string(entry.After), "Kuendigung") {
+					t.Errorf("the %s's image was redacted on an activity the reader may read in "+
+						"full, so its route resolved NULL or the wrong row: %s",
+						tc.entityType, entry.After)
+				}
+			}
+			if !found {
+				t.Fatalf("the %s's create row is absent from the page, so this proved nothing",
+					tc.entityType)
+			}
+		})
+	}
+}
+
 // TestAScheduledSendWithNoActivityIsWithheld pins the fail-closed direction. An
 // account-origin send that has not been released has neither activity_id nor
 // anchor_activity_id, by its own CHECK constraint, so the route resolves NULL

--- a/backend/internal/modules/privacy/auditlogaudience_integration_test.go
+++ b/backend/internal/modules/privacy/auditlogaudience_integration_test.go
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package privacy
+
+// The AUDIENCE boundary on the compliance log, for the four collateral types.
+//
+// Its sibling next door (auditlogboundary_integration_test.go) proves the
+// ERASURE boundary: a tombstone withholds the images written before it. This
+// one proves the other rule on the same rows — an image describing an activity
+// the reader is outside the audience of is withheld even though nothing was
+// erased.
+//
+// Both are needed because they fail independently. Erasure keys on a tombstone
+// that mostly does not exist; the audience keys on a row that always does. The
+// four collateral types passed the erasure test for a year while every one of
+// their images was legible to an admin who was not on the mail.
+//
+// Seeded through the owner connection rather than through each module's writer:
+// the subject here is what THIS read does with rows that exist, and reaching
+// four modules' stores to place them would test their write paths instead.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// TestACollateralImageFollowsItsActivitysAudience is the leak this closes: an
+// admin outside a held thread's audience reading a filename off the audit log.
+func TestACollateralImageFollowsItsActivitysAudience(t *testing.T) {
+	for _, tc := range []struct {
+		entityType string
+		// seed places the collateral row and returns the id the audit row is
+		// written against.
+		seed func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID
+	}{{
+		entityType: "attachment",
+		seed: func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID {
+			// The capture path's shape: entity pair AND activity_id.
+			return e.seedID(t, `
+				INSERT INTO attachment (id, entity_type, entity_id, activity_id, filename,
+				                        storage_key, source, captured_by)
+				VALUES ($1, 'activity', $2, $2, 'Kuendigung.pdf', 'blob/k', 'gmail',
+				        'connector:gmail:'||$3::text)`, activity, e.other)
+		},
+	}, {
+		entityType: "attachment",
+		seed: func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID {
+			// The manual-upload shape: the polymorphic pair alone, activity_id
+			// NULL. A route reading only activity_id would leave this row
+			// unjoined, and an unjoined row is withheld — safe, but it would
+			// destroy the governance record for every uploaded file, so the
+			// coalesce is what this case holds.
+			return e.seedID(t, `
+				INSERT INTO attachment (id, entity_type, entity_id, filename,
+				                        storage_key, source, captured_by)
+				VALUES ($1, 'activity', $2, 'Kuendigung.pdf', 'blob/k2', 'upload',
+				        'human:'||$3::text)`, activity, e.other)
+		},
+	}, {
+		entityType: "attachment_extraction",
+		seed: func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID {
+			attachment := e.seedID(t, `
+				INSERT INTO attachment (id, entity_type, entity_id, activity_id, filename,
+				                        storage_key, source, captured_by)
+				VALUES ($1, 'activity', $2, $2, 'Kuendigung.pdf', 'blob/k3', 'gmail',
+				        'connector:gmail:'||$3::text)`, activity, e.other)
+			return e.seedID(t, `
+				INSERT INTO attachment_extraction (id, attachment_id, requested_by)
+				VALUES ($1, $2, 'human:'||$3::text)`, attachment, e.other)
+		},
+	}, {
+		entityType: "transcript_read",
+		seed: func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID {
+			return e.seedID(t, `
+				INSERT INTO transcript_read (id, activity_id, requested_by)
+				VALUES ($1, $2, 'human:'||$3::text)`, activity, e.other)
+		},
+	}, {
+		entityType: "scheduled_send",
+		seed: func(t *testing.T, e *auditBoundaryEnv, activity ids.UUID) ids.UUID {
+			// A reply-origin send reaches its activity through
+			// anchor_activity_id, which is the only route an unreleased send
+			// has — its own activity_id is NULL until it is released.
+			return e.seedID(t, `
+				INSERT INTO scheduled_send (id, anchor_activity_id, origin_kind, status,
+				                            scheduled_at, scheduled_tz, payload,
+				                            scheduled_by, principal_kind)
+				VALUES ($1, $2, 'reply', 'scheduled', now(), 'Europe/Berlin',
+				        '{"subject":"Re: Aufhebungsvertrag"}'::jsonb, $3, 'human')`, activity, e.other)
+		},
+	}} {
+		t.Run(tc.entityType, func(t *testing.T) {
+			e := setupAuditBoundary(t)
+			activity := e.seedHeldActivity(t)
+			id := tc.seed(t, e, activity)
+			e.seedCollateralAudit(t, tc.entityType, id)
+
+			limit := 50
+			page, err := ListAuditLog(e.ctx, e.db,
+				AuditFilter{EntityType: &tc.entityType, EntityID: &id, Limit: &limit})
+			if err != nil {
+				t.Fatalf("ListAuditLog: %v", err)
+			}
+			// The row must be PRESENT and withheld. Asserting absence alone
+			// passes on an empty page, which is the shape a broken filter and a
+			// working boundary share.
+			found := false
+			for _, entry := range page.Entries {
+				if entry.Action != "create" {
+					continue
+				}
+				found = true
+				if strings.Contains(string(entry.After), "Kuendigung") ||
+					strings.Contains(string(entry.After), "Aufhebungsvertrag") {
+					t.Errorf("an admin outside the audience read the %s's content: %s",
+						tc.entityType, entry.After)
+				}
+			}
+			if !found {
+				t.Fatalf("the %s's create row is absent from the page, so this proved nothing",
+					tc.entityType)
+			}
+		})
+	}
+}
+
+// TestAnExtractionRequestKeepsItsGovernanceKeysWhenWithheld is the other
+// direction, and the one a redaction gets wrong by being too eager: withholding
+// the extraction image WHOLE destroys "who asked to read this file", which is
+// the record a compliance reader opened this log for.
+func TestAnExtractionRequestKeepsItsGovernanceKeysWhenWithheld(t *testing.T) {
+	e := setupAuditBoundary(t)
+	activity := e.seedHeldActivity(t)
+	attachment := e.seedID(t, `
+		INSERT INTO attachment (id, entity_type, entity_id, activity_id, filename,
+		                        storage_key, source, captured_by)
+		VALUES ($1, 'activity', $2, $2, 'Kuendigung.pdf', 'blob/g', 'gmail',
+		        'connector:gmail:'||$3::text)`, activity, e.other)
+	extraction := e.seedID(t, `
+		INSERT INTO attachment_extraction (id, attachment_id, requested_by)
+		VALUES ($1, $2, 'human:'||$3::text)`, attachment, e.other)
+	e.seedCollateralAudit(t, "attachment_extraction", extraction)
+
+	entityType, limit := "attachment_extraction", 50
+	page, err := ListAuditLog(e.ctx, e.db,
+		AuditFilter{EntityType: &entityType, EntityID: &extraction, Limit: &limit})
+	if err != nil {
+		t.Fatalf("ListAuditLog: %v", err)
+	}
+	found := false
+	for _, entry := range page.Entries {
+		if entry.Action != "create" {
+			continue
+		}
+		found = true
+		for _, key := range []string{"attachment_id", "requested_by"} {
+			if !strings.Contains(string(entry.After), key) {
+				t.Errorf("%q was redacted away; the audience has no claim over the record of "+
+					"who read the file: %s", key, entry.After)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("the extraction's create row is absent from the page, so this proved nothing")
+	}
+}
+
+// TestAnUploadedFileOnAHeldThreadIsWithheld holds the polymorphic half of the
+// attachment route.
+//
+// A manual upload writes only the (entity_type, entity_id) pair and leaves
+// activity_id NULL, so a route reading activity_id alone never resolves this
+// row's activity. It is the case the capture-path fixtures cannot reach, and it
+// is a real disclosure rather than a safe miss: the predicate admits a row whose
+// entity type is governed only when the activity resolves AND the audience
+// holds, so a NULL route withholds — but only because the type is governed. The
+// pair of them is what this seeds.
+func TestAnUploadedFileOnAHeldThreadIsWithheld(t *testing.T) {
+	e := setupAuditBoundary(t)
+	activity := e.seedHeldActivity(t)
+	attachment := e.seedID(t, `
+		INSERT INTO attachment (id, entity_type, entity_id, filename,
+		                        storage_key, source, captured_by)
+		VALUES ($1, 'activity', $2, 'Kuendigung.pdf', 'blob/u', 'upload',
+		        'human:'||$3::text)`, activity, e.other)
+	e.seedCollateralAudit(t, "attachment", attachment)
+
+	entityType, limit := "attachment", 50
+	page, err := ListAuditLog(e.ctx, e.db,
+		AuditFilter{EntityType: &entityType, EntityID: &attachment, Limit: &limit})
+	if err != nil {
+		t.Fatalf("ListAuditLog: %v", err)
+	}
+	found := false
+	for _, entry := range page.Entries {
+		if entry.Action != "create" {
+			continue
+		}
+		found = true
+		if strings.Contains(string(entry.After), "Kuendigung") {
+			t.Errorf("an admin outside the audience read the uploaded file's name: %s", entry.After)
+		}
+	}
+	if !found {
+		t.Fatal("the attachment's create row is absent from the page, so this proved nothing")
+	}
+}
+
+// TestAnUploadedFileOnAnOpenThreadKeepsItsName is the coalesce's own case, and
+// the only direction that can catch it.
+//
+// Dropping the polymorphic half does not disclose anything — an unresolved row
+// is withheld, which every disclosure test reads as correct. What it does is
+// withhold EVERY manually uploaded file's image, including the ones on threads
+// the reader may read in full. So the mutation is visible only from a workspace
+// activity, where the right answer is that nothing is redacted at all.
+func TestAnUploadedFileOnAnOpenThreadKeepsItsName(t *testing.T) {
+	e := setupAuditBoundary(t)
+	activity := e.seedID(t, `
+		INSERT INTO activity (id, kind, audience, source, captured_by, occurred_at)
+		VALUES ($1, 'email', 'workspace', 'gmail', 'connector:gmail:'||$2::text, $3)`,
+		e.other, boundaryEarlier)
+	attachment := e.seedID(t, `
+		INSERT INTO attachment (id, entity_type, entity_id, filename,
+		                        storage_key, source, captured_by)
+		VALUES ($1, 'activity', $2, 'Kuendigung.pdf', 'blob/o', 'upload',
+		        'human:'||$3::text)`, activity, e.other)
+	e.seedCollateralAudit(t, "attachment", attachment)
+
+	entityType, limit := "attachment", 50
+	page, err := ListAuditLog(e.ctx, e.db,
+		AuditFilter{EntityType: &entityType, EntityID: &attachment, Limit: &limit})
+	if err != nil {
+		t.Fatalf("ListAuditLog: %v", err)
+	}
+	found := false
+	for _, entry := range page.Entries {
+		if entry.Action != "create" {
+			continue
+		}
+		found = true
+		if !strings.Contains(string(entry.After), "Kuendigung") {
+			t.Errorf("an uploaded file on a workspace-visible thread was redacted; its activity "+
+				"never resolved, so every manually uploaded file's image is withheld: %s", entry.After)
+		}
+	}
+	if !found {
+		t.Fatal("the attachment's create row is absent from the page, so this proved nothing")
+	}
+}
+
+// TestAScheduledSendWithNoActivityIsWithheld pins the fail-closed direction. An
+// account-origin send that has not been released has neither activity_id nor
+// anchor_activity_id, by its own CHECK constraint, so the route resolves NULL
+// and there is no audience to consult. Answering "readable" for exactly the rows
+// whose audience cannot be checked is how the disclosure returns.
+func TestAScheduledSendWithNoActivityIsWithheld(t *testing.T) {
+	e := setupAuditBoundary(t)
+	send := e.seedID(t, `
+		INSERT INTO scheduled_send (id, origin_kind, origin_links, status,
+		                            scheduled_at, scheduled_tz, payload,
+		                            scheduled_by, principal_kind)
+		VALUES ($1, 'account', '[]'::jsonb, 'scheduled', now(), 'Europe/Berlin',
+		        '{"subject":"Re: Aufhebungsvertrag"}'::jsonb, $2, 'human')`, e.other)
+	e.seedCollateralAudit(t, "scheduled_send", send)
+
+	entityType, limit := "scheduled_send", 50
+	page, err := ListAuditLog(e.ctx, e.db,
+		AuditFilter{EntityType: &entityType, EntityID: &send, Limit: &limit})
+	if err != nil {
+		t.Fatalf("ListAuditLog: %v", err)
+	}
+	found := false
+	for _, entry := range page.Entries {
+		if entry.Action != "create" {
+			continue
+		}
+		found = true
+		if strings.Contains(string(entry.After), "Aufhebungsvertrag") {
+			t.Errorf("a send with no resolvable activity was disclosed rather than withheld: %s",
+				entry.After)
+		}
+	}
+	if !found {
+		t.Fatal("the send's create row is absent from the page, so this proved nothing")
+	}
+}
+
+// seedHeldActivity writes a participants-limited activity captured by SOMEBODY
+// ELSE.
+//
+// Both halves matter. `participants` is what the audience arm tests, and a
+// different capturer is what stops the arm's own `captured_by LIKE '%:<uuid>'`
+// clause admitting the reader — an activity this admin captured is one they may
+// read, and a fixture built that way would pass whatever the redaction did.
+func (e *auditBoundaryEnv) seedHeldActivity(t *testing.T) ids.UUID {
+	t.Helper()
+	return e.seedID(t, `
+		INSERT INTO activity (id, kind, audience, source, captured_by, occurred_at)
+		VALUES ($1, 'email', 'participants', 'gmail', 'connector:gmail:'||$2::text, $3)`,
+		e.other, boundaryEarlier)
+}
+
+// seedCollateralAudit writes the create row whose image carries the content.
+func (e *auditBoundaryEnv) seedCollateralAudit(t *testing.T, entityType string, id ids.UUID) {
+	t.Helper()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, after, occurred_at)
+		VALUES ($1, 'human', 'user:'||$2::text, 'create', $3, $4,
+		        jsonb_build_object(
+		          'filename', 'Kuendigung.pdf',
+		          'subject', 'Re: Aufhebungsvertrag',
+		          'attachment_id', 'a-uuid',
+		          'requested_by', 'human:x',
+		          'scheduled_at', '2026-03-01T09:00:00Z'), $5)`,
+		ids.NewV7(), e.other, entityType, id, boundaryEarlier); err != nil {
+		t.Fatalf("seeding the %s audit image: %v", entityType, err)
+	}
+}
+
+// seedID runs one seed statement whose first placeholder is a fresh id, and
+// returns that id.
+func (e *auditBoundaryEnv) seedID(t *testing.T, statement string, args ...any) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), statement, append([]any{id}, args...)...); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	return id
+}

--- a/backend/internal/modules/privacy/auditlogboundary_integration_test.go
+++ b/backend/internal/modules/privacy/auditlogboundary_integration_test.go
@@ -42,6 +42,11 @@ type auditBoundaryEnv struct {
 	owner  *pgx.Conn
 	ws     ids.UUID
 	user   ids.UUID
+	// other is a SECOND seat, the one who captured the held mail in the
+	// audience tests next door. The audience arm admits a row's own capturer
+	// (`captured_by LIKE '%:<uuid>'`), so a fixture where the reader captured
+	// the activity would pass whatever the redaction did.
+	other ids.UUID
 }
 
 func setupAuditBoundary(t *testing.T) *auditBoundaryEnv {
@@ -65,6 +70,7 @@ func setupAuditBoundary(t *testing.T) *auditBoundaryEnv {
 	}
 
 	ws, user, person := ids.NewV7(), ids.NewV7(), ids.New[ids.PersonKind]()
+	other := ids.NewV7()
 	for _, seed := range []struct {
 		statement string
 		args      []any
@@ -73,6 +79,10 @@ func setupAuditBoundary(t *testing.T) *auditBoundaryEnv {
 		{
 			`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Admin')`,
 			[]any{user, "admin-" + user.String() + "@boundary.test"},
+		},
+		{
+			`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Colleague')`,
+			[]any{other, "other-" + other.String() + "@boundary.test"},
 		},
 		{`INSERT INTO person (id, full_name, source, captured_by)
 		  VALUES ($1, 'Sara Subject', 'manual', 'user:'||$2::text)`, []any{person, user}},
@@ -95,6 +105,7 @@ func setupAuditBoundary(t *testing.T) *auditBoundaryEnv {
 		owner:  owner,
 		ws:     ws,
 		user:   user,
+		other:  other,
 	}
 }
 

--- a/backend/internal/modules/privacy/auditredaction_test.go
+++ b/backend/internal/modules/privacy/auditredaction_test.go
@@ -116,10 +116,26 @@ func TestRedactionKeepsGovernanceAndDropsContent(t *testing.T) {
 		image:      `{"attachment_id":"a-uuid","requested_by":"human:b-uuid"}`,
 		wantKeys:   []string{"attachment_id", "requested_by"},
 	}, {
-		name:       "a transcript read keeps who read it and how much",
+		// line_count measures the transcript, so it is content by the same
+		// argument that drops a subject: it tells a reader outside the audience
+		// how long the held conversation was. It also survives the transcript's
+		// own erasure — the purge deletes the routing row without a tombstone,
+		// so the route resolves NULL and this same redactor runs again.
+		name:       "a transcript read keeps who read it and loses how long it was",
 		entityType: "transcript_read",
-		image:      `{"activity_id":"a-uuid","requested_by":"human:b-uuid","line_count":412}`,
-		wantKeys:   []string{"activity_id", "requested_by", "line_count"},
+		image:      `{"activity_id":"a-uuid","requested_by":"human:b-uuid","status":"done","line_count":412}`,
+		wantKeys:   []string{"activity_id", "requested_by", "status", "content_state"},
+		gone:       []string{"line_count"},
+	}, {
+		name:       "a finished extraction keeps its job progress",
+		entityType: "attachment_extraction",
+		image:      `{"status":"done","grounded":4}`,
+		wantKeys:   []string{"status", "grounded"},
+	}, {
+		name:       "a hidden deal document keeps which deal and which way",
+		entityType: "attachment",
+		image:      `{"deal_id":"a-uuid","hidden_from_deal":true}`,
+		wantKeys:   []string{"deal_id", "hidden_from_deal"},
 	}, {
 		// scheduledsend.go writes the message's own subject line onto this
 		// image, so the send is a content carrier exactly like the activity.

--- a/backend/internal/modules/privacy/auditredaction_test.go
+++ b/backend/internal/modules/privacy/auditredaction_test.go
@@ -18,10 +18,13 @@ import (
 
 func TestRedactionKeepsGovernanceAndDropsContent(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		image    string
-		wantKeys []string
-		gone     []string
+		name string
+		// entityType selects the key set. Empty means "activity", so the cases
+		// that predate the collateral types read exactly as they did.
+		entityType string
+		image      string
+		wantKeys   []string
+		gone       []string
 	}{{
 		// The audience change's own audit row. Written by SetAudience, and the
 		// reason this test exists: withholding it tells a compliance reader
@@ -86,9 +89,61 @@ func TestRedactionKeepsGovernanceAndDropsContent(t *testing.T) {
 		image:    `{"audience":"selected","some_new_field":"whatever this is"}`,
 		wantKeys: []string{"audience", "content_state"},
 		gone:     []string{"some_new_field"},
+	}, {
+		// The leak this closes. capturedfiles.go stores an email attachment
+		// under its user-supplied filename, and that name is the thing a
+		// termination letter or a diagnosis gives away on its own.
+		name:       "an attachment filename is dropped while the file's shape survives",
+		entityType: "attachment",
+		image:      `{"entity_type":"activity","entity_id":"a-uuid","filename":"Kuendigung.pdf","byte_size":8241,"category":"email_attachment"}`,
+		wantKeys:   []string{"entity_type", "entity_id", "byte_size", "category", "content_state"},
+		gone:       []string{"filename"},
+	}, {
+		// A human-authored document title names the file's content as surely as
+		// the filename does.
+		name:       "a document title is dropped like a filename",
+		entityType: "attachment",
+		image:      `{"title":"Aufhebungsvertrag Entwurf","pinned":true}`,
+		wantKeys:   []string{"pinned", "content_state"},
+		gone:       []string{"title"},
+	}, {
+		// The direction that matters as much as the leak: withholding this
+		// image WHOLE would destroy "who asked to read this file", which is the
+		// governance record a compliance reader came for. Both keys survive and
+		// nothing is marked withheld.
+		name:       "an extraction request survives whole so the governance record is not destroyed",
+		entityType: "attachment_extraction",
+		image:      `{"attachment_id":"a-uuid","requested_by":"human:b-uuid"}`,
+		wantKeys:   []string{"attachment_id", "requested_by"},
+	}, {
+		name:       "a transcript read keeps who read it and how much",
+		entityType: "transcript_read",
+		image:      `{"activity_id":"a-uuid","requested_by":"human:b-uuid","line_count":412}`,
+		wantKeys:   []string{"activity_id", "requested_by", "line_count"},
+	}, {
+		// scheduledsend.go writes the message's own subject line onto this
+		// image, so the send is a content carrier exactly like the activity.
+		name:       "a scheduled send loses its subject and keeps its schedule",
+		entityType: "scheduled_send",
+		image:      `{"scheduled_at":"2026-03-01T09:00:00Z","scheduled_tz":"Europe/Berlin","subject":"Re: Aufhebungsvertrag"}`,
+		wantKeys:   []string{"scheduled_at", "scheduled_tz", "content_state"},
+		gone:       []string{"subject"},
+	}, {
+		// Fail closed at the TYPE level, not just the key level: a governed type
+		// nobody gave keys to withholds everything rather than falling through
+		// to a permissive default.
+		name:       "an entity type with no key set withholds every key",
+		entityType: "some_new_collateral",
+		image:      `{"attachment_id":"a-uuid","requested_by":"human:b-uuid"}`,
+		wantKeys:   []string{"content_state"},
+		gone:       []string{"attachment_id", "requested_by"},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := redactAuditImage([]byte(tc.image))
+			entityType := tc.entityType
+			if entityType == "" {
+				entityType = "activity"
+			}
+			got := redactAuditImage([]byte(tc.image), governanceKeysFor(entityType))
 			var fields map[string]json.RawMessage
 			if err := json.Unmarshal(got, &fields); err != nil {
 				t.Fatalf("redacted image is not an object: %s (%v)", got, err)
@@ -120,10 +175,10 @@ func TestRedactionLeavesAnAbsentImageAbsent(t *testing.T) {
 	// A row that carried no image must not gain a marker: "nothing was
 	// recorded" and "you may not see what was recorded" are the two answers a
 	// compliance reader is trying to tell apart.
-	if got := redactAuditImage(nil); got != nil {
+	if got := redactAuditImage(nil, auditImageGovernanceKeys); got != nil {
 		t.Errorf("a nil image became %s; it must stay absent", got)
 	}
-	if got := redactAuditImage([]byte{}); len(got) != 0 {
+	if got := redactAuditImage([]byte{}, auditImageGovernanceKeys); len(got) != 0 {
 		t.Errorf("an empty image became %s; it must stay absent", got)
 	}
 }
@@ -132,7 +187,7 @@ func TestRedactionWithholdsAnImageItCannotParse(t *testing.T) {
 	// A scalar or array image cannot be partially redacted. Passing it through
 	// would be the disclosure, so the unreadable case withholds.
 	for _, image := range []string{`"a bare string"`, `[1,2,3]`, `{not json`} {
-		got := string(redactAuditImage([]byte(image)))
+		got := string(redactAuditImage([]byte(image), auditImageGovernanceKeys))
 		if got == image {
 			t.Errorf("an unparseable image %s was passed through unredacted", image)
 		}


### PR DESCRIPTION
## The leak

`ListAuditLog` applied the audience test only to audit rows whose `entity_type` was `'activity'`. Four entity types hang off an activity and carry its content into their own images:

| type | what its image carries |
|---|---|
| `attachment` | the **user-supplied filename** (`capturedfiles.go` stores an email attachment under its own name) |
| `attachment_extraction` | `{attachment_id, requested_by}` |
| `transcript_read` | `{activity_id, requested_by, line_count}` |
| `scheduled_send` | the **message subject, verbatim** (`scheduledsend.go:348`) |

None was joined to its activity, so an admin who was not on a held thread read `Kuendigung.pdf` and `Re: Aufhebungsvertrag` straight off the compliance log. The file documented the gap in its own comment, so this was known rather than discovered.

Only *audience* redaction had the gap. *Erasure* redaction (`images_readable`) already covered every type.

## The build

One `LEFT JOIN LATERAL` resolves all five types into a single `aud_activity` alias, so `auth.ActivityAudienceArm` — a correlated subquery over workspace membership — renders once rather than five times.

**A route that resolves NULL is withheld, never disclosed.** An `origin_kind='account'` scheduled send that has not been released has neither `activity_id` nor `anchor_activity_id`, by its own CHECK constraint, so that row is reachable today rather than latent.

**Governance keys are per type**, derived from what each writer actually records. One shared set would be the union of five vocabularies and would admit each type's keys on every other. Withholding the collateral images *whole* would destroy the governance record — an extraction's `{attachment_id, requested_by}` is exactly what a compliance reader opened the log for.

The audience boundary moved to its own file (`auditaudienceboundary.go`) under the 500-line cap.

## Acceptance

- (IT) A held email with `Kuendigung.pdf`: an admin outside the audience sees a redacted filename — all five collateral shapes, including the two-hop extraction route and the polymorphic upload route.
- (IT) An `attachment_extraction` image still shows `attachment_id` and `requested_by` to a reader outside the audience: governance survives redaction.
- (IT) A `scheduled_send` with no resolvable activity is withheld, not disclosed.
- (unit) A `scheduled_send` loses its subject and keeps its schedule; an attachment loses `filename` and `title` and keeps `byte_size`, `category`; an entity type with no key set withholds every key.

## Mutation checks, against real Postgres

- Reverting the predicate to the single `'activity'` literal prints the filename and the subject on **all five** cases.
- Dropping the polymorphic half of the attachment route fails `TestAnUploadedFileOnAnOpenThreadKeepsItsName` — the only direction that can see it, because an unresolved row is *withheld*, which every disclosure test reads as correct while every manually uploaded file's image collapses to the withheld marker.
- Adding a type to `auditGovernedTypes` with no route or keys, routing a type that is not governed, and admitting `filename` on the attachment key set each fail with their own message.

## Gates

`make check-backend` green apart from one pre-existing failure this diff does not touch: `TestAnOpenUndatedTaskIsTheMoment` in `compose/person360` reads a task due later today as "Due in 1 days" at 05:22 local. Reproduced with these changes stashed. Filed separately.

`make craft-static`, `make rls-store-path`, `make no-jurisdiction` all green. Integration lane run under a private template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audit-log audience redaction now covers activity-linked attachments, attachment extractions, transcript reads, and scheduled sends instead of only `activity` rows. Readers outside an activity’s audience no longer see content such as user-supplied filenames or message subjects, while unrelated attachments remain readable and unresolved governed rows are withheld.

**Redaction**

- A single lateral route resolves each governed entity to its activity, including polymorphic and two-hop attachment paths.
- Per-entity allowlists preserve governance metadata while dropping content fields such as `filename`, `title`, `subject`, `line_count`, and `proposals`.
- Added safeguards distinguish non-activity attachments from governed rows with no resolvable activity.

**Tests**

- Added integration coverage for restricted and workspace-visible activities, manual uploads, route resolution, and unreleased scheduled sends.
- Added checks that governed types, routes, and key sets cannot drift or admit known content keys.
- `make check-backend` passes except the pre-existing `compose/person360` failure; `make craft-static`, `make rls-store-path`, and `make no-jurisdiction` pass.

<sup>Written for commit 01bdc94cc0c02bad0202a35bb4e4994a867aa40c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy**
  * Audit images and related content are now redacted according to their specific record type.
  * Sensitive content is withheld when the associated activity is outside the reader’s audience or cannot be identified.
  * Approved governance metadata remains visible while filenames and other sensitive fields are removed as appropriate.
  * Unknown record types and unsupported metadata fail closed for stronger privacy protection.

* **Tests**
  * Added coverage for attachments, extractions, transcripts, and scheduled sends across accessible and restricted activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->