### PR TITLE
A demo meeting is not told the plan cannot tell what it is

### DIFF
--- a/backend/internal/compose/meetingbrief/plan_test.go
+++ b/backend/internal/compose/meetingbrief/plan_test.go
@@ -235,3 +235,33 @@ func TestThePlanNeverSpellsARecordIDInItsProse(t *testing.T) {
 		}
 	}
 }
+
+// A caveat that contradicts the meeting type reads as a brief that has not
+// understood the meeting.
+//
+// The default arm is for `unknown` — "do not assume what this meeting is for" —
+// and a demo fell into it, so a brief that had just classified the room as a
+// demo, with medium confidence and a subject saying so, opened by telling the
+// rep it did not know what the meeting was. Found by reading a real brief on a
+// running stack; no unit test would have noticed, because each half was right.
+func TestEveryMeetingKindHasACaveatThatFitsIt(t *testing.T) {
+	for _, kind := range []crmcontracts.MeetingPlanTypeValue{
+		crmcontracts.MeetingPlanTypeRelationship,
+		crmcontracts.MeetingPlanTypeFirstDiscovery,
+		crmcontracts.MeetingPlanTypeFollowupDiscovery,
+		crmcontracts.MeetingPlanTypeDemo,
+		crmcontracts.MeetingPlanTypeCommercial,
+		crmcontracts.MeetingPlanTypeDecision,
+		crmcontracts.MeetingPlanTypeDelivery,
+		crmcontracts.MeetingPlanTypeRenewalRisk,
+	} {
+		if got := caveatFor(MeetingType{Value: kind}); got == caveatUnknown {
+			t.Errorf("a %q meeting is told the plan does not know what it is for", kind)
+		}
+	}
+	// And `unknown` still gets the one that says so, or the check above would
+	// pass by making every kind share a caveat that fits none of them.
+	if got := caveatFor(MeetingType{Value: crmcontracts.MeetingPlanTypeUnknown}); got != caveatUnknown {
+		t.Errorf("an unknown meeting's caveat = %q, want the one that says to ask", got)
+	}
+}

--- a/backend/internal/compose/meetingbrief/planobjective.go
+++ b/backend/internal/compose/meetingbrief/planobjective.go
@@ -28,6 +28,7 @@ const (
 	caveatCommercial   = "Do not concede on price before the value is agreed."
 	caveatDelivery     = "Do not reopen scope that is already agreed; name what changed and what it costs."
 	caveatUnknown      = "Do not assume what this meeting is for. Ask, then plan the rest of the hour."
+	caveatDemo         = "Do not tour the product. Show the two things they asked about and stop."
 )
 
 func caveatFor(typ MeetingType) string {
@@ -40,6 +41,8 @@ func caveatFor(typ MeetingType) string {
 		return caveatCommercial
 	case crmcontracts.MeetingPlanTypeDelivery, crmcontracts.MeetingPlanTypeRenewalRisk:
 		return caveatDelivery
+	case crmcontracts.MeetingPlanTypeDemo:
+		return caveatDemo
 	default:
 		return caveatUnknown
 	}


### PR DESCRIPTION
Found by reading a real brief on a running stack, which no unit test would have
caught: each half was right on its own. The classifier read "Quarterly review"
plus the deal stage and answered `demo` with medium confidence. The caveat
under it read "Do not assume what this meeting is for. Ask, then plan the rest
of the hour" — the one written for `unknown`, reached because `demo` had no arm
of its own and fell to the default.

So a brief that had just worked out what the meeting was opened by telling the
rep it had not.

The demo caveat is the one that belongs there: do not tour the product, show
the two things they asked about, stop. The test walks every kind in the enum
and fails any that lands on the unknown arm, and then checks that `unknown`
still gets it — without the second half, one caveat shared by everything would
pass the first.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes demo meetings being told the plan doesn't know what the meeting is for.

Demo meetings now get their own caveat instead of falling through to the `unknown` default. Adds a test covering every meeting kind so each has a fitting caveat, and `unknown` still gets the one that says to ask.

<sup>Written for commit feb90ca112fda32e4138710a97f65390f823425f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting brief guidance for demo meetings with a dedicated caveat.
  * Ensured recognized meeting types consistently receive the appropriate caveat.
* **Tests**
  * Added regression coverage for meeting-type caveat handling, including unknown meeting types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->