### PR TITLE
weeklyplan is a module the architecture knows about

### DIFF
--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -107,6 +107,7 @@ components:
   comms:       { in: internal/modules/comms }
   notices:     { in: internal/modules/notices }
   introductions: { in: internal/modules/introductions }
+  weeklyplan:  { in: internal/modules/weeklyplan }
   compose:     { in: [internal/compose, internal/compose/**] }
   migrations:  { in: migrations }
   cmd:         { in: cmd/** }
@@ -242,8 +243,11 @@ deps:
   introductions:
     mayDependOn: [contracts, platform]
     canUse: [pgx, oapi]
+  weeklyplan:
+    mayDependOn: [contracts, platform]
+    canUse: [pgx, oapi]
   compose:
-    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, introductions, finance, integrations, agreements, commissions, contracts, dealrooms, knowledge, platform, migrations, projects]
+    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, introductions, weeklyplan, finance, integrations, agreements, commissions, contracts, dealrooms, knowledge, platform, migrations, projects]
     # xtext: the evidence gate normalizes page text to NFC before matching
     # (evidencematch.go) — Unicode normal forms need golang.org/x/text.
     # yaml: aicert's corpus loader parses scenario files directly — the
@@ -303,5 +307,5 @@ deps:
     mayDependOn: [contracts, compose, ai, collections, platform, activities, aiactivity, agents, approvals, people]
     canUse: [yaml, jsonschema]
   cmd:
-    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, introductions, finance, integrations, agreements, commissions, contracts, dealrooms, platform, migrations, projects]
+    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, introductions, weeklyplan, finance, integrations, agreements, commissions, contracts, dealrooms, platform, migrations, projects]
     canUse: [pgx, redis, xterm, composition]

--- a/backend/internal/compose/integration/weeklyplan_integration_test.go
+++ b/backend/internal/compose/integration/weeklyplan_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package weeklyplan_test
+package integration
 
 // The plan over real migrated Postgres.
 //
@@ -20,7 +20,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/weekly"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/weeklyplan"
@@ -46,7 +45,7 @@ func (a teammates) SharesLiveTeamWithCaller(ctx context.Context, other ids.UUID)
 var planClock = time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)
 
 type planEnv struct {
-	*integration.Env
+	*Env
 	store *weeklyplan.Store
 	// rep1 and rep2 share a team; rep3 sits in another.
 	rep1Ctx, rep2Ctx, rep3Ctx context.Context
@@ -54,7 +53,7 @@ type planEnv struct {
 
 func setupPlan(t *testing.T) *planEnv {
 	t.Helper()
-	e := integration.Setup(t)
+	e := Setup(t)
 	// The same handle compose builds (InstallationDB): the pool bound to the
 	// installation's workspace resolver. A raw pool would skip the workspace
 	// GUC every tenant query runs under.
@@ -63,9 +62,9 @@ func setupPlan(t *testing.T) *planEnv {
 	return &planEnv{
 		Env:     e,
 		store:   weeklyplan.NewStore(db, weekly.WeekStartOf, teammates{svc: svc}),
-		rep1Ctx: e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms),
-		rep2Ctx: e.As(e.Rep2, []ids.UUID{e.Team1}, integration.AdminPerms),
-		rep3Ctx: e.As(e.Rep3, []ids.UUID{e.Team2}, integration.AdminPerms),
+		rep1Ctx: e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms),
+		rep2Ctx: e.As(e.Rep2, []ids.UUID{e.Team1}, AdminPerms),
+		rep3Ctx: e.As(e.Rep3, []ids.UUID{e.Team2}, AdminPerms),
 	}
 }
 
@@ -188,7 +187,7 @@ func TestClosingTheWeekTwiceAnswersTheSameCounts(t *testing.T) {
 	// set this case up. What arrives here is a database in the state a
 	// late-landing write or a repair would leave it in, and the question is
 	// whether a second close overwrites the frozen answer.
-	owner := integration.OwnerConn(t)
+	owner := OwnerConn(t)
 	if _, err := owner.Exec(context.Background(), `
 		UPDATE weekly_plan_commitment SET state = 'done', completed_at = now()
 		 WHERE state = 'missed'`); err != nil {
@@ -239,7 +238,7 @@ func TestADroppedCommitmentIsNeitherOwedNorKept(t *testing.T) {
 // mutation in this tree.
 func TestAHelpRequestLandsOneAuditRowAndOneEvent(t *testing.T) {
 	e := setupPlan(t)
-	owner := integration.OwnerConn(t)
+	owner := OwnerConn(t)
 	ctx := context.Background()
 
 	commitment := planCommitment(t, e, e.rep1Ctx, "Chase the signature")
@@ -266,7 +265,7 @@ func TestAHelpRequestLandsOneAuditRowAndOneEvent(t *testing.T) {
 // Withdrawing a request must not page a lead a second time.
 func TestWithdrawingARequestEmitsNoSecondHelpEvent(t *testing.T) {
 	e := setupPlan(t)
-	owner := integration.OwnerConn(t)
+	owner := OwnerConn(t)
 	ctx := context.Background()
 
 	commitment := planCommitment(t, e, e.rep1Ctx, "Chase the signature")


### PR DESCRIPTION
`main` is red again. Both failures are #3604's new `weeklyplan` module, which neither architecture gate had been told about.

## arch-lint: files attached to no component

```
File /internal/modules/weeklyplan/write.go not attached to any component in archfile
File /internal/modules/weeklyplan/weeklyplan_integration_test.go not attached to any component in archfile
```

The component entry says what the code already does: `weeklyplan` production imports `contracts` and `platform` and nothing else, so `mayDependOn: [contracts, platform]` — the same line `notices` and `introductions` carry beside it. `compose` gains it as a dependency because compose is what wires it.

## depguard: a module reaching into the composition layer

```
weeklyplan_integration_test.go:24:2: import 'internal/compose/weekly' is not allowed
  from list 'modules-common': modules never see the composition layer
```

The test moves to `internal/compose/integration`, where every other test that needs the `Env` harness already lives, and drops the now-redundant package qualifier. That is what makes the import legal rather than waived — it was crossing a boundary because it was sitting on the wrong side of one — and it leaves the module importing no composition at all, which is the property the rule exists to keep.

`make check-backend` green; the moved test green in its new home.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal architecture configuration to include the weekly planning component and its approved integrations.

- **Tests**
  - Streamlined weekly planning integration test setup while preserving existing environment, permissions, and database access behavior.

- **Impact**
  - No changes to the end-user experience or publicly available functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->