### PR TITLE
A drafted reply has one reader, and the note asks for what it refuses

### DIFF
--- a/backend/gates/draftreplyreader_test.go
+++ b/backend/gates/draftreplyreader_test.go
@@ -39,7 +39,9 @@ import (
 // text — which is what a caller does to a MODEL reply and to nothing else.
 // Matching the tags alone flagged an email row and a licence response that
 // merely have a subject; matching Unfence alone would flag every other reply
-// shape in the tree.
+// shape in the tree. The tag patterns admit an option list, because
+// `json:"subject,omitempty"` is the same envelope field and an exact-match
+// pattern would have read past it.
 //
 // What it cannot see: a reader that unwraps a model reply some other way, or
 // one that names the fields without the tags. Both are reachable and neither
@@ -47,8 +49,8 @@ import (
 // the scan failing SHORT, which is the one way this gate could report PASS
 // while reading nothing.
 var replyEnvelopeMarkers = []*regexp.Regexp{
-	regexp.MustCompile(`json:"subject"`),
-	regexp.MustCompile(`json:"body"`),
+	regexp.MustCompile(`json:"subject[,"]`),
+	regexp.MustCompile(`json:"body[,"]`),
 	regexp.MustCompile(`Unfence\(`),
 }
 

--- a/backend/gates/draftreplyreader_test.go
+++ b/backend/gates/draftreplyreader_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// A {subject, body} model reply has ONE reader.
+//
+// It had two. The introduction REQUEST (org360, written to a colleague) and the
+// introduction NOTE (network, forwarded to a customer) each unmarshalled the
+// same envelope and each refused on the same three conditions, written
+// independently. The prompts differ deliberately — two registers, argued in the
+// code beside each wording table — but the contract underneath never had a
+// reason to be spelled twice.
+//
+// What the duplication cost was not drift. It was that the DEFECT was copied:
+// both refused an empty subject while neither prompt asked for one, and both
+// required a name in the body that neither prompt demanded. A model obeying
+// either prompt was refused, the reader silently got the template, and fixing
+// one copy left the other live on a customer-facing path.
+//
+// So this is the test that fails when a third appears. A new drafting surface
+// reads its reply through compose/draftreply, or it states here why it cannot.
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// A reader of this reply does three things, and the gate asks for all three:
+// it declares the subject and body fields of the envelope, and it unfences the
+// text — which is what a caller does to a MODEL reply and to nothing else.
+// Matching the tags alone flagged an email row and a licence response that
+// merely have a subject; matching Unfence alone would flag every other reply
+// shape in the tree.
+//
+// What it cannot see: a reader that unwraps a model reply some other way, or
+// one that names the fields without the tags. Both are reachable and neither
+// is how this tree writes a reply reader today. The floor below is what stops
+// the scan failing SHORT, which is the one way this gate could report PASS
+// while reading nothing.
+var replyEnvelopeMarkers = []*regexp.Regexp{
+	regexp.MustCompile(`json:"subject"`),
+	regexp.MustCompile(`json:"body"`),
+	regexp.MustCompile(`Unfence\(`),
+}
+
+// draftReplyOwner is the one file allowed to define the envelope, and the floor
+// this census is held to. A scan that stops finding it has stopped reading the
+// tree rather than found the tree clean — the one way this gate could pass
+// while seeing nothing.
+const draftReplyOwner = "internal/compose/draftreply/draftreply.go"
+
+// statedReasons are the readers that do NOT share the helper and say why,
+// which is the other half of the rule: two writers of one invariant either
+// share a helper or state their reason where the next reader meets it.
+//
+// It is not an escape hatch for a copy. A reason here has to name a difference
+// in the CONTRACT, not in the caller's convenience, and adding one without a
+// difference is the finding this gate exists to make.
+var statedReasons = gatekit.Waive(map[string]string{
+	"internal/compose/replydraftmodel.go": "the customer reply draft is a different contract over the same envelope: " +
+		"it refuses a subject carrying a line break and enforces the RFC length bounds its schema declares, " +
+		"leaves the subject un-normalized because the caller sends it as typed, and splits parse from validate " +
+		"so the retry validator judges the answer the caller will get. draftreply.Parse would trim and " +
+		"plain-text the subject and drop both refusals.",
+	"internal/compose/accountdraft/write.go": "an outward customer draft carries its greeting INSIDE the body, " +
+		"and the model runs it into the first line often enough that reading the reply means splitting it " +
+		"(draftfloor.SplitGreetingLine over the recipient's name) before anything can ask whether the body is " +
+		"empty. What counts as the body differs, so the refusal cannot be shared until the helper can express " +
+		"that transform — a candidate for adoption, not a difference of taste.",
+	"internal/compose/persondraft/write.go": "the same outward-draft contract as accountdraft: the greeting is " +
+		"split out of the body before the empty check, so what the refusal judges is not the text the model " +
+		"returned. These two are also each other's copy, which is its own finding and its own change.",
+})
+
+// contractsPrefix is generated from backend/api/crm.yaml. Its envelopes are the
+// PUBLIC shape, not a reading of a model reply, and it is never hand-edited.
+const contractsPrefix = "internal/contracts"
+
+func TestASubjectBodyModelReplyHasOneReader(t *testing.T) {
+	t.Parallel()
+	var readers []string
+	ownerSeen := false
+
+	// "internal", not "..": the gates package runs with the module directory as
+	// its cwd, and walking the repo root sweeps every sibling git worktree on
+	// this machine — their copies of these files would be reported as this
+	// tree's, which is a finding about somebody else's branch.
+	err := filepath.WalkDir("internal", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		reads := true
+		for _, marker := range replyEnvelopeMarkers {
+			if !marker.Match(body) {
+				reads = false
+				break
+			}
+		}
+		if !reads {
+			return nil
+		}
+		rel := filepath.ToSlash(path)
+		switch {
+		case rel == draftReplyOwner:
+			ownerSeen = true
+		case statedReasons.Waived(t, rel):
+			// Says why it does not share the helper; the assertion below holds
+			// the register to reasons that name a contract difference.
+		case strings.HasPrefix(rel, contractsPrefix):
+			// The wire contract, generated from backend/api/crm.yaml.
+		case strings.Contains(rel, "/certcase_"):
+			// The certification harness reads a reply to SCORE it, which is the
+			// one place a second reading is the point: a case that read the
+			// answer through the production parse would certify the parse
+			// rather than the model.
+		default:
+			readers = append(readers, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the tree: %v", err)
+	}
+
+	if !ownerSeen {
+		t.Fatalf("the scan never found %s, so it is reading a tree this gate does not describe "+
+			"— a census that can fail short has already failed", draftReplyOwner)
+	}
+	// A stated reason describing a reader that is gone is a claim about a tree
+	// this one no longer is.
+	statedReasons.AssertAllMatched(t)
+	if len(readers) > 0 {
+		t.Errorf("a {subject, body} model reply is read outside compose/draftreply:\n\t%s\n\n"+
+			"Read it through draftreply.Parse. Two readers of one reply is how the same "+
+			"defect reached two sites: each refused what neither prompt asked for, and "+
+			"fixing one left the other live.", strings.Join(readers, "\n\t"))
+	}
+}

--- a/backend/internal/compose/draftreply/ask.go
+++ b/backend/internal/compose/draftreply/ask.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftreply
+
+import (
+	"context"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/ports/model"
+)
+
+// Lane is the model lane a drafting site sends through. A site declares its own
+// one-method interface for injection; this one is satisfied by the same values.
+type Lane interface {
+	Complete(ctx context.Context, req model.Request) (model.Response, error)
+}
+
+// validatedLane is a lane that can re-ask when the reply is refused. Not every
+// lane can — the offline fake and the test doubles cannot — so the dispatch
+// below asks rather than requires.
+type validatedLane interface {
+	CompleteValidated(ctx context.Context, req model.Request, validate ai.Validator) (model.Response, error)
+}
+
+// Ask sends the request, re-asking when the reply is one the site would refuse.
+//
+// validate is the site's OWN read of the reply, not a looser shape check: a
+// reply that is valid JSON and still names nobody is exactly what a retry can
+// fix, and the refusal message is what tells the model why. A shape-only check
+// would spend the attempt without naming the fault.
+//
+// This is the dispatch, and it is here rather than beside each site because
+// both wrote it identically — which is the same accident that put two readers
+// on one reply and let one defect become two.
+func Ask(ctx context.Context, lane Lane, req model.Request, validate ai.Validator) (model.Response, error) {
+	if structured, ok := lane.(validatedLane); ok {
+		return structured.CompleteValidated(ctx, req, validate)
+	}
+	return lane.Complete(ctx, req)
+}

--- a/backend/internal/compose/draftreply/ask_test.go
+++ b/backend/internal/compose/draftreply/ask_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftreply_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/draftreply"
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/ports/model"
+)
+
+// plainLane answers once and cannot re-ask, which is the offline fake and every
+// test double.
+type plainLane struct {
+	calls int
+	reply string
+}
+
+func (l *plainLane) Complete(context.Context, model.Request) (model.Response, error) {
+	l.calls++
+	return model.Response{Text: l.reply}, nil
+}
+
+// retryingLane is the structured lane: it hands the validator its first answer
+// and, when that is refused, answers again — which is what the real pipeline
+// does with the refusal message in hand.
+type retryingLane struct {
+	plainLane
+	validated int
+	refused   error
+	second    string
+}
+
+func (l *retryingLane) CompleteValidated(
+	_ context.Context, _ model.Request, validate ai.Validator,
+) (model.Response, error) {
+	l.validated++
+	if err := validate(l.reply); err != nil {
+		l.refused = err
+		return model.Response{Text: l.second}, nil
+	}
+	return model.Response{Text: l.reply}, nil
+}
+
+const refusable = `{"subject":"Intro?","body":"Could you introduce me to them?"}`
+const sendable = `{"subject":"Intro?","body":"Hi Sofia, could you introduce me to Philipp Königs?"}`
+
+func readsIt(text string) error {
+	_, _, err := draftreply.Parse(text, "Sofia", "Philipp Königs")
+	return err
+}
+
+// A lane that can re-ask is asked through the site's OWN read, so the refusal
+// the model is shown is the one the answer path would have raised.
+func TestALaneThatCanReAskIsGivenTheSitesOwnRefusal(t *testing.T) {
+	t.Parallel()
+	lane := &retryingLane{plainLane: plainLane{reply: refusable}, second: sendable}
+	res, err := draftreply.Ask(context.Background(), lane, model.Request{}, readsIt)
+	if err != nil {
+		t.Fatalf("asking: %v", err)
+	}
+	if lane.validated != 1 {
+		t.Errorf("the validated lane was used %d times, want once", lane.validated)
+	}
+	if lane.calls != 0 {
+		t.Errorf("the plain path was taken %d times on a lane that can re-ask", lane.calls)
+	}
+	if lane.refused == nil {
+		t.Fatal("the validator never refused the first answer, so nothing was re-asked")
+	}
+	if res.Text != sendable {
+		t.Errorf("the second answer did not come back: %q", res.Text)
+	}
+}
+
+// A lane that cannot re-ask still answers. Its absence is an ordinary
+// configuration, not an error: the reader gets the template rather than a
+// failure about a lane they cannot configure.
+func TestALaneThatCannotReAskStillAnswers(t *testing.T) {
+	t.Parallel()
+	lane := &plainLane{reply: sendable}
+	res, err := draftreply.Ask(context.Background(), lane, model.Request{}, readsIt)
+	if err != nil {
+		t.Fatalf("asking: %v", err)
+	}
+	if lane.calls != 1 {
+		t.Errorf("the plain lane was called %d times, want once", lane.calls)
+	}
+	if res.Text != sendable {
+		t.Errorf("the answer did not come back: %q", res.Text)
+	}
+}
+
+// failingLane is a lane that cannot answer at all.
+type failingLane struct{ err error }
+
+func (l failingLane) Complete(context.Context, model.Request) (model.Response, error) {
+	return model.Response{}, l.err
+}
+
+// The lane's own failure reaches the caller, which is what lets the site
+// degrade to its template rather than report a reply it never got.
+func TestALaneFailureReachesTheCaller(t *testing.T) {
+	t.Parallel()
+	want := errors.New("every bound tier failed")
+	if _, err := draftreply.Ask(
+		context.Background(), failingLane{err: want}, model.Request{}, readsIt,
+	); !errors.Is(err, want) {
+		t.Fatalf("the lane's failure did not reach the caller: %v", err)
+	}
+}

--- a/backend/internal/compose/draftreply/ask_test.go
+++ b/backend/internal/compose/draftreply/ask_test.go
@@ -39,15 +39,20 @@ func (l *retryingLane) CompleteValidated(
 	_ context.Context, _ model.Request, validate ai.Validator,
 ) (model.Response, error) {
 	l.validated++
-	if err := validate(l.reply); err != nil {
-		l.refused = err
-		return model.Response{Text: l.second}, nil
+	l.refused = validate(l.reply)
+	if l.refused == nil {
+		return model.Response{Text: l.reply}, nil
 	}
-	return model.Response{Text: l.reply}, nil
+	// A refusal is not this lane's failure to report: the real pipeline hands
+	// the message back to the model and asks again, and this double answers
+	// with what a corrected model would send.
+	return model.Response{Text: l.second}, nil
 }
 
-const refusable = `{"subject":"Intro?","body":"Could you introduce me to them?"}`
-const sendable = `{"subject":"Intro?","body":"Hi Sofia, could you introduce me to Philipp Königs?"}`
+const (
+	refusable = `{"subject":"Intro?","body":"Could you introduce me to them?"}`
+	sendable  = `{"subject":"Intro?","body":"Hi Sofia, could you introduce me to Philipp Königs?"}`
+)
 
 func readsIt(text string) error {
 	_, _, err := draftreply.Parse(text, "Sofia", "Philipp Königs")

--- a/backend/internal/compose/draftreply/draftreply.go
+++ b/backend/internal/compose/draftreply/draftreply.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package draftreply reads the {subject, body} reply the message-drafting
+// sites take, and refuses what a reader must not be handed.
+//
+// It exists because two sites wrote this rule independently and both wrote it
+// wrong the same way. The introduction REQUEST (org360, addressed to a
+// colleague) and the introduction NOTE (network, forwarded to a customer) are
+// two prompts with two registers, deliberately — each says so beside its own
+// wording table, and merging them would produce a customer email in a
+// colleague's voice. What they never had reason to spell twice is the contract
+// underneath: the same three refusals, over the same reply shape, from the same
+// primitives.
+//
+// The cost of writing it twice was not drift. It was that the DEFECT was
+// copied: both refused an empty subject while neither prompt asked for one, and
+// both required names in the body that neither prompt demanded. A model
+// obeying either prompt was refused, the reader silently got the template, and
+// fixing one copy left the other live. One parse makes that one bug.
+package draftreply
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
+)
+
+// Parse reads a model reply and returns the message it carries.
+//
+// mustName is who the BODY has to name — a draft that never names its reader is
+// not addressed to them, and one that never names its subject asks for nothing
+// in particular. Both read as a message the recipient must rewrite, which is
+// worse than the template they would otherwise have been handed. An empty name
+// asks nothing, so a caller may pass one it does not have.
+//
+// This is a SHAPE check, not a grounding filter: it says a message was written
+// to the right people, and claims nothing about what it says about them. What a
+// draft may CLAIM is scored by a rubric, because no substring test can.
+//
+// Errors carry no package prefix — the caller wraps with its own, because the
+// site a reader was refused by is the site that has to name itself.
+func Parse(raw string, mustName ...string) (subject, body string, err error) {
+	var answer struct {
+		Subject string `json:"subject"`
+		Body    string `json:"body"`
+	}
+	if err := json.Unmarshal([]byte(ai.Unfence(raw)), &answer); err != nil {
+		return "", "", fmt.Errorf("the reply is not the shape this site takes: %w", err)
+	}
+	subject = strings.TrimSpace(ai.PlainText(answer.Subject))
+	body = strings.TrimSpace(ai.PlainText(answer.Body))
+	if subject == "" || body == "" {
+		return "", "", fmt.Errorf("the reply carries no message to send")
+	}
+	for _, needed := range mustName {
+		if !draftfloor.NamesPerson(body, needed) {
+			return "", "", fmt.Errorf("the draft never names %q", needed)
+		}
+	}
+	return subject, body, nil
+}

--- a/backend/internal/compose/draftreply/draftreply_test.go
+++ b/backend/internal/compose/draftreply/draftreply_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftreply_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/draftreply"
+)
+
+// A message a reader can send survives, whatever the model wrapped it in.
+func TestASendableReplyIsRead(t *testing.T) {
+	t.Parallel()
+	for name, raw := range map[string]string{
+		"bare object": `{"subject":"Intro to Philipp?","body":"Hi Sofia, could you introduce me to Philipp Königs?"}`,
+		"fenced":      "```json\n{\"subject\":\"Intro to Philipp?\",\"body\":\"Hi Sofia, could you introduce me to Philipp Königs?\"}\n```",
+		"padded":      `{"subject":"  Intro to Philipp?  ","body":"  Hi Sofia, could you introduce me to Philipp Königs?  "}`,
+	} {
+		subject, body, err := draftreply.Parse(raw, "Sofia", "Philipp Königs")
+		if err != nil {
+			t.Fatalf("%s: refused a sendable reply: %v", name, err)
+		}
+		if subject != "Intro to Philipp?" {
+			t.Errorf("%s: subject came back %q", name, subject)
+		}
+		if !strings.HasPrefix(body, "Hi Sofia,") {
+			t.Errorf("%s: body came back %q", name, body)
+		}
+	}
+}
+
+// Each refusal exists because the reader would otherwise be handed something
+// worse than the template: nothing to send, or a message they must rewrite.
+func TestAReplyAReaderCannotSendIsRefused(t *testing.T) {
+	t.Parallel()
+	for name, raw := range map[string]string{
+		"not the shape":  `not json at all`,
+		"no subject":     `{"subject":"","body":"Hi Sofia, could you introduce me to Philipp Königs?"}`,
+		"no body":        `{"subject":"Intro?","body":"   "}`,
+		"names nobody":   `{"subject":"Intro?","body":"Could you introduce me to them?"}`,
+		"names only one": `{"subject":"Intro?","body":"Hi Sofia, could you introduce me to someone there?"}`,
+	} {
+		if _, _, err := draftreply.Parse(raw, "Sofia", "Philipp Königs"); err == nil {
+			t.Errorf("%s: accepted a reply the reader cannot send", name)
+		}
+	}
+}
+
+// A caller may pass a name it does not have — an absent fact asks nothing of
+// the model, and refusing on it would fail every reply for a missing field.
+func TestAnEmptyNameAsksNothing(t *testing.T) {
+	t.Parallel()
+	if _, _, err := draftreply.Parse(
+		`{"subject":"Intro?","body":"Hi Sofia, could you introduce me?"}`, "Sofia", "",
+	); err != nil {
+		t.Fatalf("an absent name refused the reply: %v", err)
+	}
+}
+
+// The refusal says which name is missing, because a reliability drop that does
+// not name its cause is a number rather than a diagnosis.
+func TestTheRefusalNamesWhoIsMissing(t *testing.T) {
+	t.Parallel()
+	_, _, err := draftreply.Parse(
+		`{"subject":"Intro?","body":"Hi Sofia, could you introduce me?"}`, "Sofia", "Philipp Königs")
+	if err == nil {
+		t.Fatal("accepted a draft naming only one of two people")
+	}
+	if !strings.Contains(err.Error(), "Philipp Königs") {
+		t.Errorf("the refusal does not name who is missing: %v", err)
+	}
+}

--- a/backend/internal/compose/draftreply/draftreply_test.go
+++ b/backend/internal/compose/draftreply/draftreply_test.go
@@ -18,16 +18,19 @@ func TestASendableReplyIsRead(t *testing.T) {
 		"fenced":      "```json\n{\"subject\":\"Intro to Philipp?\",\"body\":\"Hi Sofia, could you introduce me to Philipp Königs?\"}\n```",
 		"padded":      `{"subject":"  Intro to Philipp?  ","body":"  Hi Sofia, could you introduce me to Philipp Königs?  "}`,
 	} {
-		subject, body, err := draftreply.Parse(raw, "Sofia", "Philipp Königs")
-		if err != nil {
-			t.Fatalf("%s: refused a sendable reply: %v", name, err)
-		}
-		if subject != "Intro to Philipp?" {
-			t.Errorf("%s: subject came back %q", name, subject)
-		}
-		if !strings.HasPrefix(body, "Hi Sofia,") {
-			t.Errorf("%s: body came back %q", name, body)
-		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			subject, body, err := draftreply.Parse(raw, "Sofia", "Philipp Königs")
+			if err != nil {
+				t.Fatalf("refused a sendable reply: %v", err)
+			}
+			if subject != "Intro to Philipp?" {
+				t.Errorf("subject came back %q", subject)
+			}
+			if !strings.HasPrefix(body, "Hi Sofia,") {
+				t.Errorf("body came back %q", body)
+			}
+		})
 	}
 }
 

--- a/backend/internal/compose/network/intronote_test.go
+++ b/backend/internal/compose/network/intronote_test.go
@@ -292,3 +292,68 @@ func TestTheReasonsNameTheRouteAndOnlyWhatIsRecorded(t *testing.T) {
 		t.Errorf("the reason claims a band with none on file: %q", label)
 	}
 }
