### PR TITLE
A lead can read the week their team just closed

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2287,6 +2287,57 @@ export const de = {
   // Die kommende Woche. Der eingefrorene Rückblick sagt, was war; dies ist der
   // einzige Teil dieser Seite, den noch jemand ändern kann.
   "plan.title": "Nächste Woche planen",
+  // Die Woche eines Teams, eingefroren beim Abschluss. Zwei Wochen sind
+  // vergleichbar, weil keine sich unter dem Vergleich bewegt.
+  "teamweekly.title": "Die Woche des Teams",
+  "teamweekly.weekOf": "{team} · Woche ab {day}",
+  "teamweekly.frozen": "Eingefroren",
+  "teamweekly.loading": "Teamwoche wird gelesen",
+  "teamweekly.empty": "Für diese Woche gibt es nichts zu zeigen.",
+  "teamweekly.forbidden":
+    "Die Woche eines Teams ist eine Teamfrage, und dein Zugriff reicht nur bis zu deinen eigenen Datensätzen.",
+  "teamweekly.noSnapshot":
+    "Für dieses Team wurde noch keine Woche abgeschlossen. Die erste Momentaufnahme entsteht am Montag nach der ersten vollen Woche.",
+  "teamweekly.pickTeam": "Team auswählen",
+  "teamweekly.repsUnread":
+    "{count} Mitglied(er) konnten nicht gelesen werden. Alle Zahlen hier decken {counted} ab.",
+  "teamweekly.ofTotal": "{part} von {whole}",
+  "teamweekly.headline.plain":
+    "Die Woche lief ohne einen Wert, der in eine Richtung heraussticht.",
+  "teamweekly.headline.healthy":
+    "{reading} ist gesund bei {pct}%, gemessen an einer Schwelle von {bar}%.",
+  "teamweekly.headline.weak":
+    "{reading} ist es nicht, bei {pct}% gegen eine Schwelle von {bar}%.",
+  "teamweekly.reading.firstResponse": "Erstreaktion",
+  "teamweekly.reading.nextStep": "Termine mit nächstem Schritt",
+  "teamweekly.reading.commitments": "Eingehaltene Zusagen",
+  "teamweekly.card.firstResponse": "Rechtzeitig beantwortet",
+  "teamweekly.card.firstResponseBasis": "{breached} überschritten",
+  "teamweekly.card.meetings": "Termine mit nächstem Schritt",
+  "teamweekly.card.meetingsBasis": "der gehaltenen Termine",
+  "teamweekly.card.commitments": "Eingehaltene Zusagen",
+  "teamweekly.card.commitmentsBasis": "des Zugesagten",
+  "teamweekly.card.won": "Gewonnen",
+  "teamweekly.card.wonBasis": "{lost} verloren",
+  "teamweekly.card.reps": "Gezählte Mitglieder",
+  "teamweekly.card.repsBasis": "deren Woche vollständig gelesen wurde",
+  "teamweekly.movement.title": "Was die Woche bewegt hat",
+  "teamweekly.movement.won": "Gewonnen",
+  "teamweekly.movement.lost": "Verloren",
+  "teamweekly.movement.meetings": "Gehaltene Termine",
+  "teamweekly.movement.leads": "Zugewiesene Leads",
+  "teamweekly.coach.title": "Diese Woche begleiten",
+  "teamweekly.coach.sub":
+    "Ein Schwerpunkt pro Mitglied — auch für das Mitglied, dessen Woche gut lief.",
+  "teamweekly.coach.empty": "In dieser Woche war niemand in diesem Team.",
+  "teamweekly.focus.help_requested": "Hat um Hilfe gebeten",
+  "teamweekly.focus.leads_breached": "Leads blieben unbeantwortet",
+  "teamweekly.focus.commitments_missed": "Zusagen verpasst",
+  "teamweekly.focus.meetings_without_next_step":
+    "Termine ohne nächsten Schritt",
+  "teamweekly.focus.strong_week": "Zum Nachmachen",
+  "teamweekly.focus.quiet_week": "Eine ruhige Woche",
+
   "plan.sub": "Was du dir vorgenommen hast — und was du dafür brauchst.",
   "plan.loading": "Plan wird gelesen",
   "plan.empty": "Noch nichts auf dem Plan.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2324,6 +2324,57 @@ export const en = {
   // The week ahead. The frozen review says what happened; this is the only part
   // of that page anybody can still change.
   "plan.title": "Plan next week",
+  // A team's week, frozen when it closed. Two weeks compare because neither
+  // moves under the comparison.
+  "teamweekly.title": "The team's week",
+  "teamweekly.weekOf": "{team} · week of {day}",
+  "teamweekly.frozen": "Frozen",
+  "teamweekly.loading": "Reading the team's week",
+  "teamweekly.empty": "Nothing to show for this week.",
+  "teamweekly.forbidden":
+    "A team's week is a team question, and your access reaches your own rows only.",
+  "teamweekly.noSnapshot":
+    "No week has closed for this team yet. The first snapshot is written on the Monday after their first full week.",
+  "teamweekly.pickTeam": "Choose a team",
+  "teamweekly.repsUnread":
+    "{count} member(s) could not be read. Every figure here covers {counted}.",
+  "teamweekly.ofTotal": "{part} of {whole}",
+  "teamweekly.headline.plain":
+    "The week ran without a reading that stands out either way.",
+  "teamweekly.headline.healthy":
+    "{reading} is healthy at {pct}%, against a bar of {bar}%.",
+  "teamweekly.headline.weak":
+    "{reading} is not, at {pct}% against a bar of {bar}%.",
+  "teamweekly.reading.firstResponse": "First response",
+  "teamweekly.reading.nextStep": "Meetings with a next step",
+  "teamweekly.reading.commitments": "Promises kept",
+  "teamweekly.card.firstResponse": "Answered in time",
+  "teamweekly.card.firstResponseBasis": "{breached} breached",
+  "teamweekly.card.meetings": "Meetings with a next step",
+  "teamweekly.card.meetingsBasis": "of the meetings held",
+  "teamweekly.card.commitments": "Promises kept",
+  "teamweekly.card.commitmentsBasis": "of what was owed",
+  "teamweekly.card.won": "Won",
+  "teamweekly.card.wonBasis": "{lost} lost",
+  "teamweekly.card.reps": "Members counted",
+  "teamweekly.card.repsBasis": "whose week was read in full",
+  "teamweekly.movement.title": "What the week did",
+  "teamweekly.movement.won": "Won",
+  "teamweekly.movement.lost": "Lost",
+  "teamweekly.movement.meetings": "Meetings held",
+  "teamweekly.movement.leads": "Leads routed",
+  "teamweekly.coach.title": "Coach this week",
+  "teamweekly.coach.sub":
+    "One focus per member, including the member whose week went well.",
+  "teamweekly.coach.empty": "Nobody was on this team that week.",
+  "teamweekly.focus.help_requested": "Asked for help",
+  "teamweekly.focus.leads_breached": "Leads went unanswered",
+  "teamweekly.focus.commitments_missed": "Promises missed",
+  "teamweekly.focus.meetings_without_next_step":
+    "Meetings left without a next step",
+  "teamweekly.focus.strong_week": "Worth copying",
+  "teamweekly.focus.quiet_week": "A quiet week",
+
   "plan.sub": "What you said you would do, and what you need to do it.",
   "plan.loading": "Reading your plan",
   "plan.empty": "Nothing on the plan yet.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2271,6 +2271,57 @@ export const vi = {
   // Tuần tới. Bản tổng kết đã đóng băng nói điều đã xảy ra; đây là phần duy nhất
   // của trang đó mà vẫn còn ai đó thay đổi được.
   "plan.title": "Lập kế hoạch tuần tới",
+  // Tuần của một nhóm, đóng băng khi tuần khép lại. Hai tuần so sánh được vì
+  // không tuần nào dịch chuyển dưới phép so sánh.
+  "teamweekly.title": "Tuần của nhóm",
+  "teamweekly.weekOf": "{team} · tuần từ {day}",
+  "teamweekly.frozen": "Đã đóng băng",
+  "teamweekly.loading": "Đang đọc tuần của nhóm",
+  "teamweekly.empty": "Không có gì để hiển thị cho tuần này.",
+  "teamweekly.forbidden":
+    "Tuần của nhóm là câu hỏi cấp nhóm, còn quyền của bạn chỉ tới các bản ghi của chính bạn.",
+  "teamweekly.noSnapshot":
+    "Chưa có tuần nào khép lại cho nhóm này. Ảnh chụp đầu tiên được ghi vào thứ Hai sau tuần đầy đủ đầu tiên.",
+  "teamweekly.pickTeam": "Chọn một nhóm",
+  "teamweekly.repsUnread":
+    "Không đọc được {count} thành viên. Mọi con số ở đây bao phủ {counted}.",
+  "teamweekly.ofTotal": "{part} trên {whole}",
+  "teamweekly.headline.plain":
+    "Tuần trôi qua mà không có chỉ số nào nổi bật theo hướng nào.",
+  "teamweekly.headline.healthy":
+    "{reading} ở mức tốt là {pct}%, so với ngưỡng {bar}%.",
+  "teamweekly.headline.weak":
+    "{reading} thì không, ở {pct}% so với ngưỡng {bar}%.",
+  "teamweekly.reading.firstResponse": "Phản hồi đầu tiên",
+  "teamweekly.reading.nextStep": "Cuộc họp có bước tiếp theo",
+  "teamweekly.reading.commitments": "Cam kết đã giữ",
+  "teamweekly.card.firstResponse": "Trả lời đúng hạn",
+  "teamweekly.card.firstResponseBasis": "{breached} quá hạn",
+  "teamweekly.card.meetings": "Cuộc họp có bước tiếp theo",
+  "teamweekly.card.meetingsBasis": "trên số cuộc họp đã diễn ra",
+  "teamweekly.card.commitments": "Cam kết đã giữ",
+  "teamweekly.card.commitmentsBasis": "trên số đã cam kết",
+  "teamweekly.card.won": "Thắng",
+  "teamweekly.card.wonBasis": "{lost} thua",
+  "teamweekly.card.reps": "Thành viên được tính",
+  "teamweekly.card.repsBasis": "có tuần được đọc đầy đủ",
+  "teamweekly.movement.title": "Tuần đã làm được gì",
+  "teamweekly.movement.won": "Thắng",
+  "teamweekly.movement.lost": "Thua",
+  "teamweekly.movement.meetings": "Cuộc họp đã diễn ra",
+  "teamweekly.movement.leads": "Lead được phân",
+  "teamweekly.coach.title": "Đồng hành tuần này",
+  "teamweekly.coach.sub":
+    "Một trọng tâm cho mỗi thành viên, kể cả người có tuần tốt.",
+  "teamweekly.coach.empty": "Tuần đó không có ai trong nhóm này.",
+  "teamweekly.focus.help_requested": "Đã nhờ giúp đỡ",
+  "teamweekly.focus.leads_breached": "Lead không được trả lời",
+  "teamweekly.focus.commitments_missed": "Cam kết bị bỏ lỡ",
+  "teamweekly.focus.meetings_without_next_step":
+    "Cuộc họp không có bước tiếp theo",
+  "teamweekly.focus.strong_week": "Đáng để học theo",
+  "teamweekly.focus.quiet_week": "Một tuần yên ắng",
+
   "plan.sub": "Điều bạn đã cam kết, và điều bạn cần để làm được.",
   "plan.loading": "Đang đọc kế hoạch của bạn",
   "plan.empty": "Chưa có gì trong kế hoạch.",

--- a/frontend/src/screens/brief.teamweekly.css
+++ b/frontend/src/screens/brief.teamweekly.css
@@ -1,0 +1,37 @@
+/* A team's frozen week. The headline states two readings against the bars they
+   were measured by; everything under it is the figures those readings came from. */
+.teamweekly-headline {
+  margin: 0 0 var(--space-2);
+  color: var(--textContent);
+}
+
+.teamweekly-subhead {
+  margin: 0 0 var(--space-2);
+  color: var(--textMeta);
+}
+
+.teamweekly-coverage {
+  margin: 0;
+  color: var(--textMeta);
+}
+
+.teamweekly-rep {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.teamweekly-rep-name {
+  font-weight: 500;
+  color: var(--textContent);
+}
+
+.teamweekly-rep-focus {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  color: var(--textMeta);
+}

--- a/frontend/src/screens/brief.teamweekly.test.tsx
+++ b/frontend/src/screens/brief.teamweekly.test.tsx
@@ -1,0 +1,244 @@
+/** @vitest-environment jsdom */
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { en } from "../i18n/en";
+import {
+  headlineReadings,
+  TeamWeeklyPanel,
+  TeamWeeklySection,
+} from "./brief.teamweekly";
+import { jsonResponse, render, stubApi } from "./home.testkit";
+import type { TeamWeeklyRep, TeamWeeklyReview } from "./teamweekly.queries";
+
+// A team's frozen week. Every figure came off the snapshot, so the tests that
+// matter are the ones proving the page cannot say more than the snapshot holds.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function rep(over: Partial<TeamWeeklyRep> = {}): TeamWeeklyRep {
+  return {
+    user_id: "u1",
+    display_name: "Lena Fischer",
+    deals_won: 1,
+    leads_breached: 0,
+    meetings_held: 3,
+    commitments_due: 2,
+    commitments_kept: 2,
+    help_requested: 0,
+    focus_kind: "strong_week",
+    focus_label: "Fastest first response on the team",
+    ...over,
+  } as TeamWeeklyRep;
+}
+
+function review(
+  counts: Partial<TeamWeeklyReview["counts"]> = {},
+  over: Partial<TeamWeeklyReview> = {},
+): TeamWeeklyReview {
+  return {
+    id: "r1",
+    team_id: "t1",
+    team_name: "Nord",
+    local_week_start: "2026-06-01",
+    generated_at: "2026-06-08T06:00:00Z",
+    as_of: "2026-06-08T06:00:00Z",
+    reps_unread: 0,
+    counts: {
+      reps_counted: 2,
+      deals_won: 3,
+      deals_lost: 1,
+      leads_routed: 10,
+      leads_answered_in_target: 10,
+      leads_breached: 0,
+      meetings_held: 10,
+      meetings_with_next_step: 5,
+      commitments_due: 4,
+      commitments_kept: 3,
+      ...counts,
+    },
+    reps: [rep()],
+    ...over,
+  } as TeamWeeklyReview;
+}
+
+describe("the headline states the bar it measured against", () => {
+  // A verdict that does not name its bar is an opinion. Both clauses come off
+  // the stored counts, so the sentence cannot disagree with the figures below.
+  it("picks the healthiest reading and the weakest", () => {
+    const { best, worst } = headlineReadings(review());
+
+    expect(best?.key).toBe("teamweekly.reading.firstResponse");
+    expect(worst?.key).toBe("teamweekly.reading.nextStep");
+  });
+
+  // Zero of zero is not zero per cent. A team that routed no leads has no
+  // first-response reading, and inventing one at 0% would report a failure
+  // where nothing was attempted.
+  it("has no reading where nothing was due", () => {
+    const { best, worst } = headlineReadings(
+      review({
+        leads_routed: 0,
+        leads_answered_in_target: 0,
+        meetings_held: 0,
+        meetings_with_next_step: 0,
+        commitments_due: 0,
+        commitments_kept: 0,
+      }),
+    );
+
+    expect(best).toBeNull();
+    expect(worst).toBeNull();
+  });
+
+  // Nothing stood out. Saying so is the honest answer; manufacturing a verdict
+  // from a middling number is not.
+  it("says the plain thing when no reading is decided either way", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () =>
+        jsonResponse(
+          review({
+            leads_routed: 10,
+            leads_answered_in_target: 8,
+            meetings_held: 10,
+            meetings_with_next_step: 8,
+            commitments_due: 10,
+            commitments_kept: 8,
+          }),
+        ),
+    });
+    render(<TeamWeeklySection teamId="t1" />);
+
+    expect(
+      await screen.findByText(en["teamweekly.headline.plain"]),
+    ).toBeTruthy();
+  });
+});
+
+describe("the team's frozen week", () => {
+  // A snapshot covering four of six reps reads exactly like a team of four, and
+  // every figure on the page is short by the same two people.
+  it("states unread members rather than letting the totals imply full coverage", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () =>
+        jsonResponse(review({}, { reps_unread: 2 })),
+    });
+    render(<TeamWeeklySection teamId="t1" />);
+
+    expect(
+      await screen.findByText(
+        en["teamweekly.repsUnread"]
+          .replace("{count}", "2")
+          .replace("{counted}", "2"),
+      ),
+    ).toBeTruthy();
+  });
+
+  it("says nothing about coverage when every member was read", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () => jsonResponse(review()),
+    });
+    const { container } = render(<TeamWeeklySection teamId="t1" />);
+
+    await screen.findByText(en["teamweekly.movement.title"]);
+    expect(container.querySelector(".teamweekly-coverage")).toBeNull();
+  });
+
+  // The two absences are different facts. A screen drawing one plate over both
+  // would tell a lead they lack permission on a Tuesday in their team's first
+  // week.
+  it("tells a refusal apart from a week that has not closed yet", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () =>
+        jsonResponse({ title: "Forbidden" }, 403),
+    });
+    render(<TeamWeeklySection teamId="t1" />);
+
+    expect(await screen.findByText(en["teamweekly.forbidden"])).toBeTruthy();
+    expect(screen.queryByText(en["teamweekly.noSnapshot"])).toBeNull();
+  });
+
+  it("says no week has closed when there is no snapshot", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () =>
+        jsonResponse({ title: "Not Found" }, 404),
+    });
+    render(<TeamWeeklySection teamId="t1" />);
+
+    expect(await screen.findByText(en["teamweekly.noSnapshot"])).toBeTruthy();
+  });
+
+  // One row per member, including the member whose week went well. A page
+  // promising one focus per rep and drawing rows only for the troubled ones
+  // reads as a team where only those people exist.
+  it("draws a row for every member, the good week included", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () =>
+        jsonResponse(
+          review(
+            {},
+            {
+              reps: [
+                rep(),
+                rep({
+                  user_id: "u2",
+                  display_name: "Noah Berger",
+                  focus_kind: "leads_breached",
+                  focus_label: "Three leads went unanswered",
+                }),
+              ],
+            },
+          ),
+        ),
+    });
+    const { container } = render(<TeamWeeklySection teamId="t1" />);
+
+    await screen.findByText("Three leads went unanswered");
+    expect(container.querySelectorAll(".teamweekly-rep")).toHaveLength(2);
+    // The good week is marked as something to copy, not as a problem.
+    expect(screen.getByText(en["teamweekly.focus.strong_week"])).toBeTruthy();
+    expect(screen.getByText("Fastest first response on the team")).toBeTruthy();
+  });
+
+  it("keeps the scorecard at five slots", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () => jsonResponse(review()),
+    });
+    const { container } = render(<TeamWeeklySection teamId="t1" />);
+
+    await screen.findByText(en["teamweekly.movement.title"]);
+    const strip = container.querySelector('[data-testid="teamweekly-strip"]');
+    expect(strip?.children).toHaveLength(5);
+  });
+});
+
+describe("the team picker", () => {
+  // Offered on the same tier the team board is. A picker shown to a reader who
+  // will be refused every team is a control that exists to fail.
+  it("draws nothing at all for a reader whose scope reaches no team", () => {
+    const calls = stubApi({});
+    const { container } = render(<TeamWeeklyPanel offered={false} />);
+
+    expect(container.firstChild).toBeNull();
+    expect(calls.filter((call) => call.path === "/teams")).toHaveLength(0);
+  });
+
+  // One team is not a choice: a control whose only option is the one already
+  // showing asks the reader to confirm what they cannot change.
+  it("reads a single team straight through without a control", async () => {
+    stubApi({
+      "GET /teams": () =>
+        jsonResponse({
+          data: [{ id: "t1", name: "Nord" }],
+          page: { next_cursor: null, has_more: false },
+        }),
+      "GET /weekly-reviews/team": () => jsonResponse(review()),
+    });
+    render(<TeamWeeklyPanel offered />);
+
+    await screen.findByText(en["teamweekly.movement.title"]);
+    expect(screen.queryByLabelText(en["teamweekly.pickTeam"])).toBeNull();
+  });
+});

