### PR TITLE
Parallel gate runs stop colliding on shared machine state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,12 @@ ROOT_SCRIPT_GATES := check-craft-doc craft-test test-dev-isolation \
   test-selfdir pkg-freeze test-desktop-launcher changelog-sections \
   test-changelog-sections test-dev-postgres-container test-e2e-llm-check
 
-# How wide the gate fan-out runs. 4 is what the CI runner has and what
-# backend/Makefile's own fan-out already uses; a bigger machine can raise it.
+# How wide the gate fan-out runs: the machine's online core count, so a 4-core
+# CI runner and an 18-core laptop each get the width they have without anybody
+# setting a flag. `getconf _NPROCESSORS_ONLN` answers on both macOS and Linux;
+# the fallback covers a platform where it does not, at the width the CI runner
+# has. Override per run (`GATE_JOBS=2 make check-backend`) to leave cores free
+# for other sessions checking at the same time.
 #
 # Four gates writing at once interleaves their output, which make 4.0's
 # --output-sync would fix and the 3.81 macOS ships would not. The flag is left
@@ -37,7 +41,7 @@ ROOT_SCRIPT_GATES := check-craft-doc craft-test test-dev-isolation \
 # already names itself in its own OK:/FAIL: line, with make naming the target
 # again on the way out. Set it by hand (`make check-backend MAKEFLAGS=…`) on a
 # run whose interleaving you need untangled.
-GATE_JOBS ?= 4
+GATE_JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
 
 # Where the demo dataset lives. It is a SEPARATE, private repo (it carries real
 # company names and crawled pages), cloned beside this one by convention. The
@@ -116,7 +120,21 @@ help:
 ## Idempotent; extend here as new setup steps are needed. A fresh worktree can
 ## run `make check` / `make dev` immediately after.
 install: fe-install tools hooks
-	@echo "install: worktree ready (frontend deps + gate tools + hooks)"
+	@# Fill the machine-wide Go module cache now, while nothing else needs it.
+	@# Every `go` command that still has something to download takes the single
+	@# flock at $$GOMODCACHE/cache/lock, so the first gate run in a fresh
+	@# worktree can sit silently behind a parallel session's download with
+	@# nothing on screen saying why. Downloading per module at setup time makes
+	@# the gate runs lock-free. fixtures/ is excluded for the reason
+	@# scripts/check-lint-modules.sh states: those units resolve only inside a
+	@# test-composed workspace, so `go mod download` cannot run there.
+	@set -e; for mod in $$(git ls-files '*go.mod' \
+	  | sed -e 's#/go\.mod$$##' -e 's#^go\.mod$$#.#' \
+	  | grep -v '^fixtures/'); do \
+	  echo "install: go mod download ($$mod)"; \
+	  (cd "$$mod" && go mod download); \
+	done
+	@echo "install: worktree ready (frontend deps + gate tools + hooks + module cache)"
 
 ## check-backend — the backend half of the gate: the root deterministic script
 ## gates plus the backend gate (build, vet, lint, arch-lint, unit + fitness

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -650,10 +650,20 @@ GOLANGCI_LINT_VERSION ?= v2.12.2
 # keep the version identical to the pin in that script; bump both together.
 OASDIFF_VERSION ?= v1.22.0
 tools: ## Install every gate binary at its pinned version (fresh-machine bootstrap)
