### PR TITLE
One reader for every promise a record owes

### DIFF
--- a/backend/internal/compose/person360/claims.go
+++ b/backend/internal/compose/person360/claims.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -36,6 +37,66 @@ func (s *Service) claimsSection(ctx context.Context, tx pgx.Tx, personID ids.Per
 	if err != nil {
 		return err
 	}
-	out.Claims = &claims
+	owed, err := s.openCommitments(ctx, tx, personID, opts)
+	if err != nil {
+		return err
+	}
+	out.Claims = ptr(withOpenCommitments(claims, owed))
 	return nil
 }
+
+// withOpenCommitments returns the display page with any open promise it did
+// not already carry appended.
+//
+// The section shows the newest claims of every kind, capped at sectionCap, and
+// the moment ladder reads that same list. On a record with more than a page of
+// recent claims the two purposes disagree: a promise made in June and due
+// tomorrow is nowhere on the newest page, so the card reports nothing owed
+// while the record owes something this week.
+//
+// Appended rather than merged into the order, because the section's order is
+// its own — newest first is what a reader scrolling the card expects — and the
+// ladder does not read position. It ranks over the whole set through
+// kernel/owedwork.
+func withOpenCommitments(page, owed []crmcontracts.ConversationClaim) []crmcontracts.ConversationClaim {
+	shown := make(map[openapi_types.UUID]bool, len(page))
+	for _, claim := range page {
+		shown[claim.Id] = true
+	}
+	for _, claim := range owed {
+		if !shown[claim.Id] {
+			page = append(page, claim)
+		}
+	}
+	return page
+}
+
+// openCommitments reads the open promises of OURS on this record — a different
+// set from the claims section above, and read separately for that reason.
+//
+// Held by: TestAnOpenPromiseOffTheNewestPageStillReachesTheLadder
+// (claims_commitments_test.go), which fails when a promise the display page
+// cannot carry stops reaching the ladder.
+//
+// The section shows the NEWEST claims of every kind, capped. The moment ladder
+// asks which promise is most urgent, and off that page it cannot tell: a
+// commitment made in June and due tomorrow sits behind twenty-five newer
+// decisions and questions, so the card would report no promise at all on a
+// record that owes one this week.
+//
+// A project scope narrows it the way the section is narrowed. A promise made
+// in another engagement's mail is not this engagement's to show.
+func (s *Service) openCommitments(
+	ctx context.Context, tx pgx.Tx, personID ids.PersonID, opts AssembleOptions,
+) ([]crmcontracts.ConversationClaim, error) {
+	if err := requireRead(ctx, "activity"); err != nil {
+		return nil, err
+	}
+	return s.people.OpenCommitmentsForPerson(ctx, tx, personID, opts.ProjectID, commitmentScanCap)
+}
+
+// commitmentScanCap bounds the promise read behind the moment card. Wider than
+// the display cap because the card ranks over the set rather than showing it:
+// a bound that decided which promise is most urgent would be the read stopping
+// early wearing the ladder's clothes.
+const commitmentScanCap = 200

--- a/backend/internal/compose/person360/claims_commitments_test.go
+++ b/backend/internal/compose/person360/claims_commitments_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package person360
+
+import (
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The commitments card shows the newest claims of every kind, capped, and the
+// moment ladder reads that same list. On a record with more than a page of
+// recent claims those two purposes disagree: a promise made months ago and due
+// tomorrow is nowhere on the newest page, so the card would report nothing
+// owed while the record owes something this week.
+func TestAnOpenPromiseOffTheNewestPageStillReachesTheLadder(t *testing.T) {
+	older := crmcontracts.ConversationClaim{
+		Id:     openapi_types.UUID(ids.NewV7()),
+		Kind:   crmcontracts.CommitmentOurs,
+		Status: crmcontracts.ConversationClaimStatusOpen,
+		Body:   "Send the revised quote",
+	}
+	var newest []crmcontracts.ConversationClaim
+	for range sectionCap {
+		newest = append(newest, crmcontracts.ConversationClaim{
+			Id:     openapi_types.UUID(ids.NewV7()),
+			Kind:   crmcontracts.Decision,
+			Status: crmcontracts.ConversationClaimStatusOpen,
+			Body:   "They picked the annual plan",
+		})
+	}
+
+	got := withOpenCommitments(newest, []crmcontracts.ConversationClaim{older})
+
+	if len(got) != len(newest)+1 {
+		t.Fatalf("carried %d claims, want the page plus the promise it could not show", len(got))
+	}
+	found := false
+	for _, claim := range got {
+		if claim.Id == older.Id {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the open promise is absent; a card ranking over this list would report nothing owed")
+	}
+}
+
+// A promise the display page already carries is not carried twice. The ladder
+// would rank one promise as two, and the commitments card would list it twice.
+func TestAPromiseAlreadyOnThePageIsNotRepeated(t *testing.T) {
+	promise := crmcontracts.ConversationClaim{
+		Id:     openapi_types.UUID(ids.NewV7()),
+		Kind:   crmcontracts.CommitmentOurs,
+		Status: crmcontracts.ConversationClaimStatusOpen,
+		Body:   "Send the questionnaire",
+	}
+	got := withOpenCommitments(
+		[]crmcontracts.ConversationClaim{promise},
+		[]crmcontracts.ConversationClaim{promise},
+	)
+	if len(got) != 1 {
+		t.Errorf("carried %d copies of one promise, want 1", len(got))
+	}
+}

--- a/backend/internal/compose/person360/momentdismissalwalk.go
+++ b/backend/internal/compose/person360/momentdismissalwalk.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package person360
+
+// Walking the ladder past what a reader has already put away.
+//
+// A dismissal silences one CARD. The record still has whatever else it had, so
+// the walk has to keep going — and a rung that speaks for a set has to be asked
+// again rather than passed over, or dismissing one promise would hide the two
+// beside it.
+
+import (
+	"context"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// rungPast asks one rung for the best card its reader has NOT dismissed.
+//
+// A rung answers over a set and returns its top pick, so a dismissal has to be
+// resolved inside the rung rather than around it. This hides the dismissed
+// card from the page the rung reads and asks again, until the rung either
+// names something the reader has not put away or has nothing left to name.
+//
+// Bounded by the promises the page carries: each pass removes the card it just
+// rejected, so the walk is as long as the record's own promise list and no
+// longer.
+func rungPast(
+	ctx context.Context, now time.Time, page *crmcontracts.Person360,
+	rung func(context.Context, time.Time, *crmcontracts.Person360) (crmcontracts.PersonMoment, bool),
+	dismissed func(crmcontracts.PersonMoment) bool,
+) (crmcontracts.PersonMoment, bool) {
+	seen := map[string]bool{}
+	trimmed := *page
+	for {
+		moment, ok := rung(ctx, now, &trimmed)
+		if !ok || seen[moment.ClaimKey] {
+			return crmcontracts.PersonMoment{}, false
+		}
+		if !dismissed(moment) {
+			return moment, true
+		}
+		seen[moment.ClaimKey] = true
+		trimmed = withoutMoment(trimmed, moment)
+	}
+}
+
+// withoutMoment is the page with the rows one moment spoke for removed, so the
+// rung that produced it names its next-best card instead.
+//
+// Only the promise sources are trimmed: those are the rungs that rank over a
+// set a reader dismisses one member of at a time. A rung reading a single fact
+// — the next meeting, the last inbound message — would return the same card
+// again from the same row, so trimming nothing leaves it to the caller's
+// seen-key check and its moment is passed over.
+func withoutMoment(page crmcontracts.Person360, moment crmcontracts.PersonMoment) crmcontracts.Person360 {
+	if len(moment.Evidence) == 0 || moment.Evidence[0].Id == nil {
+		return page
+	}
+	// The evidence names the row the card was built from: the source message
+	// for a claim, the task itself for a task. Matching on it rather than on
+	// the claim key keeps this independent of how a key is spelled.
+	spoken := *moment.Evidence[0].Id
+	if page.Claims != nil {
+		kept := make([]crmcontracts.ConversationClaim, 0, len(*page.Claims))
+		for _, claim := range *page.Claims {
+			if claim.SourceActivityId != spoken || claim.Body != moment.Evidence[0].Label {
+				kept = append(kept, claim)
+			}
+		}
+		page.Claims = &kept
+	}
+	if page.NextSteps != nil {
+		steps := *page.NextSteps
+		kept := make([]crmcontracts.Activity, 0, len(steps.Data))
+		for _, task := range steps.Data {
+			if task.Id != spoken {
+				kept = append(kept, task)
+			}
+		}
+		steps.Data = kept
+		page.NextSteps = &steps
+	}
+	return page
+}

--- a/backend/internal/compose/person360/momentpromise.go
+++ b/backend/internal/compose/person360/momentpromise.go
@@ -254,7 +254,7 @@ func overdueClaimCard(now time.Time, claim crmcontracts.ConversationClaim) crmco
 		ObservedAt: claim.DueAt,
 	}}
 	return crmcontracts.PersonMoment{
-		ClaimKey:            "moment:overdue_promise",
+		ClaimKey:            claimMomentKey("moment:overdue_promise", claim),
 		Rule:                crmcontracts.PersonMomentRuleOverduePromise,
 		RuleVersion:         ptr(ruleVersion),
 		EvidenceFingerprint: fingerprintOf(evidence),
@@ -309,7 +309,7 @@ func openClaimCard(now time.Time, claim crmcontracts.ConversationClaim) crmcontr
 		ObservedAt: claim.OccurredAt,
 	}}
 	return crmcontracts.PersonMoment{
-		ClaimKey:            "moment:open_promise_claim",
+		ClaimKey:            claimMomentKey("moment:open_promise_claim", claim),
 		Rule:                crmcontracts.PersonMomentRuleOpenPromise,
 		RuleVersion:         ptr(ruleVersion),
 		EvidenceFingerprint: fingerprintOf(evidence),
@@ -341,4 +341,29 @@ func openClaimWhyNow(now time.Time, claim crmcontracts.ConversationClaim) string
 		return fmt.Sprintf("Due in %d days.", days)
 	}
 	return "Due today."
