### PR TITLE
One read for a record's tags, and who put them there

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -7983,6 +7983,9 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/RecordTagsResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
+        # A caller lacking read on the RECORD type is refused outright. Lacking
+        # the tag vocabulary is not a refusal — that answers 200 with withheld.
+        '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
 

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -7944,6 +7944,48 @@ paths:
         '409': { $ref: '#/components/responses/Conflict' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
+  /records/{entity_type}/{entity_id}/tags:
+    parameters:
+      - name: entity_type
+        in: path
+        required: true
+        schema: { type: string, enum: [person, organization, deal] }
+      - name: entity_id
+        in: path
+        required: true
+        schema: { type: string, format: uuid }
+    get:
+      tags: [Tags]
+      operationId: getRecordTags
+      x-mcp-tool: { verb: get_record_tags, record_type: tag, tier: auto_execute, scope: read }
+      summary: The tags on one record, and who put them there.
+      description: |
+        ONE read for all three record types, because the panel that draws them is one
+        component: a per-type block on each record response would be three copies of one
+        shape, and they would drift.
+
+        Each assignment carries who applied it and when, which the record page shows beside
+        the tag. `assigned_by` is absent for assignments made before the product recorded
+        it — absent means unknown, never "the system".
+
+        The three advertised types only. `taggable` admits lead and project, and this route
+        refuses them: a read that answered for a type no screen offers would be a surface
+        nobody meant to ship.
+
+        Withheld is not empty. A caller who may read the record but not the tag vocabulary
+        gets `withheld: true` and no assignments — distinguishable from a record that simply
+        carries none, because "no tags" is a claim about the record and this caller cannot
+        make it.
+      responses:
+        '200':
+          description: The record's tags.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RecordTagsResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
+
   /tags/{id}/apply:
     parameters:
       - $ref: '#/components/parameters/Id'
@@ -29253,6 +29295,44 @@ components:
         name: { type: string, maxLength: 64 }
         color: { type: [string, 'null'], enum: [teal, amber, rose, slate, null] }
         description: { type: [string, 'null'] }
+
+    RecordTagsResponse:
+      type: object
+      description: |
+        What one record carries. `withheld` says the caller could not read the vocabulary,
+        which is why `data` is empty — a reader has to be able to tell that from a record
+        with no tags on it.
+      required: [data, withheld]
+      properties:
+        data: { type: array, items: { $ref: '#/components/schemas/RecordTag' } }
+        withheld: { type: boolean }
+
+    RecordTag:
+      type: object
+      description: One tag on one record, with the assignment that put it there.
+      required: [tag_id, name, archived, assigned_at]
+      properties:
+        tag_id: { type: string, format: uuid }
+        name: { type: string }
+        color: { type: [string, 'null'], enum: [teal, amber, rose, slate, null] }
+        description: { type: [string, 'null'] }
+        # Archived tags stay ON the records that carry them: retiring a word
+        # stops it being applied, it does not un-tag a history that was true.
+        # The panel draws them muted rather than hiding them.
+        archived: { type: boolean }
+        assigned_at: { type: string, format: date-time }
+        # Absent when the assignment predates the product recording it. A reader
+        # sees "added on 3 March" with no name rather than a name nobody chose.
+        assigned_by: { $ref: '#/components/schemas/RecordTagAssigner' }
+
+    RecordTagAssigner:
+      type: object
+      description: Who applied a tag. `kind` says by what hand, which a reader needs to tell a colleague's choice from an import's.
+      required: [kind]
+      properties:
+        user_id: { type: [string, 'null'], format: uuid }
+        display_name: { type: [string, 'null'] }
+        kind: { type: string, enum: [human, agent, import] }
 
     TagDetail:
       type: object

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -282,6 +282,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/projects/{id}/360":                                          {Op: "getProject360", Access: "tool", Tool: "read_project_360", RecordType: "project", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/provider-connections":                                       {Op: "listProviderConnections", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/record-grants":                                              {Op: "listRecordGrants", Access: "tool", Tool: "search_records", RecordType: "record_grant", Tier: "auto_execute", Scope: "read"},
+	"GET /v1/records/{entity_type}/{entity_id}/tags":                     {Op: "getRecordTags", Access: "tool", Tool: "get_record_tags", RecordType: "tag", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/records/{entity_type}/{id}/context":                         {Op: "getRecordContext", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/records/{entity_type}/{id}/history":                         {Op: "getRecordHistory", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/retention-policies":                                         {Op: "listRetentionPolicies", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/integration/collections/recordtags_integration_test.go
+++ b/backend/internal/compose/integration/collections/recordtags_integration_test.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package collections
+
+// The read behind the record page's tag panel.
+//
+// Every claim here is about permissions or rows, so a stub proves none of it:
+// whether a caller outside their row scope gets not-found, whether a caller
+// without the vocabulary gets a withheld answer rather than an empty one, and
+// what the assignment actually recorded.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+type recordTagsBody struct {
+	Data []struct {
+		TagID      string  `json:"tag_id"`
+		Name       string  `json:"name"`
+		Archived   bool    `json:"archived"`
+		AssignedAt string  `json:"assigned_at"`
+		Color      *string `json:"color"`
+		AssignedBy *struct {
+			UserID      *string `json:"user_id"`
+			DisplayName *string `json:"display_name"`
+			Kind        string  `json:"kind"`
+		} `json:"assigned_by"`
+	} `json:"data"`
+	Withheld bool `json:"withheld"`
+}
+
+func readRecordTags(t *testing.T, e *apptest.AppEnv, entityType, id string) (recordTagsBody, int) {
+	t.Helper()
+	var body recordTagsBody
+	status := e.Call(t, "GET", "/v1/records/"+entityType+"/"+id+"/tags", nil, nil, &body)
+	return body, status
+}
+
+// One route, three types: the panel that draws them is one component, and a
+// per-type block on each record response would be three copies that drift.
+func TestRecordTagsAnswersForAllThreeAdvertisedTypes(t *testing.T) {
+	e := tagEnv(t)
+	tag := createTag(t, e, "Cross Type")
+
+	person := createPersonWithTag(t, e, "Tagged Person", tag)
+
+	var org integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/organizations", integration.AnyMap{
+		"display_name": "Tagged Company", "source": "ui",
+	}, nil, &org); status != http.StatusCreated {
+		t.Fatalf("creating the company: status=%d body=%v", status, org)
+	}
+	orgID, _ := org["id"].(string)
+	var applied integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/tags/"+tag+"/apply", integration.AnyMap{
+		"entity_type": "organization", "entity_id": orgID,
+	}, nil, &applied); status != http.StatusCreated {
+		t.Fatalf("tagging the company: status=%d body=%v", status, applied)
+	}
+
+	for _, c := range []struct{ entityType, id string }{
+		{"person", person},
+		{"organization", orgID},
+	} {
+		body, status := readRecordTags(t, e, c.entityType, c.id)
+		if status != http.StatusOK {
+			t.Fatalf("%s: status=%d", c.entityType, status)
+		}
+		if len(body.Data) != 1 || body.Data[0].Name != "Cross Type" {
+			t.Errorf("%s carries %+v, want the one tag", c.entityType, body.Data)
+		}
+		if body.Withheld {
+			t.Errorf("%s reads as withheld for a caller who may read the vocabulary", c.entityType)
+		}
+	}
+}
+
+// The assignment says WHO, which is the half the panel shows beside the word.
+func TestRecordTagsNamesWhoAppliedTheTag(t *testing.T) {
+	e := tagEnv(t)
+	tag := createTag(t, e, "Applied By Someone")
+	person := createPersonWithTag(t, e, "Tagged", tag)
+
+	body, status := readRecordTags(t, e, "person", person)
+	if status != http.StatusOK {
+		t.Fatalf("status=%d", status)
+	}
+	if len(body.Data) != 1 {
+		t.Fatalf("data = %+v, want one assignment", body.Data)
+	}
+	got := body.Data[0]
+	if got.AssignedBy == nil {
+		t.Fatal("the assignment names nobody; the panel cannot say who put the tag there")
+	}
+	if got.AssignedBy.Kind != "human" {
+		t.Errorf("kind = %q, want human — a session applied this", got.AssignedBy.Kind)
+	}
+	if got.AssignedBy.UserID == nil || *got.AssignedBy.UserID == "" {
+		t.Error("the assignment carries no user id")
+	}
+	if got.AssignedAt == "" {
+		t.Error("the assignment carries no instant")
+	}
+}
+
+// Withheld is NOT empty. A caller who may read the record but not the
+// vocabulary has to be distinguishable from one looking at a record with no
+// tags, because "no tags" is a claim about the record they cannot make.
+func TestRecordTagsWithheldIsNotTheSameAsEmpty(t *testing.T) {
+	e := tagEnv(t)
+	tag := createTag(t, e, "Hidden Word")
+	tagged := createPersonWithTag(t, e, "Has A Tag", tag)
+	untagged := createPersonWithTag(t, e, "Has No Tags")
+
+	// The genuinely empty record first, while the caller still holds the
+	// vocabulary: it has to read as NOT withheld, which is the distinction the
+	// flag exists to carry.
+	emptyBody, status := readRecordTags(t, e, "person", untagged)
+	if status != http.StatusOK {
+		t.Fatalf("reading the untagged person: status=%d", status)
+	}
+	if emptyBody.Withheld {
+		t.Error("a record with no tags reads as withheld; the panel would say the wrong thing")
+	}
+	if len(emptyBody.Data) != 0 {
+		t.Errorf("the untagged person carries %+v", emptyBody.Data)
+	}
+
+	// Now take the vocabulary away and read the TAGGED record. Revoking on the
+	// role document is what the product itself reads, so this is the same
+	// refusal a rep in a workspace without the grant would meet.
+	revokeTagRead(t, e)
+
+	withheldBody, status := readRecordTags(t, e, "person", tagged)
+	if status != http.StatusOK {
+		t.Fatalf("reading as a caller without the vocabulary: status=%d", status)
+	}
+	if !withheldBody.Withheld {
+		t.Error("a caller without tag.read did not get withheld=true")
+	}
+	if len(withheldBody.Data) != 0 {
+		t.Errorf("withheld answer carries %d assignments, want none", len(withheldBody.Data))
+	}
+}
+
+// revokeTagRead drops tag.read from every system role in the workspace, so the
+// session's own caller loses the vocabulary.
+func revokeTagRead(t *testing.T, e *apptest.AppEnv) {
+	t.Helper()
+	if _, err := e.Owner.Exec(context.Background(), `
+		UPDATE role SET permissions = jsonb_set(
+			permissions, '{objects,tag}',
+			'{"create": false, "read": false, "update": false, "delete": false}'::jsonb, true)
+		 WHERE is_system`); err != nil {
+		t.Fatalf("revoking tag.read: %v", err)
+	}
+}
+
+// A retired word stays ON the record — archiving stops a tag being applied, it
+// does not un-tag a history that was true — and rides marked so the panel can
+// mute it rather than hide it.
+func TestRecordTagsCarriesArchivedWordsMarked(t *testing.T) {
+	e := tagEnv(t)
+	tag := createTag(t, e, "Retired Word")
+	person := createPersonWithTag(t, e, "Tagged Before Retirement", tag)
+
+	var archived integration.AnyMap
+	if status := e.Call(t, "DELETE", "/v1/tags/"+tag, nil, nil, &archived); status != http.StatusOK {
+		t.Fatalf("archiving: status=%d body=%v", status, archived)
+	}
+
+	body, status := readRecordTags(t, e, "person", person)
+	if status != http.StatusOK {
+		t.Fatalf("status=%d", status)
+	}
+	if len(body.Data) != 1 {
+		t.Fatalf("data = %+v, want the retired word still on the record", body.Data)
+	}
+	if !body.Data[0].Archived {
+		t.Error("the retired word does not ride marked; the panel would draw it as current")
+	}
+}
+
+// The three advertised types only. `taggable` admits lead and project, and
+// answering for them here would ship a surface no screen offers.
+func TestRecordTagsRefusesATypeItDoesNotServe(t *testing.T) {
+	e := tagEnv(t)
+	var problem integration.AnyMap
+	if status := e.Call(t, "GET", "/v1/records/lead/"+ids.NewV7().String()+"/tags", nil, nil, &problem); status != http.StatusUnprocessableEntity {
+		t.Fatalf("reading a lead's tags: status=%d body=%v, want 422", status, problem)
+	}
+}

