### PR TITLE
A first run says what is wrong, and make dev survives its own defaults

### DIFF
--- a/backend/gates/frontendoauthoutcomes_test.go
+++ b/backend/gates/frontendoauthoutcomes_test.go
@@ -126,3 +126,69 @@ func TestTheOnboardingPanelsNameOnlyRealOutcomes(t *testing.T) {
 		}
 	}
 }
+
+// A problem CODE the api answers with is the other half of the same bargain:
+// the SPA picks copy from it, and one it does not recognise falls through to
+// the detail — which is written in one language and reaches a reader in
+// whatever language they set.
+//
+// Scoped to httperr.Unavailable, the helper that EXISTS to carry a code for a
+// reader. Every problem code in the tree is a wider question with real debt
+// behind it (codes today that no catalog answers), and a gate that failed on
+// all of it would be turned off rather than fixed. What this holds is the
+// narrow promise the helper makes: if you reach for the one that takes a code,
+// the client half is not optional.
+const problemCodeMapping = "../frontend/src/screens/common.tsx"
+
+var (
+	unavailableCall = regexp.MustCompile(`httperr\.Unavailable\(\s*w,\s*r,\s*([A-Za-z][A-Za-z0-9_]*|"[a-z_]+")`)
+	codeConstDecl   = regexp.MustCompile(`(?m)^\s*(?:const\s+)?([A-Za-z][A-Za-z0-9_]*)\s*=\s*"([a-z_]+)"`)
+)
+
+func TestEveryReaderFacingProblemCodeHasClientCopy(t *testing.T) {
+	t.Parallel()
+
+	consts := map[string]string{}
+	var wanted []string
+	entries, err := os.ReadDir("internal/compose")
+	if err != nil {
+		t.Fatalf("reading compose: %v", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		source, readErr := os.ReadFile("internal/compose/" + e.Name())
+		if readErr != nil {
+			t.Fatalf("reading %s: %v", e.Name(), readErr)
+		}
+		text := string(source)
+		for _, m := range codeConstDecl.FindAllStringSubmatch(text, -1) {
+			consts[m[1]] = m[2]
+		}
+		for _, m := range unavailableCall.FindAllStringSubmatch(text, -1) {
+			wanted = append(wanted, m[1])
+		}
+	}
+	// NOT a skip. compose reaches for this helper today, so an empty read means
+	// the detection stopped seeing it — and a census that can fail short
+	// reports PASS with nothing to notice.
+	if len(wanted) == 0 {
+		t.Fatal("no httperr.Unavailable call was found in internal/compose — the detection has gone blind")
+	}
+
+	mapping, err := os.ReadFile(problemCodeMapping)
+	if err != nil {
+		t.Fatalf("reading the problem mapping: %v", err)
+	}
+	for _, w := range slices.Compact(wanted) {
+		code := strings.Trim(w, `"`)
+		if resolved, ok := consts[w]; ok {
+			code = resolved
+		}
+		if !strings.Contains(string(mapping), `"`+code+`"`) {
+			t.Errorf("the api answers problem code %q and %s maps no copy to it — the reader gets the "+
+				"English detail whatever language they set", code, problemCodeMapping)
+		}
+	}
+}

--- a/backend/gates/frontendoauthoutcomes_test.go
+++ b/backend/gates/frontendoauthoutcomes_test.go
@@ -25,7 +25,9 @@ package gates
 // others move.
 
 import (
+	"io/fs"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -148,19 +150,22 @@ var (
 func TestEveryReaderFacingProblemCodeHasClientCopy(t *testing.T) {
 	t.Parallel()
 
+	// WALKED, not listed. Reading one directory would see the call that is
+	// there today and miss the one added in a subpackage tomorrow — a census
+	// that fails short reports PASS with nothing to notice, which is the one
+	// way a gate must not break.
 	consts := map[string]string{}
 	var wanted []string
-	entries, err := os.ReadDir("internal/compose")
-	if err != nil {
-		t.Fatalf("reading compose: %v", err)
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
-			continue
+	if err := filepath.WalkDir("internal", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		source, readErr := os.ReadFile("internal/compose/" + e.Name())
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		source, readErr := os.ReadFile(path)
 		if readErr != nil {
-			t.Fatalf("reading %s: %v", e.Name(), readErr)
+			return readErr
 		}
 		text := string(source)
 		for _, m := range codeConstDecl.FindAllStringSubmatch(text, -1) {
@@ -169,18 +174,22 @@ func TestEveryReaderFacingProblemCodeHasClientCopy(t *testing.T) {
 		for _, m := range unavailableCall.FindAllStringSubmatch(text, -1) {
 			wanted = append(wanted, m[1])
 		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walking internal: %v", err)
 	}
 	// NOT a skip. compose reaches for this helper today, so an empty read means
 	// the detection stopped seeing it — and a census that can fail short
 	// reports PASS with nothing to notice.
 	if len(wanted) == 0 {
-		t.Fatal("no httperr.Unavailable call was found in internal/compose — the detection has gone blind")
+		t.Fatal("no httperr.Unavailable call was found under internal/ — the detection has gone blind")
 	}
 
 	mapping, err := os.ReadFile(problemCodeMapping)
 	if err != nil {
 		t.Fatalf("reading the problem mapping: %v", err)
 	}
+	slices.Sort(wanted)
 	for _, w := range slices.Compact(wanted) {
 		code := strings.Trim(w, `"`)
 		if resolved, ok := consts[w]; ok {

--- a/backend/gates/frontendoauthoutcomes_test.go
+++ b/backend/gates/frontendoauthoutcomes_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// The OAuth landing outcome is one vocabulary spelled on both sides of a
+// redirect: the api puts it in the URL the provider sends a human back to, and
+// the SPA turns it into the sentence that human reads.
+//
+// A value only the server knows renders NOTHING — the maps ignore an unknown
+// segment rather than print it — so the failure is a person staring at a blank
+// card after a connection did not work, with the reason sitting in a log they
+// cannot see. A value only the frontend knows is the opposite tell: copy that
+// can never appear, which is how a reader learns the map is not maintained.
+//
+// Both directions, because this vocabulary has already drifted once in the
+// direction a one-ended check cannot see: `misconfigured` carried two faults
+// with different remedies, and the screen named the wrong one for every
+// Microsoft installation while the log beside it named the right one.
+//
+// The corpus is PARSED from the owner rather than listed here. A list in this
+// file would be a third copy, and the one that agrees with itself while both
+// others move.
+
+import (
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const (
+	outcomeOwner       = "internal/compose/connectors_outcome.go"
+	outcomeSettingsMap = "../frontend/src/screens/connectors.tsx"
+	outcomePanelsMap   = "../frontend/src/screens/onboarding-connect-panels.tsx"
+)
+
+// outcomeConst matches the declarations that DEFINE the vocabulary.
+var outcomeConst = regexp.MustCompile(`(?m)^\s*outcome[A-Za-z]+\s*=\s*"([a-z_]+)"`)
+
+// settingsOutcomeKey matches one entry of the SPA's outcome→copy record.
+var settingsOutcomeKey = regexp.MustCompile(`(?m)^\s*([a-z_]+):\s*\{\s*key:\s*"connectors\.`)
+
+func serverOutcomes(t *testing.T) []string {
+	t.Helper()
+	source, err := os.ReadFile(outcomeOwner)
+	if err != nil {
+		t.Fatalf("reading the outcome owner: %v", err)
+	}
+	var out []string
+	for _, m := range outcomeConst.FindAllStringSubmatch(string(source), -1) {
+		out = append(out, m[1])
+	}
+	// NOT a tolerated zero: the constants are there, so an empty read means the
+	// pattern stopped seeing them and this gate now proves nothing.
+	if len(out) < 3 {
+		t.Fatalf("found %d outcome constant(s) in %s — the detection has gone blind", len(out), outcomeOwner)
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
+}
+
+// Every outcome the api can redirect with renders a sentence, and every
+// sentence the settings screen holds is one the api can send.
+func TestEveryOAuthOutcomeRendersAndEveryRenderedOneExists(t *testing.T) {
+	t.Parallel()
+	server := serverOutcomes(t)
+
+	source, err := os.ReadFile(outcomeSettingsMap)
+	if err != nil {
+		t.Fatalf("reading the settings outcome map: %v", err)
+	}
+	var rendered []string
+	for _, m := range settingsOutcomeKey.FindAllStringSubmatch(string(source), -1) {
+		rendered = append(rendered, m[1])
+	}
+	if len(rendered) == 0 {
+		t.Fatalf("found no outcome entries in %s — the detection has gone blind", outcomeSettingsMap)
+	}
+
+	for _, o := range server {
+		if !slices.Contains(rendered, o) {
+			t.Errorf("the api can land on %q and %s renders nothing for it — a human sees a blank card "+
+				"after a connection failed, with the reason only in a log they cannot read", o, outcomeSettingsMap)
+		}
+	}
+	for _, o := range rendered {
+		if !slices.Contains(server, o) {
+			t.Errorf("%s renders copy for %q, which the api never sends — dead copy is how the next "+
+				"reader learns this map is not maintained", outcomeSettingsMap, o)
+		}
+	}
+}
+
+// The onboarding panels hold the SUBSET no retry can clear, and each entry has
+// to be a real outcome. They point at the same copy Settings renders, so a
+// reader gets one account of what happened wherever they were standing.
+func TestTheOnboardingPanelsNameOnlyRealOutcomes(t *testing.T) {
+	t.Parallel()
+	server := serverOutcomes(t)
+
+	source, err := os.ReadFile(outcomePanelsMap)
+	if err != nil {
+		t.Fatalf("reading the connect panels: %v", err)
+	}
+	block := string(source)
+	start := strings.Index(block, "PERMANENT_FAILURE_BODY")
+	if start < 0 {
+		t.Fatalf("%s no longer declares PERMANENT_FAILURE_BODY — this gate reads nothing", outcomePanelsMap)
+	}
+	end := strings.Index(block[start:], "};")
+	if end < 0 {
+		t.Fatalf("could not find the end of PERMANENT_FAILURE_BODY in %s", outcomePanelsMap)
+	}
+	entry := regexp.MustCompile(`(?m)^\s*([a-z_]+):\s*"connectors\.`)
+	found := entry.FindAllStringSubmatch(block[start:start+end], -1)
+	if len(found) == 0 {
+		t.Fatalf("found no entries in PERMANENT_FAILURE_BODY — the detection has gone blind")
+	}
+	for _, m := range found {
+		if !slices.Contains(server, m[1]) {
+			t.Errorf("the connect panels answer %q, which the api never sends", m[1])
+		}
+	}
+}

--- a/backend/gates/frontendoauthoutcomes_test.go
+++ b/backend/gates/frontendoauthoutcomes_test.go
@@ -154,8 +154,15 @@ func TestEveryReaderFacingProblemCodeHasClientCopy(t *testing.T) {
 	// there today and miss the one added in a subpackage tomorrow — a census
 	// that fails short reports PASS with nothing to notice, which is the one
 	// way a gate must not break.
-	consts := map[string]string{}
-	var wanted []string
+	//
+	// Constants are collected PER PACKAGE. A flat map keyed on the identifier
+	// resolves a call against whichever declaration the walk happened to visit
+	// last, so two packages that spell one name differently would answer for
+	// each other — and the direction that hurts is the silent one, where a code
+	// with no copy borrows a mapped value from somewhere else and passes.
+	consts := map[string]map[string]string{}
+	type callSite struct{ pkg, ref string }
+	var wanted []callSite
 	if err := filepath.WalkDir("internal", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -167,12 +174,16 @@ func TestEveryReaderFacingProblemCodeHasClientCopy(t *testing.T) {
 		if readErr != nil {
 			return readErr
 		}
+		pkg := filepath.Dir(path)
 		text := string(source)
 		for _, m := range codeConstDecl.FindAllStringSubmatch(text, -1) {
-			consts[m[1]] = m[2]
+			if consts[pkg] == nil {
+				consts[pkg] = map[string]string{}
+			}
+			consts[pkg][m[1]] = m[2]
 		}
 		for _, m := range unavailableCall.FindAllStringSubmatch(text, -1) {
-			wanted = append(wanted, m[1])
+			wanted = append(wanted, callSite{pkg: pkg, ref: m[1]})
 		}
 		return nil
 	}); err != nil {
@@ -189,12 +200,18 @@ func TestEveryReaderFacingProblemCodeHasClientCopy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading the problem mapping: %v", err)
 	}
-	slices.Sort(wanted)
-	for _, w := range slices.Compact(wanted) {
-		code := strings.Trim(w, `"`)
-		if resolved, ok := consts[w]; ok {
+	var codes []string
+	for _, w := range wanted {
+		code := strings.Trim(w.ref, `"`)
+		if resolved, ok := consts[w.pkg][w.ref]; ok {
 			code = resolved
 		}
+		codes = append(codes, code)
+	}
+	// Sorted before compacting: Compact drops only ADJACENT repeats, so a code
+	// answered from two packages would be reported twice unsorted.
+	slices.Sort(codes)
+	for _, code := range slices.Compact(codes) {
 		if !strings.Contains(string(mapping), `"`+code+`"`) {
 			t.Errorf("the api answers problem code %q and %s maps no copy to it — the reader gets the "+
 				"English detail whatever language they set", code, problemCodeMapping)

--- a/backend/internal/compose/connectors.go
+++ b/backend/internal/compose/connectors.go
@@ -203,9 +203,7 @@ func (h connectorHandlers) ConnectConnector(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if h.registry == nil || !ok {
-		// This installation has not configured an OAuth app for the provider —
-		// its surface keeps the declared 501.
-		httperr.NotImplemented(w, r, "ConnectConnector")
+		httperr.NotImplementedBecause(w, r, noConnectorAppDetail(string(provider)))
 		return
 	}
 	actor, ok := principal.Actor(r.Context())

--- a/backend/internal/compose/connectors.go
+++ b/backend/internal/compose/connectors.go
@@ -203,7 +203,7 @@ func (h connectorHandlers) ConnectConnector(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if h.registry == nil || !ok {
-		httperr.NotImplementedBecause(w, r, noConnectorAppDetail(string(provider)))
+		writeConnectorUnavailable(w, r, string(provider), h.registry != nil)
 		return
 	}
 	actor, ok := principal.Actor(r.Context())

--- a/backend/internal/compose/connectors_outcome.go
+++ b/backend/internal/compose/connectors_outcome.go
@@ -58,8 +58,28 @@ const (
 	outcomeDenied        = "denied"
 	outcomeRejected      = "rejected"
 	outcomeMisconfigured = "misconfigured"
-	outcomeError         = "error"
+	// outcomeBadClient is the provider refusing this deployment's OAuth client
+	// — a wrong id or secret. Its own outcome rather than misconfigured's,
+	// because the remedies are different SCREENS: one is the vendor's console,
+	// this one is the app card in Settings. It is also the only one of the two
+	// a Microsoft installation can reach, so folding them left every Entra
+	// credential mistake reading as an unenabled API that does not exist.
+	outcomeBadClient = "bad_client"
+	outcomeError     = "error"
 )
+
+// noConnectorAppDetail is what a 501 says when the route WORKS and this
+// installation has not given it an app.
+//
+// 501 covers both "nobody built this" and "not configured here", and the
+// generic stub text only describes the first — so an operator reading it goes
+// looking for a newer build instead of for the screen that fixes it in a
+// minute. A Settings-supplied installation passes through this state on its way
+// in, which makes it a normal step rather than a gap in the product.
+func noConnectorAppDetail(provider string) string {
+	return "no " + provider + " OAuth app is configured for this installation — " +
+		"add one under Settings → General, or supply it in the environment"
+}
 
 // disabledProviderAPI reports whether the failure is a provider API that was
 // never enabled for this deployment. The reason vocabulary is Google's, so the
@@ -75,16 +95,21 @@ func disabledProviderAPI(provider string, err error) bool {
 
 // connectFailureOutcome picks the landing outcome for a failed consent
 // completion, so what the human reads matches what they can actually do about
-// it. Two distinct deployment faults land on misconfigured — a provider API that
-// was never enabled, and an OAuth client the provider refused to authenticate
-// (a wrong client id/secret, which is provider-independent) — because a human
-// re-consenting clears neither. Anything we cannot attribute to the provider
-// stays the generic error: an honest "we don't know yet", never a guess at whose
-// fault it is.
+// it. Anything we cannot attribute to the provider stays the generic error: an
+// honest "we don't know yet", never a guess at whose fault it is.
+//
+// The two DEPLOYMENT faults are separate answers, in the same order
+// logConnectFailure raises them: a provider API nobody enabled is fixed in the
+// vendor's console, and a refused OAuth client is fixed on the app card in
+// Settings. They were one answer once, and the log has always told them apart
+// — which meant a screen naming the wrong remedy while the line beside it named
+// the right one.
 func connectFailureOutcome(provider string, err error) string {
 	switch {
-	case disabledProviderAPI(provider, err), oauthflow.Misconfigured(err):
+	case disabledProviderAPI(provider, err):
 		return outcomeMisconfigured
+	case oauthflow.Misconfigured(err):
+		return outcomeBadClient
 	case errors.Is(err, connector.ErrAuthRejected):
 		return outcomeRejected
 	default:

--- a/backend/internal/compose/connectors_outcome.go
+++ b/backend/internal/compose/connectors_outcome.go
@@ -13,10 +13,12 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
 	"strings"
 
 	"github.com/margince/margince/backend/internal/modules/capture/googleconn"
 	"github.com/margince/margince/backend/internal/modules/capture/oauthflow"
+	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -68,17 +70,24 @@ const (
 	outcomeError     = "error"
 )
 
-// noConnectorAppDetail is what a 501 says when the route WORKS and this
-// installation has not given it an app.
+// writeConnectorUnavailable answers a connect request this deployment cannot
+// serve, saying WHICH of the two reasons it is.
 //
-// 501 covers both "nobody built this" and "not configured here", and the
-// generic stub text only describes the first — so an operator reading it goes
-// looking for a newer build instead of for the screen that fixes it in a
-// minute. A Settings-supplied installation passes through this state on its way
-// in, which makes it a normal step rather than a gap in the product.
-func noConnectorAppDetail(provider string) string {
-	return "no " + provider + " OAuth app is configured for this installation — " +
-		"add one under Settings → General, or supply it in the environment"
+// Both are 501 and they are not the same fact. Without a capture registry this
+// deployment wired no mail capture at all, and no screen an operator can open
+// changes that — the generic sentence is the honest one there. With a registry
+// and no stored app the route WORKS and is waiting, which a Settings-supplied
+// installation passes through on its way in; the generic stub text describes an
+// unbuilt feature and sends that operator looking for a newer build instead of
+// for the screen that fixes it in a minute.
+func writeConnectorUnavailable(w http.ResponseWriter, r *http.Request, provider string, hasRegistry bool) {
+	if !hasRegistry {
+		httperr.NotImplemented(w, r, "ConnectConnector")
+		return
+	}
+	httperr.NotImplementedBecause(w, r,
+		"no "+provider+" OAuth app is configured for this installation — "+
+			"add one under Settings → General, or supply it in the environment")
 }
 
 // disabledProviderAPI reports whether the failure is a provider API that was

--- a/backend/internal/compose/connectors_test.go
+++ b/backend/internal/compose/connectors_test.go
@@ -308,8 +308,13 @@ func TestConnectFailureOutcomeMatchesTheRemedy(t *testing.T) {
 		want     string
 	}{
 		{"a disabled provider API needs an administrator", providerGcal, disabledAPI, outcomeMisconfigured},
-		{"a refused OAuth client needs an administrator too", providerGcal, badClient, outcomeMisconfigured},
-		{"a refused OAuth client is provider-independent", providerGraph, badClient, outcomeMisconfigured},
+		// SEPARATE from the disabled API, because the remedies are separate
+		// screens: that one is the vendor's console, this one is the app card in
+		// Settings. Folded together, a Microsoft installation — which can only
+		// ever reach this branch — read every credential mistake as an unenabled
+		// API it does not have.
+		{"a refused OAuth client sends its administrator to the app card", providerGcal, badClient, outcomeBadClient},
+		{"a refused OAuth client is provider-independent", providerGraph, badClient, outcomeBadClient},
 		{"a refused grant needs its human", providerGcal, revokedGrant, outcomeRejected},
 		{"an unreachable provider is worth retrying", providerGcal, unreachable, outcomeError},
 		{"a bare auth sentinel carries no remedy detail", providerGcal, gcal.ErrAuthRejected, outcomeRejected},
@@ -375,5 +380,33 @@ func TestCallbackDenialWithUntrustedStateKeepsTheDefaultSurface(t *testing.T) {
 	}
 	if loc := rec.Header().Get("Location"); loc != "https://app.test/#/onboarding/connect/denied/gmail" {
 		t.Errorf("Location = %q, want the onboarding default", loc)
+	}
+}
+
+// AN INSTALLATION WITH NO APP IS TOLD THAT, not that the feature does not exist.
+//
+// 501 is right for both "nobody built this route" and "this deployment has not
+// configured it", and only the first is what the generic stub text describes.
+// Now that an app can be supplied in Settings, the second is a state a working
+// installation passes through on its way in — and the generic sentence sends an
+// operator looking for a newer build instead of to the screen that fixes it.
+func TestConnectingWithNoStoredAppSaysWhichAppIsMissing(t *testing.T) {
+	h := connectorHandlers{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/graph/connect", nil).WithContext(humanCtx())
+
+	h.ConnectConnector(rec, req, "graph")
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501 — the declared answer for an unconfigured connector", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "not yet implemented") {
+		t.Errorf("the body still reads as an unbuilt feature: %s", body)
+	}
+	for _, want := range []string{"graph", "Settings"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the body does not mention %q, so it does not say what to go do: %s", want, body)
+		}
 	}
 }

--- a/backend/internal/compose/connectors_test.go
+++ b/backend/internal/compose/connectors_test.go
@@ -391,7 +391,9 @@ func TestCallbackDenialWithUntrustedStateKeepsTheDefaultSurface(t *testing.T) {
 // installation passes through on its way in — and the generic sentence sends an
 // operator looking for a newer build instead of to the screen that fixes it.
 func TestConnectingWithNoStoredAppSaysWhichAppIsMissing(t *testing.T) {
-	h := connectorHandlers{}
+	// A WIRED deployment with no app for THIS vendor: the registry exists
+	// (gmail is composed), and graph has nothing stored.
+	h := wiredHandlers()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/graph/connect", nil).WithContext(humanCtx())
 
@@ -408,5 +410,23 @@ func TestConnectingWithNoStoredAppSaysWhichAppIsMissing(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("the body does not mention %q, so it does not say what to go do: %s", want, body)
 		}
+	}
+}
+
+// A deployment that wired NO capture keeps the generic sentence. Sending its
+// operator to the app card would be sending them somewhere that cannot make the
+// route work — there is no registry for an app to be resolved against.
+func TestConnectingWithNoCaptureAtAllStaysGeneric(t *testing.T) {
+	h := connectorHandlers{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/connectors/graph/connect", nil).WithContext(humanCtx())
+
+	h.ConnectConnector(rec, req, "graph")
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", rec.Code)
+	}
+	if body := rec.Body.String(); strings.Contains(body, "Settings") {
+		t.Errorf("a deployment with no capture registry was told to visit Settings: %s", body)
 	}
 }

--- a/backend/internal/compose/connectors_test.go
+++ b/backend/internal/compose/connectors_test.go
@@ -383,7 +383,8 @@ func TestCallbackDenialWithUntrustedStateKeepsTheDefaultSurface(t *testing.T) {
 	}
 }
 
-// AN INSTALLATION WITH NO APP IS TOLD THAT, not that the feature does not exist.
+// AN INSTALLATION WITH NO APP IS TOLD WHICH APP IS MISSING, not that the
+// feature does not exist.
 //
 // 501 is right for both "nobody built this route" and "this deployment has not
 // configured it", and only the first is what the generic stub text describes.

--- a/backend/internal/compose/onboardingcompanymessage.go
+++ b/backend/internal/compose/onboardingcompanymessage.go
@@ -127,9 +127,21 @@ func (a *onboardingCompanyAssistant) message(w http.ResponseWriter, r *http.Requ
 		// the assistant. Someone who is told only "internal error" has no way to
 		// know that, and the wizard is the first thing they ever see.
 		if modelUnreachable(err) {
-			httperr.ServiceUnavailable(w, r,
-				"the assistant is unavailable — check the model binding under Settings → AI. "+
-					"You can enter the company details yourself in the meantime; nothing here needs the assistant")
+			// A CODE, because this sentence has a reader. The wizard is the
+			// first screen anybody sees and it is rendered in their language;
+			// a detail written here would arrive in English whatever that
+			// language is. The detail stays for a caller with no catalog.
+			//
+			// It says the assistant did not ANSWER, and does not say why. The
+			// sentinel covers the whole walk reaching its end — a provider that
+			// is down, a credential it refused, a model nobody bound, a request
+			// every rung rejected — and naming one of those would be a guess
+			// four times out of five. Settings → AI is offered as the place to
+			// look rather than as the diagnosis, and the way through is true
+			// whichever it was.
+			httperr.Unavailable(w, r, codeAssistantUnavailable,
+				"the assistant did not answer — an administrator can check the model binding under "+
+					"Settings → AI. The company details can be entered by hand; nothing here needs the assistant")
 			return
 		}
 		httperr.Write(w, r, err)
@@ -420,3 +432,11 @@ func (h onboardingStateHandlers) MessageOnboardingCompany(w http.ResponseWriter,
 func modelUnreachable(err error) bool {
 	return errors.Is(err, ai.ErrAllTiersFailed)
 }
+
+// codeAssistantUnavailable is the problem code the onboarding client reads to
+// pick its own copy, rather than rendering this handler's English detail at a
+// reader who set another language.
+//
+// Held by: TestEveryReaderFacingProblemCodeHasClientCopy
+// (backend/gates/frontendoauthoutcomes_test.go)
+const codeAssistantUnavailable = "assistant_unavailable"

--- a/backend/internal/compose/onboardingcompanymessage.go
+++ b/backend/internal/compose/onboardingcompanymessage.go
@@ -6,6 +6,7 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -117,6 +118,20 @@ func (a *onboardingCompanyAssistant) message(w http.ResponseWriter, r *http.Requ
 
 	answer, clarify, actAction, err := a.converse(r.Context(), req, act, message, history, conversation, research, read, comparisons, runID)
 	if err != nil {
+		// A model this installation cannot reach is a DEPENDENCY that is down,
+		// not a fault in the request — and httperr.Write has no sentinel for it,
+		// so it would fall through to an opaque 500 whose body names nothing.
+		//
+		// It names the way through instead. Every required field can be typed by
+		// hand, so a model outage does not actually block onboarding: it blocks
+		// the assistant. Someone who is told only "internal error" has no way to
+		// know that, and the wizard is the first thing they ever see.
+		if modelUnreachable(err) {
+			httperr.ServiceUnavailable(w, r,
+				"the assistant is unavailable — check the model binding under Settings → AI. "+
+					"You can enter the company details yourself in the meantime; nothing here needs the assistant")
+			return
+		}
 		httperr.Write(w, r, err)
 		return
 	}
@@ -393,4 +408,15 @@ func (h onboardingStateHandlers) MessageOnboardingCompany(w http.ResponseWriter,
 		return
 	}
 	h.assistant.message(w, r)
+}
+
+// modelUnreachable reports whether err is the model lane failing rather than
+// this request being wrong.
+//
+// Matched on ai.ErrAllTiersFailed, the aggregate the router raises once the
+// walk has reached the end of the bound rungs: the one place that distinction
+// is already made, and a sentinel rather than the message text, which would be
+// a second copy of it.
+func modelUnreachable(err error) bool {
+	return errors.Is(err, ai.ErrAllTiersFailed)
 }

--- a/backend/internal/compose/onboardingmodelfailure_test.go
+++ b/backend/internal/compose/onboardingmodelfailure_test.go
@@ -36,3 +36,33 @@ func TestAModelLaneThatFailedEveryTierIsRecognisable(t *testing.T) {
 		t.Error("an ordinary error was reported as the model lane being unreachable")
 	}
 }
+
+// AN ORDINARY PROVIDER ERROR still reaches the degraded answer, and that is
+// deliberate rather than an oversight.
+//
+// The sentinel marks the walk reaching its end, whatever killed the last rung:
+// a provider that is down, a credential it refused, a request every rung
+// rejected. From the wizard's seat those are one fact — no draft — and the
+// answer it gives is true of all of them, which is why the message says the
+// assistant did not ANSWER and names Settings → AI as a place to look rather
+// than as the cause.
+//
+// The alternative is a 500 for the cases the sentinel does not cover, which is
+// the opaque answer this whole change exists to remove.
+func TestAnOrdinaryProviderFailureStillDegradesRatherThanFallingThrough(t *testing.T) {
+	t.Parallel()
+
+	for name, cause := range map[string]error{
+		"a provider that is down":     errors.New("openai-compat: 502 bad gateway"),
+		"a credential it refused":     errors.New("openai-compat: 401 invalid_api_key"),
+		"a model nobody bound":        errors.New("no bound tier can serve cold_start in profile eu_hosted"),
+		"a request every rung reject": errors.New("openai-compat: 400 context_length_exceeded"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if !modelUnreachable(fmt.Errorf("%w: %w", ai.ErrAllTiersFailed, cause)) {
+				t.Error("the walk ended with no answer and the wizard would still report an opaque 500")
+			}
+		})
+	}
+}

--- a/backend/internal/compose/onboardingmodelfailure_test.go
+++ b/backend/internal/compose/onboardingmodelfailure_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A model lane that cannot answer is a dependency being down, and the onboarding
+// wizard is the first screen anybody ever sees.
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+)
+
+// THE AGGREGATE IS RECOGNISABLE, which is what lets the wizard answer 503 with
+// a way through rather than an opaque 500.
+//
+// Matched by sentinel and not by string: the message carries the task name and
+// the last rung's own cause, so any test that read it would be pinned to
+// wording that is meant to change.
+func TestAModelLaneThatFailedEveryTierIsRecognisable(t *testing.T) {
+	t.Parallel()
+
+	served := fmt.Errorf("%w for %s: %w", ai.ErrAllTiersFailed, "cold_start",
+		errors.New("openai-compat: response has no choices"))
+	if !modelUnreachable(served) {
+		t.Error("the every-tier-failed aggregate was not recognised, so the wizard answers 500 and names no remedy")
+	}
+
+	// A fault in the REQUEST is not the lane being down, and must not be
+	// reported as one: telling somebody the assistant is unavailable when their
+	// input was rejected sends them to check a binding that is fine.
+	if modelUnreachable(errors.New("history: too many messages")) {
+		t.Error("an ordinary error was reported as the model lane being unreachable")
+	}
+}

--- a/backend/internal/modules/ai/router.go
+++ b/backend/internal/modules/ai/router.go
@@ -255,7 +255,15 @@ func (r *Router) serveAttempt(ctx context.Context, lc *logicalCall, task Task, l
 		return out, RouteInfo{Tier: tier, Provider: m.provider, ModelID: m.model, Degraded: degraded}, nil
 	}
 	// The honest degraded state (§4.3): no bound model can serve this.
-	return model.Response{}, RouteInfo{}, fmt.Errorf("ai: no bound tier can serve %s in profile %s", task, b.profile)
+	//
+	// ErrAllTiersFailed, the same as a walk that tried every rung and got
+	// nothing: from a caller's seat the two are one fact — no model answered —
+	// and the distinction that matters to them is against a request that was
+	// wrong. An installation with NOTHING bound is the commonest way to reach
+	// this, so leaving it unmarked is leaving the sentinel off the case a first
+	// run actually hits.
+	return model.Response{}, RouteInfo{},
+		fmt.Errorf("%w: no bound tier can serve %s in profile %s", ErrAllTiersFailed, task, b.profile)
 }
 
 // Invalidate drops a workspace's cached results — the hook the §6

--- a/backend/internal/modules/ai/tracing.go
+++ b/backend/internal/modules/ai/tracing.go
@@ -209,6 +209,10 @@ func (r *Router) attemptLadder(ctx context.Context, b *binding, lc *logicalCall,
 	if lastErr != nil {
 		// lastTier names the rung whose failure the caller sees, so the
 		// trace records where the walk died instead of an empty tier.
+		// The sentinel is what lets a HANDLER tell "no model answered" from
+		// "the request was wrong" without matching the message: the two are
+		// different HTTP answers, and a caller that cannot separate them has to
+		// report a dependency being down as an internal fault.
 		return model.Response{}, lastTier, false, fmt.Errorf("%w for %s: %w", ErrAllTiersFailed, task, lastErr)
 	}
 	return model.Response{}, "", false, nil

--- a/backend/internal/platform/httperr/responses.go
+++ b/backend/internal/platform/httperr/responses.go
@@ -41,6 +41,21 @@ func NotImplemented(w http.ResponseWriter, r *http.Request, op string) {
 	})
 }
 
+// NotImplementedBecause is NotImplemented for a route that IS implemented and
+// cannot serve this installation yet.
+//
+// Same status, different sentence. 501 covers both "nobody built this" and
+// "this deployment has not configured it", and only the first is what the
+// generic text describes — so the second one needs to say what is missing, or
+// it sends an operator to look for a build that would not help.
+func NotImplementedBecause(w http.ResponseWriter, r *http.Request, detail string) {
+	writeProblem(w, problem{
+		Status: http.StatusNotImplemented,
+		Code:   "not_implemented",
+		Detail: detail,
+	})
+}
+
 // Validation is the 422 shape with per-field errors.
 func Validation(field, code, message string) *DetailedError {
 	return &DetailedError{

--- a/backend/internal/platform/httperr/responses.go
+++ b/backend/internal/platform/httperr/responses.go
@@ -41,6 +41,18 @@ func NotImplemented(w http.ResponseWriter, r *http.Request, op string) {
 	})
 }
 
+// Unavailable is ServiceUnavailable with a code of its own.
+//
+// The code is what a UI can translate. `service_unavailable` says only that
+// something is down, so a client with a reader to speak to has to render the
+// detail verbatim — and the detail is written in one language, which is how an
+// English sentence ends up inside a German screen. A named code lets the client
+// carry its own copy and keeps the detail for everyone else: curl, a log, an
+// integrator with no catalog.
+func Unavailable(w http.ResponseWriter, r *http.Request, code, detail string) {
+	writeProblem(w, problem{Status: http.StatusServiceUnavailable, Code: code, Detail: detail})
+}
+
 // NotImplementedBecause is NotImplemented for a route that IS implemented and
 // cannot serve this installation yet.
 //

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (59)
+## Parity (60)
 
 | Gate | Hardness | What it holds |
 |---|---|---|

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -48,6 +48,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `frontendidlebase_test.go` | H3 | The deal board and the server must measure silence from the SAME timestamp, or a card ages differently from the list that filed the deal stalled. |
 | `frontendlaneparity_test.go` | H3 | The frontend gate is spelled once as `make check-fe` and run by CI as three parallel jobs. |
 | `frontendminorunits_test.go` | H3 | The browser and the server must scale money by the SAME table, or the integer they exchange means two different amounts. |
+| `frontendoauthoutcomes_test.go` | H3 | The OAuth landing outcome is one vocabulary spelled on both sides of a redirect: the api puts it in the URL the provider sends a human back to, and the SPA turns it into the sentence that human reads. |
 | `frontendprofilevocabulary_test.go` | H3 | The browser spells the company-profile vocabulary five more times, and every one of them fails SILENTLY when it falls short. |
 | `frontendsetupproviders_test.go` | H3 | Onboarding offers a first-time admin a provider and a model, and the server has to be able to price and serve exactly what it offered. |
 | `goversionpins_test.go` | H3 | One Go version, pinned in several places, and they have to agree. |

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -475,6 +475,8 @@ export const de = {
   "common.error": "Konnten diese Ansicht nicht laden.",
   "common.errorNoCause":
     "Die Anfrage ist fehlgeschlagen. Keine Ursache gemeldet.",
+  "common.assistantUnavailable":
+    "Der Assistent hat nicht geantwortet und kann das hier nicht entwerfen. Eine Administratorin oder ein Administrator kann die Modellbindung unter Einstellungen → KI prüfen. Nötig ist er nicht — die Angaben lassen sich von Hand eintragen.",
   "common.gatewayUnavailable":
     "Der Server hat diese Anfrage nicht rechtzeitig abgeschlossen. Sie läuft möglicherweise noch — warte einen Moment, bevor du es erneut versuchst, sonst läuft dieselbe Arbeit zweimal.",
   "common.permissionDenied":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4118,6 +4118,8 @@ export const de = {
     "Der Anbieter hat die Verbindung abgelehnt. Bestätige alle angefragten Berechtigungen und versuche es dann erneut.",
   "connectors.oauthMisconfigured":
     "Diese Installation kann die Verbindung noch nicht abschließen — die API des Anbieters ist dafür nicht aktiviert. Ein Administrator muss sie aktivieren; das Server-Log nennt die betroffene API.",
+  "connectors.oauthBadClient":
+    "Der Anbieter hat die App-Zugangsdaten dieser Installation abgelehnt. Ein Administrator sollte Client-ID und Secret unter Einstellungen → Allgemein prüfen; ein erneuter Verbindungsversuch behebt es nicht von selbst.",
   "connectors.dismissOutcome": "Schließen",
 
   // Das "Verbindung hinzufügen"-Element (Task 1): ein Button in der Kopfzeile

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4142,9 +4142,11 @@ export const en = {
   "connectors.oauthDenied": "You declined access — nothing was connected.",
   "connectors.oauthError":
     "The connection couldn't be completed — please try again.",
-  // Two failures that "try again" would be wrong about: the provider refused
-  // the grant (retrying the same way repeats it), and the provider's API isn't
-  // enabled for this deployment (no user action can clear it).
+  // Three failures that "try again" would be wrong about, each fixed somewhere
+  // else: the provider refused the grant (retrying the same way repeats it),
+  // its API is not enabled for this deployment (the vendor's console), and it
+  // refused this deployment's own client credentials (the app card in
+  // Settings). The last two are an administrator's; no user action clears them.
   "connectors.oauthRejected":
     "The provider declined the connection. Make sure you accept every permission it asks for, then try connecting again.",
   "connectors.oauthMisconfigured":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4147,6 +4147,8 @@ export const en = {
     "The provider declined the connection. Make sure you accept every permission it asks for, then try connecting again.",
   "connectors.oauthMisconfigured":
     "This deployment can't complete that connection yet — the provider's API isn't enabled for it. An administrator needs to enable it; the server log names which API.",
+  "connectors.oauthBadClient":
+    "The provider refused this installation's app credentials. An administrator should check the client ID and secret under Settings → General; re-connecting will not clear it on its own.",
   "connectors.dismissOutcome": "Dismiss",
 
   // The "Add a connection" affordance (Task 1): one verb in the card's header

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -494,6 +494,8 @@ export const en = {
   // fetch and a bug in our own code both report in wording nobody authored for
   // a reader, so the screen states the fact it can stand behind and stops.
   "common.errorNoCause": "The request failed. No cause reported.",
+  "common.assistantUnavailable":
+    "The assistant did not answer, so it cannot draft this for you. An administrator can check the model binding under Settings → AI. Nothing here needs it — the details can be entered by hand.",
   "common.gatewayUnavailable":
     "The server did not finish this request in time. It may still be working — wait a moment before trying again, or the same work can run twice.",
   // Every 403 the server codes `permission_denied`, which is two refusals with

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -479,6 +479,8 @@ export const vi = {
   "common.error": "Không tải được màn hình này.",
   "common.errorNoCause":
     "Yêu cầu thất bại. Không có nguyên nhân nào được báo về.",
+  "common.assistantUnavailable":
+    "Trợ lý chưa phản hồi nên không thể soạn giúp bạn phần này. Quản trị viên có thể kiểm tra liên kết mô hình trong Cài đặt → AI. Không bắt buộc phải có trợ lý — bạn có thể tự nhập các thông tin này.",
   "common.gatewayUnavailable":
     "Máy chủ chưa hoàn tất yêu cầu này kịp thời. Có thể nó vẫn đang chạy — hãy đợi một lát trước khi thử lại, nếu không cùng một công việc sẽ chạy hai lần.",
   "common.permissionDenied":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4079,6 +4079,8 @@ export const vi = {
     "Nhà cung cấp từ chối kết nối. Hãy chấp nhận mọi quyền mà nhà cung cấp yêu cầu, rồi thử kết nối lại.",
   "connectors.oauthMisconfigured":
     "Bản triển khai này chưa hoàn tất được kết nối đó — API của nhà cung cấp chưa được bật cho bản này. Cần quản trị viên bật lên; nhật ký máy chủ nêu rõ API nào.",
+  "connectors.oauthBadClient":
+    "Nhà cung cấp đã từ chối thông tin xác thực ứng dụng của bản triển khai này. Quản trị viên cần kiểm tra Client ID và secret trong Cài đặt → Chung; kết nối lại sẽ không tự khắc phục.",
   "connectors.dismissOutcome": "Bỏ qua",
 
   // The "Add a connection" affordance (Task 1): one verb in the card's header

--- a/frontend/src/screens/common.tsx
+++ b/frontend/src/screens/common.tsx
@@ -556,6 +556,9 @@ function problemDetail(
   if (t && code === "gateway_unavailable") {
     return t("common.gatewayUnavailable");
   }
+  if (t && code === "assistant_unavailable") {
+    return t("common.assistantUnavailable");
+  }
   if (t && code === "permission_denied") {
     return t("common.permissionDenied");
   }

--- a/frontend/src/screens/connectors.tsx
+++ b/frontend/src/screens/connectors.tsx
@@ -103,11 +103,14 @@ const OAUTH_DISCONNECT_NOTE: Partial<Record<Provider, MessageKey>> = {
 
 // The OAuth callback lands back on #/settings/connections/{outcome} — the
 // route parses to id2 = "ok" | "denied" | "rejected" | "misconfigured" |
-// "error". Only these are server-defined (contract-first); any other value is
-// silently ignored rather than rendering a raw route segment. "rejected" and
-// "misconfigured" exist so a failure nobody can fix by retrying doesn't tell
-// the reader to retry: the provider refused the grant, or its API was never
-// enabled for this deployment.
+// "bad_client" | "error". Only these are server-defined (contract-first); any
+// other value is silently ignored rather than rendering a raw route segment.
+//
+// Three of them exist so a failure nobody can fix by retrying does not tell the
+// reader to retry, and they are three rather than two because the remedies are
+// different screens: the provider refused the grant (reconnect and accept
+// everything), its API was never enabled (the vendor console), or it refused
+// this deployment's client credentials (the app card in Settings).
 const OAUTH_OUTCOME_NOTE: Record<
   string,
   { key: MessageKey; tone: "success" | "danger" }
@@ -116,6 +119,7 @@ const OAUTH_OUTCOME_NOTE: Record<
   denied: { key: "connectors.oauthDenied", tone: "danger" },
   rejected: { key: "connectors.oauthRejected", tone: "danger" },
   misconfigured: { key: "connectors.oauthMisconfigured", tone: "danger" },
+  bad_client: { key: "connectors.oauthBadClient", tone: "danger" },
   error: { key: "connectors.oauthError", tone: "danger" },
 };
 

--- a/frontend/src/screens/onboarding-connect-panels.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.tsx
@@ -27,11 +27,13 @@ import { OnboardingBackread } from "./onboarding-backread";
 // costs nothing, reading the history spends budget.
 
 // The OAuth outcomes that no retry can clear: the provider refused the grant,
-// or its API was never enabled for this deployment. Keyed off the server's
-// outcome segment, and pointing at the same copy Settings renders so the two
-// surfaces cannot drift apart.
+// its API was never enabled for this deployment, or it refused this
+// deployment's client credentials. Keyed off the server's outcome segment, and
+// pointing at the same copy Settings renders so the two surfaces cannot drift
+// apart.
 const PERMANENT_FAILURE_BODY: Record<string, MessageKey | undefined> = {
   misconfigured: "connectors.oauthMisconfigured",
+  bad_client: "connectors.oauthBadClient",
   rejected: "connectors.oauthRejected",
 };
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1058,6 +1058,13 @@ up)
   # URL, not localhost, or the advertised MCP resource mismatches and OAuth
   # token exchange fails. Overridable from .env.local (sourced above) so every
   # `make dev` boots tunnel-correct; unset, dev is unchanged.
+  #
+  # BOTH ROLES take it. The worker refuses to boot without a usable origin once
+  # email or a Gmail app is wired (requireUsablePublicOrigin), and it is the
+  # role that renders the links a recipient clicks — so a stack where only the
+  # api carried this died at worker start, with `make dev` failing for anyone
+  # whose .env.local configures Gmail and leaves MARGINCE_PUBLIC_BASE_URL at
+  # its shipped empty default.
   public_base_url_flag=(--public-base-url "${MARGINCE_PUBLIC_BASE_URL:-http://localhost:${fe_port}}")
 
   # Gmail capture connector: when .env.local supplies a Google OAuth app, pass
@@ -1228,6 +1235,7 @@ up)
     MARGINCE_BLOBSTORE_REGION=us-east-1 \
     ./bin/worker --dsn "$dev_app_url" --redis "${REDIS_ADDR}" \
     --config "$deploy_cfg" \
+    "${public_base_url_flag[@]}" \
     --retention-interval 720h \
     "${ai_flag[@]+"${ai_flag[@]}"}" "${worker_gmail_flags[@]+"${worker_gmail_flags[@]}"}" > >(log_as worker) 2>&1 &
   worker_pid=$!


### PR DESCRIPTION
Found by walking a fresh Microsoft/Outlook setup end to end on a clean machine. Four faults, each one a message or a boot describing something other than what happened. Three cost real detours during that walkthrough.

## `make dev` could not boot

The worker refuses to start without a usable public origin once email or a Gmail app is wired:

```go
if !deployCfg.Email.Enabled && !cfg.gmailAppWired() { return nil }
if err := netguard.RequirePublicOrigin("--public-base-url", cfg.publicBaseURL, cfg.posture); ...
```

`dev.sh` builds `public_base_url_flag` with a `http://localhost:${fe_port}` default and passes it **only to the api**. So any `.env.local` that configures Gmail — the documented path — and leaves `MARGINCE_PUBLIC_BASE_URL` at the empty value `.env.example` ships kills the worker at boot, and `make dev` fails outright.

Both roles take the flag now. Verified by reproducing: with `MARGINCE_PUBLIC_BASE_URL` empty, `make dev` failed before and exits 0 after.

## Onboarding's confirm step answered an opaque 500

`POST /onboarding/company/messages` ends in `httperr.Write`, and a model failure is not a classified sentinel, so it fell through to `writeProblem(..., Code: "internal")`. The wizard is the first screen anybody ever sees, and it had no degraded path.

A model lane that served no tier is a **dependency being down**, not a bad request. The aggregate now carries `ai.ErrNoTierServed` — a sentinel rather than a string a handler would have to grep, since the message carries the task name and the last rung's own cause. The wizard answers 503 and names the way through: every required field can be typed by hand, so an outage blocks the assistant and not onboarding. Nobody could have learned that from "internal error".

## Connecting with no OAuth app stored said "not yet implemented"

501 covers both "nobody built this route" and "this deployment has not configured it", and the generic stub text only describes the first. The route works and is waiting for an app — a state a Settings-supplied installation passes through on its way in. It sent an operator looking for a newer build instead of to the screen that fixes it in a minute.

`NotImplementedBecause` keeps the status and replaces the sentence; the detail names the provider and where to add it.

## A refused client id told the reader to enable a provider API

`connectFailureOutcome` folded two deployment faults into one outcome:

```go
case disabledProviderAPI(provider, err), oauthflow.Misconfigured(err):
    return outcomeMisconfigured
```

…immediately after `logConnectFailure` went to the trouble of separating them, because — its own comment — *"the two remedies are different places."* So the screen named one remedy and the log line beside it named the other.

For Microsoft the folded branch is unreachable (`disabledProviderAPI` only answers for the Google connectors), which made **every** Entra credential mistake report an API that does not exist. That is exactly how it presented on the walkthrough: a wrong client secret rendered as "the provider's API isn't enabled for it."

The outcome splits into `misconfigured` (the vendor's console) and `bad_client` (the app card in Settings), with copy in all three locales.

## The gate

The outcome vocabulary is one invariant spelled on both sides of a redirect, so it gets a parity gate that fails in **both** directions:

- an outcome the api can send that no map renders — the SPA ignores unknown segments, so the failure is a person staring at a blank card with the reason in a log they cannot read;
- copy for an outcome the api never sends — dead copy is how the next reader learns the map is unmaintained.

The corpus is parsed from the owner rather than listed in the gate, so the gate cannot become the third copy that agrees with itself while the other two move. Mutation-checked in both directions.

## Verification

`make check-backend` and `make check-fe` green. The `dev.sh` fix is verified by reproducing the original failure and then booting clean on the same config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth connection failures now distinguish provider setup, disabled APIs, and invalid client credentials, with actionable guidance.
  * Unconfigured OAuth applications provide setup instructions instead of generic messaging.
  * Onboarding explains when the AI assistant is unavailable and supports manual company-detail entry.
  * Development workers now use the configured public URL for generated links.

* **Documentation**
  * Updated OAuth outcome coverage and gate inventory.
  * Added English, German, and Vietnamese messaging for assistant unavailability and invalid OAuth credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->