### PR TITLE
A page that only forwards is not a parked site

### DIFF
--- a/backend/internal/compose/deepreadtriage.go
+++ b/backend/internal/compose/deepreadtriage.go
@@ -291,6 +291,17 @@ const (
 // classifySeed runs the one classification call over the landing page.
 func (w *siteDeepReadWorker) classifySeed(ctx context.Context, seed crawlPage) (siteTriageVerdict, error) {
 	if strings.TrimSpace(seed.Text) == "" {
+		if seed.UnresolvedForward {
+			// This page named the site's real address and the crawl could not
+			// reach it. The emptiness is a gap in the read, not the site
+			// saying that nobody is here, so it must not settle the domain:
+			// answering `parked` here would re-create the very defect the
+			// forwarding follow exists to fix.
+			return siteTriageVerdict{
+				Kind:   siteKindUnclear,
+				Reason: "the landing page forwards to an address that could not be read",
+			}, nil
+		}
 		// A page with no readable text identifies nobody. That IS the parked
 		// answer, and it costs no model call to say so.
 		return siteTriageVerdict{

--- a/backend/internal/compose/sitecrawl.go
+++ b/backend/internal/compose/sitecrawl.go
@@ -50,6 +50,12 @@ type crawlPage struct {
 	// portal or a careers platform commonly announces itself on the one page
 	// that runs it, and a homepage-only read cannot see any of them.
 	Fingerprint webread.Fingerprint
+	// UnresolvedForward marks a landing page that named somewhere else as the
+	// site's real address, which the crawl could not reach. It is the
+	// difference between a page that says NOTHING and one that says GO HERE
+	// and could not be followed, and only the first is evidence of a parked
+	// domain.
+	UnresolvedForward bool
 }
 
 type crawlSkip struct {
@@ -237,10 +243,11 @@ func (c *siteCrawler) CrawlStream(ctx context.Context, seedURL string, onPage fu
 	pacer := c.newPacer()
 
 	requestedSeed := seedURL
-	seedURL, seedPage, err := c.fetchSeed(ctx, pacer, seedURL)
+	seed, err := c.fetchSeed(ctx, pacer, seedURL)
 	if err != nil {
 		return siteCrawl{}, err
 	}
+	seedURL, seedPage := seed.URL, seed.Page
 	seedParsed, err := url.Parse(seedURL)
 	if err != nil {
 		return siteCrawl{}, fmt.Errorf("site read: %q is not a crawlable URL: %w", seedURL, err)

--- a/backend/internal/compose/sitecrawl_test.go
+++ b/backend/internal/compose/sitecrawl_test.go
@@ -62,6 +62,9 @@ type fakeSitePage struct {
 	// input the logo resolve ranks over.
 	ogImage string
 	icons   []webread.IconRef
+	// refresh is the meta-refresh target this page declares, which the real
+	// parser only reports for a same-site target it could resolve.
+	refresh string
 }
 
 func (s *fakeSite) FetchPage(_ context.Context, rawURL string) (webread.Page, error) {
@@ -97,7 +100,7 @@ func (s *fakeSite) FetchPage(_ context.Context, rawURL string) (webread.Page, er
 	}
 	return webread.Page{
 		URL: rawURL, FinalURL: finalURL, Text: page.text, Links: page.links, Bytes: len(page.text),
-		OGImage: page.ogImage, Icons: page.icons,
+		OGImage: page.ogImage, Icons: page.icons, Refresh: page.refresh,
 	}, nil
 }
 

--- a/backend/internal/compose/sitecrawlfetch.go
+++ b/backend/internal/compose/sitecrawlfetch.go
@@ -27,13 +27,14 @@ import (
 func (c *siteCrawler) ReadSeed(ctx context.Context, seedURL string) (crawlPage, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.wall)
 	defer cancel()
-	answered, page, err := c.fetchSeed(ctx, c.newPacer(), seedURL)
+	seed, err := c.fetchSeed(ctx, c.newPacer(), seedURL)
 	if err != nil {
 		return crawlPage{}, err
 	}
 	return crawlPage{
-		URL: answered, Kind: crmcontracts.SiteReadPageKindHome,
-		Text: page.Text, Bytes: page.Bytes, Fingerprint: page.Fingerprint,
+		URL: seed.URL, Kind: crmcontracts.SiteReadPageKindHome,
+		Text: seed.Page.Text, Bytes: seed.Page.Bytes, Fingerprint: seed.Page.Fingerprint,
+		UnresolvedForward: seed.UnresolvedForward,
 	}, nil
 }
 

--- a/backend/internal/compose/siteseed.go
+++ b/backend/internal/compose/siteseed.go
@@ -29,7 +29,7 @@ import (
 // fetchSeed gets the landing page, or reports why the site could not be read
 // at all. It returns the URL that ANSWERED, which is the site's own spelling
 // of itself and what the crawl treats as on-site from then on.
-func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL string) (string, webread.Page, error) {
+func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL string) (seedRead, error) {
 	page, err := c.fetchPaced(ctx, pacer, seedURL)
 	if transientCrawlError(ctx, err) {
 		// The landing page is the only irreplaceable discovery source. One
@@ -38,15 +38,14 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 		page, err = c.fetchPaced(ctx, pacer, seedURL)
 	}
 	if err == nil {
-		answered, landed := c.settleSeed(ctx, pacer, seedURL, page)
-		return answered, landed, nil
+		return c.settleSeed(ctx, pacer, seedURL, page), nil
 	}
 	if errors.Is(err, webread.ErrRobotsDisallowed) {
 		// A refused seed carries no body, so there is nothing to follow and
 		// nothing to read: the refusal itself is the answer.
 		answered := answeredSeedURL(seedURL, page)
 		c.applyCrawlDelay(pacer, answered)
-		return answered, page, err
+		return seedRead{URL: answered, Page: page}, err
 	}
 	for _, candidate := range seedFallbacks(seedURL) {
 		if ctx.Err() != nil {
@@ -60,18 +59,29 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 			retryPage, retryErr = c.fetchPaced(ctx, pacer, candidate)
 		}
 		if retryErr == nil {
-			answered, landed := c.settleSeed(ctx, pacer, candidate, retryPage)
-			return answered, landed, nil
+			return c.settleSeed(ctx, pacer, candidate, retryPage), nil
 		}
 		// A refusal is the site's answer, not a spelling that failed to
 		// resolve. Every remaining candidate is the SAME site under another
 		// host or scheme, so trying them would be answering a "no" by
 		// knocking on the next door.
 		if errors.Is(retryErr, webread.ErrRobotsDisallowed) {
-			return seedURL, webread.Page{}, retryErr
+			return seedRead{URL: seedURL}, retryErr
 		}
 	}
-	return seedURL, webread.Page{}, err
+	return seedRead{URL: seedURL}, err
+}
+
+// seedRead is the landing page a seed resolved to: the URL that answered, the
+// body, and whether the site named an address the crawl could not reach.
+type seedRead struct {
+	URL  string
+	Page webread.Page
+	// UnresolvedForward is set when the landing page named somewhere else as
+	// the site's real address and that address could not be read. The page
+	// below is then the forwarding shell — empty, but empty for a reason that
+	// is not "this domain is parked".
+	UnresolvedForward bool
 }
 
 // settleSeed turns a seed that answered into the page the crawl should treat
@@ -92,22 +102,40 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 // pages pointing at each other would never end. A refresh that leaves the
 // site's own registrable domain was already dropped at parse time
 // (webread.refreshFrom), so the hop stays on the site we resolved to read.
-func (c *siteCrawler) settleSeed(ctx context.Context, pacer crawlPacer, requested string, page webread.Page) (string, webread.Page) {
+// A follow that does not arrive says so, in UnresolvedForward. The shell is
+// then still empty, but the triage must not read that emptiness as a parked
+// domain: the site named an address, and failing to reach it is a gap in the
+// read rather than an answer about the company.
+func (c *siteCrawler) settleSeed(ctx context.Context, pacer crawlPacer, requested string, page webread.Page) seedRead {
 	answered := answeredSeedURL(requested, page)
 	c.applyCrawlDelay(pacer, answered)
 	if !page.MetaRefreshOnly() {
-		return answered, page
+		return seedRead{URL: answered, Page: page}
 	}
+	unresolved := seedRead{URL: answered, Page: page, UnresolvedForward: true}
 	landed, err := c.fetchPaced(ctx, pacer, page.Refresh)
 	if err != nil {
-		// The trampoline is all this site gave us. Returning it unchanged
-		// leaves the triage exactly the evidence it had before — an empty
-		// landing page — rather than inventing a read that did not happen.
-		return answered, page
+		// The trampoline is all this site gave us.
+		return unresolved
 	}
 	followed := answeredSeedURL(page.Refresh, landed)
+	// Where the hop LANDED, not just where it pointed. The parse-time check
+	// judged the target URL, and a target on the site's own domain can still
+	// 30x onto somebody else's — an open redirect is an ordinary thing to find
+	// on a corporate site. Letting that through would hand the crawl a
+	// boundary, and a company identity, chosen by whoever wrote the markup.
+	//
+	// A seed that redirects off-domain by HTTP is different and stays allowed
+	// (answeredSeedURL): there the destination is where the domain WE were
+	// asked to read forwards to, which is that domain's own answer about
+	// where it lives.
+	if !webread.SameRegistrableDomain(answered, followed) {
+		return unresolved
+	}
 	c.applyCrawlDelay(pacer, followed)
-	return followed, landed
+	// A second forwarding shell is not followed again — one hop is the cap —
+	// so it leaves the read unresolved for the same reason a failed fetch does.
+	return seedRead{URL: followed, Page: landed, UnresolvedForward: landed.MetaRefreshOnly()}
 }
 
 // answeredSeedURL is the URL the seed's body actually came from. The fetch

--- a/backend/internal/compose/siteseed.go
+++ b/backend/internal/compose/siteseed.go
@@ -37,7 +37,13 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 		// crawl's wall deadline still bounds the attempt.
 		page, err = c.fetchPaced(ctx, pacer, seedURL)
 	}
-	if err == nil || errors.Is(err, webread.ErrRobotsDisallowed) {
+	if err == nil {
+		answered, landed := c.settleSeed(ctx, pacer, seedURL, page)
+		return answered, landed, nil
+	}
+	if errors.Is(err, webread.ErrRobotsDisallowed) {
+		// A refused seed carries no body, so there is nothing to follow and
+		// nothing to read: the refusal itself is the answer.
 		answered := answeredSeedURL(seedURL, page)
 		c.applyCrawlDelay(pacer, answered)
 		return answered, page, err
@@ -54,9 +60,8 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 			retryPage, retryErr = c.fetchPaced(ctx, pacer, candidate)
 		}
 		if retryErr == nil {
-			answered := answeredSeedURL(candidate, retryPage)
-			c.applyCrawlDelay(pacer, answered)
-			return answered, retryPage, nil
+			answered, landed := c.settleSeed(ctx, pacer, candidate, retryPage)
+			return answered, landed, nil
 		}
 		// A refusal is the site's answer, not a spelling that failed to
 		// resolve. Every remaining candidate is the SAME site under another
@@ -67,6 +72,42 @@ func (c *siteCrawler) fetchSeed(ctx context.Context, pacer crawlPacer, seedURL s
 		}
 	}
 	return seedURL, webread.Page{}, err
+}
+
+// settleSeed turns a seed that answered into the page the crawl should treat
+// as the landing page, following a meta-refresh trampoline once if that is
+// what answered.
+//
+// A site can publish its real address in markup instead of an HTTP redirect —
+// an empty document whose whole content is
+// `<meta http-equiv="refresh" content="0; URL=/de">`. The fetcher follows HTTP
+// redirects and never sees this one, so the crawl reads a page with no text on
+// it. That is indistinguishable from a parked domain, and the domain triage
+// judges it as one: anwr-group.com was refused a company on exactly this
+// shape, and every language-gateway site of that vintage has it.
+//
+// Followed ONCE, never in a loop. One hop reaches the site a browser would
+// land on, which is the whole gap; chaining them would let a site walk the
+// crawler through as many fetches as it cares to write, and a cycle of two
+// pages pointing at each other would never end. A refresh that leaves the
+// site's own registrable domain was already dropped at parse time
+// (webread.refreshFrom), so the hop stays on the site we resolved to read.
+func (c *siteCrawler) settleSeed(ctx context.Context, pacer crawlPacer, requested string, page webread.Page) (string, webread.Page) {
+	answered := answeredSeedURL(requested, page)
+	c.applyCrawlDelay(pacer, answered)
+	if !page.MetaRefreshOnly() {
+		return answered, page
+	}
+	landed, err := c.fetchPaced(ctx, pacer, page.Refresh)
+	if err != nil {
+		// The trampoline is all this site gave us. Returning it unchanged
+		// leaves the triage exactly the evidence it had before — an empty
+		// landing page — rather than inventing a read that did not happen.
+		return answered, page
+	}
+	followed := answeredSeedURL(page.Refresh, landed)
+	c.applyCrawlDelay(pacer, followed)
+	return followed, landed
 }
 
 // answeredSeedURL is the URL the seed's body actually came from. The fetch

--- a/backend/internal/compose/siteseed_test.go
+++ b/backend/internal/compose/siteseed_test.go
@@ -4,6 +4,8 @@
 package compose
 
 import (
+	"context"
+	"errors"
 	"slices"
 	"testing"
 )
@@ -69,5 +71,102 @@ func TestSeedFallbacksRefusesWhatItCannotParseOrShouldNotFetch(t *testing.T) {
 		if got := seedFallbacks(seed); len(got) != 0 {
 			t.Errorf("seedFallbacks(%q) = %v, want none", seed, got)
 		}
+	}
+}
+
+// The defect this fixes: a landing page that only forwards to the real site
+// read as a page with nothing on it, so the domain triage called the site
+// parked and the company was never created.
+func TestASeedThatOnlyForwardsIsFollowedToTheRealLandingPage(t *testing.T) {
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		"https://anwr-group.com":    {refresh: "https://anwr-group.com/de"},
+		"https://anwr-group.com/de": {text: "ANWR Group is a retail cooperative."},
+	}}
+	page, err := newSiteCrawler(site, CrawlCaps{}).ReadSeed(context.Background(), "https://anwr-group.com")
+	if err != nil {
+		t.Fatalf("reading the seed: %v", err)
+	}
+	if want := "https://anwr-group.com/de"; page.URL != want {
+		t.Errorf("landing page URL = %q, want %q", page.URL, want)
+	}
+	if page.Text == "" {
+		t.Error("the landing page carries no text — the triage will call this site parked")
+	}
+}
+
+// One hop, never a chain. A site can write as many trampolines as it likes,
+// and each one the crawler follows is a fetch it was told to make by the page
+// it just read.
+func TestAChainOfForwardingPagesIsFollowedOnlyOnce(t *testing.T) {
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		"https://acme.example":     {refresh: "https://acme.example/one"},
+		"https://acme.example/one": {refresh: "https://acme.example/two"},
+		"https://acme.example/two": {text: "the real site"},
+	}}
+	page, err := newSiteCrawler(site, CrawlCaps{}).ReadSeed(context.Background(), "https://acme.example")
+	if err != nil {
+		t.Fatalf("reading the seed: %v", err)
+	}
+	if want := "https://acme.example/one"; page.URL != want {
+		t.Errorf("landing page URL = %q, want %q — exactly one hop", page.URL, want)
+	}
+	if slices.Contains(site.fetched, "https://acme.example/two") {
+		t.Errorf("the crawler followed a second hop: %v", site.fetched)
+	}
+}
+
+// Two pages forwarding to each other would loop forever if the follow were
+// not capped at one, and a site can publish that by accident.
+func TestTwoPagesForwardingToEachOtherTerminate(t *testing.T) {
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		"https://acme.example":    {refresh: "https://acme.example/de"},
+		"https://acme.example/de": {refresh: "https://acme.example"},
+	}}
+	if _, err := newSiteCrawler(site, CrawlCaps{}).ReadSeed(context.Background(), "https://acme.example"); err != nil {
+		t.Fatalf("reading the seed: %v", err)
+	}
+	if len(site.fetched) > 2 {
+		t.Errorf("fetched %v — a forwarding cycle must cost at most one extra fetch", site.fetched)
+	}
+}
+
+// When the forwarding target does not answer, the triage must be left with the
+// evidence it actually had rather than an error: the empty shell is a real
+// read, and the site may still be judged from what else the crawl finds.
+func TestAForwardingTargetThatFailsLeavesTheOriginalPage(t *testing.T) {
+	site := &fakeSite{
+		pages: map[string]fakeSitePage{
+			"https://acme.example": {refresh: "https://acme.example/de"},
+		},
+		pageErrors: map[string][]error{
+			"https://acme.example/de": {errors.New("the forwarding target answered 500")},
+		},
+	}
+	page, err := newSiteCrawler(site, CrawlCaps{}).ReadSeed(context.Background(), "https://acme.example")
+	if err != nil {
+		t.Fatalf("a failed follow must not fail the seed read: %v", err)
+	}
+	if want := "https://acme.example"; page.URL != want {
+		t.Errorf("landing page URL = %q, want the page that did answer, %q", page.URL, want)
+	}
+}
+
+// A site reached through the www/scheme ladder gets the same follow: the two
+// shapes co-occur constantly, because the host that forwards by markup is
+// usually also the one that only answers on www.
+func TestASeedReachedThroughTheFallbackLadderIsAlsoFollowed(t *testing.T) {
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		"https://www.acme.example":    {refresh: "https://www.acme.example/de"},
+		"https://www.acme.example/de": {text: "the real site"},
+	}}
+	page, err := newSiteCrawler(site, CrawlCaps{}).ReadSeed(context.Background(), "https://acme.example")
+	if err != nil {
+		t.Fatalf("reading the seed: %v", err)
+	}
+	if want := "https://www.acme.example/de"; page.URL != want {
+		t.Errorf("landing page URL = %q, want %q", page.URL, want)
+	}
+	if page.Text == "" {
+		t.Error("the landing page carries no text after the ladder plus the follow")
 	}
 }

