### PR TITLE
Tags reach the roles an installation already had

### DIFF
--- a/backend/internal/compose/integration/collections_integration_test.go
+++ b/backend/internal/compose/integration/collections_integration_test.go
@@ -36,7 +36,9 @@ func TestTagsLifecycleAndApplication(t *testing.T) {
 	var tag struct {
 		ID string `json:"id"`
 	}
-	if status := e.Call(t, "POST", "/v1/tags", AnyMap{"name": "Champion", "color": "#ff6b00"}, nil, &tag); status != http.StatusCreated {
+	// A palette tone, not a hex: colour became a closed set of four when the tag
+	// vocabulary was made governed, and free text is refused.
+	if status := e.Call(t, "POST", "/v1/tags", AnyMap{"name": "Champion", "color": "amber"}, nil, &tag); status != http.StatusCreated {
 		t.Fatalf("create tag → %d", status)
 	}
 	// The name is unique case-insensitively.

--- a/backend/migrations/core/1788335000_every_role_can_read_the_tag_vocabulary.down.sql
+++ b/backend/migrations/core/1788335000_every_role_can_read_the_tag_vocabulary.down.sql
@@ -1,13 +1,14 @@
--- Remove the key this migration added.
+-- Nothing to undo, and nothing that COULD be undone honestly.
 --
--- It cannot tell a document it wrote from one that already carried tag, so it
--- removes the key from the system roles wholesale — which is the state an
--- installation predating 1788320100 was in, and the state the up migration is
--- a no-op against on re-run.
-SET LOCAL lock_timeout = '3s';
-
-UPDATE role SET permissions = permissions #- '{objects,tag}'
-    WHERE is_system
-      AND key IN ('admin', 'ops', 'management', 'manager', 'rep', 'read_only')
-      AND permissions ? 'objects'
-      AND (permissions -> 'objects') ? 'tag';
+-- The up migration ADDS objects.tag where a role has none. The row keeps no
+-- record of which documents it wrote, so a rollback cannot tell a key this
+-- migration added from one that predated it or one an operator has since set by
+-- hand — and removing the key wholesale would revoke a valid grant to undo a
+-- write that never happened for that role.
+--
+-- The forward direction is also the safe one to leave in place. Read on a
+-- vocabulary every role already applies is not a permission a rollback needs to
+-- take away: an installation running the previous code with the key present
+-- behaves exactly as one that always had it, which is what every installation
+-- bootstrapped after 1788320100 already is.
+SELECT 1;

--- a/backend/migrations/core/1788335000_every_role_can_read_the_tag_vocabulary.down.sql
+++ b/backend/migrations/core/1788335000_every_role_can_read_the_tag_vocabulary.down.sql
@@ -1,0 +1,13 @@
+-- Remove the key this migration added.
+--
+-- It cannot tell a document it wrote from one that already carried tag, so it
+-- removes the key from the system roles wholesale — which is the state an
+-- installation predating 1788320100 was in, and the state the up migration is
+-- a no-op against on re-run.
+SET LOCAL lock_timeout = '3s';
+
+UPDATE role SET permissions = permissions #- '{objects,tag}'
+    WHERE is_system
+      AND key IN ('admin', 'ops', 'management', 'manager', 'rep', 'read_only')
+      AND permissions ? 'objects'
+      AND (permissions -> 'objects') ? 'tag';

--- a/backend/migrations/core/1788335000_every_role_can_read_the_tag_vocabulary.up.sql
+++ b/backend/migrations/core/1788335000_every_role_can_read_the_tag_vocabulary.up.sql
@@ -1,0 +1,39 @@
+-- Tags reach the roles an installation already had.
+--
+-- 1788320100 made `tag` governed vocabulary and NARROWED the roles that held
+-- write on it. What it could not do is ADD the object to a role that never had
+-- it: its guard is `(permissions -> 'objects') ? 'tag'`, which is the right
+-- guard for a narrowing and the wrong one for an installation bootstrapped
+-- before tag was a governed object at all. Those roles carry no `tag` key, so
+-- every tag route answers 403 for them — permanently, since seedSystemRoles
+-- writes each document once at workspace creation and never re-syncs.
+--
+-- The verbs are the seeded matrix's own, per role: Admin and Ops administer the
+-- vocabulary, everyone else reads it and applies what is there. Adding read to
+-- the roles that only apply tags is not a widening — applying one is what the
+-- taggable surface is for, and a role that cannot READ the vocabulary cannot
+-- see the tags already on the records it works.
+--
+-- GUARDED ON ABSENCE, so it is a no-op for an installation that has the key
+-- (including one an operator has narrowed by hand, and one 1788320100 has
+-- already corrected), and re-running changes nothing.
+--
+-- lock_timeout because `role` is a pre-existing table: a deploy must fail fast
+-- rather than queue behind a long reader.
+SET LOCAL lock_timeout = '3s';
+
+UPDATE role SET permissions = jsonb_set(
+        permissions, '{objects,tag}',
+        '{"create": true, "read": true, "update": true, "delete": true}'::jsonb, true)
+    WHERE is_system
+      AND key IN ('admin', 'ops')
+      AND permissions ? 'objects'
+      AND NOT ((permissions -> 'objects') ? 'tag');
+
+UPDATE role SET permissions = jsonb_set(
+        permissions, '{objects,tag}',
+        '{"create": false, "read": true, "update": false, "delete": false}'::jsonb, true)
+    WHERE is_system
+      AND key IN ('management', 'manager', 'rep', 'read_only')
+      AND permissions ? 'objects'
+      AND NOT ((permissions -> 'objects') ? 'tag');


### PR DESCRIPTION
`main` is red on two counts, both from #3660, and every branch cut from it inherits them.

## 1. No role can reach a tag route after an upgrade

```
rbacseedparity_integration_test.go:236: every backfill in order: role "admin" holds no
  grant on "tag", so every tag route answers 403 for it — permanently, on any
  installation that took this path
```
(and the same for `management`, `manager`, `ops`, `read_only`, `rep`.)

`1788320100` made `tag` governed vocabulary and **narrowed** the roles that held write on it, guarded on `(permissions -> 'objects') ? 'tag'`. That is the right guard for a narrowing and the wrong one for an installation bootstrapped before `tag` was a governed object at all: those documents carry no `tag` key, so the UPDATE skips them — and `seedSystemRoles` writes each document once at workspace creation and never re-syncs, so nothing else would ever add it.

The new backfill **adds** the object where it is absent, with the seeded matrix's own verbs read off `defaults.go`: `crud` for `admin` and `ops`, read-only for `management`, `manager`, `rep` and `read_only`.

Read is not a widening. Applying a tag is what the taggable surface is for, and a role that cannot read the vocabulary cannot see the tags already on the records it works.

Guarded on absence in both directions: an installation that has the key — including one an operator narrowed by hand, and one `1788320100` already corrected — is untouched, and re-running changes nothing.

## 2. The tag lifecycle case posts a hex colour

```
collections_integration_test.go:40: create tag → 422
```

The same PR closed `color` to a four-tone palette; the test still sent `#ff6b00`. It sends `amber`.

`make check-backend` green; the seed-parity and tag lifecycle cases green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded access to the tag vocabulary for system roles.
  - Administrators and operations users can create, update, and delete tags.
  - Management, sales, and read-only users can view tags according to their access level.
  - Tag colors now follow a governed palette with four supported values, improving consistency across tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->