### PR TITLE
An automation firing re-checks what its owner may read

### DIFF
--- a/backend/internal/compose/integration/webhooks/webhookrevisibility_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhookrevisibility_integration_test.go
@@ -243,6 +243,36 @@ func TestARevocationHoldsAgainstALaterSweepAndReplay(t *testing.T) {
 	}
 }
 
+// assertHTTPReplayActuallyAttempted checks that the API's replay endpoint did
+// more than answer 200.
+//
+// The api role builds its deliverer through a different constructor from the one
+// these suites inject, and a replay that refuses before attempting anything
+// returns the unchanged delivery with exactly that status code — a missing
+// principal resolver is how that happens, now that the visibility re-check needs
+// one. So the assertion is on the ROW: the guarded client cannot reach a
+// loopback receiver, so the attempt fails, but a delivery that was ATTEMPTED is
+// no longer dead_lettered.
+//
+// It lives here rather than beside its caller because the property it defends
+// belongs to the re-check, and nothing else would fail if the wiring regressed.
+func (we *webhookEnv) assertHTTPReplayActuallyAttempted(t *testing.T, subID string) {
+	t.Helper()
+	var deliveries struct {
+		Data []struct {
+			Status string `json:"status"`
+		} `json:"data"`
+	}
+	we.Call(t, "GET", "/v1/webhook-subscriptions/"+subID+"/deliveries", nil, nil, &deliveries)
+	if len(deliveries.Data) != 1 {
+		t.Fatalf("delivery list after the http replay: %+v", deliveries.Data)
+	}
+	if deliveries.Data[0].Status == "dead_lettered" {
+		t.Error("the http replay answered 200 and left the delivery dead_lettered, so it " +
+			"recorded a replay it never attempted")
+	}
+}
+
 // activityEnvelope names an activity subject, whose visibility is the row's own
 // audience rather than anybody's grants.
 func activityEnvelope(wsID ids.UUID, activity ids.UUID) kevents.Envelope {

--- a/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
+++ b/backend/internal/compose/integration/webhooks/webhooks_integration_test.go
@@ -777,22 +777,7 @@ func TestWebhookRetryThenDeadLetterThenReplay(t *testing.T) {
 	if status := we.Call(t, "POST", "/v1/webhook-subscriptions/"+subID+"/deliveries/"+deliveryID+"/replay", nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("http replay → %d, want 200", status)
 	}
-	// 200 alone is not evidence the replay ran. The api role's deliverer is
-	// built by a different constructor from the one this suite injects, and a
-	// replay that refused before attempting anything — a missing principal
-	// resolver is the way that happens, since the visibility re-check needs one
-	// — returns the unchanged delivery with exactly this status code. So assert
-	// the ROW moved: the guarded client cannot reach a loopback receiver, so the
-	// attempt fails, but a delivery that was attempted is no longer
-	// dead_lettered.
-	we.Call(t, "GET", "/v1/webhook-subscriptions/"+subID+"/deliveries", nil, nil, &deliveries)
-	if len(deliveries.Data) != 1 {
-		t.Fatalf("delivery list after the http replay: %+v", deliveries.Data)
-	}
-	if deliveries.Data[0].Status == "dead_lettered" {
-		t.Error("the http replay answered 200 and left the delivery dead_lettered, so it " +
-			"recorded a replay it never attempted")
-	}
+	we.assertHTTPReplayActuallyAttempted(t, subID)
 
 	// Replay the parked delivery through the engine. A system principal
 	// satisfies the gate and the workspace is bound; the direct-engine call

--- a/backend/internal/modules/automation/audiencegate.go
+++ b/backend/internal/modules/automation/audiencegate.go
@@ -44,11 +44,24 @@ import (
 
 // activityEntity is the one entity type whose visibility this gate can answer.
 //
-// Deliberately narrow. Every other subject a firing names is already covered by
-// the object gate next door, because their visibility follows row scope, which
-// IS the owner's grants. The activity is the exception: its audience is written
-// on the row and moves without anybody's grants moving, which is exactly why
-// the object gate cannot see it.
+// Deliberately narrow, and narrow in a way worth stating because two nearby
+// shapes are NOT covered:
+//
+//   - The gate reads ev.Entity, the trigger's subject, never an action's own
+//     Target. Those can differ by design (gate.go's target-scoped arm says so),
+//     and no shipped handler produces an activity target that differs from its
+//     trigger today — people/leadrouting.go passes ev.Entity straight through.
+//     TestNoHandlerTargetsAnActivityAwayFromItsTrigger fails when one appears.
+//   - A signal carries activity-derived evidence with its own visibility
+//     (platform/auth's SignalScopeClause), and a signal-subject firing skips
+//     this gate. No human-owned signal workflow is registered
+//     (compose/workflows.go), so nothing reaches it, and
+//     TestNoCatalogTriggerCarriesASignalSubject fails when one is added.
+//
+// Every other subject's visibility follows row scope, which IS the owner's
+// grants, so the object gate next door already resolves it. The activity is the
+// exception: its audience is written on the row and moves without anybody's
+// grants moving.
 const activityEntity = datasource.EntityType("activity")
 
 // checkOwnerCanReadSubject refuses a firing whose subject the automation's
@@ -93,6 +106,25 @@ func checkOwnerCanReadSubject(ctx context.Context, db *database.DB, resolver aut
 		TeamIDs:     rbac.TeamIDs,
 		Permissions: rbac.Permissions,
 	})
+	// The OBJECT grant first, then the row. This is the order the real read
+	// path runs (activities/audience.go's GetActivityContent) and both halves
+	// are load-bearing: EnsureActivityContentVisibleLive answers row and
+	// audience scope, never whether this principal may read activities at all.
+	//
+	// The two come apart in practice. Every action in the catalog that touches
+	// an activity requires activity.CREATE (catalog_actions.go), and a role's
+	// CRUD verbs are independently editable — so an owner granted create but
+	// not read cannot open the message through the API while their automation
+	// would have fired on it.
+	if err := auth.Require(ownerCtx, "activity", principal.ActionRead); err != nil {
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			return gateDecision{
+				blocked: true,
+				reason:  "the automation's owner may not read messages at all",
+			}, nil
+		}
+		return gateDecision{}, fmt.Errorf("automation: checking the owner's read grant: %w", err)
+	}
 	err = db.Tx(ctx, func(tx pgx.Tx) error {
 		return auth.EnsureActivityContentVisibleLive(ownerCtx, tx, ev.Entity.ID)
 	})

--- a/backend/internal/modules/automation/audiencegate.go
+++ b/backend/internal/modules/automation/audiencegate.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package automation
+
+// The match-time AUDIENCE gate: may the automation's owner read the record
+// this firing is about?
+//
+// gate.go answers a different question and cannot answer this one. It asks
+// whether the owner's RBAC permits the ACTION — an object question, resolved
+// from grants alone, deliberately DB-free. Audience is a property of the ROW,
+// and no grant carries it: a colleague with full activity.update permission
+// still may not read a message limited to its participants.
+//
+// The gap that leaves is not theoretical. Capture emits activity.captured and
+// engagement.reply for a newly captured activity whatever its audience
+// (capture/sinkactivity.go, capture/sinkreply.go), engagement.reply is a
+// configurable trigger (catalog_triggers.go), and every action in the closed
+// catalog writes something a colleague can see — a task, a draft, an approval,
+// a list membership, a notification. So a rep's automation could raise a task
+// about mail they may not read, naming the contact and the moment.
+//
+// Two async peers in this tree already re-check live state at fire time rather
+// than trusting the moment they were queued: scheduled sends rerun their
+// preparation gates (activities/scheduledsendfire.go) and the approvals inbox
+// re-probes its targets (approvals/targetvisibility.go). This is the third.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/authz"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+	"github.com/margince/margince/backend/internal/shared/ports/workflow"
+)
+
+// activityEntity is the one entity type whose visibility this gate can answer.
+//
+// Deliberately narrow. Every other subject a firing names is already covered by
+// the object gate next door, because their visibility follows row scope, which
+// IS the owner's grants. The activity is the exception: its audience is written
+// on the row and moves without anybody's grants moving, which is exactly why
+// the object gate cannot see it.
+const activityEntity = datasource.EntityType("activity")
+
+// checkOwnerCanReadSubject refuses a firing whose subject the automation's
+// owner may not read.
+//
+// It runs under the OWNER's principal, built here from their live RBAC, never
+// under the engine's. The engine binds PrincipalSystem for attribution, and
+// auth.ActivityAudienceArm answers TRUE for a system principal — so a check
+// that inherited the caller's context would pass for every firing and look
+// exactly like a working gate.
+//
+// A firing that names no activity is not this gate's business and proceeds. A
+// system-seeded automation (no owner) likewise: there is no human authority
+// behind it to check, the same reasoning the object gate applies to a zero
+// OwnerID.
+func checkOwnerCanReadSubject(ctx context.Context, db *database.DB, resolver authz.Resolver, ev workflow.Event) (gateDecision, error) {
+	if ev.Entity.Type != activityEntity || ev.Entity.ID.IsZero() {
+		return gateDecision{}, nil
+	}
+	if ev.OwnerID == ids.Nil {
+		return gateDecision{}, nil
+	}
+	if resolver == nil {
+		// A composed engine always carries a resolver (compose/workflows.go);
+		// reaching here is a wiring bug, not a permission question — and it
+		// must not be swallowed into a false "allow".
+		return gateDecision{}, errors.New("automation: audience gate composed with no authz.Resolver")
+	}
+	rbac, err := resolver.EffectiveRBAC(ctx, ev.WorkspaceID, ev.OwnerID)
+	if err != nil {
+		if errors.Is(err, apperrors.ErrNotFound) {
+			// A gone, archived or suspended owner is a real denial, not an
+			// outage — the same honest hard case the object gate handles.
+			return gateDecision{blocked: true, reason: reasonOwnerGone}, nil
+		}
+		return gateDecision{}, fmt.Errorf("automation: resolving the owner's live authority: %w", err)
+	}
+	ownerCtx := principal.WithActor(ctx, principal.Principal{
+		Type:        principal.PrincipalHuman,
+		ID:          "human:" + ev.OwnerID.String(),
+		UserID:      ev.OwnerID,
+		TeamIDs:     rbac.TeamIDs,
+		Permissions: rbac.Permissions,
+	})
+	err = db.Tx(ctx, func(tx pgx.Tx) error {
+		return auth.EnsureActivityContentVisibleLive(ownerCtx, tx, ev.Entity.ID)
+	})
+	switch {
+	case err == nil:
+		return gateDecision{}, nil
+	case errors.Is(err, apperrors.ErrNotFound), errors.Is(err, apperrors.ErrPermissionDenied):
+		// Both mean the same thing here and are deliberately one answer: a row
+		// outside the owner's audience reads as absent, which is how existence
+		// stays hidden. Neither is an error to retry.
+		return gateDecision{
+			blocked: true,
+			reason:  "the automation's owner can no longer read the message this fired on",
+		}, nil
+	default:
+		// Anything else is infrastructure. Surfaced so the firing retries
+		// rather than claiming a terminal blocked row over a blip.
+		return gateDecision{}, fmt.Errorf("automation: re-checking the subject's audience: %w", err)
+	}
+}

