### PR TITLE
A person's captured meetings reach their record

### DIFF
--- a/backend/internal/compose/cohortpromotegen.go
+++ b/backend/internal/compose/cohortpromotegen.go
@@ -81,6 +81,19 @@ func (g *CohortPromoteGen) HandleEvent(ctx context.Context, env events.Envelope)
 	// record it already has; it creates nothing and admits nobody. The system
 	// principal is what the sweeps that reach the same store method use, and
 	// there is no human in an event consumer for object-RBAC to admit.
+	//
+	// The TRACE is bound from the envelope, not minted here. A subscriber
+	// carries no correlation id of its own, and this repair's last act is to
+	// publish an activity.updated for every message that moved — a publish the
+	// write shape refuses without one. Left unbound, a pass reaches that
+	// refusal AFTER writing its links, the transaction rolls back, and the
+	// event is redelivered forever: the group's messages pile up pending while
+	// every other consumer on the same stream drains, so the symptom is a
+	// contact whose captured mail and meetings never reach their record.
+	// Carrying the causing event's own id also puts the repair on the trace of
+	// the person write that caused it, which is what makes a link nobody
+	// clicked explainable afterwards.
+	ctx = principal.WithCorrelationID(ctx, env.Trace.CorrelationID)
 	ctx = principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalSystem,
 		ID:   cohortPromoteActor,

