### PR TITLE
Held mail stops moving the last contact date

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -22317,10 +22317,15 @@ components:
           format: date-time
           readOnly: true
           description: >-
-            When something last happened with this account — the newest `occurred_at` of an activity
-            linked to it, maintained on the activity write exactly as `deal.last_activity_at` is
-            (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must
-            reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-2).
+            When something last happened with this account — the newest `occurred_at` of a
+            WORKSPACE-AUDIENCE activity linked to it, maintained on the activity write exactly as
+            `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second
+            truth — a rebuild must reproduce it). NULL until the first such activity.
+            Sortable (DM-VOCAB-2).
+
+            A message limited to its participants does NOT move this date, even for a reader who
+            may read that message. The value is one number every reader sees, so it can only count
+            what every reader may see.
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         archived_at: { type: [string, 'null'], format: date-time }
@@ -26413,7 +26418,7 @@ components:
         close_date_provisional: { type: boolean, readOnly: true, description: 'True while the close date is a machine-computed replacement awaiting human confirmation (formulas §11 🟡 tier); a provisional deal stays out of Commit/Best-case. Cleared when a human sets the date.' }
         wait_until: { type: [string, 'null'], format: date, description: "'Customer asked us to wait until' date; suppresses the stalled flag but not the overdue close-date flag." }
         closed_at: { type: [string, 'null'], format: date-time }
-        last_activity_at: { type: [string, 'null'], format: date-time, description: Drives the deterministic stalled flag. }
+        last_activity_at: { type: [string, 'null'], format: date-time, description: 'Drives the deterministic stalled flag. Counts workspace-audience activities only, so a deal whose only recent mail is limited to its participants reads as stalled.' }
         stalled: { type: boolean, readOnly: true, description: Derived — no activity past the threshold (absolute duration). }
         source: { type: string }
         captured_by: { type: string, readOnly: true, description: 'Server-stamped from the authenticated principal (human:<uuid> | agent:<id> | connector:<name>); never client-supplied.' }
@@ -26858,7 +26863,7 @@ components:
           type: [string, 'null']
           format: date-time
           readOnly: true
-          description: 'Maintained from the timeline on link write; a read accelerator, never a second truth — a rebuild must reproduce it exactly.'
+          description: 'The newest WORKSPACE-AUDIENCE activity filed under the project, maintained from the timeline on link write; a read accelerator, never a second truth — a rebuild must reproduce it exactly. A message limited to its participants does not move it, even for a reader who may read that message: one number every reader sees can only count what every reader may see.'
         source: { type: string }
         captured_by: { type: string, readOnly: true, description: 'Server-stamped from the authenticated principal; never client-supplied.' }
         raw: { type: [object, 'null'], additionalProperties: true }
@@ -27033,7 +27038,7 @@ components:
         last_activity_at:
           type: [string, 'null']
           format: date-time
-          description: The newest activity filed under the project; null when nothing is filed yet.
+          description: 'The newest WORKSPACE-AUDIENCE activity filed under the project; null when nothing is filed yet. A message limited to its participants does not move it, even for a reader who may read that message.'
         activity_count: { type: integer, minimum: 0, description: Every live activity filed under the project. }
 
     CreateProjectRequest:

--- a/backend/internal/compose/integration/lastactivityaudience_integration_test.go
+++ b/backend/internal/compose/integration/lastactivityaudience_integration_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// last_activity_at stops counting mail nobody can read.
+//
+// Its sibling next door (lastactivity_integration_test.go) proves the clock
+// moves correctly — the newest wins, a back-dated capture never moves it
+// backwards, archiving moves it back. This proves the other rule on the same
+// column: a message limited to its participants is not "contact", so it must
+// not move a date every colleague sees.
+//
+// Four owner tables read that column, all from their own SQL helper, so all
+// four are exercised. The project arm is the one an earlier draft of this
+// change missed entirely.
+//
+// The narrowing goes through activities.SetAudience, the real writer, rather
+// than an UPDATE: the triggers fire on the write, and a test that set the
+// column by hand would be asserting its own seed.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestLastActivityAudience_NarrowingTheNewestMessageMovesTheClockBack(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Held Clock Org", nil)
+	person := e.SeedPerson(t, "Held Clock Contact", nil)
+	personID := ids.From[ids.PersonKind](person)
+	orgID := ids.From[ids.OrganizationKind](org)
+	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
+		Kind: "employment", PersonID: &personID, OrganizationID: &orgID,
+		IsCurrentPrimary: boolPtr(true), Source: "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
+	deal, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "Held Clock Deal", AmountMinor: int64Ptr(100), Currency: strPtr("EUR"),
+		PipelineID: pipeline, StageID: open, OrganizationID: &orgID, Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := e.seedProjectFor(t, orgID)
+
+	older := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	newest := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	links := []activities.ActivityLinkInput{
+		{EntityType: "person", EntityID: person},
+		{EntityType: "organization", EntityID: org},
+		{EntityType: "deal", EntityID: ids.UUID(deal.Id)},
+		{EntityType: "project", EntityID: project},
+	}
+	e.logAt(t, older, links...)
+	newestMessage := e.logAt(t, newest, links...)
+
+	// Every clock sits on the newest message while it is open. Asserted before
+	// narrowing, so a later "the clock is at `older`" cannot pass because the
+	// newest message never registered at all.
+	for name, got := range e.everyClock(t, personID, orgID, ids.From[ids.DealKind](ids.UUID(deal.Id)), project) {
+		if got == nil || !got.Equal(newest) {
+			t.Fatalf("%s clock = %v before narrowing, want %v — the fixture never took effect",
+				name, got, newest)
+		}
+	}
+
+	if _, err := e.Activities.SetAudience(e.Admin(), ids.From[ids.ActivityKind](newestMessage),
+		activities.SetAudienceInput{Audience: "participants"}); err != nil {
+		t.Fatalf("narrowing the newest message: %v", err)
+	}
+
+	for name, got := range e.everyClock(t, personID, orgID, ids.From[ids.DealKind](ids.UUID(deal.Id)), project) {
+		if got == nil || !got.Equal(older) {
+			t.Errorf("%s clock = %v after narrowing the newest message, want %v: a colleague "+
+				"who cannot read that message is still told it happened", name, got, older)
+		}
+	}
+}
+
+func TestLastActivityAudience_WideningTheMessageMovesTheClockForward(t *testing.T) {
+	// The admit case, and the round trip. Without it a helper that counted
+	// nothing at all would pass the test above.
+	e := Setup(t)
+	org := e.SeedOrg(t, "Widen Clock Org", nil)
+	person := e.SeedPerson(t, "Widen Clock Contact", nil)
+	personID := ids.From[ids.PersonKind](person)
+	orgID := ids.From[ids.OrganizationKind](org)
+	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
+		Kind: "employment", PersonID: &personID, OrganizationID: &orgID,
+		IsCurrentPrimary: boolPtr(true), Source: "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	older := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	newest := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	e.logAt(t, older, activities.ActivityLinkInput{EntityType: "person", EntityID: person})
+	held := e.logAt(t, newest, activities.ActivityLinkInput{EntityType: "person", EntityID: person})
+
+	heldID := ids.From[ids.ActivityKind](held)
+	if _, err := e.Activities.SetAudience(e.Admin(), heldID,
+		activities.SetAudienceInput{Audience: "participants"}); err != nil {
+		t.Fatalf("narrowing: %v", err)
+	}
+	if got := e.personClock(t, personID); got == nil || !got.Equal(older) {
+		t.Fatalf("clock = %v while the newest message is held, want %v", got, older)
+	}
+
+	if _, err := e.Activities.SetAudience(e.Admin(), heldID,
+		activities.SetAudienceInput{Audience: "workspace"}); err != nil {
+		t.Fatalf("widening: %v", err)
+	}
+	if got := e.personClock(t, personID); got == nil || !got.Equal(newest) {
+		t.Errorf("clock = %v after re-opening the message, want %v: widening must move the "+
+			"clock forward again, or a mistaken hold is permanent", got, newest)
+	}
+}
+
+func TestLastActivityAudience_AMessageBornHeldNeverMovesTheClock(t *testing.T) {
+	// The trigger arm the narrow-then-check case cannot reach. Captured mail is
+	// born with its audience already set (capture/birthdecision.go), so nothing
+	// ever UPDATEs the audience column for it — the value has to be right at
+	// INSERT, through the link trigger rather than the activity one.
+	e := Setup(t)
+	person := e.SeedPerson(t, "Born Held Contact", nil)
+	personID := ids.From[ids.PersonKind](person)
+
+	older := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	newest := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	e.logAt(t, older, activities.ActivityLinkInput{EntityType: "person", EntityID: person})
+	born := e.logAt(t, newest, activities.ActivityLinkInput{EntityType: "person", EntityID: person})
+	// Narrowed at the row before its link exists is not reproducible through the
+	// public writers, so the audience is set directly and the LINK is then
+	// re-driven — which is the order capture writes in, and the arm that proves
+	// the helper filters rather than the activity trigger happening to fire.
+	e.WsExec(t, `UPDATE activity SET audience = 'participants' WHERE id = $1`, born)
+	e.WsExec(t, `UPDATE activity_link SET person_id = person_id WHERE activity_id = $1`, born)
+
+	if got := e.personClock(t, personID); got == nil || !got.Equal(older) {
+		t.Errorf("clock = %v for a message born held, want %v", got, older)
+	}
+}
+
+// logAt writes one note at a moment, through the real writer.
+func (e *Env) logAt(t *testing.T, when time.Time, links ...activities.ActivityLinkInput) ids.UUID {
+	t.Helper()
+	subject := "touch"
+	logged, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+		Kind: "note", Subject: &subject, OccurredAt: &when, Source: "manual", Links: links,
+	})
+	if err != nil {
+		t.Fatalf("logging: %v", err)
+	}
+	return ids.UUID(logged.Id)
+}
+
+// everyClock reads all four stored last_activity_at values, keyed by the table
+// they came from so a failure names which helper is wrong.
+func (e *Env) everyClock(
+	t *testing.T, person ids.PersonID, org ids.OrganizationID, deal ids.DealID, project ids.UUID,
+) map[string]*time.Time {
+	t.Helper()
+	organization, err := e.People.GetOrganization(e.Admin(), org, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := e.Deals.GetDeal(e.Admin(), deal, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return map[string]*time.Time{
+		"person":       e.personClock(t, person),
+		"organization": organization.LastActivityAt,
+		"deal":         got.LastActivityAt,
+		"project":      e.projectClock(t, project),
+	}
+}
+
+func (e *Env) personClock(t *testing.T, id ids.PersonID) *time.Time {
+	t.Helper()
+	person, err := e.People.GetPerson(e.Admin(), id, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return person.LastActivityAt
+}
+
+// projectClock reads the column directly: project has no read surface in this
+// harness, and the column is what all four helpers write and every reader reads.
+func (e *Env) projectClock(t *testing.T, id ids.UUID) *time.Time {
+	t.Helper()
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	var at *time.Time
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT last_activity_at FROM project WHERE id = $1`, id).Scan(&at)
+	}); err != nil {
+		t.Fatalf("reading the project clock: %v", err)
+	}
+	return at
+}
+
+func (e *Env) seedProjectFor(t *testing.T, org ids.OrganizationID) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	e.WsExec(t, `
+		INSERT INTO project (id, name, organization_id, source, captured_by)
+		VALUES ($1, 'Held Clock Project', $2, 'manual', 'human:test')`, id, org)
+	return id
+}

