### PR TITLE
The Brief's layout is asserted, and it found the page naming itself twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ SEED_STACK = set -e; . scripts/lib-devstate.sh; \
     seed_dsn="postgres://margince_owner:dev@localhost:15432/$$seed_db"; \
   fi;
 
-.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-check-dco test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-siteread e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf bench-perf-check bench-record bench-capture perfdoc lint arch-lint vet gen gen-workflow mcp-apps-vocab handbook-embed gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down migrate-create run psql redis-cli tidy dev dev-stop dev-sweep dev-logs clean vuln tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-demo verify-demo seed-reset verify-boot frontend-check frontend-e2e bench-mobile bench-mobile-check perfdoc e2e-company e2e-brief e2e-llm fe-install fe-typecheck fe-typecheck-composed fe-lint fe-build fe-preview fe-format fe-test fe-test-ext fe-ds-gates fe-drift fe-unit fe-clock-drift fe-quality fe-bundle fe-storybook ds-purity font-lock icon-lint ds-spacing space-tokens native-controls ext-imports fitness-jurisdiction storybook fe-uat craft-static craft-test craft-residue check-craft-doc test-golangci-guard test-scheduled-report test-ci-verdict test-check-dco test-laneorder secret-scan test-secret-scan test-dev-dsn test-dev-isolation test-dev-cleanup test-api-entrypoint check-image-pins check-host-ports ci-doc-parity make-target-parity check-ext-migrations contract-breaking-check contract-frontend-drift test-contract-frontend-drift migration-versions test-migration-versions test-lanes env-reads gofmt lint-modules go-file-length rls-store-path no-jurisdiction one-spelling test-one-spelling money-scale test-money-scale test-selfdir pkg-freeze changelog-sections test-changelog-sections test-dev-postgres-container test-e2e-llm-check hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -708,6 +708,24 @@ e2e-company:
 		E2E_ORG_SPARSE="$(E2E_ORG_SPARSE)" \
 		pnpm exec playwright test company-record.spec.ts
 	@echo "screenshots: $(E2E_SHOT_DIR)"
+
+## e2e-brief — the Brief (Home) page's LAYOUT: which regions exist, in what
+## order, and that nothing pans at desktop, phone or 200% zoom, in both
+## palettes. The vitest suites already prove the data flow; none of them can
+## see a rail that reflowed under the work column or a panel that spilled
+## sideways under a long German label.
+## Runs on the LIVE stack (make dev, then make seed-dev) and skips loudly
+## without one. Its screenshot lands OUTSIDE the repo, for a human to compare.
+E2E_BRIEF_SHOT_DIR ?= /tmp/e2e-brief
+e2e-brief: SHELL := /bin/bash
+e2e-brief:
+	@mkdir -p "$(E2E_BRIEF_SHOT_DIR)"
+	@set -e; . scripts/lib-devstate.sh; \
+	app="$${BASE_URL:-}"; [ -n "$$app" ] || app="$$(dev_app_base_url)"; \
+	cd frontend && BASE_URL="$$app" \
+		E2E_BRIEF_SHOT_DIR="$(E2E_BRIEF_SHOT_DIR)" \
+		pnpm exec playwright test brief.spec.ts
+	@echo "screenshots: $(E2E_BRIEF_SHOT_DIR)"
 
 ## storybook — the component workbench on :6006 (the design-system catalog +
 ## the story surface fe-uat renders). Stories live beside their component as

