### PR TITLE
test(worklist): cover FocusCard's acknowledge exclusion

### DIFF
--- a/frontend/src/screens/worklist.focus.test.tsx
+++ b/frontend/src/screens/worklist.focus.test.tsx
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { FocusCard, focusOf } from "./worklist.focus";
+
+// worthFocusing's promises: a routable top row is promoted, and `acknowledge`
+// never is — it names no record to route to, the same invariant
+// WorklistRow's own VERB_DESTINATION table holds for it.
+
+type WorklistItem = components["schemas"]["WorklistItem"];
+
+function dealItem(over: Partial<WorklistItem> = {}): WorklistItem {
+  return {
+    id: "deal-1",
+    source: "deal_at_risk",
+    category: "deals_at_risk",
+    level: 3,
+    consequence: "deal_slips_past_close",
+    title: "Acme Expansion",
+    because: [{ kind: "quiet_days", value: { kind: "days", days: 83 } }],
+    actions: ["open"],
+    primary_action: "open",
+    subject: {
+      type: "deal",
+      id: "01a05500-0000-7000-8000-000000000010",
+      label: "Acme Expansion",
+    },
+    ...over,
+  };
+}
+
+function renderCard(item: WorklistItem) {
+  return render(
+    <LocaleProvider initial="en">
+      <FocusCard item={item} />
+    </LocaleProvider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("the queue's top row, drawn as the one thing to do next", () => {
+  it("draws the card for a routable action", () => {
+    renderCard(dealItem());
+    expect(screen.getByText("Acme Expansion")).toBeTruthy();
+  });
+
+  it("draws nothing for a notice's acknowledge, even with a record to name", () => {
+    const { container } = renderCard(
+      dealItem({
+        source: "notice",
+        primary_action: "acknowledge",
+        actions: ["acknowledge"],
+      }),
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("focusOf promotes a routable top row", () => {
+    const top = dealItem();
+    expect(focusOf([top])).toBe(top);
+  });
+
+  it("focusOf excludes acknowledge from the queue's top row", () => {
+    const top = dealItem({
+      source: "notice",
+      primary_action: "acknowledge",
+      actions: ["acknowledge"],
+    });
+    expect(focusOf([top])).toBeUndefined();
+  });
+
+  it("draws nothing for review work — that is judgement, not a rep's next action", () => {
+    const { container } = renderCard(dealItem({ band: "review" }));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("focusOf answers undefined for an empty queue", () => {
+    expect(focusOf([])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #3612. That PR added an early return in `worthFocusing`
(`worklist.focus.tsx`) excluding a notice's `acknowledge` `primary_action`
from the focus card — it names no record to route to, the same invariant
`WorklistRow`'s `VERB_DESTINATION` table holds for it. It shipped with a
Storybook story (for `fe-uat`) but `worklist.focus.tsx` had no vitest unit
test file at all, so the new branch measured 0% in `fe-unit`'s coverage
report.

Added `worklist.focus.test.tsx` covering `FocusCard`/`focusOf` directly:
a routable top row is promoted, `acknowledge` is excluded even when the item
carries a routable subject, review-band work is excluded, and an empty
queue answers undefined. `worklist.focus.tsx` now measures 100%
statements/functions/lines, 80% branches.

## Test plan

- [x] `make check-fe` — green
- [x] Scoped coverage check: `pnpm exec vitest run src/screens/worklist.focus.test.tsx --coverage --coverage.include='src/screens/worklist.focus.tsx'` — 100% stmts/funcs/lines, 80% branches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the first unit tests for `worklist.focus.tsx`. `FocusCard` and `focusOf` previously had no vitest coverage, so the acknowledge exclusion added for focus cards had 0% coverage in `fe-unit`; the new tests bring statements, functions, and lines to 100% and branches to 80%.

- Covers routable top-row promotion, acknowledge exclusion even with a routable subject, review-band exclusion, and the empty queue.

<sup>Written for commit a1aed654eccaf909a5476677a2df7d7205adb0fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for worklist rendering and focus selection across routable work, notices, review items, and empty queues.
  * Added shared test fixtures and locale-aware rendering setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->