+
+// A reply that obeys noteSystem to the letter must survive parseIntroNote.
+//
+// It did not. The prompt's only mention of a subject was the prohibition "No
+// subject line inside the body", so an obedient model left the field empty and
+// the note was refused; and "Write TO the recipient" never asked for the
+// recipient's NAME, which the parse requires. Every such reply fell to the
+// template, on a note a customer reads, with nothing red anywhere.
+//
+// The replies below are written from the PROMPT, never from the parse. Written
+// from the parse they would pass by construction and prove nothing.
+func TestANoteObeyingThePromptIsAccepted(t *testing.T) {
+	t.Parallel()
+	facts := warmNote()
+	for name, reply := range map[string]string{
+		"the shortest obeying reply": `{"subject":"Introducing Lena Fischer","body":"Hi Philipp, I wanted to put you in touch with Lena Fischer, a colleague of mine. Her team cut depot energy costs by a fifth at two comparable sites, which I thought might be worth a conversation."}`,
+		"no relationship claimed":    `{"subject":"Introducing Lena Fischer","body":"Hi Philipp, I thought I would introduce you to Lena Fischer. She works on depot energy costs, which may be worth a short conversation."}`,
+	} {
+		if _, err := parseIntroNote(reply, facts); err != nil {
+			t.Errorf("refused a reply that obeys the prompt (%s): %v", name, err)
+		}
+	}
+}
+
+// The mirror of the parse: every name and field the parse requires has to be
+// asked for in the prompt that must satisfy it. This is the half that was
+// missing, and its absence is why the site was refused on every request.
+func TestTheNotePromptAsksForWhatTheParseRequires(t *testing.T) {
+	t.Parallel()
+	for _, required := range []string{
+		"address them by name: open with their first name",
+		"naming them in full",
+		`Write a short subject line in the "subject" field`,
+	} {
+		if !strings.Contains(noteSystem, required) {
+			t.Fatalf("the prompt never asks for %q, but the parse refuses a reply that omits it", required)
+		}
+	}
+}
+
+// The template must survive the parse that judges the model.
+//
+// It did not: the floor greets "Hi Philipp," while the parse demanded
+// "Philipp Königs", so the site's own known-good output was refused by its own
+// checker. That is the cheapest possible statement of the contract, and it
+// needs no model, no key and no network — the floor is DERIVED from the facts
+// rather than hand-authored, so it cannot be quietly written to satisfy the
+// checker it is meant to hold.
+func TestTheNoteTemplateSurvivesItsOwnParse(t *testing.T) {
+	t.Parallel()
+	for name, facts := range map[string]noteFacts{
+		"a warm route":        warmNote(),
+		"nothing recorded":    {contact: "Philipp Königs", colleague: "Sofia Meier", requester: "Lena Fischer", lang: textlang.English},
+		"through a middleman": {contact: "Philipp Königs", colleague: "Sofia Meier", requester: "Lena Fischer", through: "Marek Janetzke", lang: textlang.English},
+	} {
+		floor := noteFloor(facts)
+		raw, err := json.Marshal(map[string]string{"subject": floor.subject, "body": floor.body})
+		if err != nil {
+			t.Fatalf("%s: marshalling the floor: %v", name, err)
+		}
+		if _, err := parseIntroNote(string(raw), facts); err != nil {
+			t.Errorf("%s: the template is refused by its own parse: %v", name, err)
+		}
+	}
+}