--- a/backend/internal/modules/automation/audiencegate_integration_test.go
+++ b/backend/internal/modules/automation/audiencegate_integration_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package automation
+
+// The match-time AUDIENCE gate over a real migrated Postgres.
+//
+// Its sibling next door (gate_integration_test.go) proves the OBJECT gate: the
+// owner's live RBAC still permits the planned action. This proves the other
+// question on the same firing — may the owner READ the record it fired on —
+// and the two fail independently. An owner holding every permission in the
+// tree still may not read a message limited to its participants, and the object
+// gate cannot see that, because no grant carries a row's audience.
+//
+// Every case seeds a real activity and drives HandleEvent. The audience is a
+// column, so a fixture that stubbed it would be asserting its own answer.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	kevents "github.com/margince/margince/backend/internal/shared/kernel/events"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/authz"
+	"github.com/margince/margince/backend/internal/shared/ports/workflow"
+)
+
+// fullyPermittedOwner grants everything the scripted handler's action needs, so
+// the object gate always passes and only the audience can block. A fixture that
+// withheld a permission would prove the wrong gate.
+func fullyPermittedOwner() fixtureResolver {
+	return fixtureResolver{rbac: authz.RBAC{Permissions: principal.Permissions{
+		RowScope: principal.RowScopeAll,
+		Objects: map[string]principal.ObjectGrant{
+			"activity": {Create: true, Read: true, Update: true, Delete: true},
+			"deal":     {Create: true, Read: true, Update: true, Delete: true},
+			"person":   {Create: true, Read: true, Update: true, Delete: true},
+			"lead":     {Create: true, Read: true, Update: true, Delete: true},
+		},
+	}}}
+}
+
+// activityEventFor is a firing naming one activity as its subject, the shape
+// engagement.reply carries (its payload's EntityType() is "activity", and the
+// entity id is the newly captured inbound message).
+func activityEventFor(activity ids.UUID) kevents.Envelope {
+	return kevents.Envelope{
+		EventID:    ids.NewV7(),
+		Type:       scriptedTrigger,
+		OccurredAt: time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC),
+		Entity:     kevents.EntityRef{Type: "activity", ID: activity},
+	}
+}
+
+// seedActivity writes one message with the given audience, captured by SOMEBODY
+// ELSE. Both halves matter: the audience arm admits a row's own capturer
+// (`captured_by LIKE '%:<uuid>'`), so an activity the automation's owner
+// captured is one they may read whatever its audience, and a fixture built that
+// way would pass against a gate that did nothing.
+func (fx *autoFixture) seedActivity(t *testing.T, audience string) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	fx.exec(t, `
+		INSERT INTO activity (id, kind, audience, source, captured_by, occurred_at)
+		VALUES ($1, 'email', $2, 'gmail', 'connector:gmail:'||$3::text, now())`,
+		id, audience, fx.rep2)
+	return id
+}
+
+func TestAFiringOnAMessageTheOwnerCannotReadIsBlocked(t *testing.T) {
+	fx := setupAutomationDB(t)
+	applyCalls := 0
+	handler := scriptedWorkflow{
+		name: "reply_on_held_mail",
+		apply: func(workflow.Event) (workflow.RunResult, error) {
+			applyCalls++
+			return workflow.RunResult{}, nil
+		},
+	}
+	fx.seedAutomationWithOwner(t, handler.name, fx.rep1)
+	held := fx.seedActivity(t, "participants")
+
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)),
+		fullyPermittedOwner())
+	engine.RegisterWorkflow(handler)
+
+	if err := engine.HandleEvent(context.Background(), activityEventFor(held)); err != nil {
+		t.Fatalf("HandleEvent err = %v, want nil — a gate block is a recorded outcome, "+
+			"not a dispatch failure", err)
+	}
+
+	run, ok := fx.runsByHandler(t)[handler.name]
+	if !ok {
+		t.Fatal("no run row recorded for the blocked firing")
+	}
+	if run.status != "blocked" {
+		t.Fatalf("run.status = %q, want %q", run.status, "blocked")
+	}
+	detail, err := parseRunDetail(run.detail)
+	if err != nil {
+		t.Fatalf("parsing run detail: %v", err)
+	}
+	if !strings.Contains(detail.Reason, "read") {
+		t.Errorf("run detail reason = %q, want it to say the owner cannot read the message — "+
+			"a reason naming a permission would send the reader to the wrong gate", detail.Reason)
+	}
+	if applyCalls != 0 {
+		t.Errorf("Apply called %d times, want 0: the firing would have created a task naming "+
+			"a contact and a moment its owner may not read", applyCalls)
+	}
+}
+
+func TestAFiringOnAMessageTheOwnerCanReadProceeds(t *testing.T) {
+	// The admit case. Without it a gate that blocked every firing would pass
+	// every other test in this file.
+	fx := setupAutomationDB(t)
+	applyCalls := 0
+	handler := scriptedWorkflow{
+		name: "reply_on_open_mail",
+		apply: func(workflow.Event) (workflow.RunResult, error) {
+			applyCalls++
+			return workflow.RunResult{}, nil
+		},
+	}
+	fx.seedAutomationWithOwner(t, handler.name, fx.rep1)
+	open := fx.seedActivity(t, "workspace")
+
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)),
+		fullyPermittedOwner())
+	engine.RegisterWorkflow(handler)
+
+	if err := engine.HandleEvent(context.Background(), activityEventFor(open)); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	run, ok := fx.runsByHandler(t)[handler.name]
+	if !ok {
+		t.Fatal("no run row recorded")
+	}
+	if run.status != "applied" {
+		t.Errorf("run.status = %q, want applied: the message is workspace-visible, so the "+
+			"firing must proceed exactly as before", run.status)
+	}
+	if applyCalls != 1 {
+		t.Errorf("Apply called %d times, want 1", applyCalls)
+	}
+}
+
+func TestAFiringOnANonActivitySubjectIsUnaffected(t *testing.T) {
+	// The gate is deliberately narrow: audience is an activity's property, and
+	// every other subject's visibility follows row scope, which the object gate
+	// already resolves. A deal-subject firing must not pay for a check that
+	// cannot apply to it — nor be blocked by one.
+	fx := setupAutomationDB(t)
+	applyCalls := 0
+	handler := scriptedWorkflow{
+		name: "deal_subject",
+		apply: func(workflow.Event) (workflow.RunResult, error) {
+			applyCalls++
+			return workflow.RunResult{}, nil
+		},
+	}
+	fx.seedAutomationWithOwner(t, handler.name, fx.rep1)
+
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)),
+		fullyPermittedOwner())
+	engine.RegisterWorkflow(handler)
+
+	if err := engine.HandleEvent(context.Background(), gateTestEnvelope(fx.ws)); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	if applyCalls != 1 {
+		t.Errorf("Apply called %d times, want 1 — a deal-subject firing is not this gate's "+
+			"business", applyCalls)
+	}
+}
+
+func TestASystemSeededFiringOnHeldMailIsUnaffected(t *testing.T) {
+	// A system-seeded automation stamps no owner_id. There is no human
+	// authority behind it to check, which is the same reasoning the object gate
+	// applies to a zero OwnerID — and the reason this suite's siblings can pass
+	// a nil resolver. Asserting it here is what stops the audience gate
+	// silently disabling the starter automations.
+	fx := setupAutomationDB(t)
+	applyCalls := 0
+	handler := scriptedWorkflow{
+		name: "system_seeded",
+		apply: func(workflow.Event) (workflow.RunResult, error) {
+			applyCalls++
+			return workflow.RunResult{}, nil
+		},
+	}
+	fx.seedAutomation(t, handler.name)
+	held := fx.seedActivity(t, "participants")
+
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), nil)
+	engine.RegisterWorkflow(handler)
+
+	if err := engine.HandleEvent(context.Background(), activityEventFor(held)); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	if applyCalls != 1 {
+		t.Errorf("Apply called %d times, want 1 — a system-seeded automation has no owner "+
+			"whose sight could have narrowed", applyCalls)
+	}
+}
+
+func TestTheAudienceGateDoesNotInheritTheEnginesSystemPrincipal(t *testing.T) {
+	// The failure this gate is one line away from. The engine binds
+	// PrincipalSystem for attribution, and auth.ActivityAudienceArm answers TRUE
+	// for a system principal — so a check that used the caller's context would
+	// admit every firing and look exactly like a working gate.
+	//
+	// Asserted by driving the whole engine, which binds that system principal
+	// before runOne: if the gate inherited it, the held case below would apply.
+	fx := setupAutomationDB(t)
+	applyCalls := 0
+	handler := scriptedWorkflow{
+		name: "not_the_system",
+		apply: func(workflow.Event) (workflow.RunResult, error) {
+			applyCalls++
+			return workflow.RunResult{}, nil
+		},
+	}
+	fx.seedAutomationWithOwner(t, handler.name, fx.rep1)
+	held := fx.seedActivity(t, "participants")
+
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)),
+		fullyPermittedOwner())
+	engine.RegisterWorkflow(handler)
+
+	// A system principal on the INBOUND context too, which is what the bus
+	// consumer carries in production.
+	sysCtx := principal.WithActor(context.Background(),
+		principal.Principal{Type: principal.PrincipalSystem, ID: "system"})
+	if err := engine.HandleEvent(sysCtx, activityEventFor(held)); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	if applyCalls != 0 {
+		t.Error("the firing applied: the audience check ran as the system principal, which " +
+			"reads every row, so it admits every firing while looking like a gate")
+	}
+}

