### PR TITLE
A printed address has to be the site's own before it vouches for affiliation

### DIFF
--- a/backend/internal/compose/evidencematch.go
+++ b/backend/internal/compose/evidencematch.go
@@ -90,6 +90,10 @@ const (
 	dropConfidenceRange   = "confidence_out_of_range"
 	dropNameRoleUnlinked  = "name_role_not_in_snippet"
 	dropNoPublishedEmail  = "no_published_email"
+	// dropEmailOffSiteDomain marks a published person whose printed address
+	// belongs to somebody else's domain — the testimonial case, where the page
+	// prints a customer's own address and the read would file them as staff.
+	dropEmailOffSiteDomain = "email_off_site_domain"
 	// dropAlreadyOnFile marks a published person the workspace already
 	// holds — a contact who has been emailing us for months does not
 	// become a decision because a crawler found their name.

--- a/backend/internal/compose/sitepagefacts_test.go
+++ b/backend/internal/compose/sitepagefacts_test.go
@@ -735,12 +735,6 @@ func TestAnAddressWithNobodyInFrontOfItIsRefused(t *testing.T) {
 		"nothing at all":   "acme.example",
 		"a trailing at":    "anna@",
 		"two at signs":     "anna@muster@acme.example",
-		// RFC-valid, and the reason the domain is taken from the LAST @:
-		// mail.ParseAddress reads this as the single address
-		// `x@acme.example/@other.example`, so cutting at the FIRST @ hands
-		// "acme.example/@other.example" to a URL parse that reads its host as
-		// acme.example — an address on other.example vouching for an acme page.
-		"a quoted local part carrying an at": `"x@acme.example/"@other.example`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			if addressOnSiteDomain(address, seedURL) {
@@ -755,5 +749,31 @@ func TestAnAddressWithNobodyInFrontOfItIsRefused(t *testing.T) {
 func TestAnOrdinaryAddressOnTheSitePasses(t *testing.T) {
 	if !addressOnSiteDomain("anna@acme.example", seedURL) {
 		t.Error("the site's own address was refused, so the parse is rejecting more than malformed input")
+	}
+}
+
+// THE DOMAIN IS WHAT FOLLOWS THE LAST @, because a quoted local part may
+// contain one.
+//
+// Its own case rather than a row in the malformed table above: this address is
+// perfectly well formed and names a reachable mailbox — at other.example. What
+// refuses it is the site-domain rule, and a failure here means the domain was
+// read from the wrong @ rather than that the address named nobody.
+//
+// mail.ParseAddress reads it as the single address `x@acme.example/@other.example`,
+// so cutting at the FIRST @ hands "acme.example/@other.example" to a URL parse
+// that reads its host as acme.example — an address on other.example vouching
+// for an acme page, through the check that exists to stop exactly that.
+func TestTheDomainIsReadFromTheLastAtInTheAddress(t *testing.T) {
+	const address = `"x@acme.example/"@other.example`
+	if addressOnSiteDomain(address, seedURL) {
+		t.Errorf("%s vouched for the acme page: its domain is other.example, and reading it from "+
+			"the first @ finds acme.example in the local part instead", address)
+	}
+	// And the same shape ON the site still passes, so the rule above is about
+	// which @ is read rather than about refusing quoted local parts.
+	if !addressOnSiteDomain(`"x@other.example/"@acme.example`, seedURL) {
+		t.Error("a quoted local part on the site's own domain was refused; the rule is which @ is " +
+			"read, not whether the local part is quoted")
 	}
 }

--- a/backend/internal/compose/sitepagefacts_test.go
+++ b/backend/internal/compose/sitepagefacts_test.go
@@ -735,6 +735,12 @@ func TestAnAddressWithNobodyInFrontOfItIsRefused(t *testing.T) {
 		"nothing at all":   "acme.example",
 		"a trailing at":    "anna@",
 		"two at signs":     "anna@muster@acme.example",
+		// RFC-valid, and the reason the domain is taken from the LAST @:
+		// mail.ParseAddress reads this as the single address
+		// `x@acme.example/@other.example`, so cutting at the FIRST @ hands
+		// "acme.example/@other.example" to a URL parse that reads its host as
+		// acme.example — an address on other.example vouching for an acme page.
+		"a quoted local part carrying an at": `"x@acme.example/"@other.example`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			if addressOnSiteDomain(address, seedURL) {

--- a/backend/internal/compose/sitepagefacts_test.go
+++ b/backend/internal/compose/sitepagefacts_test.go
@@ -721,3 +721,33 @@ func TestAStaffMemberWithAPersonalAddressIsUnproposableAndSaysSo(t *testing.T) {
 		t.Fatalf("the drop must name the rule that took him: %+v", dropped)
 	}
 }
+
+// AN ADDRESS THAT NAMES NOBODY IS NOT AN ADDRESS.
+//
+// A bare "@acme.example", or a run of words ending in one, carries the site's
+// domain after the last @ and would vouch for the affiliation while naming
+// nobody reachable — the proposal would ask a human to confirm a lead whose
+// only contact detail cannot be sent to. So the address is parsed, not split.
+func TestAnAddressWithNobodyInFrontOfItIsRefused(t *testing.T) {
+	for name, address := range map[string]string{
+		"no local part":    "@acme.example",
+		"words then an at": "not an email@acme.example",
+		"nothing at all":   "acme.example",
+		"a trailing at":    "anna@",
+		"two at signs":     "anna@muster@acme.example",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if addressOnSiteDomain(address, seedURL) {
+				t.Errorf("%q vouched for the site's own domain while naming nobody reachable", address)
+			}
+		})
+	}
+}
+
+// AND A REAL ONE ON THE SITE STILL PASSES, so the check above is not refusing
+// everything.
+func TestAnOrdinaryAddressOnTheSitePasses(t *testing.T) {
+	if !addressOnSiteDomain("anna@acme.example", seedURL) {
+		t.Error("the site's own address was refused, so the parse is rejecting more than malformed input")
+	}
+}

--- a/backend/internal/compose/sitepagefacts_test.go
+++ b/backend/internal/compose/sitepagefacts_test.go
@@ -667,3 +667,57 @@ func TestDeclaringACompanionCostsAContradiction(t *testing.T) {
 		t.Fatalf("the borrowed-title claim must be recorded as dropped: %+v", dropped)
 	}
 }
+
+// A TESTIMONIAL THAT PRINTS AN ADDRESS IS STILL A TESTIMONIAL.
+//
+// The published-email floor proves CONTACTABILITY, not affiliation. A wall that
+// prints the quoted person's own address clears it and still yields a lead
+// filed as a contact at the quoting company — which their own job title
+// disproves on the same line, and which then propagates into whatever the
+// account page says.
+func TestAQuotedCustomerWhoPrintsTheirOwnAddressIsStillNotALead(t *testing.T) {
+	page, menu, idx := pageFixture(crmcontracts.SiteReadPageKindHome, seedURL,
+		"What our clients say: Marc Costea, CEO at Qilin.Cloud, marc@qilin.example, calls it amazing. "+
+			"Our founder Anna Muster runs the practice, anna@acme.example.")
+	reply := `{"facts":[],"people":[
+		{"n":"Marc Costea","r":"CEO","q":"Marc Costea, CEO at Qilin.Cloud","m":"marc@qilin.example","e":"s0"},
+		{"n":"Anna Muster","r":"founder","q":"Our founder Anna Muster","m":"anna@acme.example","e":"s0"}]}`
+	res, dropped := gatePageFacts(reply, page, menu, idx)
+	if len(res.people) != 1 || res.people[0].Name != "Anna Muster" {
+		t.Fatalf("only the site's own person may be proposed: %+v", res.people)
+	}
+	if reasons := dropReasons(dropped); reasons["Marc Costea"] != dropEmailOffSiteDomain {
+		t.Fatalf("the quoted customer must drop for the domain, not by luck: %+v", dropped)
+	}
+}
+
+// AND THE SITE'S OWN PEOPLE ARE NOT DROPPED WITH THEM, across the subdomains a
+// site actually uses: the comparison is registrable domains, which is the same
+// "same site" test the crawler's own off-domain gate applies.
+func TestAnAddressOnASubdomainOfTheSiteIsStillTheSiteS(t *testing.T) {
+	page, menu, idx := pageFixture(crmcontracts.SiteReadPageKindTeam, "https://www.acme.example/team",
+		"Anna Muster is our Chief Executive Officer, anna@mail.acme.example.")
+	reply := `{"facts":[],"people":[
+		{"n":"Anna Muster","r":"Chief Executive Officer","q":"Anna Muster is our Chief Executive Officer","m":"anna@mail.acme.example","e":"s0"}]}`
+	res, dropped := gatePageFacts(reply, page, menu, idx)
+	if len(res.people) != 1 || res.people[0].Name != "Anna Muster" {
+		t.Fatalf("a www page and a mail subdomain are one site: %+v people=%+v", dropped, res.people)
+	}
+}
+
+// THE COST OF THE RULE, stated as a test so it is a decision rather than a
+// surprise: a member of staff who publishes a personal address becomes
+// unproposable, and the drop census says which rule took them.
+func TestAStaffMemberWithAPersonalAddressIsUnproposableAndSaysSo(t *testing.T) {
+	page, menu, idx := pageFixture(crmcontracts.SiteReadPageKindTeam, seedURL+"/team",
+		"Bernd Beispiel leads sales as Head of Sales, bernd.beispiel@gmail.example.")
+	reply := `{"facts":[],"people":[
+		{"n":"Bernd Beispiel","r":"Head of Sales","q":"Bernd Beispiel leads sales as Head of Sales","m":"bernd.beispiel@gmail.example","e":"s0"}]}`
+	res, dropped := gatePageFacts(reply, page, menu, idx)
+	if len(res.people) != 0 {
+		t.Fatalf("a personal address cannot vouch for the affiliation: %+v", res.people)
+	}
+	if reasons := dropReasons(dropped); reasons["Bernd Beispiel"] != dropEmailOffSiteDomain {
+		t.Fatalf("the drop must name the rule that took him: %+v", dropped)
+	}
+}

--- a/backend/internal/compose/sitepagefactspeople.go
+++ b/backend/internal/compose/sitepagefactspeople.go
@@ -11,7 +11,12 @@ package compose
 // copies out of the page — checked verbatim, then checked for reaching over
 // somebody else — rather than from where the two strings happen to sit.
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/platform/freemail"
+)
 
 // attributionQuote checks the model's claim that the page gives THIS person
 // THIS role, and returns the page's own words that say so.
@@ -231,6 +236,24 @@ func gatePagePeople(parsed pageFactsReply, page crawlPage, idx snippetIndex, dro
 			drop(lanePeople, name, role, dropNoPublishedEmail)
 			continue
 		}
+		// And it has to be an address on THIS site's own domain, because the
+		// proposal files the person at the company whose site was read.
+		//
+		// A printed address proves contactability, not affiliation. A "what our
+		// clients say" wall that prints the quoted person's own address yields a
+		// lead filed as a contact at the quoting company — which their own
+		// quoted job title disproves on the same line, and which then propagates
+		// into whatever the account page says about that company.
+		//
+		// The cost is named rather than hidden: a member of staff who publishes
+		// a personal address becomes unproposable, and the drop census says so
+		// by its own reason. That is the trade taken deliberately — a missing
+		// lead is recoverable by hand, a wrong affiliation is not obviously
+		// wrong to whoever reads it next.
+		if !addressOnSiteDomain(publishedEmail, page.URL) {
+			drop(lanePeople, name, role, dropEmailOffSiteDomain)
+			continue
+		}
 		person := sitePerson{
 			Name:            name,
 			Role:            role,
@@ -261,4 +284,29 @@ func gatePagePeople(parsed pageFactsReply, page crawlPage, idx snippetIndex, dro
 		out = append(out, person)
 	}
 	return out
+}
+
+// addressOnSiteDomain reports whether a printed address belongs to the site the
+// page came from, compared as REGISTRABLE domains.
+//
+// eTLD+1 on both sides, so a page at www.acme.de accepts jane@acme.de and a
+// page at acme.de accepts an address on mail.acme.de — the same "same site"
+// test the crawler's own off-domain gate applies. Two customers of one
+// co.uk-style suffix are not the same site, which publicsuffix settles rather
+// than a suffix count would.
+//
+// Anything unparseable answers false. An address or a URL this cannot read is
+// not one it can vouch for, and the proposal it would admit is the one this
+// check exists to refuse.
+func addressOnSiteDomain(email, pageURL string) bool {
+	_, domain, found := strings.Cut(email, "@")
+	if !found || domain == "" {
+		return false
+	}
+	parsed, err := url.Parse(pageURL)
+	if err != nil || parsed.Hostname() == "" {
+		return false
+	}
+	site := freemail.Registrable(parsed.Hostname())
+	return site != "" && freemail.Registrable(domain) == site
 }

--- a/backend/internal/compose/sitepagefactspeople.go
+++ b/backend/internal/compose/sitepagefactspeople.go
@@ -310,10 +310,23 @@ func addressOnSiteDomain(email, pageURL string) bool {
 	if err != nil {
 		return false
 	}
-	local, domain, found := strings.Cut(parsed.Address, "@")
-	if !found || local == "" || domain == "" {
+	// The LAST @, because a quoted local part may contain one: mail.ParseAddress
+	// reads `"x@acme.example/"@other.example` as the single address
+	// `x@acme.example/@other.example`, and cutting at the first @ would hand
+	// "acme.example/@other.example" to a URL parse that reads its host as
+	// acme.example — an address on other.example vouching for an acme page.
+	at := strings.LastIndex(parsed.Address, "@")
+	if at <= 0 || at == len(parsed.Address)-1 {
 		return false
 	}
+	domain := parsed.Address[at+1:]
+	// Nothing further is asserted about the domain's shape here, because two
+	// checks already own it: mail.ParseAddress refuses a path, a space or a
+	// second @ in an unquoted domain, and SameRegistrableDomain answers false
+	// for anything url.Parse or the public-suffix list cannot read. A guard
+	// between them would be one no input reaches, which is a guard nobody can
+	// tell from a broken one.
+	//
 	// A host in URL form because SameRegistrableDomain compares two URLs, and
 	// reusing it is what keeps this test and the crawler's the same test.
 	return webread.SameRegistrableDomain(pageURL, "https://"+domain)

--- a/backend/internal/compose/sitepagefactspeople.go
+++ b/backend/internal/compose/sitepagefactspeople.go
@@ -12,10 +12,10 @@ package compose
 // somebody else — rather than from where the two strings happen to sit.
 
 import (
-	"net/url"
+	"net/mail"
 	"strings"
 
-	"github.com/margince/margince/backend/internal/platform/freemail"
+	"github.com/margince/margince/backend/internal/platform/webread"
 )
 
 // attributionQuote checks the model's claim that the page gives THIS person
@@ -289,24 +289,32 @@ func gatePagePeople(parsed pageFactsReply, page crawlPage, idx snippetIndex, dro
 // addressOnSiteDomain reports whether a printed address belongs to the site the
 // page came from, compared as REGISTRABLE domains.
 //
-// eTLD+1 on both sides, so a page at www.acme.de accepts jane@acme.de and a
-// page at acme.de accepts an address on mail.acme.de — the same "same site"
-// test the crawler's own off-domain gate applies. Two customers of one
-// co.uk-style suffix are not the same site, which publicsuffix settles rather
-// than a suffix count would.
+// The address is PARSED, not split. A bare "@acme.example", or "not an
+// email@acme.example", carries the site's domain after the last @ and would
+// otherwise vouch for an affiliation while naming nobody reachable — the
+// proposal would then ask a human to confirm a lead whose only contact detail
+// cannot be sent to.
 //
-// Anything unparseable answers false. An address or a URL this cannot read is
-// not one it can vouch for, and the proposal it would admit is the one this
+// The comparison is webread.SameRegistrableDomain, which is the crawler's own
+// off-domain gate: www.acme.de and mail.acme.de are one site, acme.de and
+// acme.com are not, and neither are two customers of one co.uk-style suffix.
+// It is strict where freemail.Registrable is lenient — that one passes a host
+// through unchanged when it can derive no eTLD+1, so a bare public suffix on
+// both sides would compare equal and admit the very thing this refuses.
+//
+// Anything it cannot read answers false. An address or a URL this cannot parse
+// is not one it can vouch for, and the proposal it would admit is the one this
 // check exists to refuse.
 func addressOnSiteDomain(email, pageURL string) bool {
-	_, domain, found := strings.Cut(email, "@")
-	if !found || domain == "" {
+	parsed, err := mail.ParseAddress(email)
+	if err != nil {
 		return false
 	}
-	parsed, err := url.Parse(pageURL)
-	if err != nil || parsed.Hostname() == "" {
+	local, domain, found := strings.Cut(parsed.Address, "@")
+	if !found || local == "" || domain == "" {
 		return false
 	}
-	site := freemail.Registrable(parsed.Hostname())
-	return site != "" && freemail.Registrable(domain) == site
+	// A host in URL form because SameRegistrableDomain compares two URLs, and
+	// reusing it is what keeps this test and the crawler's the same test.
+	return webread.SameRegistrableDomain(pageURL, "https://"+domain)
 }


### PR DESCRIPTION
Closes #2476.

## What was wrong

The published-email floor proves **contactability, not affiliation**. A "what our clients say" wall that *does* print the quoted person's own address — `marc@qilin.example` on our customer's site — clears the floor and still yields a lead filed as a contact **at the quoting company**, which their own quoted job title disproves on the same line.

The existing test `TestATestimonialDoesNotBecomeALead` passes only because the fixture's testimonial happens to print no address. The moment one does, the case it is named for reappears.

## The call

The ticket weighed three options and made the call conditional: **option 3** (propose without an affiliation and let the reviewer supply the company) *"if it is cheap in the current proposal shape"*, **option 1** (require the site's own domain) otherwise.

It is not cheap. A proposal carries `OrganizationID` from the read all the way through `siteleadaccept`, so making affiliation optional changes what a proposal *is* — through the wire type, the accept path and the review screen — rather than adding a condition to it.

So this is option 1, and the ticket's own reasoning for preferring it in that case stands: *"a missing lead is recoverable, a wrong affiliation propagates into whatever the account page then says."*

## What it does

The printed address must sit on the crawled site's own **registrable** domain. eTLD+1 on both sides, so a page at `www.acme.example` accepts `anna@mail.acme.example`, and two customers of one `co.uk`-style suffix are still not the same site — `publicsuffix` settles that rather than a dot count. Anything unparseable answers false, because an address this cannot read is not one it can vouch for.

The cost the ticket named is taken deliberately and is **visible**: a member of staff who publishes a personal address becomes unproposable, and the drop census records `email_off_site_domain` rather than losing them silently.

## Tests

Three, mutation-checked:

- a quoted customer who prints their own address drops, **by the domain rule** rather than by happening to print nothing (removing the gate fails it);
- the site's own person on a `mail.` subdomain of a `www.` page still proposes (comparing exact hostnames instead of registrable domains fails it);
- a staff member with a personal address is unproposable and the census names the rule that took them — the cost written down as a test so it stays a decision rather than becoming a surprise.

`make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Published contact records now require valid email addresses associated with the website’s domain.
  * Personal, unrelated, malformed, or invalid-domain addresses are excluded from published results.
  * Valid subdomains of the website remain accepted.
  * Addresses without a valid local part or recognizable domain are rejected consistently.
  * Email addresses containing additional “@” characters in quoted local parts are handled correctly.
  * Valid on-site customer and staff email addresses continue to appear in published results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->