### PR TITLE
A lead's first question is answered on the page they open first

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -453,7 +453,10 @@ const SCREEN_VIEWS: Readonly<Record<Screen, (args: ScreenArgs) => ReactNode>> =
     leads: ({ id }) => (id ? <LeadScreen id={id} /> : <LeadsScreen />),
     deals: ({ id, id2 }) => <DealsRoute id={id} id2={id2} />,
     projects: ({ id }) => (id ? <ProjectScreen id={id} /> : <ProjectsScreen />),
-    worklist: () => <WorklistScreen />,
+    // One segment, and it is WHOSE day — the door a team board row needs. The
+    // other three dials stay state: putting one of four in the address would
+    // make it describe a fraction of what the reader is looking at.
+    worklist: ({ id }) => <WorklistScreen opensOn={id} />,
     reports: () => <ReportsScreen />,
     ai: () => <AskAiScreen />,
     // The screen resolves its own address, because which entry an address names

--- a/frontend/src/screens/home.teamboard.test.tsx
+++ b/frontend/src/screens/home.teamboard.test.tsx
@@ -1,0 +1,90 @@
+/** @vitest-environment jsdom */
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { en } from "../i18n/en";
+import { HomeTeamBoard } from "./home.teamboard";
+import { jsonResponse, render, stubApi } from "./home.testkit";
+
+// The team board on Home. It is the SAME component the Worklist draws, so what
+// these tests are about is not the table — it is where a row goes.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  globalThis.location.hash = "";
+});
+
+const board = {
+  as_of: "2026-06-10T06:00:00Z",
+  members: [
+    {
+      user_id: "11111111-1111-4111-8111-111111111111",
+      display_name: "Lena Fischer",
+      counts: { waiting: 3, at_risk: 1, overdue: 0 },
+    },
+  ],
+  unassigned: { waiting: 2, at_risk: 0, overdue: 0 },
+  truncated: false,
+};
+
+async function openBoard() {
+  render(<HomeTeamBoard offered />);
+  // The board sits behind a disclosure: the reader's own day is what they came
+  // for, and a table of colleagues above it would push that off the screen.
+  await userEvent.click(await screen.findByText(en["worklist.board.title"]));
+}
+
+describe("the team board on Home", () => {
+  // A rep never sees it, and the read is never made. Drawing a control on a
+  // tier the server refuses is a control that exists to fail.
+  it("draws nothing and asks nothing for a reader whose scope reaches no team", () => {
+    const calls = stubApi({});
+    const { container } = render(<HomeTeamBoard offered={false} />);
+
+    expect(container.firstChild).toBeNull();
+    expect(calls.filter((call) => call.path === "/worklist/team")).toHaveLength(
+      0,
+    );
+  });
+
+  // The row is a door to that person's day. Without the id in the address it
+  // could only reach the Worklist, leaving the reader to pick the same person
+  // a second time — a row that answers a question by asking it again.
+  it("opens a colleague's own queue by name in the address", async () => {
+    stubApi({ "GET /worklist/team": () => jsonResponse(board) });
+    await openBoard();
+
+    await userEvent.click(await screen.findByText("Lena Fischer"));
+
+    expect(globalThis.location.hash).toBe(
+      "#/worklist/11111111-1111-4111-8111-111111111111",
+    );
+  });
+
+  // The unowned pile has no person to open, so the same segment carries the
+  // scope word. Both rows are doors, not one door and one shrug.
+  it("opens the unassigned pile by its scope word", async () => {
+    stubApi({ "GET /worklist/team": () => jsonResponse(board) });
+    await openBoard();
+
+    await userEvent.click(await screen.findByText(en["worklist.board.nobody"]));
+
+    expect(globalThis.location.hash).toBe("#/worklist/unassigned");
+  });
+
+  // One read, one query key. Home and the Worklist cannot report different
+  // counts for the same morning because they are not two reads.
+  it("reads the board through the shared key, not a second endpoint", async () => {
+    const calls = stubApi({ "GET /worklist/team": () => jsonResponse(board) });
+    await openBoard();
+
+    await screen.findByText("Lena Fischer");
+    const boardReads = calls.filter((call) => call.path === "/worklist/team");
+    expect(boardReads).toHaveLength(1);
+    expect(boardReads[0].method).toBe("GET");
+  });
+});

