### PR TITLE
The Worklist says which lane it deliberately does not have

### DIFF
--- a/backend/internal/compose/attention/doc.go
+++ b/backend/internal/compose/attention/doc.go
@@ -40,9 +40,9 @@
 // claims lane, the task lane, and it.
 //
 // What would earn one is a different QUESTION rather than a second rendering of
-// this one — the unassigned open promises, say, which is the state that tool's
-// own result type calls out and which `planned` cannot show. That lane deserves
-// its own name rather than the plan's.
+// this one — the unassigned open promises, say, which is the state that the
+// tool's own result type calls out and which `planned` cannot show. That lane
+// deserves its own name rather than the plan's.
 //
 // The tool itself is untouched by any of this and still answers.
 //

--- a/backend/internal/compose/attention/doc.go
+++ b/backend/internal/compose/attention/doc.go
@@ -28,6 +28,24 @@
 // rather than a question. Sorting by producer instead would put a merge next
 // to a reminder and leave the reader to work out which one matters.
 //
+// WHAT IS DELIBERATELY NOT A LANE, so an omission is not read as an oversight.
+//
+// review_commitments is an MCP tool, and the briefing plan listed it as a
+// Worklist lane to build. It was not built, on purpose. Its seam reads open
+// tasks through activities.ListOpenTasks and its result is keyed by task id —
+// which is the same population `planned` already shows, plus the undated ones
+// `planned` excludes on purpose. A lane for it would put the same rows on the
+// same screen under a second heading, which is the duplication this package
+// exists to end, and it would make three commitment surfaces of two: the
+// claims lane, the task lane, and it.
+//
+// What would earn one is a different QUESTION rather than a second rendering of
+// this one — the unassigned open promises, say, which is the state that tool's
+// own result type calls out and which `planned` cannot show. That lane deserves
+// its own name rather than the plan's.
+//
+// The tool itself is untouched by any of this and still answers.
+//
 // A lane the caller may not read is OMITTED and named, never returned empty.
 // "You may not see this" and "there is none" are different answers, and a
 // surface whose whole promise is "this is your day" must not report a clear


### PR DESCRIPTION
Closes #2736.

The ticket exists to stop the next person reading a deliberate omission as an oversight and building the lane. A ticket is the wrong place for that: somebody adding a lane reads `attention/doc.go`, which lists what the feed is and what shapes it, and finds no mention of the one that was considered and declined.

So the reasoning moves into the package doc, beside the two rules already there:

- `review_commitments` reads open tasks through `activities.ListOpenTasks` and is keyed by task id — the population `planned` already shows, plus the undated ones `planned` excludes on purpose. A lane would put the same rows on the same screen under a second heading, which is the duplication this package exists to end, and make three commitment surfaces of two.
- What would earn a lane is a different **question**, and the doc names the candidate: the unassigned open promises, which the tool's own result type calls out and `planned` cannot show. That lane deserves its own name rather than the plan's.
- The MCP tool is untouched and still answers, which the doc says so nobody reads this as its removal.

No behaviour change. `make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected a grammatical omission in the attention-related documentation by adding the missing article before “tool’s.”
  * Improved the clarity and readability of the affected documentation while preserving the existing explanation of commitment reviews, task planning, attention categories, and related tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->