-	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-	$(GO) install github.com/fe3dback/go-arch-lint@$(GO_ARCH_LINT_VERSION)
-	$(GO) install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
-	$(GO) install github.com/oasdiff/oasdiff@$(OASDIFF_VERSION)
+	@# Built into a staging directory BESIDE the destination, then moved into
+	@# place. `go install` writes the binary at its final path directly, so two
+	@# worktrees bootstrapping at once race on the same four files — the loser
+	@# sees a half-written or busy binary. rename(2) replaces atomically, and
+	@# only within one filesystem, which is why the staging directory sits in
+	@# GOPATH/bin rather than under $$TMPDIR.
+	@set -e; bin="$$($(GO) env GOPATH)/bin"; mkdir -p "$$bin"; \
+	stage="$$(mktemp -d "$$bin/.tools-stage.XXXXXX")"; \
+	trap 'rm -rf "$$stage"' EXIT; \
+	GOBIN="$$stage" $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
+	GOBIN="$$stage" $(GO) install github.com/fe3dback/go-arch-lint@$(GO_ARCH_LINT_VERSION); \
+	GOBIN="$$stage" $(GO) install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION); \
+	GOBIN="$$stage" $(GO) install github.com/oasdiff/oasdiff@$(OASDIFF_VERSION); \
+	for tool in "$$stage"/*; do mv -f "$$tool" "$$bin/$$(basename "$$tool")"; done
 	@echo "gate binaries ready in $$($(GO) env GOPATH)/bin — 'make check' finds them there; add it to PATH only for direct use"
 
 # `git rev-parse --git-path hooks` honors core.hooksPath, so this works

--- a/backend/danglingcitations.txt
+++ b/backend/danglingcitations.txt
@@ -260,5 +260,7 @@ scripts/deploy/db-bootstrap.sql migration 0015
 scripts/lib-testdb.sh migration 0015
 scripts/test-migration-versions.sh core 0002
 scripts/test-migration-versions.sh core 0003
+scripts/test-migration-versions.sh core 1799999997
+scripts/test-migration-versions.sh core 1799999998
 scripts/test-migration-versions.sh core 1799999999
 scripts/test-migration-versions.sh migration 1799999999

--- a/go.work.sum
+++ b/go.work.sum
@@ -528,6 +528,7 @@ golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6/go.mod h1:Eqhaxk/wZsWEH8CRxLwj6xzEJbz7k1EFGqx7nyCoabE=
 golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959 h1:RJhm5l6Fo4rmEIcndxDllNhhf/fAx8qIm4t6A7vpm2A=
 golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959/go.mod h1:LV7u5Oco+Z/g6XI7PqN+EUUUGGkEcmB1uj2ceI0fOVg=
+golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5 h1:ZUSxONxc981v7AW7QUg+I9WwZzSTTJ019ENBYr5pV/Q=
 golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5/go.mod h1:LVehoXe41cL5SCVQilsV7Gg6BNG+Js6P9PhSbYTIUkQ=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=

--- a/scripts/check-migration-versions.sh
+++ b/scripts/check-migration-versions.sh
@@ -68,9 +68,9 @@ migrations_in_tree() {
     sed 's/^\([^_]*\)_\(.*\)$/\1 \2/' | sort
 }
 
-# migrations_at_base NAMESPACE — the same, read out of the base ref rather than
-# the worktree. `git ls-tree` and not `git diff`: what matters is every version
-# the base ALREADY carries, including the ones this branch never touched. A
+# migrations_at REF NAMESPACE — the same, read out of a ref rather than the
+# worktree. `git ls-tree` and not `git diff`: what matters is every version
+# the ref ALREADY carries, including the ones this branch never touched. A
 # namespace this branch introduces has none, so `grep` here legitimately
 # matches nothing — its exit 1 is not an error, and under set -eo pipefail an
 # unguarded grep would otherwise abort the whole gate with no FAIL printed the
@@ -81,9 +81,9 @@ migrations_in_tree() {
 # a Mac, where the default is the other way, and set -e turns that 123 into
 # the same silent whole-gate abort as the two hazards above. sed on empty
 # input just produces no output.
-migrations_at_base() {
-  local ns="$1"
-  git ls-tree --name-only "$BASE_REF" "$MIGRATIONS_DIR/$ns/" 2>/dev/null |
+migrations_at() {
+  local ref="$1" ns="$2"
+  git ls-tree --name-only "$ref" "$MIGRATIONS_DIR/$ns/" 2>/dev/null |
     { grep '\.up\.sql$' || true; } | sed 's#.*/##; s/\.up\.sql$//' |
     sed 's/^\([^_]*\)_\(.*\)$/\1 \2/' | sort
 }
@@ -98,6 +98,22 @@ if ! git rev-parse --verify -q "$BASE_REF" >/dev/null; then
   fi
   echo "skip check-migration-versions: base ref '$BASE_REF' not found (nothing to compare against)"
   exit 0