--- a/backend/internal/compose/siteseed_test.go
+++ b/backend/internal/compose/siteseed_test.go
@@ -149,6 +149,76 @@ func TestAForwardingTargetThatFailsLeavesTheOriginalPage(t *testing.T) {
 	if want := "https://acme.example"; page.URL != want {
 		t.Errorf("landing page URL = %q, want the page that did answer, %q", page.URL, want)
 	}
+	// Without this the empty shell reads exactly like a parked domain, which
+	// is the defect the follow exists to fix, re-created on the failure path.
+	if !page.UnresolvedForward {
+		t.Error("the page named an address the crawl could not reach and must say so")
+	}
+}
+
+// A page that says GO HERE and one that says nothing are different claims, and
+// only the second is evidence that a domain is parked.
+func TestAnUnresolvedForwardIsNotSettledAsParked(t *testing.T) {
+	unreadable := crawlPage{Text: "", UnresolvedForward: true}
+	if verdict, err := (&siteDeepReadWorker{}).classifySeed(context.Background(), unreadable); err != nil {
+		t.Fatalf("classifying: %v", err)
+	} else if verdict.Aborts() {
+		t.Errorf("verdict %+v settles the domain — an unread forward must leave the question open", verdict)
+	}
+
+	// The shortcut still holds for a page that genuinely carries nothing.
+	empty := crawlPage{Text: ""}
+	if verdict, err := (&siteDeepReadWorker{}).classifySeed(context.Background(), empty); err != nil {
+		t.Fatalf("classifying: %v", err)
+	} else if !verdict.Aborts() {
+		t.Errorf("verdict %+v does not settle a genuinely empty landing page", verdict)
+	}
+}
+
+// The one-hop cap and the unresolved mark have to agree: a second shell is
+// correctly not followed, and must therefore be reported as unread rather than
+// handed to the classifier as an empty page.
+func TestASecondForwardingShellIsReportedUnresolved(t *testing.T) {
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		"https://acme.example":     {refresh: "https://acme.example/one"},
+		"https://acme.example/one": {refresh: "https://acme.example/two"},
+		"https://acme.example/two": {text: "the real site"},
+	}}
+	page, err := newSiteCrawler(site, CrawlCaps{}).ReadSeed(context.Background(), "https://acme.example")
+	if err != nil {
+		t.Fatalf("reading the seed: %v", err)
+	}
+	if !page.UnresolvedForward {
+		t.Error("the hop landed on another forwarding shell, which is not a read of the site")
+	}
+}
+
+// The parse-time check judges where the refresh POINTS. A target on the site's
+// own domain can still redirect onto somebody else's — an open redirect is an
+// ordinary thing to find on a corporate site — and letting that through would
+// hand the crawl a boundary, and a company identity, chosen by whoever wrote
+// the markup.
+func TestAForwardingHopThatRedirectsOffTheSiteIsNotAccepted(t *testing.T) {
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		"https://acme.example": {refresh: "https://acme.example/out?to=evil"},
+		"https://acme.example/out?to=evil": {
+			text:     "a different company's site",
+			finalURL: "https://evil.test/landing",
+		},
+	}}
+	page, err := newSiteCrawler(site, CrawlCaps{}).ReadSeed(context.Background(), "https://acme.example")
+	if err != nil {
+		t.Fatalf("reading the seed: %v", err)
+	}
+	if want := "https://acme.example"; page.URL != want {
+		t.Errorf("landing page URL = %q, want %q — the hop left the site and must not become the seed", page.URL, want)
+	}
+	if page.Text != "" {
+		t.Errorf("landing page text = %q, want nothing — it came from another company's site", page.Text)
+	}
+	if !page.UnresolvedForward {
+		t.Error("the site's real address was never reached, so the read is unresolved, not parked")
+	}
 }
 
 // A site reached through the www/scheme ladder gets the same follow: the two