--- a/backend/internal/compose/network/intronotewrite.go
+++ b/backend/internal/compose/network/intronotewrite.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/margince/margince/backend/internal/compose/draftreply"
 	"github.com/margince/margince/backend/internal/compose/promptlang"
 	"github.com/margince/margince/backend/internal/compose/promptvoice"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -56,11 +57,35 @@ func writeIntroNote(
 	return wireIntroNote(written, crmcontracts.Model, facts)
 }
 
+// validatedLane is a lane that can re-ask when the reply is refused.
+//
+// The refusal message goes back to the model, which is the difference between
+// a rule it broke once and a rule it never learns: this note reaches a
+// customer, and losing the lane costs the colleague the phrasing.
+type validatedLane interface {
+	CompleteValidated(ctx context.Context, req model.Request, validate ai.Validator) (model.Response, error)
+}
+
 // noteFromModel writes the note and checks what came back.
+//
+// The retry is judged by the SAME parse the answer path runs, not a looser
+// shape check: a reply that parses as JSON and still names nobody is exactly
+// the reply a retry can fix, and telling the model only "be valid JSON" would
+// spend the attempt without saying what was wrong.
 func noteFromModel(
 	ctx context.Context, lane Completer, facts noteFacts,
 ) (introNote, error) {
-	res, err := lane.Complete(ctx, noteRequest(facts))
+	req := noteRequest(facts)
+	var res model.Response
+	var err error
+	if structured, ok := lane.(validatedLane); ok {
+		res, err = structured.CompleteValidated(ctx, req, func(text string) error {
+			_, parseErr := parseIntroNote(text, facts)
+			return parseErr
+		})
+	} else {
+		res, err = lane.Complete(ctx, req)
+	}
 	if err != nil {
 		return introNote{}, fmt.Errorf("network: drafting the introduction note: %w", err)
 	}
@@ -72,8 +97,9 @@ const noteSystem = `You write one short note that a person will FORWARD to someb
 The reader is the recipient — a customer or a prospect, not a teammate. You are writing in the voice of the person who will send it: they know the recipient, and they are passing along an introduction.
 
 Rules you must not break:
-- Write TO the recipient. Never mention that anybody was asked to make this introduction, and never refer to an internal request.
-- Say who is being introduced and why the recipient might care, in one sentence each.
+- Write TO the recipient, and address them by name: open with their first name. Never mention that anybody was asked to make this introduction, and never refer to an internal request.
+- Say who is being introduced, naming them in full, and why the recipient might care, in one sentence each.
+- Write a short subject line in the "subject" field, naming the colleague you are introducing.
 - Do not invent anything about the relationship or about the recipient's company. You are told how warm the relationship is and when they last spoke; say no more than that.
 - Ask for nothing more than a conversation. No pitch, no pricing, no meeting times.
 - No subject line inside the body.`
@@ -125,32 +151,21 @@ func noteSchema() json.RawMessage {
 
 // parseIntroNote reads the reply and refuses what a reader must not be handed.
 //
-// A SHAPE check, not a grounding filter: it says the note was written to the
-// right person about the right person, and claims nothing about what it says of
-// them. Whether it overstates the relationship is scored by the certification
-// rubric, because no substring test can decide it.
+// The refusals are draftreply's, shared with the colleague-facing request: the
+// same reply shape, judged the same way, spelled once.
+//
+// Held by: TestASubjectBodyModelReplyHasOneReader
+// (backend/gates/draftreplyreader_test.go), which fails when a third reader of
+// this envelope appears without stating how its contract differs.
 func parseIntroNote(raw string, facts noteFacts) (introNote, error) {
-	var answer struct {
-		Subject string `json:"subject"`
-		Body    string `json:"body"`
-	}
-	if err := json.Unmarshal([]byte(ai.Unfence(raw)), &answer); err != nil {
-		return introNote{}, fmt.Errorf(
-			"network: the reply is not the shape this site takes: %w", err)
-	}
-	subject := strings.TrimSpace(ai.PlainText(answer.Subject))
-	body := strings.TrimSpace(ai.PlainText(answer.Body))
-	if subject == "" || body == "" {
-		return introNote{}, fmt.Errorf("network: the reply carries no note to forward")
-	}
-	// A note that never names the person being introduced is asking for
-	// nothing in particular, and one that never names the recipient is not
-	// addressed to them. Either reads as a message the colleague must rewrite,
-	// which is worse than the template they would otherwise have had.
-	for _, needed := range []string{facts.requester, facts.contact} {
-		if needed != "" && !draftfloor.NamesPerson(body, needed) {
-			return introNote{}, fmt.Errorf("network: the note never names %q", needed)
-		}
+	// The recipient is ADDRESSED, so their first name is what a greeting
+	// carries; the colleague is TALKED ABOUT, so they are named in full. The
+	// asymmetry is org360's, and it is not cosmetic: requiring the recipient's
+	// surname refused this site's own template, whose greeting is "Hi Philipp,".
+	subject, body, err := draftreply.Parse(raw,
+		draftfloor.FirstName(facts.contact), facts.requester)
+	if err != nil {
+		return introNote{}, fmt.Errorf("network: %w", err)
 	}
 	return introNote{subject: subject, body: body}, nil
 }

--- a/backend/internal/compose/network/intronotewrite.go
+++ b/backend/internal/compose/network/intronotewrite.go
@@ -57,35 +57,17 @@ func writeIntroNote(
 	return wireIntroNote(written, crmcontracts.Model, facts)
 }
 
-// validatedLane is a lane that can re-ask when the reply is refused.
-//
-// The refusal message goes back to the model, which is the difference between
-// a rule it broke once and a rule it never learns: this note reaches a
-// customer, and losing the lane costs the colleague the phrasing.
-type validatedLane interface {
-	CompleteValidated(ctx context.Context, req model.Request, validate ai.Validator) (model.Response, error)
-}
-
 // noteFromModel writes the note and checks what came back.
 //
-// The retry is judged by the SAME parse the answer path runs, not a looser
-// shape check: a reply that parses as JSON and still names nobody is exactly
-// the reply a retry can fix, and telling the model only "be valid JSON" would
-// spend the attempt without saying what was wrong.
+// draftreply.Ask re-asks through the SAME parse the answer path runs, so a
+// reply this site would refuse goes back to the model with the reason.
 func noteFromModel(
 	ctx context.Context, lane Completer, facts noteFacts,
 ) (introNote, error) {
-	req := noteRequest(facts)
-	var res model.Response
-	var err error
-	if structured, ok := lane.(validatedLane); ok {
-		res, err = structured.CompleteValidated(ctx, req, func(text string) error {
-			_, parseErr := parseIntroNote(text, facts)
-			return parseErr
-		})
-	} else {
-		res, err = lane.Complete(ctx, req)
-	}
+	res, err := draftreply.Ask(ctx, lane, noteRequest(facts), func(text string) error {
+		_, parseErr := parseIntroNote(text, facts)
+		return parseErr
+	})
 	if err != nil {
 		return introNote{}, fmt.Errorf("network: drafting the introduction note: %w", err)
 	}

--- a/backend/internal/compose/org360/introdraft_test.go
+++ b/backend/internal/compose/org360/introdraft_test.go
@@ -4,6 +4,7 @@
 package org360
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -259,6 +260,26 @@ func TestTheIntroPromptAsksForTheNamesTheCheckerRequires(t *testing.T) {
 	} {
 		if !strings.Contains(introSystem, required) {
 			t.Fatalf("the prompt never asks the model to %q, but parseIntroDraft refuses a draft that omits it", required)
+		}
+	}
+}
+
+// The sibling of the note's floor test: the template must survive the parse
+// that judges the model. Free, derived rather than hand-authored, and the
+// cheapest place this site's contract can be stated.
+func TestTheIntroTemplateSurvivesItsOwnParse(t *testing.T) {
+	t.Parallel()
+	for name, fixture := range map[string]IntroFixture{
+		"a warm route":     warmIntro(),
+		"nothing recorded": {Colleague: "Sofia Meier", Contact: "Philipp Königs"},
+	} {
+		subject, body := IntroFloorFor(fixture)
+		raw, err := json.Marshal(map[string]string{"subject": subject, "body": body})
+		if err != nil {
+			t.Fatalf("%s: marshalling the floor: %v", name, err)
+		}
+		if _, _, err := CheckIntroDraft(string(raw), fixture); err != nil {
+			t.Errorf("%s: the template is refused by its own parse: %v", name, err)
 		}
 	}
 }

--- a/backend/internal/compose/org360/introdraftwrite.go
+++ b/backend/internal/compose/org360/introdraftwrite.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/margince/margince/backend/internal/compose/draftreply"
 	"github.com/margince/margince/backend/internal/compose/promptlang"
 	"github.com/margince/margince/backend/internal/compose/promptvoice"
 	"github.com/margince/margince/backend/internal/contracts"
@@ -52,11 +53,32 @@ func writeIntroRequest(
 	return wireIntroRequest(written, crmcontracts.Model, facts)
 }
 
+// validatedLane is a lane that can re-ask when the reply is refused. The
+// refusal message goes back to the model, so a rule it broke once is a rule it
+// is told rather than one it keeps breaking.
+type validatedLane interface {
+	CompleteValidated(ctx context.Context, req model.Request, validate ai.Validator) (model.Response, error)
+}
+
 // introFromModel writes the ask and checks what came back.
+//
+// The retry is judged by the SAME parse the answer path runs: a reply that is
+// valid JSON and still names nobody is exactly what a retry can fix, and a
+// looser shape check would spend the attempt without naming the fault.
 func introFromModel(
 	ctx context.Context, lane Completer, facts introFacts,
 ) (introDraft, error) {
-	res, err := lane.Complete(ctx, introRequest(facts))
+	req := introRequest(facts)
+	var res model.Response
+	var err error
+	if structured, ok := lane.(validatedLane); ok {
+		res, err = structured.CompleteValidated(ctx, req, func(text string) error {
+			_, parseErr := parseIntroDraft(text, facts)
+			return parseErr
+		})
+	} else {
+		res, err = lane.Complete(ctx, req)
+	}
 	if err != nil {
 		return introDraft{}, fmt.Errorf("org360: drafting the introduction request: %w", err)
 	}
@@ -126,32 +148,18 @@ func introSchema() json.RawMessage {
 }
 
 // parseIntroDraft reads the reply and refuses what a reader must not be handed.
+//
+// The refusals are draftreply's, shared with the forwardable note: the same
+// reply shape, judged the same way, spelled once.
+//
+// Held by: TestASubjectBodyModelReplyHasOneReader
+// (backend/gates/draftreplyreader_test.go), which fails when a third reader of
+// this envelope appears without stating how its contract differs.
 func parseIntroDraft(raw string, facts introFacts) (introDraft, error) {
-	var answer struct {
-		Subject string `json:"subject"`
-		Body    string `json:"body"`
-	}
-	if err := json.Unmarshal([]byte(ai.Unfence(raw)), &answer); err != nil {
-		return introDraft{}, fmt.Errorf("org360: the reply is not the shape this site takes: %w", err)
-	}
-	subject := strings.TrimSpace(ai.PlainText(answer.Subject))
-	body := strings.TrimSpace(ai.PlainText(answer.Body))
-	if subject == "" || body == "" {
-		return introDraft{}, fmt.Errorf("org360: the reply carries no message to send")
-	}
-	// A draft that never names the colleague is not addressed to them, and a
-	// draft that never names the contact is asking for nothing in particular.
-	// Both read as a message the reader has to rewrite, which is worse than the
-	// template they would otherwise have got.
-	//
-	// This is a SHAPE check, not a grounding filter — it says a message was
-	// written to the right people, and claims nothing about what it says about
-	// them. The rubric is what scores overclaiming, because no substring test
-	// can.
-	for _, needed := range []string{draftfloor.FirstName(facts.colleague), facts.contact} {
-		if !draftfloor.NamesPerson(body, needed) {
-			return introDraft{}, fmt.Errorf("org360: the draft never names %q", needed)
-		}
+	subject, body, err := draftreply.Parse(raw,
+		draftfloor.FirstName(facts.colleague), facts.contact)
+	if err != nil {
+		return introDraft{}, fmt.Errorf("org360: %w", err)
 	}
 	return introDraft{subject: subject, body: body}, nil
 }

--- a/backend/internal/compose/org360/introdraftwrite.go
+++ b/backend/internal/compose/org360/introdraftwrite.go
@@ -53,32 +53,17 @@ func writeIntroRequest(
 	return wireIntroRequest(written, crmcontracts.Model, facts)
 }
 
-// validatedLane is a lane that can re-ask when the reply is refused. The
-// refusal message goes back to the model, so a rule it broke once is a rule it
-// is told rather than one it keeps breaking.
-type validatedLane interface {
-	CompleteValidated(ctx context.Context, req model.Request, validate ai.Validator) (model.Response, error)
-}
-
 // introFromModel writes the ask and checks what came back.
 //
-// The retry is judged by the SAME parse the answer path runs: a reply that is
-// valid JSON and still names nobody is exactly what a retry can fix, and a
-// looser shape check would spend the attempt without naming the fault.
+// draftreply.Ask re-asks through the SAME parse the answer path runs, so a
+// reply this site would refuse goes back to the model with the reason.
 func introFromModel(
 	ctx context.Context, lane Completer, facts introFacts,
 ) (introDraft, error) {
-	req := introRequest(facts)
-	var res model.Response
-	var err error
-	if structured, ok := lane.(validatedLane); ok {
-		res, err = structured.CompleteValidated(ctx, req, func(text string) error {
-			_, parseErr := parseIntroDraft(text, facts)
-			return parseErr
-		})
-	} else {
-		res, err = lane.Complete(ctx, req)
-	}
+	res, err := draftreply.Ask(ctx, lane, introRequest(facts), func(text string) error {
+		_, parseErr := parseIntroDraft(text, facts)
+		return parseErr
+	})
 	if err != nil {
 		return introDraft{}, fmt.Errorf("org360: drafting the introduction request: %w", err)
 	}

--- a/backend/internal/shared/kernel/draftfloor/persontext.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext.go
@@ -16,6 +16,7 @@ package draftfloor
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 )
@@ -102,7 +103,7 @@ func NamesPerson(text, name string) bool {
 		}
 		start := at + found
 		end := start + len(wanted)
-		if !partOfAWord(folded, start-1) && !partOfAWord(folded, end) {
+		if !wordBefore(folded, start) && !partOfAWord(folded, end) {
 			return true
 		}
 		at = start + 1
@@ -114,7 +115,29 @@ func partOfAWord(text string, i int) bool {
 	if i < 0 || i >= len(text) {
 		return false
 	}
-	r := rune(text[i])
+	// Decode the rune rather than widening one byte. text[i] inside a
+	// multi-byte character is a CONTINUATION byte, and most of them widen to
+	// runes unicode.IsLetter rejects — so "MüLena" reported that it names
+	// "Lena", and a draft that buries the reader's name inside another word
+	// passed the check that exists to catch exactly that.
+	r, _ := utf8.DecodeRuneInString(text[i:])
+	if r == utf8.RuneError {
+		return false
+	}
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// wordBefore reports whether the rune ENDING at i is a letter or digit, which
+// is a different question from partOfAWord: a match's left edge is the rune
+// before it, and in UTF-8 that rune does not start at i-1.
+func wordBefore(text string, i int) bool {
+	if i <= 0 || i > len(text) {
+		return false
+	}
+	r, _ := utf8.DecodeLastRuneInString(text[:i])
+	if r == utf8.RuneError {
+		return false
+	}
 	return unicode.IsLetter(r) || unicode.IsDigit(r)
 }
 

--- a/backend/internal/shared/kernel/draftfloor/persontext.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext.go
@@ -121,10 +121,7 @@ func partOfAWord(text string, i int) bool {
 	// "Lena", and a draft that buries the reader's name inside another word
 	// passed the check that exists to catch exactly that.
 	r, _ := utf8.DecodeRuneInString(text[i:])
-	if r == utf8.RuneError {
-		return false
-	}
-	return unicode.IsLetter(r) || unicode.IsDigit(r)
+	return wordRune(r)
 }
 
 // wordBefore reports whether the rune ENDING at i is a letter or digit, which
@@ -135,10 +132,21 @@ func wordBefore(text string, i int) bool {
 		return false
 	}
 	r, _ := utf8.DecodeLastRuneInString(text[:i])
+	return wordRune(r)
+}
+
+// wordRune says whether a rune continues a written word.
+//
+// Marks count. "Lena" followed by U+0308 renders as "Lenä", which is a
+// different name than the one asked for — reading the mark as a boundary let
+// the check report that a draft named somebody it did not. RuneError is not a
+// word character: text that is not valid UTF-8 has no rune at that edge to
+// judge, and guessing there would decide a name on a broken sequence.
+func wordRune(r rune) bool {
 	if r == utf8.RuneError {
 		return false
 	}
-	return unicode.IsLetter(r) || unicode.IsDigit(r)
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r)
 }
 
 // AIDisclosure is the Art. 50 authorship line, in the draft's own language.

--- a/backend/internal/shared/kernel/draftfloor/persontext_test.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext_test.go
@@ -127,3 +127,32 @@ func TestNamesPersonMatchesAWordAndNotASubstring(t *testing.T) {
 		t.Error("an empty name refused a draft it cannot judge")
 	}
 }
+
+// A name buried inside a word is not a name the draft states, and the boundary
+// on either side of a match may be a multi-byte rune.
+//
+// It read one BYTE and widened it: inside a character like "ü" that byte is a
+// continuation byte, and most of them widen to runes unicode.IsLetter rejects.
+// So "MüLena" reported that it names "Lena" — the check that exists to catch an
+// embedded name accepted one, and only where the neighbouring text is non-ASCII.
+func TestANameInsideAWordIsNotNamedAcrossAMultiByteBoundary(t *testing.T) {
+	t.Parallel()
+	for name, text := range map[string]string{
+		"non-ASCII immediately before": "MüLena schrieb gestern",
+		"non-ASCII immediately after":  "Lenaüber alles",
+		"both sides":                   "MüLenaüber",
+	} {
+		if NamesPerson(text, "Lena") {
+			t.Errorf("%s: %q was read as naming %q", name, text, "Lena")
+		}
+	}
+	for name, text := range map[string]string{
+		"after a multi-byte word":  "Grüße Lena, kurz zum Angebot",
+		"before a multi-byte word": "Lena über das Angebot",
+		"between them":             "Grüße Lena über das Angebot",
+	} {
+		if !NamesPerson(text, "Lena") {
+			t.Errorf("%s: %q does name %q and was refused", name, text, "Lena")
+		}
+	}
+}

--- a/backend/internal/shared/kernel/draftfloor/persontext_test.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext_test.go
@@ -173,3 +173,21 @@ func TestABrokenSequenceAtTheEdgeIsNotAWordCharacter(t *testing.T) {
 		}
 	}
 }
+
+// A combining mark extends the written word, so a name followed by one is a
+// different name. "Lena" plus U+0308 renders "Lenä", and reading the mark as a
+// boundary reported that a draft named Lena when it named somebody else.
+func TestACombiningMarkExtendsTheWord(t *testing.T) {
+	t.Parallel()
+	for name, text := range map[string]string{
+		"mark after the name":  "Lenä schrieb gestern",
+		"mark before the name": "̈Lena schrieb gestern",
+	} {
+		if NamesPerson(text, "Lena") {
+			t.Errorf("%s: %q was read as naming %q", name, text, "Lena")
+		}
+	}
+	if !NamesPerson("Grüße Lena, kurz zum Angebot", "Lena") {
+		t.Error("a name beside ordinary punctuation was refused")
+	}
+}

--- a/backend/internal/shared/kernel/draftfloor/persontext_test.go
+++ b/backend/internal/shared/kernel/draftfloor/persontext_test.go
@@ -156,3 +156,20 @@ func TestANameInsideAWordIsNotNamedAcrossAMultiByteBoundary(t *testing.T) {
 		}
 	}
 }