--- a/frontend/e2e/brief.spec.ts
+++ b/frontend/e2e/brief.spec.ts
@@ -1,0 +1,345 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+/**
+ * The Brief — the page a rep and a lead open first.
+ *
+ * Behavioural tests (vitest) already prove the data flow: which rows render,
+ * what a checkbox does not send, which absence draws which plate. What none of
+ * them can see is that the readings strip came out as two stacked rows, that
+ * the rail landed under the work column at desktop, or that a panel spilled
+ * sideways under a long German label. That is what this suite is for.
+ *
+ * Two describes, and the split is the same one company-record.spec.ts makes:
+ *
+ *   - page shape — which regions exist and in what order;
+ *   - what a reader can reach — nothing pans, at three widths and in both
+ *     themes.
+ *
+ * Never pixel-equality and never the drawn English strings. The app renders
+ * German, so a copy change must not fail a layout suite; assertions are
+ * structural, or they are FLOORS ("at least this prominent"), which is the
+ * claim a layout actually makes.
+ *
+ * It runs against a LIVE stack because the states that have to look right are
+ * data states. Without BASE_URL the suite skips itself loudly rather than
+ * passing on an app it never loaded.
+ */
+
+const BASE_URL = process.env.BASE_URL;
+
+test.skip(
+  !BASE_URL,
+  "brief runs against a live stack: set BASE_URL (see make e2e-brief).",
+);
+
+const SHOTS = process.env.E2E_BRIEF_SHOT_DIR ?? "/tmp/e2e-brief";
+
+// The readings row, by the test id HomeReadingsStrip hands its StatStrip. Not
+// by class: the plate is the shared primitive's, so a class selector would
+// match every other StatStrip in the app.
+const STRIP = '[data-testid="home-readings"]';
+const GLANCE = '[data-testid="home-glance"]';
+
+/**
+ * Sign in as the dev bootstrap admin, unless the session is already up.
+ *
+ * A dev stack already logged into redirects /#/login straight to the app, so
+ * the form is ABSENT on the happy path — waiting for a navigation that never
+ * happens is a 30s timeout rather than a login failure.
+ */
+async function signIn(page: Page) {
+  await page.goto("/#/login", { waitUntil: "networkidle" });
+  const email = page
+    .locator('input[type="email"], input[name="email"]')
+    .first();
+  if ((await email.count()) === 0) {
+    return;
+  }
+  await email.fill(process.env.E2E_EMAIL ?? "admin@demo.test");
+  await page
+    .locator('input[type="password"], input[name="password"]')
+    .first()
+    .fill(process.env.E2E_PASSWORD ?? "demo-password-123");
+  await page.locator('button[type="submit"]').first().click();
+  await expect(page.locator("nav.rail").first()).toBeVisible();
+}
+
+/**
+ * Open the Brief and wait for the page to have actually settled.
+ *
+ * THREE waits, and the first two on their own are not enough. Home fans out to
+ * five independent reads, so a route that has arrived is still a column of
+ * skeletons; the glance paints first, so anchoring there measures a page whose
+ * work column is empty and whose readings are still fading in. The first
+ * capture taken that way photographed exactly that.
+ *
+ * So: the glance, then the work column having real content under it, then the
+ * entry animations having finished — a box read mid-fade is where the element
+ * passed through rather than where it rests.
+ */
+async function openBrief(page: Page) {
+  await page.goto("/#/home", { waitUntil: "networkidle" });
+  await expect(page.locator(GLANCE)).toBeVisible();
+  await expect(page.locator(".home-main section").first()).toBeVisible();
+  await settled(page);
+}
+
+/**
+ * Wait out the entry animations.
+ *
+ * The shell's core mark is excluded by NAME: its only motion is an opacity
+ * transition that cannot move a box, and it is in flight more or less always,
+ * so waiting on it would time out on every call. Excluded by name rather than
+ * by giving up on the check, which would also excuse a panel still sliding in.
+ */
+async function settled(page: Page) {
+  await page.waitForFunction(
+    (ambient) =>
+      document
+        .getAnimations()
+        .filter((animation) => animation.playState === "running")
+        .every((animation) => {
+          const effect = animation.effect;
+          const target =
+            effect instanceof KeyframeEffect && effect.target instanceof Element
+              ? `${effect.target.tagName}.${effect.target.className}`
+              : "";
+          return ambient.some((mark) => target.includes(mark));
+        }),
+    ["core-rim", "core-glass"],
+  );
+}
+
+/** The vertical position of a region, for order assertions. */
+async function topOf(locator: Locator): Promise<number> {
+  await expect(locator).toBeVisible();
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error("region is visible but has no box — cannot order it");
+  }
+  return box.y;
+}
+
+/** The horizontal position of a region, for beside-versus-under. */
+async function leftOf(locator: Locator): Promise<number> {
+  await expect(locator).toBeVisible();
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error("region is visible but has no box — cannot place it");
+  }
+  return box.x;
+}
+
+/** A computed pixel measure, for the scale floors. */
+async function px(locator: Locator, property: string): Promise<number> {
+  await expect(locator).toBeVisible();
+  const raw = await locator.evaluate(
+    (element, name) => getComputedStyle(element).getPropertyValue(name),
+    property,
+  );
+  return Number.parseFloat(raw);
+}
+
+/**
+ * The shell rendered at all.
+ *
+ * A page that threw scores zero overflow and zero violations — a dead page
+ * passing every check below. This is what stops that reading as a pass.
+ */
+async function expectShellRendered(page: Page) {
+  await expect(page.locator("nav.rail")).toBeVisible();
+}
+
+/**
+ * How far the PAGE scrolls sideways, and which scroller does it.
+ *
+ * NOT `document.body.scrollWidth`: the shell pins `.main` to `overflow: hidden`
+ * and gives `.scroll` an `overflow-y: auto` that computes `overflow-x` to
+ * `auto` with it, so wide content scrolls INSIDE the page's own scroller and
+ * the body never grows a pixel. A body read here would be structurally
+ * incapable of failing.
+ *
+ * A component that declares a horizontal scroll region of its own is not
+ * measured: `.table-scroll` around a table too wide for a phone is the
+ * sanctioned answer to wide content, and the reader panning the PAGE is what
+ * this forbids.
+ */
+async function pageOverflow(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const scrollers: { name: string; element: Element }[] = [
+      { name: "the document", element: document.documentElement },
+      ...Array.from(document.querySelectorAll(".scroll")).map((element) => ({
+        name: "the shell content scroller (.scroll)",
+        element,
+      })),
+    ];
+    return scrollers
+      .map(({ name, element }) => ({
+        name,
+        overflow: element.scrollWidth - element.clientWidth,
+      }))
+      .filter(({ overflow }) => overflow > 0)
+      .map(({ name, overflow }) => `${name}: ${overflow}px past the viewport`);
+  });
+}
+
+test.describe("the Brief — page shape", () => {
+  test.beforeEach(async ({ page }) => {
+    await signIn(page);
+  });
+
+  // Exactly one. The greeting is the page's heading, and the sentence under it
+  // would be tempting to mark up as a second — which is both a layout defect
+  // and an accessibility one, because a page with two h1s has no outline.
+  test("carries exactly one h1", async ({ page }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    await expect(page.locator("main h1")).toHaveCount(1);
+  });
+
+  // The order the day sets. The glance says what is true this morning, the
+  // readings qualify it, and the work follows — a strip of numbers above the
+  // sentence that frames them is a page asking to be read backwards.
+  test("puts the glance above the readings, and the readings above the work", async ({
+    page,
+  }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    const glance = await topOf(page.locator(GLANCE));
+    const strip = await topOf(page.locator(STRIP));
+    expect(glance).toBeLessThan(strip);
+    // The FIRST section of the work column, whichever the day put there: the
+    // deck leads when a decision is waiting and the ranked queue leads when it
+    // is not, and the claim is about the strip sitting above the work, not
+    // about which work it is.
+    expect(strip).toBeLessThan(
+      await topOf(page.locator(".home-main section").first()),
+    );
+  });
+
+  // The retrospective is LAST, under the work. It is what a rep reads once on
+  // Monday, after the work waiting on them today; above either of those it puts
+  // last week ahead of this morning.
+  test("keeps last week below today's work", async ({ page }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    expect(await topOf(page.locator("#home-today"))).toBeLessThan(
+      await topOf(page.locator("#home-weekly")),
+    );
+  });
+
+  // Frozen past above, live future below: a rep decides what next week holds by
+  // reading what this one did.
+  test("puts the week's plan under the week's review", async ({ page }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    expect(await topOf(page.locator("#home-weekly"))).toBeLessThan(
+      await topOf(page.locator("#brief-plan")),
+    );
+  });
+
+  // At desktop the rail is BESIDE the work, not under it. This is the assertion
+  // that fails when a grid rule stops applying and the aside quietly reflows to
+  // a second full-width block nobody notices from reading the code.
+  test("keeps the rail beside the work at 1280", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    expect(await leftOf(page.locator(".home-rail"))).toBeGreaterThan(
+      await leftOf(page.locator(".home-main")),
+    );
+  });
+
+  // A reading's VALUE must outweigh its label. Equal weight is the dense
+  // admin-tool rendering these tests exist to catch; a floor, not equality,
+  // because a value larger than the mockup drew is right and 12px is not.
+  test("draws a reading's figure larger than its label", async ({ page }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    const card = page.locator(`${STRIP} .stat-card`).first();
+    const value = await px(
+      card.locator(".stat-card-value").first(),
+      "font-size",
+    );
+    const label = await px(
+      card.locator(".stat-card-label").first(),
+      "font-size",
+    );
+    expect(value).toBeGreaterThan(label);
+    expect(value).toBeGreaterThanOrEqual(13);
+  });
+});
+
+test.describe("the Brief — nothing pans", () => {
+  test.beforeEach(async ({ page }) => {
+    await signIn(page);
+  });
+
+  // Three widths, and the middle one is the case a desktop-only check misses.
+  for (const [name, width, height] of [
+    ["desktop", 1280, 800],
+    ["phone", 390, 844],
+    ["200% zoom", 640, 400],
+  ] as const) {
+    test(`does not scroll sideways at ${name}`, async ({ page }) => {
+      await page.setViewportSize({ width, height });
+      await openBrief(page);
+      await expectShellRendered(page);
+
+      expect(await pageOverflow(page)).toEqual([]);
+    });
+  }
+
+  // At phone width the rail stacks UNDER the work rather than being squeezed
+  // beside it. A two-column layout at 390px is how a page comes to pan.
+  test("stacks the rail under the work at 390", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    expect(await topOf(page.locator(".home-rail"))).toBeGreaterThan(
+      await topOf(page.locator(".home-main")),
+    );
+  });
+
+  // The dark palette is its own layout: tokens defined only under one scheme
+  // are a real defect class, and a suite pinned to light never sees it.
+  test.describe("in the dark palette", () => {
+    test.use({ colorScheme: "dark" });
+
+    test("holds its order and still does not pan", async ({ page }) => {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await openBrief(page);
+      await expectShellRendered(page);
+
+      expect(await topOf(page.locator(GLANCE))).toBeLessThan(
+        await topOf(page.locator(STRIP)),
+      );
+      expect(await pageOverflow(page)).toEqual([]);
+    });
+  });
+});
+
+test.describe("the Brief — for the eye", () => {
+  // The structural assertions above prove which regions exist and in what
+  // order. None of them reads a colour, a weight or a spacing, so a page can
+  // satisfy every one and still look wrong. The capture is for a human to
+  // compare; it goes outside the repo, because a screenshot is session debris.
+  test("captures the page", async ({ page }) => {
+    await signIn(page);
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    await page.screenshot({
+      path: `${SHOTS}/brief-morning.png`,
+      fullPage: true,
+    });
+  });
+});

