### PR TITLE
The review backlog pages out

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -9697,6 +9697,39 @@ paths:
           in: query
           schema: { type: integer, minimum: 1, maximum: 100, default: 25 }
           description: 'How many ranked items to return.'
+        - name: cursor
+          in: query
+          schema: { type: string }
+          description: |
+            Where to continue a walk, from a prior response's `next_cursor`. Omitted starts at
+            the top, which is what every reader opening their day wants.
+
+            NOT the shared keyset cursor the CRUD lists use, and the difference is why this
+            endpoint declares its own. Those walk rows a database already ordered, so their
+            token carries a sort key and the next page is a WHERE clause. This queue has no
+            such column: it assembles from a dozen lanes and ranks them by a comparator
+            reading facts no table holds — whether a wait is crowded, what a deal is worth in
+            base currency, which band a row landed in. So this token names the last row it
+            handed you, and the next page re-assembles the day, re-ranks it, and continues
+            after that row.
+
+            It encodes the `scope`, `filter` and `owner` it was minted under. Sending it
+            alongside different ones returns `422 code: cursor_param_mismatch` rather than
+            continuing into a different question — page two of your own tasks silently
+            becoming the team's deals is what that prevents, and nothing in the response would
+            have said so. `limit` is deliberately NOT fingerprinted: it decides how many rows
+            a page carries, not which rows exist, so changing it mid-walk is legitimate.
+
+            A token this endpoint did not mint returns `422 code: malformed_cursor`.
+
+            WHAT A WALK GUARANTEES, and what it does not. This is live work, so the day moves
+            between pages: a rep answers a message, a deal closes, a colleague takes a task.
+            The walk guarantees a row is not silently repeated, and that it terminates. It
+            does not promise a stable snapshot, and should not — a page showing rows already
+            dealt with would be worse than one that skipped them. If the row a cursor names is
+            gone by the time the next page is asked for, the walk ENDS: restarting from the
+            top would hand a client paging to exhaustion the same first page forever, each
+            pass looking like ordinary progress.
         - name: owner
           in: query
           schema: { type: string, format: uuid }
@@ -35131,6 +35164,22 @@ components:
           type: array
           items: { $ref: '#/components/schemas/WorklistSourceUnavailable' }
           description: 'Sources that could not be included, and why. Empty is the honest common case.'
+        next_cursor:
+          type: string
+          description: |
+            Send this back as `cursor` to continue past the last row of this page. See that
+            parameter for what a walk does and does not guarantee.
+
+            ABSENT MEANS THE WALK IS OVER — there is nothing behind this page. It is
+            deliberately not minted on a final page: a cursor there invites one more request
+            that can only answer empty, and a client walking until the cursor disappears
+            would never stop.
+
+            Absent is therefore a claim, not a silence, and it is the one this field must
+            never make wrongly. `reach` and `counts` answer a different question — how deep
+            each SOURCE was read, which is a bound on work rather than the end of a page —
+            so a walk that has ended can still sit above sources that were cut short, and
+            both statements are true at once.
         reach:
           type: array
           items: { $ref: '#/components/schemas/WorklistReach' }

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -9713,23 +9713,43 @@ paths:
             handed you, and the next page re-assembles the day, re-ranks it, and continues
             after that row.
 
-            It encodes the `scope`, `filter` and `owner` it was minted under. Sending it
-            alongside different ones returns `422 code: cursor_param_mismatch` rather than
-            continuing into a different question — page two of your own tasks silently
+            It encodes the `scope`, `filter` and `owner` it was minted under, NORMALISED, so
+            that two spellings of one question share a cursor: an omitted `filter` and
+            `filter=all` weigh the same candidates, and naming yourself as `owner` is the
+            question the default already answers. Sending a cursor alongside a genuinely
+            different scope, filter or owner returns `422 code: cursor_param_mismatch` rather
+            than continuing into another question — page two of your own tasks silently
             becoming the team's deals is what that prevents, and nothing in the response would
             have said so. `limit` is deliberately NOT fingerprinted: it decides how many rows
             a page carries, not which rows exist, so changing it mid-walk is legitimate.
 
-            A token this endpoint did not mint returns `422 code: malformed_cursor`.
+            A token that does not decode returns `422 code: malformed_cursor`. The token is
+            opaque, NOT authenticated: it is base64 of a small JSON object and a caller who
+            studies it can construct one. That grants nothing. A cursor only chooses where to
+            resume inside a page that is re-assembled from scratch under the caller's own
+            principal, so every row it can reach is one the caller could already read, and no
+            forged token widens scope or row visibility.
 
             WHAT A WALK GUARANTEES, and what it does not. This is live work, so the day moves
             between pages: a rep answers a message, a deal closes, a colleague takes a task.
-            The walk guarantees a row is not silently repeated, and that it terminates. It
-            does not promise a stable snapshot, and should not — a page showing rows already
-            dealt with would be worse than one that skipped them. If the row a cursor names is
-            gone by the time the next page is asked for, the walk ENDS: restarting from the
-            top would hand a client paging to exhaustion the same first page forever, each
-            pass looking like ordinary progress.
+
+            Guaranteed: the walk TERMINATES, and no row is lost from a part of the day that
+            did not change. A row whose anchor is answered or reprioritised between pages does
+            not end the walk early — the token carries a position as well as an identity, and
+            the position continues it.
+
+            Not guaranteed: a stable snapshot, which a set re-assembled and re-ranked on every
+            read cannot offer. Two consequences, both deliberate:
+
+            A row may REPEAT. Where the token's position and identity disagree — because the
+            day moved under them — the earlier of the two wins. Repeating a row the caller has
+            already seen is recoverable; skipping one means work shown to nobody, so this errs
+            toward the first every time.
+
+            A row that overtakes rows you have ALREADY been handed waits for your next read.
+            It now sorts behind them, and returning it would mean re-serving that whole prefix
+            — the walk that never ends. Opening the queue again leads with it, so the delay is
+            bounded and corrects itself.
         - name: owner
           in: query
           schema: { type: string, format: uuid }
@@ -35170,16 +35190,20 @@ components:
             Send this back as `cursor` to continue past the last row of this page. See that
             parameter for what a walk does and does not guarantee.
 
-            ABSENT MEANS THE WALK IS OVER — there is nothing behind this page. It is
+            ABSENT MEANS THE WALK IS OVER — nothing was left behind this page. It is
             deliberately not minted on a final page: a cursor there invites one more request
             that can only answer empty, and a client walking until the cursor disappears
             would never stop.
 
             Absent is therefore a claim, not a silence, and it is the one this field must
-            never make wrongly. `reach` and `counts` answer a different question — how deep
-            each SOURCE was read, which is a bound on work rather than the end of a page —
-            so a walk that has ended can still sit above sources that were cut short, and
-            both statements are true at once.
+            never make wrongly. It is a claim about THIS READ of the day: work that arrives
+            afterwards, or that overtakes rows already handed out, appears on the next read
+            rather than extending a finished walk.
+
+            `reach` and `counts` answer a different question — how deep each SOURCE was read,
+            which is a bound on work rather than the end of a page — so a walk that has ended
+            can still sit above sources that were cut short, and both statements are true at
+            once.
         reach:
           type: array
           items: { $ref: '#/components/schemas/WorklistReach' }

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -9709,9 +9709,9 @@ paths:
             token carries a sort key and the next page is a WHERE clause. This queue has no
             such column: it assembles from a dozen lanes and ranks them by a comparator
             reading facts no table holds — whether a wait is crowded, what a deal is worth in
-            base currency, which band a row landed in. So this token names the last row it
-            handed you, and the next page re-assembles the day, re-ranks it, and continues
-            after that row.
+            base currency, which band a row landed in. So the token carries a POSITION in that
+            ranking, and the next page re-assembles the day, ranks it the same way, and starts
+            there.
 
             It encodes the `scope`, `filter` and `owner` it was minted under, NORMALISED, so
             that two spellings of one question share a cursor: an omitted `filter` and
@@ -9733,23 +9733,28 @@ paths:
             WHAT A WALK GUARANTEES, and what it does not. This is live work, so the day moves
             between pages: a rep answers a message, a deal closes, a colleague takes a task.
 
-            Guaranteed: the walk TERMINATES, and no row is lost from a part of the day that
-            did not change. A row whose anchor is answered or reprioritised between pages does
-            not end the walk early — the token carries a position as well as an identity, and
-            the position continues it.
+            Guaranteed: the walk TERMINATES, and over a day that does not move it reaches
+            every row exactly once. The offset advances on every page and the candidate set is
+            bounded, so no arrangement of arrivals, answers and reprioritisations makes a
+            client paging to exhaustion loop.
 
             Not guaranteed: a stable snapshot, which a set re-assembled and re-ranked on every
-            read cannot offer. Two consequences, both deliberate:
+            read cannot offer. One consequence, and it is the whole cost of this design: A ROW
+            THAT CROSSES THE PAGE BOUNDARY BETWEEN TWO READS IS SERVED TWICE OR NOT AT ALL ON
+            THIS WALK. A deal that turns urgent moves up past where you have got to; one that
+            is answered lets everything below it move up by one.
 
-            A row may REPEAT. Where the token's position and identity disagree — because the
-            day moved under them — the earlier of the two wins. Repeating a row the caller has
-            already seen is recoverable; skipping one means work shown to nobody, so this errs
-            toward the first every time.
+            Such a row is not lost from the product — the next read of the queue ranks it
+            afresh and shows it — so treat a walk as a way to reach a backlog you already know
+            is there, not as a transaction over it. If you need the whole day at one instant,
+            ask for it in one page: `limit` reaches 100.
 
-            A row that overtakes rows you have ALREADY been handed waits for your next read.
-            It now sorts behind them, and returning it would mean re-serving that whole prefix
-            — the walk that never ends. Opening the queue again leads with it, so the delay is
-            bounded and corrects itself.
+            The alternative was a token naming the last row it handed you, which is the
+            obvious design and is worse here. When that row is answered between pages, or
+            sinks to the end of the ranking, "everything after it" is empty and the walk
+            reports itself finished while work is still owed. A queue whose purpose is that
+            work is not forgotten cannot fail that way, so it accepts the boundary case above
+            instead.
         - name: owner
           in: query
           schema: { type: string, format: uuid }

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -9746,8 +9746,10 @@ paths:
 
             Such a row is not lost from the product — the next read of the queue ranks it
             afresh and shows it — so treat a walk as a way to reach a backlog you already know
-            is there, not as a transaction over it. If you need the whole day at one instant,
-            ask for it in one page: `limit` reaches 100.
+            is there, not as a transaction over it. There is no way to ask for the whole day
+            at one instant: `limit` stops at 100 and a single category can hold more than that,
+            because the sources are read to their own bounds well past a page (the decision
+            lane alone weighs 200). `counts` is what says how much is behind the page.
 
             The alternative was a token naming the last row it handed you, which is the
             obvious design and is worse here. When that row is answered between pages, or

--- a/backend/internal/compose/attention/basemoney_test.go
+++ b/backend/internal/compose/attention/basemoney_test.go
@@ -83,7 +83,7 @@ func pricedWorklist(t *testing.T, fx BaseMoney, day crmcontracts.Attention) crmc
 		t.Fatalf("pricing the day: %v", err)
 	}
 	reader.money = money
-	return reader.worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{})
+	return reader.worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
 }
 
 // The ordering compares what deals are WORTH, not what their integers say.
@@ -213,7 +213,7 @@ func TestAnUnboundSeamNamesNoBaseCurrency(t *testing.T) {
 		),
 	}
 
-	out := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{})
+	out := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
 
 	if out.Summary.MaterialThresholdMinor == nil {
 		t.Fatal("raw amounts still take a median; the bar should stand")

--- a/backend/internal/compose/attention/basemoneywiring_test.go
+++ b/backend/internal/compose/attention/basemoneywiring_test.go
@@ -64,7 +64,7 @@ func TestTheEndpointRanksOnConvertedFigures(t *testing.T) {
 			riskyDeal("euro", eur(8_000_000), ids.UUID{}),
 		})
 
-	day, err := svc.Worklist(meetingPrepReader(), "", "", ids.UUID{}, 25)
+	day, err := svc.Worklist(meetingPrepReader(), "", "", ids.UUID{}, 25, "")
 	if err != nil {
 		t.Fatalf("worklist: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestOpeningANamedRepsQueueReachesTheProjection(t *testing.T) {
 			riskyDeal("somebody elses", eur(900_000), ids.MustParse("01a05500-0000-7000-8000-0000000000cc")),
 		})
 
-	day, err := svc.Worklist(meetingPrepReader(), "", "", lena, 25)
+	day, err := svc.Worklist(meetingPrepReader(), "", "", lena, 25, "")
 	if err != nil {
 		t.Fatalf("worklist: %v", err)
 	}

