### PR TITLE
fix(weekly): remove teamNameOf, orphaned since AssembleTeamFor takes the name as a parameter

### DIFF
--- a/backend/internal/compose/weekly/teamreviewstore.go
+++ b/backend/internal/compose/weekly/teamreviewstore.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -274,21 +273,4 @@ func readTeamReps(ctx context.Context, tx pgx.Tx, reviewID ids.UUID) ([]TeamRep,
 		out = append(out, rep)
 	}
 	return out, rows.Err()
-}
-
-// teamNameOf reads a team's current name, for stamping into a new snapshot.
-func teamNameOf(ctx context.Context, tx pgx.Tx, teamID ids.UUID) (string, error) {
-	var name string
-	err := tx.QueryRow(ctx,
-		`SELECT name FROM team WHERE id = $1 AND archived_at IS NULL`, teamID).Scan(&name)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return "", apperrors.ErrNotFound
-	}
-	if err != nil {
-		return "", fmt.Errorf("weekly: reading the team's name: %w", err)
-	}
-	if strings.TrimSpace(name) == "" {
-		return "", apperrors.ErrNotFound
-	}
-	return name, nil
 }


### PR DESCRIPTION
## Summary

main is red: `golangci`'s `unused` check fails on `teamNameOf` in
`backend/internal/compose/weekly/teamreviewstore.go`, added alongside the
team-review snapshot work but never wired in. `AssembleTeamFor`'s only caller
(`weeklyteamjobs.go:125`) already carries the team's name from its own
listing query (`liveTeam.name`), so the helper never had a call site.

Removed the dead function and the `strings` import that only it used.
Verified `team.name` is genuinely sourced elsewhere before deleting — this
is not a missing wire-up, the helper was simply superseded.

## Test plan

- [x] `make check-backend` — green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `teamNameOf` helper from the weekly team review store, fixing the failing `golangci` unused check. The helper was never called; `AssembleTeamFor` already receives the team name from its caller. Also removes the `strings` import that only the helper used.

<sup>Written for commit 77fa5cda0a024f9a171b638312e216192bfdd137. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal team-name lookup logic and related validation.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->