### PR TITLE
The team week is frozen too

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -15264,6 +15264,55 @@ paths:
               schema: { $ref: '#/components/schemas/WeeklyReviewIndex' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /weekly-reviews/team:
+    get:
+      tags: [Brief]
+      operationId: getTeamWeeklyReview
+      summary: A team's week, frozen — what each member's week came to, and the one thing to raise.
+      description: |
+        The team half of the weekly. `/worklist/team` answers what the team is carrying NOW,
+        live and recomputed on every open; this answers what last week WAS, written once when
+        the week closed, so two weeks can be compared and neither moves under the comparison.
+
+        WHY IT IS STORED RATHER THAN SUMMED. Every figure is a total over the member reviews.
+        Team membership moves, so a read-time sum would silently put a rep who joined in
+        October into last March's team week and drop one who left — and a lead comparing two
+        quarters would be comparing two different teams without being told. The membership is
+        frozen INTO the snapshot: the rep rows name who was on the team that week, with the
+        name they had then.
+
+        Every rep gets ONE focus, including the rep whose week went well — theirs names what
+        the team should copy. A page promising one focus per rep and delivering rows only for
+        the troubled ones reads as a team where only those people exist.
+
+        `reps_unread` counts the members whose week could not be read at all. Zero is the
+        claim that every member's week was counted; a snapshot silently covering four of six
+        reps reads exactly like a team of four.
+
+        403 for a reader whose row scope reaches only their own rows: a team snapshot is a
+        team question. 404 before the first Monday the team's week closed on.
+      x-agent-access: human-only
+      parameters:
+        - name: team
+          in: query
+          required: true
+          schema: { type: string, format: uuid }
+          description: Which team's week to read.
+        - name: week
+          in: query
+          schema: { type: string, format: date }
+          description: |
+            The Monday of the week wanted. Omitted means the most recent snapshot this team
+            has.
+      responses:
+        '200':
+          description: The team's frozen week.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/TeamWeeklyReview' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
   /weekly-reviews/latest:
     get:
       tags: [Brief]
@@ -34162,6 +34211,90 @@ components:
           type: array
           items: { type: string, format: date }
           description: The Monday of each week with a review, newest first.
+
+    TeamWeeklyReview:
+      type: object
+      additionalProperties: false
+      description: One team's week, as it was measured when the week closed.
+      required: [id, team_id, team_name, local_week_start, generated_at, as_of, counts, reps]
+      properties:
+        id: { type: string, format: uuid }
+        team_id: { type: string, format: uuid }
+        team_name:
+          type: string
+          description: |
+            What the team was called that week. Frozen, so a team renamed in June does not
+            relabel March's snapshot.
+        local_week_start: { type: string, format: date }
+        generated_at: { type: string, format: date-time }
+        as_of: { type: string, format: date-time }
+        counts: { $ref: '#/components/schemas/TeamWeeklyCounts' }
+        pipeline:
+          description: |
+            What the team's week did to the pipeline. ABSENT when any member's week could not
+            be converted — summing only the ones that did would be a confident number quietly
+            missing a rep.
+          allOf: [{ $ref: '#/components/schemas/WeeklyReviewPipeline' }]
+        reps_unread:
+          type: integer
+          minimum: 0
+          description: |
+            Members whose week could not be read at all. Zero is the claim that every member's
+            week was counted.
+        reps:
+          type: array
+          items: { $ref: '#/components/schemas/TeamWeeklyRep' }
+          description: |
+            Who was on the team that week — the frozen membership, which a join against the
+            live team could never answer.
+    TeamWeeklyCounts:
+      type: object
+      additionalProperties: false
+      required: [reps_counted, deals_won, deals_lost, leads_routed, leads_answered_in_target,
+                 leads_breached, meetings_held, meetings_with_next_step,
+                 commitments_due, commitments_kept]
+      properties:
+        reps_counted: { type: integer, minimum: 0, description: 'Members whose week was read and totalled.' }
+        deals_won: { type: integer, minimum: 0 }
+        deals_lost: { type: integer, minimum: 0 }
+        leads_routed: { type: integer, minimum: 0 }
+        leads_answered_in_target: { type: integer, minimum: 0 }
+        leads_breached: { type: integer, minimum: 0 }
+        meetings_held: { type: integer, minimum: 0 }
+        meetings_with_next_step: { type: integer, minimum: 0 }
+        commitments_due: { type: integer, minimum: 0 }
+        commitments_kept: { type: integer, minimum: 0 }
+    TeamWeeklyRep:
+      type: object
+      additionalProperties: false
+      description: One member's week as their lead reads it, with the one thing to raise.
+      required: [user_id, display_name, deals_won, leads_breached, meetings_held,
+                 commitments_due, commitments_kept, help_requested, focus_kind, focus_label]
+      properties:
+        user_id: { type: string, format: uuid }
+        display_name:
+          type: string
+          description: What they were called that week — frozen, and it survives the seat being deleted.
+        deals_won: { type: integer, minimum: 0 }
+        leads_breached: { type: integer, minimum: 0 }
+        meetings_held: { type: integer, minimum: 0 }
+        commitments_due: { type: integer, minimum: 0 }
+        commitments_kept: { type: integer, minimum: 0 }
+        help_requested: { type: integer, minimum: 0, description: 'Commitments they asked for help on.' }
+        focus_kind:
+          type: string
+          enum: [help_requested, leads_breached, commitments_missed,
+                 meetings_without_next_step, strong_week, quiet_week]
+          description: |
+            Which rule picked the focus, so a reader can tell a coaching prompt from a thing to
+            celebrate. Tried in the order a lead should raise them: a rep who ASKED for help
+            outranks any metric, because walking past a request to raise a number is the
+            fastest way to teach them not to ask.
+        focus_label:
+          type: string
+          description: |
+            The focus in words, composed from the stored figures — never model-written, so it
+            cannot say something the snapshot does not hold.
 
     WeeklyReview:
       type: object

--- a/backend/gates/tableownership_test.go
+++ b/backend/gates/tableownership_test.go
@@ -409,6 +409,8 @@ var tableOwners = map[string]string{
 	// that decides the next morning's overnight window, and weekly content on
 	// brief_item would be cascaded away by deleting a deal.
 	"weekly_review":          "internal/compose/weekly",
+	"team_weekly_review":     "internal/compose/weekly",
+	"team_weekly_review_rep": "internal/compose/weekly",
 	"weekly_plan":            "internal/modules/weeklyplan",
 	"weekly_plan_commitment": "internal/modules/weeklyplan",
 	"weekly_review_deal":     "internal/compose/weekly",

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -313,6 +313,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/weekly-plans/{owner_id}/current":                            {Op: "getTeammateWeeklyPlan", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/weekly-reviews":                                             {Op: "listWeeklyReviews", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/weekly-reviews/latest":                                      {Op: "getLatestWeeklyReview", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/weekly-reviews/team":                                        {Op: "getTeamWeeklyReview", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/worklist":                                                   {Op: "getWorklist", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/worklist/team":                                              {Op: "getTeamBoard", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"PATCH /v1/activities/{id}":                                          {Op: "updateActivity", Access: "tool", Tool: "update_record", RecordType: "activity", Tier: "auto_execute", Scope: "write"},

--- a/backend/internal/compose/integration/teamweekly_integration_test.go
+++ b/backend/internal/compose/integration/teamweekly_integration_test.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration_test
+
+// The team's frozen week over real migrated Postgres.
+//
+// What these defend is the freeze and the tier gate. The freeze is why the
+// table exists at all: team membership moves, so a snapshot that re-summed on
+// read would put a rep who joined later into an older team week and drop one
+// who left, and a lead comparing two quarters would be comparing two different
+// teams without being told.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/compose/weekly"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// teamClock is a Wednesday, so the week that closed is unambiguous.
+var teamClock = time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)
+
+type teamEnv struct {
+	*integration.Env
+	engine  *weekly.Engine
+	leadCtx context.Context
+	repCtx  context.Context
+}
+
+func setupTeamWeekly(t *testing.T) *teamEnv {
+	t.Helper()
+	e := integration.Setup(t)
+	return &teamEnv{
+		Env:     e,
+		engine:  weekly.NewEngine(e.Pool),
+		leadCtx: e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms),
+		repCtx:  ownScoped(e, e.Rep2),
+	}
+}
+
+// ownScoped is a seat that reaches only its own rows.
+func ownScoped(e *integration.Env, user ids.UUID) context.Context {
+	perms := integration.AdminPerms
+	perms.RowScope = principal.RowScopeOwn
+	return e.As(user, []ids.UUID{e.Team1}, perms)
+}
+
+// members names the two reps sharing Team1 in the harness.
+func members(e *teamEnv) []weekly.TeamMember {
+	return []weekly.TeamMember{
+		{UserID: e.Rep1, DisplayName: "Rep One"},
+		{UserID: e.Rep2, DisplayName: "Rep Two"},
+	}
+}
+
+// A team snapshot is a team question. An own-scoped seat asking for one would
+// get a page about people whose rows they cannot read.
+func TestAnOwnScopedSeatIsRefusedTheTeamWeek(t *testing.T) {
+	e := setupTeamWeekly(t)
+
+	_, err := e.engine.LatestTeamReview(e.repCtx, e.Team1, nil)
+
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("an own-scoped seat got %v, wanted a refusal", err)
+	}
+}
+
+// The membership is frozen INTO the snapshot, which is the whole reason the
+// table exists rather than a view.
+//
+// A rep who leaves the team afterwards stays in the week they were part of, and
+// a rep who joins later does not appear in it.
+func TestTheMembershipIsFrozenIntoTheWeek(t *testing.T) {
+	e := setupTeamWeekly(t)
+	owner := integration.OwnerConn(t)
+	ctx := context.Background()
+
+	// Both reps must have a week to be counted at all.
+	writeRepWeek(t, e, e.Rep1)
+	writeRepWeek(t, e, e.Rep2)
+
+	written, created, err := e.engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created || len(written.Reps) != 2 {
+		t.Fatalf("the week was written with %d reps (created=%v), wanted 2 — "+
+			"without both the freeze below proves nothing", len(written.Reps), created)
+	}
+
+	// Rep2 leaves the team, and is renamed.
+	if _, err := owner.Exec(ctx,
+		`DELETE FROM team_membership WHERE team_id = $1 AND user_id = $2`,
+		e.Team1, e.Rep2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := owner.Exec(ctx,
+		`UPDATE app_user SET display_name = 'Someone Else' WHERE id = $1`, e.Rep2); err != nil {
+		t.Fatal(err)
+	}
+
+	read, err := e.engine.LatestTeamReview(e.leadCtx, e.Team1, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(read.Reps) != 2 {
+		t.Fatalf("the frozen week came back with %d reps after one left, wanted 2", len(read.Reps))
+	}
+	var found bool
+	for _, rep := range read.Reps {
+		if rep.UserID == e.Rep2 {
+			found = true
+			if rep.DisplayName != "Rep Two" {
+				t.Errorf("the departed rep reads as %q, wanted the name they had that week",
+					rep.DisplayName)
+			}
+		}
+	}
+	if !found {
+		t.Error("a rep who left the team vanished from the week they were part of")
+	}
+}
+
+// A second run answers the first snapshot rather than rewriting a week a lead
+// may already have read.
+//
+// The dispatcher ticks more than once inside a week on purpose, so a worker
+// that was down still backfills — which means this path runs repeatedly over
+// the same team week by design, not by accident.
+func TestASecondAssemblyReadsTheFirst(t *testing.T) {
+	e := setupTeamWeekly(t)
+
+	writeRepWeek(t, e, e.Rep1)
+	first, created, err := e.engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("the first assembly wrote nothing")
+	}
+
+	second, createdAgain, err := e.engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if createdAgain {
+		t.Error("a second assembly wrote a second snapshot for one team week")
+	}
+	if second.ID != first.ID {
+		t.Errorf("the second answered snapshot %v, wanted the first's %v", second.ID, first.ID)
+	}
+}
+
+// A member with no review for the week is counted as UNREAD, not as a zero row.
+//
+// A rep on leave and a rep whose measurement failed look identical as zeros,
+// and only one of those is a fact about their week.
+func TestAMemberWithNoWeekIsCountedAsUnread(t *testing.T) {
+	e := setupTeamWeekly(t)
+
+	// Only Rep1 has a week.
+	writeRepWeek(t, e, e.Rep1)
+
+	review, _, err := e.engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if review.Counts.RepsCounted != 1 {
+		t.Errorf("counted %d reps, wanted 1", review.Counts.RepsCounted)
+	}
+	if review.RepsUnread != 1 {
+		t.Errorf("reported %d unread, wanted 1 — a snapshot silently covering "+
+			"one of two reps reads exactly like a team of one", review.RepsUnread)
+	}
+	if len(review.Reps) != 1 {
+		t.Errorf("wrote %d rep rows, wanted only the one with a week", len(review.Reps))
+	}
+}
+
+// writeRepWeek gives one rep a review for the week that closed.
+func writeRepWeek(t *testing.T, e *teamEnv, user ids.UUID) {
+	t.Helper()
+	repCtx := e.As(user, []ids.UUID{e.Team1}, integration.AdminPerms)
+	if _, _, err := e.engine.AssembleFor(repCtx, teamClock); err != nil {
+		t.Fatalf("writing a week for %v: %v", user, err)
+	}
+}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -2239,6 +2239,10 @@ func (stubs) GetLatestWeeklyReview(w nethttp.ResponseWriter, r *nethttp.Request,
 	httperr.NotImplemented(w, r, "GetLatestWeeklyReview")
 }
 
+func (stubs) GetTeamWeeklyReview(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.GetTeamWeeklyReviewParams) {
+	httperr.NotImplemented(w, r, "GetTeamWeeklyReview")
+}
+
 func (stubs) GetWorklist(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.GetWorklistParams) {
 	httperr.NotImplemented(w, r, "GetWorklist")
 }

--- a/backend/internal/compose/weekly/teamreview.go
+++ b/backend/internal/compose/weekly/teamreview.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+// The team's week, assembled from the member weeks and frozen beside them.
+//
+// A LEAD's read, and a different question from the board in attention: that one
+// answers what the team is carrying NOW, live and recomputed on every open.
+// This answers what last week WAS, once, so two weeks can be compared and
+// neither moves under the comparison.
+//
+// It reads only reviews that are already written, which is why the job runs it
+// as a third phase: a snapshot assembled while reps are still being measured
+// would freeze a team that was half-counted, and nothing afterwards would say
+// so.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The rules that pick a rep's one coaching focus, in the order they are tried.
+//
+// Ordered by what a lead should raise FIRST, not by severity in the abstract: a
+// rep who asked for help has already said what they need, and walking past that
+// to raise a metric is the fastest way to teach them not to ask.
+const (
+	// They asked. Nothing outranks a request already made.
+	FocusHelpRequested = "help_requested"
+	// A customer waited past the target and nobody answered.
+	FocusLeadsBreached = "leads_breached"
+	// They planned a week and did not keep it.
+	FocusCommitmentsMissed = "commitments_missed"
+	// Meetings happened and left nothing behind.
+	FocusMeetingsWithoutNextStep = "meetings_without_next_step"
+	// Nothing to fix, and something to copy. Without this a healthy rep
+	// produces no row at all, and a page promising one focus per rep would
+	// quietly shorten to the troubled ones — which reads as a team where only
+	// those people exist.
+	FocusStrongWeek = "strong_week"
+	// Nothing to fix and nothing that stood out. Said plainly rather than
+	// dressed as either a problem or a triumph.
+	FocusQuietWeek = "quiet_week"
+)
+
+// TeamMember is one seat the snapshot should cover, as the caller knows it.
+type TeamMember struct {
+	UserID      ids.UUID
+	DisplayName string
+}
+
+// TeamReview is one team's frozen week.
+type TeamReview struct {
+	ID             ids.UUID
+	TeamID         ids.UUID
+	TeamName       string
+	LocalWeekStart time.Time
+	GeneratedAt    time.Time
+	AsOf           time.Time
+	Counts         TeamCounts
+	Money          Money
+	// RepsUnread counts the members whose week could not be read at all. Zero
+	// is the claim that every member's week was counted.
+	RepsUnread int
+	Reps       []TeamRep
+}
+
+// TeamCounts are the team's totals over its member weeks.
+type TeamCounts struct {
+	RepsCounted           int
+	DealsWon              int
+	DealsLost             int
+	LeadsRouted           int
+	LeadsAnsweredInTarget int
+	LeadsBreached         int
+	MeetingsHeld          int
+	MeetingsWithNextStep  int
+	CommitmentsDue        int
+	CommitmentsKept       int
+}
+
+// TeamRep is one member's week as their lead reads it, with the one thing to
+// raise.
+type TeamRep struct {
+	UserID          ids.UUID
+	DisplayName     string
+	DealsWon        int
+	LeadsBreached   int
+	MeetingsHeld    int
+	CommitmentsDue  int
+	CommitmentsKept int
+	HelpRequested   int
+	FocusKind       string
+	FocusLabel      string
+}
+
+// AssembleTeamFor writes the team's snapshot for the week that closed, or
+// answers the one already written.
+//
+// Idempotent by the unique constraint, like the per-rep review: the dispatcher
+// ticks more than once inside a week, and a second run must not rewrite a
+// snapshot whose numbers a lead has already read.
+func (e *Engine) AssembleTeamFor(
+	ctx context.Context, teamID ids.UUID, teamName string, members []TeamMember, now time.Time,
+) (TeamReview, bool, error) {
+	var review TeamReview
+	var created bool
+	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		thisWeek, err := WeekStartOf(ctx, tx, now)
+		if err != nil {
+			return err
+		}
+		week := thisWeek.AddDate(0, 0, -7)
+
+		review = TeamReview{
+			TeamID: teamID, TeamName: teamName,
+			LocalWeekStart: week, AsOf: now.UTC(),
+		}
+		if err := gatherTeamWeek(ctx, tx, &review, members); err != nil {
+			return err
+		}
+		id, wrote, err := insertTeamReview(ctx, tx, review)
+		if err != nil {
+			return err
+		}
+		created = wrote
+		if !wrote {
+			// Somebody already wrote this team's week. Their snapshot stands.
+			return nil
+		}
+		review.ID = id
+		return insertTeamReps(ctx, tx, id, review.Reps)
+	})
+	if err != nil {
+		return TeamReview{}, false, err
+	}
+	if !created {
+		existing, err := e.TeamReview(ctx, teamID, review.LocalWeekStart)
+		return existing, false, err
+	}
+	return review, true, nil
+}
+
+// gatherTeamWeek reads each member's frozen week and totals them.
+//
+// A member with NO review for the week is counted as unread rather than as a
+// zero row: a rep who was on leave and one whose measurement failed look
+// identical as zeros, and only one of those is a fact about their week.
+func gatherTeamWeek(
+	ctx context.Context, tx pgx.Tx, review *TeamReview, members []TeamMember,
+) error {
+	// Money is answerable only if EVERY member's week converted. One rep whose
+	// currency had no rate makes the team total unanswerable, exactly as one
+	// unconvertible deal does for that rep — a sum quietly missing a person is
+	// worse than an absent one.
+	money := Money{Known: true}
+	for _, member := range members {
+		counts, memberMoney, help, err := memberWeek(ctx, tx, member.UserID, review.LocalWeekStart)
+		if errors.Is(err, apperrors.ErrNotFound) {
+			review.RepsUnread++
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		review.Counts.RepsCounted++
+		addTeamCounts(&review.Counts, counts)
+		if !memberMoney.Known {
+			money.Known = false
+		} else if money.Known {
+			money.Currency = memberMoney.Currency
+			money.CreatedMinor += memberMoney.CreatedMinor
+			money.WonMinor += memberMoney.WonMinor
+			money.LostMinor += memberMoney.LostMinor
+		}
+		review.Reps = append(review.Reps, repFrom(member, counts, help))
+	}
+	if money.Known && money.Currency != "" {
+		review.Money = money
+	}
+	return nil
+}
+
+// addTeamCounts folds one member's week into the team's totals.
+func addTeamCounts(team *TeamCounts, member Counts) {
+	team.DealsWon += member.DealsWon
+	team.DealsLost += member.DealsLost
+	team.LeadsRouted += member.LeadsRouted
+	team.LeadsAnsweredInTarget += member.LeadsAnsweredInTarget
+	team.LeadsBreached += member.LeadsBreached
+	team.MeetingsHeld += member.MeetingsHeld
+	team.MeetingsWithNextStep += member.MeetingsWithNextStep
+	team.CommitmentsDue += member.CommitmentsDue
+	team.CommitmentsKept += member.CommitmentsKept
+}
+
+// repFrom builds one member's row, focus and all.
+func repFrom(member TeamMember, counts Counts, help int) TeamRep {
+	kind, label := focusFor(counts, help)
+	return TeamRep{
+		UserID: member.UserID, DisplayName: member.DisplayName,
+		DealsWon: counts.DealsWon, LeadsBreached: counts.LeadsBreached,
+		MeetingsHeld:   counts.MeetingsHeld,
+		CommitmentsDue: counts.CommitmentsDue, CommitmentsKept: counts.CommitmentsKept,
+		HelpRequested: help,
+		FocusKind:     kind, FocusLabel: label,
+	}
+}
+
+// focusFor picks the ONE thing a lead should raise with this rep.
+//
+// One per rep, always — including the rep whose week went well, whose focus is
+// what the team should copy. A page promising one focus per rep and delivering
+// rows only for the troubled ones reads as a team where only those people
+// exist, which is both untrue and demoralising to be listed in.
+//
+// The label is composed here rather than by a model: it states a stored figure
+// and nothing else, so it cannot say something the snapshot does not hold.
+func focusFor(counts Counts, help int) (kind, label string) {
+	switch {
+	case help > 0:
+		return FocusHelpRequested, fmt.Sprintf("Asked for help on %s", plural(help, "commitment"))
+	case counts.LeadsBreached > 0:
+		return FocusLeadsBreached, fmt.Sprintf("%s went past the response target",
+			plural(counts.LeadsBreached, "lead"))
+	case counts.CommitmentsDue > counts.CommitmentsKept:
+		return FocusCommitmentsMissed, fmt.Sprintf("Kept %d of %d commitments",
+			counts.CommitmentsKept, counts.CommitmentsDue)
+	case counts.MeetingsHeld > counts.MeetingsWithNextStep:
+		return FocusMeetingsWithoutNextStep, fmt.Sprintf("%s left without a next step",
+			plural(counts.MeetingsHeld-counts.MeetingsWithNextStep, "meeting"))
+	case counts.DealsWon > 0:
+		return FocusStrongWeek, fmt.Sprintf("Won %s — worth asking how",
+			plural(counts.DealsWon, "deal"))
+	case counts.CommitmentsDue > 0 && counts.CommitmentsDue == counts.CommitmentsKept:
+		return FocusStrongWeek, fmt.Sprintf("Kept every commitment (%d)", counts.CommitmentsDue)
+	default:
+		return FocusQuietWeek, "A quiet week"
+	}
+}
+
+// plural renders a count with its noun, so a label reads as a sentence.
+func plural(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}

--- a/backend/internal/compose/weekly/teamreview_test.go
+++ b/backend/internal/compose/weekly/teamreview_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+// The coaching focus, over fixture counts.
+//
+// A unit test because the rule is arithmetic over one member's frozen week and
+// nothing else — no database, no clock. What it defends is that EVERY rep gets
+// a row, and that a request already made outranks any metric.
+
+import "testing"
+
+func TestARepWhoAskedForHelpIsRaisedFirst(t *testing.T) {
+	// A week with something to raise on every other rung too, so this asserts
+	// the ORDER rather than the only rule that could fire.
+	counts := Counts{
+		LeadsBreached: 3, CommitmentsDue: 4, CommitmentsKept: 1,
+		MeetingsHeld: 2, MeetingsWithNextStep: 0,
+	}
+
+	kind, label := focusFor(counts, 1)
+
+	if kind != FocusHelpRequested {
+		t.Errorf("focus = %q, want %q — walking past a request to raise a metric "+
+			"is the fastest way to teach a rep not to ask", kind, FocusHelpRequested)
+	}
+	if label == "" {
+		t.Error("the focus carries no words")
+	}
+}
+
+// Every rep gets a focus, including the one whose week went well. Without this
+// a page promising one row per rep quietly shortens to the troubled ones.
+func TestEveryWeekProducesAFocus(t *testing.T) {
+	cases := map[string]struct {
+		counts Counts
+		help   int
+		want   string
+	}{
+		"asked for help":     {Counts{}, 2, FocusHelpRequested},
+		"a lead went past":   {Counts{LeadsRouted: 3, LeadsBreached: 1}, 0, FocusLeadsBreached},
+		"missed commitments": {Counts{CommitmentsDue: 3, CommitmentsKept: 1}, 0, FocusCommitmentsMissed},
+		"meetings with no next step": {
+			Counts{MeetingsHeld: 2, MeetingsWithNextStep: 1}, 0, FocusMeetingsWithoutNextStep,
+		},
+		"won something":         {Counts{DealsWon: 2}, 0, FocusStrongWeek},
+		"kept every commitment": {Counts{CommitmentsDue: 3, CommitmentsKept: 3}, 0, FocusStrongWeek},
+		"nothing happened":      {Counts{}, 0, FocusQuietWeek},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			kind, label := focusFor(tc.counts, tc.help)
+			if kind != tc.want {
+				t.Errorf("focus = %q, want %q", kind, tc.want)
+			}
+			if label == "" {
+				t.Error("the focus carries no words — a row a lead cannot read is not a focus")
+			}
+		})
+	}
+}
+
+// The label states a stored figure and nothing else, so it cannot say something
+// the snapshot does not hold.
+func TestTheFocusLabelNamesTheFiguresItRestsOn(t *testing.T) {
+	_, label := focusFor(Counts{CommitmentsDue: 5, CommitmentsKept: 2}, 0)
+
+	if label != "Kept 2 of 5 commitments" {
+		t.Errorf("label = %q, want the two stored figures", label)
+	}
+}
+
+// One is one, and two are two. A label reading "1 leads" is a small thing that
+// makes a page look machine-written.
+func TestOneReadsAsOne(t *testing.T) {
+	if got := plural(1, "lead"); got != "1 lead" {
+		t.Errorf("plural(1) = %q, want %q", got, "1 lead")
+	}
+	if got := plural(3, "lead"); got != "3 leads" {
+		t.Errorf("plural(3) = %q, want %q", got, "3 leads")
+	}
+}