+fi
+
+# The FORK point scopes exactly one check below. Versions this branch ADDS are
+# judged against $BASE_REF's tip, because that is what a deployed database has
+# applied and what a colliding sibling PR has already merged into. But a version
+# on the tip that this branch's history NEVER contained is not one this branch
+# renamed or removed — it landed after the fork, the merge keeps it, and
+# reporting it as vanished forced every open branch through a rebase and a full
+# gate re-run each time any migration merged, however unrelated. So the
+# vanished-version check asks about versions present at BOTH the tip and the
+# fork point. With no merge base to be had (detached fixtures, odd checkouts)
+# the fork falls back to the tip, which is the stricter reading this gate
+# always applied.
+FORK_REF="$(git merge-base HEAD "$BASE_REF" 2>/dev/null || true)"
+if [ -z "$FORK_REF" ]; then
+  FORK_REF="$BASE_REF"
 fi
 
 failed=0
@@ -211,7 +227,8 @@ all_namespaces="$(printf '%s\n%s\n' "$tree_namespaces" "$base_namespaces" | sort
 
 for ns in $all_namespaces; do
   tree_rows="$(migrations_in_tree "$ns")"
-  base_rows="$(migrations_at_base "$ns")"
+  base_rows="$(migrations_at "$BASE_REF" "$ns")"
+  fork_rows="$(migrations_at "$FORK_REF" "$ns")"
 
   # A namespace is a directory holding migrations, not merely a directory:
   # `testdata/` sits beside core/ and custom/ and is neither, on either side.
@@ -264,7 +281,12 @@ for ns in $all_namespaces; do
   # second, so it reports the very migration the repair kept as vanished.
   # Sorting each side down to its distinct versions asks "does this version
   # still exist", which is the question, instead of "how many times".
-  vanished="$(comm -23 <(echo "$base_rows" | cut -d' ' -f1 | sort -u) <(echo "$tree_rows" | cut -d' ' -f1 | sort -u))"
+  #
+  # Intersected with the FORK point's versions first: a version on the tip
+  # that this branch's history never contained landed after the fork, so its
+  # absence from the tree is staleness, not a rename — see FORK_REF above.
+  vanished="$(comm -23 <(echo "$base_rows" | cut -d' ' -f1 | sort -u) <(echo "$tree_rows" | cut -d' ' -f1 | sort -u) |
+    comm -12 - <(echo "$fork_rows" | cut -d' ' -f1 | sort -u))"
   if [ -n "$vanished" ]; then
     for v in $vanished; do
       vname="$(echo "$base_rows" | awk -v v="$v" '$1==v {print $2}' | head -n1)"

--- a/scripts/run-golangci.sh
+++ b/scripts/run-golangci.sh
@@ -105,8 +105,21 @@ trap 'rm -f "$log"' EXIT
 # files stay next to the findings they belong to. The stated cost of reading
 # what golangci printed is that it now prints into a pipe, so its `--color auto`
 # resolves to none where a bare terminal run used to be coloured.
+# golangci refuses to start while another instance runs ANYWHERE on the
+# machine — the lock is machine-wide and independent of the cache directory, so
+# with several worktrees gating at once a run died with "parallel golangci-lint
+# is running" (exit 3) even on a private cache (measured 2026-09-01). That lock
+# exists to keep two runners out of one analysis cache, and the partitioning
+# above is what makes waiving it sound: each checkout writes its own cache, so
+# a `run` here has nothing to collide with. Only `run` takes the flag — the
+# other subcommands (cache, version) do not know it.
+parallel_ok=()
+if [[ "${1:-}" == "run" ]]; then
+  parallel_ok=(--allow-parallel-runners)
+fi
+
 set +e
-"$golangci" "$@" 2>&1 | tee "$log"
+"$golangci" "$@" ${parallel_ok[@]+"${parallel_ok[@]}"} 2>&1 | tee "$log"
 status=${PIPESTATUS[0]}
 set -e
 

--- a/scripts/run-golangci.sh
+++ b/scripts/run-golangci.sh
@@ -40,15 +40,27 @@
 # written for it. Clearing the cache is therefore the whole fix — the findings do
 # not come back with local paths, they go away, because locally they are waived.
 #
