### PR TITLE
The guardrail has a page to read it on

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7623,6 +7623,26 @@ export const de = {
     "Routinearbeit, die hinter einer Entscheidung wartet",
   "worklist.readings.truncated":
     "Es gibt mehr Arbeit, als hier gezählt werden konnte. Das sind Untergrenzen, keine Gesamtzahlen.",
+  "worklist.hidden.title": "Was die Liste nicht zeigt",
+  "worklist.hidden.loading": "Wird geprüft, was zurückgehalten wird…",
+  "worklist.hidden.clear":
+    "Es wird nichts zurückgehalten. Jeder wartende Kunde erreicht eine Liste.",
+  "worklist.hidden.truncated":
+    "Es gibt mehr Arbeit, als hier gezählt werden konnte. Das sind Untergrenzen, keine Gesamtzahlen.",
+  "worklist.hidden.count": "{count} warten",
+  "worklist.hidden.pastHorizon": "Zu alt für die Liste",
+  "worklist.hidden.pastHorizon.detail":
+    "Das hat niemand entschieden. Sie schrieben vor Monaten und bekamen nie eine Antwort.",
+  "worklist.hidden.unlinked": "Keinem Datensatz zugeordnet",
+  "worklist.hidden.unlinked.detail":
+    "Meist kein Vertrieb. Manchmal ein Kunde, den niemand zuordnen konnte.",
+  "worklist.hidden.notSales": "Als vertriebsfremd eingestuft",
+  "worklist.hidden.notSales.detail":
+    "Für die gesamte Organisation verborgen, und es hebt sich nicht auf.",
+  "worklist.hidden.setAside": "Von Ihnen zurückgestellt",
+  "worklist.hidden.setAside.detail":
+    "Zurückgestellt oder als nicht Ihre markiert. Eine Zurückstellung kommt von selbst zurück.",
+  "worklist.hidden.shown": "Die Liste selbst führt {count}.",
   "worklist.filter.label": "Art der Arbeit",
   "worklist.filter.all": "Alle",
   "worklist.filter.customer_waiting": "Kunde wartet",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7690,6 +7690,26 @@ export const en = {
   "worklist.readings.review.detail": "Routine work queued behind a decision",
   "worklist.readings.truncated":
     "There is more work than this could count. These are floors, not totals.",
+  "worklist.hidden.title": "What the queue is not showing",
+  "worklist.hidden.loading": "Checking what is held back…",
+  "worklist.hidden.clear":
+    "Nothing is being held back. Every waiting customer reaches somebody’s queue.",
+  "worklist.hidden.truncated":
+    "There is more work than this could count. These are floors, not totals.",
+  "worklist.hidden.count": "{count} waiting",
+  "worklist.hidden.pastHorizon": "Too old for the queue",
+  "worklist.hidden.pastHorizon.detail":
+    "Nobody decided this. They wrote months ago and were never answered.",
+  "worklist.hidden.unlinked": "Attached to no record",
+  "worklist.hidden.unlinked.detail":
+    "Usually not sales. Sometimes a customer nobody managed to file.",
+  "worklist.hidden.notSales": "Judged not sales work",
+  "worklist.hidden.notSales.detail":
+    "Hidden from the whole organization, and it does not lift.",
+  "worklist.hidden.setAside": "Set aside by you",
+  "worklist.hidden.setAside.detail":
+    "Snoozed or marked not yours. A snooze comes back on its own.",
+  "worklist.hidden.shown": "The queue itself carries {count}.",
   "worklist.filter.label": "Kind of work",
   "worklist.filter.all": "All",
   "worklist.filter.customer_waiting": "Customer waiting",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7543,6 +7543,25 @@ export const vi = {
     "Việc thường lệ đang chờ sau một quyết định",
   "worklist.readings.truncated":
     "Có nhiều việc hơn số đếm được ở đây. Đây là mức tối thiểu, không phải tổng số.",
+  "worklist.hidden.title": "Những gì danh sách không hiển thị",
+  "worklist.hidden.loading": "Đang kiểm tra những gì bị giữ lại…",
+  "worklist.hidden.clear":
+    "Không có gì bị giữ lại. Mọi khách đang chờ đều đến được một danh sách.",
+  "worklist.hidden.truncated":
+    "Có nhiều việc hơn số đếm được ở đây. Đây là mức tối thiểu, không phải tổng số.",
+  "worklist.hidden.count": "{count} đang chờ",
+  "worklist.hidden.pastHorizon": "Quá cũ đối với danh sách",
+  "worklist.hidden.pastHorizon.detail":
+    "Không ai quyết định điều này. Họ viết từ nhiều tháng trước và chưa bao giờ được trả lời.",
+  "worklist.hidden.unlinked": "Không gắn với hồ sơ nào",
+  "worklist.hidden.unlinked.detail":
+    "Thường không phải bán hàng. Đôi khi là khách hàng không ai kịp lưu hồ sơ.",
+  "worklist.hidden.notSales": "Được đánh giá không phải việc bán hàng",
+  "worklist.hidden.notSales.detail": "Ẩn với toàn bộ tổ chức, và không tự bỏ.",
+  "worklist.hidden.setAside": "Bạn đã gác lại",
+  "worklist.hidden.setAside.detail":
+    "Đã hoãn hoặc đánh dấu không phải của bạn. Một lần hoãn sẽ tự quay lại.",
+  "worklist.hidden.shown": "Bản thân danh sách mang {count}.",
   "worklist.filter.label": "Loại công việc",
   "worklist.filter.all": "Tất cả",
   "worklist.filter.customer_waiting": "Khách đang chờ",

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -187,3 +187,57 @@
   flex: 0 0 auto;
   gap: var(--space-2);
 }
+
+/* The guardrail over the queue's own hiding rules. A diagnostic behind a
+   disclosure, so it is quiet by default and legible when opened. */
+.worklist-hidden {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* Every figure is a floor when the read was cut. Stated before the numbers, and
+   in the tone the surface uses for warnings about itself. */
+.worklist-hidden-truncated {
+  color: var(--textSecondary);
+  margin: 0;
+}
+
+.worklist-hidden-clear {
+  color: var(--textSecondary);
+  margin: 0;
+}
+
+.worklist-hidden-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.worklist-hidden-row {
+  display: grid;
+  gap: 0 var(--space-2);
+  grid-template-columns: auto 1fr;
+}
+
+/* The count leads, because the question a reader opens this for is "how much".
+   Tabular so four rows of figures line up rather than drifting by digit width. */
+.worklist-hidden-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+/* The detail sits under the label rather than beside it: it is a sentence about
+   whose choice the rule was, and a third column would squeeze it to one word. */
+.worklist-hidden-detail {
+  color: var(--textSecondary);
+  grid-column: 2;
+}
+
+.worklist-hidden-shown {
+  color: var(--textSecondary);
+  margin: 0;
+}

--- a/frontend/src/screens/worklist.hidden.stories.tsx
+++ b/frontend/src/screens/worklist.hidden.stories.tsx
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryProviders } from "./story-utils";
+import { HiddenFigures } from "./worklist.hidden";
+
+// The guardrail's readings — see worklist.hidden.tsx for why they sit behind a
+// disclosure and why a healthy answer is a row of zeros.
+//
+// The FIGURES rather than the panel, because the panel fetches: a story that
+// mounted it would draw a loading skeleton and nothing else.
+
+const meta: Meta<typeof HiddenFigures> = {
+  title: "Records/Worklist/Hidden backlog",
+  component: HiddenFigures,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <StoryProviders>
+        <Story />
+      </StoryProviders>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof HiddenFigures>;
+
+const base = {
+  as_of: "2026-09-02T09:00:00Z",
+  shown: 12,
+  set_aside: 0,
+  not_sales: 0,
+  past_horizon: 0,
+  unlinked: 0,
+  truncated: false,
+  clear: false,
+};
+
+// The case worth looking at: work hidden by a rule NOBODY chose. A customer who
+// wrote months ago and was never answered is what this reading exists to find.
+export const NobodyChoseThis: Story = {
+  args: { backlog: { ...base, past_horizon: 4, unlinked: 2 } },
+};
+
+// Every rule holding something, which is what a queue in trouble looks like.
+export const EveryRuleHoldingWork: Story = {
+  args: {
+    backlog: {
+      ...base,
+      past_horizon: 4,
+      unlinked: 2,
+      not_sales: 9,
+      set_aside: 3,
+    },
+  },
+};
+
+// The read hit its own scan bound, so every figure is a floor. The caveat is
+// drawn before any number, because a reader who saw the counts first would have
+// drawn a conclusion from them already.
+export const CutShortByItsOwnBound: Story = {
+  args: {
+    backlog: { ...base, shown: 200, truncated: true, past_horizon: 5 },
+  },
+};

--- a/frontend/src/screens/worklist.hidden.test.tsx
+++ b/frontend/src/screens/worklist.hidden.test.tsx
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { HiddenBacklogPanel } from "./worklist.hidden";
+
+// The surface that reports the queue's own worst failure.
+//
+// Its healthy answer is a row of zeros, which is also what a broken read looks
+// like — so what this file is about is the cases where the two must not render
+// alike: a failed read, and a read the server cut short.
+
+type HiddenBacklog = components["schemas"]["HiddenBacklog"];
+
+function backlog(over: Partial<HiddenBacklog> = {}): HiddenBacklog {
+  return {
+    as_of: "2026-09-02T09:00:00Z",
+    shown: 12,
+    set_aside: 0,
+    not_sales: 0,
+    past_horizon: 0,
+    unlinked: 0,
+    truncated: false,
+    clear: true,
+    ...over,
+  };
+}
+
+function draw(answer: HiddenBacklog | "fails", enabled = true) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      answer === "fails"
+        ? new Response(JSON.stringify({ code: "unavailable" }), {
+            status: 503,
+            headers: { "content-type": "application/problem+json" },
+          })
+        : new Response(JSON.stringify(answer), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+    ),
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <HiddenBacklogPanel enabled={enabled} />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the hidden-backlog panel", () => {
+  it("names each rule that is holding work back, and how much", async () => {
+    draw(backlog({ clear: false, past_horizon: 3, not_sales: 7 }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Too old for the queue")).toBeTruthy(),
+    );
+    expect(screen.getByText("3 waiting")).toBeTruthy();
+    expect(screen.getByText("Judged not sales work")).toBeTruthy();
+    expect(screen.getByText("7 waiting")).toBeTruthy();
+  });
+
+  // A rule holding nothing back is not news. Four rows of zeros would bury the
+  // one figure that found something.
+  it("draws only the rules that found something", async () => {
+    draw(backlog({ clear: false, past_horizon: 3 }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Too old for the queue")).toBeTruthy(),
+    );
+    expect(screen.queryByText("Set aside by you")).toBeNull();
+    expect(screen.queryByText("Judged not sales work")).toBeNull();
+  });
+
+  // THE failure this whole reading exists for. A read cut short by its own scan
+  // bound reports every difference as zero, so the numbers look perfect at the
+  // moment the check stopped working. The caveat has to be on screen before any
+  // figure a reader might otherwise trust.
+  it("says the figures are floors when the read was cut short", async () => {
+    draw(backlog({ clear: false, truncated: true, past_horizon: 2 }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/floors, not totals/)).toBeTruthy(),
+    );
+  });
+
+  // Zeros are this surface's HEALTHY answer, so a failed read drawn as zeros
+  // would report perfect health exactly when the guardrail broke.
+  it("says it could not read rather than drawing a clean bill of health", async () => {
+    draw("fails");
+
+    // The PRESENT text, not merely the absent one: asserting only that the
+    // clear message is missing passes against a component that rendered
+    // nothing at all, which is how the first version of this test survived a
+    // mutation that dropped the error state entirely.
+    await waitFor(() =>
+      expect(screen.getByText(/Could not be loaded/)).toBeTruthy(),
+    );
+    expect(screen.queryByText(/Nothing is being held back/)).toBeNull();
+  });
+
+  it("says so plainly when nothing is held back", async () => {
+    draw(backlog());
+
+    await waitFor(() =>
+      expect(screen.getByText(/Nothing is being held back/)).toBeTruthy(),
+    );
+  });
+
+  // A seat with no route to this reading does not fire the request. The figures
+  // are gated server-side either way, so this is about not making a call behind
+  // a reader's back rather than about safety.
+  it("asks nothing when the reader has no tier for it", () => {
+    const fetched = vi.fn();
+    vi.stubGlobal("fetch", fetched);
+    draw(backlog(), false);
+
+    expect(fetched).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/screens/worklist.hidden.tsx
+++ b/frontend/src/screens/worklist.hidden.tsx
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// What the queue is NOT showing, and which rule is holding it back.
+//
+// The Worklist is built to look finite, which is what makes it worth working:
+// a rep reaches the bottom and the day is done. The cost of that design is that
+// a queue hiding real work looks exactly like a queue with none, so the page
+// cannot report its own worst failure. This is the surface that can.
+//
+// Behind a disclosure, closed by default, and that is the honest placement
+// rather than a hedge. On a healthy installation every figure is zero, and a
+// row of zeros drawn above the queue every morning would train a reader to
+// scroll past the one morning it is not — while a rep whose job is to work the
+// queue is not the person who acts on a horizon that is set wrong.
+
+import { Disclosure } from "../design-system/atoms";
+import { SurfaceState } from "../design-system/surfacestate";
+import { formatNumber } from "../format/format";
+import { type Locale, type Translator, useLocale, useT } from "../i18n";
+import { type HiddenBacklog, useHiddenBacklog } from "./worklist.queries";
+import "./worklist.css";
+
+/**
+ * The guardrail, drawn for a reader who can act on it.
+ *
+ * `enabled` carries the same tier the team board's does: this is a lead's
+ * reading, not a rep's, and a seat with no route to it should not fire the
+ * request.
+ */
+export function HiddenBacklogPanel({
+  enabled,
+}: Readonly<{ enabled: boolean }>) {
+  const t = useT();
+  const hidden = useHiddenBacklog(enabled);
+  if (!enabled) {
+    return null;
+  }
+  // A guardrail that could not be read says so rather than drawing zeros. Zeros
+  // are its healthy answer, so a failed read rendered as zeros would report
+  // perfect health at the moment the check stopped working — the same failure
+  // in the client that `truncated` guards against in the server.
+  const state = hidden.isPending
+    ? "loading"
+    : hidden.isError
+      ? "unavailable"
+      : // A clear backlog IS this surface's empty state, so it is drawn by the
+        // same component that draws every other empty section rather than by a
+        // paragraph of its own. `clear` is the server's own flag and already
+        // accounts for a truncated read, so an empty page here cannot mean
+        // "nothing found" over a scan that stopped early.
+        hidden.data?.clear
+        ? "empty"
+        : "ready";
+  return (
+    <Disclosure summary={t("worklist.hidden.title")}>
+      <SurfaceState
+        state={state}
+        loadingLabel={t("worklist.hidden.loading")}
+        emptyLabel={t("worklist.hidden.clear")}
+      >
+        {hidden.data && !hidden.data.clear && (
+          <HiddenFigures backlog={hidden.data} />
+        )}
+      </SurfaceState>
+    </Disclosure>
+  );
+}
+
+// The four figures.
+//
+// Exported for its story: the panel above fetches, so a story that mounted it
+// would draw a loading skeleton and never the readings it exists to show.
+export function HiddenFigures({
+  backlog,
+}: Readonly<{ backlog: HiddenBacklog }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  return (
+    <div className="worklist-hidden">
+      {backlog.truncated && (
+        // FIRST, and stated before any number. Every figure below is a floor
+        // when the read was cut, so a reader who saw the counts before the
+        // caveat would already have drawn a conclusion from them.
+        <p className="t-body worklist-hidden-truncated">
+          {t("worklist.hidden.truncated")}
+        </p>
+      )}
+      <ul className="worklist-hidden-list">
+        {/* Ordered by whose fault it is, not by size. The two nobody chose come
+            FIRST: a wait that fell off on a date with no rep having judged
+            anything is the failure this reading exists to surface, and sorting
+            by count would bury it under an ordinary week of snoozes. */}
+        <Reading
+          count={backlog.past_horizon}
+          label={t("worklist.hidden.pastHorizon")}
+          detail={t("worklist.hidden.pastHorizon.detail")}
+          locale={locale}
+          t={t}
+        />
+        <Reading
+          count={backlog.unlinked}
+          label={t("worklist.hidden.unlinked")}
+          detail={t("worklist.hidden.unlinked.detail")}
+          locale={locale}
+          t={t}
+        />
+        <Reading
+          count={backlog.not_sales}
+          label={t("worklist.hidden.notSales")}
+          detail={t("worklist.hidden.notSales.detail")}
+          locale={locale}
+          t={t}
+        />
+        <Reading
+          count={backlog.set_aside}
+          label={t("worklist.hidden.setAside")}
+          detail={t("worklist.hidden.setAside.detail")}
+          locale={locale}
+          t={t}
+        />
+      </ul>
+      <p className="t-caption worklist-hidden-shown">
+        {t("worklist.hidden.shown", {
+          count: formatNumber(backlog.shown, locale),
+        })}
+      </p>
+    </div>
+  );
+}
+
+// One figure. Drawn only when it found something: a list of zeros says nothing
+// a reader can act on, and the clear case above already covers "all of them".
+function Reading({
+  count,
+  label,
+  detail,
+  locale,
+  t,
+}: Readonly<{
+  count: number;
+  label: string;
+  detail: string;
+  locale: Locale;
+  t: Translator;
+}>) {
+  if (count === 0) {
+    return null;
+  }
+  return (
+    <li className="worklist-hidden-row">
+      <span className="worklist-hidden-count">
+        {t("worklist.hidden.count", { count: formatNumber(count, locale) })}
+      </span>
+      <span className="worklist-hidden-label">{label}</span>
+      <span className="t-caption worklist-hidden-detail">{detail}</span>
+    </li>
+  );
+}

--- a/frontend/src/screens/worklist.queries.ts
+++ b/frontend/src/screens/worklist.queries.ts
@@ -32,6 +32,7 @@ export type WorklistDisposition = NonNullable<
 >[number];
 export type TeamBoard = components["schemas"]["TeamBoard"];
 export type TeamBoardMember = components["schemas"]["TeamBoardMember"];
+export type HiddenBacklog = components["schemas"]["HiddenBacklog"];
 
 export const worklistKey = ["worklist"] as const;
 
@@ -85,6 +86,31 @@ export function useTeamBoard(enabled: boolean) {
     queryKey: [...worklistKey, "team"],
     queryFn: async (): Promise<TeamBoard> => {
       const { data, error } = await api.GET("/worklist/team", {});
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+// What the queue is NOT showing, and which rule holds it back.
+//
+// Read on its own key rather than folded into the day: it is five SQL reads
+// where the queue is one, and a rep opening the Worklist should not wait on a
+// diagnostic to see their work. A slow or failing guardrail must cost the queue
+// nothing, which is what a separate query buys.
+//
+// `enabled` carries the same tier the team board's does. The figures are counted
+// under the caller's own visibility either way, so this is not what makes them
+// safe — it is what keeps a surface the reader has no route to from firing a
+// request behind their back.
+export function useHiddenBacklog(enabled: boolean) {
+  return useQuery({
+    enabled,
+    queryKey: [...worklistKey, "hidden"],
+    queryFn: async (): Promise<HiddenBacklog> => {
+      const { data, error } = await api.GET("/worklist/hidden", {});
       if (error) {
         throwProblem(error);
       }

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -16,6 +16,7 @@ import {
   sourceUnavailableText,
 } from "./worklist.copy";
 import { FocusCard, focusOf } from "./worklist.focus";
+import { HiddenBacklogPanel } from "./worklist.hidden";
 import { CoachControl, OwnerPicker } from "./worklist.manager";
 import { NextUp, nextUpOf } from "./worklist.nextup";
 import { hasPane, WorklistPane } from "./worklist.pane";
@@ -231,6 +232,10 @@ function WorklistBody({
       {/* The verbs a lead has over somebody else's day. Drawn only on a named
           person's queue: on the reader's own there is nobody to coach. */}
       {owner !== "" && <CoachControl owner={owner} />}
+      {/* What the queue is NOT showing. Beside the team board because it is the
+          same reader's question — a lead asking whether the day their team sees
+          is the day their team has — and on the same tier for the same reason. */}
+      <HiddenBacklogPanel enabled={day.scope_options.includes("team")} />
       {/* A day cannot read as clear while something that would have filled it
           was never read. This is the surface speaking about ITSELF, which is
           what Callout is for. */}


### PR DESCRIPTION
#3691 shipped the measurement and nothing drew it. `GET /worklist/hidden` answered correctly and no reader could see the answer — which makes a guardrail exactly as useful as not having one.

## Where it sits, and why

Behind a disclosure, closed, beside the team board. That is a decision rather than a hedge: on a healthy installation every figure is zero, and a row of zeros above the queue every morning trains a reader to scroll past the one morning it is not. It is on the team tier for the same reason the board is — a rep works the queue; a horizon set wrong is not theirs to act on.

Ordered by **whose fault it is**, not by size. The two rules nobody chose come first: a customer who wrote months ago and fell off on a date is the failure this reading exists to surface, and sorting by count would bury it under an ordinary week of snoozes. A rule holding nothing back is not drawn at all.

## Three ways this surface could lie

**A failed read must not draw zeros.** Zeros are the *healthy* answer here, so a failed read rendered as zeros would report perfect health at the moment the check broke. It draws the unavailable state instead.

The test for that asserts the error text is **present**, not that the clear text is absent. The first version asserted only the absence — and survived a mutation that dropped the error state entirely, rendering nothing at all. Caught by mutation-checking, fixed, re-checked.

**A truncated read says so before any number.** Every figure is a floor when the scan was cut, and a reader who saw the counts first would already have drawn a conclusion from them.

**A clear backlog is `SurfaceState`'s own empty state**, not a paragraph of this file's — so it draws the way every other empty section does, and `clear` is the server's flag, which already accounts for truncation.

## Verification

- 6 tests, mutation-checked one clause at a time: dropping the truncation caveat and dropping the error state each fail their own test.
- 3 Storybook stories, including the cut-short case.
- `make check-fe` green (5775), `make frontend-e2e` 222 passed, `make craft-static` clean.
- The i18n vocabulary gate caught "workspace" in the `not_sales` detail across all three locales — the product says *organization*. Fixed.

Backend untouched: no contract change, no regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes #3691 by giving the existing `GET /worklist/hidden` measurement a visible page. Previously the endpoint returned correct data but nothing rendered it; now team-tier readers can open a closed-by-default disclosure beside the team board to inspect hidden work without delaying the main queue.

- Shows nonzero counts for each hiding rule, with explanations and the number of items still visible in the queue.
- Displays unavailable state for failed reads and a warning before counts when results are truncated, instead of presenting misleading zeros.
- Adds English, German, and Vietnamese translations, plus component tests and Storybook coverage.

<sup>Written for commit f85f19ceb412cf517e77dff916bec90aff7e3685. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hidden-items section to the worklist for supported team views.
  * Users can review hidden-item counts, visible-item totals, and reasons items are excluded.
  * Added loading, empty, unavailable, and truncated-result states.
  * Added localized support in English, German, and Vietnamese.
* **Bug Fixes**
  * Hidden-item details now avoid displaying misleading zero counts when results are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->