### PR TITLE
review_commitments answers what the screens answer

### DIFF
--- a/backend/internal/compose/commercialseams.go
+++ b/backend/internal/compose/commercialseams.go
@@ -21,6 +21,9 @@ package compose
 
 import (
 	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -30,8 +33,10 @@ import (
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/owedwork"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 )
 
@@ -48,23 +53,113 @@ const handoffScanLimit = 50
 // commitmentLister serves the open-promise set from the activities module's
 // own gated read.
 func commitmentLister(pool *pgxpool.Pool) agents.CommitmentLister {
-	store := activities.NewStore(InstallationDB(pool))
+	db := InstallationDB(pool)
+	tasks := activities.NewStore(db)
+	claims := people.NewStore(db)
 	return func(ctx context.Context, in agents.CommitmentQuery) (agents.CommitmentSweep, error) {
+		now := clockNow()
 		query := activities.ListOpenTasksInput{AssigneeID: in.AssigneeID, Limit: in.Limit}
 		if in.WithinProjectID != nil {
 			project := ids.From[ids.ProjectKind](*in.WithinProjectID)
 			query.WithinProjectID = &project
 		}
-		tasks, truncated, err := store.ListOpenTasks(ctx, query)
+		filed, filedMore, err := tasks.ListOpenTasks(ctx, query)
 		if err != nil {
 			return agents.CommitmentSweep{}, err
 		}
+		said, saidMore, err := extractedCommitments(ctx, pool, claims, in)
+		if err != nil {
+			return agents.CommitmentSweep{}, err
+		}
+		promises, cut := rankPromises(now, asCommitments(filed), asExtracted(said), in.Limit)
 		return agents.CommitmentSweep{
-			AsOf:        clockNow(),
-			Commitments: asCommitments(tasks),
-			Truncated:   truncated,
+			AsOf:        now,
+			Commitments: promises,
+			Truncated:   filedMore || saidMore || cut,
 		}, nil
 	}
+}
+
+// extractedCommitments reads the promises made in conversations, or none where
+// the caller narrowed to something a claim cannot answer.
+//
+// A CLAIM CARRIES NO ASSIGNEE and no project. It records what was SAID, in a
+// message filed against a person — so "this owner's promises" and "this
+// project's promises" are questions the claim table cannot answer, and a claim
+// admitted under either filter would be a row the caller did not ask for.
+// Returning none is the honest answer; the tool's own copy says the narrowed
+// answer covers recorded tasks alone.
+func extractedCommitments(
+	ctx context.Context, pool *pgxpool.Pool, store *people.Store, in agents.CommitmentQuery,
+) ([]people.OrgCommitment, bool, error) {
+	if in.AssigneeID != nil || in.WithinProjectID != nil {
+		return nil, false, nil
+	}
+	var out []people.OrgCommitment
+	var more bool
+	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		var err error
+		out, more, err = store.OpenCommitmentsAcrossWorkspace(ctx, tx, in.Limit)
+		return err
+	})
+	return out, more, err
+}
+
+// rankPromises merges the two sources into ONE answer, ordered by the rule
+// every surface uses, and cuts it to what the caller asked for.
+//
+// The merge is what makes this tool's answer the same answer the screens give.
+// Read task-only, it reported a promise made in a meeting and never typed as
+// absent — and a model told "these are the open commitments" repeats that as
+// fact. Ranking them together in kernel/owedwork is the same ordering the
+// contact and company cards apply, so an agent and a reader looking at one
+// account agree about what is most overdue.
+func rankPromises(now time.Time, filed, said []agents.OpenCommitment, limit int) ([]agents.OpenCommitment, bool) {
+	items := make([]owedwork.Item, 0, len(filed)+len(said))
+	for _, promise := range filed {
+		items = append(items, owedwork.Item{
+			Ref: promise, Source: owedwork.FromTask, DueAt: promise.DueAt,
+		})
+	}
+	for _, promise := range said {
+		items = append(items, owedwork.Item{
+			Ref: promise, Source: owedwork.FromClaim, DueAt: promise.DueAt,
+		})
+	}
+	out := make([]agents.OpenCommitment, 0, len(items))
+	for _, item := range owedwork.Sorted(items, now) {
+		promise, ok := item.Ref.(agents.OpenCommitment)
+		if !ok {
+			continue
+		}
+		out = append(out, promise)
+	}
+	if limit > 0 && len(out) > limit {
+		return out[:limit], true
+	}
+	return out, false
+}
+
+// asExtracted carries the claim rows across the seam. A rename and nothing
+// else: the store decided which rows, and the tool decides what state each is
+// in.
+func asExtracted(claims []people.OrgCommitment) []agents.OpenCommitment {
+	out := make([]agents.OpenCommitment, 0, len(claims))
+	for _, claim := range claims {
+		claimID, activityID := claim.ID, claim.ActivityID
+		out = append(out, agents.OpenCommitment{
+			Source: agents.CommitmentFromConversation,
+			// A claim names no owner: it records what was said, not who was
+			// handed it, so the answer says nobody owns it rather than naming
+			// the person it was promised TO as though they owed it.
+			ClaimID: &claimID, SourceActivityID: &activityID,
+			Quote: claim.SourceQuote, Subject: claim.Body, DueAt: claim.DueAt,
+			About: []agents.CommitmentAbout{{
+				EntityType: "person", EntityID: claim.PersonID.UUID, Name: claim.PersonName,
+			}},
+		})
+	}
+	return out
 }
 
 // asCommitments carries the store rows across the seam. It is a rename and