--- a/backend/internal/compose/cohortpromotegen_integration_test.go
+++ b/backend/internal/compose/cohortpromotegen_integration_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The cg:cohort-promote consumer, driven the way the bus drives it.
+//
+// The repair's own SQL is covered in the people module. What is covered HERE is
+// the thing that only breaks on the consumer path: the CONTEXT a subscriber
+// hands the store. A subscriber carries no correlation id, and the repair's
+// last act is to publish an activity.updated for each message that moved — so a
+// pass that assembles the context wrong writes its links, is refused at the
+// publish, rolls back, and is redelivered forever. Every assertion below runs
+// through HandleEvent for that reason; calling PromotePersonCohortTx directly
+// would pass with the context bug in place, which is exactly how it shipped.
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
+	kevents "github.com/margince/margince/backend/internal/shared/kernel/events"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedStrandedMeeting writes the ordering this consumer exists for: a captured
+// meeting whose attendee is an ADDRESS, and the person for that address created
+// afterwards. Nothing links the two, which is the state a real calendar sync
+// leaves behind whenever the invitation arrives before the contact does.
+//
+// Written as capture writes it — connector captured_by, an address-only
+// participant row, no activity_link — because a fixture that links the meeting
+// itself would prove nothing about the repair.
+func seedStrandedMeeting(t *testing.T, e *integration.Env, address string) (person, meeting ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		ctx := context.Background()
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO activity (kind, subject, occurred_at, source, captured_by)
+			VALUES ('meeting', 'Quarterly review', now() + interval '2 days',
+			        'connector', 'connector:gcal')
+			RETURNING id`).Scan(&meeting); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO activity_participant (activity_id, address, role)
+			VALUES ($1, $2, 'to')`, meeting, address); err != nil {
+			return err
+		}
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO person (full_name, owner_id, source, captured_by, visibility)
+			VALUES ('Stranded Attendee', $1, 'manual', 'human:test', 'workspace')
+			RETURNING id`, e.Rep1).Scan(&person); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `
+			INSERT INTO person_email (person_id, email, email_type, is_primary, position, source, captured_by)
+			VALUES ($1, $2, 'work', true, 0, 'manual', 'human:test')`, person, address)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a stranded meeting: %v", err)
+	}
+	return person, meeting
+}
+
+// meetingIsFiledUnder reports the two halves of a repaired cohort separately:
+// the participant row now naming the person, and the meeting filed under them.
+// Separately because they fail for different reasons — the promotion is an
+// address match, the link is attendance — and one number could not say which.
+func meetingIsFiledUnder(t *testing.T, e *integration.Env, person, meeting ids.UUID) (named, linked bool) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		ctx := context.Background()
+		if err := tx.QueryRow(ctx, `
+			SELECT EXISTS (SELECT 1 FROM activity_participant
+			                WHERE activity_id = $1 AND person_id = $2)`,
+			meeting, person).Scan(&named); err != nil {
+			return err
+		}
+		return tx.QueryRow(ctx, `
+			SELECT EXISTS (SELECT 1 FROM activity_link
+			                WHERE activity_id = $1 AND person_id = $2)`,
+			meeting, person).Scan(&linked)
+	}); err != nil {
+		t.Fatalf("reading the repaired cohort: %v", err)
+	}
+	return named, linked
+}
+
+func cohortEnvelope(eventType string, person ids.UUID) kevents.Envelope {
+	return kevents.Envelope{
+		EventID:    ids.NewV7(),
+		Type:       eventType,
+		Version:    1,
+		OccurredAt: time.Now().UTC(),
+		Entity:     kevents.EntityRef{Type: "person", ID: person},
+		Trace:      kevents.Trace{CorrelationID: ids.NewV7()},
+	}
+}
+
+func cohortGen(e *integration.Env) *CohortPromoteGen {
+	return NewCohortPromoteGen(e.Pool, people.NewStore(e.DB()), slog.Default())
+}
+
+// The regression this file exists for.
+//
+// Reverting the WithCorrelationID line in HandleEvent fails this at the
+// HandleEvent call, not at the assertions: the repair publishes, the publish is
+// refused for want of a correlation id, and the whole transaction rolls back.
+// That is the shape the defect had in production — links written, then undone,
+// forever — so the test reproduces the mechanism rather than only the symptom.
+func TestAPersonEventFilesTheMeetingTheirAddressAttended(t *testing.T) {
+	e := integration.Setup(t)
+	person, meeting := seedStrandedMeeting(t, e, "attendee@example.test")
+
+	if named, linked := meetingIsFiledUnder(t, e, person, meeting); named || linked {
+		t.Fatal("the meeting was already filed before any event was delivered — the fixture links it itself and proves nothing")
+	}
+
+	if err := cohortGen(e).HandleEvent(context.Background(), cohortEnvelope("person.created", person)); err != nil {
+		t.Fatalf("person.created reached the repair and failed: %v", err)
+	}
+
+	named, linked := meetingIsFiledUnder(t, e, person, meeting)
+	if !named {
+		t.Error("the attendee row still names only an address, so nothing downstream can tell it is this person")
+	}
+	if !linked {
+		t.Error("the meeting is not filed under the person who attended it, so their record shows no meeting and offers no brief")
+	}
+}
+
+// Redelivery is free. The bus is at-least-once and the repair runs on somebody
+// else's retry as readily as its own, so a second pass must add nothing rather
+// than a second link.
+func TestARedeliveredPersonEventRepairsTheCohortOnce(t *testing.T) {
+	e := integration.Setup(t)
+	person, meeting := seedStrandedMeeting(t, e, "repeat@example.test")
+
+	gen := cohortGen(e)
+	ctx := context.Background()
+	for i := range 3 {
+		if err := gen.HandleEvent(ctx, cohortEnvelope("person.updated", person)); err != nil {
+			t.Fatalf("delivery %d: %v", i, err)
+		}
+	}
+
+	var links int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM activity_link WHERE activity_id = $1 AND person_id = $2`,
+			meeting, person).Scan(&links)
+	}); err != nil {
+		t.Fatalf("counting links: %v", err)
+	}
+	if links != 1 {
+		t.Errorf("three deliveries left %d links, want 1", links)
+	}
+}
+
+// An event this consumer does not act on must answer nil. The group carries the
+// whole person stream, so erroring on somebody else's traffic would wedge the
+// repair for every contact behind it — which is the failure this consumer spent
+// its first months in.
+func TestAnUnrelatedEventLeavesTheCohortAlone(t *testing.T) {
+	e := integration.Setup(t)
+	person, meeting := seedStrandedMeeting(t, e, "untouched@example.test")
+
+	gen := cohortGen(e)
+	ctx := context.Background()
+	for _, unrelated := range []kevents.Envelope{
+		cohortEnvelope("person.archived", person),
+		{
+			EventID: ids.NewV7(), Type: "deal.created", Version: 1, OccurredAt: time.Now().UTC(),
+			Entity: kevents.EntityRef{Type: "deal", ID: ids.NewV7()},
+			Trace:  kevents.Trace{CorrelationID: ids.NewV7()},
+		},
+	} {
+		if err := gen.HandleEvent(ctx, unrelated); err != nil {
+			t.Errorf("%s errored and would wedge the stream: %v", unrelated.Type, err)
+		}
+	}
+
+	if _, linked := meetingIsFiledUnder(t, e, person, meeting); linked {
+		t.Error("an event that gains the person no address filed their meeting anyway")
+	}
+}