--- a/frontend/src/screens/home.teamboard.tsx
+++ b/frontend/src/screens/home.teamboard.tsx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { navigate } from "../app/router";
+import { TeamBoard } from "./worklist.board";
+import { UNASSIGNED } from "./worklist.queries";
+
+// Who on the team is carrying what, on the page a lead opens first.
+//
+// The SAME component the Worklist draws, on the same query key — not a second
+// table over the same counts. What differs is only where a row goes: the
+// Worklist can narrow itself in place because the owner is its own state, and
+// Home has no queue to narrow, so a row hands the reader to the queue that does.
+
+/**
+ * The team board on Home, for a reader whose scope reaches a team.
+ *
+ * `offered` is read off the worklist's `scope_options` by the caller, which is
+ * the same gate the Worklist's own board uses. The board is drawn on the tier
+ * the server admits it on, so the control and the refusal cannot disagree.
+ */
+export function HomeTeamBoard({ offered }: Readonly<{ offered: boolean }>) {
+  if (!offered) {
+    return null;
+  }
+  return (
+    <TeamBoard
+      // Whose day, in the address. `#/worklist/<userId>` opens that person's
+      // queue directly — without it a row could only reach the Worklist and
+      // leave the reader to pick the same person a second time, which is a row
+      // that answers a question by asking it again.
+      onOwner={(userId) => navigate({ screen: "worklist", id: userId })}
+      // The unassigned pile has no person to open, so the same segment carries
+      // the scope word instead. Both rows are doors: one to a colleague's day,
+      // one to the work that reached nobody.
+      onUnassigned={() => navigate({ screen: "worklist", id: UNASSIGNED })}
+    />
+  );
+}

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -34,6 +34,7 @@ import {
 } from "./home.queries";
 import { OvernightPanel, PositionPanel, WatchPanel } from "./home.rail";
 import { HomeReadingsStrip } from "./home.readings";
+import { HomeTeamBoard } from "./home.teamboard";
 import { TodaySection } from "./home.today";
 import { WeeklySection } from "./home.weekly";
 import { useWorklist } from "./worklist.queries";
@@ -378,6 +379,12 @@ export function HomeScreen() {
       {/* Before the readings, because a strip of numbers a reader cannot
           trust is worse than one they can qualify. */}
       {worklistQuery.data && <BriefCoverage day={worklistQuery.data} />}
+      {/* Who on the team is carrying what — a lead's first question, on the
+          page they open first. Behind its own disclosure, so their own day
+          still leads: it is the SECOND thing they came for. */}
+      <HomeTeamBoard
+        offered={worklistQuery.data?.scope_options?.includes("team") ?? false}
+      />
       <HomeReadingsStrip
         decisions={decisionReadings}
         open={openReading}

--- a/frontend/src/screens/worklist.queries.ts
+++ b/frontend/src/screens/worklist.queries.ts
@@ -12,6 +12,15 @@ export type WorklistValue = components["schemas"]["WorklistValue"];
 // hand-written union goes stale the moment the server adds a value, and it goes
 // stale silently — nothing compares the two.
 export type WorklistScope = Worklist["scope"];
+/**
+ * The one scope word an ADDRESS carries: `#/worklist/unassigned`.
+ *
+ * Here rather than on the screen, so Home can name the same pile without
+ * importing the queue, and typed as WorklistScope so a scope renamed in
+ * crm.yaml fails to compile instead of leaving an address that silently stops
+ * opening what it names.
+ */
+export const UNASSIGNED: WorklistScope = "unassigned";
 export type WorklistFilter = NonNullable<Worklist["filter"]>;
 export type WorklistCategory = WorklistItem["category"];
 // The ways a row can be put down, derived from the item rather than spelled

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -42,14 +42,14 @@ function stub(day: Worklist, approval?: unknown) {
   );
 }
 
