### PR TITLE
The Brief leads with what is already waiting

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2289,6 +2289,14 @@ export const de = {
   // Die kommende Woche. Der eingefrorene Rückblick sagt, was war; dies ist der
   // einzige Teil dieser Seite, den noch jemand ändern kann.
   "plan.title": "Nächste Woche planen",
+  // Der Kopf der sortierten Liste, auf der Seite, die zuerst geöffnet wird —
+  // dieselben Zeilen wie in der Arbeitsliste, in der Reihenfolge des Servers.
+  "brief.donext.title": "Als Nächstes",
+  "brief.donext.sub": "Eine Reihenfolge, aus deiner Arbeitsliste.",
+  "brief.donext.loading": "Was auf dich wartet, wird gelesen",
+  "brief.donext.clear": "Gerade wartet nichts auf dich.",
+  "brief.donext.rest": "{count} weitere in der Arbeitsliste",
+
   // Die Woche eines Teams, eingefroren beim Abschluss. Zwei Wochen sind
   // vergleichbar, weil keine sich unter dem Vergleich bewegt.
   "teamweekly.title": "Die Woche des Teams",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2326,6 +2326,14 @@ export const en = {
   // The week ahead. The frozen review says what happened; this is the only part
   // of that page anybody can still change.
   "plan.title": "Plan next week",
+  // The head of the ranked queue, on the page a rep opens first. The same rows
+  // the Worklist draws, in the order the server decided.
+  "brief.donext.title": "Do next",
+  "brief.donext.sub": "One order, from your worklist.",
+  "brief.donext.loading": "Reading what waits on you",
+  "brief.donext.clear": "Nothing is waiting on you right now.",
+  "brief.donext.rest": "{count} more on the worklist",
+
   // A team's week, frozen when it closed. Two weeks compare because neither
   // moves under the comparison.
   "teamweekly.title": "The team's week",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2273,6 +2273,14 @@ export const vi = {
   // Tuần tới. Bản tổng kết đã đóng băng nói điều đã xảy ra; đây là phần duy nhất
   // của trang đó mà vẫn còn ai đó thay đổi được.
   "plan.title": "Lập kế hoạch tuần tới",
+  // Phần đầu của danh sách đã xếp hạng, trên trang mở đầu tiên — cùng những
+  // dòng mà Danh sách công việc hiển thị, theo thứ tự máy chủ đã quyết định.
+  "brief.donext.title": "Làm tiếp theo",
+  "brief.donext.sub": "Một thứ tự, từ danh sách công việc của bạn.",
+  "brief.donext.loading": "Đang đọc những gì đang chờ bạn",
+  "brief.donext.clear": "Hiện không có gì đang chờ bạn.",
+  "brief.donext.rest": "{count} mục khác trong danh sách công việc",
+
   // Tuần của một nhóm, đóng băng khi tuần khép lại. Hai tuần so sánh được vì
   // không tuần nào dịch chuyển dưới phép so sánh.
   "teamweekly.title": "Tuần của nhóm",

--- a/frontend/src/screens/brief.donext.css
+++ b/frontend/src/screens/brief.donext.css
@@ -1,0 +1,9 @@
+/* The head of the ranked queue on Home. The rows carry their own layout from
+   worklist.css; this is only the list they sit in. */
+.brief-donext-list {
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/frontend/src/screens/brief.donext.test.tsx
+++ b/frontend/src/screens/brief.donext.test.tsx
@@ -1,0 +1,183 @@
+/** @vitest-environment jsdom */
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { en } from "../i18n/en";
+import { DoNext } from "./brief.donext";
+import { render } from "./home.testkit";
+import type { Worklist, WorklistItem } from "./worklist.queries";
+
+// The head of the ranked queue, on Home.
+//
+// What these are about is not how a row looks — WorklistRow owns that and the
+// Worklist screen tests it. They are about the page not becoming a second
+// opinion: the order is the server's, the cut is a prefix, and nothing here
+// re-sorts or re-ranks.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function item(over: Partial<WorklistItem> = {}): WorklistItem {
+  return {
+    id: "i1",
+    source: "waiting_customer",
+    category: "customer_waiting",
+    title: "Aster Handel",
+    because: [],
+    actions: ["open"],
+    dispositions: [],
+    overdue: false,
+    ...over,
+  } as unknown as WorklistItem;
+}
+
+function day(queue: WorklistItem[]): Worklist {
+  return {
+    as_of: "2026-06-10T06:00:00Z",
+    scope: "mine",
+    scope_options: ["mine"],
+    queue,
+    counts: [],
+    reach: [],
+    sources_unavailable: [],
+    summary: { total: queue.length, urgent: 0 },
+  } as unknown as Worklist;
+}
+
+describe("do next", () => {
+  // The claim of the whole section. The server's tie-breaks need a
+  // base-currency conversion and a materiality threshold the browser does not
+  // hold, so a client that re-sorted would be answering a question it cannot.
+  it("draws the first three rows in wire order and re-sorts nothing", () => {
+    const { container } = render(
+      <DoNext
+        day={day([
+          item({ id: "a", title: "Zeta last-alphabetically" }),
+          item({ id: "b", title: "Alpha first-alphabetically" }),
+          item({ id: "c", title: "Mid" }),
+          item({ id: "d", title: "Fourth, below the cut" }),
+        ])}
+        state="ready"
+      />,
+    );
+
+    const titles = [...container.querySelectorAll(".worklist-row-title")].map(
+      (node) => node.textContent ?? "",
+    );
+    expect(titles).toHaveLength(3);
+    expect(titles[0]).toContain("Zeta last-alphabetically");
+    expect(titles[1]).toContain("Alpha first-alphabetically");
+    expect(titles[2]).toContain("Mid");
+    expect(container.textContent).not.toContain("Fourth, below the cut");
+  });
+
+  // The decisions deck is a surface of its own further up the SAME page, holding
+  // the same approvals and posting to the same endpoint. A row here put one
+  // decision in front of a reader twice, each copy answerable — on a page whose
+  // whole claim is that it states an order once. Found by looking at the
+  // rendered page, not by a test: every assertion above passed with it there.
+  it("leaves the decisions the deck above already answers to the deck", () => {
+    const { container } = render(
+      <DoNext
+        day={day([
+          item({
+            id: "a",
+            source: "approval",
+            title: "Confirm the close date",
+          }),
+          item({ id: "b", title: "Aster is waiting" }),
+        ])}
+        state="ready"
+      />,
+    );
+
+    expect(container.textContent).not.toContain("Confirm the close date");
+    expect(container.textContent).toContain("Aster is waiting");
+  });
+
+  // And the remainder counts what THIS section is showing, not what the queue
+  // holds: a footer that counted the excluded approvals would send a reader to
+  // the worklist for rows this page had deliberately not drawn.
+  it("counts the remainder over what it shows, not over the whole queue", () => {
+    render(
+      <DoNext
+        day={day([
+          item({ id: "a", source: "approval" }),
+          item({ id: "b" }),
+          item({ id: "c" }),
+          item({ id: "d" }),
+          item({ id: "e" }),
+        ])}
+        state="ready"
+      />,
+    );
+
+    // Four non-approval rows, three shown: one remains, not two.
+    expect(
+      screen.getByText(en["brief.donext.rest"].replace("{count}", "1")),
+    ).toBeTruthy();
+  });
+
+  // A page showing three of eleven rows that did not say where the other eight
+  // are has hidden them.
+  it("says how many rows it left out, and where they are", () => {
+    render(
+      <DoNext
+        day={day([
+          item({ id: "a" }),
+          item({ id: "b" }),
+          item({ id: "c" }),
+          item({ id: "d" }),
+          item({ id: "e" }),
+        ])}
+        state="ready"
+      />,
+    );
+
+    const link = screen.getByText(
+      en["brief.donext.rest"].replace("{count}", "2"),
+    );
+    expect(link.getAttribute("href")).toBe("#/worklist");
+  });
+
+  it("says nothing about a remainder when it is showing everything", () => {
+    render(<DoNext day={day([item()])} state="ready" />);
+
+    expect(screen.queryByText(/more on the worklist/)).toBeNull();
+  });
+
+  // Home has no second column to open a row INTO. A rank button that answered
+  // nothing is the dead control WorklistRow's own comment warns about.
+  it("draws the rank as a number, not as a control that opens nothing", () => {
+    const { container } = render(<DoNext day={day([item()])} state="ready" />);
+
+    expect(container.querySelector(".worklist-rank")).toBeTruthy();
+    expect(container.querySelector(".worklist-rank-select")).toBeNull();
+    expect(screen.queryByRole("button", { name: /Aster Handel/ })).toBeNull();
+  });
+
+  // A payload with no queue at all. The optional chain has to reach the FIELD:
+  // guarding only the payload threw and took the whole page with it, which is
+  // the second time that exact mistake reached a gate on this screen. A page
+  // that draws nothing is a bad answer; a page that throws is not an answer.
+  it("draws nothing rather than throwing on an answer with no queue", () => {
+    const { container } = render(
+      <DoNext day={{} as unknown as Worklist} state="ready" />,
+    );
+
+    expect(container.querySelector(".brief-donext-list")).toBeNull();
+    expect(screen.getByText(en["brief.donext.clear"])).toBeTruthy();
+  });
+
+  // An empty queue and a failed read are different facts. Saying "nothing is
+  // waiting" over a read that never landed is the one thing this section must
+  // not do — a rep would close the page believing their morning was clear.
+  it("tells a clear morning apart from a read that failed", () => {
+    const { rerender } = render(<DoNext day={day([])} state="ready" />);
+    expect(screen.getByText(en["brief.donext.clear"])).toBeTruthy();
+
+    rerender(<DoNext day={undefined} state="failed" />);
+    expect(screen.queryByText(en["brief.donext.clear"])).toBeNull();
+  });
+});

--- a/frontend/src/screens/brief.donext.tsx
+++ b/frontend/src/screens/brief.donext.tsx
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { Panel } from "../design-system/panel";
+import { type SectionState, SurfaceState } from "../design-system/surfacestate";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import type { Worklist } from "./worklist.queries";
+import { WorklistRow } from "./worklist.row";
+
+// The ROW's own sheet, because this draws the row. Its rules live with the
+// component rather than with the Worklist screen that first used it, and a
+// surface rendering WorklistRow without them draws an unstyled row.
+import "./worklist.css";
+import "./brief.donext.css";
+
+// What waits on this rep first, on the page they open first.
+//
+// THE SAME ROWS THE WORKLIST DRAWS, from the same query key and the same
+// component — the head of one ranked order rather than a second opinion about
+// it. Home was deal-only until now: the opportunity queue below this answers
+// "what is worth pursuing", which is a different question from "what is
+// already waiting", and a morning that led with the second one was leading with
+// the wrong half.
+//
+// NO SORT AND NO FILTER HERE. The order is the server's — its tie-breaks need a
+// base-currency conversion and a materiality threshold the browser does not
+// hold — so this takes a prefix of the queue and nothing else.
+
+/** How many rows lead the page. */
+const LEAD = 3;
+
+/**
+ * What the DECK above already answers.
+ *
+ * On the Worklist an approval is one row of one ranked order, and drawing it
+ * there is right. On Home it is not: the decisions deck is a surface of its own
+ * further up the same page, holding the same approvals and posting to the same
+ * endpoint — so a row here put one decision in front of a reader twice, each
+ * copy answerable, on a page whose whole claim is that it states an order once.
+ *
+ * Excluded by SOURCE rather than by id-matching the deck: the deck's own
+ * contents are a separate read that can be pending, empty or refused while this
+ * one is ready, and a rule that depended on it would draw a different page
+ * depending on which read landed first.
+ */
+const DECK_ANSWERS = "approval";
+
+/**
+ * The head of the ranked queue, expanded.
+ *
+ * A prefix, deliberately: the whole queue is the Worklist's page, and a rep who
+ * wants the rest has a link to it. Three is what a person acts on before the
+ * morning gets away from them.
+ */
+export function DoNext({
+  day,
+  state,
+}: Readonly<{ day: Worklist | undefined; state: SectionState }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  // The optional chain reaches the FIELD, not just the payload. A worklist
+  // answer that carried no queue crashed the whole page — the same mistake the
+  // team gate above made, and a page that throws is a worse answer than one
+  // that draws nothing.
+  const waiting =
+    day?.queue?.filter((item) => item.source !== DECK_ANSWERS) ?? [];
+  const rows = waiting.slice(0, LEAD);
+  return (
+    <section id="brief-donext" aria-label={t("brief.donext.title")}>
+      <Panel
+        title={t("brief.donext.title")}
+        sub={t("brief.donext.sub")}
+        footer={
+          // The way to the rest. A page showing three of eleven rows that did
+          // not say where the other eight are has hidden them.
+          day && waiting.length > rows.length ? (
+            <a className="entity-link" href="#/worklist">
+              {t("brief.donext.rest", {
+                count: formatNumber(waiting.length - rows.length, locale),
+              })}
+            </a>
+          ) : undefined
+        }
+      >
+        <SurfaceState
+          // A READ THAT LANDED ON NOTHING is `empty`; a read that has not
+          // landed is not. SurfaceState will not infer it — the caller is the
+          // only one who knows the difference — and saying "nothing is waiting"
+          // over a read that failed would send a rep away believing their
+          // morning was clear.
+          state={state === "ready" && rows.length === 0 ? "empty" : state}
+          emptyLabel={t("brief.donext.clear")}
+          loadingLabel={t("brief.donext.loading")}
+        >
+          {day && rows.length > 0 && (
+            // An ordered list, because the order is the claim. A screen reader
+            // gets it from the element; everybody else gets it from the rank
+            // the row prints.
+            <ol className="brief-donext-list">
+              {rows.map((item, index) => (
+                <li key={item.id}>
+                  <WorklistRow
+                    item={item}
+                    position={index + 1}
+                    // The reader's OWN day. A row is handed to somebody else
+                    // only from a page that is already about somebody else, and
+                    // this page is about the person reading it.
+                    owner=""
+                    asOf={day.as_of}
+                    // No pane and no filter on this surface, so the rank draws
+                    // as a number rather than as a control that opens nothing.
+                    // WorklistRow leaves both out when they are absent.
+                  />
+                </li>
+              ))}
+            </ol>
+          )}
+        </SurfaceState>
+      </Panel>
+    </section>
+  );
+}

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -11,6 +11,7 @@ import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
 import { useDecisionSink } from "./approvalrow";
 import { usePendingApprovals } from "./approvals.queries";
+import { DoNext } from "./brief.donext";
 import { PlanSection } from "./brief.plan";
 import { TeamWeeklyPanel } from "./brief.teamweekly";
 import { BriefCoverage } from "./briefcoverage";
@@ -37,7 +38,7 @@ import { HomeReadingsStrip } from "./home.readings";
 import { HomeTeamBoard } from "./home.teamboard";
 import { TodaySection } from "./home.today";
 import { WeeklySection } from "./home.weekly";
-import { useWorklist } from "./worklist.queries";
+import { useWorklist, type Worklist } from "./worklist.queries";
 import "./home.css";
 
 // Home — the morning handover.
@@ -191,6 +192,8 @@ function HomeWork({
   deals,
   briefState,
   teamOffered,
+  day,
+  dayState,
   onAlreadyDecided,
 }: Readonly<{
   items: readonly DecisionDeckItem[];
@@ -202,6 +205,11 @@ function HomeWork({
   // Whether the reader's scope reaches a team, off the worklist read the page
   // already makes. The same gate the team BOARD uses, so one tier decides both.
   teamOffered: boolean;
+  // The ONE ranked order, already read by the page for its coverage line. Do
+  // next shows its head, from the same query key — so the Brief and the
+  // Worklist cannot disagree about what is waiting.
+  day: Worklist | undefined;
+  dayState: SectionState;
   onAlreadyDecided: () => void;
 }>) {
   const decisions = (
@@ -239,9 +247,14 @@ function HomeWork({
   // next week holds by reading what this one did, so the frozen past leads and
   // the live future follows.
   const nextWeek = <PlanSection key="plan" />;
+  // WHAT IS ALREADY WAITING, above what is worth pursuing. The deal queue below
+  // answers a different question, and a morning that led with it led with the
+  // wrong half — decision 3 of the Brief plan, and the reason this section
+  // exists at all.
+  const doNext = <DoNext key="donext" day={day} state={dayState} />;
   return items.length > 0
-    ? [decisions, today, lastWeek, teamWeek, nextWeek]
-    : [today, decisions, lastWeek, teamWeek, nextWeek];
+    ? [decisions, doNext, today, lastWeek, teamWeek, nextWeek]
+    : [doNext, today, decisions, lastWeek, teamWeek, nextWeek];
 }
 
 /**
@@ -411,6 +424,8 @@ export function HomeScreen() {
             teamOffered={
               worklistQuery.data?.scope_options?.includes("team") ?? false
             }
+            day={worklistQuery.data}
+            dayState={readState(worklistQuery)}
             onAlreadyDecided={onAlreadyDecided}
           />
         }

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -54,9 +54,18 @@ export function WorklistRow({
   // server already decided as of a fixed instant.
   asOf: string;
   // Whether the pane beside the queue is about this row.
-  selected: boolean;
-  onSelect: () => void;
-  onReview: () => void;
+  //
+  // BOTH CALLBACKS ARE OPTIONAL, because one surface has no pane. The Brief
+  // shows the head of this same queue on the page a rep opens first, and it has
+  // no second column to open a row INTO — so passing a no-op would draw a rank
+  // button that answers nothing, which is exactly the dead control the comment
+  // on that button warns about. Absent means the affordance is not drawn and
+  // the rank reads as the number it is.
+  selected?: boolean;
+  onSelect?: () => void;
+  // Where a grouped row is reviewed. Also a filter change the Brief cannot
+  // make: it shows a fixed cut and has no filter to move.
+  onReview?: () => void;
 }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -82,30 +91,12 @@ export function WorklistRow({
         selected ? "worklist-row worklist-row-selected" : "worklist-row"
       }
     >
-      {/* The way INTO the pane. A button on the rank rather than the whole row
-          being pressable: the row already holds links and verbs, and a control
-          wrapping controls is a press whose target the reader has to guess. */}
-      <button
-        type="button"
-        className="worklist-rank-select"
-        aria-pressed={selected}
-        // Names the ROW, not the verb. Every rank button carrying the same
-        // label made them indistinguishable to anybody navigating by name, and
-        // overrode the visible digit — which is the one thing that told them
-        // apart on screen.
-        aria-label={t("worklist.pane.openRow", {
-          position: formatNumber(position, locale),
-          title,
-        })}
-        onClick={onSelect}
-      >
-        {/* The rank is the page's central claim, so it is readable rather than
-          decorative: the list element carries the order for a screen reader and
-          the number states it for everybody else. */}
-        <span className="t-caption worklist-rank">
-          {formatNumber(position, locale)}
-        </span>
-      </button>
+      <Rank
+        position={position}
+        title={title}
+        selected={selected}
+        onSelect={onSelect}
+      />
       <div className="worklist-row-text">
         <p className="t-body worklist-row-title">
           {href ? (
@@ -146,7 +137,7 @@ export function WorklistRow({
             has nothing below it to beat. */}
         {above && <p className="t-caption worklist-row-above">{above}</p>}
       </div>
-      {item.batch ? (
+      {item.batch && onReview ? (
         <BatchVerb onReview={onReview} />
       ) : (
         <RowVerbs item={item} href={href} move={moveHref(item)} />
@@ -167,6 +158,62 @@ export function WorklistRow({
         <NoticeAcknowledge id={item.id} />
       )}
     </PanelRow>
+  );
+}
+
+/**
+ * The rank, and the way INTO the pane where there is one.
+ *
+ * A button on the rank rather than the whole row being pressable: the row
+ * already holds links and verbs, and a control wrapping controls is a press
+ * whose target the reader has to guess.
+ *
+ * Without `onSelect` it is a plain number. The Brief draws these rows on a page
+ * with no second column, so a button there would open nothing — and a control
+ * that answers nothing is worse than no control, because a reader presses it
+ * once and learns the page lies about what is pressable.
+ */
+function Rank({
+  position,
+  title,
+  selected,
+  onSelect,
+}: Readonly<{
+  position: number;
+  title: string;
+  selected?: boolean;
+  onSelect?: () => void;
+}>) {
+  const t = useT();
+  const { locale } = useLocale();
+  // The rank is the page's central claim, so it is readable rather than
+  // decorative: the list element carries the order for a screen reader and the
+  // number states it for everybody else.
+  const digit = (
+    <span className="t-caption worklist-rank">
+      {formatNumber(position, locale)}
+    </span>
+  );
+  if (!onSelect) {
+    return digit;
+  }
+  return (
+    <button
+      type="button"
+      className="worklist-rank-select"
+      aria-pressed={selected ?? false}
+      // Names the ROW, not the verb. Every rank button carrying the same label
+      // made them indistinguishable to anybody navigating by name, and overrode
+      // the visible digit — which is the one thing that told them apart on
+      // screen.
+      aria-label={t("worklist.pane.openRow", {
+        position: formatNumber(position, locale),
+        title,
+      })}
+      onClick={onSelect}
+    >
+      {digit}
+    </button>
   );
 }
 


### PR DESCRIPTION
Home was deal-only. Its queue answered "what is worth pursuing", which is
a different question from "what is already waiting on me", and a morning
that led with the second one was leading with the wrong half. The plan
called this section Do next and put it above the opportunity queue; this
builds it.

THE SAME ROWS THE WORKLIST DRAWS, from the same query key and the same
component. Not a second table over the same order — the server's
tie-breaks need a base-currency conversion and a materiality threshold
the browser does not hold, so this takes a prefix of the queue and
re-sorts nothing. A test fails if it ever does.

WorklistRow's pane callbacks are optional now. Home has no second column
to open a row INTO, so passing a no-op would draw a rank button that
answers nothing — the dead control that component's own comment warns
about. Absent means the rank draws as the number it is. The rank moved
into its own component on the way, because the conditional put
WorklistRow one point over the complexity ceiling.

Decisions stay with the deck. An approval is one row of one ranked order
on the Worklist and that is right there; on Home the decisions deck holds
the same approvals further up the same page, posting to the same
endpoint. Drawing them here put one decision in front of a reader twice,
each copy answerable. Found by looking at the rendered page — every test
in this file passed with it there. Excluded by source rather than by
matching the deck's contents, which are a separate read that can be
pending while this one is ready.

Fixed along the way: the optional chain reached the payload but not the
queue, so an answer carrying no queue threw and took the whole page with
it. Second time that exact mistake has reached a gate on this screen, so
it now has a test of its own.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

Gates: `make check-fe` and `make check-backend` green, `make e2e-brief` 12 passed against a live stack. Three guards mutation-checked: a client re-sort, a failed read reading as empty, and approvals returning to the section each fail the tests that name them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Do next" section to Home that shows the first three rows of the worklist queue above the opportunity queue. Home previously only surfaced deals, which answers "what is worth pursuing" but not "what is already waiting on me."

**Details**
- Draws a server-ordered prefix of the same query key and component the Worklist uses; no client re-sort or filter.
- Excludes approval items by source so the decisions deck above stays the only answerable copy.
- Makes WorklistRow's pane callbacks optional: without them the rank renders as a number instead of a dead button.
- Fixes a crash where a worklist answer carrying no queue took the whole page down.

<sup>Written for commit 9dd374216c9ef2813827973d0459e31b561454c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Do next” section to the Home screen showing up to three prioritized work items.
  - Added links to the remaining worklist items with localized counts.
  - Improved worklist rows with optional selection and batch review actions.
  - Added English, German, and Vietnamese translations for the new section.
- **Bug Fixes**
  - Added clear handling for loading, empty, failed, and unavailable worklist states.
  - Approval-related items are excluded from the “Do next” list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->