### PR TITLE
The worklist says what the day is worth

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -34924,7 +34924,7 @@ components:
         does, widened: a source the caller may not read is named as `withheld`, and one
         that failed to answer is named as `failed`. Both keep the summary from claiming a
         clear day it did not actually see.
-      required: [as_of, queue, summary, sources_unavailable, scope, scope_options, reach, counts]
+      required: [as_of, queue, summary, sources_unavailable, scope, scope_options, reach, counts, readings]
       properties:
         as_of: { type: string, format: date-time, description: 'The instant every source below was read at.' }
         scope:
@@ -34983,6 +34983,7 @@ components:
             pill counts, and what lets the page say how much it is not showing. Counted
             before any narrowing, so a filtered page still reports the categories it is
             not drawing.
+        readings: { $ref: '#/components/schemas/WorklistReadings' }
         bands:
           type: array
           items: { $ref: '#/components/schemas/WorklistBand' }
@@ -35175,6 +35176,78 @@ components:
             the client can say WHY a deal ranked where it did. Null when the pipeline has
             no open deals to take a median of.
         base_currency: { type: [string, 'null'], pattern: '^[A-Z]{3}$', description: 'The currency every expected-revenue figure here is converted to.' }
+
+    WorklistReadings:
+      type: object
+      description: |
+        The day's four OUTCOME figures, for the strip above the queue: what money is
+        drifting, who is waiting on an answer, how much new business is in hand, and how
+        much routine work is queued behind a decision.
+
+        These are not the filter pills. `counts` says how many items of a kind the queue
+        holds; these say what those items MEAN for the day, which is why one of them is a
+        sum of money rather than a tally. Both are on the page because a rep asks two
+        different questions — "what is there" and "what is at stake".
+
+        Every figure describes the same set `counts.considered` describes: what this read
+        weighed AFTER the scope narrowing and BEFORE the category filter, the fold and the
+        page cut. That is the only set for which the numbers are stable — computed over
+        the page, the strip would shrink as a reader walked the queue and read as work
+        disappearing; computed after the filter, opening a pill would empty the other
+        three.
+
+        `more_available` carries the same honesty `WorklistCount` carries, for the same
+        reason: a source read to its work bound makes every figure here a FLOOR rather
+        than a total, and a strip stating "3 buyers waiting" over a scan that stopped
+        early tells a rep the opposite of the truth.
+      required: [revenue_at_risk_minor, buyer_replies, prospecting, review, more_available]
+      properties:
+        revenue_at_risk_minor:
+          type: [integer, 'null']
+          format: int64
+          description: |
+            What the drifting deals are worth, summed over the deals this read weighed, in
+            the currency `revenue_currency` names.
+
+            Null when no deal at risk could be priced — no amount recorded, or no stored
+            rate for its currency. Null is not zero: zero says the pipeline is safe, and
+            absence says nobody can tell. A deal the estate cannot price is left OUT of
+            the sum rather than counted as nothing, so a partly priced day reports what it
+            could price and says so through `revenue_currency`.
+        revenue_currency:
+          type: [string, 'null']
+          pattern: '^[A-Z]{3}$'
+          description: |
+            The currency `revenue_at_risk_minor` is stated in — the installation's base
+            currency, once the amounts went through the conversion seam.
+
+            Null when they did not, which makes the sum a total of raw minor units in no
+            one currency. A client must not format a figure whose units it cannot name:
+            with this absent the amount is not money yet, and drawing it as money is the
+            error the conversion seam exists to prevent.
+        buyer_replies:
+          type: integer
+          minimum: 0
+          description: 'How many customers have written and are waiting on an answer.'
+        prospecting:
+          type: integer
+          minimum: 0
+          description: 'How much new business is in hand and owed a first response.'
+        review:
+          type: integer
+          minimum: 0
+          description: |
+            How much routine work is queued behind a decision. Counted before the fold, so
+            a hundred alike approvals read as a hundred here even where the queue draws
+            them as one row — the strip says how much work there is, and the queue says
+            how much reading it costs.
+        more_available:
+          type: boolean
+          description: |
+            True when any source behind any figure here was read to its work bound, so
+            every number above is a floor. Set once for the strip rather than per reading:
+            the four are read as one row, and a reader who cannot trust one of them cannot
+            trust the row.
 
     WorklistItem:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -35206,7 +35206,7 @@ components:
           type: [integer, 'null']
           format: int64
           description: |
-            What the drifting deals are worth, summed over the deals this read weighed, in
+            What the drifting deals are worth, summed over the deals this read PRICED, in
             the currency `revenue_currency` names.
 
             Null when no deal at risk could be priced — no amount recorded, or no stored
@@ -35214,6 +35214,14 @@ components:
             absence says nobody can tell. A deal the estate cannot price is left OUT of
             the sum rather than counted as nothing, so a partly priced day reports what it
             could price and says so through `revenue_currency`.
+
+            It is a FLOOR on what is drifting, never a total, and two things put work
+            outside it. A deal nobody could price is one. The other is that only the
+            at-risk lane goes through the currency conversion, so a deal reaching the page
+            from the overnight brief draws an amount on its own card and adds nothing
+            here. Both are why `more_available` matters: read this figure as "at least
+            this much", and read the `deals_at_risk` entry in `counts` for how many deals
+            stand behind it.
         revenue_currency:
           type: [string, 'null']
           pattern: '^[A-Z]{3}$'

--- a/backend/internal/compose/attention/basemoney_test.go
+++ b/backend/internal/compose/attention/basemoney_test.go
@@ -83,7 +83,7 @@ func pricedWorklist(t *testing.T, fx BaseMoney, day crmcontracts.Attention) crmc
 		t.Fatalf("pricing the day: %v", err)
 	}
 	reader.money = money
-	return reader.worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	return reader.worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 }
 
 // The ordering compares what deals are WORTH, not what their integers say.
@@ -213,7 +213,7 @@ func TestAnUnboundSeamNamesNoBaseCurrency(t *testing.T) {
 		),
 	}
 