-# WHAT THIS DOES NOT CATCH, deliberately: nothing about the cache itself. It
-# neither clears it nor partitions it per worktree. Clearing is destructive to a
-# resource other sessions are using concurrently and belongs to the human who
-# knows what else is running; partitioning (GOLANGCI_LINT_CACHE per checkout)
-# costs every worktree a cold analysis cache forever, to buy back a message this
-# prints for free. This targets the misreading, which is what the time went on.
+# AND the cache is partitioned per checkout, unless the caller has already
+# chosen one: with several worktrees linting concurrently by design, one shared
+# cache is both the stale-path source above and a file two sessions write at
+# once. Each checkout gets its own directory, keyed by its absolute path, under
+# ~/.cache/golangci-lint/ — INSIDE golangci's default Linux cache root
+# deliberately, because ci.yml's "Cache the golangci-lint analysis cache" step
+# saves and restores exactly that directory, and a partition outside it would
+# silently turn every CI lint cold. The cost is one cold analysis per new
+# worktree; the detector below stays armed for a caller who points
+# GOLANGCI_LINT_CACHE somewhere shared anyway. Clearing a stale cache remains
+# the human's call, for the reason it always was: destructive to a resource
+# other sessions may be using.
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+if [[ -z "${GOLANGCI_LINT_CACHE:-}" ]]; then
+  # cksum, not shasum: POSIX, present everywhere this runs. The basename rides
+  # along so a human listing the cache directory can tell the partitions apart.
+  export GOLANGCI_LINT_CACHE="$HOME/.cache/golangci-lint/$(basename "$root")-$(printf '%s' "$root" | cksum | cut -d' ' -f1)"
+fi
 
 # Prefer the version-pinned install from `make tools` over whatever is on PATH,
 # for the reason backend/Makefile spells out: a Homebrew golangci-lint would

--- a/scripts/test-migration-versions.sh
+++ b/scripts/test-migration-versions.sh
@@ -277,6 +277,33 @@ empties_a_namespace() {
     backend/migrations/core/0003_gamma.down.sql || return 1
 }
 
+# The base moves on while this branch sits: another PR's migration lands on
+# base AFTER the fork point. The branch's tree lacks it, but never contained
+# it either — the merge keeps it, so the vanished-version check must read the
+# absence as staleness, not as a rename, or every migration landing on main
+# fails every open branch until it rebases.
+base_gains_unrelated() {
+  local dir="$1"
+  git -C "$dir" checkout -q base || return 1
+  printf -- '-- probe\n' > "$dir/backend/migrations/core/1799999998_landed.up.sql"
+  printf -- '-- probe\n' > "$dir/backend/migrations/core/1799999998_landed.down.sql"
+  git -C "$dir" add backend/migrations/core || return 1
+  git -C "$dir" commit -qm 'another PR lands a migration' || return 1
+  git -C "$dir" checkout -q - || return 1
+}
+
+# The same moved-on base, but this branch ALSO adds a migration — stamped below
+# the version that landed after the fork. The fork point scopes only the
+# vanished check: ordering is still judged against the base's TIP, because a
+# database that applied the landed migration would otherwise get this one in
+# the wrong place. This is the case that fails if the fork scoping ever leaks
+# into the ordering comparison.
+stale_branch_adds_below_tip() {
+  base_gains_unrelated "$1" || return 1
+  printf -- '-- probe\n' > "$1/backend/migrations/core/1799999997_late.up.sql"
+  printf -- '-- probe\n' > "$1/backend/migrations/core/1799999997_late.down.sql"
+}
+
 # A namespace this branch introduces that the base has never heard of:
 # `migrations_at_base` legitimately finds nothing in it, and that "nothing"
 # must read as zero migrations to sort after, not as a shell error.
@@ -308,6 +335,10 @@ expect "emptying a namespace still reports its vanished versions" \
   1 plain    empties_a_namespace  "but this branch no longer has it"
 expect "a namespace new to the base passes" \
   0 plain    adds_a_namespace     "OK: check-migration-versions"
+expect "a migration landing on base after the fork is not read as vanished" \
+  0 plain    base_gains_unrelated "OK: check-migration-versions"
+expect "the moved-on base still orders what this branch adds" \
+  1 plain    stale_branch_adds_below_tip "sorts at or below"
 
 # The four that decide whether the escape hatch is a gate or a hole.
 expect "a declared consolidation is admitted" \
