### PR TITLE
The identity-key guard asserts on the strip, not the slot it sits in

### DIFF
--- a/frontend/src/App.tabkey.test.tsx
+++ b/frontend/src/App.tabkey.test.tsx
@@ -18,6 +18,15 @@ import {
 // It is asserted here rather than in screens/personpage.test.tsx because the key
 // lives above every screen: that suite mounts the page with a `tab` prop and can
 // never see the router decide.
+//
+// KNOWN GAP, #3675: these two cases pass alone and fail when another App suite
+// has run first. The person page then never leaves "Loading…" — the address is
+// right and the record's name resolves, so the /360 read is what does not
+// settle, and something above this file is holding a react-query cache across
+// suites that `renderApp`'s fresh client does not clear. It is not this file's
+// stubs: it reproduces on an unmodified tree. Until that is found, treat a
+// failure here as the leak rather than as a broken identity key, and check by
+// running this file alone.
 
 type Person360 = components["schemas"]["Person360"];
 
@@ -41,22 +50,40 @@ function person(id: string, name: string): Person360 {
   };
 }
 
-// The session harness's stub, with the one read the record page cannot render
+// The session harness's stub, with the reads the record page cannot render
 // without answered on top of it. Everything else still 503s into its own error
 // state — this suite is about which DOM nodes survive a navigation.
+//
+// TWO reads, not one. The page asks for the person itself before it asks for the
+// 360 projection, and a suite that answered only the second sat at "Loading…"
+// forever: no header, no tab strip, and both cases failing on their first
+// `waitFor` rather than on the node comparison they exist for. That is a whole
+// screen this file cannot draw, so it is stubbed here rather than left to the
+// harness — the harness deliberately 503s everything it is not asked about.
 function personFetch() {
   const session = sessionOnlyFetch();
   return async (input: Request | string | URL) => {
     const url = String(input instanceof Request ? input.url : input);
-    const match = /\/v1\/people\/(p-\d+)\/360$/.exec(url);
-    if (match) {
-      return new Response(
-        JSON.stringify(person(match[1], `Person ${match[1]}`)),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
+    const whole = /\/v1\/people\/(p-\d+)\/360$/.exec(url);
+    if (whole) {
+      return json(person(whole[1], `Person ${whole[1]}`));
+    }
+    // The record itself, which the page reads for its header. Anchored to the
+    // end so it cannot swallow /360, /brief or /consent — those keep 503ing
+    // into panels of their own, which is what this suite wants.
+    const bare = /\/v1\/people\/(p-\d+)$/.exec(url);
+    if (bare) {
+      return json({ id: bare[1], full_name: `Person ${bare[1]}`, ...CAPTURED });
     }
     return session(input);
   };
+}
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 // The one element every case below compares across a navigation: the RECORD's
@@ -71,8 +98,18 @@ function recordHead(): Element {
   return found;
 }
 
+// The strip ITSELF, from the component that draws the tabs — not the slot the
+// page chrome reserves for it.
+//
+// `.record-tabs` in composed.tsx is that slot: a wrapper the record head puts
+// around whatever tabs it is handed. The tabs live inside it under
+// `recordtabs.tsx`'s own classes, and a query for `.record-tabs button` matches
+// nothing at all. This file asked for the wrapper and for buttons inside it, so
+// it compared a node that survives everything and then failed to find a current
+// tab — which is how both cases died on their first `waitFor` rather than on the
+// identity comparison they exist for.
 function tabStrip(): Element {
-  const found = document.querySelector(".record-tabs");
+  const found = document.querySelector(".recordtabs-strip");
   if (!found) {
     throw new Error("the contact record's tab strip never rendered");
   }
@@ -84,7 +121,9 @@ function tabStrip(): Element {
 // waiting on it is what makes the node comparisons below claims about a move
 // that HAPPENED rather than one still in flight.
 function currentTab(): string {
-  const on = document.querySelector('.record-tabs button[aria-pressed="true"]');
+  const on = document.querySelector(
+    '.recordtabs-strip button[aria-pressed="true"]',
+  );
   if (!on) {
     throw new Error("no tab is current");
   }


### PR DESCRIPTION
`App.tabkey.test.tsx` is the guard for `IDENTITY_DEPTH` in `app/router.tsx` — the table that decides whether moving between a record's tabs re-renders the page or throws it away. Two defects in it, and the second means **it has been passing for the wrong reason**.

## It was asserting on a node that survives everything

`currentTab()` queried `.record-tabs button[aria-pressed="true"]`. But `.record-tabs` (`composed.tsx:811`) is the *slot* the record head wraps around whatever tabs it is handed — the tabs themselves are drawn by `design-system/recordtabs.tsx` under `.recordtabs-strip` / `.recordtabs-tab`. That selector matched nothing at all.

`tabStrip()` returned that same wrapper, which survives any remount. So `expect(tabStrip()).toBe(stripBefore)` — the file's central assertion — proved nothing about the routed subtree's key.

**Mutation-checked:** with the selector corrected, changing `IDENTITY_DEPTH.contacts` from `2` to `WHOLE_ADDRESS` fails both cases. Before the fix, that mutation went undetected.

## It stubbed one read where the page makes two

The person page asks for `/v1/people/{id}` before `/v1/people/{id}/360`, and `personFetch` answered only the second. The first 503'd, so the page sat at "Loading…" — no header, no tab strip — and both cases died on their first `waitFor` rather than on the comparison they exist for.

## What this PR does not fix

A third defect, recorded in a comment at the top of the file and tracked as **#3675**: these cases pass alone and fail when another App suite has run first. The address is right and the record's name resolves, so the `/360` read is what does not settle — a react-query cache held across suites that `renderApp`'s fresh client does not clear.

It reproduces on an unmodified tree (that same pair already fails one of two before this change), so it is neither of the defects above. It belongs to the harness rather than to this file, and plausibly weakens other App-level suites too, so it wants an owner rather than a local workaround here.

Fixing the two above takes the pair-run from one failure to two — not a regression, but the corrected assertion now actually checking something and finding the leak.

## Why now

A planned change lowers `IDENTITY_DEPTH.worklist` from `WHOLE_ADDRESS` to `1`. This is the test that would catch a mistake there, so it needs to be trustworthy first.

## Verification

`make check-fe` green (5752 tests). One unrelated file, `dealemail.test.tsx`, failed on the first gate run and passed alone and on re-run — order-dependent flakiness in the suite, not this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the App tab-key guard to inspect the rendered tab strip and provide both person API responses required to render the record. The test now verifies `IDENTITY_DEPTH` remount behavior instead of comparing a persistent slot or failing while the page is still loading.

- Changing `IDENTITY_DEPTH.contacts` to an incorrect value now fails the guard as expected.
- The existing order-dependent failure tracked in #3675 remains: a `react-query` cache leak can leave `/360` unsettled after another App suite, so run this file alone when diagnosing that failure.

<sup>Written for commit d4b475539af08049fb1d7f64a03c55d8731c9801. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved keyboard tab-navigation test coverage.
  * Updated test interactions to accurately target the visible tab strip and active tab.
  * Added support for simulating related API responses in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->