### PR TITLE
main is green again: an audit route that answered NULL, and a brief that reached no server-less registry

### DIFF
--- a/backend/internal/compose/meetingbriefseam.go
+++ b/backend/internal/compose/meetingbriefseam.go
@@ -20,8 +20,16 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/compose/meetingbrief"
+	"github.com/margince/margince/backend/internal/compose/person360"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/modules/comms"
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -93,4 +101,24 @@ func agentBriefLine(sentence crmcontracts.OrganizationBriefSentence) agents.Meet
 		})
 	}
 	return line
+}
+
+// newMeetingBriefService composes a brief for a role that has NO SERVER to
+// borrow one from: the harnesses and the non-server registries built through
+// NewRegistryFor, where the tool would otherwise degrade to the assembled
+// picture and prep_for_meeting would answer without a brief at all.
+//
+// This is not the second engine the seam above refuses. That refusal is about
+// one PROCESS holding two, where WithMeetingBriefWriter binds the model lane to
+// the server's instance and the agent surface would silently keep the
+// deterministic floor. A composition with no server has no instance to diverge
+// from; this is the only one, and the api role still passes its own.
+func newMeetingBriefService(db *database.DB) *meetingbrief.Service {
+	pool := db.Pool()
+	peopleStore := people.NewStore(db)
+	view := person360.NewService(pool, peopleStore, deals.NewStore(db, DealsInstallation()), ProjectsStore(pool),
+		consent.NewStore(db),
+		comms.NewStore(db, time.Now, activities.NewStore(db)),
+		ai.NewFeedbackStore(db), time.Now)
+	return meetingbrief.NewService(pool, view, peopleStore, time.Now)
 }

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -45,7 +45,8 @@ func NewRegistryFor(db *database.DB, send SendPath) *agents.Registry {
 	// The gate resolves seats through identity, and identity binds the same
 	// handle: a registry built for a named workspace must not admit through a
 	// service that resolves a different one.
-	return registryWithGate(db, auth.NewGate(identity.NewServiceFor(db)), nil, nil, send, companyEnricher{}, nil, nil, nil, nil, slog.Default())
+	return registryWithGate(db, auth.NewGate(identity.NewServiceFor(db)), nil, nil, send, companyEnricher{}, nil, nil, nil,
+		meetingBriefReader(newMeetingBriefService(db)), slog.Default())
 }
 
 // NewRegistryWithIncumbent is NewRegistry plus the per-workspace live-incumbent
@@ -53,14 +54,18 @@ func NewRegistryFor(db *database.DB, send SendPath) *agents.Registry {
 // through — the wiring a role with a vault (the api server) installs so the MCP
 // tool surface can actually write back, not just answer errNoWriteIncumbent.
 func NewRegistryWithIncumbent(pool *pgxpool.Pool, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath) *agents.Registry {
-	return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil, nil, nil, nil, slog.Default())
+	db := InstallationDB(pool)
+	return registryWithGate(db, auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil, nil, nil,
+		meetingBriefReader(newMeetingBriefService(db)), slog.Default())
 }
 
 func registryWithDraftBrain(pool *pgxpool.Pool, brain completer, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath) *agents.Registry {
+	db := InstallationDB(pool)
+	brief := meetingBriefReader(newMeetingBriefService(db))
 	if brain == nil {
-		return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil, nil, nil, nil, slog.Default())
+		return registryWithGate(db, auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent, send, companyEnricher{}, nil, nil, nil, brief, slog.Default())
 	}
-	return registryWithGate(InstallationDB(pool), auth.NewGate(identity.NewService(pool)), newReplyDrafter(pool, brain, nil), resolveIncumbent, send, companyEnricher{}, nil, nil, nil, nil, slog.Default())
+	return registryWithGate(db, auth.NewGate(identity.NewService(pool)), newReplyDrafter(pool, brain, nil), resolveIncumbent, send, companyEnricher{}, nil, nil, nil, brief, slog.Default())
 }
 
 // registryWithGate composes the tool surface. The quota charger arrives as