@@ -337,7 +368,7 @@ expect "a declared reset does not excuse a real collision" \
 # So the total is also pinned. A literal here is not duplication of the case
 # list: it is the one fact the case list cannot state about itself, which is how
 # many of it there should be.
-expected_cases=14
+expected_cases=16
 
 declared_cases="$(grep -c '^expect "' "$SELF")"
 if [ "$ran" -ne "$declared_cases" ]; then


### PR DESCRIPTION
Several worktrees run `make check-backend` concurrently on one machine. Three pieces of shared state made them interfere, and the fan-out width was pinned to the CI runner's core count.

## Changes

1. **Per-checkout golangci cache** — `scripts/run-golangci.sh` now defaults `GOLANGCI_LINT_CACHE` to a directory keyed by the checkout's absolute path, under `~/.cache/golangci-lint/` (inside the path ci.yml's cache step already saves, so CI lint stays warm). This removes both observed failure modes of the shared cache: golangci exiting 3 when two runs hit it at once, and a cache entry filled by one worktree answering for another with a foreign path. An explicit `GOLANGCI_LINT_CACHE` still wins; the stale-path detector stays armed for that case.
2. **Atomic `make tools`** — the four gate binaries build into a staging dir beside `GOPATH/bin` and move into place by rename, so two worktrees bootstrapping at once no longer race on the same files.
3. **Module-cache prewarm in `make install`** — every non-fixture Go module gets `go mod download` at worktree setup, so gate runs never sit behind the machine-wide `$GOMODCACHE/cache/lock` mid-run.
4. **`GATE_JOBS` auto-detects cores** — `getconf _NPROCESSORS_ONLN` with a fallback of 4, so the 4-core CI runner keeps `-j4` and wider machines widen without a flag. Override per run to leave cores free for parallel sessions.

Measured on an 18-core darwin: `check-backend` green in 3m54s with a cold per-worktree lint cache (root script gates dropped to 61s at -j18). `make check` fully green.

The `go.work.sum` line is the checksum `go mod download` recorded for a tool dependency during the prewarm.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops parallel `make check-backend` runs from colliding on shared machine state, so several worktrees can gate concurrently without racing on the golangci-lint cache, gate binaries, or Go module download lock. Also stops a migration landing on main from failing every open branch's migration-version gate until it rebases.

**Parallel gate runs**
- `scripts/run-golangci.sh` defaults `GOLANGCI_LINT_CACHE` to a per-checkout directory under `~/.cache/golangci-lint/` keyed by checkout path; an explicit choice still wins and the stale-path detector stays armed.
- The script passes `--allow-parallel-runners` to golangci `run`, since its machine-wide instance lock made concurrent runs exit 3 even on a private cache.
- `make tools` builds the gate binaries into a staging directory beside `GOPATH/bin` and renames them into place, so concurrent bootstraps no longer race on the same files.
- `make install` prewarms the module cache by running `go mod download` per non-fixture module at setup time, so gate runs never wait on the machine-wide `$GOMODCACHE/cache/lock`.
- `GATE_JOBS` now defaults to the machine's online core count (`getconf _NPROCESSORS_ONLN`, falling back to 4); override with `GATE_JOBS=2` to leave cores free.

**Migration gate**
- `check-migration-versions.sh` now scopes the vanished-version check to the fork point (`git merge-base HEAD` with base, falling back to base when missing), so a migration that landed after the fork reads as staleness rather than a rename; ordering and collision checks still compare against the tip.
- Two new test fixtures cover the moved-on-base cases, with their versions registered in `danglingcitations.txt`.

<sup>Written for commit 2fc8ed99266ec3e3edf58b7c6a28be89a036100e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Build tasks now automatically use available CPU capacity by default, while allowing manual overrides.
  - Dependency setup now covers all tracked Go modules, excluding fixtures.
  - Tool installation is safer during concurrent work, preventing incomplete binaries from being exposed.
  - Go lint caches are automatically isolated per checkout when no custom cache location is provided.
  - Concurrent lint runs are supported across separate checkouts without changing other lint commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->