### PR TITLE
The worklist keeps WHOLE_ADDRESS, and a test says why

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -156,6 +156,16 @@ const IDENTITY_DEPTH: Readonly<Record<Screen, number>> = {
   leads: 2,
   deals: WHOLE_ADDRESS,
   projects: WHOLE_ADDRESS,
+  // #/worklist/<owner> and #/worklist/unassigned are real addresses the home
+  // team board navigates to, and App.tsx hands that segment to the screen as
+  // `opensOn`. The screen reads it in useState INITIALISERS, so the remount is
+  // what applies it: lower this and a manager clicking a colleague's name keeps
+  // reading their OWN queue under that colleague's address, with no error and
+  // nothing on screen to say so.
+  //
+  // Held by screens/worklist.identity.test.tsx. Selecting a row here is local
+  // state and never touches the address, which is what makes lowering this look
+  // free — the pane is not what the depth is protecting.
   worklist: WHOLE_ADDRESS,
   // #/reports/<report> — the picker chooses a view of one screen, so switching
   // reports re-renders the panel instead of throwing the screen away.

--- a/frontend/src/screens/worklist.identity.test.tsx
+++ b/frontend/src/screens/worklist.identity.test.tsx
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  memoryStorage,
+  renderApp,
+  sessionOnlyFetch,
+} from "../testing/appharness";
+
+// Why the worklist keeps WHOLE_ADDRESS in app/router.tsx's IDENTITY_DEPTH.
+//
+// Lowering it looks free. Selecting a row on this screen is local state and
+// never touches the address, so the obvious reading is that the screen has one
+// address and remounting it is waste — which is what a plan to lower it said.
+//
+// It is not one address. `#/worklist/<owner>` and `#/worklist/unassigned` are
+// real addresses that the home team board navigates to, and App.tsx hands that
+// segment to the screen as `opensOn`. The screen reads it in useState
+// INITIALISERS, so it is used once at mount and never again.
+//
+// So the remount IS the mechanism: at WHOLE_ADDRESS the two addresses have
+// different identities, the screen remounts, and the initialisers re-run with
+// the new owner. At depth 1 they share one identity, nothing remounts, the
+// initialisers never re-run — and a manager who clicks a colleague's name goes
+// on reading their own queue under that colleague's address, with no error and
+// nothing on screen to say so.
+//
+// Held here rather than as a comment because a comment cannot fail. Lower the
+// depth and this test says what breaks.
+
+const READS: string[] = [];
+
+beforeEach(() => {
+  READS.length = 0;
+  vi.stubGlobal("localStorage", memoryStorage());
+  globalThis.localStorage.setItem("margince.workspaceSlug", "acme");
+  const session = sessionOnlyFetch();
+  // Every worklist read this navigation causes, in order. The page 503s into
+  // its own error state, which is fine: this is about WHICH question the screen
+  // asks the server, not about what comes back.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: Request | string | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes("/worklist")) {
+        READS.push(url.replace(/^.*\/v1/, ""));
+      }
+      return session(input);
+    }),
+  );
+});
+
+describe("the worklist's routed identity", () => {
+  it("re-reads for the named queue when the address names one", async () => {
+    window.location.hash = "#/worklist";
+    renderApp();
+    await waitFor(() => expect(READS.length).toBeGreaterThan(0), {
+      timeout: 2000,
+    });
+    expect(READS[0]).toContain("scope=mine");
+    const before = READS.length;
+
+    // What the home team board's "unassigned" arm does.
+    window.location.hash = "#/worklist/unassigned";
+
+    // The read for the NEW question. Without a remount this never arrives, and
+    // the screen keeps answering the old one.
+    await waitFor(
+      () =>
+        expect(
+          READS.slice(before).some((url) => url.includes("scope=unassigned")),
+        ).toBe(true),
+      { timeout: 2000 },
+    );
+  });
+
+  it("re-reads for a colleague's queue when the address names a person", async () => {
+    window.location.hash = "#/worklist";
+    renderApp();
+    await waitFor(() => expect(READS.length).toBeGreaterThan(0), {
+      timeout: 2000,
+    });
+    const before = READS.length;
+
+    // What the board's per-member arm does. The owner travels as a query
+    // parameter rather than as the scope, so this is a second shape of the same
+    // question and not a rephrasing of the case above.
+    window.location.hash = "#/worklist/u-colleague";
+
+    await waitFor(
+      () =>
+        expect(
+          READS.slice(before).some((url) => url.includes("owner=u-colleague")),
+        ).toBe(true),
+      { timeout: 2000 },
+    );
+  });
+});


### PR DESCRIPTION
The worklist plan's last screen item asked to lower `IDENTITY_DEPTH.worklist` from `WHOLE_ADDRESS` to `1`: selecting a row is local state and never touches the address, so remounting the whole screen to fill one pane reads as pure waste. Two characters, said the plan, and the work is the verification.

**The verification says don't.** Selecting a row is not what the depth is protecting.

## What it is actually protecting

`#/worklist/<owner>` and `#/worklist/unassigned` are real addresses, and `home.teamboard.tsx` navigates to both — one arm per team member, one for the unassigned queue. `App.tsx:459` hands that segment to the screen as `opensOn`, and the screen reads it in `useState` **initialisers**, which run once at mount.

So the remount is the mechanism that applies it. Lowered to `1`, the two addresses share one identity, nothing remounts, the initialisers never re-run — and a manager who clicks a colleague's name goes on reading **their own queue** under that colleague's address. No error, nothing on screen to say so.

## Measured, not reasoned

I instrumented `fetch` and drove the real navigation both ways:

| `IDENTITY_DEPTH.worklist` | `#/worklist` → `#/worklist/unassigned` |
|---|---|
| `WHOLE_ADDRESS` (today) | second read, `scope=unassigned` |
| `1` (the plan's ask) | **no read at all** |

## What ships

No behaviour change. What ships is the reason, in two places that can fail:

- `worklist.identity.test.tsx` holds both arms — the scope address and the owner address, which travel differently on the wire (`scope=unassigned` vs `owner=<id>`) and so are two shapes of the question rather than one phrasing of it. Lowering the depth fails both.
- The reason now sits beside the entry in `IDENTITY_DEPTH`, where the next person to think this is free will read it — including the part that makes it look free, so they do not have to re-derive why it is not.

## Verification

`make check-fe` green (5754 tests). Mutation-checked: setting `worklist: 1` fails both new tests. `make craft-static` clean. Backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps `IDENTITY_DEPTH.worklist` at `WHOLE_ADDRESS` and documents why: the owner and unassigned routes must remount the screen so it loads the queue named by the address. Lowering it to `1` would leave users viewing the previous queue under a new address.

**Tests**

- Adds coverage for both unassigned (`scope=unassigned`) and owner (`owner=<id>`) navigation.
- Fails if the worklist identity depth is lowered to `1`.

<sup>Written for commit 10eacd6b6ab61f315ee4b54ace9dc9b228ddf3f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification for worklist routing behavior when ownership changes, helping maintain correct queue state handling.

* **Tests**
  * Added regression coverage to verify that unassigned and owner-specific worklist routes load the correct data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->