@@ -73,6 +168,7 @@ func commitmentLister(pool *pgxpool.Pool) agents.CommitmentLister {
 func asCommitments(tasks []activities.OpenTask) []agents.OpenCommitment {
 	out := make([]agents.OpenCommitment, 0, len(tasks))
 	for _, t := range tasks {
+		taskID := t.ID
 		about := make([]agents.CommitmentAbout, 0, len(t.About))
 		for _, a := range t.About {
 			about = append(about, agents.CommitmentAbout{
@@ -80,7 +176,8 @@ func asCommitments(tasks []activities.OpenTask) []agents.OpenCommitment {
 			})
 		}
 		out = append(out, agents.OpenCommitment{
-			TaskID: t.ID, Subject: t.Subject, DueAt: t.DueAt,
+			Source: agents.CommitmentFromTask,
+			TaskID: &taskID, Subject: t.Subject, DueAt: t.DueAt,
 			AssigneeID: t.AssigneeID, AssigneeName: t.AssigneeName, About: about,
 		})
 	}

--- a/backend/internal/compose/commercialseams.go
+++ b/backend/internal/compose/commercialseams.go
@@ -50,6 +50,14 @@ import (
 // seam and the tool withholds the claims a bounded read cannot support.
 const handoffScanLimit = 50
 
+// commitmentAboutPerson is the entity type a promise's "about" row carries when
+// the record it names is a contact.
+//
+// Its own constant rather than flipsource.go's flipObjectPerson: that one names
+// an object in the system-of-record FLIP, and borrowing it here would tie two
+// vocabularies together that are free to move apart.
+const commitmentAboutPerson = "person"
+
 // commitmentLister serves the open-promise set from the activities module's
 // own gated read.
 func commitmentLister(pool *pgxpool.Pool) agents.CommitmentLister {
@@ -58,7 +66,18 @@ func commitmentLister(pool *pgxpool.Pool) agents.CommitmentLister {
 	claims := people.NewStore(db)
 	return func(ctx context.Context, in agents.CommitmentQuery) (agents.CommitmentSweep, error) {
 		now := clockNow()
-		query := activities.ListOpenTasksInput{AssigneeID: in.AssigneeID, Limit: in.Limit}
+		// ONE bound for the merged answer, resolved here rather than left to
+		// each source's own default. The two disagree — the task read defaults
+		// to fifty and the claim read to two hundred — so a caller who omits
+		// the argument would get whatever the two happened to add up to, and
+		// be told nothing was cut.
+		asked := agents.CommitmentSweepLimit(in.Limit)
+		query := activities.ListOpenTasksInput{
+			AssigneeID: in.AssigneeID, Limit: asked,
+			// The bound cuts before the merge does, so the store has to keep
+			// the promise the ranking is about rather than the oldest ones.
+			MostRecentlySlippedFirst: true,
+		}
 		if in.WithinProjectID != nil {
 			project := ids.From[ids.ProjectKind](*in.WithinProjectID)
 			query.WithinProjectID = &project
@@ -67,11 +86,11 @@ func commitmentLister(pool *pgxpool.Pool) agents.CommitmentLister {
 		if err != nil {
 			return agents.CommitmentSweep{}, err
 		}
-		said, saidMore, err := extractedCommitments(ctx, pool, claims, in)
+		said, saidMore, err := extractedCommitments(ctx, pool, claims, in, asked)
 		if err != nil {
 			return agents.CommitmentSweep{}, err
 		}
-		promises, cut := rankPromises(now, asCommitments(filed), asExtracted(said), in.Limit)
+		promises, cut := rankPromises(now, asCommitments(filed), asExtracted(said), asked)
 		return agents.CommitmentSweep{
 			AsOf:        now,
 			Commitments: promises,
@@ -90,7 +109,8 @@ func commitmentLister(pool *pgxpool.Pool) agents.CommitmentLister {
 // Returning none is the honest answer; the tool's own copy says the narrowed
 // answer covers recorded tasks alone.
 func extractedCommitments(
-	ctx context.Context, pool *pgxpool.Pool, store *people.Store, in agents.CommitmentQuery,
+	ctx context.Context, pool *pgxpool.Pool, store *people.Store,
+	in agents.CommitmentQuery, limit int,
 ) ([]people.OrgCommitment, bool, error) {
 	if in.AssigneeID != nil || in.WithinProjectID != nil {
 		return nil, false, nil
@@ -99,7 +119,7 @@ func extractedCommitments(
 	var more bool
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		var err error
-		out, more, err = store.OpenCommitmentsAcrossWorkspace(ctx, tx, in.Limit)
+		out, more, err = store.OpenCommitmentsAcrossWorkspace(ctx, tx, limit)
 		return err
 	})
 	return out, more, err
@@ -118,12 +138,14 @@ func rankPromises(now time.Time, filed, said []agents.OpenCommitment, limit int)
 	items := make([]owedwork.Item, 0, len(filed)+len(said))
 	for _, promise := range filed {
 		items = append(items, owedwork.Item{
-			Ref: promise, Source: owedwork.FromTask, DueAt: promise.DueAt,
+			Ref: promise, Source: owedwork.FromTask,
+			DueAt: promise.DueAt, FiledAt: promise.FiledAt,
 		})
 	}
 	for _, promise := range said {
 		items = append(items, owedwork.Item{
-			Ref: promise, Source: owedwork.FromClaim, DueAt: promise.DueAt,
+			Ref: promise, Source: owedwork.FromClaim,
+			DueAt: promise.DueAt, FiledAt: promise.FiledAt,
 		})
 	}
 	out := make([]agents.OpenCommitment, 0, len(items))
@@ -134,7 +156,7 @@ func rankPromises(now time.Time, filed, said []agents.OpenCommitment, limit int)
 		}
 		out = append(out, promise)
 	}
-	if limit > 0 && len(out) > limit {
+	if len(out) > limit {
 		return out[:limit], true
 	}
 	return out, false
@@ -154,8 +176,10 @@ func asExtracted(claims []people.OrgCommitment) []agents.OpenCommitment {
 			// the person it was promised TO as though they owed it.
 			ClaimID: &claimID, SourceActivityID: &activityID,
 			Quote: claim.SourceQuote, Subject: claim.Body, DueAt: claim.DueAt,
+			FiledAt: claim.OccurredAt,
 			About: []agents.CommitmentAbout{{
-				EntityType: "person", EntityID: claim.PersonID.UUID, Name: claim.PersonName,
+				EntityType: commitmentAboutPerson,
+				EntityID:   claim.PersonID.UUID, Name: claim.PersonName,
 			}},
 		})
 	}
@@ -178,6 +202,7 @@ func asCommitments(tasks []activities.OpenTask) []agents.OpenCommitment {
 		out = append(out, agents.OpenCommitment{
 			Source: agents.CommitmentFromTask,
 			TaskID: &taskID, Subject: t.Subject, DueAt: t.DueAt,
+			FiledAt:    t.CreatedAt,
 			AssigneeID: t.AssigneeID, AssigneeName: t.AssigneeName, About: about,
 		})
 	}

--- a/backend/internal/compose/commitmentmerge_test.go
+++ b/backend/internal/compose/commitmentmerge_test.go
@@ -40,7 +40,7 @@ func saidInConversation(subject string, dueInDays int) agents.OpenCommitment {
 func TestAPromiseMadeInAConversationReachesTheAnswer(t *testing.T) {
 	got, _ := rankPromises(swept, nil, []agents.OpenCommitment{
 		saidInConversation("Send the security questionnaire", -2),
-	}, 0)
+	}, agents.CommitmentSweepLimit(0))
 
 	if len(got) != 1 {
 		t.Fatalf("answered with %d promises; a commitment nobody typed is still owed", len(got))
@@ -62,7 +62,7 @@ func TestBothSourcesRankByOneRule(t *testing.T) {
 	got, _ := rankPromises(swept,
 		[]agents.OpenCommitment{filedTask("Return the redlines", -20)},
 		[]agents.OpenCommitment{saidInConversation("Send the quote", -1)},
-		0)
+		agents.CommitmentSweepLimit(0))
 
 	if len(got) != 2 {
 		t.Fatalf("merged into %d promises, want both", len(got))
@@ -89,18 +89,60 @@ func TestTheMergedAnswerHonoursTheCallersBound(t *testing.T) {
 	}
 }
 
-// An unbounded ask keeps every promise. Zero means "no limit" on this seam, and
-// silently trimming would drop work nobody asked to hide.
-func TestAnUnboundedAskKeepsEveryPromise(t *testing.T) {
+// An answer that fits under the bound keeps every promise and says nothing was
+// cut. Reporting truncation on a complete answer would have a model hedge a
+// fact it could have stated.
+func TestAnAnswerThatFitsReportsNoTruncation(t *testing.T) {
 	got, truncated := rankPromises(swept,
 		[]agents.OpenCommitment{filedTask("a", -3)},
 		[]agents.OpenCommitment{saidInConversation("b", -1)},
-		0)
+		agents.CommitmentSweepLimit(0))
 
 	if len(got) != 2 {
-		t.Errorf("returned %d promises with no limit set, want both", len(got))
+		t.Errorf("returned %d promises, want both", len(got))
 	}
 	if truncated {
 		t.Error("reported truncation without cutting anything")
+	}
+}
+
+// The bound belongs to the tool, not to either read behind it. The two sources
+// default differently — fifty for tasks, two hundred for claims — so a caller
+// who omits the limit would get whatever the two happened to add up to, and be
+// told nothing was cut.
+func TestAnOmittedLimitIsTheToolsOwnCeiling(t *testing.T) {
+	var said []agents.OpenCommitment
+	for i := range 60 {
+		said = append(said, saidInConversation("promise", -i-1))
+	}
+
+	got, truncated := rankPromises(swept, nil, said, agents.CommitmentSweepLimit(0))
+
+	// Both ends, because either alone passes for the wrong reason: a ceiling
+	// with no floor is satisfied by returning nothing, and a floor with no
+	// ceiling by returning everything both reads happened to fetch.
+	if len(got) != 50 {
+		t.Errorf("returned %d promises for a caller who named no limit; the tool serves exactly "+
+			"its ceiling of 50 when more exist", len(got))
+	}
+	if !truncated {
+		t.Error("cut ten promises and reported nothing; a model reads a bounded set as everything outstanding")
+	}
+}
+
+// Two promises due the same day rank by when they were promised, whichever
+// source holds them. Left to input order, every task would beat every claim on
+// a tie regardless of which was actually made first.
+func TestASharedDeadlineBreaksOnWhenThePromiseWasMade(t *testing.T) {
+	task := filedTask("Return the redlines", 8)
+	task.FiledAt = swept.AddDate(0, 0, -1)
+	claim := saidInConversation("Send the quote", 8)
+	claim.FiledAt = swept.AddDate(0, 0, -30)
+
+	got, _ := rankPromises(swept, []agents.OpenCommitment{task}, []agents.OpenCommitment{claim}, 10)
+
+	if got[0].Subject != "Send the quote" {
+		t.Errorf("led with %q; of two promises due the same day the one promised first leads, "+
+			"and the claim was made a month before the task", got[0].Subject)
 	}
 }

--- a/backend/internal/compose/commitmentmerge_test.go
+++ b/backend/internal/compose/commitmentmerge_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+var swept = time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+
+func promiseDue(days int) *time.Time {
+	at := swept.AddDate(0, 0, days)
+	return &at
+}
+
+func filedTask(subject string, dueInDays int) agents.OpenCommitment {
+	id := ids.NewV7()
+	return agents.OpenCommitment{
+		Source: agents.CommitmentFromTask, TaskID: &id,
+		Subject: subject, DueAt: promiseDue(dueInDays),
+	}
+}
+
+func saidInConversation(subject string, dueInDays int) agents.OpenCommitment {
+	claim, source := ids.NewV7(), ids.NewV7()
+	return agents.OpenCommitment{
+		Source: agents.CommitmentFromConversation, ClaimID: &claim, SourceActivityID: &source,
+		Quote: "Ich schicke es Ihnen.", Subject: subject, DueAt: promiseDue(dueInDays),
+	}
+}
+
+// The tool answered from tasks alone, so a promise made in a meeting and never
+// typed was reported as absent — and a model told "these are the open
+// commitments" repeats that as fact.
+func TestAPromiseMadeInAConversationReachesTheAnswer(t *testing.T) {
+	got, _ := rankPromises(swept, nil, []agents.OpenCommitment{
+		saidInConversation("Send the security questionnaire", -2),
+	}, 0)
+
+	if len(got) != 1 {
+		t.Fatalf("answered with %d promises; a commitment nobody typed is still owed", len(got))
+	}
+	if got[0].Source != agents.CommitmentFromConversation {
+		t.Errorf("source = %q, want conversation", got[0].Source)
+	}
+	if got[0].Quote == "" {
+		t.Error("no quote; the sentence the promise was made in is what a claim carries")
+	}
+	if got[0].TaskID != nil {
+		t.Error("a conversation promise carries no task id — nobody filed one")
+	}
+}
+
+// Both sources rank by one rule, so an agent and a reader looking at the same
+// account agree about what is most overdue.
+func TestBothSourcesRankByOneRule(t *testing.T) {
+	got, _ := rankPromises(swept,
+		[]agents.OpenCommitment{filedTask("Return the redlines", -20)},
+		[]agents.OpenCommitment{saidInConversation("Send the quote", -1)},
+		0)
+
+	if len(got) != 2 {
+		t.Fatalf("merged into %d promises, want both", len(got))
+	}
+	if got[0].Subject != "Send the quote" {
+		t.Errorf("led with %q; the promise that slipped most recently comes first", got[0].Subject)
+	}
+}
+
+// The caller asked for a bounded set and gets exactly that, plus the fact that
+// more exist. A merged answer can exceed the bound each source respected.
+func TestTheMergedAnswerHonoursTheCallersBound(t *testing.T) {
+	got, truncated := rankPromises(swept,
+		[]agents.OpenCommitment{filedTask("a", -3), filedTask("b", -2)},
+		[]agents.OpenCommitment{saidInConversation("c", -1)},
+		2)
+
+	if len(got) != 2 {
+		t.Errorf("returned %d promises for a limit of 2", len(got))
+	}
+	if !truncated {
+		t.Error("cut a promise from the answer and did not say so; a model reports a " +
+			"bounded set as everything outstanding unless told otherwise")
+	}
+}
+
+// An unbounded ask keeps every promise. Zero means "no limit" on this seam, and
+// silently trimming would drop work nobody asked to hide.
+func TestAnUnboundedAskKeepsEveryPromise(t *testing.T) {
+	got, truncated := rankPromises(swept,
+		[]agents.OpenCommitment{filedTask("a", -3)},
+		[]agents.OpenCommitment{saidInConversation("b", -1)},
+		0)
+
+	if len(got) != 2 {
+		t.Errorf("returned %d promises with no limit set, want both", len(got))
+	}
+	if truncated {
+		t.Error("reported truncation without cutting anything")
+	}
+}

--- a/backend/internal/compose/integration/workspacecommitments_integration_test.go
+++ b/backend/internal/compose/integration/workspacecommitments_integration_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration_test
+
+// The workspace-wide promise read behind review_commitments, against a real
+// database.
+//
+// The unit lane cannot see what these pin. Which promises the read admits is a
+// pair of scope clauses and a join; the order that keeps the LIMIT from
+// truncating away the answer is SQL; and the lifecycle filter that drops a
+// settled promise touches two columns nothing in Go reads. Each of those reads
+// as a working tool against a stub and can be wrong here.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
+)
+
+var sweepClock = time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC)
+
+func workspacePromises(t *testing.T, e *integration.Env, limit int) ([]people.OrgCommitment, bool) {
+	t.Helper()
+	var rows []people.OrgCommitment
+	var more bool
+	store := people.NewStore(e.DB())
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		var err error
+		rows, more, err = store.OpenCommitmentsAcrossWorkspace(e.Admin(), tx, limit)
+		return err
+	}); err != nil {
+		t.Fatalf("reading the workspace's open promises: %v", err)
+	}
+	return rows, more
+}
+
+// The read the tool answers from must carry the promise that slipped MOST
+// RECENTLY, even when more promises exist than the caller asked for. Ordered
+// earliest-first and then cut, the bound keeps the oldest and drops the one
+// still worth rescuing — and the tool reports the least recoverable promise on
+// the record as the thing to do.
+func TestABoundedSweepKeepsThePromiseThatSlippedLast(t *testing.T) {
+	e := integration.Setup(t)
+	person := e.SeedPerson(t, "Carol Wagner", nil)
+
+	for days := 30; days >= 10; days -= 10 {
+		due := sweepClock.AddDate(0, 0, -days)
+		seedPromise(t, e, person, "Ancient promise", &due)
+	}
+	yesterday := sweepClock.AddDate(0, 0, -1)
+	seedPromise(t, e, person, "Send yesterday's file", &yesterday)
+
+	rows, more := workspacePromises(t, e, 1)
+
+	if len(rows) != 1 {
+		t.Fatalf("asked for 1 promise and got %d", len(rows))
+	}
+	if rows[0].Body != "Send yesterday's file" {
+		t.Errorf("the bounded sweep kept %q; it must keep the promise that slipped most "+
+			"recently, which is the one still worth rescuing", rows[0].Body)
+	}
+	if !more {
+		t.Error("cut promises from the sweep and did not say so; a model reports a bounded " +
+			"set as everything outstanding unless told otherwise")
+	}
+}
+
+// A promise somebody settled is done with, and one the extractor flagged as
+// contested would state as true the very thing it doubted.
+func TestASettledPromiseLeavesTheSweep(t *testing.T) {
+	e := integration.Setup(t)
+	person := e.SeedPerson(t, "Carol Wagner", nil)
+	due := sweepClock.AddDate(0, 0, -2)
+	claim := seedPromise(t, e, person, "Send the quote", &due)
+
+	if rows, _ := workspacePromises(t, e, 20); len(rows) != 1 {
+		t.Fatalf("the promise is not in the sweep to begin with: %d rows", len(rows))
+	}
+
+	// The extractor's own lifecycle column, which has no writer on this path,
+	// so the filter is exercised against the state it exists to reject.
+	e.WsExec(t, `UPDATE conversation_claim SET status = 'done' WHERE id = $1`, claim)
+
+	if rows, _ := workspacePromises(t, e, 20); len(rows) != 0 {
+		t.Errorf("a settled promise is still owed according to the sweep: %d rows", len(rows))
+	}
+}

--- a/backend/internal/compose/integration/workspacecommitments_integration_test.go
+++ b/backend/internal/compose/integration/workspacecommitments_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/platform/database"
 )
@@ -91,5 +92,79 @@ func TestASettledPromiseLeavesTheSweep(t *testing.T) {
 
 	if rows, _ := workspacePromises(t, e, 20); len(rows) != 0 {
 		t.Errorf("a settled promise is still owed according to the sweep: %d rows", len(rows))
+	}
+}
+
+// The task read behind review_commitments must keep the promise that slipped
+// LAST when the bound cuts, for the same reason the claim read must.
+//
+// Ordered earliest-first and then truncated — which is what the display queue
+// wants and what this read did — a bounded sweep holds the oldest promises and
+// drops the one that slipped yesterday. The tool then names the least
+// recoverable promise on the record and the read looks like it worked.
+func TestABoundedTaskSweepKeepsTheTaskThatSlippedLast(t *testing.T) {
+	e := integration.Setup(t)
+	person := e.SeedPerson(t, "Carol Wagner", nil)
+	seedTask := func(subject string, dueDaysAgo int) {
+		t.Helper()
+		due := sweepClock.AddDate(0, 0, -dueDaysAgo)
+		if _, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+			Kind: "task", Subject: &subject, DueAt: &due, Source: "manual",
+			Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: person}},
+		}); err != nil {
+			t.Fatalf("logging %q: %v", subject, err)
+		}
+	}
+	seedTask("Chase the ancient NDA", 30)
+	seedTask("Chase the older NDA", 20)
+	seedTask("Send yesterday's file", 1)
+
+	rows, more, err := activities.NewStore(e.DB()).ListOpenTasks(e.Admin(),
+		activities.ListOpenTasksInput{Limit: 1, MostRecentlySlippedFirst: true})
+	if err != nil {
+		t.Fatalf("reading the open tasks: %v", err)
+	}
+
+	if len(rows) != 1 {
+		t.Fatalf("asked for 1 task and got %d", len(rows))
+	}
+	if rows[0].Subject != "Send yesterday's file" {
+		t.Errorf("the bounded sweep kept %q; it must keep the task that slipped most recently, "+
+			"which is the one still worth rescuing", rows[0].Subject)
+	}
+	if !more {
+		t.Error("cut tasks from the sweep and did not say so")
+	}
+}
+
+// The queue ordering is unchanged for the callers that DISPLAY a list: they
+// want the earliest deadline at the top, and the flag is what separates the
+// two questions rather than one order being made to serve both.
+func TestTheDisplayQueueStillLeadsWithTheEarliestDeadline(t *testing.T) {
+	e := integration.Setup(t)
+	person := e.SeedPerson(t, "Carol Wagner", nil)
+	for _, row := range []struct {
+		subject    string
+		dueDaysAgo int
+	}{{"Chase the ancient NDA", 30}, {"Send yesterday's file", 1}} {
+		due := sweepClock.AddDate(0, 0, -row.dueDaysAgo)
+		subject := row.subject
+		if _, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+			Kind: "task", Subject: &subject, DueAt: &due, Source: "manual",
+			Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: person}},
+		}); err != nil {
+			t.Fatalf("logging %q: %v", subject, err)
+		}
+	}
+
+	rows, _, err := activities.NewStore(e.DB()).ListOpenTasks(e.Admin(),
+		activities.ListOpenTasksInput{Limit: 5})
+	if err != nil {
+		t.Fatalf("reading the open tasks: %v", err)
+	}
+
+	if len(rows) == 0 || rows[0].Subject != "Chase the ancient NDA" {
+		t.Errorf("the queue leads with %v; a display list is ordered by the earliest deadline",
+			rows)
 	}
 }