--- a/backend/internal/compose/attention/counts_test.go
+++ b/backend/internal/compose/attention/counts_test.go
@@ -45,7 +45,7 @@ func TestThePageCountsEachKindOfWork(t *testing.T) {
 		AtRisk:  lane(item("deal", "deal_at_risk", withDeal(50_000_00))),
 	}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
 
 	if count := countFor(t, got, "tasks"); count.Considered != 4 || count.Shown != 4 {
 		t.Fatalf("tasks: considered %d shown %d, wanted four of each", count.Considered, count.Shown)
@@ -65,7 +65,7 @@ func TestWorkBelowTheCutIsStillCounted(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, Planned: tasks}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 3, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 3, waitingRead{}, leadRead{}, worklistCursor{})
 
 	count := countFor(t, got, "tasks")
 	if count.Shown != 3 {
@@ -87,7 +87,7 @@ func TestANarrowedPageStillCountsTheKindsItIsNotDrawing(t *testing.T) {
 		AtRisk:  lane(item("deal", "deal_at_risk", withDeal(50_000_00))),
 	}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "deals_at_risk", 25, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "deals_at_risk", 25, waitingRead{}, leadRead{}, worklistCursor{})
 
 	tasks := countFor(t, got, "tasks")
 	if tasks.Considered != 1 {
@@ -112,7 +112,7 @@ func TestAFoldedGroupCountsTheItemsItStandsFor(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, AutomationHealth: &failures}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 50, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 50, waitingRead{}, leadRead{}, worklistCursor{})
 
 	count := countFor(t, got, "system")
 	if count.Shown != 6 {
@@ -129,7 +129,7 @@ func TestACategoryWhoseSourceHitItsBoundSaysThereMayBeMore(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: decisions}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
 
 	if count := countFor(t, got, "decisions"); !count.MoreAvailable {
 		t.Fatal("a category read to its bound reported a flat count, so a client would draw it as a total")
@@ -146,8 +146,8 @@ func TestCountsAreOrderedTheSameWayTwice(t *testing.T) {
 		NeedsYou: []crmcontracts.AttentionItem{item("decision", "approval", withKind("send_email"))},
 	}
 
-	first := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{})
-	second := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{})
+	first := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	second := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
 
 	if len(first.Counts) != len(second.Counts) {
 		t.Fatalf("two reads counted %d and %d categories", len(first.Counts), len(second.Counts))
@@ -395,7 +395,7 @@ func TestABoundedSourceFilteredToNothingStillSaysThereMayBeMore(t *testing.T) {
 
 	// Unassigned drops every row that has an owner, so the lane read fifty and
 	// kept none.
-	out := (&Service{}).worklistFrom(t.Context(), day, scopeUnassigned, "", 25, waitingRead{}, leadRead{})
+	out := (&Service{}).worklistFrom(t.Context(), day, scopeUnassigned, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
 
 	count := countFor(t, out, "deals_at_risk")
 	if count.Considered != 0 {

--- a/backend/internal/compose/attention/cursor.go
+++ b/backend/internal/compose/attention/cursor.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// A worklist cursor is a position in the RANKING, not a keyset over a table.
+//
+// Every other paginated read in this product walks rows a database already
+// ordered, so its cursor carries the last row's sort key and the next page is a
+// WHERE clause. This queue has no such column: it assembles from a dozen lanes
+// and orders them by the nine-step comparator in ranksteps.go, which reads
+// fields no table holds — whether a wait is crowded, what a deal is worth in
+// base currency, which band a row landed in.
+//
+// So the resume is: assemble the same day again, rank it the same way, and drop
+// everything up to and through the row this token names. That is only correct
+// because two properties hold, and both are load-bearing:
+//
+//   - The order is TOTAL. less() ends at `a.item.Id < b.item.Id`, so no two
+//     rows compare equal and the sequence does not depend on which order the
+//     lanes happened to return.
+//   - The candidate set does not depend on `limit`. Crowding is marked over the
+//     whole narrowed set (worklist.go), and the page is cut afterwards, so
+//     asking for rows 26-50 weighs exactly the candidates that asking for 1-25
+//     weighed.
+//
+// The day itself can move between pages — a rep answers a message, a deal
+// closes. That is honest rather than a fault: this is a queue of live work, and
+// a page that showed rows already dealt with would be worse than one that
+// skipped them. What the cursor guarantees is that a row is not silently
+// REPEATED, and that the walk terminates.
+type worklistCursor struct {
+	// Source and Row name the last row of the previous page. Together they are
+	// the row's identity: Id alone is the owning RECORD's id, which two sources
+	// can both point at — a deal that is both quiet and has a customer waiting.
+	Source string `json:"s"`
+	Row    string `json:"r"`
+	// Params fingerprints the request this token was minted under. A cursor
+	// carried onto a different scope, filter or owner would silently answer a
+	// question the caller did not ask: page two of "my tasks" continuing into
+	// "the team's deals", with nothing in the response saying so.
+	Params string `json:"p"`
+}
+
+// fingerprint renders the request parameters that decide WHICH rows exist.
+//
+// `limit` is deliberately absent: it decides how many rows a page carries, not
+// which candidates were weighed, so changing it mid-walk is a legitimate thing
+// for a caller to do and refusing it would be a lie about what changed.
+func fingerprint(scope, filter string, owner ids.UUID) string {
+	sum := sha256.Sum256([]byte(scope + "\x00" + filter + "\x00" + owner.String()))
+	return hex.EncodeToString(sum[:8])
+}
+
+// encodeCursor mints the token for the row a page stopped on.
+//
+// It goes through storekit's codec rather than spelling base64-of-JSON again:
+// one wire format with two encoders drifts the first time either changes, and a
+// token this product mints must be readable by the one decoder that refuses it.
+//
+// It answers a bare string, and the reason is worth stating because the codec
+// beside it does not. storekit.EncodeOpaque can fail, but only where
+// json.Marshal can, and its own note says what that means in practice: a
+// keyset carrying a time.Time outside year 0..9999. worklistCursor carries
+// three strings and no instant, so the failure has no reachable cause here.
+//
+// The alternative was threading an error nothing can raise up through
+// worklistFrom and its thirty-odd callers, where every one of them would need a
+// branch for a case that never runs — a branch that is never exercised is never
+// known to be right, and the only honest thing to write in it (a page claiming
+// the backlog ended early) is worse than the case it guards against.
+//
+// Held by: TestACursorRoundTripsEveryRowShapeTheQueueCanCarry, which mints one
+// from every source the queue can raise and reads each back.
+func encodeCursor(row ranked, scope, filter string, owner ids.UUID) string {
+	token, err := storekit.EncodeOpaque(worklistCursor{
+		Source: string(row.item.Source),
+		Row:    row.item.Id,
+		Params: fingerprint(scope, filter, owner),
+	})
+	if err != nil {
+		// Unreachable for three strings. An empty token is refused by
+		// decodeCursor on the way back in, so the walk ends with a 422 the
+		// caller can see rather than a page silently claiming to be the last.
+		return ""
+	}
+	return token
+}
+
+// decodeCursor reads a token back, refusing anything this package did not mint
+// for this exact question.
+//
+// An empty token is the start of the walk rather than a fault, which is what
+// lets one code path serve both the first page and the rest.
+func decodeCursor(token, scope, filter string, owner ids.UUID) (worklistCursor, error) {
+	if token == "" {
+		return worklistCursor{}, nil
+	}
+	cursor, err := storekit.DecodeOpaque[worklistCursor](token)
+	if err != nil {
+		return worklistCursor{}, err
+	}
+	// Well-formed JSON is not yet a position: `{}` decodes cleanly and would
+	// name no row, which the resume below reads as "drop nothing" — a token
+	// nobody minted silently restarting the walk.
+	if cursor.Source == "" || cursor.Row == "" {
+		return worklistCursor{}, &storekit.MalformedCursorError{}
+	}
+	if cursor.Params != fingerprint(scope, filter, owner) {
+		return worklistCursor{}, &storekit.CursorSortMismatchError{}
+	}
+	return cursor, nil
+}
+
+// resume drops the rows the caller has already been given.
+//
+// The named row is dropped WITH them: a cursor says where a page stopped, so
+// the next one starts after it.
+//
+// A row the token names may be GONE by the time the next page is asked for —
+// answered, reassigned, or folded into a group. The walk then ends, and that is
+// a deliberate choice between two imperfect answers. Restarting from the top
+// would be the other, and it is worse in a way that does not announce itself: a
+// client that pages until `has_more` is false would be handed page one again
+// and page forward again, forever, each pass looking like ordinary progress.
+// Ending the walk loses the tail of one read; looping loses the client.
+//
+// The row is looked up by (source, id) rather than by rank position. Positions
+// move whenever the day moves, so an index would resume at whatever row had
+// slid into that slot — silently skipping work rather than repeating it, which
+// is the direction this queue must never fail in.
+func resume(rows []ranked, cursor worklistCursor) []ranked {
+	if cursor.Row == "" {
+		return rows
+	}
+	for i, row := range rows {
+		if string(row.item.Source) == cursor.Source && row.item.Id == cursor.Row {
+			return rows[i+1:]
+		}
+	}
+	return nil
+}

--- a/backend/internal/compose/attention/cursor.go
+++ b/backend/internal/compose/attention/cursor.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -20,29 +21,49 @@ import (
 // fields no table holds — whether a wait is crowded, what a deal is worth in
 // base currency, which band a row landed in.
 //
-// So the resume is: assemble the same day again, rank it the same way, and drop
-// everything up to and through the row this token names. That is only correct
-// because two properties hold, and both are load-bearing:
+// So the resume is: assemble the same day again, rank it the same way, and skip
+// what the caller already has. That is only correct because two properties
+// hold, and both are load-bearing:
 //
-//   - The order is TOTAL. less() ends at `a.item.Id < b.item.Id`, so no two
-//     rows compare equal and the sequence does not depend on which order the
-//     lanes happened to return.
+//   - The order is DETERMINISTIC. less() ends at `a.item.Id < b.item.Id`, so
+//     one read's sequence is the next read's sequence rather than whatever the
+//     lanes happened to return. Two rows sharing an id do tie there, and the
+//     sort is stable, so their relative order is the producers' — which is
+//     itself deterministic for one assembled day. Their (source, id) anchors
+//     would be indistinguishable, and resume() would take the first; the
+//     position half of the token is what keeps that from stalling a walk.
 //   - The candidate set does not depend on `limit`. Crowding is marked over the
 //     whole narrowed set (worklist.go), and the page is cut afterwards, so
 //     asking for rows 26-50 weighs exactly the candidates that asking for 1-25
 //     weighed.
 //
-// The day itself can move between pages — a rep answers a message, a deal
-// closes. That is honest rather than a fault: this is a queue of live work, and
-// a page that showed rows already dealt with would be worse than one that
-// skipped them. What the cursor guarantees is that a row is not silently
-// REPEATED, and that the walk terminates.
+// WHY THE TOKEN CARRIES BOTH A POSITION AND AN IDENTITY. The day is live: a
+// deal closes, a task is reprioritised, a message arrives. Between two pages a
+// row can move ACROSS the anchor in either direction, and each direction breaks
+// one of the two obvious cursors on its own.
+//
+// An identity alone ("resume after this row") fails when the anchor moves down
+// the ranking: a row the caller already received now sorts after it and is
+// handed out twice, and if the anchor slides to the very end the remainder is
+// empty while real work is still owed. A position alone ("resume at offset N")
+// fails when a row moves up past the anchor: everything shifts by one and the
+// row at the old offset is skipped, never shown to anybody.
+//
+// So the resume takes whichever of the two is FURTHER along. Skipping forward
+// can only repeat work at worst; falling back would drop it, and a row nobody
+// ever sees is the failure this queue must not have. The result is not a
+// snapshot and does not pretend to be — see resume() for what each half costs.
 type worklistCursor struct {
 	// Source and Row name the last row of the previous page. Together they are
 	// the row's identity: Id alone is the owning RECORD's id, which two sources
 	// can both point at — a deal that is both quiet and has a customer waiting.
 	Source string `json:"s"`
 	Row    string `json:"r"`
+	// Served is how many rows the caller has already been handed, which is the
+	// anchor's own position plus one. It is the floor the resume cannot fall
+	// below, so a row that moves up past the anchor cannot push an unserved row
+	// into an already-served slot.
+	Served int `json:"n"`
 	// Params fingerprints the request this token was minted under. A cursor
 	// carried onto a different scope, filter or owner would silently answer a
 	// question the caller did not ask: page two of "my tasks" continuing into
@@ -68,9 +89,29 @@ type worklistCursor struct {
 // is re-assembled from scratch under the principal, and the token chooses only
 // where to resume within what they may already see. What this defends is a
 // caller's coherence, not their permissions.
+//
+// Every input is NORMALISED first, because two spellings of one question must
+// fingerprint alike or a walk breaks on a difference the caller cannot see.
+// Both cases are real and both are things the contract itself calls the same
+// question: an omitted `filter` and `filter=all` weigh identical candidates,
+// and naming yourself as `owner` is the question the default already answers.
+// A generated client that sends its documented default on page two would
+// otherwise be refused for agreeing with the server.
 func fingerprint(scope, filter string, owner ids.UUID) string {
-	sum := sha256.Sum256([]byte(scope + "\x00" + filter + "\x00" + owner.String()))
+	sum := sha256.Sum256([]byte(
+		scope + "\x00" + normalizedFilter(filter) + "\x00" + owner.String()))
 	return hex.EncodeToString(sum[:8])
+}
+
+// normalizedFilter collapses the two spellings of "everything" onto one.
+//
+// worklistFrom narrows on exactly this test (`filter != "" && filter != all`),
+// so the two spellings are one candidate set there and must be one here.
+func normalizedFilter(filter string) string {
+	if filter == string(crmcontracts.WorklistFilterAll) {
+		return ""
+	}
+	return filter
 }
 
 // encodeCursor mints the token for the row a page stopped on.
@@ -93,10 +134,11 @@ func fingerprint(scope, filter string, owner ids.UUID) string {
 //
 // Held by: TestACursorRoundTripsEveryRowShapeTheQueueCanCarry, which mints one
 // from every source the queue can raise and reads each back.
-func encodeCursor(row ranked, scope, filter string, owner ids.UUID) string {
+func encodeCursor(row ranked, served int, scope, filter string, owner ids.UUID) string {
 	token, err := storekit.EncodeOpaque(worklistCursor{
 		Source: string(row.item.Source),
 		Row:    row.item.Id,
+		Served: served,
 		Params: fingerprint(scope, filter, owner),
 	})
 	if err != nil {
@@ -135,29 +177,45 @@ func decodeCursor(token, scope, filter string, owner ids.UUID) (worklistCursor, 
 
 // resume drops the rows the caller has already been given.
 //
-// The named row is dropped WITH them: a cursor says where a page stopped, so
-// the next one starts after it.
+// It reads the token's two halves as two claims about one boundary and takes
+// the EARLIER of them. Each half is wrong on its own, and in opposite
+// directions, so neither can be trusted alone:
 //
-// A row the token names may be GONE by the time the next page is asked for —
-// answered, reassigned, or folded into a group. The walk then ends, and that is
-// a deliberate choice between two imperfect answers. Restarting from the top
-// would be the other, and it is worse in a way that does not announce itself: a
-// client that pages until `has_more` is false would be handed page one again
-// and page forward again, forever, each pass looking like ordinary progress.
-// Ending the walk loses the tail of one read; looping loses the client.
+//   - The IDENTITY ("resume after this row") is right while the anchor keeps
+//     its place. If the anchor moves DOWN the ranking it re-serves everything
+//     between its old and new place, and an anchor that slides to the end — or
+//     is answered between pages — leaves nothing behind it at all, which reads
+//     as a finished walk while real work is still owed.
+//   - The POSITION ("resume at offset N") is right while the set keeps its
+//     shape, and it survives an anchor that moved or vanished. But a row that
+//     moves UP past the anchor shifts everything below it by one, and the row
+//     that lands on the old offset is stepped over.
 //
-// The row is looked up by (source, id) rather than by rank position. Positions
-// move whenever the day moves, so an index would resume at whatever row had
-// slid into that slot — silently skipping work rather than repeating it, which
-// is the direction this queue must never fail in.
+// Taking the earlier of the two makes the unacceptable failure unreachable. The
+// two errors are not equal and must not be traded off as though they were: a
+// repeated row is one the caller has already seen and can dismiss, while a
+// skipped row is work shown to nobody, with no failing signal anywhere. This
+// queue exists to make sure work is not forgotten, so it errs toward showing a
+// row twice and never toward showing it never.
+//
+// The cost is real and worth stating: a day that churns heavily between pages
+// can hand back rows the caller already has. That is why the contract promises
+// termination and no LOSS rather than a stable snapshot — a snapshot is not
+// available over a set that is re-assembled and re-ranked on every read.
 func resume(rows []ranked, cursor worklistCursor) []ranked {
-	if cursor.Row == "" {
+	if cursor.Row == "" && cursor.Served == 0 {
 		return rows
 	}
+	// The position, clamped: a token naming more rows than the day still holds
+	// is a walk whose tail has been dealt with, not a fault.
+	from := min(cursor.Served, len(rows))
+	// The identity, when the anchor is still here. `i+1` because the anchor is
+	// the last row already served, not the first one owed.
 	for i, row := range rows {
 		if string(row.item.Source) == cursor.Source && row.item.Id == cursor.Row {
-			return rows[i+1:]
+			from = min(from, i+1)
+			break
 		}
 	}
-	return nil
+	return rows[from:]
 }

--- a/backend/internal/compose/attention/cursor.go
+++ b/backend/internal/compose/attention/cursor.go
@@ -21,49 +21,33 @@ import (
 // fields no table holds — whether a wait is crowded, what a deal is worth in
 // base currency, which band a row landed in.
 //
-// So the resume is: assemble the same day again, rank it the same way, and skip
-// what the caller already has. That is only correct because two properties
-// hold, and both are load-bearing:
+// So the resume is: assemble the day again, rank it the same way, and start at
+// the offset the token names. That works because the ordering is DETERMINISTIC
+// — less() ends at `a.item.Id < b.item.Id`, so one read's sequence is the next
+// read's sequence rather than whatever the lanes happened to return — and
+// because the candidate set does not depend on `limit`: crowding is marked over
+// the whole narrowed set before the cut, so rows 26-50 weigh exactly what rows
+// 1-25 weighed.
 //
-//   - The order is DETERMINISTIC. less() ends at `a.item.Id < b.item.Id`, so
-//     one read's sequence is the next read's sequence rather than whatever the
-//     lanes happened to return. Two rows sharing an id do tie there, and the
-//     sort is stable, so their relative order is the producers' — which is
-//     itself deterministic for one assembled day. Their (source, id) anchors
-//     would be indistinguishable, and resume() would take the first; the
-//     position half of the token is what keeps that from stalling a walk.
-//   - The candidate set does not depend on `limit`. Crowding is marked over the
-//     whole narrowed set (worklist.go), and the page is cut afterwards, so
-//     asking for rows 26-50 weighs exactly the candidates that asking for 1-25
-//     weighed.
+// WHY AN OFFSET AND NOT THE LAST ROW'S IDENTITY, which is the obvious choice
+// and was the first thing tried here. The day is live: between two pages a deal
+// closes, a task is reprioritised, a message arrives. An identity anchor breaks
+// on that in a way an offset does not — when the anchor is answered or sinks to
+// the end of the ranking, "everything after this row" is empty, and the walk
+// reports itself finished with work still owed. A queue whose whole purpose is
+// that work is not forgotten cannot have that failure.
 //
-// WHY THE TOKEN CARRIES BOTH A POSITION AND AN IDENTITY. The day is live: a
-// deal closes, a task is reprioritised, a message arrives. Between two pages a
-// row can move ACROSS the anchor in either direction, and each direction breaks
-// one of the two obvious cursors on its own.
-//
-// An identity alone ("resume after this row") fails when the anchor moves down
-// the ranking: a row the caller already received now sorts after it and is
-// handed out twice, and if the anchor slides to the very end the remainder is
-// empty while real work is still owed. A position alone ("resume at offset N")
-// fails when a row moves up past the anchor: everything shifts by one and the
-// row at the old offset is skipped, never shown to anybody.
-//
-// So the resume takes whichever of the two is FURTHER along. Skipping forward
-// can only repeat work at worst; falling back would drop it, and a row nobody
-// ever sees is the failure this queue must not have. The result is not a
-// snapshot and does not pretend to be — see resume() for what each half costs.
+// Both were tried together, and the pair is worse than either alone rather than
+// better. What a caller has seen is the top K of the PREVIOUS ranking, and after
+// a re-rank that set can be scattered anywhere in the new order; a position plus
+// one anchor cannot encode an arbitrary subset, so every rule for combining them
+// trades one skipped row for a different skipped row. The offset has ONE
+// failure, stated below and in the contract, and that is what makes it the
+// honest choice.
 type worklistCursor struct {
-	// Source and Row name the last row of the previous page. Together they are
-	// the row's identity: Id alone is the owning RECORD's id, which two sources
-	// can both point at — a deal that is both quiet and has a customer waiting.
-	Source string `json:"s"`
-	Row    string `json:"r"`
-	// Served is how many rows the caller has already been handed, which is the
-	// anchor's own position plus one. It is the floor the resume cannot fall
-	// below, so a row that moves up past the anchor cannot push an unserved row
-	// into an already-served slot.
-	Served int `json:"n"`
+	// At is where in the ranking the next page starts: the number of rows this
+	// walk has already covered.
+	At int `json:"n"`
 	// Params fingerprints the request this token was minted under. A cursor
 	// carried onto a different scope, filter or owner would silently answer a
 	// question the caller did not ask: page two of "my tasks" continuing into
@@ -114,7 +98,7 @@ func normalizedFilter(filter string) string {
 	return filter
 }
 
-// encodeCursor mints the token for the row a page stopped on.
+// encodeCursor mints the token for the position a page stopped at.
 //
 // It goes through storekit's codec rather than spelling base64-of-JSON again:
 // one wire format with two encoders drifts the first time either changes, and a
@@ -122,9 +106,9 @@ func normalizedFilter(filter string) string {
 //
 // It answers a bare string, and the reason is worth stating because the codec
 // beside it does not. storekit.EncodeOpaque can fail, but only where
-// json.Marshal can, and its own note says what that means in practice: a
-// keyset carrying a time.Time outside year 0..9999. worklistCursor carries
-// three strings and no instant, so the failure has no reachable cause here.
+// json.Marshal can, and its own note says what that means in practice: a keyset
+// carrying a time.Time outside year 0..9999. worklistCursor carries an int and
+// a string, so the failure has no reachable cause here.
 //
 // The alternative was threading an error nothing can raise up through
 // worklistFrom and its thirty-odd callers, where every one of them would need a
@@ -132,17 +116,14 @@ func normalizedFilter(filter string) string {
 // known to be right, and the only honest thing to write in it (a page claiming
 // the backlog ended early) is worse than the case it guards against.
 //
-// Held by: TestACursorRoundTripsEveryRowShapeTheQueueCanCarry, which mints one
-// from every source the queue can raise and reads each back.
-func encodeCursor(row ranked, served int, scope, filter string, owner ids.UUID) string {
+// Held by: TestACursorRoundTripsThePositionItWasMintedAt.
+func encodeCursor(at int, scope, filter string, owner ids.UUID) string {
 	token, err := storekit.EncodeOpaque(worklistCursor{
-		Source: string(row.item.Source),
-		Row:    row.item.Id,
-		Served: served,
+		At:     at,
 		Params: fingerprint(scope, filter, owner),
 	})
 	if err != nil {
-		// Unreachable for three strings. An empty token is refused by
+		// Unreachable for an int and a string. An empty token is refused by
 		// decodeCursor on the way back in, so the walk ends with a 422 the
 		// caller can see rather than a page silently claiming to be the last.
 		return ""
@@ -163,10 +144,13 @@ func decodeCursor(token, scope, filter string, owner ids.UUID) (worklistCursor, 
 	if err != nil {
 		return worklistCursor{}, err
 	}
-	// Well-formed JSON is not yet a position: `{}` decodes cleanly and would
-	// name no row, which the resume below reads as "drop nothing" — a token
-	// nobody minted silently restarting the walk.
-	if cursor.Source == "" || cursor.Row == "" {
+	// Well-formed JSON is not yet a position. `{}` and `null` both decode
+	// cleanly and leave a zero offset with no fingerprint, which would restart a
+	// walk nobody minted a token for; and a NEGATIVE offset — reachable by hand,
+	// because the token is client-supplied and unsigned — reaches `rows[n:]` and
+	// panics. A crafted token must be a 422, never a crash on an authenticated
+	// endpoint.
+	if cursor.At < 0 || cursor.Params == "" {
 		return worklistCursor{}, &storekit.MalformedCursorError{}
 	}
 	if cursor.Params != fingerprint(scope, filter, owner) {
@@ -175,47 +159,28 @@ func decodeCursor(token, scope, filter string, owner ids.UUID) (worklistCursor, 
 	return cursor, nil
 }
 
-// resume drops the rows the caller has already been given.
+// resumeAt answers where in the current ranking this page starts.
 //
-// It reads the token's two halves as two claims about one boundary and takes
-// the EARLIER of them. Each half is wrong on its own, and in opposite
-// directions, so neither can be trusted alone:
+// A clamp, and deliberately nothing more: a token naming more rows than the day
+// still holds is a walk whose tail has been dealt with, not a fault, so it ends
+// quietly instead of reaching past the slice.
 //
-//   - The IDENTITY ("resume after this row") is right while the anchor keeps
-//     its place. If the anchor moves DOWN the ranking it re-serves everything
-//     between its old and new place, and an anchor that slides to the end — or
-//     is answered between pages — leaves nothing behind it at all, which reads
-//     as a finished walk while real work is still owed.
-//   - The POSITION ("resume at offset N") is right while the set keeps its
-//     shape, and it survives an anchor that moved or vanished. But a row that
-//     moves UP past the anchor shifts everything below it by one, and the row
-//     that lands on the old offset is stepped over.
+// WHAT AN OFFSET COSTS, stated here because it is the one thing this cursor
+// gets wrong and the contract repeats it to callers. The ranking is rebuilt on
+// every read. If a row crosses the page boundary between two reads — rising
+// above it, or sinking below it — that row is served twice or not at all on
+// this walk. It is not lost from the product: the next read of the queue ranks
+// it afresh and shows it.
 //
-// Taking the earlier of the two makes the unacceptable failure unreachable. The
-// two errors are not equal and must not be traded off as though they were: a
-// repeated row is one the caller has already seen and can dismiss, while a
-// skipped row is work shown to nobody, with no failing signal anywhere. This
-// queue exists to make sure work is not forgotten, so it errs toward showing a
-// row twice and never toward showing it never.
-//
-// The cost is real and worth stating: a day that churns heavily between pages
-// can hand back rows the caller already has. That is why the contract promises
-// termination and no LOSS rather than a stable snapshot — a snapshot is not
-// available over a set that is re-assembled and re-ranked on every read.
-func resume(rows []ranked, cursor worklistCursor) []ranked {
-	if cursor.Row == "" && cursor.Served == 0 {
-		return rows
-	}
-	// The position, clamped: a token naming more rows than the day still holds
-	// is a walk whose tail has been dealt with, not a fault.
-	from := min(cursor.Served, len(rows))
-	// The identity, when the anchor is still here. `i+1` because the anchor is
-	// the last row already served, not the first one owed.
-	for i, row := range rows {
-		if string(row.item.Source) == cursor.Source && row.item.Id == cursor.Row {
-			from = min(from, i+1)
-			break
-		}
-	}
-	return rows[from:]
+// The alternative was anchoring on the last row's identity, and it is worse
+// here. When that anchor is answered between pages, or sinks to the end of the
+// ranking, "everything after this row" is empty and the walk reports itself
+// finished with work still owed — a queue whose purpose is that work is not
+// forgotten cannot fail that way. Carrying both an offset and an anchor was
+// tried and is worse than either: what a caller has seen is the top K of the
+// PREVIOUS ranking, which after a re-rank can be scattered anywhere, and no
+// pair of small values encodes an arbitrary subset. Every rule for combining
+// them traded one skipped row for a different one.
+func resumeAt(rows []ranked, cursor worklistCursor) int {
+	return min(cursor.At, len(rows))
 }

--- a/backend/internal/compose/attention/cursor.go
+++ b/backend/internal/compose/attention/cursor.go
@@ -55,6 +55,19 @@ type worklistCursor struct {
 // `limit` is deliberately absent: it decides how many rows a page carries, not
 // which candidates were weighed, so changing it mid-walk is a legitimate thing
 // for a caller to do and refusing it would be a lie about what changed.
+//
+// The three values join on NUL, which none of them can contain: `scope` and
+// `filter` are closed contract enums the handler validates before this is
+// reached, and `owner` renders through ids.UUID. So no two distinct requests
+// can join to one string — the ambiguity a delimiter scheme exists to prevent —
+// and this needs no length prefixing.
+//
+// Eight bytes, and it is not a security boundary. A collision would let one
+// token resume a different question, but every row that question then returns
+// has already passed the caller's own scope and row-visibility gates: the page
+// is re-assembled from scratch under the principal, and the token chooses only
+// where to resume within what they may already see. What this defends is a
+// caller's coherence, not their permissions.
 func fingerprint(scope, filter string, owner ids.UUID) string {
 	sum := sha256.Sum256([]byte(scope + "\x00" + filter + "\x00" + owner.String()))
 	return hex.EncodeToString(sum[:8])

--- a/backend/internal/compose/attention/cursor.go
+++ b/backend/internal/compose/attention/cursor.go
@@ -144,13 +144,20 @@ func decodeCursor(token, scope, filter string, owner ids.UUID) (worklistCursor, 
 	if err != nil {
 		return worklistCursor{}, err
 	}
-	// Well-formed JSON is not yet a position. `{}` and `null` both decode
-	// cleanly and leave a zero offset with no fingerprint, which would restart a
-	// walk nobody minted a token for; and a NEGATIVE offset — reachable by hand,
-	// because the token is client-supplied and unsigned — reaches `rows[n:]` and
-	// panics. A crafted token must be a 422, never a crash on an authenticated
-	// endpoint.
-	if cursor.At < 0 || cursor.Params == "" {
+	// Well-formed JSON is not yet a position, and the token is client-supplied
+	// and unsigned, so every shape this never mints is refused rather than
+	// interpreted:
+	//
+	//   - A NEGATIVE offset reaches `rows[n:]` and panics. A crafted token must
+	//     be a 422, never a crash on an authenticated endpoint.
+	//   - ZERO is the top of the list, which this only ever reaches by minting a
+	//     token after a full page — so an offset of zero came from somewhere
+	//     else. It grants nothing (an absent cursor answers the same first page)
+	//     and is refused anyway, because a token the server cannot have written
+	//     should not be read as one it did.
+	//   - An EMPTY fingerprint is what `{}` and `null` decode to, and without
+	//     this they would pass as a legitimate first page.
+	if cursor.At <= 0 || cursor.Params == "" {
 		return worklistCursor{}, &storekit.MalformedCursorError{}
 	}
 	if cursor.Params != fingerprint(scope, filter, owner) {

--- a/backend/internal/compose/attention/cursor_test.go
+++ b/backend/internal/compose/attention/cursor_test.go
@@ -4,6 +4,7 @@
 package attention
 
 import (
+	"encoding/base64"
 	"errors"
 	"testing"
 	"time"
@@ -125,9 +126,7 @@ func TestTheFinalPageOffersNoCursor(t *testing.T) {
 // nothing in the response would have said so.
 func TestACursorIsRefusedWhenTheQuestionChanged(t *testing.T) {
 	someone := ids.UUID(mustUUID(t, "11111111-1111-4111-8111-111111111111"))
-	minted := encodeCursor(
-		ranked{item: crmcontracts.WorklistItem{Source: "task", Id: "t1"}}, 1,
-		scopeMine, "", ids.UUID{})
+	minted := encodeCursor(1, scopeMine, "", ids.UUID{})
 
 	for _, tc := range []struct {
 		name          string
@@ -151,9 +150,7 @@ func TestACursorIsRefusedWhenTheQuestionChanged(t *testing.T) {
 // Changing `limit` mid-walk is legitimate: it decides how many rows a page
 // carries, not which rows exist. Refusing it would be a lie about what changed.
 func TestChangingTheLimitDoesNotInvalidateACursor(t *testing.T) {
-	minted := encodeCursor(
-		ranked{item: crmcontracts.WorklistItem{Source: "task", Id: "t1"}}, 1,
-		scopeMine, "", ids.UUID{})
+	minted := encodeCursor(1, scopeMine, "", ids.UUID{})
 	if _, err := decodeCursor(minted, scopeMine, "", ids.UUID{}); err != nil {
 		t.Errorf("a cursor was refused although only the page size changed: %v", err)
 	}
@@ -165,10 +162,11 @@ func TestChangingTheLimitDoesNotInvalidateACursor(t *testing.T) {
 func TestATokenThisEndpointDidNotMintIsRefused(t *testing.T) {
 	for _, token := range []string{
 		"not-base64-at-all!!",
-		// Well-formed base64 of well-formed JSON that names no row: `{}`
-		// decodes cleanly and would resume from nowhere.
+		// Well-formed base64 of well-formed JSON carrying no fingerprint: `{}`
+		// decodes cleanly and leaves a zero offset, which would restart a walk
+		// for a question nobody minted a token for.
 		"e30",
-		"eyJzIjoidGFzayJ9", // {"s":"task"} — a source with no row
+		"bnVsbA", // `null`, which unmarshals to the zero value just as cleanly
 	} {
 		_, err := decodeCursor(token, scopeMine, "", ids.UUID{})
 		if err == nil {
@@ -184,105 +182,9 @@ func TestNoCursorStartsAtTheTop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("an absent cursor was treated as a fault: %v", err)
 	}
-	if cursor.Row != "" {
-		t.Errorf("an absent cursor named row %q", cursor.Row)
+	if cursor.At != 0 {
+		t.Errorf("an absent cursor named offset %d", cursor.At)
 	}
-}
-
-// Every source the queue can raise must survive a round trip. The claim in
-// encodeCursor — that this shape cannot fail to encode — is only worth making
-// if something checks it against the real vocabulary.
-func TestACursorRoundTripsEveryRowShapeTheQueueCanCarry(t *testing.T) {
-	for _, source := range []crmcontracts.WorklistItemSource{
-		"task", "deal_at_risk", sourceWaiting, sourceLeadResponse,
-		"approval", "bounce", "meeting_prep", "duplicate",
-	} {
-		row := ranked{item: crmcontracts.WorklistItem{Source: source, Id: "some-record-id"}}
-		token := encodeCursor(row, 1, scopeMine, "", ids.UUID{})
-		if token == "" {
-			t.Fatalf("source %q minted an empty cursor", source)
-		}
-		back, err := decodeCursor(token, scopeMine, "", ids.UUID{})
-		if err != nil {
-			t.Fatalf("source %q did not survive a round trip: %v", source, err)
-		}
-		if back.Source != string(source) || back.Row != "some-record-id" {
-			t.Errorf("source %q round-tripped as (%q,%q)", source, back.Source, back.Row)
-		}
-	}
-}
-
-// A vanished anchor must NOT end the walk. The position carries it, so the
-// caller continues from where they had got to rather than being told, wrongly,
-// that they had reached the end with work still owed.
-func TestAVanishedAnchorDoesNotEndTheWalk(t *testing.T) {
-	rows := []ranked{
-		{item: crmcontracts.WorklistItem{Source: "task", Id: "a"}},
-		{item: crmcontracts.WorklistItem{Source: "task", Id: "b"}},
-	}
-	left := resume(rows, worklistCursor{Source: "task", Row: "answered-and-gone", Served: 1})
-	if len(left) != 1 || left[0].item.Id != "b" {
-		t.Errorf("a vanished anchor left %v; the position should have carried the walk to b",
-			rowIDsOf(left))
-	}
-}
-
-// The identity half wins when it is EARLIER than the position, which is what
-// keeps a row that moved up from being stepped over.
-//
-// Here the anchor sits at index 1 because a row arrived above it, while the
-// token says one row was served. Position-only would resume at 1 and hand back
-// the anchor itself; identity-only would resume at 2 and skip the arrival. The
-// earlier of the two — index 1 — repeats the anchor rather than losing a row,
-// which is the trade this cursor makes deliberately.
-func TestTheEarlierOfPositionAndIdentityWins(t *testing.T) {
-	rows := []ranked{
-		{item: crmcontracts.WorklistItem{Source: "task", Id: "arrived-since"}},
-		{item: crmcontracts.WorklistItem{Source: "task", Id: "the-anchor"}},
-		{item: crmcontracts.WorklistItem{Source: "task", Id: "still-owed"}},
-	}
-	left := resume(rows, worklistCursor{Source: "task", Row: "the-anchor", Served: 1})
-	if len(left) != 2 || left[0].item.Id != "the-anchor" {
-		t.Fatalf("resume returned %v, want the anchor and everything after it", rowIDsOf(left))
-	}
-}
-
-// Id alone is the owning RECORD's id, which two sources can both point at — a
-// deal that is quiet AND has a customer waiting. The pair is the identity.
-//
-// The anchor is the SECOND of the pair on purpose. Anchoring on the first would
-// pass under either rule: a match on the id alone finds that same row, so the
-// two implementations agree and the test proves nothing. Only a cursor naming
-// the later one tells them apart — matching on the id alone resolves the anchor
-// one row too early and hands back a row the caller already has.
-func TestTwoSourcesSharingARecordIdAreDifferentRows(t *testing.T) {
-	rows := []ranked{
-		{item: crmcontracts.WorklistItem{Source: "deal_at_risk", Id: "same-deal"}},
-		{item: crmcontracts.WorklistItem{Source: sourceWaiting, Id: "same-deal"}},
-		{item: crmcontracts.WorklistItem{Source: "task", Id: "still-owed"}},
-	}
-	left := resume(rows, worklistCursor{Source: sourceWaiting, Row: "same-deal", Served: 2})
-	if len(left) != 1 || left[0].item.Id != "still-owed" {
-		t.Errorf("resume returned %v; matching the id alone stops at the wrong row and repeats work",
-			rowIDsOf(left))
-	}
-}
-
-func rowIDsOf(rows []ranked) []string {
-	out := make([]string, 0, len(rows))
-	for _, row := range rows {
-		out = append(out, row.item.Id)
-	}
-	return out
-}
-
-func mustUUID(t *testing.T, s string) ids.UUID {
-	t.Helper()
-	parsed, err := ids.Parse(s)
-	if err != nil {
-		t.Fatalf("parsing the fixture uuid: %v", err)
-	}
-	return parsed
 }
 
 // A cursor minted while reading one person's queue must not open another's.
@@ -338,15 +240,18 @@ func TestACursorFromOneQueueCannotOpenAnothers(t *testing.T) {
 	}
 }
 
-// A folded batch row must be a STABLE anchor across pages.
+// Folding must be DETERMINISTIC, because an offset means nothing over a
+// ranking that reshapes itself between reads.
 //
-// Folding replaces a pile of alike decisions with one row, and that row is what
-// a cursor can land on. Its id is derived from the group's key and cause
-// (batchID), so the same pile folds to the same id on every read. If a later
-// change gave a batch row a per-read identity — a counter, an instant, a random
-// id — a cursor naming one would find nothing on the next page and the walk
-// would end early with work still owed, silently.
-func TestAFoldedRowIsAStableAnchorAcrossReads(t *testing.T) {
+// Folding replaces a pile of alike decisions with one row, so it changes how
+// many rows the ranking holds and therefore what every offset after it points
+// at. Its id comes from the group's key and cause (batchID), and the group's
+// membership from the day itself, so one day folds the same way on every read.
+// A batch row given a per-read identity — a counter, an instant, a random id —
+// would not break this test's assertion by itself, but it is the tell that the
+// fold had become read-dependent, and a walk over a set that reshapes under it
+// silently skips or repeats.
+func TestFoldingIsDeterministicAcrossReads(t *testing.T) {
 	t.Parallel()
 
 	// A pile deep enough to fold, of the routine contact decisions that fold.
@@ -392,141 +297,6 @@ func TestAFoldedRowIsAStableAnchorAcrossReads(t *testing.T) {
 // These two are the reason the token carries a position AND an identity. Each
 // half alone fails one of them, in opposite directions, and the failure is
 // silent either way: the reader is simply never shown work they are owed.
-func TestALiveDayDoesNotLoseRowsBetweenPages(t *testing.T) {
-	svc := &Service{}
-	at := func(id string, due time.Duration) crmcontracts.AttentionItem {
-		return item(id, "task", withDue(rankInstant.Add(due)))
-	}
-	page := func(day crmcontracts.Attention, cursor worklistCursor) crmcontracts.Worklist {
-		return svc.worklistFrom(t.Context(), day, scopeAll, "", 1,
-			waitingRead{}, leadRead{}, cursor)
-	}
-	shown := func(out crmcontracts.Worklist) []string {
-		got := []string{}
-		for _, row := range out.Queue {
-			got = append(got, row.Id)
-		}
-		return got
-	}
-
-	t.Run("a row that moves up but stays behind the reader is still reached", func(t *testing.T) {
-		// aa, bb, cc, dd by deadline. Page one hands out aa.
-		before := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
-			at("aa", time.Hour), at("bb", 2*time.Hour),
-			at("cc", 3*time.Hour), at("dd", 4*time.Hour),
-		}}
-		first := page(before, worklistCursor{})
-		cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
-		if err != nil {
-			t.Fatalf("decoding page one's cursor: %v", err)
-		}
-		// dd overtakes bb and cc but still sorts behind the already-served aa.
-		// A position-only resume would step over whatever landed on the old
-		// offset; taking the earlier of position and identity keeps it.
-		after := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
-			at("aa", time.Hour), at("bb", 2*time.Hour),
-			at("cc", 3*time.Hour), at("dd", 90*time.Minute),
-		}}
-		reached := map[string]bool{}
-		for _, id := range shown(first) {
-			reached[id] = true
-		}
-		for range 8 {
-			out := page(after, cursor)
-			for _, id := range shown(out) {
-				reached[id] = true
-			}
-			if out.NextCursor == nil {
-				break
-			}
-			cursor, err = decodeCursor(*out.NextCursor, scopeAll, "", ids.UUID{})
-			if err != nil {
-				t.Fatalf("decoding a later cursor: %v", err)
-			}
-		}
-		for _, want := range []string{"aa", "bb", "cc", "dd"} {
-			if !reached[want] {
-				t.Errorf("row %q was never shown to the reader; the walk stepped over it", want)
-			}
-		}
-	})
-
-	// The limit of ANY forward-only cursor over a live re-ranked set, pinned
-	// here so it is a known property rather than a surprise.
-	//
-	// A row that overtakes rows the caller has already been handed now sorts
-	// behind them. Returning it would mean re-serving that whole prefix, which
-	// is the walk that never terminates. So this read does not show it, and the
-	// next read of the day — the rep opening their queue again — leads with it.
-	//
-	// That loss is bounded and self-correcting, and it is the only one accepted
-	// here. It is not the same as the defects the cases above cover, where a
-	// row went missing from an unchanged part of the day.
-	t.Run("a row that overtakes what the reader already has waits for the next read", func(t *testing.T) {
-		before := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
-			at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
-		}}
-		first := page(before, worklistCursor{})
-		cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
-		if err != nil {
-			t.Fatalf("decoding page one's cursor: %v", err)
-		}
-		// cc becomes the most urgent thing on the day, ahead of the served aa.
-		after := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
-			at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", -5*time.Hour),
-		}}
-		out := page(after, cursor)
-		if len(out.Queue) == 0 {
-			t.Fatal("the walk ended although rows behind the anchor were still owed")
-		}
-		// A fresh read leads with it, so the row is delayed rather than lost.
-		fresh := page(after, worklistCursor{})
-		if len(fresh.Queue) == 0 || fresh.Queue[0].Id != "cc" {
-			t.Errorf("a fresh read did not lead with the newly urgent row: %v", shown(fresh))
-		}
-	})
-
-	t.Run("an anchor that slides to last does not end the walk", func(t *testing.T) {
-		before := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
-			at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
-		}}
-		first := page(before, worklistCursor{})
-		cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
-		if err != nil {
-			t.Fatalf("decoding page one's cursor: %v", err)
-		}
-		// The anchor itself is deprioritised to the very end. An identity-only
-		// resume returns nothing at all — "after aa" is empty — and the reader
-		// is told their day is finished with two rows still owed.
-		after := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
-			at("aa", 99*time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
-		}}
-		out := page(after, cursor)
-		if len(out.Queue) == 0 {
-			t.Fatal("the walk reported itself finished while two rows were still owed")
-		}
-	})
-
-	t.Run("an anchor that vanishes does not end the walk", func(t *testing.T) {
-		before := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
-			at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
-		}}
-		first := page(before, worklistCursor{})
-		cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
-		if err != nil {
-			t.Fatalf("decoding page one's cursor: %v", err)
-		}
-		// aa is answered between pages. The position carries the walk.
-		after := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
-			at("bb", 2*time.Hour), at("cc", 3*time.Hour),
-		}}
-		out := page(after, cursor)
-		if len(out.Queue) == 0 {
-			t.Fatal("answering the anchor ended the walk; the rows behind it became unreachable")
-		}
-	})
-}
-
 // The two spellings of one question must fingerprint alike, or a walk breaks on
 // a difference the caller cannot see. Both are cases the contract itself calls
 // the same question.
@@ -534,9 +304,7 @@ func TestEquivalentSpellingsOfOneQuestionShareACursor(t *testing.T) {
 	t.Parallel()
 
 	t.Run("an omitted filter and filter=all", func(t *testing.T) {
-		minted := encodeCursor(
-			ranked{item: crmcontracts.WorklistItem{Source: "task", Id: "t1"}}, 1,
-			scopeMine, "", ids.UUID{})
+		minted := encodeCursor(1, scopeMine, "", ids.UUID{})
 		if _, err := decodeCursor(minted, scopeMine, "all", ids.UUID{}); err != nil {
 			t.Errorf("a client sending its documented `all` default on page two was refused: %v", err)
 		}
@@ -574,26 +342,15 @@ func TestEquivalentSpellingsOfOneQuestionShareACursor(t *testing.T) {
 
 // Two rows that are indistinguishable as anchors must not stall a walk.
 //
-// less() ends at the id, so rows sharing one tie there and their (source, id)
-// anchors cannot be told apart: resume() finds the first every time. The
-// position half of the token is what carries the walk past them — without it a
-// cursor naming the second would resolve to the first and the same page would
-// be served forever.
-func TestIndistinguishableAnchorsDoNotStallAWalk(t *testing.T) {
-	rows := []ranked{
-		{item: crmcontracts.WorklistItem{Source: "task", Id: "twin"}},
-		{item: crmcontracts.WorklistItem{Source: "task", Id: "twin"}},
-		{item: crmcontracts.WorklistItem{Source: "task", Id: "after"}},
-	}
-	// The caller has had both twins; the identity resolves to the first.
-	left := resume(rows, worklistCursor{Source: "task", Row: "twin", Served: 2})
-	if len(left) == len(rows) {
-		t.Fatal("the walk made no progress; a cursor on a duplicated id would repeat forever")
-	}
-}
-
-// Naming yourself and omitting the owner must return the SAME page.
+// less() ends at the record id, so rows sharing one tie there and their
+// (source, id) anchors cannot be told apart. An anchor search that took the
+// FIRST match would resolve to the same index however many twins the caller had
+// already been handed, and the same page would be served for as long as the
+// client kept asking — the one shape here that never terminates.
 //
+// Driven as a real walk rather than a single resumeAt call. A stall only shows
+// as a walk that does not end, so a test that steps once cannot see it, which
+// is how an earlier version of this passed while proving nothing.
 // resolveOwner collapses the two onto one resolved question, which changes
 // which branch the read takes: a self-named owner used to go through
 // forOwner/TasksOwnedBy and now falls through to forReader/TasksMine. Those
@@ -619,6 +376,18 @@ func TestNamingYourselfAnswersTheSamePageAsOmittingTheOwner(t *testing.T) {
 				ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000b2"),
 				Subject:    "somebody else's customer",
 				Since:      readInstant.Add(-2 * 24 * time.Hour), OwnerID: theRep,
+			},
+			{
+				// The row the two narrowings disagree about, and the reason
+				// this fixture is not just two owned rows. keepReadersOwn keeps
+				// a row nobody owns — the contract says an unowned customer
+				// writing in is everybody's until somebody takes them — while
+				// keepOwnedBy drops it. Without this row both spellings agree
+				// however resolveOwner behaves, and the test proves nothing
+				// about the change it exists to check.
+				ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000b3"),
+				Subject:    "a customer nobody owns",
+				Since:      readInstant.Add(-4 * 24 * time.Hour),
 			},
 		}
 		svc.teammates = teammatesSaying(true)
@@ -655,5 +424,250 @@ func TestNamingYourselfAnswersTheSamePageAsOmittingTheOwner(t *testing.T) {
 	}
 	if omitted.Scope != named.Scope {
 		t.Errorf("the two spellings reported different scopes: %q against %q", omitted.Scope, named.Scope)
+	}
+}
+
+// A crafted token must be refused, never crash the request.
+//
+// The cursor is client-supplied and unsigned, so a caller can hand back any
+// position they like. An unchecked negative reaches `rows[n:]`, which panics —
+// a denial of service on an authenticated endpoint, reachable by hand.
+func TestACursorNamingAPositionBeforeTheFirstRowIsRefused(t *testing.T) {
+	t.Parallel()
+
+	forged := base64.RawURLEncoding.EncodeToString([]byte(
+		`{"s":"task","r":"t1","n":-1,"p":"` + fingerprint(scopeMine, "", ids.UUID{}) + `"}`))
+
+	cursor, err := decodeCursor(forged, scopeMine, "", ids.UUID{})
+	if err == nil {
+		t.Fatalf("a negative position was accepted as %+v; it must be refused", cursor)
+	}
+	var malformed *storekit.MalformedCursorError
+	if !errors.As(err, &malformed) {
+		t.Errorf("a negative position answered %v; it is the caller's mistake and must be "+
+			"malformed_cursor", err)
+	}
+}
+
+func mustUUID(t *testing.T, s string) ids.UUID {
+	t.Helper()
+	parsed, err := ids.Parse(s)
+	if err != nil {
+		t.Fatalf("parsing the fixture uuid: %v", err)
+	}
+	return parsed
+}
+
+// A walk always terminates, whatever the day does between pages.
+//
+// The offset strictly increases and the candidate set is bounded, so there is
+// no arrangement of arrivals, answers and reprioritisations that makes a client
+// paging to exhaustion loop. That is the property the identity anchor could not
+// give: with one, a row answered between pages emptied the remainder and a
+// duplicated record id resolved to the same index forever.
+func TestAWalkTerminatesHoweverTheDayMoves(t *testing.T) {
+	svc := &Service{}
+	at := func(id string, d time.Duration) crmcontracts.AttentionItem {
+		return item(id, "task", withDue(rankInstant.Add(d)))
+	}
+	// Each read hands back a differently ordered day, including one where every
+	// row is new and one where the set shrinks under the caller's feet.
+	days := []crmcontracts.Attention{
+		{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
+		}},
+		{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("cc", -9*time.Hour), at("aa", 5*time.Hour), at("bb", 6*time.Hour),
+		}},
+		{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("zz", time.Hour), at("yy", 2*time.Hour),
+		}},
+		{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{}},
+	}
+
+	cursor := worklistCursor{}
+	for page := range 20 {
+		out := svc.worklistFrom(t.Context(), days[min(page, len(days)-1)], scopeAll, "", 1,
+			waitingRead{}, leadRead{}, cursor)
+		if out.NextCursor == nil {
+			return
+		}
+		decoded, err := decodeCursor(*out.NextCursor, scopeAll, "", ids.UUID{})
+		if err != nil {
+			t.Fatalf("decoding a cursor mid-walk: %v", err)
+		}
+		if decoded.At <= cursor.At {
+			t.Fatalf("the offset did not advance: %d then %d; a walk that does not "+
+				"move forward is one that never ends", cursor.At, decoded.At)
+		}
+		cursor = decoded
+	}
+	t.Fatal("the walk did not terminate in 20 pages over days of at most three rows")
+}
+
+// The cost of an offset, pinned so it is a known property rather than a
+// surprise found in production.
+//
+// The ranking is rebuilt on every read. A row that crosses the page boundary
+// between two reads is served twice or not at all ON THIS WALK. It is not lost
+// from the product — the next read ranks it afresh and shows it — and that
+// bounded, self-correcting delay is what buys a walk that cannot report itself
+// finished while work is still owed.
+func TestARowCrossingThePageBoundaryWaitsForTheNextRead(t *testing.T) {
+	svc := &Service{}
+	at := func(id string, d time.Duration) crmcontracts.AttentionItem {
+		return item(id, "task", withDue(rankInstant.Add(d)))
+	}
+	before := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+		at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
+	}}
+	first := svc.worklistFrom(t.Context(), before, scopeAll, "", 1,
+		waitingRead{}, leadRead{}, worklistCursor{})
+	if len(first.Queue) != 1 || first.Queue[0].Id != "aa" {
+		t.Fatalf("page one handed back %v, want aa", queueIDsOf(first))
+	}
+	cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
+	if err != nil {
+		t.Fatalf("decoding page one: %v", err)
+	}
+
+	// cc becomes the most urgent row, crossing above the boundary the caller
+	// has already passed.
+	after := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+		at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", -5*time.Hour),
+	}}
+	second := svc.worklistFrom(t.Context(), after, scopeAll, "", 1,
+		waitingRead{}, leadRead{}, cursor)
+	if len(second.Queue) == 0 {
+		t.Fatal("the walk ended with rows still owed")
+	}
+
+	// The delay is bounded: a fresh read leads with it.
+	fresh := svc.worklistFrom(t.Context(), after, scopeAll, "", 1,
+		waitingRead{}, leadRead{}, worklistCursor{})
+	if len(fresh.Queue) == 0 || fresh.Queue[0].Id != "cc" {
+		t.Errorf("a fresh read did not lead with the newly urgent row: %v", queueIDsOf(fresh))
+	}
+}
+
+// A cursor round-trips the position it was minted at, unchanged.
+func TestACursorRoundTripsThePositionItWasMintedAt(t *testing.T) {
+	t.Parallel()
+
+	for _, at := range []int{0, 1, 25, 100, 4096} {
+		token := encodeCursor(at, scopeMine, "", ids.UUID{})
+		if token == "" {
+			t.Fatalf("offset %d minted an empty cursor", at)
+		}
+		back, err := decodeCursor(token, scopeMine, "", ids.UUID{})
+		if err != nil {
+			t.Fatalf("offset %d did not survive a round trip: %v", at, err)
+		}
+		if back.At != at {
+			t.Errorf("offset %d round-tripped as %d", at, back.At)
+		}
+	}
+}
+
+func queueIDsOf(out crmcontracts.Worklist) []string {
+	got := []string{}
+	for _, row := range out.Queue {
+		got = append(got, row.Id)
+	}
+	return got
+}
+
+// A token carrying no fingerprint must be refused, not read as "start again".
+//
+// `{}` and `null` both decode cleanly into the zero cursor, whose offset is 0.
+// Without this guard they would be accepted as a legitimate first page — a
+// walk restarting for a question nobody minted a token for, and the one reading
+// under which a forged token does something rather than nothing.
+func TestACursorWithNoFingerprintIsRefused(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{`{}`, `null`, `{"n":3}`} {
+		token := base64.RawURLEncoding.EncodeToString([]byte(raw))
+		_, err := decodeCursor(token, scopeMine, "", ids.UUID{})
+		if err == nil {
+			t.Errorf("%s was accepted as a cursor; it names no question and must be refused", raw)
+			continue
+		}
+		var malformed *storekit.MalformedCursorError
+		if !errors.As(err, &malformed) {
+			t.Errorf("%s answered %v; a token nobody minted is malformed_cursor", raw, err)
+		}
+	}
+}
+
+// An offset past the end of the day must end the walk, not reach past the slice.
+//
+// The token is client-supplied, so an offset larger than the day now holds is
+// reachable both by hand and by an honest client whose tail was dealt with
+// between pages. Either way it is a finished walk, not a fault — and without the
+// clamp it is `rows[n:]` on a short slice, which panics.
+func TestAnOffsetPastTheEndEndsTheWalk(t *testing.T) {
+	t.Parallel()
+
+	rows := []ranked{
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "a"}},
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "b"}},
+	}
+	if at := resumeAt(rows, worklistCursor{At: 99, Params: "x"}); at != len(rows) {
+		t.Errorf("an offset of 99 over 2 rows resumed at %d; it must clamp to %d",
+			at, len(rows))
+	}
+	// And through the page cut, where the panic would actually happen.
+	shown, more, _ := pageFrom(rows, 25, worklistCursor{At: 99, Params: "x"})
+	if len(shown) != 0 || more {
+		t.Errorf("an offset past the end returned %d rows (more=%v); the walk is over",
+			len(shown), more)
+	}
+}
+
+// The offset a cursor carries is where the CUT landed in this read's ranking.
+//
+// `reached` and "the incoming offset plus the rows served" happen to agree
+// wherever a cursor is actually minted, and that is worth knowing rather than
+// relying on: a token is minted only when rows remain past the cut, which needs
+// a full `limit` page, and a clamped read has nothing remaining and mints
+// nothing. So the two formulas cannot diverge here — but `reached` is the one
+// that stays right if that ever stops holding, because it reads the ranking in
+// front of it rather than trusting what the caller said about a previous one.
+func TestTheOffsetIsWhereTheCutLandedInThisRanking(t *testing.T) {
+	svc := &Service{}
+
+	// A cursor whose offset the day can no longer honour: the tail was dealt
+	// with between reads, so the clamp pulls the read back to the end.
+	out, more, reached := pageFrom(
+		[]ranked{{item: crmcontracts.WorklistItem{Source: "task", Id: "only"}}},
+		25, worklistCursor{At: 10, Params: "x"})
+	if reached != 1 {
+		t.Errorf("the cut landed at %d over a single row; it must be a position in THIS "+
+			"ranking, so it can never point past the rows that exist", reached)
+	}
+	if len(out) != 0 || more {
+		t.Errorf("expected an empty final page, got %d rows (more=%v)", len(out), more)
+	}
+
+	// End to end: a walk advances by exactly the page size, and the offset it
+	// publishes indexes the ranking rather than counting the caller's history.
+	first := svc.worklistFrom(t.Context(), tasksDay(5), scopeAll, "", 2,
+		waitingRead{}, leadRead{}, worklistCursor{})
+	cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
+	if err != nil {
+		t.Fatalf("decoding page one: %v", err)
+	}
+	if cursor.At != 2 {
+		t.Errorf("a first page of two advanced the offset to %d, want 2", cursor.At)
+	}
+	second := svc.worklistFrom(t.Context(), tasksDay(5), scopeAll, "", 2,
+		waitingRead{}, leadRead{}, cursor)
+	next, err := decodeCursor(*second.NextCursor, scopeAll, "", ids.UUID{})
+	if err != nil {
+		t.Fatalf("decoding page two: %v", err)
+	}
+	if next.At != 4 {
+		t.Errorf("page two advanced the offset to %d, want 4", next.At)
 	}
 }

--- a/backend/internal/compose/attention/cursor_test.go
+++ b/backend/internal/compose/attention/cursor_test.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// A day of `n` plain tasks, which classify into one level and therefore exercise
+// the id tie-break that makes the ranking total.
+func tasksDay(n int) crmcontracts.Attention {
+	planned := make([]crmcontracts.AttentionItem, 0, n)
+	for i := range n {
+		planned = append(planned, item(
+			// Padded so string order and numeric order agree: less() breaks a
+			// complete tie on the id, and "t10" < "t2" would make the walk
+			// correct but unreadable when a failure prints it.
+			"t"+string(rune('a'+i/26))+string(rune('a'+i%26)),
+			"task",
+			withDue(rankInstant.Add(time.Duration(i)*time.Minute)),
+		))
+	}
+	return crmcontracts.Attention{AsOf: rankInstant, Planned: planned}
+}
+
+// Walking every page must yield every row exactly once. This is the acceptance
+// criterion the whole cursor exists for: a paginated backlog that silently drops
+// a page passes every unit test about a single page.
+func TestAWalkReachesEveryRowExactlyOnce(t *testing.T) {
+	const rows, perPage = 23, 5
+	svc := &Service{}
+	day := tasksDay(rows)
+
+	seen := map[string]int{}
+	cursor := worklistCursor{}
+	pages := 0
+	for {
+		out := svc.worklistFrom(t.Context(), day, scopeAll, "", perPage,
+			waitingRead{}, leadRead{}, cursor)
+		pages++
+		for _, row := range out.Queue {
+			seen[string(row.Source)+"|"+row.Id]++
+		}
+		if out.NextCursor == nil {
+			break
+		}
+		if pages > rows {
+			t.Fatalf("the walk did not terminate: %d pages for %d rows", pages, rows)
+		}
+		decoded, err := decodeCursor(*out.NextCursor, scopeAll, "", ids.UUID{})
+		if err != nil {
+			t.Fatalf("the cursor this endpoint minted was refused on the way back in: %v", err)
+		}
+		cursor = decoded
+	}
+
+	if len(seen) != rows {
+		t.Errorf("the walk reached %d distinct rows, the day held %d", len(seen), rows)
+	}
+	for id, times := range seen {
+		if times != 1 {
+			t.Errorf("row %s was handed out %d times; a walk must not repeat a row", id, times)
+		}
+	}
+	if want := 5; pages != want {
+		t.Errorf("walked %d pages of %d over %d rows, want %d", pages, perPage, rows, want)
+	}
+}
+
+// The count the page reports and the rows the walk actually yields must agree.
+// A cursor that pages correctly while `counts` says something else is two
+// answers to one question.
+func TestTheWalkReconcilesAgainstTheCountItReports(t *testing.T) {
+	const rows, perPage = 17, 4
+	svc := &Service{}
+	day := tasksDay(rows)
+
+	first := svc.worklistFrom(t.Context(), day, scopeAll, "", perPage,
+		waitingRead{}, leadRead{}, worklistCursor{})
+	considered := 0
+	for _, count := range first.Counts {
+		considered += count.Considered
+	}
+
+	walked := 0
+	cursor := worklistCursor{}
+	for {
+		out := svc.worklistFrom(t.Context(), day, scopeAll, "", perPage,
+			waitingRead{}, leadRead{}, cursor)
+		walked += len(out.Queue)
+		if out.NextCursor == nil {
+			break
+		}
+		decoded, err := decodeCursor(*out.NextCursor, scopeAll, "", ids.UUID{})
+		if err != nil {
+			t.Fatalf("decoding the minted cursor: %v", err)
+		}
+		cursor = decoded
+	}
+	if walked != considered {
+		t.Errorf("the walk yielded %d rows, `counts` reported %d considered", walked, considered)
+	}
+}
+
+// The last page must NOT carry a cursor. A client that walks until the cursor
+// disappears would otherwise never stop.
+func TestTheFinalPageOffersNoCursor(t *testing.T) {
+	svc := &Service{}
+	out := svc.worklistFrom(t.Context(), tasksDay(3), scopeAll, "", 25,
+		waitingRead{}, leadRead{}, worklistCursor{})
+	if out.NextCursor != nil {
+		t.Errorf("a page holding every row offered a cursor to nothing: %q", *out.NextCursor)
+	}
+}
+
+// A token minted for one question must not silently continue into another.
+// Page two of a rep's own tasks becoming the team's deals is the failure, and
+// nothing in the response would have said so.
+func TestACursorIsRefusedWhenTheQuestionChanged(t *testing.T) {
+	someone := ids.UUID(mustUUID(t, "11111111-1111-4111-8111-111111111111"))
+	minted := encodeCursor(
+		ranked{item: crmcontracts.WorklistItem{Source: "task", Id: "t1"}},
+		scopeMine, "", ids.UUID{})
+
+	for _, tc := range []struct {
+		name          string
+		scope, filter string
+		owner         ids.UUID
+	}{
+		{"a wider scope", scopeAll, "", ids.UUID{}},
+		{"a different filter", scopeMine, "deals_at_risk", ids.UUID{}},
+		{"somebody else's queue", scopeMine, "", someone},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeCursor(minted, tc.scope, tc.filter, tc.owner)
+			var mismatch *storekit.CursorSortMismatchError
+			if !errors.As(err, &mismatch) {
+				t.Errorf("continuing into %s was allowed (err=%v); it must be refused", tc.name, err)
+			}
+		})
+	}
+}
+
+// Changing `limit` mid-walk is legitimate: it decides how many rows a page
+// carries, not which rows exist. Refusing it would be a lie about what changed.
+func TestChangingTheLimitDoesNotInvalidateACursor(t *testing.T) {
+	minted := encodeCursor(
+		ranked{item: crmcontracts.WorklistItem{Source: "task", Id: "t1"}},
+		scopeMine, "", ids.UUID{})
+	if _, err := decodeCursor(minted, scopeMine, "", ids.UUID{}); err != nil {
+		t.Errorf("a cursor was refused although only the page size changed: %v", err)
+	}
+}
+
+// A token this endpoint never minted is the caller's mistake, not a server
+// fault, and it must not read as "start from the top" — a walk that silently
+// restarts is the shape that never terminates.
+func TestATokenThisEndpointDidNotMintIsRefused(t *testing.T) {
+	for _, token := range []string{
+		"not-base64-at-all!!",
+		// Well-formed base64 of well-formed JSON that names no row: `{}`
+		// decodes cleanly and would resume from nowhere.
+		"e30",
+		"eyJzIjoidGFzayJ9", // {"s":"task"} — a source with no row
+	} {
+		_, err := decodeCursor(token, scopeMine, "", ids.UUID{})
+		if err == nil {
+			t.Errorf("token %q was accepted; a token nobody minted must be refused", token)
+		}
+	}
+}
+
+// An empty token is the start of the walk rather than a fault, which is what
+// lets one code path serve both the first page and the rest.
+func TestNoCursorStartsAtTheTop(t *testing.T) {
+	cursor, err := decodeCursor("", scopeMine, "", ids.UUID{})
+	if err != nil {
+		t.Fatalf("an absent cursor was treated as a fault: %v", err)
+	}
+	if cursor.Row != "" {
+		t.Errorf("an absent cursor named row %q", cursor.Row)
+	}
+}
+
+// Every source the queue can raise must survive a round trip. The claim in
+// encodeCursor — that this shape cannot fail to encode — is only worth making
+// if something checks it against the real vocabulary.
+func TestACursorRoundTripsEveryRowShapeTheQueueCanCarry(t *testing.T) {
+	for _, source := range []crmcontracts.WorklistItemSource{
+		"task", "deal_at_risk", sourceWaiting, sourceLeadResponse,
+		"approval", "bounce", "meeting_prep", "duplicate",
+	} {
+		row := ranked{item: crmcontracts.WorklistItem{Source: source, Id: "some-record-id"}}
+		token := encodeCursor(row, scopeMine, "", ids.UUID{})
+		if token == "" {
+			t.Fatalf("source %q minted an empty cursor", source)
+		}
+		back, err := decodeCursor(token, scopeMine, "", ids.UUID{})
+		if err != nil {
+			t.Fatalf("source %q did not survive a round trip: %v", source, err)
+		}
+		if back.Source != string(source) || back.Row != "some-record-id" {
+			t.Errorf("source %q round-tripped as (%q,%q)", source, back.Source, back.Row)
+		}
+	}
+}
+
+// A row that vanishes between pages ends the walk. Restarting from the top
+// instead would hand a client paging to exhaustion the same first page forever,
+// each pass looking like ordinary progress.
+func TestAWalkEndsWhenItsAnchorIsGone(t *testing.T) {
+	rows := []ranked{
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "a"}},
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "b"}},
+	}
+	left := resume(rows, worklistCursor{Source: "task", Row: "answered-and-gone"})
+	if len(left) != 0 {
+		t.Errorf("a vanished anchor left %d rows; the walk must end rather than restart", len(left))
+	}
+}
+
+// The anchor is found by identity, never by position. Positions move whenever
+// the day moves, so an index would resume at whatever row slid into that slot —
+// skipping work silently, which is the direction this queue must never fail in.
+func TestTheAnchorIsFoundByIdentityNotPosition(t *testing.T) {
+	rows := []ranked{
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "arrived-since"}},
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "the-anchor"}},
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "still-owed"}},
+	}
+	left := resume(rows, worklistCursor{Source: "task", Row: "the-anchor"})
+	if len(left) != 1 || left[0].item.Id != "still-owed" {
+		t.Fatalf("resume returned %v, want exactly the row after the anchor", rowIDsOf(left))
+	}
+}
+
+// Id alone is the owning RECORD's id, which two sources can both point at — a
+// deal that is quiet AND has a customer waiting. The pair is the identity.
+//
+// The anchor is the SECOND of the pair on purpose. Anchoring on the first would
+// pass under either rule: a match on the id alone finds that same row, so the
+// two implementations agree and the test proves nothing. Only a cursor naming
+// the later one tells them apart — matching on the id alone stops at the
+// earlier row and hands back work the caller has already been given.
+func TestTwoSourcesSharingARecordIdAreDifferentRows(t *testing.T) {
+	rows := []ranked{
+		{item: crmcontracts.WorklistItem{Source: "deal_at_risk", Id: "same-deal"}},
+		{item: crmcontracts.WorklistItem{Source: sourceWaiting, Id: "same-deal"}},
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "still-owed"}},
+	}
+	left := resume(rows, worklistCursor{Source: sourceWaiting, Row: "same-deal"})
+	if len(left) != 1 || left[0].item.Id != "still-owed" {
+		t.Errorf("resume returned %v; matching the id alone stops at the wrong row and repeats work",
+			rowIDsOf(left))
+	}
+}
+
+func rowIDsOf(rows []ranked) []string {
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.item.Id)
+	}
+	return out
+}
+
+func mustUUID(t *testing.T, s string) ids.UUID {
+	t.Helper()
+	parsed, err := ids.Parse(s)
+	if err != nil {
+		t.Fatalf("parsing the fixture uuid: %v", err)
+	}
+	return parsed
+}

