### PR TITLE
weeklyplan is a component the archfile names

### DIFF
--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -107,6 +107,7 @@ components:
   comms:       { in: internal/modules/comms }
   notices:     { in: internal/modules/notices }
   introductions: { in: internal/modules/introductions }
+  weeklyplan:  { in: internal/modules/weeklyplan }
   compose:     { in: [internal/compose, internal/compose/**] }
   migrations:  { in: migrations }
   cmd:         { in: cmd/** }
@@ -242,8 +243,11 @@ deps:
   introductions:
     mayDependOn: [contracts, platform]
     canUse: [pgx, oapi]
+  weeklyplan:
+    mayDependOn: [contracts, platform]
+    canUse: [pgx, oapi]
   compose:
-    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, introductions, finance, integrations, agreements, commissions, contracts, dealrooms, knowledge, platform, migrations, projects]
+    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, introductions, weeklyplan, finance, integrations, agreements, commissions, contracts, dealrooms, knowledge, platform, migrations, projects]
     # xtext: the evidence gate normalizes page text to NFC before matching
     # (evidencematch.go) — Unicode normal forms need golang.org/x/text.
     # yaml: aicert's corpus loader parses scenario files directly — the
@@ -303,5 +307,5 @@ deps:
     mayDependOn: [contracts, compose, ai, collections, platform, activities, aiactivity, agents, approvals, people]
     canUse: [yaml, jsonschema]
   cmd:
-    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, introductions, finance, integrations, agreements, commissions, contracts, dealrooms, platform, migrations, projects]
+    mayDependOn: [compose, identity, people, privacy, deals, activities, aiactivity, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, notices, introductions, weeklyplan, finance, integrations, agreements, commissions, contracts, dealrooms, platform, migrations, projects]
     canUse: [pgx, redis, xterm, composition]


### PR DESCRIPTION
`main` fails `arch-lint` on every branch:

```
File /internal/modules/weeklyplan/write.go not attached to any component in archfile
```

#3604 added the module and told neither architecture gate about it. #3628 has since fixed the depguard half by moving its integration test out of the module; this is the other half, which is still open.

The component entry says what the code already does: `weeklyplan` production imports `contracts` and `platform` and nothing else, so it takes the same `mayDependOn: [contracts, platform]` line `notices` and `introductions` carry beside it. `compose` gains it as a dependency because compose is what wires it.

One file changed. `make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated architecture configuration to recognize the weekly planning module and its approved integrations.
  * Added the module to permitted application dependency lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->