+}
+
+// claimMomentKey names WHICH promise a card is about, not merely that it is a
+// promise card.
+//
+// A dismissal is one row per (reader, person, claim key), so a bare rung name
+// would give every promise on a record one shared dismissal: an email that
+// says "I'll send the NDA and the quote" produces two claims, and putting the
+// first away would silence the second the moment it came up. The claim id is
+// what tells them apart.
+//
+// The fingerprint cannot do this job. It hashes the evidence — type, source
+// row and moment — and deliberately ignores the words, so that rewording a
+// promise does not re-arm a dismissal a reader already made. Two claims read
+// out of ONE message share all three, which is exactly the case that needs
+// separating.
+//
+// THIS WIDENS A SHIPPED KEY, and the overdue rung's dismissals do not survive
+// it: a reader who had put an overdue commitment away sees it once more. That
+// is the cost, and it is the cheaper of the two. The collision it removes hides
+// a promise the reader never dismissed, permanently and invisibly — they are
+// never told the second promise exists. A card that comes back is visible and
+// one click to put away again.
+func claimMomentKey(rung string, claim crmcontracts.ConversationClaim) string {
+	return rung + ":" + claim.Id.String()
 }

--- a/backend/internal/compose/person360/momentpromise.go
+++ b/backend/internal/compose/person360/momentpromise.go
@@ -17,31 +17,39 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
 	"github.com/margince/margince/backend/internal/shared/kernel/elapsed"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/owedwork"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// openPromiseMoment: an open task is filed against them and nobody has done
-// it. Dated or not — the transcript reader files "I'll send you the
-// whitepaper" without a date, and it is owed either way.
+// openPromiseMoment: something is owed and its date has not passed. Dated or
+// not — the transcript reader files "I'll send you the whitepaper" without a
+// date, and it is owed either way.
 //
 // Below gone_quiet on purpose: a promise with no clock on it can wait for a
 // day, a contact who stopped answering is already costing something. Above
 // role_change and everything under it, because a thing we said we would do
