### PR TITLE
main is green again: three things #3563 and my own #3613 left red

### DIFF
--- a/backend/internal/compose/integration/weeklyplan_integration_test.go
+++ b/backend/internal/compose/integration/weeklyplan_integration_test.go
@@ -3,9 +3,14 @@
 
 //go:build integration
 
-package weeklyplan_test
+package integration_test
 
 // The plan over real migrated Postgres.
+//
+// HERE rather than in the module, because it drives the compose harness and a
+// module may never import the composition layer — depguard says so. Every
+// module test that needs a seeded workspace lives beside the harness for the
+// same reason.
 //
 // What these defend is the access model and the settle, neither of which a unit
 // test can see: a plan is one person's, its second reader is gated on a live

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -30,7 +30,6 @@ import (
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
-	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
 
 // WaitingReply is one inbound message nobody has answered.
@@ -248,8 +247,8 @@ const waitingRepliesSQL = `
 	   AND a.archived_at IS NULL
 	   AND a.occurred_at <= $%[1]d
 	   AND %[2]s
-	   -- Entity narrowing goes HERE, before waitingScanCap's LIMIT below: a
-	   -- record's own wait can sit outside the oldest waitingScanCap threads
+	   -- Entity narrowing goes HERE, before WaitingScanCap's LIMIT below: a
+	   -- record's own wait can sit outside the oldest WaitingScanCap threads
 	   -- workspace-wide, and narrowing after the cap would report nothing
 	   -- waiting on the very record this asks about. "TRUE" for the
 	   -- workspace-wide Worklist read.
@@ -483,81 +482,3 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 
 // waitingReplyEntityClause narrows the thread walk to one record, in the SAME
 // vocabulary linktarget.go and listActivitiesFilter's own entity_type/id
-// filter use — a record type added to linkColumn or the organization arm
-// reaches this walk too, rather than a second copy silently missing it.
-func waitingReplyEntityClause(entityType string, entityID ids.UUID, arg func(any) int) (string, error) {
-	if entityType == string(datasource.RecordOrganization) {
-		// An account's timeline is wider than its direct links (mail is filed
-		// against the person it was with), so this reuses the SAME three-arm
-		// walk the timeline list and the company view both read through —
-		// see OrgLinkedActivityExists.
-		return OrgLinkedActivityExists(arg(entityID)), nil
-	}
-	column := linkColumn(entityType)
-	if column == "" {
-		return "", &InvalidLinkTypeError{EntityType: entityType}
-	}
-	typePos := arg(entityType)
-	idPos := arg(entityID)
-	return sprintf("EXISTS (SELECT 1 FROM activity_link el WHERE el.activity_id = a.id AND el.entity_type = $%d AND el.%s = $%d)",
-		typePos, column, idPos), nil
-}
-
-// waitingReplyExistsClause builds the timeline list's `waiting_reply=true`
-// filter: the SAME thread walk WaitingReplies runs for the Worklist,
-// embedded as a subquery so the outer list's own entity/kind/cursor terms
-// compose with it rather than duplicating what "unanswered" means.
-//
-// The subquery is uncorrelated — it computes its own candidate set rather
-// than reading the outer FROM — so its own `a` alias shadowing the outer
-// query's is harmless.
-func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.Time, entityType *string, entityID *ids.UUID) (string, error) {
-	instant := arg(asOf)
-	content, err := auth.ActivityContentClause(ctx, "a", arg)
-	if err != nil {
-		return "", err
-	}
-	linkVisible, err := auth.LinkTargetVisibleClause(ctx, "wl", arg)
-	if err != nil {
-		return "", err
-	}
-	if linkVisible == "" {
-		linkVisible = scopeUnbounded
-	}
-	entityClause := scopeUnbounded
-	if entityType != nil && entityID != nil {
-		entityClause, err = waitingReplyEntityClause(*entityType, *entityID, arg)
-		if err != nil {
-			return "", err
-		}
-	}
-	// The SAME reader, horizon and live-record rules WaitingReplies applies
-	// for the Worklist: a thread the Worklist would not name as waiting must
-	// not be named by a record page either, and a per-record set-aside must
-	// still be this reader's own.
-	reader := arg(readerOrNobody(ctx))
-	return "a.id IN (SELECT id FROM (" +
-		fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, waitingScanCap,
-			waitingHorizonDays,
-			liveRecord(openDealPredicate, "d"),
-			liveRecord(workingLeadPredicate, "ld"),
-			liveRecord(openDealPredicate, "openDeal"),
-			liveRecord(openDealPredicate, "fd"),
-			reader,
-			entityClause) +
-		") waiting_thread)", nil
-}
-
-// appendWaitingReplyClause is listActivitiesFilter's `waiting_reply=true`
-// term, split out so that already-long function does not have to grow to
-// hold it. A no-op when the caller did not ask for the filter.
-func appendWaitingReplyClause(ctx context.Context, in ListActivitiesInput, arg func(any) int, where []string) ([]string, error) {
-	if in.WaitingReplyAsOf == nil {
-		return where, nil
-	}
-	clause, err := waitingReplyExistsClause(ctx, arg, *in.WaitingReplyAsOf, in.EntityType, in.EntityID)
-	if err != nil {
-		return nil, err
-	}
-	return append(where, clause), nil
-}

--- a/backend/internal/modules/activities/waitingrecord.go
+++ b/backend/internal/modules/activities/waitingrecord.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Narrowing the who-is-waiting read to ONE record.
+//
+// Split from waiting.go, which answers the whole workspace question. These
+// three compose the same SQL against a single entity, for the record page's own
+// "what is owed here" panel — a different caller with a different bound, over
+// one shared statement so the two cannot come to disagree about what counts as
+// waiting.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/datasource"
+)
+
+// filter use — a record type added to linkColumn or the organization arm
+// reaches this walk too, rather than a second copy silently missing it.
+func waitingReplyEntityClause(entityType string, entityID ids.UUID, arg func(any) int) (string, error) {
+	if entityType == string(datasource.RecordOrganization) {
+		// An account's timeline is wider than its direct links (mail is filed
+		// against the person it was with), so this reuses the SAME three-arm
+		// walk the timeline list and the company view both read through —
+		// see OrgLinkedActivityExists.
+		return OrgLinkedActivityExists(arg(entityID)), nil
+	}
+	column := linkColumn(entityType)
+	if column == "" {
+		return "", &InvalidLinkTypeError{EntityType: entityType}
+	}
+	typePos := arg(entityType)
+	idPos := arg(entityID)
+	return sprintf("EXISTS (SELECT 1 FROM activity_link el WHERE el.activity_id = a.id AND el.entity_type = $%d AND el.%s = $%d)",
+		typePos, column, idPos), nil
+}
+
+// waitingReplyExistsClause builds the timeline list's `waiting_reply=true`
+// filter: the SAME thread walk WaitingReplies runs for the Worklist,
+// embedded as a subquery so the outer list's own entity/kind/cursor terms
+// compose with it rather than duplicating what "unanswered" means.
+//
+// The subquery is uncorrelated — it computes its own candidate set rather
+// than reading the outer FROM — so its own `a` alias shadowing the outer
+// query's is harmless.
+func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.Time, entityType *string, entityID *ids.UUID) (string, error) {
+	instant := arg(asOf)
+	content, err := auth.ActivityContentClause(ctx, "a", arg)
+	if err != nil {
+		return "", err
+	}
+	linkVisible, err := auth.LinkTargetVisibleClause(ctx, "wl", arg)
+	if err != nil {
+		return "", err
+	}
+	if linkVisible == "" {
+		linkVisible = scopeUnbounded
+	}
+	entityClause := scopeUnbounded
+	if entityType != nil && entityID != nil {
+		entityClause, err = waitingReplyEntityClause(*entityType, *entityID, arg)
+		if err != nil {
+			return "", err
+		}
+	}
+	// The SAME reader, horizon and live-record rules WaitingReplies applies
+	// for the Worklist: a thread the Worklist would not name as waiting must
+	// not be named by a record page either, and a per-record set-aside must
+	// still be this reader's own.
+	reader := arg(readerOrNobody(ctx))
+	return "a.id IN (SELECT id FROM (" +
+		fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, WaitingScanCap,
+			waitingHorizonDays,
+			liveRecord(openDealPredicate, "d"),
+			liveRecord(workingLeadPredicate, "ld"),
+			liveRecord(openDealPredicate, "openDeal"),
+			liveRecord(openDealPredicate, "fd"),
+			reader,
+			entityClause) +
+		") waiting_thread)", nil
+}
+
+// appendWaitingReplyClause is listActivitiesFilter's `waiting_reply=true`
+// term, split out so that already-long function does not have to grow to
+// hold it. A no-op when the caller did not ask for the filter.
+func appendWaitingReplyClause(ctx context.Context, in ListActivitiesInput, arg func(any) int, where []string) ([]string, error) {
+	if in.WaitingReplyAsOf == nil {
+		return where, nil
+	}
+	clause, err := waitingReplyExistsClause(ctx, arg, *in.WaitingReplyAsOf, in.EntityType, in.EntityID)
+	if err != nil {
+		return nil, err
+	}
+	return append(where, clause), nil
+}


### PR DESCRIPTION
Three breaks on `main`, none of which any single PR's own gate could see. All three merged green on their own branches and only collide in the tree.

## The backend did not compile

`waitingScanCap` was exported to `WaitingScanCap` by #3563, and one call site kept the old name. A comment two hundred lines up kept the old spelling too, so the rename was half-applied in both senses.

## `waiting.go` crossed the size cap

The same commit grew it to 563 lines. Rather than a waiver, the three functions it added move to `waitingrecord.go` — they answer a different question from the rest of the file: narrowing the who-is-waiting read to **one record**, for the record page's own panel, rather than to the workspace.

## And one of mine

#3613 put a module integration test where depguard forbids it. A module may never import the composition layer, and that test drives the compose harness. It moves beside the harness, which is where every other module test needing a seeded workspace already lives.

**Why I missed it:** the golangci lock was contended when I gated that branch, so I shipped on a scoped `golangci-lint run ./internal/modules/weeklyplan/...`. A scoped run does not evaluate depguard's module list — the rule is about which package the import comes *from*, and the scoped invocation had nothing to compare against. That is a real gap in how I have been working around the lock, not a one-off.

## Verified

`build`, `vet`, `arch-lint`, the full test suite, `go-file-length` and `lint` (0 issues) all green, plus the integration lane for the moved test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three breaks that only collide on `main`: the backend didn't compile, `waiting.go` crossed the file size cap, and an integration test sat where depguard forbids it.

**Bug Fixes**
- Updates the one call site and comment still using the old `waitingScanCap` spelling after the rename to `WaitingScanCap`.
- Moves the three per-record waiting functions from `waiting.go` into a new `waitingrecord.go` to get back under the 500-line cap.
- Moves the weeklyplan integration test beside the compose harness, where module tests needing a seeded workspace already live.

<sup>Written for commit a0ffadab0c6a715ccaf0323bfb235bb950525276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility filtering for waiting replies in activity records.
  * Ensured activity lists consistently apply authentication, link visibility, and waiting-reply limits.
  * Improved error handling when applying activity visibility filters.

* **Tests**
  * Updated integration test organization and documentation for Compose-based database and integration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->