### PR TITLE
The meeting brief has an address

### DIFF
--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -456,9 +456,21 @@ describe("which meeting the brief drawer asks about", () => {
     },
   };
 
-  it("requests the brief for the meeting the reader picked", async () => {
-    const asked: string[] = [];
-    installFetchStub({
+  // Which meeting the drawer asked the server about, recorded per test. The
+  // routes are shared because four tests below all turn on the SAME question —
+  // was the brief fetched, and for which meeting — and a second copy of them
+  // would let one drift into stubbing a meeting the others do not have.
+  function briefRoutes(asked: string[]): RouteMap {
+    const brief = (id: string) => () => {
+      asked.push(id);
+      return jsonResponse({
+        activity_id: id,
+        generated_at: "2026-08-13T09:00:00Z",
+        generated_by: "deterministic",
+        sections: [],
+      });
+    };
+    return {
       "GET /me": meRoute({ person: ["read", "update"], activity: ["read"] }),
       "GET /people/p-1/360": () => jsonResponse(withMeetings),
       "GET /people/p-1/brief": () =>
@@ -470,25 +482,14 @@ describe("which meeting the brief drawer asks about", () => {
       "GET /people/p-1/consent/guard": () =>
         jsonResponse({ person_id: "p-1", entries: [] }),
       "GET /channel-providers": () => jsonResponse({ data: [] }),
-      "GET /activities/a-held/meeting-brief": () => {
-        asked.push("a-held");
-        return jsonResponse({
-          activity_id: "a-held",
-          generated_at: "2026-08-13T09:00:00Z",
-          generated_by: "deterministic",
-          sections: [],
-        });
-      },
-      "GET /activities/a-booked/meeting-brief": () => {
-        asked.push("a-booked");
-        return jsonResponse({
-          activity_id: "a-booked",
-          generated_at: "2026-08-13T09:00:00Z",
-          generated_by: "deterministic",
-          sections: [],
-        });
-      },
-    });
+      "GET /activities/a-held/meeting-brief": brief("a-held"),
+      "GET /activities/a-booked/meeting-brief": brief("a-booked"),
+    };
+  }
+
+  it("requests the brief for the meeting the reader picked", async () => {
+    const asked: string[] = [];
+    installFetchStub(briefRoutes(asked));
     render(
       <StoryProviders>
         <PersonPageV2 id="p-1" tab="meetings" />
@@ -502,6 +503,68 @@ describe("which meeting the brief drawer asks about", () => {
 
     await waitFor(() => expect(asked.length).toBe(1));
     expect(asked).toEqual(["a-held"]);
+  });
+
+  // The brief is the one drawer another SCREEN sends a reader to, so it is the
+  // one with an address. Held in useState alone it could only ever be opened by
+  // pressing a button on this page, which is not what a "prepare the meeting"
+  // link on the worklist means.
+  it("opens the brief the address names, with nothing pressed", async () => {
+    const asked: string[] = [];
+    installFetchStub(briefRoutes(asked));
+    window.location.hash = "#/contacts/p-1/meetings?prep=a-held";
+    render(
+      <StoryProviders>
+        <PersonPageV2 id="p-1" tab="meetings" />
+      </StoryProviders>,
+    );
+
+    await waitFor(() => expect(asked).toEqual(["a-held"]));
+  });
+
+  // The reason it is derived from the address rather than seeded from it: a
+  // drawer in useState stays open when the reader navigates back out of it,
+  // because nothing tells it the address changed. Back is how a reader closes
+  // a thing they arrived at by link, and it has to work.
+  it("closes the brief when the address stops naming it", async () => {
+    const asked: string[] = [];
+    installFetchStub(briefRoutes(asked));
+    window.location.hash = "#/contacts/p-1/meetings?prep=a-held";
+    render(
+      <StoryProviders>
+        <PersonPageV2 id="p-1" tab="meetings" />
+      </StoryProviders>,
+    );
+    await waitFor(() => expect(asked).toEqual(["a-held"]));
+
+    window.location.hash = "#/contacts/p-1/meetings";
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+
+    // The BRIEF's dialog by its own label, not "a dialog": the page carries
+    // other modals, and querying for any of them would pass on a page where
+    // the brief never closed and something else happened to be shut.
+    await waitFor(() =>
+      expect(
+        document.querySelector('[aria-labelledby="person-meeting-title"]'),
+      ).toBeNull(),
+    );
+  });
+
+  // A link somebody edited by hand, or one whose meeting has since been
+  // deleted. The page renders; it does not throw and it does not open an empty
+  // drawer that asks the server about nothing.
+  it("renders normally when the address names no meeting", async () => {
+    const asked: string[] = [];
+    installFetchStub(briefRoutes(asked));
+    window.location.hash = "#/contacts/p-1/meetings?prep=";
+    render(
+      <StoryProviders>
+        <PersonPageV2 id="p-1" tab="meetings" />
+      </StoryProviders>,
+    );
+
+    await screen.findAllByRole("button", { name: "Brief me" });
+    expect(asked).toEqual([]);
   });
 });
 

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -17,6 +17,7 @@ import { useCanWrite } from "../app/capability";
 import { PageAside, PageAsideToggle } from "../app/pageaside";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
+import { useUrlParams } from "../app/urlstate";
 import { Button, OverflowMenu } from "../design-system/atoms";
 import { RecordView } from "../design-system/composed";
 import { IconAction } from "../design-system/iconaction";
@@ -230,6 +231,7 @@ export function PersonPageV2({
   // Which drawer is open, if any. One at a time: two surfaces over the same
   // record would each claim to be the thing the reader is doing.
   const [drawer, setDrawer] = useState<Drawer>(null);
+  const [briefedMeeting, openBrief] = useBriefedMeeting();
   // What the action that opened the composer wanted written. A rung knows WHY
   // it fired and says so in its prefill; before this the client dropped that
   // on the floor and opened the same empty composer as the generic button, so
@@ -309,10 +311,8 @@ export function PersonPageV2({
         // it briefs. An action naming its own activity is honoured over the
         // page's, because a moment about a different meeting must not open a
         // brief about this one.
-        setDrawer(
-          meetingDrawer(
-            destination.entity_id ?? view.data.next_meeting?.activity_id,
-          ),
+        openBrief(
+          destination.entity_id ?? view.data.next_meeting?.activity_id ?? null,
         );
         return;
       case "record":
@@ -440,7 +440,7 @@ export function PersonPageV2({
           tab={tab}
           personId={id}
           view={view.data}
-          onBriefMeeting={(activityId) => setDrawer(meetingDrawer(activityId))}
+          onBriefMeeting={openBrief}
         />
         <PersonComposer
           personId={id}
@@ -458,9 +458,9 @@ export function PersonPageV2({
           onClose={() => setDrawer(null)}
         />
         <PersonMeetingBrief
-          activityId={briefingMeeting(drawer)}
-          open={briefingMeeting(drawer) !== null}
-          onClose={() => setDrawer(null)}
+          activityId={briefedMeeting}
+          open={briefedMeeting !== null}
+          onClose={() => openBrief(null)}
           projects={liveProjects(view.data.projects)}
         />
         {/* Mounted only while open, so the form starts fresh each time and the
@@ -486,24 +486,45 @@ export function PersonPageV2({
 // reachable only for the soonest meeting and only while the prep moment was
 // live — every other meeting on the record had a brief the backend would
 // happily assemble and no way to ask for it.
-type Drawer =
-  | "composer"
-  | "research"
-  | "activity_log"
-  | { kind: "meeting"; activityId: string }
-  | null;
+type Drawer = "composer" | "research" | "activity_log" | null;
 
-// The brief the prep moment opens is the one for the next meeting; a timeline
-// row names its own. Both go through here so the drawer has one shape.
-function meetingDrawer(activityId: string | null | undefined): Drawer {
-  return activityId ? { kind: "meeting", activityId } : null;
-}
+// The query key naming which meeting is being briefed. One spelling, because
+// another screen composes this address and this one reads it; two would be a
+// link that opens nothing.
+export const BRIEF_PARAM = "prep";
 
-// Which meeting the open drawer is briefing, or null when it is not the brief.
-function briefingMeeting(drawer: Drawer): string | null {
-  return typeof drawer === "object" && drawer?.kind === "meeting"
-    ? drawer.activityId
-    : null;
+/**
+ * Which meeting the address says to brief, and how to change it.
+ *
+ * The meeting brief is the one drawer on this page with an ADDRESS, because it
+ * is the one another screen sends a reader to. The other three are opened by
+ * pressing something here, and a thing you can only open by pressing it needs
+ * no name.
+ *
+ * DERIVED from the query rather than seeded from it, and the difference shows
+ * on Back: a drawer held in useState stays open when the reader navigates back
+ * out of it, because nothing tells it the address changed. Deriving makes Back
+ * close it, which is what a reader pressing Back means.
+ *
+ * A hook rather than four lines in the page because the page is at its
+ * complexity ceiling — the lint says so — and this is one idea a reader should
+ * be able to take in on its own.
+ */
+function useBriefedMeeting(): [
+  string | null,
+  (activityId: string | null) => void,
+] {
+  const [params, setParams] = useUrlParams();
+  const setBriefed = (activityId: string | null) => {
+    const out = new Map(params);
+    if (activityId) {
+      out.set(BRIEF_PARAM, activityId);
+    } else {
+      out.delete(BRIEF_PARAM);
+    }
+    setParams(out);
+  };
+  return [params.get(BRIEF_PARAM) ?? null, setBriefed];
 }
 
 // The header's second line: what this person does, and where. The company is a

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -350,8 +350,13 @@ export function dealFactsText(
 // message on its timeline, one press from the draft — and naming the step
 // honestly is worth more than a label that overstates it.
 //
-// Opening the composer from here needs a deep link the app does not have. That
-// is its own change, and the label moves back when it lands.
+// Opening the composer from here needs a deep link the app does not have. The
+// meeting brief has one now (`?prep=<activityId>` on the contact record), but
+// the composer does not: it picks its transport from the person's own
+// reachability rather than from a thread a caller names, so an address could
+// open it without opening it ON the message this row is about. The worklist
+// sends no `prepare_meeting` move either — `WorklistMove.action` has one value.
+// Both are their own change, and the label moves back when they land.
 export function moveHref(item: WorklistItem): string | undefined {
   if (item.move?.action !== "draft_reply") {
     return undefined;


### PR DESCRIPTION
The meeting brief drawer was reachable only by pressing a button on the contact record. No other screen could send a reader to it. It now reads `?prep=<activityId>` from the query, so `#/contacts/p-1/meetings?prep=<id>` arrives with the brief open.

## Derived, not seeded

The param is read on every render rather than copied into `useState` once. The difference only shows on Back: a drawer held in local state stays open when the reader navigates back out of it, because nothing tells it the address changed.

Both behaviours are tested, and the seeded version was mutation-checked — it passes the arrive-by-link test and fails the Back one.

## Scope, honestly

The plan for this PR named three deep links. One landed; the other two turned out to be different work than plumbing a param, and the code now says so instead of promising them:

- **The composer** picks its transport from the person's own reachability (`useTransportChoice`, `persondrawers.tsx:329`), not from a thread a caller names. An address could open the composer without opening it *on* the message the row is about — which is the same overstated label the existing comment exists to avoid. Its send path anchors on a conversation the person page derived, so targeting a specific thread changes which transport resolves, inside a component whose own comment says it is at its complexity ceiling.
- **`prepare_meeting` is not a worklist move.** `WorklistMove.action` has exactly one value, `draft_reply`. There is no row that could carry this link yet.

`moveHref`'s comment previously said the deep links were one pending change. It now names which one landed and what each of the other two actually needs.

## Along the way

`PersonPageV2` was already at the lint's cognitive-complexity ceiling, so the address logic is a `useBriefedMeeting` hook rather than four more lines in the page — the same reason `useTransportChoice` was extracted from the composer.

## Tests

Three added to `personpage.test.tsx`: the address opens the brief with nothing pressed, Back closes it, and an empty `?prep=` renders the page normally without asking the server about nothing. The shared route stub is one helper, so four tests turning on the same question cannot drift into stubbing different meetings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the meeting brief drawer from a URL on the contact record, so other screens can send a reader to a prepared meeting.

- Derives the open brief from `?prep=<activityId>` on each render, so navigating Back closes the drawer instead of leaving it open.
- Keeps the honest worklist label: an address can't target the composer's transport, and the worklist sends no `prepare_meeting` move, so only the brief link landed.
- Adds tests for arriving by link, closing via Back, and an empty `?prep=` param.

<sup>Written for commit 75e62e54cfcdceb3062acf470fe83173ef475cce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Meeting briefs can now be opened and closed through shareable URL links.
  - Brief state is preserved when navigating between meeting actions and tabs.
  - Invalid or empty brief links are safely ignored.

- **Bug Fixes**
  - Improved handling of meeting-brief navigation when URL parameters change.

- **Documentation**
  - Clarified which meeting-brief links are supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->