--- a/backend/internal/modules/automation/audiencegate_integration_test.go
+++ b/backend/internal/modules/automation/audiencegate_integration_test.go
@@ -151,6 +151,118 @@ func TestAFiringOnAMessageTheOwnerCanReadProceeds(t *testing.T) {
 	}
 }
 
+func TestAFiringWhoseOwnerCannotReadMessagesAtAllIsBlocked(t *testing.T) {
+	// The object half, which the row half cannot answer.
+	// EnsureActivityContentVisibleLive tests row and audience scope; it never
+	// asks whether this principal may read activities at all. The two come
+	// apart because every catalog action touching an activity requires
+	// activity.CREATE, and a role's CRUD verbs are independently editable — so
+	// an owner granted create but not read cannot open the message through the
+	// API, while a gate checking only the row would fire on it. The activity
+	// here is workspace-visible, so the row half passes and only the grant can
+	// block.
+	fx := setupAutomationDB(t)
+	applyCalls := 0
+	handler := scriptedWorkflow{
+		name: "create_but_not_read",
+		apply: func(workflow.Event) (workflow.RunResult, error) {
+			applyCalls++
+			return workflow.RunResult{}, nil
+		},
+	}
+	fx.seedAutomationWithOwner(t, handler.name, fx.rep1)
+	open := fx.seedActivity(t, "workspace")
+
+	writeOnly := fixtureResolver{rbac: authz.RBAC{Permissions: principal.Permissions{
+		RowScope: principal.RowScopeAll,
+		Objects: map[string]principal.ObjectGrant{
+			"activity": {Create: true, Update: true, Delete: true},
+		},
+	}}}
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)), writeOnly)
+	engine.RegisterWorkflow(handler)
+
+	if err := engine.HandleEvent(context.Background(), activityEventFor(open)); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	run, ok := fx.runsByHandler(t)[handler.name]
+	if !ok {
+		t.Fatal("no run row recorded")
+	}
+	if run.status != "blocked" {
+		t.Errorf("run.status = %q, want blocked: the owner may create activities but not read "+
+			"them, so they cannot see the message this fired on", run.status)
+	}
+	if applyCalls != 0 {
+		t.Errorf("Apply called %d times, want 0", applyCalls)
+	}
+}
+
+func TestAFiringOnAnArchivedMessageIsBlocked(t *testing.T) {
+	// What "Live" buys. EnsureActivityContentVisible admits an archived row;
+	// the Live variant does not. A firing acts NOW, on a record a person can no
+	// longer open, so the strict variant is the right one — and swapping it for
+	// the lenient one is a one-word edit nothing else would notice.
+	fx := setupAutomationDB(t)
+	applyCalls := 0
+	handler := scriptedWorkflow{
+		name: "archived_subject",
+		apply: func(workflow.Event) (workflow.RunResult, error) {
+			applyCalls++
+			return workflow.RunResult{}, nil
+		},
+	}
+	fx.seedAutomationWithOwner(t, handler.name, fx.rep1)
+	archived := fx.seedActivity(t, "workspace")
+	fx.exec(t, `UPDATE activity SET archived_at = now() WHERE id = $1`, archived)
+
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)),
+		fullyPermittedOwner())
+	engine.RegisterWorkflow(handler)
+
+	if err := engine.HandleEvent(context.Background(), activityEventFor(archived)); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	if applyCalls != 0 {
+		t.Error("the firing applied on an archived message: the check admits rows a person " +
+			"can no longer open")
+	}
+}
+
+func TestAFiringOnAMessageTheOwnerCapturedProceeds(t *testing.T) {
+	// The second admit case, and the one that proves the check reads the real
+	// audience arm rather than testing `audience = 'workspace'`. The message is
+	// limited to its participants, but this owner's own mailbox delivered it —
+	// the arm's captured_by clause — so they may read it and the firing runs.
+	fx := setupAutomationDB(t)
+	applyCalls := 0
+	handler := scriptedWorkflow{
+		name: "own_mailbox",
+		apply: func(workflow.Event) (workflow.RunResult, error) {
+			applyCalls++
+			return workflow.RunResult{}, nil
+		},
+	}
+	fx.seedAutomationWithOwner(t, handler.name, fx.rep1)
+	mine := ids.NewV7()
+	fx.exec(t, `
+		INSERT INTO activity (id, kind, audience, source, captured_by, occurred_at)
+		VALUES ($1, 'email', 'participants', 'gmail', 'connector:gmail:'||$2::text, now())`,
+		mine, fx.rep1)
+
+	engine := NewWorkflowEngine(database.BindTo(fx.pool, ids.From[ids.WorkspaceKind](fx.ws)),
+		fullyPermittedOwner())
+	engine.RegisterWorkflow(handler)
+
+	if err := engine.HandleEvent(context.Background(), activityEventFor(mine)); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	if applyCalls != 1 {
+		t.Errorf("Apply called %d times, want 1: the owner's own mailbox delivered this "+
+			"message, so a limited audience still admits them", applyCalls)
+	}
+}
+
 func TestAFiringOnANonActivitySubjectIsUnaffected(t *testing.T) {
 	// The gate is deliberately narrow: audience is an activity's property, and
 	// every other subject's visibility follows row scope, which the object gate

--- a/backend/internal/modules/automation/audiencegatescope_test.go
+++ b/backend/internal/modules/automation/audiencegatescope_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package automation
+
+// What the audience gate does NOT cover, and why that is safe today.
+//
+// The gate reads one thing: the trigger's subject, when it is an activity. Two
+// nearby shapes are outside it, and both are safe only because nothing in the
+// tree currently produces them. A comment saying so would go stale silently —
+// the whole point of the rule that a claim about the tree needs a test — so
+// these assert the conditions rather than describing them.
+
+import (
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+)
+
+func TestNoCatalogTriggerCarriesASignalSubject(t *testing.T) {
+	// A signal's evidence is activity-derived and carries its own visibility
+	// (platform/auth's SignalScopeClause), which the audience gate does not
+	// consult. A trigger that fired on one would fan a signal's evidence into a
+	// task with no check at all.
+	//
+	// Asserted over the closed trigger registry rather than over the handlers,
+	// because the registry is what decides which event types a human-authored
+	// automation can ever be configured for.
+	for _, kind := range AllTriggerKinds() {
+		def, ok := triggerDefs[kind]
+		if !ok {
+			t.Fatalf("trigger %q is in AllTriggerKinds but not in triggerDefs, so this "+
+				"scan reads a smaller registry than exists", kind)
+		}
+		if def.EventType == "" {
+			continue
+		}
+		if entityTypeOfEvent(def.EventType) == "signal" {
+			t.Errorf("trigger %q fires on %q, whose subject is a signal. The audience gate "+
+				"reads activity subjects only, so a signal's activity-derived evidence would "+
+				"reach a firing unchecked — extend the gate before shipping this trigger",
+				kind, def.EventType)
+		}
+	}
+}
+
+// entityTypeOfEvent maps a catalog event type to the entity its envelope names.
+//
+// A small table rather than a contract lookup: the generated payload types live
+// in internal/contracts, which this module does not import, and the four event
+// types the trigger registry pins are the whole corpus. A trigger added with a
+// new event type fails the assertion below rather than passing unclassified.
+func entityTypeOfEvent(eventType string) string {
+	switch eventType {
+	case eventDealStageChanged:
+		return "deal"
+	case eventEngagementReply:
+		return "activity"
+	default:
+		return "unclassified"
+	}
+}
+
+func TestEveryPinnedTriggerEventIsClassified(t *testing.T) {
+	// The census's own guard. TestNoCatalogTriggerCarriesASignalSubject reports
+	// PASS for an event type it cannot classify, so an unclassified one has to
+	// fail here instead — under-recognition is the one way this must not break.
+	classified := 0
+	for _, kind := range AllTriggerKinds() {
+		def := triggerDefs[kind]
+		if def.EventType == "" {
+			continue
+		}
+		classified++
+		if entityTypeOfEvent(def.EventType) == "unclassified" {
+			t.Errorf("trigger %q pins event %q, which entityTypeOfEvent does not know. "+
+				"Classify it: an unknown subject reads as 'not a signal' and passes the "+
+				"scan next door without anybody deciding it should", kind, def.EventType)
+		}
+	}
+	if classified == 0 {
+		t.Fatal("no trigger pins an event type, so both scans in this file read nothing")
+	}
+}
+
+func TestTheGateReadsTheSubjectTheEngineActuallyCarries(t *testing.T) {
+	// activityEntity is compared against workflow.Event.Entity.Type, which is a
+	// datasource.EntityType. If the two vocabularies ever diverge — a rename on
+	// either side — the gate silently matches nothing and every firing passes.
+	// A string constant cannot fail to compile into that shape, so it is
+	// asserted.
+	if activityEntity != datasource.EntityType("activity") {
+		t.Errorf("activityEntity = %q, want %q: the gate compares this against the event's "+
+			"own entity type, and a mismatch admits every firing while looking like a gate",
+			activityEntity, "activity")
+	}
+}

--- a/backend/internal/modules/automation/engine_run.go
+++ b/backend/internal/modules/automation/engine_run.go
@@ -113,6 +113,18 @@ func (e *WorkflowEngine) runOne(ctx context.Context, h workflow.Handler, ev work
 		// claiming a terminal run row over an infrastructure blip.
 		return err
 	}
+	if !decision.blocked {
+		// The match-time AUDIENCE gate (audiencegate.go). The check above asks
+		// whether the owner's grants permit the action; this asks whether they
+		// may read the record it fired on, which no grant answers — an activity
+		// limited to its participants is unreadable to a colleague holding
+		// every permission there is. Second, because a firing the object gate
+		// already refused needs no second reason, and this one costs a query.
+		decision, err = checkOwnerCanReadSubject(ctx, e.db, e.resolver, ev)
+		if err != nil {
+			return err
+		}
+	}
 	if decision.blocked {
 		return e.recordBlocked(ctx, h, ev, plannedJSON, decision.reason)
 	}

--- a/backend/internal/modules/automation/gate.go
+++ b/backend/internal/modules/automation/gate.go
@@ -34,6 +34,12 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/workflow"
 )
 