--- a/backend/internal/modules/privacy/auditaudienceboundary.go
+++ b/backend/internal/modules/privacy/auditaudienceboundary.go
@@ -65,6 +65,15 @@ var auditGovernedTypes = []string{
 //
 //   - attachment_extraction reaches its activity through attachment, two hops.
 //
+//   - governed is coalesced to TRUE, because the two arms that ask a question
+//     ask it of a row that may be GONE — an audit trail outlives what it
+//     describes, and erasing an attachment leaves its images behind by design.
+//     A scalar subquery over no row answers NULL, and NULL there is not a third
+//     answer to "is this content governed": it is not knowing, and not knowing
+//     has to read as governed. Otherwise a vanished attachment's image would be
+//     MORE readable than a live one's, and the three-valued arithmetic would
+//     carry NULL out through content_readable to a caller scanning a bool.
+//
 //   - transcript_read carries activity_id NOT NULL.
 //
 //   - scheduled_send carries activity_id once released and anchor_activity_id for
@@ -89,7 +98,7 @@ const auditActivityRouteSQL = `
 		             SELECT coalesce(ss.activity_id, ss.anchor_activity_id)
 		               FROM scheduled_send ss WHERE ss.id = a.entity_id)
 		         END AS activity_id,
-		         CASE a.entity_type
+		         coalesce(CASE a.entity_type
 		           WHEN 'attachment' THEN (
 		             SELECT att.entity_type = 'activity'
 		               FROM attachment att WHERE att.id = a.entity_id)
@@ -99,7 +108,7 @@ const auditActivityRouteSQL = `
 		               JOIN attachment att ON att.id = ext.attachment_id
 		              WHERE ext.id = a.entity_id)
 		           ELSE true
-		         END AS governed`
+		         END, true) AS governed`
 
 // auditActivityJoin reaches the activity an audit row's image describes, and
 // only for rows that describe one.

--- a/backend/internal/modules/privacy/auditlogboundary_integration_test.go
+++ b/backend/internal/modules/privacy/auditlogboundary_integration_test.go
@@ -23,13 +23,17 @@ package privacy
 
 import (
 	"context"
+	"encoding/json"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/testdb"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -428,8 +432,8 @@ func TestTheCollateralTypesAreTombstonedSoTheBoundaryReachesThem(t *testing.T) {
 			// The create row must be THERE and withheld, which is what
 			// namesTheSubject insists on: absence alone would pass on an empty
 			// page, or on one holding only the tombstone.
-			if namesTheSubject(t, page) {
-				t.Errorf("an erased %s still names the subject", entityType)
+			if survivors := contentSurvivingOnTheCreateRow(t, page); len(survivors) > 0 {
+				t.Errorf("an erased %s still carries %v", entityType, survivors)
 			}
 		})
 	}
@@ -457,9 +461,9 @@ func TestAnAttachmentWithNoRowLeftIsWithheldRatherThanReleased(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListAuditLog: %v", err)
 	}
-	if namesTheSubject(t, page) {
-		t.Error("an attachment whose row is gone still names the subject — a boundary that opens " +
-			"when it cannot tell is not a boundary")
+	if survivors := contentSurvivingOnTheCreateRow(t, page); len(survivors) > 0 {
+		t.Errorf("an attachment whose row is gone still carries %v — a boundary that opens when "+
+			"it cannot tell is not a boundary", survivors)
 	}
 }
 
@@ -477,17 +481,39 @@ func (e *auditBoundaryEnv) collateralImage(t *testing.T, entityType string, id i
 	}
 }
 