--- a/backend/internal/compose/integration/lastactivityaudience_integration_test.go
+++ b/backend/internal/compose/integration/lastactivityaudience_integration_test.go
@@ -133,10 +133,16 @@ func TestLastActivityAudience_WideningTheMessageMovesTheClockForward(t *testing.
 }
 
 func TestLastActivityAudience_AMessageBornHeldNeverMovesTheClock(t *testing.T) {
-	// The trigger arm the narrow-then-check case cannot reach. Captured mail is
-	// born with its audience already set (capture/birthdecision.go), so nothing
-	// ever UPDATEs the audience column for it — the value has to be right at
-	// INSERT, through the link trigger rather than the activity one.
+	// The LINK trigger's arm, which the narrow-then-check case cannot reach.
+	// Captured mail is born with its audience already decided
+	// (capture/birthdecision.go), so nothing ever UPDATEs the audience column
+	// for it — the value has to be right when the LINK appears, through
+	// trg_activity_link_last_activity rather than the activity trigger.
+	//
+	// So the audience is set while the activity has no links at all, and the
+	// link is inserted afterwards. Setting it after a link existed would fire
+	// the activity trigger and move the clock back for the wrong reason,
+	// leaving this test green against a link trigger that did nothing.
 	e := Setup(t)
 	person := e.SeedPerson(t, "Born Held Contact", nil)
 	personID := ids.From[ids.PersonKind](person)
@@ -144,16 +150,74 @@ func TestLastActivityAudience_AMessageBornHeldNeverMovesTheClock(t *testing.T) {
 	older := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
 	newest := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
 	e.logAt(t, older, activities.ActivityLinkInput{EntityType: "person", EntityID: person})
-	born := e.logAt(t, newest, activities.ActivityLinkInput{EntityType: "person", EntityID: person})
-	// Narrowed at the row before its link exists is not reproducible through the
-	// public writers, so the audience is set directly and the LINK is then
-	// re-driven — which is the order capture writes in, and the arm that proves
-	// the helper filters rather than the activity trigger happening to fire.
-	e.WsExec(t, `UPDATE activity SET audience = 'participants' WHERE id = $1`, born)
-	e.WsExec(t, `UPDATE activity_link SET person_id = person_id WHERE activity_id = $1`, born)
+
+	// Unlinked, so no clock has heard of it yet.
+	born := ids.NewV7()
+	e.WsExec(t, `
+		INSERT INTO activity (id, kind, subject, audience, occurred_at, source, captured_by)
+		VALUES ($1, 'note', 'born held', 'participants', $2, 'manual', 'human:test')`,
+		born, newest)
+	if got := e.personClock(t, personID); got == nil || !got.Equal(older) {
+		t.Fatalf("clock = %v before the link exists, want %v — the fixture is not isolating "+
+			"the link trigger", got, older)
+	}
+
+	e.WsExec(t, `
+		INSERT INTO activity_link (activity_id, entity_type, person_id)
+		VALUES ($1, 'person', $2)`, born, person)
 
 	if got := e.personClock(t, personID); got == nil || !got.Equal(older) {
-		t.Errorf("clock = %v for a message born held, want %v", got, older)
+		t.Errorf("clock = %v after linking a message that was born held, want %v: the link "+
+			"trigger counted an activity nobody but its participants may read", got, older)
+	}
+}
+
+func TestLastActivityAudience_AClockMoveIsNotAnEdit(t *testing.T) {
+	// A narrowing moves four stored dates, and moving one must not look like
+	// somebody edited the record. set_updated_at_bump_version() fires on all
+	// four tables and suppresses itself only while margince.last_activity_move
+	// is on — which move_last_activity sets and a bare UPDATE does not. A
+	// recompute written as a plain UPDATE would bump version on every deal,
+	// organization, person and project in the installation, invalidating every
+	// If-Match a client holds.
+	//
+	// Its sibling next door asserts the same property for an ordinary clock
+	// move; this is the audience-driven one, which reaches the same movers by a
+	// different route.
+	e := Setup(t)
+	person := e.SeedPerson(t, "Version Clock Contact", nil)
+	personID := ids.From[ids.PersonKind](person)
+
+	older := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	newest := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	e.logAt(t, older, activities.ActivityLinkInput{EntityType: "person", EntityID: person})
+	held := e.logAt(t, newest, activities.ActivityLinkInput{EntityType: "person", EntityID: person})
+
+	before, err := e.People.GetPerson(e.Admin(), personID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Version == nil {
+		t.Fatal("a created person carries a version")
+	}
+
+	if _, err := e.Activities.SetAudience(e.Admin(), ids.From[ids.ActivityKind](held),
+		activities.SetAudienceInput{Audience: "participants"}); err != nil {
+		t.Fatalf("narrowing: %v", err)
+	}
+
+	after, err := e.People.GetPerson(e.Admin(), personID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.LastActivityAt == nil || !after.LastActivityAt.Equal(older) {
+		t.Fatalf("clock = %v, want %v — the narrowing did not move it, so this proved nothing",
+			after.LastActivityAt, older)
+	}
+	if after.Version == nil || *after.Version != *before.Version {
+		t.Errorf("person.version = %v after a clock move, want %v unchanged: a client holding "+
+			"the old version would be refused an edit it is entitled to make",
+			after.Version, *before.Version)
 	}
 }
 

--- a/backend/internal/compose/integration/lastactivityaudience_integration_test.go
+++ b/backend/internal/compose/integration/lastactivityaudience_integration_test.go
@@ -175,8 +175,8 @@ func TestLastActivityAudience_AMessageBornHeldNeverMovesTheClock(t *testing.T) {
 func TestLastActivityAudience_AClockMoveIsNotAnEdit(t *testing.T) {
 	// A narrowing moves four stored dates, and moving one must not look like
 	// somebody edited the record. set_updated_at_bump_version() fires on all
-	// four tables and suppresses itself only while margince.last_activity_move
-	// is on — which move_last_activity sets and a bare UPDATE does not. A
+	// four tables and suppresses itself only inside a clock move's own guard
+	// setting, which move_last_activity sets and a bare UPDATE does not. A
 	// recompute written as a plain UPDATE would bump version on every deal,
 	// organization, person and project in the installation, invalidating every
 	// If-Match a client holds.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19080,7 +19080,7 @@ type Deal struct {
 	FxRateToBase *string            `json:"fx_rate_to_base,omitempty"`
 	Id           openapi_types.UUID `json:"id"`
 
-	// LastActivityAt Drives the deterministic stalled flag.
+	// LastActivityAt Drives the deterministic stalled flag. Counts workspace-audience activities only, so a deal whose only recent mail is limited to its participants reads as stalled.
 	LastActivityAt *time.Time `json:"last_activity_at,omitempty"`
 
 	// LostReason Required when status=lost.
@@ -22926,7 +22926,8 @@ type Organization struct {
 	// cannot be archived or merged. A caller that offers company actions should tell it apart.
 	IsAnchor *bool `json:"is_anchor,omitempty"`
 
-	// LastActivityAt When something last happened with this account — the newest `occurred_at` of an activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-2).
+	// LastActivityAt When something last happened with this account — the newest `occurred_at` of a WORKSPACE-AUDIENCE activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first such activity. Sortable (DM-VOCAB-2).
+	// A message limited to its participants does NOT move this date, even for a reader who may read that message. The value is one number every reader sees, so it can only count what every reader may see.
 	LastActivityAt *time.Time `json:"last_activity_at,omitempty"`
 	LegalName      *string    `json:"legal_name,omitempty"`
 
@@ -26039,7 +26040,7 @@ type Project struct {
 	// Key The short handle a human writes in a subject line. Letter-led and bounded so it can never be a bare number, which would match dates, amounts and order numbers. Unique among LIVE projects; archiving frees it.
 	Key *string `json:"key,omitempty"`
 
-	// LastActivityAt Maintained from the timeline on link write; a read accelerator, never a second truth — a rebuild must reproduce it exactly.
+	// LastActivityAt The newest WORKSPACE-AUDIENCE activity filed under the project, maintained from the timeline on link write; a read accelerator, never a second truth — a rebuild must reproduce it exactly. A message limited to its participants does not move it, even for a reader who may read that message: one number every reader sees can only count what every reader may see.
 	LastActivityAt *time.Time `json:"last_activity_at,omitempty"`
 
 	// MaskedFields The fields of THIS row the caller may not read (a field mask). A named field is null because it is withheld, not because it is empty; absent or empty means nothing is withheld.
@@ -26213,7 +26214,7 @@ type Project360Rollups struct {
 	// ActivityCount Every live activity filed under the project.
 	ActivityCount int `json:"activity_count"`
 
-	// LastActivityAt The newest activity filed under the project; null when nothing is filed yet.
+	// LastActivityAt The newest WORKSPACE-AUDIENCE activity filed under the project; null when nothing is filed yet. A message limited to its participants does not move it, even for a reader who may read that message.
 	LastActivityAt *time.Time `json:"last_activity_at"`
 
 	// OpenCommitments Open tasks filed under the project, whole lifecycle.

--- a/backend/migrations/core/1788310045_held_mail_stops_moving_the_last_contact_date.down.sql
+++ b/backend/migrations/core/1788310045_held_mail_stops_moving_the_last_contact_date.down.sql
@@ -6,8 +6,9 @@
 -- longer produce them, and the next unrelated edit to any row would move its
 -- date for no reason a reader could see.
 
--- Bounded: CREATE OR REPLACE FUNCTION takes an exclusive lock on the function,
--- and the triggers below take one on activity, which every capture writes.
+-- Bounded, with the same caveat the up migration states: lock_timeout bounds the
+-- wait, not the hold, and the recompute at the bottom runs inside the same
+-- transaction as the trigger swap.
 SET LOCAL lock_timeout = '3s';
 
 -- The baseline bodies, restored verbatim.
@@ -84,9 +85,44 @@ CREATE TRIGGER activity_project_last_activity
 	   OR old.archived_at IS DISTINCT FROM new.archived_at)
 	EXECUTE FUNCTION trg_activity_project_last_activity();
 
--- Recomputed through the same helpers the triggers use, so there is one
--- definition of the value rather than this file's own copy.
-UPDATE deal SET last_activity_at = last_activity_of_deal(id);
-UPDATE organization SET last_activity_at = last_activity_of_organization(id);
-UPDATE person SET last_activity_at = last_activity_of_person(id);
-UPDATE project SET last_activity_at = last_activity_of_project(id);
+-- Recomputed through move_last_activity, not a raw UPDATE.
+--
+-- That is not a style preference. set_updated_at_bump_version() fires on all
+-- four tables and suppresses itself only while margince.last_activity_move is
+-- on, which move_last_activity sets and a bare UPDATE does not. Writing the
+-- column directly would stamp updated_at and bump version on every deal,
+-- organization, person and project in the installation — invalidating every
+-- outstanding If-Match a client holds and telling every "what changed
+-- recently" reader that the whole database was edited at deploy time.
+--
+-- Only rows whose derived value actually moves are touched, so an installation
+-- with no held mail writes nothing at all.
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT id FROM deal
+     WHERE last_activity_at IS DISTINCT FROM last_activity_of_deal(id)
+  LOOP
+    PERFORM move_last_activity('deal'::regclass, r.id);
+  END LOOP;
+  FOR r IN
+    SELECT id FROM organization
+     WHERE last_activity_at IS DISTINCT FROM last_activity_of_organization(id)
+  LOOP
+    PERFORM move_last_activity('organization'::regclass, r.id);
+  END LOOP;
+  FOR r IN
+    SELECT id FROM person
+     WHERE last_activity_at IS DISTINCT FROM last_activity_of_person(id)
+  LOOP
+    PERFORM move_last_activity('person'::regclass, r.id);
+  END LOOP;
+  FOR r IN
+    SELECT id FROM project
+     WHERE last_activity_at IS DISTINCT FROM last_activity_of_project(id)
+  LOOP
+    PERFORM move_last_activity('project'::regclass, r.id);
+  END LOOP;
+END $$;

--- a/backend/migrations/core/1788310045_held_mail_stops_moving_the_last_contact_date.down.sql
+++ b/backend/migrations/core/1788310045_held_mail_stops_moving_the_last_contact_date.down.sql
@@ -1,0 +1,92 @@
+-- Back to counting every unarchived activity, held or not.
+--
+-- The recompute at the end is what makes this a real reversal rather than a
+-- schema-only one: the up migration rewrote every stored last_activity_at, so
+-- leaving them alone here would keep the narrowed values under helpers that no
+-- longer produce them, and the next unrelated edit to any row would move its
+-- date for no reason a reader could see.
+
+-- Bounded: CREATE OR REPLACE FUNCTION takes an exclusive lock on the function,
+-- and the triggers below take one on activity, which every capture writes.
+SET LOCAL lock_timeout = '3s';
+
+-- The baseline bodies, restored verbatim.
+CREATE OR REPLACE FUNCTION last_activity_of_deal(did uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+   WHERE l.deal_id = did
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_organization(oid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(v) FROM (
+    -- Filed against the account itself.
+    SELECT max(a.occurred_at) AS v
+      FROM activity_link l
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       WHERE l.organization_id = oid
+    UNION ALL
+    -- Filed against one of its deals.
+    SELECT max(a.occurred_at)
+      FROM deal d
+      JOIN activity_link l ON l.deal_id = d.id
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       WHERE d.organization_id = oid
+    UNION ALL
+    -- Filed against a contact it currently employs.
+    SELECT max(a.occurred_at)
+      FROM relationship r
+      JOIN activity_link l ON l.person_id = r.person_id
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       WHERE r.organization_id = oid AND r.kind = 'employment'
+       AND r.ended_at IS NULL AND r.archived_at IS NULL
+  ) arms
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_person(pid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+   WHERE l.person_id = pid
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_project(pid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+   WHERE l.project_id = pid
+$$;
+
+-- The triggers stop watching audience: with the helpers ignoring it again, a
+-- narrowing changes nothing they would answer, so waking them for it would only
+-- burn a recompute.
+DROP TRIGGER activity_last_activity ON activity;
+CREATE TRIGGER activity_last_activity
+	AFTER UPDATE OF occurred_at, archived_at ON activity
+	FOR EACH ROW
+	WHEN (old.occurred_at IS DISTINCT FROM new.occurred_at
+	   OR old.archived_at IS DISTINCT FROM new.archived_at)
+	EXECUTE FUNCTION trg_activity_last_activity();
+
+DROP TRIGGER activity_project_last_activity ON activity;
+CREATE TRIGGER activity_project_last_activity
+	AFTER UPDATE OF occurred_at, archived_at ON activity
+	FOR EACH ROW
+	WHEN (old.occurred_at IS DISTINCT FROM new.occurred_at
+	   OR old.archived_at IS DISTINCT FROM new.archived_at)
+	EXECUTE FUNCTION trg_activity_project_last_activity();
+
+-- Recomputed through the same helpers the triggers use, so there is one
+-- definition of the value rather than this file's own copy.
+UPDATE deal SET last_activity_at = last_activity_of_deal(id);
+UPDATE organization SET last_activity_at = last_activity_of_organization(id);
+UPDATE person SET last_activity_at = last_activity_of_person(id);
+UPDATE project SET last_activity_at = last_activity_of_project(id);

--- a/backend/migrations/core/1788310045_held_mail_stops_moving_the_last_contact_date.up.sql
+++ b/backend/migrations/core/1788310045_held_mail_stops_moving_the_last_contact_date.up.sql
@@ -1,0 +1,120 @@
+-- "Contacted 2 days ago" must not be true because of mail the reader cannot open.
+--
+-- last_activity_at is a stored column on deal, organization, person and project,
+-- and 43 Go read sites read it. None of them filtered audience because none of
+-- them could: the value arrives from these four SQL helpers and two triggers,
+-- and they counted every unarchived activity. So a message limited to its
+-- participants moved a date every colleague sees, telling them a conversation
+-- happened, when, and with whom — the fact of correspondence they were
+-- deliberately not shown.
+--
+-- Fixing the SQL fixes all 43 readers at once, which is why this is a migration
+-- and not a call-site sweep.
+--
+-- This narrows a stated policy, deliberately. The audience gate's corpus rule
+-- (backend/gates/audiencereaders_test.go) holds that a reader taking
+-- max(occurred_at) off an activity owes it nothing, and that stays true for
+-- every OTHER marker reader in the tree. It stops being true for these four
+-- columns because they are read as a sentence about a person on a page, not as
+-- an internal count.
+
+-- Bounded: CREATE OR REPLACE FUNCTION takes an exclusive lock on the function,
+-- and the triggers below take one on activity, which every capture writes.
+SET LOCAL lock_timeout = '3s';
+
+-- Replacing a baseline function in a later migration, which has precedent twice
+-- (1787400000, 1787450422). The bodies are the baseline's, with one clause
+-- added to each join.
+CREATE OR REPLACE FUNCTION last_activity_of_deal(did uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
+   WHERE l.deal_id = did
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_organization(oid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(v) FROM (
+    -- Filed against the account itself.
+    SELECT max(a.occurred_at) AS v
+      FROM activity_link l
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
+     WHERE l.organization_id = oid
+    UNION ALL
+    -- Filed against one of its deals.
+    SELECT max(a.occurred_at)
+      FROM deal d
+      JOIN activity_link l ON l.deal_id = d.id
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
+     WHERE d.organization_id = oid
+    UNION ALL
+    -- Filed against a contact it currently employs.
+    SELECT max(a.occurred_at)
+      FROM relationship r
+      JOIN activity_link l ON l.person_id = r.person_id
+      JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
+     WHERE r.organization_id = oid AND r.kind = 'employment'
+       AND r.ended_at IS NULL AND r.archived_at IS NULL
+  ) arms
+$$;
+
+CREATE OR REPLACE FUNCTION last_activity_of_person(pid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
+   WHERE l.person_id = pid
+$$;
+
+-- The fourth, and the one an earlier draft of this change missed. Project
+-- surfaces read and order by this value exactly as the other three do, so
+-- rebuilding the project trigger below without it would have recomputed the
+-- same leaking number.
+CREATE OR REPLACE FUNCTION last_activity_of_project(pid uuid) RETURNS timestamptz
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT max(a.occurred_at)
+    FROM activity_link l
+    JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
+   WHERE l.project_id = pid
+$$;
+
+-- The triggers have to learn about audience too. They fire on occurred_at and
+-- archived_at only, so narrowing a message changed what the helpers WOULD
+-- answer while nothing asked them again — the stored value stayed on the held
+-- message until some other edit happened to move it.
+DROP TRIGGER activity_last_activity ON activity;
+CREATE TRIGGER activity_last_activity
+	AFTER UPDATE OF occurred_at, archived_at, audience ON activity
+	FOR EACH ROW
+	WHEN (old.occurred_at IS DISTINCT FROM new.occurred_at
+	   OR old.archived_at IS DISTINCT FROM new.archived_at
+	   OR old.audience IS DISTINCT FROM new.audience)
+	EXECUTE FUNCTION trg_activity_last_activity();
+
+DROP TRIGGER activity_project_last_activity ON activity;
+CREATE TRIGGER activity_project_last_activity
+	AFTER UPDATE OF occurred_at, archived_at, audience ON activity
+	FOR EACH ROW
+	WHEN (old.occurred_at IS DISTINCT FROM new.occurred_at
+	   OR old.archived_at IS DISTINCT FROM new.archived_at
+	   OR old.audience IS DISTINCT FROM new.audience)
+	EXECUTE FUNCTION trg_activity_project_last_activity();
+
+-- Every stored value was computed by the old helpers, so every one of them may
+-- name a held message. Recomputed through the same helpers the triggers use, so
+-- there is one definition of the value rather than a migration's own copy.
+UPDATE deal SET last_activity_at = last_activity_of_deal(id);
+UPDATE organization SET last_activity_at = last_activity_of_organization(id);
+UPDATE person SET last_activity_at = last_activity_of_person(id);
+UPDATE project SET last_activity_at = last_activity_of_project(id);

--- a/backend/migrations/core/1788310045_held_mail_stops_moving_the_last_contact_date.up.sql
+++ b/backend/migrations/core/1788310045_held_mail_stops_moving_the_last_contact_date.up.sql
@@ -19,7 +19,16 @@
 -- an internal count.
 
 -- Bounded: CREATE OR REPLACE FUNCTION takes an exclusive lock on the function,
--- and the triggers below take one on activity, which every capture writes.
+-- and the trigger swap below takes one on activity, which every capture writes.
+--
+-- lock_timeout bounds only the WAIT to acquire those locks, never how long this
+-- transaction then holds them, and the migration runner keeps each file in one
+-- transaction — so the activity lock is held until the recompute at the bottom
+-- finishes. Two things keep that window short rather than proportional to the
+-- installation: the recompute touches only rows whose value actually moves (an
+-- installation with no held mail writes nothing at all), and every helper it
+-- calls is index-served through activity_link. It is still a write pause on
+-- capture, and this is where a deploy runbook would read that it exists.
 SET LOCAL lock_timeout = '3s';
 
 -- Replacing a baseline function in a later migration, which has precedent twice
@@ -111,10 +120,44 @@ CREATE TRIGGER activity_project_last_activity
 	   OR old.audience IS DISTINCT FROM new.audience)
 	EXECUTE FUNCTION trg_activity_project_last_activity();
 
--- Every stored value was computed by the old helpers, so every one of them may
--- name a held message. Recomputed through the same helpers the triggers use, so
--- there is one definition of the value rather than a migration's own copy.
-UPDATE deal SET last_activity_at = last_activity_of_deal(id);
-UPDATE organization SET last_activity_at = last_activity_of_organization(id);
-UPDATE person SET last_activity_at = last_activity_of_person(id);
-UPDATE project SET last_activity_at = last_activity_of_project(id);
+-- Recomputed through move_last_activity, not a raw UPDATE.
+--
+-- That is not a style preference. set_updated_at_bump_version() fires on all
+-- four tables and suppresses itself only while margince.last_activity_move is
+-- on, which move_last_activity sets and a bare UPDATE does not. Writing the
+-- column directly would stamp updated_at and bump version on every deal,
+-- organization, person and project in the installation — invalidating every
+-- outstanding If-Match a client holds and telling every "what changed
+-- recently" reader that the whole database was edited at deploy time.
+--
+-- Only rows whose derived value actually moves are touched, so an installation
+-- with no held mail writes nothing at all.
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT id FROM deal
+     WHERE last_activity_at IS DISTINCT FROM last_activity_of_deal(id)
+  LOOP
+    PERFORM move_last_activity('deal'::regclass, r.id);
+  END LOOP;
+  FOR r IN
+    SELECT id FROM organization
+     WHERE last_activity_at IS DISTINCT FROM last_activity_of_organization(id)
+  LOOP
+    PERFORM move_last_activity('organization'::regclass, r.id);
+  END LOOP;
+  FOR r IN
+    SELECT id FROM person
+     WHERE last_activity_at IS DISTINCT FROM last_activity_of_person(id)
+  LOOP
+    PERFORM move_last_activity('person'::regclass, r.id);
+  END LOOP;
+  FOR r IN
+    SELECT id FROM project
+     WHERE last_activity_at IS DISTINCT FROM last_activity_of_project(id)
+  LOOP
+    PERFORM move_last_activity('project'::regclass, r.id);
+  END LOOP;
+END $$;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -9,14 +9,14 @@ public.activity.activity_done_at CHECK (((is_done = false) OR (done_at IS NOT NU
 public.activity.activity_host_user_id_fkey FOREIGN KEY (host_user_id) REFERENCES app_user(id) ON DELETE SET NULL (host_user_id)
 public.activity.activity_kind_fkey FOREIGN KEY (kind) REFERENCES activity_kind(kind)
 public.activity.activity_language_check CHECK (((language IS NULL) OR (language = ANY (ARRAY['de'::text, 'en'::text]))))
-public.activity.activity_last_activity CREATE TRIGGER activity_last_activity AFTER UPDATE OF occurred_at, archived_at ON public.activity FOR EACH ROW WHEN (((old.occurred_at IS DISTINCT FROM new.occurred_at) OR (old.archived_at IS DISTINCT FROM new.archived_at))) EXECUTE FUNCTION trg_activity_last_activity()
+public.activity.activity_last_activity CREATE TRIGGER activity_last_activity AFTER UPDATE OF occurred_at, archived_at, audience ON public.activity FOR EACH ROW WHEN (((old.occurred_at IS DISTINCT FROM new.occurred_at) OR (old.archived_at IS DISTINCT FROM new.archived_at) OR (old.audience IS DISTINCT FROM new.audience))) EXECUTE FUNCTION trg_activity_last_activity()
 public.activity.activity_meeting_host CHECK (((host_user_id IS NULL) OR (kind = 'meeting'::text)))
 public.activity.activity_meeting_no_overlap EXCLUDE USING gist (host_user_id WITH =, tsrange(timezone('UTC'::text, occurred_at), (timezone('UTC'::text, occurred_at) + '01:00:00'::interval)) WITH &&) WHERE (((kind = 'meeting'::text) AND (host_user_id IS NOT NULL) AND (archived_at IS NULL)))
 public.activity.activity_meeting_status_check CHECK (((meeting_status IS NULL) OR (meeting_status = ANY (ARRAY['booked'::text, 'held'::text, 'no_show'::text, 'canceled'::text]))))
 public.activity.activity_message_has_provider CHECK (((kind = 'message'::text) = (channel_provider IS NOT NULL)))
 public.activity.activity_no_company_meeting_on_rekind CREATE TRIGGER activity_no_company_meeting_on_rekind BEFORE UPDATE OF kind ON public.activity FOR EACH ROW EXECUTE FUNCTION activity_refuses_becoming_a_company_meeting()
 public.activity.activity_pkey PRIMARY KEY (id)
-public.activity.activity_project_last_activity CREATE TRIGGER activity_project_last_activity AFTER UPDATE OF occurred_at, archived_at ON public.activity FOR EACH ROW WHEN (((old.occurred_at IS DISTINCT FROM new.occurred_at) OR (old.archived_at IS DISTINCT FROM new.archived_at))) EXECUTE FUNCTION trg_activity_project_last_activity()
+public.activity.activity_project_last_activity CREATE TRIGGER activity_project_last_activity AFTER UPDATE OF occurred_at, archived_at, audience ON public.activity FOR EACH ROW WHEN (((old.occurred_at IS DISTINCT FROM new.occurred_at) OR (old.archived_at IS DISTINCT FROM new.archived_at) OR (old.audience IS DISTINCT FROM new.audience))) EXECUTE FUNCTION trg_activity_project_last_activity()
 public.activity.activity_refuse_restricted_mutation CREATE TRIGGER activity_refuse_restricted_mutation BEFORE DELETE OR UPDATE ON public.activity FOR EACH ROW EXECUTE FUNCTION activity_refuse_restricted_mutation()
 public.activity.activity_restricted_is_archived CHECK (((restricted_at IS NULL) OR (archived_at IS NOT NULL)))
 public.activity.activity_restriction_complete CHECK ((((restricted_at IS NULL) AND (restricted_reason IS NULL) AND (restricted_until IS NULL)) OR ((restricted_at IS NOT NULL) AND (restricted_reason IS NOT NULL) AND (restricted_until IS NOT NULL))))
@@ -2526,6 +2526,7 @@ public.last_activity_of_deal(did uuid) secdef=false cfg=- acl=-
   SELECT max(a.occurred_at)
     FROM activity_link l
     JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
    WHERE l.deal_id = did
 
 public.last_activity_of_organization(oid uuid) secdef=false cfg=- acl=- 
@@ -2534,6 +2535,7 @@ public.last_activity_of_organization(oid uuid) secdef=false cfg=- acl=-
     SELECT max(a.occurred_at) AS v
       FROM activity_link l
       JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
      WHERE l.organization_id = oid
     UNION ALL
     -- Filed against one of its deals.
@@ -2541,6 +2543,7 @@ public.last_activity_of_organization(oid uuid) secdef=false cfg=- acl=-
       FROM deal d
       JOIN activity_link l ON l.deal_id = d.id
       JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
      WHERE d.organization_id = oid
     UNION ALL
     -- Filed against a contact it currently employs.
@@ -2548,6 +2551,7 @@ public.last_activity_of_organization(oid uuid) secdef=false cfg=- acl=-
       FROM relationship r
       JOIN activity_link l ON l.person_id = r.person_id
       JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+       AND a.audience = 'workspace'
      WHERE r.organization_id = oid AND r.kind = 'employment'
        AND r.ended_at IS NULL AND r.archived_at IS NULL
   ) arms
@@ -2556,12 +2560,14 @@ public.last_activity_of_person(pid uuid) secdef=false cfg=- acl=-
   SELECT max(a.occurred_at)
     FROM activity_link l
     JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
    WHERE l.person_id = pid
 
 public.last_activity_of_project(pid uuid) secdef=false cfg=- acl=- 
   SELECT max(a.occurred_at)
     FROM activity_link l
     JOIN activity a ON a.id = l.activity_id AND a.archived_at IS NULL
+     AND a.audience = 'workspace'
    WHERE l.project_id = pid
 
 public.lead acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -15341,7 +15341,8 @@ export interface components {
             version?: components["schemas"]["RowVersion"];
             /**
              * Format: date-time
-             * @description When something last happened with this account — the newest `occurred_at` of an activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first linked activity. Sortable (DM-VOCAB-2).
+             * @description When something last happened with this account — the newest `occurred_at` of a WORKSPACE-AUDIENCE activity linked to it, maintained on the activity write exactly as `deal.last_activity_at` is (formulas-and-rules §8; a read accelerator, never a second truth — a rebuild must reproduce it). NULL until the first such activity. Sortable (DM-VOCAB-2).
+             *     A message limited to its participants does NOT move this date, even for a reader who may read that message. The value is one number every reader sees, so it can only count what every reader may see.
              */
             readonly last_activity_at?: string | null;
             /** Format: date-time */
@@ -18515,7 +18516,7 @@ export interface components {
             closed_at?: string | null;
             /**
              * Format: date-time
-             * @description Drives the deterministic stalled flag.
+             * @description Drives the deterministic stalled flag. Counts workspace-audience activities only, so a deal whose only recent mail is limited to its participants reads as stalled.
              */
             last_activity_at?: string | null;
             /** @description Derived — no activity past the threshold (absolute duration). */
@@ -18980,7 +18981,7 @@ export interface components {
             ended_at?: string | null;
             /**
              * Format: date-time
-             * @description Maintained from the timeline on link write; a read accelerator, never a second truth — a rebuild must reproduce it exactly.
+             * @description The newest WORKSPACE-AUDIENCE activity filed under the project, maintained from the timeline on link write; a read accelerator, never a second truth — a rebuild must reproduce it exactly. A message limited to its participants does not move it, even for a reader who may read that message: one number every reader sees can only count what every reader may see.
              */
             readonly last_activity_at?: string | null;
             source: string;
@@ -19132,7 +19133,7 @@ export interface components {
             open_commitments: number;
             /**
              * Format: date-time
-             * @description The newest activity filed under the project; null when nothing is filed yet.
+             * @description The newest WORKSPACE-AUDIENCE activity filed under the project; null when nothing is filed yet. A message limited to its participants does not move it, even for a reader who may read that message.
              */
             last_activity_at: string | null;
             /** @description Every live activity filed under the project. */


### PR DESCRIPTION
## The leak

`last_activity_at` is a stored column on **deal, organization, person and project**, and 43 Go read sites read it. None filtered audience because none could — the value comes from four SQL helpers and two triggers, and they counted every unarchived activity.

So a message limited to its participants moved a date every colleague sees. "Contacted 2 days ago" was true *because of mail they cannot open* — the fact of a conversation, its timing and its counterparty, all disclosed by a number.

Fixing the SQL fixes all 43 readers at once, which is why this is a migration and not a call-site sweep. Replacing a baseline function in a later migration has precedent twice (`1787400000`, `1787450422`).

## Four helpers, not three

An earlier draft had deal, organization and person and **missed `last_activity_of_project` entirely**. Project surfaces read and order by that column exactly as the others do, so rebuilding the project trigger without it would have recomputed the same leaking value. The test names all four separately, so that miss fails by name.

## The triggers had to learn about audience too

`activity_last_activity` and `activity_project_last_activity` fired on `occurred_at, archived_at` only. Narrowing a message changed what the helpers *would* answer while nothing asked them again — the stored value stayed on the held message until some unrelated edit happened to move it.

## This narrows a stated policy, on purpose

The audience gate's corpus rule ([audiencereaders_test.go:22-31](backend/gates/audiencereaders_test.go#L22)) holds that *"a reader taking `max(occurred_at)` off an activity owes it nothing."* That stays true for every other marker reader in the tree. It stops being true for these four columns because they are read as a sentence about a person on a page, not as an internal count. The migration says so where the next author will find it.

Five other metadata readers derive facts from held mail the same way (relationship-change events, `leadColumns`, deal engagement and quiet facts, org rollups, the automation last-touch scan). They are **not** in this PR — narrowing the policy everywhere is a different project with a different acceptance bar.

## Acceptance

| case | result |
|---|---|
| narrow the newest message | all four clocks move back to the newest **open** message |
| widen it again | all clocks move forward — the round trip |
| a message born held (capture's shape) | never moves the clock at all |

The narrowing goes through `activities.SetAudience`, the real writer — a test that set the column by hand would be asserting its own seed.

## Mutation checks, against real Postgres

- Dropping the **project** helper's clause fails only the project assertion, by name.
- Dropping the **triggers'** audience column fails all four clocks plus the widening round trip.

## Gates

`make check-backend`, `make craft-static`, `make rls-store-path`, `make no-jurisdiction` green. The full `backend/migrations` integration suite passes, including the up/down round-trip; `head_catalog.txt` regenerated in the same commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops held mail from moving `last_activity_at` on deal, organization, person, and project. These dates counted every unarchived activity, so a participant-only message still advanced the "contacted X days ago" date every colleague sees. They now count only workspace-audience activities.

**Migration**
- Recomputes stored values through `move_last_activity` instead of a raw `UPDATE`, so only rows whose date actually moves are touched and no `updated_at`/`version` bumps invalidate client If-Match checks.
- The down migration restores the old helpers and triggers and recomputes the old values.
- Migration comments no longer name the clock-move guard, so a Go source scan doesn't read a false positive.

**Scope**
- The triggers now fire on `audience` changes, so narrowing or widening a message moves the date immediately; a message born held never moves it.
- The policy change is limited to these four columns; other readers that derive facts from held mail are intentionally unchanged.

<sup>Written for commit ca0b7d7510d1b1269dbd98a3398c7987535298c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Last activity dates now reflect only unarchived activities visible to the workspace.
  - Restricted activities no longer advance dates for people, organizations, deals, or projects.
  - Changing activity visibility recalculates dates correctly, including when visibility is restored.
  - These updates preserve record versions and do not appear as edits.

- **Documentation**
  - Clarified visibility rules, null behavior, rebuildability, and stalled-status semantics in the CRM API.

- **Tests**
  - Added coverage for visibility changes and recalculation across supported record types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->