--- a/frontend/src/app/pagemeta.ts
+++ b/frontend/src/app/pagemeta.ts
@@ -17,6 +17,20 @@ import type { Route } from "./router";
 // own subtitle had to print its own title above it to hang it on, and the
 // shell was already printing that title — the page then named itself twice.
 //
+/**
+ * Screens that head THEMSELVES, so the shell prints no heading above them.
+ *
+ * Home greets the reader by name in its own h1 — "Guten Morgen, Demo." — and
+ * the shell's "Start" above it named the page a second time at heading level.
+ * Two top-level headings is no outline at all, and it is the same defect the
+ * shell already avoids for a record (whose name is its heading) and a unit.
+ *
+ * A screen earns a place here by rendering an h1 of its own, not by having a
+ * heading somewhere on it. A screen whose own heading is an h2 still wants the
+ * shell to name the page.
+ */
+export const SELF_HEADED_SCREENS: ReadonlySet<string> = new Set(["home"]);
+
 // Only a subtitle true of the WHOLE page qualifies. Copy that describes the
 // current tab, filter or segment belongs beside that control, where it changes
 // with it; the page heading cannot see those and would go stale.

--- a/frontend/src/app/shell.test.tsx
+++ b/frontend/src/app/shell.test.tsx
@@ -158,6 +158,15 @@ describe("PageTitle", () => {
     expect(container.querySelector(".pagesub")).toBeNull();
   });
 