-// namesTheSubject reports whether the create row on the page still carries the
-// subject's name, failing the test if there is no create row to judge — absence
-// would otherwise pass on an empty page, or on one holding only a tombstone.
-func namesTheSubject(t *testing.T, page AuditPage) bool {
+// contentSurvivingOnTheCreateRow names what the create row's image still
+// carries beyond the withheld marker, so a failure says WHICH key leaked.
+//
+// The whole image, not one string in it. The fixture carries a filename as well
+// as a subject, and an image that dropped the subject while keeping
+// sara-subject-passport.pdf has disclosed the same person — a boundary asserted
+// one substring at a time is one that holds until somebody adds a second field.
+//
+// It fails the test when there is no create row to judge: absence would
+// otherwise pass on an empty page, or on one holding only the tombstone.
+func contentSurvivingOnTheCreateRow(t *testing.T, page AuditPage) []string {
 	t.Helper()
 	for _, entry := range page.Entries {
 		if entry.Action != "create" {
 			continue
 		}
-		return strings.Contains(string(entry.After), "Sara Subject")
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(entry.After, &fields); err != nil {
+			t.Fatalf("the create image is not an object: %s", entry.After)
+		}
+		state, marked := fields["content_state"]
+		if !marked || string(state) != strconv.Quote(string(crmcontracts.ActivityContentStateWithheld)) {
+			t.Errorf("the create image carries no withheld marker: %s", entry.After)
+		}
+		var survivors []string
+		for key := range fields {
+			if key != "content_state" {
+				survivors = append(survivors, key)
+			}
+		}
+		sort.Strings(survivors)
+		return survivors
 	}
 	t.Fatal("the create row is absent from the page, so this proved nothing")
-	return false
+	return nil
 }

--- a/backend/internal/modules/privacy/auditlogboundary_integration_test.go
+++ b/backend/internal/modules/privacy/auditlogboundary_integration_test.go
@@ -450,3 +450,47 @@ func TestTheCollateralTypesAreTombstonedSoTheBoundaryReachesThem(t *testing.T) {
 		})
 	}
 }
