### PR TITLE
The Art. 15 package an access request asks for

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -11499,6 +11499,59 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/DataSubjectRequest' }
+  /data-subject-requests/{id}/package:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string, format: uuid } }
+    get:
+      tags: [Compliance]
+      operationId: downloadDataSubjectPackage
+      security: [ { cookieAuth: [] } ]   # human session only — rejects agent bearer/Passport (x-agent-access: human-only)
+      x-agent-access: human-only
+      summary: Download the Art. 15 package an access request asks for.
+      description: |
+        Assembles everything this installation holds about the subject and hands it back as a file
+        to forward to them: their record and its identifiers, the conversations they were party to
+        and what was said in them, the attachments, consent and its history, what they themselves
+        submitted through a confirm link, what was read about them from public sources, and the
+        provider originals behind the captured mail.
+
+        A privileged read that deliberately crosses the caller's own row scope, because Art. 15
+        owes the subject everything held rather than the slice one colleague may see. So it takes
+        the same trust erasure does: an ADMIN, human, holding `person.delete`, with unbounded row
+        scope. An agent is refused whatever its passport carries — an admin's read-scoped passport
+        would otherwise assemble a subject's entire record.
+
+        Only an `access` request has a package. An erasure or a rectification is answered by its
+        own path, and handing back a subject's whole record to close a request that asked for
+        something else would be the export nobody asked for.
+
+        The request's `subject_ref` must name a person id. It is free text until somebody resolves
+        it, and a request naming nobody has nothing to assemble — the same refusal fulfilling an
+        erasure gives, for the same reason. A `subject_ref` that is not a person id at all answers
+        422; one that is a well-formed id naming no person answers 404. The two look identical on a
+        stale request row and are worth telling apart.
+
+        **The download is recorded.** Assembling a package writes an audit entry against the person
+        — action `export`, naming the officer who asked and how much it carried. That record is what
+        makes a read this privileged acceptable, and it is written whether or not the package
+        reaches anybody.
+
+        This does NOT change the request's status. Producing the export and deciding the request is
+        answered are two acts by the same person: mark it fulfilled through the PATCH once you have
+        sent it, so a download that never reached anybody does not close the row.
+      responses:
+        '200':
+          description: The package, as a JSON file named after the request.
+          content:
+            application/json:
+              schema:
+                type: object
+                description: |
+                  The assembled package. Its sections follow what the installation actually holds,
+                  and the set grows whenever a new table starts holding subject data — the shape is
+                  deliberately not pinned here, because a schema mirrored in the contract would
+                  drift one release behind the export a gate checks for completeness.
+                additionalProperties: true
   /audit-log:
     get:
       tags: [Compliance]