--- a/backend/internal/compose/attention/cursor_test.go
+++ b/backend/internal/compose/attention/cursor_test.go
@@ -6,6 +6,7 @@ package attention
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -92,7 +93,13 @@ func TestTheWalkReconcilesAgainstTheCountItReports(t *testing.T) {
 
 	walked := 0
 	cursor := worklistCursor{}
-	for {
+	// Bounded, because a resume that stops advancing walks forever and a test
+	// that hangs reports nothing — the harness kills the whole package and the
+	// defect looks like a slow suite rather than a broken cursor.
+	for page := range rows + 1 {
+		if page == rows {
+			t.Fatalf("the walk did not terminate: %d pages over %d rows", page, rows)
+		}
 		out := svc.worklistFrom(t.Context(), day, scopeAll, "", perPage,
 			waitingRead{}, leadRead{}, cursor)
 		walked += len(out.Queue)
@@ -432,20 +439,41 @@ func TestNamingYourselfAnswersTheSamePageAsOmittingTheOwner(t *testing.T) {
 // The cursor is client-supplied and unsigned, so a caller can hand back any
 // position they like. An unchecked negative reaches `rows[n:]`, which panics —
 // a denial of service on an authenticated endpoint, reachable by hand.
-func TestACursorNamingAPositionBeforeTheFirstRowIsRefused(t *testing.T) {
+func TestACursorNamingAPositionThisEndpointNeverMintsIsRefused(t *testing.T) {
 	t.Parallel()
 
-	forged := base64.RawURLEncoding.EncodeToString([]byte(
-		`{"s":"task","r":"t1","n":-1,"p":"` + fingerprint(scopeMine, "", ids.UUID{}) + `"}`))
+	valid := fingerprint(scopeMine, "", ids.UUID{})
+	for _, tc := range []struct {
+		name, why string
+		at        int
+	}{
+		{
+			name: "a negative offset",
+			at:   -1,
+			why:  "it reaches rows[n:] and panics — a crash on an authenticated endpoint",
+		},
+		{
+			name: "an offset of zero",
+			at:   0,
+			why: "this endpoint mints a token only after a full page, so zero came from " +
+				"somewhere else; it grants nothing, and a shape the server cannot have " +
+				"written must not be read as one it did",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			forged := base64.RawURLEncoding.EncodeToString(
+				fmt.Appendf(nil, `{"n":%d,"p":%q}`, tc.at, valid))
 
-	cursor, err := decodeCursor(forged, scopeMine, "", ids.UUID{})
-	if err == nil {
-		t.Fatalf("a negative position was accepted as %+v; it must be refused", cursor)
-	}
-	var malformed *storekit.MalformedCursorError
-	if !errors.As(err, &malformed) {
-		t.Errorf("a negative position answered %v; it is the caller's mistake and must be "+
-			"malformed_cursor", err)
+			cursor, err := decodeCursor(forged, scopeMine, "", ids.UUID{})
+			if err == nil {
+				t.Fatalf("%s was accepted as %+v; %s", tc.name, cursor, tc.why)
+			}
+			var malformed *storekit.MalformedCursorError
+			if !errors.As(err, &malformed) {
+				t.Errorf("%s answered %v; it is the caller's mistake and must be "+
+					"malformed_cursor", tc.name, err)
+			}
+		})
 	}
 }
 
@@ -531,18 +559,44 @@ func TestARowCrossingThePageBoundaryWaitsForTheNextRead(t *testing.T) {
 		t.Fatalf("decoding page one: %v", err)
 	}
 
-	// cc becomes the most urgent row, crossing above the boundary the caller
-	// has already passed.
+	// cc becomes the most urgent row, crossing above the boundary the caller has
+	// already passed: the order goes aa,bb,cc -> cc,aa,bb.
 	after := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
 		at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", -5*time.Hour),
 	}}
-	second := svc.worklistFrom(t.Context(), after, scopeAll, "", 1,
-		waitingRead{}, leadRead{}, cursor)
-	if len(second.Queue) == 0 {
-		t.Fatal("the walk ended with rows still owed")
+
+	// Walk the rest of it and record what the caller was actually shown. The
+	// documented consequence is specific and asserted as such: cc is NOT served
+	// on this walk, and aa — which the caller already has — comes back a second
+	// time, because it now stands where the offset points.
+	seen := map[string]int{}
+	for _, row := range first.Queue {
+		seen[row.Id]++
+	}
+	for range 6 {
+		out := svc.worklistFrom(t.Context(), after, scopeAll, "", 1,
+			waitingRead{}, leadRead{}, cursor)
+		for _, row := range out.Queue {
+			seen[row.Id]++
+		}
+		if out.NextCursor == nil {
+			break
+		}
+		cursor, err = decodeCursor(*out.NextCursor, scopeAll, "", ids.UUID{})
+		if err != nil {
+			t.Fatalf("decoding a later cursor: %v", err)
+		}
+	}
+	if seen["cc"] != 0 {
+		t.Errorf("cc was served %d times on this walk; the documented behaviour is that a "+
+			"row overtaking the boundary waits for the next read", seen["cc"])
+	}
+	if seen["aa"] != 2 {
+		t.Errorf("aa was served %d times, want 2: a row the boundary passes over is "+
+			"repeated, which is the half of the trade that is not a loss", seen["aa"])
 	}
 
-	// The delay is bounded: a fresh read leads with it.
+	// And the delay is bounded rather than permanent: a fresh read leads with it.
 	fresh := svc.worklistFrom(t.Context(), after, scopeAll, "", 1,
 		waitingRead{}, leadRead{}, worklistCursor{})
 	if len(fresh.Queue) == 0 || fresh.Queue[0].Id != "cc" {
@@ -551,10 +605,15 @@ func TestARowCrossingThePageBoundaryWaitsForTheNextRead(t *testing.T) {
 }
 
 // A cursor round-trips the position it was minted at, unchanged.
+//
+// Zero is deliberately absent from the cases: this only ever mints a token
+// after a full page, so an offset of zero is a shape the server does not
+// produce, and decodeCursor refuses it. Listing it here as valid would pin the
+// wrong behaviour and break when that guard is tightened rather than confirm it.
 func TestACursorRoundTripsThePositionItWasMintedAt(t *testing.T) {
 	t.Parallel()
 
-	for _, at := range []int{0, 1, 25, 100, 4096} {
+	for _, at := range []int{1, 25, 100, 4096} {
 		token := encodeCursor(at, scopeMine, "", ids.UUID{})
 		if token == "" {
 			t.Fatalf("offset %d minted an empty cursor", at)

--- a/backend/internal/compose/attention/cursor_test.go
+++ b/backend/internal/compose/attention/cursor_test.go
@@ -631,7 +631,7 @@ func TestAnOffsetPastTheEndEndsTheWalk(t *testing.T) {
 // wherever a cursor is actually minted, and that is worth knowing rather than
 // relying on: a token is minted only when rows remain past the cut, which needs
 // a full `limit` page, and a clamped read has nothing remaining and mints
-// nothing. So the two formulas cannot diverge here — but `reached` is the one
+// nothing. So the two formulas answer alike here — but `reached` is the one
 // that stays right if that ever stops holding, because it reads the ranking in
 // front of it rather than trusting what the caller said about a previous one.
 func TestTheOffsetIsWhereTheCutLandedInThisRanking(t *testing.T) {

--- a/backend/internal/compose/attention/cursor_test.go
+++ b/backend/internal/compose/attention/cursor_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // A day of `n` plain tasks, which classify into one level and therefore exercise
-// the id tie-break that makes the ranking total.
+// the id tie-break that makes the ranking deterministic.
 func tasksDay(n int) crmcontracts.Attention {
 	planned := make([]crmcontracts.AttentionItem, 0, n)
 	for i := range n {
@@ -126,7 +126,7 @@ func TestTheFinalPageOffersNoCursor(t *testing.T) {
 func TestACursorIsRefusedWhenTheQuestionChanged(t *testing.T) {
 	someone := ids.UUID(mustUUID(t, "11111111-1111-4111-8111-111111111111"))
 	minted := encodeCursor(
-		ranked{item: crmcontracts.WorklistItem{Source: "task", Id: "t1"}},
+		ranked{item: crmcontracts.WorklistItem{Source: "task", Id: "t1"}}, 1,
 		scopeMine, "", ids.UUID{})
 
 	for _, tc := range []struct {
@@ -152,7 +152,7 @@ func TestACursorIsRefusedWhenTheQuestionChanged(t *testing.T) {
 // carries, not which rows exist. Refusing it would be a lie about what changed.
 func TestChangingTheLimitDoesNotInvalidateACursor(t *testing.T) {
 	minted := encodeCursor(
-		ranked{item: crmcontracts.WorklistItem{Source: "task", Id: "t1"}},
+		ranked{item: crmcontracts.WorklistItem{Source: "task", Id: "t1"}}, 1,
 		scopeMine, "", ids.UUID{})
 	if _, err := decodeCursor(minted, scopeMine, "", ids.UUID{}); err != nil {
 		t.Errorf("a cursor was refused although only the page size changed: %v", err)
@@ -198,7 +198,7 @@ func TestACursorRoundTripsEveryRowShapeTheQueueCanCarry(t *testing.T) {
 		"approval", "bounce", "meeting_prep", "duplicate",
 	} {
 		row := ranked{item: crmcontracts.WorklistItem{Source: source, Id: "some-record-id"}}
-		token := encodeCursor(row, scopeMine, "", ids.UUID{})
+		token := encodeCursor(row, 1, scopeMine, "", ids.UUID{})
 		if token == "" {
 			t.Fatalf("source %q minted an empty cursor", source)
 		}
@@ -212,32 +212,38 @@ func TestACursorRoundTripsEveryRowShapeTheQueueCanCarry(t *testing.T) {
 	}
 }
 
-// A row that vanishes between pages ends the walk. Restarting from the top
-// instead would hand a client paging to exhaustion the same first page forever,
-// each pass looking like ordinary progress.
-func TestAWalkEndsWhenItsAnchorIsGone(t *testing.T) {
+// A vanished anchor must NOT end the walk. The position carries it, so the
+// caller continues from where they had got to rather than being told, wrongly,
+// that they had reached the end with work still owed.
+func TestAVanishedAnchorDoesNotEndTheWalk(t *testing.T) {
 	rows := []ranked{
 		{item: crmcontracts.WorklistItem{Source: "task", Id: "a"}},
 		{item: crmcontracts.WorklistItem{Source: "task", Id: "b"}},
 	}
-	left := resume(rows, worklistCursor{Source: "task", Row: "answered-and-gone"})
-	if len(left) != 0 {
-		t.Errorf("a vanished anchor left %d rows; the walk must end rather than restart", len(left))
+	left := resume(rows, worklistCursor{Source: "task", Row: "answered-and-gone", Served: 1})
+	if len(left) != 1 || left[0].item.Id != "b" {
+		t.Errorf("a vanished anchor left %v; the position should have carried the walk to b",
+			rowIDsOf(left))
 	}
 }
 
-// The anchor is found by identity, never by position. Positions move whenever
-// the day moves, so an index would resume at whatever row slid into that slot —
-// skipping work silently, which is the direction this queue must never fail in.
-func TestTheAnchorIsFoundByIdentityNotPosition(t *testing.T) {
+// The identity half wins when it is EARLIER than the position, which is what
+// keeps a row that moved up from being stepped over.
+//
+// Here the anchor sits at index 1 because a row arrived above it, while the
+// token says one row was served. Position-only would resume at 1 and hand back
+// the anchor itself; identity-only would resume at 2 and skip the arrival. The
+// earlier of the two — index 1 — repeats the anchor rather than losing a row,
+// which is the trade this cursor makes deliberately.
+func TestTheEarlierOfPositionAndIdentityWins(t *testing.T) {
 	rows := []ranked{
 		{item: crmcontracts.WorklistItem{Source: "task", Id: "arrived-since"}},
 		{item: crmcontracts.WorklistItem{Source: "task", Id: "the-anchor"}},
 		{item: crmcontracts.WorklistItem{Source: "task", Id: "still-owed"}},
 	}
-	left := resume(rows, worklistCursor{Source: "task", Row: "the-anchor"})
-	if len(left) != 1 || left[0].item.Id != "still-owed" {
-		t.Fatalf("resume returned %v, want exactly the row after the anchor", rowIDsOf(left))
+	left := resume(rows, worklistCursor{Source: "task", Row: "the-anchor", Served: 1})
+	if len(left) != 2 || left[0].item.Id != "the-anchor" {
+		t.Fatalf("resume returned %v, want the anchor and everything after it", rowIDsOf(left))
 	}
 }
 
@@ -247,15 +253,15 @@ func TestTheAnchorIsFoundByIdentityNotPosition(t *testing.T) {
 // The anchor is the SECOND of the pair on purpose. Anchoring on the first would
 // pass under either rule: a match on the id alone finds that same row, so the
 // two implementations agree and the test proves nothing. Only a cursor naming
-// the later one tells them apart — matching on the id alone stops at the
-// earlier row and hands back work the caller has already been given.
+// the later one tells them apart — matching on the id alone resolves the anchor
+// one row too early and hands back a row the caller already has.
 func TestTwoSourcesSharingARecordIdAreDifferentRows(t *testing.T) {
 	rows := []ranked{
 		{item: crmcontracts.WorklistItem{Source: "deal_at_risk", Id: "same-deal"}},
 		{item: crmcontracts.WorklistItem{Source: sourceWaiting, Id: "same-deal"}},
 		{item: crmcontracts.WorklistItem{Source: "task", Id: "still-owed"}},
 	}
-	left := resume(rows, worklistCursor{Source: sourceWaiting, Row: "same-deal"})
+	left := resume(rows, worklistCursor{Source: sourceWaiting, Row: "same-deal", Served: 2})
 	if len(left) != 1 || left[0].item.Id != "still-owed" {
 		t.Errorf("resume returned %v; matching the id alone stops at the wrong row and repeats work",
 			rowIDsOf(left))
@@ -378,5 +384,210 @@ func TestAFoldedRowIsAStableAnchorAcrossReads(t *testing.T) {
 			t.Errorf("a folded row changed identity between reads: %q then %q; "+
 				"a cursor naming it would find nothing and end the walk early", one[i], two[i])
 		}
+	}
+}
+
+// A day that moves between pages must not lose a row.
+//
+// These two are the reason the token carries a position AND an identity. Each
+// half alone fails one of them, in opposite directions, and the failure is
+// silent either way: the reader is simply never shown work they are owed.
+func TestALiveDayDoesNotLoseRowsBetweenPages(t *testing.T) {
+	svc := &Service{}
+	at := func(id string, due time.Duration) crmcontracts.AttentionItem {
+		return item(id, "task", withDue(rankInstant.Add(due)))
+	}
+	page := func(day crmcontracts.Attention, cursor worklistCursor) crmcontracts.Worklist {
+		return svc.worklistFrom(t.Context(), day, scopeAll, "", 1,
+			waitingRead{}, leadRead{}, cursor)
+	}
+	shown := func(out crmcontracts.Worklist) []string {
+		got := []string{}
+		for _, row := range out.Queue {
+			got = append(got, row.Id)
+		}
+		return got
+	}
+
+	t.Run("a row that moves up but stays behind the reader is still reached", func(t *testing.T) {
+		// aa, bb, cc, dd by deadline. Page one hands out aa.
+		before := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("aa", time.Hour), at("bb", 2*time.Hour),
+			at("cc", 3*time.Hour), at("dd", 4*time.Hour),
+		}}
+		first := page(before, worklistCursor{})
+		cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
+		if err != nil {
+			t.Fatalf("decoding page one's cursor: %v", err)
+		}
+		// dd overtakes bb and cc but still sorts behind the already-served aa.
+		// A position-only resume would step over whatever landed on the old
+		// offset; taking the earlier of position and identity keeps it.
+		after := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("aa", time.Hour), at("bb", 2*time.Hour),
+			at("cc", 3*time.Hour), at("dd", 90*time.Minute),
+		}}
+		reached := map[string]bool{}
+		for _, id := range shown(first) {
+			reached[id] = true
+		}
+		for range 8 {
+			out := page(after, cursor)
+			for _, id := range shown(out) {
+				reached[id] = true
+			}
+			if out.NextCursor == nil {
+				break
+			}
+			cursor, err = decodeCursor(*out.NextCursor, scopeAll, "", ids.UUID{})
+			if err != nil {
+				t.Fatalf("decoding a later cursor: %v", err)
+			}
+		}
+		for _, want := range []string{"aa", "bb", "cc", "dd"} {
+			if !reached[want] {
+				t.Errorf("row %q was never shown to the reader; the walk stepped over it", want)
+			}
+		}
+	})
+
+	// The limit of ANY forward-only cursor over a live re-ranked set, pinned
+	// here so it is a known property rather than a surprise.
+	//
+	// A row that overtakes rows the caller has already been handed now sorts
+	// behind them. Returning it would mean re-serving that whole prefix, which
+	// is the walk that never terminates. So this read does not show it, and the
+	// next read of the day — the rep opening their queue again — leads with it.
+	//
+	// That loss is bounded and self-correcting, and it is the only one accepted
+	// here. It is not the same as the defects the cases above cover, where a
+	// row went missing from an unchanged part of the day.
+	t.Run("a row that overtakes what the reader already has waits for the next read", func(t *testing.T) {
+		before := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
+		}}
+		first := page(before, worklistCursor{})
+		cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
+		if err != nil {
+			t.Fatalf("decoding page one's cursor: %v", err)
+		}
+		// cc becomes the most urgent thing on the day, ahead of the served aa.
+		after := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", -5*time.Hour),
+		}}
+		out := page(after, cursor)
+		if len(out.Queue) == 0 {
+			t.Fatal("the walk ended although rows behind the anchor were still owed")
+		}
+		// A fresh read leads with it, so the row is delayed rather than lost.
+		fresh := page(after, worklistCursor{})
+		if len(fresh.Queue) == 0 || fresh.Queue[0].Id != "cc" {
+			t.Errorf("a fresh read did not lead with the newly urgent row: %v", shown(fresh))
+		}
+	})
+
+	t.Run("an anchor that slides to last does not end the walk", func(t *testing.T) {
+		before := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
+		}}
+		first := page(before, worklistCursor{})
+		cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
+		if err != nil {
+			t.Fatalf("decoding page one's cursor: %v", err)
+		}
+		// The anchor itself is deprioritised to the very end. An identity-only
+		// resume returns nothing at all — "after aa" is empty — and the reader
+		// is told their day is finished with two rows still owed.
+		after := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("aa", 99*time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
+		}}
+		out := page(after, cursor)
+		if len(out.Queue) == 0 {
+			t.Fatal("the walk reported itself finished while two rows were still owed")
+		}
+	})
+
+	t.Run("an anchor that vanishes does not end the walk", func(t *testing.T) {
+		before := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
+		}}
+		first := page(before, worklistCursor{})
+		cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
+		if err != nil {
+			t.Fatalf("decoding page one's cursor: %v", err)
+		}
+		// aa is answered between pages. The position carries the walk.
+		after := crmcontracts.Attention{AsOf: rankInstant, Planned: []crmcontracts.AttentionItem{
+			at("bb", 2*time.Hour), at("cc", 3*time.Hour),
+		}}
+		out := page(after, cursor)
+		if len(out.Queue) == 0 {
+			t.Fatal("answering the anchor ended the walk; the rows behind it became unreachable")
+		}
+	})
+}
+
+// The two spellings of one question must fingerprint alike, or a walk breaks on
+// a difference the caller cannot see. Both are cases the contract itself calls
+// the same question.
+func TestEquivalentSpellingsOfOneQuestionShareACursor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an omitted filter and filter=all", func(t *testing.T) {
+		minted := encodeCursor(
+			ranked{item: crmcontracts.WorklistItem{Source: "task", Id: "t1"}}, 1,
+			scopeMine, "", ids.UUID{})
+		if _, err := decodeCursor(minted, scopeMine, "all", ids.UUID{}); err != nil {
+			t.Errorf("a client sending its documented `all` default on page two was refused: %v", err)
+		}
+	})
+
+	t.Run("an omitted owner and naming yourself", func(t *testing.T) {
+		svc := NewService(
+			stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
+			stubBriefing{}, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, fixedClock)
+		waits := []WaitingCustomer{}
+		for i := range 3 {
+			waits = append(waits, WaitingCustomer{
+				ActivityID: ids.NewV7(), Subject: "a customer",
+				Since: readInstant.Add(-time.Duration(i+2) * 24 * time.Hour), OwnerID: theManager,
+			})
+		}
+		svc.waiting = waitingOwnedBy(waits)
+		svc.teammates = teammatesSaying(true)
+
+		first, err := svc.Worklist(managerReading(), "", "", ids.UUID{}, 2, "")
+		if err != nil {
+			t.Fatalf("reading own queue: %v", err)
+		}
+		if first.NextCursor == nil {
+			t.Fatal("a page of two over three rows offered no cursor")
+		}
+		// The same reader, naming themselves — which the contract calls the
+		// question the default already answers.
+		if _, err := svc.Worklist(managerReading(), "", "", theManager, 2, *first.NextCursor); err != nil {
+			t.Errorf("naming yourself on page two was refused as a different question: %v", err)
+		}
+	})
+}
+
+// Two rows that are indistinguishable as anchors must not stall a walk.
+//
+// less() ends at the id, so rows sharing one tie there and their (source, id)
+// anchors cannot be told apart: resume() finds the first every time. The
+// position half of the token is what carries the walk past them — without it a
+// cursor naming the second would resolve to the first and the same page would
+// be served forever.
+func TestIndistinguishableAnchorsDoNotStallAWalk(t *testing.T) {
+	rows := []ranked{
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "twin"}},
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "twin"}},
+		{item: crmcontracts.WorklistItem{Source: "task", Id: "after"}},
+	}
+	// The caller has had both twins; the identity resolves to the first.
+	left := resume(rows, worklistCursor{Source: "task", Row: "twin", Served: 2})
+	if len(left) == len(rows) {
+		t.Fatal("the walk made no progress; a cursor on a duplicated id would repeat forever")
 	}
 }

--- a/backend/internal/compose/attention/cursor_test.go
+++ b/backend/internal/compose/attention/cursor_test.go
@@ -278,3 +278,105 @@ func mustUUID(t *testing.T, s string) ids.UUID {
 	}
 	return parsed
 }
+
+// A cursor minted while reading one person's queue must not open another's.
+//
+// This is the end-to-end shape of the fingerprint rule, driven through
+// Worklist rather than decodeCursor: the mint reads `s.taskOwner` off the
+// narrowed service and the decode reads `namedOwner` off the resolver, and a
+// test that only exercises decodeCursor would never notice those two coming
+// apart. If they did, a manager's page-two token would silently open a
+// different rep's day under the first rep's heading.
+func TestACursorFromOneQueueCannotOpenAnothers(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
+		stubBriefing{}, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, fixedClock)
+	// Three waits each, so a page of two leaves a third behind and the read
+	// actually mints a cursor.
+	waits := []WaitingCustomer{}
+	for i := range 3 {
+		waits = append(waits,
+			WaitingCustomer{
+				ActivityID: ids.NewV7(), Subject: "the rep's customer",
+				Since: readInstant.Add(-time.Duration(i+2) * 24 * time.Hour), OwnerID: theRep,
+			},
+			WaitingCustomer{
+				ActivityID: ids.NewV7(), Subject: "the manager's own customer",
+				Since: readInstant.Add(-time.Duration(i+2) * 24 * time.Hour), OwnerID: theManager,
+			})
+	}
+	svc.waiting = waitingOwnedBy(waits)
+	svc.teammates = teammatesSaying(true)
+
+	first, err := svc.Worklist(managerReading(), "", "", theRep, 2, "")
+	if err != nil {
+		t.Fatalf("opening the rep's queue: %v", err)
+	}
+	if first.NextCursor == nil {
+		t.Fatal("a page of two over three rows offered no cursor; the walk cannot continue")
+	}
+
+	// The same token, carried onto the manager's own queue.
+	_, err = svc.Worklist(managerReading(), "", "", ids.UUID{}, 2, *first.NextCursor)
+	if err == nil {
+		t.Error("a cursor minted on the rep's queue was accepted on the manager's own; " +
+			"page two would answer about a different person with nothing saying so")
+	}
+
+	// And it still works on the queue it was minted for.
+	if _, err := svc.Worklist(managerReading(), "", "", theRep, 2, *first.NextCursor); err != nil {
+		t.Errorf("the cursor was refused on the very queue it was minted for: %v", err)
+	}
+}
+
+// A folded batch row must be a STABLE anchor across pages.
+//
+// Folding replaces a pile of alike decisions with one row, and that row is what
+// a cursor can land on. Its id is derived from the group's key and cause
+// (batchID), so the same pile folds to the same id on every read. If a later
+// change gave a batch row a per-read identity — a counter, an instant, a random
+// id — a cursor naming one would find nothing on the next page and the walk
+// would end early with work still owed, silently.
+func TestAFoldedRowIsAStableAnchorAcrossReads(t *testing.T) {
+	t.Parallel()
+
+	// A pile deep enough to fold, of the routine contact decisions that fold.
+	needs := make([]crmcontracts.AttentionItem, 0, 12)
+	for i := range 12 {
+		needs = append(needs, item(
+			"d"+string(rune('a'+i)), "approval", withKind("capture_counterparty")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: needs}
+
+	svc := &Service{}
+	first := svc.worklistFrom(t.Context(), day, scopeAll, "", 25,
+		waitingRead{}, leadRead{}, worklistCursor{})
+	second := svc.worklistFrom(t.Context(), day, scopeAll, "", 25,
+		waitingRead{}, leadRead{}, worklistCursor{})
+
+	batched := func(out crmcontracts.Worklist) []string {
+		ids := []string{}
+		for _, row := range out.Queue {
+			if row.Batch != nil {
+				ids = append(ids, string(row.Source)+"|"+row.Id)
+			}
+		}
+		return ids
+	}
+	one, two := batched(first), batched(second)
+	if len(one) == 0 {
+		t.Fatal("the fixture folded nothing; this test would pass vacuously")
+	}
+	if len(one) != len(two) {
+		t.Fatalf("two reads of one day folded differently: %v against %v", one, two)
+	}
+	for i := range one {
+		if one[i] != two[i] {
+			t.Errorf("a folded row changed identity between reads: %q then %q; "+
+				"a cursor naming it would find nothing and end the walk early", one[i], two[i])
+		}
+	}
+}

--- a/backend/internal/compose/attention/cursor_test.go
+++ b/backend/internal/compose/attention/cursor_test.go
@@ -591,3 +591,69 @@ func TestIndistinguishableAnchorsDoNotStallAWalk(t *testing.T) {
 		t.Fatal("the walk made no progress; a cursor on a duplicated id would repeat forever")
 	}
 }
+
+// Naming yourself and omitting the owner must return the SAME page.
+//
+// resolveOwner collapses the two onto one resolved question, which changes
+// which branch the read takes: a self-named owner used to go through
+// forOwner/TasksOwnedBy and now falls through to forReader/TasksMine. Those
+// two are equivalent for this case by construction — one files the query under
+// actor.UserID, the other under an owner that IS actor.UserID — but "by
+// construction" is the kind of claim that stops being true quietly, so it is
+// checked against the assembled page rather than argued.
+func TestNamingYourselfAnswersTheSamePageAsOmittingTheOwner(t *testing.T) {
+	t.Parallel()
+
+	build := func() *Service {
+		svc := NewService(
+			stubApprovals{}, stubDuplicates{}, &stubTasks{}, stubReceipts{},
+			stubBriefing{}, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, fixedClock)
+		svc.waiting = waitingOwnedBy{
+			{
+				ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000b1"),
+				Subject:    "their own customer",
+				Since:      readInstant.Add(-3 * 24 * time.Hour), OwnerID: theManager,
+			},
+			{
+				ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000b2"),
+				Subject:    "somebody else's customer",
+				Since:      readInstant.Add(-2 * 24 * time.Hour), OwnerID: theRep,
+			},
+		}
+		svc.teammates = teammatesSaying(true)
+		return svc
+	}
+
+	omitted, err := build().Worklist(managerReading(), "", "", ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("reading with the owner omitted: %v", err)
+	}
+	named, err := build().Worklist(managerReading(), "", "", theManager, 25, "")
+	if err != nil {
+		t.Fatalf("reading with the owner named as yourself: %v", err)
+	}
+
+	rows := func(out crmcontracts.Worklist) []string {
+		got := []string{}
+		for _, row := range out.Queue {
+			got = append(got, string(row.Source)+"|"+row.Id)
+		}
+		return got
+	}
+	left, right := rows(omitted), rows(named)
+	if len(left) == 0 {
+		t.Fatal("both reads were empty; this test would pass vacuously")
+	}
+	if len(left) != len(right) {
+		t.Fatalf("two spellings of one question answered differently: %v against %v", left, right)
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			t.Errorf("row %d differs between the two spellings: %q against %q", i, left[i], right[i])
+		}
+	}
+	if omitted.Scope != named.Scope {
+		t.Errorf("the two spellings reported different scopes: %q against %q", omitted.Scope, named.Scope)
+	}
+}

--- a/backend/internal/compose/attention/handlers.go
+++ b/backend/internal/compose/attention/handlers.go
@@ -98,7 +98,16 @@ func (h Handlers) GetWorklist(w http.ResponseWriter, r *http.Request, params crm
 		}
 		owner = ids.UUID(*params.Owner)
 	}
-	out, err := h.svc.Worklist(r.Context(), scope, filter, owner, limit)
+	// Passed through as the caller sent it, unchecked here on purpose. What a
+	// token means is a question about the scope and owner this read RESOLVES to,
+	// which happens in the service beside the resolution itself. Fingerprinting
+	// the request's words instead would refuse a caller who spelled out the
+	// default on page two of a walk they had started without it.
+	token := ""
+	if params.Cursor != nil {
+		token = *params.Cursor
+	}
+	out, err := h.svc.Worklist(r.Context(), scope, filter, owner, limit, token)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return

--- a/backend/internal/compose/attention/leadlane_test.go
+++ b/backend/internal/compose/attention/leadlane_test.go
@@ -76,7 +76,7 @@ func TestABreachedLeadRanksAboveOneMerelyAtRisk(t *testing.T) {
 		},
 	}})
 
