### PR TITLE
get_tag is waived beside the tag tools it belongs with

### DIFF
--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -272,6 +272,9 @@ var unreachableInThisLane = gatekit.Waive(map[string]string{
 	"list_tags": "same missing tag.read as apply_tag above — and unlike remove_tag it shares its " +
 		"answer shape with nothing else here, so this waiver leaves that shape unproven rather " +
 		"than proven elsewhere",
+	"get_tag": "same missing tag.read as apply_tag above. It answers ONE row of the shape list_tags " +
+		"answers many of, so the two are unproven together rather than one covering the other — " +
+		"whichever seat eventually carries tag.read reaches both",
 	"book_meeting":         "needs a live calendar provider",
 	"send_email":           "needs an outbound mail provider",
 	"send_account_email":   "needs an outbound mail provider, and a send-capable mailbox for its pre-flight",


### PR DESCRIPTION
`main` fails the tool-conformance lane on every branch:

```
toolschema_conformance_integration_test.go:228: get_tag is registered but never invoked
  here, so nothing holds its result to the schema or the envelope. Add a call above,
  or name the seam it needs in unreachableInThisLane.
```

#3660 registered the tool; the sweep refuses a tool nothing invokes, which is what that gate is for.

`get_tag` takes the same waiver its three siblings already carry — `apply_tag`, `remove_tag`, `list_tags` — and for the same stated reason: this lane's seat holds no `tag.read`, and granting it would widen the authority every other tool in the sweep runs under.

The entry says what it leaves unproven rather than implying cover it does not have: `get_tag` answers ONE row of the shape `list_tags` answers many of, and both are waived, so the shape is unproven either way. Whichever seat eventually carries `tag.read` reaches both at once.

`make check-backend` green; the conformance lane green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test coverage to account for the `get_tag` tool.
  * Documented its required read access and distinct single-result response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->