### PR TITLE
One task order, one overdue rung

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -24585,7 +24585,7 @@ components:
         `job_change` fires only on a RECORDED employment change, and `public_signal` needs a
         connected data provider. A rule that cannot fire is absent from the page, not an empty
         card.
-      enum: [meeting_prep, re_engaged, job_change, overdue_promise, overdue_task, gone_quiet, open_promise, role_change, public_signal, missing_next_step, thin_relationship, nothing_needed]
+      enum: [meeting_prep, re_engaged, job_change, overdue_promise, gone_quiet, open_promise, role_change, public_signal, missing_next_step, thin_relationship, nothing_needed]
 
     PersonMomentEvidence:
       type: object

--- a/backend/internal/compose/org360/sections.go
+++ b/backend/internal/compose/org360/sections.go
@@ -103,7 +103,11 @@ func linkScope(ctx context.Context, alias string, arg func(any) int) (string, er
 }
 
 // nextStepsSection reads the account's open tasks in the order a rep works
-// them: overdue first, then dated, then undated. A task reaches the
+// them: overdue first, then dated, then undated, and among tasks sharing a
+// date the one that has waited longest. That last tie-break is what makes
+// this list agree with the contact page's (person360's byUrgency): the same
+// two promises must not swap places depending on which record you opened
+// them from, and without it each list fell back to its own id order. A task reaches the
 // account through any of its links — the task itself, its deal, or the
 // contact it is about — which is why the reachability test is an EXISTS
 // over all three arms rather than one join.
@@ -135,7 +139,7 @@ func nextStepsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, 
 		return nil, crmcontracts.PageInfo{}, err
 	}
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
-		SELECT a.id, coalesce(a.subject, ''), a.due_at, a.assignee_id,
+		SELECT a.id, coalesce(a.subject, ''), a.due_at, a.assignee_id, a.occurred_at,
 		       (SELECT dl.deal_id FROM activity_link dl
 		         WHERE dl.activity_id = a.id AND dl.entity_type = 'deal' AND %[3]s
 		         ORDER BY dl.id LIMIT 1),
@@ -145,7 +149,7 @@ func nextStepsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, 
 		FROM activity a
 		WHERE a.kind = 'task' AND NOT a.is_done AND a.archived_at IS NULL AND %[1]s
 		  AND %[2]s%[6]s