-	out := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	if out.Summary.MaterialThresholdMinor == nil {
 		t.Fatal("raw amounts still take a median; the bar should stand")

--- a/backend/internal/compose/attention/counts_test.go
+++ b/backend/internal/compose/attention/counts_test.go
@@ -45,7 +45,7 @@ func TestThePageCountsEachKindOfWork(t *testing.T) {
 		AtRisk:  lane(item("deal", "deal_at_risk", withDeal(50_000_00))),
 	}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	if count := countFor(t, got, "tasks"); count.Considered != 4 || count.Shown != 4 {
 		t.Fatalf("tasks: considered %d shown %d, wanted four of each", count.Considered, count.Shown)
@@ -65,7 +65,7 @@ func TestWorkBelowTheCutIsStillCounted(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, Planned: tasks}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 3, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 3, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	count := countFor(t, got, "tasks")
 	if count.Shown != 3 {
@@ -87,7 +87,7 @@ func TestANarrowedPageStillCountsTheKindsItIsNotDrawing(t *testing.T) {
 		AtRisk:  lane(item("deal", "deal_at_risk", withDeal(50_000_00))),
 	}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "deals_at_risk", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "deals_at_risk", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	tasks := countFor(t, got, "tasks")
 	if tasks.Considered != 1 {
@@ -112,7 +112,7 @@ func TestAFoldedGroupCountsTheItemsItStandsFor(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, AutomationHealth: &failures}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 50, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 50, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	count := countFor(t, got, "system")
 	if count.Shown != 6 {
@@ -129,7 +129,7 @@ func TestACategoryWhoseSourceHitItsBoundSaysThereMayBeMore(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: decisions}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	if count := countFor(t, got, "decisions"); !count.MoreAvailable {
 		t.Fatal("a category read to its bound reported a flat count, so a client would draw it as a total")
@@ -146,8 +146,8 @@ func TestCountsAreOrderedTheSameWayTwice(t *testing.T) {
 		NeedsYou: []crmcontracts.AttentionItem{item("decision", "approval", withKind("send_email"))},
 	}
 
-	first := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
-	second := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	first := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
+	second := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	if len(first.Counts) != len(second.Counts) {
 		t.Fatalf("two reads counted %d and %d categories", len(first.Counts), len(second.Counts))
@@ -395,7 +395,7 @@ func TestABoundedSourceFilteredToNothingStillSaysThereMayBeMore(t *testing.T) {
 
 	// Unassigned drops every row that has an owner, so the lane read fifty and
 	// kept none.
-	out := (&Service{}).worklistFrom(t.Context(), day, scopeUnassigned, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(t.Context(), day, scopeUnassigned, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	count := countFor(t, out, "deals_at_risk")
 	if count.Considered != 0 {

--- a/backend/internal/compose/attention/cursor_test.go
+++ b/backend/internal/compose/attention/cursor_test.go
@@ -45,7 +45,7 @@ func TestAWalkReachesEveryRowExactlyOnce(t *testing.T) {
 	pages := 0
 	for {
 		out := svc.worklistFrom(t.Context(), day, scopeAll, "", perPage,
-			waitingRead{}, leadRead{}, cursor)
+			waitingRead{}, leadRead{}, cursor, nil)
 		pages++
 		for _, row := range out.Queue {
 			seen[string(row.Source)+"|"+row.Id]++
@@ -85,7 +85,7 @@ func TestTheWalkReconcilesAgainstTheCountItReports(t *testing.T) {
 	day := tasksDay(rows)
 
 	first := svc.worklistFrom(t.Context(), day, scopeAll, "", perPage,
-		waitingRead{}, leadRead{}, worklistCursor{})
+		waitingRead{}, leadRead{}, worklistCursor{}, nil)
 	considered := 0
 	for _, count := range first.Counts {
 		considered += count.Considered
@@ -101,7 +101,7 @@ func TestTheWalkReconcilesAgainstTheCountItReports(t *testing.T) {
 			t.Fatalf("the walk did not terminate: %d pages over %d rows", page, rows)
 		}
 		out := svc.worklistFrom(t.Context(), day, scopeAll, "", perPage,
-			waitingRead{}, leadRead{}, cursor)
+			waitingRead{}, leadRead{}, cursor, nil)
 		walked += len(out.Queue)
 		if out.NextCursor == nil {
 			break
@@ -122,7 +122,7 @@ func TestTheWalkReconcilesAgainstTheCountItReports(t *testing.T) {
 func TestTheFinalPageOffersNoCursor(t *testing.T) {
 	svc := &Service{}
 	out := svc.worklistFrom(t.Context(), tasksDay(3), scopeAll, "", 25,
-		waitingRead{}, leadRead{}, worklistCursor{})
+		waitingRead{}, leadRead{}, worklistCursor{}, nil)
 	if out.NextCursor != nil {
 		t.Errorf("a page holding every row offered a cursor to nothing: %q", *out.NextCursor)
 	}
@@ -271,9 +271,9 @@ func TestFoldingIsDeterministicAcrossReads(t *testing.T) {
 
 	svc := &Service{}
 	first := svc.worklistFrom(t.Context(), day, scopeAll, "", 25,
-		waitingRead{}, leadRead{}, worklistCursor{})
+		waitingRead{}, leadRead{}, worklistCursor{}, nil)
 	second := svc.worklistFrom(t.Context(), day, scopeAll, "", 25,
-		waitingRead{}, leadRead{}, worklistCursor{})
+		waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	batched := func(out crmcontracts.Worklist) []string {
 		ids := []string{}
@@ -516,7 +516,7 @@ func TestAWalkTerminatesHoweverTheDayMoves(t *testing.T) {
 	cursor := worklistCursor{}
 	for page := range 20 {
 		out := svc.worklistFrom(t.Context(), days[min(page, len(days)-1)], scopeAll, "", 1,
-			waitingRead{}, leadRead{}, cursor)
+			waitingRead{}, leadRead{}, cursor, nil)
 		if out.NextCursor == nil {
 			return
 		}
@@ -550,7 +550,7 @@ func TestARowCrossingThePageBoundaryWaitsForTheNextRead(t *testing.T) {
 		at("aa", time.Hour), at("bb", 2*time.Hour), at("cc", 3*time.Hour),
 	}}
 	first := svc.worklistFrom(t.Context(), before, scopeAll, "", 1,
-		waitingRead{}, leadRead{}, worklistCursor{})
+		waitingRead{}, leadRead{}, worklistCursor{}, nil)
 	if len(first.Queue) != 1 || first.Queue[0].Id != "aa" {
 		t.Fatalf("page one handed back %v, want aa", queueIDsOf(first))
 	}
@@ -575,7 +575,7 @@ func TestARowCrossingThePageBoundaryWaitsForTheNextRead(t *testing.T) {
 	}
 	for range 6 {
 		out := svc.worklistFrom(t.Context(), after, scopeAll, "", 1,
-			waitingRead{}, leadRead{}, cursor)
+			waitingRead{}, leadRead{}, cursor, nil)
 		for _, row := range out.Queue {
 			seen[row.Id]++
 		}
@@ -598,7 +598,7 @@ func TestARowCrossingThePageBoundaryWaitsForTheNextRead(t *testing.T) {
 
 	// And the delay is bounded rather than permanent: a fresh read leads with it.
 	fresh := svc.worklistFrom(t.Context(), after, scopeAll, "", 1,
-		waitingRead{}, leadRead{}, worklistCursor{})
+		waitingRead{}, leadRead{}, worklistCursor{}, nil)
 	if len(fresh.Queue) == 0 || fresh.Queue[0].Id != "cc" {
 		t.Errorf("a fresh read did not lead with the newly urgent row: %v", queueIDsOf(fresh))
 	}
@@ -712,7 +712,7 @@ func TestTheOffsetIsWhereTheCutLandedInThisRanking(t *testing.T) {
 	// End to end: a walk advances by exactly the page size, and the offset it
 	// publishes indexes the ranking rather than counting the caller's history.
 	first := svc.worklistFrom(t.Context(), tasksDay(5), scopeAll, "", 2,
-		waitingRead{}, leadRead{}, worklistCursor{})
+		waitingRead{}, leadRead{}, worklistCursor{}, nil)
 	cursor, err := decodeCursor(*first.NextCursor, scopeAll, "", ids.UUID{})
 	if err != nil {
 		t.Fatalf("decoding page one: %v", err)
@@ -721,7 +721,7 @@ func TestTheOffsetIsWhereTheCutLandedInThisRanking(t *testing.T) {
 		t.Errorf("a first page of two advanced the offset to %d, want 2", cursor.At)
 	}
 	second := svc.worklistFrom(t.Context(), tasksDay(5), scopeAll, "", 2,
-		waitingRead{}, leadRead{}, cursor)
+		waitingRead{}, leadRead{}, cursor, nil)
 	next, err := decodeCursor(*second.NextCursor, scopeAll, "", ids.UUID{})
 	if err != nil {
 		t.Fatalf("decoding page two: %v", err)

--- a/backend/internal/compose/attention/reach_test.go
+++ b/backend/internal/compose/attention/reach_test.go
@@ -28,7 +28,7 @@ func TestABoundedSourceSaysMoreRatherThanATotal(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, Notices: &notices}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	for _, reach := range got.Reach {
 		if reach.Source != "notice" {
@@ -51,7 +51,7 @@ func TestASourceUnderItsBoundClaimsNoMore(t *testing.T) {
 	notices := []crmcontracts.AttentionItem{item("only", "notice")}
 	day := crmcontracts.Attention{AsOf: rankInstant, Notices: &notices}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	for _, reach := range got.Reach {
 		if reach.Source == "notice" && reach.MoreAvailable {
@@ -73,7 +73,7 @@ func TestAFoldedGroupIsCountedAgainstTheSourcesItStandsFor(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, AutomationHealth: &failures}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	for _, reach := range got.Reach {
 		if reach.Source != "automation_run" {
@@ -97,8 +97,8 @@ func TestReachIsOrderedTheSameWayTwice(t *testing.T) {
 	bounces := []crmcontracts.AttentionItem{item("b", "bounce")}
 	day := crmcontracts.Attention{AsOf: rankInstant, Notices: &notices, Bounces: &bounces}
 
-	first := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
-	second := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
+	first := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{}, nil)
+	second := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	if len(first.Reach) != len(second.Reach) {
 		t.Fatalf("two reads gave %d and %d sources", len(first.Reach), len(second.Reach))
@@ -127,7 +127,7 @@ func TestReachUnderMineCountsNothingOfAColleaguesWork(t *testing.T) {
 	atRisk := []crmcontracts.AttentionItem{theirs}
 	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: &atRisk}
 
-	got := (&Service{}).worklistFrom(ctx, day, "mine", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(ctx, day, "mine", "", 50, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	for _, reach := range got.Reach {
 		if reach.Source == "deal_at_risk" && reach.Considered > 0 {
@@ -155,7 +155,7 @@ func TestEveryBoundedLaneReportsItsTruncation(t *testing.T) {
 		AsOf: rankInstant, Planned: planned, AtRisk: &atRisk, RelationshipDecay: &decay,
 	}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 500, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 500, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	marked := map[crmcontracts.WorklistReachSource]bool{}
 	for _, reach := range got.Reach {
@@ -175,7 +175,7 @@ func TestASourceReadAndFoundEmptyStillAppears(t *testing.T) {
 	none := []crmcontracts.AttentionItem{}
 	day := crmcontracts.Attention{AsOf: rankInstant, Notices: &none}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "", 50, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	for _, reach := range got.Reach {
 		if reach.Source == "notice" {
@@ -197,7 +197,7 @@ func TestNarrowingKeepsTheOtherSourcesInReach(t *testing.T) {
 	notices := []crmcontracts.AttentionItem{item("n1", "notice")}
 	day := crmcontracts.Attention{AsOf: rankInstant, Planned: planned, Notices: &notices}
 
-	got := (&Service{}).worklistFrom(t.Context(), day, "all", "system", 50, waitingRead{}, leadRead{}, worklistCursor{})
+	got := (&Service{}).worklistFrom(t.Context(), day, "all", "system", 50, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	for _, reach := range got.Reach {
 		if reach.Source != "task" {

--- a/backend/internal/compose/attention/readings.go
+++ b/backend/internal/compose/attention/readings.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The four figures the strip above the queue states.
+//
+// They answer a different question from the filter pills, which is why both are
+// on the page: `counts` says how many items of a kind the queue holds, and these
+// say what those items mean for the day. That is why one of the four is a sum of
+// money rather than a tally — "eleven deals at risk" and "€380k drifting" are not
+// the same news, and the second is the one that decides whether a rep opens the
+// pill.
+
+import (
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// readingsOf states the day's four outcome figures over the set `considered`
+// holds.
+//
+// That set — after the scope narrowing, before the category filter, the fold and
+// the page cut — is the only one for which these numbers are stable. Two
+// alternatives were tried against the shape of the screen and both lie:
+//
+//   - over the PAGE, the strip shrinks as a reader walks the queue, so work reads
+//     as disappearing while they do it;
+//   - after the FILTER, opening one pill empties the other three, so the strip
+//     answers a question nobody asked.
+//
+// `counts` already settled this for the same reason, and takes the same snapshot.
+//
+// The money is summed from what the ranking already priced rather than recomputed
+// here. `expectedBase` is the deal's amount in the base currency, decided once by
+// the conversion seam, and a second sum over raw amounts would be a second answer
+// to what a deal is worth — in the units where a yen outranks a euro.
+func readingsOf(
+	considered []ranked, bounds map[crmcontracts.WorklistItemSource]bool,
+) crmcontracts.WorklistReadings {
+	out := crmcontracts.WorklistReadings{}
+	// A priced deal is one the estate could state a comparable figure for. An
+	// unpriced one is LEFT OUT rather than added as zero: a deal nobody recorded
+	// an amount for is not a deal worth nothing, and counting it as nothing
+	// reports a safer pipeline than the one that exists.
+	var revenue int64
+	var priced bool
+	var currency string
+	for _, row := range considered {
+		switch row.item.Category {
+		case crmcontracts.WorklistItemCategoryCustomerWaiting:
+			out.BuyerReplies++
+		case categoryLeads:
+			out.Prospecting++
+		case categoryDecisions:
+			// Counted from `considered`, which is held before the fold, so a
+			// hundred alike approvals read as a hundred here even where the queue
+			// draws them as one row. The strip says how much work there is; the
+			// queue says how much reading it costs.
+			out.Review++
+		case crmcontracts.WorklistItemCategoryDealsAtRisk:
+			if !row.hasExpected {
+				continue
+			}
+			revenue += row.expectedBase
+			priced = true
+			// Every priced row on one read shares one answer, because one
+			// conversion priced them all. Taking it from the row rather than
+			// from the service keeps the currency travelling with the figure it
+			// names, which is the pairing the money values already hold.
+			currency = row.expectedCurrency
+		}
+	}
+	if priced {
+		out.RevenueAtRiskMinor = &revenue
+		if currency != "" {
+			out.RevenueCurrency = &currency
+		}
+	}
+	// One flag for the row rather than one per figure. The four are read across
+	// as a single statement about the day, so a reader who cannot trust one of
+	// them cannot trust the row — and a strip with three exact numbers and one
+	// floor invites exactly the reading where the floor is the one overlooked.
+	for _, bounded := range bounds {
+		if bounded {
+			out.MoreAvailable = true
+			break
+		}
+	}
+	return out
+}

--- a/backend/internal/compose/attention/readings.go
+++ b/backend/internal/compose/attention/readings.go
@@ -34,8 +34,17 @@ import (
 // here. `expectedBase` is the deal's amount in the base currency, decided once by
 // the conversion seam, and a second sum over raw amounts would be a second answer
 // to what a deal is worth — in the units where a yen outranks a euro.
+//
+// `unread` is the day's own list of lanes that never answered — refused to this
+// reader, or failed. It is SEPARATE from `bounds` because the two are different
+// facts and only one of them is in that map: `bounds` records lanes that ran, so
+// a lane which never ran is simply absent from it. Reading the floor flag from
+// `bounds` alone therefore states exact figures over work nobody looked at, which
+// is the one direction these numbers must never fail in.
 func readingsOf(
-	considered []ranked, bounds map[crmcontracts.WorklistItemSource]bool,
+	considered []ranked,
+	bounds map[crmcontracts.WorklistItemSource]bool,
+	unread []crmcontracts.WorklistSourceUnavailable,
 ) crmcontracts.WorklistReadings {
 	out := crmcontracts.WorklistReadings{}
 	// A priced deal is one the estate could state a comparable figure for. An
@@ -62,12 +71,22 @@ func readingsOf(
 				continue
 			}
 			revenue += row.expectedBase
+			// Taking the units from the ROW keeps the currency travelling with
+			// the figure it names, which is the pairing the money values already
+			// hold. One conversion prices a whole read, so today every priced row
+			// carries the same answer — but that is a fact about the current
+			// classifier rather than a guarantee, and a later one setting the
+			// field from somewhere else would silently label the sum with
+			// whichever row happened to come last. Disagreement therefore refuses
+			// to name a currency at all, and the client draws no money figure it
+			// cannot state the units of.
+			switch {
+			case !priced:
+				currency = row.expectedCurrency
+			case currency != row.expectedCurrency:
+				currency = ""
+			}
 			priced = true
-			// Every priced row on one read shares one answer, because one
-			// conversion priced them all. Taking it from the row rather than
-			// from the service keeps the currency travelling with the figure it
-			// names, which is the pairing the money values already hold.
-			currency = row.expectedCurrency
 		}
 	}
 	if priced {
@@ -75,6 +94,15 @@ func readingsOf(
 		if currency != "" {
 			out.RevenueCurrency = &currency
 		}
+	}
+	// A lane that never answered makes every figure a floor just as surely as one
+	// that answered to its cap — more so, since nobody knows what it held. This
+	// arm is FIRST because it is the one a reader loses silently: a refused lane
+	// leaves no rows to notice missing, so the strip reads as a clear day rather
+	// than as a day nobody could see.
+	if len(unread) > 0 {
+		out.MoreAvailable = true
+		return out
 	}
 	// One flag for the row rather than one per figure. The four are read across
 	// as a single statement about the day, so a reader who cannot trust one of

--- a/backend/internal/compose/attention/readings_test.go
+++ b/backend/internal/compose/attention/readings_test.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// The strip is a statement about the DAY, not about the page. A reader walking
+// the queue must not watch the figures fall as they go — work does not stop
+// existing because it moved behind them.
+//
+// This is the whole reason the readings are taken over `considered` rather than
+// over the rows a page carries, and it is the invariant a future refactor is
+// most likely to break by reaching for the nearest slice.
+func TestTheReadingsDoNotShrinkAsAReaderPagesThroughTheQueue(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		AtRisk: lane(
+			item("d1", "deal_at_risk", withDeal(100_00)),
+			item("d2", "deal_at_risk", withDeal(200_00)),
+			item("d3", "deal_at_risk", withDeal(300_00)),
+		),
+	}
+	considered := classifyDay(day, rankInstant, dayMoney{})
+
+	whole := readingsOf(considered, nil)
+	// The same day read one row at a time. `pageFrom` is what a page cut is, so
+	// this walks the real one rather than a slice invented here.
+	var pages []crmcontracts.WorklistReadings
+	for at := 0; at < len(considered); at++ {
+		shown, _, _ := pageFrom(append([]ranked(nil), considered...), 1, worklistCursor{At: at})
+		if len(shown) == 0 {
+			t.Fatalf("the walk ran dry at offset %d with rows still owed", at)
+		}
+		pages = append(pages, readingsOf(considered, nil))
+	}
+
+	for at, page := range pages {
+		if page.RevenueAtRiskMinor == nil || whole.RevenueAtRiskMinor == nil {
+			t.Fatalf("page %d priced nothing over a day of three priced deals", at)
+		}
+		if *page.RevenueAtRiskMinor != *whole.RevenueAtRiskMinor {
+			t.Fatalf(
+				"page %d states %d at risk, the day states %d — the strip fell as the reader walked",
+				at, *page.RevenueAtRiskMinor, *whole.RevenueAtRiskMinor)
+		}
+	}
+}
+
+// A filter narrows what the queue DRAWS, never what the day HOLDS. Opening the
+// decisions pill must not report the buyers waiting as gone.
+func TestAFilterDoesNotEmptyTheOtherReadings(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:     rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{item("a1", "approval", withKind("capture_counterparty"))},
+		AtRisk:   lane(item("d1", "deal_at_risk", withDeal(500_00))),
+	}
+	considered := classifyDay(day, rankInstant, dayMoney{})
+
+	// What a page filtered to decisions would carry, against the snapshot the
+	// readings are actually taken over.
+	narrowed := keepCategory(considered, categoryDecisions)
+	overNarrowed := readingsOf(narrowed, nil)
+	overConsidered := readingsOf(considered, nil)
+
+	if overNarrowed.RevenueAtRiskMinor != nil {
+		t.Fatal("reading the filtered rows priced a deal the filter removed — the wrong snapshot")
+	}
+	if overConsidered.RevenueAtRiskMinor == nil || *overConsidered.RevenueAtRiskMinor != 500_00 {
+		t.Fatalf("the day's own snapshot lost the at-risk deal: %v", overConsidered.RevenueAtRiskMinor)
+	}
+	if overConsidered.Review != 1 {
+		t.Fatalf("counted %d decisions, wanted the one approval", overConsidered.Review)
+	}
+}
+
+// A deal nobody could price is not a deal worth nothing. Counting it as zero
+// reports a safer pipeline than the one that exists — the direction a money
+// figure must never fail in.
+func TestAnUnpricedDealIsLeftOutRatherThanCountedAsZero(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		AtRisk: lane(
+			item("priced", "deal_at_risk", withDeal(400_00)),
+			// No amount recorded at all.
+			item("unpriced", "deal_at_risk"),
+		),
+	}
+
+	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil)
+
+	if got.RevenueAtRiskMinor == nil {
+		t.Fatal("a day with one priced deal reported no figure at all")
+	}
+	if *got.RevenueAtRiskMinor != 400_00 {
+		t.Fatalf("summed %d, wanted only the deal that could be priced", *got.RevenueAtRiskMinor)
+	}
+}
+
+// Null is not zero. Zero says the pipeline is safe; absence says nobody can
+// tell, and the two must not render alike.
+func TestADayThatCouldPriceNothingStatesNoFigure(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("d", "deal_at_risk")),
+	}
+
+	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil)
+
+	if got.RevenueAtRiskMinor != nil {
+		t.Fatalf("stated %d over a day it could price nothing on", *got.RevenueAtRiskMinor)
+	}
+	if got.RevenueCurrency != nil {
+		t.Fatalf("named %q as the units of a figure it did not state", *got.RevenueCurrency)
+	}
+}
+
+// A figure whose units nobody knows is not money. Without the conversion seam
+// the sum is raw minor units in no one currency, and naming one would assert a
+// conversion that never happened.
+func TestAnUnconvertedSumClaimsNoCurrency(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("d", "deal_at_risk", withDeal(700_00))),
+	}
+
+	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil)
+
+	if got.RevenueAtRiskMinor == nil {
+		t.Fatal("an unconverted day should still state its raw sum")
+	}
+	if got.RevenueCurrency != nil {
+		t.Fatalf("claimed currency %q on amounts that never went through the seam", *got.RevenueCurrency)
+	}
+}
+
+// Once the day is priced, the figure travels with the units it is genuinely in.
+func TestAConvertedSumNamesTheBaseCurrency(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		AtRisk: lane(
+			item("d1", "deal_at_risk", withDeal(100_00)),
+			item("d2", "deal_at_risk", withDeal(900_00)),
+		),
+	}
+	money := dayMoney{
+		ran:    true,
+		base:   "EUR",
+		byItem: map[string]int64{"d1": 150_00, "d2": 250_00},
+	}
+
+	got := readingsOf(classifyDay(day, rankInstant, money), nil)
+
+	if got.RevenueCurrency == nil || *got.RevenueCurrency != "EUR" {
+		t.Fatalf("named %v as the base currency, wanted EUR", got.RevenueCurrency)
+	}
+	// The CONVERTED figures, not the deals' own — the sum the ranking compared.
+	if got.RevenueAtRiskMinor == nil || *got.RevenueAtRiskMinor != 400_00 {
+		t.Fatalf("summed %v, wanted the converted 150+250", got.RevenueAtRiskMinor)
+	}
+}
+
+// The strip counts the work, not the rows. A hundred alike approvals fold to one
+// row in the queue and are still a hundred decisions to get through.
+func TestReviewCountsTheFoldedWorkRatherThanTheRowsDrawn(t *testing.T) {
+	needs := make([]crmcontracts.AttentionItem, 0, 12)
+	for i := range 12 {
+		needs = append(needs, item(string(rune('a'+i)), "approval", withKind("capture_counterparty")))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, NeedsYou: needs}
+	considered := classifyDay(day, rankInstant, dayMoney{})
+
+	folded := foldRoutineDecisionsBounded(append([]ranked(nil), considered...), false)
+	got := readingsOf(considered, nil)
+
+	// The fixture has to actually fold, or the assertion below passes for the
+	// wrong reason: over rows that were never folded, "counted the work" and
+	// "counted the rows" are the same number.
+	if len(folded) >= len(considered) {
+		t.Fatalf(
+			"the fixture folded %d rows into %d — nothing folded, so this proves nothing",
+			len(considered), len(folded))
+	}
+	if got.Review != len(considered) {
+		t.Fatalf(
+			"the strip states %d decisions over %d items folded into %d rows — it counted rows, not work",
+			got.Review, len(considered), len(folded))
+	}
+}
+
+// A source read to its bound makes every figure a floor. A strip stating an
+// exact count over a scan that stopped early tells a rep the opposite of the
+// truth: that they have reached the end of something they have not.
+func TestATruncatedSourceMarksTheWholeRowAsAFloor(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("d", "deal_at_risk", withDeal(100_00))),
+	}
+	considered := classifyDay(day, rankInstant, dayMoney{})
+
+	complete := readingsOf(considered, map[crmcontracts.WorklistItemSource]bool{sourceAtRisk: false})
+	cut := readingsOf(considered, map[crmcontracts.WorklistItemSource]bool{sourceAtRisk: true})
+
+	if complete.MoreAvailable {
+		t.Fatal("called the row a floor over sources that all read to the end")
+	}
+	if !cut.MoreAvailable {
+		t.Fatal("stated exact figures over a source that stopped at its bound")
+	}
+}
+
+// Each reading counts its own kind of work. A test that let two categories share
+// a count would pass while the strip put buyer replies under prospecting.
+func TestEachReadingCountsItsOwnCategory(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:     rankInstant,
+		NeedsYou: []crmcontracts.AttentionItem{item("a1", "approval", withKind("capture_counterparty"))},
+		AtRisk:   lane(item("d1", "deal_at_risk", withDeal(100_00))),
+	}
+
+	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil)
+
+	if got.Review != 1 {
+		t.Fatalf("counted %d in review, wanted the one approval", got.Review)
+	}
+	if got.BuyerReplies != 0 {
+		t.Fatalf("counted %d buyer replies on a day with none", got.BuyerReplies)
+	}
+	if got.Prospecting != 0 {
+		t.Fatalf("counted %d prospecting on a day with none", got.Prospecting)
+	}
+}

--- a/backend/internal/compose/attention/readings_test.go
+++ b/backend/internal/compose/attention/readings_test.go
@@ -27,7 +27,7 @@ func TestTheReadingsDoNotShrinkAsAReaderPagesThroughTheQueue(t *testing.T) {
 	}
 	considered := classifyDay(day, rankInstant, dayMoney{})
 
-	whole := readingsOf(considered, nil)
+	whole := readingsOf(considered, nil, nil)
 	// The same day read one row at a time. `pageFrom` is what a page cut is, so
 	// this walks the real one rather than a slice invented here.
 	var pages []crmcontracts.WorklistReadings
@@ -36,7 +36,7 @@ func TestTheReadingsDoNotShrinkAsAReaderPagesThroughTheQueue(t *testing.T) {
 		if len(shown) == 0 {
 			t.Fatalf("the walk ran dry at offset %d with rows still owed", at)
 		}
-		pages = append(pages, readingsOf(considered, nil))
+		pages = append(pages, readingsOf(considered, nil, nil))
 	}
 
 	for at, page := range pages {
@@ -64,8 +64,8 @@ func TestAFilterDoesNotEmptyTheOtherReadings(t *testing.T) {
 	// What a page filtered to decisions would carry, against the snapshot the
 	// readings are actually taken over.
 	narrowed := keepCategory(considered, categoryDecisions)
-	overNarrowed := readingsOf(narrowed, nil)
-	overConsidered := readingsOf(considered, nil)
+	overNarrowed := readingsOf(narrowed, nil, nil)
+	overConsidered := readingsOf(considered, nil, nil)
 
 	if overNarrowed.RevenueAtRiskMinor != nil {
 		t.Fatal("reading the filtered rows priced a deal the filter removed — the wrong snapshot")
@@ -91,7 +91,7 @@ func TestAnUnpricedDealIsLeftOutRatherThanCountedAsZero(t *testing.T) {
 		),
 	}
 
-	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil)
+	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil, nil)
 
 	if got.RevenueAtRiskMinor == nil {
 		t.Fatal("a day with one priced deal reported no figure at all")
@@ -109,7 +109,7 @@ func TestADayThatCouldPriceNothingStatesNoFigure(t *testing.T) {
 		AtRisk: lane(item("d", "deal_at_risk")),
 	}
 
-	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil)
+	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil, nil)
 
 	if got.RevenueAtRiskMinor != nil {
 		t.Fatalf("stated %d over a day it could price nothing on", *got.RevenueAtRiskMinor)
@@ -128,7 +128,7 @@ func TestAnUnconvertedSumClaimsNoCurrency(t *testing.T) {
 		AtRisk: lane(item("d", "deal_at_risk", withDeal(700_00))),
 	}
 
-	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil)
+	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil, nil)
 
 	if got.RevenueAtRiskMinor == nil {
 		t.Fatal("an unconverted day should still state its raw sum")
@@ -153,7 +153,7 @@ func TestAConvertedSumNamesTheBaseCurrency(t *testing.T) {
 		byItem: map[string]int64{"d1": 150_00, "d2": 250_00},
 	}
 
-	got := readingsOf(classifyDay(day, rankInstant, money), nil)
+	got := readingsOf(classifyDay(day, rankInstant, money), nil, nil)
 
 	if got.RevenueCurrency == nil || *got.RevenueCurrency != "EUR" {
 		t.Fatalf("named %v as the base currency, wanted EUR", got.RevenueCurrency)
@@ -161,6 +161,92 @@ func TestAConvertedSumNamesTheBaseCurrency(t *testing.T) {
 	// The CONVERTED figures, not the deals' own — the sum the ranking compared.
 	if got.RevenueAtRiskMinor == nil || *got.RevenueAtRiskMinor != 400_00 {
 		t.Fatalf("summed %v, wanted the converted 150+250", got.RevenueAtRiskMinor)
+	}
+}
+
+// A deal reaching the page from the overnight brief lands in `deals_at_risk`
+// and is never priced: `classifyBriefItem` sets no expected figure, and
+// `priceTheDay` converts only the at-risk lane. So its card can show an amount
+// while the strip's sum does not include it.
+//
+// The contract says this out loud — the figure is a floor, not a total — and
+// this test is what keeps the two agreeing. Widening the conversion to the brief
+// lane would change what the ORDERING weighs, not just this sum, so it is filed
+// rather than done here; when it is done, this test fails and says so.
+func TestTheSumCoversTheAtRiskLaneOnlyAndSaysSo(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("priced", "deal_at_risk", withDeal(300_00))),
+		ThisMorning: []crmcontracts.AttentionItem{
+			item("brief", "brief_item", withDeal(900_00)),
+		},
+	}
+	rows := classifyDay(day, rankInstant, dayMoney{})
+
+	brief := 0
+	for _, row := range rows {
+		if row.item.Source == "brief_item" {
+			brief++
+			if row.item.Category != crmcontracts.WorklistItemCategoryDealsAtRisk {
+				t.Fatalf("a brief row now classifies as %q; this test's premise is gone", row.item.Category)
+			}
+		}
+	}
+	if brief != 1 {
+		t.Fatalf("the fixture produced %d brief rows, wanted one", brief)
+	}
+
+	got := readingsOf(rows, nil, nil)
+
+	if got.RevenueAtRiskMinor == nil {
+		t.Fatal("the at-risk deal should still be summed")
+	}
+	if *got.RevenueAtRiskMinor != 300_00 {
+		t.Fatalf(
+			"summed %d — if the brief lane is now priced too, widen this test and the contract prose with it",
+			*got.RevenueAtRiskMinor)
+	}
+}
+
+// Two priced rows disagreeing about their units means the sum is in no one
+// currency, and naming either would label the total with a guess.
+//
+// Nothing produces this today — one conversion prices a whole read — which is
+// exactly why it is a test rather than a comment: the claim that the rows agree
+// is a fact about the current classifier, and a later one is free to break it.
+func TestPricedRowsThatDisagreeAboutUnitsNameNoCurrency(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		AtRisk: lane(
+			item("d1", "deal_at_risk", withDeal(100_00)),
+			item("d2", "deal_at_risk", withDeal(200_00)),
+		),
+	}
+	rows := classifyDay(day, rankInstant, dayMoney{
+		ran: true, base: "EUR", byItem: map[string]int64{"d1": 100_00, "d2": 200_00},
+	})
+	// The disagreement a future classifier could introduce, written directly
+	// onto the ranked row because no current code path produces it.
+	priced := 0
+	for i := range rows {
+		if rows[i].hasExpected {
+			priced++
+			if priced == 2 {
+				rows[i].expectedCurrency = "USD"
+			}
+		}
+	}
+	if priced < 2 {
+		t.Fatalf("the fixture priced %d rows; this needs two to disagree", priced)
+	}
+
+	got := readingsOf(rows, nil, nil)
+
+	if got.RevenueAtRiskMinor == nil {
+		t.Fatal("dropped the sum entirely; only the currency is in doubt")
+	}
+	if got.RevenueCurrency != nil {
+		t.Fatalf("labelled a mixed-currency sum %q", *got.RevenueCurrency)
 	}
 }
 
@@ -175,7 +261,7 @@ func TestReviewCountsTheFoldedWorkRatherThanTheRowsDrawn(t *testing.T) {
 	considered := classifyDay(day, rankInstant, dayMoney{})
 
 	folded := foldRoutineDecisionsBounded(append([]ranked(nil), considered...), false)
-	got := readingsOf(considered, nil)
+	got := readingsOf(considered, nil, nil)
 
 	// The fixture has to actually fold, or the assertion below passes for the
 	// wrong reason: over rows that were never folded, "counted the work" and
@@ -202,14 +288,107 @@ func TestATruncatedSourceMarksTheWholeRowAsAFloor(t *testing.T) {
 	}
 	considered := classifyDay(day, rankInstant, dayMoney{})
 
-	complete := readingsOf(considered, map[crmcontracts.WorklistItemSource]bool{sourceAtRisk: false})
-	cut := readingsOf(considered, map[crmcontracts.WorklistItemSource]bool{sourceAtRisk: true})
+	complete := readingsOf(considered, map[crmcontracts.WorklistItemSource]bool{sourceAtRisk: false}, nil)
+	cut := readingsOf(considered, map[crmcontracts.WorklistItemSource]bool{sourceAtRisk: true}, nil)
 
 	if complete.MoreAvailable {
 		t.Fatal("called the row a floor over sources that all read to the end")
 	}
 	if !cut.MoreAvailable {
 		t.Fatal("stated exact figures over a source that stopped at its bound")
+	}
+}
+
+// A lane nobody could read is the one a reader loses SILENTLY. A truncated lane
+// at least leaves rows on the page to notice; a refused one leaves none, so the
+// strip reads as a clear day rather than as a day nobody could see.
+//
+// This is the direction these figures must never fail in: under-reporting looks
+// exactly like good news.
+// Driven through the real worklistFrom rather than calling readingsOf directly,
+// because the defect lived in the WIRING and not in the arithmetic: the two
+// sources whose refusal produces a confident zero are read BESIDE the assembled
+// day, so they never appear in its omitted-lane list. A test that hands
+// readingsOf a refusal it built itself proves the flag works and says nothing
+// about whether the refusal reaches it.
+func TestALaneThisReaderWasRefusedMakesTheFiguresAFloor(t *testing.T) {
+	// The two lanes that produce a NUMBER when refused, rather than a null.
+	// `at_risk` is deliberately not among them: it feeds the money figure, which
+	// answers null on its own and cannot print a false zero.
+	for _, refused := range []struct {
+		name   string
+		source string
+	}{
+		{"who is waiting", sourceWaiting},
+		{"leads owed a reply", sourceLeadResponse},
+	} {
+		t.Run(refused.name, func(t *testing.T) {
+			// A day whose own lanes all answered. Only the source read beside it
+			// was refused, which is exactly the case the omitted-lane list misses.
+			day := crmcontracts.Attention{AsOf: rankInstant}
+			withheld := &crmcontracts.WorklistSourceUnavailable{
+				Source: refused.source,
+				Reason: crmcontracts.WorklistSourceUnavailableReasonWithheld,
+			}
+
+			out := (&Service{}).worklistFrom(
+				t.Context(), day, scopeAll, "", 25,
+				waitingRead{}, leadRead{}, worklistCursor{},
+				[]*crmcontracts.WorklistSourceUnavailable{withheld})
+
+			if !out.Readings.MoreAvailable {
+				t.Fatalf(
+					"the %s lane was refused and the strip still stated exact figures — "+
+						"a rep sees a confident zero over work nobody could look at",
+					refused.name)
+			}
+		})
+	}
+}
+
+// The refusal has to reach the READINGS, not only the warning list. Both are
+// published from one page, and a version that appended the refusal to the page
+// after the readings were built passed every check that looked at
+// SourcesUnavailable while the strip above it printed a zero.
+func TestARefusedLaneReachesBothTheWarningListAndTheFigures(t *testing.T) {
+	day := crmcontracts.Attention{AsOf: rankInstant}
+	withheld := &crmcontracts.WorklistSourceUnavailable{
+		Source: sourceWaiting,
+		Reason: crmcontracts.WorklistSourceUnavailableReasonWithheld,
+	}
+
+	out := (&Service{}).worklistFrom(
+		t.Context(), day, scopeAll, "", 25,
+		waitingRead{}, leadRead{}, worklistCursor{},
+		[]*crmcontracts.WorklistSourceUnavailable{withheld})
+
+	named := false
+	for _, source := range out.SourcesUnavailable {
+		if source.Source == sourceWaiting {
+			named = true
+		}
+	}
+	if !named {
+		t.Fatal("the refused lane never reached the reader's warning list")
+	}
+	if !out.Readings.MoreAvailable {
+		t.Fatal("the warning list named the refusal and the figures above it did not")
+	}
+}
+
+// The DSR lane is withheld by ROLE from every rep, permanently. Letting it set
+// the floor flag would put "these are floors" on every rep's strip forever,
+// which drowns the warning — and it hides no work these four readings count,
+// because DSR rows classify as `system` and none of the four counts that.
+func TestThePermanentlyWithheldPrivacyLaneDoesNotMarkEveryDayAFloor(t *testing.T) {
+	omitted := []crmcontracts.AttentionLanesOmitted{laneDSR}
+	day := crmcontracts.Attention{AsOf: rankInstant, LanesOmitted: &omitted}
+
+	got := readingsOf(
+		classifyDay(day, rankInstant, dayMoney{}), boundedSources(day), unavailable(day))
+
+	if got.MoreAvailable {
+		t.Fatal("the always-withheld privacy lane marked an ordinary day as a floor")
 	}
 }
 
@@ -222,7 +401,7 @@ func TestEachReadingCountsItsOwnCategory(t *testing.T) {
 		AtRisk:   lane(item("d1", "deal_at_risk", withDeal(100_00))),
 	}
 
-	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil)
+	got := readingsOf(classifyDay(day, rankInstant, dayMoney{}), nil, nil)
 
 	if got.Review != 1 {
 		t.Fatalf("counted %d in review, wanted the one approval", got.Review)

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -141,7 +141,7 @@ func TestAPageOfTheReadersOwnIsNotShortenedByColleaguesRows(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: &at}
 
-	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 3, waitingRead{}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 3, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	if len(out.Queue) != 3 {
 		t.Fatalf("a reader with three of their own rows got a page of %d", len(out.Queue))
@@ -392,7 +392,7 @@ func TestOpeningAnothersQueueCarriesTheirWorkAndNotTheReadersOwn(t *testing.T) {
 	}
 	reader := &Service{taskOwner: lena, taskScope: TasksOwnedBy}
 
-	out := reader.worklistFrom(context.Background(), day, scopeMine, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	out := reader.worklistFrom(context.Background(), day, scopeMine, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	var ids []string
 	for _, row := range out.Queue {

--- a/backend/internal/compose/attention/waitingfreshness_test.go
+++ b/backend/internal/compose/attention/waitingfreshness_test.go
@@ -176,7 +176,7 @@ func TestAnAncientWaitNoLongerOutranksTodaysDeal(t *testing.T) {
 		Since:      rankInstant.Add(-182 * 24 * time.Hour),
 	}}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{}, nil)
 
 	if out.Queue[0].Source == sourceWaiting {
 		t.Fatal("a 182-day unanswered thread still led the day over a deal at risk")
@@ -198,7 +198,7 @@ func TestTheSummaryStatesTheMaterialBar(t *testing.T) {
 		),
 	}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	if out.Summary.MaterialThresholdMinor == nil {
 		t.Fatal("a day with priced deals stated no material bar, so every material reason on it is unverifiable")
@@ -217,7 +217,7 @@ func TestTheSummaryStatesTheMaterialBar(t *testing.T) {
 func TestADayWithNoPricedDealsStatesNoBar(t *testing.T) {
 	day := crmcontracts.Attention{AsOf: rankInstant, AtRisk: lane(item("unpriced", "deal_at_risk"))}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	if out.Summary.MaterialThresholdMinor != nil {
 		t.Fatalf("a pipeline with no prices stated a bar of %d", *out.Summary.MaterialThresholdMinor)

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -128,13 +128,15 @@ func (s *Service) Worklist(
 	// left the second half seeing no named owner: it fell through to "mine" and
 	// returned the READER's own day under the named person's heading, which is
 	// the one way this page can be wrong that its reader cannot detect.
-	out := reader.worklistFrom(ctx, day, resolved, filter, limit, waiting, leads, cursor)
-	if waitingErr != nil {
-		out.SourcesUnavailable = append(out.SourcesUnavailable, *waitingErr)
-	}
-	if leadsErr != nil {
-		out.SourcesUnavailable = append(out.SourcesUnavailable, *leadsErr)
-	}
+	//
+	// The two refusals travel INTO the projection rather than onto the finished
+	// page. Appended afterwards they reached the reader's warning list but not
+	// the readings, so a rep refused the who-is-waiting lane was shown "0
+	// customers waiting on an answer" as an exact figure — above the warning
+	// that contradicted it.
+	out := reader.worklistFrom(
+		ctx, day, resolved, filter, limit, waiting, leads, cursor,
+		[]*crmcontracts.WorklistSourceUnavailable{waitingErr, leadsErr})
 	out.Scope = crmcontracts.WorklistScope(resolved)
 	out.ScopeOptions = scopeOptions(scopeOptionsFor(ctx))
 	return out, nil
@@ -145,6 +147,11 @@ func (s *Service) Worklist(
 func (s *Service) worklistFrom(
 	ctx context.Context, day crmcontracts.Attention, scope, filter string, limit int,
 	waiting waitingRead, leads leadRead, cursor worklistCursor,
+	// The refusals from the two sources read BESIDE the assembled day. They
+	// arrive here rather than being appended to the finished page because the
+	// readings have to see them: a refused waiting or leads lane is exactly the
+	// case where a tally would otherwise print a confident zero.
+	besideTheDay []*crmcontracts.WorklistSourceUnavailable,
 ) crmcontracts.Worklist {
 	if limit <= 0 {
 		limit = worklistPage
@@ -270,6 +277,24 @@ func (s *Service) worklistFrom(
 	shown, more, reached := pageFrom(rows, limit, cursor)
 	ordered := rankAll(shown)
 	bands := bandsOf(ordered)
+	// What never answered, assembled ONCE and used twice: the page names these
+	// lanes to the reader, and the readings below refuse to state exact figures
+	// over them. Two derivations of one list could disagree about whether the
+	// day was wholly seen.
+	//
+	// Both halves are needed, and missing the second half is the defect this
+	// shape exists to prevent. `unavailable(day)` reads the assembled day's own
+	// omitted lanes; the who-is-waiting and owed-leads sources are read BESIDE
+	// that day and are absent from it. Those two are precisely what
+	// `buyer_replies` and `prospecting` count, so leaving them out let a refused
+	// lane print a confident zero — the one direction these figures must never
+	// fail in.
+	missing := unavailable(day)
+	for _, refusal := range besideTheDay {
+		if refusal != nil {
+			missing = append(missing, *refusal)
+		}
+	}
 	out := crmcontracts.Worklist{
 		AsOf:  day.AsOf,
 		Queue: ordered,
@@ -280,7 +305,7 @@ func (s *Service) worklistFrom(
 		// cannot disagree, and threading it would change a signature twenty-odd
 		// callers spell.
 		Summary:            summarize(ordered, materialBarOf(day, s.money)),
-		SourcesUnavailable: unavailable(day),
+		SourcesUnavailable: missing,
 		// `considered` is every candidate this read weighed, `shown` what
 		// survived folding and the cut. Both are already in hand, so no figure
 		// here costs a query that could disagree with the page it describes.
@@ -292,7 +317,14 @@ func (s *Service) worklistFrom(
 		// The outcome figures beside the per-kind tallies, over the same
 		// snapshot: what the day's work is worth rather than how much of it
 		// there is.
-		Readings: readingsOf(considered, bounded),
+		//
+		// It takes the SAME withheld list the page publishes, so the strip cannot
+		// state a clear day over a lane this reader was refused. Sharing the value
+		// also shares its DSR suppression, which is correct here rather than
+		// merely convenient: DSR rows classify as `system` and feed none of the
+		// four readings, so a suppressed DSR lane hides no work these figures
+		// count. A lane whose rows DID feed one would have to be named.
+		Readings: readingsOf(considered, bounded, missing),
 	}
 	if filter != "" {
 		narrowed := crmcontracts.WorklistFilter(filter)

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -289,6 +289,10 @@ func (s *Service) worklistFrom(
 		// snapshots, so the per-source and per-category figures are two views of
 		// one answer rather than two answers.
 		Counts: countsOf(considered, shown, bounded),
+		// The outcome figures beside the per-kind tallies, over the same
+		// snapshot: what the day's work is worth rather than how much of it
+		// there is.
+		Readings: readingsOf(considered, bounded),
 	}
 	if filter != "" {
 		narrowed := crmcontracts.WorklistFilter(filter)

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -326,7 +326,7 @@ func TestThePageIsSummarisedAndExplainedAgainstItself(t *testing.T) {
 	}
 	day := crmcontracts.Attention{AsOf: rankInstant, Planned: tasks}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 3, waitingRead{}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 3, waitingRead{}, leadRead{}, worklistCursor{}, nil)
 
 	if out.Summary.Total != len(out.Queue) {
 		t.Fatalf("summary totals %d over a page of %d", out.Summary.Total, len(out.Queue))
@@ -411,7 +411,7 @@ func TestAWaitingCustomerLeadsTheDay(t *testing.T) {
 		Since:      rankInstant.Add(-2 * 24 * time.Hour),
 	}}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{}, nil)
 
 	if out.Queue[0].Source != "customer_waiting" {
 		t.Fatalf("the day led with %q, not the customer who is waiting", out.Queue[0].Source)
@@ -435,7 +435,7 @@ func TestAWaitingDealDoesNotAlsoAppearAsDrifting(t *testing.T) {
 		DealID:     deal,
 	}}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{}, nil)
 
 	if len(out.Queue) != 1 {
 		t.Fatalf("one unanswered message produced %d rows", len(out.Queue))
@@ -457,7 +457,7 @@ func TestTheLongestWaitLeadsAmongWaitingCustomers(t *testing.T) {
 		{ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000000b"), Since: rankInstant.Add(-9 * 24 * time.Hour)},
 	}
 
-	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{}, nil)
 
 	if out.Queue[0].Id != "01a05500-0000-7000-8000-00000000000b" {
 		t.Fatal("the two-day wait outranked the eighty-three-day one")
@@ -479,7 +479,7 @@ func TestEveryWaitingRowMayStateItsSubject(t *testing.T) {
 		Since:      rankInstant.Add(-24 * time.Hour),
 	}}
 
-	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(context.Background(), crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{}, nil)
 
 	if out.Queue[0].Title == nil || *out.Queue[0].Title != "Re: pricing" {
 		t.Fatal("a waiting row the content gate admitted lost its subject line")
@@ -504,7 +504,7 @@ func TestAColleaguesWaitingCustomerLeavesTheReadersOwnQueue(t *testing.T) {
 		{ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000a2"), Since: rankInstant.Add(-time.Hour)},
 	}
 
-	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(ctx, day, scopeMine, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{}, nil)
 
 	for _, row := range out.Queue {
 		if row.Id == "01a05500-0000-7000-8000-0000000000a1" {
@@ -683,7 +683,7 @@ func TestOneKindOfWorkCannotTakeTheWholePage(t *testing.T) {
 		Planned: []crmcontracts.AttentionItem{item("task", "task", withDue(rankInstant.Add(-time.Hour)))},
 	}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 100, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 100, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{}, nil)
 
 	// Every wait is still on the page, and every one still SAYS it is a wait.
 	// Rewriting the level of the ninth would tell the reader it was agreed work
@@ -722,7 +722,7 @@ func TestAWaitingRowNamesTheMessageAReplyWouldAnswer(t *testing.T) {
 
 	out := (&Service{}).worklistFrom(context.Background(),
 		crmcontracts.Attention{AsOf: rankInstant}, scopeAll, "", 25, waitingRead{rows: waiting, read: true},
-		leadRead{}, worklistCursor{})
+		leadRead{}, worklistCursor{}, nil)
 
 	move := out.Queue[0].Move
 	if move == nil {
@@ -756,7 +756,7 @@ func TestAnAbsorbedDealKeepsItsMoneyOnTheWaitingRow(t *testing.T) {
 		DealID:     deal,
 	}}
 
-	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{})
+	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{}, nil)
 
 	if len(out.Queue) != 1 {
 		t.Fatalf("one message about one deal produced %d rows", len(out.Queue))

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -29597,6 +29597,28 @@ type Worklist struct {
 	// is where the queue says which. Empty only when no source was read at all.
 	Reach []WorklistReach `json:"reach"`
 
+	// Readings The day's four OUTCOME figures, for the strip above the queue: what money is
+	// drifting, who is waiting on an answer, how much new business is in hand, and how
+	// much routine work is queued behind a decision.
+	//
+	// These are not the filter pills. `counts` says how many items of a kind the queue
+	// holds; these say what those items MEAN for the day, which is why one of them is a
+	// sum of money rather than a tally. Both are on the page because a rep asks two
+	// different questions — "what is there" and "what is at stake".
+	//
+	// Every figure describes the same set `counts.considered` describes: what this read
+	// weighed AFTER the scope narrowing and BEFORE the category filter, the fold and the
+	// page cut. That is the only set for which the numbers are stable — computed over
+	// the page, the strip would shrink as a reader walked the queue and read as work
+	// disappearing; computed after the filter, opening a pill would empty the other
+	// three.
+	//
+	// `more_available` carries the same honesty `WorklistCount` carries, for the same
+	// reason: a source read to its work bound makes every figure here a FLOOR rather
+	// than a total, and a strip stating "3 buyers waiting" over a scan that stopped
+	// early tells a rep the opposite of the truth.
+	Readings WorklistReadings `json:"readings"`
+
 	// Scope Whose work this read answered for.
 	Scope WorklistScope `json:"scope"`
 
@@ -30020,6 +30042,65 @@ type WorklistReach struct {
 
 // WorklistReachSource Which producer these numbers are about. The same vocabulary as an item source.
 type WorklistReachSource string
+
+// WorklistReadings The day's four OUTCOME figures, for the strip above the queue: what money is
+// drifting, who is waiting on an answer, how much new business is in hand, and how
+// much routine work is queued behind a decision.
+//
+// These are not the filter pills. `counts` says how many items of a kind the queue
+// holds; these say what those items MEAN for the day, which is why one of them is a
+// sum of money rather than a tally. Both are on the page because a rep asks two
+// different questions — "what is there" and "what is at stake".
+//
+// Every figure describes the same set `counts.considered` describes: what this read
+// weighed AFTER the scope narrowing and BEFORE the category filter, the fold and the
+// page cut. That is the only set for which the numbers are stable — computed over
+// the page, the strip would shrink as a reader walked the queue and read as work
+// disappearing; computed after the filter, opening a pill would empty the other
+// three.
+//
+// `more_available` carries the same honesty `WorklistCount` carries, for the same
+// reason: a source read to its work bound makes every figure here a FLOOR rather
+// than a total, and a strip stating "3 buyers waiting" over a scan that stopped
+// early tells a rep the opposite of the truth.
+type WorklistReadings struct {
+	// BuyerReplies How many customers have written and are waiting on an answer.
+	BuyerReplies int `json:"buyer_replies"`
+
+	// MoreAvailable True when any source behind any figure here was read to its work bound, so
+	// every number above is a floor. Set once for the strip rather than per reading:
+	// the four are read as one row, and a reader who cannot trust one of them cannot
+	// trust the row.
+	MoreAvailable bool `json:"more_available"`
+
+	// Prospecting How much new business is in hand and owed a first response.
+	Prospecting int `json:"prospecting"`
+
+	// RevenueAtRiskMinor What the drifting deals are worth, summed over the deals this read weighed, in
+	// the currency `revenue_currency` names.
+	//
+	// Null when no deal at risk could be priced — no amount recorded, or no stored
+	// rate for its currency. Null is not zero: zero says the pipeline is safe, and
+	// absence says nobody can tell. A deal the estate cannot price is left OUT of
+	// the sum rather than counted as nothing, so a partly priced day reports what it
+	// could price and says so through `revenue_currency`.
+	RevenueAtRiskMinor *int64 `json:"revenue_at_risk_minor"`
+
+	// RevenueCurrency The currency `revenue_at_risk_minor` is stated in — the installation's base
+	// currency, once the amounts went through the conversion seam.
+	//
+	// Null when they did not, which makes the sum a total of raw minor units in no
+	// one currency. A client must not format a figure whose units it cannot name:
+	// with this absent the amount is not money yet, and drawing it as money is the
+	// error the conversion seam exists to prevent.
+	RevenueCurrency *string `json:"revenue_currency,omitempty"`
+
+	// Review How much routine work is queued behind a decision. Counted before the fold, so
+	// a hundred alike approvals read as a hundred here even where the queue draws
+	// them as one row — the strip says how much work there is, and the queue says
+	// how much reading it costs.
+	Review int `json:"review"`
+}
 
 // WorklistReason One fact behind an item's rank, as a typed pair rather than a sentence: the
 // product ships three languages and a sentence composed here would reach a German

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -30076,7 +30076,7 @@ type WorklistReadings struct {
 	// Prospecting How much new business is in hand and owed a first response.
 	Prospecting int `json:"prospecting"`
 
-	// RevenueAtRiskMinor What the drifting deals are worth, summed over the deals this read weighed, in
+	// RevenueAtRiskMinor What the drifting deals are worth, summed over the deals this read PRICED, in
 	// the currency `revenue_currency` names.
 	//
 	// Null when no deal at risk could be priced — no amount recorded, or no stored
@@ -30084,6 +30084,14 @@ type WorklistReadings struct {
 	// absence says nobody can tell. A deal the estate cannot price is left OUT of
 	// the sum rather than counted as nothing, so a partly priced day reports what it
 	// could price and says so through `revenue_currency`.
+	//
+	// It is a FLOOR on what is drifting, never a total, and two things put work
+	// outside it. A deal nobody could price is one. The other is that only the
+	// at-risk lane goes through the currency conversion, so a deal reaching the page
+	// from the overnight brief draws an amount on its own card and adds nothing
+	// here. Both are why `more_available` matters: read this figure as "at least
+	// this much", and read the `deals_at_risk` entry in `counts` for how many deals
+	// stand behind it.
 	RevenueAtRiskMinor *int64 `json:"revenue_at_risk_minor"`
 
 	// RevenueCurrency The currency `revenue_at_risk_minor` is stated in — the installation's base

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -1911,6 +1911,17 @@ export async function mockApi(
             more_available: false,
           },
         ],
+        // The strip above the queue. This day is one routine decision and
+        // nothing else, so three readings are honestly zero and the money is
+        // null rather than 0 — nothing at risk means nothing to price, and a
+        // zero there would claim a safe pipeline the fixture never looked at.
+        readings: {
+          revenue_at_risk_minor: null,
+          buyer_replies: 0,
+          prospecting: 0,
+          review: 1,
+          more_available: false,
+        },
         queue: [
           {
             id: approval.id,

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -26547,7 +26547,7 @@ export interface components {
         WorklistReadings: {
             /**
              * Format: int64
-             * @description What the drifting deals are worth, summed over the deals this read weighed, in
+             * @description What the drifting deals are worth, summed over the deals this read PRICED, in
              *     the currency `revenue_currency` names.
              *
              *     Null when no deal at risk could be priced — no amount recorded, or no stored
@@ -26555,6 +26555,14 @@ export interface components {
              *     absence says nobody can tell. A deal the estate cannot price is left OUT of
              *     the sum rather than counted as nothing, so a partly priced day reports what it
              *     could price and says so through `revenue_currency`.
+             *
+             *     It is a FLOOR on what is drifting, never a total, and two things put work
+             *     outside it. A deal nobody could price is one. The other is that only the
+             *     at-risk lane goes through the currency conversion, so a deal reaching the page
+             *     from the overnight brief draws an amount on its own card and adds nothing
+             *     here. Both are why `more_available` matters: read this figure as "at least
+             *     this much", and read the `deals_at_risk` entry in `counts` for how many deals
+             *     stand behind it.
              */
             revenue_at_risk_minor: number | null;
             /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -26341,6 +26341,7 @@ export interface components {
              *     not drawing.
              */
             counts: components["schemas"]["WorklistCount"][];
+            readings: components["schemas"]["WorklistReadings"];
             /**
              * @description The outcome headings, in the order a page draws them, each with how many of this
              *     page's rows sit under it.
@@ -26520,6 +26521,70 @@ export interface components {
             material_threshold_minor?: number | null;
             /** @description The currency every expected-revenue figure here is converted to. */
             base_currency?: string | null;
+        };
+        /**
+         * @description The day's four OUTCOME figures, for the strip above the queue: what money is
+         *     drifting, who is waiting on an answer, how much new business is in hand, and how
+         *     much routine work is queued behind a decision.
+         *
+         *     These are not the filter pills. `counts` says how many items of a kind the queue
+         *     holds; these say what those items MEAN for the day, which is why one of them is a
+         *     sum of money rather than a tally. Both are on the page because a rep asks two
+         *     different questions — "what is there" and "what is at stake".
+         *
+         *     Every figure describes the same set `counts.considered` describes: what this read
+         *     weighed AFTER the scope narrowing and BEFORE the category filter, the fold and the
+         *     page cut. That is the only set for which the numbers are stable — computed over
+         *     the page, the strip would shrink as a reader walked the queue and read as work
+         *     disappearing; computed after the filter, opening a pill would empty the other
+         *     three.
+         *
+         *     `more_available` carries the same honesty `WorklistCount` carries, for the same
+         *     reason: a source read to its work bound makes every figure here a FLOOR rather
+         *     than a total, and a strip stating "3 buyers waiting" over a scan that stopped
+         *     early tells a rep the opposite of the truth.
+         */
+        WorklistReadings: {
+            /**
+             * Format: int64
+             * @description What the drifting deals are worth, summed over the deals this read weighed, in
+             *     the currency `revenue_currency` names.
+             *
+             *     Null when no deal at risk could be priced — no amount recorded, or no stored
+             *     rate for its currency. Null is not zero: zero says the pipeline is safe, and
+             *     absence says nobody can tell. A deal the estate cannot price is left OUT of
+             *     the sum rather than counted as nothing, so a partly priced day reports what it
+             *     could price and says so through `revenue_currency`.
+             */
+            revenue_at_risk_minor: number | null;
+            /**
+             * @description The currency `revenue_at_risk_minor` is stated in — the installation's base
+             *     currency, once the amounts went through the conversion seam.
+             *
+             *     Null when they did not, which makes the sum a total of raw minor units in no
+             *     one currency. A client must not format a figure whose units it cannot name:
+             *     with this absent the amount is not money yet, and drawing it as money is the
+             *     error the conversion seam exists to prevent.
+             */
+            revenue_currency?: string | null;
+            /** @description How many customers have written and are waiting on an answer. */
+            buyer_replies: number;
+            /** @description How much new business is in hand and owed a first response. */
+            prospecting: number;
+            /**
+             * @description How much routine work is queued behind a decision. Counted before the fold, so
+             *     a hundred alike approvals read as a hundred here even where the queue draws
+             *     them as one row — the strip says how much work there is, and the queue says
+             *     how much reading it costs.
+             */
+            review: number;
+            /**
+             * @description True when any source behind any figure here was read to its work bound, so
+             *     every number above is a floor. Set once for the strip rather than per reading:
+             *     the four are read as one row, and a reader who cannot trust one of them cannot
+             *     trust the row.
+             */
+            more_available: boolean;
         };
         /**
          * @description One thing to do, with the reason it sits where it sits.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7534,6 +7534,20 @@ export const de = {
   "worklist.board.nobody": "Noch niemand",
   "worklist.board.truncated":
     "Es gibt mehr Arbeit, als hier gezählt werden konnte. Das sind Untergrenzen, keine Gesamtzahlen.",
+  "worklist.readings.label": "Was heute auf dem Spiel steht",
+  "worklist.readings.revenue": "Umsatz in Gefahr",
+  "worklist.readings.revenue.detail": "Über die heute treibenden Deals",
+  "worklist.readings.revenue.unpriced": "Kein gefährdeter Deal war bewertbar",
+  "worklist.readings.replies": "Kundenantworten",
+  "worklist.readings.replies.detail": "Kunden warten auf eine Antwort",
+  "worklist.readings.prospecting": "Neugeschäft",
+  "worklist.readings.prospecting.detail":
+    "Neugeschäft, das eine erste Antwort schuldet",
+  "worklist.readings.review": "Prüfung",
+  "worklist.readings.review.detail":
+    "Routinearbeit, die hinter einer Entscheidung wartet",
+  "worklist.readings.truncated":
+    "Es gibt mehr Arbeit, als hier gezählt werden konnte. Das sind Untergrenzen, keine Gesamtzahlen.",
   "worklist.filter.label": "Art der Arbeit",
   "worklist.filter.all": "Alle",
   "worklist.filter.customer_waiting": "Kunde wartet",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7601,6 +7601,18 @@ export const en = {
   "worklist.board.nobody": "Nobody yet",
   "worklist.board.truncated":
     "There is more work than this could count. These are floors, not totals.",
+  "worklist.readings.label": "What today is worth",
+  "worklist.readings.revenue": "Revenue at risk",
+  "worklist.readings.revenue.detail": "Across the deals drifting today",
+  "worklist.readings.revenue.unpriced": "No deal at risk could be priced",
+  "worklist.readings.replies": "Buyer replies",
+  "worklist.readings.replies.detail": "Customers waiting on an answer",
+  "worklist.readings.prospecting": "Prospecting",
+  "worklist.readings.prospecting.detail": "New business owed a first reply",
+  "worklist.readings.review": "Review",
+  "worklist.readings.review.detail": "Routine work queued behind a decision",
+  "worklist.readings.truncated":
+    "There is more work than this could count. These are floors, not totals.",
   "worklist.filter.label": "Kind of work",
   "worklist.filter.all": "All",
   "worklist.filter.customer_waiting": "Customer waiting",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7453,6 +7453,21 @@ export const vi = {
   "worklist.board.nobody": "Chưa có ai",
   "worklist.board.truncated":
     "Có nhiều việc hơn số đếm được ở đây. Đây là mức tối thiểu, không phải tổng số.",
+  "worklist.readings.label": "Hôm nay có gì đang bị đe dọa",
+  "worklist.readings.revenue": "Doanh thu bị đe dọa",
+  "worklist.readings.revenue.detail": "Trên các thương vụ đang trôi hôm nay",
+  "worklist.readings.revenue.unpriced":
+    "Không thương vụ rủi ro nào định giá được",
+  "worklist.readings.replies": "Khách phản hồi",
+  "worklist.readings.replies.detail": "Khách đang chờ một câu trả lời",
+  "worklist.readings.prospecting": "Tìm kiếm khách hàng",
+  "worklist.readings.prospecting.detail":
+    "Cơ hội mới đang chờ phản hồi đầu tiên",
+  "worklist.readings.review": "Xem xét",
+  "worklist.readings.review.detail":
+    "Việc thường lệ đang chờ sau một quyết định",
+  "worklist.readings.truncated":
+    "Có nhiều việc hơn số đếm được ở đây. Đây là mức tối thiểu, không phải tổng số.",
   "worklist.filter.label": "Loại công việc",
   "worklist.filter.all": "Tất cả",
   "worklist.filter.customer_waiting": "Khách đang chờ",

--- a/frontend/src/screens/worklist.acknowledge.test.tsx
+++ b/frontend/src/screens/worklist.acknowledge.test.tsx
@@ -52,6 +52,13 @@ function day(queue: WorklistItem[]): Worklist {
       total: queue.length,
     },
     sources_unavailable: [],
+    readings: {
+      revenue_at_risk_minor: null,
+      buyer_replies: 0,
+      prospecting: 0,
+      review: 0,
+      more_available: false,
+    },
     reach: [],
     counts: [],
   };

--- a/frontend/src/screens/worklist.counts.test.tsx
+++ b/frontend/src/screens/worklist.counts.test.tsx
@@ -53,6 +53,13 @@ function day(counts: WorklistCount[], shown = 1): Worklist {
     })),
     summary: { urgent: 0, due: 0, lower_priority: 0, total: shown },
     sources_unavailable: [],
+    readings: {
+      revenue_at_risk_minor: null,
+      buyer_replies: 0,
+      prospecting: 0,
+      review: 0,
+      more_available: false,
+    },
     reach: [],
     counts,
   };

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -11,6 +11,21 @@
   margin: 0;
 }
 
+/* The four outcome readings and the caveat under them. The strip owns its own
+   plate, so this only stacks the caveat beneath it. */
+.worklist-readings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* Every figure above is a floor. Same quiet as the completeness line and for
+   the same reason: the surface reporting on its own limits, not a row of work. */
+.worklist-readings-floor {
+  color: var(--textSecondary);
+  margin: 0;
+}
+
 /* What the page is not showing. Quiet on purpose: this is the surface reporting
    on itself rather than a row of work, and it must not compete with the queue
    for the reader's eye. */

--- a/frontend/src/screens/worklist.readings.test.tsx
+++ b/frontend/src/screens/worklist.readings.test.tsx
@@ -1,0 +1,111 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { WorklistReadings } from "./worklist.readings";
+
+// What the strip above the queue claims, and what it refuses to claim.
+//
+// The readings are the server's figures; this file is about the two places a
+// client can still get them wrong — formatting a number whose units nobody
+// knows, and drawing an absent figure as a zero.
+
+type Worklist = components["schemas"]["Worklist"];
+type WorklistReadingsData = components["schemas"]["WorklistReadings"];
+
+function day(readings: Partial<WorklistReadingsData> = {}): Worklist {
+  return {
+    as_of: "2026-08-31T09:00:00Z",
+    scope: "mine",
+    scope_options: ["mine"],
+    queue: [],
+    summary: { urgent: 0, due: 0, lower_priority: 0, total: 0 },
+    sources_unavailable: [],
+    reach: [],
+    counts: [],
+    readings: {
+      revenue_at_risk_minor: null,
+      buyer_replies: 0,
+      prospecting: 0,
+      review: 0,
+      more_available: false,
+      ...readings,
+    },
+  };
+}
+
+function draw(readings: Partial<WorklistReadingsData> = {}) {
+  return render(
+    <LocaleProvider initial="en">
+      <WorklistReadings day={day(readings)} />
+    </LocaleProvider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("the worklist readings strip", () => {
+  it("states the four readings the server sent", () => {
+    draw({
+      revenue_at_risk_minor: 384_500_00,
+      revenue_currency: "EUR",
+      buyer_replies: 14,
+      prospecting: 3,
+      review: 27,
+    });
+
+    expect(screen.getByText("14")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("27")).toBeTruthy();
+  });
+
+  // A figure whose units nobody knows is not money. Drawing the raw minor units
+  // as a euro amount is the error the conversion seam exists to prevent, and it
+  // reaches the reader as a number they have no reason to doubt.
+  it("refuses to draw an amount whose currency the server would not name", () => {
+    draw({ revenue_at_risk_minor: 384_500_00, revenue_currency: null });
+
+    expect(screen.getByText("No deal at risk could be priced")).toBeTruthy();
+    // The raw minor units must not appear in any formatting.
+    expect(screen.queryByText(/384/)).toBeNull();
+    expect(screen.queryByText(/38.450.000/)).toBeNull();
+  });
+
+  // Null is not zero. Zero says the pipeline is safe; absence says nobody can
+  // tell, and a reader who cannot tell those apart is worse off than one shown
+  // nothing.
+  it("tells an unpriced day apart from a day with nothing at risk", () => {
+    const absent = draw({ revenue_at_risk_minor: null });
+    expect(screen.getByText("No deal at risk could be priced")).toBeTruthy();
+    absent.unmount();
+
+    draw({ revenue_at_risk_minor: 0, revenue_currency: "EUR" });
+    expect(screen.queryByText("No deal at risk could be priced")).toBeNull();
+    expect(screen.getByText("€0")).toBeTruthy();
+  });
+
+  // A source read to its bound makes every figure a floor. The caveat is under
+  // the whole strip rather than in one slot: the four are read across as one
+  // statement, and marking one invites the reading where the others are exact.
+  it("says so when the figures are floors rather than totals", () => {
+    const exact = draw({ buyer_replies: 4, more_available: false });
+    expect(screen.queryByText(/floors, not totals/)).toBeNull();
+    exact.unmount();
+
+    draw({ buyer_replies: 4, more_available: true });
+    expect(screen.getByText(/floors, not totals/)).toBeTruthy();
+  });
+
+  // The strip is one comparison, so it always draws its four slots — a reading
+  // that vanished at zero would make the row fold at a different width from one
+  // read to the next.
+  it("draws all four readings on a day with no work at all", () => {
+    draw();
+
+    expect(screen.getByText("Revenue at risk")).toBeTruthy();
+    expect(screen.getByText("Buyer replies")).toBeTruthy();
+    expect(screen.getByText("Prospecting")).toBeTruthy();
+    expect(screen.getByText("Review")).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/worklist.readings.tsx
+++ b/frontend/src/screens/worklist.readings.tsx
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The day's four outcome readings, in the band above the queue.
+//
+// The filter pills below already say how many items of each kind there are.
+// These say what those items MEAN: a rep scanning their morning asks "what is
+// at stake" before "what is there", and the pills cannot answer the first —
+// "eleven deals at risk" and "€380k drifting" are different news, and the
+// second is what decides whether the pill gets opened.
+//
+// Every figure is the server's. The strip formats and never computes: revenue
+// at risk is a sum over deal amounts, and a browser doing that arithmetic
+// becomes a second author of what a deal is worth, in a tree that already
+// keeps a gate over exactly that split.
+
+import { StatCard } from "../design-system/atoms";
+import { StatStrip } from "../design-system/statstrip";
+import { formatMoneyCompact, formatNumber } from "../format/format";
+import { type Locale, type Translator, useLocale, useT } from "../i18n";
+import type { Worklist } from "./worklist.queries";
+import "./worklist.css";
+
+/**
+ * The four readings. Fixed at four for the reason the deal strip is fixed at
+ * four: a row that sometimes drew a fifth would fold at a different width from
+ * one click away.
+ */
+export function WorklistReadings({ day }: Readonly<{ day: Worklist }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const readings = day.readings;
+  // A source read to its bound makes every figure a floor, so the caveat sits
+  // under the whole strip rather than in one slot. The four are read across as
+  // one statement, and a caveat on one of them invites the reading where the
+  // other three are exact.
+  return (
+    <section className="worklist-readings" aria-label={t("worklist.readings.label")}>
+      <StatStrip testId="worklist-readings">
+        <RevenueStat readings={readings} locale={locale} t={t} />
+        <CountStat
+          label={t("worklist.readings.replies")}
+          detail={t("worklist.readings.replies.detail")}
+          count={readings.buyer_replies}
+          locale={locale}
+        />
+        <CountStat
+          label={t("worklist.readings.prospecting")}
+          detail={t("worklist.readings.prospecting.detail")}
+          count={readings.prospecting}
+          locale={locale}
+        />
+        <CountStat
+          label={t("worklist.readings.review")}
+          detail={t("worklist.readings.review.detail")}
+          count={readings.review}
+          locale={locale}
+        />
+      </StatStrip>
+      {readings.more_available && (
+        <p className="t-meta worklist-readings-floor">
+          {t("worklist.readings.truncated")}
+        </p>
+      )}
+    </section>
+  );
+}
+
+// What the drifting deals are worth.
+//
+// Two absences reach here and they are NOT the same, so they do not render
+// alike. A null amount means nothing at risk could be priced — nobody can tell
+// what is drifting, which is news. A null currency means the amounts never went
+// through the conversion seam, so the sum is raw minor units in no one
+// currency: a figure whose units nobody knows is not money, and drawing it as
+// money is the error the seam exists to prevent. Both fall to the same honest
+// caption rather than to a number the reader would trust.
+function RevenueStat({
+  readings,
+  locale,
+  t,
+}: Readonly<{
+  readings: Worklist["readings"];
+  locale: Locale;
+  t: Translator;
+}>) {
+  const minor = readings.revenue_at_risk_minor;
+  const currency = readings.revenue_currency;
+  if (minor == null || !currency) {
+    return (
+      <StatCard
+        label={t("worklist.readings.revenue")}
+        value="—"
+        detail={t("worklist.readings.revenue.unpriced")}
+      />
+    );
+  }
+  return (
+    <StatCard
+      label={t("worklist.readings.revenue")}
+      value={formatMoneyCompact(minor, currency, locale)}
+      detail={t("worklist.readings.revenue.detail")}
+      // The reading is bad news whenever there is any of it: money drifting is
+      // the thing this strip exists to surface, and a rep who sees it in the
+      // page's ordinary tone reads it as a status rather than as work.
+      tone={minor > 0 ? "warn" : undefined}
+      numeric
+    />
+  );
+}
+
+// One tally, in the reader's own number formatting.
+function CountStat({
+  label,
+  detail,
+  count,
+  locale,
+}: Readonly<{
+  label: string;
+  detail: string;
+  count: number;
+  locale: Locale;
+}>) {
+  return (
+    <StatCard
+      label={label}
+      value={formatNumber(count, locale)}
+      detail={detail}
+      numeric
+    />
+  );
+}

--- a/frontend/src/screens/worklist.readings.tsx
+++ b/frontend/src/screens/worklist.readings.tsx
@@ -35,7 +35,10 @@ export function WorklistReadings({ day }: Readonly<{ day: Worklist }>) {
   // one statement, and a caveat on one of them invites the reading where the
   // other three are exact.
   return (
-    <section className="worklist-readings" aria-label={t("worklist.readings.label")}>
+    <section
+      className="worklist-readings"
+      aria-label={t("worklist.readings.label")}
+    >
       <StatStrip testId="worklist-readings">
         <RevenueStat readings={readings} locale={locale} t={t} />
         <CountStat

--- a/frontend/src/screens/worklist.stories.tsx
+++ b/frontend/src/screens/worklist.stories.tsx
@@ -71,6 +71,15 @@ export const AFullDay: Story = {
       summary: { urgent: 1, due: 2, lower_priority: 3, total: 5 },
       sources_unavailable: [],
       reach: [],
+      // A full day: money drifting, buyers waiting, a decision pile.
+      readings: {
+        revenue_at_risk_minor: 384_500_00,
+        revenue_currency: "EUR",
+        buyer_replies: 14,
+        prospecting: 3,
+        review: 27,
+        more_available: false,
+      },
       // More work than the page carries, which is the ordinary case and the one
       // these figures exist for: four decisions sit behind the single row drawn.
       counts: [
@@ -176,6 +185,15 @@ export const NothingWaiting: Story = {
       summary: { urgent: 0, due: 0, lower_priority: 0, total: 0 },
       sources_unavailable: [],
       reach: [],
+      // Nothing waiting: every figure honestly zero, and the money priced.
+      readings: {
+        revenue_at_risk_minor: 0,
+        revenue_currency: "EUR",
+        buyer_replies: 0,
+        prospecting: 0,
+        review: 0,
+        more_available: false,
+      },
       // A genuinely clear day: nothing read, nothing counted, nothing hidden.
       counts: [],
       queue: [],
@@ -200,6 +218,15 @@ export const PartlyUnread: Story = {
       sources_unavailable: [{ source: "capture_health", reason: "failed" }],
       queue: [],
       reach: [],
+      // Partly unread: the figures are floors, so the strip says so.
+      readings: {
+        revenue_at_risk_minor: 42_000_00,
+        revenue_currency: "EUR",
+        buyer_replies: 2,
+        prospecting: 1,
+        review: 5,
+        more_available: true,
+      },
       // Nothing counted, because the source that would have filled the day is
       // the one that could not be read. The warning says so; the counts do not
       // pretend otherwise.
@@ -228,6 +255,14 @@ export const ALeadsDay: Story = {
       summary: { urgent: 0, due: 1, lower_priority: 0, total: 1 },
       sources_unavailable: [],
       reach: [],
+      // A leads day: prospecting carries it, and nothing at risk could be priced.
+      readings: {
+        revenue_at_risk_minor: null,
+        buyer_replies: 1,
+        prospecting: 9,
+        review: 0,
+        more_available: false,
+      },
       counts: [
         { category: "tasks", considered: 1, shown: 1, more_available: false },
       ],
@@ -268,6 +303,15 @@ export const ATeamBiggerThanTheBoardCanCount: Story = {
         summary: { urgent: 0, due: 0, lower_priority: 0, total: 0 },
         sources_unavailable: [],
         reach: [],
+        // A team bigger than the board can count: every figure a floor.
+        readings: {
+          revenue_at_risk_minor: 1_250_000_00,
+          revenue_currency: "EUR",
+          buyer_replies: 61,
+          prospecting: 24,
+          review: 140,
+          more_available: true,
+        },
         counts: [],
         queue: [],
       },

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -65,6 +65,13 @@ function day(over: Partial<Worklist> = {}): Worklist {
     sources_unavailable: [],
     reach: [],
     counts: [],
+    readings: {
+      revenue_at_risk_minor: null,
+      buyer_replies: 0,
+      prospecting: 0,
+      review: 0,
+      more_available: false,
+    },
     ...over,
   };
 }

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -18,6 +18,7 @@ import {
 import { FocusCard, focusOf } from "./worklist.focus";
 import { CoachControl, OwnerPicker } from "./worklist.manager";
 import { hasPane, WorklistPane } from "./worklist.pane";
+import { WorklistReadings } from "./worklist.readings";
 import {
   useWorklist,
   type Worklist,
@@ -121,6 +122,10 @@ function WorklistHeader({
           lower: formatNumber(day.summary.lower_priority, locale),
         })}
       </p>
+      {/* What the day is WORTH, above the controls that narrow it. The figures
+          describe the whole day rather than the page or the filter, so they sit
+          above both rather than beside the pills they would be confused with. */}
+      <WorklistReadings day={day} />
       {/* Drawn only when there is a choice: a rep who can see only their own
           work is never offered a switch that would refuse when pressed. */}
       {scopes.length > 1 && owner === "" && (

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -18,7 +18,6 @@ import {
 import { FocusCard, focusOf } from "./worklist.focus";
 import { CoachControl, OwnerPicker } from "./worklist.manager";
 import { hasPane, WorklistPane } from "./worklist.pane";
-import { WorklistReadings } from "./worklist.readings";
 import {
   useWorklist,
   type Worklist,
@@ -26,6 +25,7 @@ import {
   type WorklistItem,
   type WorklistScope,
 } from "./worklist.queries";
+import { WorklistReadings } from "./worklist.readings";
 import { WorklistRow } from "./worklist.row";
 import "./worklist.css";
 


### PR DESCRIPTION
The filter pills say how many items of each kind the queue holds. They cannot say what those items mean, and "eleven deals at risk" is different news from "€384k drifting" — the second is what decides whether a rep opens the pill at all.

So the response carries four outcome readings beside `counts`: revenue at risk, buyer replies, prospecting, review. The strip above the queue draws them through the design system's existing `StatStrip` (five screens already use it; this adds no second one).

## The server computes, the client displays

Revenue at risk is a sum over deal amounts. A browser doing that arithmetic becomes a second author of what a deal is worth — the split this tree already keeps a gate over, between `values.MinorUnitExceptions()` and `frontend/src/format/minorunits.ts`.

The sum reuses the figures the ranking already priced through the FX seam (`ranked.expectedBase`, set by `basemoney.go`) rather than re-deriving them, so the queue and the strip cannot learn two answers to what a deal is worth.

## Three things the readings refuse to claim

**They describe the day, not the page.** Taken over the same snapshot `counts.considered` uses — after the scope narrowing, before the filter, the fold and the page cut. Computed over the page the strip would shrink as a reader walked the queue, and work would read as disappearing while they did it. Computed after the filter, opening one pill would empty the other three. `TestTheReadingsDoNotShrinkAsAReaderPagesThroughTheQueue` walks the real `pageFrom` cut and holds this.

**A deal nobody could price is left out, not counted as zero.** A day that could price nothing states `null` rather than `0`. Zero says the pipeline is safe; absence says nobody can tell, and the strip renders them differently.

**A sum that never went through the conversion seam names no currency**, and the client refuses to format a figure whose units it cannot name. Naming one would assert a conversion that did not happen.

`more_available` marks the whole row as a floor rather than one slot: the four are read across as one statement, and a caveat on one invites the reading where the other three are exact.

## Verification

- 9 backend tests in `readings_test.go`, 5 frontend tests in `worklist.readings.test.tsx`.
- Mutation-checked, one clause at a time: counting an unpriced deal as zero, taking the readings over the page, claiming a currency when unconverted, and never setting the floor flag each fail their own test. On the frontend, formatting money with a guessed currency fails its test.
- `make check-backend`, `make check-fe`, `make frontend-e2e` (222 passed) all green; `craft-static`, `rls-store-path`, `no-jurisdiction` clean.
- Contract regenerated with both generators; `frontend/e2e/seed.ts` grew with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a readings strip above the worklist queue so reps see what the day is worth, not just how many items it holds, and closes a gap where a refused source lane printed confident zeroes in those readings. The filter pills still count items; the new strip states revenue at risk, buyer replies, prospecting, and review.

**Readings**

- Computed over the same snapshot as `counts`, so they don't shrink as the reader pages or filters.
- Revenue at risk reuses the ranking's already-converted figures; the server sums, the client only formats.
- Unpriced deals are left out of the sum, and a day that could price nothing reports `null`, not `0`.
- The strip names no currency for unconverted amounts or for priced rows that disagree; the client won't format a figure without one.
- The sum covers the at-risk lane only; brief-lane deals show an amount on their cards but add nothing here.
- A refused, failed, or truncated source lane marks the whole row as a floor, so exact figures never appear over work nobody saw.
- The worklist response now requires `readings`; clients must include it.

<sup>Written for commit b7253f9f8aacadc8c36d809f78756512b38388c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a worklist summary showing revenue at risk, waiting buyer replies, prospecting tasks, and items needing review.
  - Revenue risk displays with currency when available, or an unpriced indicator when details are incomplete.
  - Added messaging to clarify when figures represent lower bounds due to truncated results.
  - Added support for English, German, and Vietnamese translations.

- **Testing**
  - Added coverage for calculations, filtering, pagination, missing values, localization, and summary display states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->