### PR TITLE
main compiles again, and its lint and craft gates pass

### DIFF
--- a/backend/internal/compose/integration/meetingcoaching_integration_test.go
+++ b/backend/internal/compose/integration/meetingcoaching_integration_test.go
@@ -64,7 +64,7 @@ func coachingRoom(t *testing.T, e *Env, seated ids.UUID) ids.UUID {
 	return meeting
 }
 
-func coachingOn(t *testing.T, e *Env, ctx context.Context, meeting ids.UUID) *crmcontracts.MeetingPlanCoaching {
+func coachingOn(ctx context.Context, t *testing.T, e *Env, meeting ids.UUID) *crmcontracts.MeetingPlanCoaching {
 	t.Helper()
 	brief, err := meetingBriefService(e).Get(ctx, meeting)
 	if err != nil {
@@ -82,7 +82,7 @@ func TestALeadReadingATeammatesMeetingIsCoached(t *testing.T) {
 	meeting := coachingRoom(t, e, e.Rep2)
 	// Rep1 and Rep2 share Team1.
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, coachPerms())
-	if coachingOn(t, e, ctx, meeting) == nil {
+	if coachingOn(ctx, t, e, meeting) == nil {
 		t.Error("a lead reading their teammate's meeting was not coached")
 	}
 }
@@ -176,7 +176,7 @@ func TestARepIsNeverCoachedEvenOnATeammatesMeeting(t *testing.T) {
 	e := Setup(t)
 	meeting := coachingRoom(t, e, e.Rep2)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, repPerms())
-	if coachingOn(t, e, ctx, meeting) != nil {
+	if coachingOn(ctx, t, e, meeting) != nil {
 		t.Error("a rep sharing a team with the seated colleague was coached")
 	}
 }
@@ -188,7 +188,7 @@ func TestASeatedLeadIsStillCoached(t *testing.T) {
 	meeting := coachingRoom(t, e, e.Rep2)
 	seatUserInRoom(t, owner, meeting, e.Rep1)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, coachPerms())
-	if coachingOn(t, e, ctx, meeting) == nil {
+	if coachingOn(ctx, t, e, meeting) == nil {
 		t.Error("a lead who is in the room was not coached; being seated is not a disqualifier")
 	}
 }
@@ -214,7 +214,7 @@ func TestALeadAloneInTheRoomIsNotCoached(t *testing.T) {
 	e := Setup(t)
 	meeting := coachingRoom(t, e, e.Rep1)
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, coachPerms())
-	if coachingOn(t, e, ctx, meeting) != nil {
+	if coachingOn(ctx, t, e, meeting) != nil {
 		t.Error("a lead alone in the room was coached about themselves")
 	}
 }

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -30,7 +30,6 @@ import (
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
-	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
 
 // WaitingReply is one inbound message nobody has answered.
@@ -248,8 +247,8 @@ const waitingRepliesSQL = `
 	   AND a.archived_at IS NULL
 	   AND a.occurred_at <= $%[1]d
 	   AND %[2]s
-	   -- Entity narrowing goes HERE, before waitingScanCap's LIMIT below: a
-	   -- record's own wait can sit outside the oldest waitingScanCap threads
+	   -- Entity narrowing goes HERE, before WaitingScanCap's LIMIT below: a
+	   -- record's own wait can sit outside the oldest WaitingScanCap threads
 	   -- workspace-wide, and narrowing after the cap would report nothing
 	   -- waiting on the very record this asks about. "TRUE" for the
 	   -- workspace-wide Worklist read.
@@ -479,85 +478,4 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 		return nil, fmt.Errorf("activities: reading who is waiting for a reply: %w", err)
 	}
 	return waiting, nil
-}
-
-// waitingReplyEntityClause narrows the thread walk to one record, in the SAME
-// vocabulary linktarget.go and listActivitiesFilter's own entity_type/id
-// filter use — a record type added to linkColumn or the organization arm
-// reaches this walk too, rather than a second copy silently missing it.
-func waitingReplyEntityClause(entityType string, entityID ids.UUID, arg func(any) int) (string, error) {
-	if entityType == string(datasource.RecordOrganization) {
-		// An account's timeline is wider than its direct links (mail is filed
-		// against the person it was with), so this reuses the SAME three-arm
-		// walk the timeline list and the company view both read through —
-		// see OrgLinkedActivityExists.
-		return OrgLinkedActivityExists(arg(entityID)), nil
-	}
-	column := linkColumn(entityType)
-	if column == "" {
-		return "", &InvalidLinkTypeError{EntityType: entityType}
-	}
-	typePos := arg(entityType)
-	idPos := arg(entityID)
-	return sprintf("EXISTS (SELECT 1 FROM activity_link el WHERE el.activity_id = a.id AND el.entity_type = $%d AND el.%s = $%d)",
-		typePos, column, idPos), nil
-}
-
-// waitingReplyExistsClause builds the timeline list's `waiting_reply=true`
-// filter: the SAME thread walk WaitingReplies runs for the Worklist,
-// embedded as a subquery so the outer list's own entity/kind/cursor terms
-// compose with it rather than duplicating what "unanswered" means.
-//
-// The subquery is uncorrelated — it computes its own candidate set rather
-// than reading the outer FROM — so its own `a` alias shadowing the outer
-// query's is harmless.
-func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.Time, entityType *string, entityID *ids.UUID) (string, error) {
-	instant := arg(asOf)
-	content, err := auth.ActivityContentClause(ctx, "a", arg)
-	if err != nil {
-		return "", err
-	}
-	linkVisible, err := auth.LinkTargetVisibleClause(ctx, "wl", arg)
-	if err != nil {
-		return "", err
-	}
-	if linkVisible == "" {
-		linkVisible = scopeUnbounded
-	}
-	entityClause := scopeUnbounded
-	if entityType != nil && entityID != nil {
-		entityClause, err = waitingReplyEntityClause(*entityType, *entityID, arg)
-		if err != nil {
-			return "", err
-		}
-	}
-	// The SAME reader, horizon and live-record rules WaitingReplies applies
-	// for the Worklist: a thread the Worklist would not name as waiting must
-	// not be named by a record page either, and a per-record set-aside must
-	// still be this reader's own.
-	reader := arg(readerOrNobody(ctx))
-	return "a.id IN (SELECT id FROM (" +
-		fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, waitingScanCap,
-			waitingHorizonDays,
-			liveRecord(openDealPredicate, "d"),
-			liveRecord(workingLeadPredicate, "ld"),
-			liveRecord(openDealPredicate, "openDeal"),
-			liveRecord(openDealPredicate, "fd"),
-			reader,
-			entityClause) +
-		") waiting_thread)", nil
-}
-
-// appendWaitingReplyClause is listActivitiesFilter's `waiting_reply=true`
-// term, split out so that already-long function does not have to grow to
-// hold it. A no-op when the caller did not ask for the filter.
-func appendWaitingReplyClause(ctx context.Context, in ListActivitiesInput, arg func(any) int, where []string) ([]string, error) {
-	if in.WaitingReplyAsOf == nil {
-		return where, nil
-	}
-	clause, err := waitingReplyExistsClause(ctx, arg, *in.WaitingReplyAsOf, in.EntityType, in.EntityID)
-	if err != nil {
-		return nil, err
-	}
-	return append(where, clause), nil
 }

--- a/backend/internal/modules/activities/waitingrecordscope.go
+++ b/backend/internal/modules/activities/waitingrecordscope.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Narrowing the waiting-reply walk to ONE record.
+//
+// The workspace-wide read is the Worklist's; this is what a record page asks,
+// and the two share a statement rather than a resemblance. The narrowing goes
+// inside that statement, before the scan cap's LIMIT: a record's own wait can
+// sit outside the oldest WaitingScanCap threads workspace-wide, and narrowing
+// after the cap would report nothing waiting on the very record being asked
+// about.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+)
+
+// waitingReplyEntityClause narrows the thread walk to one record, in the SAME
+// vocabulary linktarget.go and listActivitiesFilter's own entity_type/id
+// filter use — a record type added to linkColumn or the organization arm
+// reaches this walk too, rather than a second copy silently missing it.
+func waitingReplyEntityClause(entityType string, entityID ids.UUID, arg func(any) int) (string, error) {
+	if entityType == string(datasource.RecordOrganization) {
+		// An account's timeline is wider than its direct links (mail is filed
+		// against the person it was with), so this reuses the SAME three-arm
+		// walk the timeline list and the company view both read through —
+		// see OrgLinkedActivityExists.
+		return OrgLinkedActivityExists(arg(entityID)), nil
+	}
+	column := linkColumn(entityType)
+	if column == "" {
+		return "", &InvalidLinkTypeError{EntityType: entityType}
+	}
+	typePos := arg(entityType)
+	idPos := arg(entityID)
+	return sprintf("EXISTS (SELECT 1 FROM activity_link el WHERE el.activity_id = a.id AND el.entity_type = $%d AND el.%s = $%d)",
+		typePos, column, idPos), nil
+}
+
+// waitingReplyExistsClause builds the timeline list's `waiting_reply=true`
+// filter: the SAME thread walk WaitingReplies runs for the Worklist,
+// embedded as a subquery so the outer list's own entity/kind/cursor terms
+// compose with it rather than duplicating what "unanswered" means.
+//
+// The subquery is uncorrelated — it computes its own candidate set rather
+// than reading the outer FROM — so its own `a` alias shadowing the outer
+// query's is harmless.
+func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.Time, entityType *string, entityID *ids.UUID) (string, error) {
+	instant := arg(asOf)
+	content, err := auth.ActivityContentClause(ctx, "a", arg)
+	if err != nil {
+		return "", err
+	}
+	linkVisible, err := auth.LinkTargetVisibleClause(ctx, "wl", arg)
+	if err != nil {
+		return "", err
+	}
+	if linkVisible == "" {
+		linkVisible = scopeUnbounded
+	}
+	entityClause := scopeUnbounded
+	if entityType != nil && entityID != nil {
+		entityClause, err = waitingReplyEntityClause(*entityType, *entityID, arg)
+		if err != nil {
+			return "", err
+		}
+	}
+	// The SAME reader, horizon and live-record rules WaitingReplies applies
+	// for the Worklist: a thread the Worklist would not name as waiting must
+	// not be named by a record page either, and a per-record set-aside must
+	// still be this reader's own.
+	reader := arg(readerOrNobody(ctx))
+	return "a.id IN (SELECT id FROM (" +
+		fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, WaitingScanCap,
+			waitingHorizonDays,
+			liveRecord(openDealPredicate, "d"),
+			liveRecord(workingLeadPredicate, "ld"),
+			liveRecord(openDealPredicate, "openDeal"),
+			liveRecord(openDealPredicate, "fd"),
+			reader,
+			entityClause) +
+		") waiting_thread)", nil
+}
+
+// appendWaitingReplyClause is listActivitiesFilter's `waiting_reply=true`
+// term, split out so that already-long function does not have to grow to
+// hold it. A no-op when the caller did not ask for the filter.
+func appendWaitingReplyClause(ctx context.Context, in ListActivitiesInput, arg func(any) int, where []string) ([]string, error) {
+	if in.WaitingReplyAsOf == nil {
+		return where, nil
+	}
+	clause, err := waitingReplyExistsClause(ctx, arg, *in.WaitingReplyAsOf, in.EntityType, in.EntityID)
+	if err != nil {
+		return nil, err
+	}
+	return append(where, clause), nil
+}


### PR DESCRIPTION
`main` does not compile. Three failures, all from PRs that landed in the last few hours.

## 1. The activities module does not build

```
internal/modules/activities/waiting.go:540:65: undefined: waitingScanCap
```

#3563 added a call site spelling the constant `waitingScanCap`; it is `WaitingScanCap`, declared two hundred lines above and spelled correctly at the other call site in the same file. Every lane that compiles this module has been failing since it merged.

## 2. waiting.go crossed the 500-line cap

The same PR took it to 564, and `craft static --strict` blocks on it.

The record-scoped narrowing is the concept to lift: `waitingReplyEntityClause`, `waitingReplyExistsClause` and `appendWaitingReplyClause` move to `waitingrecordscope.go`, and `waiting.go` keeps the walk itself. That is the seam #3563 was working along — the workspace-wide read is the Worklist's, and this is what a record page asks of the same statement.

## 3. revive refuses coachingOn's parameter order

```
meetingcoaching_integration_test.go:67:39: context-as-argument: context.Context should be the first parameter (revive)
```

Reordered, with its four call sites.

`make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity record filtering for waiting replies.
  * Waiting-reply results now respect authorization, content visibility, timing, live-record, and scan-limit rules.
  * Filters are applied when a waiting-reply reference time is provided, with relevant errors surfaced appropriately.

* **Refactor**
  * Simplified activity waiting logic by removing unused helper functionality.
  * Updated internal test helper usage without changing runtime behavior or test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->