### PR TITLE
The Brief says the morning in a sentence

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2294,6 +2294,16 @@ export const de = {
   // Der Kopf der sortierten Liste, auf der Seite, die zuerst geöffnet wird —
   // dieselben Zeilen wie in der Arbeitsliste, in der Reihenfolge des Servers.
   "brief.donext.title": "Als Nächstes",
+  // Der Eröffnungssatz des Briefings, aus den Zeilen zusammengesetzt, die die
+  // Seite zeigt — nie von einem Modell geschrieben.
+  "brief.eyebrow": "Dein Morgen",
+  "brief.sentence.clear": "Heute Morgen wartet nichts auf dich.",
+  "brief.sentence.one": "Zuerst: {lead}",
+  "brief.sentence.oneWithCost": "Zuerst: {lead} — {consequence}",
+  "brief.sentence.many": "Zuerst: {lead} Danach {rest} weitere.",
+  "brief.sentence.manyWithCost":
+    "Zuerst: {lead} — {consequence} Danach {rest} weitere.",
+
   "brief.donext.sub": "Eine Reihenfolge, aus deiner Arbeitsliste.",
   "brief.donext.loading": "Was auf dich wartet, wird gelesen",
   "brief.donext.clear": "Gerade wartet nichts auf dich.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2331,6 +2331,16 @@ export const en = {
   // The head of the ranked queue, on the page a rep opens first. The same rows
   // the Worklist draws, in the order the server decided.
   "brief.donext.title": "Do next",
+  // The Brief's opening sentence, composed from the rows the page is showing —
+  // never model-written, so it cannot say what the rows contradict.
+  "brief.eyebrow": "Your morning",
+  "brief.sentence.clear": "Nothing is waiting on you this morning.",
+  "brief.sentence.one": "First: {lead}",
+  "brief.sentence.oneWithCost": "First: {lead} — {consequence}",
+  "brief.sentence.many": "First: {lead} Then {rest} more.",
+  "brief.sentence.manyWithCost":
+    "First: {lead} — {consequence} Then {rest} more.",
+
   "brief.donext.sub": "One order, from your worklist.",
   "brief.donext.loading": "Reading what waits on you",
   "brief.donext.clear": "Nothing is waiting on you right now.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2278,6 +2278,16 @@ export const vi = {
   // Phần đầu của danh sách đã xếp hạng, trên trang mở đầu tiên — cùng những
   // dòng mà Danh sách công việc hiển thị, theo thứ tự máy chủ đã quyết định.
   "brief.donext.title": "Làm tiếp theo",
+  // Câu mở đầu của bản tóm tắt, ghép từ chính những dòng trang đang hiển thị —
+  // không do mô hình viết.
+  "brief.eyebrow": "Buổi sáng của bạn",
+  "brief.sentence.clear": "Sáng nay không có gì đang chờ bạn.",
+  "brief.sentence.one": "Trước tiên: {lead}",
+  "brief.sentence.oneWithCost": "Trước tiên: {lead} — {consequence}",
+  "brief.sentence.many": "Trước tiên: {lead} Rồi {rest} mục nữa.",
+  "brief.sentence.manyWithCost":
+    "Trước tiên: {lead} — {consequence} Rồi {rest} mục nữa.",
+
   "brief.donext.sub": "Một thứ tự, từ danh sách công việc của bạn.",
   "brief.donext.loading": "Đang đọc những gì đang chờ bạn",
   "brief.donext.clear": "Hiện không có gì đang chờ bạn.",

--- a/frontend/src/screens/brief.donext.tsx
+++ b/frontend/src/screens/brief.donext.tsx
@@ -5,6 +5,7 @@ import { Panel } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
+import { waitingRows } from "./brief.sentence";
 import type { Worklist } from "./worklist.queries";
 import { WorklistRow } from "./worklist.row";
 
@@ -31,22 +32,6 @@ import "./brief.donext.css";
 const LEAD = 3;
 
 /**
- * What the DECK above already answers.
- *
- * On the Worklist an approval is one row of one ranked order, and drawing it
- * there is right. On Home it is not: the decisions deck is a surface of its own
- * further up the same page, holding the same approvals and posting to the same
- * endpoint — so a row here put one decision in front of a reader twice, each
- * copy answerable, on a page whose whole claim is that it states an order once.
- *
- * Excluded by SOURCE rather than by id-matching the deck: the deck's own
- * contents are a separate read that can be pending, empty or refused while this
- * one is ready, and a rule that depended on it would draw a different page
- * depending on which read landed first.
- */
-const DECK_ANSWERS = "approval";
-
-/**
  * The head of the ranked queue, expanded.
  *
  * A prefix, deliberately: the whole queue is the Worklist's page, and a rep who
@@ -63,8 +48,10 @@ export function DoNext({
   // answer that carried no queue crashed the whole page — the same mistake the
   // team gate above made, and a page that throws is a worse answer than one
   // that draws nothing.
-  const waiting =
-    day?.queue?.filter((item) => item.source !== DECK_ANSWERS) ?? [];
+  // The SAME rows the opening sentence is composed from — one spelling of
+  // "what this page is answerable for", so the sentence cannot name a row this
+  // section did not draw.
+  const waiting = waitingRows(day);
   const rows = waiting.slice(0, LEAD);
   return (
     <section id="brief-donext" aria-label={t("brief.donext.title")}>

--- a/frontend/src/screens/brief.sentence.test.ts
+++ b/frontend/src/screens/brief.sentence.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { de } from "../i18n/de";
+import type { MessageKey } from "../i18n/en";
+import { en } from "../i18n/en";
+import { vi } from "../i18n/vi";
+import { briefSentence, leadOf, waitingRows } from "./brief.sentence";
+import { itemTitle } from "./worklist.copy";
+import type { Worklist, WorklistItem } from "./worklist.queries";
+
+// The Brief's opening sentence.
+//
+// What these are about is the one property that makes a composed sentence
+// honest: it may say nothing the rows below it do not already say. So the tests
+// compare it against those rows rather than against a string.
+
+/** The catalog's own lookup, with the interpolation the screen does. */
+function t(key: MessageKey, values?: Record<string, string>): string {
+  const raw = en[key];
+  if (!values) {
+    return raw;
+  }
+  return Object.entries(values).reduce<string>(
+    (text, [name, value]) => text.replaceAll(`{${name}}`, value),
+    raw,
+  );
+}
+
+function item(over: Partial<WorklistItem> = {}): WorklistItem {
+  return {
+    id: "i1",
+    source: "waiting_customer",
+    category: "customer_waiting",
+    title: "Aster Handel",
+    because: [],
+    actions: ["open"],
+    dispositions: [],
+    overdue: false,
+    ...over,
+  } as unknown as WorklistItem;
+}
+
+function day(queue: WorklistItem[]): Worklist {
+  return {
+    as_of: "2026-06-10T06:00:00Z",
+    scope: "mine",
+    scope_options: ["mine"],
+    queue,
+    counts: [],
+    reach: [],
+    sources_unavailable: [],
+    summary: { total: queue.length, urgent: 0 },
+  } as unknown as Worklist;
+}
+
+describe("the opening sentence", () => {
+  // A page that said "nothing needs you" over a read that never landed would
+  // send a rep away believing their morning was clear. Absent is the honest
+  // answer; a cheerful one is not.
+  it("says nothing at all about a day it could not read", () => {
+    expect(briefSentence(undefined, t, "en")).toBeNull();
+    expect(briefSentence({} as unknown as Worklist, t, "en")).toBeNull();
+  });
+
+  it("says the morning is clear only when the queue is genuinely empty", () => {
+    const sentence = briefSentence(day([]), t, "en");
+    expect(sentence?.key).toBe("brief.sentence.clear");
+  });
+
+  // THE PROPERTY THE WHOLE COMPOSITION RESTS ON. The sentence names the row the
+  // section below draws first, through the same helper that row prints its own
+  // title with — so the two cannot describe the same work differently.
+  it("names the same lead the section below draws first, in its own words", () => {
+    const first = item({ id: "a", title: "Aster Handel" });
+    const rows = day([first, item({ id: "b", title: "Weber" })]);
+
+    const sentence = briefSentence(rows, t, "en");
+    expect(sentence?.values.lead).toBe(itemTitle(first, t, "en"));
+    expect(leadOf(rows)?.id).toBe("a");
+  });
+
+  // The deck above answers approvals. A sentence opening with a decision the
+  // section below deliberately did not draw would put the page's first words on
+  // a row it does not show.
+  it("skips the decisions the deck answers when picking the lead", () => {
+    const rows = day([
+      item({ id: "a", source: "approval", title: "Confirm the close date" }),
+      item({ id: "b", title: "Aster Handel" }),
+    ]);
+
+    expect(leadOf(rows)?.id).toBe("b");
+    expect(waitingRows(rows)).toHaveLength(1);
+    const sentence = briefSentence(rows, t, "en");
+    expect(t(sentence?.key ?? "brief.eyebrow", sentence?.values)).not.toContain(
+      "Confirm the close date",
+    );
+  });
+
+  // A day whose only row IS a decision reads as clear HERE, because the deck is
+  // where it is answered — not as an empty product.
+  it("reads a deck-only morning as clear rather than as nothing at all", () => {
+    const sentence = briefSentence(
+      day([item({ source: "approval" })]),
+      t,
+      "en",
+    );
+    expect(sentence?.key).toBe("brief.sentence.clear");
+  });
+
+  // A ROW TITLE IS A CLAUSE, NOT A NOUN PHRASE. itemTitle returns whole
+  // sentences, so a template that embedded one produced "Fang mit Die Nacht hat
+  // das herausgesucht an" — which is not German, and no unit test caught it
+  // because every assertion was about which key fired. The templates must place
+  // the title after a separator rather than inside a phrase, in every language.
+  it("never embeds the title inside a phrase, in any language", () => {
+    for (const catalog of [en, de, vi]) {
+      for (const key of [
+        "brief.sentence.one",
+        "brief.sentence.oneWithCost",
+        "brief.sentence.many",
+        "brief.sentence.manyWithCost",
+      ] as const) {
+        const template = catalog[key];
+        // The hole is the last thing before a separator or the end — never
+        // wrapped by words on both sides of the same clause.
+        expect(template).toMatch(/[:—]\s*\{lead\}/);
+      }
+    }
+  });
+
+  // The remainder counts what is left AFTER the named row, over the rows this
+  // page is answerable for — never over the raw queue.
+  it("counts the rest over the rows the page shows", () => {
+    const rows = day([
+      item({ id: "a" }),
+      item({ id: "b" }),
+      item({ id: "c" }),
+      item({ id: "d", source: "approval" }),
+    ]);
+
+    expect(briefSentence(rows, t, "en")?.values.rest).toBe("2");
+  });
+
+  it("names no remainder when the lead is the only row", () => {
+    const sentence = briefSentence(day([item()]), t, "en");
+    expect(sentence?.key).toMatch(/^brief\.sentence\.one/);
+  });
+});

--- a/frontend/src/screens/brief.sentence.ts
+++ b/frontend/src/screens/brief.sentence.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Locale } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { consequenceText, itemTitle } from "./worklist.copy";
+import type { Worklist, WorklistItem } from "./worklist.queries";
+
+// The Brief's opening sentence, composed from the rows the page is showing.
+//
+// DETERMINISTIC, AND THAT IS THE POINT. No model writes this. It is built from
+// the same queue the section below it draws, using the same copy helpers those
+// rows use — so the sentence cannot say something the rows contradict, and it
+// needs no pass to have run before the page can speak.
+//
+// It is also why the sentence carries NO agent tag: indigo means "Margince
+// decided this" everywhere in the product, and marking a client-composed
+// sentence that way would be a claim about authorship that is simply false.
+// The overnight narrative is agent-written and IS tagged, one line further
+// down, where TodayNarrative draws it.
+
+/**
+ * What the sentence says, as a key and the parts to fill it with.
+ *
+ * A key rather than a built string: this composes in three languages, and a
+ * function that concatenated clauses would produce German with English word
+ * order. The translator gets a whole sentence with named holes.
+ */
+export type BriefSentence = Readonly<{
+  key: MessageKey;
+  values: Readonly<Record<string, string>>;
+}>;
+
+/** How many rows the sentence is allowed to name. */
+const NAMED = 1;
+
+/**
+ * What the DECISIONS DECK above already answers, and this page therefore does
+ * not count twice.
+ *
+ * ONE spelling for the whole Brief. The sentence names the lead row and the
+ * section below draws it, so a rule kept in two places would let the sentence
+ * open with a decision the section deliberately did not show — which is the
+ * duplication that rule exists to stop, reappearing one element higher.
+ */
+const DECK_ANSWERS = "approval";
+
+/** The rows this page is answerable for, in the server's order. */
+export function waitingRows(
+  day: Worklist | undefined,
+): readonly WorklistItem[] {
+  // The optional chain reaches the FIELD, not just the payload: an answer that
+  // carried no queue must draw nothing rather than throw.
+  return day?.queue?.filter((item) => item.source !== DECK_ANSWERS) ?? [];
+}
+
+/**
+ * The day in one sentence, or null when there is nothing true to say.
+ *
+ * Null on an unread day, deliberately. A page that said "nothing needs you"
+ * over a read that never landed would send a rep away believing their morning
+ * was clear — the same distinction the section below keeps between an empty
+ * queue and a failed read.
+ */
+export function briefSentence(
+  day: Worklist | undefined,
+  t: (key: MessageKey, values?: Record<string, string>) => string,
+  locale: Locale,
+): BriefSentence | null {
+  if (!day?.queue) {
+    return null;
+  }
+  const waiting = waitingRows(day);
+  if (waiting.length === 0) {
+    return { key: "brief.sentence.clear", values: {} };
+  }
+  const lead = waiting[0];
+  // A ROW TITLE IS A CLAUSE, NOT A NOUN PHRASE. `itemTitle` returns whole
+  // sentences — "Die Nacht hat das herausgesucht", "43 likely automated
+  // senders" — so a template that embedded it ("Start with {lead}.") produced
+  // "Fang mit Die Nacht hat das herausgesucht an", which is not German. The
+  // title therefore stands as its own sentence and the template says what is
+  // true AROUND it.
+  //
+  // Still the row's own words through the same helpers the row prints them
+  // with: a second phrasing here would be a second answer to "what is this row
+  // about", and the two drift the first time either moves.
+  const values: Record<string, string> = {
+    lead: itemTitle(lead, t, locale),
+    rest: String(waiting.length - NAMED),
+  };
+  const consequence = consequenceText(lead, t);
+  if (consequence) {
+    values.consequence = consequence;
+  }
+  if (waiting.length === NAMED) {
+    return {
+      key: consequence ? "brief.sentence.oneWithCost" : "brief.sentence.one",
+      values,
+    };
+  }
+  return {
+    key: consequence ? "brief.sentence.manyWithCost" : "brief.sentence.many",
+    values,
+  };
+}
+
+/**
+ * The row the page opens with.
+ *
+ * Exported so a test can prove the sentence names the SAME lead the section
+ * below draws first — the one property that makes this composition honest
+ * rather than decorative.
+ */
+export function leadOf(day: Worklist | undefined): WorklistItem | undefined {
+  return waitingRows(day)[0];
+}

