### PR TITLE
A tag is governed vocabulary, and an assignment says who made it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29093,8 +29093,12 @@ components:
       required: [id, name]
       properties:
         id: { type: string, format: uuid }
-        name: { type: string }
-        color: { type: [string, 'null'] }
+        name: { type: string, maxLength: 64 }
+        # The palette the design system draws, closed on purpose: a tag is a
+        # shared word, and a colour a reader cannot tell from another one is
+        # not a distinction. Mirrors the tag_color_check constraint.
+        color: { type: [string, 'null'], enum: [teal, amber, rose, slate, null] }
+        description: { type: [string, 'null'] }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         archived_at: { type: [string, 'null'], format: date-time }
@@ -29103,8 +29107,12 @@ components:
       type: object
       required: [name]
       properties:
-        name: { type: string }
-        color: { type: [string, 'null'] }
+        # Bounded because the server bounds it: leading and inner whitespace is
+        # collapsed before the length is measured, so a name that fits once
+        # normalized is accepted even when it was typed longer.
+        name: { type: string, maxLength: 64 }
+        color: { type: [string, 'null'], enum: [teal, amber, rose, slate, null] }
+        description: { type: [string, 'null'] }
 
     Taggable:
       type: object

--- a/backend/internal/compose/integration/collections/filtervocabulary_http_integration_test.go
+++ b/backend/internal/compose/integration/collections/filtervocabulary_http_integration_test.go
@@ -297,14 +297,23 @@ func TestARetiredCustomFieldLeavesTheVocabularyAndKeepsEvaluating(t *testing.T) 
 	// And the stored filter written against it still evaluates rather than
 	// erroring: the export path resolves the view's predicate through the same
 	// engine a live clause runs on.
