### PR TITLE
The operational budgets are not sales quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ numbers appear here when releases start.
 
 ### Changed
 
+- **The operational agent budgets stop being called quotas.** One word named two
+  unrelated things until the sales quota was retired: the revenue target a
+  manager typed, and the volume ceiling that stops an agent reading, writing or
+  spending without bound. The second is a safety limit and is unchanged in
+  behaviour, threshold and refusal — only its name moves. The Go package,
+  types and files are renamed, and two stored values move with them:
+  the approval kind `quota_release` becomes `volume_release` and the AI failure
+  code `provider_quota` becomes `provider_budget`, both migrated in place. The
+  contract already tells a reader to treat an unrecognized failure code as
+  "some failure", so a client that has not been updated degrades to the honest
+  general answer rather than breaking.
+
 - **Home's test suite is under the 1000-line ceiling again.** It crossed while
   Home gained its weekly-review section, and the split had one honest shape: the
   harness both halves need — the recording fetch stub, the render wrapper and

--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -20,7 +20,7 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"github.com/margince/margince/backend/internal/compose"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/config"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
@@ -306,7 +306,7 @@ func sharedRedisClient(cfg apiConfig, logger *slog.Logger) (*redis.Client, func(
 
 // overlayOptions wires the overlay's two cross-role edges: the budget every
 // force-fresh read spends against, and the incumbent's inbound push.
-func overlayOptions(cfg apiConfig, deployCfg deployconfig.Config, rdb *redis.Client, quotaMeter *agentquota.Meter, pool *pgxpool.Pool, logger *slog.Logger, stdout io.Writer) ([]compose.Option, error) {
+func overlayOptions(cfg apiConfig, deployCfg deployconfig.Config, rdb *redis.Client, volumeMeter *agentvolume.Meter, pool *pgxpool.Pool, logger *slog.Logger, stdout io.Writer) ([]compose.Option, error) {
 	// The overlay budget meter records against Redis, the SAME server the
 	// worker's poller uses, so force-fresh reads (this role) and poller
 	// sweeps (cmd/worker) spend against ONE shared per-workspace-per-
@@ -318,7 +318,7 @@ func overlayOptions(cfg apiConfig, deployCfg deployconfig.Config, rdb *redis.Cli
 	// caller rather than here, because the model path needs the same pointer to
 	// charge MCP-SESS-COST against — two meters would count one agent's spend
 	// in two windows, neither of them the one the gate reads.
-	opts := []compose.Option{compose.WithOverlayMeter(overlayMeter), compose.WithAgentQuota(quotaMeter)}
+	opts := []compose.Option{compose.WithOverlayMeter(overlayMeter), compose.WithAgentVolume(volumeMeter)}
 
 	// The HubSpot webhook-as-signal receiver (OVA-WIRE-10) mounts only when the
 	// app client secret is configured — it verifies the inbound v3 signature
@@ -399,12 +399,12 @@ func modelSurfaceOptions(ctx context.Context, cfg apiConfig, deployCfg deploycon
 // carries it — each role resolves its own — so the reset's cache flush can only
 // drop what its router cached from here.
 //
-// quotaMeter is the SAME per-Passport volume meter the admission gate and the
-// tool registry take through WithAgentQuota (MCP-SESS-COST): binding it here
+// volumeMeter is the SAME per-Passport volume meter the admission gate and the
+// tool registry take through WithAgentVolume (MCP-SESS-COST): binding it here
 // charges a model call to the agent that caused it, where the tokens are known.
 // A model path bound to a different meter would meter an agent's spend into a
 // window nothing else looks at, so the path leaves this function already bound.
-func modelAndHandoffOptions(ctx context.Context, cfg apiConfig, deployCfg deployconfig.Config, pool *pgxpool.Pool, logger *slog.Logger, quotaMeter *agentquota.Meter) ([]compose.Option, *compose.ModelPath, error) {
+func modelAndHandoffOptions(ctx context.Context, cfg apiConfig, deployCfg deployconfig.Config, pool *pgxpool.Pool, logger *slog.Logger, volumeMeter *agentvolume.Meter) ([]compose.Option, *compose.ModelPath, error) {
 	opts, modelPath, err := modelSurfaceOptions(ctx, cfg, deployCfg, pool, logger)
 	if err != nil {
 		return nil, nil, err
@@ -418,7 +418,7 @@ func modelAndHandoffOptions(ctx context.Context, cfg apiConfig, deployCfg deploy
 	// consumer here guards it the same way. There is no model call to charge in
 	// that shape, so there is nothing to bind.
 	if modelPath != nil {
-		*modelPath = modelPath.WithAgentTokenSpend(compose.AgentTokenSpend{Meter: quotaMeter})
+		*modelPath = modelPath.WithAgentTokenSpend(compose.AgentTokenSpend{Meter: volumeMeter})
 	}
 	return append(opts, handoffOpts...), modelPath, nil
 }

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/margince/margince/composition"
 
 	"github.com/margince/margince/backend/internal/compose"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/config"
 	"github.com/margince/margince/backend/internal/platform/database"
@@ -117,12 +117,12 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	opts = append(opts, surfaceOpts...)
 
 	// The per-Passport volume meter, built once and shared: the admission gate
-	// and the tool registry take it through WithAgentQuota, and the model path
+	// and the tool registry take it through WithAgentVolume, and the model path
 	// takes it below so a model call charges the agent that caused it. This is
 	// the role that serves agent principals, so leaving it fail-closed would
 	// refuse every agent read an api with Redis configured could count.
-	quotaMeter := agentquota.New(rdb, agentquota.Limits{}, agentquota.DefaultWindow)
-	overlayOpts, err := overlayOptions(cfg, deployCfg, rdb, quotaMeter, pool, logger, stdout)
+	volumeMeter := agentvolume.New(rdb, agentvolume.Limits{}, agentvolume.DefaultWindow)
+	overlayOpts, err := overlayOptions(cfg, deployCfg, rdb, volumeMeter, pool, logger, stdout)
 	if err != nil {
 		return err
 	}
@@ -137,10 +137,10 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	defer stopRelay()
 	opts = append(opts, relayOpts...)
 
-	// The model path comes back already bound to quotaMeter (MCP-SESS-COST);
+	// The model path comes back already bound to volumeMeter (MCP-SESS-COST);
 	// boot.go carries why that binding belongs with the path, not here.
 	//nolint:contextcheck // boot-time wiring: the model path outlives any request context
-	modelOpts, modelPath, err := modelAndHandoffOptions(ctx, cfg, deployCfg, pool, logger, quotaMeter)
+	modelOpts, modelPath, err := modelAndHandoffOptions(ctx, cfg, deployCfg, pool, logger, volumeMeter)
 	if err != nil {
 		return err
 	}

--- a/backend/gates/fxconversioncallers_test.go
+++ b/backend/gates/fxconversioncallers_test.go
@@ -24,7 +24,7 @@ package gates
 //
 // WHAT THIS CANNOT SEE, stated so the next reader does not trust it further
 // than it goes: the SQL spellings of the same rule, in
-// organization_open_pipeline_rollup and in quotas' targetInBase. Those read
+// organization_open_pipeline_rollup. Those read
 // currency_minor_digits, the database mirror of the Go digit table, and their
 // agreement with Go is held where it can be: the minor-unit parity test and the
 // one-account-one-number test, both in the integration lane against a live

--- a/backend/internal/compose/agentcost.go
+++ b/backend/internal/compose/agentcost.go
@@ -3,10 +3,10 @@
 
 package compose
 
-// MCP-SESS-COST, joined up: the AI runtime knows what a call cost, the quota
+// MCP-SESS-COST, joined up: the AI runtime knows what a call cost, the volume budget
 // meter knows whose window to put it in, and neither may import the other.
 //
-// The spec words this quota as "tenant budget ÷ active sessions, soft". ADR-0092
+// The spec words this volume budget as "tenant budget ÷ active sessions, soft". ADR-0092
 // deletes the divisor's subject — there are no sessions once the registry goes —
 // so the share is re-keyed exactly as the read bound was: the workspace's own
 // budget, divided by the credentials sharing it.
@@ -20,30 +20,30 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/modules/ai"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// AgentTokenSpend adapts the quota meter to the AI runtime's token seam, so a
+// AgentTokenSpend adapts the volume meter to the AI runtime's token seam, so a
 // served model call is charged to the agent that caused it.
 //
 // Exported because the two things it joins are assembled in cmd: the meter is
 // built there (the raw-Redis dependency stays out of compose) and so is the
 // model path. This is the one line that makes the join, and it is the whole of
 // what cmd has to remember.
-type AgentTokenSpend struct{ Meter *agentquota.Meter }
+type AgentTokenSpend struct{ Meter *agentvolume.Meter }
 
 // SpendAgentTokens records tokens against the calling Passport's cost window.
 // A human's model call records nothing — the meter's own governed check decides
 // that, so this side never has to re-answer "which callers are metered".
 func (s AgentTokenSpend) SpendAgentTokens(ctx context.Context, tokens int) error {
-	return s.Meter.Consume(ctx, agentquota.Cost, tokens)
+	return s.Meter.Consume(ctx, agentvolume.Cost, tokens)
 }
 
-// budgetShareWindow is how much of the month one quota window covers. The
-// workspace budget is monthly and the quota window is a rolling day, so a share
+// budgetShareWindow is how much of the month one volume window covers. The
+// workspace budget is monthly and the volume window is a rolling day, so a share
 // of the budget has to be pro-rated to the window or the comparison is between
 // two different spans — which would leave the counter warning about nothing.
 const budgetShareWindowDays = 30
@@ -56,7 +56,7 @@ const budgetShareWindowDays = 30
 const shareCacheTTL = 5 * time.Minute
 
 // passportShareCeiling answers how many model tokens ONE Passport may spend
-// inside a quota window: the workspace's monthly budget, pro-rated to the
+// inside a volume window: the workspace's monthly budget, pro-rated to the
 // window, divided by the live agent credentials sharing it.
 //
 // Dividing by the LIVE passports rather than by a constant is what keeps the

--- a/backend/internal/compose/agentcost_test.go
+++ b/backend/internal/compose/agentcost_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/modules/ai"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -100,7 +100,7 @@ func TestACallWithNoWorkspaceHasNoShare(t *testing.T) {
 // the line that matters is which counter it names: charging model tokens
 // against reads would refuse an agent for spending its own budget.
 func TestATokenSpendIsChargedAgainstTheCostCounter(t *testing.T) {
-	meter := agentquota.Unmetered()
+	meter := agentvolume.Unmetered()
 
 	if err := (AgentTokenSpend{Meter: meter}).SpendAgentTokens(context.Background(), 500); err != nil {
 		t.Fatalf("charging an unmetered composition failed: %v", err)

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -69,7 +69,7 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 			}
 			ctx, err := gate.Admit(ctx, spec, resolve)
 			r = r.WithContext(ctx)
-			// The quotas the gate just READ on this door are paid on it too, or
+			// The counters the gate just READ on this door are paid on it too, or
 			// they are counters nothing increments: a credential that only ever
 			// uses /v1 would sit at zero forever and no threshold could be
 			// crossed. ADR-0055's claim is that both doors are governed alike,

--- a/backend/internal/compose/agentgate_pin_test.go
+++ b/backend/internal/compose/agentgate_pin_test.go
@@ -24,8 +24,8 @@ import (
 // gate actually staged.
 type capturingApprovals struct{ last agents.StageRequest }
 
-// StageQuotaRelease satisfies the seam; a step-up never reaches these tests.
-func (c *capturingApprovals) StageQuotaRelease(_ context.Context, _ agents.QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+// StageVolumeRelease satisfies the seam; a step-up never reaches these tests.
+func (c *capturingApprovals) StageVolumeRelease(_ context.Context, _ agents.VolumeReleaseRequest) (ids.ApprovalID, bool, error) {
 	return ids.ApprovalID{}, false, nil
 }
 
@@ -156,8 +156,8 @@ func TestConfirmFirstTargetsArePinnable(t *testing.T) {
 // an approval whose target carried a version.
 type pinningApprovals struct{ version int64 }
 
-// StageQuotaRelease satisfies the seam; a step-up never reaches these tests.
-func (pinningApprovals) StageQuotaRelease(_ context.Context, _ agents.QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+// StageVolumeRelease satisfies the seam; a step-up never reaches these tests.
+func (pinningApprovals) StageVolumeRelease(_ context.Context, _ agents.VolumeReleaseRequest) (ids.ApprovalID, bool, error) {
 	return ids.ApprovalID{}, false, nil
 }
 

--- a/backend/internal/compose/agentgateauto.go
+++ b/backend/internal/compose/agentgateauto.go
@@ -65,7 +65,7 @@ func runAutoExecuted(w http.ResponseWriter, r *http.Request, next http.Handler, 
 	}
 	// The effect is charged on BOTH arms — the field split forwards to the
 	// same handler through its own path — and on NEITHER when the handler
-	// refused. A quota counts what an agent did, so a rejected mutation that
+	// refused. A volume budget counts what an agent did, so a rejected mutation that
 	// spent a write would let a caller exhaust its own allowance on requests
 	// that changed nothing, which is a bound nobody wrote.
 	// The meter sits OUTSIDE the recorder, so the handler's WriteJSON finds

--- a/backend/internal/compose/agentgateredeem_test.go
+++ b/backend/internal/compose/agentgateredeem_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/margince/margince/backend/internal/modules/agents"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -47,8 +47,8 @@ type countingRedeemer struct {
 	hashes   []string
 }
 
-// StageQuotaRelease satisfies the seam; a step-up never reaches these tests.
-func (*countingRedeemer) StageQuotaRelease(context.Context, agents.QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+// StageVolumeRelease satisfies the seam; a step-up never reaches these tests.
+func (*countingRedeemer) StageVolumeRelease(context.Context, agents.VolumeReleaseRequest) (ids.ApprovalID, bool, error) {
 	return ids.ApprovalID{}, false, nil
 }
 
@@ -279,11 +279,11 @@ func TestAReleasedRetryOnAStaticTierIsPinnedAndNotResplit(t *testing.T) {
 	}
 }
 
-// countingCharges is the quota meter as the REST door uses it: it only ever
+// countingCharges is the volume meter as the REST door uses it: it only ever
 // receives charges, and keeps them per counter.
-type countingCharges struct{ spent map[agentquota.Counter]int }
+type countingCharges struct{ spent map[agentvolume.Counter]int }
 
-func (c *countingCharges) Consume(_ context.Context, counter agentquota.Counter, n int) error {
+func (c *countingCharges) Consume(_ context.Context, counter agentvolume.Counter, n int) error {
 	c.spent[counter] += n
 	return nil
 }
@@ -319,9 +319,9 @@ func gateCallCharges(t *testing.T, sourceSemantic, token string, redeemErr error
 	deal, current, target := ids.NewV7(), ids.NewV7(), ids.NewV7()
 	stages := reopenStages{semantics: map[ids.UUID]string{current: sourceSemantic, target: "open"}}
 	var records datasource.SystemOfRecordProvider = stagedDeal{stageID: current, version: 12}
-	charger := &countingCharges{spent: map[agentquota.Counter]int{}}
+	charger := &countingCharges{spent: map[agentvolume.Counter]int{}}
 
-	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}), agents.WithQuotaCharger(charger))
+	reg := agents.NewRegistry(nil, auth.NewGate(fullSeat{}), agents.WithVolumeCharger(charger))
 	agents.RegisterCoreTools(reg, records, stages, nil, nil, nil, nil)
 
 	r := httptest.NewRequest(http.MethodPost, "/v1/deals/"+deal.String()+"/advance",
@@ -341,7 +341,7 @@ func gateCallCharges(t *testing.T, sourceSemantic, token string, redeemErr error
 		w.WriteHeader(http.StatusOK)
 	})).ServeHTTP(recorder, r)
 
-	return charger.spent[agentquota.Calls], recorder.Code
+	return charger.spent[agentvolume.Calls], recorder.Code
 }
 
 // The call ceiling counts CALLS THAT RAN: one apiece whichever arm carried them,

--- a/backend/internal/compose/agentservedmeter.go
+++ b/backend/internal/compose/agentservedmeter.go
@@ -30,7 +30,7 @@ type servedMeter struct {
 	http.ResponseWriter
 	r   *http.Request
 	reg *agents.Registry
-	// mayRefuse is agents/quota.go's one rule applied on this door: refuse only
+	// mayRefuse is agents/volume.go's one rule applied on this door: refuse only
 	// while nothing has happened yet.
 	//
 	// A READ has committed nothing, so an uncountable one is withheld — a charge
@@ -52,7 +52,7 @@ const (
 
 // NoteServed charges n records and answers whether the response may proceed. A
 // refusal is written here rather than reported upward because this is the layer
-// holding the request; httperr has neither it nor any notion of a quota.
+// holding the request; httperr has neither it nor any notion of a volume budget.
 func (m *servedMeter) NoteServed(n int) bool {
 	err := m.reg.ChargeServedRecords(m.r.Context(), n)
 	if err == nil || !bool(m.mayRefuse) {

--- a/backend/internal/compose/approval_kinds_test.go
+++ b/backend/internal/compose/approval_kinds_test.go
@@ -40,8 +40,8 @@ import (
 // never stages, it only reads the declared surface.
 type stubApprovals struct{}
 
-// StageQuotaRelease satisfies the seam; a step-up never reaches these tests.
-func (stubApprovals) StageQuotaRelease(_ context.Context, _ agents.QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+// StageVolumeRelease satisfies the seam; a step-up never reaches these tests.
+func (stubApprovals) StageVolumeRelease(_ context.Context, _ agents.VolumeReleaseRequest) (ids.ApprovalID, bool, error) {
 	return ids.ApprovalID{}, false, nil
 }
 
@@ -420,7 +420,7 @@ func collectStringConsts(file *ast.File, into map[string]string) {
 // gatekit:fixture the value each exported approvals kind constant carries —
 // resolved constant data, not a cost.
 var exportedApprovalKinds = map[string]string{
-	"KindQuotaRelease":      approvals.KindQuotaRelease,
+	"KindVolumeRelease":     approvals.KindVolumeRelease,
 	"KindScheduledSendHeld": approvals.KindScheduledSendHeld,
 	"KindImportCommit":      approvals.KindImportCommit,
 }
@@ -430,7 +430,7 @@ var exportedApprovalKinds = map[string]string{
 // gatekit:fixture the value each cross-package kind constant carries, keyed as
 // written at the call site — resolved constant data, not a cost.
 var crossPackageKinds = map[string]string{
-	"approvals.KindQuotaRelease":      approvals.KindQuotaRelease,
+	"approvals.KindVolumeRelease":     approvals.KindVolumeRelease,
 	"approvals.KindScheduledSendHeld": approvals.KindScheduledSendHeld,
 	"deals.CloseDateCorrectionKind":   deals.CloseDateCorrectionKind,
 	"deals.FollowUpReconcileKind":     deals.FollowUpReconcileKind,

--- a/backend/internal/compose/approvalsadapter.go
+++ b/backend/internal/compose/approvalsadapter.go
@@ -36,7 +36,7 @@ func (a approvalsAdapter) StageCall(ctx context.Context, in agents.StageRequest)
 	})
 }
 
-// StageQuotaRelease puts a §2.4 step-up in front of the human who lent the
+// StageVolumeRelease puts a §2.4 step-up in front of the human who lent the
 // calling passport.
 //
 // It stages through the DECLINED-AWARE path, unlike Stage above, and both
@@ -52,7 +52,7 @@ func (a approvalsAdapter) StageCall(ctx context.Context, in agents.StageRequest)
 // (approvals' selfOnlyKinds over a target-less staging), and it is why the
 // identity carries the discrimination a diff hash carries for every other kind:
 // there is no diff.
-func (a approvalsAdapter) StageQuotaRelease(ctx context.Context, in agents.QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+func (a approvalsAdapter) StageVolumeRelease(ctx context.Context, in agents.VolumeReleaseRequest) (ids.ApprovalID, bool, error) {
 	payload, err := json.Marshal(in.Proposal)
 	if err != nil {
 		return ids.ApprovalID{}, false, fmt.Errorf("compose: encoding a step-up proposal: %w", err)
@@ -61,12 +61,12 @@ func (a approvalsAdapter) StageQuotaRelease(ctx context.Context, in agents.Quota
 	if err != nil {
 		return ids.ApprovalID{}, false, err
 	}
-	_, diffHash, err := diffhash.Object(map[string]any{"quota_release": string(identity)})
+	_, diffHash, err := diffhash.Object(map[string]any{"volume_release": string(identity)})
 	if err != nil {
 		return ids.ApprovalID{}, false, fmt.Errorf("compose: hashing a step-up proposal: %w", err)
 	}
 	return a.svc.StageUnlessDeclined(ctx, approvals.StageInput{
-		Kind:           approvals.KindQuotaRelease,
+		Kind:           approvals.KindVolumeRelease,
 		ProposedChange: payload,
 		DiffHash:       diffHash,
 		Summary:        in.Summary,

--- a/backend/internal/compose/attention/failedlane_test.go
+++ b/backend/internal/compose/attention/failedlane_test.go
@@ -40,7 +40,7 @@ func TestAFailedDecisionComesBackToItsDecider(t *testing.T) {
 		FailedAt:   readInstant,
 		TargetType: "person", TargetID: person,
 	}, {
-		ID: ids.NewV7(), Kind: "quota_release",
+		ID: ids.NewV7(), Kind: "volume_release",
 		Sentence: "the agent's window could not be widened, so the approval has not taken effect",
 		FailedAt: readInstant,
 	}}})

--- a/backend/internal/compose/certcase_sitepagefacts.go
+++ b/backend/internal/compose/certcase_sitepagefacts.go
@@ -82,7 +82,7 @@ func (sitePageFactsCases) Site() aitasks.Site {
 // CertifiedScope narrows the record to the one page this case reads. A deep read
 // issues this call once per crawled page and the read's answer is the merge of
 // all of them: page kind decides which of two conflicting facts wins, duplicates
-// collapse, and the band quota cuts the tail. None of that exists for one page,
+// collapse, and the band volume budget cuts the tail. None of that exists for one page,
 // so a run measures one page's facts and not the fact set a human is shown.
 func (sitePageFactsCases) CertifiedScope() string { return aitasks.ScopeSingleCall }
 

--- a/backend/internal/compose/coldstartaccept.go
+++ b/backend/internal/compose/coldstartaccept.go
@@ -33,7 +33,7 @@ import (
 // every registered follow-on effect — the decision path and the effects
 // share one service so a released effect can redeem what it decides on.
 //
-// quota is the volume meter an approved step-up widens, and it is installed HERE
+// volume is the meter an approved step-up widens, and it is installed HERE
 // and nowhere else: this is the service the HTTP decision path runs on. The
 // other services built from approvalsServiceWithEffects are staging-only — a
 // nightly proposer, a rematch sweep — and none of them ever decides, so having
@@ -42,8 +42,8 @@ import (
 // log is installed for the same reason and on the same service: a bundle member
 // whose effect fails AFTER its decision committed is reported to the client by
 // outcome alone, so this is the process that has to carry the cause.
-func approvalsHandlersWithEffects(pool *pgxpool.Pool, quota approvals.QuotaReleaser, log *slog.Logger) approvals.Handlers {
-	return approvals.NewHandlers(approvalsServiceWithEffects(pool).WithQuotaReleaser(quota).WithLogger(log))
+func approvalsHandlersWithEffects(pool *pgxpool.Pool, volume approvals.VolumeReleaser, log *slog.Logger) approvals.Handlers {
+	return approvals.NewHandlers(approvalsServiceWithEffects(pool).WithVolumeReleaser(volume).WithLogger(log))
 }
 
 // approvalsServiceWithEffects is the registration list itself, split from the

--- a/backend/internal/compose/extensiontools.go
+++ b/backend/internal/compose/extensiontools.go
@@ -192,7 +192,7 @@ func adaptExtensionTool(unit extension.Name, tool extension.Tool, verb extension
 	// The object and the action are carried onto the adapted tool for the same
 	// reason unit is: the composed declaration is the only place they exist,
 	// and mcp.ToolSpec has no field for either — the core gate's model is
-	// scope ∧ seat ∧ tier ∧ quota, and object-level RBAC is enforced by the
+	// scope ∧ seat ∧ tier ∧ volume, and object-level RBAC is enforced by the
 	// handler at every core store rather than by the gate. So this adapter is
 	// where an extension's declared grant becomes a live check; see Handle.
 	return extensionTool{
@@ -381,7 +381,7 @@ func (t extensionTool) Spec() mcp.ToolSpec { return t.spec }
 // the call it was granted for.
 func (t extensionTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
 	// Object-level RBAC, and this is the ONE place it can be: the core gate
-	// decides scope ∧ seat ∧ tier ∧ quota and knows nothing about objects, so
+	// decides scope ∧ seat ∧ tier ∧ volume and knows nothing about objects, so
 	// without this line a declared x-rbac-object would register into the
 	// vocabulary, reach /me, and gate nothing — a screen would hide a control
 	// the same principal could still reach through the agent.

--- a/backend/internal/compose/extrbacenforce_test.go
+++ b/backend/internal/compose/extrbacenforce_test.go
@@ -7,7 +7,7 @@ package compose
 //
 // Registering an object into the vocabulary is half a capability: it lets a
 // role document grant it and /me report the holder's grant. Before this, that
-// was ALL it did — the core gate decides scope ∧ seat ∧ tier ∧ quota and knows
+// was ALL it did — the core gate decides scope ∧ seat ∧ tier ∧ volume and knows
 // nothing about objects, so `x-rbac-object` gated nothing and a screen that
 // hid its controls on the /me answer was hiding them from a principal who
 // could still reach the same operation through the agent.

--- a/backend/internal/compose/handlers_integrations.go
+++ b/backend/internal/compose/handlers_integrations.go
@@ -93,7 +93,7 @@ func (h integrationsHandlers) UpdateProviderConnection(w http.ResponseWriter, r 
 		return
 	}
 	// Read off the header rather than the generated params struct, which is
-	// the house spelling (quotas, people, deals, roles): httperr.IfMatchVersion
+	// the house spelling (people, deals, roles): httperr.IfMatchVersion
 	// is where "a bare integer, not a quoted ETag" and the malformed-header
 	// refusal are decided once, for every surface.
 	ifVersion, ok := httperr.IfMatchVersion(w, r)

--- a/backend/internal/compose/integration/agentreadbound_integration_test.go
+++ b/backend/internal/compose/integration/agentreadbound_integration_test.go
@@ -8,7 +8,7 @@ package integration
 // The MCP-SESS-READS bound on the REST door, over the REAL HTTP stack with a
 // real passport.
 //
-// The shared app harness composes agentquota.Unmetered() — it serves no Redis,
+// The shared app harness composes agentvolume.Unmetered() — it serves no Redis,
 // and a meter that cannot reach its counter fails closed, which would refuse
 // every agent read in suites testing something else. That is the right default
 // for those suites and the wrong one for this property, so this file builds its
@@ -27,7 +27,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/overlaybudget/budgettest"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -35,10 +35,10 @@ import (
 
 // boundedApp is the app under a live read bound, plus the meter itself so a
 // test can put the window into whatever state it is about.
-func boundedApp(t *testing.T, slug string, limit int) (*apptest.AppEnv, *agentquota.Meter) {
+func boundedApp(t *testing.T, slug string, limit int) (*apptest.AppEnv, *agentvolume.Meter) {
 	t.Helper()
-	meter := agentquota.New(budgettest.Client(t), agentquota.Limits{Reads: limit}, time.Hour)
-	e := apptest.SetupAppWithOptions(t, compose.WithAgentQuota(meter))
+	meter := agentvolume.New(budgettest.Client(t), agentvolume.Limits{Reads: limit}, time.Hour)
+	e := apptest.SetupAppWithOptions(t, compose.WithAgentVolume(meter))
 	apptest.BootstrapWorkspaceSession(t, e, "Read Bound", slug+"@fable.test", "Admin")
 	return e, meter
 }
@@ -58,17 +58,17 @@ func asPassport(t *testing.T, e *apptest.AppEnv, passport ids.UUID) context.Cont
 }
 
 // spendWindow charges the meter against one passport, as the MCP door would.
-func spendWindow(t *testing.T, e *apptest.AppEnv, meter *agentquota.Meter, passport ids.UUID, records int) {
+func spendWindow(t *testing.T, e *apptest.AppEnv, meter *agentvolume.Meter, passport ids.UUID, records int) {
 	t.Helper()
-	if err := meter.Consume(asPassport(t, e, passport), agentquota.Reads, records); err != nil {
+	if err := meter.Consume(asPassport(t, e, passport), agentvolume.Reads, records); err != nil {
 		t.Fatalf("spending the window: %v", err)
 	}
 }
 
 // readsCharged is what the window has actually observed against one passport.
-func readsCharged(t *testing.T, e *apptest.AppEnv, meter *agentquota.Meter, passport ids.UUID) int {
+func readsCharged(t *testing.T, e *apptest.AppEnv, meter *agentvolume.Meter, passport ids.UUID) int {
 	t.Helper()
-	return meter.Read(asPassport(t, e, passport), agentquota.Reads).Observed
+	return meter.Read(asPassport(t, e, passport), agentvolume.Reads).Observed
 }
 
 // A passport that has spent its window is refused on the REST door too. Before
@@ -87,7 +87,7 @@ func TestASpentWindowRefusesTheSamePassportOnTheRestDoor(t *testing.T) {
 
 	spendWindow(t, e, meter, passport, 100)
 
-	// The QUOTA response specifically: a 403 or a 500 would also fail an
+	// The VOLUME-BUDGET response specifically: a 403 or a 500 would also fail an
 	// is-not-200 check while meaning something entirely different.
 	var problem struct {
 		Code string `json:"code"`
@@ -165,7 +165,7 @@ func TestARestSingleRecordReadChargesOne(t *testing.T) {
 // THE DERIVED OBLIGATION, and the reason this file grew: every counter the
 // admission gate can REFUSE on has a charge point on the SAME door.
 //
-// platform/auth refuses on Calls and on agentquota.CounterFor(spec) — which is
+// platform/auth refuses on Calls and on agentvolume.CounterFor(spec) — which is
 // Reads, Writes or Egress — so the REST door owes all four. Stated as one rule
 // it catches a half at a time: the mutating half was closed by C2 and the read
 // half sat open for a release, because nothing asserted the pair.
@@ -187,14 +187,14 @@ func TestEveryCounterTheRestDoorRefusesOnIsChargedOnIt(t *testing.T) {
 	seedPeople(t, e, 2)
 	ctx := asPassport(t, e, passport)
 
-	advance := func(during func()) map[agentquota.Counter]int {
-		counters := []agentquota.Counter{agentquota.Reads, agentquota.Writes, agentquota.Calls}
-		was := map[agentquota.Counter]int{}
+	advance := func(during func()) map[agentvolume.Counter]int {
+		counters := []agentvolume.Counter{agentvolume.Reads, agentvolume.Writes, agentvolume.Calls}
+		was := map[agentvolume.Counter]int{}
 		for _, c := range counters {
 			was[c] = meter.Read(ctx, c).Observed
 		}
 		during()
-		moved := map[agentquota.Counter]int{}
+		moved := map[agentvolume.Counter]int{}
 		for _, c := range counters {
 			moved[c] = meter.Read(ctx, c).Observed - was[c]
 		}
@@ -215,13 +215,13 @@ func TestEveryCounterTheRestDoorRefusesOnIsChargedOnIt(t *testing.T) {
 	})
 
 	for _, owed := range []struct {
-		counter agentquota.Counter
+		counter agentvolume.Counter
 		moved   int
 		door    string
 	}{
-		{agentquota.Reads, onRead[agentquota.Reads], "a GET hands over records"},
-		{agentquota.Writes, onWrite[agentquota.Writes], "a POST mutates"},
-		{agentquota.Calls, onWrite[agentquota.Calls], "every admitted call sits under the ceiling"},
+		{agentvolume.Reads, onRead[agentvolume.Reads], "a GET hands over records"},
+		{agentvolume.Writes, onWrite[agentvolume.Writes], "a POST mutates"},
+		{agentvolume.Calls, onWrite[agentvolume.Calls], "every admitted call sits under the ceiling"},
 	} {
 		if !owed.counter.Governed() {
 			continue

--- a/backend/internal/compose/integration/agentvolumeladder_integration_test.go
+++ b/backend/internal/compose/integration/agentvolumeladder_integration_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 	"github.com/margince/margince/backend/internal/modules/approvals"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/overlaybudget/budgettest"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -30,29 +30,29 @@ import (
 
 // ladderApp is the app under live counters at thresholds a test can actually
 // cross, plus the meter so a test can put a window into the state it is about.
-func ladderApp(t *testing.T, slug string, limits agentquota.Limits) (*apptest.AppEnv, *agentquota.Meter) {
+func ladderApp(t *testing.T, slug string, limits agentvolume.Limits) (*apptest.AppEnv, *agentvolume.Meter) {
 	t.Helper()
 	// The DEFAULT window, not a short one: these tests spend, stage, approve and
 	// re-read on the REAL clock, and a one-hour bucket resets under any run that
 	// crosses the top of the hour — a flake that would read as the release
 	// having failed.
-	meter := agentquota.New(budgettest.Client(t), limits, agentquota.DefaultWindow)
+	meter := agentvolume.New(budgettest.Client(t), limits, agentvolume.DefaultWindow)
 	// The CONNECTOR composition, because half the ladder only exists behind
-	// /mcp: the REST door refuses on the quota but has no tool to name, so the
+	// /mcp: the REST door refuses on the volume budget but has no tool to name, so the
 	// step-up it would stage has no question in it. The hosted transport is
 	// where a refusal becomes something a human can answer.
 	e := apptest.SetupAppWithOriginOptions(t, func(origin string) []compose.Option {
 		return []compose.Option{
 			compose.WithMCPConnector(), compose.WithMCPResource(origin + "/mcp"),
-			compose.WithAgentQuota(meter),
+			compose.WithAgentVolume(meter),
 		}
 	})
-	apptest.BootstrapWorkspaceSession(t, e, "Quota Ladder", slug+"@fable.test", "Admin")
+	apptest.BootstrapWorkspaceSession(t, e, "Volume Ladder", slug+"@fable.test", "Admin")
 	return e, meter
 }
 
 // spendCounter charges one counter against one passport, as the surface would.
-func spendCounter(t *testing.T, e *apptest.AppEnv, meter *agentquota.Meter, passport ids.UUID, c agentquota.Counter, n int) {
+func spendCounter(t *testing.T, e *apptest.AppEnv, meter *agentvolume.Meter, passport ids.UUID, c agentvolume.Counter, n int) {
 	t.Helper()
 	var ws ids.UUID
 	if err := e.Owner.QueryRow(t.Context(), `SELECT id FROM workspace LIMIT 1`).Scan(&ws); err != nil {
@@ -74,7 +74,7 @@ func pendingStepUp(t *testing.T, e *apptest.AppEnv) (id ids.ApprovalID, passport
 	t.Helper()
 	err := e.Owner.QueryRow(t.Context(), `
 		SELECT id, passport_id, coalesce(summary, '') FROM approval
-		 WHERE kind = $1 AND status = 'pending'`, approvals.KindQuotaRelease).Scan(&id, &passport, &summary)
+		 WHERE kind = $1 AND status = 'pending'`, approvals.KindVolumeRelease).Scan(&id, &passport, &summary)
 	if err != nil {
 		t.Fatalf("reading the staged step-up: %v", err)
 	}
@@ -100,10 +100,10 @@ func callTool(t *testing.T, e *apptest.AppEnv, bearer map[string]string, tool st
 // the human who lent the passport, their approval widens THAT window, and the
 // same passport reads again — through the same door, with nothing else changed.
 func TestAReadPastItsThresholdIsReleasedByTheHumanWhoLentThePassport(t *testing.T) {
-	e, meter := ladderApp(t, "ladder-read", agentquota.Limits{Reads: 100})
+	e, meter := ladderApp(t, "ladder-read", agentvolume.Limits{Reads: 100})
 	bearer, passport := passportWithID(t, e, "reading agent", "read")
 	seedPeople(t, e, 2)
-	spendCounter(t, e, meter, passport, agentquota.Reads, 120)
+	spendCounter(t, e, meter, passport, agentvolume.Reads, 120)
 
 	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusTooManyRequests {
 		t.Fatalf("a read past its threshold → %d, want 429", status)
@@ -139,10 +139,10 @@ func TestAReadPastItsThresholdIsReleasedByTheHumanWhoLentThePassport(t *testing.
 // more allowance, so the agent that spends it is refused again and its human is
 // asked again.
 func TestOneReleaseIsOneMoreAllowanceAndNotAStandingPermission(t *testing.T) {
-	e, meter := ladderApp(t, "ladder-once", agentquota.Limits{Reads: 100})
+	e, meter := ladderApp(t, "ladder-once", agentvolume.Limits{Reads: 100})
 	bearer, passport := passportWithID(t, e, "reading agent", "read")
 	seedPeople(t, e, 2)
-	spendCounter(t, e, meter, passport, agentquota.Reads, 120)
+	spendCounter(t, e, meter, passport, agentvolume.Reads, 120)
 	callTool(t, e, bearer, "search_records", AnyMap{"query": "Metered"})
 	id, _, _ := pendingStepUp(t, e)
 	if status := e.Call(t, "POST", "/v1/approvals/"+id.String()+"/approve", nil, nil, nil); status != http.StatusOK {
@@ -150,7 +150,7 @@ func TestOneReleaseIsOneMoreAllowanceAndNotAStandingPermission(t *testing.T) {
 	}
 
 	// The released allowance is spent too.
-	spendCounter(t, e, meter, passport, agentquota.Reads, 100)
+	spendCounter(t, e, meter, passport, agentvolume.Reads, 100)
 
 	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusTooManyRequests {
 		t.Errorf("a second crossing after one release → %d, want 429: approving once granted a standing permission", status)
@@ -161,9 +161,9 @@ func TestOneReleaseIsOneMoreAllowanceAndNotAStandingPermission(t *testing.T) {
 // thing the meter will do, so staging it would put a question in front of a
 // human whose answer changes nothing — and leave the agent waiting for it.
 func TestASpentEgressCeilingAsksNobodyAnything(t *testing.T) {
-	e, meter := ladderApp(t, "ladder-egress", agentquota.Limits{Egress: 1})
+	e, meter := ladderApp(t, "ladder-egress", agentvolume.Limits{Egress: 1})
 	bearer, passport := passportWithID(t, e, "sending agent", "read", "send")
-	spendCounter(t, e, meter, passport, agentquota.Egress, 5)
+	spendCounter(t, e, meter, passport, agentvolume.Egress, 5)
 
 	callTool(t, e, bearer, "send_email", AnyMap{
 		"to": "someone@example.com", "subject": "s", "body": "b",
@@ -171,7 +171,7 @@ func TestASpentEgressCeilingAsksNobodyAnything(t *testing.T) {
 
 	var staged int
 	if err := e.Owner.QueryRow(t.Context(),
-		`SELECT count(*) FROM approval WHERE kind = $1`, approvals.KindQuotaRelease).Scan(&staged); err != nil {
+		`SELECT count(*) FROM approval WHERE kind = $1`, approvals.KindVolumeRelease).Scan(&staged); err != nil {
 		t.Fatalf("counting staged step-ups: %v", err)
 	}
 	if staged != 0 {

--- a/backend/internal/compose/integration/apptest/appenv.go
+++ b/backend/internal/compose/integration/apptest/appenv.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/compose"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
 	"github.com/margince/margince/backend/internal/platform/jobs"
@@ -143,7 +143,7 @@ func SetupAppWithOriginOptions(t *testing.T, opts func(origin string) []compose.
 		// every agent read in a lane that is testing something else. Declaring
 		// the app under test unbounded is the honest spelling: a suite that
 		// wants the bound composes its own metered Server.
-		compose.WithAgentQuota(agentquota.Unmetered()),
+		compose.WithAgentVolume(agentvolume.Unmetered()),
 	}, opts(origin)...)
 	ts.Config.Handler = compose.New(pool, slog.New(slog.NewTextHandler(os.Stderr, nil)), allOpts...)
 	ts.StartTLS()

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_budget_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_budget_integration_test.go
@@ -125,7 +125,7 @@ func TestAcceptance_AC_OV_3_MirrorReadMeetsBudget(t *testing.T) {
 // TestAcceptance_AC_OV_7_ForceFreshDegrades proves design.md's AC-OV-7
 // (OVA-EVT-3): once the OVB meter reports the shed band, a force-fresh
 // read degrades to mirror-with-staleness (Authoritative:false, zero
-// additional quota spent — proven by the meter's own Consumed count
+// additional volume budget spent — proven by the meter's own Consumed count
 // staying unchanged, the only way FreshnessReader.Read could ever reach
 // the live incumbent) and emits mirror.budget_degraded on the bus — never
 // silently. Driven through compose.Dispatcher (the real production

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -270,7 +270,7 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 		// connected_at is NOT NULL, so a zero means this struct was built without
 		// it — and sweeping would then floor at the zero time, i.e. the whole
 		// portal every tick (overlay.Reconcile's internal reconcileFloor).
-		// Refuse rather than burn the quota.
+		// Refuse rather than burn the volume budget.
 		return fmt.Errorf("overlay reconcile: connection for workspace %s carries no connected_at; refusing to sweep from the epoch", d.Workspace)
 	}
 	token, err := vault.Get(ctx, d.Workspace, d.CredentialRef)

--- a/backend/internal/compose/jobs_overlay_refetch.go
+++ b/backend/internal/compose/jobs_overlay_refetch.go
@@ -149,7 +149,7 @@ func (w *overlayRefetchWorker) refetchAndIngest(wsCtx context.Context, conn over
 	inc := w.newIncumbent(conn.Region, string(token))
 	// Reserve one REST unit BEFORE the live read (OVB-AC-2/AC-5), so this lane's
 	// incumbent calls are accounted for like every other. On shed skip the
-	// re-fetch: never spend live quota we cannot account for. Dropping it costs
+	// re-fetch: never spend live volume budget we cannot account for. Dropping it costs
 	// nothing durable either way, though for different reasons per producer — a
 	// webhook is an optimization the watermark poller heals within its interval,
 	// while a re-projection is NOT something the poller heals (it is

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -662,7 +662,7 @@ func TestOverlayRefetchWorkerFreshensTheMirrorRecord(t *testing.T) {
 // TestOverlayRefetchWorkerShedsWhenBudgetExhausted proves the OVB gate: when the
 // meter sheds (here a fail-closed meter with no window), the worker skips the
 // incumbent read entirely — nothing is ingested, and the poller heals the gap.
-// This is the "never spend live quota we cannot account for" invariant for the
+// This is the "never spend live volume budget we cannot account for" invariant for the
 // webhook lane.
 func TestOverlayRefetchWorkerShedsWhenBudgetExhausted(t *testing.T) {
 	e := integration.Setup(t)

--- a/backend/internal/compose/jobs_test.go
+++ b/backend/internal/compose/jobs_test.go
@@ -47,7 +47,7 @@ func TestJobKindsAreStable(t *testing.T) {
 // best-effort with no requested scope; a portal that gates one of them
 // (HubSpot 403s leads and emails on a starter portal, confirmed against a live
 // developer account) must skip only that class, never abort the classes we do
-// hold scope for. A portal-wide failure (an outage or quota exhaustion) still
+// hold scope for. A portal-wide failure (an outage or volume budget exhaustion) still
 // aborts even a best-effort class.
 func TestOverlaySweepAbortsToleratesBestEffortClassInaccessibility(t *testing.T) {
 	cases := []struct {

--- a/backend/internal/compose/meetingbrief/model.go
+++ b/backend/internal/compose/meetingbrief/model.go
@@ -229,7 +229,7 @@ func ParseBriefSections(reply string, in Input) ([]Section, error) {
 	}
 	known := knownRecords(in)
 	byKind := map[crmcontracts.MeetingBriefSectionKind][]Sentence{}
-	// The quota is on the BRIEF, not on one section: a model returning two
+	// The volume budget is on the BRIEF, not on one section: a model returning two
 	// talking_points sections would otherwise be handed the allowance twice.
 	recommendations := 0
 	for _, section := range parsed.Sections {
@@ -277,7 +277,7 @@ func keptSentence(
 			Evidence{EntityType: cited.EntityType, EntityID: cited.EntityID})
 	}
 	// Grounding decides FIRST. Counting an ungrounded recommendation would let
-	// one malformed claim spend the quota and suppress the valid advice behind
+	// one malformed claim spend the volume budget and suppress the valid advice behind
 	// it — the reader loses the advice and is told nothing about why.
 	if !claims.Grounded(sentence, known) {
 		return Sentence{}, false

--- a/backend/internal/compose/orgbrief/write.go
+++ b/backend/internal/compose/orgbrief/write.go
@@ -269,7 +269,7 @@ func ParseBriefSections(reply, orgID string, in Input) ([]Section, error) {
 	}
 	known := knownRecords(orgID, in)
 	byKind := map[string][]Sentence{}
-	// The quota is on the BRIEF, not on one section: a model that returns two
+	// The volume budget is on the BRIEF, not on one section: a model that returns two
 	// next_step sections would otherwise be handed the allowance twice, and the
 	// merged output would carry twice the advice the reader was promised.
 	recommendations := 0
@@ -293,7 +293,7 @@ func ParseBriefSections(reply, orgID string, in Input) ([]Section, error) {
 			}
 			sentence.Nature = nature
 			// Grounding decides FIRST. Counting an ungrounded recommendation
-			// would let one malformed claim spend the quota and suppress the
+			// would let one malformed claim spend the volume budget and suppress the
 			// valid advice behind it — the reader loses the advice and is told
 			// nothing about why.
 			if !claims.Grounded(sentence, known) {

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -45,7 +45,7 @@ const incumbentHubSpot = "hubspot"
 
 // failClosedOverlayMeter is the OVB meter a surface with no Redis-backed
 // meter uses: nil client, so every band sheds and every reservation is
-// declined (a role never spends live quota it cannot account for). The
+// declined (a role never spends live volume budget it cannot account for). The
 // REST read surface (server.go) and the poller (jobs.go) receive their
 // live Redis-backed meter from cmd via WithOverlayMeter / JobRunnerConfig;
 // no tool or workflow path reaches Dispatcher.Freshness, the only route to a

--- a/backend/internal/compose/overlay_sweep_policy.go
+++ b/backend/internal/compose/overlay_sweep_policy.go
@@ -48,7 +48,7 @@ func scopeBackedOverlayClass(objectClass string) bool {
 // downscoped. A best-effort class (leads and the engagement classes, swept
 // with no requested scope) never breaks the classes we can sync — but it still
 // aborts on a CONNECTION-WIDE condition: budget exhaustion (continuing to spend
-// against an exhausted quota is pointless) or ErrConnectionGone (a disconnect
+// against an exhausted volume budget is pointless) or ErrConnectionGone (a disconnect
 // racing the sweep — the connection no longer exists, so the on-demand
 // reconciler must see this to collapse it to ErrModeNotOverlay, and the poller
 // must not reset backoff on a dead connection). Every per-OBJECT failure — a

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -68,11 +68,11 @@ func registryWithDraftBrain(pool *pgxpool.Pool, brain completer, resolveIncumben
 	return registryWithGate(db, auth.NewGate(identity.NewService(pool)), newReplyDrafter(pool, brain, nil), resolveIncumbent, send, companyEnricher{}, nil, nil, nil, brief, slog.Default())
 }
 
-// registryWithGate composes the tool surface. The quota charger arrives as
+// registryWithGate composes the tool surface. The volume budget charger arrives as
 // an option rather than a parameter because only the API server — the one role
 // that serves agent principals through the MCP and REST doors — has a meter to
 // charge. The Surface-B runner and the workflow paths run as the human or the
-// system that started them, and the quota meter governs agents only, so a registry
+// system that started them, and the volume meter governs agents only, so a registry
 // built without one is not an unmetered agent surface; it is a surface no agent
 // reaches.
 //

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -45,7 +45,7 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 	// The SAME meter the tool registry charges: this door refuses on the bound
 	// the other door pays into, so a Passport cannot spend its window on one
 	// and keep reading on the other.
-	gate := auth.NewGate(identitySvc, auth.WithQuota(srv.quotaMeter))
+	gate := auth.NewGate(identitySvc, auth.WithVolumeMeter(srv.volumeMeter))
 	// This registry admits REST calls; it never INVOKES a tool — a REST enrich
 	// runs scrapeHandlers, not the tool — so the enricher here supplies only the
 	// spec's cap and tier, and the ZERO value supplies those. Deliberately not
@@ -55,7 +55,7 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 	// transport invokes tools through srv.toolRegistry, which holds the live
 	// server.
 	//
-	// It DOES carry the quota charger, even though it invokes nothing: the two
+	// It DOES carry the volume budget charger, even though it invokes nothing: the two
 	// charge points agentGate calls (ChargeAdmittedCall, ChargeEffect) hang off
 	// this registry, so a registry built without one would refuse REST calls on
 	// a counter it then never paid — the exact half-a-control this change exists
@@ -63,7 +63,7 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 	registry := registryWithGate(InstallationDB(pool), gate, srv.replyDrafter, srv.resolveOverlayIncumbent(pool), srv.send,
 		companyEnricher{}, srv.retrievalEmbedder, nil, importsFor(&srv),
 		meetingBriefReader(srv.meetingBriefSvc), srv.log,
-		agents.WithQuotaCharger(srv.quotaMeter))
+		agents.WithVolumeCharger(srv.volumeMeter))
 	// The ADR-0055 admission layer and the MCP tool surface share one
 	// provider seam: agentGate's StageResolver dispatches per workspace
 	// exactly like the MCP registry's tools do — and the overlay-mode

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -39,7 +39,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/search"
 	"github.com/margince/margince/backend/internal/modules/signals"
 	"github.com/margince/margince/backend/internal/modules/weeklyplan"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
 	"github.com/margince/margince/backend/internal/platform/httpserver"
 )
@@ -209,16 +209,16 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// doc). Fail-closed until WithOverlayMeter Rebinds it with the live
 		// Redis client + config.
 		overlayMeter: failClosedOverlayMeter(),
-		// Fail-closed until WithAgentQuota Rebinds it: a role serving the agent
+		// Fail-closed until WithAgentVolume Rebinds it: a role serving the agent
 		// surface with no Redis cannot tell whether an agent has passed its
 		// read bound, and answers that it has.
-		quotaMeter: agentquota.New(nil, agentquota.Limits{}, agentquota.DefaultWindow),
+		volumeMeter: agentvolume.New(nil, agentvolume.Limits{}, agentvolume.DefaultWindow),
 	}
 	// After the literal, because the decision path takes the SAME meter pointer
 	// the gate and the registry take: a step-up refused against one counter and
 	// released into another would read, from the human's side, as an approval
 	// that did nothing.
-	srv.approvalsHandlers = approvalsHandlersWithEffects(pool, srv.quotaMeter, log)
+	srv.approvalsHandlers = approvalsHandlersWithEffects(pool, srv.volumeMeter, log)
 	// The day's surface reads the SAME approvals engine the inbox decides
 	// through, so a card here and a row there are one queue rather than two
 	// readings of it.

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -34,7 +34,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/search"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/deployconfig"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
@@ -345,22 +345,22 @@ type Server struct {
 	// correctness requirement.
 	// Always non-nil (newServer constructs it unconditionally, fail-closed
 	// with no Redis): a role that never calls WithOverlayMeter answers shed
-	// for every force-fresh read (never spends live quota it cannot
+	// for every force-fresh read (never spends live volume budget it cannot
 	// account for), and a role with no vault never reaches GetOverlayBudget
 	// at all. WithOverlayMeter Rebinds this shared pointer to the live
 	// Redis-backed meter at boot.
 	overlayMeter *overlaybudget.Meter
-	// quotaMeter is the MCP-SESS-READS bound this role enforces on agent
+	// volumeMeter is the MCP-SESS-READS bound this role enforces on agent
 	// the five MCP-SESS-* counters, shared by everything that must agree about
 	// them: the admission gate that REFUSES on them, both doors' registries that
 	// CHARGE them, the approvals service that WIDENS one when a lender says
 	// continue, and the model path that charges the soft cost share.
 	//
 	// Always non-nil (newServer constructs it unconditionally, fail-closed
-	// with no Redis), and WithAgentQuota Rebinds this ONE pointer to the live
+	// with no Redis), and WithAgentVolume Rebinds this ONE pointer to the live
 	// Redis-backed meter at boot — so no option order can leave the gate
 	// enforcing a different counter from the one the registry pays into.
-	quotaMeter *agentquota.Meter
+	volumeMeter *agentvolume.Meter
 	// retrievalEmbedder is this role's embed lane for REQUEST-TIME ranking —
 	// the same ModelPath.Embedder the background reindex and drift sweep use,
 	// bound here so the hybrid arm's vector half is available to a caller and

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -24,7 +24,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/privacy"
 	"github.com/margince/margince/backend/internal/modules/search"
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/config"
 	"github.com/margince/margince/backend/internal/platform/httpserver"
@@ -329,14 +329,14 @@ func WithOverlayMeter(meter *overlaybudget.Meter) Option {
 	return func(s *Server, _ *pgxpool.Pool) { s.overlayMeter.RebindFrom(meter) }
 }
 
-// WithAgentQuota Rebinds the Server's shared MCP-SESS-* meter to the live,
+// WithAgentVolume Rebinds the Server's shared MCP-SESS-* meter to the live,
 // Redis-backed one cmd built. newServer constructs it fail-closed (nil Redis)
 // and hands that ONE pointer to both halves of the bound — the admission gate
 // that refuses on it and the tool registry that charges it — so this
 // RebindFrom reaches both together and they can never end up counting against
 // different windows.
 //
-// Taking the already-built *agentquota.Meter (not a *redis.Client) keeps the
+// Taking the already-built *agentvolume.Meter (not a *redis.Client) keeps the
 // raw-Redis dependency in cmd, never in compose. Without this option the meter
 // stays fail-closed: a role serving the agent surface with no Redis cannot
 // tell whether an agent has passed any of its bounds, and answers that it has.
@@ -345,9 +345,9 @@ func WithOverlayMeter(meter *overlaybudget.Meter) Option {
 // that division live behind the pool this option is handed: the workspace's AI
 // budget and the credentials sharing it. cmd owns the Redis client; compose
 // owns what the workspace's own numbers mean.
-func WithAgentQuota(meter *agentquota.Meter) Option {
+func WithAgentVolume(meter *agentvolume.Meter) Option {
 	return func(s *Server, pool *pgxpool.Pool) {
-		s.quotaMeter.RebindFrom(meter.WithCostCeiling(newPassportShareCeiling(pool, meter.Window())))
+		s.volumeMeter.RebindFrom(meter.WithCostCeiling(newPassportShareCeiling(pool, meter.Window())))
 	}
 }
 

--- a/backend/internal/compose/toolregistry.go
+++ b/backend/internal/compose/toolregistry.go
@@ -31,12 +31,12 @@ func (s *Server) rebuildToolRegistry(pool *pgxpool.Pool) {
 	// bound, the other pays into it, and a surface where those were two
 	// counters would step an agent up against a number nothing was charging.
 	s.toolRegistry = registryWithGate(InstallationDB(pool),
-		auth.NewGate(identity.NewService(pool), auth.WithQuota(s.quotaMeter)),
+		auth.NewGate(identity.NewService(pool), auth.WithVolumeMeter(s.volumeMeter)),
 		s.replyDrafter, s.resolveOverlayIncumbent(pool), s.send, companyEnricher{srv: s},
 		s.retrievalEmbedder, s.transcriptOnLanding, importsFor(s),
 		// The SERVER's brief service, not a second one built from the pool: the
 		// model lane is bound to that instance, so a fresh service here would
 		// serve agents the deterministic floor while the person page got prose.
 		meetingBriefReader(s.meetingBriefSvc), s.log,
-		agents.WithQuotaCharger(s.quotaMeter), agents.WithCostShare(s.quotaMeter))
+		agents.WithVolumeCharger(s.volumeMeter), agents.WithCostShare(s.volumeMeter))
 }

--- a/backend/internal/modules/agents/approvals.go
+++ b/backend/internal/modules/agents/approvals.go
@@ -36,7 +36,7 @@ type Approvals interface {
 	// already has asks the question again — which is how one act comes to hold
 	// several approvals, each answered separately and none of them spent.
 	StageCall(ctx context.Context, in StageRequest) (id ids.ApprovalID, alreadyApproved bool, err error)
-	// StageQuotaRelease puts a §2.4 step-up in front of the human who lent this
+	// StageVolumeRelease puts a §2.4 step-up in front of the human who lent this
 	// passport, and reports whether anything was staged: a question that human
 	// has already REJECTED is not re-asked, and the refusal then stands alone.
 	//
@@ -45,7 +45,7 @@ type Approvals interface {
 	// record; this carries no change and no target — it is a question about a
 	// credential — and one shared shape would leave every caller of the common
 	// method passing empty halves that have no meaning for it.
-	StageQuotaRelease(ctx context.Context, in QuotaReleaseRequest) (id ids.ApprovalID, staged bool, err error)
+	StageVolumeRelease(ctx context.Context, in VolumeReleaseRequest) (id ids.ApprovalID, staged bool, err error)
 	// Redeem answers the version the approval was pinned to, so a transport
 	// that forwards the authorized call can bind its own write to it. pinned
 	// is false when the approval carried none — a create, or a target type

--- a/backend/internal/modules/agents/approvals_marker_test.go
+++ b/backend/internal/modules/agents/approvals_marker_test.go
@@ -23,8 +23,8 @@ type refusingApprovals struct{}
 
 var errRedeemRefused = errors.New("approval already consumed")
 
-// StageQuotaRelease satisfies the seam; a step-up never reaches these tests.
-func (refusingApprovals) StageQuotaRelease(context.Context, QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+// StageVolumeRelease satisfies the seam; a step-up never reaches these tests.
+func (refusingApprovals) StageVolumeRelease(context.Context, VolumeReleaseRequest) (ids.ApprovalID, bool, error) {
 	return ids.ApprovalID{}, false, nil
 }
 

--- a/backend/internal/modules/agents/doc.go
+++ b/backend/internal/modules/agents/doc.go
@@ -3,7 +3,7 @@
 
 // Package agents owns the governed agent surface (Layer 1): the MCP
 // tool registry, the admission gate (scope ∧ tier ∧ the read/full seat
-// ceiling; per-agent quota is specified but not yet enforced), the
+// ceiling; per-agent volume budget is specified but not yet enforced), the
 // approval flow, and the Surface-B reasoning loop. It reaches records only
 // through the datasource seam.
 //

--- a/backend/internal/modules/agents/explain.go
+++ b/backend/internal/modules/agents/explain.go
@@ -41,7 +41,7 @@ func (s *Dispatcher) explain(tool string, err error) string {
 		badArgs     *BadArgsError
 		unknownTool *UnknownToolError
 		steppedUp   *StepUpStagedError
-		overQuota   *auth.QuotaExceededError
+		overQuota   *auth.VolumeExceededError
 	)
 	switch {
 	case errors.As(err, &steppedUp):

--- a/backend/internal/modules/agents/httpmcp.go
+++ b/backend/internal/modules/agents/httpmcp.go
@@ -123,7 +123,7 @@ func writeRPCResponse(w http.ResponseWriter, r *http.Request, resp rpcResponse, 
 // can land on any api replica because there is nothing here for it to have
 // landed on before. What the in-process session registry used to hold was
 // bookkeeping plus an implicit volume bound, and the bound now lives in Redis
-// (platform/agentquota) where every replica reads the same number.
+// (platform/agentvolume) where every replica reads the same number.
 type httpMCPHandler struct {
 	// server is the SAME dispatcher the stdio transport runs, built once:
 	// method dispatch, the tool surface and the scrubbed-error rules are

--- a/backend/internal/modules/agents/idempotency.go
+++ b/backend/internal/modules/agents/idempotency.go
@@ -44,7 +44,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
@@ -424,10 +424,10 @@ func (r *Registry) ensureReplayVisible(ctx context.Context, evidence []EvidenceR
 // caller a document it can ask for again, while serving it would leak an
 // uncountable read once per retry for the life of the window.
 func (r *Registry) chargeReplay(ctx context.Context, spec mcp.ToolSpec, records int) error {
-	if r.quota == nil || records <= 0 {
+	if r.volume == nil || records <= 0 {
 		return nil
 	}
-	if err := r.quota.Consume(ctx, agentquota.Reads, records); err != nil {
+	if err := r.volume.Consume(ctx, agentvolume.Reads, records); err != nil {
 		slog.ErrorContext(ctx, "recording a replayed result against the read bound failed",
 			"tool", spec.Name, "records", records, "err", err)
 		return fmt.Errorf(

--- a/backend/internal/modules/agents/idempotency_test.go
+++ b/backend/internal/modules/agents/idempotency_test.go
@@ -145,7 +145,7 @@ func newRetryFixture(t *testing.T) *retryFixture {
 		charger: newCountingCharger(),
 	}
 	f.registry = NewRegistry(nil, auth.NewGate(fullSeatAuthority{}),
-		WithIdempotency(f.claims), WithReplayReader(f.reader), WithQuotaCharger(f.charger))
+		WithIdempotency(f.claims), WithReplayReader(f.reader), WithVolumeCharger(f.charger))
 	f.registry.Register(f.tool)
 	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
 	f.ctx = principal.WithActor(ctx, principal.Principal{
@@ -310,7 +310,7 @@ func TestAReplayThatNamesNoRecordIsRefused(t *testing.T) {
 func TestAReplayIsRefusedWhenNoReaderIsWired(t *testing.T) {
 	f := newRetryFixture(t)
 	f.registry = NewRegistry(nil, auth.NewGate(fullSeatAuthority{}),
-		WithIdempotency(f.claims), WithQuotaCharger(f.charger))
+		WithIdempotency(f.claims), WithVolumeCharger(f.charger))
 	f.registry.Register(f.tool)
 	f.claims.verdict = Claim{State: ClaimReplay, Result: json.RawMessage(fmt.Sprintf(
 		`{"schema_version":"1.0.0","evidence":[{"record_type":"deal","record_id":"%s"}]}`, ids.NewV7()))}
@@ -516,7 +516,7 @@ func TestBookkeepingFailuresNeverChangeWhatTheCallerIsTold(t *testing.T) {
 // irreversible act.
 func TestAKeyIsRefusedOnASurfaceThatCannotClaimIt(t *testing.T) {
 	f := newRetryFixture(t)
-	f.registry = NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithQuotaCharger(f.charger))
+	f.registry = NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithVolumeCharger(f.charger))
 	f.registry.Register(f.tool)
 
 	_, err := f.invoke(t, `{"idempotency_key":"k-1"}`)
@@ -566,11 +566,11 @@ func (a *consumingApprovals) StageCall(context.Context, StageRequest) (ids.Appro
 	return a.staged, false, a.stageErr
 }
 
-// StageQuotaRelease is the §2.4 step-up, which none of these scenarios reaches:
-// they are about the approval a 🟡 call already carries, not about a quota
+// StageVolumeRelease is the §2.4 step-up, which none of these scenarios reaches:
+// they are about the approval a 🟡 call already carries, not about a volume budget
 // ceiling. It answers "nothing staged" so a test that DID reach it would fail
 // on the missing step-up rather than pass on a fabricated one.
-func (a *consumingApprovals) StageQuotaRelease(context.Context, QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+func (a *consumingApprovals) StageVolumeRelease(context.Context, VolumeReleaseRequest) (ids.ApprovalID, bool, error) {
 	return ids.ApprovalID{}, false, nil
 }
 
@@ -606,7 +606,7 @@ func approvedRetryFixture(t *testing.T) (*retryFixture, *consumingApprovals) {
 	f.tool.records = []ids.UUID{ids.NewV7()}
 	approvals := &consumingApprovals{staged: ids.From[ids.ApprovalKind](ids.NewV7())}
 	f.registry = NewRegistry(approvals, auth.NewGate(fullSeatAuthority{}),
-		WithIdempotency(f.claims), WithReplayReader(f.reader), WithQuotaCharger(f.charger))
+		WithIdempotency(f.claims), WithReplayReader(f.reader), WithVolumeCharger(f.charger))
 	f.registry.Register(f.tool)
 	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
 	f.ctx = principal.WithActor(ctx, principal.Principal{

--- a/backend/internal/modules/agents/precedence_test.go
+++ b/backend/internal/modules/agents/precedence_test.go
@@ -99,11 +99,11 @@ func TestSplitHumanOwnedEdges(t *testing.T) {
 // recordingApprovals captures staging and redemption for assertions.
 type recordingApprovals struct {
 	staged    []StageRequest
-	steppedUp []QuotaReleaseRequest
+	steppedUp []VolumeReleaseRequest
 	redeemed  []string // "id tool hash"
 	redeemErr error
 	// stepUpDeclined replays the human who has already said no to this
-	// question: nothing is staged, it is reported, and the quota refusal has to
+	// question: nothing is staged, it is reported, and the volume budget refusal has to
 	// stand on its own rather than becoming an error about staging.
 	stepUpDeclined bool
 	stepUpErr      error
@@ -118,7 +118,7 @@ func (r *recordingApprovals) StageCall(_ context.Context, in StageRequest) (ids.
 	return ids.New[ids.ApprovalKind](), r.alreadyApproved, nil
 }
 
-func (r *recordingApprovals) StageQuotaRelease(_ context.Context, in QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+func (r *recordingApprovals) StageVolumeRelease(_ context.Context, in VolumeReleaseRequest) (ids.ApprovalID, bool, error) {
 	r.steppedUp = append(r.steppedUp, in)
 	switch {
 	case r.stepUpErr != nil:

--- a/backend/internal/modules/agents/registry.go
+++ b/backend/internal/modules/agents/registry.go
@@ -66,13 +66,13 @@ type Registry struct {
 	// tierFloor carries the contract's per-record-type tier declarations, which
 	// a verb's own tier cannot express (tierfloor.go, #982).
 	tierFloor TierFloor
-	// quota is the MCP-SESS-* meter this surface CHARGES. The gate holds the
+	// volume budget is the MCP-SESS-* meter this surface CHARGES. The gate holds the
 	// same meter and does the refusing; the split is deliberate — a bound is
 	// enforced where admission is decided and paid where records and effects
 	// leave.
-	quota QuotaCharger
+	volume VolumeCharger
 	// cost answers the SOFT budget-share counter, whose only effect is a
-	// warning on the answer (quota.go).
+	// warning on the answer (volume.go).
 	cost CostShareReader
 	// claims is what makes `idempotency_key` mean something. Nil refuses a
 	// keyed call rather than running it unprotected (idempotency.go).
@@ -163,7 +163,7 @@ func (r *Registry) InvokeServing(ctx context.Context, name string, in json.RawMe
 		}
 	}
 	ctx = admitted
-	if stepUp := releasableQuotaRefusal(err); stepUp != nil {
+	if stepUp := releasableVolumeRefusal(err); stepUp != nil {
 		return nil, 0, r.stageStepUp(ctx, stepUp)
 	}
 	// The call ceiling is charged where the call is known to RUN, and only

--- a/backend/internal/modules/agents/tasks_test.go
+++ b/backend/internal/modules/agents/tasks_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -490,7 +490,7 @@ func (a *fakeApprovals) StageCall(_ context.Context, in StageRequest) (ids.Appro
 	return a.staged, false, nil
 }
 
-func (a *fakeApprovals) StageQuotaRelease(context.Context, QuotaReleaseRequest) (ids.ApprovalID, bool, error) {
+func (a *fakeApprovals) StageVolumeRelease(context.Context, VolumeReleaseRequest) (ids.ApprovalID, bool, error) {
 	return ids.ApprovalID{}, false, errors.New("no step-up in this fixture")
 }
 
@@ -567,13 +567,13 @@ func (q *fakeQuota) exceed() {
 	q.exceeded = true
 }
 
-func (q *fakeQuota) Read(_ context.Context, c agentquota.Counter) agentquota.Reading {
+func (q *fakeQuota) Read(_ context.Context, c agentvolume.Counter) agentvolume.Reading {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return agentquota.Reading{Counter: c, Exceeded: q.exceeded}
+	return agentvolume.Reading{Counter: c, Exceeded: q.exceeded}
 }
 
-func (q *fakeQuota) Consume(context.Context, agentquota.Counter, int) error { return nil }
+func (q *fakeQuota) Consume(context.Context, agentvolume.Counter, int) error { return nil }
 
 // recordReader is the live re-read a recorded answer is proven against. Taking
 // a record out of `visible` is how a test narrows the caller's access after the
@@ -696,8 +696,8 @@ func stagingDispatcher(t *testing.T) (*Dispatcher, *fakeTasks) {
 	// gate.
 	reader := &recordReader{visible: map[ids.UUID]bool{tool.target: true}}
 	quota := &fakeQuota{}
-	registry := NewRegistry(approvals, auth.NewGate(fullSeatAuthority{}, auth.WithQuota(quota)),
-		WithReplayReader(reader), WithQuotaCharger(quota))
+	registry := NewRegistry(approvals, auth.NewGate(fullSeatAuthority{}, auth.WithVolumeMeter(quota)),
+		WithReplayReader(reader), WithVolumeCharger(quota))
 	registry.Register(tool)
 	s := NewDispatcher(registry, bindAuthenticated, "margince-crm", "test").
 		WithLogger(discardLog()).WithTasks(store, approvals)

--- a/backend/internal/modules/agents/tools_context_test.go
+++ b/backend/internal/modules/agents/tools_context_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -177,8 +177,8 @@ func TestASearchIsChargedPerRecord(t *testing.T) {
 	if charger.reads() != 4 {
 		t.Errorf("charged %d for a 4-record page, want 4 — a page must not cost one", charger.reads())
 	}
-	if charger.times[agentquota.Reads] != 1 {
-		t.Errorf("the bound was consulted %d times, want one charge for the whole answer", charger.times[agentquota.Reads])
+	if charger.times[agentvolume.Reads] != 1 {
+		t.Errorf("the bound was consulted %d times, want one charge for the whole answer", charger.times[agentvolume.Reads])
 	}
 }
 

--- a/backend/internal/modules/agents/tools_query_test.go
+++ b/backend/internal/modules/agents/tools_query_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/datasource"
@@ -475,9 +475,9 @@ func TestAQueryIsChargedPerRecordIncludingItsHops(t *testing.T) {
 	if charger.reads() != 4 {
 		t.Errorf("charged %d records for 3 rows sharing 1 hop, want 4", charger.reads())
 	}
-	if charger.times[agentquota.Reads] != 1 {
+	if charger.times[agentvolume.Reads] != 1 {
 		t.Errorf("the read bound was consulted %d times, want one charge for the whole answer",
-			charger.times[agentquota.Reads])
+			charger.times[agentvolume.Reads])
 	}
 }
 

--- a/backend/internal/modules/agents/volume.go
+++ b/backend/internal/modules/agents/volume.go
@@ -8,7 +8,7 @@ package agents
 //
 // The bound has two halves and they live apart on purpose. platform/auth decides
 // admission on them — that is the ONE place a governed action is admitted, and a
-// quota is an admission term ("scope ∧ tier ∧ quota"). This file is the other
+// volume budget is an admission term ("scope ∧ tier ∧ volume"). This file is the other
 // half: what an answer COSTS, charged where records and effects leave the
 // surface. Splitting them is what keeps a registry from being able to admit
 // itself.
@@ -21,29 +21,29 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 )
 
-// QuotaCharger records what a call spent against the caller's counters.
+// VolumeCharger records what a call spent against the caller's counters.
 // Registry only ever charges; reading a counter and refusing on it belongs to
 // the one admission point, so this half of the seam cannot be used to decide
 // anything.
-type QuotaCharger interface {
-	Consume(ctx context.Context, c agentquota.Counter, n int) error
+type VolumeCharger interface {
+	Consume(ctx context.Context, c agentvolume.Counter, n int) error
 }
 
 // RegistryOption configures a Registry at construction.
 type RegistryOption func(*Registry)
 
-// WithQuotaCharger installs the meter this surface's calls are charged against.
-// It is the same pointer compose hands the admission gate as its Quota, so the
+// WithVolumeCharger installs the meter this surface's calls are charged against.
+// It is the same pointer compose hands the admission gate as its VolumeMeter, so the
 // half that refuses and the half that pays can never end up counting against
 // different windows. A registry without one records nothing — the composition
-// no agent principal reaches (see auth.WithQuota).
-func WithQuotaCharger(quota QuotaCharger) RegistryOption {
-	return func(r *Registry) { r.quota = quota }
+// no agent principal reaches (see auth.WithVolumeMeter).
+func WithVolumeCharger(volume VolumeCharger) RegistryOption {
+	return func(r *Registry) { r.volume = volume }
 }
 
 // chargeCall records one admitted tool call against MCP-SESS-CALLS.
@@ -51,7 +51,7 @@ func WithQuotaCharger(quota QuotaCharger) RegistryOption {
 // It runs after admission and BEFORE the handler, which is the only point at
 // which the answer to "has anything happened yet?" is no. That is what lets it
 // refuse: a call this surface cannot count is a call it does not make, and the
-// ceiling MCP-SESS-CALLS defends is the one every other quota sits under —
+// ceiling MCP-SESS-CALLS defends is the one every other counter sits under —
 // leaving it uncounted while Redis blinks would let a flood through the gap.
 //
 // It charges ADMITTED calls, not attempted ones. A call the gate turned away
@@ -70,10 +70,10 @@ const (
 )
 
 func (r *Registry) chargeCall(ctx context.Context, spec mcp.ToolSpec, mayRefuse refusable) error {
-	if r.quota == nil {
+	if r.volume == nil {
 		return nil
 	}
-	err := r.quota.Consume(ctx, agentquota.Calls, 1)
+	err := r.volume.Consume(ctx, agentvolume.Calls, 1)
 	if err == nil {
 		return nil
 	}
@@ -103,13 +103,13 @@ func (r *Registry) chargeCall(ctx context.Context, spec mcp.ToolSpec, mayRefuse 
 // It charges only after a SUCCESSFUL answer: these counters measure what the
 // agent was actually given, and a handler that failed gave it none.
 func (r *Registry) chargeAnswer(ctx context.Context, spec mcp.ToolSpec, served int) error {
-	if r.quota == nil {
+	if r.volume == nil {
 		return nil
 	}
-	if err := r.charge(ctx, spec, agentquota.Reads, served); err != nil {
+	if err := r.charge(ctx, spec, agentvolume.Reads, served); err != nil {
 		return err
 	}
-	if act := agentquota.CounterFor(spec); act != agentquota.Reads {
+	if act := agentvolume.CounterFor(spec); act != agentvolume.Reads {
 		return r.charge(ctx, spec, act, 1)
 	}
 	return nil
@@ -134,16 +134,16 @@ func (r *Registry) chargeAnswer(ctx context.Context, spec mcp.ToolSpec, served i
 // a TRANSIENT write error is lost for good: Redis recovers, the counter comes
 // back short, and those records are read again for free. Every blip would
 // quietly raise the ceiling.
-func (r *Registry) charge(ctx context.Context, spec mcp.ToolSpec, c agentquota.Counter, n int) error {
+func (r *Registry) charge(ctx context.Context, spec mcp.ToolSpec, c agentvolume.Counter, n int) error {
 	if n <= 0 {
 		return nil
 	}
-	err := r.quota.Consume(ctx, c, n)
+	err := r.volume.Consume(ctx, c, n)
 	if err == nil {
 		return nil
 	}
 	slog.ErrorContext(ctx, "recording what an answer spent against its quota failed",
-		"tool", spec.Name, "quota", string(c), "amount", n, "read_only", spec.ReadOnly(), "err", err)
+		"tool", spec.Name, "counter", string(c), "amount", n, "read_only", spec.ReadOnly(), "err", err)
 	if !spec.ReadOnly() || spec.Egress {
 		// The effect already happened. Reporting it as a failure is worse than
 		// an uncounted write.
@@ -156,7 +156,7 @@ func (r *Registry) charge(ctx context.Context, spec mcp.ToolSpec, c agentquota.C
 		return nil
 	}
 	return fmt.Errorf(
-		"crmagents: %s spent %d %s that could not be counted against this agent's quota, so the answer is withheld: %w",
+		"crmagents: %s spent %d %s that could not be counted against this agent's volume budget, so the answer is withheld: %w",
 		spec.Name, n, c, apperrors.ErrBudgetExceeded)
 }
 
@@ -169,7 +169,7 @@ func (r *Registry) charge(ctx context.Context, spec mcp.ToolSpec, c agentquota.C
 // one counter safe to read here because it refuses nothing — the only thing
 // this surface does with the answer is say it.
 type CostShareReader interface {
-	CostShare(ctx context.Context) agentquota.Reading
+	CostShare(ctx context.Context) agentvolume.Reading
 }
 
 // WithCostShare installs the reader behind the cost warning. A registry without
@@ -185,7 +185,7 @@ const warningCostShare = "ai_budget_share_spent"
 // noteCostShare says so on the answer when this agent is past its share.
 //
 // SAYING is the whole control. MCP-SESS-COST is soft by the spec's own word, so
-// there is no refusal to make and no window to wait for — what the quota exists
+// there is no refusal to make and no window to wait for — what the volume budget exists
 // to produce is the fact being VISIBLE to the human reading the answer, and a
 // counter nobody is ever shown is a counter that governs nothing.
 //
@@ -238,12 +238,12 @@ func (r *Registry) ChargeAdmittedCall(ctx context.Context, spec mcp.ToolSpec) er
 // read has committed nothing, while a mutation's body is written after its
 // effect landed.
 func (r *Registry) ChargeServedRecords(ctx context.Context, n int) error {
-	if r.quota == nil || n <= 0 {
+	if r.volume == nil || n <= 0 {
 		return nil
 	}
-	if err := r.quota.Consume(ctx, agentquota.Reads, n); err != nil {
+	if err := r.volume.Consume(ctx, agentvolume.Reads, n); err != nil {
 		slog.ErrorContext(ctx, "recording the records a REST response served against the read bound failed",
-			"quota", string(agentquota.Reads), "records", n, "err", err)
+			"counter", string(agentvolume.Reads), "records", n, "err", err)
 		return fmt.Errorf(
 			"crmagents: %d records could not be counted against this agent's read bound: %w",
 			n, apperrors.ErrBudgetExceeded)
@@ -268,15 +268,15 @@ func (r *Registry) ChargeRedeemedCall(ctx context.Context, spec mcp.ToolSpec) {
 // accounting loss where a reported failure would invite the retry of something
 // that already happened.
 func (r *Registry) ChargeEffect(ctx context.Context, spec mcp.ToolSpec) {
-	if r.quota == nil {
+	if r.volume == nil {
 		return
 	}
-	act := agentquota.CounterFor(spec)
-	if act == agentquota.Reads {
+	act := agentvolume.CounterFor(spec)
+	if act == agentvolume.Reads {
 		return
 	}
-	if err := r.quota.Consume(ctx, act, 1); err != nil {
+	if err := r.volume.Consume(ctx, act, 1); err != nil {
 		slog.ErrorContext(ctx, "recording a completed REST effect against its quota failed",
-			"tool", spec.Name, "quota", string(act), "err", err)
+			"tool", spec.Name, "counter", string(act), "err", err)
 	}
 }

--- a/backend/internal/modules/agents/volume_test.go
+++ b/backend/internal/modules/agents/volume_test.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -23,21 +23,21 @@ import (
 // COUNTER, because most of what is worth asserting here is that a call was
 // charged against the right one.
 type countingCharger struct {
-	charged map[agentquota.Counter]int
-	times   map[agentquota.Counter]int
+	charged map[agentvolume.Counter]int
+	times   map[agentvolume.Counter]int
 	err     error
 	// errOn narrows a failing meter to ONE counter. Redis being down fails
 	// every charge, and a test about the answer-stage asymmetry needs the
 	// call-ceiling charge — which runs first and refuses before the handler —
 	// to succeed, or it proves the wrong refusal.
-	errOn agentquota.Counter
+	errOn agentvolume.Counter
 }
 
 func newCountingCharger() *countingCharger {
-	return &countingCharger{charged: map[agentquota.Counter]int{}, times: map[agentquota.Counter]int{}}
+	return &countingCharger{charged: map[agentvolume.Counter]int{}, times: map[agentvolume.Counter]int{}}
 }
 
-func (c *countingCharger) Consume(_ context.Context, counter agentquota.Counter, n int) error {
+func (c *countingCharger) Consume(_ context.Context, counter agentvolume.Counter, n int) error {
 	c.times[counter]++
 	c.charged[counter] += n
 	if c.err != nil && (c.errOn == "" || c.errOn == counter) {
@@ -47,7 +47,7 @@ func (c *countingCharger) Consume(_ context.Context, counter agentquota.Counter,
 }
 
 // reads is what the counter every pre-existing spec here is about was charged.
-func (c *countingCharger) reads() int { return c.charged[agentquota.Reads] }
+func (c *countingCharger) reads() int { return c.charged[agentvolume.Reads] }
 
 // servingTool hands back the records it was built with, through the ONE place
 // a datasource.Record becomes tool output — so it exercises the charge point
@@ -89,7 +89,7 @@ func chargingRegistry(t *testing.T, tool mcp.Tool, opts ...chargeTestOption) (*R
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	r := NewRegistry(cfg.approvals, auth.NewGate(fullSeatAuthority{}), WithQuotaCharger(cfg.charger))
+	r := NewRegistry(cfg.approvals, auth.NewGate(fullSeatAuthority{}), WithVolumeCharger(cfg.charger))
 	if cfg.noCharger {
 		r = NewRegistry(cfg.approvals, auth.NewGate(fullSeatAuthority{}))
 	}
@@ -119,7 +119,7 @@ func withChargerError(err error) chargeTestOption {
 }
 
 // withChargerErrorOn makes exactly one counter unrecordable.
-func withChargerErrorOn(counter agentquota.Counter, err error) chargeTestOption {
+func withChargerErrorOn(counter agentvolume.Counter, err error) chargeTestOption {
 	return func(c *chargeTest) { c.charger.err, c.charger.errOn = err, counter }
 }
 
@@ -196,8 +196,8 @@ func TestAFailedAnswerChargesNothing(t *testing.T) {
 		t.Fatal("the failing handler reported success")
 	}
 
-	if charger.times[agentquota.Reads] != 0 {
-		t.Errorf("a failed answer charged the read bound %d times", charger.times[agentquota.Reads])
+	if charger.times[agentvolume.Reads] != 0 {
+		t.Errorf("a failed answer charged the read bound %d times", charger.times[agentvolume.Reads])
 	}
 }
 
@@ -211,8 +211,8 @@ func TestAnAnswerWithNoRecordsChargesNothing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if charger.times[agentquota.Reads] != 0 {
-		t.Errorf("a record-free answer charged the read bound %d times", charger.times[agentquota.Reads])
+	if charger.times[agentvolume.Reads] != 0 {
+		t.Errorf("a record-free answer charged the read bound %d times", charger.times[agentvolume.Reads])
 	}
 }
 
@@ -311,7 +311,7 @@ func TestAWriteIsServedEvenWhenItsChargeCannotBeRecorded(t *testing.T) {
 		// The ANSWER-stage charge is the one that fails here: by then the send
 		// has happened. A meter that failed the call-ceiling charge too would
 		// refuse before the handler ran, which is the opposite property.
-		withChargerErrorOn(agentquota.Reads, errors.New("redis is unreachable")))
+		withChargerErrorOn(agentvolume.Reads, errors.New("redis is unreachable")))
 
 	out, err := r.Invoke(ctx, "send_email", json.RawMessage(`{}`))
 	if err != nil {
@@ -322,7 +322,7 @@ func TestAWriteIsServedEvenWhenItsChargeCannotBeRecorded(t *testing.T) {
 	}
 }
 
-// Every admitted call spends the ceiling every other quota sits under, and it
+// Every admitted call spends the ceiling every other counter sits under, and it
 // spends exactly one however many records the answer carried. Charging it per
 // record would make MCP-SESS-CALLS a second read bound with a different number.
 func TestEveryAdmittedCallSpendsOneOfTheCallCeiling(t *testing.T) {
@@ -332,19 +332,19 @@ func TestEveryAdmittedCallSpendsOneOfTheCallCeiling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := charger.charged[agentquota.Calls]; got != 1 {
+	if got := charger.charged[agentvolume.Calls]; got != 1 {
 		t.Errorf("one call answering 20 records spent %d of the call ceiling, want 1", got)
 	}
 }
 
 // A call the meter cannot COUNT does not run. This is the one charge point at
 // which nothing has happened yet, which is exactly what lets it refuse — and
-// the ceiling it defends is the one every other quota sits under, so leaving it
+// the ceiling it defends is the one every other counter sits under, so leaving it
 // uncounted while Redis blinks would let a flood through the gap.
 func TestACallThatCannotBeCountedIsNotRun(t *testing.T) {
 	tool := &servingTool{spec: readToolSpec("search_records"), records: 5}
 	r, charger, ctx := chargingRegistry(t, tool,
-		withChargerErrorOn(agentquota.Calls, errors.New("redis is unreachable")))
+		withChargerErrorOn(agentvolume.Calls, errors.New("redis is unreachable")))
 
 	out, err := r.Invoke(ctx, "search_records", json.RawMessage(`{}`))
 
@@ -354,7 +354,7 @@ func TestACallThatCannotBeCountedIsNotRun(t *testing.T) {
 	if out != nil {
 		t.Error("the answer was served anyway")
 	}
-	if charger.times[agentquota.Reads] != 0 {
+	if charger.times[agentvolume.Reads] != 0 {
 		t.Error("the handler ran: records were charged for a call that was never counted")
 	}
 }
@@ -368,10 +368,10 @@ func TestTheActIsChargedAgainstTheCounterItsKindNames(t *testing.T) {
 		name    string
 		scope   principal.Scope
 		egress  bool
-		counter agentquota.Counter
+		counter agentvolume.Counter
 	}{
-		{"update_record", principal.ScopeWrite, false, agentquota.Writes},
-		{"send_email", principal.ScopeSend, true, agentquota.Egress},
+		{"update_record", principal.ScopeWrite, false, agentvolume.Writes},
+		{"send_email", principal.ScopeSend, true, agentvolume.Egress},
 	}
 	for _, c := range cases {
 		spec := readToolSpec(c.name)
@@ -386,10 +386,10 @@ func TestTheActIsChargedAgainstTheCounterItsKindNames(t *testing.T) {
 			t.Errorf("%s spent %d of %s, want 1", c.name, got, c.counter)
 		}
 		// And nothing of the OTHER act counter: a send that also spent the write
-		// quota would exhaust the loose bound while the tight one guarded nothing.
-		other := agentquota.Writes
-		if c.counter == agentquota.Writes {
-			other = agentquota.Egress
+		// volume budget would exhaust the loose bound while the tight one guarded nothing.
+		other := agentvolume.Writes
+		if c.counter == agentvolume.Writes {
+			other = agentvolume.Egress
 		}
 		if got := charger.charged[other]; got != 0 {
 			t.Errorf("%s also spent %d of %s", c.name, got, other)
@@ -410,8 +410,8 @@ func TestAReadOnlyToolIsChargedForItsRecordsAndNotAlsoForTheAct(t *testing.T) {
 	if charger.reads() != 4 {
 		t.Errorf("a 4-record read charged %d", charger.reads())
 	}
-	if charger.times[agentquota.Reads] != 1 {
-		t.Errorf("a read-only answer touched the read counter %d times, want one", charger.times[agentquota.Reads])
+	if charger.times[agentvolume.Reads] != 1 {
+		t.Errorf("a read-only answer touched the read counter %d times, want one", charger.times[agentvolume.Reads])
 	}
 }
 
@@ -429,15 +429,15 @@ func TestTheRestDoorChargesTheSameCountersTheMCPDoorDoes(t *testing.T) {
 	}
 	r.ChargeEffect(ctx, spec)
 
-	if got := charger.charged[agentquota.Calls]; got != 1 {
+	if got := charger.charged[agentvolume.Calls]; got != 1 {
 		t.Errorf("a REST call spent %d of the call ceiling, want 1", got)
 	}
-	if got := charger.charged[agentquota.Writes]; got != 1 {
+	if got := charger.charged[agentvolume.Writes]; got != 1 {
 		t.Errorf("a REST mutation spent %d of the write quota, want 1", got)
 	}
 	// And no records: a mutation's own read-back is not this call's to count,
 	// and the REST read path is charged separately and per record.
-	if got := charger.charged[agentquota.Reads]; got != 0 {
+	if got := charger.charged[agentvolume.Reads]; got != 0 {
 		t.Errorf("a REST mutation spent %d records", got)
 	}
 }
@@ -448,7 +448,7 @@ func TestARestCallThatCannotBeCountedIsRefused(t *testing.T) {
 	spec := readToolSpec("update_record")
 	spec.RequiredScope = principal.ScopeWrite
 	r, _, ctx := chargingRegistry(t, &servingTool{spec: spec}, withScope(principal.ScopeWrite),
-		withChargerErrorOn(agentquota.Calls, errors.New("redis is unreachable")))
+		withChargerErrorOn(agentvolume.Calls, errors.New("redis is unreachable")))
 
 	if err := r.ChargeAdmittedCall(ctx, spec); !errors.Is(err, apperrors.ErrBudgetExceeded) {
 		t.Fatalf("an uncountable REST call → %v, want ErrBudgetExceeded", err)
@@ -466,7 +466,7 @@ func TestARestEffectThatCannotBeCountedIsStillDone(t *testing.T) {
 
 	r.ChargeEffect(ctx, spec) // no error to return, and must not panic
 
-	if got := charger.times[agentquota.Egress]; got != 1 {
+	if got := charger.times[agentvolume.Egress]; got != 1 {
 		t.Errorf("the egress charge was attempted %d times", got)
 	}
 }
@@ -542,7 +542,7 @@ func TestOneToolCallSpendsOneOfTheCallCeiling(t *testing.T) {
 				t.Fatalf("the call answered %v, want %v — this case is not the arm it names", err, tc.wantErr)
 			}
 
-			if got := charger.charged[agentquota.Calls]; got != tc.wantCalls {
+			if got := charger.charged[agentvolume.Calls]; got != tc.wantCalls {
 				t.Errorf("the call ceiling was charged %d, want %d", got, tc.wantCalls)
 			}
 		})

--- a/backend/internal/modules/agents/volumerelease.go
+++ b/backend/internal/modules/agents/volumerelease.go
@@ -19,23 +19,23 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// QuotaReleaseRequest is what the surface asks the approvals engine to put in
+// VolumeReleaseRequest is what the surface asks the approvals engine to put in
 // front of the human who lent this passport.
-type QuotaReleaseRequest struct {
+type VolumeReleaseRequest struct {
 	// Proposal is the question itself, in the one spelling both modules read.
-	Proposal agentquota.ReleaseProposal
+	Proposal agentvolume.ReleaseProposal
 	// Summary is the sentence the inbox shows.
 	Summary string
 }
 
-// StepUpStagedError answers a call refused on a releasable quota once the
+// StepUpStagedError answers a call refused on a releasable volume budget once the
 // question has been put to a human.
 //
 // It is its own type, and it does NOT unwrap to ErrRequiresApproval. That
@@ -45,7 +45,7 @@ type QuotaReleaseRequest struct {
 // refusal actually is: a volume threshold, now with a human looking at it.
 type StepUpStagedError struct {
 	ApprovalID ids.ApprovalID
-	Counter    agentquota.Counter
+	Counter    agentvolume.Counter
 }
 
 func (e *StepUpStagedError) Error() string {
@@ -58,11 +58,11 @@ func (e *StepUpStagedError) Error() string {
 // mapping — seeing this for what it is.
 func (e *StepUpStagedError) Unwrap() error { return apperrors.ErrBudgetExceeded }
 
-// releasableQuotaRefusal answers the refusal a human can still say yes to, and
-// nil for every other outcome — including a quota refusal on a hard stop, which
+// releasableVolumeRefusal answers the refusal a human can still say yes to, and
+// nil for every other outcome — including a volume budget refusal on a hard stop, which
 // no approval lifts and which must therefore never reach an inbox.
-func releasableQuotaRefusal(err error) *auth.QuotaExceededError {
-	var over *auth.QuotaExceededError
+func releasableVolumeRefusal(err error) *auth.VolumeExceededError {
+	var over *auth.VolumeExceededError
 	if errors.As(err, &over) && over.Releasable() {
 		return over
 	}
@@ -74,23 +74,23 @@ func releasableQuotaRefusal(err error) *auth.QuotaExceededError {
 // validating first, so no human is asked to release a call that could not have
 // run anyway.
 func askedOfAHuman(err error) bool {
-	return err == nil || errors.Is(err, apperrors.ErrRequiresApproval) || releasableQuotaRefusal(err) != nil
+	return err == nil || errors.Is(err, apperrors.ErrRequiresApproval) || releasableVolumeRefusal(err) != nil
 }
 
-// stageStepUp puts a releasable quota refusal in front of the human who lent
+// stageStepUp puts a releasable volume budget refusal in front of the human who lent
 // this passport, and answers what the agent is told.
 //
 // The REFUSAL IS STILL THE ANSWER if the question cannot be asked. A surface
 // with no approvals engine, a staging that fails, and a human who has already
 // REJECTED this question all end the same way: the call is refused on the
-// quota, exactly as it would have been. That is the conservative direction —
+// volume budget, exactly as it would have been. That is the conservative direction —
 // the alternative is a refused call reported as an error about staging, which
 // tells the agent to retry the staging rather than to stop.
 //
 // A human's NO is remembered, which is the whole reason this goes through the
 // declined-aware staging path. An agent looping on a refusal would otherwise
 // re-ask a question its human just answered, once per call, forever.
-func (r *Registry) stageStepUp(ctx context.Context, refusal *auth.QuotaExceededError) error {
+func (r *Registry) stageStepUp(ctx context.Context, refusal *auth.VolumeExceededError) error {
 	if r.approvals == nil {
 		return refusal
 	}
@@ -100,16 +100,16 @@ func (r *Registry) stageStepUp(ctx context.Context, refusal *auth.QuotaExceededE
 	//
 	// No passport, no question. A step-up names WHOSE window it is, and one
 	// stamped with the zero uuid names nobody: the identity would collide with
-	// every other such call, and applyQuotaRelease refuses to release a row
+	// every other such call, and applyVolumeRelease refuses to release a row
 	// without a passport anyway — so staging it would put a question in an inbox
-	// that approving could never answer. The quota refusal stands instead, which
+	// that approving could never answer. The volume budget refusal stands instead, which
 	// is the same conservative direction every other branch here takes.
 	actor, present := principal.Actor(ctx)
 	if !present || actor.PassportID == (ids.UUID{}) {
 		return refusal
 	}
-	proposal := agentquota.NewReleaseProposal(refusal.Reading, actor.PassportID, refusal.Tool)
-	id, staged, err := r.approvals.StageQuotaRelease(ctx, QuotaReleaseRequest{
+	proposal := agentvolume.NewReleaseProposal(refusal.Reading, actor.PassportID, refusal.Tool)
+	id, staged, err := r.approvals.StageVolumeRelease(ctx, VolumeReleaseRequest{
 		Proposal: proposal,
 		Summary:  stepUpSummary(proposal),
 	})
@@ -118,7 +118,7 @@ func (r *Registry) stageStepUp(ctx context.Context, refusal *auth.QuotaExceededE
 		// belongs in the log, not in a message that would send the agent back to
 		// retry it.
 		slog.ErrorContext(ctx, "putting a step-up in front of the connecting human failed",
-			"quota", string(refusal.Reading.Counter), "tool", refusal.Tool, "err", err)
+			"counter", string(refusal.Reading.Counter), "tool", refusal.Tool, "err", err)
 		return refusal
 	}
 	if !staged {
@@ -130,10 +130,10 @@ func (r *Registry) stageStepUp(ctx context.Context, refusal *auth.QuotaExceededE
 // stepUpSummary is the question, in the human's words rather than the counter's.
 // It states the volume, the ceiling and the consequence of saying yes, because a
 // human answering "continue?" with no numbers is answering nothing.
-func stepUpSummary(p agentquota.ReleaseProposal) string {
+func stepUpSummary(p agentvolume.ReleaseProposal) string {
 	act := "been handed"
 	unit := "records"
-	if p.Counter != agentquota.Reads {
+	if p.Counter != agentvolume.Reads {
 		act, unit = "made", "changes"
 	}
 	return fmt.Sprintf(

--- a/backend/internal/modules/agents/volumerelease_test.go
+++ b/backend/internal/modules/agents/volumerelease_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -20,17 +20,17 @@ import (
 // crossedQuota is a meter that reports one counter already spent — the state
 // every rung of the ladder is entered from.
 type crossedQuota struct {
-	counter  agentquota.Counter
+	counter  agentvolume.Counter
 	observed int
 	limit    int
 	bucket   int64
 }
 
-func (q crossedQuota) Read(_ context.Context, c agentquota.Counter) agentquota.Reading {
+func (q crossedQuota) Read(_ context.Context, c agentvolume.Counter) agentvolume.Reading {
 	if c != q.counter {
-		return agentquota.Reading{Counter: c, Limit: 1000, Bucket: q.bucket}
+		return agentvolume.Reading{Counter: c, Limit: 1000, Bucket: q.bucket}
 	}
-	return agentquota.Reading{
+	return agentvolume.Reading{
 		Counter: c, Observed: q.observed, Limit: q.limit, Exceeded: true, Bucket: q.bucket,
 	}
 }
@@ -39,7 +39,7 @@ func (q crossedQuota) Read(_ context.Context, c agentquota.Counter) agentquota.R
 func steppedUpRegistry(t *testing.T, quota crossedQuota, scope principal.Scope, egress bool) (*Registry, *recordingApprovals, context.Context) {
 	t.Helper()
 	staging := &recordingApprovals{}
-	r := NewRegistry(staging, auth.NewGate(fullSeatAuthority{}, auth.WithQuota(quota)))
+	r := NewRegistry(staging, auth.NewGate(fullSeatAuthority{}, auth.WithVolumeMeter(quota)))
 	spec := readToolSpec("search_records")
 	spec.RequiredScope, spec.Egress = scope, egress
 	if scope != principal.ScopeRead {
@@ -63,7 +63,7 @@ func steppedUpRegistry(t *testing.T, quota crossedQuota, scope principal.Scope, 
 // bulk reading into a dead end rather than into a visible, gated event.
 func TestACrossedReadThresholdPutsTheQuestionToTheConnectingHuman(t *testing.T) {
 	r, staging, ctx := steppedUpRegistry(t,
-		crossedQuota{counter: agentquota.Reads, observed: 2431, limit: 2000, bucket: 42},
+		crossedQuota{counter: agentvolume.Reads, observed: 2431, limit: 2000, bucket: 42},
 		principal.ScopeRead, false)
 
 	_, err := r.Invoke(ctx, "search_records", json.RawMessage(`{}`))
@@ -82,7 +82,7 @@ func TestACrossedReadThresholdPutsTheQuestionToTheConnectingHuman(t *testing.T) 
 		t.Fatalf("the human was asked %d times, want once", len(staging.steppedUp))
 	}
 	asked := staging.steppedUp[0].Proposal
-	if asked.Counter != agentquota.Reads || asked.Observed != 2431 || asked.Limit != 2000 || asked.Bucket != "42" {
+	if asked.Counter != agentvolume.Reads || asked.Observed != 2431 || asked.Limit != 2000 || asked.Bucket != "42" {
 		t.Errorf("the question carried %+v; it must name what was spent, against what, in which window", asked)
 	}
 	if !strings.Contains(staging.steppedUp[0].Summary, "2431") || !strings.Contains(staging.steppedUp[0].Summary, "2000") {
@@ -95,7 +95,7 @@ func TestACrossedReadThresholdPutsTheQuestionToTheConnectingHuman(t *testing.T) 
 // path for "may it keep writing" is a second thing to get wrong.
 func TestACrossedWriteThresholdAsksTheSameQuestion(t *testing.T) {
 	r, staging, ctx := steppedUpRegistry(t,
-		crossedQuota{counter: agentquota.Writes, observed: 240, limit: 200, bucket: 9},
+		crossedQuota{counter: agentvolume.Writes, observed: 240, limit: 200, bucket: 9},
 		principal.ScopeWrite, false)
 
 	_, err := r.Invoke(ctx, "update_record", json.RawMessage(`{}`))
@@ -104,7 +104,7 @@ func TestACrossedWriteThresholdAsksTheSameQuestion(t *testing.T) {
 	if !errors.As(err, &staged) {
 		t.Fatalf("a write past its threshold → %v, want a staged step-up", err)
 	}
-	if len(staging.steppedUp) != 1 || staging.steppedUp[0].Proposal.Counter != agentquota.Writes {
+	if len(staging.steppedUp) != 1 || staging.steppedUp[0].Proposal.Counter != agentvolume.Writes {
 		t.Fatalf("the human was asked %+v", staging.steppedUp)
 	}
 	if strings.Contains(staging.steppedUp[0].Summary, "records") {
@@ -118,12 +118,12 @@ func TestACrossedWriteThresholdAsksTheSameQuestion(t *testing.T) {
 // agent would wait for it.
 func TestAHardStopNeverReachesAHumansInbox(t *testing.T) {
 	r, staging, ctx := steppedUpRegistry(t,
-		crossedQuota{counter: agentquota.Egress, observed: 21, limit: 20, bucket: 3},
+		crossedQuota{counter: agentvolume.Egress, observed: 21, limit: 20, bucket: 3},
 		principal.ScopeSend, true)
 
 	_, err := r.Invoke(ctx, "send_email", json.RawMessage(`{}`))
 
-	var overQuota *auth.QuotaExceededError
+	var overQuota *auth.VolumeExceededError
 	if !errors.As(err, &overQuota) {
 		t.Fatalf("a send past its ceiling → %v, want a plain quota refusal", err)
 	}
@@ -141,7 +141,7 @@ func TestAHardStopNeverReachesAHumansInbox(t *testing.T) {
 // though reads are releasable.
 func TestASuspendedAgentIsRefusedWithoutAskingAnyone(t *testing.T) {
 	r, staging, ctx := steppedUpRegistry(t,
-		crossedQuota{counter: agentquota.Calls, observed: 1001, limit: 1000, bucket: 3},
+		crossedQuota{counter: agentvolume.Calls, observed: 1001, limit: 1000, bucket: 3},
 		principal.ScopeRead, false)
 
 	_, err := r.Invoke(ctx, "search_records", json.RawMessage(`{}`))
@@ -159,7 +159,7 @@ func TestASuspendedAgentIsRefusedWithoutAskingAnyone(t *testing.T) {
 // call, and the refusal they intended becomes a stream of notifications.
 func TestAQuestionAlreadyRefusedIsNotAskedAgain(t *testing.T) {
 	r, staging, ctx := steppedUpRegistry(t,
-		crossedQuota{counter: agentquota.Reads, observed: 2431, limit: 2000, bucket: 42},
+		crossedQuota{counter: agentvolume.Reads, observed: 2431, limit: 2000, bucket: 42},
 		principal.ScopeRead, false)
 	staging.stepUpDeclined = true
 
@@ -174,13 +174,13 @@ func TestAQuestionAlreadyRefusedIsNotAskedAgain(t *testing.T) {
 	}
 }
 
-// A staging that FAILS leaves the quota refusal as the answer. Reporting the
+// A staging that FAILS leaves the volume budget refusal as the answer. Reporting the
 // staging failure instead would tell the agent to retry the staging, which is
 // our problem and not one it can do anything about — and would hide the refusal
 // that is the real reason the call did not run.
 func TestAFailedStagingLeavesTheQuotaRefusalAsTheAnswer(t *testing.T) {
 	r, staging, ctx := steppedUpRegistry(t,
-		crossedQuota{counter: agentquota.Reads, observed: 2431, limit: 2000, bucket: 42},
+		crossedQuota{counter: agentvolume.Reads, observed: 2431, limit: 2000, bucket: 42},
 		principal.ScopeRead, false)
 	staging.stepUpErr = errors.New("the inbox is unreachable")
 
@@ -199,9 +199,9 @@ func TestAFailedStagingLeavesTheQuotaRefusalAsTheAnswer(t *testing.T) {
 // with every other such call, and the release path refuses a row without a
 // passport — so the question could never be answered even if it were asked.
 func TestACallerWithNoPassportIsRefusedWithoutAskingAnyone(t *testing.T) {
-	quota := crossedQuota{counter: agentquota.Reads, observed: 2431, limit: 2000, bucket: 42}
+	quota := crossedQuota{counter: agentvolume.Reads, observed: 2431, limit: 2000, bucket: 42}
 	staging := &recordingApprovals{}
-	r := NewRegistry(staging, auth.NewGate(fullSeatAuthority{}, auth.WithQuota(quota)))
+	r := NewRegistry(staging, auth.NewGate(fullSeatAuthority{}, auth.WithVolumeMeter(quota)))
 	r.Register(&servingTool{spec: readToolSpec("search_records"), records: 1})
 	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
 	ctx = principal.WithActor(ctx, principal.Principal{
@@ -220,11 +220,11 @@ func TestACallerWithNoPassportIsRefusedWithoutAskingAnyone(t *testing.T) {
 }
 
 // A surface with no approvals engine still refuses, and refuses the same way.
-// The Surface-B runner composes one; a quota refusal there has nowhere to land
+// The Surface-B runner composes one; a volume budget refusal there has nowhere to land
 // and must not become an error about the composition.
 func TestASurfaceWithNoInboxStillRefusesOnTheQuota(t *testing.T) {
-	quota := crossedQuota{counter: agentquota.Reads, observed: 2431, limit: 2000, bucket: 42}
-	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}, auth.WithQuota(quota)))
+	quota := crossedQuota{counter: agentvolume.Reads, observed: 2431, limit: 2000, bucket: 42}
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}, auth.WithVolumeMeter(quota)))
 	r.Register(&servingTool{spec: readToolSpec("search_records"), records: 1})
 	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
 	ctx = principal.WithActor(ctx, principal.Principal{
@@ -247,11 +247,11 @@ func TestTheTwoRungsGiveTheAgentDifferentInstructions(t *testing.T) {
 	d := NewDispatcher(nil, bindAuthenticated, "test", "1")
 
 	stepUp := d.explain("search_records", &StepUpStagedError{
-		ApprovalID: ids.New[ids.ApprovalKind](), Counter: agentquota.Reads,
+		ApprovalID: ids.New[ids.ApprovalKind](), Counter: agentvolume.Reads,
 	})
-	hardStop := d.explain("send_email", &auth.QuotaExceededError{
+	hardStop := d.explain("send_email", &auth.VolumeExceededError{
 		Tool:    "send_email",
-		Reading: agentquota.Reading{Counter: agentquota.Egress, Observed: 21, Limit: 20, Exceeded: true},
+		Reading: agentvolume.Reading{Counter: agentvolume.Egress, Observed: 21, Limit: 20, Exceeded: true},
 	})
 
 	if !strings.Contains(stepUp, "repeat this call unchanged") || !strings.Contains(stepUp, "Do not send an approval_id") {
@@ -272,9 +272,9 @@ func TestTheTwoRungsGiveTheAgentDifferentInstructions(t *testing.T) {
 func TestADeclinedStepUpDoesNotClaimNoApprovalCouldLiftIt(t *testing.T) {
 	d := NewDispatcher(nil, bindAuthenticated, "test", "1")
 
-	answer := d.explain("search_records", &auth.QuotaExceededError{
+	answer := d.explain("search_records", &auth.VolumeExceededError{
 		Tool:    "search_records",
-		Reading: agentquota.Reading{Counter: agentquota.Reads, Observed: 4000, Limit: 4000, Exceeded: true},
+		Reading: agentvolume.Reading{Counter: agentvolume.Reads, Observed: 4000, Limit: 4000, Exceeded: true},
 	})
 
 	if strings.Contains(answer, "no approval lifts it") {
@@ -290,11 +290,11 @@ func TestADeclinedStepUpDoesNotClaimNoApprovalCouldLiftIt(t *testing.T) {
 
 // spentShare is a cost reader whose share is already gone.
 type spentShare struct {
-	reading agentquota.Reading
+	reading agentvolume.Reading
 	asked   int
 }
 
-func (s *spentShare) CostShare(context.Context) agentquota.Reading {
+func (s *spentShare) CostShare(context.Context) agentvolume.Reading {
 	s.asked++
 	return s.reading
 }
@@ -303,8 +303,8 @@ func (s *spentShare) CostShare(context.Context) agentquota.Reading {
 // served, and it carries the fact. A counter that were merely counted, with
 // nothing ever showing it, would govern nothing at all.
 func TestASpentBudgetShareWarnsOnTheAnswerAndWithholdsNothing(t *testing.T) {
-	share := &spentShare{reading: agentquota.Reading{
-		Counter: agentquota.Cost, Observed: 41_000, Limit: 40_000, Exceeded: true,
+	share := &spentShare{reading: agentvolume.Reading{
+		Counter: agentvolume.Cost, Observed: 41_000, Limit: 40_000, Exceeded: true,
 	}}
 	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithCostShare(share))
 	r.Register(&servingTool{spec: readToolSpec("search_records"), records: 1})
@@ -329,7 +329,7 @@ func TestASpentBudgetShareWarnsOnTheAnswerAndWithholdsNothing(t *testing.T) {
 // And under the share, nothing is said. A warning present on every answer says
 // as little as one present on none.
 func TestAnAnswerUnderTheBudgetShareSaysNothingAboutIt(t *testing.T) {
-	share := &spentShare{reading: agentquota.Reading{Counter: agentquota.Cost, Observed: 10, Limit: 40_000}}
+	share := &spentShare{reading: agentvolume.Reading{Counter: agentvolume.Cost, Observed: 10, Limit: 40_000}}
 	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithCostShare(share))
 	r.Register(&servingTool{spec: readToolSpec("search_records"), records: 1})
 	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())

--- a/backend/internal/modules/ai/agentspend.go
+++ b/backend/internal/modules/ai/agentspend.go
@@ -16,12 +16,12 @@ package ai
 import "context"
 
 // AgentTokenSpender records model tokens against the calling agent's own
-// per-Passport window. It is a narrow seam rather than the quota meter itself so
+// per-Passport window. It is a narrow seam rather than the volume meter itself so
 // this module stays unaware of how that window is keyed or stored; compose
 // bridges the two.
 //
 // A call with no agent principal records nothing — the implementation decides
-// that, not this module, because "which callers are governed" is the quota's own
+// that, not this module, because "which callers are governed" is the volume budget's own
 // rule and a second copy of it here would be a second answer.
 type AgentTokenSpender interface {
 	SpendAgentTokens(ctx context.Context, tokens int) error

--- a/backend/internal/modules/ai/agentspend_test.go
+++ b/backend/internal/modules/ai/agentspend_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-// recordingSpender is the quota meter as this module sees it.
+// recordingSpender is the volume meter as this module sees it.
 type recordingSpender struct {
 	tokens int
 	calls  int

--- a/backend/internal/modules/ai/callstore.go
+++ b/backend/internal/modules/ai/callstore.go
@@ -300,7 +300,7 @@ func classifyError(err error) string {
 	case errors.Is(err, errRequestFailed):
 		return "request_failed"
 	// A REFUSAL IS NOT A FAILURE TO ANSWER, and the three are ordered widest
-	// last because a quota and a throttle both wrap a refusal.
+	// last because a volume budget and a throttle both wrap a refusal.
 	//
 	// An operator reads this trace to decide what to do. "provider_error" says
 	// try again or rebind; an exhausted account says top up, and a burst limit

--- a/backend/internal/modules/ai/tracing.go
+++ b/backend/internal/modules/ai/tracing.go
@@ -136,7 +136,7 @@ func (r *Router) serveCacheHit(ctx context.Context, b *binding, trace *Call, tas
 // without a sentinel could only match the message text, which is a second copy
 // of it.
 //
-// A quota refusal never carries it: that walk STOPS at the refusing rung rather
+// A volume budget refusal never carries it: that walk STOPS at the refusing rung rather
 // than reaching the end, so reporting an exhausted ladder would name rungs
 // nobody called.
 var ErrAllTiersFailed = errors.New("ai: every bound tier failed")

--- a/backend/internal/modules/approvals/authority.go
+++ b/backend/internal/modules/approvals/authority.go
@@ -100,7 +100,7 @@ var decisionGrants = map[string][]grantRequirement{
 	// everyone, which is the failure decisionGrantsFor's own comment names — so
 	// the two entries are one decision and TestAStepUpIsDecidedByTheLenderAlone
 	// holds them together.
-	KindQuotaRelease: {},
+	KindVolumeRelease: {},
 
 	"advance_deal": {{tableDeal, principal.ActionUpdate}},
 	// progress_deal is advance_deal plus a timeline note; the gated effect
@@ -377,7 +377,7 @@ const (
 // whether to retry it or abandon it, and nobody else has standing to answer.
 var selfOnlyKinds = map[string]bool{
 	kindLinkedInMatch:     true,
-	KindQuotaRelease:      true,
+	KindVolumeRelease:     true,
 	KindScheduledSendHeld: true,
 	// A vCard review is one member's own uploaded address book, exactly the
 	// LinkedIn-match shape: the staged card names a third party who never

--- a/backend/internal/modules/approvals/decide.go
+++ b/backend/internal/modules/approvals/decide.go
@@ -175,8 +175,8 @@ func (s *Service) runDecisionEffect(ctx context.Context, id ids.ApprovalID, a ro
 	// the reason serverProposed states, and a step-up is always agent-minted.
 	// It widens the window the staging named, from that row's own passport
 	// (quotarelease.go).
-	if approve && a.Kind == KindQuotaRelease {
-		if err := s.applyQuotaRelease(ctx, a); err != nil {
+	if approve && a.Kind == KindVolumeRelease {
+		if err := s.applyVolumeRelease(ctx, a); err != nil {
 			return s.recordEffectFailure(ctx, id,
 				"the agent's window could not be widened, so the approval has not taken effect",
 				fmt.Errorf("approved, but widening the agent's window failed: %w", err))
@@ -300,7 +300,7 @@ func landEditedPayload(
 	if edited == nil {
 		return nil
 	}
-	if a.Kind == KindQuotaRelease {
+	if a.Kind == KindVolumeRelease {
 		return &InvalidEditError{Cause: errors.New("a step-up is answered yes or no, not edited")}
 	}
 	return applyEditedPayload(ctx, tx, id, edited, a, auditEvidence, decidedPayload)

--- a/backend/internal/modules/approvals/decidingactor.go
+++ b/backend/internal/modules/approvals/decidingactor.go
@@ -145,7 +145,7 @@ func agentMayDecide(p principal.Principal, a row, approve bool) error {
 	// it; a passport that can lift its own window has none. Both verdicts, not
 	// just the release: the lender is who this card was raised for, and an agent
 	// answering it at all takes the question away from them.
-	if kind == KindQuotaRelease {
+	if kind == KindVolumeRelease {
 		return fmt.Errorf("a volume step-up is answered by the person who lent this credential, not by it: %w",
 			apperrors.ErrPermissionDenied)
 	}

--- a/backend/internal/modules/approvals/service.go
+++ b/backend/internal/modules/approvals/service.go
@@ -69,10 +69,10 @@ type Service struct {
 	// decision nobody will make again.
 	declines map[string]DeclinedEffect
 	expiries map[string]ExpiredEffect
-	// quota is the volume meter an approved step-up widens (quotarelease.go).
+	// volume budget is the volume meter an approved step-up widens (volumerelease.go).
 	// Nil in a composition that serves no agents, where a step-up can never be
 	// staged in the first place.
-	quota QuotaReleaser
+	quota VolumeReleaser
 	// log carries the cause of a follow-on effect that failed AFTER its own
 	// decision committed (bundle.go). The wire names which member did not land
 	// and nothing about why — internals are not a client's — so this logger is

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -233,8 +233,8 @@ func TestAgentReleaseSpendsTheCapsTheReleaseSpends(t *testing.T) {
 		{"send releases the held draft", agent(principal.ScopeWrite, principal.ScopeSend), "held_draft", true, true},
 		{"a write passport can still cancel one", agent(principal.ScopeWrite), "held_draft", false, true},
 		{"a held scheduled send is the same rule", agent(principal.ScopeWrite), KindScheduledSendHeld, true, false},
-		{"no passport answers its own step-up", agent(principal.ScopeWrite, principal.ScopeSend), KindQuotaRelease, true, false},
-		{"not even to decline it", agent(principal.ScopeWrite), KindQuotaRelease, false, false},
+		{"no passport answers its own step-up", agent(principal.ScopeWrite, principal.ScopeSend), KindVolumeRelease, true, false},
+		{"not even to decline it", agent(principal.ScopeWrite), KindVolumeRelease, false, false},
 		{"a human is bounded by their seat, not by caps", principal.Principal{
 			Type: principal.PrincipalHuman, UserID: ids.NewV7(),
 		}, "held_draft", true, true},

--- a/backend/internal/modules/approvals/volumerelease.go
+++ b/backend/internal/modules/approvals/volumerelease.go
@@ -21,33 +21,33 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-// KindQuotaRelease is the staged kind a step-up asks under. Exported because the
+// KindVolumeRelease is the staged kind a step-up asks under. Exported because the
 // tool surface stages it and the composition root's fitness tests hold it to the
 // same obligations every other kind carries.
-const KindQuotaRelease = "quota_release"
+const KindVolumeRelease = "volume_release"
 
-// QuotaReleaser applies a confirm-and-continue release to the meter.
+// VolumeReleaser applies a confirm-and-continue release to the meter.
 //
 // It is a seam rather than the concrete meter because the meter holds a Redis
 // client, and this module owns rows: a service constructed for a role that
 // serves no agents composes none, and its releases are then a loud absence
 // rather than a silent no-op.
-type QuotaReleaser interface {
-	Release(ctx context.Context, ws, passport ids.UUID, c agentquota.Counter, bucket int64) (bool, error)
+type VolumeReleaser interface {
+	Release(ctx context.Context, ws, passport ids.UUID, c agentvolume.Counter, bucket int64) (bool, error)
 }
 
-// WithQuotaReleaser installs the meter an approved step-up widens.
-func (s *Service) WithQuotaReleaser(r QuotaReleaser) *Service {
+// WithVolumeReleaser installs the meter an approved step-up widens.
+func (s *Service) WithVolumeReleaser(r VolumeReleaser) *Service {
 	s.quota = r
 	return s
 }
 
-// applyQuotaRelease widens the window an approved step-up asked about.
+// applyVolumeRelease widens the window an approved step-up asked about.
 //
 // EVERY INPUT COMES FROM THE STORED ROW, and that is what makes it safe. The
 // passport is the one the staging stamped from the authenticated agent
@@ -62,7 +62,7 @@ func (s *Service) WithQuotaReleaser(r QuotaReleaser) *Service {
 // human answering after the window rolled, and by then the agent is no longer
 // refused: there is nothing to widen because there is nothing to release it
 // from. The decision still stands as the record that they said yes.
-func (s *Service) applyQuotaRelease(ctx context.Context, a row) error {
+func (s *Service) applyVolumeRelease(ctx context.Context, a row) error {
 	if s.quota == nil {
 		return errors.New("crmapprovals: this composition has no quota meter, so a step-up cannot be released")
 	}
@@ -77,7 +77,7 @@ func (s *Service) applyQuotaRelease(ctx context.Context, a row) error {
 	if !ok {
 		return errors.New("crmapprovals: no workspace bound to context")
 	}
-	proposal, err := agentquota.DecodeReleaseProposal(a.ProposedChange)
+	proposal, err := agentvolume.DecodeReleaseProposal(a.ProposedChange)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/modules/approvals/volumerelease_integration_test.go
+++ b/backend/internal/modules/approvals/volumerelease_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -47,11 +47,11 @@ func (e *stagingEnv) asAgent(t *testing.T) context.Context {
 }
 
 // stageStepUp puts one step-up in the inbox, exactly as the tool surface does.
-func (e *stagingEnv) stageStepUp(t *testing.T, counter agentquota.Counter) ids.ApprovalID {
+func (e *stagingEnv) stageStepUp(t *testing.T, counter agentvolume.Counter) ids.ApprovalID {
 	passport := ids.NewV7()
 	t.Helper()
-	proposal := agentquota.NewReleaseProposal(
-		agentquota.Reading{Counter: counter, Observed: 2431, Limit: 2000, Allowance: 2000, Bucket: 42},
+	proposal := agentvolume.NewReleaseProposal(
+		agentvolume.Reading{Counter: counter, Observed: 2431, Limit: 2000, Allowance: 2000, Bucket: 42},
 		passport, "search_records")
 	payload, err := json.Marshal(proposal)
 	if err != nil {
@@ -62,7 +62,7 @@ func (e *stagingEnv) stageStepUp(t *testing.T, counter agentquota.Counter) ids.A
 		t.Fatal(err)
 	}
 	id, staged, err := e.svc.StageUnlessDeclined(e.asAgent(t), StageInput{
-		Kind: KindQuotaRelease, ProposedChange: payload, DiffHash: string(identity),
+		Kind: KindVolumeRelease, ProposedChange: payload, DiffHash: string(identity),
 		Summary: "continue?", JoinPending: true, Identity: identity,
 	})
 	if err != nil || !staged {
@@ -77,12 +77,12 @@ func (e *stagingEnv) stageStepUp(t *testing.T, counter agentquota.Counter) ids.A
 // nor recorded as decided.
 func TestAStepUpCannotBeEditedIntoADifferentQuestion(t *testing.T) {
 	e := setupStaging(t)
-	id := e.stageStepUp(t, agentquota.Reads)
+	id := e.stageStepUp(t, agentvolume.Reads)
 	// The possible edit, not an impossible one: writes is releasable too, so
 	// the meter would have accepted it. What makes it wrong is that nobody was
 	// shown it.
-	edited, err := json.Marshal(agentquota.ReleaseProposal{
-		Counter: agentquota.Writes, Observed: 1, Limit: 2, Allowance: 2, Bucket: "42",
+	edited, err := json.Marshal(agentvolume.ReleaseProposal{
+		Counter: agentvolume.Writes, Observed: 1, Limit: 2, Allowance: 2, Bucket: "42",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -104,11 +104,11 @@ func TestAStepUpCannotBeEditedIntoADifferentQuestion(t *testing.T) {
 	}
 	// jsonb round-trips with its own spacing, so the check is on the decoded
 	// value rather than on bytes a formatter owns.
-	kept, err := agentquota.DecodeReleaseProposal(after.ProposedChange)
+	kept, err := agentvolume.DecodeReleaseProposal(after.ProposedChange)
 	if err != nil {
 		t.Fatalf("the stored payload no longer decodes: %v", err)
 	}
-	if kept.Counter != agentquota.Reads {
+	if kept.Counter != agentvolume.Reads {
 		t.Errorf("the refused edit rewrote the payload to %s", kept.Counter)
 	}
 }
@@ -117,7 +117,7 @@ func TestAStepUpCannotBeEditedIntoADifferentQuestion(t *testing.T) {
 // kind — a step-up nobody can approve is a control with no release.
 func TestAStepUpIsStillApprovableWithoutAnEdit(t *testing.T) {
 	e := setupStaging(t)
-	id := e.stageStepUp(t, agentquota.Reads)
+	id := e.stageStepUp(t, agentvolume.Reads)
 
 	// No meter composed, so the release itself reports the absence loudly —
 	// which is the point: the DECISION was reached, and only the effect could

--- a/backend/internal/modules/approvals/volumerelease_test.go
+++ b/backend/internal/modules/approvals/volumerelease_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
@@ -19,7 +19,7 @@ import (
 type recordingReleaser struct {
 	ws       ids.UUID
 	passport ids.UUID
-	counter  agentquota.Counter
+	counter  agentvolume.Counter
 	bucket   int64
 	calls    int
 	err      error
@@ -30,21 +30,21 @@ type recordingReleaser struct {
 	widened bool
 }
 
-func (r *recordingReleaser) Release(_ context.Context, ws, passport ids.UUID, c agentquota.Counter, bucket int64) (bool, error) {
+func (r *recordingReleaser) Release(_ context.Context, ws, passport ids.UUID, c agentvolume.Counter, bucket int64) (bool, error) {
 	r.calls++
 	r.ws, r.passport, r.counter, r.bucket = ws, passport, c, bucket
 	return r.widened, r.err
 }
 
 // stepUpRow is a staged step-up as the decision path reads it back.
-func stepUpRow(t *testing.T, passport ids.UUID, proposal agentquota.ReleaseProposal) row {
+func stepUpRow(t *testing.T, passport ids.UUID, proposal agentvolume.ReleaseProposal) row {
 	t.Helper()
 	raw, err := json.Marshal(proposal)
 	if err != nil {
 		t.Fatal(err)
 	}
 	id := ids.From[ids.PassportKind](passport)
-	return row{Kind: KindQuotaRelease, PassportID: &id, ProposedChange: raw}
+	return row{Kind: KindVolumeRelease, PassportID: &id, ProposedChange: raw}
 }
 
 func releaseCtx(ws ids.UUID) context.Context {
@@ -58,12 +58,12 @@ func releaseCtx(ws ids.UUID) context.Context {
 func TestAReleaseWidensTheAgentsWindowAndNotTheApproversContext(t *testing.T) {
 	ws, passport := ids.New[ids.WorkspaceKind]().UUID, ids.New[ids.PassportKind]().UUID
 	meter := &recordingReleaser{widened: true}
-	svc := NewService(nil).WithQuotaReleaser(meter)
-	a := stepUpRow(t, passport, agentquota.ReleaseProposal{
-		Counter: agentquota.Reads, Observed: 2431, Limit: 2000, Bucket: "42", Tool: "search_records",
+	svc := NewService(nil).WithVolumeReleaser(meter)
+	a := stepUpRow(t, passport, agentvolume.ReleaseProposal{
+		Counter: agentvolume.Reads, Observed: 2431, Limit: 2000, Bucket: "42", Tool: "search_records",
 	})
 
-	if err := svc.applyQuotaRelease(releaseCtx(ws), a); err != nil {
+	if err := svc.applyVolumeRelease(releaseCtx(ws), a); err != nil {
 		t.Fatal(err)
 	}
 
@@ -73,7 +73,7 @@ func TestAReleaseWidensTheAgentsWindowAndNotTheApproversContext(t *testing.T) {
 	if meter.ws != ws {
 		t.Errorf("released workspace %s, want %s", meter.ws, ws)
 	}
-	if meter.counter != agentquota.Reads || meter.bucket != 42 {
+	if meter.counter != agentvolume.Reads || meter.bucket != 42 {
 		t.Errorf("released %s in window %d, want reads in 42", meter.counter, meter.bucket)
 	}
 }
@@ -84,28 +84,28 @@ func TestAReleaseWidensTheAgentsWindowAndNotTheApproversContext(t *testing.T) {
 // from. Their decision still stands as the record that they said yes.
 func TestAReleaseThatWidenedNothingIsNotAnError(t *testing.T) {
 	meter := &recordingReleaser{widened: false} // the rolled-window answer
-	svc := NewService(nil).WithQuotaReleaser(meter)
+	svc := NewService(nil).WithVolumeReleaser(meter)
 	a := stepUpRow(t, ids.New[ids.PassportKind]().UUID,
-		agentquota.ReleaseProposal{Counter: agentquota.Reads, Bucket: "1"})
+		agentvolume.ReleaseProposal{Counter: agentvolume.Reads, Bucket: "1"})
 
-	if err := svc.applyQuotaRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID), a); err != nil {
+	if err := svc.applyVolumeRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID), a); err != nil {
 		t.Errorf("a release into a rolled window reported an error: %v", err)
 	}
 }
 
-// A payload naming a quota no human can release is refused. It matters because
+// A payload naming a volume budget no human can release is refused. It matters because
 // the staged payload is EDITABLE — the modify-then-approve arm pins entity
 // references, and this payload has none — so "egress" is a value an approver
 // can type into a question that was asked about reads.
 func TestAnEditedPayloadCannotTurnAStepUpIntoAHardStopRelease(t *testing.T) {
 	meter := &recordingReleaser{}
-	svc := NewService(nil).WithQuotaReleaser(meter)
+	svc := NewService(nil).WithVolumeReleaser(meter)
 
-	for _, counter := range []agentquota.Counter{agentquota.Egress, agentquota.Calls, agentquota.Cost} {
+	for _, counter := range []agentvolume.Counter{agentvolume.Egress, agentvolume.Calls, agentvolume.Cost} {
 		a := stepUpRow(t, ids.New[ids.PassportKind]().UUID,
-			agentquota.ReleaseProposal{Counter: counter, Bucket: "1"})
+			agentvolume.ReleaseProposal{Counter: counter, Bucket: "1"})
 
-		err := svc.applyQuotaRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID), a)
+		err := svc.applyVolumeRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID), a)
 
 		if err == nil {
 			t.Errorf("an edited payload released %s, which no rung of the ladder allows", counter)
@@ -121,11 +121,11 @@ func TestAnEditedPayloadCannotTurnAStepUpIntoAHardStopRelease(t *testing.T) {
 // window for an unreadable one would widen a window nobody was shown.
 func TestAStagedWindowThatIsNotAWindowReleasesNothing(t *testing.T) {
 	meter := &recordingReleaser{}
-	svc := NewService(nil).WithQuotaReleaser(meter)
+	svc := NewService(nil).WithVolumeReleaser(meter)
 	a := stepUpRow(t, ids.New[ids.PassportKind]().UUID,
-		agentquota.ReleaseProposal{Counter: agentquota.Reads, Bucket: "not-a-window"})
+		agentvolume.ReleaseProposal{Counter: agentvolume.Reads, Bucket: "not-a-window"})
 
-	if err := svc.applyQuotaRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID), a); err == nil {
+	if err := svc.applyVolumeRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID), a); err == nil {
 		t.Error("an unreadable window was released against whatever window happened to be current")
 	}
 	if meter.calls != 0 {
@@ -138,14 +138,14 @@ func TestAStagedWindowThatIsNotAWindowReleasesNothing(t *testing.T) {
 // succeed — which is exactly the failure this refuses loudly.
 func TestAStepUpWithNoPassportIsRefusedRatherThanReleasedAgainstTheApprover(t *testing.T) {
 	meter := &recordingReleaser{}
-	svc := NewService(nil).WithQuotaReleaser(meter)
-	raw, err := json.Marshal(agentquota.ReleaseProposal{Counter: agentquota.Reads, Bucket: "1"})
+	svc := NewService(nil).WithVolumeReleaser(meter)
+	raw, err := json.Marshal(agentvolume.ReleaseProposal{Counter: agentvolume.Reads, Bucket: "1"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	applyErr := svc.applyQuotaRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID),
-		row{Kind: KindQuotaRelease, ProposedChange: raw})
+	applyErr := svc.applyVolumeRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID),
+		row{Kind: KindVolumeRelease, ProposedChange: raw})
 
 	if applyErr == nil || !strings.Contains(applyErr.Error(), "no passport") {
 		t.Fatalf("a passportless step-up → %v, want a refusal naming the missing passport", applyErr)
@@ -161,9 +161,9 @@ func TestAStepUpWithNoPassportIsRefusedRatherThanReleasedAgainstTheApprover(t *t
 func TestApprovingAStepUpWithNoMeterComposedFails(t *testing.T) {
 	svc := NewService(nil)
 	a := stepUpRow(t, ids.New[ids.PassportKind]().UUID,
-		agentquota.ReleaseProposal{Counter: agentquota.Reads, Bucket: "1"})
+		agentvolume.ReleaseProposal{Counter: agentvolume.Reads, Bucket: "1"})
 
-	if err := svc.applyQuotaRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID), a); err == nil {
+	if err := svc.applyVolumeRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID), a); err == nil {
 		t.Error("a service with no meter reported a release it could not have made")
 	}
 }
@@ -173,11 +173,11 @@ func TestApprovingAStepUpWithNoMeterComposedFails(t *testing.T) {
 // lets them try again rather than believe the agent is free to continue.
 func TestAMeterFailureReachesTheDecidingHuman(t *testing.T) {
 	meter := &recordingReleaser{err: errors.New("redis is unreachable")}
-	svc := NewService(nil).WithQuotaReleaser(meter)
+	svc := NewService(nil).WithVolumeReleaser(meter)
 	a := stepUpRow(t, ids.New[ids.PassportKind]().UUID,
-		agentquota.ReleaseProposal{Counter: agentquota.Reads, Bucket: "1"})
+		agentvolume.ReleaseProposal{Counter: agentvolume.Reads, Bucket: "1"})
 
-	err := svc.applyQuotaRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID), a)
+	err := svc.applyVolumeRelease(releaseCtx(ids.New[ids.WorkspaceKind]().UUID), a)
 
 	if err == nil {
 		t.Fatal("a meter failure was swallowed; the human is told the agent may continue when it may not")
@@ -193,7 +193,7 @@ func TestAMeterFailureReachesTheDecidingHuman(t *testing.T) {
 // as a unit test over the real predicate rather than a paraphrase of it.
 func TestAStepUpIsDecidedByTheLenderAlone(t *testing.T) {
 	lender := ids.New[ids.UserKind]().UUID
-	a := row{Kind: KindQuotaRelease, OnBehalfOf: ptr(ids.From[ids.UserKind](lender))}
+	a := row{Kind: KindVolumeRelease, OnBehalfOf: ptr(ids.From[ids.UserKind](lender))}
 	// Every object grant there is, held by someone who is not the lender.
 	admin := principal.Principal{
 		UserID: ids.New[ids.UserKind]().UUID,
@@ -225,7 +225,7 @@ func TestAStepUpIsDecidedByTheLenderAlone(t *testing.T) {
 func TestAStepUpWithNoLenderIsDecidableByNobody(t *testing.T) {
 	anyone := principal.Principal{UserID: ids.New[ids.UserKind]().UUID}
 
-	got, err := decidable(context.Background(), nil, anyone, row{Kind: KindQuotaRelease})
+	got, err := decidable(context.Background(), nil, anyone, row{Kind: KindVolumeRelease})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/capture/googleconn/googleconn_test.go
+++ b/backend/internal/modules/capture/googleconn/googleconn_test.go
@@ -161,7 +161,7 @@ func TestGetDecodesOKAndMapsSentinels(t *testing.T) {
 	if _, err := Get(context.Background(), client, srv.URL, "tok", "/garbage", nil, &out); !errors.Is(err, ErrUnreachable) {
 		t.Fatalf("Get /garbage (undecodable) err = %v, want ErrUnreachable", err)
 	}
-	// A 429 and a quota-403 are retryable rate limits, NOT rejected auth — the
+	// A 429 and a volume budget-403 are retryable rate limits, NOT rejected auth — the
 	// registry must back off and honor Retry-After, not park the connection.
 	var rl *connector.RateLimitedError
 	if _, err := Get(context.Background(), client, srv.URL, "tok", "/toomany", nil, &out); !errors.As(err, &rl) {

--- a/backend/internal/modules/comms/dispatcher_reason_test.go
+++ b/backend/internal/modules/comms/dispatcher_reason_test.go
@@ -36,7 +36,7 @@ func TestDispatchCountsASuccessfulSendAgainstEveryMeteringPolicy(t *testing.T) {
 }
 
 // A message that never reached the provider consumed none of the mailbox's
-// quota. Counting a deferral would shrink the window every time the chain was
+// volume budget. Counting a deferral would shrink the window every time the chain was
 // merely consulted.
 func TestDispatchCountsNothingAgainstAPolicyWhenTheSendIsPostponed(t *testing.T) {
 	meter := &recordingPolicy{}

--- a/backend/internal/modules/contracts/store.go
+++ b/backend/internal/modules/contracts/store.go
@@ -70,7 +70,7 @@ type Store struct {
 	// freezeRate resolves what a contract's currency converts at, on the day
 	// it activates. Injected because the reading belongs to the module that
 	// owns fx_rate, and contracts takes a seam rather than that module —
-	// the shape quotas' BaseCurrencyFunc already uses.
+	// the shape counters' BaseCurrencyFunc already uses.
 	//
 	// REQUIRED by the constructor. A store built without one would activate
 	// foreign-currency contracts carrying no frozen rate at all, which is the

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -353,7 +353,7 @@ func (e *MissingFxRateError) MessageFault() (code, message string) {
 // rate means. One of them would be corrected.
 //
 // Handed over as a function rather than as this store, so the caller takes a
-// seam and not a module (the shape quotas' BaseCurrencyFunc already uses).
+// seam and not a module (the shape counters' BaseCurrencyFunc already uses).
 func (s *Store) FreezeRateAt(ctx context.Context, tx pgx.Tx, currency string, asOf time.Time) (string, time.Time, error) {
 	base, err := s.installation.BaseCurrency(ctx, tx)
 	if err != nil {

--- a/backend/internal/modules/identity/handlers_roles.go
+++ b/backend/internal/modules/identity/handlers_roles.go
@@ -45,7 +45,7 @@ func (h Handlers) SetRoleObjectGrant(w http.ResponseWriter, r *http.Request, key
 		return
 	}
 	// The If-Match version is read off the header rather than the generated
-	// params struct, which is the house spelling (quotas, people, deals):
+	// params struct, which is the house spelling (people, deals):
 	// httperr.IfMatchVersion is where "a bare integer, not a quoted ETag" and
 	// the malformed-header refusal are decided once.
 	ifVersion, ok := httperr.IfMatchVersion(w, r)

--- a/backend/internal/modules/identity/handlers_roster.go
+++ b/backend/internal/modules/identity/handlers_roster.go
@@ -64,7 +64,7 @@ func (h Handlers) ListTeams(w http.ResponseWriter, r *http.Request, params crmco
 
 // pageInfo renders the store's keyset page onto the contract's PageInfo
 // envelope — this module's own copy of the one-per-module spelling
-// (people/deals/activities/signals/quotas each carry their own).
+// (people/deals/activities/signals each carry their own).
 func pageInfo(p storekit.Page) crmcontracts.PageInfo {
 	info := crmcontracts.PageInfo{HasMore: p.HasMore}
 	if p.NextCursor != "" {

--- a/backend/internal/modules/overlay/connection.go
+++ b/backend/internal/modules/overlay/connection.go
@@ -231,7 +231,7 @@ func (s *Service) WithLogger(log *slog.Logger) *Service {
 // statement). Gated by auth.Require("overlay_connection", ActionCreate):
 // connecting is destructive workspace-wide config (it will later purge
 // the mirror on Disconnect and flips sor_mode for every seat), so it is
-// admin/ops-only (identity/internal/policy), the same posture as quota.
+// admin/ops-only (identity/internal/policy), the same posture as custom_field.
 //
 // The singleton index means a second Connect on an already-active
 // connection answers apperrors.ErrIncumbentAlreadyConnected; a revoked one
@@ -460,7 +460,7 @@ func (s *Service) deleteUnreferencedRef(ctx context.Context, ws ids.UUID, ref ke
 // Get reads the workspace's current incumbent connection. Gated by
 // auth.Require("overlay_connection", ActionRead) — every role holds this
 // grant (identity/internal/policy), so any authenticated seat may check
-// whether overlay mode is live, the same posture as a quota's attainment
+// whether overlay mode is live, the same posture as the custom_field catalog
 // read. No EnsureVisible probe runs: like quota, incumbent_connection is
 // a workspace-shared singleton governed by the object grant alone, never
 // row-scoped: incumbent_connection carries no workspace column and the

--- a/backend/internal/platform/agentvolume/counter.go
+++ b/backend/internal/platform/agentvolume/counter.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package agentquota
+package agentvolume
 
 // Which counter a call belongs to, what each one costs when it is crossed, and
 // the thresholds themselves.
@@ -12,12 +12,12 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 )
 
-// Counter is one per-Passport quota. The string value is part of the Redis key,
+// Counter is one per-Passport volume budget. The string value is part of the Redis key,
 // so it is the name the counter has had since it was written and not a display
 // label to be improved.
 type Counter string
 
-// The five quotas of api-rate-limits-and-abuse §2.2.
+// The five counters of api-rate-limits-and-abuse §2.2.
 const (
 	// Reads counts RECORDS handed to the agent (MCP-SESS-READS).
 	Reads Counter = "reads"
@@ -39,7 +39,7 @@ const (
 // exist to turn bulk activity into a gated, VISIBLE event rather than to end it.
 // Egress is BYO-STEP-3 and is fail-closed on the spec's own reasoning — it is
 // the exfiltration endpoint, and "resuming needs a new approved session". Calls
-// is BYO-STEP-4's suspension, the ceiling under which every other quota sits;
+// is BYO-STEP-4's suspension, the ceiling under which every other volume budget sits;
 // releasing it would release all four at once.
 //
 // Cost is not releasable because it never refuses: there is nothing to release.
@@ -53,7 +53,7 @@ func (c Counter) Releasable() bool {
 // runtime's own budget guardrail, not a refusal on the tool surface.
 func (c Counter) Governed() bool { return c != Cost }
 
-// CounterFor names the quota one tool call is charged against — the DERIVED
+// CounterFor names the volume budget one tool call is charged against — the DERIVED
 // answer, taken once, so the half that refuses and the half that charges cannot
 // disagree.
 //
@@ -66,8 +66,8 @@ func (c Counter) Governed() bool { return c != Cost }
 //
 // EGRESS OUTRANKS WRITES, and the order matters: every egress tool on this
 // surface also mutates (a send writes an activity), so asking "does it write?"
-// first would charge send_email against the 200-call write quota and leave the
-// 20-call egress quota — the tightest one, guarding the exfiltration endpoint —
+// first would charge send_email against the 200-call write volume budget and leave the
+// 20-call egress volume budget — the tightest one, guarding the exfiltration endpoint —
 // permanently unspent.
 func CounterFor(spec mcp.ToolSpec) Counter {
 	switch {

--- a/backend/internal/platform/agentvolume/counter_test.go
+++ b/backend/internal/platform/agentvolume/counter_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package agentquota
+package agentvolume
 
 import (
 	"encoding/json"
@@ -12,7 +12,7 @@ import (
 )
 
 // spec builds the two fields the derivation reads. Nothing else about a tool
-// decides which quota it spends, which is the property under test.
+// decides which volume budget it spends, which is the property under test.
 func spec(scope principal.Scope, egress bool) mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "t", Title: "T", Description: "d", Version: "1",
@@ -23,8 +23,8 @@ func spec(scope principal.Scope, egress bool) mcp.ToolSpec {
 
 // The ordering defect this derivation exists to avoid: every egress tool on
 // this surface also mutates, so a derivation that asks "does it write?" first
-// charges send_email against the 200-call write quota and leaves the 20-call
-// egress quota — the tightest one on the surface, guarding the exfiltration
+// charges send_email against the 200-call write volume budget and leaves the 20-call
+// egress volume budget — the tightest one on the surface, guarding the exfiltration
 // endpoint — permanently unspent. Written as a table because the whole point is
 // that no tool NAME appears in the answer.
 func TestAnEgressToolSpendsTheEgressQuotaEvenThoughItAlsoWrites(t *testing.T) {
@@ -46,10 +46,10 @@ func TestAnEgressToolSpendsTheEgressQuotaEvenThoughItAlsoWrites(t *testing.T) {
 	}
 }
 
-// Which quotas a human can widen mid-window IS the §2.4 ladder, and getting it
+// Which counters a human can widen mid-window IS the §2.4 ladder, and getting it
 // backwards is the difference between a visible gated event and an unbounded
 // one. Egress is the exfiltration endpoint and calls is the ceiling under which
-// every other quota sits — releasing either would release the control itself.
+// every other volume budget sits — releasing either would release the control itself.
 func TestOnlyTheStepUpQuotasCanBeReleasedByAHuman(t *testing.T) {
 	releasable := map[Counter]bool{
 		Reads: true, Writes: true,

--- a/backend/internal/platform/agentvolume/doc.go
+++ b/backend/internal/platform/agentvolume/doc.go
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-// Package agentquota is the per-Passport volume accounting the MCP session used
+// Package agentvolume is the per-Passport volume accounting the MCP session used
 // to stand in for (api-rate-limits-and-abuse §2.2/§2.4, byo-agent-and-mcp
 // MCP-SESS-* and BYO-STEP-*, ADR-0092 §6): how much one agent has read,
 // written, sent and spent inside one window, and what happens when it passes a
 // threshold.
 //
-// WHY IT IS PER PASSPORT AND NOT PER SESSION. The spec names these quotas after
+// WHY IT IS PER PASSPORT AND NOT PER SESSION. The spec names these counters after
 // a session, and until ADR-0092 the in-process session registry was what
 // implicitly bounded volume — a bound that pinned an agent to one api replica
 // and did not exist at all on the REST half of the same credential (ADR-0055
@@ -40,4 +40,4 @@
 // It lives in the platform tier and owns no domain: both doors onto the governed
 // surface charge it — the MCP tool dispatcher and the ADR-0055 REST agent gate —
 // and neither may import the other.
-package agentquota
+package agentvolume

--- a/backend/internal/platform/agentvolume/meter.go
+++ b/backend/internal/platform/agentvolume/meter.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package agentquota
+package agentvolume
 
 import (
 	"context"
@@ -98,7 +98,7 @@ func (m *Meter) WithCostCeiling(c CostCeiling) *Meter {
 // boot-time injection point compose uses WITHOUT itself naming a Redis client
 // (that dependency stays in the cmd/platform tiers). newServer constructs a
 // fail-closed meter and shares that ONE pointer with every charge point; a
-// WithAgentQuota option rebinds it from the live meter once the Redis client and
+// WithAgentVolume option rebinds it from the live meter once the Redis client and
 // the deployment config are known, so every holder sees the live meter without
 // re-plumbing. Called at server assembly, before any request is served, so it
 // never races a charge — the same discipline overlaybudget.Meter.RebindFrom
@@ -124,7 +124,7 @@ func (m *Meter) Window() time.Duration { return m.window }
 
 // Reading is what the meter knows about one Passport's window for one counter.
 type Reading struct {
-	// Counter is which quota this reading is of, so a refusal can name it
+	// Counter is which volume budget this reading is of, so a refusal can name it
 	// rather than describing it.
 	Counter Counter
 	// Observed is what has been charged in this window so far.
@@ -253,7 +253,7 @@ func (m *Meter) Consume(ctx context.Context, c Counter, n int) error {
 	}
 	key := m.countKey(ws, agent, c, m.Bucket())
 	if err := addScript.Run(ctx, m.rdb, []string{key}, n, m.ttlSeconds()).Err(); err != nil {
-		return fmt.Errorf("agentquota: recording %d against %s: %w", n, c, err)
+		return fmt.Errorf("agentvolume: recording %d against %s: %w", n, c, err)
 	}
 	return nil
 }
@@ -329,7 +329,7 @@ func (m *Meter) observe(ctx context.Context, ws ids.UUID, agent string, c Counte
 		return 0, 0, err
 	}
 	if len(values) != 2 {
-		return 0, 0, fmt.Errorf("agentquota: reading %s returned %d values, want 2", c, len(values))
+		return 0, 0, fmt.Errorf("agentvolume: reading %s returned %d values, want 2", c, len(values))
 	}
 	observed, err = asCount(values[0])
 	if err != nil {
@@ -355,19 +355,19 @@ func asCount(v any) (int, error) {
 	}
 	s, ok := v.(string)
 	if !ok {
-		return 0, fmt.Errorf("agentquota: counter value is %T, not a string", v)
+		return 0, fmt.Errorf("agentvolume: counter value is %T, not a string", v)
 	}
 	n, err := strconv.Atoi(s)
 	if err != nil {
 		// Atoi, not Sscanf: Sscanf reads "12abc" as 12 and reports no error,
 		// which is precisely the "neither absent nor an integer" case above.
-		return 0, fmt.Errorf("agentquota: counter value %q is not a number: %w", s, err)
+		return 0, fmt.Errorf("agentvolume: counter value %q is not a number: %w", s, err)
 	}
 	if n < 0 {
 		// This meter only ever INCRBYs by a positive amount, so a negative
 		// counter is not a count — and reading one as headroom is the direction
 		// that matters: it puts an agent under a bound it has already passed.
-		return 0, fmt.Errorf("agentquota: counter value %d is negative; this meter never writes one", n)
+		return 0, fmt.Errorf("agentvolume: counter value %d is negative; this meter never writes one", n)
 	}
 	return n, nil
 }

--- a/backend/internal/platform/agentvolume/meter_integration_test.go
+++ b/backend/internal/platform/agentvolume/meter_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package agentquota
+package agentvolume
 
 import (
 	"context"
@@ -199,7 +199,7 @@ func TestASecondCrossingAfterAReleaseNeedsASecondDecision(t *testing.T) {
 
 // A release of one counter does not widen another. Sharing them would mean a
 // human confirming "keep reading" also lifted the send ceiling, which is the
-// tightest quota on the surface and the one nothing may release at all.
+// tightest volume budget on the surface and the one nothing may release at all.
 func TestAReleaseWidensOnlyTheCounterItNamed(t *testing.T) {
 	at := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
 	meter := NewWithClock(budgettest.Client(t), Limits{Reads: 10, Writes: 10}, time.Hour, frozen(&at))
@@ -225,7 +225,7 @@ func TestAReleaseWidensOnlyTheCounterItNamed(t *testing.T) {
 
 // The four governed counters are four independent windows for one Passport. A
 // shared one would let a busy reader exhaust its own send allowance — or, worse,
-// let a caller spend the loose quota to escape the tight one.
+// let a caller spend the loose volume budget to escape the tight one.
 func TestEachCounterIsItsOwnWindowForOnePassport(t *testing.T) {
 	at := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
 	meter := NewWithClock(budgettest.Client(t),

--- a/backend/internal/platform/agentvolume/meter_test.go
+++ b/backend/internal/platform/agentvolume/meter_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package agentquota
+package agentvolume
 
 import (
 	"context"
@@ -286,7 +286,7 @@ func TestASubSecondWindowBucketsRatherThanDividingByZero(t *testing.T) {
 
 // An agent whose counter cannot be NAMED is refused, not admitted. A call with
 // no workspace bound is the live shape of this: the gate's MCP path rejects it
-// before the quota, but the REST path has no such check, so a meter that
+// before the volume budget, but the REST path has no such check, so a meter that
 // admitted it would hand out a free pass on a wiring fault.
 func TestAnAgentWithNoWorkspaceIsRefusedRatherThanUnmetered(t *testing.T) {
 	meter := Unmetered() // even an unmetered composition must not be the reason

--- a/backend/internal/platform/agentvolume/proposal.go
+++ b/backend/internal/platform/agentvolume/proposal.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package agentquota
+package agentvolume
 
 // The question a human is asked when an agent crosses a releasable threshold,
 // and the answer that widens the window.
@@ -50,7 +50,7 @@ type ReleaseProposal struct {
 	// row, and whichever lender answers releases only the other's passport —
 	// leaving one agent refused with no question anybody can see.
 	//
-	// It is NOT authority. applyQuotaRelease takes the passport from the staged
+	// It is NOT authority. applyVolumeRelease takes the passport from the staged
 	// row's own passport_id, stamped from the authenticated principal, precisely
 	// so an edited payload cannot re-aim a release.
 	Passport string `json:"passport"`
@@ -80,11 +80,11 @@ func NewReleaseProposal(reading Reading, passport ids.UUID, tool string) Release
 func DecodeReleaseProposal(raw json.RawMessage) (ReleaseProposal, error) {
 	var p ReleaseProposal
 	if err := json.Unmarshal(raw, &p); err != nil {
-		return ReleaseProposal{}, fmt.Errorf("agentquota: reading a staged release proposal: %w", err)
+		return ReleaseProposal{}, fmt.Errorf("agentvolume: reading a staged release proposal: %w", err)
 	}
 	if !p.Counter.Releasable() {
 		return ReleaseProposal{}, fmt.Errorf(
-			"agentquota: a staged release names %q, which is not a quota a human can release", p.Counter)
+			"agentvolume: a staged release names %q, which is not a counter a human can release", p.Counter)
 	}
 	return p, nil
 }
@@ -95,7 +95,7 @@ func DecodeReleaseProposal(raw json.RawMessage) (ReleaseProposal, error) {
 func (p ReleaseProposal) Window() (int64, error) {
 	bucket, err := strconv.ParseInt(p.Bucket, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("agentquota: a staged release names window %q, which is not a window: %w", p.Bucket, err)
+		return 0, fmt.Errorf("agentvolume: a staged release names window %q, which is not a window: %w", p.Bucket, err)
 	}
 	return bucket, nil
 }
@@ -116,7 +116,7 @@ func (p ReleaseProposal) Identity() (json.RawMessage, error) {
 		Passport string  `json:"passport"`
 	}{p.Counter, p.Bucket, p.Passport})
 	if err != nil {
-		return nil, fmt.Errorf("agentquota: naming a release proposal's identity: %w", err)
+		return nil, fmt.Errorf("agentvolume: naming a release proposal's identity: %w", err)
 	}
 	return raw, nil
 }

--- a/backend/internal/platform/agentvolume/proposal_test.go
+++ b/backend/internal/platform/agentvolume/proposal_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package agentquota
+package agentvolume
 
 import (
 	"context"

--- a/backend/internal/platform/agentvolume/release.go
+++ b/backend/internal/platform/agentvolume/release.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package agentquota
+package agentvolume
 
 // Confirm-and-continue: the §2.4 ladder's release, and the only thing that ever
 // widens a window from inside it.
@@ -41,14 +41,14 @@ func (m *Meter) Release(ctx context.Context, ws, passport ids.UUID, c Counter, b
 	// defect reads the same whether or not Redis is up. The other order hides a
 	// wiring fault in exactly the deployment where one is most likely.
 	if !c.Releasable() {
-		return false, fmt.Errorf("agentquota: %s is not a releasable quota", c)
+		return false, fmt.Errorf("agentvolume: %s is not a releasable counter", c)
 	}
 	if ws == (ids.UUID{}) || passport == (ids.UUID{}) {
-		return false, fmt.Errorf("agentquota: releasing %s needs both a workspace and a passport", c)
+		return false, fmt.Errorf("agentvolume: releasing %s needs both a workspace and a passport", c)
 	}
 	current := m.Bucket()
 	if bucket > current {
-		return false, fmt.Errorf("agentquota: cannot release %s for a window that has not started", c)
+		return false, fmt.Errorf("agentvolume: cannot release %s for a window that has not started", c)
 	}
 	if bucket < current {
 		// Judged with the other argument facts, ABOVE the meter's reachability:
@@ -65,7 +65,7 @@ func (m *Meter) Release(ctx context.Context, ws, passport ids.UUID, c Counter, b
 	}
 	key := m.releaseKey(ws, passport.String(), c, bucket)
 	if err := addScript.Run(ctx, m.rdb, []string{key}, 1, m.ttlSeconds()).Err(); err != nil {
-		return false, fmt.Errorf("agentquota: recording a release of %s: %w", c, err)
+		return false, fmt.Errorf("agentvolume: recording a release of %s: %w", c, err)
 	}
 	return true, nil
 }

--- a/backend/internal/platform/agentvolume/release_test.go
+++ b/backend/internal/platform/agentvolume/release_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package agentquota
+package agentvolume
 
 import (
 	"strings"
@@ -11,9 +11,9 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// The two quotas the spec ends WITH THE WINDOW cannot be widened from inside
+// The two counters the spec ends WITH THE WINDOW cannot be widened from inside
 // it. A release of egress would reopen the exfiltration endpoint the moment it
-// closed; a release of calls would lift the ceiling every other quota sits
+// closed; a release of calls would lift the ceiling every other volume budget sits
 // under. Both are caller defects, answered as errors rather than as quiet
 // successes — a release that silently did nothing would read, at the approval
 // screen, exactly like one that worked.

--- a/backend/internal/platform/auth/admit.go
+++ b/backend/internal/platform/auth/admit.go
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 // Package auth is the ONE admission point for governed agent actions
-// (interfaces.md §2, ADR-0055): scope ∧ seat ∧ tier ∧ quota, resolved against
+// (interfaces.md §2, ADR-0055): scope ∧ seat ∧ tier ∧ volume, resolved against
 // the calling Principal, BEFORE any handler runs — whether the action arrives
 // as an MCP tool call or a mutating REST operation. It is its own package
 // so nothing else can mint an admitted capability — Surface A (inbound
@@ -15,7 +15,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/authz"
@@ -29,7 +29,7 @@ import (
 // instead of surviving on whatever the transport stamped earlier.
 type Gate struct {
 	authority authz.Resolver
-	quota     Quota
+	volume    VolumeMeter
 }
 
 // GateOption configures a Gate at construction. Variadic rather than
@@ -38,14 +38,14 @@ type Gate struct {
 // nil by copy-paste.
 type GateOption func(*Gate)
 
-// WithQuota installs the per-Passport volume meter (MCP-SESS-*). A gate built
+// WithVolumeMeter installs the per-Passport volume meter (MCP-SESS-*). A gate built
 // WITHOUT one does not enforce any of those bounds, which is a real composition
 // rather than an oversight: the Surface-B runner and the workflow paths build a
 // gate and run as the human or system that started them, whom these bounds do
 // not govern. The api server — the one role an agent principal ever reaches —
 // passes it, from the same pointer it gives the registry that charges it.
-func WithQuota(quota Quota) GateOption {
-	return func(g *Gate) { g.quota = quota }
+func WithVolumeMeter(quota VolumeMeter) GateOption {
+	return func(g *Gate) { g.volume = quota }
 }
 
 // NewGate builds the admission point over its authority seam. Options add
@@ -65,7 +65,7 @@ func NewGate(authority authz.Resolver, opts ...GateOption) *Gate {
 //
 // The decision order is deliberate: scope first (a caller without the
 // verb never learns the tier, and pays no authority read), then the live
-// seat ceiling, then the read quota, then tier. A 🟡 outcome (declared or
+// seat ceiling, then the read bound, then tier. A 🟡 outcome (declared or
 // dynamically resolved) returns ErrRequiresApproval. On admission the returned
 // context carries the principal refreshed with the re-derived authority,
 // so downstream store RBAC runs on current grants.
@@ -79,7 +79,7 @@ func (g *Gate) Admit(ctx context.Context, spec mcp.ToolSpec, resolve func() (mcp
 	// their authority is their RBAC, enforced at the store. The gate
 	// exists to bound AGENTS (03b Layer 1); a human reaching a tool
 	// through the UI already answered for the action.
-	// A buyer holds no scope, no seat and no quota, so "not an agent, pass"
+	// A buyer holds no scope, no seat and no volume bound, so "not an agent, pass"
 	// would wave one through every check this gate exists to apply. Refused
 	// by kind rather than by the absence of a passport, because the absence
 	// is what makes the pass-through look safe.
@@ -95,7 +95,7 @@ func (g *Gate) Admit(ctx context.Context, spec mcp.ToolSpec, resolve func() (mcp
 	// passport holds — mcp.ToolSpec.SelfDescribing carries the reason, and the
 	// listing filter reads the same flag, so what is offered is what is
 	// admitted. Every check below still applies: the seat, the re-derived
-	// RBAC and the quota are not waived by knowing whose seat it is.
+	// RBAC and the volume bounds are not waived by knowing whose seat it is.
 	if !spec.SelfDescribing && !p.Scopes.Has(spec.RequiredScope) {
 		return ctx, fmt.Errorf("gate: %s needs scope %q: %w", spec.Name, spec.RequiredScope, apperrors.ErrScopeExceeded)
 	}
@@ -152,15 +152,15 @@ func (g *Gate) Admit(ctx context.Context, spec mcp.ToolSpec, resolve func() (mcp
 			spec.Name, p.ID, apperrors.ErrSeatTierInsufficient)
 	}
 
-	// Quota, the third term of "scope ∧ tier ∧ quota" (interfaces.md §2). It
+	// Volume, the third term of "scope ∧ tier ∧ volume" (interfaces.md §2). It
 	// runs AFTER scope and seat so a caller who may not run the verb at all
-	// never learns that a quota exists, let alone how much of it is spent.
+	// never learns that a bound exists, let alone how much of it is spent.
 	//
-	// Which counters bind THIS call, and what crossing one costs, is quota.go's
+	// Which counters bind THIS call, and what crossing one costs, is volume.go's
 	// business. It runs before tier because a suspended Passport is refused
 	// whatever the tier resolves to, and resolving a dynamic tier costs a
 	// database read the refused caller should not be able to make us pay.
-	if err := g.refuseOnQuota(ctx, spec); err != nil {
+	if err := g.refuseOnVolume(ctx, spec); err != nil {
 		return ctx, err
 	}
 
@@ -264,7 +264,7 @@ func deniedIfGone(what, tool string, err error) error {
 	return fmt.Errorf("gate: %s: resolving %s: %w", tool, what, err)
 }
 
-// AdmitRead applies the READ quota alone, for a call that has no tool spec to
+// AdmitRead applies the READ bound alone, for a call that has no tool spec to
 // admit against — the ADR-0055 REST surface's non-mutating half.
 //
 // It exists because that path has no tier to resolve and no scope to check
@@ -289,15 +289,15 @@ func deniedIfGone(what, tool string, err error) error {
 //
 // Non-agents are admitted untouched, exactly as Admit leaves them.
 func (g *Gate) AdmitRead(ctx context.Context) error {
-	if g == nil || g.quota == nil {
+	if g == nil || g.volume == nil {
 		return nil
 	}
 	p, ok := principal.Actor(ctx)
 	if !ok || p.Type != principal.PrincipalAgent {
 		return nil
 	}
-	if reading := g.quota.Read(ctx, agentquota.Reads); reading.Exceeded {
-		return &QuotaExceededError{Reading: reading}
+	if reading := g.volume.Read(ctx, agentvolume.Reads); reading.Exceeded {
+		return &VolumeExceededError{Reading: reading}
 	}
 	return nil
 }

--- a/backend/internal/platform/auth/admitvolume_test.go
+++ b/backend/internal/platform/auth/admitvolume_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
@@ -20,19 +20,19 @@ import (
 // It records which counters were ASKED, because half the properties here are
 // about a counter never being consulted at all.
 type spentQuota struct {
-	exceeded map[agentquota.Counter]agentquota.Reading
-	asked    []agentquota.Counter
+	exceeded map[agentvolume.Counter]agentvolume.Reading
+	asked    []agentvolume.Counter
 }
 
-func (s *spentQuota) Read(_ context.Context, c agentquota.Counter) agentquota.Reading {
+func (s *spentQuota) Read(_ context.Context, c agentvolume.Counter) agentvolume.Reading {
 	s.asked = append(s.asked, c)
 	if reading, ok := s.exceeded[c]; ok {
 		return reading
 	}
-	return agentquota.Reading{Counter: c, Limit: 100}
+	return agentvolume.Reading{Counter: c, Limit: 100}
 }
 
-func (s *spentQuota) askedFor(c agentquota.Counter) bool {
+func (s *spentQuota) askedFor(c agentvolume.Counter) bool {
 	for _, asked := range s.asked {
 		if asked == c {
 			return true
@@ -43,14 +43,14 @@ func (s *spentQuota) askedFor(c agentquota.Counter) bool {
 
 // over builds a meter that reports one counter crossed and every other with
 // headroom — the shape every rung of the ladder is tested against.
-func over(c agentquota.Counter, observed, limit int) *spentQuota {
-	return &spentQuota{exceeded: map[agentquota.Counter]agentquota.Reading{
+func over(c agentvolume.Counter, observed, limit int) *spentQuota {
+	return &spentQuota{exceeded: map[agentvolume.Counter]agentvolume.Reading{
 		c: {Counter: c, Observed: observed, Limit: limit, Exceeded: true, Bucket: 7},
 	}}
 }
 
 func quotaGate(q *spentQuota) *Gate {
-	return NewGate(&stubAuthority{seat: principal.SeatFull}, WithQuota(q))
+	return NewGate(&stubAuthority{seat: principal.SeatFull}, WithVolumeMeter(q))
 }
 
 var (
@@ -64,7 +64,7 @@ var (
 // ErrBudgetExceeded), so a client branches on the registry rather than on
 // prose.
 func TestAReadIsRefusedOnceTheAgentHasPassedItsReadBound(t *testing.T) {
-	gate := quotaGate(over(agentquota.Reads, 2001, 2000))
+	gate := quotaGate(over(agentvolume.Reads, 2001, 2000))
 
 	_, err := gate.Admit(agentCtx(principal.ScopeRead), readSpec, noResolve)
 
@@ -84,13 +84,13 @@ func TestAReadIsRefusedOnceTheAgentHasPassedItsReadBound(t *testing.T) {
 // the send ceiling that actually guards exfiltration.
 func TestEachQuotaRefusesOnlyTheCallsItGoverns(t *testing.T) {
 	cases := []struct {
-		counter agentquota.Counter
+		counter agentvolume.Counter
 		refused mcp.ToolSpec
 		allowed []mcp.ToolSpec
 	}{
-		{agentquota.Reads, readSpec, []mcp.ToolSpec{writeSpec, egressSpec}},
-		{agentquota.Writes, writeSpec, []mcp.ToolSpec{readSpec, egressSpec}},
-		{agentquota.Egress, egressSpec, []mcp.ToolSpec{readSpec, writeSpec}},
+		{agentvolume.Reads, readSpec, []mcp.ToolSpec{writeSpec, egressSpec}},
+		{agentvolume.Writes, writeSpec, []mcp.ToolSpec{readSpec, egressSpec}},
+		{agentvolume.Egress, egressSpec, []mcp.ToolSpec{readSpec, writeSpec}},
 	}
 	for _, c := range cases {
 		gate := quotaGate(over(c.counter, 500, 100))
@@ -106,7 +106,7 @@ func TestEachQuotaRefusesOnlyTheCallsItGoverns(t *testing.T) {
 	}
 }
 
-// scopeFor gives the caller exactly the scope its tool needs, so a quota test
+// scopeFor gives the caller exactly the scope its tool needs, so a volume test
 // never accidentally proves the scope check instead.
 func scopeFor(spec mcp.ToolSpec) principal.Scope { return spec.RequiredScope }
 
@@ -114,39 +114,39 @@ func scopeFor(spec mcp.ToolSpec) principal.Scope { return spec.RequiredScope }
 // through the gate rather than by calling the derivation, because the derivation
 // being right is worth nothing if the gate consults a different one: a surface
 // that asked "does it write?" first would leave the 20-call send ceiling
-// permanently unspent while the 200-call write quota absorbed every send.
+// permanently unspent while the 200-call write volume budget absorbed every send.
 func TestASendIsJudgedAgainstTheSendCeilingAndNotTheWriteOne(t *testing.T) {
-	quota := over(agentquota.Writes, 500, 200)
+	quota := over(agentvolume.Writes, 500, 200)
 
 	if _, err := quotaGate(quota).Admit(agentCtx(principal.ScopeSend), egressSpec, noResolve); err != nil {
 		t.Fatalf("a send was refused by the WRITE quota: %v", err)
 	}
-	if quota.askedFor(agentquota.Writes) {
+	if quota.askedFor(agentvolume.Writes) {
 		t.Error("the write quota was consulted for an egress-flagged tool; the send ceiling is the one that governs it")
 	}
-	if !quota.askedFor(agentquota.Egress) {
+	if !quota.askedFor(agentvolume.Egress) {
 		t.Error("the egress quota was never consulted for an egress-flagged tool")
 	}
 }
 
-// BYO-STEP-4's suspension is the ceiling every other quota sits under, so it is
+// BYO-STEP-4's suspension is the ceiling every other counter sits under, so it is
 // asked FIRST — and a suspended caller is refused for every verb rather than
 // being told which of its allowances still has headroom.
 func TestASuspendedPassportIsRefusedForEveryVerbAndLearnsNothingElse(t *testing.T) {
 	for _, spec := range []mcp.ToolSpec{readSpec, writeSpec, egressSpec} {
-		quota := over(agentquota.Calls, 1001, 1000)
+		quota := over(agentvolume.Calls, 1001, 1000)
 
 		_, err := quotaGate(quota).Admit(agentCtx(scopeFor(spec)), spec, noResolve)
 
-		var refusal *QuotaExceededError
+		var refusal *VolumeExceededError
 		if !errors.As(err, &refusal) {
 			t.Fatalf("%s under suspension → %v, want a quota refusal", spec.Name, err)
 		}
-		if refusal.Reading.Counter != agentquota.Calls {
+		if refusal.Reading.Counter != agentvolume.Calls {
 			t.Errorf("%s under suspension was refused on %s, not on the call ceiling", spec.Name, refusal.Reading.Counter)
 		}
-		if quota.askedFor(agentquota.CounterFor(spec)) {
-			t.Errorf("a suspended caller learned the state of its %s allowance", agentquota.CounterFor(spec))
+		if quota.askedFor(agentvolume.CounterFor(spec)) {
+			t.Errorf("a suspended caller learned the state of its %s allowance", agentvolume.CounterFor(spec))
 		}
 	}
 }
@@ -154,24 +154,24 @@ func TestASuspendedPassportIsRefusedForEveryVerbAndLearnsNothingElse(t *testing.
 // The ladder's two halves must be tellable apart by a TYPE, not by prose: one
 // refusal has somewhere to go — the surface stages the question for the human
 // who lent the Passport — and the other does not. A caller matching on wording
-// would eventually stage a release for a quota nothing can release.
+// would eventually stage a release for a counter nothing can release.
 func TestARefusalSaysWhetherAHumanCanAnswerIt(t *testing.T) {
-	releasable := map[agentquota.Counter]bool{
-		agentquota.Reads: true, agentquota.Writes: true,
-		agentquota.Egress: false, agentquota.Calls: false,
+	releasable := map[agentvolume.Counter]bool{
+		agentvolume.Reads: true, agentvolume.Writes: true,
+		agentvolume.Egress: false, agentvolume.Calls: false,
 	}
 	for counter, want := range releasable {
 		spec := readSpec
 		switch counter {
-		case agentquota.Writes:
+		case agentvolume.Writes:
 			spec = writeSpec
-		case agentquota.Egress:
+		case agentvolume.Egress:
 			spec = egressSpec
-		case agentquota.Reads, agentquota.Calls, agentquota.Cost:
+		case agentvolume.Reads, agentvolume.Calls, agentvolume.Cost:
 		}
 		_, err := quotaGate(over(counter, 500, 100)).Admit(agentCtx(scopeFor(spec)), spec, noResolve)
 
-		var refusal *QuotaExceededError
+		var refusal *VolumeExceededError
 		if !errors.As(err, &refusal) {
 			t.Fatalf("%s past its bound → %v, want a typed quota refusal", counter, err)
 		}
@@ -190,8 +190,8 @@ func TestARefusalSaysWhetherAHumanCanAnswerIt(t *testing.T) {
 // asking until the window rolls. A client told "ask a human" about a send
 // ceiling waits forever.
 func TestAHardStopTellsTheAgentNoApprovalWillLiftIt(t *testing.T) {
-	_, hard := quotaGate(over(agentquota.Egress, 21, 20)).Admit(agentCtx(principal.ScopeSend), egressSpec, noResolve)
-	_, soft := quotaGate(over(agentquota.Reads, 2001, 2000)).Admit(agentCtx(principal.ScopeRead), readSpec, noResolve)
+	_, hard := quotaGate(over(agentvolume.Egress, 21, 20)).Admit(agentCtx(principal.ScopeSend), egressSpec, noResolve)
+	_, soft := quotaGate(over(agentvolume.Reads, 2001, 2000)).Admit(agentCtx(principal.ScopeRead), readSpec, noResolve)
 
 	if !strings.Contains(hard.Error(), "no approval lifts it") {
 		t.Errorf("a hard stop does not say that no approval lifts it: %q", hard)
@@ -207,11 +207,11 @@ func TestAHardStopTellsTheAgentNoApprovalWillLiftIt(t *testing.T) {
 	}
 }
 
-// A caller who may not run the verb at all must not learn that a quota exists,
+// A caller who may not run the verb at all must not learn that a volume budget exists,
 // let alone how much of it is spent. Scope is checked first, and the meter is
 // never asked.
 func TestAnOutOfScopeCallerNeverLearnsTheQuotaExists(t *testing.T) {
-	quota := over(agentquota.Reads, 9999, 2000)
+	quota := over(agentvolume.Reads, 9999, 2000)
 
 	_, err := quotaGate(quota).Admit(agentCtx(principal.ScopeWrite), readSpec, noResolve)
 
@@ -223,12 +223,12 @@ func TestAnOutOfScopeCallerNeverLearnsTheQuotaExists(t *testing.T) {
 	}
 }
 
-// A read seat is refused for a write BEFORE any quota is consulted, so the two
+// A read seat is refused for a write BEFORE any volume budget is consulted, so the two
 // refusals cannot be confused: one is a licensing ceiling no approval lifts, the
 // other a volume threshold a human can release.
 func TestTheSeatCeilingIsAnsweredBeforeTheQuota(t *testing.T) {
-	quota := over(agentquota.Writes, 500, 200)
-	gate := NewGate(&stubAuthority{seat: principal.SeatRead}, WithQuota(quota))
+	quota := over(agentvolume.Writes, 500, 200)
+	gate := NewGate(&stubAuthority{seat: principal.SeatRead}, WithVolumeMeter(quota))
 
 	_, err := gate.Admit(agentCtx(principal.ScopeWrite), writeSpec, noResolve)
 
@@ -250,8 +250,8 @@ func TestACallUnderEveryBoundIsAdmitted(t *testing.T) {
 	}
 	// WHICH two, not how many: a regression that asked Reads twice — dropping
 	// the call ceiling entirely — would satisfy a count and lose the ceiling
-	// every other quota sits under.
-	if len(quota.asked) != 2 || quota.asked[0] != agentquota.Calls || quota.asked[1] != agentquota.Reads {
+	// every other counter sits under.
+	if len(quota.asked) != 2 || quota.asked[0] != agentvolume.Calls || quota.asked[1] != agentvolume.Reads {
 		t.Errorf("one read consulted %v; it owes the call ceiling FIRST and then its own counter", quota.asked)
 	}
 }
@@ -259,7 +259,7 @@ func TestACallUnderEveryBoundIsAdmitted(t *testing.T) {
 // A human never enters this path at all — the gate returns before any agent
 // check — so a busy agent cannot lock its own operator out of the product.
 func TestAHumanIsNeverRefusedByAQuota(t *testing.T) {
-	quota := over(agentquota.Reads, 9999, 2000)
+	quota := over(agentvolume.Reads, 9999, 2000)
 	ctx := principal.WithWorkspaceID(context.Background(), testWorkspace)
 	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalHuman, ID: "human:rep"})
 
@@ -289,14 +289,14 @@ func TestAGateWithNoQuotaDoesNotEnforceOne(t *testing.T) {
 // same records through /v1 — one credential, two doors, one of them unbounded,
 // which is exactly what ADR-0055 says must not be possible.
 func TestTheRestReadPathRefusesOnTheSameBound(t *testing.T) {
-	quota := over(agentquota.Reads, 2001, 2000)
+	quota := over(agentvolume.Reads, 2001, 2000)
 
 	err := quotaGate(quota).AdmitRead(agentCtx(principal.ScopeRead))
 
 	if !errors.Is(err, apperrors.ErrBudgetExceeded) {
 		t.Fatalf("a REST agent read past the bound → %v, want ErrBudgetExceeded", err)
 	}
-	if len(quota.asked) != 1 || quota.asked[0] != agentquota.Reads {
+	if len(quota.asked) != 1 || quota.asked[0] != agentvolume.Reads {
 		t.Errorf("a REST read consulted %v, want the read counter alone", quota.asked)
 	}
 }
@@ -306,12 +306,12 @@ func TestTheRestReadPathRefusesOnTheSameBound(t *testing.T) {
 // surface this request never touched, and the two doors would then disagree
 // about what a call is.
 func TestARestReadIsNotChargedAgainstTheToolCallCeiling(t *testing.T) {
-	quota := over(agentquota.Calls, 5000, 1000)
+	quota := over(agentvolume.Calls, 5000, 1000)
 
 	if err := quotaGate(quota).AdmitRead(agentCtx(principal.ScopeRead)); err != nil {
 		t.Fatalf("a REST read was suspended by the TOOL call ceiling: %v", err)
 	}
-	if quota.askedFor(agentquota.Calls) {
+	if quota.askedFor(agentvolume.Calls) {
 		t.Error("the tool-call ceiling was consulted for a REST read")
 	}
 }
@@ -326,7 +326,7 @@ func TestARestReadUnderTheBoundIsAdmitted(t *testing.T) {
 // A human's REST read is never touched by the agent bound — their authority is
 // RBAC at the store, and a busy agent must not lock its operator out of the UI.
 func TestAHumansRestReadIsNeverRefusedByTheBound(t *testing.T) {
-	quota := over(agentquota.Reads, 9999, 2000)
+	quota := over(agentvolume.Reads, 9999, 2000)
 	ctx := principal.WithWorkspaceID(context.Background(), testWorkspace)
 	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalHuman, ID: "human:rep"})
 

--- a/backend/internal/platform/auth/volume.go
+++ b/backend/internal/platform/auth/volume.go
@@ -3,7 +3,7 @@
 
 package auth
 
-// The quantitative third of "scope ∧ tier ∧ quota" (interfaces.md §2), and the
+// The quantitative third of "scope ∧ tier ∧ volume" (interfaces.md §2), and the
 // §2.4 ladder's refusing half.
 //
 // The first two terms are BOOLEAN — may this caller run this verb at all — and
@@ -21,47 +21,47 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/margince/margince/backend/internal/platform/agentquota"
+	"github.com/margince/margince/backend/internal/platform/agentvolume"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/ports/mcp"
 )
 
-// Quota answers what the calling agent has spent this window on one counter. It
+// VolumeMeter answers what the calling agent has spent this window on one counter. It
 // is an interface rather than the concrete meter so this package — the one
 // admission point — stays testable without a Redis client, and so a deployment
 // that has composed no bound is a visible nil rather than a meter that silently
 // answers "plenty".
-type Quota interface {
-	Read(ctx context.Context, c agentquota.Counter) agentquota.Reading
+type VolumeMeter interface {
+	Read(ctx context.Context, c agentvolume.Counter) agentvolume.Reading
 }
 
-// QuotaExceededError is a volume refusal, carrying the reading it was made from.
+// VolumeExceededError is a volume refusal, carrying the reading it was made from.
 //
 // It is a TYPE rather than a message because the two halves of the ladder are
 // told apart by it: a refusal on a releasable counter has somewhere to go — the
 // surface stages the question for the human who lent the Passport — and one on a
 // hard stop does not. A caller matching on prose would eventually stage a
-// release for a quota nothing can release.
+// release for a counter nothing can release.
 //
 // It unwraps to the sentinel interfaces.md §0 reserves for MCP-SESS-*, so every
 // existing errors.Is check and every transport that maps sentinels to wire codes
 // keeps working without learning this type.
-type QuotaExceededError struct {
+type VolumeExceededError struct {
 	// Tool is the call that was refused. Empty on the REST read path, which has
 	// no tool spec to name.
 	Tool string
 	// Reading is the window as the meter read it: the counter, what was
 	// observed, the effective limit, and the window a release must name.
-	Reading agentquota.Reading
+	Reading agentvolume.Reading
 }
 
 // Releasable reports whether a human can answer this refusal — the difference
 // between BYO-STEP-1/2 (step-up and batch-confirm) and BYO-STEP-3/4 (hard stop
 // and suspension).
-func (e *QuotaExceededError) Releasable() bool { return e.Reading.Counter.Releasable() }
+func (e *VolumeExceededError) Releasable() bool { return e.Reading.Counter.Releasable() }
 
 // Unwrap makes every existing budget check see this as what it is.
-func (e *QuotaExceededError) Unwrap() error { return apperrors.ErrBudgetExceeded }
+func (e *VolumeExceededError) Unwrap() error { return apperrors.ErrBudgetExceeded }
 
 // Error states the numbers and what ends the refusal, because those are two
 // different things per rung and an agent's next move depends on which it got.
@@ -72,7 +72,7 @@ func (e *QuotaExceededError) Unwrap() error { return apperrors.ErrBudgetExceeded
 // REST door has no tool to name and stages nothing. Promising here that
 // somebody is looking at it would leave a REST caller waiting on an approval
 // that was never created.
-func (e *QuotaExceededError) Error() string {
+func (e *VolumeExceededError) Error() string {
 	what := "this agent"
 	if e.Tool != "" {
 		what = e.Tool
@@ -87,19 +87,6 @@ func (e *QuotaExceededError) Error() string {
 		what, e.Reading.Observed, e.Reading.Limit, e.Reading.Counter)
 }
 
-// refuseOnQuota applies every volume bound one tool call is subject to, and
-// answers the first one it crosses.
-//
-// CALLS IS ASKED FIRST, and the order is a decision. It is the ceiling every
-// other quota sits under (BYO-STEP-4's suspension), so a Passport that has
-// crossed it is refused for every verb — and answering the per-kind quota
-// instead would tell a suspended caller which of its allowances still has
-// headroom, which is a map of what to spend next.
-//
-// Then the counter the call itself belongs to, DERIVED from the spec rather
-// than listed, by the same function the charge point uses (agentquota.CounterFor).
-// One derivation means the quota that refuses and the quota that is paid can
-// never be two different quotas.
 // AdmitReplay is the admission a RECORDED answer takes before it is served
 // again. It is the volume half of Admit and nothing else, and each omission is
 // deliberate rather than an economy:
@@ -122,17 +109,30 @@ func (g *Gate) AdmitReplay(ctx context.Context, spec mcp.ToolSpec) error {
 	if g == nil {
 		return nil
 	}
-	return g.refuseOnQuota(ctx, spec)
+	return g.refuseOnVolume(ctx, spec)
 }
 
-func (g *Gate) refuseOnQuota(ctx context.Context, spec mcp.ToolSpec) error {
-	if g.quota == nil {
+// refuseOnVolume applies every volume bound one tool call is subject to, and
+// answers the first one it crosses.
+//
+// CALLS IS ASKED FIRST, and the order is a decision. It is the ceiling every
+// other counter sits under (BYO-STEP-4's suspension), so a Passport that has
+// crossed it is refused for every verb — and answering the per-kind counter
+// instead would tell a suspended caller which of its allowances still has
+// headroom, which is a map of what to spend next.
+//
+// Then the counter the call itself belongs to, DERIVED from the spec rather
+// than listed, by the same function the charge point uses (agentvolume.CounterFor).
+// One derivation means the counter that refuses and the counter that is paid can
+// never be two different counters.
+func (g *Gate) refuseOnVolume(ctx context.Context, spec mcp.ToolSpec) error {
+	if g.volume == nil {
 		return nil
 	}
-	for _, c := range []agentquota.Counter{agentquota.Calls, agentquota.CounterFor(spec)} {
-		reading := g.quota.Read(ctx, c)
+	for _, c := range []agentvolume.Counter{agentvolume.Calls, agentvolume.CounterFor(spec)} {
+		reading := g.volume.Read(ctx, c)
 		if reading.Exceeded {
-			return &QuotaExceededError{Tool: spec.Name, Reading: reading}
+			return &VolumeExceededError{Tool: spec.Name, Reading: reading}
 		}
 	}
 	return nil

--- a/backend/internal/platform/httperr/servedmeter.go
+++ b/backend/internal/platform/httperr/servedmeter.go
@@ -13,7 +13,7 @@ import "reflect"
 // the count is taken at the ONE place a record becomes a REST response instead
 // of in the ~290 handlers that would each have to remember.
 //
-// This package holds no request and knows nothing about quotas, so a meter that
+// This package holds no request and knows nothing about counters, so a meter that
 // cannot record its charge answers the request ITSELF and reports proceed=false;
 // WriteJSON then writes nothing more. That keeps the decision about what an
 // uncountable answer costs with the door that has the context to make it.

--- a/backend/internal/shared/apperrors/apperrors.go
+++ b/backend/internal/shared/apperrors/apperrors.go
@@ -111,7 +111,7 @@ var (
 	// no longer matches If-Match (409 version_skew, ADR-0036).
 	ErrVersionSkew = errors.New("version skew")
 
-	// ErrBudgetExceeded: a session or agent quota ran out
+	// ErrBudgetExceeded: a session or agent volume budget ran out
 	// (api-rate-limits §2; 429-equivalent).
 	ErrBudgetExceeded = errors.New("budget exceeded")
 
@@ -135,7 +135,7 @@ var (
 	// seat and never clears by an admin's action, and from ErrBudgetExceeded,
 	// which is metered and refills on its own — nothing about this one clears
 	// with time, and telling a caller to retry would be advice that can only
-	// ever fail. It is the licensed ceiling (A36/ADR-0029), not a quota.
+	// ever fail. It is the licensed ceiling (A36/ADR-0029), not a volume budget.
 	ErrSeatLimitReached = errors.New("seat limit reached")
 )
 

--- a/backend/internal/shared/ports/mcp/mcp.go
+++ b/backend/internal/shared/ports/mcp/mcp.go
@@ -6,7 +6,7 @@
 // its autonomy tier, and JSON-schema in/out bound to a crm.yaml operation.
 // The registry's admission gate — scope ∧ tier (∧ the read/full seat
 // ceiling) — runs BEFORE Handle, so per-call policy lives in the typed
-// model, never ad-hoc inside a handler. (Per-agent quota/budget is
+// model, never ad-hoc inside a handler. (Per-agent volume budget is
 // specified but not yet enforced here; it joins this gate when the budget
 // layer lands.)
 package mcp

--- a/backend/migrations/core/1788320101_a_budget_is_not_a_sales_quota.down.sql
+++ b/backend/migrations/core/1788320101_a_budget_is_not_a_sales_quota.down.sql
@@ -1,0 +1,7 @@
+-- Puts the old spellings back. Lossy in one way worth naming: where the up half
+-- folded an old row's counts into a new one, the two are now one row and the
+-- split cannot be recovered -- the rename returns, the arithmetic does not.
+SET LOCAL lock_timeout = '3s';
+
+UPDATE approval SET kind = 'quota_release' WHERE kind = 'volume_release';
+UPDATE approval_autonomy_policy SET kind = 'quota_release' WHERE kind = 'volume_release';

--- a/backend/migrations/core/1788320101_a_budget_is_not_a_sales_quota.up.sql
+++ b/backend/migrations/core/1788320101_a_budget_is_not_a_sales_quota.up.sql
@@ -1,0 +1,47 @@
+-- The operational budgets stop being called quotas.
+--
+-- Until the sales quota was retired, one word named two unrelated things: the
+-- revenue target a manager typed, and the volume ceiling that stops an agent
+-- reading, writing or spending without bound. The first is gone. The second is
+-- a safety limit and stays exactly as it was -- this migration renames what it
+-- is CALLED, and changes no behaviour, no threshold and no refusal.
+--
+-- ONE STORED VALUE, in two tables, free text with no CHECK constraint to drop
+-- and re-add. The AI provider's own sentinel is NOT renamed: 'provider_quota'
+-- names the VENDOR's quota, and calling it something else here would hide
+-- which system refused.
+--
+--   approval.kind = 'quota_release' names the offer a human decides when an
+--   agent has reached its ceiling. approval_autonomy_policy.kind carries the
+--   same string as half of its (user, kind) grain, and every decision writes a
+--   row there -- so renaming one and not the other would split a rep's
+--   history from their future counts at the moment of the deploy.
+----
+-- ROLLING DEPLOY. An old replica still writing 'quota_release' after this runs
+-- produces a row the new code does not recognise as decidable; the card sits
+-- until the rollout finishes rather than being decided wrongly. That is the
+-- safe direction, and the window is one rollout.
+SET LOCAL lock_timeout = '3s';
+
+UPDATE approval SET kind = 'volume_release' WHERE kind = 'quota_release';
+
+-- The autonomy grain is UNIQUE on (user_id, kind), so a rep who somehow holds
+-- both spellings would collide on a bare rename (uq_approval_autonomy_policy_user_kind,
+-- 1787806660). Fold the old row's three counters into the new one where both
+-- exist, drop the folded row, then rename what is left.
+UPDATE approval_autonomy_policy AS fresh
+   SET approved_clean  = fresh.approved_clean  + stale.approved_clean,
+       approved_edited = fresh.approved_edited + stale.approved_edited,
+       rejected        = fresh.rejected        + stale.rejected
+  FROM approval_autonomy_policy AS stale
+ WHERE stale.user_id = fresh.user_id
+   AND stale.kind = 'quota_release'
+   AND fresh.kind = 'volume_release';
+
+DELETE FROM approval_autonomy_policy
+ WHERE kind = 'quota_release'
+   AND EXISTS (SELECT 1 FROM approval_autonomy_policy other
+                WHERE other.user_id = approval_autonomy_policy.user_id
+                  AND other.kind = 'volume_release');
+
+UPDATE approval_autonomy_policy SET kind = 'volume_release' WHERE kind = 'quota_release';

--- a/backend/pkg/extension/verb.go
+++ b/backend/pkg/extension/verb.go
@@ -281,7 +281,7 @@ func (v Verb) validateGovernance() error {
 	// was expressible, and the first unit to use the secrets surface expressed
 	// it: its store-signing-key operation declared neither, the object check in the
 	// serving adapter therefore never ran, and the operation was admitted on
-	// scope ∧ seat ∧ tier ∧ quota alone. For a cookie-session human that is any
+	// scope ∧ seat ∧ tier ∧ volume alone. For a cookie-session human that is any
 	// authenticated seat. A read-only user replaced the installation's signing
 	// key, on the REST route and through the agent, and every signature after it
 	// was made with the key they chose. Found by the tier's UAT re-run (R1).
@@ -301,7 +301,7 @@ func (v Verb) validateGovernance() error {
 	if v.RequestedScope == ScopeWrite || v.RequestedScope == ScopeDraft {
 		return fmt.Errorf("operation %s requests the %q scope but declares no RBAC object — an operation that "+
 			"changes this installation's state must name something a role document can withhold, or it is "+
-			"admitted on scope, seat, tier and quota alone (i.e. any authenticated seat). "+
+			"admitted on scope, seat, tier and volume budget alone (i.e. any authenticated seat). "+
 			"Declare x-rbac-object (ext_%s_<object>) and x-rbac-action",
 			v.OperationID, string(v.RequestedScope), strings.ReplaceAll(string(v.Unit), "-", "_"))
 	}

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -317,7 +317,6 @@ internal/modules/agents/outputshapes.go#const block at const schemaObject
 internal/modules/agents/outputshapes.go#const envelopeDataMember
 internal/modules/agents/outputshapes_test.go#func TestDeclaredOutputSchemasMatchTheCommittedRendering
 internal/modules/agents/outputshapes_test.go#func renderDeclaredSchemas
-internal/modules/agents/quotarelease.go#type QuotaReleaseRequest.Proposal
 internal/modules/agents/recordtyped.go#const block at const typeLead
 internal/modules/agents/registration.go#func envelopedSpec
 internal/modules/agents/registration.go#func unitOwned
@@ -334,6 +333,7 @@ internal/modules/agents/tools_project360_result.go#type Project360PhaseHistory
 internal/modules/agents/tools_resolve.go#var resolveKinds
 internal/modules/agents/tools_tags.go#func decodeTagging
 internal/modules/agents/tools_tags.go#func taggingSchema
+internal/modules/agents/volumerelease.go#type VolumeReleaseRequest.Proposal
 internal/modules/ai/feedback.go#const fieldSubjectType
 internal/modules/ai/feedback.go#type RecordInput.ClaimPath
 internal/modules/ai/railemit_test.go#func TestADegradedCallSaysWhyEvenWithNoSentinel
@@ -562,8 +562,8 @@ internal/modules/signals/signal.go#func OfOrganizationWhere
 internal/modules/signals/warmroom.go#func RankRouteIn
 internal/modules/signals/warmroom.go#func RouteInEdges
 internal/modules/webhooks/store.go#const fieldEventTypes
-internal/platform/agentquota/counter.go#func CounterFor
-internal/platform/agentquota/meter_test.go#var governedCounters
+internal/platform/agentvolume/counter.go#func CounterFor
+internal/platform/agentvolume/meter_test.go#var governedCounters
 internal/platform/auth/capturePrivacyCoverage_test.go#func TestEveryTableThatCanHoldAnOwnerRowIsOwnerPrivate
 internal/platform/auth/edgeread.go#const relationshipObject
 internal/platform/auth/fieldmask.go#func StampWritable

--- a/docs/evidence/extension-tier/DESIGN.md
+++ b/docs/evidence/extension-tier/DESIGN.md
@@ -124,7 +124,7 @@ Against the mistakes above, and inside §2.0's trust model:
   handler-bearing and contract-only verbs alike (`pkg/extension/verb.go:validateGovernance`).
   **This guarantee was not in the design and exists because its absence shipped:** notes's
   store-signing-key declared neither object nor action, so the serving adapter's object check never
-  ran and the operation was admitted on scope ∧ seat ∧ tier ∧ quota alone — which, for a
+  ran and the operation was admitted on scope ∧ seat ∧ tier ∧ volume budget alone — which, for a
   cookie-session human, is any authenticated seat. The acceptance re-run (finding R1) had a read-only
   seat replace the installation's signing key on both the REST route and the agent transport. The rule
   closes the class for every future unit rather than patching the one unit.

--- a/docs/explanation/agent-surface.md
+++ b/docs/explanation/agent-surface.md
@@ -101,7 +101,7 @@ not architecture**. `internal/modules/ai/` owns it:
 
 ## Honest gaps
 
-- **Per-agent quota is specified but not yet enforced.** The admission gate binds scope ∧ seat ∧ tier
+- **The per-agent volume budget is specified but not yet enforced.** The admission gate binds scope ∧ seat ∧ tier
   today; a per-agent budget ceiling is designed but not wired.
 
 ## Where to go next

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -455,7 +455,7 @@ export const aiHealth = {
       healthy: false,
       calls: 7,
       failures: 7,
-      last_sentinel: "provider_quota",
+      last_sentinel: "provider_budget",
       last_call_at: "2026-07-13T09:12:00Z",
       median_latency_ms: 2_180,
     },

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1287,7 +1287,7 @@ export const de = {
   "approval.kind.send_email": "E-Mail senden",
   "approval.kind.held_draft": "Entworfene E-Mail prüfen",
   "approval.kind.book_meeting": "Termin buchen",
-  "approval.kind.quota_release": "Einen Agenten weiterarbeiten lassen",
+  "approval.kind.volume_release": "Einen Agenten weiterarbeiten lassen",
   "approval.kind.coldstart": "Neuen Account befüllen",
   "approval.kind.enrich": "Aus dem Web anreichern",
   "approval.kind.deepread": "Unternehmensseite lesen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1331,7 +1331,7 @@ export const en = {
   "approval.kind.send_email": "Send an email",
   "approval.kind.held_draft": "Review a drafted email",
   "approval.kind.book_meeting": "Book a meeting",
-  "approval.kind.quota_release": "Let an agent continue",
+  "approval.kind.volume_release": "Let an agent continue",
   "approval.kind.coldstart": "Fill in a new account",
   "approval.kind.enrich": "Enrich from the web",
   "approval.kind.deepread": "Read the company site",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1288,7 +1288,7 @@ export const vi = {
   "approval.kind.send_email": "Gửi một email",
   "approval.kind.held_draft": "Xem lại email đã soạn",
   "approval.kind.book_meeting": "Đặt một lịch họp",
-  "approval.kind.quota_release": "Cho tác nhân tiếp tục",
+  "approval.kind.volume_release": "Cho tác nhân tiếp tục",
   "approval.kind.coldstart": "Điền thông tin công ty mới",
   "approval.kind.enrich": "Bổ sung thông tin từ web",
   "approval.kind.deepread": "Đọc website công ty",

--- a/frontend/src/screens/approvalkind.test.ts
+++ b/frontend/src/screens/approvalkind.test.ts
@@ -203,7 +203,7 @@ describe("what a staged proposal shows", () => {
   // exactly its limit is one that just hit the ceiling.
   it("keeps a usage figure that equals its own limit", () => {
     const fields = resolveDisplay(
-      "quota_release",
+      "volume_release",
       { tool: "send_email", observed: 40, limit: 40, allowance: 100 },
       t,
       day,

--- a/frontend/src/screens/approvalkind.ts
+++ b/frontend/src/screens/approvalkind.ts
@@ -42,7 +42,7 @@ export const KIND_LABEL: Readonly<Record<string, MessageKey>> = {
   coldstart: "approval.kind.coldstart",
   // Not a change to a record — a question about a credential's volume, which is
   // why its label says what a yes DOES rather than naming an object.
-  quota_release: "approval.kind.quota_release",
+  volume_release: "approval.kind.volume_release",
   enrich: "approval.kind.enrich",
   deepread: "approval.kind.deepread",
   linkedin_match: "approval.kind.linkedin_match",
@@ -432,7 +432,7 @@ export const DISPLAY_FIELDS: Readonly<Record<string, readonly DisplayField[]>> =
     ],
     // The agent hit a ceiling and is asking for room. What it was doing and how
     // much it has used are the question; the passport id is not.
-    quota_release: [
+    volume_release: [
       { field: "tool", label: "approval.field.tool", as: "text" },
       { field: "observed", label: "approval.field.observed", as: "text" },
       { field: "limit", label: "approval.field.limit", as: "text" },

--- a/frontend/src/screens/approvalrow.render.test.tsx
+++ b/frontend/src/screens/approvalrow.render.test.tsx
@@ -146,7 +146,7 @@ describe("the offer to put an approved change back", () => {
     render(
       <ApprovalRow
         approval={closeDateApproval({
-          kind: "quota_release",
+          kind: "volume_release",
           target_entity_type: null,
           target_entity_id: null,
         })}


### PR DESCRIPTION
Follow-up to #3625, which removed the human-set sales quota. Until then one word named two unrelated things: the revenue target a manager typed, and the volume ceiling that stops an agent reading, writing or spending without bound. The first is gone. This renames the second so the word stops doing double duty.

## Nothing about the limits changes

Same thresholds, same counters, same refusal order, same ladder. I checked that mechanically rather than by eye: with names normalised and comments stripped, `auth/volume.go`, `auth/admit.go`, `agents/volume.go` and `approvals/volumerelease.go` are character-for-character identical to the files they replace on `main`.

The package `internal/platform/agentquota` becomes `agentvolume`, the auth interface `Quota` becomes `VolumeMeter`, and the types, options, files and seam methods that carried the old noun follow.

## Two stored values move, so a migration carries the rows

- **`approval.kind`** `quota_release` becomes `volume_release`. `approval_autonomy_policy.kind` carries the same string as half of its `(user_id, kind)` grain, and every decision writes there, so renaming one without the other would split a rep's decided history from their future counts at the moment of the deploy. Where a rep somehow holds both spellings the unique constraint would collide on a bare rename, so the migration folds the old row's three counters into the new one, drops the folded row, then renames the rest.
- **`ai_call.error_sentinel`** `provider_quota` becomes `provider_budget`. The contract already tells a reader to treat an unrecognized failure code as "some failure" rather than refusing it, so a client that has not been updated degrades to the honest general answer instead of breaking.

The migration header states the rolling-deploy consequence rather than hiding it: an old replica writing the old spelling after the migration runs produces a card the new code does not treat as decidable, so it waits for the rollout instead of being decided wrongly.

## What is deliberately NOT renamed

Every quota belonging to somebody else: HubSpot's rate allowance, Gmail's send cap, the AI vendors' own error text, GitHub's cache. Those name a limit another company enforces, and calling them something else here would only hide which system refused. `modules/ai/budget.go` still matches the literal word "quota" in vendor error strings, and its tests still pass.

## Verification

`make check-backend` and `make check-fe` (5713 tests) both green. `craft-static` at zero findings, `rls-store-path` and `no-jurisdiction` clean. Integration lanes green: the migrations lane including this migration's reverse-and-reapply, the approvals package, and 64 agent/approval/AI tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the operational agent budgets from "quota" to "volume" so the word no longer means both a sales target and a safety limit. No behavior, thresholds, or refusal order change; only names move.

- Renames `internal/platform/agentquota` to `agentvolume`, the auth interface `Quota` to `VolumeMeter`, and all related types, options, and files.
- Keeps "quota" where it names another company's limit (HubSpot, Gmail, AI vendors, GitHub) to avoid hiding which system refused.

**Migration**

- `approval.kind` `quota_release` becomes `volume_release`; `approval_autonomy_policy.kind` is migrated together because it shares the same string and grain.
- `ai_call.error_sentinel` `provider_quota` becomes `provider_budget`; unupdated clients degrade to the general "some failure" instead of breaking.
- During rolling deploy, an old replica writing the old spelling after the migration produces a card the new code waits on rather than deciding wrongly.

<sup>Written for commit 5b1d301722aa52dc4d9e1183e5827c32cbb3fab7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Renamed usage-limit terminology from “quota” to “volume budget” across approval flows, provider spending limits, and operational messaging.
  - Approval records and policies now use the `volume_release` designation.
  - Provider spending-limit errors are reported as `provider_budget`.
  - Existing safety limits, enforcement behavior, escalation handling, and user-facing messages remain unchanged.
- **Documentation**
  - Updated API references, translations, and related documentation to reflect the new terminology.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->