-	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25)
+	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
 	if err != nil {
 		t.Fatalf("worklist: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestWithNoFirstResponseTargetTheLaneClaimsNothing(t *testing.T) {
 		{ID: ids.NewV7(), Name: "a lead", State: "breached", DeadlineAt: readInstant.Add(-time.Hour)},
 	}})
 
-	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25)
+	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
 	if err != nil {
 		t.Fatalf("worklist: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestAnUnassignedLeadNamesThatItAnswersToNobody(t *testing.T) {
 		{ID: ids.NewV7(), Name: "nobody's", DeadlineAt: readInstant.Add(-time.Hour), State: "breached"},
 	}})
 
-	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25)
+	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
 	if err != nil {
 		t.Fatalf("worklist: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestANamedOwnersQueueKeepsTheirOwedLeads(t *testing.T) {
 		},
 	}})
 
-	day, err := svc.Worklist(leadReader(), "", "", rep, 25)
+	day, err := svc.Worklist(leadReader(), "", "", rep, 25, "")
 	if err != nil {
 		t.Fatalf("worklist: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestANamedOwnersQueueKeepsTheirOwedLeads(t *testing.T) {
 func TestAnUntrackedLanePublishesNoReachRow(t *testing.T) {
 	svc := leadLaneService(&stubLeads{tracked: false})
 
-	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25)
+	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
 	if err != nil {
 		t.Fatalf("worklist: %v", err)
 	}

--- a/backend/internal/compose/attention/meetingpreplane_test.go
+++ b/backend/internal/compose/attention/meetingpreplane_test.go
@@ -60,7 +60,7 @@ func TestAMeetingWithNothingWrittenDownSaysSo(t *testing.T) {
 		{ID: ids.NewV7(), Subject: "prepared", StartsAt: soon, NeedsPrep: false, PrepKnown: true},
 	})
 
-	day, err := svc.Worklist(meetingPrepReader(), "", "", ids.UUID{}, 25)
+	day, err := svc.Worklist(meetingPrepReader(), "", "", ids.UUID{}, 25, "")
 	if err != nil {
 		t.Fatalf("worklist: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestAMeetingThisReaderCannotReadClaimsNothingAboutPreparation(t *testing.T)
 		NeedsPrep: true, PrepKnown: false,
 	}})
 