-// outranks a thing we might do next. The overdue rung above reads claims
-// from correspondence; this one reads the task list, so a promise the reader
-// accepted from a transcript reaches the card the moment it becomes a task.
+// outranks a thing we might do next.
+//
+// BOTH SOURCES, like the overdue rung above it. A promise read out of a
+// conversation and one somebody typed are the same debt, so a claim that is
+// not yet due reaches this card exactly as a task does. Reading only tasks
+// here was how a person owing nothing but an extracted commitment showed
+// "nothing needed" while the commitments card beneath said otherwise.
 func openPromiseMoment(ctx context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
-	task, ok := nearestOpenTask(page)
+	next, ok := owedwork.Soonest(owedPromises(page), now)
 	if !ok {
 		return crmcontracts.PersonMoment{}, false
 	}
-	// A task already past its date is the rung above; this one speaks for the
-	// promises that are undated or still ahead.
-	if deadline.Passed(task.DueAt, now) {
+	switch promise := next.Ref.(type) {
+	case crmcontracts.Activity:
+		return openPromiseFrom(ctx, now, promise), true
+	case crmcontracts.ConversationClaim:
+		return openClaimCard(now, promise), true
+	default:
+		// owedPromises puts only those two types in a Ref; a third would be a
+		// promise this card cannot render rather than one to show blank.
 		return crmcontracts.PersonMoment{}, false
 	}
-	moment := openPromiseFrom(ctx, now, task)
-	return moment, true
 }
 
 // openPromiseFrom is the card both promise rungs show: same headline, same
@@ -135,19 +143,6 @@ func heldByAnother(ctx context.Context, task crmcontracts.Activity) bool {
 	return ids.UUID(*task.AssigneeId) != viewer.UserID
 }
 
-// nearestOpenTask is the section's FIRST row, and the ordering is the
-// section's own: the next-steps read sorts by due date, then filing order
-// (byUrgency in sectionstimeline.go), so the row a reader sees at the top of
-// their task list is the row the card speaks for. Picking a different one
-// here would put the card and the list beneath it in disagreement, and
-// re-sorting the 25 rows this page carries could not see the 26th anyway.
-func nearestOpenTask(page *crmcontracts.Person360) (crmcontracts.Activity, bool) {
-	if page.NextSteps == nil || len(page.NextSteps.Data) == 0 {
-		return crmcontracts.Activity{}, false
-	}
-	return page.NextSteps.Data[0], true
-}
-
 // openPromiseWhyNow says what the date on the promise is, in the reader's
 // terms: a deadline still ahead, one already behind, or none at all.
 func openPromiseWhyNow(now time.Time, task crmcontracts.Activity) string {
@@ -174,51 +169,62 @@ func openPromiseWhyNow(now time.Time, task crmcontracts.Activity) string {
 // the reader should do next. Ranking them apart made identical lateness
 // outrank a silence from one source and lose to it from the other.
 //
-// When both are late the LATER date wins: the promise closest to its
-// deadline is the one still recoverable, and the one a reader is most likely
-// to be able to act on today. A tie goes to the claim, which carries a quote
-// from the conversation the promise was made in.
+// The choice of WHICH late promise to name is kernel/owedwork's, so this card
+// and every other surface answering "what do we owe them?" name the same one.
+// That package states why the latest slip wins and why a tie goes to the claim.
 func overduePromiseMoment(ctx context.Context, now time.Time, page *crmcontracts.Person360) (crmcontracts.PersonMoment, bool) {
-	claim, hasClaim := latestOverdueCommitment(now, page)
-	task, hasTask := latestOverdueTask(now, page)
-	switch {
-	case hasClaim && hasTask:
-		if task.DueAt.After(*claim.DueAt) {
-			return overdueTaskCard(ctx, now, task), true
-		}
-		return overdueClaimCard(now, claim), true
-	case hasClaim:
-		return overdueClaimCard(now, claim), true
-	case hasTask:
-		return overdueTaskCard(ctx, now, task), true
+	slipped, ok := owedwork.MostRecentlySlipped(owedPromises(page), now)
+	if !ok {
+		return crmcontracts.PersonMoment{}, false
+	}
+	switch promise := slipped.Ref.(type) {
+	case crmcontracts.Activity:
+		return overdueTaskCard(ctx, now, promise), true
+	case crmcontracts.ConversationClaim:
+		return overdueClaimCard(now, promise), true
 	default:
+		// owedPromises puts only those two types in a Ref; a third would be a
+		// promise this card cannot render rather than one to show blank.
 		return crmcontracts.PersonMoment{}, false
 	}
 }
 
-// latestOverdueTask is the overdue task whose date passed MOST RECENTLY, which
-// is the one the rung asks for. Not the section's first row: that one is the
-// EARLIEST deadline, so on a record owing three late promises it would name
-// the oldest — the least recoverable — while the one that slipped yesterday
-// went unmentioned.
-func latestOverdueTask(now time.Time, page *crmcontracts.Person360) (crmcontracts.Activity, bool) {
-	if page.NextSteps == nil {
-		return crmcontracts.Activity{}, false
-	}
-	var latest *crmcontracts.Activity
-	for i := range page.NextSteps.Data {
-		task := &page.NextSteps.Data[i]
-		if !deadline.Passed(task.DueAt, now) {
-			continue
+// owedPromises is the page's open promises, from both places one gets written
+// down, in the shape the shared ranking reads.
+//
+// Held by: TestAnUpcomingCommitmentIsTheMomentWithNoTaskFiled and
+// TestTheLatestOverduePromiseWinsWhicheverSourceHoldsIt
+// (internal/compose/person360/moments_test.go), which fail if either source
+// stops reaching the card.
+//
+// A UNION, NOT A JOIN. Nothing writes conversation_claim.task_activity_id, so
+// an extracted commitment and a task about the same thing are two unlinked
+// rows here. A reader who filed a task for a promise an extractor also read
+// may therefore see both, which is the honest answer until that link is
+// written — the alternative is guessing which pairs mean one promise.
+func owedPromises(page *crmcontracts.Person360) []owedwork.Item {
+	var items []owedwork.Item
+	if page.NextSteps != nil {
+		for _, task := range page.NextSteps.Data {
+			items = append(items, owedwork.Item{
+				Ref: task, Source: owedwork.FromTask,
+				DueAt: task.DueAt, FiledAt: task.OccurredAt,
+			})
 		}
-		if latest == nil || task.DueAt.After(*latest.DueAt) {
-			latest = task
+	}
+	if page.Claims != nil {
+		for _, claim := range *page.Claims {
+			if claim.Kind != crmcontracts.CommitmentOurs ||
+				claim.Status != crmcontracts.ConversationClaimStatusOpen {
+				continue
+			}
+			items = append(items, owedwork.Item{
+				Ref: claim, Source: owedwork.FromClaim,
+				DueAt: claim.DueAt, FiledAt: claimFiledAt(claim),
+			})
 		}
 	}
-	if latest == nil {
-		return crmcontracts.Activity{}, false
-	}
-	return *latest, true
+	return items
 }
 
 // overdueTaskCard is the promise card for a late TASK.
@@ -267,4 +273,72 @@ func overdueClaimCard(now time.Time, claim crmcontracts.ConversationClaim) crmco
 			},
 		},
 	}
+}
+
+// claimFiledAt is when the promise was said, for the tie-break between two
+// promises sharing a due date.
+//
+// A claim whose source message carries no moment gets the zero time, which
+// loses every tie rather than inventing one. The alternative — reaching for
+// "now" — would make an undated claim the newest promise on the record on
+// every render, and it would move each time the page was drawn.
+func claimFiledAt(claim crmcontracts.ConversationClaim) time.Time {
+	if claim.OccurredAt == nil {
+		return time.Time{}
+	}
+	return *claim.OccurredAt
+}
+
+// openClaimCard is the card for a promise read out of a conversation whose
+// date has NOT passed, or which carries none.
+//
+// The sibling of overdueClaimCard, and it exists for the same reason
+// openPromiseFrom does: the promise is the same either way, so the two cards
+// differ only in what they say about the date. Both quote the sentence the
+// promise was made in, which is the one thing a claim has and a task does not.
+//
+// No holder marker, unlike the task card. A claim carries no assignee — it
+// records what was said, not who was given it — so it is always the
+// workspace's promise and the reader is the workspace.
+func openClaimCard(now time.Time, claim crmcontracts.ConversationClaim) crmcontracts.PersonMoment {
+	evidence := []crmcontracts.PersonMomentEvidence{{
+		Type:       crmcontracts.PersonMomentEvidenceTypeActivity,
+		Id:         &claim.SourceActivityId,
+		Label:      claim.Body,
+		Snippet:    &claim.SourceQuote,
+		ObservedAt: claim.OccurredAt,
+	}}
+	return crmcontracts.PersonMoment{
+		ClaimKey:            "moment:open_promise_claim",
+		Rule:                crmcontracts.PersonMomentRuleOpenPromise,
+		RuleVersion:         ptr(ruleVersion),
+		EvidenceFingerprint: fingerprintOf(evidence),
+		Headline:            fmt.Sprintf("You owe them: %s", claim.Body),
+		WhyNow:              openClaimWhyNow(now, claim),
+		Confidence:          crmcontracts.PersonMomentConfidenceObservedFact,
+		Evidence:            evidence,
+		FreshnessAt:         claim.OccurredAt,
+		RecommendedAction: crmcontracts.PersonMomentAction{
+			Kind:  crmcontracts.PersonMomentActionKindDraftReply,
+			Label: "Write to them about it",
+			State: crmcontracts.PersonMomentActionStateWillConfirm,
+			Destination: &crmcontracts.PersonMomentDestination{
+				Surface: crmcontracts.PersonMomentDestinationSurfaceComposer,
+				Prefill: prefill(map[string]string{prefillIntent: "deliver_commitment", "subject": claim.Body}),
+			},
+		},
+	}
+}
+
+// openClaimWhyNow says what the date on a promised commitment is. The task
+// rung's sentence, for the source that has no task: a deadline still ahead,
+// or none at all.
+func openClaimWhyNow(now time.Time, claim crmcontracts.ConversationClaim) string {
+	if claim.DueAt == nil {
+		return "Promised in a conversation with no date set. It stays open until you do it or close it."
+	}
+	if days := elapsed.FullDaysUntil(now, *claim.DueAt); days > 0 {
+		return fmt.Sprintf("Due in %d days.", days)
+	}
+	return "Due today."
 }

--- a/backend/internal/compose/person360/momentrules.go
+++ b/backend/internal/compose/person360/momentrules.go
@@ -22,7 +22,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
-	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
 	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
@@ -214,34 +213,6 @@ func bookMeeting() crmcontracts.PersonMomentAction {
 		State:         crmcontracts.PersonMomentActionStateBlocked,
 		BlockedReason: &reason,
 	}
-}
-
-// latestOverdueCommitment finds the promise of OURS that has been late longest.
-//
-// Oldest rather than newest: the one that has been waiting longest is the one
-// with the most damage already done, and the one a reader would be most
-// embarrassed to discover from the other side.
-func latestOverdueCommitment(now time.Time, page *crmcontracts.Person360) (crmcontracts.ConversationClaim, bool) {
-	if page.Claims == nil {
-		return crmcontracts.ConversationClaim{}, false
-	}
-	var latest *crmcontracts.ConversationClaim
-	for i := range *page.Claims {
-		claim := &(*page.Claims)[i]
-		if claim.Kind != crmcontracts.CommitmentOurs || claim.Status != crmcontracts.ConversationClaimStatusOpen {
-			continue
-		}
-		if !deadline.Passed(claim.DueAt, now) {
-			continue
-		}
-		if latest == nil || claim.DueAt.After(*latest.DueAt) {
-			latest = claim
-		}
-	}
-	if latest == nil {
-		return crmcontracts.ConversationClaim{}, false
-	}
-	return *latest, true
 }
 
 // inboundEvidence names the actual message where the page is showing it, and

--- a/backend/internal/compose/person360/moments.go
+++ b/backend/internal/compose/person360/moments.go
@@ -82,16 +82,20 @@ const prefillIntent = "intent"
 //
 // It runs LAST among the sections so it can read what the others gathered.
 func (s *Service) momentsSection(ctx context.Context, tx pgx.Tx, personID ids.PersonID, now time.Time, out *crmcontracts.Person360) error {
-	moment := deriveMoment(ctx, now, out)
-	dismissed, err := s.momentDismissed(ctx, tx, personID, moment)
-	if err != nil {
-		return err
+	var readErr error
+	dismissed := func(moment crmcontracts.PersonMoment) bool {
+		if readErr != nil {
+			return false
+		}
+		put, err := s.momentDismissed(ctx, tx, personID, moment)
+		if err != nil {
+			readErr = err
+		}
+		return put
 	}
-	if dismissed {
-		// Dismissed against THIS evidence. The quiet success state is what the
-		// reader asked for by dismissing, and it is a moment of its own rather
-		// than an empty card.
-		moment = nothingNeededMoment(ctx, now, out)
+	moment := deriveMomentPast(ctx, now, out, dismissed)
+	if readErr != nil {
+		return readErr
 	}
 	withholdLogActivity(ctx, &moment)
 	out.Moment = &moment
@@ -169,9 +173,40 @@ func (s *Service) momentDismissed(ctx context.Context, tx pgx.Tx, personID ids.P
 // inputs this build does not have, and a rule that cannot fire belongs nowhere
 // on the page.
 func deriveMoment(ctx context.Context, now time.Time, page *crmcontracts.Person360) crmcontracts.PersonMoment {
+	return deriveMomentPast(ctx, now, page, func(crmcontracts.PersonMoment) bool { return false })
+}
+
+// deriveMomentPast walks the same ladder and skips the rungs whose card this
+// reader has already put away.
+//
+// A DISMISSAL SILENCES ONE CARD, NOT THE RECORD. Stopping at the first rung
+// and answering "nothing needs you today" when that card was dismissed says
+// something false about everything below it: a reader who puts one promise
+// away is told the contact needs nothing while a second promise sits open.
+// The card they dismissed is the card they meant, and the next reason down is
+// still a reason.
+//
+// A rung that fires and is dismissed is passed over rather than ending the
+// walk, so the ladder's order still decides what the reader sees — they see
+// the highest rung they have NOT put away.
+func deriveMomentPast(
+	ctx context.Context, now time.Time, page *crmcontracts.Person360,
+	dismissed func(crmcontracts.PersonMoment) bool,
+) crmcontracts.PersonMoment {
 	for _, rung := range momentLadder {
-		if moment, ok := rung(ctx, now, page); ok {
-			return moment
+		moment, ok := rung(ctx, now, page)
+		if !ok || !dismissed(moment) {
+			if ok {
+				return moment
+			}
+			continue
+		}
+		// The rung fired and this reader has put THAT card away. Ask it again
+		// without the dismissed card in front of it: a rung speaks for a set —
+		// three open promises, one card — so passing over the rung would hide
+		// the other two along with the one that was dismissed.
+		if next, ok := rungPast(ctx, now, page, rung, dismissed); ok {
+			return next
 		}
 	}
 	// 10. Nothing needs you today. A quiet success state, not a blank card:

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -791,3 +791,111 @@ func TestTheNearestUpcomingPromiseWinsWhicheverSourceHoldsIt(t *testing.T) {
 		t.Errorf("headline = %q, want the claim, whose deadline is nearer", got)
 	}
 }
+
+// Two promises read out of ONE message must be dismissable apart. A dismissal
+// is one row per (reader, person, claim key), so a key naming only the rung
+// would let putting the first away silence the second — a promise the reader
+// never dismissed and is never told about.
+//
+// The fingerprint cannot separate them: it hashes the source row and its
+// moment and ignores the words, which both claims share.
+func TestTwoPromisesFromOneMessageDismissApart(t *testing.T) {
+	now := time.Now()
+	said := now.Add(-24 * time.Hour)
+	source := openapi_types.UUID(ids.NewV7())
+	due := now.Add(48 * time.Hour)
+	claim := func(body string) crmcontracts.ConversationClaim {
+		return crmcontracts.ConversationClaim{
+			Id:               openapi_types.UUID(ids.NewV7()),
+			Kind:             crmcontracts.CommitmentOurs,
+			Status:           crmcontracts.ConversationClaimStatusOpen,
+			Body:             body,
+			SourceQuote:      "Ich schicke Ihnen die Unterlagen.",
+			SourceActivityId: source,
+			DueAt:            &due,
+			OccurredAt:       &said,
+		}
+	}
+
+	nda := openClaimCard(now, claim("Send the NDA"))
+	quote := openClaimCard(now, claim("Send the quote"))
+
+	if nda.ClaimKey == quote.ClaimKey {
+		t.Errorf("both promises carry claim key %q; dismissing one would silence the other", nda.ClaimKey)
+	}
+	if nda.EvidenceFingerprint != quote.EvidenceFingerprint {
+		t.Error("the fingerprints differ, so this test no longer covers the case it was written for: " +
+			"two claims sharing one source message and moment")
+	}
+}
+
+// A dismissal silences ONE card, not the record. A reader who puts one promise
+// away must still be told about the next: stopping at the first rung and
+// answering "nothing needs you today" says something false about every promise
+// below the dismissed one.
+//
+// The rung has to resolve this, not the ladder around it. A rung speaks for a
+// SET — three open promises, one card — so passing over the rung would hide the
+// other two along with the one that was dismissed.
+func TestDismissingOnePromiseShowsTheNext(t *testing.T) {
+	now := time.Now()
+	said := now.Add(-24 * time.Hour)
+	source := openapi_types.UUID(ids.NewV7())
+	claim := func(body string, dueInDays int) crmcontracts.ConversationClaim {
+		due := now.Add(time.Duration(dueInDays) * 24 * time.Hour)
+		return crmcontracts.ConversationClaim{
+			Id:               openapi_types.UUID(ids.NewV7()),
+			Kind:             crmcontracts.CommitmentOurs,
+			Status:           crmcontracts.ConversationClaimStatusOpen,
+			Body:             body,
+			SourceQuote:      "Ich schicke Ihnen beides.",
+			SourceActivityId: source,
+			DueAt:            &due,
+			OccurredAt:       &said,
+		}
+	}
+	page := &crmcontracts.Person360{
+		Claims: &[]crmcontracts.ConversationClaim{claim("Send the NDA", 2), claim("Send the quote", 5)},
+	}
+
+	first := deriveMoment(readerCtx(), now, page)
+	if first.Headline != "You owe them: Send the NDA" {
+		t.Fatalf("headline = %q, want the nearer promise first", first.Headline)
+	}
+
+	// The reader puts that one away. The second promise is untouched.
+	next := deriveMomentPast(readerCtx(), now, page, func(m crmcontracts.PersonMoment) bool {
+		return m.ClaimKey == first.ClaimKey
+	})
+	if next.Rule == crmcontracts.PersonMomentRuleNothingNeeded {
+		t.Fatal("dismissing one promise reported the contact as needing nothing, " +
+			"while a second promise is still open")
+	}
+	if next.Headline != "You owe them: Send the quote" {
+		t.Errorf("headline = %q, want the promise the reader has not dismissed", next.Headline)
+	}
+}
+
+// With every promise dismissed there IS nothing left, and the quiet success
+// state is the honest answer rather than a card the reader already put away.
+func TestDismissingEveryPromiseReachesTheQuietState(t *testing.T) {
+	now := time.Now()
+	said := now.Add(-24 * time.Hour)
+	due := now.Add(48 * time.Hour)
+	page := &crmcontracts.Person360{
+		Claims: &[]crmcontracts.ConversationClaim{{
+			Id:               openapi_types.UUID(ids.NewV7()),
+			Kind:             crmcontracts.CommitmentOurs,
+			Status:           crmcontracts.ConversationClaimStatusOpen,
+			Body:             "Send the NDA",
+			SourceQuote:      "Ich schicke die NDA.",
+			SourceActivityId: openapi_types.UUID(ids.NewV7()),
+			DueAt:            &due,
+			OccurredAt:       &said,
+		}},
+	}
+	got := deriveMomentPast(readerCtx(), now, page, func(crmcontracts.PersonMoment) bool { return true })
+	if got.Rule != crmcontracts.PersonMomentRuleNothingNeeded {
+		t.Errorf("rule = %q, want nothing_needed once every card is dismissed", got.Rule)
+	}
+}

--- a/backend/internal/compose/person360/moments_test.go
+++ b/backend/internal/compose/person360/moments_test.go
@@ -716,3 +716,78 @@ func TestTheLateTaskCardKeepsItsDismissalKey(t *testing.T) {
 		t.Errorf("rule = %q, want overdue_promise — one rung covers both sources", moment.Rule)
 	}
 }
+
+// A promise read out of a conversation is owed whether or not anybody typed it
+// as a task. Before the two sources shared one reader this rung looked only at
+// the task list, so a person owing nothing but an extracted commitment was
+// told "nothing needs you today" while the commitments card beneath the fold
+// listed the promise.
+func TestAnUpcomingCommitmentIsTheMomentWithNoTaskFiled(t *testing.T) {
+	now := time.Now()
+	due := now.Add(3 * 24 * time.Hour)
+	said := now.Add(-48 * time.Hour)
+	page := &crmcontracts.Person360{
+		Claims: &[]crmcontracts.ConversationClaim{{
+			Kind:             crmcontracts.CommitmentOurs,
+			Status:           crmcontracts.ConversationClaimStatusOpen,
+			Body:             "Send the security questionnaire",
+			SourceQuote:      "Ich schicke Ihnen den Fragebogen diese Woche.",
+			SourceActivityId: openapi_types.UUID(ids.NewV7()),
+			DueAt:            &due,
+			OccurredAt:       &said,
+		}},
+	}
+
+	moment := deriveMoment(readerCtx(), now, page)
+
+	if moment.Rule != crmcontracts.PersonMomentRuleOpenPromise {
+		t.Fatalf("rule = %q, want open_promise; a commitment nobody typed as a task is still owed", moment.Rule)
+	}
+	if moment.Headline != "You owe them: Send the security questionnaire" {
+		t.Errorf("headline = %q, want the promise itself", moment.Headline)
+	}
+	if moment.Evidence[0].Snippet == nil {
+		t.Error("the card carries no quote; the sentence the promise was made in is what a claim has")
+	}
+	if moment.WhyNow != "Due in 3 days." {
+		t.Errorf("why-now = %q, want the deadline still ahead", moment.WhyNow)
+	}
+}
+
+// The not-yet-due rung ranks its two sources by date alone, exactly as the
+// overdue rung above it does. A nearer task beats a further commitment and the
+// reverse, so which table a promise sits in never decides what a reader is
+// shown next.
+func TestTheNearestUpcomingPromiseWinsWhicheverSourceHoldsIt(t *testing.T) {
+	now := time.Now()
+	said := now.Add(-48 * time.Hour)
+	pageWith := func(claimDays, taskDays int) *crmcontracts.Person360 {
+		claimDue := now.Add(time.Duration(claimDays) * 24 * time.Hour)
+		taskDue := now.Add(time.Duration(taskDays) * 24 * time.Hour)
+		return &crmcontracts.Person360{
+			Claims: &[]crmcontracts.ConversationClaim{{
+				Kind:             crmcontracts.CommitmentOurs,
+				Status:           crmcontracts.ConversationClaimStatusOpen,
+				Body:             "Send the questionnaire",
+				SourceQuote:      "Diese Woche.",
+				SourceActivityId: openapi_types.UUID(ids.NewV7()),
+				DueAt:            &claimDue,
+				OccurredAt:       &said,
+			}},
+			NextSteps: &struct {
+				Data []crmcontracts.Activity `json:"data"`
+				Page crmcontracts.PageInfo   `json:"page"`
+			}{Data: []crmcontracts.Activity{{
+				Id: openapi_types.UUID(ids.NewV7()), Kind: "task",
+				Subject: ptr("Book the workshop"), OccurredAt: said, DueAt: &taskDue,
+			}}},
+		}
+	}
+
+	if got := deriveMoment(readerCtx(), now, pageWith(9, 2)).Headline; got != "You owe them: Book the workshop" {
+		t.Errorf("headline = %q, want the task, whose deadline is nearer", got)
+	}
+	if got := deriveMoment(readerCtx(), now, pageWith(2, 9)).Headline; got != "You owe them: Send the questionnaire" {
+		t.Errorf("headline = %q, want the claim, whose deadline is nearer", got)
+	}
+}

--- a/backend/internal/modules/people/conversationclaim.go
+++ b/backend/internal/modules/people/conversationclaim.go
@@ -186,6 +186,36 @@ func claimSourceWithinProject(projectPos int) string {
 // whose source the caller may not read is not returned, because the claim
 // would otherwise quote a message the reader has no grant for.
 func (s *Store) ClaimsForPerson(ctx context.Context, tx pgx.Tx, personID ids.PersonID, within *ids.ProjectID, limit int) ([]crmcontracts.ConversationClaim, error) {
+	return s.readClaims(ctx, tx, personID, within, sqlAlwaysVisible, "c.created_at DESC", limit)
+}
+
+// OpenCommitmentsForPerson reads the open promises WE made to this person,
+// soonest deadline first with the undated behind them.
+//
+// A DIFFERENT QUESTION FROM ClaimsForPerson, which is why it is a second entry
+// point and not a filter the caller applies afterwards. That read answers
+// "what has been said on this record lately" — every kind of claim, newest
+// first, capped for display. This one answers "what do we owe them, most
+// urgent first", and the two disagree exactly where it matters: a commitment
+// made in June and due tomorrow sits far below the newest twenty-five rows, so
+// a caller filtering that page finds no promise on a record that owes one this
+// week.
+//
+// Same statement, same gates, same scan — only the filter and the order move.
+// Two spellings of one read is how the two end up disagreeing about which
+// claims exist.
+func (s *Store) OpenCommitmentsForPerson(ctx context.Context, tx pgx.Tx, personID ids.PersonID, within *ids.ProjectID, limit int) ([]crmcontracts.ConversationClaim, error) {
+	const open = `c.kind = 'commitment_ours' AND c.status = 'open' AND NOT c.needs_review`
+	return s.readClaims(ctx, tx, personID, within, open, "c.due_at ASC NULLS LAST, a.occurred_at ASC, c.id", limit)
+}
+
+// readClaims is the read both entry points share. `extra` narrows the
+// rows and `order` ranks them; both are compile-time literals from this file,
+// never anything off a request.
+func (s *Store) readClaims(
+	ctx context.Context, tx pgx.Tx, personID ids.PersonID, within *ids.ProjectID,
+	extra, order string, limit int,
+) ([]crmcontracts.ConversationClaim, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	personPos := arg(personID)
@@ -206,9 +236,9 @@ func (s *Store) ClaimsForPerson(ctx context.Context, tx pgx.Tx, personID ids.Per
 		       c.corrected_at, c.task_activity_id
 		FROM conversation_claim c
 		JOIN activity a ON a.id = c.source_activity_id AND a.archived_at IS NULL
-		WHERE c.person_id = $%d AND c.archived_at IS NULL AND (%s) AND %s
-		ORDER BY c.created_at DESC
-		LIMIT %d`, personPos, scope, filed, limit), args...)
+		WHERE c.person_id = $%d AND c.archived_at IS NULL AND (%s) AND %s AND (%s)
+		ORDER BY %s
+		LIMIT %d`, personPos, scope, filed, extra, order, limit), args...)
 	if err != nil {
 		return nil, fmt.Errorf("read the conversation claims: %w", err)
 	}

--- a/backend/internal/shared/kernel/owedwork/owedwork.go
+++ b/backend/internal/shared/kernel/owedwork/owedwork.go
@@ -57,6 +57,11 @@ type Item struct {
 	DueAt *time.Time
 	// FiledAt is when the promise was made. It breaks ties between two items
 	// sharing a due date, and orders the undated ones among themselves.
+	//
+	// The zero time means "not known", and it LOSES every tie rather than
+	// winning one. A caller whose row carries no moment must leave this zero:
+	// the zero time is before every real one, so ordering on it naively would
+	// make the promise nobody can date the oldest thing on the record.
 	FiledAt time.Time
 }
 
@@ -157,14 +162,35 @@ func Sorted(items []Item, now time.Time) []Item {
 func beforeInQueue(a, b Item) bool {
 	switch {
 	case a.DueAt == nil && b.DueAt == nil:
-		return a.FiledAt.Before(b.FiledAt)
+		return filedEarlier(a, b)
 	case a.DueAt == nil:
 		return false
 	case b.DueAt == nil:
 		return true
 	case a.DueAt.Equal(*b.DueAt):
-		return a.FiledAt.Before(b.FiledAt)
+		return filedEarlier(a, b)
 	default:
 		return a.DueAt.Before(*b.DueAt)
+	}
+}
+
+// filedEarlier reports whether a was promised before b, with an unknown moment
+// losing to a known one.
+//
+// The zero time is before every real time, so comparing it directly would rank
+// the promise nobody can date as the oldest on the record — first in a queue
+// ordered oldest-first, on the strength of a timestamp that is missing rather
+// than early. An unknown moment sorts last instead, and two unknowns are equal
+// so the caller's own order survives the stable sort.
+func filedEarlier(a, b Item) bool {
+	switch {
+	case a.FiledAt.IsZero() && b.FiledAt.IsZero():
+		return false
+	case a.FiledAt.IsZero():
+		return false
+	case b.FiledAt.IsZero():
+		return true
+	default:
+		return a.FiledAt.Before(b.FiledAt)
 	}
 }

--- a/backend/internal/shared/kernel/owedwork/owedwork.go
+++ b/backend/internal/shared/kernel/owedwork/owedwork.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package owedwork ranks the promises a record is carrying, whichever of the
+// two places they were written down.
+//
+// THE PRODUCT DECISION THIS ENCODES: a promise made in a conversation and a
+// promise somebody typed as a task are the SAME THING to a reader. Where it
+// was recorded is a fact about this system, not about what is owed. Every
+// surface that answers "what do we owe them?" therefore ranks both sources by
+// one rule, and this package is that rule.
+//
+// WHY A PACKAGE RATHER THAN A HELPER ON ONE SIDE. The two sources live in
+// tables owned by different modules — `activity` in activities,
+// `conversation_claim` in people — and a module never imports a sibling, so
+// neither side can host a comparison over both. Ranking them is not a
+// database question anyway: it is a pure function of due dates, and putting it
+// where every tier may import it is what stops the next surface from writing a
+// third spelling.
+//
+// Stdlib only, by the shared tier's rule. That is also why the type below is
+// this package's own rather than the wire contract's: a caller maps its rows in
+// and reads the ranking out, and the contract stays where it belongs.
+package owedwork
+
+import (
+	"sort"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
+)
+
+// Source names where a promise was written down. It travels with the item
+// because a surface renders the two differently — a claim can quote the
+// sentence it was read from, a task cannot — even though both rank alike.
+type Source string
+
+const (
+	// FromClaim is a promise an extractor read out of a captured conversation.
+	FromClaim Source = "claim"
+	// FromTask is a promise somebody filed as a task.
+	FromTask Source = "task"
+)
+
+// Item is one thing owed, reduced to what ranking needs. A caller keeps its
+// own row and uses Ref to find it again.
+type Item struct {
+	// Ref identifies the caller's row. This package never reads it — it only
+	// hands it back — so a caller may put an id, an index, or the row itself
+	// behind an interface value in it.
+	Ref any
+	// Source is which of the two places this promise was recorded.
+	Source Source
+	// DueAt is the promised moment, or nil where none was set. An undated
+	// promise is real work that is not yet late, which is what NotYetDue and
+	// Overdue between them say.
+	DueAt *time.Time
+	// FiledAt is when the promise was made. It breaks ties between two items
+	// sharing a due date, and orders the undated ones among themselves.
+	FiledAt time.Time
+}
+
+// Overdue reports whether this promise is behind its date. Undated work is
+// never overdue: nothing with no date can have missed it.
+func (i Item) Overdue(now time.Time) bool { return deadline.Passed(i.DueAt, now) }
+
+// MostRecentlySlipped is the overdue promise whose date passed LAST, and
+// whether any is overdue at all.
+//
+// The latest slip rather than the oldest, and the choice matters on a record
+// owing several. The one that went past yesterday is the one still
+// recoverable — an apology today is worth something, and the reader can
+// plausibly deliver it. The promise three months late has already done its
+// damage, and naming it first sends a reader to the one thing they cannot
+// rescue while the rescuable one goes unmentioned.
+//
+// A tie goes to the CLAIM, because a claim carries the sentence the promise
+// was made in and a task carries only what somebody retyped. Shown a choice
+// between two equally late promises, the one that can quote itself is the one
+// a reader can act on without going to look it up.
+func MostRecentlySlipped(items []Item, now time.Time) (Item, bool) {
+	var best Item
+	found := false
+	for _, item := range items {
+		if !item.Overdue(now) {
+			continue
+		}
+		if !found || slippedLater(item, best) {
+			best, found = item, true
+		}
+	}
+	return best, found
+}
+
+// slippedLater reports whether a beats b for the most-recently-slipped seat.
+// Both are known overdue, so both due dates are set.
+func slippedLater(a, b Item) bool {
+	if a.DueAt.Equal(*b.DueAt) {
+		return a.Source == FromClaim && b.Source != FromClaim
+	}
+	return a.DueAt.After(*b.DueAt)
+}
+
+// Soonest is the promise a reader should do next among those NOT yet late,
+// and whether there is one.
+//
+// The nearest deadline first, then the undated ones. An undated promise sorts
+// behind every dated one rather than being dropped: "I'll send you the
+// whitepaper" with no date is owed, and a queue that silently excludes it
+// tells a reader they are clear when they are not. Among the undated, the
+// oldest promise comes first — it has been waiting longest.
+func Soonest(items []Item, now time.Time) (Item, bool) {
+	var best Item
+	found := false
+	for _, item := range items {
+		if item.Overdue(now) {
+			continue
+		}
+		if !found || beforeInQueue(item, best) {
+			best, found = item, true
+		}
+	}
+	return best, found
+}
+
+// Sorted returns the items in the order every surface shows them: overdue
+// first, most recently slipped at the top, then the rest by nearest deadline
+// with the undated behind them.
+//
+// The overdue block leads because lateness is the thing a reader must be told
+// about, and it is ordered by the same rule MostRecentlySlipped applies, so
+// the card at the top of a page and the first row of the list beneath it name
+// the same promise. Two surfaces disagreeing about "what first" was the defect
+// this package exists to remove.
+//
+// The sort is stable, so items this rule considers equal keep the order the
+// caller read them in rather than shuffling between two renders of one page.
+func Sorted(items []Item, now time.Time) []Item {
+	out := make([]Item, len(items))
+	copy(out, items)
+	sort.SliceStable(out, func(a, b int) bool {
+		x, y := out[a], out[b]
+		xLate, yLate := x.Overdue(now), y.Overdue(now)
+		if xLate != yLate {
+			return xLate
+		}
+		if xLate {
+			return slippedLater(x, y)
+		}
+		return beforeInQueue(x, y)
+	})
+	return out
+}
+
+// beforeInQueue orders two promises that are not yet late: nearest deadline
+// first, undated last, oldest promise first among the undated.
+func beforeInQueue(a, b Item) bool {
+	switch {
+	case a.DueAt == nil && b.DueAt == nil:
+		return a.FiledAt.Before(b.FiledAt)
+	case a.DueAt == nil:
+		return false
+	case b.DueAt == nil:
+		return true
+	case a.DueAt.Equal(*b.DueAt):
+		return a.FiledAt.Before(b.FiledAt)
+	default:
+		return a.DueAt.Before(*b.DueAt)
+	}
+}

--- a/backend/internal/shared/kernel/owedwork/owedwork_test.go
+++ b/backend/internal/shared/kernel/owedwork/owedwork_test.go
@@ -230,3 +230,35 @@ func TestNoPromisesIsNoAnswer(t *testing.T) {
 		t.Errorf("sorted an empty record into %d rows", len(got))
 	}
 }
+
+// A promise whose filing moment is unknown must not win the "oldest first"
+// tie-break on the strength of a missing timestamp. The zero time is before
+// every real one, so comparing it directly ranks the one promise nobody can
+// date as the longest-waiting thing on the record.
+func TestAnUnknownFilingMomentLosesTheTieBreak(t *testing.T) {
+	unknown := owedwork.Item{Ref: "undatedSource", Source: owedwork.FromClaim}
+	known := undated("waitingSinceTuesday", 3, owedwork.FromClaim)
+
+	for _, order := range [][]owedwork.Item{{unknown, known}, {known, unknown}} {
+		got, ok := owedwork.Soonest(order, now)
+		if !ok {
+			t.Fatal("two open promises and none was named")
+		}
+		if ref := refOf(t, got); ref != "waitingSinceTuesday" {
+			t.Errorf("named %q; a promise with no filing moment loses to one that has it", ref)
+		}
+	}
+}
+
+// Two promises whose filing moments are both unknown are equal, so the stable
+// sort keeps the order the caller read them in rather than shuffling them
+// between two renders of one page.
+func TestTwoUnknownFilingMomentsKeepTheirOrder(t *testing.T) {
+	first := owedwork.Item{Ref: "first", Source: owedwork.FromClaim}
+	second := owedwork.Item{Ref: "second", Source: owedwork.FromClaim}
+	sorted := owedwork.Sorted([]owedwork.Item{first, second}, now)
+	if refOf(t, sorted[0]) != "first" || refOf(t, sorted[1]) != "second" {
+		t.Errorf("order became %q, %q; two undatable promises must keep the caller's order",
+			refOf(t, sorted[0]), refOf(t, sorted[1]))
+	}
+}

--- a/backend/internal/shared/kernel/owedwork/owedwork_test.go
+++ b/backend/internal/shared/kernel/owedwork/owedwork_test.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package owedwork_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/owedwork"
+)
+
+var now = time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+
+// at builds a promise due the given number of days from now, negative for
+// late. The ref is the caller's own handle, and every assertion below reads it
+// rather than comparing whole items — which is what a surface does.
+func at(ref string, days int, source owedwork.Source) owedwork.Item {
+	due := now.AddDate(0, 0, days)
+	return owedwork.Item{Ref: ref, Source: source, DueAt: &due, FiledAt: now.AddDate(0, 0, -30)}
+}
+
+func undated(ref string, filedDaysAgo int, source owedwork.Source) owedwork.Item {
+	return owedwork.Item{Ref: ref, Source: source, FiledAt: now.AddDate(0, 0, -filedDaysAgo)}
+}
+
+func refOf(t *testing.T, item owedwork.Item) string {
+	t.Helper()
+	ref, ok := item.Ref.(string)
+	if !ok {
+		t.Fatalf("ref is %T, not the string the test put in", item.Ref)
+	}
+	return ref
+}
+
+// The rule that made this package necessary: a claim and a task rank by their
+// dates alone. Given the same date, the answer may not depend on which table
+// the promise was read from.
+func TestSourceDoesNotChangeTheRanking(t *testing.T) {
+	asClaim := []owedwork.Item{at("late", -5, owedwork.FromClaim), at("later", -1, owedwork.FromTask)}
+	asTask := []owedwork.Item{at("late", -5, owedwork.FromTask), at("later", -1, owedwork.FromClaim)}
+
+	fromClaims, ok := owedwork.MostRecentlySlipped(asClaim, now)
+	if !ok {
+		t.Fatal("two overdue promises and none was named")
+	}
+	fromTasks, ok := owedwork.MostRecentlySlipped(asTask, now)
+	if !ok {
+		t.Fatal("two overdue promises and none was named")
+	}
+	if got, want := refOf(t, fromClaims), refOf(t, fromTasks); got != want {
+		t.Errorf("swapping which source holds which date changed the answer: %q then %q", want, got)
+	}
+	if got := refOf(t, fromClaims); got != "later" {
+		t.Errorf("named %q; the most recently slipped promise is %q", got, "later")
+	}
+}
+
+func TestMostRecentlySlippedPrefersTheRecoverablePromise(t *testing.T) {
+	items := []owedwork.Item{
+		at("ancient", -90, owedwork.FromTask),
+		at("yesterday", -1, owedwork.FromClaim),
+		at("ahead", 3, owedwork.FromTask),
+	}
+	got, ok := owedwork.MostRecentlySlipped(items, now)
+	if !ok {
+		t.Fatal("two promises are late and none was named")
+	}
+	if ref := refOf(t, got); ref != "yesterday" {
+		t.Errorf("named %q; the latest slip is %q, the one still worth rescuing", ref, "yesterday")
+	}
+}
+
+func TestATieGoesToThePromiseThatCanQuoteItself(t *testing.T) {
+	items := []owedwork.Item{
+		at("retyped", -2, owedwork.FromTask),
+		at("quoted", -2, owedwork.FromClaim),
+	}
+	got, ok := owedwork.MostRecentlySlipped(items, now)
+	if !ok {
+		t.Fatal("both promises are late and none was named")
+	}
+	if ref := refOf(t, got); ref != "quoted" {
+		t.Errorf("named %q; a tie goes to the claim, which carries the sentence it was read from", ref)
+	}
+}
+
+func TestNothingLateIsNotAnOverduePromise(t *testing.T) {
+	items := []owedwork.Item{at("ahead", 3, owedwork.FromTask), undated("someday", 10, owedwork.FromClaim)}
+	if item, ok := owedwork.MostRecentlySlipped(items, now); ok {
+		t.Errorf("named %q as overdue; neither promise is past a date", refOf(t, item))
+	}
+}
+
+// A promise falling due exactly now is due, not late — the reading
+// kernel/deadline states and this package inherits.
+func TestAPromiseDueThisInstantIsNotYetLate(t *testing.T) {
+	item := owedwork.Item{Ref: "onTheDot", Source: owedwork.FromTask, DueAt: &now, FiledAt: now}
+	if item.Overdue(now) {
+		t.Error("called a promise late at the instant it fell due")
+	}
+	if _, ok := owedwork.Soonest([]owedwork.Item{item}, now); !ok {
+		t.Error("a promise due this instant is still owed and should be the next thing to do")
+	}
+}
+
+func TestSoonestTakesTheNearestDeadlineAmongWhatIsNotLate(t *testing.T) {
+	items := []owedwork.Item{
+		at("late", -1, owedwork.FromTask),
+		at("nextWeek", 7, owedwork.FromClaim),
+		at("tomorrow", 1, owedwork.FromTask),
+	}
+	got, ok := owedwork.Soonest(items, now)
+	if !ok {
+		t.Fatal("two promises are still ahead and none was named")
+	}
+	if ref := refOf(t, got); ref != "tomorrow" {
+		t.Errorf("named %q; the nearest deadline not yet passed is %q", ref, "tomorrow")
+	}
+}
+
+// An undated promise is owed. A queue that drops it tells a reader they are
+// clear when they are not.
+func TestAnUndatedPromiseIsStillOwed(t *testing.T) {
+	items := []owedwork.Item{undated("whitepaper", 4, owedwork.FromClaim)}
+	got, ok := owedwork.Soonest(items, now)
+	if !ok {
+		t.Fatal("an undated promise reached no queue at all")
+	}
+	if ref := refOf(t, got); ref != "whitepaper" {
+		t.Errorf("named %q, not the one promise there is", ref)
+	}
+}
+
+func TestUndatedSortsBehindEveryDatedPromise(t *testing.T) {
+	items := []owedwork.Item{
+		undated("someday", 40, owedwork.FromClaim),
+		at("nextMonth", 30, owedwork.FromTask),
+	}
+	got, ok := owedwork.Soonest(items, now)
+	if !ok {
+		t.Fatal("nothing was named from two open promises")
+	}
+	if ref := refOf(t, got); ref != "nextMonth" {
+		t.Errorf("named %q; a dated promise comes before an undated one however far off", ref)
+	}
+}
+
+func TestTheOldestUndatedPromiseComesFirst(t *testing.T) {
+	items := []owedwork.Item{
+		undated("recent", 2, owedwork.FromTask),
+		undated("waitingLongest", 60, owedwork.FromClaim),
+	}
+	got, ok := owedwork.Soonest(items, now)
+	if !ok {
+		t.Fatal("nothing was named from two undated promises")
+	}
+	if ref := refOf(t, got); ref != "waitingLongest" {
+		t.Errorf("named %q; among undated promises the one waiting longest comes first", ref)
+	}
+}
+
+// The whole-list order, which is what a card at the top of a page and the list
+// beneath it must share.
+func TestSortedLeadsWithTheOverdueBlock(t *testing.T) {
+	items := []owedwork.Item{
+		undated("someday", 5, owedwork.FromClaim),
+		at("tomorrow", 1, owedwork.FromTask),
+		at("ancient", -90, owedwork.FromTask),
+		at("yesterday", -1, owedwork.FromClaim),
+	}
+	var got []string
+	for _, item := range owedwork.Sorted(items, now) {
+		got = append(got, refOf(t, item))
+	}
+	want := []string{"yesterday", "ancient", "tomorrow", "someday"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order was %v; wanted %v", got, want)
+		}
+	}
+}
+
+// The card names one promise and the list ranks them all. Both read this
+// package, and this test is what holds them to the same answer: it fails if
+// MostRecentlySlipped and Sorted ever disagree about which promise leads.
+func TestTheTopOfTheListIsTheCardsPromise(t *testing.T) {
+	items := []owedwork.Item{
+		at("ancient", -90, owedwork.FromTask),
+		at("yesterday", -1, owedwork.FromClaim),
+		at("ahead", 2, owedwork.FromTask),
+	}
+	card, ok := owedwork.MostRecentlySlipped(items, now)
+	if !ok {
+		t.Fatal("nothing was named for the card")
+	}
+	first := owedwork.Sorted(items, now)[0]
+	if refOf(t, card) != refOf(t, first) {
+		t.Errorf("the card names %q and the list leads with %q", refOf(t, card), refOf(t, first))
+	}
+}
+
+func TestSortedKeepsEveryPromise(t *testing.T) {
+	items := []owedwork.Item{
+		at("late", -1, owedwork.FromTask),
+		at("ahead", 1, owedwork.FromClaim),
+		undated("someday", 3, owedwork.FromTask),
+	}
+	if got := len(owedwork.Sorted(items, now)); got != len(items) {
+		t.Errorf("sorted %d promises into %d rows; ranking may not drop work", len(items), got)
+	}
+}
+
+func TestSortedLeavesTheCallersSliceAlone(t *testing.T) {
+	items := []owedwork.Item{at("ancient", -90, owedwork.FromTask), at("yesterday", -1, owedwork.FromClaim)}
+	owedwork.Sorted(items, now)
+	if ref := refOf(t, items[0]); ref != "ancient" {
+		t.Errorf("Sorted reordered the caller's own slice; it now leads with %q", ref)
+	}
+}
+
+func TestNoPromisesIsNoAnswer(t *testing.T) {
+	if _, ok := owedwork.MostRecentlySlipped(nil, now); ok {
+		t.Error("named an overdue promise from an empty record")
+	}
+	if _, ok := owedwork.Soonest(nil, now); ok {
+		t.Error("named a next promise from an empty record")
+	}
+	if got := owedwork.Sorted(nil, now); len(got) != 0 {
+		t.Errorf("sorted an empty record into %d rows", len(got))
+	}
+}


### PR DESCRIPTION
A promise gets written down in two places: a task somebody typed, and a
commitment an extractor read out of a conversation. Which of the two a surface
could see decided what it told a reader, so the same record answered "what do we
owe them?" differently depending on where you asked.

## What this adds

`internal/shared/kernel/owedwork` is now the one rule over both sources: which
promises are late, which slipped most recently, what comes next, and the order a
list shows them in.

It lives in the shared tier because it has to. `activity` is owned by the
`activities` module and `conversation_claim` by `people`, and a module never
imports a sibling — so neither side can host a comparison spanning both. Ranking
is not a database question anyway: it is a pure function of due dates, and
putting it where every tier may import it is what stops the next surface writing
a third spelling.

## What changes on the person page

The overdue rung keeps the behaviour it had; its existing tests pass unchanged.

The not-yet-due rung gains a source. It read only the task list, so a person
owing nothing but an extracted commitment was told "Nothing needs you today"
while the commitments card beneath the fold listed the promise. Verified live on
a dev stack: the same record went from `nothing_needed` to

    You owe them: Send the security questionnaire
    Due in 2 days.
    "Ich schicke Ihnen den Fragebogen bis Ende der Woche."

and to `overdue_promise` once the date was moved into the past.

## A union, not a join

Nothing writes `conversation_claim.task_activity_id` — `schema_fitness_integration_test.go`
records it as a column with no writer. So an extracted commitment and a task
about the same thing are two unlinked rows, and merging them is a union. A
reader who filed a task for a promise an extractor also read may see both, which
is the honest answer until that link is written; the alternative is guessing
which pairs mean one promise.

## Dismissals

`overdueTaskCard` keeps its claim key `moment:overdue_task` even though the rule
is the merged `overdue_promise`. A dismissal is matched on the key exactly, so
renaming it would resurrect every card a reader had already put away.

## Tests

`owedwork_test.go` states each decision as a case: the source may not change the
ranking, the latest slip wins, a tie goes to the claim, an undated promise is
still owed but sorts last, and the card's promise is the top of the list. Every
guard was mutation-checked — reverting each one fails a named test.

Two new person-360 tests cover the behaviour change, and both fail if claims stop
reaching the rungs.

Gate: `make check-backend` green, `craft static --strict` clean on the diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies how promises are ranked on the person page so a promise read from a conversation and one typed as a task are answered by the same rule. Previously the not-yet-due rung read only the task list, so a person owing only an extracted commitment was told "Nothing needs you today"; now both sources feed the rungs through the new `owedwork` kernel package, and the overdue rung keeps its behavior.

- The merge is a union, not a join; a reader may see both a task and a claim for the same thing until that link is written.
- The ladder ranks promises by deadline, so an older commitment due soon still reaches the card.
- Dismissing a card re-asks its rung without it, showing the next open promise instead of "nothing needed".
- Claim dismissal keys now carry the claim id: two promises from one message dismiss apart, and previously dismissed overdue commitment cards may reappear.
- The overdue task card keeps its `moment:overdue_task` key.

<sup>Written for commit 0aa69b7ee718bff9922704c36cdf4031adf26851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open and overdue promises now include both tasks and conversation commitments.
  * Conversation commitments can appear as promise cards with due-date details, supporting quotes, and follow-up actions.
  * Promises are prioritized across sources by overdue status and upcoming due dates.
  * Open commitments missing from the latest claims view are now included without duplicates.
  * Dismissing a promise reveals the next available promise.

* **Bug Fixes**
  * Improved handling of undated promises and consistent ordering when deadlines are shared.
  * Dismissing all promises now correctly reaches a quiet state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->