+// reasonOwnerGone is what both gates say when the owner's authority no longer
+// resolves. One spelling, because the two answer different questions about the
+// same person and a reader comparing two run rows should not have to work out
+// whether two wordings mean the same thing.
+const reasonOwnerGone = "the automation's owner no longer has access"
+
 // gateDecision is the pure, DB-free verdict checkOwnerPermission renders.
 // The zero value means "proceed" — runOne turns a blocked verdict into a
 // durable run row (recordBlocked) and lets a non-nil error (a transient
@@ -74,7 +80,7 @@ func checkOwnerPermission(ctx context.Context, resolver authz.Resolver, ev workf
 		if errors.Is(err, apperrors.ErrNotFound) {
 			// Same honest-hard-case as EffectiveRBAC below: a gone/archived/
 			// suspended owner is a real denial, never an outage.
-			return gateDecision{blocked: true, reason: "the automation's owner no longer has access"}, nil
+			return gateDecision{blocked: true, reason: reasonOwnerGone}, nil
 		}
 		return gateDecision{}, fmt.Errorf("automation: resolving the owner's live seat: %w", err)
 	}
@@ -89,7 +95,7 @@ func checkOwnerPermission(ctx context.Context, resolver authz.Resolver, ev workf
 			// archived, or suspended — never to an empty-but-valid
 			// authority (shared/ports/authz's Resolver doc). That is a
 			// real denial, not an outage.
-			return gateDecision{blocked: true, reason: "the automation's owner no longer has access"}, nil
+			return gateDecision{blocked: true, reason: reasonOwnerGone}, nil
 		}
 		return gateDecision{}, fmt.Errorf("automation: resolving the owner's live authority: %w", err)
 	}


