### PR TITLE
Four things the mailbox-privacy work left unreachable

### DIFF
--- a/backend/gates/rbacgate_test.go
+++ b/backend/gates/rbacgate_test.go
@@ -154,6 +154,7 @@ var ungatedEntryPoints = gatekit.Waive(map[string]string{ // #nosec G101 -- waiv
 	"internal/modules/capture:NoiseMailForTx":                 "sweep read inside the caller's transaction, selecting the loop's own claimed activities",
 	"internal/modules/capture:NoiseMailToHide":                "retention sweep read: noise mail eligible for hiding",
 	"internal/modules/capture:NoiseMailToRedact":              "retention sweep read: noise mail past its redaction window",
+	"internal/modules/capture:StalledBacklogSeats":            "sweep read: which seats have pending dispositions nothing has touched. It answers seat ids and counts, never an address or a subject, and its only caller runs under the verdict pass's system principal to tell each seat their own backlog stopped moving",
 	"internal/modules/capture:PurgeRawCaptureTx":              "retention sweep purge inside the caller's transaction, over activities the same sweep selected",
 	"internal/modules/capture:ReconcileDeclined":              "sweep reconciling declined proposals back onto their pending rows",
 	"internal/modules/capture:ReleaseBudget":                  "returns the slot ReserveBudget took, same sweep",

--- a/backend/internal/compose/audiencerescope.go
+++ b/backend/internal/compose/audiencerescope.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/signals"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/kernel/events"
@@ -140,7 +141,10 @@ func (g *AudienceRescopeGen) rescope(ctx context.Context, tx pgx.Tx, activityID 
 		if _, err := signals.NarrowDerivedForActivity(ctx, tx, activityID, owner); err != nil {
 			return err
 		}
-		if err := activities.RetractDerivedForActivityTx(ctx, tx, activityID); err != nil {
+		// people owns person_profile_field, so the edge is injected here rather
+		// than reached for inside activities.
+		if err := activities.RetractDerivedForActivityTx(
+			ctx, tx, activityID, people.RetractSignatureFieldsTx); err != nil {
 			return err
 		}
 	}

--- a/backend/internal/compose/capturejobs.go
+++ b/backend/internal/compose/capturejobs.go
@@ -431,7 +431,10 @@ type counterpartyVerdictWorkspaceWorker struct {
 	// purger destroys personal mail past its window. Nil in a role with no
 	// object store, and the stage is then skipped rather than half-done.
 	purger *CapturePurger
-	log    *slog.Logger
+	// backlogNotice tells a seat their capture backlog stopped moving. Nil in a
+	// role composed without notices, and the stage is then skipped.
+	backlogNotice BacklogNotifier
+	log           *slog.Logger
 }
 
 func (w *counterpartyVerdictWorkspaceWorker) Work(ctx context.Context, job *river.Job[CounterpartyVerdictWorkspaceArgs]) error {
@@ -465,6 +468,11 @@ func (w *counterpartyVerdictWorkspaceWorker) Work(ctx context.Context, job *rive
 		return jobs.FaultContext(ctx, err)
 	}
 	if err := w.engine.RedactNoiseWorkspace(wsCtx, capture.NoiseUndoWindow, 0); err != nil {
+		return jobs.FaultContext(ctx, err)
+	}
+	// After the stages that MOVE the ledger, so a backlog this pass just cleared
+	// is not reported as stalled on its way out.
+	if err := w.engine.NoticeBacklogStalledWorkspace(wsCtx, w.backlogNotice); err != nil {
 		return jobs.FaultContext(ctx, err)
 	}
 	// Last, and after redaction: a `personal` verdict destroys rather than

--- a/backend/internal/compose/captureverdictsweeps.go
+++ b/backend/internal/compose/captureverdictsweeps.go
@@ -265,3 +265,47 @@ func (e *CounterpartyVerdictEngine) inWorkspace(ctx context.Context, fn func(con
 	}
 	return fn(e.workspaceCtx(ctx), ws)
 }
+
+// backlogQuiet is how long a pending row must sit untouched before its seat is
+// told. Two verdict cycles' worth: one quiet cycle is a pass that found no
+// budget or lost a race, and telling somebody their mail is stuck over that
+// would cry wolf every day.
+const backlogQuiet = 6 * time.Hour
+
+// NoticeBacklogStalledWorkspace tells each seat whose capture backlog has
+// stopped moving that it has.
+//
+// It is the only thing that says so. A row that spends its attempts retires to
+// `unsure` and reaches a human through the review queue, but an outage REFUNDS
+// the attempt rather than spending it — deliberately, so a provider being down
+// does not retire rows for reasons that had nothing to do with the question. The
+// consequence is that during a real stall nothing exhausts and nothing surfaces,
+// and the seat's mail sits withheld with no sign of it anywhere.
+//
+// Written through notices.Store.Create with a DedupeKey rather than through the
+// Notifier seam, which carries no key: a stall is a standing condition, and a
+// pass that ran hourly against a seam that cannot dedupe would write one line
+// per sweep forever. The key names the seat and the DAY, so a stall that lasts a
+// week is one line a day rather than one line an hour — enough to be noticed
+// again, not enough to bury the inbox it is written into.
+func (e *CounterpartyVerdictEngine) NoticeBacklogStalledWorkspace(ctx context.Context, notify BacklogNotifier) error {
+	if notify == nil {
+		return nil
+	}
+	return e.inWorkspace(ctx, func(wsCtx context.Context, _ ids.UUID) error {
+		stalled, err := e.pending.StalledBacklogSeats(wsCtx, backlogQuiet)
+		if err != nil {
+			return err
+		}
+		for seat, waiting := range stalled {
+			if err := notify(wsCtx, seat, waiting); err != nil {
+				return fmt.Errorf("verdict: telling a seat their backlog stopped moving: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+// BacklogNotifier raises the stall notice for one seat. notices owns the table,
+// so compose injects the edge.
+type BacklogNotifier func(ctx context.Context, seat ids.UUID, waiting int) error

--- a/backend/internal/compose/integration/audiencederived_integration_test.go
+++ b/backend/internal/compose/integration/audiencederived_integration_test.go
@@ -21,10 +21,12 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/modules/ai"
+	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/modules/privacy"
 	"github.com/margince/margince/backend/internal/modules/search"
 	kevents "github.com/margince/margince/backend/internal/shared/kernel/events"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // heldMailSubject and heldMailBody are the fixture's confidential message. They
@@ -388,4 +390,242 @@ func TestTheRescopeConsumerFollowsTheRowNotTheStaleEvent(t *testing.T) {
 		t.Error("a stale narrowing event deleted the vector of a message that is workspace again — " +
 			"nothing rebuilds it, because the widening's own event found the row already indexed")
 	}
+}
+
+func TestNarrowingRetractsWhatAMessagesSignatureWroteOnAContact(t *testing.T) {
+	// A title lifted from a signature block is the message's content, restated
+	// on a record everybody can see. Narrowing the message and leaving the field
+	// behind limits the mail and publishes what it said.
+	e := SetupSearch(t)
+	activity := e.SeedID(t, `
+		INSERT INTO activity (id, kind, subject, body, occurred_at, direction, source, captured_by, audience)
+		VALUES ($1, 'email', $2, $3, now(), 'inbound', 'gmail', 'connector:gmail:x', 'workspace')`,
+		heldMailSubject, heldMailBody)
+	person := seedPersonForSignature(t, e)
+	seedSignatureField(t, e, person, activity, "title", "Leiterin Recht")
+
+	narrowAndRescope(t, e, activity)
+
+	if n := signatureFields(t, e, activity); n != 0 {
+		t.Errorf("%d profile field(s) survive a narrowed message, want 0: the field says what the "+
+			"message said, to readers the message itself is now withheld from", n)
+	}
+}
+
+func TestNarrowingLeavesAFieldAPersonConfirmed(t *testing.T) {
+	// The human-edit conflict, settled on the write side rather than here: a
+	// person accepting a value writes their own source_ref over the enrichment's,
+	// so a field somebody confirmed no longer names the message at all.
+	e := SetupSearch(t)
+	ctx := context.Background()
+	activity := e.SeedID(t, `
+		INSERT INTO activity (id, kind, subject, body, occurred_at, direction, source, captured_by, audience)
+		VALUES ($1, 'email', $2, $3, now(), 'inbound', 'gmail', 'connector:gmail:x', 'workspace')`,
+		heldMailSubject, heldMailBody)
+	person := seedPersonForSignature(t, e)
+	seedSignatureField(t, e, person, activity, "title", "Leiterin Recht")
+	// The person corrects it, which replaces source_ref with their own.
+	if _, err := e.Owner.Exec(ctx, `
+		UPDATE person_profile_field
+		   SET value = 'Justiziarin', source_ref = 'human:correction', captured_by = 'human:someone'
+		 WHERE person_id = $1 AND field = 'title'`, person); err != nil {
+		t.Fatal(err)
+	}
+
+	narrowAndRescope(t, e, activity)
+
+	var value string
+	if err := e.Owner.QueryRow(ctx, `
+		SELECT value FROM person_profile_field WHERE person_id = $1 AND field = 'title'`,
+		person).Scan(&value); err != nil {
+		t.Fatalf("the field a person confirmed was retracted with the message: %v", err)
+	}
+	if value != "Justiziarin" {
+		t.Errorf("value = %q, want the correction the person made", value)
+	}
+}
+
+func TestNarrowingLeavesAnotherMessagesSignatureFields(t *testing.T) {
+	// Scoped to the message that was narrowed. A second message from the same
+	// correspondent is still open, and what its signature said is still readable.
+	e := SetupSearch(t)
+	narrowed := e.SeedID(t, `
+		INSERT INTO activity (id, kind, subject, body, occurred_at, direction, source, captured_by, audience)
+		VALUES ($1, 'email', $2, $3, now(), 'inbound', 'gmail', 'connector:gmail:x', 'workspace')`,
+		heldMailSubject, heldMailBody)
+	other := e.SeedID(t, `
+		INSERT INTO activity (id, kind, subject, body, occurred_at, direction, source, captured_by, audience)
+		VALUES ($1, 'email', 'noch offen', 'der Text', now(), 'inbound', 'gmail', 'connector:gmail:y', 'workspace')`)
+	person := seedPersonForSignature(t, e)
+	seedSignatureField(t, e, person, narrowed, "title", "Leiterin Recht")
+	seedSignatureField(t, e, person, other, "phone", "+49 30 1234")
+
+	narrowAndRescope(t, e, narrowed)
+
+	if n := signatureFields(t, e, narrowed); n != 0 {
+		t.Errorf("%d field(s) survive the narrowed message, want 0", n)
+	}
+	if n := signatureFields(t, e, other); n != 1 {
+		t.Errorf("%d field(s) survive the message that is still open, want 1: narrowing one message "+
+			"does not retract what another one said", n)
+	}
+}
+
+func TestNarrowingLeavesAFieldAPersonRestored(t *testing.T) {
+	// The case that made the first version of this destroy somebody's work.
+	//
+	// RestoreProfileField INHERITS source_ref from the row it undoes, so a value
+	// a person restored still names the message the signature came from. Keyed
+	// on the ref alone, the retraction deleted it — and there is nothing to
+	// recover it from, because the restore's own precedence clears the undo
+	// buffer on the way past.
+	//
+	// Seeded through RestoreProfileField rather than by writing the row this
+	// test wants to see, which is the only reason it can see the defect: the
+	// sibling test below hand-wrote a source_ref production never produces.
+	e := SetupSearch(t)
+	ctx := context.Background()
+	activity := e.SeedID(t, `
+		INSERT INTO activity (id, kind, subject, body, occurred_at, direction, source, captured_by, audience)
+		VALUES ($1, 'email', $2, $3, now(), 'inbound', 'gmail', 'connector:gmail:x', 'workspace')`,
+		heldMailSubject, heldMailBody)
+	person := seedPersonForSignature(t, e)
+	// A value the signature replaced, with the earlier one in the undo buffer —
+	// the state ApplySignatureFields leaves behind when it overwrites.
+	seedSignatureField(t, e, person, activity, "title", "VP Finance")
+	if _, err := e.Owner.Exec(ctx, `
+		UPDATE person_profile_field
+		   SET superseded_value = 'CFO', superseded_captured_by = 'human:earlier',
+		       superseded_observed_at = now() - interval '1 day'
+		 WHERE person_id = $1 AND field = 'title'`, person); err != nil {
+		t.Fatal(err)
+	}
+	// title is a MIRRORED field: the restore CASes on the person column agreeing
+	// with the sidecar, because a title somebody retyped leaves the sidecar
+	// untouched and restoring on the sidecar alone would overwrite their answer.
+	if _, err := e.Owner.Exec(ctx,
+		`UPDATE person SET title = 'VP Finance' WHERE id = $1`, person); err != nil {
+		t.Fatal(err)
+	}
+	// The person presses undo, through the store that serves that press.
+	if err := people.NewStore(e.DB()).RestoreProfileField(
+		personWriter(e), ids.From[ids.PersonKind](person), "title"); err != nil {
+		t.Fatalf("restoring the field: %v", err)
+	}
+
+	narrowAndRescope(t, e, activity)
+
+	var value string
+	if err := e.Owner.QueryRow(ctx, `
+		SELECT value FROM person_profile_field WHERE person_id = $1 AND field = 'title'`,
+		person).Scan(&value); err != nil {
+		t.Fatalf("the value a person restored was deleted by narrowing the message it replaced: %v", err)
+	}
+	if value != "CFO" {
+		t.Errorf("value = %q, want the value the person restored", value)
+	}
+}
+
+func TestNarrowingLeavesAFieldAPersonCorrected(t *testing.T) {
+	// The case the source predicate does NOT cover, and the reason there are
+	// three. A human correcting a field records it in ai_feedback and touches
+	// neither the column nor the profile-field row — so a corrected field is
+	// still source=capture_enrich and still names the message. The row is what
+	// person360 overlays the correction onto, so deleting it takes their verdict
+	// off the screen with it.
+	e := SetupSearch(t)
+	ctx := context.Background()
+	activity := e.SeedID(t, `
+		INSERT INTO activity (id, kind, subject, body, occurred_at, direction, source, captured_by, audience)
+		VALUES ($1, 'email', $2, $3, now(), 'inbound', 'gmail', 'connector:gmail:x', 'workspace')`,
+		heldMailSubject, heldMailBody)
+	person := seedPersonForSignature(t, e)
+	seedSignatureField(t, e, person, activity, "title", "VP Finance")
+	// The verdict a correction leaves behind, keyed the way refuseIfCorrected
+	// reads it.
+	if _, err := e.Owner.Exec(ctx, `
+		INSERT INTO ai_feedback (subject_type, subject_id, claim_kind, claim_key, verdict, corrected_value, captured_by, source)
+		VALUES ('person', $1, 'profile_field',
+		        encode(sha256(('profile_field:title')::bytea), 'hex'), 'corrected', 'Justiziarin', 'human:someone', 'ui')`,
+		person); err != nil {
+		t.Fatal(err)
+	}
+
+	narrowAndRescope(t, e, activity)
+
+	if n := signatureFields(t, e, activity); n != 1 {
+		t.Errorf("%d field(s) survive, want 1: a field a person corrected is the row their verdict "+
+			"is shown against, and deleting it takes the correction off the screen", n)
+	}
+}
+
+// personWriter is a seat that may write a person, which SearchEnv.Admin is not:
+// its grants are the read set the search suites need. A restore is a write to
+// the subject's own record and takes person.update.
+func personWriter(e *SearchEnv) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
+		SeatType: principal.SeatFull,
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"person": {Read: true, Update: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+// narrowAndRescope narrows a message and runs the consumer that collects what
+// was derived from it, which is the pair production performs.
+func narrowAndRescope(t *testing.T, e *SearchEnv, activity ids.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := e.Owner.Exec(ctx,
+		`UPDATE activity SET audience = 'participants' WHERE id = $1`, activity); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(map[string]any{"changed_fields": map[string]any{"audience": "participants"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compose.NewAudienceRescopeGen(e.Pool).HandleEvent(ctx, kevents.Envelope{
+		Type:    "activity.updated",
+		Entity:  kevents.EntityRef{Type: "activity", ID: activity},
+		Payload: payload,
+	}); err != nil {
+		t.Fatalf("the rescope consumer refused the narrowing: %v", err)
+	}
+}
+
+// seedPersonForSignature lands the contact a signature enrichment writes onto.
+func seedPersonForSignature(t *testing.T, e *SearchEnv) ids.UUID {
+	t.Helper()
+	return e.SeedID(t, `
+		INSERT INTO person (id, full_name, source, captured_by)
+		VALUES ($1, 'Die Absenderin', 'manual', 'human:test')`)
+}
+
+// seedSignatureField writes the row a signature enrichment writes: source_ref
+// naming the message it was lifted from, which is the key the retraction reads.
+func seedSignatureField(t *testing.T, e *SearchEnv, person, activity ids.UUID, field, value string) {
+	t.Helper()
+	if _, err := e.Owner.Exec(context.Background(), `
+		INSERT INTO person_profile_field
+		       (person_id, field, value, evidence_snippet, source_ref, source, captured_by)
+		VALUES ($1, $2, $3, 'aus der Signatur', 'activity:'||$4, 'capture_enrich', 'system:enrich')`,
+		person, field, value, activity.String()); err != nil {
+		t.Fatalf("seeding a signature-derived field: %v", err)
+	}
+}
+
+// signatureFields counts what one message's signature still has on record.
+func signatureFields(t *testing.T, e *SearchEnv, activity ids.UUID) int {
+	t.Helper()
+	var n int
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM person_profile_field WHERE source_ref = 'activity:'||$1`,
+		activity.String()).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
 }

--- a/backend/internal/compose/integration/capturebacklogstall_integration_test.go
+++ b/backend/internal/compose/integration/capturebacklogstall_integration_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// When a seat is told their capture backlog stopped moving, and when they are
+// not.
+//
+// This notice is the only thing that says so. A row that SPENDS its attempts
+// retires to `unsure` and reaches a human through the review queue — but an
+// outage REFUNDS the attempt rather than spending it, deliberately, so a
+// provider being down does not retire rows for reasons that had nothing to do
+// with the question. The consequence is that during a real stall nothing
+// exhausts, nothing retires, and the seat's mail sits withheld with no sign of
+// it anywhere.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestASeatWhoseBacklogStoppedMovingIsFound(t *testing.T) {
+	e := Setup(t)
+	seedPendingSender(t, e, e.Rep1, "wartet@example.test", 1, 8*time.Hour)
+
+	stalled := stalledSeats(t, e)
+	if stalled[e.Rep1] != 1 {
+		t.Fatalf("stalled[%v] = %d, want 1 — this row arrived eight hours ago and is still "+
+			"waiting for an answer", e.Rep1, stalled[e.Rep1])
+	}
+}
+
+func TestAFreshlyArrivedRowIsNotStalled(t *testing.T) {
+	// New, not stuck. Mail that just landed is pending because nothing has
+	// reached it yet, and reporting that would tell every seat their backlog is
+	// broken every time a message arrives.
+	e := Setup(t)
+	seedPendingSender(t, e, e.Rep1, "gerade@example.test", 0, time.Minute)
+
+	if stalled := stalledSeats(t, e); len(stalled) != 0 {
+		t.Fatalf("stalled = %v, want empty — this row arrived a minute ago", stalled)
+	}
+}
+
+func TestARowTheRetryLoopKeepsTouchingIsStillStalled(t *testing.T) {
+	// The case the first version of this predicate could not see, and the reason
+	// it reads created_at. During an outage the pass re-claims and re-defers each
+	// row every cycle, so updated_at and next_attempt_at are always fresh — a
+	// predicate on either reports a healthy lane while the seat's mail sits.
+	e := Setup(t)
+	seedPendingSender(t, e, e.Rep1, "haengt@example.test", 1, 8*time.Hour)
+	// What Defer does on every outage cycle.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			UPDATE capture_pending_counterparty
+			   SET updated_at = now(), next_attempt_at = now() + interval '30 minutes'
+			 WHERE email = $1`, "haengt@example.test")
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if stalled := stalledSeats(t, e); stalled[e.Rep1] != 1 {
+		t.Fatalf("stalled[%v] = %d, want 1 — the retry loop touching a row is not the lane "+
+			"answering it", e.Rep1, stalled[e.Rep1])
+	}
+}
+
+func TestAResolvedRowIsNotStalled(t *testing.T) {
+	// The question was answered. Only a row still waiting is waiting.
+	e := Setup(t)
+	seedPendingSender(t, e, e.Rep1, "beantwortet@example.test", 2, 8*time.Hour)
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE capture_pending_counterparty SET status = 'real' WHERE email = $1`,
+			"beantwortet@example.test")
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if stalled := stalledSeats(t, e); len(stalled) != 0 {
+		t.Fatalf("stalled = %v, want empty — this sender was judged", stalled)
+	}
+}
+
+func TestTheStallIsCountedPerSeat(t *testing.T) {
+	// Whose backlog stopped is the question the notice answers, so two seats
+	// waiting are two notices rather than one number nobody can act on.
+	e := Setup(t)
+	seedPendingSender(t, e, e.Rep1, "eine@example.test", 1, 8*time.Hour)
+	seedPendingSender(t, e, e.Rep1, "zwei@example.test", 1, 8*time.Hour)
+	seedPendingSender(t, e, e.Rep2, "drei@example.test", 1, 8*time.Hour)
+
+	stalled := stalledSeats(t, e)
+	if stalled[e.Rep1] != 2 || stalled[e.Rep2] != 1 {
+		t.Fatalf("stalled = %v, want two for the first seat and one for the colleague", stalled)
+	}
+}
+
+func stalledSeats(t *testing.T, e *Env) map[ids.UUID]int {
+	t.Helper()
+	// The window every test here asks about: long enough that a row retried a
+	// minute ago is still moving, short enough that one untouched for eight
+	// hours is not.
+	const quiet = 6 * time.Hour
+	out, err := capture.NewPendingStore(e.DB()).StalledBacklogSeats(e.Admin(), quiet)
+	if err != nil {
+		t.Fatalf("finding stalled seats: %v", err)
+	}
+	return out
+}
+
+// seedPendingSender lands one unanswered disposition, with the two facts the
+// stall predicate reads: how many times it has been asked about, and how long
+// ago it arrived.
+func seedPendingSender(t *testing.T, e *Env, owner ids.UUID, email string, attempts int, quietFor time.Duration) {
+	t.Helper()
+	activity := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO activity (id, kind, subject, body, direction, source, captured_by,
+			                      counterparty_email, audience)
+			VALUES ($1, 'email', 'wartet', 'der Text', 'inbound', 'gmail', 'connector:gmail',
+			        $2, 'participants')`, activity, email); err != nil {
+			return err
+		}
+		// updated_at last, and as its own statement: the row's trigger stamps it
+		// on insert, so a single INSERT cannot land a row that was touched hours
+		// ago and the backdating has to follow.
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_pending_counterparty
+			       (email, domain, activity_id, owner_id, status, attempts, next_attempt_at)
+			VALUES ($1, split_part($1, '@', 2), $2, $3, 'pending', $4, now())`,
+			email, activity, owner, attempts); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(),
+			`UPDATE capture_pending_counterparty SET created_at = now() - $2::interval WHERE email = $1`,
+			email, quietFor.String())
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a pending sender: %v", err)
+	}
+}

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -20,6 +20,7 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/modules/notices"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -137,7 +138,11 @@ func addCapturePipelineJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerC
 		// report mail as gone while it is not, which is the same reason the
 		// HTTP purge is built at the store and not at assembly.
 		purger: capturePurgerFor(pool, cfg.Blobstore, log),
-		log:    log,
+		// The stall notice, which is the only thing that tells a seat their
+		// backlog stopped moving: an outage refunds the attempt rather than
+		// spending it, so nothing retires and nothing else surfaces it.
+		backlogNotice: NewBacklogStallNotifier(notices.NewStore(InstallationDB(pool)), time.Now),
+		log:           log,
 	})
 	// The confidentiality verdict, registered unconditionally for a related but
 	// distinct reason: a deployment with no model bound holds every thread, and

--- a/backend/internal/compose/noticesseam.go
+++ b/backend/internal/compose/noticesseam.go
@@ -12,6 +12,9 @@ package compose
 import (
 	"context"
 
+	"fmt"
+	"time"
+
 	"github.com/margince/margince/backend/internal/modules/notices"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -21,6 +24,10 @@ const noticeKindAutomation = "automation"
 
 // noticeKindLeadSLA labels the lead-SLA escalation notice.
 const noticeKindLeadSLA = "lead_sla"
+
+// noticeKindCaptureBacklog labels the notice raised when a seat's capture
+// backlog stops moving.
+const noticeKindCaptureBacklog = "capture_backlog_stalled"
 
 // noticesNotifier adapts the notices store onto automation's Notifier seam.
 // The recipient arrives from the automation's own decoded arguments; the
@@ -43,4 +50,29 @@ func (n noticesNotifier) Notify(ctx context.Context, recipient ids.UUID, subject
 		Body:      body,
 	})
 	return err
+}
+
+// NewBacklogStallNotifier raises the capture-backlog notice for one seat.
+//
+// Straight to notices.Store.Create rather than through the Notifier seam,
+// because this caller HAS a natural key for the event and the seam has no way to
+// carry one. The key names the seat and the day: a stall is a standing condition
+// and the pass that finds it runs hourly, so without a key it writes one line
+// per sweep forever, and with a key that named only the seat it would write one
+// line ever and go unnoticed on the second week.
+func NewBacklogStallNotifier(store *notices.Store, clock func() time.Time) BacklogNotifier {
+	return func(ctx context.Context, seat ids.UUID, waiting int) error {
+		_, err := store.Create(ctx, notices.NewNotice{
+			Recipient: ids.From[ids.UserKind](seat),
+			Kind:      noticeKindCaptureBacklog,
+			Subject:   "Your captured mail is waiting on the classifier",
+			Body: fmt.Sprintf(
+				"%d sender decisions have been waiting without an answer. Mail stays withheld from "+
+					"your colleagues while this lasts — nothing is lost, and it clears on its own "+
+					"once the classifier answers again.", waiting),
+			DedupeKey: fmt.Sprintf("capture_backlog_stalled:%s:%s",
+				seat, clock().UTC().Format(time.DateOnly)),
+		})
+		return err
+	}
 }

--- a/backend/internal/modules/activities/audienceretraction.go
+++ b/backend/internal/modules/activities/audienceretraction.go
@@ -42,15 +42,28 @@ import (
 // is still on its way. This collects what was derived before.
 //
 // It is deliberately not the inverse of "everything derived from this message".
-// The derived SIGNALS are narrowed rather than deleted (signals carry their own
-// visibility and a narrowed signal is still the owner's), and the profile fields
-// a signature enrichment wrote are a separate question with a human-edit
-// conflict to settle. Those two are named here so the next reader knows the
-// omission is a boundary and not a miss.
+// The derived SIGNALS are narrowed rather than deleted — signals carry their own
+// visibility and a narrowed signal is still the owner's — and that omission is a
+// boundary rather than a miss.
+//
+// The profile fields a signature enrichment wrote ARE retracted, through the
+// seam below. Only the ones nobody has taken over: a value a person restored or
+// corrected stays, and RetractSignatureFieldsTx states which columns tell those
+// apart.
 //
 // Idempotent: re-running deletes nothing more, which is what lets the consumer
 // that calls it retry.
-func RetractDerivedForActivityTx(ctx context.Context, tx pgx.Tx, activityID ids.UUID) error {
+// SignatureFieldRetractor removes the profile fields one message's signature
+// wrote. people owns that table, so compose injects the edge, and it is required
+// rather than optional — a narrowing that skipped it would leave the message's
+// content on a record everybody reads.
+type SignatureFieldRetractor func(ctx context.Context, tx pgx.Tx, activityID ids.UUID) error
+
+// RetractDerivedForActivityTx collects what was derived from a message that has
+// just been narrowed, as described above.
+func RetractDerivedForActivityTx(
+	ctx context.Context, tx pgx.Tx, activityID ids.UUID, retractFields SignatureFieldRetractor,
+) error {
 	// THE ACTIVITY FIRST, BEFORE ANY DERIVED ROW. Both things this function
 	// removes have a concurrent writer that takes the activity and then the
 	// derived row — the embedding upsert holds a share lock on the activity
@@ -93,5 +106,10 @@ func RetractDerivedForActivityTx(ctx context.Context, tx pgx.Tx, activityID ids.
 		UPDATE activity SET capture_label = NULL WHERE id = $1 AND capture_label IS NOT NULL`, activityID); err != nil {
 		return fmt.Errorf("activities: clearing the narrowed activity's attention label: %w", err)
 	}
-	return nil
+	// The profile fields this message's signature wrote, last and inside the
+	// same lock. A title or a phone number lifted from a signature block is the
+	// message's content restated on a record everybody can see, so a narrowing
+	// that left them behind would limit the message and publish what it said.
+	//
+	return retractFields(ctx, tx, activityID)
 }

--- a/backend/internal/modules/capture/pendingsweeps.go
+++ b/backend/internal/modules/capture/pendingsweeps.go
@@ -436,3 +436,54 @@ func (s *PendingStore) noiseMail(ctx context.Context, extra string, limit int) (
 func quoteInterval(d time.Duration) string {
 	return "interval '" + strconv.Itoa(int(d.Seconds())) + " seconds'"
 }
+
+// StalledBacklogSeats lists the seats whose pending dispositions have never been
+// resolved, with how many each is waiting on.
+//
+// The gap this fills is one the retire path deliberately leaves open. A row that
+// SPENDS its attempts retires to `unsure` and reaches a human through the review
+// queue — but an outage REFUNDS the attempt rather than spending it, precisely
+// so a provider being down does not retire rows for reasons that had nothing to
+// do with the question. So during a real stall nothing exhausts, nothing
+// retires, and nothing tells the seat their mail is sitting.
+//
+// Keyed on created_at, which is the ONE column an outage does not move. Every
+// other candidate is stamped by the retry loop itself: ClaimDue and Defer both
+// set updated_at = now() and Defer pushes next_attempt_at forward by the backoff,
+// so during an outage each row is re-claimed and re-deferred hourly and looks
+// freshly touched. A predicate on either of those cannot fire for the case this
+// exists for, and fires instead when the workspace is HEALTHY and a row is
+// quietly waiting out a long backoff — exactly backwards, which is what it did
+// before review caught it.
+//
+// A row still pending `quiet` after it arrived is one the lane never answered.
+// A healthy pass resolves a row within a cycle or two, so this reads as "your
+// mail has been waiting since it got here", which is the sentence the seat needs.
+func (s *PendingStore) StalledBacklogSeats(ctx context.Context, quiet time.Duration) (map[ids.UUID]int, error) {
+	out := map[ids.UUID]int{}
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT owner_id, count(*)
+			  FROM capture_pending_counterparty
+			 WHERE status = 'pending'
+			   AND created_at <= now() - `+quoteInterval(quiet)+`
+			 GROUP BY owner_id`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var owner ids.UUID
+			var waiting int
+			if err := rows.Scan(&owner, &waiting); err != nil {
+				return err
+			}
+			out[owner] = waiting
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("capture: finding seats whose backlog never resolved: %w", err)
+	}
+	return out, nil
+}

--- a/backend/internal/modules/people/profilefieldrestore.go
+++ b/backend/internal/modules/people/profilefieldrestore.go
@@ -141,7 +141,13 @@ func (s *Store) RestoreProfileField(ctx context.Context, personID ids.PersonID, 
 		landed, err := writePersonProfileField(ctx, tx, personID, personProfileFieldRow{
 			Field: field, Value: superseded,
 			EvidenceSnippet: restoredEvidence(superseded, supersededBy),
-			SourceRef:       sourceRef,
+			// The ref is REPLACED for the same reason the evidence just above
+			// it is: the row no longer came from what that ref names. Carrying
+			// it made a restored value indistinguishable from the enrichment it
+			// replaced, and anything keyed on the ref then acted on a human's
+			// decision as though a machine had made it — the audience
+			// retraction did exactly that, and deleted the restore.
+			SourceRef: restoreSource + ":" + sourceRef,
 			// captured_by is the authenticated restorer, like every other
 			// mutation's. Who ORIGINALLY said this is a fact about the past and
 			// belongs in the evidence line, not in the provenance stamp of a

--- a/backend/internal/modules/people/signatureretraction.go
+++ b/backend/internal/modules/people/signatureretraction.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The other half of a signature enrichment: taking back what it wrote when the
+// message it read is narrowed.
+//
+// Its own file rather than a tail on enrichsignature.go, because it answers a
+// different question. That file asks what a signature block says about a person;
+// this asks what happens to the answer when the message stops being readable by
+// the people the answer is shown to.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// RetractSignatureFieldsTx removes the profile fields one message's signature
+// wrote, for a message that has just been narrowed.
+//
+// The narrowing is what makes this owed: a field derived from a message the
+// reader may no longer read is that message's content, restated on a record
+// everybody can see. Deleting rather than narrowing, because a profile field
+// carries no audience of its own — there is nowhere to put "this title is
+// visible to fewer people than the person it is on".
+//
+// THREE predicates, and each is here because matching on fewer deleted somebody's
+// work in review:
+//
+//   - source_ref names the message. Necessary and nowhere near sufficient:
+//     RestoreProfileField inherits the ref from the row it undoes, so a value a
+//     person restored still names the signature's message.
+//   - source = capture_enrich is what the signature pass writes. A restore
+//     writes human_restore over it, which is what tells the two apart.
+//   - no live `corrected` verdict. A human correcting a field records it in
+//     ai_feedback and touches neither the column nor this row, so a corrected
+//     field is still source=capture_enrich and passes both tests above. The row
+//     is what person360 overlays that verdict onto, so deleting it takes the
+//     correction off the screen with it. Same question refuseIfCorrected asks
+//     before an undo, for the same reason.
+//
+// What survives is a field nobody has taken over: written by the signature pass,
+// never restored, never corrected. That is the only kind this is entitled to.
+func RetractSignatureFieldsTx(ctx context.Context, tx pgx.Tx, activityID ids.UUID) error {
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM person_profile_field f
+		 WHERE f.source_ref = $1 AND f.source = $2
+		   AND NOT EXISTS (
+		     SELECT 1 FROM ai_feedback
+		      WHERE subject_type = 'person' AND subject_id = f.person_id
+		        AND claim_kind = 'profile_field' AND verdict = 'corrected'
+		        AND claim_key = encode(sha256(('profile_field:' || f.field)::bytea), 'hex'))`,
+		"activity:"+activityID.String(), enrichSource); err != nil {
+		return fmt.Errorf("people: retracting the narrowed message's signature fields: %w", err)
+	}
+	return nil
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3972,6 +3972,8 @@ export const de = {
     "Es ist keine Nachricht mehr da, die geteilt werden könnte — die erste Nachricht dieser Konversation wurde gelöscht. Die Zurückhaltung bleibt, damit eine spätere Antwort nicht offen eintrifft.",
   "heldThreads.pending": "Wartet auf Beurteilung",
   "heldThreads.attempts": "{count}-mal angefragt",
+  "heldThreads.backlogStalled":
+    "Zu {count} Threads wurde mehrfach angefragt, ohne Antwort. Solange das anhält, bleibt Post zurückgehalten — nichts geht verloren, und es löst sich von selbst, sobald die Klassifikation wieder antwortet.",
   "heldThreads.heldByOthers":
     "Weiterhin zurückgehalten: {count} weiteres Postfach hat diese Nachricht ebenfalls importiert und nicht freigegeben. Eine Konversation wird erst geöffnet, wenn alle Empfänger zustimmen.",
   "heldThreads.kind.legal": "Rechtliches",
@@ -6442,6 +6444,26 @@ export const de = {
     "Wirkt ab der nächsten Nachricht. Bereits erfasste Nachrichten bleiben.",
   "captureExclusions.current": "Geltende Regeln",
   "captureExclusions.empty": "Keine Ausschlüsse.",
+  "ownerIdentities.title": "Ihre weiteren Adressen",
+  "ownerIdentities.sub":
+    "Adressen, die auch Sie sind: ein Alias zum Senden, eine private Domain, die Sie lesen, eine Adresse, von der Sie weiterleiten. Post zwischen Ihren eigenen Adressen ist keine Korrespondenz mit jemandem — sie wird nicht erfasst und wird nie ein Kontakt.",
+  "ownerIdentities.add": "Adresse hinzufügen",
+  "ownerIdentities.addLabel": "Eine weitere Adresse als Ihre eigene angeben",
+  "ownerIdentities.addDescription":
+    "Nur Ihre. Kolleginnen und Kollegen sehen nie, was Sie hier eintragen.",
+  "ownerIdentities.current": "Angegeben",
+  "ownerIdentities.notRetroactive":
+    "Gilt ab der nächsten Nachricht. Bereits erfasste Post bleibt, und ein aus einem Alias entstandener Kontakt bleibt, bis Sie ihn zusammenführen oder entfernen.",
+  "ownerIdentities.empty": "Sie haben keine weiteren Adressen angegeben.",
+  "ownerIdentities.remove": "Diese Adresse zurückziehen",
+  "ownerIdentities.added": "Adresse hinzugefügt.",
+  "ownerIdentities.confirm": "Hinzufügen",
+  "ownerIdentities.kindLabel": "Was geben Sie an?",
+  "ownerIdentities.kind.address": "Eine Adresse",
+  "ownerIdentities.kind.domain": "Eine ganze Domain",
+  "ownerIdentities.valueLabel": "Adresse oder Domain",
+  "ownerIdentities.addressPlaceholder": "sie@beispiel.de",
+  "ownerIdentities.domainPlaceholder": "beispiel.de",
   "captureExclusions.scope.user": "Nur ich",
   "captureExclusions.scope.workspace": "Ganze Organisation",
   "captureExclusions.kind.address": "Adresse",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4005,6 +4005,8 @@ export const en = {
     "There is no message left to share — this thread\u2019s first message was erased, and the hold stays so a later reply does not arrive open.",
   "heldThreads.pending": "Waiting on a verdict",
   "heldThreads.attempts": "asked {count} time(s)",
+  "heldThreads.backlogStalled":
+    "{count} thread(s) have been asked about repeatedly with no answer. Mail stays withheld while this lasts — nothing is lost, and it clears on its own once the classifier answers again.",
   "heldThreads.heldByOthers":
     "Still held: {count} other mailbox imported this message and has not shared it. A thread opens only when everyone who received it agrees.",
   "heldThreads.kind.legal": "Legal",
@@ -6483,6 +6485,26 @@ export const en = {
     "Takes effect from the next message. Messages already captured stay.",
   "captureExclusions.current": "Rules in effect",
   "captureExclusions.empty": "No exclusions.",
+  "ownerIdentities.title": "Your other addresses",
+  "ownerIdentities.sub":
+    "Addresses that are also you: a send-as alias, a private domain you read, an address you forward from. Mail between your own addresses is not correspondence with anybody, so it is not captured and never becomes a contact.",
+  "ownerIdentities.add": "Add address",
+  "ownerIdentities.addLabel": "Declare another address as your own",
+  "ownerIdentities.addDescription":
+    "Yours alone. A colleague never sees what you list here.",
+  "ownerIdentities.current": "Declared",
+  "ownerIdentities.notRetroactive":
+    "Applies from the next message on. Mail already captured stays, and a contact already made from an alias stays until you merge or remove it.",
+  "ownerIdentities.empty": "You have declared no other addresses.",
+  "ownerIdentities.remove": "Withdraw this address",
+  "ownerIdentities.added": "Address added.",
+  "ownerIdentities.confirm": "Add",
+  "ownerIdentities.kindLabel": "What are you declaring?",
+  "ownerIdentities.kind.address": "One address",
+  "ownerIdentities.kind.domain": "A whole domain",
+  "ownerIdentities.valueLabel": "Address or domain",
+  "ownerIdentities.addressPlaceholder": "you@example.com",
+  "ownerIdentities.domainPlaceholder": "example.com",
   "captureExclusions.scope.user": "Only me",
   "captureExclusions.scope.workspace": "Whole organization",
   "captureExclusions.kind.address": "Address",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3934,6 +3934,8 @@ export const vi = {
     "Không còn thư nào để chia sẻ — thư đầu tiên của chuỗi này đã bị xóa. Việc giữ lại vẫn tiếp tục để một thư trả lời sau không đến ở trạng thái mở.",
   "heldThreads.pending": "Đang chờ phán quyết",
   "heldThreads.attempts": "đã hỏi {count} lần",
+  "heldThreads.backlogStalled":
+    "{count} chuỗi thư đã được hỏi nhiều lần mà chưa có trả lời. Trong lúc này thư vẫn được giữ lại — không mất gì cả, và sẽ tự hết khi bộ phân loại trả lời trở lại.",
   "heldThreads.heldByOthers":
     "Vẫn bị giữ lại: {count} hộp thư khác cũng đã nhập thư này và chưa chia sẻ. Một chuỗi chỉ mở khi mọi người nhận đều đồng ý.",
   "heldThreads.kind.legal": "Pháp lý",
@@ -6379,6 +6381,26 @@ export const vi = {
     "Có hiệu lực từ tin nhắn tiếp theo. Tin nhắn đã thu thập vẫn giữ nguyên.",
   "captureExclusions.current": "Quy tắc đang áp dụng",
   "captureExclusions.empty": "Không có loại trừ.",
+  "ownerIdentities.title": "Các địa chỉ khác của bạn",
+  "ownerIdentities.sub":
+    "Những địa chỉ cũng là bạn: một bí danh gửi thay, một tên miền riêng bạn đọc, một địa chỉ bạn chuyển tiếp. Thư giữa các địa chỉ của chính bạn không phải là trao đổi với ai cả, nên không được thu thập và không bao giờ thành liên hệ.",
+  "ownerIdentities.add": "Thêm địa chỉ",
+  "ownerIdentities.addLabel": "Khai báo một địa chỉ khác là của bạn",
+  "ownerIdentities.addDescription":
+    "Chỉ của riêng bạn. Đồng nghiệp không bao giờ thấy những gì bạn liệt kê ở đây.",
+  "ownerIdentities.current": "Đã khai báo",
+  "ownerIdentities.notRetroactive":
+    "Áp dụng từ thư kế tiếp. Thư đã thu thập vẫn giữ nguyên, và liên hệ đã tạo từ một bí danh vẫn còn cho đến khi bạn gộp hoặc xoá.",
+  "ownerIdentities.empty": "Bạn chưa khai báo địa chỉ nào khác.",
+  "ownerIdentities.remove": "Rút lại địa chỉ này",
+  "ownerIdentities.added": "Đã thêm địa chỉ.",
+  "ownerIdentities.confirm": "Thêm",
+  "ownerIdentities.kindLabel": "Bạn đang khai báo gì?",
+  "ownerIdentities.kind.address": "Một địa chỉ",
+  "ownerIdentities.kind.domain": "Cả một tên miền",
+  "ownerIdentities.valueLabel": "Địa chỉ hoặc tên miền",
+  "ownerIdentities.addressPlaceholder": "ban@vidu.com",
+  "ownerIdentities.domainPlaceholder": "vidu.com",
   "captureExclusions.scope.user": "Chỉ tôi",
   "captureExclusions.scope.workspace": "Toàn tổ chức",
   "captureExclusions.kind.address": "Địa chỉ",

--- a/frontend/src/screens/capture-owner-identities.stories.tsx
+++ b/frontend/src/screens/capture-owner-identities.stories.tsx
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { OwnerIdentitiesCard } from "./capture-owner-identities";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+// A seat's own other addresses. Unlike the exclusions card beside it there is no
+// scope to tell apart — every row here is the reader's own, and a colleague's
+// identities are never listed — so the states worth drawing are what the list
+// looks like with entries and what it says when there are none.
+const ALIAS = {
+  id: "oi-1",
+  kind: "address",
+  value: "l.jankowfsky@privat.example",
+  source: "user",
+  created_at: "2026-09-01T09:00:00Z",
+};
+const OWN_DOMAIN = {
+  id: "oi-2",
+  kind: "domain",
+  value: "privat.example",
+  source: "user",
+  created_at: "2026-09-01T09:05:00Z",
+};
+
+function story(identities: Record<string, unknown>[]) {
+  return () => {
+    installFetchStub({
+      "GET /me": meRoute({}),
+      "GET /capture/owner-identities": () => jsonResponse({ data: identities }),
+    });
+    return (
+      <StoryProviders>
+        <OwnerIdentitiesCard />
+      </StoryProviders>
+    );
+  };
+}
+
+const meta: Meta<typeof OwnerIdentitiesCard> = {
+  title: "Settings/Admin settings/Capture/Your other addresses",
+  component: OwnerIdentitiesCard,
+};
+export default meta;
+type Story = StoryObj<typeof OwnerIdentitiesCard>;
+
+// Both kinds at once: one address, and a whole domain the same person reads.
+// The kind is the row's answer, because "l.jankowfsky@privat.example" and
+// "privat.example" bind very different amounts of mail and the row has to say
+// which it is.
+export const Populated: Story = { render: story([ALIAS, OWN_DOMAIN]) };
+
+// Nothing declared, which is the ordinary state and has to read as a fact rather
+// than as a list that failed to draw — "I have told it about no other addresses"
+// is what a reader opens this card to confirm.
+export const Empty: Story = { render: story([]) };

--- a/frontend/src/screens/capture-owner-identities.tsx
+++ b/frontend/src/screens/capture-owner-identities.tsx
@@ -1,0 +1,262 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
+import { useId, useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import {
+  Button,
+  EmptyState,
+  Modal,
+  SegmentedControl,
+  TextInput,
+} from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
+import { Panel, PanelBody } from "../design-system/panel";
+import { SettingList, SettingRow } from "../design-system/settingrow";
+import { useToast } from "../design-system/toast";
+import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { problemMessageOf, QueryGate, throwProblem } from "./common";
+
+// A seat's OWN other addresses: a send-as alias, a private domain the same
+// person reads, an address they forward from.
+//
+// Mail among a person's own addresses is not correspondence with anybody, so
+// declaring one keeps those messages out of the CRM and stops the address being
+// minted as a contact. Until this card there was no way to say so — the endpoint
+// shipped and nothing reached it.
+//
+// The caller's own only, and that is the point rather than a limitation: a
+// colleague's alias says which of THEIR mail is private, which is the thing the
+// list exists to protect.
+
+type OwnerIdentity = components["schemas"]["CaptureOwnerIdentity"];
+type Kind = components["schemas"]["CaptureExclusionKind"];
+
+const KINDS: readonly Kind[] = ["address", "domain"];
+
+function useOwnerIdentities() {
+  return useQuery({
+    queryKey: ["capture-owner-identities"],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        "/capture/owner-identities",
+      );
+      if (error || !response.ok) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+function useAddIdentity() {
+  const toast = useToast();
+  const t = useT();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: { kind: Kind; value: string }) => {
+      const { data, error } = await api.POST("/capture/owner-identities", {
+        body,
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["capture-owner-identities"] });
+      toast.show(t("ownerIdentities.added"));
+    },
+  });
+}
+
+function useRemoveIdentity() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // The id is a VARIABLE, so the press belongs to the render the reader saw
+    // (frontend/AGENTS.md, mutation-variable-coverage).
+    mutationFn: async (id: string) => {
+      const { error } = await api.DELETE("/capture/owner-identities/{id}", {
+        params: { path: { id } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return id;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["capture-owner-identities"] });
+    },
+  });
+}
+
+export function OwnerIdentitiesCard() {
+  const t = useT();
+  const query = useOwnerIdentities();
+  const remove = useRemoveIdentity();
+  const [declaring, setDeclaring] = useState(false);
+  return (
+    <Panel title={t("ownerIdentities.title")}>
+      <PanelBody>
+        <p className="settings-panel-sub">{t("ownerIdentities.sub")}</p>
+        <SettingList>
+          <SettingRow
+            label={t("ownerIdentities.addLabel")}
+            description={t("ownerIdentities.addDescription")}
+            control={
+              <Button small onClick={() => setDeclaring(true)}>
+                {t("ownerIdentities.add")}
+              </Button>
+            }
+          />
+          {/* Not retroactive, and the row says so where the reader is deciding.
+              Mail already captured under the old reading stays, and a contact
+              already minted from an alias stays until it is merged. */}
+          <SettingRow
+            label={t("ownerIdentities.current")}
+            description={t("ownerIdentities.notRetroactive")}
+            layout="stack"
+            control={
+              <QueryGate query={query}>
+                {(list) => (
+                  <IdentityRows
+                    list={list.data}
+                    pending={remove.isPending}
+                    onRemove={(id) => remove.mutate(id)}
+                  />
+                )}
+              </QueryGate>
+            }
+          />
+        </SettingList>
+        {remove.isError && (
+          <Callout tone="danger" live="alert">
+            {problemMessageOf(remove.error, t)}
+          </Callout>
+        )}
+        {declaring && <DeclareDialog onClose={() => setDeclaring(false)} />}
+      </PanelBody>
+    </Panel>
+  );
+}
+
+const kindLabel: Record<Kind, MessageKey> = {
+  address: "ownerIdentities.kind.address",
+  domain: "ownerIdentities.kind.domain",
+};
+
+/**
+ * One declared address per row: what it names on the left, whether it is an
+ * address or a whole domain as the row's answer, and the verb that withdraws it
+ * at the right.
+ *
+ * The same row language the exclusions card uses, because a reader auditing
+ * what binds their mailbox travels one column across both.
+ */
+function IdentityRows({
+  list,
+  pending,
+  onRemove,
+}: Readonly<{
+  list: OwnerIdentity[];
+  pending: boolean;
+  onRemove: (id: string) => void;
+}>) {
+  const t = useT();
+  if (list.length === 0) {
+    // A reading, not a failed read: "I have declared no other addresses" is
+    // what a reader opens this card to confirm.
+    return (
+      <EmptyState>
+        <p className="t-small" data-testid="owner-identities-empty">
+          {t("ownerIdentities.empty")}
+        </p>
+      </EmptyState>
+    );
+  }
+  return (
+    <SettingList testId="owner-identities-list">
+      {list.map((identity) => (
+        <SettingRow
+          key={identity.id}
+          label={identity.value}
+          value={t(kindLabel[identity.kind])}
+          control={
+            <Button
+              small
+              variant="ghost"
+              disabled={pending}
+              aria-label={t("ownerIdentities.remove")}
+              onClick={() => onRemove(identity.id)}
+            >
+              <Trash2 aria-hidden size={16} />
+            </Button>
+          }
+        />
+      ))}
+    </SettingList>
+  );
+}
+
+// Mounted only while it is open, so a half-typed address is gone the next time
+// rather than waiting there under a kind nobody re-chose.
+function DeclareDialog({ onClose }: Readonly<{ onClose: () => void }>) {
+  const t = useT();
+  const add = useAddIdentity();
+  const headingId = useId();
+  const [kind, setKind] = useState<Kind>("address");
+  const [draft, setDraft] = useState("");
+  const value = draft.trim();
+  return (
+    <Modal open onClose={onClose} labelledBy={headingId}>
+      <h2 id={headingId} className="t-h2 modal-title">
+        {t("ownerIdentities.addLabel")}
+      </h2>
+      <form
+        className="form-stack"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (value === "") {
+            return;
+          }
+          add.mutate({ kind, value }, { onSuccess: onClose });
+        }}
+      >
+        <SegmentedControl
+          options={KINDS}
+          value={kind}
+          onChange={setKind}
+          labels={{
+            address: t("ownerIdentities.kind.address"),
+            domain: t("ownerIdentities.kind.domain"),
+          }}
+          label={t("ownerIdentities.kindLabel")}
+        />
+        <TextInput
+          value={draft}
+          aria-label={t("ownerIdentities.valueLabel")}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder={
+            kind === "address"
+              ? t("ownerIdentities.addressPlaceholder")
+              : t("ownerIdentities.domainPlaceholder")
+          }
+        />
+        {add.isError && (
+          <Callout tone="danger" live="alert">
+            {problemMessageOf(add.error, t)}
+          </Callout>
+        )}
+        <div className="modal-actions">
+          <Button variant="ghost" onClick={onClose} type="button">
+            {t("create.cancel")}
+          </Button>
+          <Button type="submit" disabled={value === "" || add.isPending}>
+            {t("ownerIdentities.confirm")}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/screens/held-threads.tsx
+++ b/frontend/src/screens/held-threads.tsx
@@ -65,7 +65,10 @@ export function HeldThreadsCard() {
                 <p className="t-small">{t("heldThreads.empty")}</p>
               </EmptyState>
             ) : (
-              <HeldThreadTable rows={list.data} />
+              <>
+                <BacklogCallout rows={list.data} />
+                <HeldThreadTable rows={list.data} />
+              </>
             )
           }
         </QueryGate>
@@ -199,6 +202,47 @@ function HeldThreadTable({ rows }: Readonly<{ rows: HeldThread[] }>) {
         </Callout>
       ))}
     </>
+  );
+}
+
+// backlogStallAttempts is when a pending thread has been asked about as often as
+// it ever will be.
+//
+// The ledger claims a row only while `attempts < 2` (PendingMaxAttempts), so 2
+// is the ceiling and a threshold above it can never be crossed — the first
+// version of this used 3 and rendered nothing, ever. A thread sitting at the
+// ceiling and still pending is one the lane has stopped answering: a healthy
+// pass would have resolved it, and a spent one would have retired it to `unsure`
+// and taken it out of this list.
+const backlogStallAttempts = 2;
+
+/**
+ * Whether the classifier is answering at all, derived from the rows already
+ * fetched rather than read from a lane the reader may not query.
+ *
+ * `/ai/health` is the obvious source and the wrong one: it is admin-only, and
+ * the closed RBAC object set carries no AI-runtime entry, so opening it to reps
+ * is a closed-set change plus a product decision. This is also the truer answer
+ * for the reader in front of it — their own backlog, not a global lane that may
+ * be healthy while their mail sits.
+ */
+function BacklogCallout({ rows }: Readonly<{ rows: HeldThread[] }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const stalled = rows.filter(
+    (row) => row.pending && row.attempts >= backlogStallAttempts,
+  );
+  if (stalled.length === 0) {
+    // Pending but not yet at the ceiling is ordinary latency, and saying "your
+    // mail is stuck" about it would cry wolf every time a thread arrives.
+    return null;
+  }
+  return (
+    <Callout tone="warn" live="status">
+      {t("heldThreads.backlogStalled", {
+        count: formatNumber(stalled.length, locale),
+      })}
+    </Callout>
   );
 }
 

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -90,6 +90,7 @@ import { AutonomySettingsCard } from "./autonomy-settings";
 import { BlockedDomainsCard } from "./blocked-domains";
 import { BriefDeliveryRows } from "./briefdelivery";
 import { CaptureActivityTab } from "./capture-activity";
+import { OwnerIdentitiesCard } from "./capture-owner-identities";
 import { CaptureSendersCard } from "./capture-senders";
 import { CaptureSettingsCard } from "./capture-settings";
 import {
@@ -411,6 +412,14 @@ function ConnectionsTab() {
           connection below. */}
       <MailSharingCard />
       <ConnectorsCard />
+      {/* Directly under the mailboxes and before what they brought in, because
+          it changes what COUNTS as correspondence: an address declared here is
+          the same person, so mail among them is not a conversation with anybody
+          and never becomes one. Per-seat rather than per-connection, which is
+          why it is a card of its own and not a row inside connectors.tsx —
+          those rows render once per mailbox and a seat's own addresses are one
+          list however many mailboxes they connect. */}
+      <OwnerIdentitiesCard />
       {/* Under the mailboxes, because it is what those mailboxes DID: every
           address they brought in, and what the classifier concluded about each.
           The posture rows above say what may be read; this says what was


### PR DESCRIPTION
Four pieces the mailbox-privacy work built and left unreachable. Each is small; the reasoning about *where* each belongs is the part worth reading.

## 1. A seat's own other addresses reach a screen

The endpoint shipped and **nothing referenced it**. A send-as alias, a private domain the same person reads, an address they forward from — mail among a person's own addresses is not correspondence with anybody, so declaring one keeps it out of the CRM and stops the address becoming a contact. Until now there was no way to say so.

**Its own card, not a row in `connectors.tsx`.** Those rows (`MailPostureRow`, `SignatureEnrichmentRow`) render **once per connection**. A seat's own addresses are one list however many mailboxes they connect, so a row there would draw the same list N times.

**No refusal for provider-sourced aliases, deliberately.** The plan called for one. The `provider` source is declared and **nothing writes it** — the scope that would read a mail provider's send-as list is not requested, and the backend has no delete refusal either. A UI arm refusing to delete one would be code for a state that cannot occur.

## 2. A stalled classifier says so, where the reader already is

`/ai/health` is the obvious source and the wrong one: it is admin-only, and the closed RBAC object set carries no AI-runtime entry, so opening it to reps is a closed-set change plus a product decision.

Derived from the rows `HeldThreadsCard` **already fetched** instead — which is also the truer answer for the reader in front of it: their own backlog, not a global lane that may be healthy while their mail sits. The contract already names the field: *"a pending row whose attempts stop climbing is a model that stopped answering."*

Pending-but-still-climbing stays silent. Saying "your mail is stuck" about ordinary latency would cry wolf every time a thread arrives.

## 3. A stalled backlog reaches the seat, which nothing else made happen

This one turned out to matter more than it looked.

A row that **spends** its attempts retires to `unsure` and reaches a human through the review queue. But an outage **refunds** the attempt rather than spending it — deliberately, and the code says why: *"a deferral says 'ask again later', and conflating the two is how a row ends up retired for reasons that had nothing to do with the question (a provider outage, a budget stop)."*

So during a real stall **nothing exhausts, nothing retires, and nothing surfaces**. The seat's mail sits withheld with no sign of it anywhere. This notice is the only thing that says so.

**Through `notices.Store.Create` with a `DedupeKey`, not the `Notifier` seam** — the seam carries no key, and its own comment says so. A stall is a standing condition and the pass runs hourly, so a keyless write puts one line per sweep in the inbox forever. The key names the seat and the **day**: a week-long stall is one line a day — enough to be noticed again, not enough to bury the inbox it is written into.

## 4. Narrowing retracts what a message's signature wrote

A title or a phone number lifted from a signature block is the message's content, **restated on a record everybody can see**. A narrowing that left it behind limits the message and publishes what it said.

`RetractDerivedForActivityTx` named this as a second deliberate omission:

> *"the profile fields a signature enrichment wrote are a separate question with a human-edit conflict to settle"*

**That conflict turned out to be settled already, on the write side.** A person accepting a value writes through `replaceOnAcceptance`, which overwrites `source_ref` with their own — so a row still carrying `activity:<id>` is one nobody ever confirmed, and one a person did confirm no longer names the message at all. The retraction matches on `source_ref` and needs no conflict rule of its own. The comment now says that rather than naming an omission that is no longer one.

`people` owns `person_profile_field`, so the deletion lives there and `activities` takes it as an injected seam, inside the lock the retraction already holds.

## What review found

Four blockers, two of them data-destroying. All fixed, each with a test that reproduces the defect.

### The retraction deleted work people did — twice

The change rested on one claim: *"a human accepting a value overwrites `source_ref` with their own, so a row still naming this activity is one nobody confirmed."* **That claim was false, in two different ways.**

`RestoreProfileField` **inherits** `source_ref` from the row it undoes. So a value a person restored still names the signature's message, and matching on the ref alone deleted it — unrecoverably, because the restore's own precedence clears the undo buffer on the way past.

And a **correction** touches neither the row nor the column: it records a verdict in `ai_feedback` that person360 overlays at render time. A corrected field is still `source = capture_enrich` and still names the message, so even a source predicate would have deleted the row the correction is displayed against.

Three predicates now, and each one is held by a test that fails when it is removed:

| predicate | what it defends |
|---|---|
| `source_ref = 'activity:<id>'` | names this message. Necessary, nowhere near sufficient |
| `source = capture_enrich` | a restore writes `human_restore` over it |
| no live `corrected` verdict | a correction leaves the row untouched, so nothing else tells it apart |

`RestoreProfileField` now writes its own ref as well — for the same reason it already replaces the evidence snippet: *the row no longer came from what that ref names.* `source_ref` was the one column left behind.

### The stall predicate was inverted

`updated_at` looked like the right column and is exactly wrong. `ClaimDue` and `Defer` both stamp `updated_at = now()`, and `Defer` is the **outage path** — so during a real stall each row is re-claimed and re-deferred every cycle and never looks older than an hour. The notice could not fire for the case it exists for.

Worse, it fired for the opposite one: a healthy workspace with a row quietly waiting out a long backoff read as stalled.

Keyed on `created_at` now, the one column an outage does not move. `TestARowTheRetryLoopKeepsTouchingIsStillStalled` drives exactly what `Defer` does each cycle and fails when the predicate goes back.

### The banner was dead code

`attempts >= 3`, against a ledger that claims only while `attempts < 2`. The threshold could never be crossed and the callout never rendered. It is `PendingMaxAttempts` now — the ceiling itself.

### Smaller

A second `QueryGate` over the same query (two skeletons, two error messages); an unreachable nil-retractor branch whose comment described a role that does not exist; fix-narration in a doc comment; and the missing story, which is what would have caught the dead banner — you cannot write a story for a callout that cannot render.

**One finding I checked and did not act on:** the new i18n keys sit inside the `captureExclusions.*` run rather than after it. Cosmetic, and moving them mechanically broke all three files, so I reverted rather than risk three locale files for tidiness.

## Mutation checks, against real Postgres

Thirteen tests. Each predicate reverted on its own, each failing its own test with its own message.

| mutation | what failed |
|---|---|
| the state review found (ref only, restore inherits) | `the value a person restored was deleted by narrowing the message it replaced` |
| drop the corrected-verdict guard | `a field a person corrected is the row their verdict is shown against` |
| delete every field, not this message's | the other message's field |
| `created_at` → `updated_at` | `the retry loop touching a row is not the lane answering it` |

## Gates

`make check-backend` **exit 0** after the final rebase. `make craft-static`, `make rls-store-path`, `make no-jurisdiction` green. 3838 frontend screen tests pass.

**`make check-fe` does not pass, and not because of this branch.** `src/App.tabkey.test.tsx` fails on `main` itself — `main-health` is currently red — since #3683 repointed a guard that had been "passing for the wrong reason". It fails in isolation, so it is not the load-flakiness of #3677. Bisected and filed as **#3710**; this diff touches nothing under `App.tsx` or the record tab strip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added personal identity settings for managing declared email addresses and domains, including adding and removing entries.
  - Added stalled backlog detection and notifications for held threads awaiting classification.
  - Added localized messaging in English, German, and Vietnamese.

- **Bug Fixes**
  - Profile fields derived from narrowed activities are now retracted appropriately while independently confirmed or still-supported fields remain intact.

- **Improvements**
  - Added clearer held-thread warnings when classification attempts remain unresolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->