+
+// Text that is not valid UTF-8 has no rune at the edge to judge, and the
+// boundary check says so rather than guessing. A model reply is bytes off a
+// wire; a draft carrying a broken sequence must not decide a name by accident.
+func TestABrokenSequenceAtTheEdgeIsNotAWordCharacter(t *testing.T) {
+	t.Parallel()
+	// 0xFF is not a legal UTF-8 start byte, so the rune on either side of the
+	// match decodes as RuneError from a single byte.
+	for name, text := range map[string]string{
+		"broken byte before": "\xffLena wrote",
+		"broken byte after":  "Lena\xff wrote",
+	} {
+		if !NamesPerson(text, "Lena") {
+			t.Errorf("%s: %q names Lena and was refused", name, text)
+		}
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -79,7 +79,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (82)
+## Census (83)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -105,6 +105,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `dealtargettype_test.go` | H2 | Every deal-scoped staging names its target type through one constant. |
 | `declaredfilters_test.go` | H2 | A declared narrowing parameter is read by the handler it is declared on, or it is not declared. |
 | `docslinktargets_test.go` | H3 | Every relative link under docs/ points at a file that exists. |
+| `draftreplyreader_test.go` | H2 | A {subject, body} model reply has ONE reader. |
 | `edgeendpointcensus_test.go` | H2 | Every end a link can have is an end that link's history is read from. |
 | `edgereaders_test.go` | H2 | `relationship` is a first-class RBAC object, and it is the only join table in the schema that is one. |
 | `emptylistwire_test.go` | H2 | Every list envelope carries its rows in a field the writer can find. |


### PR DESCRIPTION
Part of #3531, and a direct follow-up to #3642. Records unchanged — nothing here restamps a `PromptVersion`.

## Two writers of one invariant

The introduction **request** (`org360`, written to a colleague) and the introduction **note** (`network`, forwarded to a customer) each unmarshalled the same `{subject, body}` envelope and each refused on the same three conditions, written independently.

The prompts differ deliberately and should stay two. The tree already argues it, in two places — beside `org360`'s wording table:

> Bending the outward wording into this shape would produce a message that reads like a customer email sent to a colleague.

and again at the wiring (`serveroptions_companyview.go:190`):

> two prompts with two registers, and a deployment could reasonably want the internal one and not the outward one — the note is read by a customer.

That is the rulebook satisfied: two writers of one invariant **either share a helper or say why they do not**, and the prose split has its why, in the code, where the next reader meets it.

The **contract underneath** never had that why. And the cost of writing it twice was not drift — **the defect was copied.** Both refused an empty subject while neither prompt asked for one; both required a name in the body that neither prompt demanded. #3642 fixed the request and left the note live, uncertified, on the path that reaches a customer.

`compose/draftreply` now owns the read. Both sites keep their own prompt, wording table and floor.

## Three defects the extraction surfaced, all in the note

1. **`noteSystem` never asked for a subject.** Its only mention was the prohibition *"No subject line inside the body"*, so an obedient model left the field empty and the parse refused it. Verbatim the defect that made `draft_reply/intro` score 0 of 6 in #3642.
2. **It said "Write TO the recipient" and never said to name them**, while the parse required it.
3. **The parse itself was wrong**, and this one was not predicted. It required the recipient's FULL name while the site's own template greets `Hi Philipp,` — so **the deterministic floor was refused by its own checker.** The recipient is ADDRESSED and takes a first name; the colleague is TALKED ABOUT and is named in full. That asymmetry is `org360`'s, and the note had it inverted.

Found by writing the test, not by reading the code. I predicted 1 and 2 statically and would have shipped 3.

## Re-ask, which we already owned

Both sites called plain `Complete`. They now go through `CompleteValidated` — the machinery 17 other production files already use — judged by **the same parse the answer path runs**, so the refusal message is what goes back to the model. A reply that is valid JSON and still names nobody is exactly what a retry can fix; a looser shape check would spend the attempt without naming the fault.

The two sites that failed hardest as `invalid` were the two without re-ask. That was not a coincidence.

## The cheap half of the contract

Three test shapes, none needing a model, a key or a network:

- **the template must survive its own parse** — the strongest, because the floor is DERIVED from the facts rather than hand-authored, so it cannot be quietly written to satisfy the checker it is meant to hold. This is what caught defect 3.
- **a reply obeying the prompt must be accepted** — written from the prompt, never from the parse. Written from the parse it would pass by construction and prove nothing.
- **the prompt must ask for what the parse refuses** — the mirror.

## The census, and what it caught

`TestASubjectBodyModelReplyHasOneReader` fails when a third reader appears without stating how its contract differs.

**It immediately found two readers this session's own grep had missed** — `accountdraft/write.go` and `persondraft/write.go`. I had checked their `knownRecords` implementations, concluded "repeated shape, not a repeated rule", and never looked at their reply parse. They are registered with a stated reason rather than forced to adopt: an outward draft carries its greeting INSIDE the body and splits it out (`draftfloor.SplitGreetingLine`) before anything asks whether the body is empty, so what the refusal judges is not the text the model returned. The customer reply drafter states its own difference — it refuses a subject line break, enforces RFC length bounds, and leaves the subject un-normalized because the caller sends it as typed.

The register is `gatekit.Waive`, so a reason describing a reader that is gone is reported rather than left standing.

Three corrections the tree forced during the build, each worth knowing:

- the walk started at the repo root and was scanning **sibling git worktrees**, reporting their files as this tree's
- matching the `subject` tag alone flagged an email row and a licence response; the signature needs `Unfence`, which is what a caller does to a MODEL reply and nothing else
- a hand-rolled exemption map was rejected by `TestEveryPackageLevelReasonMapIsAWaiverOrADeclaredFixture` in favour of `gatekit.Waive`

The gate states what it cannot see: a reader that unwraps a reply some other way, or one that names the fields without the tags. A floor assertion fails the run if the scan ever stops finding `draftreply` itself, which is the one way a census can report PASS while reading nothing.

## Not in this PR

The intro note ships under the `draft_reply` task (`cmd/api/modelwiring.go:183`) but is **absent from that task's site list** in `ai-tasks.yaml` (`[reply, person, account, first, intro]`). So it routes, budgets and traces like a certified site while being invisible to certification — which is why nothing ever measured it. Registering it is a contract change with its own gates and its own paid runs, and belongs in its own PR.

## Verification

`go test ./internal/compose/... ./gates/` — green. The gate suite needs `-timeout 30m` locally; it runs 485s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `{subject, body}` parsing for `org360` introduction requests and `network` introduction notes into `compose/draftreply`, replacing two duplicated readers with one shared contract. The note prompt now asks for a subject and for the names the parse requires, and both paths retry validation failures through `CompleteValidated` instead of accepting unusable replies.

**Bug Fixes**

- Fixes `NamesPerson` to decode runes at word boundaries, so `MüLena` and `Lenä` no longer count as naming `Lena`, and a broken UTF-8 edge no longer decides a match by accident.
- Requires the recipient’s first name and the introduced colleague’s full name, matching each site’s template.
- Adds tests covering prompt requirements, derived templates, the `Ask` retry dispatch branches, and the boundary edges.

**Refactors**

- Adds a census gate that flags new readers of the envelope unless they document a different contract.
- Records the existing account, person, and customer reply readers as explicit contract exceptions.
- Updates the gate inventory.

<sup>Written for commit 9c2f179fc8779c4729eeb03e877eb8503f20df92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent parsing and validation for structured generated replies, including text cleanup and required-name checks.
  * Improved introduction note and draft generation with clearer prompts, validated responses, and automatic retries.

* **Bug Fixes**
  * Improved handling of malformed, incomplete, or unusable generated replies.
  * Prevented incorrect name matches within multibyte or marked text.
  * Ensured generated introduction content remains valid after serialization.

* **Tests**
  * Expanded coverage for reply parsing, generation, validation, and template compatibility.
  * Added checks for unapproved reply readers.

* **Documentation**
  * Updated the gate inventory with the new validation check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->