--- a/backend/internal/modules/activities/commitments.go
+++ b/backend/internal/modules/activities/commitments.go
@@ -88,6 +88,33 @@ type ListOpenTasksInput struct {
 	// Limit bounds the sweep. A caller passing zero or less gets
 	// openTasksDefaultLimit rather than an unbounded read.
 	Limit int
+	// MostRecentlySlippedFirst orders the overdue promises by the deadline
+	// that passed LAST rather than by the earliest deadline.
+	//
+	// It exists because the LIMIT decides what a caller can see. A caller that
+	// RANKS the rows — asking which promise slipped most recently — and reads
+	// them earliest-first gets a page holding the oldest promises, with the one
+	// that slipped yesterday truncated away: it then names the least
+	// recoverable promise on the record, and the read looks like it worked. A
+	// caller that DISPLAYS a queue wants the earliest deadline at the top and
+	// leaves this false.
+	MostRecentlySlippedFirst bool
+}
+
+// openTasksOrder is how one sweep is ranked, and the choice is the caller's
+// because the LIMIT below it decides what they can see.
+//
+// `now()` rather than a bound instant in the slipped ordering: the clause only
+// SEPARATES late from not-late for the sort, and every caller re-judges each
+// row against one instant of its own. A row landing on the wrong side at the
+// boundary changes its position in an over-long list, never the verdict shown.
+func openTasksOrder(slippedFirst bool) string {
+	if slippedFirst {
+		return `(a.due_at IS NOT NULL AND a.due_at < now()) DESC,
+		         CASE WHEN a.due_at < now() THEN a.due_at END DESC,
+		         a.due_at ASC NULLS LAST, a.created_at ASC, a.id ASC`
+	}
+	return `a.due_at ASC NULLS LAST, a.id ASC`
 }
 
 // openTasksDefaultLimit and openTasksMaxLimit bound one sweep. The read is a