### PR DESCRIPTION
## What was wrong

`cg:cohort-promote` — the consumer that files a person's captured mail and meetings onto their record — never bound a correlation id. Every repair it ever attempted failed at its own publish:

```
people: publishing a cohort repair: store: no correlation id bound to context
```

The repair's last act is an `activity.updated` per message that moved, and the write shape refuses that publish without a correlation id. So each pass wrote its links, hit the refusal, and rolled the whole transaction back — then the bus redelivered the event and it happened again.

On a stack with real captured mail the group sat on **139 pending messages, some delivered 281 times**, while every other consumer on the same person stream had drained to zero.

## What it looks like to a user

A contact whose meeting never appears. A calendar invitation captured before its attendee was a contact leaves an address-only participant row; this repair is what turns that into a person and files the meeting under them.

With the repair unable to commit, `personReachesActivity` finds nothing, `next_meeting` is null, and the person page says a meeting is booked with nobody — no meeting strip, and no brief to prepare from. Found on a real contact with a meeting booked in two days.

## The fix

Bind the trace from the envelope rather than minting one, matching `audiencerescope` and `commissiongen`. The causing event's own id is what puts the repair on the trace of the person write that caused it, so a link nobody clicked is explainable afterwards.

The three other event consumers that bind no correlation id (`captureenrichtrigger`, `orgautoenrich`, `vcardingesttrigger`) only enqueue jobs and never write through a store, so none of them needs one.

## Tests

The consumer had **none**, which is how this shipped.

The three added here all drive `HandleEvent`. That is the load-bearing detail: calling `PromotePersonCohortTx` directly binds whatever context the test chooses and passes with the defect in place, which is exactly the trap that hid it.

Mutation-checked — reverting the one line fails the two repair tests at the `HandleEvent` call with the production error, and correctly leaves the routing test green.

## Gates

`make check-backend` green; the three integration tests pass under a private template.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `cg:cohort-promote` consumer so a person's captured meetings reach their record. The consumer never bound a correlation id, so each repair wrote its links, hit a publish refusal, and rolled the transaction back — redelivering forever and leaving meetings stranded. It now binds the trace from the envelope.

**Bug Fixes**
- Binds the correlation id from the envelope rather than minting one, matching `audiencerescope` and `commissiongen`.
- The three other consumers without correlation ids only enqueue jobs and need none.

**Tests**
- Adds three integration tests that drive `HandleEvent`, since calling the transaction directly would pass with the defect in place.

<sup>Written for commit 3e7aa04d80d2692f5e10e3896a7f8f22a600fd6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cohort repairs now successfully update related participant and activity links while preserving event traceability.
  * Repeated event deliveries remain idempotent, preventing duplicate or unintended updates.
  * Unrelated events no longer modify cohort data.

* **Tests**
  * Added integration coverage for cohort promotion, link repair, repeated deliveries, and unrelated events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->