### PR TITLE
A deferred ticket says so on the status axis, not by lying about severity

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -91,8 +91,13 @@
   description: "Reporting, saved views, filters, export"
 
 # ---------------------------------------------------------------------------
-# Status — an issue that is not yet workable.
+# Status — an issue nobody should pick up yet, whether because it cannot be
+# worked or because it is deliberately not now's work. Both colours sit in the
+# needs-decision yellow: same axis, and the paler one is the calmer state.
 # ---------------------------------------------------------------------------
+- name: "status: deferred"
+  color: "FEF2C0"
+  description: "Real and agreed, deliberately not scheduled - no milestone yet. Do not pick it up"
 - name: "status: needs-decision"
   color: "FBCA04"
   description: "Unactionable until someone rules on it - 'decide or decline X'"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ exploitable weakness to a private advisory. The test: if you can write the
 reproduction, it belongs in an advisory, not here.
 
 Every issue you do open carries exactly one `priority:` and exactly one `area:`,
-plus `status:` when it is not yet workable. Unlabelled means nobody has looked at
+plus `status:` when it is not now's work. Unlabelled means nobody has looked at
 it yet, so filing without labels tells the next reader something false. The full
 taxonomy: [docs/reference/issue-labels.md](docs/reference/issue-labels.md).
 

--- a/docs/reference/issue-labels.md
+++ b/docs/reference/issue-labels.md
@@ -27,7 +27,8 @@ Every issue you open carries **exactly one `priority:` and exactly one `area:`**
 
 **Priority** is a claim about severity, never about your schedule. Do not demote
 a real defect because it is not this week's work — the milestone carries the
-schedule, the label carries the truth:
+schedule, or `status: deferred` when no milestone fits it yet, and the label
+carries the truth:
 
 | Label | It qualifies when |
 |---|---|
@@ -52,13 +53,21 @@ misleads about.
 
 ## Status
 
-**Status**, when it applies — these mark an issue that is not yet workable, and
-leaving them off puts unactionable work in somebody's queue:
+**Status**, when it applies — these mark an issue nobody should pick up yet,
+whether because it cannot be worked or because it is deliberately not now's
+work. Leaving one off puts that issue in somebody's queue:
 
 - `status: needs-decision` — unactionable until a human rules, whether the ruling
   is technical or a product call. Say what the options are and which you
   recommend: an issue that only asks "what should we do?" gives the decider
   nothing to decide from.
+- `status: deferred` — understood and agreed, and deliberately not scheduled:
+  a later release, and nobody knows which yet. It keeps its honest priority,
+  because deferring is a schedule and the priority is the severity — parking a
+  real defect by relabelling it `priority: low` makes the tracker lie about what
+  is wrong with the product. Drop the label when the work gets a milestone. Say
+  in the issue what it is waiting for, so the reader who filters it back in
+  knows what changed.
 
 ## Provenance
 

--- a/docs/reference/issue-labels.md
+++ b/docs/reference/issue-labels.md
@@ -1,7 +1,7 @@
 # Issue labels
 
 Every issue in this repository carries **exactly one `priority:` and exactly one
-`area:`**, plus a `status:` when it is not yet workable and whatever provenance
+`area:`**, plus a `status:` when it is not now's work and whatever provenance
 labels apply. This page is the full taxonomy; the binding short form is in
 `AGENTS.md`.
 


### PR DESCRIPTION
## Why

There was nowhere honest to put a ticket we agree on and deliberately do not schedule — the case of "file it now, do it in some later release, nobody knows which yet". The tracker offered two ways to park one and both cost something:

- demote it to `priority: low` — and the priority label stops meaning severity, which the reference page is explicit about ("a claim about severity, never about your schedule"). A real defect then reads as a want.
- leave it looking workable — and it sits in somebody's queue forever, which is what the `status:` axis exists to prevent.

## What

`status: deferred` — *Real and agreed, deliberately not scheduled - no milestone yet. Do not pick it up* — in `FEF2C0`, the pale end of the `needs-decision` yellow, because colour carries meaning within an axis and this is the calmer state on the same one.

It says the schedule, so `priority:` keeps saying the severity: a deferred issue carries its honest `priority: high` and its `area:`, and the workable queue is the filter that excludes it.

The Status axis widens from "an issue that is not yet workable" to "an issue nobody should pick up yet", which is what both of its labels have always meant operationally — a deferred issue *can* be worked, we just don't want it worked now. Filing it under the old description would have contradicted the description.

## Where

`.github/labels.yml` is the source, so that is the one edit that matters; the other two are what the source obliges:

- `docs/reference/issue-labels.md` — checked against the source in both directions by `backend/gates/issuelabels_test.go`, so a label in one and not the other fails `make check`.
- `AGENTS.md` — its digest said "plus `status:` when it is not yet workable", which would have told an agent not to reach for this label. Now "when it is not now's work", in the same four lines: `TestNoRulebookGrowsPastItsCeiling` holds the file at 330 lines and the addition pays for itself rather than raising the ratchet.

The reference page also now names the label in the Priority section, where the sentence about not demoting a real defect points at the milestone as the place a schedule lives — and `status: deferred` is where it lives when no milestone fits yet.

## Verification

- `make check` green (9m48s, backend + frontend).
- Mutation-checked the gate rather than trusting a pass: removing the new bullet from the reference page fails `TestEachSectionOfTheReferencePageListsExactlyItsLabels/Status` with `## Status lists [needs-decision] and the source declares [deferred needs-decision]`, so the gate genuinely sees this label. Restored, green again.

## Follow-up, on merge

`scripts/sync-labels.sh` is run by hand — the workflow that would call it on a push to `main` is still not in the tree — so the label reaches the repository when somebody runs it after this merges. Until then the file is the taxonomy and GitHub is one label behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `status: deferred` issue label for agreed work that is deliberately unscheduled and has no milestone.
  * Clarified how deferred issues differ from issues awaiting a decision.

* **Documentation**
  * Updated issue-labeling guidance for work that is deferred or not currently actionable.
  * Documented how deferred status works with priority and scheduling, including removing the status when work is scheduled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->