### PR TITLE
The moment card's due-today case stops depending on the hour it runs

### DIFF
--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -428,7 +428,12 @@ func TestLogActivityIsWithheldFromACallerWithoutTheCreateGrant(t *testing.T) {
 // "I'll send you the whitepaper" without one, and the card used to fall past
 // every rung to "nothing is owed" while that task sat directly beneath it.
 func TestAnOpenUndatedTaskIsTheMoment(t *testing.T) {
-	now := time.Now()
+	// A FIXED INSTANT, and midday UTC at that. The card counts days in UTC, so
+	// a `now` taken from the clock puts "due two hours from now" on TOMORROW's
+	// UTC day for the two hours before midnight — and the case below asks for
+	// "Due today." A test that passes for twenty-two hours a day is one that
+	// fails the merge queue at random and tells whoever hits it nothing.
+	now := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	page := &crmcontracts.Person360{
 		NextSteps: &struct {
 			Data []crmcontracts.Activity `json:"data"`


### PR DESCRIPTION
## What was failing

`TestAnOpenUndatedTaskIsTheMoment` fails on `main` for two hours out of every twenty-four. It took `now` from the clock and asserted that a task due two hours later reads `"Due today."`:

```
moments_test.go:487: why_now for a task due later today = "Due in 1 days.", want "Due today."
```

`openPromiseWhyNow` counts days through `elapsed.Days`, which buckets by **UTC calendar day**. So between 22:00 and 24:00 UTC, `now.Add(2 * time.Hour)` lands on tomorrow's day and the wording is `"Due in 1 days."` — which is correct: a task due after midnight is due tomorrow, and the card saying so is the behaviour anyone would want.

Caught it on the merge queue at 22:16 UTC. Reproduced by pinning `now` to 23:00 UTC, which fails with exactly that line; at midday it passes.

## The fix

The test's `now` is a fixed instant at midday UTC. No production change: what was wrong is a test that passes for twenty-two hours a day, fails the merge queue at random, and tells whoever hits it nothing.

## What I checked and left alone

The other `time.Now()` in the file (line 403) hands it to `nothingNeededMoment` over an empty page and does no date arithmetic. I also swept every test package whose subject calls `elapsed.Days` or `deadline.DaysPast` for the same shape — a clock-derived `now` offset by hours and then asserted against day-bucketed wording — and this was the only one. The rest pass `time.Now()` as a plain reference point without crossing a boundary in an assertion.

`make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of date-sensitive moment tests by using a fixed UTC timestamp.
  * Prevented test results from varying based on the current system time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->