--- a/frontend/src/screens/brief.teamweekly.tsx
+++ b/frontend/src/screens/brief.teamweekly.tsx
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useState } from "react";
+import { useRecordZone } from "../app/recordzone";
+import { Badge, StatCard } from "../design-system/atoms";
+import { Panel, PanelBody, PanelRow } from "../design-system/panel";
+import { Meter } from "../design-system/readings";
+import { Select } from "../design-system/select";
+import { StatStrip } from "../design-system/statstrip";
+import { SurfaceState } from "../design-system/surfacestate";
+import { formatDate, formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { EntityRef } from "./entityref";
+import {
+  type TeamWeeklyFocusKind,
+  type TeamWeeklyReview,
+  useTeams,
+  useTeamWeeklyReview,
+} from "./teamweekly.queries";
+
+import "./brief.teamweekly.css";
+
+// A team's week, frozen. `/worklist/team` says what the team is carrying now;
+// this says what last week WAS, so two weeks compare and neither moves under
+// the comparison.
+
+/**
+ * The bars the reader is told they were measured against.
+ *
+ * Declared constants rather than numbers buried in a condition, because the
+ * headline states a verdict and a verdict has to name its bar — "answered in
+ * time on 9 of 10 leads" is a reading, "first response is healthy" is a claim,
+ * and the second one is only honest if the reader can see where the line was
+ * drawn.
+ */
+const HEALTHY_RATE = 0.9;
+const WEAK_RATE = 0.7;
+
+/** Which focus rules are a coaching prompt and which are something to copy. */
+const CELEBRATED: ReadonlySet<TeamWeeklyFocusKind> = new Set([
+  "strong_week",
+  "quiet_week",
+]);
+
+const FOCUS_LABEL: Readonly<Record<TeamWeeklyFocusKind, MessageKey>> = {
+  help_requested: "teamweekly.focus.help_requested",
+  leads_breached: "teamweekly.focus.leads_breached",
+  commitments_missed: "teamweekly.focus.commitments_missed",
+  meetings_without_next_step: "teamweekly.focus.meetings_without_next_step",
+  strong_week: "teamweekly.focus.strong_week",
+  quiet_week: "teamweekly.focus.quiet_week",
+};
+
+/** A rate, or null when nothing was due — zero of zero is not zero per cent. */
+function rate(part: number, whole: number): number | null {
+  return whole === 0 ? null : part / whole;
+}
+
+/** One reading, with what it was measured against carried beside it. */
+type Reading = Readonly<{
+  key: MessageKey;
+  value: number;
+  verdict: "healthy" | "weak" | "middling";
+}>;
+
+function readingOf(key: MessageKey, value: number | null): Reading | null {
+  if (value === null) {
+    return null;
+  }
+  const verdict =
+    value >= HEALTHY_RATE
+      ? "healthy"
+      : value <= WEAK_RATE
+        ? "weak"
+        : "middling";
+  return { key, value, verdict };
+}
+
+/**
+ * The two clauses of the headline: the healthiest reading and the weakest.
+ *
+ * Both come from the stored snapshot, so the sentence cannot disagree with the
+ * figures under it. When no reading is decided either way the caller says the
+ * plainest true thing instead — a verdict the data does not support is worse
+ * than no verdict.
+ */
+export function headlineReadings(
+  review: TeamWeeklyReview,
+): Readonly<{ best: Reading | null; worst: Reading | null }> {
+  const counts = review.counts;
+  const readings = [
+    readingOf(
+      "teamweekly.reading.firstResponse",
+      rate(counts.leads_answered_in_target, counts.leads_routed),
+    ),
+    readingOf(
+      "teamweekly.reading.nextStep",
+      rate(counts.meetings_with_next_step, counts.meetings_held),
+    ),
+    readingOf(
+      "teamweekly.reading.commitments",
+      rate(counts.commitments_kept, counts.commitments_due),
+    ),
+  ].filter((reading): reading is Reading => reading !== null);
+
+  return {
+    best: pick(readings, "healthy", (a, b) => a.value > b.value),
+    worst: pick(readings, "weak", (a, b) => a.value < b.value),
+  };
+}
+
+/** The one reading of a verdict that `beats` every other of the same verdict. */
+function pick(
+  readings: readonly Reading[],
+  verdict: Reading["verdict"],
+  beats: (a: Reading, b: Reading) => boolean,
+): Reading | null {
+  return readings.reduce<Reading | null>(
+    (best, reading) =>
+      reading.verdict !== verdict
+        ? best
+        : best === null || beats(reading, best)
+          ? reading
+          : best,
+    null,
+  );
+}
+
+export function TeamWeeklySection({
+  teamId,
+  week,
+}: Readonly<{ teamId: string | undefined; week?: string }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const recordZone = useRecordZone();
+  const answer = useTeamWeeklyReview(teamId, week);
+
+  const state = answer.isPending
+    ? "loading"
+    : answer.isError
+      ? "unavailable"
+      : "ready";
+  const review = answer.data?.kind === "review" ? answer.data.review : null;
+
+  return (
+    <section id="brief-team-weekly" aria-label={t("teamweekly.title")}>
+      <Panel
+        title={t("teamweekly.title")}
+        sub={
+          review
+            ? t("teamweekly.weekOf", {
+                team: review.team_name,
+                day: formatDate(review.local_week_start, locale, recordZone),
+              })
+            : undefined
+        }
+        titleAction={
+          review ? <Badge quiet>{t("teamweekly.frozen")}</Badge> : undefined
+        }
+      >
+        <SurfaceState
+          state={state}
+          emptyLabel={t("teamweekly.empty")}
+          loadingLabel={t("teamweekly.loading")}
+          detail={{ onRetry: () => void answer.refetch() }}
+        >
+          {answer.data?.kind === "absent" && (
+            <PanelBody>
+              <p>
+                {answer.data.why === "forbidden"
+                  ? t("teamweekly.forbidden")
+                  : t("teamweekly.noSnapshot")}
+              </p>
+            </PanelBody>
+          )}
+          {review && (
+            <>
+              <PanelBody>
+                <Headline review={review} />
+                <Coverage review={review} />
+              </PanelBody>
+              <Scorecard review={review} />
+              <Movement review={review} />
+            </>
+          )}
+        </SurfaceState>
+      </Panel>
+      {review && <CoachPanel review={review} />}
+    </section>
+  );
+}
+
+/** Two clauses, each naming a reading against the bar it was measured by. */
+function Headline({ review }: Readonly<{ review: TeamWeeklyReview }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const { best, worst } = headlineReadings(review);
+
+  if (!best && !worst) {
+    return (
+      <h3 className="teamweekly-headline">{t("teamweekly.headline.plain")}</h3>
+    );
+  }
+  return (
+    <h3 className="teamweekly-headline">
+      {best &&
+        t("teamweekly.headline.healthy", {
+          reading: t(best.key),
+          pct: formatNumber(Math.round(best.value * 100), locale),
+          bar: formatNumber(Math.round(HEALTHY_RATE * 100), locale),
+        })}{" "}
+      {worst &&
+        t("teamweekly.headline.weak", {
+          reading: t(worst.key),
+          pct: formatNumber(Math.round(worst.value * 100), locale),
+          bar: formatNumber(Math.round(WEAK_RATE * 100), locale),
+        })}
+    </h3>
+  );
+}
+
+/**
+ * How much of the team the snapshot actually covers.
+ *
+ * `reps_unread` is drawn whenever it is non-zero, never behind a disclosure: a
+ * snapshot silently covering four of six reps reads exactly like a team of
+ * four, and every figure above is short by the same two people.
+ */
+function Coverage({ review }: Readonly<{ review: TeamWeeklyReview }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const unread = review.reps_unread ?? 0;
+  if (unread === 0) {
+    return null;
+  }
+  return (
+    <p className="teamweekly-coverage">
+      {t("teamweekly.repsUnread", {
+        count: formatNumber(unread, locale),
+        counted: formatNumber(review.counts.reps_counted, locale),
+      })}
+    </p>
+  );
+}
+
+function Scorecard({ review }: Readonly<{ review: TeamWeeklyReview }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const counts = review.counts;
+  const n = (value: number) => formatNumber(value, locale);
+  const ofTotal = (part: number, whole: number) =>
+    t("teamweekly.ofTotal", { part: n(part), whole: n(whole) });
+
+  return (
+    <StatStrip testId="teamweekly-strip">
+      <StatCard
+        label={t("teamweekly.card.firstResponse")}
+        value={ofTotal(counts.leads_answered_in_target, counts.leads_routed)}
+        detail={t("teamweekly.card.firstResponseBasis", {
+          breached: n(counts.leads_breached),
+        })}
+      />
+      <StatCard
+        label={t("teamweekly.card.meetings")}
+        value={ofTotal(counts.meetings_with_next_step, counts.meetings_held)}
+        detail={t("teamweekly.card.meetingsBasis")}
+      />
+      <StatCard
+        label={t("teamweekly.card.commitments")}
+        value={ofTotal(counts.commitments_kept, counts.commitments_due)}
+        detail={t("teamweekly.card.commitmentsBasis")}
+      />
+      <StatCard
+        label={t("teamweekly.card.won")}
+        value={n(counts.deals_won)}
+        detail={t("teamweekly.card.wonBasis", { lost: n(counts.deals_lost) })}
+      />
+      <StatCard
+        label={t("teamweekly.card.reps")}
+        value={n(counts.reps_counted)}
+        detail={t("teamweekly.card.repsBasis")}
+      />
+    </StatStrip>
+  );
+}
+
+/**
+ * What the week did, as bars sharing one baseline.
+ *
+ * Length follows magnitude and the figure carries the reading — a bar whose
+ * length alone said "good" or "bad" would be making a claim the snapshot does
+ * not, since a team that lost four deals and won four drew two equal bars.
+ */
+function Movement({ review }: Readonly<{ review: TeamWeeklyReview }>) {
+  const t = useT();
+  const counts = review.counts;
+  const rows = [
+    { key: "teamweekly.movement.won" as const, value: counts.deals_won },
+    { key: "teamweekly.movement.lost" as const, value: counts.deals_lost },
+    {
+      key: "teamweekly.movement.meetings" as const,
+      value: counts.meetings_held,
+    },
+    { key: "teamweekly.movement.leads" as const, value: counts.leads_routed },
+  ];
+  // One baseline for every bar. A per-row max would draw four full bars and say
+  // nothing about which number is the big one.
+  const max = Math.max(...rows.map((row) => row.value), 1);
+
+  return (
+    <PanelBody>
+      <h3 className="teamweekly-subhead">{t("teamweekly.movement.title")}</h3>
+      {rows.map((row) => (
+        <Meter
+          key={row.key}
+          label={t(row.key)}
+          value={row.value}
+          max={max}
+          dense
+          flat
+        />
+      ))}
+    </PanelBody>
+  );
+}
+
+/**
+ * One row per rep, including the rep whose week went well.
+ *
+ * A page promising one focus per rep and delivering rows only for the troubled
+ * ones reads as a team where only those people exist — which is why the server
+ * has positive focus kinds at all.
+ */
+function CoachPanel({ review }: Readonly<{ review: TeamWeeklyReview }>) {
+  const t = useT();
+  return (
+    <Panel title={t("teamweekly.coach.title")} sub={t("teamweekly.coach.sub")}>
+      {review.reps.length === 0 && (
+        <PanelBody>
+          <p>{t("teamweekly.coach.empty")}</p>
+        </PanelBody>
+      )}
+      {review.reps.map((rep) => (
+        <PanelRow key={rep.user_id}>
+          <div className="teamweekly-rep">
+            <span className="teamweekly-rep-name">
+              <EntityRef kind="user" id={rep.user_id} name={rep.display_name} />
+            </span>
+            <span className="teamweekly-rep-focus">
+              <Badge
+                quiet
+                tone={CELEBRATED.has(rep.focus_kind) ? "success" : "warn"}
+              >
+                {t(FOCUS_LABEL[rep.focus_kind])}
+              </Badge>
+              {/* Composed by the server from the stored figures, never
+                  model-written, so it cannot say what the snapshot does not
+                  hold. */}
+              <span>{rep.focus_label}</span>
+            </span>
+          </div>
+        </PanelRow>
+      ))}
+    </Panel>
+  );
+}
+
+/**
+ * The team weekly with its team picker, for a reader whose scope reaches a team.
+ *
+ * Gated on the same `scope_options` the team board beside it reads, so the
+ * control and the refusal cannot disagree — a picker offered to a rep who will
+ * be refused every team is a control that exists to fail.
+ */
+export function TeamWeeklyPanel({ offered }: Readonly<{ offered: boolean }>) {
+  const t = useT();
+  const teams = useTeams();
+  const [teamId, setTeamId] = useState("");
+  if (!offered) {
+    return null;
+  }
+  const options = (teams.data ?? []).map((team) => ({
+    value: team.id,
+    label: team.name,
+  }));
+  // One team is not a choice. Reading it straight skips a control whose only
+  // option is the one already showing.
+  const chosen = teamId || (options.length === 1 ? options[0].value : "");
+  return (
+    <>
+      {options.length > 1 && (
+        <Select
+          options={options}
+          value={chosen}
+          onChange={setTeamId}
+          placeholder={t("teamweekly.pickTeam")}
+          aria-label={t("teamweekly.pickTeam")}
+        />
+      )}
+      {chosen !== "" && <TeamWeeklySection teamId={chosen} />}
+    </>
+  );
+}

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -12,6 +12,7 @@ import { useLocale, useT } from "../i18n";
 import { useDecisionSink } from "./approvalrow";
 import { usePendingApprovals } from "./approvals.queries";
 import { PlanSection } from "./brief.plan";
+import { TeamWeeklyPanel } from "./brief.teamweekly";
 import { BriefCoverage } from "./briefcoverage";
 import { useMe } from "./common";
 import { DecisionsSection } from "./home.decisions";
@@ -188,6 +189,7 @@ function HomeWork({
   brief,
   deals,
   briefState,
+  teamOffered,
   onAlreadyDecided,
 }: Readonly<{
   items: readonly DecisionDeckItem[];
@@ -196,6 +198,9 @@ function HomeWork({
   brief: MorningBrief | null;
   deals: readonly Deal[];
   briefState: SectionState;
+  // Whether the reader's scope reaches a team, off the worklist read the page
+  // already makes. The same gate the team BOARD uses, so one tier decides both.
+  teamOffered: boolean;
   onAlreadyDecided: () => void;
 }>) {
   const decisions = (
@@ -226,13 +231,16 @@ function HomeWork({
   // Monday, after the work that is waiting on them today. Ordering it above
   // either of those would put last week ahead of this morning.
   const lastWeek = <WeeklySection key="weekly" />;
+  // The team's frozen week, on the same tier the team BOARD is offered on:
+  // read off scope_options so the control and the refusal cannot disagree.
+  const teamWeek = <TeamWeeklyPanel key="team-weekly" offered={teamOffered} />;
   // The plan goes UNDER the retrospective, never above it. A rep decides what
   // next week holds by reading what this one did, so the frozen past leads and
   // the live future follows.
   const nextWeek = <PlanSection key="plan" />;
   return items.length > 0
-    ? [decisions, today, lastWeek, nextWeek]
-    : [today, decisions, lastWeek, nextWeek];
+    ? [decisions, today, lastWeek, teamWeek, nextWeek]
+    : [today, decisions, lastWeek, teamWeek, nextWeek];
 }
 
 /**
@@ -389,6 +397,13 @@ export function HomeScreen() {
             brief={brief}
             deals={deals}
             briefState={readState(briefQuery)}
+            // The optional chain reaches the FIELD, not just the payload: a
+            // worklist answer that carried no scope_options crashed the whole
+            // page, and a page that throws is a worse answer than one that
+            // simply does not offer the team view.
+            teamOffered={
+              worklistQuery.data?.scope_options?.includes("team") ?? false
+            }
             onAlreadyDecided={onAlreadyDecided}
           />
         }

--- a/frontend/src/screens/teamweekly.queries.ts
+++ b/frontend/src/screens/teamweekly.queries.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { throwProblem } from "./common";
+
+export type Team = components["schemas"]["Team"];
+export type TeamWeeklyReview = components["schemas"]["TeamWeeklyReview"];
+export type TeamWeeklyRep = components["schemas"]["TeamWeeklyRep"];
+export type TeamWeeklyFocusKind = TeamWeeklyRep["focus_kind"];
+
+/**
+ * How a read of a team's frozen week can come back with nothing to draw.
+ *
+ * The two absences are different facts and the screen says different things
+ * about them: `forbidden` is a reader whose row scope reaches only their own
+ * rows, and `no_snapshot` is a team whose first week has not closed yet. A
+ * screen that drew one plate over both would tell a lead they lack permission
+ * on a Tuesday in their team's first week.
+ */
+export type TeamWeeklyAbsence = "forbidden" | "no_snapshot";
+
+export type TeamWeeklyAnswer =
+  | { kind: "review"; review: TeamWeeklyReview }
+  | { kind: "absent"; why: TeamWeeklyAbsence };
+
+/**
+ * One team's week as it was measured when the week closed.
+ *
+ * `week` omitted means the most recent snapshot the team has. Keyed on both, so
+ * moving between weeks does not overwrite the cache of either.
+ */
+export function useTeamWeeklyReview(
+  teamId: string | undefined,
+  week?: string,
+): UseQueryResult<TeamWeeklyAnswer> {
+  return useQuery({
+    queryKey: ["weekly-review", "team", teamId, week ?? "latest"],
+    enabled: Boolean(teamId),
+    queryFn: async (): Promise<TeamWeeklyAnswer> => {
+      const { data, error, response } = await api.GET("/weekly-reviews/team", {
+        params: { query: { team: teamId ?? "", ...(week ? { week } : {}) } },
+      });
+      if (response.status === 403) {
+        return { kind: "absent", why: "forbidden" };
+      }
+      if (response.status === 404) {
+        return { kind: "absent", why: "no_snapshot" };
+      }
+      if (error) {
+        throwProblem(error);
+      }
+      if (!data) {
+        return { kind: "absent", why: "no_snapshot" };
+      }
+      return { kind: "review", review: data };
+    },
+  });
+}
+
+/**
+ * The workspace's teams, for the picker.
+ *
+ * There is no "my teams" read: `/teams` lists every unarchived team any member
+ * may see. Which of them a reader may have a WEEK of is the team-weekly
+ * endpoint's own answer — it refuses a reader whose scope reaches only their own
+ * rows — so the picker offers and the server decides, rather than this screen
+ * inventing a second membership rule beside the one that already ships.
+ */
+export function useTeams(): UseQueryResult<readonly Team[]> {
+  return useQuery({
+    queryKey: ["teams", "for-weekly"],
+    queryFn: async (): Promise<readonly Team[]> => {
+      const { data, error } = await api.GET("/teams", {
+        params: { query: { limit: 100 } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data?.data ?? [];
+    },
+  });
+}


### PR DESCRIPTION
GET /weekly-reviews/team shipped with the snapshot behind it — frozen
membership, frozen names, one focus per member — and no screen asked for
it. This is the screen, offered on the same tier the team board beside it
is offered on, read off scope_options so the control and the refusal
cannot disagree.

The headline states two readings and names the bar each was measured
against: first response healthy at 100% against a bar of 90%, meetings
with a next step not, at 50% against a bar of 70%. Both come off the
stored counts, so the sentence cannot say something the snapshot does not
hold, and where no reading is decided either way the page says the week
had none rather than manufacturing a verdict.

Zero of zero is not zero per cent. A team that routed no leads has no
first-response reading at all — reporting 0% would call a failure on
something nobody attempted.

reps_unread is drawn whenever it is non-zero and never behind a
disclosure. A snapshot covering four of six reps reads exactly like a
team of four, and every figure on the page is short by the same two
people.

Every member gets a row, including the member whose week went well; their
row names what the team should copy. A page promising one focus per rep
and drawing rows only for the troubled ones reads as a team where only
those people exist.

Fixed along the way: the team gate's optional chain reached the payload
but not the field, so a worklist answer carrying no scope_options threw
and took the whole of Home with it.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

Gates: `make check-fe` and `make check-backend` both green. Three guards mutation-checked — collapsing the two absences, reporting zero-of-zero as 0%, and dropping the good-week rows each fail exactly one test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a screen where a lead can read the week their team just closed, served from the frozen snapshot already shipped behind `GET /weekly-reviews/team`.

- Headline states the healthiest and weakest readings against the bars each was measured by; zero-of-zero is no reading, not 0%.
- Unread members are disclosed whenever any exist, so a partial snapshot isn't mistaken for a complete one.
- Every member gets a row, including good weeks marked "worth copying."
- Fixed a crash where a worklist answer without `scope_options` threw and took down Home.

<sup>Written for commit 1ba0f4606a38b64177b168ac1f64ee0c810dbdef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a team weekly review panel to the home screen when team access is available.
  * View frozen-week summaries, headline performance readings, scorecards, movement metrics, coverage details, and coaching focus for team members.
  * Select among available teams and review loading, unavailable, restricted-access, or missing-snapshot states.
* **Localization**
  * Added German, English, and Vietnamese translations for the team weekly review experience.
* **Style**
  * Improved visual presentation of weekly headlines, coverage information, and coaching details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->