### PR TITLE
The org360 budget records the account-owes card

### DIFF
--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -194,7 +194,13 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// per project, and the open commitment they made to us per project. Each
 	// is one statement over the whole page's ids, so the cost is flat in the
 	// number of deals and projects exactly like the sections they decorate.
-	const budget = 42
+	//
+	// 43 since the account owes card (#3629): one read of the open promises
+	// filed against the account, bounded by its own limit rather than by how
+	// many there are — the same statement the next-steps section already ran,
+	// asked a second time at a different bound. Flat in the size of the
+	// account, like every section above.
+	const budget = 43
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}


### PR DESCRIPTION
`main` fails the org360 query budget on every branch:

```
org360_querycount_integration_test.go:199: one 360 issued 43 queries, budget is 42
```

#3629 added the account-owes card, which asks `readNextSteps` a second time at a different bound, and left the budget at 42.

## Why 43 rather than an investigation

The property this test protects is the flatness assertion above the budget — `largeCost != smallCost` fails if the composite read grows with the account — and that still passes. The new read is one statement bounded by its own limit rather than by how many promises exist, so a large account costs exactly what a small one does.

The number only records where the flat cost now sits, which is what every entry in that comment block says of itself. So this raises it and adds the paragraph naming the section that moved it, in the same idiom as the eight above it (including the one that notes the last time this number moved without its line and "the gate went red on main for every branch cut afterwards").

`make check-backend` green; the org360 integration package green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the integration test’s query budget to account for an additional account-promises read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->