+  // Home greets the reader by name in its own h1, so the shell adds none: two
+  // top-level headings is no document outline at all. Same yield-whole rule as
+  // a record route below, for the same reason.
+  it("renders nothing at all on a screen that heads itself", () => {
+    const { container } = render(<PageTitle route={{ screen: "home" }} />);
+    expect(container.querySelector(".pagetitle")).toBeNull();
+    expect(screen.queryByRole("heading", { level: 1 })).toBeNull();
+  });
+
   // A record names itself: its surface prints the identity block, and that is
   // the page's one h1. This yields whole — no heading, no subtitle, no element
   // at all — or the document would offer two page titles for the same record.

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -40,7 +40,12 @@ import {
   useNavWalk,
 } from "./navlevel";
 import { PageAsideProvider, PageAsideRegion } from "./pageaside";
-import { PAGE_SUB_KEYS, resolveTitle, sectionHead } from "./pagemeta";
+import {
+  PAGE_SUB_KEYS,
+  resolveTitle,
+  SELF_HEADED_SCREENS,
+  sectionHead,
+} from "./pagemeta";
 import { usePopoverDismiss } from "./popover";
 import { type Route, routeHash, useRoute } from "./router";
 import { useScrollMemory } from "./scrollmemory";
@@ -636,12 +641,21 @@ export function PageTitle({
   // yielding to a surface that will not name itself either.
   const unitNamesPage =
     route.screen === EXTENSION_SCREEN && findExtension(route.id) !== null;
+  // A screen that heads ITSELF. Home greets the reader by name in its own h1,
+  // so the shell printing "Start" above it named the page twice at heading
+  // level — a document outline with two top-level headings, which is exactly
+  // what the branches above exist to prevent for records and units.
+  //
+  // A set rather than a second boolean: the next screen that grows its own
+  // heading joins a list instead of adding a clause, and the list is the one
+  // place to read which screens do this.
+  const selfHeaded = SELF_HEADED_SCREENS.has(route.screen);
   // Read only on the branch that prints an h1: a surface that names itself gets
   // no subtitle from here either, or the page would carry a description of a
   // heading it is not showing.
   const subKey = PAGE_SUB_KEYS[route.screen];
 
-  if (recordNamesPage || unitNamesPage) {
+  if (recordNamesPage || unitNamesPage || selfHeaded) {
     return null;
   }
 


### PR DESCRIPTION
The vitest suites prove the Brief's data flow — which rows render, what a
checkbox does not send, which absence draws which plate. None of them can
see that the rail reflowed under the work column, that the readings came
out as two stacked rows, or that a panel spilled sideways under a long
German label. frontend/e2e/brief.spec.ts asserts those, and make e2e-brief
runs it against a live stack.

Structural or floors, never pixels and never the drawn strings: the app
renders German, so a copy change must not fail a layout suite.

It immediately found a real defect. The Brief carried TWO h1s — the
shell's "Start" and the page's own "Guten Morgen, Demo." — so Home offered
a screen reader two top-level headings and no outline. The shell already
prevents this for a record and for a unit, and its own comment claims the
page is "named exactly once at heading level"; Home was simply not on the
list. SELF_HEADED_SCREENS is that list, in pagemeta.ts beside the other
page-title policy, and a unit test fails if Home leaves it.

The capture step needed fixing before it was worth anything. Anchoring on
the glance photographed a page whose work column was still empty and whose
readings were mid-fade — the exact "shooting skeletons" failure the
company-record suite warns about. openBrief now waits for the work column
to have content and for the entry animations to finish.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

Gates: `make check-fe` and `make check-backend` both green (the Makefile change puts `make-target-parity` and `ci-doc-parity` in scope — both pass). The spec was RUN against a live stack, not just written: 12 passed. The h1 fix is mutation-checked — emptying SELF_HEADED_SCREENS fails the new shell test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end layout suite for the Brief and fixes the duplicate top-level heading it caught: the shell’s “Start” and the page’s own “Guten Morgen, Demo.” were both h1s, so Home had no document outline. Home now heads itself and the shell prints nothing above it.

**New Features**
- `frontend/e2e/brief.spec.ts` asserts structural layout: region order, no sideways panning at desktop, phone, or 200% zoom, rail beside work at desktop and stacked under it at 390px, and dark palette included.
- `make e2e-brief` runs the suite against a live stack and skips loudly without `BASE_URL`.
- Assertions are structural or size floors, never pixel equality or UI copy, so German copy changes won’t fail the suite.
- The capture waits for the work column to have content and entry animations to finish before screenshotting.

**Bug Fixes**
- Home is in `SELF_HEADED_SCREENS`; `PageTitle` returns null for screens in that set.
- A unit test in `shell.test.tsx` fails if Home is removed from the set.

<sup>Written for commit ce0f4d61f382ee6f7dd3ecb3d46f49b767fb6114. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate page headings on the home screen, providing a cleaner and more consistent layout.
  * Improved heading behavior for pages that provide their own titles.

* **Tests**
  * Added responsive coverage for the Brief page across desktop, mobile, zoomed, and dark-mode views.
  * Added checks for page structure, typography, layout ordering, overflow, and visual screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->