--- a/frontend/src/screens/home.css
+++ b/frontend/src/screens/home.css
@@ -295,3 +295,18 @@ button.glance-count:active {
 .home-narrative-absent {
   color: var(--textMeta);
 }
+
+/* The Brief's opening block: a scope label, the greeting, then the day in one
+   sentence. The sentence is body-weight rather than caption — it is the thing
+   the page is FOR, and the counts under it are the detail. */
+.glance-eyebrow {
+  color: var(--textMeta);
+  display: block;
+  margin-bottom: var(--space-1);
+}
+
+.glance-sentence {
+  color: var(--textContent);
+  margin: 0 0 var(--space-3);
+  max-width: 62ch;
+}

--- a/frontend/src/screens/home.glance.tsx
+++ b/frontend/src/screens/home.glance.tsx
@@ -3,11 +3,14 @@
 
 import { ArrowRight } from "lucide-react";
 import type { ReactNode } from "react";
+import { Eyebrow } from "../design-system/eyebrow";
 import { type CappedCount, cappedCountLabel } from "../format/cappedcount";
 import { hourInZone } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, usePlural, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import { briefSentence } from "./brief.sentence";
+import type { Worklist } from "./worklist.queries";
 
 // The first thing a reader sees each morning: who they are, what hour it is for
 // them, and the day stated in sentences. The readings strip directly below says
@@ -92,6 +95,10 @@ export type GlanceFacts = Readonly<{
   /** Open deals that have gone quiet. */
   /** Open deals gone quiet, as a floor: Home reads one page of deals. */
   stalled: CappedCount | null;
+  /** The ranked queue this page is showing, for the opening sentence. Undefined
+   *  while it is in flight or after it failed — the sentence is then absent
+   *  rather than guessed at. */
+  day: Worklist | undefined;
 }>;
 
 export type GlanceProps = GlanceFacts &
@@ -183,6 +190,7 @@ function GlanceLine({
 export function HomeGlance({
   firstName,
   now,
+  day,
   decisions,
   brief,
   overnight,
@@ -201,10 +209,25 @@ export function HomeGlance({
     ? t(greetingKey(hour), { name: firstName })
     : t(anonGreetingKey(hour));
 
+  const { locale } = useLocale();
+  // THE DAY IN ONE SENTENCE, from the rows the page is already showing. The
+  // lines below say the same facts as separate counts; this says what to do
+  // about the first one, which a column of figures cannot.
+  const sentence = briefSentence(day, t, locale);
+
   return (
     <header className="glance arrive" data-testid="home-glance">
+      {/* Scope and date, above the greeting. A span rather than a heading: the
+          page has ONE h1 and this is its label, not a level of its own. */}
+      <Eyebrow className="glance-eyebrow">{t("brief.eyebrow")}</Eyebrow>
       <h1 className="glance-greeting t-display">{greeting}</h1>
-      <p className="glance-intro t-caption">{t("home.glance.intro")}</p>
+      {sentence ? (
+        <p className="glance-sentence" data-testid="glance-sentence">
+          {t(sentence.key, sentence.values)}
+        </p>
+      ) : (
+        <p className="glance-intro t-caption">{t("home.glance.intro")}</p>
+      )}
       <div className="glance-lines">
         {decisions !== null && decisions.pending === 0 && (
           <p className="glance-line glance-line-plain">

--- a/frontend/src/screens/home.parts.stories.tsx
+++ b/frontend/src/screens/home.parts.stories.tsx
@@ -91,12 +91,48 @@ const GLANCE_GO = {
   onGoToWatch: () => undefined,
 };
 
+// A day with work in it, for the opening sentence. The sentence names the FIRST
+// row through the same helpers the queue prints it with, so a story that passed
+// no queue would show the block without the thing it exists to say.
+const GLANCE_DAY = {
+  as_of: "2026-06-10T06:00:00Z",
+  scope: "mine",
+  scope_options: ["mine"],
+  queue: [
+    {
+      id: "g1",
+      source: "waiting_customer",
+      category: "customer_waiting",
+      title: "Aster Handel",
+      because: [],
+      actions: ["open"],
+      dispositions: [],
+      overdue: false,
+    },
+    {
+      id: "g2",
+      source: "task",
+      category: "housekeeping",
+      title: "Send the Weber quote",
+      because: [],
+      actions: ["open"],
+      dispositions: [],
+      overdue: false,
+    },
+  ],
+  counts: [],
+  reach: [],
+  sources_unavailable: [],
+  summary: { total: 2, urgent: 1 },
+} as unknown as Parameters<typeof HomeGlance>[0]["day"];
+
 // The full briefing: six sentences, each led by the figure that is also the way
 // to what it counts. What to look at — the numerals share one column, so the
 // sentences start on a single x rather than wherever their own digits ended.
 export const Glance: Story = {
   render: part(
     <HomeGlance
+      day={GLANCE_DAY}
       firstName="Lena"
       now={NOW_DATE}
       decisions={{ pending: 6, expiringToday: 2 }}
@@ -117,6 +153,7 @@ export const Glance: Story = {
 export const GlanceCalm: Story = {
   render: part(
     <HomeGlance
+      day={GLANCE_DAY}
       firstName="Lena"
       now={NOW_DATE}
       decisions={{ pending: 0, expiringToday: 0 }}
@@ -133,6 +170,7 @@ export const GlanceCalm: Story = {
 export const GlanceCapped: Story = {
   render: part(
     <HomeGlance
+      day={GLANCE_DAY}
       firstName="Lena"
       now={NOW_DATE}
       decisions={{ pending: 6, expiringToday: 2 }}
@@ -154,6 +192,7 @@ export const GlanceCapped: Story = {
 export const GlanceUnread: Story = {
   render: part(
     <HomeGlance
+      day={GLANCE_DAY}
       firstName={null}
       now={NOW_DATE}
       decisions={{ pending: 4, expiringToday: 0 }}

--- a/frontend/src/screens/home.test.tsx
+++ b/frontend/src/screens/home.test.tsx
@@ -321,6 +321,10 @@ describe("HomeGlance — the greeting follows the reader's own hour", () => {
         <HomeGlance
           firstName={firstName}
           now={new Date(2026, 6, 5, hour, 30, 0)}
+          // These cases are about the GREETING's hour. An unread day is the
+          // right value for them: the sentence is then absent, and the greeting
+          // is what the assertion reads.
+          day={undefined}
           decisions={null}
           brief={null}
           overnight={null}
@@ -362,6 +366,7 @@ describe("HomeGlance — the greeting follows the reader's own hour", () => {
         <HomeGlance
           firstName="Ada"
           now={new Date(2026, 6, 5, 9, 0, 0)}
+          day={undefined}
           decisions={null}
           brief={null}
           overnight={null}

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -378,6 +378,7 @@ export function HomeScreen() {
   return (
     <div className="wrap">
       <HomeGlance
+        day={worklistQuery.data}
         firstName={firstNameOf(me.data?.user?.display_name)}
         now={new Date(nowMs)}
         decisions={decisionReadings}


### PR DESCRIPTION
Home opened with a greeting and then a stack of seven one-fact lines,
each a count with its own jump link. The plan calls that the biggest
single gap between the code and the concept: a list is not a sentence,
and a reader had to assemble the morning from six separate figures.

There is now an eyebrow, the greeting as the page's one h1, and one
sentence saying what to start with — composed from the rows the section
below already draws, through the same helpers those rows print their own
title and consequence with. So the sentence cannot say something the
rows contradict, and no pass has to have run before the page can speak.

It carries NO agent tag, deliberately. Indigo means "Margince decided
this" everywhere in the product, and marking a client-composed sentence
that way would be a claim about authorship that is false. The overnight
narrative is agent-written and is still tagged, one section down.

An unread day gets no sentence at all. Saying "nothing is waiting on you"
over a read that never landed would send a rep away believing their
morning was clear — the same distinction Do next keeps between an empty
queue and a failed read.

waitingRows is now one function both this and Do next read, so the
sentence cannot open with a decision the section below deliberately did
not draw. That rule existed in one place and was about to exist in two.

Fixed before it shipped: a row title is a CLAUSE, not a noun phrase.
itemTitle returns whole sentences, so the first templates produced "Fang
mit Die Nacht hat das herausgesucht an" — not German, and invisible to
every unit test, because they all asserted which key fired rather than
what it read like. Found by looking at the rendered page. The title now
stands as its own sentence after a separator, and a test checks that
shape in all three catalogs.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

Gates: `make check-fe`, `make check-backend` and `make e2e-brief` (12 passed, live stack) all green. Three guards mutation-checked — reading the raw queue instead of the shown rows fails 3 tests, an unread day reading as clear fails 1, and re-embedding the title in the German template fails the grammar test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Home now opens with an eyebrow, greeting, and one sentence that says what to start with instead of making readers assemble the morning from separate count lines. The sentence is composed from the loaded worklist rows, stays consistent with the work shown below, and carries no agent-authorship tag.

- Shares `waitingRows` with Do next, excluding approval rows handled by the decisions deck.
- Shows no sentence until the worklist loads, and reports a clear morning only when no waiting rows remain.
- Reuses existing row title and consequence helpers across English, German, and Vietnamese copy.
- Adds tests for unread states, row alignment, remaining counts, and clause-safe localized templates.

<sup>Written for commit 1eb65075b8d6a70e6e5690536890d1935d0a7bad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized morning briefing summary to the home screen.
  * Summaries now reflect clear, single-item, and multiple-item worklists, including consequences and remaining-item counts.
  * Added a briefing scope label and improved presentation styling.
  * Added English, German, and Vietnamese translations.

* **Bug Fixes**
  * Waiting worklist items are now consistently used when generating briefing summaries.

* **Tests**
  * Added coverage for empty states, unread worklists, approval exclusions, multilingual text, and item counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->