### PR DESCRIPTION
## The leak

Capture emits `activity.captured` and `engagement.reply` for a newly captured activity **whatever its audience** ([sinkactivity.go:135](backend/internal/modules/capture/sinkactivity.go#L135), [sinkreply.go:98](backend/internal/modules/capture/sinkreply.go#L98)). `engagement.reply` is a user-configurable trigger ([catalog_triggers.go:71](backend/internal/modules/automation/catalog_triggers.go#L71)), and every action in the closed catalog writes something a colleague can see — a task, a draft, an approval, a list membership, a notification.

So a rep's automation could raise a task about mail they may not read, naming the contact and the moment.

## Why the existing gate could not catch it

`checkOwnerPermission` asks whether the owner's RBAC permits the **action**. That is an object question, answered from grants alone, and it is deliberately DB-free. **Audience is a property of the row and no grant carries it** — a colleague holding every permission in the tree still may not read a message limited to its participants.

## The build

A second gate beside the first, in its own file because it needs the DB. It runs under the **owner's** principal, built from their live RBAC — never the engine's.

That last point is the whole correctness property. The engine binds `PrincipalSystem` for attribution, and `auth.ActivityAudienceArm` returns `TRUE` for a system principal, so a check that inherited the caller's context would admit every firing **and look exactly like a working gate**.

Narrow on purpose: `activity` only. Every other subject's visibility follows row scope, which the object gate already resolves.

An outage is not a denial — a resolver or query failure surfaces so the firing retries, rather than claiming a terminal `blocked` row over a blip. A gone owner *is* a denial.

## Acceptance

| case | result |
|---|---|
| firing on a `participants` message the owner is not on | `blocked`, reason names reading, Apply never runs |
| firing on a `workspace` message | **applied** — the admit case |
| firing on a deal subject | unaffected |
| system-seeded automation (no owner) on held mail | unaffected |
| the check under an inbound system principal | still blocked |

## Mutation checks, against real Postgres

- Removing the call: the two refusal tests fail, both admit cases stay green.
- Using the caller's context instead of the owner's: `TestTheAudienceGateDoesNotInheritTheEnginesSystemPrincipal` fires with *"the audience check ran as the system principal, which reads every row, so it admits every firing while looking like a gate"*.

## Two things carried along

**`main` is red and this fixes it.** `agenttierfloor_integration_test.go`'s `registryWithGate` call was not updated when the signature gained `MeetingBriefReader` and a logger (#3596), so `internal/compose` fails to typecheck under the integration tag. One argument. I checked for an open fix first; there was none.

**The http-replay assertion from #3597 moved into a helper** beside the re-check it defends, taking `webhooks_integration_test.go` back under the 1000-line test cap. Mutation-checked after the move — a nil resolver still fails it.

## Gates

`make check-backend`, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` green. Integration lane run under a private template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automation firings now re-check whether the owner can read the activity they fire on. Previously the match-time gate only checked whether the owner's RBAC permitted the action, so a firing on a `participants`-limited message the owner isn't on would pass and raise a task naming a contact and moment the owner may not read.

The new gate runs under the owner's live principal, never the engine's system principal (which reads every row and would admit every firing). It verifies both halves of the read path — the owner's `read` grant on `activity` and the row's live audience — so an owner granted create but not read, or a message outside their audience, gets a block. It applies only to `activity` subjects, treats a gone owner as a denial, and surfaces infrastructure errors so the firing retries instead of recording a terminal `blocked` row.

**Bug Fixes**
- Fixes a red `main`: `agenttierfloor_integration_test.go` now passes the `slog.Logger` argument the `registryWithGate` signature gained.

**Refactors**
- Moved the http-replay assertion from `webhooks_integration_test.go` into a helper beside the visibility re-check it defends, bringing the test file back under the 1000-line cap.

<sup>Written for commit e94ca73ce06e29a56bf5cdc3a51e9eb9dedccf5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automations now re-check activity visibility when triggered, preventing dispatch when the owner can no longer access the activity.
  * Workspace-visible activities continue to run, while non-activity events and ownerless system automations remain unaffected.
  * Blocked automation runs now record consistent reasons when an owner is unavailable or lacks access.
* **Tests**
  * Expanded integration coverage for audience checks and verified that webhook replay attempts are actually performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->