### PR TITLE
The csv export case does not decode its body as json

### DIFF
--- a/backend/internal/compose/integration/collections/filtervocabulary_http_integration_test.go
+++ b/backend/internal/compose/integration/collections/filtervocabulary_http_integration_test.go
@@ -297,10 +297,13 @@ func TestARetiredCustomFieldLeavesTheVocabularyAndKeepsEvaluating(t *testing.T) 
 	// And the stored filter written against it still evaluates rather than
 	// erroring: the export path resolves the view's predicate through the same
 	// engine a live clause runs on.
-	var exported integration.AnyMap
+	// No destination: the response IS the csv this asked for, and handing the
+	// helper a JSON map to decode it into fails on the header row every time.
+	// What this case is about is the status — that the predicate still resolves
+	// — and the export's own body has its own tests.
 	if status := e.Call(t, "POST", "/v1/exports", integration.AnyMap{
 		"view_id": viewID, "format": "csv",
-	}, nil, &exported); status != http.StatusOK {
+	}, nil, nil); status != http.StatusOK {
 		t.Errorf("the stored filter naming the retired %s no longer evaluates: status=%d", column, status)
 	}
 }


### PR DESCRIPTION
`main` fails `integration / integration shard (6/6)` on branches cut from it — #3642 and #3643 both, on a test neither touches:

```
filtervocabulary_http_integration_test.go:301: POST /v1/exports:
  decoding "id,first_name,last_name,full_name,...,cf_retiring_tier\n":
  invalid character 'i' looking for beginning of value
```

## What is wrong

The case asks for `"format": "csv"` and passes `&exported` — an `integration.AnyMap` — as the destination. `AppEnv.Call` unmarshals the body as JSON whenever `out != nil && len(raw) > 0`, so the header row is fed to `json.Unmarshal` and fails on its first character.

It passes wherever the export writes no body at all, which is why it looks like a flake rather than a mistake: the seeded data decides whether there is anything to choke on.

## The fix

No destination. The status is what this case is about — that a stored filter naming a retired custom field still resolves through the export path — and the export's own body has its own tests.

`make check-backend` green; the collections package green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSV export handling for saved filters that reference retired fields.
  * Confirmed these filters continue to evaluate successfully while export requests return valid HTTP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->