--- a/backend/internal/platform/webread/asset_test.go
+++ b/backend/internal/platform/webread/asset_test.go
@@ -81,7 +81,8 @@ func TestHeadAssetExtraction(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotOG, gotIcons := extractHeadAssets(tc.html, base)
+			head := extractHeadAssets(tc.html, base)
+			gotOG, gotIcons := head.ogImage, head.icons
 			if gotOG != tc.wantOG {
 				t.Fatalf("og:image = %q, want %q", gotOG, tc.wantOG)
 			}
@@ -272,14 +273,18 @@ func TestOnlyTheHeadDeclaresTheVisualIdentity(t *testing.T) {
 	// A page carrying user-generated content is exactly where body markup an
 	// attacker wrote shows up. The head's declaration is the site's; the
 	// body's is anybody's.
-	og, icons := extractHeadAssets(
+	head := extractHeadAssets(
 		`<html><head><link rel="icon" href="/real.png"></head>`+
 			`<body><link rel="icon" href="/injected.png">`+
+			`<meta http-equiv="refresh" content="0; URL=/injected-page">`+
 			`<meta property="og:image" content="/injected-share.png"></body></html>`, base)
-	if og != "" {
-		t.Fatalf("og:image = %q, want nothing — it was declared in the body", og)
+	if head.ogImage != "" {
+		t.Fatalf("og:image = %q, want nothing — it was declared in the body", head.ogImage)
 	}
-	if len(icons) != 1 || icons[0].URL != "https://acme.example/real.png" {
-		t.Fatalf("icons = %+v, want only the head's declaration", icons)
+	if head.refresh != "" {
+		t.Fatalf("refresh = %q, want nothing — it was declared in the body", head.refresh)
+	}
+	if len(head.icons) != 1 || head.icons[0].URL != "https://acme.example/real.png" {
+		t.Fatalf("icons = %+v, want only the head's declaration", head.icons)
 	}
 }

--- a/backend/internal/platform/webread/page.go
+++ b/backend/internal/platform/webread/page.go
@@ -164,21 +164,7 @@ func extractHeadAssets(rawHTML string, base *url.URL) headAssets {
 			return head
 		}
 		name, hasAttr := tokenizer.TagName()
-		// The harvest stops where the head does, because that is where a site
-		// declares its own identity. Markup in the body is not the same claim:
-		// on a page that renders user-generated content, whoever wrote that
-		// content also wrote the tags around it, and a <link rel="icon"> down
-		// there would let them choose the company's face — or, for a refresh,
-		// where the crawler goes next.
-		//
-		// A page may legally omit </head>, so <body> ends it too. Testing only
-		// for the closing tag let body markup on such a page be read as the
-		// site's own declaration, which is the whole thing this boundary
-		// exists to prevent.
-		if tokenType == html.EndTagToken && string(name) == "head" {
-			return head
-		}
-		if tokenType == html.StartTagToken && string(name) == "body" {
+		if endsHead(tokenType, string(name)) {
 			return head
 		}
 		if !hasAttr {
@@ -207,6 +193,25 @@ func extractHeadAssets(rawHTML string, base *url.URL) headAssets {
 			}
 		}
 	}
+}
+
+// endsHead reports whether this token ends the document head, which is where
+// the asset harvest stops.
+//
+// The head is where a site declares its own identity. Markup in the body is
+// not the same claim: on a page that renders user-generated content, whoever
+// wrote that content also wrote the tags around it, and a <link rel="icon">
+// down there would let them choose the company's face — or, for a refresh,
+// where the crawler goes next.
+//
+// A page may legally omit </head>, so an opening <body> ends it too. Testing
+// only for the closing tag let body markup on such a page be read as the
+// site's own declaration, which is the whole thing this boundary prevents.
+func endsHead(tokenType html.TokenType, name string) bool {
+	if tokenType == html.EndTagToken && name == "head" {
+		return true
+	}
+	return tokenType == html.StartTagToken && name == "body"
 }
 
 // tagAttrs collects the current tag's attributes, keys lowercased. The

--- a/backend/internal/platform/webread/page.go
+++ b/backend/internal/platform/webread/page.go
@@ -164,12 +164,21 @@ func extractHeadAssets(rawHTML string, base *url.URL) headAssets {
 			return head
 		}
 		name, hasAttr := tokenizer.TagName()
-		// The harvest stops at </head>, because that is where a site declares
-		// its own identity. Markup in the body is not the same claim: on a page
-		// that renders user-generated content, whoever wrote that content also
-		// wrote the tags around it, and a <link rel="icon"> down there would
-		// let them choose the company's face.
+		// The harvest stops where the head does, because that is where a site
+		// declares its own identity. Markup in the body is not the same claim:
+		// on a page that renders user-generated content, whoever wrote that
+		// content also wrote the tags around it, and a <link rel="icon"> down
+		// there would let them choose the company's face — or, for a refresh,
+		// where the crawler goes next.
+		//
+		// A page may legally omit </head>, so <body> ends it too. Testing only
+		// for the closing tag let body markup on such a page be read as the
+		// site's own declaration, which is the whole thing this boundary
+		// exists to prevent.
 		if tokenType == html.EndTagToken && string(name) == "head" {
+			return head
+		}
+		if tokenType == html.StartTagToken && string(name) == "body" {
 			return head
 		}
 		if !hasAttr {
@@ -265,12 +274,15 @@ func refreshTarget(content string) (string, bool) {
 	if !found {
 		return "", false
 	}
-	rest := strings.TrimSpace(after)
-	if !strings.HasPrefix(strings.ToLower(rest), "url") {
+	key, target, found := strings.Cut(after, "=")
+	if !found {
 		return "", false
 	}
-	_, target, found := strings.Cut(rest, "=")
-	if !found {
+	// The key must be exactly `url`, not merely start with it. Accepting any
+	// `url…=` spelling turned `garbage; url-not=/private` into a redirect
+	// nobody wrote, and every one of those is a fetch the crawler makes on
+	// markup it misread.
+	if !strings.EqualFold(strings.TrimSpace(key), "url") {
 		return "", false
 	}
 	// Quotes are common in hand-written markup and are not part of the URL.

--- a/backend/internal/platform/webread/page.go
+++ b/backend/internal/platform/webread/page.go
@@ -44,6 +44,24 @@ type Page struct {
 	// the one page that runs it and nowhere else, and the crawl has already
 	// paid for that page.
 	Fingerprint Fingerprint
+	// Refresh is the <meta http-equiv="refresh"> target this page declared
+	// (absolute), or "" when it declared none, none that resolves, or one
+	// leaving the page's own registrable domain. A caller follows it only
+	// after finding nothing else to read — see MetaRefreshOnly.
+	Refresh string
+}
+
+// MetaRefreshOnly reports whether this page is a redirect trampoline: it
+// declares a refresh target and carries no readable text of its own.
+//
+// This is a real shape, not a defensive one. A site can announce its language
+// choice this way — an empty document whose whole content is
+// `<meta http-equiv="refresh" content="0; URL=/de">` — and a browser lands on
+// the real site without the person ever seeing the shell. A reader that stops
+// at the shell sees a page with nothing on it, which is indistinguishable from
+// a parked domain and gets judged as one.
+func (p Page) MetaRefreshOnly() bool {
+	return p.Refresh != "" && strings.TrimSpace(p.Text) == ""
 }
 
 // Icon rel kinds a page can declare. Callers rank by kind rather than by
@@ -107,33 +125,43 @@ func (f *Fetcher) FetchPage(ctx context.Context, rawURL string) (Page, error) {
 		base = parsed
 	}
 	body := string(got.body)
-	ogImage, icons := extractHeadAssets(body, base)
+	head := extractHeadAssets(body, base)
 	return Page{
 		URL:         rawURL,
 		FinalURL:    base.String(),
 		Text:        StripTags(body),
 		Links:       extractLinks(body, base),
 		Bytes:       len(body),
-		OGImage:     ogImage,
-		Icons:       icons,
+		OGImage:     head.ogImage,
+		Icons:       head.icons,
+		Refresh:     head.refresh,
 		Fingerprint: fingerprintOf(got.header, body, base),
 	}, nil
 }
 
-// extractHeadAssets harvests the visual identity a page declares: its
-// og:image and every <link rel> naming an icon. Both live in attributes
-// StripTags destroys, so — like extractLinks — the harvest runs on the raw
-// HTML. URLs come back absolute; a candidate whose href does not resolve to
-// an http(s) URL is dropped rather than guessed at.
-func extractHeadAssets(rawHTML string, base *url.URL) (ogImage string, icons []IconRef) {
+// headAssets is what a page's <head> declared about itself: its visual
+// identity, and where it says the reader should go instead.
+type headAssets struct {
+	ogImage string
+	icons   []IconRef
+	refresh string
+}
+
+// extractHeadAssets harvests what a page's <head> declares about itself: its
+// og:image, every <link rel> naming an icon, and any meta-refresh target. All
+// live in attributes StripTags destroys, so — like extractLinks — the harvest
+// runs on the raw HTML. URLs come back absolute; a candidate whose href does
+// not resolve to an http(s) URL is dropped rather than guessed at.
+func extractHeadAssets(rawHTML string, base *url.URL) headAssets {
 	tokenizer := html.NewTokenizer(strings.NewReader(rawHTML))
+	var head headAssets
 	seen := map[string]bool{}
 	for {
 		tokenType := tokenizer.Next()
 		if tokenType == html.ErrorToken {
 			// io.EOF or a malformed tail: the parseable prefix has been
 			// harvested, which is all a best-effort discovery aid owes.
-			return ogImage, icons
+			return head
 		}
 		name, hasAttr := tokenizer.TagName()
 		// The harvest stops at </head>, because that is where a site declares
@@ -142,23 +170,31 @@ func extractHeadAssets(rawHTML string, base *url.URL) (ogImage string, icons []I
 		// wrote the tags around it, and a <link rel="icon"> down there would
 		// let them choose the company's face.
 		if tokenType == html.EndTagToken && string(name) == "head" {
-			return ogImage, icons
+			return head
 		}
 		if !hasAttr {
 			continue
 		}
 		switch string(name) {
 		case "meta":
-			if found, ok := ogImageFrom(tokenizer, base); ok && ogImage == "" {
+			// A <meta> is at most one of these, but which one is only known
+			// after its attributes are read, and the tokenizer yields those
+			// once — so both readings take the attribute set, not the
+			// tokenizer.
+			attrs := tagAttrs(tokenizer)
+			if found, ok := ogImageFrom(attrs, base); ok && head.ogImage == "" {
 				// First declaration wins: a page repeating og:image offers no
 				// basis to rank the repeats, and the first is conventionally
 				// the canonical one.
-				ogImage = found
+				head.ogImage = found
+			}
+			if found, ok := refreshFrom(attrs, base); ok && head.refresh == "" {
+				head.refresh = found
 			}
 		case "link":
 			if icon, ok := iconFrom(tokenizer, base); ok && !seen[icon.URL] {
 				seen[icon.URL] = true
-				icons = append(icons, icon)
+				head.icons = append(head.icons, icon)
 			}
 		}
 	}
@@ -179,14 +215,66 @@ func tagAttrs(tokenizer *html.Tokenizer) map[string]string {
 	}
 }
 
-// ogImageFrom reads one <meta> as an og:image declaration. Open Graph names
-// the field in `property`; some CMSs emit it in `name`, so both are accepted.
-func ogImageFrom(tokenizer *html.Tokenizer, base *url.URL) (string, bool) {
-	attrs := tagAttrs(tokenizer)
+// ogImageFrom reads one <meta>'s attributes as an og:image declaration. Open
+// Graph names the field in `property`; some CMSs emit it in `name`, so both
+// are accepted.
+func ogImageFrom(attrs map[string]string, base *url.URL) (string, bool) {
 	if attrs["property"] != "og:image" && attrs["name"] != "og:image" {
 		return "", false
 	}
 	return resolveAsset(base, attrs["content"])
+}
+
+// refreshFrom reads one <meta>'s attributes as a refresh declaration, and
+// returns the absolute URL it points at.
+//
+// The target must stay on the page's own registrable domain. A refresh is
+// markup, so whoever writes the page chooses it, and following one off-site
+// would let any page we read redirect the crawl at a host we never decided to
+// visit — including one chosen to be read as the company's own site. Staying
+// on-domain keeps the follow within the site we already resolved to read, so
+// it can reach `/de` on the same host but never someone else's server.
+//
+// Only a same-document `URL=` target is refused too: a refresh that names no
+// URL is a page telling itself to reload, which is not somewhere else to go.
+func refreshFrom(attrs map[string]string, base *url.URL) (string, bool) {
+	if !strings.EqualFold(strings.TrimSpace(attrs["http-equiv"]), "refresh") {
+		return "", false
+	}
+	target, ok := refreshTarget(attrs["content"])
+	if !ok {
+		return "", false
+	}
+	resolved, ok := resolveAsset(base, target)
+	if !ok {
+		return "", false
+	}
+	if !SameRegistrableDomain(base.String(), resolved) {
+		return "", false
+	}
+	return resolved, true
+}
+
+// refreshTarget pulls the URL out of a refresh content attribute. The value is
+// a delay, optionally followed by `; url=<target>` — `0; URL=/de` is the
+// ordinary spelling. The delay is not read: a site that says to leave after
+// ten seconds is still naming somewhere else as its real address, and the
+// crawler is not a browser waiting out a countdown.
+func refreshTarget(content string) (string, bool) {
+	_, after, found := strings.Cut(content, ";")
+	if !found {
+		return "", false
+	}
+	rest := strings.TrimSpace(after)
+	if !strings.HasPrefix(strings.ToLower(rest), "url") {
+		return "", false
+	}
+	_, target, found := strings.Cut(rest, "=")
+	if !found {
+		return "", false
+	}
+	// Quotes are common in hand-written markup and are not part of the URL.
+	return strings.Trim(strings.TrimSpace(target), `"'`), true
 }
 
 // iconFrom reads one <link> as an icon declaration.

--- a/backend/internal/platform/webread/refresh_test.go
+++ b/backend/internal/platform/webread/refresh_test.go
@@ -128,11 +128,57 @@ func TestRefreshSpellingsTheWebActuallyUses(t *testing.T) {
 			html: `<meta http-equiv="content-type" content="text/html; charset=utf-8">`,
 			want: "",
 		},
+		{
+			// The key must be exactly `url`. Accepting anything that merely
+			// starts with it invents a redirect out of markup nobody wrote,
+			// and the crawler pays a fetch for the misreading.
+			name: "a key that only begins with url",
+			html: `<meta http-equiv="refresh" content="garbage; url-not=/private">`,
+			want: "",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if head := extractHeadAssets(tc.html, base); head.refresh != tc.want {
 				t.Fatalf("refresh = %q, want %q", head.refresh, tc.want)
+			}
+		})
+	}
+}
+
+// HTML permits a page to omit </head>, and a page that does was still having
+// its body markup read as the site's own declaration — which is how a refresh
+// somebody else wrote could send the crawler somewhere.
+func TestBodyMarkupIsIgnoredEvenWhenTheHeadIsNeverClosed(t *testing.T) {
+	base := mustParseURL(t, "https://acme.example/")
+	unclosed := []struct {
+		name string
+		html string
+	}{
+		{
+			name: "a body opened without the head being closed",
+			html: `<html><head><title>x</title><body>` +
+				`<meta http-equiv="refresh" content="0; URL=/injected">` +
+				`<meta property="og:image" content="/injected.png">` +
+				`<link rel="icon" href="/injected-icon.png"></body></html>`,
+		},
+		{
+			name: "a page with no head element at all",
+			html: `<html><body><meta http-equiv="refresh" content="0; URL=/injected">` +
+				`<link rel="icon" href="/injected-icon.png"></body></html>`,
+		},
+	}
+	for _, tc := range unclosed {
+		t.Run(tc.name, func(t *testing.T) {
+			head := extractHeadAssets(tc.html, base)
+			if head.refresh != "" {
+				t.Errorf("refresh = %q, want nothing — it was declared in the body", head.refresh)
+			}
+			if head.ogImage != "" {
+				t.Errorf("og:image = %q, want nothing — it was declared in the body", head.ogImage)
+			}
+			if len(head.icons) != 0 {
+				t.Errorf("icons = %+v, want none — they were declared in the body", head.icons)
 			}
 		})
 	}

--- a/backend/internal/platform/webread/refresh_test.go
+++ b/backend/internal/platform/webread/refresh_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+import (
+	"net/url"
+	"testing"
+)
+
+// The shape this whole feature exists for, byte for byte as anwr-group.com
+// serves it: a document with no content but a refresh pointing at the real
+// site. A reader that stops here sees an empty page and calls the domain
+// parked.
+const languageGatewayHTML = `<!DOCTYPE html>
+<html lang="de">
+  <head>
+	<meta http-equiv="refresh" content="0; URL=/de">
+    <meta charset="utf-8" />
+  </head>
+  <body></body>
+</html>`
+
+func TestARefreshOnlyLandingPageNamesWhereTheSiteReallyIs(t *testing.T) {
+	base := mustParseURL(t, "https://www.anwr-group.com/")
+	head := extractHeadAssets(languageGatewayHTML, base)
+	if want := "https://www.anwr-group.com/de"; head.refresh != want {
+		t.Fatalf("refresh = %q, want %q", head.refresh, want)
+	}
+
+	page := Page{Text: StripTags(languageGatewayHTML), Refresh: head.refresh}
+	if !page.MetaRefreshOnly() {
+		t.Fatalf("a page with no text and a refresh target must read as a trampoline, text = %q", page.Text)
+	}
+}
+
+// A page with something to say is not a trampoline, even when it also carries
+// a refresh: following it would abandon text the site did publish.
+func TestAPageWithTextIsNotATrampolineEvenWhenItRefreshes(t *testing.T) {
+	page := Page{Text: "ANWR Group is a retail cooperative.", Refresh: "https://acme.example/de"}
+	if page.MetaRefreshOnly() {
+		t.Fatal("a page carrying text must not be treated as a redirect shell")
+	}
+}
+
+func TestRefreshTargetsOffTheSitesOwnDomainAreRefused(t *testing.T) {
+	base := mustParseURL(t, "https://acme.example/")
+	offSite := []struct {
+		name string
+		html string
+	}{
+		{
+			name: "another company's server",
+			html: `<meta http-equiv="refresh" content="0; URL=https://evil.test/pretend">`,
+		},
+		{
+			// The classic suffix trick: acme.example.evil.test only LOOKS
+			// like it belongs to acme.example.
+			name: "a host that merely starts with the site's name",
+			html: `<meta http-equiv="refresh" content="0; URL=https://acme.example.evil.test/">`,
+		},
+		{
+			name: "a scheme that is not fetchable at all",
+			html: `<meta http-equiv="refresh" content="0; URL=file:///etc/passwd">`,
+		},
+	}
+	for _, tc := range offSite {
+		t.Run(tc.name, func(t *testing.T) {
+			if head := extractHeadAssets(tc.html, base); head.refresh != "" {
+				t.Fatalf("refresh = %q, want nothing — the target leaves the site", head.refresh)
+			}
+		})
+	}
+}
+
+// A refresh may point anywhere on the site's own domain, including another
+// host under it — that is still the site we resolved to read.
+func TestARefreshOntoTheSitesOwnDomainIsFollowed(t *testing.T) {
+	base := mustParseURL(t, "https://acme.example/")
+	head := extractHeadAssets(`<meta http-equiv="refresh" content="0; URL=https://www.acme.example/de">`, base)
+	if want := "https://www.acme.example/de"; head.refresh != want {
+		t.Fatalf("refresh = %q, want %q", head.refresh, want)
+	}
+}
+
+func TestRefreshSpellingsTheWebActuallyUses(t *testing.T) {
+	base := mustParseURL(t, "https://acme.example/")
+	cases := []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			name: "lowercase url and no space after the semicolon",
+			html: `<meta http-equiv="refresh" content="0;url=/de">`,
+			want: "https://acme.example/de",
+		},
+		{
+			name: "an attribute name in capitals",
+			html: `<meta HTTP-EQUIV="REFRESH" content="0; URL=/de">`,
+			want: "https://acme.example/de",
+		},
+		{
+			name: "a quoted target",
+			html: `<meta http-equiv="refresh" content="0; url='/de'">`,
+			want: "https://acme.example/de",
+		},
+		{
+			// A delay is not a reason to ignore the target: the site is still
+			// naming its real address, and the crawler is not waiting it out.
+			name: "a delay before the redirect",
+			html: `<meta http-equiv="refresh" content="10; URL=/de">`,
+			want: "https://acme.example/de",
+		},
+		{
+			// A reload names nowhere to go.
+			name: "a refresh with no url at all",
+			html: `<meta http-equiv="refresh" content="30">`,
+			want: "",
+		},
+		{
+			name: "a refresh naming an empty url",
+			html: `<meta http-equiv="refresh" content="0; URL=">`,
+			want: "",
+		},
+		{
+			name: "some other http-equiv entirely",
+			html: `<meta http-equiv="content-type" content="text/html; charset=utf-8">`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if head := extractHeadAssets(tc.html, base); head.refresh != tc.want {
+				t.Fatalf("refresh = %q, want %q", head.refresh, tc.want)
+			}
+		})
+	}
+}
+
+// The first declaration wins, the same rule og:image follows: a page naming
+// two destinations gives no basis to rank them, and a browser obeys the first.
+func TestTheFirstRefreshDeclarationWins(t *testing.T) {
+	base := mustParseURL(t, "https://acme.example/")
+	head := extractHeadAssets(
+		`<meta http-equiv="refresh" content="0; URL=/de">`+
+			`<meta http-equiv="refresh" content="0; URL=/en">`, base)
+	if want := "https://acme.example/de"; head.refresh != want {
+		t.Fatalf("refresh = %q, want %q", head.refresh, want)
+	}
+}
+
+// og:image and a refresh both arrive as <meta>, and the tokenizer yields a
+// tag's attributes only once — so reading one must not consume the other.
+func TestARefreshAndAnOpenGraphImageBothSurviveTheSameHead(t *testing.T) {
+	base := mustParseURL(t, "https://acme.example/")
+	head := extractHeadAssets(
+		`<head><meta property="og:image" content="/share.png">`+
+			`<meta http-equiv="refresh" content="0; URL=/de"></head>`, base)
+	if want := "https://acme.example/share.png"; head.ogImage != want {
+		t.Fatalf("og:image = %q, want %q", head.ogImage, want)
+	}
+	if want := "https://acme.example/de"; head.refresh != want {
+		t.Fatalf("refresh = %q, want %q", head.refresh, want)
+	}
+}
+
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", rawURL, err)
+	}
+	return parsed
+}

--- a/backend/migrations/core/1788316716_a_forwarding_page_gets_a_second_look.down.sql
+++ b/backend/migrations/core/1788316716_a_forwarding_page_gets_a_second_look.down.sql
@@ -1,0 +1,12 @@
+-- Nothing to undo, and nothing that COULD be undone honestly.
+--
+-- The up migration reopened a set of domain verdicts for another look. Rolling
+-- that back would mean writing 'no_site' onto whatever those domains say now —
+-- including the ones the retry has since read properly and turned into
+-- companies, which would be inventing a verdict rather than restoring one. The
+-- rows carry no record of the state they held before, so there is no restore
+-- available even in principle.
+--
+-- Reopening a domain costs one site read that the sweep bounds anyway, so the
+-- forward direction is safe to leave in place.
+SELECT 1;

--- a/backend/migrations/core/1788316716_a_forwarding_page_gets_a_second_look.up.sql
+++ b/backend/migrations/core/1788316716_a_forwarding_page_gets_a_second_look.up.sql
@@ -17,7 +17,14 @@
 -- only picks up rows whose next_attempt_at is set, which a settled row's is
 -- not.
 --
--- So the rows the old reading settled are reopened here, and only those.
+-- WHAT THIS REOPENS, AND WHAT IT CANNOT TELL APART. The classifier writes the
+-- same verdict and the same sentence for EVERY landing page with no readable
+-- text, and the stored read keeps no page text, so nothing in the database
+-- distinguishes a forwarding page from a genuinely parked one. This therefore
+-- reopens both. That is deliberate and it is the cheap direction to be wrong
+-- in: a domain that really is parked costs one bounded re-read and settles as
+-- parked again, while one left closed stays wrong forever with no company and
+-- nobody looking. A domain settled on any OTHER evidence is untouched.
 SET LOCAL lock_timeout = '5s';
 
 UPDATE organization_domain_disposition

--- a/backend/migrations/core/1788316716_a_forwarding_page_gets_a_second_look.up.sql
+++ b/backend/migrations/core/1788316716_a_forwarding_page_gets_a_second_look.up.sql
@@ -1,0 +1,49 @@
+-- Domains written off as parked, when the crawl had only read a forwarding page.
+--
+-- WHAT WAS WRONG. A site can publish its real address in markup rather than in
+-- an HTTP redirect: a document with no content whose whole head is
+-- `<meta http-equiv="refresh" content="0; URL=/de">`. The crawler followed HTTP
+-- redirects and never this one, so it read a page with no text on it. The
+-- triage classifier treats a landing page with no readable text as parked
+-- WITHOUT a model call — that is the correct reading of a genuinely empty page
+-- and the wrong reading of this one — and the domain settled as `no_site` with
+-- no company created. anwr-group.com is the case that surfaced it; every
+-- language-gateway site of that vintage has the same shape.
+--
+-- The crawler now follows such a page once before the classifier sees it, so
+-- new triage reads land on the real site. That fix cannot reach a domain
+-- already settled: a settled disposition is deliberately final ("stop asking"
+-- is what the status means to the next message that arrives), and the sweep
+-- only picks up rows whose next_attempt_at is set, which a settled row's is
+-- not.
+--
+-- So the rows the old reading settled are reopened here, and only those.
+SET LOCAL lock_timeout = '5s';
+
+UPDATE organization_domain_disposition
+SET status = 'pending',
+    -- The settled-shape constraint requires source and organization_id to be
+    -- absent on a pending row: this domain is genuinely unanswered again, not
+    -- answered by the read that got it wrong.
+    source = NULL,
+    evidence = NULL,
+    site_read_id = NULL,
+    -- Due now, and the attempt budget returned. The old attempt read a page
+    -- the crawler could not follow, so charging the domain for it would let a
+    -- site exhaust its budget on a page it never really got to see.
+    attempts = 0,
+    next_attempt_at = now(),
+    updated_at = now()
+WHERE status = 'no_site'
+  -- Only a verdict a site read produced. A heuristic or a human settled the
+  -- domain on other evidence, and neither was misled by the empty page.
+  AND source = 'site_read'
+  -- The classifier's own sentence for this reading, which is the narrowest
+  -- true description of the defect. A read that failed to load, or one that
+  -- read real text and found no company, settled correctly and stays settled.
+  AND evidence = 'the site classifies as parked: the landing page carries no readable text'
+  -- A row that produced a company is not a miss, whatever else it says.
+  AND organization_id IS NULL
+  -- An admission decision outranks this correction: a domain somebody chose to
+  -- suppress must not be quietly put back in the queue.
+  AND admission IS DISTINCT FROM 'suppressed';


### PR DESCRIPTION
A contact captured from an ANWR calendar invite had no employer, and ANWR Group
was never created as a company. This is why, and the fix.

## What was wrong

anwr-group.com serves a landing page with no content. Its whole head is:

```html
<meta http-equiv="refresh" content="0; URL=/de">
```

The site is real and lives at `/de`. A browser lands there without the visitor
ever seeing the shell. The crawler follows HTTP redirects but never this one, so
it read a page with no text.

`classifySeed` treats a landing page with no readable text as parked, with
confidence 1 and no model call. That is the correct reading of a genuinely empty
page and the wrong reading of this one. The domain settled as `no_site`, no
company was created, and a settled disposition is deliberately final — the retry
sweep only picks up rows whose `next_attempt_at` is set, which a settled row's is
not. Every language-gateway site of this vintage has the same shape.

## The fix

`webread` reports the refresh target a page's head declared, and `fetchSeed`
follows it once before anything classifies the page. Both of its success paths —
the direct seed and the www/scheme fallback ladder — go through the same
`settleSeed`.

Bounds on the follow, each with a test that fails when the guard alone is
reverted:

- **One hop, never a chain.** Each hop is a fetch the crawler was told to make by
  the page it just read. Two pages pointing at each other would never terminate:
  the test for that hangs, rather than merely failing, when the cap is removed.
- **The target must stay on the page's own registrable domain**, checked both
  where it points and where it lands. An open redirect on the site's own domain
  is an ordinary thing to find, and following one would hand the crawl a
  boundary — and a company identity — chosen by whoever wrote the markup.
- **Body markup is ignored**, the same rule `og:image` and the icon links follow.
  HTML permits omitting `</head>`, so the harvest now ends at `<body>` too; that
  gap applied to og:image and icons already, and the refresh made it able to
  trigger a fetch.
- **`url` must be the whole key.** `garbage; url-not=/private` was being read as
  a redirect nobody wrote.
- **A follow that fails is not an answer.** The empty shell used to go to the
  classifier and settle as parked — the original defect, on the failure path. The
  page now carries `UnresolvedForward`, and such a page gets `unclear` instead:
  the site named an address, so failing to reach it is a gap in the read, not the
  site saying nobody is here. A genuinely empty page still takes the shortcut.

A page that carries text is never treated as a trampoline, so the follow can only
add a read, never abandon one.

## The migration

Migration `1788316716` reopens the verdicts the old reading settled: `no_site`,
from a site read, carrying the classifier's own "no readable text" sentence, with
no company created and no suppression decision. It returns their attempt budget,
since the old attempt was charged for a page the crawler could not follow.

**It reopens correctly-parked domains too, and cannot avoid that.** The classifier
writes the same verdict and sentence for every text-free page, and the stored read
keeps no page text, so nothing distinguishes the two after the fact. That is the
cheap direction to be wrong in: a genuinely parked domain costs one bounded
re-read and settles again, while one left closed stays wrong forever with nobody
looking. The migration says so in its own comment rather than overstating what its
predicate selects.

It reopens two rows in the current dev database: anwr-group.com, and
intouchsports.com — which is **not** the same defect. That one is a
JavaScript-rendered site that also reads as empty text; this fix does not help it,
and client-rendered sites reading as parked is a separate gap worth its own issue.

## Checks

`make check-backend` green, `craft static` clean across all four roots,
`rls-store-path` and `no-jurisdiction` clean, and the `compose` and `people`
integration lanes both green against real Postgres. Every guard was
mutation-checked by reverting it alone and confirming its own test fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops treating a page that only forwards by meta-refresh as parked, so sites like anwr-group.com are read at their real address and no longer refused a company. The crawler follows the refresh target once before classifying, and a follow that fails or lands on another shell reads as unclear instead of parked.

**Migration**
- Migration `1788316716` reopens `no_site` verdicts from a site read with the classifier's "no readable text" sentence, no company, and no suppression, returning their attempt budget.
- It also reopens genuinely parked domains, which the stored data can't distinguish; a bounded re-read settles them again.

<sup>Written for commit 93e3f2c40e229b5e728ab88f7c6f1342c36d723f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of pages that forward visitors through same-domain HTML meta-refresh links.
  - Prevented unreadable forwarding pages from being incorrectly classified as parked or unavailable.
  - Forwarding failures now continue through the standard site resolution process.
  - Off-domain and invalid forwarding targets are safely rejected.
  - Previously misclassified sites may be reevaluated automatically.
- **Reliability**
  - Improved detection of forwarding-only landing pages while preserving page metadata such as images and icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->