@@ -148,7 +175,7 @@ func listOpenTasks(ctx context.Context, tx pgx.Tx, in ListOpenTasksInput) ([]Ope
 		// NULLS LAST is the ascending default and is spelled anyway: an
 		// undated promise sorts after every dated one, and that is a product
 		// decision rather than a property of the index it happens to match.
-		sprintf(` ORDER BY a.due_at ASC NULLS LAST, a.id ASC LIMIT %d`, limit+1), args...)
+		sprintf(` ORDER BY %s LIMIT %d`, openTasksOrder(in.MostRecentlySlippedFirst), limit+1), args...)
 	if err != nil {
 		return nil, false, err
 	}

--- a/backend/internal/modules/agents/results_commercial.go
+++ b/backend/internal/modules/agents/results_commercial.go
@@ -20,8 +20,25 @@ import (
 
 // CommitmentItem is one open promise as review_commitments reports it.
 type CommitmentItem struct {
-	TaskID  ids.UUID `json:"task_id"`
-	Subject string   `json:"subject"`
+	// TaskID is the task row a promise was filed as, absent for a promise read
+	// out of a conversation and never written down as one. Source says which.
+	TaskID *ids.UUID `json:"task_id,omitempty"`
+	// ClaimID is the extracted commitment a promise was read from, absent for a
+	// promise somebody typed. Exactly one of TaskID and ClaimID is set.
+	ClaimID *ids.UUID `json:"claim_id,omitempty"`
+	// Source is `task` | `conversation`, so a reader knows which id to expect
+	// and how the promise came to be recorded. A promise made out loud and
+	// extracted from the thread is as owed as one somebody typed; where it was
+	// written down is a fact about this system, not about the debt.
+	Source string `json:"source"`
+	// SourceActivityID is the message a conversation-sourced promise was read
+	// from — what a reader opens to check the quote against what was written.
+	SourceActivityID *ids.UUID `json:"source_activity_id,omitempty"`
+	// Quote is the sentence the promise was read from, present only for a
+	// conversation source. A task carries what somebody retyped and has nothing
+	// to quote.
+	Quote   string `json:"quote,omitempty"`
+	Subject string `json:"subject"`
 	// DueAt is absent for a promise nobody dated, which is a different state
 	// from one that is late — see State.
 	DueAt *time.Time `json:"due_at,omitempty"`

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -4604,11 +4604,25 @@
                 "assignee_name": {
                   "type": "string"
                 },
+                "claim_id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
                 "days_overdue": {
                   "type": "integer"
                 },
                 "due_at": {
                   "type": "string"
+                },
+                "quote": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "source_activity_id": {
+                  "type": "string",
+                  "format": "uuid"
                 },
                 "state": {
                   "type": "string"
@@ -4623,9 +4637,9 @@
               },
               "required": [
                 "about",
+                "source",
                 "state",
-                "subject",
-                "task_id"
+                "subject"
               ]
             }
           },
@@ -6298,11 +6312,25 @@
                     "assignee_name": {
                       "type": "string"
                     },
+                    "claim_id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
                     "days_overdue": {
                       "type": "integer"
                     },
                     "due_at": {
                       "type": "string"
+                    },
+                    "quote": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    },
+                    "source_activity_id": {
+                      "type": "string",
+                      "format": "uuid"
                     },
                     "state": {
                       "type": "string"
@@ -6317,9 +6345,9 @@
                   },
                   "required": [
                     "about",
+                    "source",
                     "state",
-                    "subject",
-                    "task_id"
+                    "subject"
                   ]
                 }
               },
@@ -7453,11 +7481,25 @@
                 "assignee_name": {
                   "type": "string"
                 },
+                "claim_id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
                 "days_overdue": {
                   "type": "integer"
                 },
                 "due_at": {
                   "type": "string"
+                },
+                "quote": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "source_activity_id": {
+                  "type": "string",
+                  "format": "uuid"
                 },
                 "state": {
                   "type": "string"
@@ -7472,9 +7514,9 @@
               },
               "required": [
                 "about",
+                "source",
                 "state",
-                "subject",
-                "task_id"
+                "subject"
               ]
             }
           }

