### PR TITLE
The worklist answers "and then?"

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7528,6 +7528,7 @@ export const de = {
   "worklist.pane.lastOutbound": "Wir zuletzt geschrieben",
   "worklist.pane.never": "Nie",
   "worklist.focus.title": "Das als Nächstes",
+  "worklist.nextup.title": "Und danach",
   "worklist.focus.verb.decide": "Entscheiden",
   "worklist.focus.verb.merge": "Paar prüfen",
   "worklist.focus.verb.complete": "Erledigen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7598,7 +7598,7 @@ export const en = {
   "worklist.focus.verb.merge": "Review the pair",
   "worklist.focus.verb.complete": "Complete it",
   "worklist.focus.verb.act": "Act on it",
-  // Required by the template's key type, never produced: worthFocusing
+  // Required by the template's key type, never produced: worthActingOn
   // excludes primary_action "acknowledge" before this key is ever built.
   "worklist.focus.verb.acknowledge": "Acknowledge",
   "worklist.focus.verb.open": "Open it",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7593,6 +7593,7 @@ export const en = {
   "worklist.pane.lastOutbound": "We last wrote",
   "worklist.pane.never": "Never",
   "worklist.focus.title": "Do this next",
+  "worklist.nextup.title": "And then",
   "worklist.focus.verb.decide": "Decide",
   "worklist.focus.verb.merge": "Review the pair",
   "worklist.focus.verb.complete": "Complete it",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7447,6 +7447,7 @@ export const vi = {
   "worklist.pane.lastOutbound": "Chúng ta viết lần cuối",
   "worklist.pane.never": "Chưa bao giờ",
   "worklist.focus.title": "Làm việc này tiếp theo",
+  "worklist.nextup.title": "Và sau đó",
   "worklist.focus.verb.decide": "Quyết định",
   "worklist.focus.verb.merge": "Xem cặp trùng",
   "worklist.focus.verb.complete": "Hoàn thành",

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -118,10 +118,6 @@
   padding: 0;
 }
 
-.worklist-nextup-row {
-  margin: 0;
-}
-
 /* The band heading, above the first row of its run.
    Inside the list item rather than between them, because an <ol> may hold only
    <li> children — a heading placed as a sibling would be invalid structure that

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -106,6 +106,22 @@
   margin-top: var(--space-2);
 }
 
+/* What follows the focus card. A plain list of titles: the evidence is on the
+   card above and the rows below, and a third copy would be a third surface to
+   keep in agreement about one deal. */
+.worklist-nextup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.worklist-nextup-row {
+  margin: 0;
+}
+
 /* The band heading, above the first row of its run.
    Inside the list item rather than between them, because an <ol> may hold only
    <li> children — a heading placed as a sibling would be invalid structure that

--- a/frontend/src/screens/worklist.focus.test.tsx
+++ b/frontend/src/screens/worklist.focus.test.tsx
@@ -8,7 +8,7 @@ import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { FocusCard, focusOf } from "./worklist.focus";
 
-// worthFocusing's promises: a routable top row is promoted, and `acknowledge`
+// worthActingOn's promises: a routable top row is promoted, and `acknowledge`
 // never is — it names no record to route to, the same invariant
 // WorklistRow's own VERB_DESTINATION table holds for it.
 

--- a/frontend/src/screens/worklist.focus.tsx
+++ b/frontend/src/screens/worklist.focus.tsx
@@ -36,7 +36,7 @@ export function FocusCard({ item }: Readonly<{ item: WorklistItem }>) {
   const t = useT();
   const { locale } = useLocale();
   const zone = viewerZone();
-  if (!worthFocusing(item)) {
+  if (!worthActingOn(item)) {
     return null;
   }
   const href = rowHref(item);
@@ -89,14 +89,18 @@ export function FocusCard({ item }: Readonly<{ item: WorklistItem }>) {
   );
 }
 
-// Whether this row is worth promoting to the card.
+// Whether this row is something the reader can act on now.
+//
+// Exported because the Next-up list asks the same question of the rows after
+// the focused one. One rule, two surfaces: a row that list offered and this
+// card refused would be the page contradicting itself about one morning.
 //
 // A recommended action has to be something the rep DOES, and it has to be
 // theirs to do now. Review work is neither: it is judgement the queue collects
 // so it can be worked through in one pass, and a page headed "do this next"
 // over a duplicate-merge suggestion would be telling a rep something false
 // about their morning.
-function worthFocusing(item: WorklistItem): boolean {
+export function worthActingOn(item: WorklistItem): boolean {
   if (item.band === "review" || item.primary_action === undefined) {
     return false;
   }
@@ -122,5 +126,5 @@ export function focusOf(
   queue: readonly WorklistItem[],
 ): WorklistItem | undefined {
   const first = queue[0];
-  return first && worthFocusing(first) ? first : undefined;
+  return first && worthActingOn(first) ? first : undefined;
 }

--- a/frontend/src/screens/worklist.nextup.stories.tsx
+++ b/frontend/src/screens/worklist.nextup.stories.tsx
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import { StoryProviders } from "./story-utils";
+import { NextUp } from "./worklist.nextup";
+
+// What follows the focus card — see worklist.nextup.tsx for why it is bounded,
+// and for why these rows may all turn out to be one kind of work.
+
+type WorklistItem = components["schemas"]["WorklistItem"];
+
+const meta: Meta<typeof NextUp> = {
+  title: "Records/Worklist/Next up",
+  component: NextUp,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <StoryProviders>
+        <Story />
+      </StoryProviders>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof NextUp>;
+
+// The list as a reader usually meets it: three different kinds of work, each
+// naming the record it is about.
+export const ThreeDifferentJobs: Story = {
+  args: {
+    items: [
+      {
+        id: "01a05500-0000-7000-8000-000000000001",
+        source: "customer_waiting",
+        category: "customer_waiting",
+        level: 1,
+        consequence: "buyer_waits",
+        title: "Re: pricing for the second site",
+        because: [],
+        actions: ["act"],
+        primary_action: "act",
+        subject: {
+          type: "person",
+          id: "01a05500-0000-7000-8000-000000000001",
+          label: "Marta Kowalski",
+        },
+      },
+      {
+        id: "01a05500-0000-7000-8000-000000000002",
+        source: "deal_at_risk",
+        category: "deals_at_risk",
+        level: 3,
+        consequence: "deal_slips_past_close",
+        title: "Acme Expansion",
+        because: [],
+        actions: ["open"],
+        primary_action: "open",
+        subject: {
+          type: "deal",
+          id: "01a05500-0000-7000-8000-000000000002",
+          label: "Acme Expansion",
+        },
+      },
+      {
+        id: "01a05500-0000-7000-8000-000000000003",
+        source: "task",
+        category: "tasks",
+        level: 4,
+        consequence: "task_slips",
+        title: "Send the signed order form",
+        because: [],
+        actions: ["complete"],
+        primary_action: "complete",
+        subject: {
+          type: "organization",
+          id: "01a05500-0000-7000-8000-000000000003",
+          label: "Northwind Ltd",
+        },
+      },
+    ] satisfies WorklistItem[],
+  },
+};
+
+// A row filed under no record has nowhere for a link to GO, so its title draws
+// as plain text rather than as a link to nothing. Kept as a story because no
+// other surface renders that branch, and a dead link is the kind of thing only
+// a rendered page shows.
+export const ARowWithNowhereToGo: Story = {
+  args: {
+    items: [
+      {
+        id: "01a05500-0000-7000-8000-000000000004",
+        source: "task",
+        category: "tasks",
+        level: 4,
+        consequence: "task_slips",
+        title: "Write up the quarterly territory plan",
+        because: [],
+        actions: ["complete"],
+        primary_action: "complete",
+      },
+    ] satisfies WorklistItem[],
+  },
+};
+
+// One kind of work, three times over. This is what the ranking's missing
+// anti-monopoly cap looks like on the page: the component is behaving
+// correctly, and the day still reads as a single sentence repeated.
+export const AllOneKindOfWork: Story = {
+  args: {
+    items: [1, 2, 3].map((n) => ({
+      id: `01a05500-0000-7000-8000-00000000001${n}`,
+      source: "bounce" as const,
+      category: "system" as const,
+      level: 5,
+      consequence: "customer_never_received" as const,
+      title: `Message to contact ${n} bounced`,
+      because: [],
+      actions: ["act" as const],
+      primary_action: "act" as const,
+    })) satisfies WorklistItem[],
+  },
+};

--- a/frontend/src/screens/worklist.nextup.test.tsx
+++ b/frontend/src/screens/worklist.nextup.test.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
 /** @vitest-environment jsdom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/frontend/src/screens/worklist.nextup.test.tsx
+++ b/frontend/src/screens/worklist.nextup.test.tsx
@@ -1,0 +1,132 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { focusOf } from "./worklist.focus";
+import { NextUp, nextUpOf } from "./worklist.nextup";
+
+// The short answer to "and then?".
+//
+// Two things make this list worth having rather than a second queue: it never
+// repeats the row the focus card already took, and it never offers a row that
+// card would have refused. Both are about the page agreeing with itself.
+
+type WorklistItem = components["schemas"]["WorklistItem"];
+
+function item(id: string, over: Partial<WorklistItem> = {}): WorklistItem {
+  return {
+    id,
+    source: "customer_waiting",
+    category: "customer_waiting",
+    level: 1,
+    consequence: "buyer_waits",
+    title: `Row ${id}`,
+    because: [],
+    actions: ["act"],
+    primary_action: "act",
+    band: "now",
+    subject: { type: "person", id: `person-${id}`, label: `Person ${id}` },
+    ...over,
+  };
+}
+
+afterEach(cleanup);
+
+describe("the Next-up list", () => {
+  // The focus card lifts the first row OUT. A list that then re-offered it
+  // would tell the reader their next two jobs are the same job.
+  it("never repeats the row the focus card took", () => {
+    const queue = [item("a"), item("b"), item("c")];
+    const focused = focusOf(queue);
+
+    const next = nextUpOf(queue, focused);
+
+    expect(focused?.id).toBe("a");
+    expect(next.map((row) => row.id)).toEqual(["b", "c"]);
+  });
+
+  // One admission rule, two surfaces. A review row is judgement the queue
+  // collects to be worked in one pass, and offering it as "and then" tells a
+  // rep that hygiene is their morning.
+  it("offers nothing the focus card would have refused", () => {
+    const queue = [
+      item("a"),
+      item("hygiene", { band: "review", category: "decisions" }),
+      item("noverb", { primary_action: undefined, actions: [] }),
+      item("b"),
+    ];
+
+    const next = nextUpOf(queue, focusOf(queue));
+
+    expect(next.map((row) => row.id)).toEqual(["b"]);
+  });
+
+  // `id` is the OWNING RECORD's id, not the row's — the contract says so, and
+  // the queue keys its rows on source+id because of it. A person with an
+  // unanswered message and an overdue task appears twice under one id, so
+  // excluding the focused row by id would silently drop the second row too.
+  it("drops only the focused row when one record raises two", () => {
+    const queue = [
+      item("person-1"),
+      item("person-1", { source: "task", category: "tasks", level: 4 }),
+      item("other"),
+    ];
+    const focused = focusOf(queue);
+
+    const next = nextUpOf(queue, focused);
+
+    expect(next.length).toBe(2);
+    expect(next[0]?.source).toBe("task");
+    expect(next[1]?.id).toBe("other");
+  });
+
+  // Bounded, or it is the queue again in a smaller box. A reader has to be able
+  // to see the end of it.
+  it("stays finite however long the day is", () => {
+    const queue = Array.from({ length: 40 }, (_, i) => item(`row-${i}`));
+
+    const next = nextUpOf(queue, focusOf(queue));
+
+    expect(next.length).toBe(3);
+  });
+
+  // The server ranked these rows; the list re-ranks nothing. Reordering here
+  // would be a second answer to what matters most today.
+  it("keeps the server's order", () => {
+    const queue = [item("a"), item("b"), item("c"), item("d")];
+
+    const next = nextUpOf(queue, focusOf(queue));
+
+    expect(next.map((row) => row.id)).toEqual(["b", "c", "d"]);
+  });
+
+  // A day whose only actionable row is the focused one has no "and then". An
+  // empty panel there would report a finished morning as a broken component.
+  it("draws nothing when there is nothing after the focused row", () => {
+    render(
+      <LocaleProvider initial="en">
+        <NextUp items={[]} />
+      </LocaleProvider>,
+    );
+
+    expect(screen.queryByText("And then")).toBeNull();
+  });
+
+  // Through `itemTitle`, so the list names a row exactly as the queue and the
+  // card do — including the record's own name beside a title that does not
+  // carry it. Three rows reading "Follow up with the new lead" cannot be told
+  // apart, which is the defect that rule exists for.
+  it("names each row the way the rest of the page names it", () => {
+    const rows = [item("b"), item("c")];
+    render(
+      <LocaleProvider initial="en">
+        <NextUp items={rows} />
+      </LocaleProvider>,
+    );
+
+    expect(screen.getByText("And then")).toBeTruthy();
+    expect(screen.getByText("Row b · Person b")).toBeTruthy();
+    expect(screen.getByText("Row c · Person c")).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/worklist.nextup.tsx
+++ b/frontend/src/screens/worklist.nextup.tsx
@@ -10,11 +10,23 @@
 // whole difference between a plan for a morning and a backlog.
 //
 // It SELECTS NOTHING. The rows are the ones the server already ranked, taken in
-// the order it ranked them, and the diversity is already in that ordering:
-// `waitingLead` and `leadLead` demote the ninth of a kind through `crowded`, so
-// one noisy lane cannot own the top of the page before these rows are taken.
-// Choosing representatives here would be a second answer to a question the
-// ranking already answers, and two clients would then disagree about one day.
+// the order it ranked them. Re-ranking here would be a second answer to what
+// matters most today, and two clients would then disagree about one morning.
+//
+// SO THESE FOUR ROWS CAN ALL BE ONE KIND OF WORK, and that is worth saying
+// plainly rather than implying otherwise. The queue's anti-monopoly rule is the
+// `crowded` flag, and it reaches only two lanes — unanswered customers and
+// overdue leads — each at a threshold of eight. Every other producer (tasks,
+// bounces, decisions, the health lanes) has no cap at all, and even the two that
+// do cannot fire before position nine. This list reads positions two to four. So
+// six overdue tasks make a focus card and three rows that are all the same
+// sentence, and nothing in the current ranking prevents it.
+//
+// A quota HERE is still the wrong fix: the client would be answering a question
+// the server owns, and the queue below would disagree with the list above it.
+// Widening `crowded` to the other lanes is the fix, and it belongs to the
+// ranking rather than here — filed as #3673. Until then this list is honest
+// about being the top of one order rather than a survey of the day.
 
 import { Panel } from "../design-system/panel";
 import { useLocale, useT } from "../i18n";

--- a/frontend/src/screens/worklist.nextup.tsx
+++ b/frontend/src/screens/worklist.nextup.tsx
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The few rows after the focus card, drawn as a finite list.
+//
+// The focus card says what to do NEXT and the queue says what there is. Between
+// them sat nothing: a reader who had done the one thing the card named went back
+// to a list of twenty-five rows and had to re-find their place in it. This is
+// the short answer to "and then?" — bounded, so it can be finished, which is the
+// whole difference between a plan for a morning and a backlog.
+//
+// It SELECTS NOTHING. The rows are the ones the server already ranked, taken in
+// the order it ranked them, and the diversity is already in that ordering:
+// `waitingLead` and `leadLead` demote the ninth of a kind through `crowded`, so
+// one noisy lane cannot own the top of the page before these rows are taken.
+// Choosing representatives here would be a second answer to a question the
+// ranking already answers, and two clients would then disagree about one day.
+
+import { Panel } from "../design-system/panel";
+import { useLocale, useT } from "../i18n";
+import { itemTitle, rowHref } from "./worklist.copy";
+import { worthActingOn } from "./worklist.focus";
+import type { WorklistItem } from "./worklist.queries";
+import "./worklist.css";
+
+// How many rows the list carries.
+//
+// Small enough to be a plan rather than a page: a reader has to be able to see
+// the end of it without scrolling, or it is the queue again in a smaller box.
+// The focus card is the first of the day's work, so this is what follows it.
+const NEXT_UP = 3;
+
+/**
+ * The rows after the focused one, or nothing.
+ *
+ * Asked of the whole queue so the screen does not have to know the rule, the
+ * way `focusOf` is. Returns the rows in the server's own order.
+ */
+export function nextUpOf(
+  queue: readonly WorklistItem[],
+  focused: WorklistItem | undefined,
+): readonly WorklistItem[] {
+  // Everything the focus card would itself have accepted, minus the row it took.
+  // Reusing that rule rather than restating it is what keeps the two surfaces
+  // agreeing about what a reader can act on: a row this list offered and the
+  // card refused would be the page contradicting itself about the same morning.
+  //
+  // The focused row is excluded by IDENTITY, not by id, and the two differ on a
+  // queue that names one record twice — a person with an unanswered message and
+  // an overdue task carries the same `id` on both rows, and excluding by id
+  // would drop the second along with the first. Identity is sound here because
+  // both this and `focusOf` read the same `day.queue` array in one render, so a
+  // refetch replaces the focused row and this list's rows together. `selected`
+  // in the screen resolves by id for the opposite reason: it is held across
+  // renders in state, where an object goes stale.
+  return queue
+    .filter((item) => item !== focused && worthActingOn(item))
+    .slice(0, NEXT_UP);
+}
+
+/**
+ * The list. Titles and one link each — the evidence lives on the row below and
+ * in the card above, and repeating it here would make three surfaces to keep in
+ * agreement about one deal.
+ */
+export function NextUp({
+  items,
+}: Readonly<{ items: readonly WorklistItem[] }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <Panel title={t("worklist.nextup.title")}>
+      <ol className="worklist-nextup">
+        {items.map((item) => {
+          const href = rowHref(item);
+          return (
+            <li
+              key={`${item.source}-${item.id}`}
+              className="worklist-nextup-row"
+            >
+              {href ? (
+                <a className="entity-link" href={href}>
+                  {itemTitle(item, t, locale)}
+                </a>
+              ) : (
+                itemTitle(item, t, locale)
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </Panel>
+  );
+}

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -17,6 +17,7 @@ import {
 } from "./worklist.copy";
 import { FocusCard, focusOf } from "./worklist.focus";
 import { CoachControl, OwnerPicker } from "./worklist.manager";
+import { NextUp, nextUpOf } from "./worklist.nextup";
 import { hasPane, WorklistPane } from "./worklist.pane";
 import {
   UNASSIGNED,
@@ -195,6 +196,9 @@ function WorklistBody({
   const t = useT();
   const missing = day.sources_unavailable;
   const focus = focusOf(day.queue);
+  // What follows it, bounded. Taken in the server's own order — the ranking
+  // has already kept one lane from owning the top of the page.
+  const next = nextUpOf(day.queue, focus);
   // The row the pane is about. Resolved from the id rather than held as the
   // item itself: a refetch replaces every row object, and a held one would go
   // on describing a version of the day that is no longer on screen.
@@ -242,6 +246,10 @@ function WorklistBody({
           the queue below: removing it would make the rank numbers lie and the
           counts disagree with the page. */}
       {focus && <FocusCard item={focus} />}
+      {/* And then? A finite list a reader can see the end of, so a morning has a
+          shape rather than a backlog. Drawn only under a focus card: without
+          one there is no "next", only the queue. */}
+      {focus && <NextUp items={next} />}
       {day.queue.length === 0 ? (
         // One line, not a panel. No card is drawn to report a zero.
         <p className="t-body worklist-clear">

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -196,8 +196,9 @@ function WorklistBody({
   const t = useT();
   const missing = day.sources_unavailable;
   const focus = focusOf(day.queue);
-  // What follows it, bounded. Taken in the server's own order — the ranking
-  // has already kept one lane from owning the top of the page.
+  // What follows it, bounded, in the server's own order. These rows may all be
+  // one kind of work — worklist.nextup.tsx says why that is the ranking's to
+  // fix rather than this page's.
   const next = nextUpOf(day.queue, focus);
   // The row the pane is about. Resolved from the id rather than held as the
   // item itself: a refetch replaces every row object, and a held one would go


### PR DESCRIPTION
The focus card says what to do next and the queue says what there is. Between them sat nothing: a reader who had done the one thing the card named went back to a list of twenty-five rows and had to re-find their place in it.

"And then" is the short answer — three rows, bounded, so a reader can see the end of it. A list you can finish is a plan for a morning; one you cannot is the backlog again in a smaller box.

## It selects nothing, and these rows may all be one kind of work

The rows are the ones the server already ranked, in the order it ranked them. Re-ranking in the client would be a second answer to what matters most today, and two clients would then disagree about one morning.

The plan asked for server-side source-diversity quotas so one noisy lane could not own the page. **The tree does not provide that, and an earlier draft of this PR wrongly claimed it did** — a reviewer caught it. The facts:

- `crowded` is the queue's only anti-monopoly rule, and it is set in exactly two places: unanswered customers past `waitingLead`, and overdue leads past `leadLead`. `classify.go` appends fifteen further lanes with no cap at all.
- Both thresholds are **8**, so `crowded` cannot fire before position nine. This list reads positions two to four, where the rule is provably inert even for the two lanes that have it.

So six overdue tasks produce a focus card and three rows that are all the same sentence. The header comment says that plainly, the `AllOneKindOfWork` story shows it, and **#3673** carries the fix — widening `crowded` belongs to the ranking, where changing it re-runs the ordering's property tests. A quota in the client would be the wrong place: the queue below would disagree with the list above it.

## One admission rule, two surfaces

`worthFocusing` becomes the exported `worthActingOn`, because this list asks the same question of the rows after the focused one. A row this list offered while the card refused it would be the page contradicting itself about one morning. Review work is refused by both: it is judgement the queue collects to be worked in one pass, and offering a duplicate-merge suggestion as "and then" tells a rep that hygiene is their morning.

## The detail worth a reviewer's eye

**The focused row is excluded by identity, not by id.** `id` is the *owning record's* id, not the row's — the contract says so, and the queue keys its rows on `source`+`id` because of it. A person with an unanswered message and an overdue task appears twice under one id, so excluding by id would silently drop the second row too. Identity is sound because both this and `focusOf` read the same `day.queue` array in one render. (`selected` in the screen resolves by id for the opposite reason: it is held across renders in state, where an object goes stale.)

## Verification

- 7 tests in `worklist.nextup.test.tsx`, plus a Storybook story covering the populated list, a row with nowhere to link, and the one-kind-of-work case.
- Mutation-checked one clause at a time: dropping the focused-row exclusion, dropping the shared admission rule, and swapping identity for id each fail their own test.
- `make check-fe` green (5752 tests), `make frontend-e2e` 222 passed, `make craft-static` clean. Backend untouched — no contract regeneration, no migration.

## Filed along the way

- **#3673** — the anti-monopoly cap reaches two lanes of seventeen and cannot fire before position nine.
- **#3675** — `App.tabkey.test.tsx` passes in the full suite but fails when run alone, so it cannot be debugged in the narrow lane. Unrelated to this diff, found while gating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Next up” section to the worklist, showing up to three actionable follow-up items in server order.
  * Excludes the currently focused item and supports links to related records.
  * Added localized titles in English, German, and Vietnamese.
* **Style**
  * Improved layout and spacing for the Next up list.
* **Tests**
  * Added coverage for filtering, ordering, limits, empty states, and localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->