--- a/backend/internal/compose/weekly/teamreviewhandlers.go
+++ b/backend/internal/compose/weekly/teamreviewhandlers.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+import (
+	"net/http"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// GetTeamWeeklyReview answers a team's frozen week.
+//
+// It serves a snapshot that was WRITTEN when the week closed and never
+// assembles one, for the reason the per-rep read gives: a read that could
+// re-derive the week would answer differently depending on when it was asked.
+func (h Handlers) GetTeamWeeklyReview(
+	w http.ResponseWriter, r *http.Request, params crmcontracts.GetTeamWeeklyReviewParams,
+) {
+	var week *time.Time
+	if params.Week != nil {
+		day := params.Week.Time
+		week = &day
+	}
+	review, err := h.engine.LatestTeamReview(r.Context(), ids.UUID(params.Team), week)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, teamReviewToWire(review))
+}
+
+// teamReviewToWire puts the snapshot on the contract's shape.
+func teamReviewToWire(review TeamReview) crmcontracts.TeamWeeklyReview {
+	reps := make([]crmcontracts.TeamWeeklyRep, 0, len(review.Reps))
+	for _, rep := range review.Reps {
+		reps = append(reps, crmcontracts.TeamWeeklyRep{
+			UserId:          openapi_types.UUID(rep.UserID),
+			DisplayName:     rep.DisplayName,
+			DealsWon:        rep.DealsWon,
+			LeadsBreached:   rep.LeadsBreached,
+			MeetingsHeld:    rep.MeetingsHeld,
+			CommitmentsDue:  rep.CommitmentsDue,
+			CommitmentsKept: rep.CommitmentsKept,
+			HelpRequested:   rep.HelpRequested,
+			FocusKind:       crmcontracts.TeamWeeklyRepFocusKind(rep.FocusKind),
+			FocusLabel:      rep.FocusLabel,
+		})
+	}
+	c := review.Counts
+	return crmcontracts.TeamWeeklyReview{
+		Id:             openapi_types.UUID(review.ID),
+		TeamId:         openapi_types.UUID(review.TeamID),
+		TeamName:       review.TeamName,
+		LocalWeekStart: openapi_types.Date{Time: review.LocalWeekStart},
+		GeneratedAt:    review.GeneratedAt,
+		AsOf:           review.AsOf,
+		RepsUnread:     &review.RepsUnread,
+		Counts: crmcontracts.TeamWeeklyCounts{
+			RepsCounted: c.RepsCounted,
+			DealsWon:    c.DealsWon, DealsLost: c.DealsLost,
+			LeadsRouted: c.LeadsRouted, LeadsAnsweredInTarget: c.LeadsAnsweredInTarget,
+			LeadsBreached: c.LeadsBreached,
+			MeetingsHeld:  c.MeetingsHeld, MeetingsWithNextStep: c.MeetingsWithNextStep,
+			CommitmentsDue: c.CommitmentsDue, CommitmentsKept: c.CommitmentsKept,
+		},
+		Pipeline: pipelineToWire(review.Money),
+		Reps:     reps,
+	}
+}

