### PR TITLE
The rep's own promises reach their worklist

### DIFF
--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -36,6 +36,11 @@ const sourceWaiting = "customer_waiting"
 // out of the queue it was asked for.
 const sourceTask = "task"
 
+// sourceClaim names the rep's own promises. keepUnowned reads it: a claim has
+// no assignee column, so the row arrives ownerless while already belonging to
+// the rep whose query produced it.
+const sourceClaim = "conversation_claim"
+
 // sourceAtRisk names the quiet-deal producer. Three readers spell it — the
 // bounds table, the category map and the classifier — which is two more than a
 // literal survives.

--- a/backend/internal/compose/attention/scope.go
+++ b/backend/internal/compose/attention/scope.go
@@ -284,9 +284,19 @@ func narrowedByItsOwnLane(row ranked) bool {
 // The counterpart to keepReadersOwn, over the same evidence: a row with an owner
 // belongs to that person and not to this queue. A row with nobody to name stays,
 // which is what the scope is for.
+//
+// A promise is the exception, and it is not decorative. A conversation claim
+// has no assignee column, so it reaches here with no owner to read while
+// already belonging to the rep whose query produced it. Reading only answersTo
+// would file the rep's own debt under work nobody answers for.
+//
+// An ownerless task or lead genuinely answers to nobody — those stay.
 func keepUnowned(rows []ranked) []ranked {
 	kept := make([]ranked, 0, len(rows))
 	for _, row := range rows {
+		if row.item.Source == sourceClaim {
+			continue
+		}
 		if _, ok := answersTo(row); !ok {
 			kept = append(kept, row)
 		}

--- a/backend/internal/compose/attention/scope_test.go
+++ b/backend/internal/compose/attention/scope_test.go
@@ -181,6 +181,32 @@ func TestARowWithNoOwnerStaysUnderMine(t *testing.T) {
 	}
 }
 
+// A promise the rep made is THEIRS, not work nobody answers for.
+//
+// A claim carries no assignee column, so the row reaches the filters with no
+// owner to read. The lane's query already narrowed to the acting rep's user id,
+// which is why the source is named in narrowedByItsOwnLane — without that, the
+// ownerless test drops the promise out of "mine" and hands it to "unassigned",
+// putting the rep's own debt in the queue for work with nobody behind it.
+func TestTheReadersOwnPromiseIsNotWorkNobodyAnswersFor(t *testing.T) {
+	reader := ids.MustParse("01a05500-0000-7000-8000-000000000001")
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, UserID: reader,
+		Permissions: principal.Permissions{RowScope: principal.RowScopeOwn},
+	})
+	promise := []ranked{{item: crmcontracts.WorklistItem{
+		Id: "my-promise", Source: sourceClaim, Actions: []crmcontracts.WorklistItemActions{},
+	}}}
+
+	if len(keepReadersOwn(ctx, promise)) != 1 {
+		t.Error("the rep's own promise was dropped from their own queue")
+	}
+	if kept := keepUnowned(promise); len(kept) != 0 {
+		t.Errorf("the rep's own promise appeared under unassigned (%d rows), which is the "+
+			"queue for work nobody answers for", len(kept))
+	}
+}
+
 func ownedDeal(id string, owner ids.UUID) crmcontracts.WorklistItem {
 	uuid := openapi_types.UUID(owner)
 	return crmcontracts.WorklistItem{

--- a/backend/internal/compose/attentionlanebinding_test.go
+++ b/backend/internal/compose/attentionlanebinding_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A lane whose seam is written must be wired to it.
+//
+// The attention feed takes each optional lane as an interface, and nil is a
+// legitimate value: it renders the lane ABSENT, which is the honest answer for
+// an installation that genuinely cannot fill it. That makes an unwired lane
+// indistinguishable from a deliberate one — the commitments lane sat nil for
+// months after its writer landed, so every rep's own promises were missing from
+// their queue and nothing failed.
+//
+// This reads the wiring itself rather than keeping a list beside it, so a lane
+// that grows a seam and is never bound fails here instead of going quiet.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestEveryLaneWithASeamIsWiredToIt fails when newAttentionService passes nil
+// for a lane whose seam type exists in this package.
+//
+// The corpus is derived from the seam types themselves — every `attention<Name>`
+// struct in this package that satisfies a lane interface — so a new lane joins
+// the check by being written, not by being remembered.
+func TestEveryLaneWithASeamIsWiredToIt(t *testing.T) {
+	files := composeSourceFiles(t)
+	seams := seamTypeNames(files)
+	if len(seams) == 0 {
+		t.Fatal("found no attention seam types at all — the scan is looking in the wrong place, " +
+			"which would report PASS on a tree where every lane was unwired")
+	}
+	wired := wiredSeamNames(t, files)
+
+	for _, seam := range seams {
+		if !wired[seam] {
+			t.Errorf("%s is written but newAttentionService does not pass it. A lane left nil "+
+				"renders ABSENT, so the rows it would serve are silently missing rather than "+
+				"reported as withheld. Wire it, or say in newAttentionService why this "+
+				"installation cannot fill it.", seam)
+		}
+	}
+}
+
+// composeSourceFiles parses the Go files of this package, keyed by file name so
+// a caller can tell a test file from production wiring.
+func composeSourceFiles(t *testing.T) map[string]*ast.File {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the compose package directory: %v", err)
+	}
+	fset := token.NewFileSet()
+	files := map[string]*ast.File{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		parsed, parseErr := parser.ParseFile(fset, name, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", name, parseErr)
+		}
+		files[name] = parsed
+	}
+	if len(files) == 0 {
+		t.Fatal("the compose package parsed to nothing; this test reads its own wiring")
+	}
+	return files
+}
+
+// seamTypeNames collects the `attention<Name>` structs declared in this package,
+// skipping test files so a fixture cannot pose as a seam.
+func seamTypeNames(files map[string]*ast.File) []string {
+	var out []string
+	for path, file := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			spec, ok := n.(*ast.TypeSpec)
+			if !ok || !strings.HasPrefix(spec.Name.Name, "attention") {
+				return true
+			}
+			if _, isStruct := spec.Type.(*ast.StructType); isStruct {
+				out = append(out, spec.Name.Name)
+			}
+			return true
+		})
+	}
+	return out
+}
+
+// wiredSeamNames collects the struct types passed as ARGUMENTS to a binding
+// call inside newAttentionService.
+//
+// Two calls bind a lane: attention.NewService takes the required ones directly,
+// and the optional ones arrive through a With<Lane> method chained off it.
+// Arguments only, never any literal in the function body — a seam constructed
+// into an unused variable is not a lane the service received, and counting it
+// would let a lane be built beside the nil that was passed in its place, which
+// is the exact defect this file exists to catch.
+func wiredSeamNames(t *testing.T, files map[string]*ast.File) map[string]bool {
+	t.Helper()
+	wired := map[string]bool{}
+	found := false
+	for _, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != "newAttentionService" || fn.Body == nil {
+				return true
+			}
+			found = true
+			ast.Inspect(fn.Body, func(inner ast.Node) bool {
+				call, ok := inner.(*ast.CallExpr)
+				if !ok || !bindsALane(call.Fun) {
+					return true
+				}
+				for _, arg := range call.Args {
+					lit, ok := arg.(*ast.CompositeLit)
+					if !ok {
+						continue
+					}
+					if name, ok := lit.Type.(*ast.Ident); ok {
+						wired[name.Name] = true
+					}
+				}
+				return true
+			})
+			return false
+		})
+	}
+	if !found {
+		t.Fatal("newAttentionService was not found; the scan would report every lane unwired")
+	}
+	if len(wired) == 0 {
+		t.Fatal("no lane was read out of the binding calls — attention.NewService was renamed " +
+			"or reshaped, and this scan would report every lane unwired")
+	}
+	return wired
+}
+
+// bindsALane recognises the two calls that hand a seam to the feed:
+// attention.NewService and any With<Lane> method chained off it.
+func bindsALane(fun ast.Expr) bool {
+	sel, ok := fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	if strings.HasPrefix(sel.Sel.Name, "With") {
+		return true
+	}
+	if sel.Sel.Name != "NewService" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "attention"
+}

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -47,11 +47,6 @@ import (
 // the feed omits and NAMES the lane instead of reporting a clear day.
 type attentionCommitments struct{ store *people.Store }
 
-// The binding is deliberately not wired today (newAttentionService passes nil
-// — the lane's production writer is issue #849's), so this assertion is the
-// one thing keeping the seam compiled against the interface it will be
-// rebound as. The store read behind it keeps its own integration test; the
-// seam wiring itself is untested exactly because nothing wires it.
 var _ attention.Commitments = attentionCommitments{}
 
 func (c attentionCommitments) DueBy(ctx context.Context, by time.Time, limit int) ([]attention.Commitment, error) {

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -359,19 +359,17 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, meter *over
 		attentionTasks{store: activities.NewStore(db)},
 		attentionReceipts{svc: svc},
 		attentionBriefing{engine: briefs.NewBriefEngine(pool, people.NewStore(db)), now: now},
-		// Commitments is deliberately UNBOUND: the lane's production writer —
-		// the extraction task that reads promises out of captured
-		// conversations — does not exist yet (issue #849), so no real
-		// installation can put a row behind it, and a lane fed only by demo
-		// seeds would show every real customer an empty promise list dressed
-		// as a feature. A nil binding renders the lane ABSENT (the contract's
-		// honest "this feed does not do commitments"), and rebinding is the
-		// one-line attentionCommitments{store: people.NewStore(db)} when #849
-		// lands. The seam type stays compiled against the interface (the
-		// assertion beside it in attentionlanesseam.go), and the store read
-		// behind it keeps its own integration test — what is NOT tested is
-		// the seam wiring itself, because nothing wires it.
-		nil,
+		// Commitments is bound now that claims have a writer. It was nil while
+		// nothing could put a row behind the lane: a lane fed only by demo
+		// seeds would have shown every real customer an empty promise list
+		// dressed as a feature, and absent is the honest rendering of "this
+		// feed does not do commitments".
+		//
+		// That is no longer true. POST /people/{id}/claims writes through
+		// people.RecordConversationClaim, and the transcript reader files what
+		// a reader accepts from a meeting. A promise a rep made is then real
+		// data the queue was still refusing to show.
+		attentionCommitments{store: people.NewStore(db)},
 		attentionAtRisk{lister: quietDealScan(pool, deals.QuietThresholdDays)},
 		attentionDecay{pool: pool, store: people.NewStore(db), now: now},
 		attentionMeetings{store: activities.NewStore(db)},


### PR DESCRIPTION
The attention feed's Commitments lane was passed nil, so a promise the rep
made in an email never entered the queue. The lane renders ABSENT when nil,
which is indistinguishable from an installation that genuinely cannot fill
it, so nothing failed and nobody saw the gap.

The stated reason was that conversation claims had no writer. They do:
RecordConversationClaim is served through people.Handlers and the transcript
reader files claims, so the lane now takes a people store.

Binding it put every claim through the scope filters, where a second defect
waited: a claim has no assignee column, and keepUnowned reads answersTo
alone, so the rep's own promise was filed under "unassigned" — the queue for
work nobody is accountable for. keepUnowned now skips the claim source. An
ownerless task or lead genuinely answers to nobody and still belongs there,
so the exception names the one source it is for.

A gate holds the binding. It derives its corpus from the seam types in the
compose package rather than a list beside them, and it reads the ARGUMENTS
of attention.NewService and its With<Lane> methods rather than any literal
in the function body, so a seam built into a variable beside the nil passed
in its place does not satisfy it.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds the attention feed's Commitments lane to the people store so a rep's own promises now reach their worklist instead of rendering ABSENT, and fixes the scope filters so those promises land under "mine" rather than "unassigned."

**Bug Fixes**
- Claims carry no assignee column, so `keepUnowned` now skips the claim source instead of filing the rep's own promise under work nobody answers for.
- Adds a test gate that fails when a lane with a written seam is passed `nil`, so an unwired lane goes loud instead of silent.

<sup>Written for commit 10662fe37fc2947fe1700aa74b1c82e6adcd5142. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Commitments lane to the attention view, making commitment-related items available for review.

- **Bug Fixes**
  - Improved queue assignment so conversation claims appear in the acting representative’s personal queue.
  - Prevented conversation claims from incorrectly appearing in the unassigned queue.
  - Continued to include genuinely ownerless tasks and lead responses in the unassigned queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->