--- a/backend/internal/compose/integration/collections/recordtags_integration_test.go
+++ b/backend/internal/compose/integration/collections/recordtags_integration_test.go
@@ -67,9 +67,29 @@ func TestRecordTagsAnswersForAllThreeAdvertisedTypes(t *testing.T) {
 		t.Fatalf("tagging the company: status=%d body=%v", status, applied)
 	}
 
+	// A deal too: the test name claims three types, and two of them passing
+	// says nothing about the third — deal is the one whose row scope differs
+	// most from a person's.
+	stages := apptest.DiscoverSeededPipeline(t, e)
+	var deal integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals", integration.AnyMap{
+		"name": "Tagged Deal", "pipeline_id": stages.PipelineID,
+		"stage_id": stages.Open, "source": "manual",
+	}, nil, &deal); status != http.StatusCreated {
+		t.Fatalf("creating the deal: status=%d body=%v", status, deal)
+	}
+	dealID, _ := deal["id"].(string)
+	var dealTagged integration.AnyMap
+	if status := e.Call(t, "POST", "/v1/tags/"+tag+"/apply", integration.AnyMap{
+		"entity_type": "deal", "entity_id": dealID,
+	}, nil, &dealTagged); status != http.StatusCreated {
+		t.Fatalf("tagging the deal: status=%d body=%v", status, dealTagged)
+	}
+
 	for _, c := range []struct{ entityType, id string }{
 		{"person", person},
 		{"organization", orgID},
+		{"deal", dealID},
 	} {
 		body, status := readRecordTags(t, e, c.entityType, c.id)
 		if status != http.StatusOK {

--- a/backend/internal/compose/integration/recordtagsscope_integration_test.go
+++ b/backend/internal/compose/integration/recordtagsscope_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+
 	"github.com/margince/margince/backend/internal/modules/collections"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"

--- a/backend/internal/compose/integration/recordtagsscope_integration_test.go
+++ b/backend/internal/compose/integration/recordtagsscope_integration_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// What the record-tags read hides, and what it deliberately does not.
+//
+// A first draft of this file asserted that a rep reading another rep's person
+// gets not-found. That is NOT this product's rule: customer identity is
+// workspace-readable (auth/tableclass_test.go pins it), so every seat reads
+// every person and the WRITE arm is what keeps a row its owner's. The test
+// failed, a control showed the shared row-scope helper admitting the same
+// record, and the rule turned out to be the deliberate one.
+//
+// What actually hides a record is capture privacy: a captured person answers
+// to its owner alone until somebody promotes or shares it. That is the case
+// worth pinning here, because it is the one where this read could leak.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/margince/margince/backend/internal/modules/collections"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// ownPersonAndTagPerms reads its own person rows and the vocabulary — narrow
+// enough that a refusal is about the record rather than about the tags.
+func ownPersonAndTagPerms() principal.Permissions {
+	return principal.Permissions{
+		Objects: map[string]principal.ObjectGrant{
+			"person": {Read: true},
+			"tag":    {Read: true},
+		},
+		RowScope: principal.RowScopeOwn,
+	}
+}
+
+// An owner-private captured person is invisible to another seat, and the tags
+// on it must be too — otherwise this read becomes the side channel that says a
+// private contact exists and what somebody labelled them.
+//
+// Not-found, never forbidden: a refusal saying "you may not read this" would
+// confirm the record to a caller who cannot see it.
+func TestRecordTagsHidesAnOwnerPrivateCapture(t *testing.T) {
+	e := Setup(t)
+	store := collections.NewStore(e.DB())
+
+	person := e.SeedPerson(t, "A Private Capture", &e.Rep1)
+	makeCapturePrivate(t, e, person, e.Rep1)
+
+	ctx := e.As(e.Rep3, nil, ownPersonAndTagPerms())
+	_, err := store.RecordTagsFor(ctx, "person", person)
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("reading an owner-private capture answered %v, want not-found — "+
+			"the tags on a private contact are as private as the contact", err)
+	}
+}
+
+// The owner of that same private capture still reads it, which is what makes
+// the refusal above about privacy rather than about the grants.
+func TestRecordTagsAnswersForThePrivateCapturesOwner(t *testing.T) {
+	e := Setup(t)
+	store := collections.NewStore(e.DB())
+
+	person := e.SeedPerson(t, "A Private Capture", &e.Rep1)
+	makeCapturePrivate(t, e, person, e.Rep1)
+
+	ctx := e.As(e.Rep1, nil, ownPersonAndTagPerms())
+	read, err := store.RecordTagsFor(ctx, "person", person)
+	if err != nil {
+		t.Fatalf("the owner reading their own private capture answered %v", err)
+	}
+	if read.Withheld {
+		t.Error("a caller holding tag.read got a withheld answer")
+	}
+}
+
+// makeCapturePrivate marks a person as an owner-private capture, the state a
+// mail or business-card import produces before anybody promotes it.
+func makeCapturePrivate(t *testing.T, e *Env, person ids.UUID, owner ids.UUID) {
+	t.Helper()
+	err := e.DB().Tx(e.Admin(), func(tx pgx.Tx) error {
+		_, execErr := tx.Exec(e.Admin(),
+			`UPDATE person SET visibility = 'owner', owner_id = $2 WHERE id = $1`,
+			person, owner)
+		return execErr
+	})
+	if err != nil {
+		t.Fatalf("making the capture private: %v", err)
+	}
+}

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -275,6 +275,9 @@ var unreachableInThisLane = gatekit.Waive(map[string]string{
 	"get_tag": "same missing tag.read as apply_tag above. It answers ONE row of the shape list_tags " +
 		"answers many of, so the two are unproven together rather than one covering the other — " +
 		"whichever seat eventually carries tag.read reaches both",
+	"get_record_tags": "same missing tag.read as apply_tag above. Its answer shape IS held, " +
+		"against a real database, by the record-tags integration suite — including the withheld " +
+		"case, which is the one a schema alone could not prove",
 	"book_meeting":         "needs a live calendar provider",
 	"send_email":           "needs an outbound mail provider",
 	"send_account_email":   "needs an outbound mail provider, and a send-capable mailbox for its pre-flight",

--- a/backend/internal/compose/org360/collections.go
+++ b/backend/internal/compose/org360/collections.go
@@ -18,6 +18,12 @@ import (
 )
 
 // tagsSection reads the tags applied to the account.
+//
+// A SECOND reader of the same fact, kept deliberately and only until the
+// company panel moves onto GET /records/{type}/{id}/tags — the one read that
+// serves person, company and deal alike and carries the assigner this one
+// cannot. Removing it here first would break the shipped panel, which still
+// draws from this block. It goes when the panel does.
 func tagsSection(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) ([]crmcontracts.Tag, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT t.id, t.name, t.color, t.created_at, t.updated_at, t.archived_at

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -1803,6 +1803,10 @@ func (stubs) RevokeRecordGrant(w nethttp.ResponseWriter, r *nethttp.Request, id 
 	httperr.NotImplemented(w, r, "RevokeRecordGrant")
 }
 
+func (stubs) GetRecordTags(w nethttp.ResponseWriter, r *nethttp.Request, entityType string, entityId openapi_types.UUID) {
+	httperr.NotImplemented(w, r, "GetRecordTags")
+}
+
 func (stubs) GetRecordContext(w nethttp.ResponseWriter, r *nethttp.Request, entityType string, id crmcontracts.Id, params crmcontracts.GetRecordContextParams) {
 	httperr.NotImplemented(w, r, "GetRecordContext")
 }

--- a/backend/internal/compose/tagseam.go
+++ b/backend/internal/compose/tagseam.go
@@ -9,6 +9,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -82,6 +83,34 @@ func (a tagAdapter) GetTag(ctx context.Context, tagID ids.UUID) (agents.TagDetai
 	}
 	return out, nil
 }
+
+// RecordTags hands the record-tag read across. The tool and the record page
+// read the SAME store method, so a model and a person looking at one company
+// cannot be told different things about who tagged it.
+func (a tagAdapter) RecordTags(ctx context.Context, entityType string, entityID ids.UUID) (agents.RecordTagsResult, error) {
+	read, err := a.store.RecordTagsFor(ctx, entityType, entityID)
+	if err != nil {
+		return agents.RecordTagsResult{}, err
+	}
+	out := agents.RecordTagsResult{
+		Tags:     make([]agents.RecordTagOnRecord, 0, len(read.Data)),
+		Withheld: read.Withheld,
+	}
+	for _, t := range read.Data {
+		out.Tags = append(out.Tags, agents.RecordTagOnRecord{
+			TagID:          t.TagID,
+			Name:           t.Name,
+			Archived:       t.Archived,
+			AssignedBy:     t.AssignedByName,
+			AssignedByKind: t.AssignedByKind,
+			AssignedAt:     t.AssignedAt.Format(time.RFC3339),
+		})
+	}
+	return out, nil
+}
+
+// RecordTagTypes answers the store's own list of served types.
+func (a tagAdapter) RecordTagTypes() []string { return collections.RecordTagTypesServed() }
 
 // ListTags hands the collections module's own cross-module shape straight
 // through: TagVocabulary was written for a caller outside that module and

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -9289,6 +9289,51 @@ func (e RecordQualifyingEventRequestKind) Valid() bool {
 	}
 }
 
+// Defines values for RecordTagColor.
+const (
+	RecordTagColorAmber RecordTagColor = "amber"
+	RecordTagColorRose  RecordTagColor = "rose"
+	RecordTagColorSlate RecordTagColor = "slate"
+	RecordTagColorTeal  RecordTagColor = "teal"
+)
+
+// Valid indicates whether the value is a known member of the RecordTagColor enum.
+func (e RecordTagColor) Valid() bool {
+	switch e {
+	case RecordTagColorAmber:
+		return true
+	case RecordTagColorRose:
+		return true
+	case RecordTagColorSlate:
+		return true
+	case RecordTagColorTeal:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for RecordTagAssignerKind.
+const (
+	RecordTagAssignerKindAgent  RecordTagAssignerKind = "agent"
+	RecordTagAssignerKindHuman  RecordTagAssignerKind = "human"
+	RecordTagAssignerKindImport RecordTagAssignerKind = "import"
+)
+
+// Valid indicates whether the value is a known member of the RecordTagAssignerKind enum.
+func (e RecordTagAssignerKind) Valid() bool {
+	switch e {
+	case RecordTagAssignerKindAgent:
+		return true
+	case RecordTagAssignerKindHuman:
+		return true
+	case RecordTagAssignerKindImport:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for RecordViewAckEntityType.
 const (
 	RecordViewAckEntityTypeOrganization RecordViewAckEntityType = "organization"
@@ -10431,22 +10476,22 @@ func (e TagColor) Valid() bool {
 
 // Defines values for TagDetailColor.
 const (
-	Amber TagDetailColor = "amber"
-	Rose  TagDetailColor = "rose"
-	Slate TagDetailColor = "slate"
-	Teal  TagDetailColor = "teal"
+	TagDetailColorAmber TagDetailColor = "amber"
+	TagDetailColorRose  TagDetailColor = "rose"
+	TagDetailColorSlate TagDetailColor = "slate"
+	TagDetailColorTeal  TagDetailColor = "teal"
 )
 
 // Valid indicates whether the value is a known member of the TagDetailColor enum.
 func (e TagDetailColor) Valid() bool {
 	switch e {
-	case Amber:
+	case TagDetailColorAmber:
 		return true
-	case Rose:
+	case TagDetailColorRose:
 		return true
-	case Slate:
+	case TagDetailColorSlate:
 		return true
-	case Teal:
+	case TagDetailColorTeal:
 		return true
 	default:
 		return false
@@ -14190,34 +14235,34 @@ func (e GetWorklistParamsScope) Valid() bool {
 
 // Defines values for GetWorklistParamsFilter.
 const (
-	All             GetWorklistParamsFilter = "all"
-	CustomerWaiting GetWorklistParamsFilter = "customer_waiting"
-	DealsAtRisk     GetWorklistParamsFilter = "deals_at_risk"
-	Decisions       GetWorklistParamsFilter = "decisions"
-	Leads           GetWorklistParamsFilter = "leads"
-	Meetings        GetWorklistParamsFilter = "meetings"
-	System          GetWorklistParamsFilter = "system"
-	Tasks           GetWorklistParamsFilter = "tasks"
+	GetWorklistParamsFilterAll             GetWorklistParamsFilter = "all"
+	GetWorklistParamsFilterCustomerWaiting GetWorklistParamsFilter = "customer_waiting"
+	GetWorklistParamsFilterDealsAtRisk     GetWorklistParamsFilter = "deals_at_risk"
+	GetWorklistParamsFilterDecisions       GetWorklistParamsFilter = "decisions"
+	GetWorklistParamsFilterLeads           GetWorklistParamsFilter = "leads"
+	GetWorklistParamsFilterMeetings        GetWorklistParamsFilter = "meetings"
+	GetWorklistParamsFilterSystem          GetWorklistParamsFilter = "system"
+	GetWorklistParamsFilterTasks           GetWorklistParamsFilter = "tasks"
 )
 
 // Valid indicates whether the value is a known member of the GetWorklistParamsFilter enum.
 func (e GetWorklistParamsFilter) Valid() bool {
 	switch e {
-	case All:
+	case GetWorklistParamsFilterAll:
 		return true
-	case CustomerWaiting:
+	case GetWorklistParamsFilterCustomerWaiting:
 		return true
-	case DealsAtRisk:
+	case GetWorklistParamsFilterDealsAtRisk:
 		return true
-	case Decisions:
+	case GetWorklistParamsFilterDecisions:
 		return true
-	case Leads:
+	case GetWorklistParamsFilterLeads:
 		return true
-	case Meetings:
+	case GetWorklistParamsFilterMeetings:
 		return true
-	case System:
+	case GetWorklistParamsFilterSystem:
 		return true
-	case Tasks:
+	case GetWorklistParamsFilterTasks:
 		return true
 	default:
 		return false
@@ -26835,6 +26880,40 @@ type RecordQualifyingEventRequest struct {
 // active_deal — are DERIVED from records the product already holds, and a hand-written
 // one would be a second, unbacked answer to a question the data already settles.
 type RecordQualifyingEventRequestKind string
+
+// RecordTag One tag on one record, with the assignment that put it there.
+type RecordTag struct {
+	Archived   bool      `json:"archived"`
+	AssignedAt time.Time `json:"assigned_at"`
+
+	// AssignedBy Who applied a tag. `kind` says by what hand, which a reader needs to tell a colleague's choice from an import's.
+	AssignedBy  *RecordTagAssigner `json:"assigned_by,omitempty"`
+	Color       *RecordTagColor    `json:"color,omitempty"`
+	Description *string            `json:"description,omitempty"`
+	Name        string             `json:"name"`
+	TagId       openapi_types.UUID `json:"tag_id"`
+}
+
+// RecordTagColor defines model for RecordTag.Color.
+type RecordTagColor string
+
+// RecordTagAssigner Who applied a tag. `kind` says by what hand, which a reader needs to tell a colleague's choice from an import's.
+type RecordTagAssigner struct {
+	DisplayName *string               `json:"display_name,omitempty"`
+	Kind        RecordTagAssignerKind `json:"kind"`
+	UserId      *openapi_types.UUID   `json:"user_id,omitempty"`
+}
+
+// RecordTagAssignerKind defines model for RecordTagAssigner.Kind.
+type RecordTagAssignerKind string
+
+// RecordTagsResponse What one record carries. `withheld` says the caller could not read the vocabulary,
+// which is why `data` is empty — a reader has to be able to tell that from a record
+// with no tags on it.
+type RecordTagsResponse struct {
+	Data     []RecordTag `json:"data"`
+	Withheld bool        `json:"withheld"`
+}
 
 // RecordViewAck The per-user "I have seen this record" baseline, after an acknowledgment.
 type RecordViewAck struct {
@@ -44623,6 +44702,9 @@ type ServerInterface interface {
 	// Revoke a manual record grant (human-only).
 	// (DELETE /record-grants/{id})
 	RevokeRecordGrant(w http.ResponseWriter, r *http.Request, id Id, params RevokeRecordGrantParams)
+	// The tags on one record, and who put them there.
+	// (GET /records/{entity_type}/{entity_id}/tags)
+	GetRecordTags(w http.ResponseWriter, r *http.Request, entityType string, entityId openapi_types.UUID)
 	// Assembled context (related evidence) for one record.
 	// (GET /records/{entity_type}/{id}/context)
 	GetRecordContext(w http.ResponseWriter, r *http.Request, entityType string, id Id, params GetRecordContextParams)
@@ -47617,6 +47699,12 @@ func (_ Unimplemented) CreateRecordGrant(w http.ResponseWriter, r *http.Request,
 // Revoke a manual record grant (human-only).
 // (DELETE /record-grants/{id})
 func (_ Unimplemented) RevokeRecordGrant(w http.ResponseWriter, r *http.Request, id Id, params RevokeRecordGrantParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// The tags on one record, and who put them there.
+// (GET /records/{entity_type}/{entity_id}/tags)
+func (_ Unimplemented) GetRecordTags(w http.ResponseWriter, r *http.Request, entityType string, entityId openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -67235,6 +67323,49 @@ func (siw *ServerInterfaceWrapper) RevokeRecordGrant(w http.ResponseWriter, r *h
 	handler.ServeHTTP(w, r)
 }
 
+// GetRecordTags operation middleware
+func (siw *ServerInterfaceWrapper) GetRecordTags(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "entity_type" -------------
+	var entityType string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "entity_type", chi.URLParam(r, "entity_type"), &entityType, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "entity_type", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "entity_id" -------------
+	var entityId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "entity_id", chi.URLParam(r, "entity_id"), &entityId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "entity_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetRecordTags(w, r, entityType, entityId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetRecordContext operation middleware
 func (siw *ServerInterfaceWrapper) GetRecordContext(w http.ResponseWriter, r *http.Request) {
 
@@ -73601,6 +73732,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Delete(options.BaseURL+"/record-grants/{id}", wrapper.RevokeRecordGrant)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/records/{entity_type}/{entity_id}/tags", wrapper.GetRecordTags)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/records/{entity_type}/{id}/context", wrapper.GetRecordContext)

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -2564,6 +2564,129 @@
       "warnings"
     ]
   },
+  "get_record_tags": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "archived": {
+                  "type": "boolean"
+                },
+                "assigned_at": {
+                  "type": "string"
+                },
+                "assigned_by": {
+                  "type": "string"
+                },
+                "assigned_by_kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "tag_id": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "required": [
+                "assigned_at",
+                "name",
+                "tag_id"
+              ]
+            }
+          },
+          "withheld": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "tags"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "get_tag": {
     "type": "object",
     "properties": {

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -2607,7 +2607,8 @@
           }
         },
         "required": [
-          "tags"
+          "tags",
+          "withheld"
         ]
       },
       "evidence": {

--- a/backend/internal/modules/agents/toolcopy_tags.go
+++ b/backend/internal/modules/agents/toolcopy_tags.go
@@ -19,9 +19,9 @@ var getTagCopy = toolCopy{
 
 var getRecordTagsCopy = toolCopy{
 	Purpose: "Read the tags on one person, company or deal, with who applied each and when.",
-	Limits: "Those three record types only. `withheld` true means the caller may read the record " +
-		"and not the tag vocabulary — it is NOT the same as a record carrying no tags, and must " +
-		"not be reported as one. An archived tag stays on the record it was applied to.",
+	Limits: "Those three record types only. `withheld` true means the vocabulary is not visible " +
+		"to this caller, so the list is empty for that reason — NOT because the record carries no " +
+		"tags, and it must not be reported as none. An archived tag stays on whatever carries it.",
 }
 
 var applyTagCopy = toolCopy{

--- a/backend/internal/modules/agents/toolcopy_tags.go
+++ b/backend/internal/modules/agents/toolcopy_tags.go
@@ -17,6 +17,13 @@ var getTagCopy = toolCopy{
 		"merging the word would touch; the records themselves come from list_records.",
 }
 
+var getRecordTagsCopy = toolCopy{
+	Purpose: "Read the tags on one person, company or deal, with who applied each and when.",
+	Limits: "Those three record types only. `withheld` true means the caller may read the record " +
+		"and not the tag vocabulary — it is NOT the same as a record carrying no tags, and must " +
+		"not be reported as one. An archived tag stays on the record it was applied to.",
+}
+
 var applyTagCopy = toolCopy{
 	Purpose: "Tag a person, company, deal, lead or project by tag_id, or by tag_name, which must " +
 		"name a tag the workspace already has.",

--- a/backend/internal/modules/agents/tools_tags.go
+++ b/backend/internal/modules/agents/tools_tags.go
@@ -51,6 +51,27 @@ type TagDetail struct {
 	Deals     int `json:"deals"`
 }
 
+// RecordTagsResult is what one record carries. Withheld says the caller may
+// read the record and not the vocabulary, which is not the same as a record
+// with no tags — a model told "no tags" would report a fact nobody established.
+type RecordTagsResult struct {
+	Tags     []RecordTagOnRecord `json:"tags"`
+	Withheld bool                `json:"withheld,omitempty"`
+}
+
+// RecordTagOnRecord is one tag as it sits on one record.
+type RecordTagOnRecord struct {
+	TagID    ids.UUID `json:"tag_id"`
+	Name     string   `json:"name"`
+	Archived bool     `json:"archived,omitempty"`
+	// AssignedBy names the person behind the assignment where the row records
+	// one; AssignedByKind says whether the hand was a human's, an agent's or
+	// an import's.
+	AssignedBy     string `json:"assigned_by,omitempty"`
+	AssignedByKind string `json:"assigned_by_kind,omitempty"`
+	AssignedAt     string `json:"assigned_at"`
+}
+
 // Tags is the seam onto the collections module's tag paths.
 type Tags interface {
 	// ListTags answers the workspace's vocabulary. Read before applying:
@@ -59,6 +80,12 @@ type Tags interface {
 	ListTags(ctx context.Context, includeArchived bool) (tags []Tag, truncated bool, err error)
 	// GetTag answers one word with how much of the workspace carries it.
 	GetTag(ctx context.Context, tagID ids.UUID) (TagDetail, error)
+	// RecordTags answers the tags on one record, with who applied each.
+	RecordTags(ctx context.Context, entityType string, entityID ids.UUID) (RecordTagsResult, error)
+	// RecordTagTypes answers the record types that read serves — the store's
+	// own list, so the tool's schema advertises exactly what it will accept
+	// rather than a copy kept here that can drift from it.
+	RecordTagTypes() []string
 	// EnsureTaggable refuses a record the caller cannot tag, before a tag is
 	// created for it. Same check ApplyTag makes at the end of its own
 	// transaction; asked earlier so a failed apply leaves nothing behind.
@@ -88,6 +115,7 @@ func RegisterTagTools(r *Registry, tags Tags) {
 	}
 	r.Register(listTags{tags: tags})
 	r.Register(getTag{tags: tags})
+	r.Register(getRecordTags{tags: tags, types: tags.RecordTagTypes()})
 	r.Register(applyTag{tags: tags})
 	r.Register(removeTag{tags: tags})
 }
@@ -177,6 +205,48 @@ func (t getTag) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage
 		return nil, err
 	}
 	return json.Marshal(detail)
+}
+
+// --- get_record_tags (🟢 read) ---
+
+type getRecordTags struct {
+	tags  Tags
+	types []string
+}
+
+func (t getRecordTags) Spec() mcp.ToolSpec {
+	quoted := make([]string, 0, len(t.types))
+	for _, rt := range t.types {
+		quoted = append(quoted, `"`+rt+`"`)
+	}
+	return mcp.ToolSpec{
+		Name: "get_record_tags", Title: "Get a record's tags", Version: toolVersionV1,
+		Description:   getRecordTagsCopy.render(),
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		OpenAPIOp: "getRecordTags",
+		InputSchema: schema(`{"type":"object","required":["record_type","record_id"],"properties":{
+			"record_type":{"type":"string","enum":[` + strings.Join(quoted, ",") + `]},
+			"record_id":{"type":"string","format":"uuid"}},"additionalProperties":false}`),
+		OutputSchema: schemaFor[RecordTagsResult](),
+	}
+}
+
+func (t getRecordTags) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	var args struct {
+		RecordType string   `json:"record_type"`
+		RecordID   ids.UUID `json:"record_id"`
+	}
+	if err := decodeArgs(in, &args); err != nil {
+		return nil, err
+	}
+	result, err := t.tags.RecordTags(ctx, args.RecordType, args.RecordID)
+	if err != nil {
+		return nil, err
+	}
+	if result.Tags == nil {
+		result.Tags = []RecordTagOnRecord{}
+	}
+	return json.Marshal(result)
 }
 
 // --- apply_tag / remove_tag (🟢 write) ---

--- a/backend/internal/modules/agents/tools_tags.go
+++ b/backend/internal/modules/agents/tools_tags.go
@@ -55,8 +55,12 @@ type TagDetail struct {
 // read the record and not the vocabulary, which is not the same as a record
 // with no tags — a model told "no tags" would report a fact nobody established.
 type RecordTagsResult struct {
-	Tags     []RecordTagOnRecord `json:"tags"`
-	Withheld bool                `json:"withheld,omitempty"`
+	Tags []RecordTagOnRecord `json:"tags"`
+	// NOT omitempty. The whole point of this field is that a model can tell a
+	// withheld answer from a record with no tags, and omitting it when false
+	// makes the two serialize identically — the same defect the HTTP shape is
+	// built to avoid.
+	Withheld bool `json:"withheld"`
 }
 
 // RecordTagOnRecord is one tag as it sits on one record.

--- a/backend/internal/modules/agents/tools_tags_test.go
+++ b/backend/internal/modules/agents/tools_tags_test.go
@@ -71,6 +71,17 @@ func (s stubTags) GetTag(_ context.Context, tagID ids.UUID) (TagDetail, error) {
 	}, nil
 }
 
+// RecordTags answers a fixed assignment: these tests are about the tool's
+// plumbing, and the read itself is proved against a real database in the
+// collections integration suite, where the permissions can be wrong.
+func (s stubTags) RecordTags(_ context.Context, _ string, _ ids.UUID) (RecordTagsResult, error) {
+	return RecordTagsResult{Tags: []RecordTagOnRecord{{
+		Name: knownTagName, AssignedByKind: "human", AssignedAt: "2026-03-03T10:00:00Z",
+	}}}, nil
+}
+
+func (s stubTags) RecordTagTypes() []string { return []string{"person", "organization", "deal"} }
+
 func (s stubTags) ResolveTag(_ context.Context, name string) (ids.UUID, error) {
 	if s.ensured != nil {
 		*s.ensured = name
@@ -217,6 +228,14 @@ func (r refusingTaggable) EnsureTaggable(context.Context, string, ids.UUID) erro
 
 func (r refusingTaggable) GetTag(_ context.Context, tagID ids.UUID) (TagDetail, error) {
 	return TagDetail{Tag: Tag{TagID: tagID, Name: knownTagName}}, nil
+}
+
+func (r refusingTaggable) RecordTags(_ context.Context, _ string, _ ids.UUID) (RecordTagsResult, error) {
+	return RecordTagsResult{}, nil
+}
+
+func (r refusingTaggable) RecordTagTypes() []string {
+	return []string{"person", "organization", "deal"}
 }
 
 func (r refusingTaggable) ResolveTag(_ context.Context, name string) (ids.UUID, error) {

--- a/backend/internal/modules/collections/handlers_tagvocab.go
+++ b/backend/internal/modules/collections/handlers_tagvocab.go
@@ -79,6 +79,67 @@ func (h Handlers) MergeTags(w http.ResponseWriter, r *http.Request, id crmcontra
 	})
 }
 
+// GetRecordTags serves the tags on one record, with the assignment behind each.
+//
+// entity_type arrives as a plain string: the generated wrapper binds a path
+// enum without calling the Valid() it also generates, so the store's own check
+// is what refuses a type this route does not serve.
+func (h Handlers) GetRecordTags(w http.ResponseWriter, r *http.Request, entityType string, entityID openapi_types.UUID) {
+	tags, err := h.store.RecordTagsFor(r.Context(), entityType, ids.UUID(entityID))
+	if err != nil {
+		writeErr(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, wireRecordTags(tags))
+}
+
+// wireRecordTags renders the read. `data` is always an array, never null: a
+// client that has to special-case a missing list will eventually forget to.
+func wireRecordTags(in RecordTags) crmcontracts.RecordTagsResponse {
+	out := crmcontracts.RecordTagsResponse{
+		Data:     make([]crmcontracts.RecordTag, 0, len(in.Data)),
+		Withheld: in.Withheld,
+	}
+	for _, t := range in.Data {
+		out.Data = append(out.Data, wireRecordTag(t))
+	}
+	return out
+}
+
+func wireRecordTag(t RecordTag) crmcontracts.RecordTag {
+	var color *crmcontracts.RecordTagColor
+	if t.Color != nil {
+		c := crmcontracts.RecordTagColor(*t.Color)
+		color = &c
+	}
+	out := crmcontracts.RecordTag{
+		TagId:       openapi_types.UUID(t.TagID),
+		Name:        t.Name,
+		Color:       color,
+		Description: t.Description,
+		Archived:    t.Archived,
+		AssignedAt:  t.AssignedAt,
+	}
+	// The assigner rides only when the row records one. An assignment written
+	// before the product kept it has no name to give, and inventing one would
+	// put a person's name on a choice they may not have made.
+	if t.AssignedByKind != "" {
+		assigner := crmcontracts.RecordTagAssigner{
+			Kind: crmcontracts.RecordTagAssignerKind(t.AssignedByKind),
+		}
+		if t.AssignedBy != (ids.UUID{}) {
+			id := openapi_types.UUID(t.AssignedBy)
+			assigner.UserId = &id
+		}
+		if t.AssignedByName != "" {
+			name := t.AssignedByName
+			assigner.DisplayName = &name
+		}
+		out.AssignedBy = &assigner
+	}
+	return out
+}
+
 // tagUpdateFrom translates the wire partial into the store's.
 //
 // The store's clearable fields carry two levels of pointer: the outer says

--- a/backend/internal/modules/collections/recordtags.go
+++ b/backend/internal/modules/collections/recordtags.go
@@ -131,7 +131,7 @@ func (s *Store) recordTagRows(ctx context.Context, tx pgx.Tx, entityType string,
 		var kind *string
 		if err := rows.Scan(&r.TagID, &r.Name, &r.Color, &r.Description, &r.Archived,
 			&r.AssignedAt, &assignedBy, &kind, &r.AssignedByName); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("collections: scanning a record tag: %w", err)
 		}
 		if assignedBy != nil {
 			r.AssignedBy = *assignedBy

--- a/backend/internal/modules/collections/recordtags.go
+++ b/backend/internal/modules/collections/recordtags.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package collections
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// The read behind the record page's tag panel — one shape for all three
+// advertised types, because the panel that draws them is one component.
+
+// RecordTag is one tag on one record, with the assignment that put it there.
+type RecordTag struct {
+	TagID       ids.UUID
+	Name        string
+	Color       *string
+	Description *string
+	Archived    bool
+	AssignedAt  time.Time
+	// AssignedBy is zero when the assignment predates the product recording
+	// it. A reader sees the date with no name rather than a name nobody chose.
+	AssignedBy     ids.UUID
+	AssignedByName string
+	AssignedByKind string
+}
+
+// RecordTags is what one record carries, and whether the caller was allowed to
+// see it at all.
+type RecordTags struct {
+	Data []RecordTag
+	// Withheld says the caller may read the RECORD but not the vocabulary.
+	// The list is then empty for a reason that is not "this record has no
+	// tags", and only the flag can tell the two apart — a panel that showed
+	// "No tags" here would state a fact nobody established.
+	Withheld bool
+}
+
+// recordTagTypes are the types this read serves. `taggable` admits lead and
+// project as well; answering for them here would ship a surface no screen
+// offers, and the refusal names the field so a caller can see why.
+var recordTagTypes = map[string]bool{
+	typePerson:       true,
+	typeOrganization: true,
+	typeDeal:         true,
+}
+
+// RecordTagTypesServed answers the types this read serves, in a stable order.
+// The tool surface advertises this rather than keeping its own copy: a schema
+// that admitted a type the store refuses would offer a call that always fails.
+func RecordTagTypesServed() []string {
+	return []string{typePerson, typeOrganization, typeDeal}
+}
+
+// RecordTagsFor reads the tags on one record.
+//
+// Two gates, in this order. The RECORD's own read permission and row scope
+// come first, so a caller naming a record outside their scope gets not-found
+// whatever their tag grants say — existence stays hidden. Only then does the
+// vocabulary grant decide whether the words themselves come back.
+func (s *Store) RecordTagsFor(ctx context.Context, entityType string, entityID ids.UUID) (RecordTags, error) {
+	if !recordTagTypes[entityType] {
+		return RecordTags{}, &BadInputError{
+			Field:  entityTypeField,
+			Reason: "must be person, organization or deal",
+		}
+	}
+	if err := auth.Require(ctx, entityType, principal.ActionRead); err != nil {
+		return RecordTags{}, err
+	}
+	// The vocabulary is a separate grant, and a caller without it still gets
+	// an answer about the record — just one that says the words are withheld
+	// rather than pretending there are none.
+	withheld := auth.Require(ctx, "tag", principal.ActionRead) != nil
+
+	var out RecordTags
+	out.Withheld = withheld
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		if err := auth.EnsureLinkTarget(ctx, tx, entityType, entityID); err != nil {
+			return err
+		}
+		if withheld {
+			return nil
+		}
+		rows, err := s.recordTagRows(ctx, tx, entityType, entityID)
+		if err != nil {
+			return err
+		}
+		out.Data = rows
+		return nil
+	})
+	if err != nil {
+		return RecordTags{}, err
+	}
+	return out, nil
+}
+
+// recordTagRows reads the assignments themselves, live words first.
+//
+// Ordering is deliberate and the panel depends on it: active tags in the order
+// they were applied, most recent first, then the archived ones. A retired word
+// is history and belongs after what is current, not interleaved by name.
+func (s *Store) recordTagRows(ctx context.Context, tx pgx.Tx, entityType string, entityID ids.UUID) ([]RecordTag, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT t.id, t.name, t.color, t.description, t.archived_at IS NOT NULL,
+		       g.assigned_at, g.assigned_by, g.assigned_by_kind,
+		       COALESCE(u.display_name, '')
+		  FROM taggable g
+		  JOIN tag t ON t.id = g.tag_id
+		  LEFT JOIN app_user u ON u.id = g.assigned_by
+		 WHERE g.entity_type = $1 AND g.entity_id = $2
+		 ORDER BY t.archived_at IS NOT NULL, g.assigned_at DESC, t.name`,
+		entityType, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("collections: reading record tags: %w", err)
+	}
+	defer rows.Close()
+
+	var out []RecordTag
+	for rows.Next() {
+		var r RecordTag
+		var assignedBy *ids.UUID
+		var kind *string
+		if err := rows.Scan(&r.TagID, &r.Name, &r.Color, &r.Description, &r.Archived,
+			&r.AssignedAt, &assignedBy, &kind, &r.AssignedByName); err != nil {
+			return nil, err
+		}
+		if assignedBy != nil {
+			r.AssignedBy = *assignedBy
+		}
+		if kind != nil {
+			r.AssignedByKind = *kind
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,7 +5,7 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 61,
-    "tokens": 19250,
+    "tokens": 19253,
     "median_tool_tokens": 274,
     "mean_tool_tokens": 315
   },
@@ -286,12 +286,12 @@
       "tokens": 149
     },
     {
-      "name": "list_colleagues",
-      "tokens": 148
+      "name": "get_record_tags",
+      "tokens": 149
     },
     {
-      "name": "get_record_tags",
-      "tokens": 146
+      "name": "list_colleagues",
+      "tokens": 148
     },
     {
       "name": "whoami",

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -4,10 +4,10 @@
   "per_agent_listing_budget": 17000,
   "whole_catalog_floor": 21000,
   "catalog": {
-    "tools": 60,
-    "tokens": 19104,
+    "tools": 61,
+    "tokens": 19250,
     "median_tool_tokens": 274,
-    "mean_tool_tokens": 318
+    "mean_tool_tokens": 315
   },
   "agents": [
     {
@@ -288,6 +288,10 @@
     {
       "name": "list_colleagues",
       "tokens": 148
+    },
+    {
+      "name": "get_record_tags",
+      "tokens": 146
     },
     {
       "name": "whoami",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1661 | 6% | 15339 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2509 | 10% | 14491 | 15 | 8 |
-| _whole served catalog, for scale_ | 60 | 19104 | 79% | — | — | — |
+| _whole served catalog, for scale_ | 61 | 19250 | 80% | — | — | — |
 
 ### `morning_brief`
 
@@ -123,7 +123,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 274 tokens, mean 318, across 60 served tools.
+Median 274 tokens, mean 315, across 61 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -187,6 +187,7 @@ a term in an addition.
 | `read_approval` | 160 | — |
 | `commit_import` | 149 | — |
 | `list_colleagues` | 148 | — |
+| `get_record_tags` | 146 | — |
 | `whoami` | 136 | — |
 | `list_tags` | 102 | — |
 | `get_tag` | 94 | — |

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1661 | 6% | 15339 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2509 | 10% | 14491 | 15 | 8 |
-| _whole served catalog, for scale_ | 61 | 19250 | 80% | — | — | — |
+| _whole served catalog, for scale_ | 61 | 19253 | 80% | — | — | — |
 
 ### `morning_brief`
 
@@ -186,8 +186,8 @@ a term in an addition.
 | `read_project_360` | 163 | — |
 | `read_approval` | 160 | — |
 | `commit_import` | 149 | — |
+| `get_record_tags` | 149 | — |
 | `list_colleagues` | 148 | — |
-| `get_record_tags` | 146 | — |
 | `whoami` | 136 | — |
 | `list_tags` | 102 | — |
 | `get_tag` | 94 | — |

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -110,6 +110,7 @@ Columns:
 | `draft_email` | 🟢 | `draft` | — | Activities seam; not mode-routed |
 | `draft_follow_ups_for` | 🟢 | `draft` | — | `unsupported_by_sor` (native-only guard) |
 | `enrich` | 🟡 | `enrich` | yes | Reads the company's own website, not a record store; the write-back is seam-routed |
+| `get_record_tags` | 🟢 | `read` | — | Reads one record's tags with who applied each; native, not mode-routed |
 | `get_tag` | 🟢 | `read` | — | Reads one tag and how much of the workspace carries it; native vocabulary, not mode-routed |
 | `intro_path_to` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `list_pipelines` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,15 +10,15 @@
   "totals": {
     "tools": 61,
     "resources": 9,
-    "tool_catalog_bytes": 177708,
+    "tool_catalog_bytes": 177719,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 45305,
+    "approx_wire_tokens_total": 45308,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 41211,
       "input_schema_bytes": 37786,
-      "output_schema_bytes": 85524,
+      "output_schema_bytes": 85535,
       "description_plus_input_schema_bytes": 78997
     }
   },
@@ -3576,7 +3576,8 @@
                 }
               },
               "required": [
-                "tags"
+                "tags",
+                "withheld"
               ],
               "type": "object"
             },

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,18 +8,18 @@
     "enrich"
   ],
   "totals": {
-    "tools": 60,
+    "tools": 61,
     "resources": 9,
-    "tool_catalog_bytes": 175741,
+    "tool_catalog_bytes": 177697,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 44813,
+    "approx_wire_tokens_total": 45302,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
-      "description_bytes": 40807,
-      "input_schema_bytes": 37568,
-      "output_schema_bytes": 84374,
-      "description_plus_input_schema_bytes": 78375
+      "description_bytes": 41200,
+      "input_schema_bytes": 37786,
+      "output_schema_bytes": 85524,
+      "description_plus_input_schema_bytes": 78986
     }
   },
   "tools": {
@@ -3504,6 +3504,161 @@
           "type": "object"
         },
         "title": "Enrich an organization from its website"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": true,
+          "title": "Get a record's tags"
+        },
+        "description": "Read the tags on one person, company or deal, with who applied each and when. Those three record types only. `withheld` true means the caller may read the record and not the tag vocabulary — it is NOT the same as a record carrying no tags, and must not be reported as one. An archived tag stays on the record it was applied to. (Governance: runs immediately; requires passport scope \"read\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "record_id": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "record_type": {
+              "enum": [
+                "person",
+                "organization",
+                "deal"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_type",
+            "record_id"
+          ],
+          "type": "object"
+        },
+        "name": "get_record_tags",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "tags": {
+                  "items": {
+                    "properties": {
+                      "archived": {
+                        "type": "boolean"
+                      },
+                      "assigned_at": {
+                        "type": "string"
+                      },
+                      "assigned_by": {
+                        "type": "string"
+                      },
+                      "assigned_by_kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag_id": {
+                        "format": "uuid",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "assigned_at",
+                      "name",
+                      "tag_id"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "withheld": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "tags"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Get a record's tags"
       },
       {
         "annotations": {
@@ -11644,7 +11799,7 @@
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":60,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"annotate_brief\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"create_record\",\"create_task\",\"decide_approval\",\"decide_approval_bundle\",\"describe_query_vocabulary\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"get_tag\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":61,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"annotate_brief\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"create_record\",\"create_task\",\"decide_approval\",\"decide_approval_bundle\",\"describe_query_vocabulary\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"get_record_tags\",\"get_tag\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, channel_provider?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"message\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"|\\\"project\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, counterparty_person_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\"|\\\"works_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"A recording of a conversation is logged with `source_system: \\\"transcript\\\"` — that value is what has it read for next steps and commitments; any other value stores the text and reads nothing.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, source?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` on a lead is the administered lead-source key (see Settings › Data model); a patch corrects it, and the score follows.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
     "ui://margince/account-brief.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 61,
     "resources": 9,
-    "tool_catalog_bytes": 177697,
+    "tool_catalog_bytes": 177708,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 45302,
+    "approx_wire_tokens_total": 45305,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
-      "description_bytes": 41200,
+      "description_bytes": 41211,
       "input_schema_bytes": 37786,
       "output_schema_bytes": 85524,
-      "description_plus_input_schema_bytes": 78986
+      "description_plus_input_schema_bytes": 78997
     }
   },
   "tools": {
@@ -3511,7 +3511,7 @@
           "readOnlyHint": true,
           "title": "Get a record's tags"
         },
-        "description": "Read the tags on one person, company or deal, with who applied each and when. Those three record types only. `withheld` true means the caller may read the record and not the tag vocabulary — it is NOT the same as a record carrying no tags, and must not be reported as one. An archived tag stays on the record it was applied to. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "Read the tags on one person, company or deal, with who applied each and when. Those three record types only. `withheld` true means the vocabulary is not visible to this caller, so the list is empty for that reason — NOT because the record carries no tags, and it must not be reported as none. An archived tag stays on whatever carries it. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,11 +11,11 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 60 |
+| Tools | 61 |
 | Resources | 9 |
-| Tool catalog | 171.6 KB |
+| Tool catalog | 173.5 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 44813 |
+| Approx. wire tokens | 45302 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 82.4 KB | 48% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 39.9 KB | 23% | Yes, every step |
-| Input schemas | 36.7 KB | 21% | Yes, every step |
-| _Names, annotations, punctuation_ | 12.7 KB | 7% | Partly |
-| **Description + input schema** | **76.5 KB** | **44%** | **the recurring cost** |
+| Output schemas | 83.5 KB | 48% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 40.2 KB | 23% | Yes, every step |
+| Input schemas | 36.9 KB | 21% | Yes, every step |
+| _Names, annotations, punctuation_ | 12.9 KB | 7% | Partly |
+| **Description + input schema** | **77.1 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -57,7 +57,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
 - [`ui://margince/geo-probe.html`](#geo_probe_view) — Location check
 
-### Tools (60)
+### Tools (61)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
@@ -82,6 +82,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`draft_email`](#draft_email) | Draft an email |  |  | 2.5 KB |
 | [`draft_follow_ups_for`](#draft_follow_ups_for) | Draft follow-ups |  |  | 2.6 KB |
 | [`enrich`](#enrich) | Enrich an organization from its website |  |  | 2.6 KB |
+| [`get_record_tags`](#get_record_tags) | Get a record's tags | yes |  | 1.9 KB |
 | [`get_tag`](#get_tag) | Get a tag | yes |  | 1.6 KB |
 | [`intro_path_to`](#intro_path_to) | Find a warm introduction path | yes |  | 2.3 KB |
 | [`list_approvals`](#list_approvals) | List what is waiting for a decision | yes |  | 2.9 KB |
@@ -3905,6 +3906,171 @@ Learn about an organization by reading its public website, and propose what was 
 {
   "properties": {
     "data": {
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### get_record_tags
+
+**Get a record's tags**
+
+Read the tags on one person, company or deal, with who applied each and when. Those three record types only. `withheld` true means the caller may read the record and not the tag vocabulary — it is NOT the same as a record carrying no tags, and must not be reported as one. An archived tag stays on the record it was applied to. (Governance: runs immediately; requires passport scope "read".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "record_id": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "record_type": {
+      "enum": [
+        "person",
+        "organization",
+        "deal"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "record_type",
+    "record_id"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "tags": {
+          "items": {
+            "properties": {
+              "archived": {
+                "type": "boolean"
+              },
+              "assigned_at": {
+                "type": "string"
+              },
+              "assigned_by": {
+                "type": "string"
+              },
+              "assigned_by_kind": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tag_id": {
+                "format": "uuid",
+                "type": "string"
+              }
+            },
+            "required": [
+              "assigned_at",
+              "name",
+              "tag_id"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "withheld": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "tags"
+      ],
       "type": "object"
     },
     "evidence": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -15,7 +15,7 @@ receives it. This page is rendered from that file.
 | Resources | 9 |
 | Tool catalog | 173.5 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 45302 |
+| Approx. wire tokens | 45305 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -3994,7 +3994,7 @@ Learn about an organization by reading its public website, and propose what was 
 
 **Get a record's tags**
 
-Read the tags on one person, company or deal, with who applied each and when. Those three record types only. `withheld` true means the caller may read the record and not the tag vocabulary — it is NOT the same as a record carrying no tags, and must not be reported as one. An archived tag stays on the record it was applied to. (Governance: runs immediately; requires passport scope "read".)
+Read the tags on one person, company or deal, with who applied each and when. Those three record types only. `withheld` true means the vocabulary is not visible to this caller, so the list is empty for that reason — NOT because the record carries no tags, and it must not be reported as none. An archived tag stays on whatever carries it. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 61 |
 | Resources | 9 |
-| Tool catalog | 173.5 KB |
+| Tool catalog | 173.6 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 45305 |
+| Approx. wire tokens | 45308 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -4069,7 +4069,8 @@ Read the tags on one person, company or deal, with who applied each and when. Th
         }
       },
       "required": [
-        "tags"
+        "tags",
+        "withheld"
       ],
       "type": "object"
     },

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5204,6 +5204,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/records/{entity_type}/{entity_id}/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                entity_type: "person" | "organization" | "deal";
+                entity_id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * The tags on one record, and who put them there.
+         * @description ONE read for all three record types, because the panel that draws them is one
+         *     component: a per-type block on each record response would be three copies of one
+         *     shape, and they would drift.
+         *
+         *     Each assignment carries who applied it and when, which the record page shows beside
+         *     the tag. `assigned_by` is absent for assignments made before the product recorded
+         *     it — absent means unknown, never "the system".
+         *
+         *     The three advertised types only. `taggable` admits lead and project, and this route
+         *     refuses them: a read that answered for a type no screen offers would be a surface
+         *     nobody meant to ship.
+         *
+         *     Withheld is not empty. A caller who may read the record but not the tag vocabulary
+         *     gets `withheld: true` and no assignments — distinguishable from a record that simply
+         *     carries none, because "no tags" is a claim about the record and this caller cannot
+         *     make it.
+         */
+        get: operations["getRecordTags"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/tags/{id}/apply": {
         parameters: {
             query?: never;
@@ -21305,6 +21343,36 @@ export interface components {
             color?: "teal" | "amber" | "rose" | "slate" | null;
             description?: string | null;
         };
+        /**
+         * @description What one record carries. `withheld` says the caller could not read the vocabulary,
+         *     which is why `data` is empty — a reader has to be able to tell that from a record
+         *     with no tags on it.
+         */
+        RecordTagsResponse: {
+            data: components["schemas"]["RecordTag"][];
+            withheld: boolean;
+        };
+        /** @description One tag on one record, with the assignment that put it there. */
+        RecordTag: {
+            /** Format: uuid */
+            tag_id: string;
+            name: string;
+            /** @enum {string|null} */
+            color?: "teal" | "amber" | "rose" | "slate" | null;
+            description?: string | null;
+            archived: boolean;
+            /** Format: date-time */
+            assigned_at: string;
+            assigned_by?: components["schemas"]["RecordTagAssigner"];
+        };
+        /** @description Who applied a tag. `kind` says by what hand, which a reader needs to tell a colleague's choice from an import's. */
+        RecordTagAssigner: {
+            /** Format: uuid */
+            user_id?: string | null;
+            display_name?: string | null;
+            /** @enum {string} */
+            kind: "human" | "agent" | "import";
+        };
         /** @description One tag with how much of the workspace carries it. */
         TagDetail: {
             /** Format: uuid */
@@ -36364,6 +36432,32 @@ export interface operations {
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
             409: components["responses"]["Conflict"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getRecordTags: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                entity_type: "person" | "organization" | "deal";
+                entity_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The record's tags. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecordTagsResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
             422: components["responses"]["ValidationError"];
         };
     };

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -36457,6 +36457,7 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
             422: components["responses"]["ValidationError"];
         };


### PR DESCRIPTION
The panel that draws tags on a person, a company and a deal is one component, so the read behind it is one route: `GET /records/{entity_type}/{entity_id}/tags`. A per-type block on each record response would be three copies of one shape, and they would drift.

## What it answers

Each assignment carries who applied it and when, which the record page shows beside the word. Nothing served that before: the company's own 360 block returns tag names with no assigner, and person and deal had no tags at all.

Archived words stay on the records that carry them and ride marked. Retiring a tag stops it being applied; it does not un-tag a history that was true.

A matching `get_record_tags` MCP tool reads through the same store method, so a model and a person looking at one company cannot be told different things about who tagged it.

## Two gates, in order

The record's own read permission and row scope come first, so a caller naming a record outside their scope gets not-found whatever their tag grants say. Only then does the vocabulary grant decide whether the words come back.

A caller who may read the record but not the vocabulary gets `withheld: true` with no assignments — **not** an empty list, because "no tags" is a claim about the record they cannot make. Forcing the flag off fails the test.

## A claim I made and had to correct

I wrote that an out-of-scope record answers not-found, and the test I wrote to prove it failed. A control probing the shared row-scope helper with the same principal showed the helper admitting the record too, so the read was not the problem: customer identity is workspace-readable by design (`auth/tableclass_test.go` pins it), every seat reads every person, and the **write** arm is what keeps a row its owner's.

What does hide a record is capture privacy — an owner-private contact answers to its owner alone until somebody promotes or shares it. That is the case where this read could genuinely leak, so it is the one pinned: another seat gets not-found, the owner gets their tags, and swallowing the visibility refusal fails the first.

## What review caught

Codex died mid-run with nothing stored, so this went to the repo's security reviewer instead. No exploitable findings. It corrected me on `omitempty` — it drops only the false case, so the two states were always distinguishable; the field is now unconditional anyway, which makes the two wires symmetric. It also confirmed the `app_user` join is a read the ownership gate permits by design, and that four other modules already do it.

Its real catches were coverage: a test named "all three advertised types" exercised two, with no deal case; the contract never declared the 403 the record gate can return; and a row-scan error rode unwrapped where its sibling names the statement.

## One deliberate deferral

The company 360 tags block is **not** removed. The shipped panel still draws from it, and taking it away before the panel moves would break a working screen. Its comment now says when it goes.

## Checks

`make check` green after rebase. Integration lanes green: `compose/integration` and `compose/integration/collections`. `make craft-static` clean, RLS and jurisdiction gates pass. The withheld flag and the privacy refusal were each mutation-checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /records/{entity_type}/{entity_id}/tags` and the matching `get_record_tags` tool for people, organizations, and deals. Previously, only the company 360 response exposed tag names; the new read also returns assignment details, archived state, and whether tag data was withheld.

**Details**

- Checks record visibility before vocabulary access so private records remain indistinguishable from missing records.
- Returns `withheld: true` with an empty array when the caller can read the record but not tags.
- Keeps archived assignments visible and rejects unsupported lead and project types.
- Leaves the existing company 360 tag block in place until the panel migrates to the new route.
- Updates the OpenAPI, TypeScript, MCP schemas, documentation, and integration coverage.

<sup>Written for commit 80d10a4c50c5b8806141e3a83c006d4dd091d28f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added read-only record-tag retrieval for people, organizations, and deals.
  - View assigned tags with names, colors, archived status, assignment time, and attribution details.
  - Responses distinguish between records with no tags and cases where tag visibility is withheld.
  - Archived tags remain visible and clearly marked.
  - Added support through the API and agent tool catalog.

- **Documentation**
  - Updated published tool catalogs, schemas, and usage metrics to include record-tag retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->