-	// No destination: the response IS the csv this asked for, and handing the
-	// helper a JSON map to decode it into fails on the header row every time.
-	// What this case is about is the status — that the predicate still resolves
-	// — and the export's own body has its own tests.
+	// json, not csv: this asserts the predicate still RESOLVES, and a decoder
+	// pointed at a CSV body fails on the header row for a reason that has
+	// nothing to do with the filter.
+	var exported struct {
+		Object   string `json:"object"`
+		RowCount int    `json:"row_count"`
+	}
 	if status := e.Call(t, "POST", "/v1/exports", integration.AnyMap{
-		"view_id": viewID, "format": "csv",
-	}, nil, nil); status != http.StatusOK {
+		"view_id": viewID, "format": "json",
+	}, nil, &exported); status != http.StatusOK {
 		t.Errorf("the stored filter naming the retired %s no longer evaluates: status=%d", column, status)
+	}
+	// It resolved rather than erroring, and it resolved to the RIGHT object:
+	// a filter that silently evaluated against the wrong resource would also
+	// answer 200.
+	if exported.Object != "person" {
+		t.Errorf("the stored filter exported %q, want person", exported.Object)
 	}
 }
 

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -40,8 +40,10 @@ import (
 func tagCurator(e *Env) context.Context {
 	return e.As(ids.NewV7(), nil, principal.Permissions{
 		Objects: map[string]principal.ObjectGrant{
-			"tag":    {Create: true, Read: true, Update: true},
-			"person": {Read: true},
+			"tag": {Create: true, Read: true, Update: true},
+			// update, not merely read: applying a tag writes to the PERSON,
+			// so the curator needs the verb that changes one.
+			"person": {Read: true, Update: true},
 		},
 		RowScope: principal.RowScopeAll,
 	})

--- a/backend/internal/compose/integration/e2e/usecases/case1_log_it_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case1_log_it_test.go
@@ -376,6 +376,22 @@ func (s *scenario) readString(t *testing.T, table, column string, id ids.UUID) s
 	return out
 }
 
+// seedTag puts one word in the workspace's vocabulary, the way an admin would
+// before anyone applies it. Written straight to the table rather than through
+// the MCP surface on purpose: the agent scopes these scenarios run under
+// deliberately cannot coin a tag, which is the rule under test elsewhere.
+func (s *scenario) seedTag(t *testing.T, name string) {
+	t.Helper()
+	err := apptest.InWorkspace(s.AppEnv, t, func(tx pgx.Tx) error {
+		_, execErr := tx.Exec(context.Background(),
+			`INSERT INTO tag (name) VALUES ($1)`, name)
+		return execErr
+	})
+	if err != nil {
+		t.Fatalf("seeding the tag %q: %v", name, err)
+	}
+}
+
 // countRows answers one counting query.
 func (s *scenario) countRows(t *testing.T, sql string, args ...any) int {
 	t.Helper()

--- a/backend/internal/compose/integration/e2e/usecases/case2_business_card_test.go
+++ b/backend/internal/compose/integration/e2e/usecases/case2_business_card_test.go
@@ -189,17 +189,22 @@ func TestCase2ASharedPhoneLandsAndIsFiledForReview(t *testing.T) {
 
 // TestCase2ATagIsAppliedByNameInOneStep pins criterion 6.
 //
-// Including a word the workspace has never used. "Add tag: K5 Conference 2026"
-// is one call — an assistant that had to create the tag first, look up its id
-// and then apply it would be three round trips deep in a conversation about a
-// business card.
+// By NAME, in one call: "Add tag: Champion" is one act to the person asking,
+// and an assistant that had to look the id up first would be two round trips
+// deep in a conversation about a business card.
+//
+// The word has to exist. The vocabulary is Admin and Ops's to extend, so the
+// name is a reference to a word somebody already chose — this test creates it
+// as an admin first, which is the same order a real workspace works in.
 func TestCase2ATagIsAppliedByNameInOneStep(t *testing.T) {
 	s := boot(t, scopesReadWrite)
 	person := s.createFromCard(t, cardFields(cardEmail))
 
-	const newWord = "Tech Sauce Bangkok 2026"
+	const word = "Tech Sauce Bangkok 2026"
+	s.seedTag(t, word)
+
 	got := s.MCP.CallOK(t, "apply_tag", map[string]any{
-		"tag_name": newWord, "record_type": "person", "record_id": person.ID.String(),
+		"tag_name": word, "record_type": "person", "record_id": person.ID.String(),
 	})
 	var applied agents.TagAppliedResult
 	got.JSON(t, &applied)
@@ -211,13 +216,32 @@ func TestCase2ATagIsAppliedByNameInOneStep(t *testing.T) {
 		t.Fatalf("case 2 criterion 6: the tag was applied without naming the word's id, so a " +
 			"caller cannot refer to it again")
 	}
-	// The word was COINED, not silently dropped: a workspace that had never
-	// used it now holds it, attached to this person.
 	if n := s.countRows(t, `SELECT count(*) FROM taggable WHERE tag_id = $1 AND entity_type = 'person' AND entity_id = $2`,
 		applied.TagID, person.ID); n != 1 {
 		t.Fatalf("case 2 criterion 6: the tag reports applied and %d rows attach it to the person", n)
 	}
-	if name := s.readString(t, "tag", "name", applied.TagID); name != newWord {
-		t.Fatalf("case 2 criterion 6: the coined tag reads %q, want %q", name, newWord)
+	if name := s.readString(t, "tag", "name", applied.TagID); name != word {
+		t.Fatalf("case 2 criterion 6: the applied tag reads %q, want %q", name, word)
+	}
+}
+
+// The other half of criterion 6, and the reason the vocabulary is governed: a
+// word the workspace has never chosen is REFUSED, not coined. An assistant
+// that could mint one would put a misspelling of somebody's tag into the
+// shared vocabulary permanently, which is the drift a shared vocabulary is for
+// preventing.
+func TestCase2AnUnknownTagNameIsRefusedRatherThanCoined(t *testing.T) {
+	s := boot(t, scopesReadWrite)
+	person := s.createFromCard(t, cardFields(cardEmail))
+
+	const unknown = "Tech Sauce Bangkok 2027"
+	s.MCP.CallRefused(t, "apply_tag", map[string]any{
+		"tag_name": unknown, "record_type": "person", "record_id": person.ID.String(),
+	})
+
+	// Refused AND nothing written: a call that coined the word and then failed
+	// for some other reason would leave the same permanent row behind.
+	if n := s.countRows(t, `SELECT count(*) FROM tag WHERE name = $1`, unknown); n != 0 {
+		t.Fatalf("the refused name exists as a tag (%d row(s)); apply_tag coined a word only an admin may add", n)
 	}
 }

--- a/backend/internal/compose/tagseam.go
+++ b/backend/internal/compose/tagseam.go
@@ -8,7 +8,6 @@ package compose
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -28,41 +27,35 @@ func tagSeam(pool *pgxpool.Pool) agents.Tags {
 	return tagAdapter{store: collections.NewStore(InstallationDB(pool))}
 }
 
-// EnsureTag reuses the workspace's own word before minting a new one.
+// ResolveTag answers the id of an EXISTING workspace tag with this name, and
+// refuses when there is none.
+//
+// It does not create. The vocabulary is governed — only Admin and Ops coin a
+// word — so a tool that minted one on a name it did not recognise would hand
+// every agent, and through it every rep, the authority the governance exists
+// to withhold. A misspelling would become a permanent second tag nobody
+// chose, which is exactly the drift a shared vocabulary is for preventing.
 //
 // Case-insensitive, because "K5 Conference" and "k5 conference" are the same
-// tag to everyone except a database, and a vocabulary that holds both has
-// stopped being a vocabulary. An ARCHIVED tag of that name is not reused: it
-// was retired on purpose, and quietly resurrecting it would undo that decision
-// on the strength of a coincidence of spelling.
-func (a tagAdapter) EnsureTag(ctx context.Context, name string) (ids.UUID, error) {
+// tag to everyone except a database. An ARCHIVED tag of that name is refused
+// with a distinct message: the word exists, it was retired on purpose, and
+// the caller needs to know that rather than being told it is unknown.
+func (a tagAdapter) ResolveTag(ctx context.Context, name string) (ids.UUID, error) {
 	if found, ok, err := a.store.FindTag(ctx, name); err != nil || ok {
 		return found, err
 	}
-	created, err := a.store.NewTag(ctx, name, "")
-	if err == nil {
-		return created.TagID, nil
-	}
-	// Two callers can both miss the lookup and both try to create; uq_tag_name
-	// lets exactly one win. The loser reuses the winner's tag rather than
-	// failing a call that asked for a state now true — the reuse this method
-	// exists for, arriving a moment later than expected.
-	//
-	// A name whose only holder is ARCHIVED lands here too and stays a
-	// conflict: the index does not exempt archived rows, and quietly
-	// resurrecting a word somebody retired is not this call's decision to make.
-	if !errors.Is(err, apperrors.ErrConflict) {
+	// A miss is either a word nobody has coined or one somebody retired. The
+	// two need different answers: the second is not "no such tag".
+	_, state, err := a.store.LookupTagName(ctx, name)
+	if err != nil {
 		return ids.UUID{}, err
 	}
-	found, ok, findErr := a.store.FindTag(ctx, name)
-	if findErr != nil {
-		return ids.UUID{}, findErr
+	if state.Archived() {
+		return ids.UUID{}, fmt.Errorf("the tag %q was archived and cannot be applied; an admin can restore it: %w",
+			name, apperrors.ErrConflict)
 	}
-	if !ok {
-		return ids.UUID{}, fmt.Errorf("a tag named %q exists but is archived and is not reused; use a different name: %w",
-			name, err)
-	}
-	return found, nil
+	return ids.UUID{}, fmt.Errorf("no tag named %q exists, and this tool does not create one; an admin or ops seat can add it to the vocabulary: %w",
+		name, apperrors.ErrNotFound)
 }
 
 // ListTags hands the collections module's own cross-module shape straight

--- a/backend/internal/compose/tagseamarchive_integration_test.go
+++ b/backend/internal/compose/tagseamarchive_integration_test.go
@@ -5,10 +5,9 @@
 
 package compose
 
-// EnsureTag's own comment says an archived name is never silently reused —
-// that decision is deliberate and this test does not touch it. What it
-// guards is the error that decision produces: it must not direct the caller
-// to an action the contract cannot perform.
+// ResolveTag never creates and never resurrects. These tests drive the REAL
+// seam against a real database, because that is where the rule lives: a test
+// against a stub proves only what the stub was written to do.
 
 import (
 	"strings"
@@ -42,15 +41,37 @@ func TestEnsureTagOnAnArchivedNameDoesNotPromiseARestoreThatDoesNotExist(t *test
 		t.Fatalf("archiving the fixture tag: %v", err)
 	}
 
-	_, err = tagSeam(e.Pool).EnsureTag(ctx, "Repro Tag")
+	_, err = tagSeam(e.Pool).ResolveTag(ctx, "Repro Tag")
 	if err == nil {
-		t.Fatal("EnsureTag on an archived-only name succeeded; want a conflict — the vocabulary deliberately does not reuse an archived word")
+		t.Fatal("ResolveTag on an archived-only name succeeded; want a refusal — an archived word was retired on purpose")
 	}
-	if strings.Contains(err.Error(), "restore") {
-		t.Fatalf("EnsureTag's error directs the caller to %q, which the contract has no operation for: %v",
-			"restore", err)
+	// The refusal has to say the word EXISTS and is retired. "No such tag"
+	// would send a rep to ask for a tag the workspace already has, and an
+	// admin would then coin a duplicate of a word they deliberately retired.
+	if !strings.Contains(err.Error(), "archived") {
+		t.Fatalf("ResolveTag's refusal does not say the name is archived, so a caller cannot tell it from an unknown word: %v", err)
 	}
-	if !strings.Contains(err.Error(), "is not reused") {
-		t.Fatalf("EnsureTag's error does not explain why the name was refused: %v", err)
+}
+
+// The governance rule at the seam that enforces it: an unknown name is a
+// refusal, and nothing is written. This is the half a stub cannot prove — the
+// tag table has to still be empty afterwards.
+func TestResolveTagRefusesAnUnknownNameAndCoinsNothing(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.AdminUser, nil, tagAdminPerms)
+	store := collections.NewStore(InstallationDB(e.Pool))
+
+	_, err := tagSeam(e.Pool).ResolveTag(ctx, "Never Coined")
+	if err == nil {
+		t.Fatal("an unknown name resolved; want a refusal, because coining one here is the authority only admin and ops hold")
+	}
+
+	// The word must not exist now. A seam that created it and then returned
+	// the id would also have answered without error above, so the absence is
+	// the assertion that separates the two.
+	if _, found, findErr := store.FindTag(ctx, "Never Coined"); findErr != nil {
+		t.Fatalf("looking the name up afterwards: %v", findErr)
+	} else if found {
+		t.Error("the refused name exists as a tag; ResolveTag coined the word it was asked to refuse")
 	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -4372,6 +4372,30 @@ func (e CreateStageRequestSemantic) Valid() bool {
 	}
 }
 
+// Defines values for CreateTagRequestColor.
+const (
+	CreateTagRequestColorAmber CreateTagRequestColor = "amber"
+	CreateTagRequestColorRose  CreateTagRequestColor = "rose"
+	CreateTagRequestColorSlate CreateTagRequestColor = "slate"
+	CreateTagRequestColorTeal  CreateTagRequestColor = "teal"
+)
+
+// Valid indicates whether the value is a known member of the CreateTagRequestColor enum.
+func (e CreateTagRequestColor) Valid() bool {
+	switch e {
+	case CreateTagRequestColorAmber:
+		return true
+	case CreateTagRequestColorRose:
+		return true
+	case CreateTagRequestColorSlate:
+		return true
+	case CreateTagRequestColorTeal:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for CreateTaskRequestLinksEntityType.
 const (
 	CreateTaskRequestLinksEntityTypeDeal         CreateTaskRequestLinksEntityType = "deal"
@@ -10375,6 +10399,30 @@ func (e StartBackfillRequestWindow) Valid() bool {
 	case StartBackfillRequestWindowN60m:
 		return true
 	case StartBackfillRequestWindowN6m:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for TagColor.
+const (
+	TagColorAmber TagColor = "amber"
+	TagColorRose  TagColor = "rose"
+	TagColorSlate TagColor = "slate"
+	TagColorTeal  TagColor = "teal"
+)
+
+// Valid indicates whether the value is a known member of the TagColor enum.
+func (e TagColor) Valid() bool {
+	switch e {
+	case TagColorAmber:
+		return true
+	case TagColorRose:
+		return true
+	case TagColorSlate:
+		return true
+	case TagColorTeal:
 		return true
 	default:
 		return false
@@ -18744,9 +18792,13 @@ type CreateStageRequestSemantic string
 
 // CreateTagRequest defines model for CreateTagRequest.
 type CreateTagRequest struct {
-	Color *string `json:"color,omitempty"`
-	Name  string  `json:"name"`
+	Color       *CreateTagRequestColor `json:"color,omitempty"`
+	Description *string                `json:"description,omitempty"`
+	Name        string                 `json:"name"`
 }
+
+// CreateTagRequestColor defines model for CreateTagRequest.Color.
+type CreateTagRequestColor string
 
 // CreateTaskRequest What a task needs. Stored as an activity of kind `task`.
 type CreateTaskRequest struct {
@@ -28043,13 +28095,17 @@ type StartCompanySiteReadRequest struct {
 
 // Tag A tag. Mirrors the `tag` table.
 type Tag struct {
-	ArchivedAt *time.Time         `json:"archived_at,omitempty"`
-	Color      *string            `json:"color,omitempty"`
-	CreatedAt  *time.Time         `json:"created_at,omitempty"`
-	Id         openapi_types.UUID `json:"id"`
-	Name       string             `json:"name"`
-	UpdatedAt  *time.Time         `json:"updated_at,omitempty"`
+	ArchivedAt  *time.Time         `json:"archived_at,omitempty"`
+	Color       *TagColor          `json:"color,omitempty"`
+	CreatedAt   *time.Time         `json:"created_at,omitempty"`
+	Description *string            `json:"description,omitempty"`
+	Id          openapi_types.UUID `json:"id"`
+	Name        string             `json:"name"`
+	UpdatedAt   *time.Time         `json:"updated_at,omitempty"`
 }
+
+// TagColor defines model for Tag.Color.
+type TagColor string
 
 // TagListResponse defines model for TagListResponse.
 type TagListResponse struct {

--- a/backend/internal/modules/agents/toolcopy_tags.go
+++ b/backend/internal/modules/agents/toolcopy_tags.go
@@ -12,10 +12,12 @@ var listTagsCopy = toolCopy{
 }
 
 var applyTagCopy = toolCopy{
-	Purpose: "Tag a person, company, deal, lead or project by tag_id, or by tag_name, which reuses " +
-		"the workspace's word or coins it.",
-	Limits: "Prefer a tag_id from list_tags: a name matches case-insensitively, and a near-miss " +
-		"makes a NEW word. The same tag twice is a conflict.",
+	Purpose: "Tag a person, company, deal, lead or project by tag_id, or by tag_name, which must " +
+		"name a tag the workspace already has.",
+	Limits: "This tool never creates a tag: an unknown name is refused, and only an admin or ops " +
+		"seat can add a word to the vocabulary. A name matches case-insensitively; an archived " +
+		"word is refused as archived rather than as unknown. Prefer a tag_id from list_tags. " +
+		"The same tag twice is a conflict.",
 }
 
 var removeTagCopy = toolCopy{

--- a/backend/internal/modules/agents/tools_tags.go
+++ b/backend/internal/modules/agents/tools_tags.go
@@ -55,10 +55,11 @@ type Tags interface {
 	// ok=false when there is none. Remove uses it: a name that names nothing
 	// means the tagging is already absent.
 	FindTag(ctx context.Context, name string) (ids.UUID, bool, error)
-	// EnsureTag answers the id of the workspace tag with this name, creating
-	// it only when no such word exists. Reuse is the default because a
-	// vocabulary that grows a near-duplicate per call stops being one.
-	EnsureTag(ctx context.Context, name string) (ids.UUID, error)
+	// ResolveTag answers the id of an EXISTING workspace tag with this name
+	// and refuses when there is none. It never creates: the vocabulary is
+	// governed, so a tool that coined a word on a name it did not recognise
+	// would hand every agent the authority only Admin and Ops hold.
+	ResolveTag(ctx context.Context, name string) (ids.UUID, error)
 	ApplyTag(ctx context.Context, tagID ids.UUID, entityType string, entityID ids.UUID) error
 	RemoveTag(ctx context.Context, tagID ids.UUID, entityType string, entityID ids.UUID) error
 	// TaggableTypes answers the record types a tagging may name — the store's
@@ -165,14 +166,13 @@ func (t applyTag) Handle(ctx context.Context, in json.RawMessage) (json.RawMessa
 		if args.TagName == "" {
 			return nil, &BadArgsError{Cause: errors.New("give tag_id, or tag_name to reuse or create one")}
 		}
-		// The TARGET is authorized before anything is created. Creating first
-		// left a live, audited tag behind when the record turned out not to
-		// exist or to be outside the caller's scope — a write nobody asked for,
-		// produced by a call that then failed.
+		// The TARGET is authorized first, so a caller naming a record they
+		// cannot reach is refused for that reason rather than learning which
+		// tags exist from the resolution error.
 		if err := t.tags.EnsureTaggable(ctx, args.RecordType, args.RecordID); err != nil {
 			return nil, err
 		}
-		resolved, err := t.tags.EnsureTag(ctx, args.TagName)
+		resolved, err := t.tags.ResolveTag(ctx, args.TagName)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/modules/agents/tools_tags.go
+++ b/backend/internal/modules/agents/tools_tags.go
@@ -93,7 +93,7 @@ func taggingSchema(taggableTypes []string) string {
 	}
 	return `{"type":"object","required":["record_type","record_id"],"properties":{
 	"tag_id":{"type":"string","format":"uuid"},
-	"tag_name":{"type":"string","maxLength":120,"description":"Instead of tag_id: the tag is created if the workspace has no such word"},
+	"tag_name":{"type":"string","maxLength":64,"description":"Instead of tag_id: the name of a tag the workspace ALREADY has. An unknown name is refused, never created"},
 	"record_type":{"type":"string","enum":[` + strings.Join(quoted, ",") + `]},
 	"record_id":{"type":"string","format":"uuid"}},"additionalProperties":false}`
 }
@@ -164,7 +164,7 @@ func (t applyTag) Handle(ctx context.Context, in json.RawMessage) (json.RawMessa
 	// two spellings of the same tag.
 	if args.TagID.IsZero() {
 		if args.TagName == "" {
-			return nil, &BadArgsError{Cause: errors.New("give tag_id, or tag_name to reuse or create one")}
+			return nil, &BadArgsError{Cause: errors.New("give tag_id, or tag_name naming a tag the workspace already has")}
 		}
 		// The TARGET is authorized first, so a caller naming a record they
 		// cannot reach is refused for that reason rather than learning which

--- a/backend/internal/modules/agents/tools_tags_test.go
+++ b/backend/internal/modules/agents/tools_tags_test.go
@@ -57,9 +57,16 @@ func (s stubTags) FindTag(_ context.Context, name string) (ids.UUID, bool, error
 	return ids.NewV7(), true, nil
 }
 
-func (s stubTags) EnsureTag(_ context.Context, name string) (ids.UUID, error) {
+// ResolveTag stands in for a governed vocabulary: it answers for a name the
+// workspace already holds and REFUSES anything else. Returning a fresh id for
+// every name — which the stub it replaced did — would let a test claiming
+// "apply_tag never creates" pass against a tool that creates.
+func (s stubTags) ResolveTag(_ context.Context, name string) (ids.UUID, error) {
 	if s.ensured != nil {
 		*s.ensured = name
+	}
+	if name != knownTagName {
+		return ids.UUID{}, errNoSuchTag
 	}
 	return ids.NewV7(), nil
 }
@@ -101,25 +108,44 @@ func TestApplyAndRemoveReachTheSameTaggingBothWays(t *testing.T) {
 	}
 }
 
-// A NAME rather than an id is the capture flow's shape: "add tag: K5
-// Conference 2026" is one act to the person asking. Making them call a create
-// verb first, only to hand its answer straight back, is a second call that
-// exists for the surface's convenience rather than theirs.
-func TestApplyTagTakesANameAndReusesOrCreatesTheWord(t *testing.T) {
-	var ensured string
+// A NAME rather than an id is the capture flow's shape: "add tag: Champion" is
+// one act to the person asking. Making them call a lookup verb first, only to
+// hand its answer straight back, is a second call that exists for the
+// surface's convenience rather than theirs.
+func TestApplyTagTakesANameAndResolvesTheExistingWord(t *testing.T) {
+	var resolved string
 	var applied taggingArgs
-	_, err := (applyTag{tags: stubTags{applied: &applied, ensured: &ensured}}).Handle(
+	_, err := (applyTag{tags: stubTags{applied: &applied, ensured: &resolved}}).Handle(
 		context.Background(),
-		json.RawMessage(`{"tag_name":"K5 Conference 2026","record_type":"organization",`+
+		json.RawMessage(`{"tag_name":"`+knownTagName+`","record_type":"organization",`+
 			`"record_id":"`+ids.NewV7().String()+`"}`))
 	if err != nil {
 		t.Fatalf("applying by name answered %v, want the tag resolved", err)
 	}
-	if ensured != "K5 Conference 2026" {
-		t.Errorf("the seam was asked to ensure %q, want the name as given", ensured)
+	if resolved != knownTagName {
+		t.Errorf("the seam was asked to resolve %q, want the name as given", resolved)
 	}
 	if applied.TagID.IsZero() {
 		t.Error("the tagging carries no tag id, want the resolved one")
+	}
+}
+
+// The governance rule, asserted where an agent would break it. The vocabulary
+// is Admin and Ops's to extend; a tool that coined a word on a name it did not
+// recognise would hand every agent — and through it every rep — the authority
+// the governance exists to withhold. A misspelling would become a permanent
+// second tag nobody chose.
+func TestApplyTagRefusesAnUnknownNameRatherThanCoiningIt(t *testing.T) {
+	var applied taggingArgs
+	_, err := (applyTag{tags: stubTags{applied: &applied}}).Handle(
+		context.Background(),
+		json.RawMessage(`{"tag_name":"Champoin","record_type":"organization",`+
+			`"record_id":"`+ids.NewV7().String()+`"}`))
+	if err == nil {
+		t.Fatal("a typo'd name was accepted; want a refusal, because accepting it creates a second tag nobody chose")
+	}
+	if !applied.TagID.IsZero() {
+		t.Errorf("a tagging reached the seam as %+v after the name was refused; nothing may be written", applied)
 	}
 }
 
@@ -179,14 +205,22 @@ func (r refusingTaggable) EnsureTaggable(context.Context, string, ids.UUID) erro
 	return errNoSuchRecord
 }
 
-func (r refusingTaggable) EnsureTag(_ context.Context, name string) (ids.UUID, error) {
+func (r refusingTaggable) ResolveTag(_ context.Context, name string) (ids.UUID, error) {
 	if r.ensured != nil {
 		*r.ensured = name
+	}
+	if name != knownTagName {
+		return ids.UUID{}, errNoSuchTag
 	}
 	return ids.NewV7(), nil
 }
 
 var errNoSuchRecord = errors.New("no such record in this workspace")
+
+// knownTagName is the one word these stubs' vocabulary holds.
+const knownTagName = "Champion"
+
+var errNoSuchTag = errors.New("no tag by that name exists, and this tool does not create one")
 
 type noSuchTag struct{ stubTags }
 

--- a/backend/internal/modules/collections/handlers.go
+++ b/backend/internal/modules/collections/handlers.go
@@ -59,7 +59,14 @@ func (h Handlers) CreateTag(w http.ResponseWriter, r *http.Request) {
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	tag, err := h.store.CreateTag(r.Context(), req.Name, req.Color)
+	// The generated palette type is a string underneath; the store speaks the
+	// column's own type, and the CHECK is what actually holds the value.
+	var color *string
+	if req.Color != nil {
+		c := string(*req.Color)
+		color = &c
+	}
+	tag, err := h.store.CreateTag(r.Context(), req.Name, color)
 	if err != nil {
 		writeErr(w, r, err)
 		return

--- a/backend/internal/modules/collections/tagapplyauthz_test.go
+++ b/backend/internal/modules/collections/tagapplyauthz_test.go
@@ -21,19 +21,61 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
-func TestADirectTagIDApplyStillAsksTheTargetsObjectType(t *testing.T) {
-	store := NewStore(nil)
-	ctx := principal.WithActor(context.Background(), principal.Principal{
+func taggerWith(objects map[string]principal.ObjectGrant) context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:tagger",
-		Permissions: principal.Permissions{
-			RoleKeys: []string{"fixture"},
-			Objects: map[string]principal.ObjectGrant{
-				"tag": {Read: true, Update: true},
-			},
-		},
+		Permissions: principal.Permissions{RoleKeys: []string{"fixture"}, Objects: objects},
+	})
+}
+
+// Applying a tag writes to the RECORD, so it needs UPDATE on the record — not
+// merely read. A seat that may look at a project and not change it must not be
+// able to hang a tag on it, because a tag steers who finds that project in a
+// filter and what an automation does with it.
+//
+// The case is chosen to fail under the OLD pairing too: read on the target is
+// present and update is missing, which the previous rule admitted.
+func TestApplyingATagNeedsUpdateOnTheTargetNotMerelyRead(t *testing.T) {
+	store := NewStore(nil)
+	ctx := taggerWith(map[string]principal.ObjectGrant{
+		"tag":     {Read: true},
+		"project": {Read: true},
 	})
 	_, err := store.ApplyTag(ctx, ids.New[ids.TagKind](), "project", ids.NewV7())
 	if !errors.Is(err, apperrors.ErrPermissionDenied) {
-		t.Fatalf("tag.update without project.read applied a tag by id: %v", err)
+		t.Fatalf("a seat holding project.read but not project.update applied a tag: %v", err)
+	}
+}
+
+// The other half of the inversion: vocabulary authority is no longer what
+// admits an application. A seat that may apply tags does NOT thereby hold the
+// right to coin them, and this proves the gate asks for tag.read rather than
+// tag.update — a rep holds the first and not the second.
+func TestApplyingATagNeedsOnlyReadOnTheVocabulary(t *testing.T) {
+	store := NewStore(nil)
+	ctx := taggerWith(map[string]principal.ObjectGrant{
+		"tag":     {Read: true},
+		"project": {Read: true, Update: true},
+	})
+	// nil pool: the permission gates run before any query, so reaching the
+	// database is itself the assertion that both gates admitted this caller.
+	// A refusal here would be a permission refusal, which is what fails the
+	// test; anything else is the nil pool and means the gates passed.
+	_, err := store.ApplyTag(ctx, ids.New[ids.TagKind](), "project", ids.NewV7())
+	if errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a seat with tag.read and project.update was refused; applying must not require tag.update: %v", err)
+	}
+}
+
+// Removing is the same write and carries the same pair.
+func TestRemovingATagNeedsUpdateOnTheTarget(t *testing.T) {
+	store := NewStore(nil)
+	ctx := taggerWith(map[string]principal.ObjectGrant{
+		"tag":     {Read: true},
+		"project": {Read: true},
+	})
+	err := store.RemoveTag(ctx, ids.New[ids.TagKind](), "project", ids.NewV7())
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a seat holding project.read but not project.update removed a tag: %v", err)
 	}
 }

--- a/backend/internal/modules/collections/tagname_test.go
+++ b/backend/internal/modules/collections/tagname_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package collections
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The spelling rule is one function because three write paths share it —
+// create, rename, and the name an agent resolves against. These cases are the
+// collisions it exists to prevent, not a tour of the string library: each one
+// is a pair a reader would call the same tag and a database would not.
+func TestNormalizeTagName(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"the ends are trimmed", "  Key Account  ", "Key Account"},
+		{"an inner run collapses", "Key   Account", "Key Account"},
+		{"a tab is whitespace like any other", "Key\tAccount", "Key Account"},
+		{"a newline does not survive into a badge", "Key\nAccount", "Key Account"},
+		{"an already-clean name is untouched", "Key Account", "Key Account"},
+		{"nothing but whitespace normalizes to nothing", "   \t ", ""},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NormalizeTagName(c.in); got != c.want {
+				t.Errorf("NormalizeTagName(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// The two spellings a database would hold as separate rows and a person would
+// read as one word. This is the whole reason the rule exists, so it is asserted
+// as a property rather than left implied by the cases above.
+func TestNormalizeTagNameFoldsWhatAReaderCannotTellApart(t *testing.T) {
+	if NormalizeTagName("Key  Account") != NormalizeTagName("Key Account") {
+		t.Error("two spacings of one name normalize differently, so the vocabulary can hold both")
+	}
+}
+
+func TestValidateTagNameRefusesWhatCannotBeATag(t *testing.T) {
+	t.Run("an empty name is refused, and says which field", func(t *testing.T) {
+		_, err := ValidateTagName("   ")
+		var bad *BadInputError
+		if !errors.As(err, &bad) || bad.Field != "name" {
+			t.Fatalf("err = %v, want a BadInputError naming `name`", err)
+		}
+	})
+
+	t.Run("the cap counts runes, not bytes", func(t *testing.T) {
+		// 64 two-byte runes: 128 bytes, and exactly at the limit. A byte cap
+		// would refuse this while admitting 64 ASCII characters, which would
+		// make the same name legal in English and illegal in German.
+		if _, err := ValidateTagName(strings.Repeat("ü", 64)); err != nil {
+			t.Fatalf("64 multi-byte runes were refused: %v", err)
+		}
+		if _, err := ValidateTagName(strings.Repeat("ü", 65)); err == nil {
+			t.Error("65 runes were admitted; the cap is 64")
+		}
+	})
+
+	t.Run("the returned name is the normalized one", func(t *testing.T) {
+		got, err := ValidateTagName("  Key   Account ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "Key Account" {
+			t.Errorf("got %q, want the normalized %q — a caller that stores the raw input reintroduces the collision", got, "Key Account")
+		}
+	})
+
+	t.Run("length is measured after normalizing", func(t *testing.T) {
+		// 64 characters plus inner double-spaces: over the cap as typed, at it
+		// once collapsed. Measuring first would refuse a name that fits.
+		typed := strings.Repeat("ab ", 21) + "c" // 21*3+1 = 64 runes normalized
+		if _, err := ValidateTagName(strings.ReplaceAll(typed, " ", "  ")); err != nil {
+			t.Errorf("a name that fits once collapsed was refused: %v", err)
+		}
+	})
+}

--- a/backend/internal/modules/collections/tags.go
+++ b/backend/internal/modules/collections/tags.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -82,15 +83,16 @@ func (s *Store) CreateTag(ctx context.Context, name string, color *string) (tagR
 	if err := auth.Require(ctx, "tag", principal.ActionCreate); err != nil {
 		return tagRow{}, err
 	}
-	if strings.TrimSpace(name) == "" {
-		return tagRow{}, &BadInputError{Field: "name", Reason: "required"}
+	name, err := ValidateTagName(name)
+	if err != nil {
+		return tagRow{}, err
 	}
 	var out tagRow
-	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO tag (name, color)
 			VALUES ($1, $2)
-			RETURNING `+tagColumns, strings.TrimSpace(name), color)
+			RETURNING `+tagColumns, name, color)
 		var err error
 		if out, err = scanTag(row); err != nil {
 			if constraint, ok := storekit.UniqueViolation(err); ok && constraint == "uq_tag_name" {
@@ -136,25 +138,66 @@ type taggableRow struct {
 	CreatedAt  time.Time
 }
 
+// assigningPrincipal names who is putting this tag on this record, for the
+// taggable row's own columns. Both are nullable and both stay nil for a
+// principal the auth layer never bound: an assignment whose author is unknown
+// has to READ as unknown, because "system" would be a claim nobody made.
+//
+// The kind is the coarse one the record page shows — a reader needs to know a
+// tag arrived from an import rather than from a colleague, and does not need
+// the passport behind it. Connector and system principals are deliberately
+// unmapped: neither applies tags today, and inventing a name for a caller
+// that does not exist is how a wrong label gets believed later.
+func assigningPrincipal(ctx context.Context) (*ids.UUID, *string) {
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		return nil, nil
+	}
+	var kind string
+	switch actor.Type {
+	case principal.PrincipalHuman:
+		kind = "human"
+	case principal.PrincipalAgent:
+		kind = "agent"
+	default:
+		return nil, nil
+	}
+	// OnBehalfOf is the human authority behind an agent action; an agent
+	// tagging a record is that human's reach, so the row names them and the
+	// kind says the hand was an agent's.
+	who := actor.UserID
+	if actor.Type == principal.PrincipalAgent && actor.OnBehalfOf != (ids.UUID{}) {
+		who = actor.OnBehalfOf
+	}
+	if who == (ids.UUID{}) {
+		return nil, &kind
+	}
+	return &who, &kind
+}
+
 func (s *Store) ApplyTag(ctx context.Context, tagID ids.TagID, entityType string, entityID ids.UUID) (taggableRow, error) {
 	// Required by the contract, true only if checked: the zero UUID would reach
 	// the row-scope link gate and answer not-found for a record nobody named.
 	if err := httperr.RequireBodyID(entityIDField, entityID); err != nil {
 		return taggableRow{}, err
 	}
-	if err := auth.Require(ctx, "tag", principal.ActionUpdate); err != nil {
+	// READ on the vocabulary, not update: `tag` authority now governs the
+	// VOCABULARY — who may coin, rename or retire a word — and only Admin and
+	// Ops hold it. Applying an existing word is not a change to the
+	// vocabulary, so requiring tag.update here would have made every rep who
+	// tags a company also able to invent tags.
+	if err := auth.Require(ctx, "tag", principal.ActionRead); err != nil {
 		return taggableRow{}, err
 	}
 	if !memberEntityTables[entityType] {
 		return taggableRow{}, &BadInputError{Field: entityTypeField, Reason: "must be " + memberEntityVocabulary}
 	}
-	// READ on the target's own object type, the same gate RemoveTag and
-	// EnsureTaggable hold: tagging a record is a read of it, and without this
-	// a role holding tag.update but not <type>.read could tag rows it may not
-	// see. Only the tag_name path went through EnsureTaggable, so a direct
-	// tag_id apply was the one door where the target's object type went
-	// unasked.
-	if err := auth.Require(ctx, entityType, principal.ActionRead); err != nil {
+	// UPDATE on the target, not merely read. A tag is part of the record: it
+	// steers who sees it in a filter and what an automation does with it, so
+	// writing one onto a record a caller may only READ would let them change
+	// a record they cannot edit. EnsureLinkTarget below still answers
+	// not-found for a row outside their scope, so existence stays hidden.
+	if err := auth.Require(ctx, entityType, principal.ActionUpdate); err != nil {
 		return taggableRow{}, err
 	}
 	var out taggableRow
@@ -172,12 +215,13 @@ func (s *Store) ApplyTag(ctx context.Context, tagID ids.TagID, entityType string
 		if err := auth.EnsureLinkTarget(ctx, tx, entityType, entityID); err != nil {
 			return err
 		}
+		by, byKind := assigningPrincipal(ctx)
 		row := tx.QueryRow(ctx, `
-			INSERT INTO taggable (tag_id, entity_type, entity_id)
-			VALUES ($1, $2, $3)
+			INSERT INTO taggable (tag_id, entity_type, entity_id, assigned_by, assigned_by_kind)
+			VALUES ($1, $2, $3, $4, $5)
 			ON CONFLICT (tag_id, entity_type, entity_id) DO NOTHING
 			RETURNING id, tag_id, entity_type, entity_id, created_at`,
-			tagID, entityType, entityID)
+			tagID, entityType, entityID, by, byKind)
 		err = row.Scan(&out.ID, &out.TagID, &out.EntityType, &out.EntityID, &out.CreatedAt)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("already tagged: %w", apperrors.ErrConflict)
@@ -210,17 +254,17 @@ func (s *Store) RemoveTag(ctx context.Context, tagID ids.TagID, entityType strin
 	if err := httperr.RequireBodyID(entityIDField, entityID); err != nil {
 		return err
 	}
-	if err := auth.Require(ctx, "tag", principal.ActionUpdate); err != nil {
+	if err := auth.Require(ctx, "tag", principal.ActionRead); err != nil {
 		return err
 	}
 	if !memberEntityTables[entityType] {
 		return &BadInputError{Field: entityTypeField, Reason: "must be " + memberEntityVocabulary}
 	}
-	// READ on the target's own object type, not only tag.update. Without it a
-	// role holding tag.update and deal.read=false could take taggings off
-	// deals it may not see, and learn from the refusal whether a given deal id
-	// exists at all.
-	if err := auth.Require(ctx, entityType, principal.ActionRead); err != nil {
+	// UPDATE on the target, the same gate applying holds: taking a tag off a
+	// record changes the record, and a caller who may only read it must not be
+	// able to. EnsureLinkTarget still answers not-found for a row outside
+	// their scope, so a refusal never confirms a deal id exists.
+	if err := auth.Require(ctx, entityType, principal.ActionUpdate); err != nil {
 		return err
 	}
 	return s.db.Tx(ctx, func(tx pgx.Tx) error {
@@ -276,27 +320,95 @@ func (s *Store) EnsureTaggable(ctx context.Context, entityType string, entityID 
 	})
 }
 
+// maxTagNameRunes bounds a tag name. Counted in RUNES, not bytes: the limit is
+// about what a person can read on a badge, and a byte cap would let an English
+// name run half again as long as a German one.
+const maxTagNameRunes = 64
+
+// NormalizeTagName is the ONE spelling rule every write path shares: create,
+// rename, and the name an agent resolves against. Trim the ends, collapse any
+// run of inner whitespace to one space.
+//
+// It exists because a vocabulary that holds "Key Account" and "Key  Account"
+// has stopped being one, and the two are indistinguishable to a reader. The
+// uniqueness index folds case; nothing folded spacing, so the collision it is
+// there to prevent could still be typed.
+//
+// Held by: TestNormalizeTagName (collections/tagname_test.go)
+func NormalizeTagName(name string) string {
+	return strings.Join(strings.Fields(name), " ")
+}
+
+// ValidateTagName applies the rule and says why a name is refused. An empty
+// name and an over-long one are the caller's to fix, so both name the field.
+func ValidateTagName(name string) (string, error) {
+	normalized := NormalizeTagName(name)
+	if normalized == "" {
+		return "", &BadInputError{Field: "name", Reason: "must not be empty"}
+	}
+	if utf8.RuneCountInString(normalized) > maxTagNameRunes {
+		return "", &BadInputError{
+			Field:  "name",
+			Reason: fmt.Sprintf("must be at most %d characters", maxTagNameRunes),
+		}
+	}
+	return normalized, nil
+}
+
 // FindTag answers the id of the LIVE tag with this name, or ok=false.
 //
 // Case-insensitive, matching the uq_tag_name index, and live-only: an archived
 // word was retired on purpose and is not what a caller naming it means.
 func (s *Store) FindTag(ctx context.Context, name string) (ids.UUID, bool, error) {
+	id, state, err := s.lookupTagByName(ctx, name)
+	return id, state == tagNameLive, err
+}
+
+// TagNameState says which of the three answers a name lookup gave, because a
+// caller that has to explain a refusal cannot tell them apart from an id and a
+// bool: an unknown word and a retired one need different sentences, and
+// collapsing them tells somebody their tag does not exist when an admin can
+// restore it.
+type TagNameState int
+
+const (
+	tagNameMissing TagNameState = iota
+	tagNameLive
+	tagNameArchived
+)
+
+// LookupTagName resolves a name to its id and which state it is in.
+func (s *Store) LookupTagName(ctx context.Context, name string) (ids.UUID, TagNameState, error) {
+	return s.lookupTagByName(ctx, name)
+}
+
+// Archived returns whether the name resolved to a retired tag.
+func (st TagNameState) Archived() bool { return st == tagNameArchived }
+
+// Live returns whether the name resolved to a tag that may be applied.
+func (st TagNameState) Live() bool { return st == tagNameLive }
+
+func (s *Store) lookupTagByName(ctx context.Context, name string) (ids.UUID, TagNameState, error) {
 	if err := auth.Require(ctx, "tag", principal.ActionRead); err != nil {
-		return ids.UUID{}, false, err
+		return ids.UUID{}, tagNameMissing, err
 	}
 	var id ids.TagID
+	var archived *time.Time
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
-			SELECT id FROM tag
-			 WHERE lower(name) = lower($1) AND archived_at IS NULL`, strings.TrimSpace(name)).Scan(&id)
+			SELECT id, archived_at FROM tag
+			 WHERE lower(name) = lower($1)`, NormalizeTagName(name)).Scan(&id, &archived)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
-		return ids.UUID{}, false, nil
+		return ids.UUID{}, tagNameMissing, nil
 	}
 	if err != nil {
-		return ids.UUID{}, false, fmt.Errorf("collections: finding tag by name: %w", err)
+		return ids.UUID{}, tagNameMissing, fmt.Errorf("collections: finding tag by name: %w", err)
 	}
-	return id.UUID, true, nil
+	if archived != nil {
+		return id.UUID, tagNameArchived, nil
+	}
+	return id.UUID, tagNameLive, nil
 }
 
 // TagSummary is the tag as another module sees it. tagRow is unexported

--- a/backend/internal/modules/collections/tags.go
+++ b/backend/internal/modules/collections/tags.go
@@ -467,10 +467,15 @@ func (s *Store) NewTag(ctx context.Context, name, color string) (TagSummary, err
 }
 
 func wireTag(t tagRow) crmcontracts.Tag {
+	var color *crmcontracts.TagColor
+	if t.Color != nil {
+		c := crmcontracts.TagColor(*t.Color)
+		color = &c
+	}
 	return crmcontracts.Tag{
 		Id:         openapi_types.UUID(t.ID.UUID),
 		Name:       t.Name,
-		Color:      t.Color,
+		Color:      color,
 		CreatedAt:  &t.CreatedAt,
 		UpdatedAt:  &t.UpdatedAt,
 		ArchivedAt: t.ArchivedAt,

--- a/backend/internal/modules/identity/internal/policy/defaults.go
+++ b/backend/internal/modules/identity/internal/policy/defaults.go
@@ -77,7 +77,7 @@ var (
 // and migrate-in screens are admin surfaces.
 // managerObjects is the grid a team lead (`manager`) and the whole-organization
 // `management` seat share; only their row scope differs.
-var managerObjects = objects(crud, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly, readOnly, crud, readOnly, grant{}, readOnly, grant{}, grant{}, grant{Create: true, Read: true}, crud, readOnly, grant{}, readOnly, readOnly, readOnly, grant{}, readOnly, grant{}, crud, grant{}, crud, crud, readOnly, readOnly, writeNoDelete, crud)
+var managerObjects = objects(crud, crud, crud, crud, crud, readOnly, crud, readOnly, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly, readOnly, crud, readOnly, grant{}, readOnly, grant{}, grant{}, grant{Create: true, Read: true}, crud, readOnly, grant{}, readOnly, readOnly, readOnly, grant{}, readOnly, grant{}, crud, grant{}, crud, crud, readOnly, readOnly, writeNoDelete, crud)
 
 var defaults = map[string]Document{
 	"admin": {
@@ -131,7 +131,7 @@ var defaults = map[string]Document{
 			grant{Create: true, Read: true, Update: true},
 			readOnly,
 			grant{Create: true, Read: true, Update: true},
-			grant{Create: true, Read: true, Update: true},
+			readOnly,
 			grant{Create: true, Read: true, Update: true},
 			readOnly,
 			readOnly,

--- a/backend/migrations/core/1788320100_a_tag_is_governed_vocabulary.down.sql
+++ b/backend/migrations/core/1788320100_a_tag_is_governed_vocabulary.down.sql
@@ -3,6 +3,10 @@
 -- the constraint is the honest reverse — the column goes back to free text
 -- holding the tone names, which it accepts.
 
+-- Bounded for the same reason the up half is: dropping a column and a
+-- constraint takes the same ACCESS EXCLUSIVE lock on a live table.
+SET LOCAL lock_timeout = '3s';
+
 ALTER TABLE tag DROP CONSTRAINT IF EXISTS tag_color_check;
 
 ALTER TABLE taggable DROP CONSTRAINT IF EXISTS taggable_assigned_by_kind_check;

--- a/backend/migrations/core/1788320100_a_tag_is_governed_vocabulary.down.sql
+++ b/backend/migrations/core/1788320100_a_tag_is_governed_vocabulary.down.sql
@@ -1,0 +1,15 @@
+-- The colour values are NOT restored: the up migration folded whatever was
+-- there onto four names, and the original hex is gone from the row. Dropping
+-- the constraint is the honest reverse — the column goes back to free text
+-- holding the tone names, which it accepts.
+
+ALTER TABLE tag DROP CONSTRAINT IF EXISTS tag_color_check;
+
+ALTER TABLE taggable DROP CONSTRAINT IF EXISTS taggable_assigned_by_kind_check;
+
+ALTER TABLE taggable
+    DROP COLUMN IF EXISTS assigned_at,
+    DROP COLUMN IF EXISTS assigned_by_kind,
+    DROP COLUMN IF EXISTS assigned_by;
+
+ALTER TABLE tag DROP COLUMN IF EXISTS description;

--- a/backend/migrations/core/1788320100_a_tag_is_governed_vocabulary.up.sql
+++ b/backend/migrations/core/1788320100_a_tag_is_governed_vocabulary.up.sql
@@ -1,0 +1,56 @@
+-- A tag is governed vocabulary, and an assignment says who made it.
+--
+-- Three changes, in the order they have to happen.
+--
+-- 1. `description` gives a tag somewhere to say what it means. A vocabulary
+--    only Admin and Ops may extend needs to explain itself to everyone who
+--    may only apply it.
+--
+-- 2. `taggable` learns who assigned the tag and when. The row already carried
+--    created_at, but not the principal: without it the record page cannot say
+--    "added by Lena on 3 March", and an assignment made by an agent is
+--    indistinguishable from one a human chose. assigned_by is nullable
+--    because rows written before this migration have no principal to name —
+--    absent means unknown, never "the system".
+--
+-- 3. `color` becomes a closed palette. It was free text, so the values in a
+--    deployed database are whatever a caller sent — the seeder wrote hex.
+--    The UPDATE maps every hex the product has ever written onto the four
+--    named tones, and anything unrecognised onto slate, BEFORE the CHECK
+--    arrives. A constraint added first would fail the migration on the
+--    installation that has data, which is the one that matters.
+
+ALTER TABLE tag ADD COLUMN description text;
+
+ALTER TABLE taggable
+    ADD COLUMN assigned_by uuid,
+    ADD COLUMN assigned_by_kind text,
+    ADD COLUMN assigned_at timestamptz;
+
+-- Backfill the instant from the row's own creation: it is the truth we have,
+-- and leaving it null would make every pre-existing assignment render as
+-- "assigned at unknown" on a page that has the date in the next column.
+UPDATE taggable SET assigned_at = created_at WHERE assigned_at IS NULL;
+
+ALTER TABLE taggable
+    ALTER COLUMN assigned_at SET DEFAULT now(),
+    ALTER COLUMN assigned_at SET NOT NULL;
+
+ALTER TABLE taggable
+    ADD CONSTRAINT taggable_assigned_by_kind_check
+    CHECK (assigned_by_kind IS NULL OR assigned_by_kind IN ('human', 'agent', 'import'));
+
+-- The four tones the design system draws. Hex values the product wrote before
+-- the palette existed map onto the nearest tone rather than being dropped: a
+-- tag that loses its colour looks like a tag somebody re-coloured.
+UPDATE tag SET color = CASE
+    WHEN color IS NULL THEN NULL
+    WHEN lower(color) IN ('#b45309', '#d97706', '#f59e0b', 'amber') THEN 'amber'
+    WHEN lower(color) IN ('#b91c1c', '#dc2626', '#ef4444', 'rose') THEN 'rose'
+    WHEN lower(color) IN ('#1d4ed8', '#2563eb', '#0d9488', '#14b8a6', 'teal') THEN 'teal'
+    ELSE 'slate'
+END;
+
+ALTER TABLE tag
+    ADD CONSTRAINT tag_color_check
+    CHECK (color IS NULL OR color IN ('teal', 'amber', 'rose', 'slate'));

--- a/backend/migrations/core/1788320100_a_tag_is_governed_vocabulary.up.sql
+++ b/backend/migrations/core/1788320100_a_tag_is_governed_vocabulary.up.sql
@@ -46,6 +46,20 @@ ALTER TABLE taggable
     ADD CONSTRAINT taggable_assigned_by_kind_check
     CHECK (assigned_by_kind IS NULL OR assigned_by_kind IN ('human', 'agent', 'import'));
 
+-- Names get the same rule the code now applies. lookupTagByName collapses inner
+-- whitespace before it matches, so a row stored as "Key  Account" would stop
+-- being findable by the very name it displays: apply-by-name would refuse a tag
+-- the workspace can see, and remove-by-name would quietly do nothing. Folding
+-- the stored names is what keeps the column and the lookup agreeing.
+--
+-- The unique index is on lower(name), so two rows can only collide here if they
+-- already differed by spacing alone. That pair is the defect this rule exists to
+-- prevent, and it has to be reported rather than silently merged: the update
+-- fails on the constraint, and whoever runs it decides which word survives.
+UPDATE tag
+   SET name = btrim(regexp_replace(name, '\s+', ' ', 'g'))
+ WHERE name <> btrim(regexp_replace(name, '\s+', ' ', 'g'));
+
 -- The four tones the design system draws. Hex values the product wrote before
 -- the palette existed map onto the nearest tone rather than being dropped: a
 -- tag that loses its colour looks like a tag somebody re-coloured.
@@ -60,3 +74,27 @@ END;
 ALTER TABLE tag
     ADD CONSTRAINT tag_color_check
     CHECK (color IS NULL OR color IN ('teal', 'amber', 'rose', 'slate'));
+
+-- Reach the installations that already exist. seedSystemRoles writes each role
+-- document once at workspace creation and never re-syncs, so narrowing the
+-- compiled defaults alone changes nothing for anyone who bootstrapped earlier:
+-- their management, team-lead and rep seats would keep tag CRUD for good, and
+-- the governance this migration exists for would hold on a fresh database and
+-- nowhere else.
+--
+-- Unlike an ADDED object, this one is a narrowing, so it cannot be guarded on
+-- the key being absent — it is present and wrong. The guard is instead that the
+-- role still carries a WRITE verb on tag: a workspace an operator has already
+-- narrowed by hand is left as they set it, and re-running is a no-op.
+UPDATE role SET permissions = jsonb_set(
+        permissions, '{objects,tag}',
+        '{"create": false, "read": true, "update": false, "delete": false}'::jsonb, true)
+    WHERE is_system
+      AND key IN ('management', 'manager', 'rep')
+      AND permissions ? 'objects'
+      AND (permissions -> 'objects') ? 'tag'
+      AND (
+            ((permissions -> 'objects' -> 'tag' ->> 'create')::boolean IS TRUE)
+         OR ((permissions -> 'objects' -> 'tag' ->> 'update')::boolean IS TRUE)
+         OR ((permissions -> 'objects' -> 'tag' ->> 'delete')::boolean IS TRUE)
+      );

--- a/backend/migrations/core/1788320100_a_tag_is_governed_vocabulary.up.sql
+++ b/backend/migrations/core/1788320100_a_tag_is_governed_vocabulary.up.sql
@@ -20,6 +20,12 @@
 --    arrives. A constraint added first would fail the migration on the
 --    installation that has data, which is the one that matters.
 
+-- Bounded: every ALTER below takes an ACCESS EXCLUSIVE lock on a table the
+-- product writes while people are working — tag on every create, taggable on
+-- every apply. Waiting forever behind an open transaction would stall the
+-- deploy and every writer behind it.
+SET LOCAL lock_timeout = '3s';
+
 ALTER TABLE tag ADD COLUMN description text;
 
 ALTER TABLE taggable

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -4420,19 +4420,25 @@ public.tag acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_
 public.tag.archived_at timestamp with time zone gen=- def=-
 public.tag.color text gen=- def=-
 public.tag.created_at timestamp with time zone NOT NULL gen=- def=now()
+public.tag.description text gen=- def=-
 public.tag.id uuid NOT NULL gen=- def=uuidv7()
 public.tag.name text NOT NULL gen=- def=-
+public.tag.tag_color_check CHECK (((color IS NULL) OR (color = ANY (ARRAY['teal'::text, 'amber'::text, 'rose'::text, 'slate'::text]))))
 public.tag.tag_pkey PRIMARY KEY (id)
 public.tag.trg_tag_updated CREATE TRIGGER trg_tag_updated BEFORE UPDATE ON public.tag FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version()
 public.tag.updated_at timestamp with time zone NOT NULL gen=- def=now()
 public.tag.version bigint NOT NULL gen=- def=1
 public.tag_pkey CREATE UNIQUE INDEX tag_pkey ON public.tag USING btree (id)
 public.taggable acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
+public.taggable.assigned_at timestamp with time zone NOT NULL gen=- def=now()
+public.taggable.assigned_by uuid gen=- def=-
+public.taggable.assigned_by_kind text gen=- def=-
 public.taggable.created_at timestamp with time zone NOT NULL gen=- def=now()
 public.taggable.entity_id uuid NOT NULL gen=- def=-
 public.taggable.entity_type text NOT NULL gen=- def=-
 public.taggable.id uuid NOT NULL gen=- def=uuidv7()
 public.taggable.tag_id uuid NOT NULL gen=- def=-
+public.taggable.taggable_assigned_by_kind_check CHECK (((assigned_by_kind IS NULL) OR (assigned_by_kind = ANY (ARRAY['human'::text, 'agent'::text, 'import'::text]))))
 public.taggable.taggable_entity_type_check CHECK ((entity_type = ANY (ARRAY['person'::text, 'organization'::text, 'deal'::text, 'lead'::text, 'project'::text])))
 public.taggable.taggable_pkey PRIMARY KEY (id)
 public.taggable.taggable_tag_id_fkey FOREIGN KEY (tag_id) REFERENCES tag(id) ON DELETE CASCADE

--- a/backend/migrations/testdata/rbac_seeded_defaults.json
+++ b/backend/migrations/testdata/rbac_seeded_defaults.json
@@ -487,10 +487,10 @@
         "update": true
       },
       "tag": {
-        "create": true,
-        "delete": true,
+        "create": false,
+        "delete": false,
         "read": true,
-        "update": true
+        "update": false
       },
       "voice_profile": {
         "create": true,
@@ -744,10 +744,10 @@
         "update": true
       },
       "tag": {
-        "create": true,
-        "delete": true,
+        "create": false,
+        "delete": false,
         "read": true,
-        "update": true
+        "update": false
       },
       "voice_profile": {
         "create": true,
@@ -1515,10 +1515,10 @@
         "update": true
       },
       "tag": {
-        "create": true,
+        "create": false,
         "delete": false,
         "read": true,
-        "update": true
+        "update": false
       },
       "voice_profile": {
         "create": true,

--- a/backend/tools/seed-demo/surfaces.go
+++ b/backend/tools/seed-demo/surfaces.go
@@ -56,12 +56,12 @@ var demoTags = []struct {
 	// Applies decides which companies carry this tag, from their profile.
 	Applies func(profile) bool
 }{
-	{"Key Account", "#b45309", func(p profile) bool { return p.Lifecycle == "customer" }},
-	{"Churn Risk", "#b91c1c", func(p profile) bool { return p.Lifecycle == "former_customer" }},
-	{"Inbound", "#1d4ed8", func(p profile) bool { return p.LeadState != "" }},
+	{"Key Account", "amber", func(p profile) bool { return p.Lifecycle == "customer" }},
+	{"Churn Risk", "rose", func(p profile) bool { return p.Lifecycle == "former_customer" }},
+	{"Inbound", "teal", func(p profile) bool { return p.LeadState != "" }},
 	// `parked` is not a lifecycle the product carries, so the planner maps it
 	// to `target` and this tag is what preserves the distinction.
-	{"Parked", "#6b7280", func(p profile) bool { return p.Lifecycle == "target" && p.DealStage == "" }},
+	{"Parked", "slate", func(p profile) bool { return p.Lifecycle == "target" && p.DealStage == "" }},
 }
 
 func seedTags(c *client, refs pipelineRefs, plan map[string]profile, mode runMode) (int, error) {

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,9 +5,9 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 59,
-    "tokens": 18954,
+    "tokens": 19010,
     "median_tool_tokens": 275,
-    "mean_tool_tokens": 320
+    "mean_tool_tokens": 321
   },
   "agents": [
     {
@@ -214,6 +214,10 @@
       "tokens": 260
     },
     {
+      "name": "apply_tag",
+      "tokens": 258
+    },
+    {
       "name": "account_coverage",
       "tokens": 252
     },
@@ -246,10 +250,6 @@
       "tokens": 213
     },
     {
-      "name": "apply_tag",
-      "tokens": 211
-    },
-    {
       "name": "who_knows",
       "tokens": 201
     },
@@ -258,12 +258,12 @@
       "tokens": 198
     },
     {
-      "name": "intro_path_to",
-      "tokens": 197
+      "name": "remove_tag",
+      "tokens": 198
     },
     {
-      "name": "remove_tag",
-      "tokens": 190
+      "name": "intro_path_to",
+      "tokens": 197
     },
     {
       "name": "list_channel_providers",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1661 | 6% | 15339 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2509 | 10% | 14491 | 15 | 8 |
-| _whole served catalog, for scale_ | 59 | 18954 | 78% | — | — | — |
+| _whole served catalog, for scale_ | 59 | 19010 | 79% | — | — | — |
 
 ### `morning_brief`
 
@@ -123,7 +123,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 275 tokens, mean 320, across 59 served tools.
+Median 275 tokens, mean 321, across 59 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -168,6 +168,7 @@ a term in an addition.
 | `decide_approval_bundle` | 266 | — |
 | `qualify_lead` | 261 | — |
 | `create_task` | 260 | — |
+| `apply_tag` | 258 | — |
 | `account_coverage` | 252 | 2 scenarios |
 | `relink_activities` | 237 | — |
 | `read_record` | 229 | 2 scenarios |
@@ -176,11 +177,10 @@ a term in an addition.
 | `whats_slipping_this_week` | 218 | 2 scenarios |
 | `at_risk_relationships` | 215 | — |
 | `read_brief` | 213 | — |
-| `apply_tag` | 211 | — |
 | `who_knows` | 201 | — |
 | `list_pipelines` | 198 | — |
+| `remove_tag` | 198 | — |
 | `intro_path_to` | 197 | 2 scenarios |
-| `remove_tag` | 190 | — |
 | `list_channel_providers` | 181 | — |
 | `check_location_support` | 163 | — |
 | `read_project_360` | 163 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 59,
     "resources": 9,
-    "tool_catalog_bytes": 173884,
+    "tool_catalog_bytes": 174105,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 44349,
+    "approx_wire_tokens_total": 44404,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
-      "description_bytes": 40370,
-      "input_schema_bytes": 37376,
+      "description_bytes": 40525,
+      "input_schema_bytes": 37442,
       "output_schema_bytes": 83313,
-      "description_plus_input_schema_bytes": 77746
+      "description_plus_input_schema_bytes": 77967
     }
   },
   "tools": {
@@ -736,7 +736,7 @@
           "readOnlyHint": false,
           "title": "Apply a tag to a record"
         },
-        "description": "Tag a person, company, deal, lead or project by tag_id, or by tag_name, which reuses the workspace's word or coins it. Prefer a tag_id from list_tags: a name matches case-insensitively, and a near-miss makes a NEW word. The same tag twice is a conflict. (Governance: runs immediately; requires passport scope \"write\".)",
+        "description": "Tag a person, company, deal, lead or project by tag_id, or by tag_name, which must name a tag the workspace already has. This tool never creates a tag: an unknown name is refused, and only an admin or ops seat can add a word to the vocabulary. A name matches case-insensitively; an archived word is refused as archived rather than as unknown. Prefer a tag_id from list_tags. The same tag twice is a conflict. (Governance: runs immediately; requires passport scope \"write\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -764,8 +764,8 @@
               "type": "string"
             },
             "tag_name": {
-              "description": "Instead of tag_id: the tag is created if the workspace has no such word",
-              "maxLength": 120,
+              "description": "Instead of tag_id: the name of a tag the workspace ALREADY has. An unknown name is refused, never created",
+              "maxLength": 64,
               "type": "string"
             }
           },
@@ -9083,8 +9083,8 @@
               "type": "string"
             },
             "tag_name": {
-              "description": "Instead of tag_id: the tag is created if the workspace has no such word",
-              "maxLength": 120,
+              "description": "Instead of tag_id: the name of a tag the workspace ALREADY has. An unknown name is refused, never created",
+              "maxLength": 64,
               "type": "string"
             }
           },

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 59 |
 | Resources | 9 |
-| Tool catalog | 169.8 KB |
+| Tool catalog | 170.0 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 44349 |
+| Approx. wire tokens | 44404 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -30,10 +30,10 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
 | Output schemas | 81.4 KB | 47% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 39.4 KB | 23% | Yes, every step |
-| Input schemas | 36.5 KB | 21% | Yes, every step |
+| Descriptions (incl. governance clause) | 39.6 KB | 23% | Yes, every step |
+| Input schemas | 36.6 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.5 KB | 7% | Partly |
-| **Description + input schema** | **75.9 KB** | **44%** | **the recurring cost** |
+| **Description + input schema** | **76.1 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -65,7 +65,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`advance_deal`](#advance_deal) | Advance a deal to a stage |  |  | 3.1 KB |
 | [`advance_project_phase`](#advance_project_phase) | Move a project to a phase |  |  | 2.2 KB |
 | [`annotate_brief`](#annotate_brief) | Write findings onto the morning brief |  |  | 2.9 KB |
-| [`apply_tag`](#apply_tag) | Apply a tag to a record |  |  | 2.0 KB |
+| [`apply_tag`](#apply_tag) | Apply a tag to a record |  |  | 2.2 KB |
 | [`archive_record`](#archive_record) | Archive a record |  |  | 2.2 KB |
 | [`at_risk_relationships`](#at_risk_relationships) | Relationships going cold | yes |  | 2.6 KB |
 | [`book_meeting`](#book_meeting) | Book a meeting |  |  | 2.7 KB |
@@ -1054,7 +1054,7 @@ Write what you found onto the morning brief you just read: one sentence about th
 
 **Apply a tag to a record**
 
-Tag a person, company, deal, lead or project by tag_id, or by tag_name, which reuses the workspace's word or coins it. Prefer a tag_id from list_tags: a name matches case-insensitively, and a near-miss makes a NEW word. The same tag twice is a conflict. (Governance: runs immediately; requires passport scope "write".)
+Tag a person, company, deal, lead or project by tag_id, or by tag_name, which must name a tag the workspace already has. This tool never creates a tag: an unknown name is refused, and only an admin or ops seat can add a word to the vocabulary. A name matches case-insensitively; an archived word is refused as archived rather than as unknown. Prefer a tag_id from list_tags. The same tag twice is a conflict. (Governance: runs immediately; requires passport scope "write".)
 
 <details><summary>Input schema</summary>
 
@@ -1086,8 +1086,8 @@ Tag a person, company, deal, lead or project by tag_id, or by tag_name, which re
       "type": "string"
     },
     "tag_name": {
-      "description": "Instead of tag_id: the tag is created if the workspace has no such word",
-      "maxLength": 120,
+      "description": "Instead of tag_id: the name of a tag the workspace ALREADY has. An unknown name is refused, never created",
+      "maxLength": 64,
       "type": "string"
     }
   },
@@ -9804,8 +9804,8 @@ Take one tag off one record — by tag_id or tag_name — leaving the word itsel
       "type": "string"
     },
     "tag_name": {
-      "description": "Instead of tag_id: the tag is created if the workspace has no such word",
-      "maxLength": 120,
+      "description": "Instead of tag_id: the name of a tag the workspace ALREADY has. An unknown name is refused, never created",
+      "maxLength": 64,
       "type": "string"
     }
   },

--- a/docs/reference/rbac-matrix.md
+++ b/docs/reference/rbac-matrix.md
@@ -101,7 +101,7 @@ changes none.
 | `retention_policy` | CRUD | ---- | ---- | ---- | ---- | CRUD |
 | `saved_view` | CRUD | CRUD | CRUD | CRUD | CRUD | CRUD |
 | `signal` | CRUD | CRUD | CRUD | CRU- | -R-- | CRUD |
-| `tag` | CRUD | CRUD | CRUD | CRU- | -R-- | CRUD |
+| `tag` | CRUD | -R-- | -R-- | -R-- | -R-- | CRUD |
 | `voice_profile` | CRUD | CRUD | CRUD | CRU- | -R-- | CRUD |
 | `webhook_subscription` | CRUD | -R-- | -R-- | -R-- | -R-- | CRUD |
 | `weekly_plan` | CRUD | CRUD | CRUD | CRU- | -R-- | CRUD |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21188,7 +21188,9 @@ export interface components {
             /** Format: uuid */
             id: string;
             name: string;
-            color?: string | null;
+            /** @enum {string|null} */
+            color?: "teal" | "amber" | "rose" | "slate" | null;
+            description?: string | null;
             /** Format: date-time */
             created_at?: string;
             /** Format: date-time */
@@ -21198,7 +21200,9 @@ export interface components {
         };
         CreateTagRequest: {
             name: string;
-            color?: string | null;
+            /** @enum {string|null} */
+            color?: "teal" | "amber" | "rose" | "slate" | null;
+            description?: string | null;
         };
         Taggable: {
             /** Format: uuid */

--- a/scripts/contract-breaking-allowlist.txt
+++ b/scripts/contract-breaking-allowlist.txt
@@ -28,3 +28,4 @@ a35057f55a688d0b19b9e0e295f54bafa5193517 5b2fdab6f36d98ba92f83b152962152b47cd611
 5d27bdf8d88f1313480daca24b8e2229f6e05ea8 2a7d64e559a8435ac313169829f7c9c2d89e88d6 ratified-one-oauth-app-resource-per-vendor-microsoft-joins-google
 8d76c31f65ec76a683156160d689191425b20858 e0c11716048a939f1f1187d6992754335300ac41 ratified-v1-lists-leave-the-product-tags-are-the-one-grouping
 e0c11716048a939f1f1187d6992754335300ac41 ce200199d82e76fca7c07e5781a7af1a963b4963 ratified-the-human-set-sales-quota-is-retired
+e0c11716048a939f1f1187d6992754335300ac41 87d8a0bc37bcbd565b4c9d7e47be5b4799b72609 ratified-v1-tag-colour-is-a-closed-palette-and-a-name-is-bounded

--- a/scripts/contract-breaking-allowlist.txt
+++ b/scripts/contract-breaking-allowlist.txt
@@ -28,4 +28,4 @@ a35057f55a688d0b19b9e0e295f54bafa5193517 5b2fdab6f36d98ba92f83b152962152b47cd611
 5d27bdf8d88f1313480daca24b8e2229f6e05ea8 2a7d64e559a8435ac313169829f7c9c2d89e88d6 ratified-one-oauth-app-resource-per-vendor-microsoft-joins-google
 8d76c31f65ec76a683156160d689191425b20858 e0c11716048a939f1f1187d6992754335300ac41 ratified-v1-lists-leave-the-product-tags-are-the-one-grouping
 e0c11716048a939f1f1187d6992754335300ac41 ce200199d82e76fca7c07e5781a7af1a963b4963 ratified-the-human-set-sales-quota-is-retired
-e0c11716048a939f1f1187d6992754335300ac41 87d8a0bc37bcbd565b4c9d7e47be5b4799b72609 ratified-v1-tag-colour-is-a-closed-palette-and-a-name-is-bounded
+0110dee350c9277dc41e5147dbba9c0a127c3f8a f26fe6c3b9c6e8dc75128b7bea48799033ecdab3 ratified-v1-tag-colour-is-a-closed-palette-and-a-name-is-bounded


### PR DESCRIPTION
Three rules that only make sense together, plus the migration they need.

## Who may do what

**The vocabulary belongs to Admin and Ops.** Management, team lead and rep drop to `tag.read`. Coining, renaming and retiring a word is governance, and a vocabulary every seat can extend is not one.

**Applying a tag is a write to the RECORD, not to the vocabulary.** So apply and remove now want `tag.read` plus `<type>.update`, where they used to want `tag.update` plus `<type>.read`. The old pairing had it backwards in both directions: a rep could invent tags, and could tag a company they were only allowed to look at.

**`apply_tag` never creates.** The seam's `EnsureTag` became `ResolveTag`, which answers for a word the workspace holds and refuses anything else — with different sentences for a name nobody coined and one somebody retired. A rep told "no such tag" about an archived word will ask an admin for a duplicate of it.

## The migration

Adds `description`, and `assigned_by` / `assigned_by_kind` / `assigned_at` on `taggable` so the record page can say who put a tag there. Colour becomes the four-tone palette.

Two ordering details matter. The colour conversion runs **before** the CHECK, because the seeder wrote hex and a constraint added first would fail exactly on the installations that have data. And stored names get the same whitespace rule the code now applies, because `lookupTagByName` collapses inner spacing before matching — a row stored as `Key  Account` would otherwise stop being findable by the name it displays.

## What Codex caught that the gates could not

**A blocker.** `seedSystemRoles` writes each role document once at workspace creation and never re-syncs. Narrowing the compiled defaults alone reached nobody who bootstrapped earlier: their seats would have kept tag CRUD for good, and the governance would have held on a fresh database and nowhere else. The migration now carries the same `UPDATE role` the weekly-plan RBAC change used, guarded on the role still holding a write verb so a workspace an operator already narrowed by hand is left alone.

**Two tests that proved nothing.** The apply-authz test granted neither project verb, so it passed under the old pairing and the new one alike; it now grants read without update, which is exactly the case the inversion changed. The business-card acceptance test pinned tag coining as a criterion — it now seeds the word as an admin and applies it, with a sibling proving an unknown name is refused and writes nothing.

**A contract that promised what the server refuses.** The published `apply_tag` description and its `tag_name` schema still told the model a tag would be created, with a 120-character cap against the server's 64.

One finding I did not act on: Codex reads the audit call's arguments as an authorization claim. They are the subject and action of the audit row, not the grant that admitted the call.

## Checks

`make check` green (both halves). Integration lanes green: `backend/migrations` and `compose/integration/collections`. `make craft-static` clean, RLS and jurisdiction gates pass. Every new guard was mutation-checked one clause at a time — including one that initially passed under mutation, which turned out to be testing a stub rather than the seam.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes tags a governed vocabulary: only Admin and Ops may coin, rename, or retire a word, while management, team lead, and rep drop to `tag.read`. Applying or removing a tag is now a write to the record, so it requires `tag.read` plus update on the target type instead of the old `tag.update` plus read, and `apply_tag` never creates a tag.

**Migration**

- Adds `description` and `assigned_by` / `assigned_by_kind` / `assigned_at` to `taggable` so the record page can show who assigned a tag.
- Closes the color palette to teal, amber, rose, and slate; the conversion runs before the CHECK constraint because the seeder wrote hex.
- Updates existing role documents for management, manager, and rep seats to remove tag write verbs, since `seedSystemRoles` writes once at workspace creation and never re-syncs; workspaces already narrowed by hand are left alone.
- Normalizes stored tag names to match the new whitespace-collapsing lookup rule; a spacing-only collision fails the migration rather than merging silently.
- The API contract now ratifies the narrowed surface: color is an enum, `tag_name` drops from 120 to 64 characters, and the `apply_tag` tool copy and schema describe a resolve-only operation.

<sup>Written for commit 1b3f727cc9111802b74e57281fbc010a55cedfe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tags now support optional descriptions and standardized colors: teal, amber, rose, or slate.
  - Tag assignments record when and by whom they were made.
  - Tag names are normalized and limited to 64 characters.

- **Behavior Changes**
  - Applying or removing tags requires appropriate access to the target and tag vocabulary.
  - Tag-based actions now require existing, active tags; unknown or archived tags are refused instead of created.
  - Management, manager, and rep roles now have read-only tag access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->