### PR TITLE
The brief says what it did not read, and offers no button that lies

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2272,7 +2272,6 @@ export const de = {
     "{count} Deals fehlen in diesen Zahlen – Ihre Berechtigung deckt sie nicht ab.",
   "home.pipelineUnavailable": "Diese Zahl konnte nicht geladen werden.",
   "home.asOf": "Stand {at}",
-  "home.refresh": "Briefing aktualisieren",
   "home.refreshing": "Sortiere neu…",
   "home.generate": "Briefing jetzt holen",
   "home.noneBody":
@@ -2969,6 +2968,9 @@ export const de = {
   "settings.signatureEdit": "Signatur bearbeiten",
   "settings.signatureNone": "Keine Grußformel gesetzt",
   "settings.signatureCancel": "Abbrechen",
+  "brief.coverage.summary": "Einige Quellen haben mehr, als diese Seite zeigt",
+  "brief.coverage.bounded":
+    "{shown} von mindestens {considered} gelesenen angezeigt",
   "delivery.morningLabel": "Ihr Tagesbriefing",
   "delivery.morningHelp":
     "Ob das Briefing des Tages zusätzlich per E-Mail kommt. Auf Ihrer Briefing-Seite steht es ohnehin.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2304,7 +2304,6 @@ export const en = {
     "{count} deals are not in these figures — your access does not cover them.",
   "home.pipelineUnavailable": "This figure could not be loaded.",
   "home.asOf": "as of {at}",
-  "home.refresh": "Refresh brief",
   "home.refreshing": "Ranking…",
   "home.generate": "Get today's brief now",
   "home.noneBody":
@@ -3006,6 +3005,8 @@ export const en = {
   "settings.signatureEdit": "Edit signature",
   "settings.signatureNone": "No sign-off set",
   "settings.signatureCancel": "Cancel",
+  "brief.coverage.summary": "Some sources have more than this page shows",
+  "brief.coverage.bounded": "{shown} shown of at least {considered} read",
   "delivery.morningLabel": "Your morning brief",
   "delivery.morningHelp":
     "Whether the day's brief also arrives by email. It is on your Brief page either way.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2256,7 +2256,6 @@ export const vi = {
     "{count} deal không nằm trong các số này — quyền của bạn không bao gồm chúng.",
   "home.pipelineUnavailable": "Không tải được số liệu này.",
   "home.asOf": "tính đến {at}",
-  "home.refresh": "Làm mới tóm tắt",
   "home.refreshing": "Đang xếp hạng…",
   "home.generate": "Lấy tóm tắt hôm nay",
   "home.noneBody":
@@ -2943,6 +2942,9 @@ export const vi = {
   "settings.signatureEdit": "Sửa chữ ký",
   "settings.signatureNone": "Chưa đặt lời kết",
   "settings.signatureCancel": "Hủy",
+  "brief.coverage.summary":
+    "Một số nguồn có nhiều hơn những gì trang này hiển thị",
+  "brief.coverage.bounded": "Hiển thị {shown} trên ít nhất {considered} đã đọc",
   "delivery.morningLabel": "Bản tóm tắt buổi sáng",
   "delivery.morningHelp":
     "Bản tóm tắt trong ngày có được gửi qua email hay không. Dù sao nó cũng có trên trang Tóm tắt.",

--- a/frontend/src/screens/briefcoverage.test.tsx
+++ b/frontend/src/screens/briefcoverage.test.tsx
@@ -1,0 +1,100 @@
+/** @vitest-environment jsdom */
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { en } from "../i18n/en";
+import { BriefCoverage } from "./briefcoverage";
+import { render } from "./home.testkit";
+import type { Worklist } from "./worklist.queries";
+
+// What the page is NOT showing, per source.
+//
+// A short day has two very different causes — a source that was withheld, and
+// a source that simply had nothing — and a reader cannot act on the first
+// without being told. `Worklist.reach` carried the answer and nothing rendered
+// it until now.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const empty: Worklist = {
+  as_of: "2026-06-10T06:00:00Z",
+  scope: "mine",
+  scope_options: ["mine"],
+  queue: [],
+  counts: [],
+  reach: [],
+  sources_unavailable: [],
+  summary: { total: 0, urgent: 0 },
+} as unknown as Worklist;
+
+describe("the coverage disclosure", () => {
+  // A day where every source answered has nothing to disclose. A panel that
+  // said "all sources complete" every morning would teach a reader to stop
+  // reading it, and then it would not be read on the morning it mattered.
+  it("says nothing when there is nothing to say", () => {
+    const { container } = render(<BriefCoverage day={empty} />);
+
+    expect(container.querySelector(".brief-coverage")).toBeNull();
+  });
+
+  // A refusal is a fact about the reader's day, not a detail to expand: they
+  // are being shown less than the product knows, and no amount of scrolling
+  // will reveal it.
+  it("names a withheld source without asking the reader to expand anything", () => {
+    render(
+      <BriefCoverage
+        day={{
+          ...empty,
+          sources_unavailable: [{ source: "task", reason: "withheld" }],
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        en["worklist.source.withheld"].replace(
+          "{source}",
+          en["worklist.untitled.task"],
+        ),
+      ),
+    ).toBeTruthy();
+  });
+
+  // A bounded source IS a detail: the page read it and there is simply more
+  // behind it, which is a different fact from not having read it at all.
+  it("puts a bounded source behind the disclosure, with its figures", async () => {
+    render(
+      <BriefCoverage
+        day={{
+          ...empty,
+          reach: [
+            {
+              source: "task",
+              considered: 200,
+              shown: 25,
+              more_available: true,
+            },
+            // Read to the end: nothing more behind it, so listing it would
+            // bury the one that matters.
+            {
+              source: "meeting",
+              considered: 4,
+              shown: 4,
+              more_available: false,
+            },
+          ],
+        }}
+      />,
+    );
+
+    await userEvent
+      .setup()
+      .click(screen.getByText(en["brief.coverage.summary"]));
+
+    expect(screen.getByText(en["worklist.untitled.task"])).toBeTruthy();
+    expect(screen.queryByText(en["worklist.untitled.meeting"])).toBeNull();
+  });
+});

--- a/frontend/src/screens/briefcoverage.tsx
+++ b/frontend/src/screens/briefcoverage.tsx
@@ -1,0 +1,66 @@
+// What the page is NOT showing, per source.
+//
+// `Worklist.reach` has been on the wire since the queue shipped and was read by
+// nothing: the completeness line beside it totals the counts, which answers
+// "how much is missing" and not "missing from where". A rep who sees a short
+// day needs the second question answered before they can trust the first — a
+// queue that is short because one source was withheld is a different day from
+// one that is short because there is nothing to do.
+
+import { Disclosure } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { FactList } from "../design-system/factlist";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import { sourceName, sourceUnavailableText } from "./worklist.copy";
+import type { Worklist } from "./worklist.queries";
+
+/**
+ * The coverage disclosure, or nothing.
+ *
+ * Drawn only when there is something to disclose: a day where every source
+ * answered and none was bounded has nothing to say, and a panel that said "all
+ * sources complete" every morning would teach a reader to stop reading it.
+ */
+export function BriefCoverage({ day }: Readonly<{ day: Worklist }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const missing = day.sources_unavailable ?? [];
+  // A source that stopped at its bound has MORE than it showed. One that read
+  // everything it had does not, and listing it would bury the two that matter.
+  const bounded = (day.reach ?? []).filter((row) => row.more_available);
+  if (missing.length === 0 && bounded.length === 0) {
+    return null;
+  }
+  return (
+    <Callout tone="info" className="brief-coverage">
+      {/* The refusals first and outside the disclosure: a source the reader may
+          not see at all is a fact about their day, not a detail to expand. A
+          bounded source is the detail — the page did read it, and there is
+          simply more behind it. */}
+      {missing.map((source) => (
+        <p key={source.source} className="t-caption">
+          {sourceUnavailableText(source, t)}
+        </p>
+      ))}
+      {bounded.length > 0 && (
+        <Disclosure summary={t("brief.coverage.summary")}>
+          <FactList
+            facts={bounded.map((row) => ({
+              key: row.source,
+              term: sourceName(row.source, t),
+              // `considered` is a FLOOR where the source was bounded, so the
+              // sentence says "at least" rather than printing a figure the read
+              // cannot stand behind. The contract says the same thing where the
+              // field is declared.
+              value: t("brief.coverage.bounded", {
+                shown: formatNumber(row.shown, locale),
+                considered: formatNumber(row.considered, locale),
+              }),
+            }))}
+          />
+        </Disclosure>
+      )}
+    </Callout>
+  );
+}

--- a/frontend/src/screens/home.test.tsx
+++ b/frontend/src/screens/home.test.tsx
@@ -767,3 +767,36 @@ describe("HomeScreen — the sentence about the night", () => {
     await screen.findByText("He asked about the delivery date yesterday.");
   });
 });
+
+// ── The one control that promised what the click could not do ──
+
+describe("HomeScreen — the brief is generated, never re-ranked", () => {
+  // POST /brief answers "today's run already existed; this is it, unchanged".
+  // It assembles a brief where none exists and re-ranks nothing — so a control
+  // labelled "Refresh brief" beside an existing run promised a re-rank the
+  // click could not perform, and a rep who pressed it and saw the same order
+  // concluded the ranking was stuck.
+  it("offers no refresh once today's run exists", async () => {
+    stubApi({
+      "GET /brief": () => jsonResponse(run),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    render(<HomeScreen />);
+
+    await screen.findByText("Fleet retrofit");
+    expect(screen.queryByTestId("brief-refresh")).toBeNull();
+  });
+
+  // And the affordance that DOES something stays: a rep whose overnight pass
+  // has not run has a real button to press, and it is the only one.
+  it("offers to generate one when there is none", async () => {
+    stubApi({
+      "GET /brief": () => new Response(null, { status: 404 }),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    render(<HomeScreen />);
+
+    const generate = await screen.findByTestId("brief-refresh");
+    expect(generate.textContent).toContain(en["home.generate"]);
+  });
+});

--- a/frontend/src/screens/home.today.tsx
+++ b/frontend/src/screens/home.today.tsx
@@ -53,17 +53,28 @@ export function TodaySection({
               })
             : undefined
         }
+        // The button is drawn ONLY when there is no run to show.
+        //
+        // POST /brief answers "today's run already existed; this is it,
+        // unchanged" — it assembles a brief where none exists and re-ranks
+        // nothing. So a control labelled "Refresh brief" beside an existing
+        // run promised a re-rank the click could not perform, and a rep who
+        // pressed it and saw the same order concluded the ranking was stuck.
+        //
+        // What a reader actually wants at that moment is the queue as it
+        // stands, which the page already refetches on focus.
         titleAction={
-          <Button
-            small
-            pending={refresh.isPending}
-            busyLabel={t("home.refreshing")}
-            onClick={() => refresh.mutate()}
-            data-testid="brief-refresh"
-          >
-            <RefreshCw aria-hidden />{" "}
-            {t(brief ? "home.refresh" : "home.generate")}
-          </Button>
+          brief ? undefined : (
+            <Button
+              small
+              pending={refresh.isPending}
+              busyLabel={t("home.refreshing")}
+              onClick={() => refresh.mutate()}
+              data-testid="brief-refresh"
+            >
+              <RefreshCw aria-hidden /> {t("home.generate")}
+            </Button>
+          )
         }
         footer={
           brief && brief.items.length > 0 ? (

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -11,6 +11,7 @@ import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { useDecisionSink } from "./approvalrow";
 import { usePendingApprovals } from "./approvals.queries";
+import { BriefCoverage } from "./briefcoverage";
 import { useMe } from "./common";
 import { DecisionsSection } from "./home.decisions";
 import {
@@ -33,6 +34,7 @@ import { OvernightPanel, PositionPanel, WatchPanel } from "./home.rail";
 import { HomeReadingsStrip } from "./home.readings";
 import { TodaySection } from "./home.today";
 import { WeeklySection } from "./home.weekly";
+import { useWorklist } from "./worklist.queries";
 import "./home.css";
 
 // Home — the morning handover.
@@ -290,6 +292,12 @@ export function HomeScreen() {
   const briefQuery = useMorningBrief();
   const digestQuery = useMorningDigest();
   const dealsQuery = useHomeDeals();
+  // The ONE ranked order, read here for its coverage. Home has always been
+  // deal-only; what it could not say is which sources it never saw, and that
+  // answer lives on the worklist read rather than on any of the five deal
+  // reads beside it. Same query key as the Worklist screen, so the two cannot
+  // disagree about what was read.
+  const worklistQuery = useWorklist("mine", "all");
   const pipelineQuery = usePipelineValue();
 
   const approvals = approvalsQuery.data?.data ?? [];
@@ -354,6 +362,9 @@ export function HomeScreen() {
         onGoToDuplicates={() => navigate({ screen: "worklist" })}
         onGoToWatch={() => goToSection("home-watch")}
       />
+      {/* Before the readings, because a strip of numbers a reader cannot
+          trust is worse than one they can qualify. */}
+      {worklistQuery.data && <BriefCoverage day={worklistQuery.data} />}
       <HomeReadingsStrip
         decisions={decisionReadings}
         open={openReading}

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -415,12 +415,21 @@ export function sourceUnavailableText(
   missing: NonNullable<Worklist["sources_unavailable"]>[number],
   t: T,
 ): string {
-  const name = knownSource(missing.source as WorklistItem["source"])
-    ? t(`worklist.untitled.${missing.source as keyof typeof KNOWN_SOURCES}`)
-    : t("worklist.untitled.generic");
+  const name = sourceName(missing.source, t);
   return missing.reason === "withheld"
     ? t("worklist.source.withheld", { source: name })
     : t("worklist.source.failed", { source: name });
+}
+
+// One source, in the reader's words.
+//
+// Through the same known-source check the titles use, so a source this build
+// has never heard of is described generically rather than printed as its own
+// identifier — a reader must never be shown `ai_work_health` as a noun.
+export function sourceName(source: string, t: T): string {
+  return knownSource(source as WorklistItem["source"])
+    ? t(`worklist.untitled.${source as keyof typeof KNOWN_SOURCES}`)
+    : t("worklist.untitled.generic");
 }
 
 // The sources this build can name without its own sentence.


### PR DESCRIPTION
Two things the Brief page owed its reader.

The coverage panel. Worklist.reach has been on the wire since the queue
shipped and was rendered by nothing, so a page could say "clear" while a
source had been refused or read only in part. BriefCoverage states the
refusals outright — a withheld source is a fact about your day, not a
detail to expand — and puts bounded sources behind a disclosure that says
"at least N read", never a floor printed as a total. A complete day draws
nothing.

The Refresh button. POST /brief answers "Today's run already existed;
this is it, unchanged" — it assembles where none exists and re-ranks
nothing. Beside an existing run the button promised a reordering the
click could not do. It is now drawn only when there is no run, and the
dead home.refresh key is gone from all three catalogs.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

Gates: `make check-fe` and `make check-backend` both green after rebase onto `aff6af57c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a coverage panel to the Brief page that shows what the page could not read, and stops offering a Refresh button when there is nothing to refresh.

- `BriefCoverage` renders `Worklist.reach`, which was fetched but never shown: withheld sources are stated outright, bounded sources sit behind a disclosure that says "at least N read", and a complete day draws nothing.
- The Refresh button promised a re-ranking that POST /brief cannot do (it only assembles a brief where none exists), so it is now drawn only when there is no run.
- The dead `home.refresh` i18n key is removed from the English, German, and Vietnamese catalogs.

<sup>Written for commit 6b20b3efda631ad1f243809781cedba147a40619. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coverage notices to daily briefs for unavailable sources and sources with additional available content.
  * Coverage details include localized source names, counts, and expandable information where applicable.
  * Added English, German, and Vietnamese translations for coverage messages.

* **Bug Fixes**
  * Existing briefs no longer display a refresh control; generation remains available when no brief exists.

* **Tests**
  * Added coverage and daily brief behavior tests for empty, unavailable, and bounded-source scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->