### PR TITLE
A module test does not import compose

### DIFF
--- a/backend/internal/compose/integration/weeklyplan_integration_test.go
+++ b/backend/internal/compose/integration/weeklyplan_integration_test.go
@@ -3,9 +3,14 @@
 
 //go:build integration
 
-package weeklyplan_test
+package integration_test
 
 // The plan over real migrated Postgres.
+//
+// HERE rather than in the module, because it drives the compose harness and a
+// module may never import the composition layer — depguard says so, and every
+// other module test needing a seeded workspace already lives beside the
+// harness for the same reason.
 //
 // What these defend is the access model and the settle, neither of which a unit
 // test can see: a plan is one person's, its second reader is gated on a live


### PR DESCRIPTION
The last thing red on `main` after #3615 fixed the rest, and it is mine.

#3613 put a `weeklyplan` integration test inside the module. It drives the compose harness, and **a module may never import the composition layer** — depguard says so, and `arch-lint` states the DAG the same way. It moves beside the harness, which is where every other module test needing a seeded workspace already lives.

## Why I missed it

The golangci lock was contended when I gated that branch, so I shipped on a scoped `golangci-lint run ./internal/modules/weeklyplan/...`.

**A scoped run does not evaluate depguard's module list.** The rule is about which package an import comes *from*, so the scoped invocation had nothing to compare against and reported 0 issues on a file that violates it. That is a real gap in how I have been working around the lock, not a one-off: a scoped lint substitutes for the full one on findings *inside* a file, and not on rules about where a file sits.

## Verified

Full `make check-backend` — build, vet, arch-lint, the whole test suite, gates, drift, composition, and lint at 0 issues across all six lanes. Plus the integration lane for the moved test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the `weeklyplan` integration test from the module into the compose integration harness. A module may never import the composition layer, so the old location violated depguard and `arch-lint` and was the last red on `main`.

- The test now lives beside the other module tests that need a seeded workspace.
- Scoped `golangci-lint` runs don't evaluate depguard's module list, so verify with a full `make check-backend`.

<sup>Written for commit f21375757c70949780dcce87e03b9c1086213f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

