### PR TITLE
Every outbound draft is written in the sender's own voice

### DIFF
--- a/backend/internal/compose/certcase_firstdraft.go
+++ b/backend/internal/compose/certcase_firstdraft.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/margince/margince/backend/internal/compose/aitasks"
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/ai"
 )
 
@@ -83,16 +84,22 @@ func (firstDraftCases) Prepare(fixture, expected json.RawMessage) (aitasks.Prepa
 // firstDraftCase is one first-message request ready to be answered.
 type firstDraftCase struct{ data replyActivityData }
 
-// Run drives the production lane — the same completeChecked, correction loop and
-// validators DraftFirstEmail drives — and records every request it issued.
+// Run drives the production lane — the same completeFirstVoiced, correction loop
+// and validators DraftFirstEmail drives — and records every request it issued.
 //
 // The drafter is built with a brain and nothing else because this path does no
 // I/O at all: unlike the reply, there is no activity to read and no voice signal
 // to record, which is the same property that lets the seam take an intent and
 // nothing else.
+//
+// The voice state is the EMPTY one, which certifies the plain variant. That is
+// this site's only certified register today and saying so here is the point: a
+// scenario cannot yet state a profile for a first message, so nothing measures
+// the voiced turn. Certifying the voiced variant needs a fixture that carries a
+// voice artifact, the way the reply site's does.
 func (c *firstDraftCase) Run(ctx context.Context, completer aitasks.Completer) (aitasks.Trace, error) {
 	recorder := &replyDraftRecorder{completer: completer}
-	_, err := replyDrafter{brain: recorder}.completeChecked(ctx, firstDraftSystem, c.data, nil)
+	_, err := replyDrafter{brain: recorder}.completeFirstVoiced(ctx, c.data, draftvoice.Context{})
 	trace := aitasks.Trace{Requests: recorder.requests}
 	if recorder.failed != nil {
 		return trace, fmt.Errorf("%s: the model call did not complete: %w", firstDraftSite, recorder.failed)

--- a/backend/internal/compose/certcase_replydraft.go
+++ b/backend/internal/compose/certcase_replydraft.go
@@ -372,8 +372,12 @@ func replyDraftServedRegister(trace aitasks.Trace) (string, error) {
 		return "", errors.New("compose: the drafter issued no request, so no draft was served")
 	}
 	system := trace.Requests[len(trace.Requests)-1].System
+	// The voice rule is what separates the two variants, and it is asked
+	// FIRST: a voiced call is its site's own prompt PLUS that rule, so a check
+	// ordered the other way would match the site prefix on both and report
+	// every voiced draft as plain.
 	switch {
-	case strings.HasPrefix(system, string(replyDraftVoiceSystem)):
+	case strings.Contains(system, draftvoice.SystemRule):
 		return replyDraftRegisterVoiced, nil
 	case strings.HasPrefix(system, string(replyDraftSystem)):
 		return replyDraftRegisterPlain, nil

--- a/backend/internal/compose/certcase_replydraft_test.go
+++ b/backend/internal/compose/certcase_replydraft_test.go
@@ -263,7 +263,7 @@ func TestReplyDraftCaseRecordsEveryRequestTheDrafterIssued(t *testing.T) {
 			len(trace.Requests))
 	}
 	voiced, retry, fallback := trace.Requests[0], trace.Requests[1], trace.Requests[2]
-	if !strings.HasPrefix(voiced.System, string(replyDraftVoiceSystem)) {
+	if !strings.HasPrefix(voiced.System, string(voicedSite(replyDraftSystem))) {
 		t.Errorf("the first request is not in the voice variant: %q", voiced.System)
 	}
 	for _, fragment := range []string{"Voice profile:", "Blunt, never hedges.", "We ship Monday."} {

--- a/backend/internal/compose/draftrulesparity_test.go
+++ b/backend/internal/compose/draftrulesparity_test.go
@@ -60,10 +60,17 @@ import (
 // description of this table.
 func draftingSurfaces(fence promptfence.Fence) map[string][]string {
 	return map[string][]string{
+		// Two sites in two registers, which is four assemblies rather than
+		// three: a voiced turn is its own site's prompt plus the voice rule, so
+		// the first message has a voiced variant of its own. It used to send the
+		// REPLY's prompt whenever a profile was loaded, telling the model an
+		// activity was the authoritative reason for a message that answers
+		// nothing.
 		"replydraftmodel.go": {
 			replyDraftSystemFor(replyDraftSystem, fence),
-			replyDraftSystemFor(replyDraftVoiceSystem, fence),
+			replyDraftSystemFor(voicedSite(replyDraftSystem), fence),
 			replyDraftSystemFor(firstDraftSystem, fence),
+			replyDraftSystemFor(voicedSite(firstDraftSystem), fence),
 		},
 		"persondraft/write.go": {
 			persondraft.SystemPromptFor(fence),

--- a/backend/internal/compose/draftvoicenil_test.go
+++ b/backend/internal/compose/draftvoicenil_test.go
@@ -23,6 +23,7 @@ import (
 	"go/ast"
 	"go/token"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -46,60 +47,100 @@ func TestNoDraftingEntryPointIsAlwaysUnvoiced(t *testing.T) {
 	// voice load across files (the reply drafter does), so a caller in a
 	// sibling file is still this surface's.
 	checked := map[string]bool{}
+	governed := 0
 	for _, where := range surfaces {
 		dir := filepath.Dir(where)
 		if checked[dir] {
 			continue
 		}
 		checked[dir] = true
-		for _, finding := range alwaysUnvoicedCallers(t, dir) {
-			t.Errorf("%s reaches the model only ever with a literal nil where the sender's voice goes, so "+
-				"a rep who has built a voice profile is written by a generic writer here and by their own "+
-				"voice on every other drafting surface. Load the profile with draftvoice.Load and pass it; "+
-				"an unvoiced call is fine only as the fallback beside a voiced one", finding)
+		found, reached := alwaysUnvoicedCallers(t, dir)
+		governed += reached
+		for _, finding := range found {
+			t.Errorf("%s reaches the model only ever without the sender's voice, so a rep who has built a "+
+				"voice profile is written by a generic writer here and by their own voice on every other "+
+				"drafting surface. Load the profile with draftvoice.Load and pass it; an unvoiced call is "+
+				"fine only as the fallback beside a voiced one", finding)
 		}
+	}
+	// The census must not be able to fail SHORT. This gate recognises a voice
+	// argument by its parameter NAME, so renaming that parameter would drop its
+	// callers from the sweep — the gate would then read a smaller tree, find
+	// nothing, and report PASS with no failing assertion to notice.
+	//
+	// Pinning the count is what makes that visible. A drop means the sweep
+	// stopped seeing calls it used to see: either look at why, or lower this
+	// number deliberately. A rise is ordinary — a new drafting call — and
+	// raising it is the whole of the response.
+	const governedCalls = 36
+	if governed != governedCalls {
+		t.Errorf("the sweep reached %d voice-carrying calls and this gate pins %d. Fewer means it stopped "+
+			"recognising calls it used to read — most likely a voice parameter was renamed out of "+
+			"voiceBlockParameterNames, which silently shrinks what this gate governs. Confirm every "+
+			"drafting call is still swept, then move the number", governed, governedCalls)
 	}
 }
 
 // alwaysUnvoicedCallers reports every production function in the package at dir
-// that reaches a voice-taking call and passes a literal nil at EVERY such call.
+// that reaches a voice-taking call and carries no voice at EVERY such call, plus
+// how many voice-carrying calls the sweep read in total.
 //
 // Every, not any. A function holding both shapes is the healthy one: it drafts
 // under the profile when there is a profile and falls back to the plain draft
 // when the sender has none or the voiced attempt broke the anti-AI floor. A
-// function holding only the nil shape is a path no profile can ever reach.
-func alwaysUnvoicedCallers(t *testing.T, dir string) []string {
+// function holding only the empty shape is a path no profile can ever reach.
+//
+// The count comes back so the caller can pin it. This sweep recognises its
+// subject by parameter name, and a census that can quietly read a smaller tree
+// than it did yesterday reports PASS for the wrong reason.
+func alwaysUnvoicedCallers(t *testing.T, dir string) (findings []string, reached int) {
 	t.Helper()
 	fset := token.NewFileSet()
 	files := parsePackageFiles(t, fset, dir)
 	positions := voiceParameterPositions(files)
 	if len(positions) == 0 {
-		return nil
+		return nil, 0
 	}
-	var out []string
 	for _, parsed := range files {
 		for _, decl := range parsed.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
 			if !ok || fn.Body == nil {
 				continue
 			}
+			voiced, unvoiced := voiceArgumentShapes(fn, positions)
+			reached += voiced + unvoiced
 			// A function that itself takes the voice block is plumbing rather
 			// than an entry point: it passes on what its own caller resolved,
-			// and the caller is where the question belongs.
+			// and the caller is where the question belongs. Its calls still
+			// COUNT — the census must see them — but it is not judged.
 			if _, plumbing := positions[fn.Name.Name]; plumbing {
 				continue
 			}
-			voiced, unvoiced := voiceArgumentShapes(fn, positions)
+			// Nor is a certification case an entry point. It drives the
+			// production lane to MEASURE one register, and the register it
+			// measures is the scenario's to state — a case pinned to the plain
+			// variant is certifying the plain variant, not drafting a mail
+			// somebody sends. Its calls still count toward the census.
+			if isCertificationCase(fset.Position(fn.Pos()).Filename) {
+				continue
+			}
 			if unvoiced > 0 && voiced == 0 {
-				out = append(out, fset.Position(fn.Pos()).String()+" ("+fn.Name.Name+")")
+				findings = append(findings, fset.Position(fn.Pos()).String()+" ("+fn.Name.Name+")")
 			}
 		}
 	}
-	return out
+	return findings, reached
 }
 
 // voiceArgumentShapes counts the calls in fn that pass a voice block, split by
-// whether the argument is a literal nil or anything else.
+// whether the argument can carry a voice at all.
+//
+// Two spellings say "no voice", and both must count as unvoiced: a literal nil
+// for the func-shaped block, and an empty draftvoice.Context{} for the struct
+// one. Counting only nil let a site that always constructs the empty struct read
+// as voiced while taking the unvoiced branch on every call — which is what the
+// first-message certification case does deliberately, and what a production site
+// could do by accident.
 func voiceArgumentShapes(fn *ast.FuncDecl, positions map[string]int) (voiced, unvoiced int) {
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
@@ -114,7 +155,7 @@ func voiceArgumentShapes(fn *ast.FuncDecl, positions map[string]int) (voiced, un
 		if !governed || at >= len(call.Args) {
 			return true
 		}
-		if isUntypedNil(call.Args[at]) {
+		if carriesNoVoice(call.Args[at]) {
 			unvoiced++
 			return true
 		}
@@ -178,8 +219,28 @@ func calledFunctionName(call *ast.CallExpr) (string, bool) {
 	}
 }
 
-// isUntypedNil reports whether an argument is the bare identifier nil.
-func isUntypedNil(expr ast.Expr) bool {
-	ident, ok := expr.(*ast.Ident)
-	return ok && ident.Name == "nil"
+// isCertificationCase reports whether a path holds an ai-tasks certification
+// case rather than a drafting surface.
+//
+// Read off the file NAME, which this tree spells one way (certcase_*.go).
+// Reading it off the content instead — "does this file mention aitasks" — would
+// let a drafting surface that happened to import the package exempt itself, and
+// a selector that can eat its own subject is worse than no selector.
+func isCertificationCase(path string) bool {
+	return strings.HasPrefix(filepath.Base(path), "certcase")
+}
+
+// carriesNoVoice reports whether an argument is one of the two ways this tree
+// spells "no profile": the bare identifier nil, or an empty composite literal
+// (draftvoice.Context{}), whose OK field is false and which every drafting
+// method branches to the unvoiced path on.
+//
+// A composite literal with fields set is NOT this: draftvoice.Context{OK: true,
+// …} is a real voice, and the empty one is the only shape that cannot be.
+func carriesNoVoice(expr ast.Expr) bool {
+	if ident, ok := expr.(*ast.Ident); ok {
+		return ident.Name == "nil"
+	}
+	composite, ok := expr.(*ast.CompositeLit)
+	return ok && len(composite.Elts) == 0
 }

--- a/backend/internal/compose/draftvoicenil_test.go
+++ b/backend/internal/compose/draftvoicenil_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// No drafting entry point can only ever draft in nobody's voice.
+//
+// The census next door (TestEveryDraftingSurfaceLoadsTheSenderVoice) asks
+// whether a surface's PACKAGE can reach draftvoice.Load. That question has one
+// answer for a package and several entry points inside it, which is how the
+// first-message drafter shipped unvoiced: it lives beside the reply drafter, its
+// package loads the voice for the reply, and its own function passed a literal
+// nil straight to the model. The package census read green the whole time.
+//
+// So this reads the entry points. An unvoiced call is not itself a defect — a
+// rep with no profile is drafted for unvoiced, and a voiced draft that trips the
+// anti-AI floor is re-drafted unvoiced on purpose. Both of those live in a
+// function that ALSO has a voiced path. What is a defect is a function whose
+// every model call is unvoiced: no profile can reach it, so the rep who built
+// one is written by a generic writer here and by their own voice next door.
+
+import (
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"testing"
+)
+
+// voiceBlockParameterNames are the parameter names a drafting call uses for the
+// voice block it renders into the prompt.
+//
+// Named rather than positional because the two shapes in this tree differ: the
+// reply lane passes a voiceBlockFor func and the composers pass a
+// draftvoice.Context. What they share is the name, which is what makes an
+// argument at that position readable without type information.
+var voiceBlockParameterNames = []string{"voiceBlock", "voice"}
+
+// Every drafting entry point can draft in the sender's own voice.
+func TestNoDraftingEntryPointIsAlwaysUnvoiced(t *testing.T) {
+	surfaces := filesComposingTheSharedRules(t)
+	if len(surfaces) == 0 {
+		t.Fatal("no file under internal/compose composes draftrules.Shared, so this gate is reading an " +
+			"empty tree rather than a governed one")
+	}
+	// The package, not the one file: a surface splits its model call and its
+	// voice load across files (the reply drafter does), so a caller in a
+	// sibling file is still this surface's.
+	checked := map[string]bool{}
+	for _, where := range surfaces {
+		dir := filepath.Dir(where)
+		if checked[dir] {
+			continue
+		}
+		checked[dir] = true
+		for _, finding := range alwaysUnvoicedCallers(t, dir) {
+			t.Errorf("%s reaches the model only ever with a literal nil where the sender's voice goes, so "+
+				"a rep who has built a voice profile is written by a generic writer here and by their own "+
+				"voice on every other drafting surface. Load the profile with draftvoice.Load and pass it; "+
+				"an unvoiced call is fine only as the fallback beside a voiced one", finding)
+		}
+	}
+}
+
+// alwaysUnvoicedCallers reports every production function in the package at dir
+// that reaches a voice-taking call and passes a literal nil at EVERY such call.
+//
+// Every, not any. A function holding both shapes is the healthy one: it drafts
+// under the profile when there is a profile and falls back to the plain draft
+// when the sender has none or the voiced attempt broke the anti-AI floor. A
+// function holding only the nil shape is a path no profile can ever reach.
+func alwaysUnvoicedCallers(t *testing.T, dir string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	files := parsePackageFiles(t, fset, dir)
+	positions := voiceParameterPositions(files)
+	if len(positions) == 0 {
+		return nil
+	}
+	var out []string
+	for _, parsed := range files {
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			// A function that itself takes the voice block is plumbing rather
+			// than an entry point: it passes on what its own caller resolved,
+			// and the caller is where the question belongs.
+			if _, plumbing := positions[fn.Name.Name]; plumbing {
+				continue
+			}
+			voiced, unvoiced := voiceArgumentShapes(fn, positions)
+			if unvoiced > 0 && voiced == 0 {
+				out = append(out, fset.Position(fn.Pos()).String()+" ("+fn.Name.Name+")")
+			}
+		}
+	}
+	return out
+}
+
+// voiceArgumentShapes counts the calls in fn that pass a voice block, split by
+// whether the argument is a literal nil or anything else.
+func voiceArgumentShapes(fn *ast.FuncDecl, positions map[string]int) (voiced, unvoiced int) {
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		name, ok := calledFunctionName(call)
+		if !ok {
+			return true
+		}
+		at, governed := positions[name]
+		if !governed || at >= len(call.Args) {
+			return true
+		}
+		if isUntypedNil(call.Args[at]) {
+			unvoiced++
+			return true
+		}
+		voiced++
+		return true
+	})
+	return voiced, unvoiced
+}
+
+// voiceParameterPositions maps each function in the package that takes a voice
+// block to the argument index that block occupies.
+//
+// One parameter declaration can name several parameters (`a, b Type`), so the
+// index is counted over NAMES rather than over fields — counting fields would
+// point at the wrong argument for every call to such a function.
+func voiceParameterPositions(files []*ast.File) map[string]int {
+	out := map[string]int{}
+	for _, parsed := range files {
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Type.Params == nil {
+				continue
+			}
+			at := 0
+			for _, field := range fn.Type.Params.List {
+				for _, name := range field.Names {
+					if isVoiceBlockParameter(name.Name) {
+						out[fn.Name.Name] = at
+					}
+					at++
+				}
+				if len(field.Names) == 0 {
+					at++
+				}
+			}
+		}
+	}
+	return out
+}
+
+// isVoiceBlockParameter reports whether a parameter name is the voice block's.
+func isVoiceBlockParameter(name string) bool {
+	for _, want := range voiceBlockParameterNames {
+		if name == want {
+			return true
+		}
+	}
+	return false
+}
+
+// calledFunctionName reads the name of the function a call targets, for both a
+// plain call and a method call on a receiver.
+func calledFunctionName(call *ast.CallExpr) (string, bool) {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name, true
+	case *ast.SelectorExpr:
+		return fn.Sel.Name, true
+	default:
+		return "", false
+	}
+}
+
+// isUntypedNil reports whether an argument is the bare identifier nil.
+func isUntypedNil(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == "nil"
+}

--- a/backend/internal/compose/firstdraft.go
+++ b/backend/internal/compose/firstdraft.go
@@ -23,8 +23,10 @@ import (
 	"context"
 	"strings"
 
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
+	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 )
 
 var _ activities.FirstEmailDrafter = replyDrafter{}
@@ -69,16 +71,56 @@ func (d replyDrafter) DraftFirstEmail(ctx context.Context, intent string) (strin
 		Thread: threadFlag(false),
 		Intent: boundedRunes(intent, replyActivityMaxRunes),
 	}
-	// No voice block, which puts this site where the two composers already are:
-	// ai-tasks.yaml records that the reply site alone has a voiced variant, and
-	// the composers gain theirs when Voice DNA reaches them. It is also what
-	// keeps this path free of a learning signal nobody can answer — a rep
-	// rejects a voiced draft through a draft_ref, and this surface returns
-	// text only.
-	draft, err := d.completeChecked(ctx, firstDraftSystem, data, nil)
+	// The message goes out under a person's name, so it is written in that
+	// person's voice — the same rule the reply path obeys, and the reason this
+	// surface may not opt out of it: one rep, one mailbox, two writers is
+	// exactly the split Voice DNA exists to close.
+	//
+	// What it does NOT do is record a learning signal. A rep answers for a
+	// served draft through a draft_ref keyed on the activity it replied to,
+	// and there is no activity here — so a signal written now is one no
+	// feedback could ever land on.
+	draft, err := d.completeFirstVoiced(ctx, data, d.loadVoice(ctx))
 	if err != nil {
 		d.logger().WarnContext(ctx, "model first-message draft unavailable; using deterministic draft", "err", err)
 		return fallbackSubject, fallbackBody, nil
 	}
 	return draft.Subject, draft.Body, nil
+}
+
+// completeFirstVoiced drafts the opening message under the sender's voice when
+// they have one, holding the same deterministic anti-AI floor the reply path
+// holds: detect on the raw draft, one critic retry, sanitize, and on surviving
+// violations serve the plain draft instead.
+//
+// It is separate from completeVoiced because that one's every failure path
+// writes a learning signal against an anchor, and this site has no anchor. What
+// counts as a violation is not restated here: both methods ask
+// draftvoice.Violations and draftvoice.Sanitize, so this one decides only what
+// to do when the floor trips.
+func (d replyDrafter) completeFirstVoiced(ctx context.Context, data replyActivityData, voice draftvoice.Context) (replyDraft, error) {
+	if !voice.OK {
+		return d.completeChecked(ctx, firstDraftSystem, data, nil)
+	}
+	block := voice.Block
+	draft, err := d.completeChecked(ctx, firstDraftSystem, data, block)
+	if err != nil {
+		return replyDraft{}, err
+	}
+	if violations := voiceDraftViolations(draft); len(violations) > 0 {
+		withFeedback := func(fence promptfence.Fence) string {
+			return block(fence) + draftvoice.Feedback(violations)
+		}
+		retried, retryErr := d.completeWith(ctx, firstDraftSystem, data, withFeedback, "")
+		if retryErr == nil {
+			draft = retried
+		}
+	}
+	draft.Subject, draft.Body = draftvoice.Sanitize(draft.Subject, draft.Body)
+	// The sanitizer edits text, so the floor and the shape are re-checked on
+	// what would actually be served.
+	if len(voiceDraftViolations(draft)) > 0 || validateReplyDraft(draft) != nil {
+		return d.completeChecked(ctx, firstDraftSystem, data, nil)
+	}
+	return draft, nil
 }

--- a/backend/internal/compose/network/intronote.go
+++ b/backend/internal/compose/network/intronote.go
@@ -45,6 +45,14 @@ type Completer interface {
 }
 
 // WithIntroNoteLane binds the lane that phrases the forwardable note.
+//
+// It binds no Voice DNA, and that is a decision rather than the gap it looks
+// like. Every other outbound drafting surface writes as the person operating
+// it, so it loads that person's voice; this note is sent by the COLLEAGUE, and
+// the rep operating the page is the person being introduced. Loading the
+// caller's profile here would sign the colleague's message in somebody else's
+// style — and the colleague need not be a Margince user at all, so there is
+// frequently no profile to load even in principle.
 func (h Reads) WithIntroNoteLane(lane Completer) Reads {
 	h.introNoteLane = lane
 	return h

--- a/backend/internal/compose/replydraft_test.go
+++ b/backend/internal/compose/replydraft_test.go
@@ -139,8 +139,16 @@ func TestVoicedDraftInjectsTheProfileAndStampsTheVersion(t *testing.T) {
 		t.Fatalf("draft = %+v", draft)
 	}
 	req := brain.requests[0]
-	if !strings.Contains(req.System, "user's own voice") {
-		t.Fatalf("voiced draft must use the voice system prompt, got %q", req.System)
+	// The voice RULE, which is what a voiced turn adds to its site's prompt.
+	// Asserting a phrase out of a whole-prompt variant went quiet the moment
+	// the variant became an addition rather than a replacement.
+	if !strings.Contains(req.System, draftvoice.SystemRule) {
+		t.Fatalf("voiced draft must carry the voice rule, got %q", req.System)
+	}
+	// And the site's own prompt survives beside it. Without this the check
+	// above passes for a voiced call that dropped the reply site's grounding.
+	if !strings.Contains(req.System, string(replyDraftSystem)) {
+		t.Fatalf("the voiced draft dropped the reply site's own prompt, got %q", req.System)
 	}
 	content := req.Messages[0].Content
 	for _, fragment := range []string{"Voice profile:", "Blunt, never hedges.", "How you think", "We ship Monday.", "limits, NOT targets"} {

--- a/backend/internal/compose/replydraftmodel.go
+++ b/backend/internal/compose/replydraftmodel.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/draftcore"
 	"github.com/margince/margince/backend/internal/compose/draftrules"
+	"github.com/margince/margince/backend/internal/compose/draftvoice"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/shared/kernel/promptfence"
 	"github.com/margince/margince/backend/internal/shared/ports/model"
@@ -83,6 +84,18 @@ func replyDraftSystemFor(system draftSystem, fence promptfence.Fence) string {
 	return string(system) + "\n\n" + draftrules.Shared + "\n" + fence.Rule("activity")
 }
 
+// voicedSite is a site's prompt with the voice rule added — the system turn a
+// call carrying a profile block is made under.
+//
+// A function rather than a second constant per site, because the voiced turn is
+// DERIVED from the plain one. Two spelled-out variants drift the moment a site's
+// own rules change, and the first-message site's variant would then be a copy of
+// the reply's that nobody remembered to update — which is precisely the shape
+// this replaced.
+func voicedSite(site draftSystem) draftSystem {
+	return draftSystem(string(site) + "\n\n" + draftvoice.SystemRule)
+}
+
 // replyDraftRequest builds the one request a draft call sends, in whichever of
 // this site's two system variants the call is made under. The workspace's Voice
 // DNA state selects the variant per call — a loaded profile supplies a block and
@@ -103,7 +116,14 @@ func replyDraftRequest(site draftSystem, activity replyActivityData, voiceBlock 
 	system := site
 	content := fence.Wrap(string(payload))
 	if voiceBlock != nil {
-		system = replyDraftVoiceSystem
+		// The voice rule is ADDED to whichever site this call is made under,
+		// never substituted for it. A swap carried the reply site's evidence
+		// claim onto every voiced call, and on the first-message site that
+		// claim is false: telling a model "the activity is the authoritative
+		// reason for this reply" when there is no activity is an invitation to
+		// invent the thread, which is the one error a first message to a
+		// stranger cannot be edited back from.
+		system = voicedSite(site)
 		content = voiceBlock(fence) + "\n\n" + content
 	}
 	// The correction rides the USER turn and never the variant choice: it is

--- a/backend/internal/compose/replydraftvoice.go
+++ b/backend/internal/compose/replydraftvoice.go
@@ -121,15 +121,6 @@ func (d replyDrafter) recordVoiceRejection(ctx context.Context, voice draftvoice
 	}
 }
 
-// replyDraftVoiceSystem replaces the no-voice guard when a profile block is
-// supplied: the profile controls expression, never facts.
-const replyDraftVoiceSystem draftSystem = `Draft a professional email reply on behalf of the CRM user's company, written in the user's own voice.
-Return ONLY a JSON object: {"subject":"...","body":"..."}.
-- The activity and stated intent are the authoritative reason for this reply.
-- The supplied voice profile controls expression — rhythm, vocabulary, directness, structure — never facts.
-- Use only facts present in the supplied data. Never invent customers, outcomes, prices, commitments, or capabilities.
-- Obey the profile's avoid rules and the universal anti-AI rules; treat its style metrics as limits, not targets.`
-
 // voiceBlockFor renders the voice profile block under the CALLING call's fence.
 // The block is prepended to that call's user turn, so it must be bounded by the
 // marker that call's system prompt declares — not one of its own.

--- a/backend/internal/modules/ai/voice_draftread.go
+++ b/backend/internal/modules/ai/voice_draftread.go
@@ -80,24 +80,29 @@ func (s *VoiceStore) ActiveVoiceForActor(ctx context.Context) (VoiceProfile, Voi
 
 // voiceSender answers whose voice a draft on this call is written in.
 //
-// The explicit sender wins over the actor, and the ORDER is the whole of it: on
-// an automation's firing the actor is the system principal, which names no
-// person, so reading the actor first would resolve nothing and the bound owner
-// would never be reached. Everywhere else no sender is bound and the actor is
-// the sender, which is why this is a fallback rather than a second parameter on
-// every drafting call.
+// An ACTOR THAT NAMES A PERSON is that person, and no bound sender may override
+// them. This ordering is a boundary, not a preference: a voice profile holds its
+// owner's verbatim written text, so a call that could name somebody else's owner
+// is a read of that person's private writing. A human call already knows whose
+// voice it wants — their own — and admitting an override there would make this
+// value an authorization input, which it must never be.
+//
+// The bound sender is consulted only when the actor names nobody. That is the
+// automation's firing: the engine composes under the system principal so its
+// writes stay attributed to the system, while the mail leaves under the
+// automation owner's name. There is no person to override in that case, which
+// is why the override is safe exactly there and nowhere else.
 //
 // A false answer is a caller with nobody to write as — a system job with no
 // owner behind it — and the read above refuses rather than guessing.
 func voiceSender(ctx context.Context) (ids.UUID, bool) {
+	if actor, ok := principal.Actor(ctx); ok && !actor.UserID.IsZero() {
+		return actor.UserID, true
+	}
 	if sender, ok := principal.SendingHuman(ctx); ok {
 		return sender, true
 	}
-	actor, ok := principal.Actor(ctx)
-	if !ok || actor.UserID.IsZero() {
-		return ids.Nil, false
-	}
-	return actor.UserID, true
+	return ids.Nil, false
 }
 
 // RecordDraftedSignal remembers that a voice draft was served, keyed by the

--- a/backend/internal/modules/ai/voice_draftread.go
+++ b/backend/internal/modules/ai/voice_draftread.go
@@ -28,15 +28,22 @@ import (
 // for the weekly learning delta, far short of forever.
 const voiceLearningSignalRetention = 180 * 24 * time.Hour
 
-// ActiveVoiceForActor returns the acting user's ready profile and its
-// active version. ok=false — no profile, none ready, or no activated
-// artifact — is the drafter's clean-fallback signal, never an error.
+// ActiveVoiceForActor returns the ready profile and active version of the
+// person the message goes out AS. ok=false — no profile, none ready, or no
+// activated artifact — is the drafter's clean-fallback signal, never an error.
+//
+// The sender is usually the actor, and on an automation's firing it is not: the
+// engine composes under PrincipalSystem so its writes stay attributed to the
+// system actor, while the mail still leaves under the automation owner's name.
+// principal.WithSendingHuman names that owner, and until this read consulted it
+// every automated draft resolved a zero UserID, failed the check below, and was
+// written in nobody's voice.
 func (s *VoiceStore) ActiveVoiceForActor(ctx context.Context) (VoiceProfile, VoiceProfileVersion, bool, error) {
 	if err := auth.Require(ctx, "voice_profile", principal.ActionRead); err != nil {
 		return VoiceProfile{}, VoiceProfileVersion{}, false, err
 	}
-	actor, ok := principal.Actor(ctx)
-	if !ok || actor.UserID.IsZero() {
+	sender, ok := voiceSender(ctx)
+	if !ok {
 		return VoiceProfile{}, VoiceProfileVersion{}, false, apperrors.ErrPermissionDenied
 	}
 	var (
@@ -48,7 +55,7 @@ func (s *VoiceStore) ActiveVoiceForActor(ctx context.Context) (VoiceProfile, Voi
 		p, err := scanVoiceProfile(tx.QueryRow(ctx, storekit.SQLf(`
 			SELECT %s FROM voice_profile
 			WHERE archived_at IS NULL AND scope = 'user' AND owner_id = $1 AND status = 'ready'
-			ORDER BY created_at DESC LIMIT 1`, voiceProfileColumns), actor.UserID))
+			ORDER BY created_at DESC LIMIT 1`, voiceProfileColumns), sender))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
@@ -69,6 +76,28 @@ func (s *VoiceStore) ActiveVoiceForActor(ctx context.Context) (VoiceProfile, Voi
 		return nil
 	})
 	return profile, version, found, err
+}
+
+// voiceSender answers whose voice a draft on this call is written in.
+//
+// The explicit sender wins over the actor, and the ORDER is the whole of it: on
+// an automation's firing the actor is the system principal, which names no
+// person, so reading the actor first would resolve nothing and the bound owner
+// would never be reached. Everywhere else no sender is bound and the actor is
+// the sender, which is why this is a fallback rather than a second parameter on
+// every drafting call.
+//
+// A false answer is a caller with nobody to write as — a system job with no
+// owner behind it — and the read above refuses rather than guessing.
+func voiceSender(ctx context.Context) (ids.UUID, bool) {
+	if sender, ok := principal.SendingHuman(ctx); ok {
+		return sender, true
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID.IsZero() {
+		return ids.Nil, false
+	}
+	return actor.UserID, true
 }
 
 // RecordDraftedSignal remembers that a voice draft was served, keyed by the

--- a/backend/internal/modules/ai/voice_draftsender_test.go
+++ b/backend/internal/modules/ai/voice_draftsender_test.go
@@ -47,14 +47,15 @@ func TestTheVoiceSenderIsTheHumanTheMailGoesOutAs(t *testing.T) {
 			want: owner,
 			ok:   true,
 		},
-		// The bound sender WINS over an actor that could also have answered.
-		// Without this the order is untested: both fields are populated on an
-		// agent call, and reading the actor first would send a colleague's mail
-		// out in the acting agent's owner's voice.
-		"a bound sender beside a human actor": {
+		// A human actor CANNOT be overridden. A voice profile holds its owner's
+		// verbatim written text, so honouring a bound sender here would turn
+		// this value into an authorization input: a call acting as one person
+		// would read another person's private writing. The actor already knows
+		// whose voice they want.
+		"a bound sender never overrides a human actor": {
 			ctx: principal.WithSendingHuman(
 				principal.WithActor(context.Background(), human), owner),
-			want: owner,
+			want: rep,
 			ok:   true,
 		},
 		// A system job nobody owns has no voice to write in, and guessing one
@@ -79,6 +80,36 @@ func TestTheVoiceSenderIsTheHumanTheMailGoesOutAs(t *testing.T) {
 				t.Errorf("the draft would be written in %s's voice, want %s", got, tc.want)
 			}
 		})
+	}
+}
+
+// A bound sender cannot make one person's call read another's voice profile.
+//
+// A profile carries its owner's verbatim written text — the personality they
+// typed and excerpts of their own mail — so "whose profile is loaded" is a read
+// of somebody's private writing. The sending human exists for a principal that
+// names nobody, and letting it override a principal that DOES name somebody
+// would make it an authorization input.
+func TestABoundSenderCannotRedirectAHumansVoiceRead(t *testing.T) {
+	rep := ids.NewV7()
+	victim := ids.NewV7()
+
+	ctx := principal.WithSendingHuman(
+		principal.WithActor(context.Background(), principal.Principal{
+			Type: principal.PrincipalHuman, ID: "human:" + rep.String(), UserID: rep,
+		}), victim)
+
+	got, ok := voiceSender(ctx)
+	if !ok {
+		t.Fatal("a human call resolved no sender at all")
+	}
+	if got == victim {
+		t.Fatalf("a bound sender redirected the voice read to %s, whose profile holds their own "+
+			"verbatim writing — this value selects whose private text is loaded and must never "+
+			"override an actor who names a person", victim)
+	}
+	if got != rep {
+		t.Errorf("the voice read resolved %s, want the acting rep %s", got, rep)
 	}
 }
 

--- a/backend/internal/modules/ai/voice_draftsender_test.go
+++ b/backend/internal/modules/ai/voice_draftsender_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// Whose voice a draft is written in.
+//
+// The rule has one interesting case and it is the one that shipped broken: an
+// automation composes under the system principal, which names no person, while
+// the mail it drafts still leaves under the automation owner's name. Reading the
+// actor alone resolved nothing there, so every automated draft was written in
+// nobody's voice — and it failed silently, because a voice that cannot be loaded
+// degrades to the plain draft by design.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// TestTheVoiceSenderIsTheHumanTheMailGoesOutAs pins the resolution order.
+func TestTheVoiceSenderIsTheHumanTheMailGoesOutAs(t *testing.T) {
+	rep := ids.NewV7()
+	owner := ids.NewV7()
+
+	human := principal.Principal{Type: principal.PrincipalHuman, ID: "human:" + rep.String(), UserID: rep}
+	system := principal.Principal{Type: principal.PrincipalSystem, ID: "system"}
+
+	for name, tc := range map[string]struct {
+		ctx  context.Context
+		want ids.UUID
+		ok   bool
+	}{
+		// The ordinary path: a rep pressing "Write email" is the sender.
+		"a human drafting for themselves": {
+			ctx:  principal.WithActor(context.Background(), human),
+			want: rep,
+			ok:   true,
+		},
+		// The automation path, and the whole reason the sender is bound at all.
+		// The actor names no person; the owner does.
+		"an automation firing under the system actor": {
+			ctx: principal.WithSendingHuman(
+				principal.WithActor(context.Background(), system), owner),
+			want: owner,
+			ok:   true,
+		},
+		// The bound sender WINS over an actor that could also have answered.
+		// Without this the order is untested: both fields are populated on an
+		// agent call, and reading the actor first would send a colleague's mail
+		// out in the acting agent's owner's voice.
+		"a bound sender beside a human actor": {
+			ctx: principal.WithSendingHuman(
+				principal.WithActor(context.Background(), human), owner),
+			want: owner,
+			ok:   true,
+		},
+		// A system job nobody owns has no voice to write in, and guessing one
+		// would sign a message in a person who never asked for it.
+		"the system actor with no sender bound": {
+			ctx:  principal.WithActor(context.Background(), system),
+			want: ids.Nil,
+			ok:   false,
+		},
+		"no actor at all": {
+			ctx:  context.Background(),
+			want: ids.Nil,
+			ok:   false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, ok := voiceSender(tc.ctx)
+			if ok != tc.ok {
+				t.Fatalf("resolved=%t, want %t", ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Errorf("the draft would be written in %s's voice, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// A zero sending human is not a sender.
+//
+// The automation engine binds the owner only when the firing has one, but a
+// caller that bound a zero id anyway must not resolve to it: every voice profile
+// row is owned by a real user, so a zero id would read as "no profile" instead
+// of falling through to the actor who does have one.
+func TestAZeroSendingHumanFallsThroughToTheActor(t *testing.T) {
+	rep := ids.NewV7()
+	ctx := principal.WithSendingHuman(
+		principal.WithActor(context.Background(), principal.Principal{
+			Type: principal.PrincipalHuman, ID: "human:" + rep.String(), UserID: rep,
+		}), ids.Nil)
+
+	got, ok := voiceSender(ctx)
+	if !ok || got != rep {
+		t.Errorf("a zero sending human resolved to %s/%t, want the acting rep %s", got, ok, rep)
+	}
+}

--- a/backend/internal/modules/automation/engine_run.go
+++ b/backend/internal/modules/automation/engine_run.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/workflow"
 )
 
@@ -143,7 +144,7 @@ func (e *WorkflowEngine) runOne(ctx context.Context, h workflow.Handler, ev work
 	// see two instances minting one record.
 	effect.Handler = h.Spec().Name
 	effect.OccurrenceKey = h.IdempotencyKey(ev)
-	result, applyErr := h.Apply(ctx, ev, effect, nil)
+	result, applyErr := h.Apply(withSendingOwner(ctx, ev), ev, effect, nil)
 	// The outcome record commits in its OWN transaction before the apply
 	// error surfaces — returning applyErr from inside the tx closure would
 	// roll the very 'failed' row back and leave the claim lying 'applied'.
@@ -159,6 +160,26 @@ func (e *WorkflowEngine) runOne(ctx context.Context, h workflow.Handler, ev work
 		return applyErr
 	}
 	return nil
+}
+
+// withSendingOwner names the human an outbound message this firing composes
+// goes out AS.
+//
+// A message an automation drafts leaves under the OWNER's name, so the owner is
+// who it must sound like. The acting principal stays the system actor —
+// attribution, audit and row scope are all deliberately unmoved, and this value
+// authorizes nothing; the only question that reads it is whose voice to write
+// in (ai.ActiveVoiceForActor). Before it existed, every automated draft resolved
+// the system actor's zero UserID and was written in nobody's voice while a rep
+// with a built profile got their own voice everywhere else.
+//
+// A system-seeded firing has no owner and binds nothing, which drafts unvoiced —
+// the honest answer for a message no human authored.
+func withSendingOwner(ctx context.Context, ev workflow.Event) context.Context {
+	if ev.OwnerID == ids.Nil {
+		return ctx
+	}
+	return principal.WithSendingHuman(ctx, ev.OwnerID)
 }
 
 // recordApplyOutcome writes the terminal shape of one Apply call onto its

--- a/backend/internal/modules/automation/engine_sendingowner_test.go
+++ b/backend/internal/modules/automation/engine_sendingowner_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package automation
+
+// An automation's draft is written in its owner's voice.
+//
+// The firing runs under the system actor so its writes stay attributed to the
+// system, and that is also why the drafter could not tell whose voice to write
+// in: a system principal names no person. The owner is bound alongside it, for
+// that one question and nothing else.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/workflow"
+)
+
+// A human-authored firing names its owner as the sender.
+func TestAFiringNamesItsOwnerAsTheSendingHuman(t *testing.T) {
+	owner := ids.NewV7()
+	// The system actor the engine really binds, so the test measures the
+	// context production assembles rather than an empty one.
+	ctx := principal.WithActor(context.Background(),
+		principal.Principal{Type: principal.PrincipalSystem, ID: systemActor})
+
+	got, ok := principal.SendingHuman(withSendingOwner(ctx, workflow.Event{OwnerID: owner}))
+	if !ok {
+		t.Fatal("a firing owned by a human binds no sending human, so anything it drafts is written " +
+			"in nobody's voice")
+	}
+	if got != owner {
+		t.Errorf("the draft would be written in %s's voice, want the automation's owner %s", got, owner)
+	}
+}
+
+// A system-seeded firing names nobody.
+//
+// The other half, and the one that keeps the binding honest: an automation no
+// human authored has no voice to borrow, and inventing one would sign a message
+// in a person who never asked for it.
+func TestASystemSeededFiringNamesNoSendingHuman(t *testing.T) {
+	ctx := principal.WithActor(context.Background(),
+		principal.Principal{Type: principal.PrincipalSystem, ID: systemActor})
+
+	if _, ok := principal.SendingHuman(withSendingOwner(ctx, workflow.Event{})); ok {
+		t.Error("a firing with no owner names a sending human anyway, so a message no human authored " +
+			"would go out written in somebody's voice")
+	}
+}
+
+// Binding the sender moves nothing else.
+//
+// The acting principal is what audit, row scope and every permission check read.
+// A fix that bound the owner as the ACTOR would have made an automation's writes
+// look like the owner's own and widened what it may touch to whatever they may
+// touch — a far larger claim than "sign this in their voice".
+func TestBindingTheSenderLeavesTheActingPrincipalAlone(t *testing.T) {
+	ctx := principal.WithActor(context.Background(),
+		principal.Principal{Type: principal.PrincipalSystem, ID: systemActor})
+
+	actor, ok := principal.Actor(withSendingOwner(ctx, workflow.Event{OwnerID: ids.NewV7()}))
+	if !ok {
+		t.Fatal("binding the sender dropped the acting principal")
+	}
+	if actor.Type != principal.PrincipalSystem {
+		t.Errorf("the firing now acts as %q; an automation's writes must stay attributed to the system "+
+			"actor, not to its owner", actor.Type)
+	}
+	if !actor.UserID.IsZero() {
+		t.Error("the acting principal gained a UserID, which is a row-scope key — binding the sender " +
+			"must not widen what the firing may read or write")
+	}
+}

--- a/backend/internal/shared/kernel/principal/principal.go
+++ b/backend/internal/shared/kernel/principal/principal.go
@@ -221,6 +221,7 @@ const (
 	correlationKey
 	causationKey
 	agentRunKey
+	sendingHumanKey
 )
 
 // WithWorkspaceID binds the workspace a request resolved. No statement
@@ -292,6 +293,34 @@ func WithAgentRunID(ctx context.Context, id ids.UUID) context.Context {
 func AgentRunID(ctx context.Context) (ids.UUID, bool) {
 	id, ok := ctx.Value(agentRunKey).(ids.UUID)
 	return id, ok
+}
+
+// WithSendingHuman names the person an outbound message goes out AS, when that
+// is somebody other than the acting principal.
+//
+// It exists for one question — whose voice is this written in — and answers
+// nothing else. An automation composes under PrincipalSystem so its writes stay
+// attributed to the system actor, and a system principal carries no UserID, so
+// a drafter asking "whose voice?" of the actor gets no answer and writes in
+// nobody's. The message still leaves under a human's name, and that human is
+// the automation's owner.
+//
+// It is deliberately NOT a principal: binding the owner as the actor would move
+// the audit trail, the row scope and the permission checks along with it, which
+// is a far larger claim than "sign this in their voice". Nothing may authorize
+// a read or a write from this value.
+func WithSendingHuman(ctx context.Context, id ids.UUID) context.Context {
+	return context.WithValue(ctx, sendingHumanKey, id)
+}
+
+// SendingHuman returns the person an outbound message goes out as; ok is false
+// on every path where the actor IS the sender, which is most of them.
+func SendingHuman(ctx context.Context) (ids.UUID, bool) {
+	id, ok := ctx.Value(sendingHumanKey).(ids.UUID)
+	if !ok || id.IsZero() {
+		return ids.Nil, false
+	}
+	return id, true
 }
 
 // HumanIDPrefix is how a Principal.ID names a person. It is the ONE spelling

--- a/backend/internal/shared/kernel/principal/principal.go
+++ b/backend/internal/shared/kernel/principal/principal.go
@@ -309,6 +309,12 @@ func AgentRunID(ctx context.Context) (ids.UUID, bool) {
 // the audit trail, the row scope and the permission checks along with it, which
 // is a far larger claim than "sign this in their voice". Nothing may authorize
 // a read or a write from this value.
+//
+// And it may only be CONSULTED where the actor names nobody. The one thing it
+// selects — which voice profile is loaded — is a read of that person's verbatim
+// writing, so a reader that let this override an actor who already names a
+// person would have made it an authorization input by the back door. ai's
+// voiceSender is that reader, and it asks the actor first.
 func WithSendingHuman(ctx context.Context, id ids.UUID) context.Context {
 	return context.WithValue(ctx, sendingHumanKey, id)
 }


### PR DESCRIPTION
A rep who has built a Voice DNA profile got their own voice on some drafting surfaces and a generic writer on others. Three paths reached the model without the profile, each for a different reason.

## The automation's draft (the one you can see)

The overnight automation composes under `PrincipalSystem`, so its writes stay attributed to the system actor. A system principal carries no `UserID`, so `ActiveVoiceForActor` resolved nobody, returned a permission error, and `draftvoice.Load` degraded to the plain draft. It failed silently, because an unloadable voice is a supported state — every automated draft ever composed was written in nobody's voice.

`principal.WithSendingHuman` names the person a message goes out AS when that is somebody other than the actor. It authorizes nothing: binding the owner as the ACTOR would have moved audit, row scope and every permission check along with it, which is a far larger claim than "sign this in their voice". The only reader is the voice lookup. A system-seeded firing has no owner, binds nothing, and drafts unvoiced.

## The first message

`DraftFirstEmail` passed a literal nil where the voice block goes, with a comment saying the two composers had no Voice DNA either. They gained it in #3336 and this site was never revisited.

Wiring it surfaced a second defect: a voiced call **replaced** the site's system prompt rather than adding to it. A voiced first message would have been told "the activity and stated intent are the authoritative reason for this reply" with no activity in existence — an invitation to invent the thread, which is the one error a first message to a stranger cannot be edited back from. The voice rule is now added to whichever site the call is made under.

## The gate

`TestNoDraftingEntryPointIsAlwaysUnvoiced` is what keeps this from coming back.

The existing census (`TestEveryDraftingSurfaceLoadsTheSenderVoice`) asks whether a surface's PACKAGE can reach `draftvoice.Load`. That is why `firstdraft.go` was invisible for as long as it was: it sits beside the reply drafter, whose package loads the voice for the reply. The new gate reads entry points instead, and fails a function whose every model call passes a literal nil. An unvoiced call beside a voiced one is fine — that is the fallback for a rep with no profile, and for a voiced draft that trips the anti-AI floor.

It immediately found the first-message certification case measuring the unvoiced turn only, so ai-tasks was certifying a prompt no rep with a profile ever receives.

## What is deliberately left alone

The intro drafts, now documented rather than left looking like a gap. The intro request is written TO a colleague in Margince's own register. The intro note is sent BY that colleague rather than by the rep operating the page, so loading the caller's profile would sign the wrong person's message — and the colleague need not be a Margince user at all.

## Verification

Full `make check-backend` green, plus `craft-static`, `rls-store-path` and `no-jurisdiction`.

Every new guard was mutation-checked one clause at a time:
- removing the sender lookup fails the automation case and the precedence case independently
- binding a zero owner (a mutation that still compiles) fails the engine test
- reverting `firstdraft.go` to its nil makes the new gate name `DraftFirstEmail` exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes outbound drafts use the sender's Voice DNA profile, so automation drafts and first messages no longer fall back to a generic writer when the sender has built one.

**Bug Fixes**
- The automation engine binds the firing's owner as the sending human; audit, row scope, and permission checks still read the acting principal, and a system-seeded firing with no owner still drafts unvoiced.
- The sending human is only consulted when the actor names nobody, so it can never redirect a human actor's voice read to another person's profile.
- `DraftFirstEmail` now loads the sender's voice and applies the same anti-AI floor as the reply path.
- A voiced call now appends the voice rule to its site's own prompt instead of replacing it, so a first message is not told to treat a nonexistent activity as authoritative.
- A new gate reads drafting entry points and fails any function whose every model call carries no voice; `nil` and empty `draftvoice.Context{}` both count as unvoiced, and the sweep's call count is pinned so coverage can't silently shrink.
- Intro drafts stay unvoiced by design because the intro note is sent by the colleague; that decision is now documented.

<sup>Written for commit cb2e3afb9ec996db116aa315809ec8fbb41df95e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - First-message drafts now use the sender’s Voice DNA when available.
  - Automated outbound messages now use the appropriate human sender identity for voice personalization.
  - Voice-enabled drafts preserve the selected drafting context while applying shared voice guidance.

- **Bug Fixes**
  - Improved recognition and handling of voice-enabled reply drafts across different drafting surfaces.
  - Prevented bound sender information from overriding the actual human sender’s voice profile.
  - Draft generation retains existing fallback behavior when no voice profile is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->