-		ORDER BY (a.due_at IS NULL), a.due_at, a.id
+		ORDER BY (a.due_at IS NULL), a.due_at, a.occurred_at, a.id
 		LIMIT %[5]d`,
 		activityScope, activities.OrgLinkedActivityExists(orgPos), linkVisible, personVisible, sectionLimit+1,
 		opts.projectScope(arg)), args...)
@@ -156,7 +160,11 @@ func nextStepsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, 
 		var step crmcontracts.Organization360NextStep
 		var id ids.UUID
 		var assignee, dealID, personID *ids.UUID
-		if err := row.Scan(&id, &step.Subject, &step.DueAt, &assignee, &dealID, &personID); err != nil {
+		// Read only to order by: the account's task list does not show when a
+		// task was filed, but two tasks due the same day have to rank the same
+		// here as on the contact page, and there the older one leads.
+		var occurredAt time.Time
+		if err := row.Scan(&id, &step.Subject, &step.DueAt, &assignee, &occurredAt, &dealID, &personID); err != nil {
 			return step, err
 		}
 		step.ActivityId = openapi_types.UUID(id)

--- a/backend/internal/compose/person360/momentpromise.go
+++ b/backend/internal/compose/person360/momentpromise.go
@@ -157,31 +157,114 @@ func openPromiseWhyNow(now time.Time, task crmcontracts.Activity) string {
 	if past, ok := deadline.DaysPast(task.DueAt, now); ok {
 		return fmt.Sprintf("Due %d days ago and still open.", past)
 	}
-	// A task logged from the record page carries today's date unless the
-	// writer picks another, so "in 0 days" is the common case, not a corner.
-	if days := elapsed.Days(now, *task.DueAt); days > 0 {
+	// Whole days of REMAINING TIME, not calendar boundaries crossed — see
+	// elapsed.FullDaysUntil for why a deadline counts differently from a pair
+	// of dates. A task logged from the record page is due at the end of
+	// today, so this is the common case rather than a corner.
+	if days := elapsed.FullDaysUntil(now, *task.DueAt); days > 0 {
 		return fmt.Sprintf("Due in %d days.", days)
 	}
 	return "Due today."
 }
 
-// overdueTaskMoment: a task we owe them was due and is still open.
+// overduePromiseMoment: we are past the date on something we said we would
+// do. ONE rung over both places a promise is written down — a commitment an
+// extractor read out of a conversation, and a task somebody filed — because
+// where a promise was recorded is a fact about this system, not about what
+// the reader should do next. Ranking them apart made identical lateness
+// outrank a silence from one source and lose to it from the other.
 //
-// It sits directly under the overdue-claim rung and ABOVE gone_quiet, which
-// is the whole point of separating it from openPromiseMoment below. The two
-// rungs read one fact — we are late on something we agreed — from the two
-// places a promise gets written down: a claim an extractor read out of an
-// email, and a task a person filed or confirmed. Ranking them apart made the
-// same lateness outrank a silence when it came from mail and lose to one when
-// it came from the task list, which is a rule about provenance rather than
-// about what the reader should do next.
-func overdueTaskMoment(ctx context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
-	task, ok := nearestOpenTask(page)
-	if !ok || !deadline.Passed(task.DueAt, now) {
+// When both are late the LATER date wins: the promise closest to its
+// deadline is the one still recoverable, and the one a reader is most likely
+// to be able to act on today. A tie goes to the claim, which carries a quote
+// from the conversation the promise was made in.
+func overduePromiseMoment(ctx context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
+	claim, hasClaim := latestOverdueCommitment(now, page)
+	task, hasTask := latestOverdueTask(now, page)
+	switch {
+	case hasClaim && hasTask:
+		if task.DueAt.After(*claim.DueAt) {
+			return overdueTaskCard(ctx, now, task), true
+		}
+		return overdueClaimCard(now, claim), true
+	case hasClaim:
+		return overdueClaimCard(now, claim), true
+	case hasTask:
+		return overdueTaskCard(ctx, now, task), true
+	default:
 		return crmcontracts.PersonMoment{}, false
 	}
+}
+
+// latestOverdueTask is the overdue task whose date passed MOST RECENTLY, which
+// is the one the rung asks for. Not the section's first row: that one is the
+// EARLIEST deadline, so on a record owing three late promises it would name
+// the oldest — the least recoverable — while the one that slipped yesterday
+// went unmentioned.
+func latestOverdueTask(now time.Time, page *crmcontracts.Person360) (crmcontracts.Activity, bool) {
+	if page.NextSteps == nil {
+		return crmcontracts.Activity{}, false
+	}
+	var latest *crmcontracts.Activity
+	for i := range page.NextSteps.Data {
+		task := &page.NextSteps.Data[i]
+		if !deadline.Passed(task.DueAt, now) {
+			continue
+		}
+		if latest == nil || task.DueAt.After(*latest.DueAt) {
+			latest = task
+		}
+	}
+	if latest == nil {
+		return crmcontracts.Activity{}, false
+	}
+	return *latest, true
+}
+
+// overdueTaskCard is the promise card for a late TASK.
+//
+// Its claim key stays "moment:overdue_task" even though the rule is now the
+// merged overdue_promise. A dismissal is stored against the claim key and
+// looked up by exact match, so renaming the key would resurrect every task a
+// reader had already put away — and the key is also what keeps a dismissal of
+// the late card from silencing the not-yet-due one, which shares the task but
+// says something different about it.
+func overdueTaskCard(ctx context.Context, now time.Time, task crmcontracts.Activity) crmcontracts.PersonMoment {
 	moment := openPromiseFrom(ctx, now, task)
 	moment.ClaimKey = "moment:overdue_task"
-	moment.Rule = crmcontracts.PersonMomentRuleOverdueTask
-	return moment, true
+	moment.Rule = crmcontracts.PersonMomentRuleOverduePromise
+	return moment
+}
+
+// overdueClaimCard is the card for a promise read out of a conversation. It
+// carries the quote it was read from, which a task has nothing to match.
+func overdueClaimCard(now time.Time, claim crmcontracts.ConversationClaim) crmcontracts.PersonMoment {
+	overdue := elapsed.Days(*claim.DueAt, now)
+	evidence := []crmcontracts.PersonMomentEvidence{{
+		Type:       crmcontracts.PersonMomentEvidenceTypeActivity,
+		Id:         &claim.SourceActivityId,
+		Label:      claim.Body,
+		Snippet:    &claim.SourceQuote,
+		ObservedAt: claim.DueAt,
+	}}
+	return crmcontracts.PersonMoment{
+		ClaimKey:            "moment:overdue_promise",
+		Rule:                crmcontracts.PersonMomentRuleOverduePromise,
+		RuleVersion:         ptr(ruleVersion),
+		EvidenceFingerprint: fingerprintOf(evidence),
+		Headline:            fmt.Sprintf("You owe them: %s", claim.Body),
+		WhyNow:              fmt.Sprintf("Promised for a date that passed %d days ago.", overdue),
+		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
+		Evidence:            evidence,
+		FreshnessAt:         claim.DueAt,
+		RecommendedAction: crmcontracts.PersonMomentAction{
+			Kind:  crmcontracts.PersonMomentActionKindDraftReply,
+			Label: "Send it now",
+			State: crmcontracts.PersonMomentActionStateWillConfirm,
+			Destination: &crmcontracts.PersonMomentDestination{
+				Surface: crmcontracts.PersonMomentDestinationSurfaceComposer,
+				Prefill: prefill(map[string]string{prefillIntent: "deliver_commitment", "subject": claim.Body}),
+			},
+		},
+	}
 }

--- a/backend/internal/compose/person360/momentrules.go
+++ b/backend/internal/compose/person360/momentrules.go
@@ -216,16 +216,16 @@ func bookMeeting() crmcontracts.PersonMomentAction {
 	}
 }
 
-// oldestOverdueCommitment finds the promise of OURS that has been late longest.
+// latestOverdueCommitment finds the promise of OURS that has been late longest.
 //
 // Oldest rather than newest: the one that has been waiting longest is the one
 // with the most damage already done, and the one a reader would be most
 // embarrassed to discover from the other side.
-func oldestOverdueCommitment(now time.Time, page *crmcontracts.Person360) (crmcontracts.ConversationClaim, bool) {
+func latestOverdueCommitment(now time.Time, page *crmcontracts.Person360) (crmcontracts.ConversationClaim, bool) {
 	if page.Claims == nil {
 		return crmcontracts.ConversationClaim{}, false
 	}
-	var oldest *crmcontracts.ConversationClaim
+	var latest *crmcontracts.ConversationClaim
 	for i := range *page.Claims {
 		claim := &(*page.Claims)[i]
 		if claim.Kind != crmcontracts.CommitmentOurs || claim.Status != crmcontracts.ConversationClaimStatusOpen {
@@ -234,14 +234,14 @@ func oldestOverdueCommitment(now time.Time, page *crmcontracts.Person360) (crmco
 		if !deadline.Passed(claim.DueAt, now) {
 			continue
 		}
-		if oldest == nil || claim.DueAt.Before(*oldest.DueAt) {
-			oldest = claim
+		if latest == nil || claim.DueAt.After(*latest.DueAt) {
+			latest = claim
 		}
 	}
-	if oldest == nil {
+	if latest == nil {
 		return crmcontracts.ConversationClaim{}, false
 	}
-	return *oldest, true
+	return *latest, true
 }
 
 // inboundEvidence names the actual message where the page is showing it, and

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -55,7 +55,7 @@ import (
 // ruleVersion stamps the ladder that selected a moment. It changes whenever a
 // rung's condition or order changes, so the same evidence rendering differently
 // across two clients is visible rather than silent.
-const ruleVersion = "person-moment-ladder-v2"
+const ruleVersion = "person-moment-ladder-v3"
 
 // meetingHorizonHours is how far ahead a meeting is worth preparing for
 // (ADR-0096 D2 rung 1). Three days, not the week the earlier ladder used: a
@@ -188,8 +188,7 @@ func deriveMoment(ctx context.Context, now time.Time, page *crmcontracts.Person3
 var momentLadder = []func(context.Context, time.Time, *crmcontracts.Person360) (crmcontracts.PersonMoment, bool){
 	meetingPrepMoment,      // 1. a meeting within 72 hours
 	reEngagedMoment,        // 2. new inbound after a material quiet period
-	overduePromiseMoment,   // 4. an open commitment of ours is overdue
-	overdueTaskMoment,      // 4b. an open task of ours whose date has passed
+	overduePromiseMoment,   // 4. a promise of ours is past its date, from mail or the task list
 	goneQuietMoment,        // 5. outbound unanswered past the configured rule
 	openPromiseMoment,      // 5b. an open task we owe them, undated or ahead
 	roleChangeMoment,       // 6. a new deal role or material relationship change
@@ -205,7 +204,6 @@ var momentLadderNames = []string{
 	"meeting_prep",
 	"re_engaged",
 	"overdue_promise",
-	"overdue_task",
 	"gone_quiet",
 	"open_promise",
 	"role_change",
@@ -305,46 +303,6 @@ func reEngagedMoment(_ context.Context, now time.Time, page *crmcontracts.Person
 			Destination: &crmcontracts.PersonMomentDestination{
 				Surface: crmcontracts.PersonMomentDestinationSurfaceComposer,
 				Prefill: prefill(map[string]string{prefillIntent: "reply"}),
-			},
-		},
-	}, true
-}
-
-// overduePromiseMoment: WE said we would do something and the date has passed.
-//
-// Ours outranks theirs on purpose. A promise we owe is entirely within the
-// reader's control, and it is the one they would be most embarrassed to
-// discover from the other side.
-func overduePromiseMoment(_ context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
-	claim, ok := oldestOverdueCommitment(now, page)
-	if !ok {
-		return crmcontracts.PersonMoment{}, false
-	}
-	overdue := elapsed.Days(*claim.DueAt, now)
-	evidence := []crmcontracts.PersonMomentEvidence{{
-		Type:       crmcontracts.PersonMomentEvidenceTypeActivity,
-		Id:         &claim.SourceActivityId,
-		Label:      claim.Body,
-		Snippet:    &claim.SourceQuote,
-		ObservedAt: claim.DueAt,
-	}}
-	return crmcontracts.PersonMoment{
-		ClaimKey:            "moment:overdue_promise",
-		Rule:                crmcontracts.PersonMomentRuleOverduePromise,
-		RuleVersion:         ptr(ruleVersion),
-		EvidenceFingerprint: fingerprintOf(evidence),
-		Headline:            fmt.Sprintf("You owe them: %s", claim.Body),
-		WhyNow:              fmt.Sprintf("Promised for a date that passed %d days ago.", overdue),
-		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
-		Evidence:            evidence,
-		FreshnessAt:         claim.DueAt,
-		RecommendedAction: crmcontracts.PersonMomentAction{
-			Kind:  crmcontracts.PersonMomentActionKindDraftReply,
-			Label: "Send it now",
-			State: crmcontracts.PersonMomentActionStateWillConfirm,
-			Destination: &crmcontracts.PersonMomentDestination{
-				Surface: crmcontracts.PersonMomentDestinationSurfaceComposer,
-				Prefill: prefill(map[string]string{prefillIntent: "deliver_commitment", "subject": claim.Body}),
 			},
 		},
 	}, true

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -197,8 +197,8 @@ func TestEveryOfferedActionEitherGoesSomewhereOrSaysWhyItCannot(t *testing.T) {
 				Subject: ptr("Send the MCP whitepaper"), OccurredAt: at(1),
 			}}},
 		},
-		// Rung 4b wants an open task whose date has passed — the same lateness
-		// the claim rung above reads, from the task list instead.
+		// The overdue rung reads BOTH sources; this page reaches it through the
+		// task list, the one above it through a claim.
 		"overdue task": {
 			NextSteps: &struct {
 				Data []crmcontracts.Activity `json:"data"`
@@ -527,8 +527,9 @@ func TestAnOverdueTaskOutranksASilence(t *testing.T) {
 		Page crmcontracts.PageInfo   `json:"page"`
 	}{Data: task(now.Add(-30 * time.Hour))}
 	moment := deriveMoment(readerCtx(), now, late)
-	if moment.Rule != crmcontracts.PersonMomentRuleOverdueTask {
-		t.Errorf("rule = %q, want overdue_task — a promise we are late on outranks their silence", moment.Rule)
+	if moment.Rule != crmcontracts.PersonMomentRuleOverduePromise {
+		t.Errorf("rule = %q, want overdue_promise — a promise we are late on outranks their silence, "+
+			"and one rung covers both places a promise is written down", moment.Rule)
 	}
 	if moment.Headline != "You owe them: Send the signed contract" {
 		t.Errorf("headline = %q, want the overdue promise named", moment.Headline)
@@ -584,5 +585,132 @@ func TestReassigningAPromiseRearmsItsDismissal(t *testing.T) {
 	if theirs.EvidenceFingerprint == ours.EvidenceFingerprint {
 		t.Error("the fingerprint is unchanged across a reassignment, so a dismissal of one card " +
 			"silences the other — the promise disappears exactly when it changes hands")
+	}
+}
+
+// One rung, two sources, and when both are late it shows the promise closest
+// to its deadline. The reader is likeliest to be able to still act on that
+// one, and which source recorded it says nothing about that.
+func TestTheLatestOverduePromiseWinsWhicheverSourceHoldsIt(t *testing.T) {
+	now := time.Now()
+	claimDue := now.Add(-10 * 24 * time.Hour)
+	overdueClaim := []crmcontracts.ConversationClaim{{
+		Kind:             crmcontracts.CommitmentOurs,
+		Status:           crmcontracts.ConversationClaimStatusOpen,
+		Body:             "Send the revised quote",
+		SourceQuote:      "Ich schicke dir das Angebot bis Freitag.",
+		SourceActivityId: openapi_types.UUID(ids.NewV7()),
+		DueAt:            &claimDue,
+	}}
+	pageWith := func(taskDue time.Time) *crmcontracts.Person360 {
+		return &crmcontracts.Person360{
+			Claims: &overdueClaim,
+			NextSteps: &struct {
+				Data []crmcontracts.Activity `json:"data"`
+				Page crmcontracts.PageInfo   `json:"page"`
+			}{Data: []crmcontracts.Activity{{
+				Id: openapi_types.UUID(ids.NewV7()), Kind: "task",
+				Subject: ptr("Send the signed contract"), OccurredAt: now.Add(-72 * time.Hour),
+				DueAt: &taskDue,
+			}}},
+		}
+	}
+
+	// The task is the more recent deadline, so it leads.
+	recent := deriveMoment(readerCtx(), now, pageWith(now.Add(-2*24*time.Hour)))
+	if recent.Rule != crmcontracts.PersonMomentRuleOverduePromise {
+		t.Fatalf("rule = %q, want overdue_promise", recent.Rule)
+	}
+	if recent.Headline != "You owe them: Send the signed contract" {
+		t.Errorf("headline = %q, want the task, whose deadline passed most recently", recent.Headline)
+	}
+
+	// The claim is, so it leads — and it brings the quote a task cannot.
+	older := deriveMoment(readerCtx(), now, pageWith(now.Add(-30*24*time.Hour)))
+	if older.Headline != "You owe them: Send the revised quote" {
+		t.Errorf("headline = %q, want the claim, whose deadline passed most recently", older.Headline)
+	}
+	if older.Evidence[0].Snippet == nil {
+		t.Error("the claim's card carries no quote; the conversation it was read from is the " +
+			"one thing a claim has that a task does not")
+	}
+}
+
+// The rung shows the promise that slipped MOST RECENTLY, and it has to look at
+// all of them to know which that is. Picking the earliest overdue claim and
+// comparing only that one against the tasks named the oldest, least
+// recoverable promise while one that slipped yesterday went unmentioned.
+func TestTheRungLooksPastTheOldestOverduePromise(t *testing.T) {
+	now := time.Now()
+	claimDue := func(days int) *time.Time {
+		at := now.Add(-time.Duration(days) * 24 * time.Hour)
+		return &at
+	}
+	claims := []crmcontracts.ConversationClaim{
+		{
+			Kind: crmcontracts.CommitmentOurs, Status: crmcontracts.ConversationClaimStatusOpen,
+			Body: "Send the ancient quote", SourceQuote: "Bis Montag.",
+			SourceActivityId: openapi_types.UUID(ids.NewV7()), DueAt: claimDue(10),
+		},
+		{
+			Kind: crmcontracts.CommitmentOurs, Status: crmcontracts.ConversationClaimStatusOpen,
+			Body: "Send yesterday's quote", SourceQuote: "Bis gestern.",
+			SourceActivityId: openapi_types.UUID(ids.NewV7()), DueAt: claimDue(1),
+		},
+	}
+	taskDue := now.Add(-5 * 24 * time.Hour)
+	page := &crmcontracts.Person360{
+		Claims: &claims,
+		NextSteps: &struct {
+			Data []crmcontracts.Activity `json:"data"`
+			Page crmcontracts.PageInfo   `json:"page"`
+		}{Data: []crmcontracts.Activity{{
+			Id: openapi_types.UUID(ids.NewV7()), Kind: "task",
+			Subject: ptr("Send the signed contract"), OccurredAt: now.Add(-72 * time.Hour),
+			DueAt: &taskDue,
+		}}},
+	}
+
+	// Yesterday's claim is the most recent slip, ahead of the 5-day task and
+	// the 10-day claim.
+	if got := deriveMoment(readerCtx(), now, page).Headline; got != "You owe them: Send yesterday's quote" {
+		t.Errorf("headline = %q, want the promise that slipped most recently", got)
+	}
+
+	// Among several overdue TASKS the same rule holds.
+	recent := now.Add(-2 * time.Hour)
+	page.NextSteps.Data = append(page.NextSteps.Data, crmcontracts.Activity{
+		Id: openapi_types.UUID(ids.NewV7()), Kind: "task",
+		Subject: ptr("Send this morning's file"), OccurredAt: now.Add(-24 * time.Hour),
+		DueAt: &recent,
+	})
+	if got := deriveMoment(readerCtx(), now, page).Headline; got != "You owe them: Send this morning's file" {
+		t.Errorf("headline = %q, want the task that slipped most recently", got)
+	}
+}
+
+// A dismissal is stored against the claim key, so the key a task's late card
+// carries must not change when the rule around it is renamed — every task a
+// reader had put away would come back on deploy.
+func TestTheLateTaskCardKeepsItsDismissalKey(t *testing.T) {
+	now := time.Now()
+	due := now.Add(-24 * time.Hour)
+	page := &crmcontracts.Person360{
+		NextSteps: &struct {
+			Data []crmcontracts.Activity `json:"data"`
+			Page crmcontracts.PageInfo   `json:"page"`
+		}{Data: []crmcontracts.Activity{{
+			Id: openapi_types.UUID(ids.NewV7()), Kind: "task",
+			Subject: ptr("Send the signed contract"), OccurredAt: now.Add(-72 * time.Hour), DueAt: &due,
+		}}},
+	}
+
+	moment := deriveMoment(readerCtx(), now, page)
+	if moment.ClaimKey != "moment:overdue_task" {
+		t.Errorf("claim key = %q, want moment:overdue_task — dismissals are looked up by exact "+
+			"key, so renaming it un-dismisses every task a reader already put away", moment.ClaimKey)
+	}
+	if moment.Rule != crmcontracts.PersonMomentRuleOverduePromise {
+		t.Errorf("rule = %q, want overdue_promise — one rung covers both sources", moment.Rule)
 	}
 }

--- a/backend/internal/compose/tasklistorder_integration_test.go
+++ b/backend/internal/compose/tasklistorder_integration_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// One task list, two pages. A rep opens the same two promises from the
+// contact and from the account, and they must be in the same order: a list
+// that reorders itself depending on which record you came in through teaches
+// the reader that neither order means anything.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/compose/org360"
+	"github.com/margince/margince/backend/internal/compose/person360"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/modules/comms"
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestBothPagesRankTwoPromisesTheSameWay(t *testing.T) {
+	e := integration.Setup(t)
+	person := seedLinkedPerson(t, e, "beide@kunde.example")
+	org := seedEmployerOf(t, e, person, "Kunde GmbH")
+	due := time.Now().Add(24 * time.Hour).Truncate(time.Microsecond)
+
+	// Both due the same day, so only the tie-break separates them. The one
+	// filed FIRST has waited longest and leads on both pages.
+	older := logTaskDueAt(t, e, person, "Send the signed contract", due, time.Now().Add(-48*time.Hour))
+	logTaskDueAt(t, e, person, "Book the workshop room", due, time.Now().Add(-2*time.Hour))
+
+	personSvc := person360.NewService(e.Pool, e.People, e.Deals, e.Projects,
+		consent.NewStore(InstallationDB(e.Pool)),
+		comms.NewStore(InstallationDB(e.Pool), time.Now, activities.NewStore(InstallationDB(e.Pool))),
+		ai.NewFeedbackStore(InstallationDB(e.Pool)), time.Now)
+	orgSvc := org360.NewService(e.Pool, e.People, e.Deals, e.Projects,
+		approvals.NewService(InstallationDB(e.Pool)), time.Now)
+
+	personPage, err := personSvc.Assemble(e.Admin(), ids.From[ids.PersonKind](person))
+	if err != nil {
+		t.Fatalf("assembling the contact: %v", err)
+	}
+	orgPage, err := orgSvc.Assemble(e.Admin(), ids.From[ids.OrganizationKind](org))
+	if err != nil {
+		t.Fatalf("assembling the account: %v", err)
+	}
+	if personPage.NextSteps == nil || len(personPage.NextSteps.Data) != 2 {
+		t.Fatalf("the contact carries %v tasks, want the two just written", personPage.NextSteps)
+	}
+	if orgPage.NextSteps == nil || len(orgPage.NextSteps.Data) != 2 {
+		t.Fatalf("the account carries %v tasks, want the two just written", orgPage.NextSteps)
+	}
+
+	if got := personPage.NextSteps.Data[0].Id; ids.UUID(got) != older {
+		t.Errorf("the contact leads with %v, want the promise filed first %v", got, older)
+	}
+	if got := orgPage.NextSteps.Data[0].ActivityId; ids.UUID(got) != older {
+		t.Errorf("the account leads with %v, want the same promise the contact leads with (%v) — "+
+			"two lists of one task set that disagree teach the reader that neither order means anything",
+			got, older)
+	}
+}
+
+// seedEmployerOf gives a person an employer, so the account's any-link task
+// read reaches the tasks filed against them.
+func seedEmployerOf(t *testing.T, e *integration.Env, person ids.UUID, name string) ids.UUID {
+	t.Helper()
+	orgID := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO organization (id, owner_id, display_name, name_source, source, captured_by)
+			VALUES ($1, $2, $3, 'domain', 'connector:gmail', 'connector:gmail')`,
+			orgID, e.Rep1, name); err != nil {
+			return err
+		}
+		// An employment is a relationship row, which is the arm the account's
+		// task read walks (activities.OrgLinkedActivityExists).
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO relationship (id, kind, person_id, organization_id, is_current_primary, source, captured_by)
+			VALUES ($1, 'employment', $2, $3, true, 'connector:gmail', 'connector:gmail')`,
+			ids.NewV7(), person, orgID)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding an employer: %v", err)
+	}
+	return orgID
+}
+
+// logTaskDueAt writes one open task through the real writer, filed against a
+// person, with both dates the ordering reads.
+func logTaskDueAt(t *testing.T, e *integration.Env, person ids.UUID, subject string, due, occurred time.Time) ids.UUID {
+	t.Helper()
+	row, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+		Kind: "task", Subject: &subject, DueAt: &due, OccurredAt: &occurred, Source: "manual",
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: person}},
+	})
+	if err != nil {
+		t.Fatalf("logging task %q: %v", subject, err)
+	}
+	return ids.UUID(row.Id)
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -8293,7 +8293,6 @@ const (
 	PersonMomentRuleNothingNeeded    PersonMomentRule = "nothing_needed"
 	PersonMomentRuleOpenPromise      PersonMomentRule = "open_promise"
 	PersonMomentRuleOverduePromise   PersonMomentRule = "overdue_promise"
-	PersonMomentRuleOverdueTask      PersonMomentRule = "overdue_task"
 	PersonMomentRulePublicSignal     PersonMomentRule = "public_signal"
 	PersonMomentRuleReEngaged        PersonMomentRule = "re_engaged"
 	PersonMomentRuleRoleChange       PersonMomentRule = "role_change"
@@ -8316,8 +8315,6 @@ func (e PersonMomentRule) Valid() bool {
 	case PersonMomentRuleOpenPromise:
 		return true
 	case PersonMomentRuleOverduePromise:
-		return true
-	case PersonMomentRuleOverdueTask:
 		return true
 	case PersonMomentRulePublicSignal:
 		return true

--- a/backend/internal/shared/kernel/elapsed/elapsed.go
+++ b/backend/internal/shared/kernel/elapsed/elapsed.go
@@ -41,3 +41,22 @@ func Days(from, to time.Time) int {
 	toDay := to.UTC().Truncate(hoursPerDay * time.Hour)
 	return int(toDay.Sub(fromDay).Hours() / hoursPerDay)
 }
+
+// FullDaysUntil counts whole days of REMAINING TIME from now to a future
+// moment, rounding down. Zero once less than a day is left, whatever the
+// calendar says.
+//
+// The counterpart to Days, and deliberately not the same rule. Days counts
+// calendar boundaries, which is what a reader comparing two DATES does. A
+// deadline is not a date on a wall: a promise due in two hours is due today
+// even when those two hours cross midnight, and counting boundaries called it
+// "due in 1 days" — most evenings in a UTC+7 office. Negative durations
+// return zero, because "due in -1 days" is not a sentence; a caller past the
+// deadline asks deadline.DaysPast instead.
+func FullDaysUntil(now, future time.Time) int {
+	remaining := future.Sub(now)
+	if remaining <= 0 {
+		return 0
+	}
+	return int(remaining.Hours() / hoursPerDay)
+}

--- a/backend/internal/shared/kernel/elapsed/elapsed_test.go
+++ b/backend/internal/shared/kernel/elapsed/elapsed_test.go
@@ -49,3 +49,25 @@ func TestDaysReadsBothMomentsInUTC(t *testing.T) {
 		t.Errorf("48 hours is 2 days however the second moment is zoned, got %d", got)
 	}
 }
+
+// A deadline counts differently from a pair of dates. These pin the boundary
+// where the two rules disagree, which is where the bug was: a promise due in
+// two hours, read across UTC midnight.
+func TestFullDaysUntilCountsRemainingTimeNotCalendarBoundaries(t *testing.T) {
+	// 23:00 UTC, due 01:00 the next day: one calendar boundary, no whole day.
+	now := time.Date(2026, 9, 1, 23, 0, 0, 0, time.UTC)
+	soon := now.Add(2 * time.Hour)
+	if got := elapsed.FullDaysUntil(now, soon); got != 0 {
+		t.Errorf("FullDaysUntil = %d for a deadline two hours away, want 0 — it reads as \"due today\"", got)
+	}
+	if got := elapsed.Days(now, soon); got != 1 {
+		t.Fatalf("Days = %d, want 1; without the calendar rule differing here these two would be one function", got)
+	}
+	if got := elapsed.FullDaysUntil(now, now.Add(50*time.Hour)); got != 2 {
+		t.Errorf("FullDaysUntil = %d for 50 hours out, want 2", got)
+	}
+	// A deadline already past is not "in -1 days"; DaysPast answers that.
+	if got := elapsed.FullDaysUntil(now, now.Add(-time.Hour)); got != 0 {
+		t.Errorf("FullDaysUntil = %d for a past deadline, want 0", got)
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -17066,7 +17066,7 @@ export interface components {
          *     card.
          * @enum {string}
          */
-        PersonMomentRule: "meeting_prep" | "re_engaged" | "job_change" | "overdue_promise" | "overdue_task" | "gone_quiet" | "open_promise" | "role_change" | "public_signal" | "missing_next_step" | "thin_relationship" | "nothing_needed";
+        PersonMomentRule: "meeting_prep" | "re_engaged" | "job_change" | "overdue_promise" | "gone_quiet" | "open_promise" | "role_change" | "public_signal" | "missing_next_step" | "thin_relationship" | "nothing_needed";
         /** @description One thing that actually happened, which the reader can open. */
         PersonMomentEvidence: {
             /** @enum {string} */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6771,7 +6771,6 @@ export const de = {
   "person.moment.rule.re_engaged": "Sie haben sich gemeldet",
   "person.moment.rule.job_change": "Neue Stelle",
   "person.moment.rule.overdue_promise": "Zusage überfällig",
-  "person.moment.rule.overdue_task": "Versprechen überfällig",
   "person.moment.rule.gone_quiet": "Still geworden",
   "person.moment.rule.open_promise": "Offenes Versprechen",
   "person.moment.rule.role_change": "Rolle geändert",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6819,7 +6819,6 @@ export const en = {
   "person.moment.rule.re_engaged": "They came back",
   "person.moment.rule.job_change": "They moved on",
   "person.moment.rule.overdue_promise": "Promise overdue",
-  "person.moment.rule.overdue_task": "Promise overdue",
   "person.moment.rule.gone_quiet": "Gone quiet",
   "person.moment.rule.open_promise": "You owe them",
   "person.moment.rule.role_change": "Role changed",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6697,7 +6697,6 @@ export const vi = {
   "person.moment.rule.re_engaged": "Họ đã quay lại",
   "person.moment.rule.job_change": "Đã đổi việc",
   "person.moment.rule.overdue_promise": "Lời hứa quá hạn",
-  "person.moment.rule.overdue_task": "Lời hứa quá hạn",
   "person.moment.rule.gone_quiet": "Đã im lặng",
   "person.moment.rule.open_promise": "Lời hứa còn mở",
   "person.moment.rule.role_change": "Đã đổi vai trò",

--- a/frontend/src/screens/persontoday.tsx
+++ b/frontend/src/screens/persontoday.tsx
@@ -41,7 +41,6 @@ const MOMENT_RULE_LABEL = {
   re_engaged: "person.moment.rule.re_engaged",
   job_change: "person.moment.rule.job_change",
   overdue_promise: "person.moment.rule.overdue_promise",
-  overdue_task: "person.moment.rule.overdue_task",
   gone_quiet: "person.moment.rule.gone_quiet",
   open_promise: "person.moment.rule.open_promise",
   role_change: "person.moment.rule.role_change",
@@ -71,16 +70,12 @@ function standingTone(rule: PersonMoment["rule"]): StandingTone {
   return rule === "nothing_needed" ? "calm" : "accent";
 }
 
-// The three rules that mean somebody is being kept waiting. A promise past
-// its date is late whether it was read out of an email or filed as a task, so
-// both rungs colour the card the same; a promise not yet due is a live thread,
-// not a warning.
+// The two rules that mean somebody is being kept waiting. A promise past its
+// date is late whether it was read out of an email or filed as a task — one
+// rung covers both — while a promise not yet due is a live thread, not a
+// warning.
 function isLate(rule: PersonMoment["rule"]): boolean {
-  return (
-    rule === "gone_quiet" ||
-    rule === "overdue_promise" ||
-    rule === "overdue_task"
-  );
+  return rule === "gone_quiet" || rule === "overdue_promise";
 }
 
 export function PersonToday({


### PR DESCRIPTION
Two changes to how the product talks about what a record owes.

**1. One task set, one order.** The account's task list and the contact's both put dated tasks before undated ones, earliest first — so they agreed until two tasks shared a date. There each fell back to its own tie-break (the contact to filing order, the account to row id), and the same two promises swapped places depending on which record the reader opened them from. The account now falls through to filing order too. `tasklistorder_integration_test.go` writes two tasks due the same day and asserts both pages lead with the same one; mutation-checked by reverting the ORDER BY.

**2. One rung for a promise past its date.** The ladder had two overdue rungs — one reading commitments an extractor pulled out of a conversation, one reading the task list — ranked apart, so identical lateness outranked a silence from mail and lost to it from a task. `overduePromiseMoment` now reads both and shows whichever promise passed its date most recently, because that is the one still recoverable; a tie goes to the claim, which carries the quote from the conversation the promise was made in. The `overdue_task` rule value is gone from the contract and the ladder version says v3.

**Fixed along the way:** "due in N days" counted UTC calendar boundaries, so a promise due in two hours read "due in 1 days" whenever those hours crossed midnight — most evenings in a UTC+7 office. `elapsed.FullDaysUntil` now counts whole days of remaining time, next to `elapsed.Days` which stays calendar-based for comparing dates, with tests pinning where the two rules differ.

Gates: backend, frontend (5648 unit tests), the full compose integration lane, craft static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task ordering so the contact and account pages show the same promise first when two tasks share a due date, and merges the two overdue-promise moments into one so identical lateness ranks the same whether it came from a conversation claim or a task.

**Behavior**
- The account's task list now uses filing order as its tie-break, matching the contact page; the older promise leads on both.
- The overdue rung now reads both claims and tasks; when both are late, the most recently missed deadline wins, and ties go to the claim because it carries the source quote.
- "Due in N days" now counts whole days of remaining time, so a deadline two hours away reads "Due today" instead of "Due in 1 days" across UTC midnight.

**Breaking change**
- The `overdue_task` rule value is removed from the API contract and translations; `overdue_promise` now covers overdue tasks too.
- The overdue task card keeps its `moment:overdue_task` dismissal key, so existing dismissals are not resurrected.

<sup>Written for commit c371fbc908743b59b733832b04d928f09162a159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified overdue tasks and conversation commitments into a single overdue promise indicator.
  * The most recently due overdue commitment now determines the displayed indicator and supporting details.
  * Improved task ordering consistency when due dates match across contact and account views.
  * Future deadlines now use complete elapsed days for more accurate timing.
* **Updates**
  * Removed the separate overdue-task moment type and label from the application.
  * Overdue conversation commitments now include supporting quote evidence and composer details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->