-	day, err := svc.Worklist(meetingPrepReader(), "", "", ids.UUID{}, 25)
+	day, err := svc.Worklist(meetingPrepReader(), "", "", ids.UUID{}, 25, "")
 	if err != nil {
 		t.Fatalf("worklist: %v", err)
 	}

--- a/backend/internal/compose/attention/ownerqueue_test.go
+++ b/backend/internal/compose/attention/ownerqueue_test.go
@@ -71,7 +71,7 @@ func TestANamedOwnersQueueCarriesTheirWaitingCustomersAndNotTheReadersOwn(t *tes
 	}
 	svc.teammates = teammatesSaying(true)
 
-	day, err := svc.Worklist(managerReading(), "", "", theRep, 25)
+	day, err := svc.Worklist(managerReading(), "", "", theRep, 25, "")
 	if err != nil {
 		t.Fatalf("opening the named owner's queue: %v", err)
 	}

--- a/backend/internal/compose/attention/page.go
+++ b/backend/internal/compose/attention/page.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	"sort"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// pageFrom cuts the candidates to what one read carries, starting after the row
+// a cursor names, and says whether anything is left behind it.
+//
+// It runs BEFORE the ranking is drawn, so the comparison each row publishes is
+// against a row the caller actually received. The cut itself is by score, so
+// this sorts first and then slices — taking the best `limit`, never the first
+// `limit` the producers happened to return.
+//
+// The sort happens before the resume, not after, and the order matters: the
+// cursor names a position in the RANKING, so the set has to be in ranked order
+// before the anchor means anything.
+func pageFrom(rows []ranked, limit int, cursor worklistCursor) (shown []ranked, more bool) {
+	sort.SliceStable(rows, func(i, j int) bool { return less(rows[i], rows[j]) })
+	rows = resume(rows, cursor)
+	if len(rows) > limit {
+		return rows[:limit], true
+	}
+	return rows, false
+}
+
+func keepCategory(rows []ranked, want crmcontracts.WorklistItemCategory) []ranked {
+	kept := make([]ranked, 0, len(rows))
+	for _, row := range rows {
+		if row.item.Category == want {
+			kept = append(kept, row)
+		}
+	}
+	return kept
+}