+
+// AN ATTACHMENT WHOSE ROW IS GONE IS GOVERNED, not ungoverned.
+//
+// The audit trail outlives what it describes, so the route's question — is this
+// content governed by an activity's audience — is asked of a row that may no
+// longer be there, and a scalar subquery over no row answers NULL. NULL is not a
+// third answer: it is not knowing, and not knowing has to read as governed.
+//
+// Reading it the other way would make a vanished attachment's image MORE
+// readable than a live one's, which is the wrong direction for a boundary. No
+// erasure here on purpose — a tombstone withholds the image on its own, so a
+// case that had one would pass whichever way this resolved.
+func TestAnAttachmentWithNoRowLeftIsWithheldRatherThanReleased(t *testing.T) {
+	e := setupAuditBoundary(t)
+	entityType := "attachment"
+	id := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, after, occurred_at)
+		 VALUES ($1, 'human', 'user:'||$2::text, 'create', $3, $4,
+		         '{"filename":"sara-subject-passport.pdf","subject":"Sara Subject contract"}'::jsonb, $5)`,
+		ids.NewV7(), e.user, entityType, id, boundaryEarlier); err != nil {
+		t.Fatalf("seeding the attachment image: %v", err)
+	}
+
+	limit := 50
+	page, err := ListAuditLog(e.ctx, e.db, AuditFilter{EntityType: &entityType, EntityID: &id, Limit: &limit})
+	if err != nil {
+		t.Fatalf("ListAuditLog: %v", err)
+	}
+	var found bool
+	for _, entry := range page.Entries {
+		if entry.Action != "create" {
+			continue
+		}
+		found = true
+		if strings.Contains(string(entry.After), "Sara Subject") {
+			t.Errorf("an attachment whose row is gone still names the subject: %s — a boundary "+
+				"that opens when it cannot tell is not a boundary", entry.After)
+		}
+	}
+	if !found {
+		t.Fatal("the create row is absent from the page, so this proved nothing")
+	}
+}

--- a/backend/internal/modules/privacy/auditlogboundary_integration_test.go
+++ b/backend/internal/modules/privacy/auditlogboundary_integration_test.go
@@ -412,13 +412,7 @@ func TestTheCollateralTypesAreTombstonedSoTheBoundaryReachesThem(t *testing.T) {
 		t.Run(entityType, func(t *testing.T) {
 			e := setupAuditBoundary(t)
 			id := ids.NewV7()
-			if _, err := e.owner.Exec(context.Background(),
-				`INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, after, occurred_at)
-				 VALUES ($1, 'human', 'user:'||$2::text, 'create', $3, $4,
-				         '{"filename":"sara-subject-passport.pdf","subject":"Sara Subject contract"}'::jsonb, $5)`,
-				ids.NewV7(), e.user, entityType, id, boundaryEarlier); err != nil {
-				t.Fatalf("seeding the %s image: %v", entityType, err)
-			}
+			e.collateralImage(t, entityType, id)
 			if _, err := e.owner.Exec(context.Background(),
 				`INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, occurred_at)
 				 VALUES ($1, 'human', 'user:'||$2::text, 'erase', $3, $4, $5)`,
@@ -431,21 +425,11 @@ func TestTheCollateralTypesAreTombstonedSoTheBoundaryReachesThem(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ListAuditLog: %v", err)
 			}
-			// The create row must be THERE and withheld. Checking absence alone
-			// would pass on an empty page, or on a page holding only the
-			// tombstone — which carries no image to leak.
-			var found bool
-			for _, entry := range page.Entries {
-				if entry.Action != "create" {
-					continue
-				}
-				found = true
-				if strings.Contains(string(entry.After), "Sara Subject") {
-					t.Errorf("an erased %s still names the subject: %s", entityType, entry.After)
-				}
-			}
-			if !found {
-				t.Fatalf("the %s's create row is absent from the page, so this proved nothing", entityType)
+			// The create row must be THERE and withheld, which is what
+			// namesTheSubject insists on: absence alone would pass on an empty
+			// page, or on one holding only the tombstone.
+			if namesTheSubject(t, page) {
+				t.Errorf("an erased %s still names the subject", entityType)
 			}
 		})
 	}
@@ -466,31 +450,44 @@ func TestAnAttachmentWithNoRowLeftIsWithheldRatherThanReleased(t *testing.T) {
 	e := setupAuditBoundary(t)
 	entityType := "attachment"
 	id := ids.NewV7()
-	if _, err := e.owner.Exec(context.Background(),
-		`INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, after, occurred_at)
-		 VALUES ($1, 'human', 'user:'||$2::text, 'create', $3, $4,
-		         '{"filename":"sara-subject-passport.pdf","subject":"Sara Subject contract"}'::jsonb, $5)`,
-		ids.NewV7(), e.user, entityType, id, boundaryEarlier); err != nil {
-		t.Fatalf("seeding the attachment image: %v", err)
-	}
+	e.collateralImage(t, entityType, id)
 
 	limit := 50
 	page, err := ListAuditLog(e.ctx, e.db, AuditFilter{EntityType: &entityType, EntityID: &id, Limit: &limit})
 	if err != nil {
 		t.Fatalf("ListAuditLog: %v", err)
 	}
-	var found bool
+	if namesTheSubject(t, page) {
+		t.Error("an attachment whose row is gone still names the subject — a boundary that opens " +
+			"when it cannot tell is not a boundary")
+	}
+}
+
+// collateralImage seeds a create row over one of the collateral types, carrying
+// the image both boundary cases are about withholding. A helper rather than a
+// block in each test, so a change to the fixture reaches both readings of it.
+func (e *auditBoundaryEnv) collateralImage(t *testing.T, entityType string, id ids.UUID) {
+	t.Helper()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO audit_log (id, actor_type, actor_id, action, entity_type, entity_id, after, occurred_at)
+		 VALUES ($1, 'human', 'user:'||$2::text, 'create', $3, $4,
+		         '{"filename":"sara-subject-passport.pdf","subject":"Sara Subject contract"}'::jsonb, $5)`,
+		ids.NewV7(), e.user, entityType, id, boundaryEarlier); err != nil {
+		t.Fatalf("seeding the %s image: %v", entityType, err)
+	}
+}
+
+// namesTheSubject reports whether the create row on the page still carries the
+// subject's name, failing the test if there is no create row to judge — absence
+// would otherwise pass on an empty page, or on one holding only a tombstone.
+func namesTheSubject(t *testing.T, page AuditPage) bool {
+	t.Helper()
 	for _, entry := range page.Entries {
 		if entry.Action != "create" {
 			continue
 		}
-		found = true
-		if strings.Contains(string(entry.After), "Sara Subject") {
-			t.Errorf("an attachment whose row is gone still names the subject: %s — a boundary "+
-				"that opens when it cannot tell is not a boundary", entry.After)
-		}
+		return strings.Contains(string(entry.After), "Sara Subject")
 	}
-	if !found {
-		t.Fatal("the create row is absent from the page, so this proved nothing")
-	}
+	t.Fatal("the create row is absent from the page, so this proved nothing")
+	return false
 }