--- a/backend/gates/processingrecord_test.go
+++ b/backend/gates/processingrecord_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// The Art. 30 processing record names the code that enforces each entry, and
+// this fails when that code is not there any more.
+//
+// A processing record is a promise about what the software does. Every activity
+// in it carries a `Durchsetzung` row naming the file that carries out the
+// promise — that is what makes the document checkable rather than aspirational,
+// and it is the only part of it a test can hold. A renamed or deleted file turns
+// the promise into a citation of nothing, and nothing else in the tree notices:
+// the document is prose, the code compiles, and the discrepancy surfaces at an
+// audit.
+//
+// What this does NOT check, said plainly rather than left to be assumed: whether
+// the named file still does what the row claims. No test can read that. The
+// obligation this holds is narrower — that a reader following the citation
+// arrives somewhere — and it is worth holding because the failure it catches
+// (a path that resolves to nothing) is the one that happens by accident.
+//
+// Deriving the subjects from the document rather than listing them here is the
+// point. A list would be a second copy of the record, and a new activity added
+// to the record with a bad path would pass a gate that only knew the old ones.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// processingRecords are the Art. 30 documents this rule covers. A record in a
+// language not listed here is not exempt — it is unwritten, and adding one adds
+// it here.
+var processingRecords = []string{
+	"../docs/compliance/de/verarbeitungsverzeichnis-und-dsfa.md",
+}
+
+// citedGoFile matches a backtick-quoted Go path in the record's prose, which is
+// how every Durchsetzung row spells the code it points at.
+//
+// Anchored on the `.go` suffix rather than on the row label, so a citation that
+// moves into a different column or a sentence is still checked. The paths are
+// written relative to `internal/` with the leading segments trimmed
+// (`capture/sinkactivity.go`), which is how a reader would say it out loud.
+var citedGoFile = regexp.MustCompile("`([a-z][a-zA-Z0-9_]*(?:/[a-zA-Z0-9_]+)*\\.go)`")
+
+func TestTheProcessingRecordCitesCodeThatExists(t *testing.T) {
+	t.Parallel()
+	for _, record := range processingRecords {
+		body, err := os.ReadFile(record)
+		if err != nil {
+			t.Fatalf("reading the processing record %s: %v", record, err)
+		}
+		cited := citedGoFile.FindAllStringSubmatch(string(body), -1)
+		// A record citing nothing has either lost its Durchsetzung rows or the
+		// pattern has stopped matching them. Either way this gate is passing
+		// vacuously, which is the one failure a census must not have.
+		if len(cited) == 0 {
+			t.Errorf("%s cites no Go file at all — either the enforcement rows are gone, or "+
+				"citedGoFile no longer matches how they are written. A record that names no code "+
+				"is a promise nothing holds.", record)
+			continue
+		}
+		seen := map[string]bool{}
+		for _, match := range cited {
+			path := match[1]
+			if seen[path] {
+				continue
+			}
+			seen[path] = true
+			switch matches := resolveCitedFile(t, path); len(matches) {
+			case 1:
+			case 0:
+				t.Errorf("%s cites `%s`, which is not in the tree. The Art. 30 record names this "+
+					"file as what enforces a processing activity, so a reader following the citation "+
+					"arrives nowhere. Update the record in the same change that moved the code.",
+					record, path)
+			default:
+				t.Errorf("%s cites `%s`, which %d files answer to (%s). A reader following the "+
+					"citation cannot tell which enforces the activity — write the citation long "+
+					"enough to name one.", record, path, len(matches), strings.Join(matches, ", "))
+			}
+		}
+	}
+}
+
+// resolveCitedFile finds the cited path under the module, or returns "" — and
+// reports an ambiguous citation as a failure rather than picking one.
+//
+// A suffix match rather than an exact one, because the record writes the path
+// the way a reader says it — `capture/sinkactivity.go` for what actually lives
+// at `internal/modules/capture/sinkactivity.go`. Requiring the full path in the
+// document would make it harder to read.
+//
+// Every match is collected rather than the first taken. A short-circuit would
+// resolve a collision to whichever file the walk reached first and report PASS,
+// which is the under-recognition shape a census must not have: it reads a
+// smaller answer and nothing fails to say so. Two files answering one citation
+// means a reader following it cannot tell which was meant, and that ambiguity is
+// itself the finding.
+func resolveCitedFile(t *testing.T, cited string) []string {
+	t.Helper()
+	var found []string
+	err := filepath.Walk("internal", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(filepath.ToSlash(path), "/"+cited) {
+			found = append(found, filepath.ToSlash(path))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the tree for %s: %v", cited, err)
+	}
+	return found
+}

--- a/backend/gates/uniquenessclaims_test.go
+++ b/backend/gates/uniquenessclaims_test.go
@@ -461,7 +461,7 @@ func TestTheRegisterHoldsNoEntryThatIsNoLongerAClaim(t *testing.T) {
 // moved and whether the tree moved with it.
 var shapeCensus = map[string]int{
 	"cannot-drift":   169,
-	"once":           178,
+	"once":           177,
 	"one-of-a-kind":  178,
 	"is-every-named": 91,
 	"only-noun":      12,

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -207,6 +207,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/contracts/{id}":                                             {Op: "getContract", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/custom-fields":                                              {Op: "listCustomFields", Access: "tool", Tool: "search_records", RecordType: "custom_field", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/data-subject-requests":                                      {Op: "listDataSubjectRequests", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/data-subject-requests/{id}/package":                         {Op: "downloadDataSubjectPackage", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/deal-rooms":                                                 {Op: "listDealRooms", Access: "tool", Tool: "search_records", RecordType: "deal_room", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/deal-rooms/{id}":                                            {Op: "getDealRoom", Access: "tool", Tool: "read_record", RecordType: "deal_room", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/deal-rooms/{id}/documents":                                  {Op: "listDealRoomDocuments", Access: "tool", Tool: "search_records", RecordType: "deal_room_document", Tier: "auto_execute", Scope: "read"},

--- a/backend/internal/compose/integration/dsr_package_integration_test.go
+++ b/backend/internal/compose/integration/dsr_package_integration_test.go
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The Art. 15 package an access request asks for: who may assemble one, which
+// requests have one, and what it has to contain.
+//
+// Before this the queue could record an access request and an officer could mark
+// it fulfilled with no product path that produced anything, so "fulfilled" meant
+// somebody had said so. These tests are about the half that makes the word true.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/modules/privacy"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestTheAccessPackageCarriesWhatIsHeldAboutTheSubject(t *testing.T) {
+	e := Setup(t)
+	person := seedSubjectWithMail(t, e)
+
+	pkg, err := privacy.AssembleSAR(e.Admin(), e.DB(), ids.From[ids.PersonKind](person))
+	if err != nil {
+		t.Fatalf("assembling the package: %v", err)
+	}
+	if len(pkg.Subject) == 0 {
+		t.Error("the package names no subject")
+	}
+	if len(pkg.Emails) == 0 {
+		t.Error("the package carries no address for a subject whose address is on file")
+	}
+	// The correspondence, not only the identifiers. An export that hands back a
+	// name and no messages answers a question the subject did not ask.
+	if len(pkg.Activities) == 0 {
+		t.Error("the package carries no activities for a subject with mail on their timeline")
+	}
+}
+
+func TestAssemblingAPackageNeedsTheTrustErasureNeeds(t *testing.T) {
+	// AssembleSAR's own two conditions: the person.delete grant, and an
+	// unbounded row scope because Art. 15 owes the subject everything held
+	// rather than the slice one colleague may see.
+	e := Setup(t)
+	person := seedSubjectWithMail(t, e)
+
+	// read_only holds no person.delete and is refused by the grant.
+	readOnly := e.As(ids.NewV7(), []ids.UUID{e.Team1}, ReadOnlyPerms)
+	if _, err := privacy.AssembleSAR(readOnly, e.DB(), ids.From[ids.PersonKind](person)); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("read_only assembled a subject-access package: err=%v, want permission denied", err)
+	}
+	// A bounded rep is refused twice over — no grant, and no scope.
+	repCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+	if _, err := privacy.AssembleSAR(repCtx, e.DB(), ids.From[ids.PersonKind](person)); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("a bounded rep assembled a subject-access package: err=%v, want permission denied", err)
+	}
+}
+
+func TestTheQueueGateIsWhatKeepsTheExportAdminOnly(t *testing.T) {
+	// The gap this route must not open. AssembleSAR admits any unbounded human
+	// holding person.delete, and the seeded defaults give that to ops and
+	// management as well as admin — so the assembler ALONE is more open than the
+	// queue that owns this workflow.
+	//
+	// What closes it is reading the request first: GetDSR takes requireDSRAdmin,
+	// which is admin-only, so a handler that reaches the request before it
+	// assembles anything is gated by the narrower of the two. This pins both
+	// halves, because a future handler that assembled from a person id in the
+	// path instead would silently be reachable by two more roles.
+	e := Setup(t)
+	store := consent.NewStore(e.DB())
+	person := seedSubjectWithMail(t, e)
+	created, err := store.CreateDSR(e.Admin(), consent.CreateDSRInput{
+		Kind:       "access",
+		SubjectRef: person.String(),
+		DueAt:      time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("seeding an access request: %v", err)
+	}
+
+	opsCtx := e.As(ids.NewV7(), []ids.UUID{e.Team1}, OpsPerms)
+	// The assembler admits ops: this is the fact the route has to defend against,
+	// not a defect in AssembleSAR — its own contract is the erasure trust level.
+	if _, err := privacy.AssembleSAR(opsCtx, e.DB(), ids.From[ids.PersonKind](person)); err != nil {
+		t.Fatalf("ops is refused by the assembler itself, so this test no longer describes the "+
+			"reason the queue gate matters: %v", err)
+	}
+	// And the queue refuses them, which is what the route reads first.
+	if _, err := store.GetDSR(opsCtx, created.ID); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("ops read a subject request: err=%v, want permission denied — the queue gate is "+
+			"the only thing keeping the Art. 15 export admin-only", err)
+	}
+}
+
+func TestAnAgentIsRefusedTheAccessPackageWhateverItsPassportCarries(t *testing.T) {
+	// The arm the object grant cannot express. An agent acting under a passport
+	// carries the granting human's live grants, so an admin's read-scoped
+	// passport would otherwise assemble a subject's entire record.
+	e := Setup(t)
+	person := seedSubjectWithMail(t, e)
+
+	agent := principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:sdr",
+		SeatType:    principal.SeatFull,
+		Permissions: AdminPerms,
+	}
+	ctx := principal.WithActor(
+		principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), e.WS), ids.NewV7()),
+		agent)
+	if _, err := privacy.AssembleSAR(ctx, e.DB(), ids.From[ids.PersonKind](person)); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("an agent carrying an admin's grants assembled a package: err=%v, want permission denied", err)
+	}
+}
+
+func TestOnlyAnAccessRequestHasAPackage(t *testing.T) {
+	// An erasure and a rectification are answered by their own paths. Handing
+	// back a subject's whole record to close a request that asked for something
+	// else is the export nobody asked for.
+	e := Setup(t)
+	store := consent.NewStore(e.DB())
+	person := seedSubjectWithMail(t, e)
+
+	for _, kind := range []string{"erasure", "rectify"} {
+		created, err := store.CreateDSR(e.Admin(), consent.CreateDSRInput{
+			Kind:       kind,
+			SubjectRef: person.String(),
+			DueAt:      time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC),
+		})
+		if err != nil {
+			t.Fatalf("seeding a %s request: %v", kind, err)
+		}
+		got, err := store.GetDSR(e.Admin(), created.ID)
+		if err != nil {
+			t.Fatalf("reading back the %s request: %v", kind, err)
+		}
+		if got.Kind == "access" {
+			t.Fatalf("a %s request reads back as access, so the handler's kind check cannot refuse it", kind)
+		}
+	}
+}
+
+func TestAnAccessRequestNamingNobodyHasNothingToAssemble(t *testing.T) {
+	// subject_ref is free text until somebody resolves it to a person. The
+	// erasure path already refuses one that names nobody; the access path owes
+	// the same answer rather than a confusing one from further in.
+	e := Setup(t)
+	store := consent.NewStore(e.DB())
+	created, err := store.CreateDSR(e.Admin(), consent.CreateDSRInput{
+		Kind:       "access",
+		SubjectRef: subjectAddress,
+		DueAt:      time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("seeding an access request naming an address: %v", err)
+	}
+	got, err := store.GetDSR(e.Admin(), created.ID)
+	if err != nil {
+		t.Fatalf("reading back the request: %v", err)
+	}
+	if _, parseErr := ids.Parse(got.SubjectRef); parseErr == nil {
+		t.Fatal("an address parsed as a person id, so the handler's refusal is unreachable")
+	}
+}
+
+func TestTheAssembledPackageIsSerializable(t *testing.T) {
+	// The seam hands bytes across, so a package that cannot be marshalled is a
+	// 500 on the one endpoint an officer needs under a statutory deadline.
+	e := Setup(t)
+	person := seedSubjectWithMail(t, e)
+
+	pkg, err := privacy.AssembleSAR(e.Admin(), e.DB(), ids.From[ids.PersonKind](person))
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	body, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatalf("the assembled package does not serialize: %v", err)
+	}
+	var round map[string]any
+	if err := json.Unmarshal(body, &round); err != nil {
+		t.Fatalf("the serialized package does not parse back: %v", err)
+	}
+	for _, section := range []string{"subject", "emails", "activities"} {
+		if _, ok := round[section]; !ok {
+			t.Errorf("the serialized package has no %q section", section)
+		}
+	}
+}
+
+// recordingAssembler stands in for the Art. 15 export so a handler test can
+// assert whether it was reached at all.
+//
+// Whether it RAN is the assertion that matters: the route's whole authority
+// argument is that the request is read through the queue's admin-only gate
+// BEFORE anything is assembled. A test that only checked the status code would
+// stay green if the two calls were swapped, and ops would have a route to any
+// subject's entire record.
+type recordingAssembler struct {
+	calls int
+}
+
+func (a *recordingAssembler) AssemblePackage(context.Context, ids.UUID) ([]byte, error) {
+	a.calls++
+	return []byte(`{"subject":{}}`), nil
+}
+
+// downloadPackage drives the real handler, with the real store behind it.
+func downloadPackage(
+	ctx context.Context, t *testing.T, e *Env, requestID ids.UUID, assembler consent.SubjectAccessAssembler,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	h := consent.NewHandlers(e.DB()).WithSubjectAccessAssembler(assembler)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/data-subject-requests/x/package", nil).WithContext(ctx)
+	h.DownloadDataSubjectPackage(rec, req, crmcontracts.Id(requestID))
+	return rec
+}
+
+func TestTheHandlerReadsTheRequestBeforeItAssemblesAnything(t *testing.T) {
+	// The ordering the whole design rests on. AssembleSAR admits ops and
+	// management; the queue's gate does not. Reading the request first is what
+	// makes the route admin-only, and swapping the two calls would leave every
+	// other test in this file green.
+	e := Setup(t)
+	person := seedSubjectWithMail(t, e)
+	request := seedAccessRequest(t, e, person.String())
+
+	assembler := &recordingAssembler{}
+	opsCtx := e.As(ids.NewV7(), []ids.UUID{e.Team1}, OpsPerms)
+	rec := downloadPackage(opsCtx, t, e, request, assembler)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("ops got %d from the package route, want 403", rec.Code)
+	}
+	if assembler.calls != 0 {
+		t.Errorf("the assembler ran %d times for a caller the queue refuses: the request must be "+
+			"read through the admin-only gate BEFORE anything is assembled", assembler.calls)
+	}
+}
+
+func TestTheHandlerAnswersAnAdminWithThePackage(t *testing.T) {
+	// The admit case. Without it the refusals above could all pass against an
+	// authority that turns everybody away.
+	e := Setup(t)
+	person := seedSubjectWithMail(t, e)
+	request := seedAccessRequest(t, e, person.String())
+
+	assembler := &recordingAssembler{}
+	rec := downloadPackage(e.Admin(), t, e, request, assembler)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("an admin got %d from the package route, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if assembler.calls != 1 {
+		t.Errorf("the assembler ran %d times for an admin, want 1", assembler.calls)
+	}
+	if got := rec.Header().Get("Content-Disposition"); !strings.Contains(got, request.String()) {
+		t.Errorf("Content-Disposition = %q, want the request id in the filename so the copy an "+
+			"officer sent ties to the row that recorded it", got)
+	}
+}
+
+func TestTheHandlerRefusesARequestOfTheWrongKind(t *testing.T) {
+	// An erasure is answered by its own path. Handing back a subject's whole
+	// record to close a request that asked for something else is the export
+	// nobody asked for.
+	e := Setup(t)
+	person := seedSubjectWithMail(t, e)
+	store := consent.NewStore(e.DB())
+	created, err := store.CreateDSR(e.Admin(), consent.CreateDSRInput{
+		Kind: "erasure", SubjectRef: person.String(),
+		DueAt: time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("seeding an erasure request: %v", err)
+	}
+
+	assembler := &recordingAssembler{}
+	rec := downloadPackage(e.Admin(), t, e, created.ID, assembler)
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("an erasure request produced a package: %s", rec.Body.String())
+	}
+	if assembler.calls != 0 {
+		t.Errorf("the assembler ran for an erasure request, so the kind check does not guard it")
+	}
+}
+
+func TestTheHandlerRefusesARequestNamingNobody(t *testing.T) {
+	// subject_ref is free text until somebody resolves it to a person id.
+	e := Setup(t)
+	request := seedAccessRequest(t, e, subjectAddress)
+
+	assembler := &recordingAssembler{}
+	rec := downloadPackage(e.Admin(), t, e, request, assembler)
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("a request naming an address produced a package: %s", rec.Body.String())
+	}
+	if assembler.calls != 0 {
+		t.Errorf("the assembler ran for a request naming nobody, so the resolution check does not guard it")
+	}
+}
+
+// seedAccessRequest lands one Art. 15 request naming whatever the caller says.
+func seedAccessRequest(t *testing.T, e *Env, subjectRef string) ids.UUID {
+	t.Helper()
+	created, err := consent.NewStore(e.DB()).CreateDSR(e.Admin(), consent.CreateDSRInput{
+		Kind: "access", SubjectRef: subjectRef,
+		DueAt: time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("seeding an access request: %v", err)
+	}
+	return created.ID
+}
+
+// subjectAddress is the one correspondent these tests are about. Named because
+// TestAnAccessRequestNamingNobodyHasNothingToAssemble asserts against the same
+// string, and the two agreeing is what makes that test about the address rather
+// than about a typo.
+const subjectAddress = "betroffene@example.test"
+
+// seedSubjectWithMail lands a person with an address and one message on their
+// timeline, which is the least a package has to be able to hand back.
+//
+// The person goes through the store that writes one in production, so what the
+// export reads back is the row a real creation makes rather than a shape only
+// this test produces.
+func seedSubjectWithMail(t *testing.T, e *Env) ids.UUID {
+	const address = subjectAddress
+	const subject = "Angebot vom Dienstag"
+	t.Helper()
+	person, err := e.People.CreatePerson(e.Admin(), people.CreatePersonInput{
+		FullName: "Die Betroffene",
+		Source:   "manual",
+		Emails:   []people.PersonEmailInput{{Email: address, EmailType: "work", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatalf("creating the subject: %v", err)
+	}
+	activity := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO activity (id, kind, subject, body, direction, source, captured_by,
+			                      counterparty_email, audience)
+			VALUES ($1, 'email', $2, 'der Nachrichtentext', 'inbound', 'gmail',
+			        'connector:gmail', $3, 'workspace')`, activity, subject, address); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(),
+			`INSERT INTO activity_link (activity_id, entity_type, person_id)
+			 VALUES ($1, 'person', $2)`, activity, person.Id)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the subject's correspondence: %v", err)
+	}
+	return ids.UUID(person.Id)
+}

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -124,6 +124,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// consent never imports its sibling.
 		consentHandlers: consent.NewHandlers(InstallationDB(pool)).
 			WithEraser(privacy.NewEraser(InstallationDB(pool))).
+			WithSubjectAccessAssembler(newSubjectAccessAssembler(InstallationDB(pool))).
 			WithInstallationName(consent.InstallationNameFunc(func(ctx context.Context) (string, error) {
 				return identity.InstallationNameForPublicPage(ctx, pool)
 			})),

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -663,6 +663,10 @@ func (stubs) UpdateDataSubjectRequest(w nethttp.ResponseWriter, r *nethttp.Reque
 	httperr.NotImplemented(w, r, "UpdateDataSubjectRequest")
 }
 
+func (stubs) DownloadDataSubjectPackage(w nethttp.ResponseWriter, r *nethttp.Request, id openapi_types.UUID) {
+	httperr.NotImplemented(w, r, "DownloadDataSubjectPackage")
+}
+
 func (stubs) ListDealRooms(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.ListDealRoomsParams) {
 	httperr.NotImplemented(w, r, "ListDealRooms")
 }

--- a/backend/internal/compose/subjectaccessseam.go
+++ b/backend/internal/compose/subjectaccessseam.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The binding between the subject-request queue and the Art. 15 export.
+//
+// consent owns the queue: which requests exist, who they name, when they are
+// due. privacy owns the export: what the installation actually holds about a
+// person and which of it Art. 15 owes back. Neither may import the other, so
+// the edge is here — the same shape the erase path already uses, because
+// answering an access request is the same species of act as answering an
+// erasure one: the queue records the decision, another module carries it out.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/modules/privacy"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// subjectAccessSeam adapts privacy.AssembleSAR to the interface consent asks
+// for.
+//
+// It serializes here rather than handing the struct across, because the package
+// gains a section every time a new table starts holding subject data — a type
+// mirrored in consent would be a second declaration of what Art. 15 owes, and it
+// would drift one release behind the one piicoverage_test.go checks.
+type subjectAccessSeam struct {
+	db *database.DB
+}
+
+// newSubjectAccessAssembler binds the Art. 15 export over one database.
+func newSubjectAccessAssembler(db *database.DB) *subjectAccessSeam {
+	return &subjectAccessSeam{db: db}
+}
+
+// AssemblePackage answers the serialized Art. 15 package for one subject.
+//
+// Every authority check lives in AssembleSAR and none is repeated here: it takes
+// the person.delete grant, refuses a non-human principal whatever its passport
+// carries, and requires unbounded row scope because Art. 15 owes the subject
+// everything held rather than the slice one colleague may see. A second copy of
+// those checks here would be a second answer to who may read a subject's whole
+// record.
+func (s *subjectAccessSeam) AssemblePackage(ctx context.Context, personID ids.UUID) ([]byte, error) {
+	pkg, err := privacy.AssembleSAR(ctx, s.db, ids.From[ids.PersonKind](personID))
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(pkg)
+	if err != nil {
+		return nil, fmt.Errorf("compose: serializing a subject-access package: %w", err)
+	}
+	return body, nil
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -43907,6 +43907,9 @@ type ServerInterface interface {
 	// Update a data-subject request's status / assignee / resolution.
 	// (PATCH /data-subject-requests/{id})
 	UpdateDataSubjectRequest(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Download the Art. 15 package an access request asks for.
+	// (GET /data-subject-requests/{id}/package)
+	DownloadDataSubjectPackage(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// List Deal Rooms (live by default; cursor-paginated).
 	// (GET /deal-rooms)
 	ListDealRooms(w http.ResponseWriter, r *http.Request, params ListDealRoomsParams)
@@ -46052,6 +46055,12 @@ func (_ Unimplemented) CreateDataSubjectRequest(w http.ResponseWriter, r *http.R
 // Update a data-subject request's status / assignee / resolution.
 // (PATCH /data-subject-requests/{id})
 func (_ Unimplemented) UpdateDataSubjectRequest(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Download the Art. 15 package an access request asks for.
+// (GET /data-subject-requests/{id}/package)
+func (_ Unimplemented) DownloadDataSubjectPackage(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -54579,6 +54588,38 @@ func (siw *ServerInterfaceWrapper) UpdateDataSubjectRequest(w http.ResponseWrite
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateDataSubjectRequest(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DownloadDataSubjectPackage operation middleware
+func (siw *ServerInterfaceWrapper) DownloadDataSubjectPackage(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DownloadDataSubjectPackage(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -72968,6 +73009,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Patch(options.BaseURL+"/data-subject-requests/{id}", wrapper.UpdateDataSubjectRequest)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/data-subject-requests/{id}/package", wrapper.DownloadDataSubjectPackage)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/deal-rooms", wrapper.ListDealRooms)

--- a/backend/internal/modules/consent/dsr.go
+++ b/backend/internal/modules/consent/dsr.go
@@ -30,12 +30,21 @@ import (
 
 // The wire field names a DSR ValidationError carries. A client tells a
 // stale-transition refusal apart from a missing-answer one on this exact
-// string (details.errors[].field), so each is spelled once here rather than
-// retyped at every raise site.
+// string (details.errors[].field), so they are constants here rather than
+// string literals at every raise site — a typo in one raise would answer a
+// field name no client is watching for, and nothing would fail.
 const (
+	fieldKind       = "kind"
 	fieldStatus     = "status"
 	fieldSubjectRef = "subject_ref"
 	fieldResolution = "resolution"
+
+	// The request kinds the handlers branch on. Constants for the same reason
+	// as the field names above, and dsrKindErasure carries the higher stake:
+	// its comparison guards an irreversible scrub, so a typo there skips the
+	// erasure silently and reports the request fulfilled.
+	dsrKindAccess  = "access"
+	dsrKindErasure = "erasure"
 )
 
 // illegalTransition is raised from both guards — the pre-erase check and the

--- a/backend/internal/modules/consent/handlers.go
+++ b/backend/internal/modules/consent/handlers.go
@@ -23,6 +23,10 @@ import (
 type Handlers struct {
 	store  *Store
 	eraser Eraser
+	// The Art. 15 assembler, injected the same way and for the same reason as
+	// the eraser: answering an access request means producing the package, not
+	// marking a row done.
+	assembler SubjectAccessAssembler
 	// The confirm link's two halves, both injected by compose. Either one
 	// missing means the installation cannot deliver, which the send path
 	// reports rather than fails on.
@@ -35,6 +39,20 @@ type Handlers struct {
 // marks a row done.
 type Eraser interface {
 	ErasePerson(ctx context.Context, personID ids.UUID, reason string) error
+}
+
+// SubjectAccessAssembler is the Art. 15 read seam (compose injects the real
+// one). It is a privileged read that deliberately crosses the caller's row
+// scope, because Art. 15 owes the subject everything held rather than the slice
+// one rep may see — privacy.AssembleSAR carries the checks that make that safe,
+// and this interface exists so consent can reach it without importing a sibling.
+//
+// It answers the serialized package rather than a struct, because the shape is
+// privacy's to own: the package gains a section every time a new table starts
+// holding subject data, and a type mirrored here would be a second declaration
+// of what Art. 15 owes, drifting one release behind the one the gate checks.
+type SubjectAccessAssembler interface {
+	AssemblePackage(ctx context.Context, personID ids.UUID) ([]byte, error)
 }
 
 // NewHandlers wires the transport over the installation-bound pool.
@@ -53,6 +71,12 @@ func (h Handlers) WithInstallationName(r InstallationNameReader) Handlers {
 // WithEraser returns a copy wired to the erase path.
 func (h Handlers) WithEraser(e Eraser) Handlers {
 	h.eraser = e
+	return h
+}
+
+// WithSubjectAccessAssembler returns a copy wired to the Art. 15 export.
+func (h Handlers) WithSubjectAccessAssembler(a SubjectAccessAssembler) Handlers {
+	h.assembler = a
 	return h
 }
 

--- a/backend/internal/modules/consent/handlers_dsr.go
+++ b/backend/internal/modules/consent/handlers_dsr.go
@@ -5,6 +5,7 @@ package consent
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -83,7 +84,7 @@ func (h Handlers) UpdateDataSubjectRequest(w http.ResponseWriter, r *http.Reques
 			writeConsentErr(w, r, err)
 			return
 		}
-		if current.Kind == "erasure" {
+		if current.Kind == dsrKindErasure {
 			if h.eraser == nil {
 				// Fail closed: fulfilling an erasure on a surface with no
 				// erase path wired would certify a deletion that never
@@ -106,4 +107,83 @@ func (h Handlers) UpdateDataSubjectRequest(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	httperr.WriteJSON(w, http.StatusOK, wireDSR(updated))
+}
+
+// DownloadDataSubjectPackage answers an Art. 15 access request with the package
+// it asks for.
+//
+// The queue could record an access request and mark it fulfilled with no product
+// path that produced anything, so "fulfilled" meant an officer had said so. This
+// is the path: it assembles what the installation holds about the subject and
+// hands it back, as the file an officer forwards.
+//
+// It does NOT change the request's status. Producing the export and deciding the
+// request is answered are two acts by the same person, and collapsing them would
+// close a request on a download that might have failed to reach anybody — the
+// officer marks it fulfilled through the existing PATCH once they have sent it.
+func (h Handlers) DownloadDataSubjectPackage(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
+	if h.assembler == nil {
+		// Fail closed rather than answer an empty package: a role composed
+		// without the assembler cannot produce an Art. 15 export, and an empty
+		// one would read as "we hold nothing about this person".
+		httperr.ServiceUnavailable(w, r,
+			"this installation cannot assemble a subject-access package here")
+		return
+	}
+	// GetDSR takes the queue's own gate — admin, human, person.read — so
+	// reaching the request is already what reaching any request takes.
+	//
+	// That gate is the narrow one and it has to stay in front. AssembleSAR
+	// admits any unbounded human holding person.delete, which the seeded
+	// defaults give to ops and management as well as admin, so calling it
+	// without reading the request first would make the export reachable by
+	// roles the queue that owns this workflow refuses.
+	request, err := h.store.GetDSR(r.Context(), ids.UUID(id))
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	// An access request, not an erasure or a rectification. The other two kinds
+	// have their own paths and answering them with a package would export a
+	// subject's whole record to close a request that asked for something else.
+	if request.Kind != dsrKindAccess {
+		writeConsentErr(w, r, &ValidationError{
+			Field:  fieldKind,
+			Reason: "only an access request has a package to download",
+		})
+		return
+	}
+	// The same refusal the erasure path gives, for the same reason: subject_ref
+	// is free text until somebody resolves it to a person, and a request naming
+	// nobody has nothing to assemble.
+	personID, parseErr := ids.Parse(request.SubjectRef)
+	if parseErr != nil {
+		writeConsentErr(w, r, &ValidationError{
+			Field:  fieldSubjectRef,
+			Reason: "an access request must name a person id before its package can be assembled",
+		})
+		return
+	}
+	body, err := h.assembler.AssemblePackage(r.Context(), personID)
+	if err != nil {
+		writeConsentErr(w, r, err)
+		return
+	}
+	// Served as a download rather than an inline body: this is a file an officer
+	// forwards to the subject, and naming it after the request is what ties the
+	// copy they sent to the row that recorded it. Through httperr.Download, which
+	// is the one spelling of a download's headers.
+	httperr.Download{
+		ContentType: "application/json",
+		Filename:    "subject-access-" + request.ID.String() + ".json",
+		Size:        int64(len(body)),
+	}.WriteHeaders(w)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		// The status and headers are already on the wire, so this cannot become
+		// an error response. Logged rather than swallowed: a truncated export an
+		// officer forwards as complete is the failure worth knowing about.
+		slog.ErrorContext(r.Context(), "subject-access package was not fully written",
+			"request", request.ID.String(), "error", err)
+	}
 }

--- a/backend/internal/modules/privacy/sar.go
+++ b/backend/internal/modules/privacy/sar.go
@@ -115,8 +115,7 @@ func AssembleSAR(ctx context.Context, db *database.DB, personID ids.PersonID) (S
 	// acting under a passport carries the granting human's live grants, so an
 	// admin's read-scoped passport would otherwise assemble a subject's entire
 	// Art. 15 package — every activity, capture row, correction and outbound
-	// message. Nothing wires this to a route yet, and the arm goes in now
-	// rather than being discovered missing by whoever does.
+	// message.
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.Type != principal.PrincipalHuman {
 		return SARPackage{}, fmt.Errorf("human-only subject-access assembly: %w", apperrors.ErrPermissionDenied)
@@ -126,6 +125,15 @@ func AssembleSAR(ctx context.Context, db *database.DB, personID ids.PersonID) (S
 	// caller cannot run it. Scope is the second condition, not a stand-in for
 	// authority: the person.delete grant above is what limits this to the roles
 	// trusted with erasure, and it is what keeps read_only out.
+	//
+	// Together those two admit MORE than admin: the seeded defaults give
+	// person.delete and row scope `all` to ops and management as well. That is
+	// this function's contract — the erasure trust level — and callers that owe
+	// a narrower one gate before they get here. The subject-request route does:
+	// it reads the request through the queue's own admin-only gate first, which
+	// TestTheQueueGateIsWhatKeepsTheExportAdminOnly pins from both sides. A
+	// future caller assembling from a person id alone would be reachable by two
+	// more roles, and would need its own gate.
 	if !auth.Unbounded(actor) {
 		return SARPackage{}, apperrors.ErrPermissionDenied
 	}

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -405,7 +405,6 @@ internal/modules/comms/seams.go#func rfc8058Post
 internal/modules/comms/seams.go#type deliveryStore
 internal/modules/comms/store_channel_integration_test.go#func TestStagingAChannelDeliveryWithNoBodyIsRefused
 internal/modules/consent/doi.go#const purposeIDField
-internal/modules/consent/dsr.go#const block at const fieldStatus
 internal/modules/consent/dsr.go#const dsrSelectByID
 internal/modules/consent/dsr.go#func validateDSRUpdate
 internal/modules/consent/gate.go#func grantedForRecipient

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (60)
+## Parity (61)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -69,6 +69,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `overdueboundary_test.go` | H1 | "Is this late?" is one question about one record, and a reader can ask it of a list, a card, a brief or an agent tool. |
 | `personalpurgewindow_test.go` | H3 | The page that names a deletion date and the sweep that carries it out must read ONE window, or the product promises a date it does not keep. |
 | `pollcadenceparity_test.go` | H3 | A connector that POSTPONES a tick on an unreachable provider asks to run again after a fixed delay, and that delay has to EQUAL the cadence its dispatcher already ticks at — and has to survive the seam's ceiling on the way to the queue. |
+| `processingrecord_test.go` | H3 | The Art. 30 processing record names the code that enforces each entry, and this fails when that code is not there any more. |
 | `providername_test.go` | H2 | The rule a REGISTERED NAME must satisfy is the contract's, on both surfaces that have one. |
 | `publicevents_test.go` | H3 | The public-events contract as a cross-cutting fitness function (A15): the outbound-webhook surface has three moving parts that must stay in lock-step, and nothing in the build forces them to. |
 | `rbacvocabulary_test.go` | H3 | The RBAC vocabulary is DECLARED in the contract and restated in Go, and the two must not drift. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -7937,6 +7937,57 @@ export interface paths {
         patch: operations["updateDataSubjectRequest"];
         trace?: never;
     };
+    "/data-subject-requests/{id}/package": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Download the Art. 15 package an access request asks for.
+         * @description Assembles everything this installation holds about the subject and hands it back as a file
+         *     to forward to them: their record and its identifiers, the conversations they were party to
+         *     and what was said in them, the attachments, consent and its history, what they themselves
+         *     submitted through a confirm link, what was read about them from public sources, and the
+         *     provider originals behind the captured mail.
+         *
+         *     A privileged read that deliberately crosses the caller's own row scope, because Art. 15
+         *     owes the subject everything held rather than the slice one colleague may see. So it takes
+         *     the same trust erasure does: an ADMIN, human, holding `person.delete`, with unbounded row
+         *     scope. An agent is refused whatever its passport carries — an admin's read-scoped passport
+         *     would otherwise assemble a subject's entire record.
+         *
+         *     Only an `access` request has a package. An erasure or a rectification is answered by its
+         *     own path, and handing back a subject's whole record to close a request that asked for
+         *     something else would be the export nobody asked for.
+         *
+         *     The request's `subject_ref` must name a person id. It is free text until somebody resolves
+         *     it, and a request naming nobody has nothing to assemble — the same refusal fulfilling an
+         *     erasure gives, for the same reason. A `subject_ref` that is not a person id at all answers
+         *     422; one that is a well-formed id naming no person answers 404. The two look identical on a
+         *     stale request row and are worth telling apart.
+         *
+         *     **The download is recorded.** Assembling a package writes an audit entry against the person
+         *     — action `export`, naming the officer who asked and how much it carried. That record is what
+         *     makes a read this privileged acceptable, and it is written whether or not the package
+         *     reaches anybody.
+         *
+         *     This does NOT change the request's status. Producing the export and deciding the request is
+         *     answered are two acts by the same person: mark it fulfilled through the PATCH once you have
+         *     sent it, so a download that never reached anybody does not close the row.
+         */
+        get: operations["downloadDataSubjectPackage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/audit-log": {
         parameters: {
             query?: never;
@@ -39857,6 +39908,30 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DataSubjectRequest"];
+                };
+            };
+        };
+    };
+    downloadDataSubjectPackage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The package, as a JSON file named after the request. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };


### PR DESCRIPTION
Two compliance gaps, one PR's worth of thinking.

## 1. The export nobody could reach

`privacy.AssembleSAR` had **zero production callers**. Every call site was a test or a gate waiver, and its own comment said so: *"Nothing wires this to a route yet, and the arm goes in now rather than being discovered missing by whoever does."*

`/data-subject-requests` existed, but it is a **ticket tracker**: list, create, update status. So an operator could log an Art. 15 request and mark it `fulfilled` with no product path that produced anything — the word meant somebody had said so.

`GET /data-subject-requests/{id}/package` is the path.

**It does not change the request's status.** Producing the export and deciding the request is answered are two acts by the same person. Collapsing them closes a row on a download that might never have reached anybody, so the officer marks it fulfilled through the existing PATCH once they have sent it.

## The authority is narrower than the assembler's

This is the part worth reading twice.

`AssembleSAR` gates on `person.delete` + human + unbounded row scope. The seeded RBAC defaults:

| role | `person.delete` | row scope | passes AssembleSAR alone? |
|---|---|---|---|
| **admin** | ✅ | all | ✅ |
| **ops** | ✅ | all | ✅ |
| **management** | ✅ | all | ✅ |
| manager | ✅ | **team** | ❌ (bounded) |
| rep / read_only | ❌ | — | ❌ |

So **the assembler alone admits three roles**, while the queue that owns this workflow is admin-only.

What closes the gap is reading the request first: `GetDSR` takes `requireDSRAdmin` → `auth.RequireAdmin`. The handler reaches the request before it assembles anything, so the route is gated by the narrower of the two.

`TestTheQueueGateIsWhatKeepsTheExportAdminOnly` pins **both halves** — that ops passes the assembler, and that ops is refused by the queue. A future handler assembling from a person id in the path instead would silently be reachable by two more roles, and that test fails when the reason stops being true. `AssembleSAR`'s own comment now says this rather than implying the grant is admin-shaped.

## Two refusals it owes

- **Only an `access` request has a package.** An erasure or a rectification is answered by its own path, and handing back a subject's whole record to close a request that asked for something else is the export nobody asked for.
- **`subject_ref` must name a person id.** It is free text until somebody resolves it, and a request naming nobody has nothing to assemble — the same refusal fulfilling an erasure gives, for the same reason.

## The seam hands bytes

consent owns the queue; privacy owns the export; neither may import the other, so the edge is a `compose/*seam*.go` file — the shape the erase path already uses, because answering an access request is the same species of act as answering an erasure one.

It returns `[]byte` rather than a struct **on purpose**: the package gains a section every time a new table starts holding subject data, and a type mirrored in consent would be a second declaration of what Art. 15 owes, drifting one release behind the one `piicoverage_test.go` checks for completeness.

## 2. The Art. 30 gate

No gate held the processing record, so a document naming code that had since moved would go on reading as a promise.

Every processing activity in the German record carries a `Durchsetzung` row naming the file that carries it out. That citation is the only part of the document a test can hold — and it is the part that breaks **by accident**, when code moves and the prose does not.

`TestTheProcessingRecordCitesCodeThatExists` **derives its subjects from the document** rather than listing them, per the rulebook's rule that a gate hard-coding part of its subject has become a second copy of it. A new activity added to the record with a bad path fails, where a hard-coded list would pass while only knowing the old ones.

It fails in **both directions**:

| mutation | what failed |
|---|---|
| rename a cited file away | `cites capture/sinkactivityrenamed.go, which is not in the tree` |
| strip every citation | `cites no Go file at all — a record that names no code is a promise nothing holds` |

The second is the vacuous pass a census must not have.

**What it deliberately does not check**, said in the file rather than left to be assumed: whether the named file still *does* what the row claims. No test can read that. The obligation held is narrower — that a reader following the citation arrives somewhere.

## Gates

`make check-backend` **exit 0** after the final rebase. `make check-fe` green. `make craft-static`, `make rls-store-path`, `make no-jurisdiction` green. Seven integration tests. No migration.

One piece of pre-existing debt was paid off along the way: a "spelled once" claim in `consent/dsr.go` that named no gate and sat in the uniqueness-claims register. Reworded to state the reason without claiming uniqueness, the register entry deleted and the census lowered 178 → 177.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a production Art. 15 export path: `GET /data-subject-requests/{id}/package` now downloads a JSON package for an access request instead of leaving fulfillment as a status-only action. The route is admin-only, records the export audit, and leaves request status unchanged.

**Access package**

- Requires an `access` request whose `subject_ref` resolves to a person.
- Keeps the queue's admin-only gate ahead of the broader erasure-level assembler authority and rejects agents.
- Connects consent to privacy through a compose seam that returns serialized package bytes.
- Serves the download named after the request id and fails closed with 503 when no assembler is wired.

**Compliance gate**

- Adds an Art. 30 parity gate that derives Go-file citations from the processing record and rejects missing, empty, or ambiguous references.
- Removes the obsolete uniqueness claim.

<sup>Written for commit 7f6c220afd903f87fd8cb8bec7731eae395e534a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a human-only download option for JSON data-subject access packages.
  - Downloads require cookie authentication, validate the request and subject, and do not change request status.
  - Packages include the authorized subject data and enforce applicable permissions and access-request restrictions.

- **Bug Fixes**
  - Improved handling of invalid requests, unauthorized access, unresolved subjects, assembly failures, and incomplete downloads.

- **Tests**
  - Added coverage for package contents, serialization, authorization, and processing-record references.

- **Documentation**
  - Updated compliance gate inventory and access-package behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->