### PR TITLE
main is red: get_tag was left out of the waiver its siblings share

### DIFF
--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -272,6 +272,8 @@ var unreachableInThisLane = gatekit.Waive(map[string]string{
 	"list_tags": "same missing tag.read as apply_tag above — and unlike remove_tag it shares its " +
 		"answer shape with nothing else here, so this waiver leaves that shape unproven rather " +
 		"than proven elsewhere",
+	"get_tag": "same missing tag.read as apply_tag above, and the same unproven answer shape as " +
+		"list_tags: TagDetail is read back by nothing else in this sweep",
 	"book_meeting":         "needs a live calendar provider",
 	"send_email":           "needs an outbound mail provider",
 	"send_account_email":   "needs an outbound mail provider, and a send-capable mailbox for its pre-flight",


### PR DESCRIPTION
`integration / integration shard (1/6)` has been red on the tip since the tag
tools landed. One tool, one line.

```
toolschema_conformance_integration_test.go:228: get_tag is registered but never invoked
here, so nothing holds its result to the schema or the envelope. Add a call above, or name
the seam it needs in unreachableInThisLane.
```

Verified against a clean `origin/main` worktree at `c4ac4ef7f` before writing
anything — it reproduces there with no branch of mine in sight.

## Why a waiver rather than a call

`get_tag` requires `tag.read`, and this lane's seat does not carry it. That is
not a new situation: its three siblings are already waived for exactly that
reason —

- `apply_tag` — "needs a seat holding tag.read, which this lane's seat does not
  carry — granting it here would widen the authority every other tool in the
  sweep runs under"
- `remove_tag` — "same missing tag.read as apply_tag above"
- `list_tags` — "same missing tag.read as apply_tag above — and unlike
  remove_tag it shares its answer shape with nothing else here"

`get_tag` was simply left out of that list when the family landed. It is in the
same position as `list_tags`: same missing grant, and its answer shape
(`TagDetail`) is read back by nothing else in the sweep, so the waiver leaves
that shape unproven rather than proven elsewhere. The entry says both, because
the waiver list is read by the census and a reason that stops being true has to
be visible when it does.

Granting `tag.read` to the sweep's seat instead would widen the authority
**every other tool in the lane** runs under, which is the objection its siblings'
waiver already records.

## Not fixed here

The `TagDetail` answer shape stays unproven by this lane, exactly as `list_tags`'
shape does. Closing that properly means a second seat or a per-call grant in the
conformance sweep, which is a change to how the lane is composed rather than a
red-fixing one-liner, and it should be argued on its own.

## Verification

```
make test-it DIR=backend/internal/compose/integration \
  RUN='TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas'
ok  github.com/margince/margince/backend/internal/compose/integration  2.081s
```

Watched failing first: the assertion above is what the lane printed before this
entry existed. And the waiver list is not a free pass — the census fails a tool
listed here that IS reachable, so an unnecessary entry would have red-flagged
itself.

Separate from #3682, which fixes the tag RBAC backfill. Same origin, different
gate; neither includes the other.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red `integration shard (1/6)` on main by adding `get_tag` to the `unreachableInThisLane` waiver list, matching its siblings.

`get_tag` requires `tag.read`, which this lane's seat doesn't carry; granting it would widen authority for every other tool in the sweep. Its answer shape `TagDetail` is read back by nothing else here, so this waiver leaves that shape unproven just like `list_tags`.

<sup>Written for commit 86e2d97cc67883decb6f0bbd96e2f6f573746d60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated integration test handling for the `get_tag` tool to account for currently unavailable permission coverage and an unverified response format.
  - No user-facing functionality or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->