### PR TITLE
The destination is called Brief

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -258,7 +258,7 @@ test("AC-shell-1: the rail renders the canonical 10 items in order", async ({
       links.map((link) => link.getAttribute("aria-label")),
     );
   expect(labels).toEqual([
-    "Start",
+    "Briefing",
     "Kontakte",
     "Firmen",
     "Leads",

--- a/frontend/src/app/pagemeta.ts
+++ b/frontend/src/app/pagemeta.ts
@@ -21,7 +21,8 @@ import type { Route } from "./router";
  * Screens that head THEMSELVES, so the shell prints no heading above them.
  *
  * Home greets the reader by name in its own h1 — "Guten Morgen, Demo." — and
- * the shell's "Start" above it named the page a second time at heading level.
+ * the shell's own nav label above it named the page a second time at heading
+ * level.
  * Two top-level headings is no outline at all, and it is the same defect the
  * shell already avoids for a record (whose name is its heading) and a unit.
  *

--- a/frontend/src/app/rail.test.tsx
+++ b/frontend/src/app/rail.test.tsx
@@ -90,7 +90,7 @@ afterEach(() => {
 // The route id never changes with a label: `deals` presents as Pipeline, which
 // names the board this row opens.
 const CANONICAL_ORDER = [
-  "Home",
+  "Brief",
   "Contacts",
   "Companies",
   "Leads",
@@ -159,7 +159,7 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
     // is asserted where it belongs.
     expect(levelLabels()).toEqual(CANONICAL_ORDER);
     // The mark leads them, which is what "logomark → home" means.
-    const home = screen.getByRole("link", { name: "Home" });
+    const home = screen.getByRole("link", { name: "Brief" });
     expect(
       brand.compareDocumentPosition(home) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeGreaterThan(0);
@@ -335,7 +335,7 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
           ? "agent"
           : "more",
     );
-    expect(cells).toEqual(["Home", "Contacts", "agent", "Pipeline", "more"]);
+    expect(cells).toEqual(["Brief", "Contacts", "agent", "Pipeline", "more"]);
   });
 
   // The Worklist is the destination the bar gave up for that cell. Off the bar
@@ -396,7 +396,7 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
     render(<WorkspaceRail route={{ screen: "home" }} />);
     await user.click(screen.getByRole("button", { name: "More" }));
     expect(document.activeElement).toBe(
-      screen.getByRole("link", { name: "Home" }),
+      screen.getByRole("link", { name: "Brief" }),
     );
 
     await user.keyboard("{Escape}");
@@ -506,7 +506,7 @@ describe("Rail levels (a section's entries as the second level)", () => {
     // the document on <body>.
     await waitFor(() => expect(levelLabels()).toEqual(CANONICAL_ORDER));
     expect(document.activeElement).toBe(
-      screen.getByRole("link", { name: "Home" }),
+      screen.getByRole("link", { name: "Brief" }),
     );
   });
 
@@ -537,7 +537,7 @@ describe("Rail levels (a section's entries as the second level)", () => {
 
     await waitFor(() => expect(levelLabels()).toEqual(CANONICAL_ORDER));
     expect(document.activeElement).toBe(
-      screen.getByRole("link", { name: "Home" }),
+      screen.getByRole("link", { name: "Brief" }),
     );
   });
 

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -642,7 +642,7 @@ export function PageTitle({
   const unitNamesPage =
     route.screen === EXTENSION_SCREEN && findExtension(route.id) !== null;
   // A screen that heads ITSELF. Home greets the reader by name in its own h1,
-  // so the shell printing "Start" above it named the page twice at heading
+  // so the shell printing the nav label above it named the page twice at heading
   // level — a document outline with two top-level headings, which is exactly
   // what the branches above exist to prevent for records and units.
   //

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -156,7 +156,7 @@ export const de = {
   "autonomy.auto": "automatisch",
   "autonomy.confirm": "erst bestätigen",
 
-  "nav.home": "Start",
+  "nav.home": "Briefing",
   "nav.contacts": "Kontakte",
   "nav.companies": "Firmen",
   "nav.leads": "Leads",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -158,7 +158,7 @@ export const en = {
   "autonomy.auto": "auto-execute",
   "autonomy.confirm": "confirm-first",
 
-  "nav.home": "Home",
+  "nav.home": "Brief",
   "nav.contacts": "Contacts",
   "nav.companies": "Companies",
   "nav.leads": "Leads",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -162,7 +162,7 @@ export const vi = {
   "autonomy.auto": "tự động thực thi",
   "autonomy.confirm": "xác nhận trước",
 
-  "nav.home": "Trang chủ",
+  "nav.home": "Bản tóm tắt",
   "nav.contacts": "Contact",
   "nav.companies": "Công ty",
   "nav.leads": "Lead",


### PR DESCRIPTION
The nav said "Home" / "Start" / "Trang chủ" — a location, not a thing.
The page is the Brief: the morning stated in a sentence, what to do
next, the team's load, the week just gone and the week ahead. Decision 1
of the plan renames the label and leaves the route id alone, so every
deep link, SCREENS entry and stored address keeps working.

The rail's unit tests assert the label directly and now say Brief, as
does the German nav order in ac.spec.ts.

Two comments in shell.tsx and pagemeta.ts quoted the old label while
explaining why Home heads itself. They now name the nav label rather
than a string that no longer exists, so a reader is not sent looking for
"Start".

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

Gates: `make check-fe` and `make check-backend` green; the rail's 35 unit tests assert the new label directly.

Note: the `AC-shell-*` Playwright specs fail on this branch AND on unmodified main — they find zero nav items because the suite assumes a session it does not create. Pre-existing, unrelated to the rename, verified by stashing the change and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the home screen's nav label from 'Home'/'Start'/'Trang chủ' to 'Brief'/'Briefing'/'Bản tóm tắt' to describe what the page actually is. The route id stays `home`, so deep links and stored addresses keep working.

- Updates rail unit tests and the German nav order spec to assert the new labels.
- Fixes comments in `shell.tsx` and `pagemeta.ts` that quoted the old label.
- The `AC-shell-*` Playwright specs fail on this branch and on unmodified main because they assume a session they don't create; unrelated to this rename.

<sup>Written for commit 7c6d029cc86520ed21f4202973d3b543bbc98360. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Interface**
  - Renamed the primary navigation item to “Brief” in English, “Briefing” in German, and “Bản tóm tắt” in Vietnamese.
  - Updated related navigation labels and accessibility references to reflect the new wording.

- **Tests**
  - Updated navigation and focus behavior checks to use the revised label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->