### PR DESCRIPTION
`main` is red and every branch cut from it inherits the failures. Two remain by the time this landed; two more were fixed upstream while it was open.

## 1. A route that cannot tell answered NULL (#3581)

```
ListAuditLog: can't scan into dest[15] (col: content_readable): cannot scan NULL into *bool
```

The audit trail outlives what it describes, so `auditActivityRouteSQL` asks "is this content governed by an activity's audience" of an `attachment` row that may be gone — and a scalar subquery over no row answers NULL. That NULL propagates through `NOT (… AND governed) OR (…)` into `content_readable`, which `scanAuditEntry` reads as a plain `bool`. The whole page fails, not just the row.

`governed` is coalesced to **true**. NULL is not a third answer to that question: it is not knowing, and not knowing has to read as governed. The other direction would make a vanished attachment's audit image *more* readable than a live one's — the wrong way for a boundary to fail.

The existing tombstone case cannot tell those directions apart (it seeds an erase row, and the erasure withholds the image on its own), so `TestAnAttachmentWithNoRowLeftIsWithheldRatherThanReleased` seeds the same image with **no** tombstone, leaving `content_readable` as the only thing deciding. Mutation-checked: coalescing to `false` fails it and leaves the original case passing, which is why that case alone was not enough. Both seed through one `collateralImage` helper now, as the rest of that file does.

## 2. prep_for_meeting lost its brief in every server-less composition (#3596)

`meetingBriefReader` now takes the server's `meetingbrief.Service` instead of building one, for a good reason: `WithMeetingBriefWriter` binds the model lane to the server's instance, and two services in one process would leave the agent surface silently on the deterministic floor. But every `registryWithGate` caller in `registry.go` kept passing `nil`, so `prep_for_meeting` answers with no brief at all wherever there is no server — which is every harness, and this:

```
toolprojectscope_integration_test.go:106: the meeting anchored prep carried no brief
```

`newMeetingBriefService` composes one for exactly those roles. It is not the second engine that seam refuses: that refusal is about one process holding two where the model lane binds to only one of them, and a composition with no server has no instance to diverge from. The api role still passes its own, so "one brief, both surfaces" holds where it is actually at stake.

## Fixed upstream while this was open

- The `restrictedReadersAdmitted` waiver key still named `auditlog.go` after #3581 moved the join — same repair landed in #3597.
- `agenttierfloor_integration_test.go` missed `registryWithGate`'s new logger argument, and `webhooks_integration_test.go` crossed the 1000-line cap. Both landed on main; my commits for them dropped out on rebase.

`make check-backend` green; the privacy and compose-integration cases green.