### PR TITLE
A staged proposal remembers what its target is called

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -32266,6 +32266,15 @@ components:
             than only the part of it that was new.
         target_entity_type: { type: [string, 'null'], description: Entity the effect mutates (for precondition re-validation). }
         target_entity_id: { type: [string, 'null'], format: uuid }
+        target_label:
+          type: [string, 'null']
+          description: >-
+            What the target record was CALLED when this proposal was staged, where its type
+            has a name at all. Resolved at staging time and frozen: the record may be
+            renamed, archived or merged before anyone opens the inbox, and a caption
+            re-resolved then would name something the approver was never shown. Absent means
+            the type carries no name, or the row had already gone — a card then says nothing
+            rather than "unknown".
         target_version: { type: [integer, 'null'], description: 'The `version` of the target row when the diff was staged. On approve-execute the server RE-READS the row; if its current version ≠ target_version the execution is rejected with 409 ErrVersionSkew (the world changed since the human last saw the diff — re-stage). This closes the stage→approval race (ADR-0036).' }
         diff_hash: { type: [string, 'null'], description: 'Hash of the staged proposed_change; the minted approval_token is bound to this hash so a token cannot authorize a different effect.' }
         summary: { type: [string, 'null'], description: One-line description of the proposed change. }

--- a/backend/internal/compose/integration/approvaltargetlabel_integration_test.go
+++ b/backend/internal/compose/integration/approvaltargetlabel_integration_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// What a staged proposal remembers its target being called.
+//
+// Roughly half the stageable kinds carry no typed payload — the raw args a tool
+// was called with, an automation action's, a canonicalized HTTP body — so the
+// card has nothing but the summary to work from, and the summaries those paths
+// compose name the record by uuid. The label is what lets the card say which
+// record without the reader opening the payload.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/approvals"
+	"github.com/margince/margince/backend/internal/shared/kernel/diffhash"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// stagedLabel stages one proposal and reads back what it recorded the target as
+// being called, through the same wire the inbox serves.
+func stagedLabel(t *testing.T, e *Env, svc *approvals.Service, kind, targetType string, target ids.UUID) *string {
+	t.Helper()
+	change, hash, err := diffhash.Canonical(json.RawMessage(`{"note": "staged"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := svc.Stage(e.AgentCtx(), approvals.StageInput{
+		Kind: kind, ProposedChange: change, DiffHash: hash,
+		TargetType: targetType, TargetID: target, Summary: "a summary naming nothing",
+	})
+	if err != nil {
+		t.Fatalf("staging: %v", err)
+	}
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+	rows, _, err := svc.ListWire(rep, approvals.ListInput{})
+	if err != nil {
+		t.Fatalf("reading the inbox: %v", err)
+	}
+	for _, row := range rows {
+		if ids.UUID(row.Id) == id.UUID {
+			return row.TargetLabel
+		}
+	}
+	t.Fatal("the staged proposal is absent from the inbox, so this proved nothing")
+	return nil
+}
+
+// A PROPOSAL REMEMBERS WHAT ITS TARGET IS CALLED.
+//
+// Without it the reader of an untyped kind gets a verb and a uuid, and decides
+// on the verb alone.
+func TestAStagedProposalRemembersWhatItsTargetIsCalled(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	deal := e.SeedDeal(t, "Weber GmbH — Phase 2", pipeline, open, &e.Rep1)
+
+	label := stagedLabel(t, e, approvals.NewService(e.DB()), "advance_deal", "deal", deal)
+	if label == nil || *label != "Weber GmbH — Phase 2" {
+		t.Errorf("target_label = %v, want the deal's own name — a card with only the uuid asks "+
+			"somebody to approve a change to a record it will not name", label)
+	}
+}
+
+// AND IT IS THE NAME AT STAGING TIME, not at reading time.
+//
+// The record may be renamed before anyone opens the inbox, and a caption
+// resolved then would put a word in front of the approver that the proposal was
+// never about.
+func TestTheLabelIsTheNameTheProposalWasStagedAgainst(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	pipeline, open, _ := DealFixture(t, e)
+	deal := e.SeedDeal(t, "Weber GmbH — Phase 2", pipeline, open, &e.Rep1)
+
+	svc := approvals.NewService(e.DB())
+	change, hash, err := diffhash.Canonical(json.RawMessage(`{"note": "staged"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := svc.Stage(e.AgentCtx(), approvals.StageInput{
+		Kind: "advance_deal", ProposedChange: change, DiffHash: hash,
+		TargetType: "deal", TargetID: deal, Summary: "a summary naming nothing",
+	})
+	if err != nil {
+		t.Fatalf("staging: %v", err)
+	}
+	if _, err := owner.Exec(e.AgentCtx(),
+		`UPDATE deal SET name = 'Renamed after staging' WHERE id = $1`, deal); err != nil {
+		t.Fatalf("renaming the deal: %v", err)
+	}
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+	rows, _, err := svc.ListWire(rep, approvals.ListInput{})
+	if err != nil {
+		t.Fatalf("reading the inbox: %v", err)
+	}
+	for _, row := range rows {
+		if ids.UUID(row.Id) != id.UUID {
+			continue
+		}
+		if row.TargetLabel == nil || *row.TargetLabel != "Weber GmbH — Phase 2" {
+			t.Errorf("target_label = %v after a rename, want the name the proposal was staged "+
+				"against — the approver is being shown a record they were not asked about", row.TargetLabel)
+		}
+		return
+	}
+	t.Fatal("the staged proposal is absent from the inbox")
+}
+
+// A TARGET TYPE WITH NO NAME RECORDS NOTHING, rather than a blank or an
+// "unknown": absence is what tells the card to say nothing at all.
+func TestATargetWithNoNameRecordsNoLabel(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	activity := ids.NewV7()
+	if _, err := owner.Exec(e.AgentCtx(), `
+		INSERT INTO activity (id, kind, direction, subject, occurred_at, source, captured_by)
+		VALUES ($1, 'note', NULL, 'a note', now(), 'seed', 'test')`, activity); err != nil {
+		t.Fatalf("seeding an activity: %v", err)
+	}
+
+	svc := approvals.NewService(e.DB())
+	change, hash, err := diffhash.Canonical(json.RawMessage(`{"note": "staged"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := svc.Stage(e.AgentCtx(), approvals.StageInput{
+		Kind: "relink_activity", ProposedChange: change, DiffHash: hash,
+		TargetType: "activity", TargetID: activity, Summary: "a summary naming nothing",
+	})
+	if err != nil {
+		t.Fatalf("staging: %v", err)
+	}
+	// Read straight off the row: what this case is about is what was STORED,
+	// and an activity's kind reaches a narrower inbox than the deal cases above.
+	var label *string
+	if err := owner.QueryRow(e.AgentCtx(),
+		`SELECT target_label FROM approval WHERE id = $1`, id.UUID).Scan(&label); err != nil {
+		t.Fatalf("reading the staged row: %v", err)
+	}
+	if label != nil {
+		t.Errorf("target_label = %q for an activity, want none: a timeline entry has no name a "+
+			"person calls it by, and inventing one would caption the card with a word its "+
+			"reader never uses", *label)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15274,6 +15274,9 @@ type Approval struct {
 	// TargetEntityType Entity the effect mutates (for precondition re-validation).
 	TargetEntityType *string `json:"target_entity_type,omitempty"`
 
+	// TargetLabel What the target record was CALLED when this proposal was staged, where its type has a name at all. Resolved at staging time and frozen: the record may be renamed, archived or merged before anyone opens the inbox, and a caption re-resolved then would name something the approver was never shown. Absent means the type carries no name, or the row had already gone — a card then says nothing rather than "unknown".
+	TargetLabel *string `json:"target_label,omitempty"`
+
 	// TargetVersion The `version` of the target row when the diff was staged. On approve-execute the server RE-READS the row; if its current version ≠ target_version the execution is rejected with 409 ErrVersionSkew (the world changed since the human last saw the diff — re-stage). This closes the stage→approval race (ADR-0036).
 	TargetVersion *int `json:"target_version,omitempty"`
 }

--- a/backend/internal/modules/approvals/handlers.go
+++ b/backend/internal/modules/approvals/handlers.go
@@ -262,6 +262,7 @@ func wire(a row, now time.Time) crmcontracts.Approval {
 	if a.TargetType != nil {
 		out.TargetEntityType = a.TargetType
 	}
+	out.TargetLabel = a.TargetLabel
 	if a.TargetID != nil {
 		v := openapi_types.UUID(*a.TargetID)
 		out.TargetEntityId = &v

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -35,9 +34,13 @@ type row struct {
 	// TargetType + TargetID are the polymorphic pointer to the entity the
 	// staging acts on (deal, org, person, lead, activity, …); the id stays
 	// untyped because the pair IS the discriminated reference.
-	TargetType     *string
-	TargetID       *ids.UUID
-	TargetVersion  *int64
+	TargetType    *string
+	TargetID      *ids.UUID
+	TargetVersion *int64
+	// TargetLabel is what the target was CALLED when the proposal was staged.
+	// Nil where the type has no name, or where the row had gone by then — the
+	// card says nothing rather than saying unknown.
+	TargetLabel    *string
 	Summary        *string
 	ProposedChange json.RawMessage
 	DiffHash       string
@@ -60,14 +63,14 @@ type row struct {
 }
 
 const columns = `id, kind, status, proposed_by, on_behalf_of, passport_id,
-	target_entity_type, target_entity_id, target_version, summary,
+	target_entity_type, target_entity_id, target_version, target_label, summary,
 	proposed_change, diff_hash, expires_at, decided_by, decided_at, consumed_at, created_at,
 	bundle_id, evidence, effect_failed_at, effect_failure`
 
 func scan(r pgx.Row) (row, error) {
 	var a row
 	err := r.Scan(&a.ID, &a.Kind, &a.Status, &a.ProposedBy, &a.OnBehalfOf, &a.PassportID,
-		&a.TargetType, &a.TargetID, &a.TargetVersion, &a.Summary,
+		&a.TargetType, &a.TargetID, &a.TargetVersion, &a.TargetLabel, &a.Summary,
 		&a.ProposedChange, &a.DiffHash, &a.ExpiresAt, &a.DecidedBy, &a.DecidedAt, &a.ConsumedAt, &a.CreatedAt,
 		&a.BundleID, &a.Evidence, &a.EffectFailedAt, &a.EffectFailure)
 	return a, err
@@ -389,72 +392,6 @@ func collect(ctx context.Context, tx pgx.Tx, q string, args []any) ([]row, error
 		out = append(out, a)
 	}
 	return out, rows.Err()
-}
-
-// PendingForTarget returns the pending approvals staged against ONE record,
-// filtered by the same decidability rule the inbox uses — a record page must
-// never become the side channel List refuses to be. It takes the caller's
-// transaction so a composite record read assembles every section at one
-// instant instead of opening a second connection for this one.
-//
-// It answers the wire shape rather than the store row: the caller is another
-// package, and re-deriving the effective status (lazy expiry) outside this
-// module is exactly the drift the type keeps unexported to prevent.
-//
-// Every row here shares ONE target, so the target-visibility half of
-// decidable is asked once for the record rather than once per row — the
-// inbox's per-row probe exists because its rows point at different records.
-// The per-kind grant check still varies by row and stays in the loop.
-//
-// The scan is bounded at PendingScanCap rows so one record page cannot pay
-// for an unbounded backlog. A caller counting rather than listing must treat
-// a full result as "this many or more"; limit bounds the RETURNED rows, so
-// pass PendingScanCap to mean "everything the scan found".
-func (s *Service) PendingForTarget(ctx context.Context, tx pgx.Tx, targetType string, targetID ids.UUID, limit int) ([]crmcontracts.Approval, error) {
-	if err := actingForAHuman(ctx); err != nil {
-		return nil, err
-	}
-	p, _ := principal.Actor(ctx)
-	if limit <= 0 || limit > PendingScanCap {
-		limit = PendingScanCap
-	}
-	visible, err := targetVisible(ctx, tx, &targetType, &targetID)
-	if err != nil {
-		return nil, err
-	}
-	if !visible {
-		// The record itself is one this caller could not read — an ungranted
-		// type or an out-of-scope row — so nothing staged against it is
-		// decidable, and saying so is the same existence-hiding answer the
-		// record read gives.
-		return []crmcontracts.Approval{}, nil
-	}
-	now := s.now()
-	pending := statusPending
-	q, args := approvalPageQuery(ListInput{
-		Status: &pending, TargetType: &targetType, TargetID: &targetID,
-	}, nil)
-	batch, err := collect(ctx, tx, q, args)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]crmcontracts.Approval, 0, len(batch))
-	for i := range batch {
-		a := batch[i]
-		if a.effectiveStatus(now) != statusPending {
-			// Lazy expiry: a row past its expiry is not a decision anyone
-			// still owes, so it must not appear as one on the record page.
-			continue
-		}
-		if requireDecisionGrants(p, a) != nil {
-			continue
-		}
-		out = append(out, wire(a, now))
-		if len(out) >= limit {
-			break
-		}
-	}
-	return out, nil
 }
 
 func (s *Service) Get(ctx context.Context, id ids.ApprovalID) (row, error) {

--- a/backend/internal/modules/approvals/pendingfortarget.go
+++ b/backend/internal/modules/approvals/pendingfortarget.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+// The proposals standing against ONE record, for the panel a record page shows.
+//
+// A different question from the inbox's, and gated differently for it: the
+// record's own visibility is settled once by the caller, where the inbox has to
+// probe per row because its rows point at different records.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// PendingForTarget returns the pending approvals staged against ONE record,
+// filtered by the same decidability rule the inbox uses — a record page must
+// never become the side channel List refuses to be. It takes the caller's
+// transaction so a composite record read assembles every section at one
+// instant instead of opening a second connection for this one.
+//
+// It answers the wire shape rather than the store row: the caller is another
+// package, and re-deriving the effective status (lazy expiry) outside this
+// module is exactly the drift the type keeps unexported to prevent.
+//
+// Every row here shares ONE target, so the target-visibility half of
+// decidable is asked once for the record rather than once per row — the
+// inbox's per-row probe exists because its rows point at different records.
+// The per-kind grant check still varies by row and stays in the loop.
+//
+// The scan is bounded at PendingScanCap rows so one record page cannot pay
+// for an unbounded backlog. A caller counting rather than listing must treat
+// a full result as "this many or more"; limit bounds the RETURNED rows, so
+// pass PendingScanCap to mean "everything the scan found".
+func (s *Service) PendingForTarget(ctx context.Context, tx pgx.Tx, targetType string, targetID ids.UUID, limit int) ([]crmcontracts.Approval, error) {
+	if err := actingForAHuman(ctx); err != nil {
+		return nil, err
+	}
+	p, _ := principal.Actor(ctx)
+	if limit <= 0 || limit > PendingScanCap {
+		limit = PendingScanCap
+	}
+	visible, err := targetVisible(ctx, tx, &targetType, &targetID)
+	if err != nil {
+		return nil, err
+	}
+	if !visible {
+		// The record itself is one this caller could not read — an ungranted
+		// type or an out-of-scope row — so nothing staged against it is
+		// decidable, and saying so is the same existence-hiding answer the
+		// record read gives.
+		return []crmcontracts.Approval{}, nil
+	}
+	now := s.now()
+	pending := statusPending
+	q, args := approvalPageQuery(ListInput{
+		Status: &pending, TargetType: &targetType, TargetID: &targetID,
+	}, nil)
+	batch, err := collect(ctx, tx, q, args)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]crmcontracts.Approval, 0, len(batch))
+	for i := range batch {
+		a := batch[i]
+		if a.effectiveStatus(now) != statusPending {
+			// Lazy expiry: a row past its expiry is not a decision anyone
+			// still owes, so it must not appear as one on the record page.
+			continue
+		}
+		if requireDecisionGrants(p, a) != nil {
+			continue
+		}
+		out = append(out, wire(a, now))
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -412,12 +412,13 @@ func (s *Service) insertProposalInTx(ctx context.Context, tx pgx.Tx, in StageInp
 	if err := tx.QueryRow(ctx,
 		`INSERT INTO approval (id, kind, proposed_by, on_behalf_of, passport_id,
 			                       target_entity_type, target_entity_id, target_version,
-			                       summary, proposed_change, diff_hash, expires_at, bundle_id,
-			                       evidence)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now() + $12::interval, $13, $14)
+			                       target_label, summary, proposed_change, diff_hash, expires_at,
+			                       bundle_id, evidence)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, now() + $13::interval, $14, $15)
 			 RETURNING expires_at`,
 		id, in.Kind, p.ID, nullUUID(p.OnBehalfOf), nullUUID(p.PassportID),
 		nullStr(in.TargetType), nullUUID(in.TargetID), in.TargetVersion,
+		targetLabel(ctx, tx, in.TargetType, in.TargetID),
 		nullStr(in.Summary), in.ProposedChange, in.DiffHash, ttlFor(in.Kind, in.TTL).String(),
 		nullUUID(in.BundleID), evidence).Scan(&expiresAt); err != nil {
 		return ids.ApprovalID{}, err

--- a/backend/internal/modules/approvals/targetlabel.go
+++ b/backend/internal/modules/approvals/targetlabel.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+// What a proposal's target is CALLED, recorded when the proposal is staged.
+//
+// Roughly half the stageable kinds carry no typed payload — the raw arguments a
+// tool was called with, an automation action's args, a canonicalized HTTP body —
+// so a card has nothing but the summary to work from, and the summaries those
+// paths compose name the record by uuid. This is the one field that lets the
+// card say which record without asking the reader to open the payload.
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// targetLabelColumns names the column that holds each target type's display
+// name, for the types that have one.
+//
+// A SUBSET of versionTables on purpose, and not derived from it: being
+// version-pinnable says the row bumps a counter on write, which is a different
+// fact from having something a person calls it by. A relationship is an edge, a
+// saved view is a per-user filter — a caption drawn from either would be
+// labelling the proposal with a word its reader never uses.
+//
+// Absent from this map means "no name to record", which the column stores as
+// NULL and the card reads as "say nothing" rather than "say unknown".
+//
+// The column is a person's own name where the proposal is about a person, so the
+// Art. 17 redaction clears it with the summary and the payload —
+// privacy.blankStagedProposal, held by gates/piicolumncoverage_test.go, which
+// refuses a text column on a PII table that the redaction neither clears nor
+// accounts for.
+// columnName is the column several of these types happen to share, lifted out
+// so the map below reads as a set of choices rather than a repeated literal.
+// Sharing a column name is a coincidence of schema, not a rule: a type is in
+// this map because somebody calls the row by that field, and the next one may
+// spell it differently.
+const columnName = "name"
+
+var targetLabelColumns = map[string]string{
+	tablePerson:       "full_name",
+	tableOrganization: "display_name",
+	tableDeal:         columnName,
+	tableLead:         "full_name",
+	tableProject:      columnName,
+	tableList:         columnName,
+	targetProduct:     columnName,
+	targetTag:         columnName,
+}
+
+// targetLabel reads what the proposal's target is called, at staging time.
+//
+// AT STAGING, not at read: the target may be renamed, archived or merged before
+// anybody opens the inbox, and a card that resolved the name then would put a
+// word in front of the approver that the proposal was never about. The version
+// pin beside it is taken in the same transaction for the same reason.
+//
+// A target that has vanished between the caller reading it and this insert is
+// not an error here: the staging is refused elsewhere if the row matters, and a
+// missing caption is not a reason to fail a proposal that is otherwise sound.
+func targetLabel(ctx context.Context, tx pgx.Tx, table string, id ids.UUID) *string {
+	column, named := targetLabelColumns[table]
+	if !named || id.IsZero() {
+		return nil
+	}
+	var label *string
+	if err := tx.QueryRow(ctx,
+		`SELECT `+column+` FROM `+table+` WHERE id = $1`, id).Scan(&label); err != nil {
+		return nil
+	}
+	if label != nil && strings.TrimSpace(*label) == "" {
+		// An empty name is not a name. Storing it would put a blank caption
+		// where the card would otherwise say nothing, which reads as a record
+		// whose name somebody deleted.
+		return nil
+	}
+	return label
+}

--- a/backend/internal/modules/privacy/erasure_approvals.go
+++ b/backend/internal/modules/privacy/erasure_approvals.go
@@ -72,14 +72,21 @@ const subjectApprovalMatch = `
 	OR summary               ~* ANY($3::text[])`
 
 // blankStagedProposal is what emptying a staged proposal IS: the payload, the
-// summary a human reads, and the material it was read out of.
+// summary a human reads, the name of the record it was about, and the material
+// it was read out of.
 //
 // One spelling because three statements in this package perform it, and a
 // content column added to one of them is a content column the other two leave
 // behind — which is exactly how the quotation came to outlive an erasure that
 // emptied everything beside it.
+//
+// target_label is a person's own name where the proposal was about a person, so
+// it goes with the rest. NULL rather than ”: the column's absence is what the
+// card reads as "say nothing", and an empty string would leave a blank caption
+// where a name used to be.
 const blankStagedProposal = `proposed_change = '{}'::jsonb,
 	       summary         = '',
+	       target_label    = NULL,
 	       evidence        = NULL`
 
 // The reasons this package writes onto a proposal it withdraws. Three, because

--- a/backend/migrations/core/1788345000_a_proposal_names_the_record_it_is_about.down.sql
+++ b/backend/migrations/core/1788345000_a_proposal_names_the_record_it_is_about.down.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE approval DROP COLUMN target_label;

--- a/backend/migrations/core/1788345000_a_proposal_names_the_record_it_is_about.up.sql
+++ b/backend/migrations/core/1788345000_a_proposal_names_the_record_it_is_about.up.sql
@@ -1,0 +1,25 @@
+-- A staged proposal remembers what its target is CALLED.
+--
+-- Roughly half the stageable kinds carry no typed payload: their
+-- proposed_change is the raw arguments a tool was called with, an automation
+-- action's args, or a canonicalized HTTP body. Nothing in that bag names the
+-- record, so the card falls back to the summary — and the summaries those paths
+-- compose read like `automation wants to assign_owner on deal
+-- 01a03781-9083-7565-8d65-5939ec0f3e70`. A rep asked to approve a change to a
+-- record identified only by a uuid decides on the verb alone.
+--
+-- The name is resolved at STAGING time, in the transaction that writes the row,
+-- because that is the last moment it is reliably in hand: the target may be
+-- renamed, archived or merged before anyone opens the inbox, and a card that
+-- re-resolved it then would name a record the approver was not shown.
+--
+-- Nullable, and nullable is meaningful: a kind whose target is a type with no
+-- name, or a create with no target at all, has nothing to record — which is a
+-- different fact from a name that was not looked up, and the read path leaves
+-- the caption off rather than inventing one.
+--
+-- lock_timeout because `approval` is a pre-existing table: a deploy must fail
+-- fast rather than queue behind a long reader.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE approval ADD COLUMN target_label text;

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -659,6 +659,7 @@ public.approval.status text NOT NULL gen=- def='pending'::text
 public.approval.summary text gen=- def=-
 public.approval.target_entity_id uuid gen=- def=-
 public.approval.target_entity_type text gen=- def=-
+public.approval.target_label text gen=- def=-
 public.approval.target_version bigint gen=- def=-
 public.approval.trg_approval_updated CREATE TRIGGER trg_approval_updated BEFORE UPDATE ON public.approval FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version()
 public.approval.updated_at timestamp with time zone NOT NULL gen=- def=now()

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -23658,6 +23658,8 @@ export interface components {
             target_entity_type?: string | null;
             /** Format: uuid */
             target_entity_id?: string | null;
+            /** @description What the target record was CALLED when this proposal was staged, where its type has a name at all. Resolved at staging time and frozen: the record may be renamed, archived or merged before anyone opens the inbox, and a caption re-resolved then would name something the approver was never shown. Absent means the type carries no name, or the row had already gone — a card then says nothing rather than "unknown". */
+            target_label?: string | null;
             /** @description The `version` of the target row when the diff was staged. On approve-execute the server RE-READS the row; if its current version ≠ target_version the execution is rejected with 409 ErrVersionSkew (the world changed since the human last saw the diff — re-stage). This closes the stage→approval race (ADR-0036). */
             target_version?: number | null;
             /** @description Hash of the staged proposed_change; the minted approval_token is bound to this hash so a token cannot authorize a different effect. */

--- a/frontend/src/design-system/decisioncard.tsx
+++ b/frontend/src/design-system/decisioncard.tsx
@@ -698,6 +698,19 @@ function readPayload(
   };
 }
 
+// cardName is what this card is ABOUT, in the order a reader wants it: the
+// drafted subject where there is one, then the record's own name.
+//
+// Spelled once because two places ask it — the headline, and the article's
+// accessible name — and a card whose heading and whose aria-labelledby
+// disagreed would be a card screen readers announce as something else.
+function cardName(
+  approval: DecisionApproval,
+  draft: DecisionDraft,
+): string | null {
+  return draft.subject ?? approval.target_label ?? null;
+}
+
 // The chips line, then the headline and the sentence explaining it.
 //
 // The headline is the drafted SUBJECT where there is one, because that is the
@@ -732,7 +745,7 @@ function DecisionHead({
   provenance?: Provenance;
   confidence?: ConfidenceLevel;
 }>) {
-  const named = draft.subject ?? approval.target_label ?? null;
+  const named = cardName(approval, draft);
   const headline = named ?? approval.summary ?? null;
   return (
     <>
@@ -807,7 +820,10 @@ export function DecisionCard({
   const headingId = useId();
   const payload = readPayload(approval, layout, display);
   const lapsed = !decided && decisionLapsed(approval, now);
-  const named = payload.draft.subject ?? approval.summary ?? null;
+  // The SAME question the headline asks, so the article's accessible name and
+  // the line a sighted reader sees cannot come apart: a card named only by its
+  // target_label rendered a headline and pointed aria-labelledby at nothing.
+  const named = cardName(approval, payload.draft) ?? approval.summary ?? null;
 
   return (
     <article

--- a/frontend/src/design-system/decisioncard.tsx
+++ b/frontend/src/design-system/decisioncard.tsx
@@ -703,9 +703,16 @@ function readPayload(
 // The headline is the drafted SUBJECT where there is one, because that is the
 // line that differs: the server's summary names only the addressee, so a queue
 // of drafts to the same handful of people reads as one sentence over and over.
-// The summary then explains it underneath — and only underneath a subject, since
-// with no subject the summary IS the headline and printing it twice reads as two
-// facts.
+//
+// Failing that it is the RECORD'S NAME, where the server recorded one. Half the
+// stageable kinds carry no typed payload, and the summaries their paths compose
+// name the target by uuid — "automation wants to assign_owner on deal
+// 01a03781-9083-…". A reader asked to approve that decides on the verb alone.
+// The name answers "which record" in the one line they are certain to read.
+//
+// The summary then explains whichever of those two the headline was — and only
+// underneath one, since with neither the summary IS the headline and printing it
+// twice reads as two facts.
 function DecisionHead({
   approval,
   draft,
@@ -725,7 +732,8 @@ function DecisionHead({
   provenance?: Provenance;
   confidence?: ConfidenceLevel;
 }>) {
-  const headline = draft.subject ?? approval.summary ?? null;
+  const named = draft.subject ?? approval.target_label ?? null;
+  const headline = named ?? approval.summary ?? null;
   return (
     <>
       <div className="dcard-meta">
@@ -748,7 +756,7 @@ function DecisionHead({
           {headline}
         </p>
       )}
-      {draft.subject && approval.summary && (
+      {named && approval.summary && (
         <p className="t-small approval-why">{approval.summary}</p>
       )}
     </>


### PR DESCRIPTION
Toward #2738.

## What was wrong

Roughly half the stageable kinds carry no typed payload — `proposed_change` is the raw arguments a tool was called with, an automation rule's action args, or a canonicalized HTTP body. Nothing in that bag names the record, so the card falls back to the summary, and the summaries those paths compose read like:

```
automation wants to assign_owner on deal 01a03781-9083-7565-8d65-5939ec0f3e70
```

A rep asked to approve that decides on the verb alone.

## What changed

`approval.target_label` records what the target was **called**, resolved inside the transaction that stages the row.

**At staging, not at reading.** The record may be renamed, archived or merged before anybody opens the inbox, and a caption resolved then would name a record the approver was never shown. The version pin beside it is taken in the same transaction for the same reason.

**In `insertProposalInTx`**, which the ticket itself identifies as the one place every staging path lands on — so the REST gate, the MCP tool twins and the automation engine all get it without any of them composing a second sentence.

**Nullable, and meaningfully.** A type with no name records nothing, and the card says nothing rather than "unknown". The label-column map is a deliberate *subset* of the version-pinnable tables: being version-pinnable says a row bumps a counter on write, which is a different fact from having something a person calls it by — a relationship is an edge and a saved view is a per-user filter, and a caption drawn from either would label the proposal with a word its reader never uses.

**The card** uses it as the headline where there is no drafted subject, with the summary underneath — the shape the drafted-subject case already had, so no new frontend seam.

**The erasure takes it.** It is a person's own name where the proposal was about a person, so `blankStagedProposal` clears it alongside the summary and the payload. `TestTheArt17RedactionAccountsForEveryTextColumn` caught that before this description was written, which is exactly what that gate is for.

## Tests

Three, mutation-checked: a staged proposal carries the deal's own name (storing nothing fails it); the label survives a rename of the target, so it is the name the proposal was staged against; and an activity records none (pointing the map at `subject` fails it, with `"a note"` named).

## What this does not do

The ticket's fuller shape is `{title, target_label, changes[]}`. This is the `target_label` third — the part that fixes the stated harm — and it is complete on its own.

The other two need a decision the ticket flags and does not make. `changes[]` would mean captioning a bag of unknown keys, which the ticket itself argues is guessing at what the software meant; and `title` runs into the bigger problem it names at the end — card headlines are English strings frozen into the database at staging time, and fixing that is a contract change across ~20 producers "to be decided as one, not drifted into". I have left #2738 open for those two rather than closing it on a third.

`make check-backend` green; the new integration cases green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Approval proposals now retain the record name captured when they were staged, even if the record is later renamed, archived, or merged.
  - Approval cards use the record name when no drafted subject is available, with the proposal summary shown beneath it.
  - Proposals for records without names continue to display without a record label.
  - Approval details now include the preserved target name when available.

- **Privacy**
  - Erasing staged proposal data also removes the stored record name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->