--- a/backend/internal/modules/agents/toolcopy_intents.go
+++ b/backend/internal/modules/agents/toolcopy_intents.go
@@ -54,17 +54,21 @@ var whatsSlippingCopy = toolCopy{
 }
 
 var reviewCommitmentsCopy = toolCopy{
-	Purpose: "Answer \"what have we promised and not delivered?\": the open tasks across the " +
-		"workspace, earliest due date first and undated ones last, each with the person who owes " +
-		"it, when it came due and the record it was made about.",
-	Limits: "A promise appears here only because someone recorded it as a task — what was agreed " +
-		"in a meeting and never written down is absent — so this is what the workspace has on " +
-		"record, not everything owed. It is scoped to the records the caller may see.",
+	Purpose: "Answer \"what have we promised and not delivered?\": the open promises across the " +
+		"workspace, most overdue first, from BOTH places a promise is recorded — a task somebody " +
+		"filed, and a commitment read out of a captured conversation, which carries the sentence " +
+		"it was read from. Each names when it came due and the record it was made about.",
+	Limits: "It reads what the workspace captured: a promise made in an uncaptured call, or in a " +
+		"thread nobody filed, is absent. The two sources are not linked, so a promise both said " +
+		"and typed can appear twice. Narrowing by assignee or project returns recorded TASKS " +
+		"alone — a conversation commitment carries neither — so a narrowed answer is a smaller " +
+		"question than the unnarrowed one. It is scoped to the records the caller may see.",
 	Instead: "Use whats_slipping_this_week when the question is which DEALS are at risk rather " +
 		"than which promises are outstanding, and catch_me_up_on for everything that has happened " +
 		"on one record.",
-	Retain: "Each item carries task_id and, where there is one, assignee_id. Every state is " +
-		"judged against as_of, so carry that too if you report the answer later.",
+	Retain: "Each item carries source (task | conversation) and the id for that source — task_id " +
+		"or claim_id — plus assignee_id where a task has one. Every state is judged against " +
+		"as_of, so carry that too if you report the answer later.",
 }
 
 var prepareHandoffCopy = toolCopy{

--- a/backend/internal/modules/agents/tools_commitments.go
+++ b/backend/internal/modules/agents/tools_commitments.go
@@ -7,17 +7,21 @@ package agents
 // date first, each with the person who owes it and the record it was made
 // about.
 //
-// EARLIEST DUE, not oldest promise. The order is the due date ascending with
-// undated last — a promise made a year ago and never dated sorts behind one
-// made this morning for tomorrow, because what a reviewer is chasing is the
-// date that has passed rather than the day the words were said.
+// MOST OVERDUE FIRST, and the order is kernel/owedwork's — the same ranking the
+// contact and company pages apply, so an agent and a reader looking at one
+// account agree about what is most overdue. Among late promises the one whose
+// deadline passed LAST leads, because that is the one still recoverable; then
+// the rest by nearest deadline, with undated ones behind them.
 //
-// A promise here is a TASK ACTIVITY that nobody has ticked off. That is the
-// whole definition, and it is the tool's honesty problem: a commitment made
-// out loud in a meeting and never written down is not in this answer, and a
-// model told nothing would report the list as "what we owe" rather than as
-// "what we recorded that we owe". The description says so, and the tool
-// refuses to imply more than the rows support.
+// The order matters more than a display choice would, because the bound cuts
+// against it: read earliest-first and truncated, a bounded answer holds the
+// oldest promises and drops the one that slipped yesterday.
+//
+// A promise here is EITHER a task nobody ticked off or a commitment an
+// extractor read out of a captured conversation. The two are unlinked rows, so
+// one promise both said and typed appears twice; what is absent is a promise
+// made where nothing was captured at all. The description says both, and the
+// tool refuses to imply more than the rows support.
 //
 // THE TOOL IS CLOCK-FREE. The seam stamps the instant it swept at, and
 // everything below is a pure function of (due date, that instant) — which is
@@ -70,9 +74,13 @@ type OpenCommitment struct {
 	SourceActivityID *ids.UUID
 	// Quote is the sentence the promise was made in. Claims only: a task
 	// carries what somebody retyped and has nothing to quote.
-	Quote        string
-	Subject      string
-	DueAt        *time.Time
+	Quote   string
+	Subject string
+	DueAt   *time.Time
+	// FiledAt is when the promise was made: a task's creation, a claim's
+	// message. It breaks ties between two promises sharing a deadline, so the
+	// answer does not depend on which source a seam happened to read first.
+	FiledAt      time.Time
 	AssigneeID   *ids.UUID
 	AssigneeName string
 	About        []CommitmentAbout
@@ -143,12 +151,26 @@ const (
 // a model told nothing reports it as one. It matters more here than most,
 // because the question this tool answers is "is anything being dropped".
 const commitmentsTruncatedMessage = "More open commitments exist than are listed here. " +
-	"Report these as the soonest-due promises found, not as everything outstanding."
+	"Report these as the most overdue promises found, not as everything outstanding."
 
 // maxCommitments bounds one call. It is the schema's maximum and the
 // server-side ceiling both, so a caller that omits the argument gets a
 // bounded read rather than the whole table.
 const maxCommitments = 50
+
+// CommitmentSweepLimit is how many promises one call serves, for a seam that
+// merges more than one source.
+//
+// The bound belongs to the TOOL, not to either read behind it. Each source has
+// a default of its own — they differ — so a seam that passed the caller's zero
+// straight through would return whatever the two happened to add up to, and
+// report nothing as cut because neither read had hit its own bound.
+func CommitmentSweepLimit(asked int) int {
+	if asked <= 0 || asked > maxCommitments {
+		return maxCommitments
+	}
+	return asked
+}
 
 type reviewCommitments struct{ list CommitmentLister }
 

--- a/backend/internal/modules/agents/tools_commitments.go
+++ b/backend/internal/modules/agents/tools_commitments.go
@@ -49,15 +49,43 @@ type CommitmentAbout struct {
 	Name string `json:"name,omitempty"`
 }
 
-// OpenCommitment is one outstanding promise as the seam read it.
+// OpenCommitment is one outstanding promise as the seam read it, from either
+// of the two places a promise gets written down.
+//
+// EXACTLY ONE OF TaskID AND ClaimID. A promise somebody typed is a task row; a
+// promise an extractor read out of a conversation is a claim row, and the two
+// are unlinked — nothing writes conversation_claim.task_activity_id — so one
+// promise recorded both ways arrives here as two. That is the honest answer
+// until the link is written; guessing which pairs mean one promise would be
+// this surface inventing a fact.
 type OpenCommitment struct {
-	TaskID       ids.UUID
+	// Source is `task` or `conversation`, and says which of the two ids below
+	// is set.
+	Source string
+	// TaskID is the task activity, for a task-sourced promise.
+	TaskID *ids.UUID
+	// ClaimID is the extracted commitment, and SourceActivityID is the message
+	// it was read from — which is what a reader opens to check it.
+	ClaimID          *ids.UUID
+	SourceActivityID *ids.UUID
+	// Quote is the sentence the promise was made in. Claims only: a task
+	// carries what somebody retyped and has nothing to quote.
+	Quote        string
 	Subject      string
 	DueAt        *time.Time
 	AssigneeID   *ids.UUID
 	AssigneeName string
 	About        []CommitmentAbout
 }
+
+// The two places a promise is recorded, as this surface names them.
+const (
+	// CommitmentFromTask is a promise somebody typed as a task.
+	CommitmentFromTask = "task"
+	// CommitmentFromConversation is a promise an extractor read out of a
+	// captured conversation and nobody typed.
+	CommitmentFromConversation = "conversation"
+)
 
 // CommitmentSweep is ONE reading of the open-promise set: the rows, the
 // instant they are judged against, and whether the sweep stopped at its
@@ -165,8 +193,9 @@ func (t reviewCommitments) Handle(ctx context.Context, in json.RawMessage) (json
 	noteDerivedContent(ctx)
 	items := make([]CommitmentItem, 0, len(sweep.Commitments))
 	for _, c := range sweep.Commitments {
-		noteEvidence(ctx, datasource.EntityActivity, c.TaskID)
-		items = append(items, c.wire(sweep.AsOf))
+		item := c.wire(sweep.AsOf)
+		noteCommitmentEvidence(ctx, item)
+		items = append(items, item)
 	}
 	if sweep.Truncated {
 		noteWarning(ctx, warningSweepTruncated, commitmentsTruncatedMessage)
@@ -191,7 +220,9 @@ func requireCommitmentLimit(limit int) error {
 // state it is in as of the sweep's own instant.
 func (c OpenCommitment) wire(asOf time.Time) CommitmentItem {
 	item := CommitmentItem{
-		TaskID: c.TaskID, Subject: c.Subject, DueAt: c.DueAt,
+		TaskID: c.TaskID, ClaimID: c.ClaimID, Source: c.Source,
+		SourceActivityID: c.SourceActivityID,
+		Quote:            c.Quote, Subject: c.Subject, DueAt: c.DueAt,
 		State: commitmentState(c.DueAt, asOf),
 		// Never null: a model handed null reads it as "unknown" where an empty
 		// array says "this promise names no record".
@@ -229,4 +260,19 @@ func commitmentState(dueAt *time.Time, asOf time.Time) string {
 // whether it is past it at all.
 func daysOverdue(dueAt *time.Time, asOf time.Time) (int, bool) {
 	return deadline.DaysPast(dueAt, asOf)
+}
+
+// noteCommitmentEvidence records the row a promise was read from, whichever
+// kind it is.
+//
+// Both point at an activity: a task IS an activity row, and a claim quotes the
+// message it was extracted from. So the caller's evidence trail lands on
+// something they can open either way, which is what the trail is for.
+func noteCommitmentEvidence(ctx context.Context, item CommitmentItem) {
+	switch {
+	case item.TaskID != nil:
+		noteEvidence(ctx, datasource.EntityActivity, *item.TaskID)
+	case item.SourceActivityID != nil:
+		noteEvidence(ctx, datasource.EntityActivity, *item.SourceActivityID)
+	}
 }

--- a/backend/internal/modules/agents/tools_commitments_test.go
+++ b/backend/internal/modules/agents/tools_commitments_test.go
@@ -95,11 +95,11 @@ func TestDaysOverdueCountsWholeElapsedDays(t *testing.T) {
 // An overdue item carries the count; an upcoming one carries no count at all
 // rather than a zero a reader would print as "0 days overdue".
 func TestOnlyAnOverduePromiseCarriesADayCount(t *testing.T) {
-	overdue := OpenCommitment{TaskID: ids.NewV7(), DueAt: at(-25 * time.Hour)}.wire(sweptAt())
+	overdue := OpenCommitment{TaskID: newTaskID(), DueAt: at(-25 * time.Hour)}.wire(sweptAt())
 	if overdue.DaysOverdue == nil || *overdue.DaysOverdue != 1 {
 		t.Errorf("an overdue promise carries days_overdue = %v, want 1", overdue.DaysOverdue)
 	}
-	upcoming := OpenCommitment{TaskID: ids.NewV7(), DueAt: at(time.Hour)}.wire(sweptAt())
+	upcoming := OpenCommitment{TaskID: newTaskID(), DueAt: at(time.Hour)}.wire(sweptAt())
 	if upcoming.DaysOverdue != nil {
 		t.Errorf("an upcoming promise carries days_overdue = %v, want absent", *upcoming.DaysOverdue)
 	}
@@ -109,7 +109,7 @@ func TestOnlyAnOverduePromiseCarriesADayCount(t *testing.T) {
 // assignee members are absent TOGETHER — a name beside no id would be a
 // promise attributed to nobody in particular.
 func TestAnUnownedPromiseCarriesNeitherIdNorName(t *testing.T) {
-	item := OpenCommitment{TaskID: ids.NewV7(), AssigneeName: "leaked"}.wire(sweptAt())
+	item := OpenCommitment{TaskID: newTaskID(), AssigneeName: "leaked"}.wire(sweptAt())
 	if item.AssigneeID != nil || item.AssigneeName != "" {
 		t.Errorf("an unassigned promise reports assignee (%v, %q), want both absent",
 			item.AssigneeID, item.AssigneeName)
@@ -119,7 +119,7 @@ func TestAnUnownedPromiseCarriesNeitherIdNorName(t *testing.T) {
 // A promise that names no record answers an empty list, never null: a model
 // handed null reads it as "unknown" where an empty array says "none".
 func TestAPromiseAboutNothingAnswersAnEmptyListNotNull(t *testing.T) {
-	raw, err := json.Marshal(OpenCommitment{TaskID: ids.NewV7()}.wire(sweptAt()))
+	raw, err := json.Marshal(OpenCommitment{TaskID: newTaskID()}.wire(sweptAt()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestAPromiseAboutNothingAnswersAnEmptyListNotNull(t *testing.T) {
 func TestTheAnswerCarriesTheInstantItsStatesWereJudgedAgainst(t *testing.T) {
 	tool := reviewCommitments{list: commitmentSweepOf(CommitmentSweep{
 		AsOf:        sweptAt(),
-		Commitments: []OpenCommitment{{TaskID: ids.NewV7(), Subject: "Send the SOW", DueAt: at(-48 * time.Hour)}},
+		Commitments: []OpenCommitment{{TaskID: newTaskID(), Subject: "Send the SOW", DueAt: at(-48 * time.Hour)}},
 	})}
 
 	raw, err := tool.Handle(context.Background(), json.RawMessage(`{}`))
@@ -171,7 +171,7 @@ func TestABoundedCommitmentSweepSaysSo(t *testing.T) {
 	} {
 		tool := reviewCommitments{list: commitmentSweepOf(CommitmentSweep{
 			AsOf:        sweptAt(),
-			Commitments: []OpenCommitment{{TaskID: ids.NewV7()}},
+			Commitments: []OpenCommitment{{TaskID: newTaskID()}},
 			Truncated:   tc.truncated,
 		})}
 		registry := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
@@ -203,4 +203,12 @@ func TestALimitOutsideTheServedRangeIsRefusedByName(t *testing.T) {
 	if _, err := tool.Handle(context.Background(), json.RawMessage(`{"limit":50}`)); err != nil {
 		t.Errorf("the ceiling itself is refused: %v", err)
 	}
+}
+
+// newTaskID is one task-sourced promise's id. A promise now carries EITHER a
+// task id or a claim id, so the pointer says which of the two this row is —
+// and every fixture here is a filed task.
+func newTaskID() *ids.UUID {
+	id := ids.NewV7()
+	return &id
 }

--- a/backend/internal/modules/agents/tools_handoff.go
+++ b/backend/internal/modules/agents/tools_handoff.go
@@ -146,8 +146,9 @@ func (t prepareHandoff) Handle(ctx context.Context, in json.RawMessage) (json.Ra
 	}
 	commitments := make([]CommitmentItem, 0, len(facts.OpenCommitments))
 	for _, c := range facts.OpenCommitments {
-		noteEvidence(ctx, datasource.EntityActivity, c.TaskID)
-		commitments = append(commitments, c.wire(facts.AsOf))
+		item := c.wire(facts.AsOf)
+		noteCommitmentEvidence(ctx, item)
+		commitments = append(commitments, item)
 	}
 	if facts.CommitmentsTruncated || facts.DealsTruncated || facts.StakeholdersTruncated {
 		noteWarning(ctx, warningSweepTruncated, handoffTruncatedMessage)

--- a/backend/internal/modules/agents/tools_handoff_test.go
+++ b/backend/internal/modules/agents/tools_handoff_test.go
@@ -42,7 +42,7 @@ func wholeHandoff() HandoffFacts {
 		}},
 		Stakeholders: []HandoffStakeholder{{PersonID: ids.NewV7(), Role: "Sponsor"}},
 		OpenCommitments: []OpenCommitment{{
-			TaskID: ids.NewV7(), Subject: "Book the kickoff", DueAt: at(48 * time.Hour),
+			TaskID: newTaskID(), Subject: "Book the kickoff", DueAt: at(48 * time.Hour),
 		}},
 	}
 }
@@ -176,10 +176,10 @@ func TestAnOpenDealBesideAWonOneIsNotAMissingSale(t *testing.T) {
 func TestTheOverdueGapCountsOnlyThePromisesThatArePastDue(t *testing.T) {
 	facts := wholeHandoff()
 	facts.OpenCommitments = []OpenCommitment{
-		{TaskID: ids.NewV7(), DueAt: at(-72 * time.Hour)},
-		{TaskID: ids.NewV7(), DueAt: at(-24 * time.Hour)},
-		{TaskID: ids.NewV7(), DueAt: at(48 * time.Hour)},
-		{TaskID: ids.NewV7()},
+		{TaskID: newTaskID(), DueAt: at(-72 * time.Hour)},
+		{TaskID: newTaskID(), DueAt: at(-24 * time.Hour)},
+		{TaskID: newTaskID(), DueAt: at(48 * time.Hour)},
+		{TaskID: newTaskID()},
 	}
 	out := prepared(t, facts)
 

--- a/backend/internal/modules/agents/tools_project360.go
+++ b/backend/internal/modules/agents/tools_project360.go
@@ -104,7 +104,7 @@ func chargeProject360(ctx context.Context, r Project360Result) {
 	}
 	if r.Commitments != nil {
 		for _, c := range r.Commitments.Items {
-			noteEvidence(ctx, datasource.EntityActivity, c.TaskID)
+			noteCommitmentEvidence(ctx, c)
 		}
 	}
 	if r.Activities != nil {

--- a/backend/internal/modules/agents/tools_project360_carry.go
+++ b/backend/internal/modules/agents/tools_project360_carry.go
@@ -125,8 +125,13 @@ func project360Documents(rows []crmcontracts.Attachment) []Project360Document {
 func project360Commitments(rows []crmcontracts.Project360Commitment, asOf time.Time) []CommitmentItem {
 	out := make([]CommitmentItem, 0, len(rows))
 	for _, c := range rows {
+		// The project page reads open TASKS, so every row here is task-sourced.
+		// Naming that rather than leaving it blank is what lets a reader tell
+		// this answer apart from one that also carries extracted commitments.
+		taskID := ids.UUID(c.ActivityId)
 		promise := OpenCommitment{
-			TaskID: ids.UUID(c.ActivityId), Subject: c.Subject, DueAt: c.DueAt,
+			Source: CommitmentFromTask, TaskID: &taskID,
+			Subject: c.Subject, DueAt: c.DueAt,
 			AssigneeID: (*ids.UUID)(c.AssigneeId), AssigneeName: orBlank(c.AssigneeName),
 		}
 		out = append(out, promise.wire(asOf))

--- a/backend/internal/modules/people/orgcommitments.go
+++ b/backend/internal/modules/people/orgcommitments.go
@@ -230,3 +230,87 @@ func orgCommitmentsLimit(asked int) int {
 	}
 	return asked
 }
+
+// OpenCommitmentsAcrossWorkspace reads the promises WE made, wherever they were
+// made, most urgent first.
+//
+// FOR THE REVIEW SURFACE, which asks the workspace-wide question the two reads
+// above ask of one record. It is the same rows under the same gates; only the
+// subject widens, from "this account" or "this person" to "everything the
+// caller may see".
+//
+// NO EDGE GATE, unlike the account read. That one reaches through the
+// employment edge to decide which promises belong to a company, which discloses
+// an endpoint pair. This one asks for the caller's visible promises directly:
+// the claim names its person, the person row scope decides whether that person
+// is theirs to see, and no relationship row is read at all.
+//
+// The order is the ranking's, for the reason the account read states: overdue
+// first with the latest slip at the top, so a bound cannot truncate away the
+// promise the answer is about.
+func (s *Store) OpenCommitmentsAcrossWorkspace(
+	ctx context.Context, tx pgx.Tx, limit int,
+) ([]OrgCommitment, bool, error) {
+	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+		return nil, false, err
+	}
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return nil, false, err
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	activityScope, err := auth.ActivityContentClause(ctx, "a", arg)
+	if err != nil {
+		return nil, false, err
+	}
+	if activityScope == "" {
+		activityScope = sqlAlwaysVisible
+	}
+	personScope, err := auth.ScopeClauseFor(ctx, "person", "pr", arg)
+	if err != nil {
+		return nil, false, err
+	}
+	if personScope == "" {
+		personScope = sqlAlwaysVisible
+	}
+	capped := orgCommitmentsLimit(limit)
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT c.id, c.person_id, coalesce(pr.full_name, ''), c.body, c.source_quote,
+		       c.source_activity_id, c.due_at, a.occurred_at
+		  FROM conversation_claim c
+		  JOIN activity a ON a.id = c.source_activity_id AND a.archived_at IS NULL
+		  JOIN person pr ON pr.id = c.person_id AND pr.archived_at IS NULL
+		 WHERE c.kind = 'commitment_ours' AND c.status = 'open' AND NOT c.needs_review
+		   AND c.archived_at IS NULL
+		   AND (%[1]s) AND (%[2]s)
+		 ORDER BY (c.due_at IS NOT NULL AND c.due_at < now()) DESC,
+		          CASE WHEN c.due_at < now() THEN c.due_at END DESC,
+		          c.due_at ASC NULLS LAST, a.occurred_at ASC, c.id
+		 LIMIT %[3]d`,
+		activityScope, personScope, capped+1), args...)
+	if err != nil {
+		return nil, false, fmt.Errorf("read the workspace's open commitments: %w", err)
+	}
+	defer rows.Close()
+
+	var out []OrgCommitment
+	for rows.Next() {
+		var row OrgCommitment
+		if err := rows.Scan(&row.ID, &row.PersonID, &row.PersonName, &row.Body, &row.SourceQuote,
+			&row.ActivityID, &row.DueAt, &row.OccurredAt); err != nil {
+			return nil, false, fmt.Errorf("scan a workspace commitment: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, fmt.Errorf("read the workspace's open commitments: %w", err)
+	}
+	// One row past the cap was fetched to ANSWER whether more exist, and it is
+	// dropped rather than served: a caller asking for fifty gets fifty, and is
+	// told there are more. Counting the rows returned against the cap cannot
+	// tell "exactly fifty" from "fifty and more".
+	if len(out) > capped {
+		return out[:capped], true, nil
+	}
+	return out, false, nil
+}

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,9 +5,9 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 59,
-    "tokens": 18861,
+    "tokens": 18954,
     "median_tool_tokens": 275,
-    "mean_tool_tokens": 319
+    "mean_tool_tokens": 320
   },
   "agents": [
     {
@@ -45,9 +45,9 @@
         "review_commitments",
         "whats_slipping_this_week"
       ],
-      "tokens": 2416,
+      "tokens": 2509,
       "percent_of_ceiling": 10,
-      "headroom_tokens": 14584,
+      "headroom_tokens": 14491,
       "dangling_cross_references": [
         "at_risk_relationships → account_coverage",
         "at_risk_relationships → intro_path_to",
@@ -130,6 +130,10 @@
       "tokens": 424
     },
     {
+      "name": "review_commitments",
+      "tokens": 409
+    },
+    {
       "name": "search_records",
       "tokens": 392
     },
@@ -148,10 +152,6 @@
     {
       "name": "draft_email",
       "tokens": 317
-    },
-    {
-      "name": "review_commitments",
-      "tokens": 316
     },
     {
       "name": "send_message",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -25,8 +25,8 @@ feature is expected to argue with.
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1661 | 6% | 15339 | 6 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2416 | 10% | 14584 | 15 | 8 |
-| _whole served catalog, for scale_ | 59 | 18861 | 78% | — | — | — |
+| `overnight_at_risk_sweep` | 7 | 2509 | 10% | 14491 | 15 | 8 |
+| _whole served catalog, for scale_ | 59 | 18954 | 78% | — | — | — |
 
 ### `morning_brief`
 
@@ -55,7 +55,7 @@ cannot call, so a run may spend a step discovering the refusal:
 
 > Sweep this workspace's open deals for risk: find deals with no activity in 14+ days, stakeholders gone quiet, or missing next steps. Log ONE note activity per at-risk deal summarizing the risk and the evidence (cite the records you read). Do not advance stages, send anything, or archive anything.
 
-Attaches 7 tools for 2416 tokens, leaving 14584 of its budget and 21584 tokens of the
+Attaches 7 tools for 2509 tokens, leaving 14491 of its budget and 21491 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `at_risk_relationships`
@@ -123,7 +123,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 275 tokens, mean 319, across 59 served tools.
+Median 275 tokens, mean 320, across 59 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -147,12 +147,12 @@ a term in an addition.
 | `book_meeting` | 431 | — |
 | `create_record` | 429 | 1 scenario |
 | `enrich` | 424 | — |
+| `review_commitments` | 409 | — |
 | `search_records` | 392 | 6 scenarios |
 | `search_context` | 352 | — |
 | `prep_for_meeting` | 333 | — |
 | `merge_records` | 323 | — |
 | `draft_email` | 317 | — |
-| `review_commitments` | 316 | — |
 | `send_message` | 314 | — |
 | `advance_project_phase` | 310 | — |
 | `relink_activity` | 308 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 59,
     "resources": 9,
-    "tool_catalog_bytes": 173056,
+    "tool_catalog_bytes": 173884,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 44142,
+    "approx_wire_tokens_total": 44349,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
-      "description_bytes": 39998,
+      "description_bytes": 40370,
       "input_schema_bytes": 37376,
-      "output_schema_bytes": 82857,
-      "description_plus_input_schema_bytes": 77374
+      "output_schema_bytes": 83313,
+      "description_plus_input_schema_bytes": 77746
     }
   },
   "tools": {
@@ -5940,10 +5940,24 @@
                       "assignee_name": {
                         "type": "string"
                       },
+                      "claim_id": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
                       "days_overdue": {
                         "type": "integer"
                       },
                       "due_at": {
+                        "type": "string"
+                      },
+                      "quote": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      },
+                      "source_activity_id": {
+                        "format": "uuid",
                         "type": "string"
                       },
                       "state": {
@@ -5959,9 +5973,9 @@
                     },
                     "required": [
                       "about",
+                      "source",
                       "state",
-                      "subject",
-                      "task_id"
+                      "subject"
                     ],
                     "type": "object"
                   },
@@ -7952,10 +7966,24 @@
                           "assignee_name": {
                             "type": "string"
                           },
+                          "claim_id": {
+                            "format": "uuid",
+                            "type": "string"
+                          },
                           "days_overdue": {
                             "type": "integer"
                           },
                           "due_at": {
+                            "type": "string"
+                          },
+                          "quote": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "source_activity_id": {
+                            "format": "uuid",
                             "type": "string"
                           },
                           "state": {
@@ -7971,9 +7999,9 @@
                         },
                         "required": [
                           "about",
+                          "source",
                           "state",
-                          "subject",
-                          "task_id"
+                          "subject"
                         ],
                         "type": "object"
                       },
@@ -9417,7 +9445,7 @@
           "readOnlyHint": true,
           "title": "Review open commitments"
         },
-        "description": "Answer \"what have we promised and not delivered?\": the open tasks across the workspace, earliest due date first and undated ones last, each with the person who owes it, when it came due and the record it was made about. A promise appears here only because someone recorded it as a task — what was agreed in a meeting and never written down is absent — so this is what the workspace has on record, not everything owed. It is scoped to the records the caller may see. Use whats_slipping_this_week when the question is which DEALS are at risk rather than which promises are outstanding, and catch_me_up_on for everything that has happened on one record. Each item carries task_id and, where there is one, assignee_id. Every state is judged against as_of, so carry that too if you report the answer later. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Answer \"what have we promised and not delivered?\": the open promises across the workspace, most overdue first, from BOTH places a promise is recorded — a task somebody filed, and a commitment read out of a captured conversation, which carries the sentence it was read from. Each names when it came due and the record it was made about. It reads what the workspace captured: a promise made in an uncaptured call, or in a thread nobody filed, is absent. The two sources are not linked, so a promise both said and typed can appear twice. Narrowing by assignee or project returns recorded TASKS alone — a conversation commitment carries neither — so a narrowed answer is a smaller question than the unnarrowed one. It is scoped to the records the caller may see. Use whats_slipping_this_week when the question is which DEALS are at risk rather than which promises are outstanding, and catch_me_up_on for everything that has happened on one record. Each item carries source (task | conversation) and the id for that source — task_id or claim_id — plus assignee_id where a task has one. Every state is judged against as_of, so carry that too if you report the answer later. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -9480,10 +9508,24 @@
                       "assignee_name": {
                         "type": "string"
                       },
+                      "claim_id": {
+                        "format": "uuid",
+                        "type": "string"
+                      },
                       "days_overdue": {
                         "type": "integer"
                       },
                       "due_at": {
+                        "type": "string"
+                      },
+                      "quote": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      },
+                      "source_activity_id": {
+                        "format": "uuid",
                         "type": "string"
                       },
                       "state": {
@@ -9499,9 +9541,9 @@
                     },
                     "required": [
                       "about",
+                      "source",
                       "state",
-                      "subject",
-                      "task_id"
+                      "subject"
                     ],
                     "type": "object"
                   },

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 59 |
 | Resources | 9 |
-| Tool catalog | 169.0 KB |
+| Tool catalog | 169.8 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 44142 |
+| Approx. wire tokens | 44349 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 80.9 KB | 47% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 39.1 KB | 23% | Yes, every step |
+| Output schemas | 81.4 KB | 47% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 39.4 KB | 23% | Yes, every step |
 | Input schemas | 36.5 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.5 KB | 7% | Partly |
-| **Description + input schema** | **75.6 KB** | **44%** | **the recurring cost** |
+| **Description + input schema** | **75.9 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -92,7 +92,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`log_activity`](#log_activity) | Log an activity |  |  | 3.8 KB |
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
 | [`prep_for_meeting`](#prep_for_meeting) | Prepare for a meeting | yes |  | 8.7 KB |
-| [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.8 KB |
+| [`prepare_handoff`](#prepare_handoff) | Prepare a delivery handoff | yes | [`ui://margince/handoff.html`](#handoff_view) | 3.9 KB |
 | [`preview_import`](#preview_import) | Preview an import |  |  | 4.2 KB |
 | [`progress_deal`](#progress_deal) | Progress a deal with a note |  |  | 3.0 KB |
 | [`promote_lead`](#promote_lead) | Promote a lead to a person |  |  | 2.4 KB |
@@ -102,14 +102,14 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`read_brief`](#read_brief) | Read the morning brief | yes | [`ui://margince/account-brief.html`](#account_brief_view) | 3.0 KB |
 | [`read_import_report`](#read_import_report) | Read an import report | yes |  | 2.9 KB |
 | [`read_import_run`](#read_import_run) | Read an import run | yes |  | 1.4 KB |
-| [`read_project_360`](#read_project_360) | Read a project's page | yes |  | 6.2 KB |
+| [`read_project_360`](#read_project_360) | Read a project's page | yes |  | 6.4 KB |
 | [`read_record`](#read_record) | Read a record | yes |  | 2.0 KB |
 | [`relink_activities`](#relink_activities) | Re-associate a set of activities to a record |  |  | 2.0 KB |
 | [`relink_activity`](#relink_activity) | Re-associate an activity to a record |  |  | 2.3 KB |
 | [`relink_thread`](#relink_thread) | Re-associate a whole conversation to a record |  |  | 2.0 KB |
 | [`remove_tag`](#remove_tag) | Take a tag off a record |  |  | 1.9 KB |
 | [`resolve_entities`](#resolve_entities) | Resolve people and companies | yes |  | 3.6 KB |
-| [`review_commitments`](#review_commitments) | Review open commitments | yes | [`ui://margince/commitments.html`](#commitments_view) | 2.9 KB |
+| [`review_commitments`](#review_commitments) | Review open commitments | yes | [`ui://margince/commitments.html`](#commitments_view) | 3.4 KB |
 | [`run_report`](#run_report) | Run a report | yes |  | 6.0 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.1 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.8 KB |
@@ -6524,10 +6524,24 @@ Renders its result in [`ui://margince/handoff.html`](#handoff_view), visible to 
               "assignee_name": {
                 "type": "string"
               },
+              "claim_id": {
+                "format": "uuid",
+                "type": "string"
+              },
               "days_overdue": {
                 "type": "integer"
               },
               "due_at": {
+                "type": "string"
+              },
+              "quote": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "source_activity_id": {
+                "format": "uuid",
                 "type": "string"
               },
               "state": {
@@ -6543,9 +6557,9 @@ Renders its result in [`ui://margince/handoff.html`](#handoff_view), visible to 
             },
             "required": [
               "about",
+              "source",
               "state",
-              "subject",
-              "task_id"
+              "subject"
             ],
             "type": "object"
           },
@@ -8629,10 +8643,24 @@ Read one project's whole page: company, phase history with time per phase, deals
                   "assignee_name": {
                     "type": "string"
                   },
+                  "claim_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
                   "days_overdue": {
                     "type": "integer"
                   },
                   "due_at": {
+                    "type": "string"
+                  },
+                  "quote": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "source_activity_id": {
+                    "format": "uuid",
                     "type": "string"
                   },
                   "state": {
@@ -8648,9 +8676,9 @@ Read one project's whole page: company, phase history with time per phase, deals
                 },
                 "required": [
                   "about",
+                  "source",
                   "state",
-                  "subject",
-                  "task_id"
+                  "subject"
                 ],
                 "type": "object"
               },
@@ -10145,7 +10173,7 @@ Find out whether the people and companies named in something you are holding alr
 
 **Review open commitments**
 
-Answer "what have we promised and not delivered?": the open tasks across the workspace, earliest due date first and undated ones last, each with the person who owes it, when it came due and the record it was made about. A promise appears here only because someone recorded it as a task — what was agreed in a meeting and never written down is absent — so this is what the workspace has on record, not everything owed. It is scoped to the records the caller may see. Use whats_slipping_this_week when the question is which DEALS are at risk rather than which promises are outstanding, and catch_me_up_on for everything that has happened on one record. Each item carries task_id and, where there is one, assignee_id. Every state is judged against as_of, so carry that too if you report the answer later. (Governance: runs immediately; requires passport scope "read".)
+Answer "what have we promised and not delivered?": the open promises across the workspace, most overdue first, from BOTH places a promise is recorded — a task somebody filed, and a commitment read out of a captured conversation, which carries the sentence it was read from. Each names when it came due and the record it was made about. It reads what the workspace captured: a promise made in an uncaptured call, or in a thread nobody filed, is absent. The two sources are not linked, so a promise both said and typed can appear twice. Narrowing by assignee or project returns recorded TASKS alone — a conversation commitment carries neither — so a narrowed answer is a smaller question than the unnarrowed one. It is scoped to the records the caller may see. Use whats_slipping_this_week when the question is which DEALS are at risk rather than which promises are outstanding, and catch_me_up_on for everything that has happened on one record. Each item carries source (task | conversation) and the id for that source — task_id or claim_id — plus assignee_id where a task has one. Every state is judged against as_of, so carry that too if you report the answer later. (Governance: runs immediately; requires passport scope "read".)
 
 Renders its result in [`ui://margince/commitments.html`](#commitments_view), visible to `model`, `app`.
 
@@ -10220,10 +10248,24 @@ Renders its result in [`ui://margince/commitments.html`](#commitments_view), vis
               "assignee_name": {
                 "type": "string"
               },
+              "claim_id": {
+                "format": "uuid",
+                "type": "string"
+              },
               "days_overdue": {
                 "type": "integer"
               },
               "due_at": {
+                "type": "string"
+              },
+              "quote": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "source_activity_id": {
+                "format": "uuid",
                 "type": "string"
               },
               "state": {
@@ -10239,9 +10281,9 @@ Renders its result in [`ui://margince/commitments.html`](#commitments_view), vis
             },
             "required": [
               "about",
+              "source",
               "state",
-              "subject",
-              "task_id"
+              "subject"
             ],
             "type": "object"
           },

--- a/frontend/src/mcp-apps/commitments/main.ts
+++ b/frontend/src/mcp-apps/commitments/main.ts
@@ -32,6 +32,11 @@ const SWEEP_TRUNCATED = "sweep_truncated";
 
 type Commitment = {
   subject: string;
+  // Which of the two places the promise was recorded. A conversation promise
+  // can quote the sentence it was read from; a task carries only what somebody
+  // retyped, so the two rows say different amounts about the same kind of debt.
+  source: string;
+  quote: string;
   state: string;
   dueAt: string;
   daysOverdue: unknown;
@@ -49,7 +54,9 @@ function known(data: Record<string, unknown>): Commitment[] {
       (c): c is Record<string, unknown> => typeof c === "object" && c !== null,
     )
     .map((c) => ({
-      subject: asText(c.subject) || "Untitled task",
+      subject: asText(c.subject) || "Untitled promise",
+      source: asText(c.source),
+      quote: asText(c.quote),
       state: asText(c.state),
       dueAt: asText(c.due_at),
       daysOverdue: c.days_overdue,
@@ -96,14 +103,27 @@ function commitmentRow(commitment: Commitment): HTMLElement {
     el("span", stateClass(commitment.state), stateText(commitment)),
   );
   row.appendChild(head);
+  // The sentence the promise was made in, where there is one. It is the whole
+  // reason a conversation promise is checkable: a reader can see what was
+  // actually written rather than trusting a summary of it.
+  if (commitment.quote !== "") {
+    row.appendChild(el("div", "quote", `“${commitment.quote}”`));
+  }
   const facts = el("div", "factors");
   // "unowned" rather than an empty space: a promise nobody holds is the single
   // most useful thing on this panel, so it is said out loud.
+  // "unowned" is right for a task nobody holds. A conversation promise has no
+  // assignee to be missing — it records what was said, not who was handed it —
+  // so saying "unowned" there would report an absence that is not one.
   facts.appendChild(
     el(
       "span",
       "factor",
-      commitment.owner === "" ? "unowned" : commitment.owner,
+      commitment.source === "conversation"
+        ? "from a conversation"
+        : commitment.owner === ""
+          ? "unowned"
+          : commitment.owner,
     ),
   );
   facts.appendChild(
@@ -128,7 +148,7 @@ function metaLine(found: number, asOf: string, bounded: boolean): string {
   if (bounded) {
     return `${found} shown — more are outstanding than are listed here${judged}`;
   }
-  return `${found} open commitment(s), oldest promise first${judged}`;
+  return `${found} open commitment(s), most overdue first${judged}`;
 }
 
 export function render(
@@ -174,7 +194,7 @@ export function render(
         "div",
         "empty",
         "Nothing is outstanding. That is the answer, not a gap — " +
-          "though only promises written down as tasks are counted.",
+          "though a promise made where nothing was captured is not counted.",
       ),
     );
     return;


### PR DESCRIPTION
An agent asked "what have we promised and not delivered?" got the open tasks
and nothing else. A promise made in a meeting, extracted from the thread and
never typed as a task, was absent — and a model told "these are the open
commitments" repeats that absence as fact.

The tool's own description admitted it, which made it honest and still wrong.
The screens fixed this in #3607 and #3629; this is the same fix for the tool
surface.

## What changes

`commitmentLister` reads both places a promise is recorded and ranks them
together through `kernel/owedwork` — the same ordering the contact and company
cards apply. An agent and a reader looking at one account now agree about what
is most overdue.

Each promise carries its source and the id for that source:

- `source: "task"` with `task_id`, for one somebody filed.
- `source: "conversation"` with `claim_id`, `source_activity_id` and the
  `quote` it was read from.

Exactly one of the two ids is set. The rows are unlinked — nothing writes
`conversation_claim.task_activity_id` — so a promise both said and typed
arrives as two. The description says that rather than guessing which pairs mean
one promise.

## The narrowing carve-out

Narrowing by `assignee_id` or `project_id` returns recorded tasks alone, and
the description says so. A claim records what was **said**, in a message filed
against a person; it carries neither an owner nor a project, so admitting one
under either filter would hand back a row the caller did not ask for.

## The new read

`OpenCommitmentsAcrossWorkspace`. Same gates as its two siblings, and
deliberately **no edge gate** — it asks for the caller's visible promises
directly rather than reaching through an employment edge, so it reads no
`relationship` row at all.

Its ORDER BY is the ranking's, not a display's, because the LIMIT decides what
the ranking can see. Overdue first with the latest slip at the top. Ordered the
obvious way — earliest deadline first, then cut — a bounded sweep keeps the
oldest promises and drops the one that slipped yesterday, so the tool names the
least recoverable promise on the record and looks like it worked.

`workspacecommitments_integration_test.go` plants exactly that case against real
Postgres: twenty-one promises, a limit of one, and the one that slipped
yesterday is what comes back. Reverting the ORDER BY to the naive form makes it
return `"Ancient promise"` instead — mutation-checked.

## Docs

`docs/reference/mcp-info.{json,md}` and `agent-tool-budget.{json,md}` regenerated.
The description grew 316 → 409 tokens; the heaviest agent still has 14491 tokens
of run room.

## Gate

`make check-backend` green except one pre-existing failure on main: `teamNameOf`
unused in `compose/weekly/teamreviewstore.go` from #3631, filed as #3637 and
already being fixed on another branch. Nothing in `weekly/` is in this diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `review_commitments` to report the same open promises the contact and company cards show: conversation-extracted commitments now join filed tasks, ranked together through `kernel/owedwork`, so a promise made in a meeting and never typed as a task no longer reads as absent.

- Each item carries `source` (`task` | `conversation`) and exactly one of `task_id` or `claim_id`/`source_activity_id`; conversation items also carry the `quote` they were read from.
- The sources are unlinked, so a promise both said and typed can appear twice.
- Narrowing by `assignee_id` or `project_id` returns filed tasks alone, because a claim carries neither an owner nor a project.
- Adds `OpenCommitmentsAcrossWorkspace`, gated on the caller's visibility with no employment-edge read.
- The merged answer gets one bound of 50, both sources order most-recently-slipped first, and each item's `FiledAt` breaks ties on a shared deadline — so a bounded sweep keeps the promise the ranking is about.
- The commitments MCP app shows each conversation promise's quote and labels it "from a conversation" instead of "unowned".
- Output consumers must set `source`; `task_id` is now optional.

<sup>Written for commit 33906ad9e075c2da24e0ebc39a8616bb9e619995. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Commitment views now include open promises from recorded tasks and conversations.
  - Results combine sources using urgency-based ranking, with source details, quotes, and originating records.
  - Bounded searches indicate when additional commitments are available, with a default limit of 50.
  - Conversation commitments appear in broad workspace searches; assignee- or project-filtered searches remain task-only.
  - Commitment displays identify conversation sources and prioritize the most overdue promises.

- **Bug Fixes**
  - Completed commitments are excluded from open-commitment results.

- **Documentation**
  - Updated tool schemas and reference documentation for conversation commitments and source metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->