-function renderWorklist(locale: Locale = "en") {
+function renderWorklist(locale: Locale = "en", opensOn?: string) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={client}>
       <LocaleProvider initial={locale}>
-        <WorklistScreen />
+        <WorklistScreen opensOn={opensOn} />
       </LocaleProvider>
     </QueryClientProvider>,
   );
@@ -976,5 +976,62 @@ describe("what the selected row is about", () => {
     await waitFor(() => {
       expect(container.querySelectorAll("aside")).toHaveLength(0);
     });
+  });
+});
+
+// What `#/worklist/<segment>` opens on.
+//
+// The address is the other half of the team board's row: a board that writes a
+// hash nothing reads is a row that goes nowhere. These assert the REQUEST, not
+// the rendering, because whose day the page is showing is a question about
+// which day it asked the server for.
+describe("the address opens a queue", () => {
+  function requestedUrls(): string[] {
+    const mock = globalThis.fetch as unknown as {
+      mock: { calls: readonly (readonly unknown[])[] };
+    };
+    return mock.mock.calls
+      .map(([input]) =>
+        String(input instanceof Request ? input.url : (input as string)),
+      )
+      .filter((url) => url.includes("/worklist"));
+  }
+
+  it("asks for a named colleague's day when the segment is a user id", async () => {
+    stub(day({ scope_options: ["mine", "team"] }));
+    renderWorklist("en", "11111111-1111-4111-8111-111111111111");
+
+    await waitFor(() => expect(requestedUrls().length).toBeGreaterThan(0));
+    expect(
+      requestedUrls().some((url) =>
+        url.includes("owner=11111111-1111-4111-8111-111111111111"),
+      ),
+    ).toBe(true);
+  });
+
+  // The scope word is not an owner. Passing it as one would ask the server for
+  // a person whose id is the string "unassigned", which is a 403 or a 404 where
+  // the reader asked a perfectly ordinary question.
+  it("asks for the unowned pile when the segment is the scope word", async () => {
+    stub(day({ scope: "unassigned", scope_options: ["mine", "team"] }));
+    renderWorklist("en", "unassigned");
+
+    await waitFor(() => expect(requestedUrls().length).toBeGreaterThan(0));
+    expect(
+      requestedUrls().some((url) => url.includes("scope=unassigned")),
+    ).toBe(true);
+    expect(requestedUrls().some((url) => url.includes("owner="))).toBe(false);
+  });
+
+  // No segment is the reader's own day, which is what every seat sees.
+  it("asks for the reader's own day when the address names nothing", async () => {
+    stub(day());
+    renderWorklist();
+
+    await waitFor(() => expect(requestedUrls().length).toBeGreaterThan(0));
+    expect(requestedUrls().some((url) => url.includes("owner="))).toBe(false);
+    expect(requestedUrls().some((url) => url.includes("scope=mine"))).toBe(
+      true,
+    );
   });
 });

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -19,6 +19,7 @@ import { FocusCard, focusOf } from "./worklist.focus";
 import { CoachControl, OwnerPicker } from "./worklist.manager";
 import { hasPane, WorklistPane } from "./worklist.pane";
 import {
+  UNASSIGNED,
   useWorklist,
   type Worklist,
   type WorklistFilter,
@@ -331,16 +332,32 @@ function PageZonesWhenPaned({
 }
 
 // The Worklist screen.
-export function WorklistScreen() {
+export function WorklistScreen({
+  opensOn,
+}: Readonly<{
+  // What the address asked for, from `#/worklist/<segment>`: a user id opens
+  // that person's queue, and the literal "unassigned" opens the unowned pile.
+  // Both are doors a team board row needs — a row that could only reach this
+  // page would ask the reader to pick the same thing a second time.
+  //
+  // It SEEDS the dials and nothing more. They stay state afterwards and the
+  // address does not follow them, for the reason the dials give below: an
+  // address carrying one of four would describe a fraction of what is on screen.
+  opensOn?: string;
+}> = {}) {
   const t = useT();
   // The dials are state rather than a stored preference: a scope is a question
   // about right now, and a remembered one would answer a different question
   // than the reader asked on their next visit.
-  const [scope, setScope] = useState<WorklistScope>("mine");
+  const [scope, setScope] = useState<WorklistScope>(
+    opensOn === UNASSIGNED ? UNASSIGNED : "mine",
+  );
   const [filter, setFilter] = useState<WorklistFilter>("all");
   // Whose queue, when it is not the reader's own. Empty means their own day,
   // which is what every seat sees and the only thing most seats may ask for.
-  const [owner, setOwner] = useState("");
+  const [owner, setOwner] = useState(
+    opensOn && opensOn !== UNASSIGNED ? opensOn : "",
+  );
   // Which row the context pane is about. Local state, not the address: the
   // page's other dials are state too, and putting one of the four in the URL
   // would make the address describe a fraction of what the reader is looking


### PR DESCRIPTION
"Who is drowning this morning?" was answerable only on the Worklist,
behind a disclosure a lead had to go looking for. The team board now also
draws on Home, where they land.

It is the SAME component on the SAME query key, not a second table over
the same counts — so the two surfaces cannot report different figures for
one morning. What differs is only where a row goes. The Worklist narrows
itself in place because the owner is its own state; Home has no queue to
narrow, so a row hands the reader to the queue that does.

That needed an address. `#/worklist/<userId>` opens that colleague's day
and `#/worklist/unassigned` opens the work that reached nobody, both
through the id segment the Route type already carries. Without it a row
could only reach the Worklist and leave the reader to pick the same
person a second time, which is a row that answers a question by asking it
again.

The segment SEEDS the dials and nothing more. They stay state and the
address does not follow them, which is the choice worklist.tsx already
made and states: an address carrying one of four dials would describe a
fraction of what the reader is looking at.

The scope word is not an owner. Passing "unassigned" through as one would
ask the server for a person by that id — a refusal where the reader asked
an ordinary question — so the two are told apart, and a test fails if
they stop being.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

Gates: `make check-fe` green (no changed file is read by a backend gate — checked). Two guards mutation-checked: passing the scope word through as an owner id, and a row that forgets who it was about, each fail exactly one test.

Note on scope: the plan's PR 3 asked for a new `GET /worklist/team-summary` with quota pace and coverage. That endpoint would have been a second answer to a question `GET /worklist/team` (#3579) already answers, and the quota half was retired outright by #3625. So this reuses the shipped rollup and adds only the placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Answers "who is drowning this morning?" on Home, where leads land, by drawing the same team board the Worklist uses — same component on the same query key, so the two surfaces can't report different counts for one morning.

- Team board rows now link to `#/worklist/<userId>` and `#/worklist/unassigned`, opening that colleague's queue or the unowned pile directly.
- The address segment only seeds the owner and scope state; dial changes after that don't rewrite the URL.
- The scope word `unassigned` is sent as a scope parameter, never as an owner id, so it can't be mistaken for a person.

<sup>Written for commit a2f9bd2e9f153496d7096e17a832bd2645de9a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a team board to the home screen when enabled, showing colleague and unassigned work queues.
  * Selecting a colleague or unassigned row now opens the corresponding worklist.
  * Worklist links can open directly to a selected user’s queue or the unassigned queue.

* **Tests**
  * Added coverage for team board visibility, navigation, request behavior, and worklist route selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->