--- a/backend/internal/compose/weekly/teamreviewstore.go
+++ b/backend/internal/compose/weekly/teamreviewstore.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weekly
+
+// Reading and writing the team's frozen week.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// teamReviewSelect is the snapshot's columns, in the order scanTeamReview reads
+// them. ONE spelling, for the reason reviewSelect is one: two copies is how the
+// same week comes to render two different ways.
+const teamReviewSelect = `
+	SELECT id, team_id, team_name, local_week_start, generated_at, as_of,
+	       reps_counted, deals_won, deals_lost,
+	       leads_routed, leads_answered_in_target, leads_breached,
+	       meetings_held, meetings_with_next_step,
+	       commitments_due, commitments_kept,
+	       pipeline_created_minor, pipeline_won_minor, pipeline_lost_minor,
+	       base_currency, reps_unread
+	  FROM team_weekly_review`
+
+// memberWeek reads one member's frozen week, and how many commitments they
+// asked for help on.
+//
+// ErrNotFound when that rep has no review for the week — which is a fact about
+// the snapshot ("this member's week was not counted"), not an error.
+func memberWeek(
+	ctx context.Context, tx pgx.Tx, userID ids.UUID, week time.Time,
+) (Counts, Money, int, error) {
+	var c Counts
+	var created, won, lost *int64
+	var currency *string
+	err := tx.QueryRow(ctx, `
+		SELECT deals_won, deals_lost,
+		       leads_routed, leads_answered_in_target, leads_breached,
+		       meetings_held, meetings_with_next_step,
+		       commitments_due, commitments_kept,
+		       pipeline_created_minor, pipeline_won_minor, pipeline_lost_minor, base_currency
+		  FROM weekly_review WHERE user_id = $1 AND local_week_start = $2`, userID, week).
+		Scan(&c.DealsWon, &c.DealsLost,
+			&c.LeadsRouted, &c.LeadsAnsweredInTarget, &c.LeadsBreached,
+			&c.MeetingsHeld, &c.MeetingsWithNextStep,
+			&c.CommitmentsDue, &c.CommitmentsKept,
+			&created, &won, &lost, &currency)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Counts{}, Money{}, 0, apperrors.ErrNotFound
+	}
+	if err != nil {
+		return Counts{}, Money{}, 0, fmt.Errorf("weekly: reading a member's week: %w", err)
+	}
+	money := Money{}
+	if currency != nil {
+		money = Money{
+			CreatedMinor: deref(created), WonMinor: deref(won), LostMinor: deref(lost),
+			Currency: *currency, Known: true,
+		}
+	}
+	// How many of that week's commitments carried a request for help. Counted
+	// from the plan rather than the review, because the review freezes what the
+	// week came to and not what was asked along the way.
+	var help int
+	if err := tx.QueryRow(ctx, `
+		SELECT count(*) FROM weekly_plan_commitment c
+		  JOIN weekly_plan p ON p.id = c.plan_id
+		 WHERE p.owner_id = $1 AND p.local_week_start = $2
+		   AND btrim(c.help_requested) <> ''`, userID, week).Scan(&help); err != nil {
+		return Counts{}, Money{}, 0, fmt.Errorf("weekly: counting a member's requests: %w", err)
+	}
+	return c, money, help, nil
+}
+
+// insertTeamReview writes the snapshot unless this team already has one for the
+// week, reporting which of the two happened.
+func insertTeamReview(ctx context.Context, tx pgx.Tx, review TeamReview) (ids.UUID, bool, error) {
+	c := review.Counts
+	cols, args := insertColumns{}, []any(nil)
+	add := func(name string, value any) {
+		cols = append(cols, name)
+		args = append(args, value)
+	}
+	add("team_id", review.TeamID)
+	add("team_name", review.TeamName)
+	add("local_week_start", review.LocalWeekStart)
+	add("as_of", review.AsOf)
+	add("reps_counted", c.RepsCounted)
+	add("reps_unread", review.RepsUnread)
+	add("deals_won", c.DealsWon)
+	add("deals_lost", c.DealsLost)
+	add("leads_routed", c.LeadsRouted)
+	add("leads_answered_in_target", c.LeadsAnsweredInTarget)
+	add("leads_breached", c.LeadsBreached)
+	add("meetings_held", c.MeetingsHeld)
+	add("meetings_with_next_step", c.MeetingsWithNextStep)
+	add("commitments_due", c.CommitmentsDue)
+	add("commitments_kept", c.CommitmentsKept)
+	// The four money columns go together or not at all — the table's own CHECK
+	// says a figure names its currency and a currency names figures.
+	if review.Money.Known {
+		add("pipeline_created_minor", review.Money.CreatedMinor)
+		add("pipeline_won_minor", review.Money.WonMinor)
+		add("pipeline_lost_minor", review.Money.LostMinor)
+		add("base_currency", review.Money.Currency)
+	}
+
+	var id ids.UUID
+	err := tx.QueryRow(ctx, fmt.Sprintf(`
+		INSERT INTO team_weekly_review (%s) VALUES (%s)
+		ON CONFLICT ON CONSTRAINT uq_team_weekly_review_team_week DO NOTHING
+		RETURNING id`, cols.names(), cols.placeholders()), args...).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The team's week already had a snapshot. The loser of that race is not
+		// an error: the constraint did its job.
+		return ids.Nil, false, nil
+	}
+	if err != nil {
+		return ids.Nil, false, fmt.Errorf("weekly: writing the team's week: %w", err)
+	}
+	return id, true, nil
+}
+
+// insertTeamReps writes the frozen membership.
+func insertTeamReps(ctx context.Context, tx pgx.Tx, reviewID ids.UUID, reps []TeamRep) error {
+	for _, rep := range reps {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO team_weekly_review_rep
+			    (team_weekly_review_id, user_id, display_name, deals_won, leads_breached,
+			     meetings_held, commitments_due, commitments_kept, help_requested,
+			     focus_kind, focus_label)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+			reviewID, rep.UserID, rep.DisplayName, rep.DealsWon, rep.LeadsBreached,
+			rep.MeetingsHeld, rep.CommitmentsDue, rep.CommitmentsKept, rep.HelpRequested,
+			rep.FocusKind, rep.FocusLabel); err != nil {
+			return fmt.Errorf("weekly: writing a member's row: %w", err)
+		}
+	}
+	return nil
+}
+
+// TeamReview answers one team's frozen week.
+//
+// Gated on a row scope of team or wider: a team snapshot is a team question,
+// and an own-scoped reader asking it would get a page about people whose rows
+// they cannot read. The membership itself is not re-checked here — the caller
+// resolved which teams they lead when they asked, and the snapshot names the
+// team it is about.
+func (e *Engine) TeamReview(
+	ctx context.Context, teamID ids.UUID, week time.Time,
+) (TeamReview, error) {
+	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
+		return TeamReview{}, err
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Permissions.RowScope == principal.RowScopeOwn {
+		return TeamReview{}, apperrors.ErrPermissionDenied
+	}
+	var review TeamReview
+	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, teamReviewSelect+`
+			 WHERE team_id = $1 AND local_week_start = $2`, teamID, week)
+		var err error
+		review, err = scanTeamReview(ctx, tx, row)
+		return err
+	})
+	if err != nil {
+		return TeamReview{}, err
+	}
+	return review, nil
+}
+
+// LatestTeamReview answers a team's most recent frozen week, or a named one.
+//
+// Same gate as TeamReview, and the same reason it is a separate entry point
+// rather than a nil week on that one: "the newest" and "this one" are different
+// questions, and a caller passing a zero time by accident would silently get
+// the newest instead of a refusal.
+func (e *Engine) LatestTeamReview(
+	ctx context.Context, teamID ids.UUID, week *time.Time,
+) (TeamReview, error) {
+	if week != nil {
+		return e.TeamReview(ctx, teamID, *week)
+	}
+	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
+		return TeamReview{}, err
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Permissions.RowScope == principal.RowScopeOwn {
+		return TeamReview{}, apperrors.ErrPermissionDenied
+	}
+	var review TeamReview
+	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, teamReviewSelect+`
+			 WHERE team_id = $1 ORDER BY local_week_start DESC LIMIT 1`, teamID)
+		var err error
+		review, err = scanTeamReview(ctx, tx, row)
+		return err
+	})
+	if err != nil {
+		return TeamReview{}, err
+	}
+	return review, nil
+}
+
+// scanTeamReview reads one snapshot row and its frozen membership.
+func scanTeamReview(ctx context.Context, tx pgx.Tx, row pgx.Row) (TeamReview, error) {
+	var review TeamReview
+	c := &review.Counts
+	var created, won, lost *int64
+	var currency *string
+	switch err := row.Scan(&review.ID, &review.TeamID, &review.TeamName,
+		&review.LocalWeekStart, &review.GeneratedAt, &review.AsOf,
+		&c.RepsCounted, &c.DealsWon, &c.DealsLost,
+		&c.LeadsRouted, &c.LeadsAnsweredInTarget, &c.LeadsBreached,
+		&c.MeetingsHeld, &c.MeetingsWithNextStep,
+		&c.CommitmentsDue, &c.CommitmentsKept,
+		&created, &won, &lost, &currency, &review.RepsUnread); {
+	case errors.Is(err, pgx.ErrNoRows):
+		return TeamReview{}, apperrors.ErrNotFound
+	case err != nil:
+		return TeamReview{}, err
+	}
+	if currency != nil {
+		review.Money = Money{
+			CreatedMinor: deref(created), WonMinor: deref(won), LostMinor: deref(lost),
+			Currency: *currency, Known: true,
+		}
+	}
+	reps, err := readTeamReps(ctx, tx, review.ID)
+	if err != nil {
+		return TeamReview{}, err
+	}
+	review.Reps = reps
+	return review, nil
+}
+
+// readTeamReps reads the frozen membership, ordered as the page draws it.
+//
+// It joins NOTHING. Every word was written when the snapshot was, so a rep
+// renamed or deleted since leaves the row exactly as the week recorded it.
+func readTeamReps(ctx context.Context, tx pgx.Tx, reviewID ids.UUID) ([]TeamRep, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT user_id, display_name, deals_won, leads_breached, meetings_held,
+		       commitments_due, commitments_kept, help_requested, focus_kind, focus_label
+		  FROM team_weekly_review_rep
+		 WHERE team_weekly_review_id = $1
+		 ORDER BY display_name, user_id`, reviewID)
+	if err != nil {
+		return nil, fmt.Errorf("weekly: reading the team's members: %w", err)
+	}
+	defer rows.Close()
+	var out []TeamRep
+	for rows.Next() {
+		var rep TeamRep
+		if err := rows.Scan(&rep.UserID, &rep.DisplayName, &rep.DealsWon,
+			&rep.LeadsBreached, &rep.MeetingsHeld, &rep.CommitmentsDue,
+			&rep.CommitmentsKept, &rep.HelpRequested,
+			&rep.FocusKind, &rep.FocusLabel); err != nil {
+			return nil, err
+		}
+		out = append(out, rep)
+	}
+	return out, rows.Err()
+}
+
+// teamNameOf reads a team's current name, for stamping into a new snapshot.
+func teamNameOf(ctx context.Context, tx pgx.Tx, teamID ids.UUID) (string, error) {
+	var name string
+	err := tx.QueryRow(ctx,
+		`SELECT name FROM team WHERE id = $1 AND archived_at IS NULL`, teamID).Scan(&name)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", apperrors.ErrNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("weekly: reading the team's name: %w", err)
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", apperrors.ErrNotFound
+	}
+	return name, nil
+}

--- a/backend/internal/compose/weeklyjobs.go
+++ b/backend/internal/compose/weeklyjobs.go
@@ -171,6 +171,17 @@ func (w *weeklyGenerateWorkspaceWorker) measureWorkspace(
 			principal.WithActor(ctx, ready.rep), ids.NewV7())
 		w.mailWeekly(sendCtx, ready.reviewID, now)
 	}
+	// The team snapshots THIRD, and last for a reason of its own: each one is a
+	// total over member reviews, so a snapshot assembled while reps were still
+	// being measured would freeze a team that was half-counted and nothing
+	// afterwards would say so. It runs after the mail because it is the least
+	// urgent of the three — a lead reads it on Monday, and a tick that ran out
+	// of budget here costs a snapshot the next tick rebuilds, not a review.
+	//
+	// Failures are collected, not returned: one team that cannot be assembled
+	// must not report the whole workspace's reviews as failed when they are
+	// written and committed.
+	failures = append(failures, w.snapshotTeams(sysCtx, wsID, now)...)
 	if len(failures) > 0 {
 		return fmt.Errorf("weekly_review_generate_workspace: %d of %d reps: %w",
 			len(failures), len(due), errors.Join(failures...))

--- a/backend/internal/compose/weeklyseam.go
+++ b/backend/internal/compose/weeklyseam.go
@@ -19,6 +19,13 @@ func (s Server) ListWeeklyReviews(w http.ResponseWriter, r *http.Request) {
 	s.weeklyHandlers.ListWeeklyReviews(w, r)
 }
 
+// GetTeamWeeklyReview implements (GET /weekly-reviews/team).
+func (s Server) GetTeamWeeklyReview(
+	w http.ResponseWriter, r *http.Request, params crmcontracts.GetTeamWeeklyReviewParams,
+) {
+	s.weeklyHandlers.GetTeamWeeklyReview(w, r, params)
+}
+
 // GetLatestWeeklyReview implements (GET /weekly-reviews/latest).
 func (s Server) GetLatestWeeklyReview(
 	w http.ResponseWriter, r *http.Request, params crmcontracts.GetLatestWeeklyReviewParams,

--- a/backend/internal/compose/weeklyteamjobs.go
+++ b/backend/internal/compose/weeklyteamjobs.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The weekly job's third phase: freezing each team's week.
+//
+// Its own file because it is a different subject from the per-rep pass beside
+// it — that one measures one person under their own authority, this one totals
+// people already measured and stamps who was on the team. It runs LAST for a
+// reason stated at its call site: a snapshot assembled while reps were still
+// being measured would freeze a team that was half-counted.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/weekly"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// snapshotTeams freezes each live team's week, once the member reviews are in.
+//
+// One snapshot per team, assembled under the authority of a member who leads
+// it: the read is of frozen rows the team's own people wrote, and the tier gate
+// on TeamReview is what stops an own-scoped seat asking for one.
+func (w *weeklyGenerateWorkspaceWorker) snapshotTeams(
+	ctx context.Context, wsID ids.UUID, now time.Time,
+) []error {
+	teams, err := w.liveTeams(ctx)
+	if err != nil {
+		return []error{fmt.Errorf("listing the workspace's teams: %w", err)}
+	}
+	var failures []error
+	for _, team := range teams {
+		if err := w.snapshotTeam(ctx, wsID, team, now); err != nil {
+			failures = append(failures, fmt.Errorf("team weekly for %s: %w", team.id, err))
+		}
+	}
+	return failures
+}
+
+// liveTeam is one team to snapshot, with the seat whose authority reads it.
+type liveTeam struct {
+	id   ids.UUID
+	name string
+	// lead is a member seat the snapshot is assembled under. Any member does:
+	// the read is of frozen rows their own team wrote, and the alternative — a
+	// system principal — bypasses both the object grant and the row scope,
+	// which is exactly the authority a snapshot must not be assembled with.
+	lead ids.UUID
+}
+
+// liveTeams lists the workspace's live teams with a member to act as.
+//
+// A team with no live members is skipped rather than snapshotted empty: an
+// empty week for a team that has nobody on it is a row saying the team did
+// nothing, which is not what happened.
+func (w *weeklyGenerateWorkspaceWorker) liveTeams(ctx context.Context) ([]liveTeam, error) {
+	var teams []liveTeam
+	err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT t.id, t.name, min(u.id::text)
+			  FROM team t
+			  JOIN team_membership m ON m.team_id = t.id
+			  JOIN app_user u ON u.id = m.user_id
+			    AND u.deactivated_at IS NULL AND NOT u.is_agent
+			 WHERE t.archived_at IS NULL
+			 GROUP BY t.id, t.name
+			 ORDER BY t.id`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var team liveTeam
+			var lead string
+			if err := rows.Scan(&team.id, &team.name, &lead); err != nil {
+				return err
+			}
+			parsed, err := ids.Parse(lead)
+			if err != nil {
+				return err
+			}
+			team.lead = parsed
+			teams = append(teams, team)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return teams, nil
+}
+
+// snapshotTeam freezes one team's week under a member's own authority.
+func (w *weeklyGenerateWorkspaceWorker) snapshotTeam(
+	ctx context.Context, wsID ids.UUID, team liveTeam, now time.Time,
+) error {
+	rbac, seat, err := w.users.EffectiveAuthority(ctx, wsID, team.lead)
+	if err != nil {
+		return fmt.Errorf("resolving the member's authority: %w", err)
+	}
+	memberCtx := principal.WithActor(ctx, principal.Principal{
+		Type:        principal.PrincipalHuman,
+		ID:          "human:" + team.lead.String(),
+		UserID:      team.lead,
+		SeatType:    seat,
+		TeamIDs:     rbac.TeamIDs,
+		Permissions: rbac.Permissions,
+	})
+	memberCtx = principal.WithCorrelationID(memberCtx, ids.NewV7())
+
+	members, err := w.teamMembers(memberCtx, team.id)
+	if err != nil {
+		return err
+	}
+	_, _, err = w.engine.AssembleTeamFor(memberCtx, team.id, team.name, members, now)
+	if err != nil {
+		// A seat whose role grants no deal read has no team week to assemble,
+		// for the reason measureFor gives about its own rep: it is a
+		// configuration rather than a fault, and failing here would make one
+		// such team cost the workspace its other snapshots.
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			w.log.InfoContext(ctx, "no team weekly for a team whose members' roles do not grant reading deals",
+				"team", team.id, "workspace", wsID)
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// teamMembers lists who was on the team, for freezing into the snapshot.
+//
+// Read HERE rather than through the identity roster seam because that one
+// answers "who shares a team with the caller" — the union across every team
+// they are on. A snapshot is about ONE team, and a lead on two would otherwise
+// freeze both teams' people into each.
+func (w *weeklyGenerateWorkspaceWorker) teamMembers(
+	ctx context.Context, teamID ids.UUID,
+) ([]weekly.TeamMember, error) {
+	var members []weekly.TeamMember
+	err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT u.id, u.display_name FROM team_membership m
+			  JOIN app_user u ON u.id = m.user_id
+			    AND u.deactivated_at IS NULL AND NOT u.is_agent
+			 WHERE m.team_id = $1
+			 ORDER BY u.display_name, u.id`, teamID)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var member weekly.TeamMember
+			if err := rows.Scan(&member.UserID, &member.DisplayName); err != nil {
+				return err
+			}
+			members = append(members, member)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("weekly: listing the team's members: %w", err)
+	}
+	return members, nil
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -10537,6 +10537,36 @@ func (e TaggableEntityType) Valid() bool {
 	}
 }
 
+// Defines values for TeamWeeklyRepFocusKind.
+const (
+	CommitmentsMissed       TeamWeeklyRepFocusKind = "commitments_missed"
+	HelpRequested           TeamWeeklyRepFocusKind = "help_requested"
+	LeadsBreached           TeamWeeklyRepFocusKind = "leads_breached"
+	MeetingsWithoutNextStep TeamWeeklyRepFocusKind = "meetings_without_next_step"
+	QuietWeek               TeamWeeklyRepFocusKind = "quiet_week"
+	StrongWeek              TeamWeeklyRepFocusKind = "strong_week"
+)
+
+// Valid indicates whether the value is a known member of the TeamWeeklyRepFocusKind enum.
+func (e TeamWeeklyRepFocusKind) Valid() bool {
+	switch e {
+	case CommitmentsMissed:
+		return true
+	case HelpRequested:
+		return true
+	case LeadsBreached:
+		return true
+	case MeetingsWithoutNextStep:
+		return true
+	case QuietWeek:
+		return true
+	case StrongWeek:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for TechnicalEnrichLaneLane.
 const (
 	TechnicalEnrichLaneCertLog  TechnicalEnrichLaneLane = "certlog"
@@ -28406,6 +28436,81 @@ type TeamListResponse struct {
 	Page PageInfo `json:"page"`
 }
 
+// TeamWeeklyCounts defines model for TeamWeeklyCounts.
+type TeamWeeklyCounts struct {
+	CommitmentsDue        int `json:"commitments_due"`
+	CommitmentsKept       int `json:"commitments_kept"`
+	DealsLost             int `json:"deals_lost"`
+	DealsWon              int `json:"deals_won"`
+	LeadsAnsweredInTarget int `json:"leads_answered_in_target"`
+	LeadsBreached         int `json:"leads_breached"`
+	LeadsRouted           int `json:"leads_routed"`
+	MeetingsHeld          int `json:"meetings_held"`
+	MeetingsWithNextStep  int `json:"meetings_with_next_step"`
+
+	// RepsCounted Members whose week was read and totalled.
+	RepsCounted int `json:"reps_counted"`
+}
+
+// TeamWeeklyRep One member's week as their lead reads it, with the one thing to raise.
+type TeamWeeklyRep struct {
+	CommitmentsDue  int `json:"commitments_due"`
+	CommitmentsKept int `json:"commitments_kept"`
+	DealsWon        int `json:"deals_won"`
+
+	// DisplayName What they were called that week — frozen, and it survives the seat being deleted.
+	DisplayName string `json:"display_name"`
+
+	// FocusKind Which rule picked the focus, so a reader can tell a coaching prompt from a thing to
+	// celebrate. Tried in the order a lead should raise them: a rep who ASKED for help
+	// outranks any metric, because walking past a request to raise a number is the
+	// fastest way to teach them not to ask.
+	FocusKind TeamWeeklyRepFocusKind `json:"focus_kind"`
+
+	// FocusLabel The focus in words, composed from the stored figures — never model-written, so it
+	// cannot say something the snapshot does not hold.
+	FocusLabel string `json:"focus_label"`
+
+	// HelpRequested Commitments they asked for help on.
+	HelpRequested int                `json:"help_requested"`
+	LeadsBreached int                `json:"leads_breached"`
+	MeetingsHeld  int                `json:"meetings_held"`
+	UserId        openapi_types.UUID `json:"user_id"`
+}
+
+// TeamWeeklyRepFocusKind Which rule picked the focus, so a reader can tell a coaching prompt from a thing to
+// celebrate. Tried in the order a lead should raise them: a rep who ASKED for help
+// outranks any metric, because walking past a request to raise a number is the
+// fastest way to teach them not to ask.
+type TeamWeeklyRepFocusKind string
+
+// TeamWeeklyReview One team's week, as it was measured when the week closed.
+type TeamWeeklyReview struct {
+	AsOf           time.Time          `json:"as_of"`
+	Counts         TeamWeeklyCounts   `json:"counts"`
+	GeneratedAt    time.Time          `json:"generated_at"`
+	Id             openapi_types.UUID `json:"id"`
+	LocalWeekStart openapi_types.Date `json:"local_week_start"`
+
+	// Pipeline What the team's week did to the pipeline. ABSENT when any member's week could not
+	// be converted — summing only the ones that did would be a confident number quietly
+	// missing a rep.
+	Pipeline *WeeklyReviewPipeline `json:"pipeline,omitempty"`
+
+	// Reps Who was on the team that week — the frozen membership, which a join against the
+	// live team could never answer.
+	Reps []TeamWeeklyRep `json:"reps"`
+
+	// RepsUnread Members whose week could not be read at all. Zero is the claim that every member's
+	// week was counted.
+	RepsUnread *int               `json:"reps_unread,omitempty"`
+	TeamId     openapi_types.UUID `json:"team_id"`
+
+	// TeamName What the team was called that week. Frozen, so a team renamed in June does not
+	// relabel March's snapshot.
+	TeamName string `json:"team_name"`
+}
+
 // TechnicalEnrichLane What one public source last did.
 type TechnicalEnrichLane struct {
 	// Attempts How many times this lane has been tried since it last succeeded.
@@ -34810,6 +34915,16 @@ type SetWeeklyPlanCommitmentStateJSONBodyState string
 // GetLatestWeeklyReviewParams defines parameters for GetLatestWeeklyReview.
 type GetLatestWeeklyReviewParams struct {
 	// Week The Monday of the week to open, in the installation reporting timezone. Omitted serves the most recent.
+	Week *openapi_types.Date `form:"week,omitempty" json:"week,omitempty"`
+}
+
+// GetTeamWeeklyReviewParams defines parameters for GetTeamWeeklyReview.
+type GetTeamWeeklyReviewParams struct {
+	// Team Which team's week to read.
+	Team openapi_types.UUID `form:"team" json:"team"`
+
+	// Week The Monday of the week wanted. Omitted means the most recent snapshot this team
+	// has.
 	Week *openapi_types.Date `form:"week,omitempty" json:"week,omitempty"`
 }
 
@@ -44881,6 +44996,9 @@ type ServerInterface interface {
 	// The acting rep's most recent weekly review, or a named week's.
 	// (GET /weekly-reviews/latest)
 	GetLatestWeeklyReview(w http.ResponseWriter, r *http.Request, params GetLatestWeeklyReviewParams)
+	// A team's week, frozen — what each member's week came to, and the one thing to raise.
+	// (GET /weekly-reviews/team)
+	GetTeamWeeklyReview(w http.ResponseWriter, r *http.Request, params GetTeamWeeklyReviewParams)
 	// The rep's day as ONE ranked queue — every actionable item, ordered by what to do next.
 	// (GET /worklist)
 	GetWorklist(w http.ResponseWriter, r *http.Request, params GetWorklistParams)
@@ -48214,6 +48332,12 @@ func (_ Unimplemented) ListWeeklyReviews(w http.ResponseWriter, r *http.Request)
 // The acting rep's most recent weekly review, or a named week's.
 // (GET /weekly-reviews/latest)
 func (_ Unimplemented) GetLatestWeeklyReview(w http.ResponseWriter, r *http.Request, params GetLatestWeeklyReviewParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// A team's week, frozen — what each member's week came to, and the one thing to raise.
+// (GET /weekly-reviews/team)
+func (_ Unimplemented) GetTeamWeeklyReview(w http.ResponseWriter, r *http.Request, params GetTeamWeeklyReviewParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -72301,6 +72425,60 @@ func (siw *ServerInterfaceWrapper) GetLatestWeeklyReview(w http.ResponseWriter, 
 	handler.ServeHTTP(w, r)
 }
 
+// GetTeamWeeklyReview operation middleware
+func (siw *ServerInterfaceWrapper) GetTeamWeeklyReview(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetTeamWeeklyReviewParams
+
+	// ------------- Required query parameter "team" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "team", r.URL.Query(), &params.Team, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "team"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "team", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "week" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "week", r.URL.Query(), &params.Week, runtime.BindQueryParameterOptions{Type: "string", Format: "date"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "week"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "week", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTeamWeeklyReview(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetWorklist operation middleware
 func (siw *ServerInterfaceWrapper) GetWorklist(w http.ResponseWriter, r *http.Request) {
 
@@ -74177,6 +74355,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/weekly-reviews/latest", wrapper.GetLatestWeeklyReview)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/weekly-reviews/team", wrapper.GetTeamWeeklyReview)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/worklist", wrapper.GetWorklist)

--- a/backend/migrations/core/1788312572_the_team_week_is_frozen_too.down.sql
+++ b/backend/migrations/core/1788312572_the_team_week_is_frozen_too.down.sql
@@ -1,0 +1,4 @@
+SET LOCAL lock_timeout = '5s';
+
+DROP TABLE IF EXISTS team_weekly_review_rep;
+DROP TABLE IF EXISTS team_weekly_review;

--- a/backend/migrations/core/1788312572_the_team_week_is_frozen_too.up.sql
+++ b/backend/migrations/core/1788312572_the_team_week_is_frozen_too.up.sql
@@ -1,0 +1,149 @@
+-- The team's week, frozen the way each rep's already is.
+--
+-- WHY IT IS STORED RATHER THAN SUMMED ON READ. Every figure here is a total
+-- over the member reviews, so a read-time SUM would be simpler — and wrong.
+-- Team membership moves: a rep who joins in October would silently appear in
+-- last March's team week, one who leaves would silently vanish from it, and a
+-- lead comparing two quarters would be comparing two different teams without
+-- being told. The same reason weekly_review freezes its own counts rather than
+-- recomputing them, and the same reason weekly_review_deal stores the label
+-- beside the id.
+--
+-- So the membership is frozen INTO the snapshot: the rep rows below name who
+-- was on the team that week, with the display name they had then.
+SET LOCAL lock_timeout = '5s';
+
+CREATE TABLE team_weekly_review (
+    id uuid DEFAULT uuidv7() NOT NULL,
+    team_id uuid NOT NULL,
+    -- The Monday under review, in the installation's reporting zone — the same
+    -- shape and zone weekly_review.local_week_start uses, so a team week and
+    -- the rep weeks inside it name the same seven days.
+    local_week_start date NOT NULL,
+    -- The team's name that week. Frozen for the reason every label here is: a
+    -- team renamed in June must not relabel March's snapshot.
+    team_name text NOT NULL,
+    generated_at timestamptz DEFAULT now() NOT NULL,
+    as_of timestamptz NOT NULL,
+
+    -- The team's own totals, summed over the member reviews at write time.
+    reps_counted int DEFAULT 0 NOT NULL,
+    deals_won int DEFAULT 0 NOT NULL,
+    deals_lost int DEFAULT 0 NOT NULL,
+    leads_routed int DEFAULT 0 NOT NULL,
+    leads_answered_in_target int DEFAULT 0 NOT NULL,
+    leads_breached int DEFAULT 0 NOT NULL,
+    meetings_held int DEFAULT 0 NOT NULL,
+    meetings_with_next_step int DEFAULT 0 NOT NULL,
+    commitments_due int DEFAULT 0 NOT NULL,
+    commitments_kept int DEFAULT 0 NOT NULL,
+
+    -- Money the team's week moved, in the installation's base currency.
+    --
+    -- NULLABLE together with its currency, and for the reason the per-rep
+    -- figures are: a member week that could not be converted makes the team
+    -- total unanswerable too. Summing the ones that DID convert would be a
+    -- confident number quietly missing a rep, which is worse than an absent
+    -- one — and a lead comparing two weeks would not be told.
+    pipeline_created_minor bigint,
+    pipeline_won_minor bigint,
+    pipeline_lost_minor bigint,
+    base_currency text,
+
+    -- Which member weeks this snapshot could not read at all.
+    --
+    -- A count rather than a list: the names are in the rep rows, and a team
+    -- week that silently covered four of six reps reads exactly like a team of
+    -- four. Zero is the claim that every member's week was counted.
+    reps_unread int DEFAULT 0 NOT NULL,
+
+    CONSTRAINT team_weekly_review_pkey PRIMARY KEY (id),
+    CONSTRAINT team_weekly_review_counts_are_tallies CHECK (
+        reps_counted >= 0 AND reps_unread >= 0
+        AND deals_won >= 0 AND deals_lost >= 0
+        AND leads_routed >= 0 AND leads_answered_in_target >= 0 AND leads_breached >= 0
+        AND meetings_held >= 0 AND meetings_with_next_step >= 0
+        AND commitments_due >= 0 AND commitments_kept >= 0
+        AND (pipeline_created_minor IS NULL OR pipeline_created_minor >= 0)
+        AND (pipeline_won_minor IS NULL OR pipeline_won_minor >= 0)
+        AND (pipeline_lost_minor IS NULL OR pipeline_lost_minor >= 0)),
+    -- A subset is never larger than the set it is drawn from.
+    CONSTRAINT team_weekly_review_subsets CHECK (
+        meetings_with_next_step <= meetings_held
+        AND commitments_kept <= commitments_due
+        AND leads_answered_in_target + leads_breached <= leads_routed),
+    -- A converted figure names its currency, and a currency names figures.
+    CONSTRAINT team_weekly_review_money_names_its_currency CHECK (
+        (base_currency IS NULL) = (pipeline_created_minor IS NULL
+                                   AND pipeline_won_minor IS NULL
+                                   AND pipeline_lost_minor IS NULL)),
+    CONSTRAINT team_weekly_review_currency_check CHECK (
+        base_currency IS NULL OR base_currency ~ '^[A-Z]{3}$'),
+    CONSTRAINT team_weekly_review_name_present CHECK (btrim(team_name) <> '')
+);
+
+-- One snapshot per team per week. The same arbiter weekly_review uses: the job
+-- runs more than once inside a week so a worker that was down still backfills,
+-- and this collapses those runs into one.
+ALTER TABLE team_weekly_review
+    ADD CONSTRAINT uq_team_weekly_review_team_week UNIQUE (team_id, local_week_start);
+
+-- NO FOREIGN KEY on team_id, deliberately, and the same ruling
+-- weekly_review_deal makes about deal_id: a team disbanded in June must leave
+-- March's snapshot saying what it said. team_name is stored beside the id for
+-- exactly that case.
+
+CREATE INDEX idx_team_weekly_review_team
+    ON team_weekly_review (team_id, local_week_start DESC);
+
+-- One row per rep who was on the team that week.
+--
+-- This IS the frozen membership. Reading it back tells a lead who was on the
+-- team in March, which a join against team_membership could never answer.
+CREATE TABLE team_weekly_review_rep (
+    id uuid DEFAULT uuidv7() NOT NULL,
+    team_weekly_review_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    -- What they were called that week. Frozen for the reason every label here
+    -- is, and it also survives the seat being deleted.
+    display_name text NOT NULL,
+
+    deals_won int DEFAULT 0 NOT NULL,
+    leads_breached int DEFAULT 0 NOT NULL,
+    meetings_held int DEFAULT 0 NOT NULL,
+    commitments_due int DEFAULT 0 NOT NULL,
+    commitments_kept int DEFAULT 0 NOT NULL,
+    help_requested int DEFAULT 0 NOT NULL,
+
+    -- The one thing this rep's lead should raise with them, and which rule
+    -- picked it. Every team has one per rep — including a rep whose week went
+    -- well, whose focus is the thing the team should copy.
+    focus_kind text NOT NULL,
+    focus_label text NOT NULL,
+
+    CONSTRAINT team_weekly_review_rep_pkey PRIMARY KEY (id),
+    CONSTRAINT team_weekly_review_rep_counts_are_tallies CHECK (
+        deals_won >= 0 AND leads_breached >= 0 AND meetings_held >= 0
+        AND commitments_due >= 0 AND commitments_kept >= 0 AND help_requested >= 0
+        AND commitments_kept <= commitments_due),
+    CONSTRAINT team_weekly_review_rep_name_present CHECK (btrim(display_name) <> ''),
+    CONSTRAINT team_weekly_review_rep_focus_present CHECK (btrim(focus_label) <> ''),
+    -- The rule that fired, so a reader can tell a coaching prompt from a thing
+    -- to celebrate — and so a test can assert the positive fallback is
+    -- reachable rather than trusting that it is.
+    CONSTRAINT team_weekly_review_rep_focus_kind_check CHECK (
+        focus_kind IN ('help_requested', 'leads_breached', 'commitments_missed',
+                       'meetings_without_next_step', 'strong_week', 'quiet_week'))
+);
+
+ALTER TABLE team_weekly_review_rep
+    ADD CONSTRAINT team_weekly_review_rep_review_fkey FOREIGN KEY (team_weekly_review_id)
+    REFERENCES team_weekly_review(id) ON DELETE CASCADE;
+
+-- One row per rep per snapshot: a second would double every team total drawn
+-- from these rows.
+ALTER TABLE team_weekly_review_rep
+    ADD CONSTRAINT uq_team_weekly_review_rep UNIQUE (team_weekly_review_id, user_id);
+
+CREATE INDEX idx_team_weekly_review_rep_review
+    ON team_weekly_review_rep (team_weekly_review_id, display_name);

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2353,6 +2353,8 @@ public.idx_taggable_entity CREATE INDEX idx_taggable_entity ON public.taggable U
 public.idx_taggable_tag CREATE INDEX idx_taggable_tag ON public.taggable USING btree (tag_id)
 public.idx_team_membership_team CREATE INDEX idx_team_membership_team ON public.team_membership USING btree (team_id)
 public.idx_team_membership_user CREATE INDEX idx_team_membership_user ON public.team_membership USING btree (user_id)
+public.idx_team_weekly_review_rep_review CREATE INDEX idx_team_weekly_review_rep_review ON public.team_weekly_review_rep USING btree (team_weekly_review_id, display_name)
+public.idx_team_weekly_review_team CREATE INDEX idx_team_weekly_review_team ON public.team_weekly_review USING btree (team_id, local_week_start DESC)
 public.idx_technical_lookup_cache_expiry CREATE INDEX idx_technical_lookup_cache_expiry ON public.technical_lookup_cache USING btree (expires_at)
 public.idx_transcript_read_latest CREATE INDEX idx_transcript_read_latest ON public.transcript_read USING btree (activity_id, created_at DESC)
 public.idx_voice_corpus_profile CREATE INDEX idx_voice_corpus_profile ON public.voice_corpus_source USING btree (voice_profile_id, created_at DESC)
@@ -4478,6 +4480,57 @@ public.team_membership_pkey CREATE UNIQUE INDEX team_membership_pkey ON public.t
 public.team_membership_unique CREATE UNIQUE INDEX team_membership_unique ON public.team_membership USING btree (team_id, user_id)
 public.team_name_unique CREATE UNIQUE INDEX team_name_unique ON public.team USING btree (name)
 public.team_pkey CREATE UNIQUE INDEX team_pkey ON public.team USING btree (id)
+public.team_weekly_review acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
+public.team_weekly_review.as_of timestamp with time zone NOT NULL gen=- def=-
+public.team_weekly_review.base_currency text gen=- def=-
+public.team_weekly_review.commitments_due integer NOT NULL gen=- def=0
+public.team_weekly_review.commitments_kept integer NOT NULL gen=- def=0
+public.team_weekly_review.deals_lost integer NOT NULL gen=- def=0
+public.team_weekly_review.deals_won integer NOT NULL gen=- def=0
+public.team_weekly_review.generated_at timestamp with time zone NOT NULL gen=- def=now()
+public.team_weekly_review.id uuid NOT NULL gen=- def=uuidv7()
+public.team_weekly_review.leads_answered_in_target integer NOT NULL gen=- def=0
+public.team_weekly_review.leads_breached integer NOT NULL gen=- def=0
+public.team_weekly_review.leads_routed integer NOT NULL gen=- def=0
+public.team_weekly_review.local_week_start date NOT NULL gen=- def=-
+public.team_weekly_review.meetings_held integer NOT NULL gen=- def=0
+public.team_weekly_review.meetings_with_next_step integer NOT NULL gen=- def=0
+public.team_weekly_review.pipeline_created_minor bigint gen=- def=-
+public.team_weekly_review.pipeline_lost_minor bigint gen=- def=-
+public.team_weekly_review.pipeline_won_minor bigint gen=- def=-
+public.team_weekly_review.reps_counted integer NOT NULL gen=- def=0
+public.team_weekly_review.reps_unread integer NOT NULL gen=- def=0
+public.team_weekly_review.team_id uuid NOT NULL gen=- def=-
+public.team_weekly_review.team_name text NOT NULL gen=- def=-
+public.team_weekly_review.team_weekly_review_counts_are_tallies CHECK (((reps_counted >= 0) AND (reps_unread >= 0) AND (deals_won >= 0) AND (deals_lost >= 0) AND (leads_routed >= 0) AND (leads_answered_in_target >= 0) AND (leads_breached >= 0) AND (meetings_held >= 0) AND (meetings_with_next_step >= 0) AND (commitments_due >= 0) AND (commitments_kept >= 0) AND ((pipeline_created_minor IS NULL) OR (pipeline_created_minor >= 0)) AND ((pipeline_won_minor IS NULL) OR (pipeline_won_minor >= 0)) AND ((pipeline_lost_minor IS NULL) OR (pipeline_lost_minor >= 0))))
+public.team_weekly_review.team_weekly_review_currency_check CHECK (((base_currency IS NULL) OR (base_currency ~ '^[A-Z]{3}$'::text)))
+public.team_weekly_review.team_weekly_review_money_names_its_currency CHECK (((base_currency IS NULL) = ((pipeline_created_minor IS NULL) AND (pipeline_won_minor IS NULL) AND (pipeline_lost_minor IS NULL))))
+public.team_weekly_review.team_weekly_review_name_present CHECK ((btrim(team_name) <> ''::text))
+public.team_weekly_review.team_weekly_review_pkey PRIMARY KEY (id)
+public.team_weekly_review.team_weekly_review_subsets CHECK (((meetings_with_next_step <= meetings_held) AND (commitments_kept <= commitments_due) AND ((leads_answered_in_target + leads_breached) <= leads_routed)))
+public.team_weekly_review.uq_team_weekly_review_team_week UNIQUE (team_id, local_week_start)
+public.team_weekly_review_pkey CREATE UNIQUE INDEX team_weekly_review_pkey ON public.team_weekly_review USING btree (id)
+public.team_weekly_review_rep acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
+public.team_weekly_review_rep.commitments_due integer NOT NULL gen=- def=0
+public.team_weekly_review_rep.commitments_kept integer NOT NULL gen=- def=0
+public.team_weekly_review_rep.deals_won integer NOT NULL gen=- def=0
+public.team_weekly_review_rep.display_name text NOT NULL gen=- def=-
+public.team_weekly_review_rep.focus_kind text NOT NULL gen=- def=-
+public.team_weekly_review_rep.focus_label text NOT NULL gen=- def=-
+public.team_weekly_review_rep.help_requested integer NOT NULL gen=- def=0
+public.team_weekly_review_rep.id uuid NOT NULL gen=- def=uuidv7()
+public.team_weekly_review_rep.leads_breached integer NOT NULL gen=- def=0
+public.team_weekly_review_rep.meetings_held integer NOT NULL gen=- def=0
+public.team_weekly_review_rep.team_weekly_review_id uuid NOT NULL gen=- def=-
+public.team_weekly_review_rep.team_weekly_review_rep_counts_are_tallies CHECK (((deals_won >= 0) AND (leads_breached >= 0) AND (meetings_held >= 0) AND (commitments_due >= 0) AND (commitments_kept >= 0) AND (help_requested >= 0) AND (commitments_kept <= commitments_due)))
+public.team_weekly_review_rep.team_weekly_review_rep_focus_kind_check CHECK ((focus_kind = ANY (ARRAY['help_requested'::text, 'leads_breached'::text, 'commitments_missed'::text, 'meetings_without_next_step'::text, 'strong_week'::text, 'quiet_week'::text])))
+public.team_weekly_review_rep.team_weekly_review_rep_focus_present CHECK ((btrim(focus_label) <> ''::text))
+public.team_weekly_review_rep.team_weekly_review_rep_name_present CHECK ((btrim(display_name) <> ''::text))
+public.team_weekly_review_rep.team_weekly_review_rep_pkey PRIMARY KEY (id)
+public.team_weekly_review_rep.team_weekly_review_rep_review_fkey FOREIGN KEY (team_weekly_review_id) REFERENCES team_weekly_review(id) ON DELETE CASCADE
+public.team_weekly_review_rep.uq_team_weekly_review_rep UNIQUE (team_weekly_review_id, user_id)
+public.team_weekly_review_rep.user_id uuid NOT NULL gen=- def=-
+public.team_weekly_review_rep_pkey CREATE UNIQUE INDEX team_weekly_review_rep_pkey ON public.team_weekly_review_rep USING btree (id)
 public.technical_lookup_cache acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.technical_lookup_cache.answer jsonb NOT NULL gen=- def=-
 public.technical_lookup_cache.expires_at timestamp with time zone NOT NULL gen=- def=-
@@ -4639,6 +4692,8 @@ public.uq_site_read_triage_inflight CREATE UNIQUE INDEX uq_site_read_triage_infl
 public.uq_site_read_ws_id CREATE UNIQUE INDEX uq_site_read_ws_id ON public.site_read USING btree (id)
 public.uq_stage_position CREATE UNIQUE INDEX uq_stage_position ON public.stage USING btree (pipeline_id, "position") WHERE (archived_at IS NULL)
 public.uq_tag_name CREATE UNIQUE INDEX uq_tag_name ON public.tag USING btree (lower(name))
+public.uq_team_weekly_review_rep CREATE UNIQUE INDEX uq_team_weekly_review_rep ON public.team_weekly_review_rep USING btree (team_weekly_review_id, user_id)
+public.uq_team_weekly_review_team_week CREATE UNIQUE INDEX uq_team_weekly_review_team_week ON public.team_weekly_review USING btree (team_id, local_week_start)
 public.uq_transcript_read_inflight CREATE UNIQUE INDEX uq_transcript_read_inflight ON public.transcript_read USING btree (activity_id) WHERE (status = ANY (ARRAY['queued'::text, 'running'::text]))
 public.uq_voice_corpus_source_ref CREATE UNIQUE INDEX uq_voice_corpus_source_ref ON public.voice_corpus_source USING btree (voice_profile_id, source_ref)
 public.uq_voice_learning_signal_draft CREATE UNIQUE INDEX uq_voice_learning_signal_draft ON public.voice_learning_signal USING btree (draft_ref_hash)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -10290,6 +10290,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/weekly-reviews/team": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * A team's week, frozen — what each member's week came to, and the one thing to raise.
+         * @description The team half of the weekly. `/worklist/team` answers what the team is carrying NOW,
+         *     live and recomputed on every open; this answers what last week WAS, written once when
+         *     the week closed, so two weeks can be compared and neither moves under the comparison.
+         *
+         *     WHY IT IS STORED RATHER THAN SUMMED. Every figure is a total over the member reviews.
+         *     Team membership moves, so a read-time sum would silently put a rep who joined in
+         *     October into last March's team week and drop one who left — and a lead comparing two
+         *     quarters would be comparing two different teams without being told. The membership is
+         *     frozen INTO the snapshot: the rep rows name who was on the team that week, with the
+         *     name they had then.
+         *
+         *     Every rep gets ONE focus, including the rep whose week went well — theirs names what
+         *     the team should copy. A page promising one focus per rep and delivering rows only for
+         *     the troubled ones reads as a team where only those people exist.
+         *
+         *     `reps_unread` counts the members whose week could not be read at all. Zero is the
+         *     claim that every member's week was counted; a snapshot silently covering four of six
+         *     reps reads exactly like a team of four.
+         *
+         *     403 for a reader whose row scope reaches only their own rows: a team snapshot is a
+         *     team question. 404 before the first Monday the team's week closed on.
+         */
+        get: operations["getTeamWeeklyReview"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/weekly-reviews/latest": {
         parameters: {
             query?: never;
@@ -25520,6 +25560,81 @@ export interface components {
         WeeklyReviewIndex: {
             /** @description The Monday of each week with a review, newest first. */
             weeks: string[];
+        };
+        /** @description One team's week, as it was measured when the week closed. */
+        TeamWeeklyReview: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            team_id: string;
+            /**
+             * @description What the team was called that week. Frozen, so a team renamed in June does not
+             *     relabel March's snapshot.
+             */
+            team_name: string;
+            /** Format: date */
+            local_week_start: string;
+            /** Format: date-time */
+            generated_at: string;
+            /** Format: date-time */
+            as_of: string;
+            counts: components["schemas"]["TeamWeeklyCounts"];
+            /**
+             * @description What the team's week did to the pipeline. ABSENT when any member's week could not
+             *     be converted — summing only the ones that did would be a confident number quietly
+             *     missing a rep.
+             */
+            pipeline?: components["schemas"]["WeeklyReviewPipeline"];
+            /**
+             * @description Members whose week could not be read at all. Zero is the claim that every member's
+             *     week was counted.
+             */
+            reps_unread?: number;
+            /**
+             * @description Who was on the team that week — the frozen membership, which a join against the
+             *     live team could never answer.
+             */
+            reps: components["schemas"]["TeamWeeklyRep"][];
+        };
+        TeamWeeklyCounts: {
+            /** @description Members whose week was read and totalled. */
+            reps_counted: number;
+            deals_won: number;
+            deals_lost: number;
+            leads_routed: number;
+            leads_answered_in_target: number;
+            leads_breached: number;
+            meetings_held: number;
+            meetings_with_next_step: number;
+            commitments_due: number;
+            commitments_kept: number;
+        };
+        /** @description One member's week as their lead reads it, with the one thing to raise. */
+        TeamWeeklyRep: {
+            /** Format: uuid */
+            user_id: string;
+            /** @description What they were called that week — frozen, and it survives the seat being deleted. */
+            display_name: string;
+            deals_won: number;
+            leads_breached: number;
+            meetings_held: number;
+            commitments_due: number;
+            commitments_kept: number;
+            /** @description Commitments they asked for help on. */
+            help_requested: number;
+            /**
+             * @description Which rule picked the focus, so a reader can tell a coaching prompt from a thing to
+             *     celebrate. Tried in the order a lead should raise them: a rep who ASKED for help
+             *     outranks any metric, because walking past a request to raise a number is the
+             *     fastest way to teach them not to ask.
+             * @enum {string}
+             */
+            focus_kind: "help_requested" | "leads_breached" | "commitments_missed" | "meetings_without_next_step" | "strong_week" | "quiet_week";
+            /**
+             * @description The focus in words, composed from the stored figures — never model-written, so it
+             *     cannot say something the snapshot does not hold.
+             */
+            focus_label: string;
         };
         /**
          * @description One rep's week, as it was measured when the week closed. Every count is as-of `as_of`,
@@ -44198,6 +44313,37 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+        };
+    };
+    getTeamWeeklyReview: {
+        parameters: {
+            query: {
+                /** @description Which team's week to read. */
+                team: string;
+                /**
+                 * @description The Monday of the week wanted. Omitted means the most recent snapshot this team
+                 *     has.
+                 */
+                week?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The team's frozen week. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TeamWeeklyReview"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
         };
     };
     getLatestWeeklyReview: {


### PR DESCRIPTION
`GET /worklist/team` answers what a team is carrying **now** — live, recomputed on every open. This answers what last week **was**, written once when the week closed, so two weeks can be compared and neither moves under the comparison.

## Why it is stored rather than summed on read

Every figure is a total over the member reviews, so a read-time `SUM` would be simpler and wrong.

**Team membership moves.** A rep who joins in October would silently appear in last March's team week; one who leaves would silently vanish from it; and a lead comparing two quarters would be comparing two different teams without being told.

So the membership is frozen **into** the snapshot: the rep rows name who was on the team that week, with the name they had then — which a join against the live team could never answer. The same ruling `weekly_review_deal` makes about storing a deal's label beside its id.

## One focus per rep, always

Including the rep whose week went well, whose focus names what the team should copy. A page promising one focus per rep and delivering rows only for the troubled ones reads as a team where only those people exist — and is demoralising to be listed in.

The rules are tried in the order a lead should raise them, and a rep who **asked** for help outranks any metric. Walking past a request already made to raise a number is the fastest way to teach someone not to ask.

The label is composed from the stored figures, never model-written, so it cannot say something the snapshot does not hold. `focus_kind` records which rule fired, so a reader can tell a coaching prompt from a thing to celebrate — and so a test can assert the positive fallback is reachable rather than trusting that it is.

## Absence is said, not implied

A member with no review for the week is counted as **unread**, not as a zero row: a rep on leave and a rep whose measurement failed look identical as zeros, and only one of those is a fact about their week. `reps_unread: 0` is the claim that every member's week was counted.

The money is absent when **any** member's week could not be converted. Summing only the ones that did would be a confident number quietly missing a rep.

## The job's third phase

It runs after every rep review is written, and after the mail. A snapshot assembled while reps were still being measured would freeze a team that was half-counted and nothing afterwards would say so. It is assembled under a **member's** authority, never a system principal — which would bypass both the object grant and the row scope.

## Tests

Four integration tests over real Postgres and four unit tests over the focus rule. The freeze and the unread guard were mutation-checked: reading the display name live fails the freeze test, and treating a missing week as zeros fails the unread test with all three assertions.

Craft flagged `weeklyjobs.go` at the size cap; the team phase moved to its own file rather than taking a waiver — it is a different subject from the per-rep pass beside it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a frozen team weekly review so a lead can compare two weeks without either moving under the comparison.

**New Features**
- Freezes team membership, display names, and figures into the snapshot at week close; later joins, leaves, and renames don't rewrite history.
- Every member gets one focus, help requests outrank metrics, and members without a week are `reps_unread`, not zero rows.
- Pipeline money is absent unless every member's week converted.
- The job assembles snapshots as a third phase, after all rep reviews and mail, under a member's authority.
- `GET /weekly-reviews/team` returns 403 to own-scoped readers and 404 before the first snapshot exists.
- Adds `team_weekly_review` and `team_weekly_review_rep` tables; assembly is idempotent per team and week.

<sup>Written for commit b412386543f636407776af8cc5ccf2a2224a2200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added team weekly review snapshots with aggregate performance metrics and per-member activity details.
  * Added coaching focus indicators, including help requests, missed commitments, breached leads, and strong or quiet weeks.
  * Added an API endpoint to retrieve the latest or a specified team review.
  * Team membership, names, and review data are frozen for consistent historical reporting.
  * Weekly processing now generates snapshots automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->