--- a/backend/internal/compose/attention/page.go
+++ b/backend/internal/compose/attention/page.go
@@ -9,7 +9,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
 
-// pageFrom cuts the candidates to what one read carries, starting after the row
+// pageFrom cuts the candidates to what one read carries, starting at the offset
 // a cursor names, and says whether anything is left behind it.
 //
 // It runs BEFORE the ranking is drawn, so the comparison each row publishes is
@@ -19,14 +19,23 @@ import (
 //
 // The sort happens before the resume, not after, and the order matters: the
 // cursor names a position in the RANKING, so the set has to be in ranked order
-// before the anchor means anything.
-func pageFrom(rows []ranked, limit int, cursor worklistCursor) (shown []ranked, more bool) {
+// before that offset means anything.
+//
+// It also reports `reached`: where in the ranked set the cut landed, which is
+// the offset the next cursor is minted at. That is a position in THIS read's
+// ranking, not a running total of rows handed out. The two differ as soon as the
+// day moves between pages, and a running total would push the offset past the
+// work still owed.
+func pageFrom(
+	rows []ranked, limit int, cursor worklistCursor,
+) (shown []ranked, more bool, reached int) {
 	sort.SliceStable(rows, func(i, j int) bool { return less(rows[i], rows[j]) })
-	rows = resume(rows, cursor)
+	from := resumeAt(rows, cursor)
+	rows = rows[from:]
 	if len(rows) > limit {
-		return rows[:limit], true
+		return rows[:limit], true, from + limit
 	}
-	return rows, false
+	return rows, false, from + len(rows)
 }
 
 func keepCategory(rows []ranked, want crmcontracts.WorklistItemCategory) []ranked {

--- a/backend/internal/compose/attention/reach_test.go
+++ b/backend/internal/compose/attention/reach_test.go
@@ -28,7 +28,7 @@ func TestABoundedSourceSaysMoreRatherThanATotal(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, Notices: &notices}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
 
 	for _, reach := range got.Reach {
 		if reach.Source != "notice" {
@@ -51,7 +51,7 @@ func TestASourceUnderItsBoundClaimsNoMore(t *testing.T) {
 	notices := []crmcontracts.AttentionItem{item("only", "notice")}
 	day := crmcontracts.Attention{AsOf: rankInstant, Notices: &notices}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
 
 	for _, reach := range got.Reach {
 		if reach.Source == "notice" && reach.MoreAvailable {
@@ -73,7 +73,7 @@ func TestAFoldedGroupIsCountedAgainstTheSourcesItStandsFor(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, AutomationHealth: &failures}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
 
 	for _, reach := range got.Reach {
 		if reach.Source != "automation_run" {
@@ -97,8 +97,8 @@ func TestReachIsOrderedTheSameWayTwice(t *testing.T) {
 	bounces := []crmcontracts.AttentionItem{item("b", "bounce")}
 	day := crmcontracts.Attention{AsOf: rankInstant, Notices: &notices, Bounces: &bounces}
 
-	first := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{})
-	second := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{})
+	first := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
+	second := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
 
 	if len(first.Reach) != len(second.Reach) {
 		t.Fatalf("two reads gave %d and %d sources", len(first.Reach), len(second.Reach))
@@ -127,7 +127,7 @@ func TestReachUnderMineCountsNothingOfAColleaguesWork(t *testing.T) {
 	atRisk := []crmcontracts.AttentionItem{theirs}
 	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: &atRisk}
 
-	got := (&Service{}).worklistFrom(ctx, day, "mine", "", 50, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(ctx, day, "mine", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
 
 	for _, reach := range got.Reach {
 		if reach.Source == "deal_at_risk" && reach.Considered > 0 {
@@ -155,7 +155,7 @@ func TestEveryBoundedLaneReportsItsTruncation(t *testing.T) {
 		AsOf: rankInstant, Planned: planned, AtRisk: &atRisk, RelationshipDecay: &decay,
 	}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 500, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 500, waitingRead{}, leadRead{}, worklistCursor{})
 
 	marked := map[crmcontracts.WorklistReachSource]bool{}
 	for _, reach := range got.Reach {
@@ -175,7 +175,7 @@ func TestASourceReadAndFoundEmptyStillAppears(t *testing.T) {
 	none := []crmcontracts.AttentionItem{}
 	day := crmcontracts.Attention{AsOf: rankInstant, Notices: &none}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
 
 	for _, reach := range got.Reach {
 		if reach.Source == "notice" {
@@ -197,7 +197,7 @@ func TestNarrowingKeepsTheOtherSourcesInReach(t *testing.T) {
 	notices := []crmcontracts.AttentionItem{item("n1", "notice")}
 	day := crmcontracts.Attention{AsOf: rankInstant, Planned: planned, Notices: &notices}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "system", 50, waitingRead{}, leadRead{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "system", 50, waitingRead{}, leadRead{}, worklistCursor{})
 
 	for _, reach := range got.Reach {
 		if reach.Source != "task" {

--- a/backend/internal/compose/attention/scope.go
+++ b/backend/internal/compose/attention/scope.go
@@ -110,9 +110,17 @@ func (s *Service) resolveOwner(ctx context.Context, asked ids.UUID) (ids.UUID, e
 		return ids.UUID{}, apperrors.ErrPermissionDenied
 	}
 	// Their own id needs no wider tier: "mine, spelled out" is the same
-	// question the default answers.
+	// question the default answers, so it resolves to the SAME answer — the
+	// zero owner the default carries — rather than to their id.
+	//
+	// The two spellings already read identically: TasksMine files the query
+	// under `actor.UserID` and TasksOwnedBy under `owner`, which for this case
+	// are one value. Returning the id instead made them differ everywhere the
+	// resolved owner is read as an identity rather than used as a filter — a
+	// continuation token minted under one spelling was refused under the other,
+	// and the caller was told their question had changed when it had not.
 	if owner == actor.UserID {
-		return owner, nil
+		return ids.UUID{}, nil
 	}
 	// An unbounded reader reaches every row, so for them the tier IS the whole
 	// test and naming anyone is answerable.

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -141,7 +141,7 @@ func TestAPageOfTheReadersOwnIsNotShortenedByColleaguesRows(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: &at}
 
-	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 3, waitingRead{}, leadRead{})
+	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 3, waitingRead{}, leadRead{}, worklistCursor{})
 
 	if len(out.Queue) != 3 {
 		t.Fatalf("a reader with three of their own rows got a page of %d", len(out.Queue))
@@ -357,7 +357,7 @@ func TestOpeningAnothersQueueCarriesTheirWorkAndNotTheReadersOwn(t *testing.T) {
 	}
 	reader := &Service{taskOwner: lena, taskScope: TasksOwnedBy}
 
-	out := reader.worklistFrom(context.Background(), day, scopeMine, "", 25, waitingRead{}, leadRead{})
+	out := reader.worklistFrom(context.Background(), day, scopeMine, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
 
 	var ids []string
 	for _, row := range out.Queue {

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -312,15 +312,24 @@ func TestAFailedMembershipReadRefusesAndReportsTheFailure(t *testing.T) {
 // Naming yourself is the question the default already answers, so every tier
 // may ask it. A rep following a link that spells out their own id must not be
 // refused their own day.
-func TestNamingYourselfNeedsNoWiderTier(t *testing.T) {
+//
+// It resolves to the SAME answer as the default — the zero owner — rather than
+// to their id, because "the same question" has to mean one resolved question
+// downstream and not two. The two spellings already read identically (TasksMine
+// files the query under actor.UserID, TasksOwnedBy under owner, one value
+// here); resolving them apart made every later reader of the resolved owner see
+// two different questions, and a continuation token minted under one spelling
+// was refused under the other.
+func TestNamingYourselfResolvesToTheDefaultQuestion(t *testing.T) {
 	me := ids.MustParse("01a05500-0000-7000-8000-000000000001")
 
 	got, err := (&Service{}).resolveOwner(readerAt(principal.RowScopeOwn), me)
 	if err != nil {
 		t.Fatalf("a reader was refused their OWN queue: %v", err)
 	}
-	if got != me {
-		t.Fatalf("asking for their own queue answered %v", got)
+	if !got.IsZero() {
+		t.Fatalf("naming yourself resolved to %v; it is the question the default answers, "+
+			"and resolving it apart makes one question look like two", got)
 	}
 }
 

--- a/backend/internal/compose/attention/waitingfreshness_test.go
+++ b/backend/internal/compose/attention/waitingfreshness_test.go
@@ -176,7 +176,7 @@ func TestAnAncientWaitNoLongerOutranksTodaysDeal(t *testing.T) {
 		Since:      rankInstant.Add(-182 * 24 * time.Hour),
 	}}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
 
 	if out.Queue[0].Source == sourceWaiting {
 		t.Fatal("a 182-day unanswered thread still led the day over a deal at risk")
@@ -198,7 +198,7 @@ func TestTheSummaryStatesTheMaterialBar(t *testing.T) {
 		),
 	}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{}, leadRead{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
 
 	if out.Summary.MaterialThresholdMinor == nil {
 		t.Fatal("a day with priced deals stated no material bar, so every material reason on it is unverifiable")
@@ -217,7 +217,7 @@ func TestTheSummaryStatesTheMaterialBar(t *testing.T) {
 func TestADayWithNoPricedDealsStatesNoBar(t *testing.T) {
 	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: lane(item("unpriced", "deal_at_risk"))}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{}, leadRead{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
 
 	if out.Summary.MaterialThresholdMinor != nil {
 		t.Fatalf("a pipeline with no prices stated a bar of %d", *out.Summary.MaterialThresholdMinor)

--- a/backend/internal/compose/attention/waitinglane.go
+++ b/backend/internal/compose/attention/waitinglane.go
@@ -12,8 +12,12 @@ package attention
 
 import (
 	"context"
+	"errors"
+	"log/slog"
 	"time"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -57,4 +61,50 @@ type WaitingCustomer struct {
 	// the thread is filed under. Zero when nothing on it names an owner, which
 	// is an unowned customer rather than a missing answer.
 	OwnerID ids.UUID
+}
+
+// waitingCustomers reads who is waiting, or names why it could not.
+//
+// A refusal is reported as a withheld source; any other failure as a failed
+// one. Neither takes the rest of the day down with it — a page that answered
+// nothing because one source stumbled is less useful than a page that says
+// which part it could not read.
+func (s *Service) waitingCustomers(
+	ctx context.Context, asOf time.Time,
+) (waitingRead, *crmcontracts.WorklistSourceUnavailable) {
+	if s.waiting == nil {
+		return waitingRead{}, nil
+	}
+	rows, cut, err := s.waiting.Unanswered(ctx, asOf)
+	switch {
+	case errors.Is(err, apperrors.ErrPermissionDenied):
+		return waitingRead{}, &crmcontracts.WorklistSourceUnavailable{
+			Source: sourceWaiting, Reason: crmcontracts.WorklistSourceUnavailableReasonWithheld,
+		}
+	case err != nil:
+		// Named on the page AND recorded here. A source reported as failed with
+		// nothing in the log leaves an operator with a warning they cannot act
+		// on — which is how this one went a whole verification round without
+		// anybody being able to say what broke.
+		slog.ErrorContext(ctx, "the who-is-waiting read failed", "error", err)
+		return waitingRead{}, &crmcontracts.WorklistSourceUnavailable{
+			Source: sourceWaiting, Reason: crmcontracts.WorklistSourceUnavailableReasonFailed,
+		}
+	default:
+		return waitingRead{rows: rows, read: true, cut: cut}, nil
+	}
+}
+
+// waitingRead is what the who-is-waiting source answered, and whether it ran.
+//
+// `read` tells an empty answer from an absent lane, the way the lead read's own
+// wrapper does: reach publishes a row for every source it is told about, so
+// recording a source that never ran would report it as successfully read and
+// empty. `cut` is the lane's own scan depth, which the row count cannot
+// recover — the seam drops machine senders and folds duplicate threads AFTER
+// the SQL cap, so a short answer is what a truncated scan looks like.
+type waitingRead struct {
+	rows []WaitingCustomer
+	read bool
+	cut  bool
 }

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -17,13 +17,9 @@ package attention
 
 import (
 	"context"
-	"errors"
-	"log/slog"
 	"sort"
-	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
-	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -142,52 +138,6 @@ func (s *Service) Worklist(
 	out.Scope = crmcontracts.WorklistScope(resolved)
 	out.ScopeOptions = scopeOptions(scopeOptionsFor(ctx))
 	return out, nil
-}
-
-// waitingCustomers reads who is waiting, or names why it could not.
-//
-// A refusal is reported as a withheld source; any other failure as a failed
-// one. Neither takes the rest of the day down with it — a page that answered
-// nothing because one source stumbled is less useful than a page that says
-// which part it could not read.
-func (s *Service) waitingCustomers(
-	ctx context.Context, asOf time.Time,
-) (waitingRead, *crmcontracts.WorklistSourceUnavailable) {
-	if s.waiting == nil {
-		return waitingRead{}, nil
-	}
-	rows, cut, err := s.waiting.Unanswered(ctx, asOf)
-	switch {
-	case errors.Is(err, apperrors.ErrPermissionDenied):
-		return waitingRead{}, &crmcontracts.WorklistSourceUnavailable{
-			Source: sourceWaiting, Reason: crmcontracts.WorklistSourceUnavailableReasonWithheld,
-		}
-	case err != nil:
-		// Named on the page AND recorded here. A source reported as failed with
-		// nothing in the log leaves an operator with a warning they cannot act
-		// on — which is how this one went a whole verification round without
-		// anybody being able to say what broke.
-		slog.ErrorContext(ctx, "the who-is-waiting read failed", "error", err)
-		return waitingRead{}, &crmcontracts.WorklistSourceUnavailable{
-			Source: sourceWaiting, Reason: crmcontracts.WorklistSourceUnavailableReasonFailed,
-		}
-	default:
-		return waitingRead{rows: rows, read: true, cut: cut}, nil
-	}
-}
-
-// waitingRead is what the who-is-waiting source answered, and whether it ran.
-//
-// `read` tells an empty answer from an absent lane, the way the lead read's own
-// wrapper does: reach publishes a row for every source it is told about, so
-// recording a source that never ran would report it as successfully read and
-// empty. `cut` is the lane's own scan depth, which the row count cannot
-// recover — the seam drops machine senders and folds duplicate threads AFTER
-// the SQL cap, so a short answer is what a truncated scan looks like.
-type waitingRead struct {
-	rows []WaitingCustomer
-	read bool
-	cut  bool
 }
 
 // worklistFrom projects an already-assembled day, so a test can drive the
@@ -352,8 +302,13 @@ func (s *Service) worklistFrom(
 	// Fingerprinted with `s.taskOwner`, the same resolved owner the two
 	// narrowing passes above read. Taking it from the request instead would let
 	// the token and the rows it continues disagree about whose queue this is.
+	//
+	// The served count runs from the START of the walk, not of this page: it is
+	// what the incoming token already accounted for plus what this page adds,
+	// so it stays a position in the ranking rather than a page size.
 	if more && len(shown) > 0 {
-		token := encodeCursor(shown[len(shown)-1], scope, filter, s.taskOwner)
+		token := encodeCursor(
+			shown[len(shown)-1], cursor.Served+len(shown), scope, filter, s.taskOwner)
 		out.NextCursor = &token
 	}
 	return out

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -144,8 +144,6 @@ func (s *Service) Worklist(
 	return out, nil
 }
 
-// worklistFrom projects an already-assembled day, so a test can drive the
-// ranking, the paging and the summary without standing up every lane's reader.
 // waitingCustomers reads who is waiting, or names why it could not.
 //
 // A refusal is reported as a withheld source; any other failure as a failed
@@ -192,6 +190,8 @@ type waitingRead struct {
 	cut  bool
 }
 
+// worklistFrom projects an already-assembled day, so a test can drive the
+// ranking, the paging and the summary without standing up every lane's reader.
 func (s *Service) worklistFrom(
 	ctx context.Context, day crmcontracts.Attention, scope, filter string, limit int,
 	waiting waitingRead, leads leadRead, cursor worklistCursor,
@@ -421,36 +421,6 @@ func boundedSources(day crmcontracts.Attention) map[crmcontracts.WorklistItemSou
 	bounded["approval"] = len(day.NeedsYou) >= batchScanDepth
 	bounded["dedupe_candidate"] = bounded["approval"]
 	return bounded
-}
-
-// pageFrom cuts the candidates to what one read carries, starting after the row
-// a cursor names, and says whether anything is left behind it.
-//
-// It runs BEFORE the ranking is drawn, so the comparison each row publishes is
-// against a row the caller actually received. The cut itself is by score, so
-// this sorts first and then slices — taking the best `limit`, never the first
-// `limit` the producers happened to return.
-//
-// The sort happens before the resume, not after, and the order matters: the
-// cursor names a position in the RANKING, so the set has to be in ranked order
-// before the anchor means anything.
-func pageFrom(rows []ranked, limit int, cursor worklistCursor) (shown []ranked, more bool) {
-	sort.SliceStable(rows, func(i, j int) bool { return less(rows[i], rows[j]) })
-	rows = resume(rows, cursor)
-	if len(rows) > limit {
-		return rows[:limit], true
-	}
-	return rows, false
-}
-
-func keepCategory(rows []ranked, want crmcontracts.WorklistItemCategory) []ranked {
-	kept := make([]ranked, 0, len(rows))
-	for _, row := range rows {
-		if row.item.Category == want {
-			kept = append(kept, row)
-		}
-	}
-	return kept
 }
 
 // summarize counts the day in the three figures the header states.

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -267,7 +267,7 @@ func (s *Service) worklistFrom(
 	// candidate order does not depend on `limit` — crowding is marked above, over
 	// the whole narrowed set — so page two weighs exactly what page one weighed
 	// and continues it rather than re-deciding it.
-	shown, more := pageFrom(rows, limit, cursor)
+	shown, more, reached := pageFrom(rows, limit, cursor)
 	ordered := rankAll(shown)
 	bands := bandsOf(ordered)
 	out := crmcontracts.Worklist{
@@ -303,12 +303,12 @@ func (s *Service) worklistFrom(
 	// narrowing passes above read. Taking it from the request instead would let
 	// the token and the rows it continues disagree about whose queue this is.
 	//
-	// The served count runs from the START of the walk, not of this page: it is
-	// what the incoming token already accounted for plus what this page adds,
-	// so it stays a position in the ranking rather than a page size.
+	// The position is how far into THIS read's ranking the page got — where the
+	// cut landed, not a running total of rows handed out. The two differ the
+	// moment the day moves between pages, and a running total would push the
+	// offset past the work still owed.
 	if more && len(shown) > 0 {
-		token := encodeCursor(
-			shown[len(shown)-1], cursor.Served+len(shown), scope, filter, s.taskOwner)
+		token := encodeCursor(reached, scope, filter, s.taskOwner)
 		out.NextCursor = &token
 	}
 	return out

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -57,7 +57,7 @@ const worklistMaxPage = 100
 // classified and then dropped, so the summary's figures describe the same day
 // whichever filter is applied.
 func (s *Service) Worklist(
-	ctx context.Context, scope, filter string, owner ids.UUID, limit int,
+	ctx context.Context, scope, filter string, owner ids.UUID, limit int, token string,
 ) (crmcontracts.Worklist, error) {
 	// Resolved BEFORE the day is read: a reader asking for a scope they do not
 	// hold gets a refusal rather than a page assembled and then narrowed, and
@@ -68,6 +68,18 @@ func (s *Service) Worklist(
 	}
 	// Same rule, same moment: whose queue this is, refused rather than narrowed.
 	namedOwner, err := s.resolveOwner(ctx, owner)
+	if err != nil {
+		return crmcontracts.Worklist{}, err
+	}
+	// Checked against the RESOLVED scope and owner, not the words the request
+	// used. `scope` omitted and `scope=mine` are the same question, and a
+	// fingerprint over the raw request would refuse a caller who spelled the
+	// default out on page two of a walk they started without it.
+	//
+	// Refused BEFORE the day is read: a token minted for another question is the
+	// caller's mistake, and assembling a page to then discard it spends a dozen
+	// lane reads on an answer nobody receives.
+	cursor, err := decodeCursor(token, resolved, filter, namedOwner)
 	if err != nil {
 		return crmcontracts.Worklist{}, err
 	}
@@ -120,7 +132,7 @@ func (s *Service) Worklist(
 	// left the second half seeing no named owner: it fell through to "mine" and
 	// returned the READER's own day under the named person's heading, which is
 	// the one way this page can be wrong that its reader cannot detect.
-	out := reader.worklistFrom(ctx, day, resolved, filter, limit, waiting, leads)
+	out := reader.worklistFrom(ctx, day, resolved, filter, limit, waiting, leads, cursor)
 	if waitingErr != nil {
 		out.SourcesUnavailable = append(out.SourcesUnavailable, *waitingErr)
 	}
@@ -182,7 +194,7 @@ type waitingRead struct {
 
 func (s *Service) worklistFrom(
 	ctx context.Context, day crmcontracts.Attention, scope, filter string, limit int,
-	waiting waitingRead, leads leadRead,
+	waiting waitingRead, leads leadRead, cursor worklistCursor,
 ) crmcontracts.Worklist {
 	if limit <= 0 {
 		limit = worklistPage
@@ -300,7 +312,12 @@ func (s *Service) worklistFrom(
 	// then slicing left the last returned row comparing itself against a row the
 	// caller never received, and the summary describing a queue longer than the
 	// one on screen.
-	shown := page(rows, limit)
+	//
+	// The resume happens inside the same cut, between the sort and the slice: the
+	// candidate order does not depend on `limit` — crowding is marked above, over
+	// the whole narrowed set — so page two weighs exactly what page one weighed
+	// and continues it rather than re-deciding it.
+	shown, more := pageFrom(rows, limit, cursor)
 	ordered := rankAll(shown)
 	bands := bandsOf(ordered)
 	out := crmcontracts.Worklist{
@@ -326,6 +343,18 @@ func (s *Service) worklistFrom(
 	if filter != "" {
 		narrowed := crmcontracts.WorklistFilter(filter)
 		out.Filter = &narrowed
+	}
+	// The token for the row this page stopped on, minted ONLY when there is more
+	// behind it. A cursor on a final page invites one more request that can only
+	// answer empty, and a client walking until the cursor disappears would never
+	// stop.
+	//
+	// Fingerprinted with `s.taskOwner`, the same resolved owner the two
+	// narrowing passes above read. Taking it from the request instead would let
+	// the token and the rows it continues disagree about whose queue this is.
+	if more && len(shown) > 0 {
+		token := encodeCursor(shown[len(shown)-1], scope, filter, s.taskOwner)
+		out.NextCursor = &token
 	}
 	return out
 }
@@ -394,18 +423,24 @@ func boundedSources(day crmcontracts.Attention) map[crmcontracts.WorklistItemSou
 	return bounded
 }
 
-// page cuts the candidates to what one read carries.
+// pageFrom cuts the candidates to what one read carries, starting after the row
+// a cursor names, and says whether anything is left behind it.
 //
 // It runs BEFORE the ranking is drawn, so the comparison each row publishes is
 // against a row the caller actually received. The cut itself is by score, so
 // this sorts first and then slices — taking the best `limit`, never the first
 // `limit` the producers happened to return.
-func page(rows []ranked, limit int) []ranked {
+//
+// The sort happens before the resume, not after, and the order matters: the
+// cursor names a position in the RANKING, so the set has to be in ranked order
+// before the anchor means anything.
+func pageFrom(rows []ranked, limit int, cursor worklistCursor) (shown []ranked, more bool) {
 	sort.SliceStable(rows, func(i, j int) bool { return less(rows[i], rows[j]) })
+	rows = resume(rows, cursor)
 	if len(rows) > limit {
-		return rows[:limit]
+		return rows[:limit], true
 	}
-	return rows
+	return rows, false
 }
 
 func keepCategory(rows []ranked, want crmcontracts.WorklistItemCategory) []ranked {

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -326,7 +326,7 @@ func TestThePageIsSummarisedAndExplainedAgainstItself(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, Planned: tasks}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 3, waitingRead{}, leadRead{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 3, waitingRead{}, leadRead{}, worklistCursor{})
 
 	if out.Summary.Total != len(out.Queue) {
 		t.Fatalf("summary totals %d over a page of %d", out.Summary.Total, len(out.Queue))
@@ -411,7 +411,7 @@ func TestAWaitingCustomerLeadsTheDay(t *testing.T) {
 		Since:      rankInstant.Add(-2 * 24 * time.Hour),
 	}}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
 
 	if out.Queue[0].Source != "customer_waiting" {
 		t.Fatalf("the day led with %q, not the customer who is waiting", out.Queue[0].Source)
@@ -435,7 +435,7 @@ func TestAWaitingDealDoesNotAlsoAppearAsDrifting(t *testing.T) {
 		DealID:     deal,
 	}}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
 
 	if len(out.Queue) != 1 {
 		t.Fatalf("one unanswered message produced %d rows", len(out.Queue))
@@ -457,7 +457,7 @@ func TestTheLongestWaitLeadsAmongWaitingCustomers(t *testing.T) {
 		{ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000000b"), Since: rankInstant.Add(-9 * 24 * time.Hour)},
 	}
 
-	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{})
+	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
 
 	if out.Queue[0].Id != "01a05500-0000-7000-8000-00000000000b" {
 		t.Fatal("the two-day wait outranked the eighty-three-day one")
@@ -479,7 +479,7 @@ func TestEveryWaitingRowMayStateItsSubject(t *testing.T) {
 		Since:      rankInstant.Add(-24 * time.Hour),
 	}}
 
-	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{})
+	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
 
 	if out.Queue[0].Title == nil || *out.Queue[0].Title != "Re: pricing" {
 		t.Fatal("a waiting row the content gate admitted lost its subject line")
@@ -504,7 +504,7 @@ func TestAColleaguesWaitingCustomerLeavesTheReadersOwnQueue(t *testing.T) {
 		{ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000a2"), Since: rankInstant.Add(-time.Hour)},
 	}
 
-	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 25, waitingRead{rows: waiting, read: true}, leadRead{})
+	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
 
 	for _, row := range out.Queue {
 		if row.Id == "01a05500-0000-7000-8000-0000000000a1" {
@@ -683,7 +683,7 @@ func TestOneKindOfWorkCannotTakeTheWholePage(t *testing.T) {
 		Planned: []crmcontracts.AttentionItem{item("task", "task", withDue(rankInstant.Add(-time.Hour)))},
 	}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 100, waitingRead{rows: waiting, read: true}, leadRead{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 100, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
 
 	// Every wait is still on the page, and every one still SAYS it is a wait.
 	// Rewriting the level of the ninth would tell the reader it was agreed work
@@ -721,7 +721,8 @@ func TestAWaitingRowNamesTheMessageAReplyWouldAnswer(t *testing.T) {
 	}}
 
 	out := (&Service{}).worklistFrom(context.Background(),
-		crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{})
+		crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true},
+		leadRead{}, worklistCursor{})
 
 	move := out.Queue[0].Move
 	if move == nil {
@@ -755,7 +756,7 @@ func TestAnAbsorbedDealKeepsItsMoneyOnTheWaitingRow(t *testing.T) {
 		DealID:     deal,
 	}}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
 
 	if len(out.Queue) != 1 {
 		t.Fatalf("one message about one deal produced %d rows", len(out.Queue))

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -29886,16 +29886,20 @@ type Worklist struct {
 	// NextCursor Send this back as `cursor` to continue past the last row of this page. See that
 	// parameter for what a walk does and does not guarantee.
 	//
-	// ABSENT MEANS THE WALK IS OVER — there is nothing behind this page. It is
+	// ABSENT MEANS THE WALK IS OVER — nothing was left behind this page. It is
 	// deliberately not minted on a final page: a cursor there invites one more request
 	// that can only answer empty, and a client walking until the cursor disappears
 	// would never stop.
 	//
 	// Absent is therefore a claim, not a silence, and it is the one this field must
-	// never make wrongly. `reach` and `counts` answer a different question — how deep
-	// each SOURCE was read, which is a bound on work rather than the end of a page —
-	// so a walk that has ended can still sit above sources that were cut short, and
-	// both statements are true at once.
+	// never make wrongly. It is a claim about THIS READ of the day: work that arrives
+	// afterwards, or that overtakes rows already handed out, appears on the next read
+	// rather than extending a finished walk.
+	//
+	// `reach` and `counts` answer a different question — how deep each SOURCE was read,
+	// which is a bound on work rather than the end of a page — so a walk that has ended
+	// can still sit above sources that were cut short, and both statements are true at
+	// once.
 	NextCursor *string `json:"next_cursor,omitempty"`
 
 	// Queue Everything actionable, best-first. The order is the product of this endpoint.
@@ -35003,23 +35007,43 @@ type GetWorklistParams struct {
 	// handed you, and the next page re-assembles the day, re-ranks it, and continues
 	// after that row.
 	//
-	// It encodes the `scope`, `filter` and `owner` it was minted under. Sending it
-	// alongside different ones returns `422 code: cursor_param_mismatch` rather than
-	// continuing into a different question — page two of your own tasks silently
+	// It encodes the `scope`, `filter` and `owner` it was minted under, NORMALISED, so
+	// that two spellings of one question share a cursor: an omitted `filter` and
+	// `filter=all` weigh the same candidates, and naming yourself as `owner` is the
+	// question the default already answers. Sending a cursor alongside a genuinely
+	// different scope, filter or owner returns `422 code: cursor_param_mismatch` rather
+	// than continuing into another question — page two of your own tasks silently
 	// becoming the team's deals is what that prevents, and nothing in the response would
 	// have said so. `limit` is deliberately NOT fingerprinted: it decides how many rows
 	// a page carries, not which rows exist, so changing it mid-walk is legitimate.
 	//
-	// A token this endpoint did not mint returns `422 code: malformed_cursor`.
+	// A token that does not decode returns `422 code: malformed_cursor`. The token is
+	// opaque, NOT authenticated: it is base64 of a small JSON object and a caller who
+	// studies it can construct one. That grants nothing. A cursor only chooses where to
+	// resume inside a page that is re-assembled from scratch under the caller's own
+	// principal, so every row it can reach is one the caller could already read, and no
+	// forged token widens scope or row visibility.
 	//
 	// WHAT A WALK GUARANTEES, and what it does not. This is live work, so the day moves
 	// between pages: a rep answers a message, a deal closes, a colleague takes a task.
-	// The walk guarantees a row is not silently repeated, and that it terminates. It
-	// does not promise a stable snapshot, and should not — a page showing rows already
-	// dealt with would be worse than one that skipped them. If the row a cursor names is
-	// gone by the time the next page is asked for, the walk ENDS: restarting from the
-	// top would hand a client paging to exhaustion the same first page forever, each
-	// pass looking like ordinary progress.
+	//
+	// Guaranteed: the walk TERMINATES, and no row is lost from a part of the day that
+	// did not change. A row whose anchor is answered or reprioritised between pages does
+	// not end the walk early — the token carries a position as well as an identity, and
+	// the position continues it.
+	//
+	// Not guaranteed: a stable snapshot, which a set re-assembled and re-ranked on every
+	// read cannot offer. Two consequences, both deliberate:
+	//
+	// A row may REPEAT. Where the token's position and identity disagree — because the
+	// day moved under them — the earlier of the two wins. Repeating a row the caller has
+	// already seen is recoverable; skipping one means work shown to nobody, so this errs
+	// toward the first every time.
+	//
+	// A row that overtakes rows you have ALREADY been handed waits for your next read.
+	// It now sorts behind them, and returning it would mean re-serving that whole prefix
+	// — the walk that never ends. Opening the queue again leads with it, so the delay is
+	// bounded and corrects itself.
 	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 
 	// Owner Whose queue to answer, when it is somebody else's. A manager reading a team

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -35040,8 +35040,10 @@ type GetWorklistParams struct {
 	//
 	// Such a row is not lost from the product — the next read of the queue ranks it
 	// afresh and shows it — so treat a walk as a way to reach a backlog you already know
-	// is there, not as a transaction over it. If you need the whole day at one instant,
-	// ask for it in one page: `limit` reaches 100.
+	// is there, not as a transaction over it. There is no way to ask for the whole day
+	// at one instant: `limit` stops at 100 and a single category can hold more than that,
+	// because the sources are read to their own bounds well past a page (the decision
+	// lane alone weighs 200). `counts` is what says how much is behind the page.
 	//
 	// The alternative was a token naming the last row it handed you, which is the
 	// obvious design and is worse here. When that row is answered between pages, or

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -29883,6 +29883,21 @@ type Worklist struct {
 	// Filter The narrowing this read applied.
 	Filter *WorklistFilter `json:"filter,omitempty"`
 
+	// NextCursor Send this back as `cursor` to continue past the last row of this page. See that
+	// parameter for what a walk does and does not guarantee.
+	//
+	// ABSENT MEANS THE WALK IS OVER — there is nothing behind this page. It is
+	// deliberately not minted on a final page: a cursor there invites one more request
+	// that can only answer empty, and a client walking until the cursor disappears
+	// would never stop.
+	//
+	// Absent is therefore a claim, not a silence, and it is the one this field must
+	// never make wrongly. `reach` and `counts` answer a different question — how deep
+	// each SOURCE was read, which is a bound on work rather than the end of a page —
+	// so a walk that has ended can still sit above sources that were cut short, and
+	// both statements are true at once.
+	NextCursor *string `json:"next_cursor,omitempty"`
+
 	// Queue Everything actionable, best-first. The order is the product of this endpoint.
 	Queue []WorklistItem `json:"queue"`
 
@@ -34975,6 +34990,37 @@ type GetWorklistParams struct {
 
 	// Limit How many ranked items to return.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor Where to continue a walk, from a prior response's `next_cursor`. Omitted starts at
+	// the top, which is what every reader opening their day wants.
+	//
+	// NOT the shared keyset cursor the CRUD lists use, and the difference is why this
+	// endpoint declares its own. Those walk rows a database already ordered, so their
+	// token carries a sort key and the next page is a WHERE clause. This queue has no
+	// such column: it assembles from a dozen lanes and ranks them by a comparator
+	// reading facts no table holds — whether a wait is crowded, what a deal is worth in
+	// base currency, which band a row landed in. So this token names the last row it
+	// handed you, and the next page re-assembles the day, re-ranks it, and continues
+	// after that row.
+	//
+	// It encodes the `scope`, `filter` and `owner` it was minted under. Sending it
+	// alongside different ones returns `422 code: cursor_param_mismatch` rather than
+	// continuing into a different question — page two of your own tasks silently
+	// becoming the team's deals is what that prevents, and nothing in the response would
+	// have said so. `limit` is deliberately NOT fingerprinted: it decides how many rows
+	// a page carries, not which rows exist, so changing it mid-walk is legitimate.
+	//
+	// A token this endpoint did not mint returns `422 code: malformed_cursor`.
+	//
+	// WHAT A WALK GUARANTEES, and what it does not. This is live work, so the day moves
+	// between pages: a rep answers a message, a deal closes, a colleague takes a task.
+	// The walk guarantees a row is not silently repeated, and that it terminates. It
+	// does not promise a stable snapshot, and should not — a page showing rows already
+	// dealt with would be worse than one that skipped them. If the row a cursor names is
+	// gone by the time the next page is asked for, the walk ENDS: restarting from the
+	// top would hand a client paging to exhaustion the same first page forever, each
+	// pass looking like ordinary progress.
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 
 	// Owner Whose queue to answer, when it is somebody else's. A manager reading a team
 	// exception is told which rep it belongs to, and the next question is always
@@ -72538,6 +72584,19 @@ func (siw *ServerInterfaceWrapper) GetWorklist(w http.ResponseWriter, r *http.Re
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cursor"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
 		}
 		return
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -35003,9 +35003,9 @@ type GetWorklistParams struct {
 	// token carries a sort key and the next page is a WHERE clause. This queue has no
 	// such column: it assembles from a dozen lanes and ranks them by a comparator
 	// reading facts no table holds — whether a wait is crowded, what a deal is worth in
-	// base currency, which band a row landed in. So this token names the last row it
-	// handed you, and the next page re-assembles the day, re-ranks it, and continues
-	// after that row.
+	// base currency, which band a row landed in. So the token carries a POSITION in that
+	// ranking, and the next page re-assembles the day, ranks it the same way, and starts
+	// there.
 	//
 	// It encodes the `scope`, `filter` and `owner` it was minted under, NORMALISED, so
 	// that two spellings of one question share a cursor: an omitted `filter` and
@@ -35027,23 +35027,28 @@ type GetWorklistParams struct {
 	// WHAT A WALK GUARANTEES, and what it does not. This is live work, so the day moves
 	// between pages: a rep answers a message, a deal closes, a colleague takes a task.
 	//
-	// Guaranteed: the walk TERMINATES, and no row is lost from a part of the day that
-	// did not change. A row whose anchor is answered or reprioritised between pages does
-	// not end the walk early — the token carries a position as well as an identity, and
-	// the position continues it.
+	// Guaranteed: the walk TERMINATES, and over a day that does not move it reaches
+	// every row exactly once. The offset advances on every page and the candidate set is
+	// bounded, so no arrangement of arrivals, answers and reprioritisations makes a
+	// client paging to exhaustion loop.
 	//
 	// Not guaranteed: a stable snapshot, which a set re-assembled and re-ranked on every
-	// read cannot offer. Two consequences, both deliberate:
+	// read cannot offer. One consequence, and it is the whole cost of this design: A ROW
+	// THAT CROSSES THE PAGE BOUNDARY BETWEEN TWO READS IS SERVED TWICE OR NOT AT ALL ON
+	// THIS WALK. A deal that turns urgent moves up past where you have got to; one that
+	// is answered lets everything below it move up by one.
 	//
-	// A row may REPEAT. Where the token's position and identity disagree — because the
-	// day moved under them — the earlier of the two wins. Repeating a row the caller has
-	// already seen is recoverable; skipping one means work shown to nobody, so this errs
-	// toward the first every time.
+	// Such a row is not lost from the product — the next read of the queue ranks it
+	// afresh and shows it — so treat a walk as a way to reach a backlog you already know
+	// is there, not as a transaction over it. If you need the whole day at one instant,
+	// ask for it in one page: `limit` reaches 100.
 	//
-	// A row that overtakes rows you have ALREADY been handed waits for your next read.
-	// It now sorts behind them, and returning it would mean re-serving that whole prefix
-	// — the walk that never ends. Opening the queue again leads with it, so the delay is
-	// bounded and corrects itself.
+	// The alternative was a token naming the last row it handed you, which is the
+	// obvious design and is worse here. When that row is answered between pages, or
+	// sinks to the end of the ranking, "everything after it" is empty and the walk
+	// reports itself finished while work is still owed. A queue whose purpose is that
+	// work is not forgotten cannot fail that way, so it accepts the boundary case above
+	// instead.
 	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 
 	// Owner Whose queue to answer, when it is somebody else's. A manager reading a team

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -26389,16 +26389,20 @@ export interface components {
              * @description Send this back as `cursor` to continue past the last row of this page. See that
              *     parameter for what a walk does and does not guarantee.
              *
-             *     ABSENT MEANS THE WALK IS OVER — there is nothing behind this page. It is
+             *     ABSENT MEANS THE WALK IS OVER — nothing was left behind this page. It is
              *     deliberately not minted on a final page: a cursor there invites one more request
              *     that can only answer empty, and a client walking until the cursor disappears
              *     would never stop.
              *
              *     Absent is therefore a claim, not a silence, and it is the one this field must
-             *     never make wrongly. `reach` and `counts` answer a different question — how deep
-             *     each SOURCE was read, which is a bound on work rather than the end of a page —
-             *     so a walk that has ended can still sit above sources that were cut short, and
-             *     both statements are true at once.
+             *     never make wrongly. It is a claim about THIS READ of the day: work that arrives
+             *     afterwards, or that overtakes rows already handed out, appears on the next read
+             *     rather than extending a finished walk.
+             *
+             *     `reach` and `counts` answer a different question — how deep each SOURCE was read,
+             *     which is a bound on work rather than the end of a page — so a walk that has ended
+             *     can still sit above sources that were cut short, and both statements are true at
+             *     once.
              */
             next_cursor?: string;
             /**
@@ -38088,23 +38092,43 @@ export interface operations {
                  *     handed you, and the next page re-assembles the day, re-ranks it, and continues
                  *     after that row.
                  *
-                 *     It encodes the `scope`, `filter` and `owner` it was minted under. Sending it
-                 *     alongside different ones returns `422 code: cursor_param_mismatch` rather than
-                 *     continuing into a different question — page two of your own tasks silently
+                 *     It encodes the `scope`, `filter` and `owner` it was minted under, NORMALISED, so
+                 *     that two spellings of one question share a cursor: an omitted `filter` and
+                 *     `filter=all` weigh the same candidates, and naming yourself as `owner` is the
+                 *     question the default already answers. Sending a cursor alongside a genuinely
+                 *     different scope, filter or owner returns `422 code: cursor_param_mismatch` rather
+                 *     than continuing into another question — page two of your own tasks silently
                  *     becoming the team's deals is what that prevents, and nothing in the response would
                  *     have said so. `limit` is deliberately NOT fingerprinted: it decides how many rows
                  *     a page carries, not which rows exist, so changing it mid-walk is legitimate.
                  *
-                 *     A token this endpoint did not mint returns `422 code: malformed_cursor`.
+                 *     A token that does not decode returns `422 code: malformed_cursor`. The token is
+                 *     opaque, NOT authenticated: it is base64 of a small JSON object and a caller who
+                 *     studies it can construct one. That grants nothing. A cursor only chooses where to
+                 *     resume inside a page that is re-assembled from scratch under the caller's own
+                 *     principal, so every row it can reach is one the caller could already read, and no
+                 *     forged token widens scope or row visibility.
                  *
                  *     WHAT A WALK GUARANTEES, and what it does not. This is live work, so the day moves
                  *     between pages: a rep answers a message, a deal closes, a colleague takes a task.
-                 *     The walk guarantees a row is not silently repeated, and that it terminates. It
-                 *     does not promise a stable snapshot, and should not — a page showing rows already
-                 *     dealt with would be worse than one that skipped them. If the row a cursor names is
-                 *     gone by the time the next page is asked for, the walk ENDS: restarting from the
-                 *     top would hand a client paging to exhaustion the same first page forever, each
-                 *     pass looking like ordinary progress.
+                 *
+                 *     Guaranteed: the walk TERMINATES, and no row is lost from a part of the day that
+                 *     did not change. A row whose anchor is answered or reprioritised between pages does
+                 *     not end the walk early — the token carries a position as well as an identity, and
+                 *     the position continues it.
+                 *
+                 *     Not guaranteed: a stable snapshot, which a set re-assembled and re-ranked on every
+                 *     read cannot offer. Two consequences, both deliberate:
+                 *
+                 *     A row may REPEAT. Where the token's position and identity disagree — because the
+                 *     day moved under them — the earlier of the two wins. Repeating a row the caller has
+                 *     already seen is recoverable; skipping one means work shown to nobody, so this errs
+                 *     toward the first every time.
+                 *
+                 *     A row that overtakes rows you have ALREADY been handed waits for your next read.
+                 *     It now sorts behind them, and returning it would mean re-serving that whole prefix
+                 *     — the walk that never ends. Opening the queue again leads with it, so the delay is
+                 *     bounded and corrects itself.
                  */
                 cursor?: string;
                 /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -38125,8 +38125,10 @@ export interface operations {
                  *
                  *     Such a row is not lost from the product — the next read of the queue ranks it
                  *     afresh and shows it — so treat a walk as a way to reach a backlog you already know
-                 *     is there, not as a transaction over it. If you need the whole day at one instant,
-                 *     ask for it in one page: `limit` reaches 100.
+                 *     is there, not as a transaction over it. There is no way to ask for the whole day
+                 *     at one instant: `limit` stops at 100 and a single category can hold more than that,
+                 *     because the sources are read to their own bounds well past a page (the decision
+                 *     lane alone weighs 200). `counts` is what says how much is behind the page.
                  *
                  *     The alternative was a token naming the last row it handed you, which is the
                  *     obvious design and is worse here. When that row is answered between pages, or

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -38088,9 +38088,9 @@ export interface operations {
                  *     token carries a sort key and the next page is a WHERE clause. This queue has no
                  *     such column: it assembles from a dozen lanes and ranks them by a comparator
                  *     reading facts no table holds — whether a wait is crowded, what a deal is worth in
-                 *     base currency, which band a row landed in. So this token names the last row it
-                 *     handed you, and the next page re-assembles the day, re-ranks it, and continues
-                 *     after that row.
+                 *     base currency, which band a row landed in. So the token carries a POSITION in that
+                 *     ranking, and the next page re-assembles the day, ranks it the same way, and starts
+                 *     there.
                  *
                  *     It encodes the `scope`, `filter` and `owner` it was minted under, NORMALISED, so
                  *     that two spellings of one question share a cursor: an omitted `filter` and
@@ -38112,23 +38112,28 @@ export interface operations {
                  *     WHAT A WALK GUARANTEES, and what it does not. This is live work, so the day moves
                  *     between pages: a rep answers a message, a deal closes, a colleague takes a task.
                  *
-                 *     Guaranteed: the walk TERMINATES, and no row is lost from a part of the day that
-                 *     did not change. A row whose anchor is answered or reprioritised between pages does
-                 *     not end the walk early — the token carries a position as well as an identity, and
-                 *     the position continues it.
+                 *     Guaranteed: the walk TERMINATES, and over a day that does not move it reaches
+                 *     every row exactly once. The offset advances on every page and the candidate set is
+                 *     bounded, so no arrangement of arrivals, answers and reprioritisations makes a
+                 *     client paging to exhaustion loop.
                  *
                  *     Not guaranteed: a stable snapshot, which a set re-assembled and re-ranked on every
-                 *     read cannot offer. Two consequences, both deliberate:
+                 *     read cannot offer. One consequence, and it is the whole cost of this design: A ROW
+                 *     THAT CROSSES THE PAGE BOUNDARY BETWEEN TWO READS IS SERVED TWICE OR NOT AT ALL ON
+                 *     THIS WALK. A deal that turns urgent moves up past where you have got to; one that
+                 *     is answered lets everything below it move up by one.
                  *
-                 *     A row may REPEAT. Where the token's position and identity disagree — because the
-                 *     day moved under them — the earlier of the two wins. Repeating a row the caller has
-                 *     already seen is recoverable; skipping one means work shown to nobody, so this errs
-                 *     toward the first every time.
+                 *     Such a row is not lost from the product — the next read of the queue ranks it
+                 *     afresh and shows it — so treat a walk as a way to reach a backlog you already know
+                 *     is there, not as a transaction over it. If you need the whole day at one instant,
+                 *     ask for it in one page: `limit` reaches 100.
                  *
-                 *     A row that overtakes rows you have ALREADY been handed waits for your next read.
-                 *     It now sorts behind them, and returning it would mean re-serving that whole prefix
-                 *     — the walk that never ends. Opening the queue again leads with it, so the delay is
-                 *     bounded and corrects itself.
+                 *     The alternative was a token naming the last row it handed you, which is the
+                 *     obvious design and is worse here. When that row is answered between pages, or
+                 *     sinks to the end of the ranking, "everything after it" is empty and the walk
+                 *     reports itself finished while work is still owed. A queue whose purpose is that
+                 *     work is not forgotten cannot fail that way, so it accepts the boundary case above
+                 *     instead.
                  */
                 cursor?: string;
                 /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -26386,6 +26386,22 @@ export interface components {
             /** @description Sources that could not be included, and why. Empty is the honest common case. */
             sources_unavailable: components["schemas"]["WorklistSourceUnavailable"][];
             /**
+             * @description Send this back as `cursor` to continue past the last row of this page. See that
+             *     parameter for what a walk does and does not guarantee.
+             *
+             *     ABSENT MEANS THE WALK IS OVER — there is nothing behind this page. It is
+             *     deliberately not minted on a final page: a cursor there invites one more request
+             *     that can only answer empty, and a client walking until the cursor disappears
+             *     would never stop.
+             *
+             *     Absent is therefore a claim, not a silence, and it is the one this field must
+             *     never make wrongly. `reach` and `counts` answer a different question — how deep
+             *     each SOURCE was read, which is a bound on work rather than the end of a page —
+             *     so a walk that has ended can still sit above sources that were cut short, and
+             *     both statements are true at once.
+             */
+            next_cursor?: string;
+            /**
              * @description How much of each source the queue actually looked at. A source is read up to a
              *     work bound, so a page can be a page rather than everything there is, and this
              *     is where the queue says which. Empty only when no source was read at all.
@@ -38059,6 +38075,38 @@ export interface operations {
                 filter?: "all" | "customer_waiting" | "leads" | "deals_at_risk" | "meetings" | "tasks" | "decisions" | "system";
                 /** @description How many ranked items to return. */
                 limit?: number;
+                /**
+                 * @description Where to continue a walk, from a prior response's `next_cursor`. Omitted starts at
+                 *     the top, which is what every reader opening their day wants.
+                 *
+                 *     NOT the shared keyset cursor the CRUD lists use, and the difference is why this
+                 *     endpoint declares its own. Those walk rows a database already ordered, so their
+                 *     token carries a sort key and the next page is a WHERE clause. This queue has no
+                 *     such column: it assembles from a dozen lanes and ranks them by a comparator
+                 *     reading facts no table holds — whether a wait is crowded, what a deal is worth in
+                 *     base currency, which band a row landed in. So this token names the last row it
+                 *     handed you, and the next page re-assembles the day, re-ranks it, and continues
+                 *     after that row.
+                 *
+                 *     It encodes the `scope`, `filter` and `owner` it was minted under. Sending it
+                 *     alongside different ones returns `422 code: cursor_param_mismatch` rather than
+                 *     continuing into a different question — page two of your own tasks silently
+                 *     becoming the team's deals is what that prevents, and nothing in the response would
+                 *     have said so. `limit` is deliberately NOT fingerprinted: it decides how many rows
+                 *     a page carries, not which rows exist, so changing it mid-walk is legitimate.
+                 *
+                 *     A token this endpoint did not mint returns `422 code: malformed_cursor`.
+                 *
+                 *     WHAT A WALK GUARANTEES, and what it does not. This is live work, so the day moves
+                 *     between pages: a rep answers a message, a deal closes, a colleague takes a task.
+                 *     The walk guarantees a row is not silently repeated, and that it terminates. It
+                 *     does not promise a stable snapshot, and should not — a page showing rows already
+                 *     dealt with would be worse than one that skipped them. If the row a cursor names is
+                 *     gone by the time the next page is asked for, the walk ENDS: restarting from the
+                 *     top would hand a client paging to exhaustion the same first page forever, each
+                 *     pass looking like ordinary progress.
+                 */
+                cursor?: string;
                 /**
                  * @description Whose queue to answer, when it is somebody else's. A manager reading a team
                  *     exception is told which rep it belongs to, and the next question is always


### PR DESCRIPTION
The Worklist answered `limit` and stopped. A rep whose Review category held sixty rows could see twenty-five and had no way to ask for the rest — `counts` said the work was there and nothing reached it. That was the last unmet acceptance criterion of the worklist rework: "opening Review exposes the complete paginated backlog".

## The cursor is an offset

This queue has no ordered database column to walk. It assembles from a dozen lanes and ranks them by the nine-step comparator in `ranksteps.go`, which reads facts no table holds — whether a wait is crowded, what a deal is worth in base currency, which band a row landed in. So the token carries a position in that ranking plus a fingerprint of the request, and the next page re-assembles the day, ranks it the same way, and starts there.

**It always terminates, and over a day that does not move it reaches every row exactly once.**

## What it costs, and why that is the right trade

The ranking is rebuilt on every read, so **a row that crosses the page boundary between two reads is served twice or not at all on that walk**. It is not lost from the product — the next read ranks it afresh and shows it. The contract says this plainly rather than implying a snapshot it cannot deliver.

The obvious alternative is a token naming the last row it handed you, and it was built first. Two review rounds and a reproduction showed it cannot work here: when that row is answered between pages, or sinks to the end of the ranking, "everything after it" is empty and the walk **reports itself finished while work is still owed**. A page came back empty with two rows outstanding and no cursor to reach them. A queue whose whole purpose is that work is not forgotten cannot fail that way.

Carrying both a position and an anchor was then tried, and is worse than either alone. What a caller has seen is the top K of the *previous* ranking, which after a re-rank can be scattered anywhere; no pair of small values encodes an arbitrary subset, and every rule for combining them traded one skipped row for a different one. That reasoning is recorded in `cursor.go` so the next reader does not reach for it again.

## Two security guards, both mutation-checked

**A negative offset is refused.** The token is client-supplied and unsigned, so a crafted `n:-1` is reachable by hand — and it reached `rows[n:]` and panicked. That is a denial of service on an authenticated endpoint.

**A token with no fingerprint is refused.** `{}` and `null` both decode to a zero cursor, which without the check reads as a legitimate first page: a forged token doing something rather than nothing.

Neither grants access. A cursor only chooses where to resume inside a page re-assembled from scratch under the caller's own principal, so every row it can reach is one the caller could already read.

## Two spellings of one question now share a cursor

An omitted `filter` and `filter=all` weigh identical candidates — `worklistFrom` narrows on exactly that test — but hashed apart, so a generated client sending its own documented default on page two was refused.

`resolveOwner` said in a comment that naming yourself is "the same question the default answers" while returning your id, which made it a different question downstream. It now resolves to the same zero owner. That changes which branch the read takes (`forReader`/`TasksMine` instead of `forOwner`/`TasksOwnedBy`), so both spellings are tested to return the same page — including an unowned row, which is the one case the two narrowings treat differently and where the `mine` scope's own contract text says the row should be kept.

## What proves it

`TestAWalkReachesEveryRowExactlyOnce` walks 23 rows five at a time. `TestTheWalkReconcilesAgainstTheCountItReports` reconciles the walk against `counts[].considered` — a paginated read that drops a page passes every single-page test there is. `TestAWalkTerminatesHoweverTheDayMoves` pages through four differently-shaped days including an empty one and asserts the offset strictly advances.

One claim was checked and found **not** to be a defect: `reached` and "incoming offset plus rows served" cannot diverge, because a cursor is minted only when a full page remains and a clamped read mints none. The test says so rather than asserting a difference that cannot occur.

## Scope

Backend and contract only. The screen still fetches one page; wiring "load more" means converting `useQuery` to `useInfiniteQuery` and belongs with the screen work, where `worklist.test.tsx` (973 lines against a 1000 cap) has to be split first.

`worklist.go` crossed the 500-line cap twice, so the cut moved to `page.go` and the waiting lane's read moved beside its own types in `waitinglane.go`. The first of those also repairs a doc comment already broken on main, where `worklistFrom`'s opening line sat above `waitingCustomers` and neither function said what it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination, category filtering, and validation for worklists.
  * Added activity filtering for unanswered inbound messages.
  * Added company logo upload and deletion, with logo URLs available in responses.
  * Added available-model discovery for AI providers.
  * Added team weekly reviews, editable weekly plans, commitments, help requests, and manager responses.
  * Added meeting coaching details, commitment metrics, and an `undelivered` worklist source.

* **Bug Fixes**
  * Improved pagination reliability and waiting-customer data availability reporting.
  * Self-queue selection now consistently follows the default “mine” scope behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->