### PR TITLE
main is green again: an unused function and a query budget

### DIFF
--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -194,7 +194,13 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// per project, and the open commitment they made to us per project. Each
 	// is one statement over the whole page's ids, so the cost is flat in the
 	// number of deals and projects exactly like the sections they decorate.
-	const budget = 42
+	//
+	// 43 since the account owes card (#3629): one read of the open promises
+	// filed against the account, bounded by its own limit rather than by how
+	// many there are — the same statement the next-steps section already ran,
+	// asked a second time at a different bound. Flat in the size of the
+	// account, like every section above.
+	const budget = 43
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}

--- a/backend/internal/compose/weekly/teamreviewstore.go
+++ b/backend/internal/compose/weekly/teamreviewstore.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -274,21 +273,4 @@ func readTeamReps(ctx context.Context, tx pgx.Tx, reviewID ids.UUID) ([]TeamRep,
 		out = append(out, rep)
 	}
 	return out, rows.Err()
-}
-
-// teamNameOf reads a team's current name, for stamping into a new snapshot.
-func teamNameOf(ctx context.Context, tx pgx.Tx, teamID ids.UUID) (string, error) {
-	var name string
-	err := tx.QueryRow(ctx,
-		`SELECT name FROM team WHERE id = $1 AND archived_at IS NULL`, teamID).Scan(&name)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return "", apperrors.ErrNotFound
-	}
-	if err != nil {
-		return "", fmt.Errorf("weekly: reading the team's name: %w", err)
-	}
-	if strings.TrimSpace(name) == "" {
-		return "", apperrors.ErrNotFound
-	}
-	return name, nil
 }


### PR DESCRIPTION
Two failures on `main`, each of which failed the other's fix, so they travel together.

## 1. lint: a function nothing calls

```
internal/compose/weekly/teamreviewstore.go:280:6: func teamNameOf is unused (unused)
```

`AssembleTeamFor(ctx, teamID, teamName, members, now)` takes the name from its caller and stamps it straight into the snapshot, which left `teamNameOf` with nothing calling it.

Deleted rather than waived. What it did is now the caller's to do, and a reader finding both would reasonably wonder which one the snapshot trusts — the answer being that only one of them still runs.

## 2. shard 4: the org360 query budget

```
org360_querycount_integration_test.go:199: one 360 issued 43 queries, budget is 42
```

#3629 added the account-owes card, which asks `readNextSteps` a second time at a different bound, and left the budget at 42.

The property this test protects is the flatness assertion above the budget — `largeCost != smallCost` fails if the composite read grows with the account — and that still passes: the new read is one statement bounded by its own limit rather than by how many promises exist, so a large account costs exactly what a small one does. The number only records where the flat cost now sits, which is what every entry in that comment block says of itself, so this raises it and adds the paragraph naming the section that moved it.

There is a precedent two paragraphs above, from the last time it moved without one: "The number moved without this line and the gate went red on main for every branch cut afterwards."

`make check-backend` green; the org360 integration package green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal team-name handling by removing unused code.
  * No user-facing behavior or public features were changed.

* **Tests**
  * Updated integration test coverage to reflect the current number of organization data queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->