### PR TITLE
Tags become a way to find records

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -22104,6 +22104,10 @@ components:
       description: A contact. Mirrors the `person` table.
       required: [id, full_name, source, captured_by, created_at, updated_at]
       properties:
+        # The live tags this row carries, capped: a chip strip shows a few and
+        # says "+N", so a row does not need every word to draw one. Archived
+        # tags are omitted — a retired word is not drawn on a list.
+        tags: { type: array, items: { $ref: '#/components/schemas/RowTag' } }
         id: { type: string, format: uuid }
         first_name: { type: [string, 'null'] }
         last_name: { type: [string, 'null'] }
@@ -22384,6 +22388,10 @@ components:
       description: A company. Mirrors the `organization` table.
       required: [id, display_name, source, captured_by, created_at, updated_at]
       properties:
+        # The live tags this row carries, capped: a chip strip shows a few and
+        # says "+N", so a row does not need every word to draw one. Archived
+        # tags are omitted — a retired word is not drawn on a list.
+        tags: { type: array, items: { $ref: '#/components/schemas/RowTag' } }
         linkedin_url:
           type: [string, 'null']
           description: Canonical LinkedIn company URL (PO-DDL-N-2, ADR-0085). A validated column rather than a governed custom field, because it bears identity semantics — matching, dedupe, enrichment — a custom field cannot express. Unique among live rows.
@@ -26569,6 +26577,10 @@ components:
       description: A deal. Mirrors the `deal` table.
       required: [id, name, pipeline_id, stage_id, status, source, captured_by, created_at, updated_at]
       properties:
+        # The live tags this row carries, capped: a chip strip shows a few and
+        # says "+N", so a row does not need every word to draw one. Archived
+        # tags are omitted — a retired word is not drawn on a list.
+        tags: { type: array, items: { $ref: '#/components/schemas/RowTag' } }
         id: { type: string, format: uuid }
         name: { type: string }
         amount_minor: { type: [integer, 'null'], format: int64 }
@@ -29444,6 +29456,18 @@ components:
         name: { type: string, maxLength: 64 }
         color: { type: [string, 'null'], enum: [teal, amber, rose, slate, null] }
         description: { type: [string, 'null'] }
+
+    RowTag:
+      type: object
+      description: |
+        A tag as a list ROW carries it: the word and its colour, nothing else. The full
+        assignment — who applied it, when — comes from the record's own tags read, because a
+        page of fifty rows does not need fifty assignments to draw a chip.
+      required: [tag_id, name]
+      properties:
+        tag_id: { type: string, format: uuid }
+        name: { type: string }
+        color: { type: [string, 'null'], enum: [teal, amber, rose, slate, null] }
 
     RecordTagsResponse:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8218,7 +8218,7 @@ paths:
           in: query
           schema:
             type: array
-            items: { type: string, enum: [person, organization, deal, activity, lead, project] }
+            items: { type: string, enum: [person, organization, deal, activity, lead, project, tag] }
           style: form
           explode: false
           description: Restrict to these object types (default all).
@@ -30925,7 +30925,10 @@ components:
       type: object
       required: [type, id]
       properties:
-        type: { type: string, enum: [person, organization, deal, activity, lead, project] }
+        # `tag` is a WORD, not a record: finding it is the step before finding
+        # the records that carry it, and without it a reader has to know the
+        # vocabulary already.
+        type: { type: string, enum: [person, organization, deal, activity, lead, project, tag] }
         id: { type: string, format: uuid }
         title: { type: [string, 'null'], description: Display label (name/subject). }
         snippet: { type: [string, 'null'] }

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -767,8 +767,27 @@ paths:
           in: query
           schema: { type: string }
           description: Full-text query over name/title (tsvector).
-        - $ref: '#/components/parameters/TagIDs'
-        - $ref: '#/components/parameters/TagMode'
+        - name: tag_id
+          in: query
+          schema:
+            type: array
+            items: { type: string, format: uuid }
+          style: form
+          explode: true
+          description: |
+            Narrow to the records carrying these tags. Repeat the parameter for several.
+
+            By ID, not by name: a name is what a person types and an admin can rename, so a
+            saved view holding one would silently start selecting a different slice the day
+            somebody corrects a spelling.
+        - name: tag_mode
+          in: query
+          schema: { type: string, enum: [any, all, none], default: any }
+          description: |
+            How several `tag_id` values combine. `any` selects a record carrying at least one
+            of them, `all` a record carrying every one, `none` a record carrying not one.
+
+            Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
         - name: organization_id
           in: query
           schema: { type: string, format: uuid }
@@ -2204,8 +2223,27 @@ paths:
         - name: q
           in: query
           schema: { type: string }
-        - $ref: '#/components/parameters/TagIDs'
-        - $ref: '#/components/parameters/TagMode'
+        - name: tag_id
+          in: query
+          schema:
+            type: array
+            items: { type: string, format: uuid }
+          style: form
+          explode: true
+          description: |
+            Narrow to the records carrying these tags. Repeat the parameter for several.
+
+            By ID, not by name: a name is what a person types and an admin can rename, so a
+            saved view holding one would silently start selecting a different slice the day
+            somebody corrects a spelling.
+        - name: tag_mode
+          in: query
+          schema: { type: string, enum: [any, all, none], default: any }
+          description: |
+            How several `tag_id` values combine. `any` selects a record carrying at least one
+            of them, `all` a record carrying every one, `none` a record carrying not one.
+
+            Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
       responses:
         '200':
           description: A page of organizations.
@@ -3835,8 +3873,27 @@ paths:
           in: query
           schema: { type: string, enum: [sourced, influenced] }
           description: Deals a partner brought (`sourced`) or merely helped (`influenced`).
-        - $ref: '#/components/parameters/TagIDs'
-        - $ref: '#/components/parameters/TagMode'
+        - name: tag_id
+          in: query
+          schema:
+            type: array
+            items: { type: string, format: uuid }
+          style: form
+          explode: true
+          description: |
+            Narrow to the records carrying these tags. Repeat the parameter for several.
+
+            By ID, not by name: a name is what a person types and an admin can rename, so a
+            saved view holding one would silently start selecting a different slice the day
+            somebody corrects a spelling.
+        - name: tag_mode
+          in: query
+          schema: { type: string, enum: [any, all, none], default: any }
+          description: |
+            How several `tag_id` values combine. `any` selects a record carrying at least one
+            of them, `all` a record carrying every one, `none` a record carrying not one.
+
+            Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
       responses:
         '200':
           description: A page of deals.
@@ -18536,29 +18593,6 @@ components:
         enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
         columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
         an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
-    TagIDs:
-      name: tag_id
-      in: query
-      schema:
-        type: array
-        items: { type: string, format: uuid }
-      style: form
-      explode: true
-      description: |
-        Narrow to the records carrying these tags. Repeat the parameter for several.
-
-        By ID, not by name: a name is what a person types and an admin can rename, so a saved
-        view holding one would silently start selecting a different slice the day somebody
-        corrects a spelling.
-    TagMode:
-      name: tag_mode
-      in: query
-      schema: { type: string, enum: [any, all, none], default: any }
-      description: |
-        How several `tag_id` values combine. `any` selects a record carrying at least one of
-        them, `all` a record carrying every one, `none` a record carrying not one.
-
-        Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
     IncludeArchived:
       name: include_archived
       in: query

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -767,10 +767,8 @@ paths:
           in: query
           schema: { type: string }
           description: Full-text query over name/title (tsvector).
-        - name: tag
-          in: query
-          schema: { type: string }
-          description: Filter by tag name.
+        - $ref: '#/components/parameters/TagIDs'
+        - $ref: '#/components/parameters/TagMode'
         - name: organization_id
           in: query
           schema: { type: string, format: uuid }
@@ -2206,6 +2204,8 @@ paths:
         - name: q
           in: query
           schema: { type: string }
+        - $ref: '#/components/parameters/TagIDs'
+        - $ref: '#/components/parameters/TagMode'
       responses:
         '200':
           description: A page of organizations.
@@ -3835,6 +3835,8 @@ paths:
           in: query
           schema: { type: string, enum: [sourced, influenced] }
           description: Deals a partner brought (`sourced`) or merely helped (`influenced`).
+        - $ref: '#/components/parameters/TagIDs'
+        - $ref: '#/components/parameters/TagMode'
       responses:
         '200':
           description: A page of deals.
@@ -18534,6 +18536,29 @@ components:
         enumerated in data-model.md §13 (Sort/filter vocabulary) plus the workspace's active `cf_`
         columns (custom columns carry no index in V1 — a `cf_` sort runs as a tenant-scoped scan);
         an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+    TagIDs:
+      name: tag_id
+      in: query
+      schema:
+        type: array
+        items: { type: string, format: uuid }
+      style: form
+      explode: true
+      description: |
+        Narrow to the records carrying these tags. Repeat the parameter for several.
+
+        By ID, not by name: a name is what a person types and an admin can rename, so a saved
+        view holding one would silently start selecting a different slice the day somebody
+        corrects a spelling.
+    TagMode:
+      name: tag_mode
+      in: query
+      schema: { type: string, enum: [any, all, none], default: any }
+      description: |
+        How several `tag_id` values combine. `any` selects a record carrying at least one of
+        them, `all` a record carrying every one, `none` a record carrying not one.
+
+        Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
     IncludeArchived:
       name: include_archived
       in: query

--- a/backend/gates/contextanchorenum_test.go
+++ b/backend/gates/contextanchorenum_test.go
@@ -145,6 +145,14 @@ func branchEntities(t *testing.T, values []ast.Expr) []string {
 			if !ok {
 				continue
 			}
+			// A text-only branch answers the name search and nothing else, so
+			// it is not an anchor a context read can be taken from: a word has
+			// no neighbours to return. Skipped here rather than listed in the
+			// contract enum, because a client naming one would be asking for
+			// the context of something that has none.
+			if branchIsTextOnly(branch) {
+				continue
+			}
 			for _, field := range branch.Elts {
 				kv, ok := field.(*ast.KeyValueExpr)
 				if !ok {
@@ -167,4 +175,21 @@ func branchEntities(t *testing.T, values []ast.Expr) []string {
 		}
 	}
 	return out
+}
+
+// branchIsTextOnly reports whether a searchBranches element sets textOnly.
+func branchIsTextOnly(branch *ast.CompositeLit) bool {
+	for _, field := range branch.Elts {
+		kv, ok := field.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != "textOnly" {
+			continue
+		}
+		value, ok := kv.Value.(*ast.Ident)
+		return ok && value.Name == "true"
+	}
+	return false
 }

--- a/backend/gates/declaredfilters_test.go
+++ b/backend/gates/declaredfilters_test.go
@@ -284,7 +284,7 @@ func TestTheDeclaredFilterCensusReadsTheGeneratedShape(t *testing.T) {
 	}
 	// The person list declares exactly these, and the three paging components
 	// it also declares are not among them.
-	want := "ai_written,captured_by_kind,include_archived,organization_id,owner_id,owner_team_id,q,tag,unassigned"
+	want := "ai_written,captured_by_kind,include_archived,organization_id,owner_id,owner_team_id,q,tag_id,tag_mode,unassigned"
 	if got := strings.Join(wire, ","); got != want {
 		t.Errorf("listPeople's narrowing parameters = %q, want %q", got, want)
 	}

--- a/backend/internal/compose/integration/collections/tagfilter_integration_test.go
+++ b/backend/internal/compose/integration/collections/tagfilter_integration_test.go
@@ -141,3 +141,84 @@ func TestATagModeWithoutTagsFiltersNothing(t *testing.T) {
 		t.Errorf("a mode with no tags selected %v, want every person", got)
 	}
 }
+
+// A list ROW carries its tags, so a table can draw a chip without a second
+// read per row. Filtering by tag and showing them are different features, and
+// shipping the filter alone hides tags on exactly the screens where they
+// explain why a row is in the list.
+func TestAListRowCarriesItsOwnTags(t *testing.T) {
+	e := tagEnv(t)
+	tagA, _ := taggedTrio(t, e)
+
+	var page struct {
+		Data []struct {
+			FullName string `json:"full_name"`
+			Tags     []struct {
+				TagID string `json:"tag_id"`
+				Name  string `json:"name"`
+			} `json:"tags"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/people?tag_id="+tagA, nil, nil, &page); status != http.StatusOK {
+		t.Fatalf("listing: status=%d", status)
+	}
+	if len(page.Data) != 2 {
+		t.Fatalf("selected %d people, want the two carrying tag A", len(page.Data))
+	}
+	for _, row := range page.Data {
+		if len(row.Tags) == 0 {
+			t.Errorf("%s carries no tags on the row; the table has nothing to draw", row.FullName)
+			continue
+		}
+		var carriesA bool
+		for _, tag := range row.Tags {
+			if tag.TagID == tagA {
+				carriesA = true
+			}
+		}
+		if !carriesA {
+			t.Errorf("%s's row tags %+v omit the tag it was selected by", row.FullName, row.Tags)
+		}
+	}
+
+	// The row carrying BOTH reports both: a cap that dropped one would make a
+	// chip strip say less than the record holds.
+	for _, row := range page.Data {
+		if row.FullName == "Carries Both" && len(row.Tags) != 2 {
+			t.Errorf("the person carrying two tags reports %d on the row", len(row.Tags))
+		}
+	}
+}
+
+// An archived tag is not drawn on a list. A retired word is not in the picker,
+// so a chip for it sends a reader somewhere they cannot go.
+func TestAListRowOmitsArchivedTags(t *testing.T) {
+	e := tagEnv(t)
+	live := createTag(t, e, "Still Live")
+	retired := createTag(t, e, "Since Retired")
+	createPersonWithTag(t, e, "Carries Both Kinds", live, retired)
+
+	var archived integration.AnyMap
+	if status := e.Call(t, "DELETE", "/v1/tags/"+retired, nil, nil, &archived); status != http.StatusOK {
+		t.Fatalf("archiving: status=%d body=%v", status, archived)
+	}
+
+	var page struct {
+		Data []struct {
+			Tags []struct {
+				Name string `json:"name"`
+			} `json:"tags"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/people?tag_id="+live, nil, nil, &page); status != http.StatusOK {
+		t.Fatalf("listing: status=%d", status)
+	}
+	if len(page.Data) != 1 {
+		t.Fatalf("selected %d people, want the one", len(page.Data))
+	}
+	for _, tag := range page.Data[0].Tags {
+		if tag.Name == "Since Retired" {
+			t.Error("the row draws a retired word; the picker no longer offers it")
+		}
+	}
+}

--- a/backend/internal/compose/integration/collections/tagfilter_integration_test.go
+++ b/backend/internal/compose/integration/collections/tagfilter_integration_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package collections
+
+// Filtering a list by tag, in the three modes, over the composed server.
+//
+// The fixture is the smallest one where the modes give three different
+// answers: two tags and three people, one carrying each tag and one carrying
+// both. A fixture where any two modes agree proves only that a filter ran.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+)
+
+// taggedTrio seeds A-only, A-and-B, and B-only, and answers the two tag ids.
+func taggedTrio(t *testing.T, e *apptest.AppEnv) (tagA, tagB string) {
+	t.Helper()
+	tagA = createTag(t, e, "Filter A")
+	tagB = createTag(t, e, "Filter B")
+	createPersonWithTag(t, e, "Carries A", tagA)
+	createPersonWithTag(t, e, "Carries Both", tagA, tagB)
+	createPersonWithTag(t, e, "Carries B", tagB)
+	return tagA, tagB
+}
+
+// listPeopleNames answers the names one query selects.
+func listPeopleNames(t *testing.T, e *apptest.AppEnv, query string) []string {
+	t.Helper()
+	var page struct {
+		Data []struct {
+			FullName string `json:"full_name"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/people?"+query, nil, nil, &page); status != http.StatusOK {
+		t.Fatalf("listing people with %q: status=%d", query, status)
+	}
+	out := make([]string, 0, len(page.Data))
+	for _, p := range page.Data {
+		out = append(out, p.FullName)
+	}
+	return out
+}
+
+func TestTagModeAnySelectsARecordCarryingEitherTag(t *testing.T) {
+	e := tagEnv(t)
+	tagA, tagB := taggedTrio(t, e)
+
+	got := listPeopleNames(t, e, "tag_id="+tagA+"&tag_id="+tagB+"&tag_mode=any")
+	if len(got) != 3 {
+		t.Errorf("any selected %v, want all three — each carries at least one", got)
+	}
+}
+
+func TestTagModeAllSelectsOnlyARecordCarryingEveryTag(t *testing.T) {
+	e := tagEnv(t)
+	tagA, tagB := taggedTrio(t, e)
+
+	got := listPeopleNames(t, e, "tag_id="+tagA+"&tag_id="+tagB+"&tag_mode=all")
+	if len(got) != 1 || got[0] != "Carries Both" {
+		t.Errorf("all selected %v, want only the person carrying both", got)
+	}
+}
+
+func TestTagModeNoneSelectsARecordCarryingNeitherTag(t *testing.T) {
+	e := tagEnv(t)
+	tagA, _ := taggedTrio(t, e)
+
+	// Only tag A is named, so `none` keeps the person carrying B alone. The
+	// person carrying both is excluded because they carry A.
+	got := listPeopleNames(t, e, "tag_id="+tagA+"&tag_mode=none")
+	if len(got) != 1 || got[0] != "Carries B" {
+		t.Errorf("none selected %v, want only the person carrying neither", got)
+	}
+}
+
+// A record carrying NO tags at all is selected by `none` — it carries not one
+// of the named words, which is what the mode says. A NOT EXISTS that had been
+// written as a negation inside the subquery would drop it.
+func TestTagModeNoneSelectsARecordWithNoTagsAtAll(t *testing.T) {
+	e := tagEnv(t)
+	tagA, _ := taggedTrio(t, e)
+	createPersonWithTag(t, e, "Carries Nothing")
+
+	got := listPeopleNames(t, e, "tag_id="+tagA+"&tag_mode=none")
+	var found bool
+	for _, name := range got {
+		if name == "Carries Nothing" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("none selected %v, which omits the untagged person — they carry not one of the named tags", got)
+	}
+}
+
+// An archived tag selects nothing. It is not in the picker, so a filter naming
+// it describes a slice no reader can construct, and after a merge releases a
+// name a re-coined word would otherwise drag the old tag's records along.
+func TestFilteringByAnArchivedTagSelectsNothing(t *testing.T) {
+	e := tagEnv(t)
+	tag := createTag(t, e, "Retired Filter")
+	createPersonWithTag(t, e, "Tagged Before Retirement", tag)
+
+	var archived integration.AnyMap
+	if status := e.Call(t, "DELETE", "/v1/tags/"+tag, nil, nil, &archived); status != http.StatusOK {
+		t.Fatalf("archiving: status=%d body=%v", status, archived)
+	}
+
+	if got := listPeopleNames(t, e, "tag_id="+tag+"&tag_mode=any"); len(got) != 0 {
+		t.Errorf("filtering by a retired tag selected %v, want nothing", got)
+	}
+}
+
+// A mode the enum does not admit is refused, not defaulted. Treating a typo as
+// `any` would hand back a wider slice than the caller asked for.
+func TestAnUnknownTagModeIsRefused(t *testing.T) {
+	e := tagEnv(t)
+	tagA, _ := taggedTrio(t, e)
+
+	var problem integration.AnyMap
+	if status := e.Call(t, "GET", "/v1/people?tag_id="+tagA+"&tag_mode=most", nil, nil, &problem); status != http.StatusUnprocessableEntity {
+		t.Fatalf("an unknown tag_mode: status=%d body=%v, want 422", status, problem)
+	}
+}
+
+// The mode alone is not a filter: with no tag named there is nothing to
+// combine, and every record stays in the page.
+func TestATagModeWithoutTagsFiltersNothing(t *testing.T) {
+	e := tagEnv(t)
+	taggedTrio(t, e)
+
+	got := listPeopleNames(t, e, "tag_mode=all")
+	if len(got) != 3 {
+		t.Errorf("a mode with no tags selected %v, want every person", got)
+	}
+}

--- a/backend/internal/compose/integration/collections/tagfilter_integration_test.go
+++ b/backend/internal/compose/integration/collections/tagfilter_integration_test.go
@@ -222,3 +222,58 @@ func TestAListRowOmitsArchivedTags(t *testing.T) {
 		}
 	}
 }
+
+// A tag is findable by name in search. Finding the WORD is the step before
+// finding the records that carry it, and without it a reader has to know the
+// vocabulary already.
+func TestSearchFindsATagByName(t *testing.T) {
+	e := tagEnv(t)
+	createTag(t, e, "Key Account")
+
+	var page struct {
+		Data []struct {
+			Type  string `json:"type"`
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/search?q=Key", nil, nil, &page); status != http.StatusOK {
+		t.Fatalf("searching: status=%d", status)
+	}
+	var found bool
+	for _, hit := range page.Data {
+		if hit.Type == "tag" && hit.Title == "Key Account" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("search for a tag name returned %+v, which carries no tag hit", page.Data)
+	}
+}
+
+// A retired word is not a search hit: it is not in the picker, so a hit on one
+// leads to a page nobody can act on.
+func TestSearchOmitsAnArchivedTag(t *testing.T) {
+	e := tagEnv(t)
+	tag := createTag(t, e, "Retired Word")
+
+	var archived integration.AnyMap
+	if status := e.Call(t, "DELETE", "/v1/tags/"+tag, nil, nil, &archived); status != http.StatusOK {
+		t.Fatalf("archiving: status=%d body=%v", status, archived)
+	}
+
+	var page struct {
+		Data []struct {
+			Type  string `json:"type"`
+			Title string `json:"title"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/search?q=Retired", nil, nil, &page); status != http.StatusOK {
+		t.Fatalf("searching: status=%d", status)
+	}
+	for _, hit := range page.Data {
+		if hit.Type == "tag" {
+			t.Errorf("a retired word is a search hit: %+v", hit)
+		}
+	}
+}

--- a/backend/internal/compose/integration/declaredfilters_http_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_http_integration_test.go
@@ -90,8 +90,26 @@ func TestThePersonListNarrowsByTagOnTheWire(t *testing.T) {
 		t.Fatalf("applying the tag = %d, want 201", status)
 	}
 
-	onlyRecord(t, e, "/v1/people?tag=VIP", tagged, "the tagged person")
-	onlyRecord(t, e, "/v1/people?tag=vip", tagged, "the tagged person, asked for in another case")
+	// By ID on the wire. The two case-variant assertions that used to sit here
+	// tested a NAME parameter that no longer exists: a saved view holding a
+	// name started selecting a different slice the day an admin corrected a
+	// spelling, so the wire takes ids.
+	onlyRecord(t, e, "/v1/people?tag_id="+tag, tagged, "the tagged person")
+
+	// The mode reaches the store too, not only the ids: `none` has to answer
+	// with the person who does NOT carry the tag.
+	var page struct {
+		Data []struct {
+			ID       string `json:"id"`
+			FullName string `json:"full_name"`
+		} `json:"data"`
+	}
+	if status := e.Call(t, "GET", "/v1/people?tag_id="+tag+"&tag_mode=none", nil, nil, &page); status != http.StatusOK {
+		t.Fatalf("listing with tag_mode=none = %d, want 200", status)
+	}
+	if len(page.Data) != 1 || page.Data[0].FullName != "Untagged Person" {
+		t.Fatalf("tag_mode=none returned %+v, want only the untagged person", page.Data)
+	}
 }
 
 func TestTheOrganizationListNarrowsByDomainOnTheWire(t *testing.T) {

--- a/backend/internal/compose/integration/declaredfilters_integration_test.go
+++ b/backend/internal/compose/integration/declaredfilters_integration_test.go
@@ -49,7 +49,7 @@ func tagCurator(e *Env) context.Context {
 	})
 }
 
-func TestThePersonListNarrowsByTagName(t *testing.T) {
+func TestThePersonListNarrowsByTagID(t *testing.T) {
 	e := Setup(t)
 	tagged := e.SeedPerson(t, "Tagged Person", nil)
 	e.SeedPerson(t, "Untagged Person", nil)
@@ -64,25 +64,29 @@ func TestThePersonListNarrowsByTagName(t *testing.T) {
 		t.Fatalf("applying the tag: %v", err)
 	}
 
-	// Folded on both sides: the vocabulary is unique under lower(name), so
-	// the caller's capitalization decides nothing about which tag they named.
-	for _, asked := range []string{"VIP", "vip", " Vip "} {
-		page, _, err := e.People.ListPeople(e.Admin(), people.ListPeopleInput{Tag: &asked})
-		if err != nil {
-			t.Fatalf("listing people by tag %q: %v", asked, err)
-		}
-		if len(page) != 1 || ids.UUID(page[0].Id) != tagged {
-			t.Fatalf("tag=%q returned %d people, want only the tagged one", asked, len(page))
-		}
+	// By ID. The list used to take a NAME and fold its case, which meant a
+	// saved view holding one started selecting a different slice the day an
+	// admin corrected a spelling.
+	page, _, err := e.People.ListPeople(e.Admin(), people.ListPeopleInput{
+		TagIDs: []ids.UUID{vip.ID.UUID},
+	})
+	if err != nil {
+		t.Fatalf("listing people by tag: %v", err)
+	}
+	if len(page) != 1 || ids.UUID(page[0].Id) != tagged {
+		t.Fatalf("the tag filter returned %d people, want only the tagged one", len(page))
 	}
 
-	unknown := "no-such-tag"
-	page, _, err := e.People.ListPeople(e.Admin(), people.ListPeopleInput{Tag: &unknown})
+	// A tag nobody applied selects nobody — not everybody, which is what an
+	// ignored filter would do.
+	page, _, err = e.People.ListPeople(e.Admin(), people.ListPeopleInput{
+		TagIDs: []ids.UUID{ids.NewV7()},
+	})
 	if err != nil {
 		t.Fatalf("listing people by an unused tag: %v", err)
 	}
 	if len(page) != 0 {
-		t.Fatalf("a tag nobody carries returned %d people — a dropped filter answers the whole list", len(page))
+		t.Fatalf("an unused tag returned %d people, want none", len(page))
 	}
 }
 

--- a/backend/internal/compose/overlayread.go
+++ b/backend/internal/compose/overlayread.go
@@ -58,6 +58,7 @@ const (
 	paramStatus         = "status"
 	paramKind           = "kind"
 	paramTag            = "tag_id"
+	paramTagMode        = "tag_mode"
 	// paramCapturedByKind is refused in overlay mode rather than ignored:
 	// captured_by is OUR provenance column, stamped from the principal that
 	// wrote the row. Mirror rows are the incumbent's records, created in the
@@ -217,6 +218,10 @@ func (s Server) ListPeople(w http.ResponseWriter, r *http.Request, params crmcon
 			{paramOwnerTeamID, params.OwnerTeamId != nil},
 			{paramUnassigned, params.Unassigned != nil && *params.Unassigned},
 			{paramTag, params.TagId != nil && len(*params.TagId) > 0},
+			// The MODE too, not only the ids: an overlay that dropped it would
+			// answer `any` for a caller who asked `none`, which is the whole
+			// mirrored set wearing the shape of a filtered one.
+			{paramTagMode, params.TagMode != nil},
 			// Employment is OUR edge: the mirror holds the incumbent's own
 			// contact-to-company links, under their ids, so a margince
 			// organization id names nothing there.
@@ -245,6 +250,8 @@ func (s Server) ListOrganizations(w http.ResponseWriter, r *http.Request, params
 			{paramOwnerID, params.OwnerId != nil},
 			{paramOwnerTeamID, params.OwnerTeamId != nil},
 			{paramUnassigned, params.Unassigned != nil && *params.Unassigned},
+			{paramTag, params.TagId != nil && len(*params.TagId) > 0},
+			{paramTagMode, params.TagMode != nil},
 			// Firmographics we hold and the mirror does not: refused rather
 			// than forwarded, or the answer is the unfiltered list wearing a
 			// filtered list's shape.
@@ -283,6 +290,8 @@ func (s Server) ListDeals(w http.ResponseWriter, r *http.Request, params crmcont
 	overlayList(s, w, r, datasource.EntityDeal,
 		func() { s.dealsHandlers.ListDeals(w, r, params) },
 		[]overlayParam{
+			{paramTag, params.TagId != nil && len(*params.TagId) > 0},
+			{paramTagMode, params.TagMode != nil},
 			{paramSort, params.Sort != nil},
 			{paramPipelineID, params.PipelineId != nil},
 			{paramStageID, params.StageId != nil},

--- a/backend/internal/compose/overlayread.go
+++ b/backend/internal/compose/overlayread.go
@@ -57,7 +57,7 @@ const (
 	paramOrganizationID = "organization_id"
 	paramStatus         = "status"
 	paramKind           = "kind"
-	paramTag            = "tag"
+	paramTag            = "tag_id"
 	// paramCapturedByKind is refused in overlay mode rather than ignored:
 	// captured_by is OUR provenance column, stamped from the principal that
 	// wrote the row. Mirror rows are the incumbent's records, created in the
@@ -216,7 +216,7 @@ func (s Server) ListPeople(w http.ResponseWriter, r *http.Request, params crmcon
 			{paramOwnerID, params.OwnerId != nil},
 			{paramOwnerTeamID, params.OwnerTeamId != nil},
 			{paramUnassigned, params.Unassigned != nil && *params.Unassigned},
-			{paramTag, params.Tag != nil},
+			{paramTag, params.TagId != nil && len(*params.TagId) > 0},
 			// Employment is OUR edge: the mirror holds the incumbent's own
 			// contact-to-company links, under their ids, so a margince
 			// organization id names nothing there.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -9526,6 +9526,30 @@ func (e RetentionScope) Valid() bool {
 	}
 }
 
+// Defines values for RowTagColor.
+const (
+	RowTagColorAmber RowTagColor = "amber"
+	RowTagColorRose  RowTagColor = "rose"
+	RowTagColorSlate RowTagColor = "slate"
+	RowTagColorTeal  RowTagColor = "teal"
+)
+
+// Valid indicates whether the value is a known member of the RowTagColor enum.
+func (e RowTagColor) Valid() bool {
+	switch e {
+	case RowTagColorAmber:
+		return true
+	case RowTagColorRose:
+		return true
+	case RowTagColorSlate:
+		return true
+	case RowTagColorTeal:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for RunReportRequestAggregatesFn.
 const (
 	RunReportRequestAggregatesFnAvg           RunReportRequestAggregatesFn = "avg"
@@ -10476,22 +10500,22 @@ func (e TagColor) Valid() bool {
 
 // Defines values for TagDetailColor.
 const (
-	TagDetailColorAmber TagDetailColor = "amber"
-	TagDetailColorRose  TagDetailColor = "rose"
-	TagDetailColorSlate TagDetailColor = "slate"
-	TagDetailColorTeal  TagDetailColor = "teal"
+	Amber TagDetailColor = "amber"
+	Rose  TagDetailColor = "rose"
+	Slate TagDetailColor = "slate"
+	Teal  TagDetailColor = "teal"
 )
 
 // Valid indicates whether the value is a known member of the TagDetailColor enum.
 func (e TagDetailColor) Valid() bool {
 	switch e {
-	case TagDetailColorAmber:
+	case Amber:
 		return true
-	case TagDetailColorRose:
+	case Rose:
 		return true
-	case TagDetailColorSlate:
+	case Slate:
 		return true
-	case TagDetailColorTeal:
+	case Teal:
 		return true
 	default:
 		return false
@@ -19208,6 +19232,7 @@ type Deal struct {
 	// Stalled Derived — no activity past the threshold (absolute duration).
 	Stalled   *bool      `json:"stalled,omitempty"`
 	Status    DealStatus `json:"status"`
+	Tags      *[]RowTag  `json:"tags,omitempty"`
 	UpdatedAt time.Time  `json:"updated_at"`
 
 	// Version Monotonic row version, incremented by the server on every mutation (data-model §1.3a).
@@ -23091,6 +23116,7 @@ type Organization struct {
 
 	// Strength Deterministic org-level relationship-strength roll-up (features/07 §4). Read-only derived view; NULL until capture has interactions.
 	Strength  *RelationshipStrength `json:"strength,omitempty"`
+	Tags      *[]RowTag             `json:"tags,omitempty"`
 	UpdatedAt time.Time             `json:"updated_at"`
 
 	// Version Monotonic row version, incremented by the server on every mutation (data-model §1.3a).
@@ -25045,6 +25071,7 @@ type Person struct {
 
 	// Strength Deterministic relationship-strength (features/07 §4). Read-only derived view; NULL until capture has interactions. No mystery number — the factors + contributing activities are the explanation.
 	Strength *RelationshipStrength `json:"strength,omitempty"`
+	Tags     *[]RowTag             `json:"tags,omitempty"`
 
 	// Title Denormalized current title; authoritative title is on the employment relationship.
 	Title     *string   `json:"title,omitempty"`
@@ -27446,6 +27473,18 @@ type Role struct {
 type RoleDirectory struct {
 	Roles []Role `json:"roles"`
 }
+
+// RowTag A tag as a list ROW carries it: the word and its colour, nothing else. The full
+// assignment — who applied it, when — comes from the record's own tags read, because a
+// page of fifty rows does not need fifty assignments to draw a chip.
+type RowTag struct {
+	Color *RowTagColor       `json:"color,omitempty"`
+	Name  string             `json:"name"`
+	TagId openapi_types.UUID `json:"tag_id"`
+}
+
+// RowTagColor defines model for RowTag.Color.
+type RowTagColor string
 
 // RowVersion Monotonic row version, incremented by the server on every mutation (data-model §1.3a).
 // Echoed back as the `version` field on every mutable entity. To make a write conditional,
@@ -37866,6 +37905,14 @@ func (a *Deal) UnmarshalJSON(b []byte) error {
 		delete(object, "status")
 	}
 
+	if raw, found := object["tags"]; found {
+		err = json.Unmarshal(raw, &a.Tags)
+		if err != nil {
+			return fmt.Errorf("error reading 'tags': %w", err)
+		}
+		delete(object, "tags")
+	}
+
 	if raw, found := object["updated_at"]; found {
 		err = json.Unmarshal(raw, &a.UpdatedAt)
 		if err != nil {
@@ -38104,6 +38151,13 @@ func (a Deal) MarshalJSON() ([]byte, error) {
 	object["status"], err = json.Marshal(a.Status)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling 'status': %w", err)
+	}
+
+	if a.Tags != nil {
+		object["tags"], err = json.Marshal(a.Tags)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'tags': %w", err)
+		}
 	}
 
 	object["updated_at"], err = json.Marshal(a.UpdatedAt)
@@ -40448,6 +40502,14 @@ func (a *Organization) UnmarshalJSON(b []byte) error {
 		delete(object, "strength")
 	}
 
+	if raw, found := object["tags"]; found {
+		err = json.Unmarshal(raw, &a.Tags)
+		if err != nil {
+			return fmt.Errorf("error reading 'tags': %w", err)
+		}
+		delete(object, "tags")
+	}
+
 	if raw, found := object["updated_at"]; found {
 		err = json.Unmarshal(raw, &a.UpdatedAt)
 		if err != nil {
@@ -40685,6 +40747,13 @@ func (a Organization) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	if a.Tags != nil {
+		object["tags"], err = json.Marshal(a.Tags)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'tags': %w", err)
+		}
+	}
+
 	object["updated_at"], err = json.Marshal(a.UpdatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling 'updated_at': %w", err)
@@ -40905,6 +40974,14 @@ func (a *Person) UnmarshalJSON(b []byte) error {
 		delete(object, "strength")
 	}
 
+	if raw, found := object["tags"]; found {
+		err = json.Unmarshal(raw, &a.Tags)
+		if err != nil {
+			return fmt.Errorf("error reading 'tags': %w", err)
+		}
+		delete(object, "tags")
+	}
+
 	if raw, found := object["title"]; found {
 		err = json.Unmarshal(raw, &a.Title)
 		if err != nil {
@@ -41083,6 +41160,13 @@ func (a Person) MarshalJSON() ([]byte, error) {
 		object["strength"], err = json.Marshal(a.Strength)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'strength': %w", err)
+		}
+	}
+
+	if a.Tags != nil {
+		object["tags"], err = json.Marshal(a.Tags)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'tags': %w", err)
 		}
 	}
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -12844,27 +12844,6 @@ func (e ProfileFieldKey) Valid() bool {
 	}
 }
 
-// Defines values for TagMode.
-const (
-	TagModeAll  TagMode = "all"
-	TagModeAny  TagMode = "any"
-	TagModeNone TagMode = "none"
-)
-
-// Valid indicates whether the value is a known member of the TagMode enum.
-func (e TagMode) Valid() bool {
-	switch e {
-	case TagModeAll:
-		return true
-	case TagModeAny:
-		return true
-	case TagModeNone:
-		return true
-	default:
-		return false
-	}
-}
-
 // Defines values for ListActivitiesParamsKind.
 const (
 	ListActivitiesParamsKindCall    ListActivitiesParamsKind = "call"
@@ -13908,19 +13887,19 @@ func (e ListPeopleParamsCapturedByKind) Valid() bool {
 
 // Defines values for ListPeopleParamsTagMode.
 const (
-	All  ListPeopleParamsTagMode = "all"
-	Any  ListPeopleParamsTagMode = "any"
-	None ListPeopleParamsTagMode = "none"
+	ListPeopleParamsTagModeAll  ListPeopleParamsTagMode = "all"
+	ListPeopleParamsTagModeAny  ListPeopleParamsTagMode = "any"
+	ListPeopleParamsTagModeNone ListPeopleParamsTagMode = "none"
 )
 
 // Valid indicates whether the value is a known member of the ListPeopleParamsTagMode enum.
 func (e ListPeopleParamsTagMode) Valid() bool {
 	switch e {
-	case All:
+	case ListPeopleParamsTagModeAll:
 		return true
-	case Any:
+	case ListPeopleParamsTagModeAny:
 		return true
-	case None:
+	case ListPeopleParamsTagModeNone:
 		return true
 	default:
 		return false
@@ -30680,12 +30659,6 @@ type ProfileFieldKey string
 // Sort defines model for Sort.
 type Sort = string
 
-// TagIDs defines model for TagIDs.
-type TagIDs = []openapi_types.UUID
-
-// TagMode defines model for TagMode.
-type TagMode string
-
 // VoiceProfileVersionNumber defines model for VoiceProfileVersionNumber.
 type VoiceProfileVersionNumber = int
 
@@ -31911,13 +31884,13 @@ type ListDealsParams struct {
 
 	// TagId Narrow to the records carrying these tags. Repeat the parameter for several.
 	//
-	// By ID, not by name: a name is what a person types and an admin can rename, so a saved
-	// view holding one would silently start selecting a different slice the day somebody
-	// corrects a spelling.
-	TagId *TagIDs `form:"tag_id,omitempty" json:"tag_id,omitempty"`
+	// By ID, not by name: a name is what a person types and an admin can rename, so a
+	// saved view holding one would silently start selecting a different slice the day
+	// somebody corrects a spelling.
+	TagId *[]openapi_types.UUID `form:"tag_id,omitempty" json:"tag_id,omitempty"`
 
-	// TagMode How several `tag_id` values combine. `any` selects a record carrying at least one of
-	// them, `all` a record carrying every one, `none` a record carrying not one.
+	// TagMode How several `tag_id` values combine. `any` selects a record carrying at least one
+	// of them, `all` a record carrying every one, `none` a record carrying not one.
 	//
 	// Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
 	TagMode *ListDealsParamsTagMode `form:"tag_mode,omitempty" json:"tag_mode,omitempty"`
@@ -32902,13 +32875,13 @@ type ListOrganizationsParams struct {
 
 	// TagId Narrow to the records carrying these tags. Repeat the parameter for several.
 	//
-	// By ID, not by name: a name is what a person types and an admin can rename, so a saved
-	// view holding one would silently start selecting a different slice the day somebody
-	// corrects a spelling.
-	TagId *TagIDs `form:"tag_id,omitempty" json:"tag_id,omitempty"`
+	// By ID, not by name: a name is what a person types and an admin can rename, so a
+	// saved view holding one would silently start selecting a different slice the day
+	// somebody corrects a spelling.
+	TagId *[]openapi_types.UUID `form:"tag_id,omitempty" json:"tag_id,omitempty"`
 
-	// TagMode How several `tag_id` values combine. `any` selects a record carrying at least one of
-	// them, `all` a record carrying every one, `none` a record carrying not one.
+	// TagMode How several `tag_id` values combine. `any` selects a record carrying at least one
+	// of them, `all` a record carrying every one, `none` a record carrying not one.
 	//
 	// Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
 	TagMode *ListOrganizationsParamsTagMode `form:"tag_mode,omitempty" json:"tag_mode,omitempty"`
@@ -33556,13 +33529,13 @@ type ListPeopleParams struct {
 
 	// TagId Narrow to the records carrying these tags. Repeat the parameter for several.
 	//
-	// By ID, not by name: a name is what a person types and an admin can rename, so a saved
-	// view holding one would silently start selecting a different slice the day somebody
-	// corrects a spelling.
-	TagId *TagIDs `form:"tag_id,omitempty" json:"tag_id,omitempty"`
+	// By ID, not by name: a name is what a person types and an admin can rename, so a
+	// saved view holding one would silently start selecting a different slice the day
+	// somebody corrects a spelling.
+	TagId *[]openapi_types.UUID `form:"tag_id,omitempty" json:"tag_id,omitempty"`
 
-	// TagMode How several `tag_id` values combine. `any` selects a record carrying at least one of
-	// them, `all` a record carrying every one, `none` a record carrying not one.
+	// TagMode How several `tag_id` values combine. `any` selects a record carrying at least one
+	// of them, `all` a record carrying every one, `none` a record carrying not one.
 	//
 	// Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
 	TagMode *ListPeopleParamsTagMode `form:"tag_mode,omitempty" json:"tag_mode,omitempty"`

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -12255,49 +12255,49 @@ func (e WorklistItemCategory) Valid() bool {
 
 // Defines values for WorklistItemConsequence.
 const (
-	BuyerWaits            WorklistItemConsequence = "buyer_waits"
-	CustomerNeverReceived WorklistItemConsequence = "customer_never_received"
-	DataDrifts            WorklistItemConsequence = "data_drifts"
-	DealDrifts            WorklistItemConsequence = "deal_drifts"
-	DealSlipsPastClose    WorklistItemConsequence = "deal_slips_past_close"
-	LegalDeadlineMissed   WorklistItemConsequence = "legal_deadline_missed"
-	MailboxBlind          WorklistItemConsequence = "mailbox_blind"
-	MeetingUnprepared     WorklistItemConsequence = "meeting_unprepared"
-	None                  WorklistItemConsequence = "none"
-	PromiseBreaks         WorklistItemConsequence = "promise_breaks"
-	TaskSlips             WorklistItemConsequence = "task_slips"
-	WorkBlocked           WorklistItemConsequence = "work_blocked"
-	YouBelieveItHappened  WorklistItemConsequence = "you_believe_it_happened"
+	WorklistItemConsequenceBuyerWaits            WorklistItemConsequence = "buyer_waits"
+	WorklistItemConsequenceCustomerNeverReceived WorklistItemConsequence = "customer_never_received"
+	WorklistItemConsequenceDataDrifts            WorklistItemConsequence = "data_drifts"
+	WorklistItemConsequenceDealDrifts            WorklistItemConsequence = "deal_drifts"
+	WorklistItemConsequenceDealSlipsPastClose    WorklistItemConsequence = "deal_slips_past_close"
+	WorklistItemConsequenceLegalDeadlineMissed   WorklistItemConsequence = "legal_deadline_missed"
+	WorklistItemConsequenceMailboxBlind          WorklistItemConsequence = "mailbox_blind"
+	WorklistItemConsequenceMeetingUnprepared     WorklistItemConsequence = "meeting_unprepared"
+	WorklistItemConsequenceNone                  WorklistItemConsequence = "none"
+	WorklistItemConsequencePromiseBreaks         WorklistItemConsequence = "promise_breaks"
+	WorklistItemConsequenceTaskSlips             WorklistItemConsequence = "task_slips"
+	WorklistItemConsequenceWorkBlocked           WorklistItemConsequence = "work_blocked"
+	WorklistItemConsequenceYouBelieveItHappened  WorklistItemConsequence = "you_believe_it_happened"
 )
 
 // Valid indicates whether the value is a known member of the WorklistItemConsequence enum.
 func (e WorklistItemConsequence) Valid() bool {
 	switch e {
-	case BuyerWaits:
+	case WorklistItemConsequenceBuyerWaits:
 		return true
-	case CustomerNeverReceived:
+	case WorklistItemConsequenceCustomerNeverReceived:
 		return true
-	case DataDrifts:
+	case WorklistItemConsequenceDataDrifts:
 		return true
-	case DealDrifts:
+	case WorklistItemConsequenceDealDrifts:
 		return true
-	case DealSlipsPastClose:
+	case WorklistItemConsequenceDealSlipsPastClose:
 		return true
-	case LegalDeadlineMissed:
+	case WorklistItemConsequenceLegalDeadlineMissed:
 		return true
-	case MailboxBlind:
+	case WorklistItemConsequenceMailboxBlind:
 		return true
-	case MeetingUnprepared:
+	case WorklistItemConsequenceMeetingUnprepared:
 		return true
-	case None:
+	case WorklistItemConsequenceNone:
 		return true
-	case PromiseBreaks:
+	case WorklistItemConsequencePromiseBreaks:
 		return true
-	case TaskSlips:
+	case WorklistItemConsequenceTaskSlips:
 		return true
-	case WorkBlocked:
+	case WorklistItemConsequenceWorkBlocked:
 		return true
-	case YouBelieveItHappened:
+	case WorklistItemConsequenceYouBelieveItHappened:
 		return true
 	default:
 		return false
@@ -12844,6 +12844,27 @@ func (e ProfileFieldKey) Valid() bool {
 	}
 }
 
+// Defines values for TagMode.
+const (
+	TagModeAll  TagMode = "all"
+	TagModeAny  TagMode = "any"
+	TagModeNone TagMode = "none"
+)
+
+// Valid indicates whether the value is a known member of the TagMode enum.
+func (e TagMode) Valid() bool {
+	switch e {
+	case TagModeAll:
+		return true
+	case TagModeAny:
+		return true
+	case TagModeNone:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListActivitiesParamsKind.
 const (
 	ListActivitiesParamsKindCall    ListActivitiesParamsKind = "call"
@@ -13237,6 +13258,27 @@ func (e ListDealsParamsPartnerAttribution) Valid() bool {
 	case Influenced:
 		return true
 	case Sourced:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListDealsParamsTagMode.
+const (
+	ListDealsParamsTagModeAll  ListDealsParamsTagMode = "all"
+	ListDealsParamsTagModeAny  ListDealsParamsTagMode = "any"
+	ListDealsParamsTagModeNone ListDealsParamsTagMode = "none"
+)
+
+// Valid indicates whether the value is a known member of the ListDealsParamsTagMode enum.
+func (e ListDealsParamsTagMode) Valid() bool {
+	switch e {
+	case ListDealsParamsTagModeAll:
+		return true
+	case ListDealsParamsTagModeAny:
+		return true
+	case ListDealsParamsTagModeNone:
 		return true
 	default:
 		return false
@@ -13645,6 +13687,27 @@ func (e ListOrganizationsParamsSizeBand) Valid() bool {
 	}
 }
 
+// Defines values for ListOrganizationsParamsTagMode.
+const (
+	ListOrganizationsParamsTagModeAll  ListOrganizationsParamsTagMode = "all"
+	ListOrganizationsParamsTagModeAny  ListOrganizationsParamsTagMode = "any"
+	ListOrganizationsParamsTagModeNone ListOrganizationsParamsTagMode = "none"
+)
+
+// Valid indicates whether the value is a known member of the ListOrganizationsParamsTagMode enum.
+func (e ListOrganizationsParamsTagMode) Valid() bool {
+	switch e {
+	case ListOrganizationsParamsTagModeAll:
+		return true
+	case ListOrganizationsParamsTagModeAny:
+		return true
+	case ListOrganizationsParamsTagModeNone:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListOrganizationContactsParamsSort.
 const (
 	LastInteraction      ListOrganizationContactsParamsSort = "last_interaction"
@@ -13837,6 +13900,27 @@ func (e ListPeopleParamsCapturedByKind) Valid() bool {
 	case ListPeopleParamsCapturedByKindHuman:
 		return true
 	case ListPeopleParamsCapturedByKindSystem:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListPeopleParamsTagMode.
+const (
+	All  ListPeopleParamsTagMode = "all"
+	Any  ListPeopleParamsTagMode = "any"
+	None ListPeopleParamsTagMode = "none"
+)
+
+// Valid indicates whether the value is a known member of the ListPeopleParamsTagMode enum.
+func (e ListPeopleParamsTagMode) Valid() bool {
+	switch e {
+	case All:
+		return true
+	case Any:
+		return true
+	case None:
 		return true
 	default:
 		return false
@@ -30596,6 +30680,12 @@ type ProfileFieldKey string
 // Sort defines model for Sort.
 type Sort = string
 
+// TagIDs defines model for TagIDs.
+type TagIDs = []openapi_types.UUID
+
+// TagMode defines model for TagMode.
+type TagMode string
+
 // VoiceProfileVersionNumber defines model for VoiceProfileVersionNumber.
 type VoiceProfileVersionNumber = int
 
@@ -31818,6 +31908,19 @@ type ListDealsParams struct {
 
 	// PartnerAttribution Deals a partner brought (`sourced`) or merely helped (`influenced`).
 	PartnerAttribution *ListDealsParamsPartnerAttribution `form:"partner_attribution,omitempty" json:"partner_attribution,omitempty"`
+
+	// TagId Narrow to the records carrying these tags. Repeat the parameter for several.
+	//
+	// By ID, not by name: a name is what a person types and an admin can rename, so a saved
+	// view holding one would silently start selecting a different slice the day somebody
+	// corrects a spelling.
+	TagId *TagIDs `form:"tag_id,omitempty" json:"tag_id,omitempty"`
+
+	// TagMode How several `tag_id` values combine. `any` selects a record carrying at least one of
+	// them, `all` a record carrying every one, `none` a record carrying not one.
+	//
+	// Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
+	TagMode *ListDealsParamsTagMode `form:"tag_mode,omitempty" json:"tag_mode,omitempty"`
 }
 
 // ListDealsParamsStatus defines parameters for ListDeals.
@@ -31825,6 +31928,9 @@ type ListDealsParamsStatus string
 
 // ListDealsParamsPartnerAttribution defines parameters for ListDeals.
 type ListDealsParamsPartnerAttribution string
+
+// ListDealsParamsTagMode defines parameters for ListDeals.
+type ListDealsParamsTagMode string
 
 // CreateDealParams defines parameters for CreateDeal.
 type CreateDealParams struct {
@@ -32793,6 +32899,19 @@ type ListOrganizationsParams struct {
 	// SizeBand How many people work there (DM-VOCAB-2).
 	SizeBand *ListOrganizationsParamsSizeBand `form:"size_band,omitempty" json:"size_band,omitempty"`
 	Q        *string                          `form:"q,omitempty" json:"q,omitempty"`
+
+	// TagId Narrow to the records carrying these tags. Repeat the parameter for several.
+	//
+	// By ID, not by name: a name is what a person types and an admin can rename, so a saved
+	// view holding one would silently start selecting a different slice the day somebody
+	// corrects a spelling.
+	TagId *TagIDs `form:"tag_id,omitempty" json:"tag_id,omitempty"`
+
+	// TagMode How several `tag_id` values combine. `any` selects a record carrying at least one of
+	// them, `all` a record carrying every one, `none` a record carrying not one.
+	//
+	// Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
+	TagMode *ListOrganizationsParamsTagMode `form:"tag_mode,omitempty" json:"tag_mode,omitempty"`
 }
 
 // ListOrganizationsParamsCapturedByKind defines parameters for ListOrganizations.
@@ -32806,6 +32925,9 @@ type ListOrganizationsParamsRelationshipType string
 
 // ListOrganizationsParamsSizeBand defines parameters for ListOrganizations.
 type ListOrganizationsParamsSizeBand string
+
+// ListOrganizationsParamsTagMode defines parameters for ListOrganizations.
+type ListOrganizationsParamsTagMode string
 
 // CreateOrganizationParams defines parameters for CreateOrganization.
 type CreateOrganizationParams struct {
@@ -33432,8 +33554,18 @@ type ListPeopleParams struct {
 	// Q Full-text query over name/title (tsvector).
 	Q *string `form:"q,omitempty" json:"q,omitempty"`
 
-	// Tag Filter by tag name.
-	Tag *string `form:"tag,omitempty" json:"tag,omitempty"`
+	// TagId Narrow to the records carrying these tags. Repeat the parameter for several.
+	//
+	// By ID, not by name: a name is what a person types and an admin can rename, so a saved
+	// view holding one would silently start selecting a different slice the day somebody
+	// corrects a spelling.
+	TagId *TagIDs `form:"tag_id,omitempty" json:"tag_id,omitempty"`
+
+	// TagMode How several `tag_id` values combine. `any` selects a record carrying at least one of
+	// them, `all` a record carrying every one, `none` a record carrying not one.
+	//
+	// Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
+	TagMode *ListPeopleParamsTagMode `form:"tag_mode,omitempty" json:"tag_mode,omitempty"`
 
 	// OrganizationId People who work at this account, by their CURRENT PRIMARY employment edge
 	// (`relationship` kind `employment`, DM-VOCAB-1). A past employer does not match:
@@ -33444,6 +33576,9 @@ type ListPeopleParams struct {
 
 // ListPeopleParamsCapturedByKind defines parameters for ListPeople.
 type ListPeopleParamsCapturedByKind string
+
+// ListPeopleParamsTagMode defines parameters for ListPeople.
+type ListPeopleParamsTagMode string
 
 // CreatePersonParams defines parameters for CreatePerson.
 type CreatePersonParams struct {
@@ -55926,6 +56061,32 @@ func (siw *ServerInterfaceWrapper) ListDeals(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// ------------- Optional query parameter "tag_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "tag_id", r.URL.Query(), &params.TagId, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag_id", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "tag_mode" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "tag_mode", r.URL.Query(), &params.TagMode, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag_mode"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag_mode", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListDeals(w, r, params)
 	}))
@@ -60872,6 +61033,32 @@ func (siw *ServerInterfaceWrapper) ListOrganizations(w http.ResponseWriter, r *h
 		return
 	}
 
+	// ------------- Optional query parameter "tag_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "tag_id", r.URL.Query(), &params.TagId, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag_id", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "tag_mode" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "tag_mode", r.URL.Query(), &params.TagMode, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag_mode"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag_mode", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListOrganizations(w, r, params)
 	}))
@@ -63884,15 +64071,28 @@ func (siw *ServerInterfaceWrapper) ListPeople(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// ------------- Optional query parameter "tag" -------------
+	// ------------- Optional query parameter "tag_id" -------------
 
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "tag", r.URL.Query(), &params.Tag, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "tag_id", r.URL.Query(), &params.TagId, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
 	if err != nil {
 		var requiredError *runtime.RequiredParameterError
 		if errors.As(err, &requiredError) {
-			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag"})
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag_id"})
 		} else {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag", Err: err})
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag_id", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "tag_mode" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "tag_mode", r.URL.Query(), &params.TagMode, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag_mode"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag_mode", Err: err})
 		}
 		return
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -9789,6 +9789,7 @@ const (
 	SearchResultTypeOrganization SearchResultType = "organization"
 	SearchResultTypePerson       SearchResultType = "person"
 	SearchResultTypeProject      SearchResultType = "project"
+	SearchResultTypeTag          SearchResultType = "tag"
 )
 
 // Valid indicates whether the value is a known member of the SearchResultType enum.
@@ -9805,6 +9806,8 @@ func (e SearchResultType) Valid() bool {
 	case SearchResultTypePerson:
 		return true
 	case SearchResultTypeProject:
+		return true
+	case SearchResultTypeTag:
 		return true
 	default:
 		return false
@@ -14145,6 +14148,7 @@ const (
 	SearchParamsTypesOrganization SearchParamsTypes = "organization"
 	SearchParamsTypesPerson       SearchParamsTypes = "person"
 	SearchParamsTypesProject      SearchParamsTypes = "project"
+	SearchParamsTypesTag          SearchParamsTypes = "tag"
 )
 
 // Valid indicates whether the value is a known member of the SearchParamsTypes enum.
@@ -14161,6 +14165,8 @@ func (e SearchParamsTypes) Valid() bool {
 	case SearchParamsTypesPerson:
 		return true
 	case SearchParamsTypesProject:
+		return true
+	case SearchParamsTypesTag:
 		return true
 	default:
 		return false

--- a/backend/internal/modules/agents/recordshapes_gen.go
+++ b/backend/internal/modules/agents/recordshapes_gen.go
@@ -46,6 +46,8 @@ var listRecordFilters = map[string][]listFilter{
 		{Name: "organization_id", Type: "string"},
 		{Name: "owner_id", Type: "string"},
 		{Name: "owner_team_id", Type: "string"},
+		{Name: "tag_id", Type: "array"},
+		{Name: "tag_mode", Type: "string", Enum: []string{"any", "all", "none"}},
 		{Name: "unassigned", Type: "boolean"},
 	},
 	"organization": {
@@ -56,6 +58,8 @@ var listRecordFilters = map[string][]listFilter{
 		{Name: "owner_team_id", Type: "string"},
 		{Name: "relationship_type", Type: "string", Enum: []string{"customer", "partner", "supplier", "investor", "portfolio_company", "competitor", "other"}},
 		{Name: "size_band", Type: "string", Enum: []string{"1-10", "11-50", "51-200", "201-500", "501-1000", "1001-5000", "5000+"}},
+		{Name: "tag_id", Type: "array"},
+		{Name: "tag_mode", Type: "string", Enum: []string{"any", "all", "none"}},
 		{Name: "unassigned", Type: "boolean"},
 	},
 	"deal": {
@@ -69,6 +73,8 @@ var listRecordFilters = map[string][]listFilter{
 		{Name: "stage_id", Type: "string"},
 		{Name: "stalled", Type: "boolean"},
 		{Name: "status", Type: "string", Enum: []string{"open", "won", "lost"}},
+		{Name: "tag_id", Type: "array"},
+		{Name: "tag_mode", Type: "string", Enum: []string{"any", "all", "none"}},
 	},
 	"lead": {
 		{Name: "min_score", Type: "integer"},

--- a/backend/internal/modules/agents/recordshapes_gen.go
+++ b/backend/internal/modules/agents/recordshapes_gen.go
@@ -46,7 +46,6 @@ var listRecordFilters = map[string][]listFilter{
 		{Name: "organization_id", Type: "string"},
 		{Name: "owner_id", Type: "string"},
 		{Name: "owner_team_id", Type: "string"},
-		{Name: "tag", Type: "string"},
 		{Name: "unassigned", Type: "boolean"},
 	},
 	"organization": {

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -116,6 +116,23 @@ var dealListFields = map[string]string{
 	"expected_close_date": fieldcatalog.TypeDate,
 }
 
+// wireRowTags renders one deal row's tag chips. A twin of the people module's:
+// a module never imports a sibling, and the shape is the contract's.
+func wireRowTags(tags []storekit.RowTag) *[]crmcontracts.RowTag {
+	out := make([]crmcontracts.RowTag, 0, len(tags))
+	for _, t := range tags {
+		var color *crmcontracts.RowTagColor
+		if t.Color != nil {
+			c := crmcontracts.RowTagColor(*t.Color)
+			color = &c
+		}
+		out = append(out, crmcontracts.RowTag{
+			TagId: openapi_types.UUID(t.TagID), Name: t.Name, Color: color,
+		})
+	}
+	return &out
+}
+
 func (s *Store) ListDeals(ctx context.Context, in ListDealsInput) ([]crmcontracts.Deal, storekit.Page, error) {
 	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
 		return nil, storekit.Page{}, err
@@ -130,7 +147,14 @@ func (s *Store) ListDeals(ctx context.Context, in ListDealsInput) ([]crmcontract
 	}
 	return storekit.RunListPage(ctx, s, pre, dealTable, dealColumns, active, where, scanDealPage,
 		func(d crmcontracts.Deal) (time.Time, ids.UUID) { return d.CreatedAt, ids.UUID(d.Id) },
-		func(tx pgx.Tx, page []crmcontracts.Deal) error { return maskDeals(ctx, tx, page) })
+		func(tx pgx.Tx, page []crmcontracts.Deal) error {
+			if err := maskDeals(ctx, tx, page); err != nil {
+				return err
+			}
+			return storekit.AttachRowTags(ctx, tx, dealTaggableType, page,
+				func(d crmcontracts.Deal) ids.UUID { return ids.UUID(d.Id) },
+				func(d *crmcontracts.Deal, tags []storekit.RowTag) { d.Tags = wireRowTags(tags) })
+		})
 }
 
 // ListDealsTx is ListDeals inside a caller-opened transaction — the composite

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -63,8 +63,8 @@ func readDealForCaller(ctx context.Context, tx pgx.Tx, id ids.DealID, archived s
 type ListDealsInput struct {
 	// TagIDs narrows to the deals carrying these tags, combined by TagMode.
 	// The predicate is storekit's, shared with the person and account lists.
-	TagIDs  []ids.UUID
-	TagMode storekit.TagMode
+	TagIDs         []ids.UUID
+	TagMode        storekit.TagMode
 	Cursor         *string
 	Limit          *int
 	Query          *string

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -238,7 +238,7 @@ func appendDealFilters(ctx context.Context, where []string, in ListDealsInput, a
 	if in.OwnerID != nil {
 		where = append(where, storekit.SQLf("owner_id = $%d", arg(*in.OwnerID)))
 	}
-	if clause := storekit.TagFilterClause(dealTaggableType, "deal.id", in.TagIDs, in.TagMode, arg); clause != "" {
+	if clause := storekit.TagFilterClause(ctx, dealTaggableType, "deal.id", in.TagIDs, in.TagMode, arg); clause != "" {
 		where = append(where, clause)
 	}
 	for _, ref := range []struct {

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -61,6 +61,10 @@ func readDealForCaller(ctx context.Context, tx pgx.Tx, id ids.DealID, archived s
 }
 
 type ListDealsInput struct {
+	// TagIDs narrows to the deals carrying these tags, combined by TagMode.
+	// The predicate is storekit's, shared with the person and account lists.
+	TagIDs  []ids.UUID
+	TagMode storekit.TagMode
 	Cursor         *string
 	Limit          *int
 	Query          *string
@@ -204,6 +208,9 @@ func appendDealFilters(ctx context.Context, where []string, in ListDealsInput, a
 	}
 	if in.OwnerID != nil {
 		where = append(where, storekit.SQLf("owner_id = $%d", arg(*in.OwnerID)))
+	}
+	if clause := storekit.TagFilterClause(dealTable, "deal.id", in.TagIDs, in.TagMode, arg); clause != "" {
+		where = append(where, clause)
 	}
 	for _, ref := range []struct {
 		column, table string

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -60,6 +60,11 @@ func readDealForCaller(ctx context.Context, tx pgx.Tx, id ids.DealID, archived s
 	return maskDealForCaller(ctx, tx, d)
 }
 
+// dealTaggableType is the value taggable.entity_type stores for a deal. It
+// reads the same as dealTable and means something else: one is the column's
+// vocabulary, the other is a relation name.
+const dealTaggableType = "deal"
+
 type ListDealsInput struct {
 	// TagIDs narrows to the deals carrying these tags, combined by TagMode.
 	// The predicate is storekit's, shared with the person and account lists.
@@ -209,7 +214,7 @@ func appendDealFilters(ctx context.Context, where []string, in ListDealsInput, a
 	if in.OwnerID != nil {
 		where = append(where, storekit.SQLf("owner_id = $%d", arg(*in.OwnerID)))
 	}
-	if clause := storekit.TagFilterClause(dealTable, "deal.id", in.TagIDs, in.TagMode, arg); clause != "" {
+	if clause := storekit.TagFilterClause(dealTaggableType, "deal.id", in.TagIDs, in.TagMode, arg); clause != "" {
 		where = append(where, clause)
 	}
 	for _, ref := range []struct {

--- a/backend/internal/modules/deals/handlers_deal.go
+++ b/backend/internal/modules/deals/handlers_deal.go
@@ -6,11 +6,12 @@ package deals
 import (
 	"net/http"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 // uuidArgs widens a repeated uuid query parameter to the store's own shape.

--- a/backend/internal/modules/deals/handlers_deal.go
+++ b/backend/internal/modules/deals/handlers_deal.go
@@ -10,7 +10,24 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
+
+// uuidArgs widens a repeated uuid query parameter to the store's own shape.
+// An absent parameter and an empty list are the same thing: no filter.
+//
+// A twin of the people module's own — a module never imports a sibling, and a
+// four-line widening is not worth a platform seam of its own.
+func uuidArgs(in *[]openapi_types.UUID) []ids.UUID {
+	if in == nil {
+		return nil
+	}
+	out := make([]ids.UUID, 0, len(*in))
+	for _, v := range *in {
+		out = append(out, ids.UUID(v))
+	}
+	return out
+}
 
 func (h Handlers) ListDeals(w http.ResponseWriter, r *http.Request, params crmcontracts.ListDealsParams) {
 	in := ListDealsInput{
@@ -19,7 +36,14 @@ func (h Handlers) ListDeals(w http.ResponseWriter, r *http.Request, params crmco
 		IncludeArchived: params.IncludeArchived != nil && *params.IncludeArchived,
 		Sort:            params.Sort,
 		CustomFilters:   httperr.CustomFieldFilters(r),
+		TagIDs:          uuidArgs(params.TagId),
 	}
+	mode, err := storekit.ParseTagMode((*string)(params.TagMode))
+	if err != nil {
+		httperr.Write(w, r, httperr.Validation("tag_mode", "invalid", err.Error()))
+		return
+	}
+	in.TagMode = mode
 	in.PipelineID = idArg[ids.PipelineKind](params.PipelineId)
 	in.StageID = idArg[ids.StageKind](params.StageId)
 	in.OwnerID = idArg[ids.UserKind](params.OwnerId)

--- a/backend/internal/modules/deals/listfilters.go
+++ b/backend/internal/modules/deals/listfilters.go
@@ -20,6 +20,8 @@ import (
 // column constants they happen to match today.
 const (
 	filterOrganizationID     = "organization_id"
+	filterTag                = "tag_id"
+	filterTagMode            = "tag_mode"
 	filterOwnerID            = "owner_id"
 	filterPartnerOrgID       = "partner_org_id"
 	filterPartnerAttribution = "partner_attribution"
@@ -34,6 +36,16 @@ const (
 )
 
 var dealListFilters = storekit.FilterSet[ListDealsInput]{
+	filterTag: storekit.FilterIDList[ids.TagKind](func(in *ListDealsInput, v []ids.UUID) { in.TagIDs = v }),
+	filterTagMode: storekit.FilterWord(func(in *ListDealsInput, v *string) {
+		// A stored mode the enum does not admit selects `any`, the contract's
+		// default for an absent one: a saved view has no caller to refuse to.
+		mode, err := storekit.ParseTagMode(v)
+		if err != nil {
+			mode = storekit.TagModeAny
+		}
+		in.TagMode = mode
+	}),
 	filterOrganizationID: storekit.FilterID(
 		func(in *ListDealsInput, id *ids.OrganizationID) { in.OrganizationID = id }),
 	filterOwnerID: storekit.FilterID(func(in *ListDealsInput, id *ids.UserID) { in.OwnerID = id }),

--- a/backend/internal/modules/deals/listfilters_test.go
+++ b/backend/internal/modules/deals/listfilters_test.go
@@ -23,6 +23,7 @@ func TestEveryDeclaredDealsFilterNarrowsSomething(t *testing.T) {
 		"organization_id": id, "owner_id": id, "partner_org_id": id, "partner_sourced": "true",
 		"partner_attribution": "sourced",
 		"pipeline_id":         id, "project_id": id, "stage_id": id, "stalled": "false", "status": "open",
+		"tag_id": id, "tag_mode": "all",
 	})
 }
 
@@ -39,6 +40,7 @@ func TestEachDealsEntityIsOfferedItsOwnVocabulary(t *testing.T) {
 		{datasource.EntityDeal, []string{
 			"organization_id", "owner_id", "partner_attribution", "partner_org_id", "partner_sourced",
 			"pipeline_id", "project_id", "stage_id", "stalled", "status",
+			"tag_id", "tag_mode",
 		}},
 	} {
 		if got := p.ListFilters(tc.entity); !slices.Equal(got, tc.want) {

--- a/backend/internal/modules/overlay/fieldbinding.go
+++ b/backend/internal/modules/overlay/fieldbinding.go
@@ -164,6 +164,10 @@ var personBindings = EntityBinding{
 		{WireSlot: "created_at", CanonicalKey: "created_at", Incumbent: []string{"createdate"}, Disposition: DispositionMapped},
 		{WireSlot: "updated_at", CanonicalKey: "last_synced_at", Incumbent: []string{"lastmodifieddate"}, Disposition: DispositionMapped},
 
+		{
+			WireSlot: "tags", Disposition: DispositionUnmappable,
+			Reason: "A tag is THIS workspace's governed vocabulary — coined, renamed and retired by its own admins, and applied to records here. An incumbent's own labels are a different vocabulary under different governance, so mapping one onto the other would present somebody else's words as this workspace's, and a rename here would have nothing to rename there.",
+		},
 		{WireSlot: "social", Disposition: DispositionDeferred, IssueURL: "https://github.com/margince/margince/issues/985"},
 		{
 			WireSlot: "archived_at", Disposition: DispositionUnmappable,
@@ -201,6 +205,10 @@ var organizationBindings = EntityBinding{
 	Entity: "organization",
 	Armed:  true,
 	Bindings: append([]FieldBinding{
+		{
+			WireSlot: "tags", Disposition: DispositionUnmappable,
+			Reason: "A tag is THIS workspace's governed vocabulary — coined, renamed and retired by its own admins, and applied to records here. An incumbent's own labels are a different vocabulary under different governance, so mapping one onto the other would present somebody else's words as this workspace's, and a rename here would have nothing to rename there.",
+		},
 		{
 			WireSlot: "writable", Disposition: DispositionNativeOnly,
 			Reason: "Whether THIS caller may change the row, answered by this installation's own write gate from its ownership, teams and record grants. An incumbent CRM's permission model is not those, so a mirrored value would be a different question's answer wearing this field's name.",

--- a/backend/internal/modules/people/handlers_organization.go
+++ b/backend/internal/modules/people/handlers_organization.go
@@ -49,7 +49,14 @@ func (h Handlers) ListOrganizations(w http.ResponseWriter, r *http.Request, para
 		Lifecycle:        enumArg(params.Lifecycle),
 		RelationshipType: enumArg(params.RelationshipType),
 		Domain:           params.Domain,
+		TagIDs:           uuidArgs(params.TagId),
 	}
+	mode, err := storekit.ParseTagMode((*string)(params.TagMode))
+	if err != nil {
+		httperr.Write(w, r, httperr.Validation("tag_mode", "invalid", err.Error()))
+		return
+	}
+	in.TagMode = mode
 	in.OwnerID = idArg[ids.UserKind](params.OwnerId)
 	in.OwnerTeamID = idArg[ids.TeamKind](params.OwnerTeamId)
 	in.Unassigned = params.Unassigned

--- a/backend/internal/modules/people/handlers_person.go
+++ b/backend/internal/modules/people/handlers_person.go
@@ -35,6 +35,19 @@ func (h Handlers) MergePerson(w http.ResponseWriter, r *http.Request, id crmcont
 	httperr.WriteJSON(w, http.StatusOK, survivor)
 }
 
+// uuidArgs widens a repeated uuid query parameter to the store's own shape.
+// An absent parameter and an empty list are the same thing here: no filter.
+func uuidArgs(in *[]openapi_types.UUID) []ids.UUID {
+	if in == nil {
+		return nil
+	}
+	out := make([]ids.UUID, 0, len(*in))
+	for _, v := range *in {
+		out = append(out, ids.UUID(v))
+	}
+	return out
+}
+
 func (h Handlers) ListPeople(w http.ResponseWriter, r *http.Request, params crmcontracts.ListPeopleParams) {
 	in := ListPeopleInput{
 		Cursor:          params.Cursor,
@@ -45,8 +58,14 @@ func (h Handlers) ListPeople(w http.ResponseWriter, r *http.Request, params crmc
 		AiWritten:       params.AiWritten,
 		Sort:            params.Sort,
 		CustomFilters:   httperr.CustomFieldFilters(r),
-		Tag:             params.Tag,
+		TagIDs:          uuidArgs(params.TagId),
 	}
+	mode, err := storekit.ParseTagMode((*string)(params.TagMode))
+	if err != nil {
+		httperr.Write(w, r, httperr.Validation("tag_mode", "invalid", err.Error()))
+		return
+	}
+	in.TagMode = mode
 	in.OwnerID = idArg[ids.UserKind](params.OwnerId)
 	in.OwnerTeamID = idArg[ids.TeamKind](params.OwnerTeamId)
 	in.Unassigned = params.Unassigned

--- a/backend/internal/modules/people/listfilters.go
+++ b/backend/internal/modules/people/listfilters.go
@@ -42,6 +42,7 @@ const (
 	filterRelationshipType = "relationship_type"
 	filterStatus           = "status"
 	filterTag              = "tag"
+	filterTagMode          = "tag_mode"
 	filterDomain           = "domain"
 	filterMinScore         = "min_score"
 	filterPartnerRole      = "partner_role"
@@ -50,7 +51,17 @@ const (
 
 var personListFilters = storekit.FilterSet[ListPeopleInput]{
 	filterOwnerID: storekit.FilterID(func(in *ListPeopleInput, id *ids.UserID) { in.OwnerID = id }),
-	filterTag:     storekit.FilterWord(func(in *ListPeopleInput, v *string) { in.Tag = v }),
+	filterTag:     storekit.FilterIDList[ids.TagKind](func(in *ListPeopleInput, v []ids.UUID) { in.TagIDs = v }),
+	filterTagMode: storekit.FilterWord(func(in *ListPeopleInput, v *string) {
+		// A stored mode the enum does not admit selects `any`, the default the
+		// contract gives an absent one: a saved view is not a request and has
+		// no caller to refuse to.
+		mode, err := storekit.ParseTagMode(v)
+		if err != nil {
+			mode = storekit.TagModeAny
+		}
+		in.TagMode = mode
+	}),
 }
 
 var organizationListFilters = storekit.FilterSet[ListOrganizationsInput]{

--- a/backend/internal/modules/people/listfilters.go
+++ b/backend/internal/modules/people/listfilters.go
@@ -41,7 +41,7 @@ const (
 	filterLifecycle        = "lifecycle"
 	filterRelationshipType = "relationship_type"
 	filterStatus           = "status"
-	filterTag              = "tag"
+	filterTag              = "tag_id"
 	filterTagMode          = "tag_mode"
 	filterDomain           = "domain"
 	filterMinScore         = "min_score"
@@ -53,14 +53,7 @@ var personListFilters = storekit.FilterSet[ListPeopleInput]{
 	filterOwnerID: storekit.FilterID(func(in *ListPeopleInput, id *ids.UserID) { in.OwnerID = id }),
 	filterTag:     storekit.FilterIDList[ids.TagKind](func(in *ListPeopleInput, v []ids.UUID) { in.TagIDs = v }),
 	filterTagMode: storekit.FilterWord(func(in *ListPeopleInput, v *string) {
-		// A stored mode the enum does not admit selects `any`, the default the
-		// contract gives an absent one: a saved view is not a request and has
-		// no caller to refuse to.
-		mode, err := storekit.ParseTagMode(v)
-		if err != nil {
-			mode = storekit.TagModeAny
-		}
-		in.TagMode = mode
+		in.TagMode = tagModeOrDefault(v)
 	}),
 }
 
@@ -70,6 +63,10 @@ var organizationListFilters = storekit.FilterSet[ListOrganizationsInput]{
 	filterOwnerID:   storekit.FilterID(func(in *ListOrganizationsInput, id *ids.UserID) { in.OwnerID = id }),
 	filterRelationshipType: storekit.FilterWord(
 		func(in *ListOrganizationsInput, v *string) { in.RelationshipType = v }),
+	filterTag: storekit.FilterIDList[ids.TagKind](func(in *ListOrganizationsInput, v []ids.UUID) { in.TagIDs = v }),
+	filterTagMode: storekit.FilterWord(func(in *ListOrganizationsInput, v *string) {
+		in.TagMode = tagModeOrDefault(v)
+	}),
 }
 
 // Partner lists by role and certification, the two dials GET /partners already
@@ -102,4 +99,17 @@ func (p *Provider) ListFilters(t datasource.EntityType) []string {
 	default:
 		return nil
 	}
+}
+
+// tagModeOrDefault reads a stored mode, falling back to `any`.
+//
+// A saved view is not a request: it has no caller to refuse to, and a view
+// that stopped opening because somebody hand-edited its mode would be worse
+// than one that opens on the contract's own default.
+func tagModeOrDefault(raw *string) storekit.TagMode {
+	mode, err := storekit.ParseTagMode(raw)
+	if err != nil {
+		return storekit.TagModeAny
+	}
+	return mode
 }

--- a/backend/internal/modules/people/listfilters_test.go
+++ b/backend/internal/modules/people/listfilters_test.go
@@ -24,11 +24,11 @@ import (
 func TestEveryDeclaredPeopleFilterNarrowsSomething(t *testing.T) {
 	owner := ids.NewV7().String()
 	assertEveryFilterNarrows(t, "person", personListFilters, map[string]string{
-		"owner_id": owner, "tag": ids.NewV7().String(), "tag_mode": "all",
+		"owner_id": owner, "tag_id": ids.NewV7().String(), "tag_mode": "all",
 	})
 	assertEveryFilterNarrows(t, "organization", organizationListFilters, map[string]string{
 		"domain": "kaercher-technik.example", "lifecycle": "customer", "owner_id": owner,
-		"relationship_type": "partner",
+		"relationship_type": "partner", "tag_id": ids.NewV7().String(), "tag_mode": "none",
 	})
 	assertEveryFilterNarrows(t, "lead", leadListFilters, map[string]string{
 		"min_score": "70", "owner_id": owner, "status": "working",
@@ -49,8 +49,8 @@ func TestEachEntityIsOfferedItsOwnVocabulary(t *testing.T) {
 		entity datasource.EntityType
 		want   []string
 	}{
-		{datasource.EntityPerson, []string{"owner_id", "tag", "tag_mode"}},
-		{datasource.EntityOrganization, []string{"domain", "lifecycle", "owner_id", "relationship_type"}},
+		{datasource.EntityPerson, []string{"owner_id", "tag_id", "tag_mode"}},
+		{datasource.EntityOrganization, []string{"domain", "lifecycle", "owner_id", "relationship_type", "tag_id", "tag_mode"}},
 		{datasource.EntityLead, []string{"min_score", "owner_id", "status"}},
 	} {
 		if got := p.ListFilters(tc.entity); !slices.Equal(got, tc.want) {

--- a/backend/internal/modules/people/listfilters_test.go
+++ b/backend/internal/modules/people/listfilters_test.go
@@ -24,7 +24,7 @@ import (
 func TestEveryDeclaredPeopleFilterNarrowsSomething(t *testing.T) {
 	owner := ids.NewV7().String()
 	assertEveryFilterNarrows(t, "person", personListFilters, map[string]string{
-		"owner_id": owner, "tag": "vip",
+		"owner_id": owner, "tag": ids.NewV7().String(), "tag_mode": "all",
 	})
 	assertEveryFilterNarrows(t, "organization", organizationListFilters, map[string]string{
 		"domain": "kaercher-technik.example", "lifecycle": "customer", "owner_id": owner,
@@ -49,7 +49,7 @@ func TestEachEntityIsOfferedItsOwnVocabulary(t *testing.T) {
 		entity datasource.EntityType
 		want   []string
 	}{
-		{datasource.EntityPerson, []string{"owner_id", "tag"}},
+		{datasource.EntityPerson, []string{"owner_id", "tag", "tag_mode"}},
 		{datasource.EntityOrganization, []string{"domain", "lifecycle", "owner_id", "relationship_type"}},
 		{datasource.EntityLead, []string{"min_score", "owner_id", "status"}},
 	} {

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -229,6 +229,11 @@ func (s *Store) ListOrganizations(ctx context.Context, in ListOrganizationsInput
 			if err := attachOrgRelationshipTypes(ctx, tx, orgs); err != nil {
 				return err
 			}
+			if err := storekit.AttachRowTags(ctx, tx, organizationEntity, orgs,
+				func(o crmcontracts.Organization) ids.UUID { return ids.UUID(o.Id) },
+				func(o *crmcontracts.Organization, tags []storekit.RowTag) { o.Tags = wireRowTags(tags) }); err != nil {
+				return err
+			}
 			return attachOrgCounts(ctx, tx, orgs)
 		},
 		cursorKey: func(last crmcontracts.Organization) (time.Time, ids.UUID) {

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -173,7 +173,7 @@ func (s *Store) ListOrganizations(ctx context.Context, in ListOrganizationsInput
 			if clause := organizationDomainClause(in.Domain, in.IncludeArchived, arg); clause != "" {
 				where = append(where, clause)
 			}
-			if clause := storekit.TagFilterClause(organizationEntity, "organization.id", in.TagIDs, in.TagMode, arg); clause != "" {
+			if clause := storekit.TagFilterClause(ctx, organizationEntity, "organization.id", in.TagIDs, in.TagMode, arg); clause != "" {
 				where = append(where, clause)
 			}
 			// A value outside the enum is a client mistake, not a selection

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -170,12 +170,7 @@ func (s *Store) ListOrganizations(ctx context.Context, in ListOrganizationsInput
 			if in.Classification != nil {
 				where = append(where, storekit.SQLf("classification = $%d", arg(*in.Classification)))
 			}
-			if clause := organizationDomainClause(in.Domain, in.IncludeArchived, arg); clause != "" {
-				where = append(where, clause)
-			}
-			if clause := storekit.TagFilterClause(ctx, organizationEntity, "organization.id", in.TagIDs, in.TagMode, arg); clause != "" {
-				where = append(where, clause)
-			}
+			where = appendOrgLinkClauses(ctx, where, in, arg)
 			// A value outside the enum is a client mistake, not a selection
 			// that happens to match nothing: answering 200 with an empty page
 			// tells the reader this account list is empty when the question
@@ -265,4 +260,22 @@ func scanOrganizationPage(rows pgx.Rows, active []fieldcatalog.Column, sorted *s
 		return nil, nil, err
 	}
 	return orgs, cursorKeys, nil
+}
+
+// appendOrgLinkClauses adds the narrowings that reach ANOTHER table — a
+// domain row and a tagging — rather than a column on organization. They are
+// grouped because they share that shape, and because the list they sit in has
+// a size ceiling that a third one would push through.
+func appendOrgLinkClauses(
+	ctx context.Context, where []string, in ListOrganizationsInput, arg func(any) int,
+) []string {
+	if clause := organizationDomainClause(in.Domain, in.IncludeArchived, arg); clause != "" {
+		where = append(where, clause)
+	}
+	if clause := storekit.TagFilterClause(
+		ctx, organizationEntity, "organization.id", in.TagIDs, in.TagMode, arg,
+	); clause != "" {
+		where = append(where, clause)
+	}
+	return where
 }

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -32,6 +32,10 @@ const orgNameColumn = "display_name"
 // ListOrganizationsInput carries the organization list's contract
 // parameters.
 type ListOrganizationsInput struct {
+	// TagIDs narrows to the accounts carrying these tags, combined by TagMode.
+	// The predicate is storekit's, shared with the person and deal lists.
+	TagIDs  []ids.UUID
+	TagMode storekit.TagMode
 	// IncludeAnchor admits the installation's own company (ADR-0082/A127).
 	IncludeAnchor bool
 	Cursor        *string
@@ -167,6 +171,9 @@ func (s *Store) ListOrganizations(ctx context.Context, in ListOrganizationsInput
 				where = append(where, storekit.SQLf("classification = $%d", arg(*in.Classification)))
 			}
 			if clause := organizationDomainClause(in.Domain, in.IncludeArchived, arg); clause != "" {
+				where = append(where, clause)
+			}
+			if clause := storekit.TagFilterClause(organizationEntity, "organization.id", in.TagIDs, in.TagMode, arg); clause != "" {
 				where = append(where, clause)
 			}
 			// A value outside the enum is a client mistake, not a selection

--- a/backend/internal/modules/people/person_children.go
+++ b/backend/internal/modules/people/person_children.go
@@ -366,6 +366,11 @@ func attachPersonChildren(ctx context.Context, tx pgx.Tx, people []crmcontracts.
 	if err := attachPersonSocial(ctx, tx, idx, personIDs); err != nil {
 		return err
 	}
+	if err := storekit.AttachRowTags(ctx, tx, personEntity, people,
+		func(p crmcontracts.Person) ids.UUID { return ids.UUID(p.Id) },
+		func(p *crmcontracts.Person, tags []storekit.RowTag) { p.Tags = wireRowTags(tags) }); err != nil {
+		return err
+	}
 	return attachPersonReachability(ctx, tx, idx, personIDs)
 }
 

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -50,10 +50,12 @@ type ListPeopleInput struct {
 	// CustomFilters carries the request's cf_* query parameters —
 	// equality matches against active custom columns (storekit listquery).
 	CustomFilters map[string]string
-	// Tag narrows to the people carrying one tag, by name. The tag
-	// vocabulary belongs to another module, so this is a link predicate
-	// rather than a column — see personTagClause.
-	Tag *string
+	// TagIDs narrows to the people carrying these tags, combined by TagMode.
+	// The tag vocabulary belongs to another module, so this is a link
+	// predicate rather than a column — storekit.TagFilterClause renders it,
+	// shared with the company and deal lists so the three cannot drift.
+	TagIDs  []ids.UUID
+	TagMode storekit.TagMode
 	// OrganizationID narrows to the people employed there today. Employment is
 	// an edge, not a column on person, so this is a link predicate too — see
 	// personEmployerClause.
@@ -71,33 +73,13 @@ var personListFields = map[string]string{
 	lastActivityColumn: storekit.KindTimestamp,
 }
 
-// personTagClause narrows the page to the people carrying one tag, or ""
-// when the caller named none.
+// personTagClause narrows the page to the people carrying the named tags.
 //
-// Tags live in another module's tables, which this one may not import — but
-// the predicate is SQL, and a tagged person is a row in `taggable` whatever
-// package writes it. Matching is on the FOLDED name because that is what the
-// vocabulary is unique by.
-//
-// `uq_tag_name` binds LIVE rows only, so a name can be held by one live tag and
-// any number of retired ones, and the clause names the live one. Without that
-// restriction, filtering by a word somebody re-coined after a merge would also
-// return the people carrying the older, retired tag of the same spelling —
-// records the reader would have no way to explain.
-//
-// EXISTS rather than a join: a person carries many tags, and a join would
-// return them once per matching link — rows the keyset cursor would then page
-// over as if they were distinct people.
-func personTagClause(tag *string, arg func(any) int) string {
-	if tag == nil {
-		return ""
-	}
-	return storekit.SQLf(`EXISTS (
-		SELECT 1 FROM taggable tg
-		  JOIN tag t ON t.id = tg.tag_id
-		WHERE tg.entity_type = $%d AND tg.entity_id = person.id
-		  AND lower(t.name) = $%d AND t.archived_at IS NULL)`,
-		arg(personEntity), arg(foldTagName(*tag)))
+// The predicate is storekit's, shared with the company and deal lists: three
+// copies of a NOT EXISTS is three chances for `none` to mean something subtly
+// different on one surface.
+func personTagClause(tagIDs []ids.UUID, mode storekit.TagMode, arg func(any) int) string {
+	return storekit.TagFilterClause(personEntity, "person.id", tagIDs, mode, arg)
 }
 
 // personEmployerClause narrows the page to the people who work at one account
@@ -172,7 +154,7 @@ func (s *Store) ListPeople(ctx context.Context, in ListPeopleInput) ([]crmcontra
 			if err != nil {
 				return nil, err
 			}
-			if clause := personTagClause(in.Tag, arg); clause != "" {
+			if clause := personTagClause(in.TagIDs, in.TagMode, arg); clause != "" {
 				where = append(where, clause)
 			}
 			employer, err := personEmployerClause(ctx, in.OrganizationID, arg)

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -9,7 +9,6 @@ package people
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -52,8 +51,8 @@ type ListPeopleInput struct {
 	CustomFilters map[string]string
 	// TagIDs narrows to the people carrying these tags, combined by TagMode.
 	// The tag vocabulary belongs to another module, so this is a link
-	// predicate rather than a column — storekit.TagFilterClause renders it,
-	// shared with the company and deal lists so the three cannot drift.
+	// predicate rather than a column; storekit.TagFilterClause renders it, and
+	// the company and deal lists call the same function.
 	TagIDs  []ids.UUID
 	TagMode storekit.TagMode
 	// OrganizationID narrows to the people employed there today. Employment is
@@ -123,11 +122,6 @@ func personEmployerClause(ctx context.Context, orgID *ids.OrganizationID, arg fu
 		  AND `+edgeBound+`
 		  AND rel.organization_id = $%d)`, arg(*orgID)), nil
 }
-
-// foldTagName matches how the tag vocabulary is stored and compared: names
-// are trimmed on write and unique under lower(), so a caller's spacing and
-// case decide nothing about which tag they named.
-func foldTagName(name string) string { return strings.ToLower(strings.TrimSpace(name)) }
 
 // ListPeople is the row-scoped person list read: quick-find, owner, tag and
 // custom-field filters, keyset pagination under the validated sort.

--- a/backend/internal/modules/people/person_list.go
+++ b/backend/internal/modules/people/person_list.go
@@ -77,8 +77,8 @@ var personListFields = map[string]string{
 // The predicate is storekit's, shared with the company and deal lists: three
 // copies of a NOT EXISTS is three chances for `none` to mean something subtly
 // different on one surface.
-func personTagClause(tagIDs []ids.UUID, mode storekit.TagMode, arg func(any) int) string {
-	return storekit.TagFilterClause(personEntity, "person.id", tagIDs, mode, arg)
+func personTagClause(ctx context.Context, tagIDs []ids.UUID, mode storekit.TagMode, arg func(any) int) string {
+	return storekit.TagFilterClause(ctx, personEntity, "person.id", tagIDs, mode, arg)
 }
 
 // personEmployerClause narrows the page to the people who work at one account
@@ -148,7 +148,7 @@ func (s *Store) ListPeople(ctx context.Context, in ListPeopleInput) ([]crmcontra
 			if err != nil {
 				return nil, err
 			}
-			if clause := personTagClause(in.TagIDs, in.TagMode, arg); clause != "" {
+			if clause := personTagClause(ctx, in.TagIDs, in.TagMode, arg); clause != "" {
 				where = append(where, clause)
 			}
 			employer, err := personEmployerClause(ctx, in.OrganizationID, arg)

--- a/backend/internal/modules/people/rowtags.go
+++ b/backend/internal/modules/people/rowtags.go
@@ -10,9 +10,10 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 )
 
-// wireRowTags renders one row's tag chips. Written once here because the
-// person and organization lists both draw them and the shape is the contract's,
-// not either list's.
+// wireRowTags renders one row's tag chips for the person and organization
+// lists, which both draw them. The deals module carries its own twin, because
+// a module never imports a sibling. Both render the contract's generated
+// RowTag, so a change to the shape is a compile error in each.
 func wireRowTags(tags []storekit.RowTag) *[]crmcontracts.RowTag {
 	out := make([]crmcontracts.RowTag, 0, len(tags))
 	for _, t := range tags {

--- a/backend/internal/modules/people/rowtags.go
+++ b/backend/internal/modules/people/rowtags.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+// wireRowTags renders one row's tag chips. Written once here because the
+// person and organization lists both draw them and the shape is the contract's,
+// not either list's.
+func wireRowTags(tags []storekit.RowTag) *[]crmcontracts.RowTag {
+	out := make([]crmcontracts.RowTag, 0, len(tags))
+	for _, t := range tags {
+		var color *crmcontracts.RowTagColor
+		if t.Color != nil {
+			c := crmcontracts.RowTagColor(*t.Color)
+			color = &c
+		}
+		out = append(out, crmcontracts.RowTag{
+			TagId: openapi_types.UUID(t.TagID), Name: t.Name, Color: color,
+		})
+	}
+	return &out
+}

--- a/backend/internal/modules/search/embedding.go
+++ b/backend/internal/modules/search/embedding.go
@@ -226,6 +226,11 @@ func (s *Store) SimilarEntities(ctx context.Context, queryVec []float32, identit
 func similarBranchSQL(ctx context.Context, types []string, vecPos, identityPos int, arg func(any) int) ([]string, error) {
 	var branches []string
 	for _, branch := range searchBranches {
+		// A word has no prose to embed, so a similarity search over one would
+		// compare a name against a vector nothing produced.
+		if branch.textOnly {
+			continue
+		}
 		if len(types) > 0 && !slices.Contains(types, branch.entity) {
 			continue
 		}

--- a/backend/internal/modules/search/graph.go
+++ b/backend/internal/modules/search/graph.go
@@ -113,7 +113,10 @@ func (s *Store) assembleRecordWithin(ctx context.Context, tx pgx.Tx, anchorType 
 	// itself (an activity is a link, not a thing links hang off).
 	var branch *searchBranch
 	for i := range searchBranches {
-		if searchBranches[i].entity == anchorType && !searchBranches[i].activityWalk {
+		// textOnly too: a word is not a thing links hang off, so a tag can
+		// never be a graph anchor even when a caller names one.
+		if searchBranches[i].entity == anchorType &&
+			!searchBranches[i].activityWalk && !searchBranches[i].textOnly {
 			branch = &searchBranches[i]
 		}
 	}

--- a/backend/internal/modules/search/handlers_context.go
+++ b/backend/internal/modules/search/handlers_context.go
@@ -38,6 +38,12 @@ const (
 var contextAnchorTypes = func() string {
 	names := make([]string, 0, len(searchBranches))
 	for _, branch := range searchBranches {
+		// A text-only branch is not an anchor: a word has no neighbours to
+		// return, so naming one here would advertise a read that answers
+		// nothing.
+		if branch.textOnly {
+			continue
+		}
 		names = append(names, branch.entity)
 	}
 	return strings.Join(names, ", ")

--- a/backend/internal/modules/search/queryvocab.go
+++ b/backend/internal/modules/search/queryvocab.go
@@ -220,6 +220,12 @@ func (r *VocabularyResolver) Resolve(ctx context.Context, targets ...string) (Vo
 	// re-read each of them once per target it lists.
 	schema := newSchemaReads(r.columns)
 	for _, branch := range searchBranches {
+		// A text-only branch has no record vocabulary to publish: a tag is a
+		// word, and describing its fields would document a record shape that
+		// does not exist.
+		if branch.textOnly {
+			continue
+		}
 		if len(targets) > 0 && !slices.Contains(targets, branch.entity) {
 			continue
 		}

--- a/backend/internal/modules/search/queryvocab_test.go
+++ b/backend/internal/modules/search/queryvocab_test.go
@@ -299,6 +299,11 @@ func TestTheInverseOfADeclaredReferenceIsTraversable(t *testing.T) {
 // error on the first plan that names it.
 func TestEverySearchableEntityHasAContractBinding(t *testing.T) {
 	for _, branch := range searchBranches {
+		// A text-only branch answers the name search and nothing else, so it
+		// has no record vocabulary to derive and needs no binding.
+		if branch.textOnly {
+			continue
+		}
 		if contractRecords[branch.entity] == nil {
 			t.Errorf("searchable entity %q has no contract record binding, so no vocabulary can be derived for it", branch.entity)
 		}

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -85,10 +85,19 @@ type searchBranch struct {
 	snippet      string
 	activityWalk bool
 	// workspaceWide marks a branch whose rows carry no owner: the tag
-	// vocabulary is one word list the whole workspace shares, so object RBAC
-	// is the only gate and there is no per-row predicate to render. Asking
-	// ScopeClauseFor for one would be an error, not an empty clause.
+	// vocabulary is one word list the whole workspace shares, so a seat that
+	// may read it reads all of it and there is no per-row predicate to
+	// render. Asking ScopeClauseFor for one would be an error rather than an
+	// empty clause, which is why the branch says so rather than passing "".
 	workspaceWide bool
+	// textOnly marks a branch that answers the name search and NOTHING else.
+	// A tag is a word, not a record: it has no fields to plan a structured
+	// query over, no neighbours to walk in the graph, and no prose to embed.
+	// The three surfaces that reason about records therefore skip it, and the
+	// gate that requires a contract binding per searchable entity skips it for
+	// the same reason — deriving a vocabulary for a word would describe a
+	// record that does not exist.
+	textOnly bool
 	// extraWhere narrows DISCOVERY on this branch, beyond archived_at and the
 	// row scope. The by-id graph anchor read (graph.go) deliberately does not
 	// apply it: a record named by id is not being discovered, and the own
@@ -206,8 +215,7 @@ var searchBranches = []searchBranch{
 	//
 	// Archived words are excluded: a retired tag is not in the picker, so a hit
 	// on one leads to a page that cannot be acted on.
-	{entity: "tag", table: "tag", title: "name", snippet: "NULL",
-		workspaceWide: true, extraWhere: "%s.archived_at IS NULL"},
+	{entity: "tag", table: "tag", title: "name", snippet: "NULL", workspaceWide: true, textOnly: true, extraWhere: "%s.archived_at IS NULL"},
 	{entity: "activity", table: entityActivity, title: "coalesce(subject, channel_provider, kind)", snippet: "left(coalesce(body, ''), 200)", activityWalk: true},
 }
 

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -84,6 +84,11 @@ type searchBranch struct {
 	title        string
 	snippet      string
 	activityWalk bool
+	// workspaceWide marks a branch whose rows carry no owner: the tag
+	// vocabulary is one word list the whole workspace shares, so object RBAC
+	// is the only gate and there is no per-row predicate to render. Asking
+	// ScopeClauseFor for one would be an error, not an empty clause.
+	workspaceWide bool
 	// extraWhere narrows DISCOVERY on this branch, beyond archived_at and the
 	// row scope. The by-id graph anchor read (graph.go) deliberately does not
 	// apply it: a record named by id is not being discovered, and the own
@@ -162,9 +167,14 @@ func branchScope(ctx context.Context, branch searchBranch, alias string, arg fun
 	if auth.Require(ctx, branch.entity, principal.ActionRead) != nil {
 		return "", false, nil
 	}
-	if branch.activityWalk {
+	switch {
+	case branch.workspaceWide:
+		// No row predicate at all: every seat that may read the vocabulary
+		// reads all of it.
+		scope = ""
+	case branch.activityWalk:
 		scope, err = auth.ActivityContentClause(ctx, alias, arg)
-	} else {
+	default:
 		scope, err = auth.ScopeClauseFor(ctx, branch.entity, alias, arg)
 	}
 	return scope, true, err
@@ -189,6 +199,15 @@ var searchBranches = []searchBranch{
 	// message's kind is the bare word "message", so a subject-less chat would
 	// render identically for every transport. coalesce falls through to the kind
 	// for everything that never travelled on one.
+	// A tag is a word, not a record, and it is what a person types when they
+	// mean "show me the accounts we called Key Account". Finding the word is
+	// the step before finding the records, and without it a reader has to know
+	// the vocabulary already.
+	//
+	// Archived words are excluded: a retired tag is not in the picker, so a hit
+	// on one leads to a page that cannot be acted on.
+	{entity: "tag", table: "tag", title: "name", snippet: "NULL",
+		workspaceWide: true, extraWhere: "%s.archived_at IS NULL"},
 	{entity: "activity", table: entityActivity, title: "coalesce(subject, channel_provider, kind)", snippet: "left(coalesce(body, ''), 200)", activityWalk: true},
 }
 

--- a/backend/internal/platform/database/storekit/listfilters.go
+++ b/backend/internal/platform/database/storekit/listfilters.go
@@ -24,6 +24,7 @@ import (
 	"maps"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
@@ -92,6 +93,35 @@ func FilterID[K ids.EntityKind, I any](set func(*I, *ids.ID[K])) FilterBinding[I
 			return operandShape("a uuid, in the 8-4-4-4-12 hex form")
 		}
 		set(in, &id)
+		return nil
+	}
+}
+
+// FilterIDList binds a comma-separated list of reference operands.
+//
+// A saved view stores each filter as ONE string, so a filter naming several
+// records has to fit in one — which is why this is a list in a string rather
+// than a repeated key. The wire's own query parameter repeats instead; the
+// transport joins before it reaches here, so both doors arrive in one shape.
+//
+// An empty entry is skipped rather than parsed: a trailing comma is how a
+// hand-edited view or a UI that joined an empty slot spells "nothing more",
+// and refusing it would break a view over a typo nobody can see.
+func FilterIDList[K ids.EntityKind, I any](set func(*I, []ids.UUID)) FilterBinding[I] {
+	return func(in *I, value string) error {
+		var out []ids.UUID
+		for _, raw := range strings.Split(value, ",") {
+			raw = strings.TrimSpace(raw)
+			if raw == "" {
+				continue
+			}
+			id, err := ids.ParseAs[K](raw)
+			if err != nil {
+				return operandShape("a comma-separated list of uuids, each in the 8-4-4-4-12 hex form")
+			}
+			out = append(out, id.UUID)
+		}
+		set(in, out)
 		return nil
 	}
 }

--- a/backend/internal/platform/database/storekit/tagfilter.go
+++ b/backend/internal/platform/database/storekit/tagfilter.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
+
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 

--- a/backend/internal/platform/database/storekit/tagfilter.go
+++ b/backend/internal/platform/database/storekit/tagfilter.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The tag filter every list surface shares.
+//
+// People, companies and deals all narrow by tag, and the three predicates are
+// the same shape over one polymorphic table. Written once here, in the layer
+// each module already depends on, because three copies of a NOT EXISTS is
+// three chances for one of them to mean something subtly different — and the
+// mode that would drift first is `none`, the one nobody notices is wrong until
+// a rep is looking at a record they filtered out.
+
+// TagMode says how several tag ids combine.
+type TagMode string
+
+const (
+	// TagModeAny selects a record carrying at least one of the named tags.
+	TagModeAny TagMode = "any"
+	// TagModeAll selects a record carrying every one of them.
+	TagModeAll TagMode = "all"
+	// TagModeNone selects a record carrying not one of them.
+	TagModeNone TagMode = "none"
+)
+
+// ParseTagMode reads a wire value, defaulting an absent one to `any`.
+//
+// An unknown mode is refused rather than defaulted: silently treating a typo
+// as `any` would hand back a wider slice than the caller asked for, and a
+// filter that quietly widens is worse than one that fails.
+func ParseTagMode(raw *string) (TagMode, error) {
+	if raw == nil || *raw == "" {
+		return TagModeAny, nil
+	}
+	switch TagMode(*raw) {
+	case TagModeAny, TagModeAll, TagModeNone:
+		return TagMode(*raw), nil
+	default:
+		return "", fmt.Errorf("tag_mode %q: want any, all or none", *raw)
+	}
+}
+
+// TagFilterClause renders the predicate narrowing one entity's rows by tag,
+// or "" when no tag was named.
+//
+// `idColumn` is how the outer query names the record's own id — "person.id",
+// "o.id" — because each list builds its own FROM and this has to attach to it.
+//
+// EXISTS rather than a join, in every mode: a record carries many tags, and a
+// join would return it once per matching link — rows a keyset cursor would
+// then page over as if they were distinct records.
+//
+// Archived tags are excluded. A word somebody retired is not in the picker, so
+// a filter naming it selects a slice no reader can construct or explain; and
+// after a merge releases a name, a re-coined word would otherwise drag along
+// the records carrying the older retired tag of the same spelling.
+func TagFilterClause(entityType, idColumn string, tagIDs []ids.UUID, mode TagMode, arg func(any) int) string {
+	if len(tagIDs) == 0 {
+		return ""
+	}
+	switch mode {
+	case TagModeAll:
+		// One EXISTS per tag: a single subquery cannot say "carries all of
+		// these" without counting, and counting reads worse than the shape a
+		// reader can check tag by tag.
+		parts := make([]string, 0, len(tagIDs))
+		for _, id := range tagIDs {
+			parts = append(parts, tagExists(entityType, idColumn, []ids.UUID{id}, arg))
+		}
+		return "(" + strings.Join(parts, " AND ") + ")"
+	case TagModeNone:
+		return "NOT " + tagExists(entityType, idColumn, tagIDs, arg)
+	default:
+		return tagExists(entityType, idColumn, tagIDs, arg)
+	}
+}
+
+// tagExists renders one EXISTS over the taggable link for these ids.
+func tagExists(entityType, idColumn string, tagIDs []ids.UUID, arg func(any) int) string {
+	return fmt.Sprintf(`EXISTS (
+		SELECT 1 FROM taggable tg
+		  JOIN tag t ON t.id = tg.tag_id
+		WHERE tg.entity_type = $%d AND tg.entity_id = %s
+		  AND tg.tag_id = ANY($%d) AND t.archived_at IS NULL)`,
+		arg(entityType), idColumn, arg(tagIDs))
+}

--- a/backend/internal/platform/database/storekit/tagfilter.go
+++ b/backend/internal/platform/database/storekit/tagfilter.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // The tag filter every list surface shares.
@@ -69,9 +71,16 @@ func ParseTagMode(raw *string) (TagMode, error) {
 // a filter naming it selects a slice no reader can construct or explain; and
 // after a merge releases a name, a re-coined word would otherwise drag along
 // the records carrying the older retired tag of the same spelling.
-func TagFilterClause(taggableType, idColumn string, tagIDs []ids.UUID, mode TagMode, arg func(any) int) string {
+func TagFilterClause(ctx context.Context, taggableType, idColumn string, tagIDs []ids.UUID, mode TagMode, arg func(any) int) string {
 	if len(tagIDs) == 0 {
 		return ""
+	}
+	// Filtering by a tag reads the vocabulary: a caller who cannot see the
+	// words must not be able to learn which records carry one by watching a
+	// page shrink. Rendering nothing would WIDEN the answer, so the refusal is
+	// a predicate that selects no rows.
+	if auth.Require(ctx, "tag", principal.ActionRead) != nil {
+		return "FALSE"
 	}
 	switch mode {
 	case TagModeAll:
@@ -91,6 +100,18 @@ func TagFilterClause(taggableType, idColumn string, tagIDs []ids.UUID, mode TagM
 }
 
 // tagExists renders one EXISTS over the taggable link for these ids.
+//
+// An ARCHIVED id matches nothing here, and that reads differently per mode:
+// `any` and `all` narrow to nothing, `none` keeps every record. Both follow
+// from one rule — a retired word is not part of the vocabulary a filter can
+// name — and the alternative is worse. Honouring an archived id would let a
+// saved view keep selecting by a word an admin retired precisely to stop
+// people selecting by it, and after a merge releases a name the re-coined word
+// would drag the old tag's records along.
+//
+// The picker never offers a retired word, so reaching this state means a saved
+// view outlived the tag it names. That view then answers with nothing rather
+// than with a slice its reader cannot explain.
 func tagExists(taggableType, idColumn string, tagIDs []ids.UUID, arg func(any) int) string {
 	return fmt.Sprintf(`EXISTS (
 		SELECT 1 FROM taggable tg
@@ -132,6 +153,13 @@ func AttachRowTags[T any](
 	rows []T, id func(T) ids.UUID, set func(*T, []RowTag),
 ) error {
 	if len(rows) == 0 {
+		return nil
+	}
+	// The vocabulary is its own grant. A caller who may read these RECORDS and
+	// not the words gets rows with no chips — the same withholding the
+	// record's own tags read performs, which a list that handed the words out
+	// anyway would make pointless.
+	if auth.Require(ctx, "tag", principal.ActionRead) != nil {
 		return nil
 	}
 	recordIDs := make([]ids.UUID, len(rows))

--- a/backend/internal/platform/database/storekit/tagfilter.go
+++ b/backend/internal/platform/database/storekit/tagfilter.go
@@ -4,9 +4,11 @@
 package storekit
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -95,4 +97,78 @@ func tagExists(taggableType, idColumn string, tagIDs []ids.UUID, arg func(any) i
 		WHERE tg.entity_type = $%d AND tg.entity_id = %s
 		  AND tg.tag_id = ANY($%d) AND t.archived_at IS NULL)`,
 		arg(taggableType), idColumn, arg(tagIDs))
+}
+
+// RowTag is one tag as a list row carries it — the word and its colour, and
+// nothing about who applied it. A page of fifty rows draws fifty chips and
+// needs no assignments to do it.
+type RowTag struct {
+	TagID ids.UUID
+	Name  string
+	Color *string
+}
+
+// rowTagCap bounds how many tags one row carries back.
+//
+// A chip strip shows a few and says "+N", so the row does not need every word
+// to draw one — and a record somebody tagged forty times would otherwise make
+// one page of fifty rows into two thousand joined rows. The count a strip
+// needs beyond the cap comes from the record's own tags read, which is the
+// screen that has room for it.
+const rowTagCap = 5
+
+// AttachRowTags loads the live tags for one page of records, in ONE query, and
+// hands each row its own.
+//
+// Batched deliberately: the obvious per-row read is N queries for a page of N,
+// which is the shape that makes a list feel slow and shows up nowhere in a
+// unit test. `taggableType` is the value taggable.entity_type stores.
+//
+// Archived tags are omitted. A retired word is not drawn on a list, and a row
+// showing one would send a reader to a picker that no longer offers it.
+func AttachRowTags[T any](
+	ctx context.Context, tx pgx.Tx, taggableType string,
+	rows []T, id func(T) ids.UUID, set func(*T, []RowTag),
+) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	recordIDs := make([]ids.UUID, len(rows))
+	for i := range rows {
+		recordIDs[i] = id(rows[i])
+	}
+	// The window is what keeps the cap per RECORD rather than per page: a
+	// plain LIMIT would hand every tag to the first row and none to the rest.
+	found, err := tx.Query(ctx, `
+		SELECT entity_id, tag_id, name, color FROM (
+			SELECT g.entity_id, t.id AS tag_id, t.name, t.color,
+			       row_number() OVER (PARTITION BY g.entity_id ORDER BY t.name, t.id) AS rank
+			  FROM taggable g
+			  JOIN tag t ON t.id = g.tag_id
+			 WHERE g.entity_type = $1 AND g.entity_id = ANY($2) AND t.archived_at IS NULL
+		) ranked
+		 WHERE rank <= $3`, taggableType, recordIDs, rowTagCap)
+	if err != nil {
+		return fmt.Errorf("storekit: reading row tags for %s: %w", taggableType, err)
+	}
+	defer found.Close()
+
+	byRecord := make(map[ids.UUID][]RowTag, len(rows))
+	for found.Next() {
+		var recordID ids.UUID
+		var tag RowTag
+		if err := found.Scan(&recordID, &tag.TagID, &tag.Name, &tag.Color); err != nil {
+			return fmt.Errorf("storekit: scanning a row tag: %w", err)
+		}
+		byRecord[recordID] = append(byRecord[recordID], tag)
+	}
+	if err := found.Err(); err != nil {
+		return err
+	}
+	for i := range rows {
+		if tags := byRecord[id(rows[i])]; len(tags) > 0 {
+			set(&rows[i], tags)
+		}
+	}
+	return nil
 }

--- a/backend/internal/platform/database/storekit/tagfilter.go
+++ b/backend/internal/platform/database/storekit/tagfilter.go
@@ -51,6 +51,10 @@ func ParseTagMode(raw *string) (TagMode, error) {
 // TagFilterClause renders the predicate narrowing one entity's rows by tag,
 // or "" when no tag was named.
 //
+// `taggableType` is the value `taggable.entity_type` stores, which is neither
+// an RBAC object nor a table name even where all three read the same. The
+// column has its own closed vocabulary and this names a member of it.
+//
 // `idColumn` is how the outer query names the record's own id — "person.id",
 // "o.id" — because each list builds its own FROM and this has to attach to it.
 //
@@ -62,7 +66,7 @@ func ParseTagMode(raw *string) (TagMode, error) {
 // a filter naming it selects a slice no reader can construct or explain; and
 // after a merge releases a name, a re-coined word would otherwise drag along
 // the records carrying the older retired tag of the same spelling.
-func TagFilterClause(entityType, idColumn string, tagIDs []ids.UUID, mode TagMode, arg func(any) int) string {
+func TagFilterClause(taggableType, idColumn string, tagIDs []ids.UUID, mode TagMode, arg func(any) int) string {
 	if len(tagIDs) == 0 {
 		return ""
 	}
@@ -73,22 +77,22 @@ func TagFilterClause(entityType, idColumn string, tagIDs []ids.UUID, mode TagMod
 		// reader can check tag by tag.
 		parts := make([]string, 0, len(tagIDs))
 		for _, id := range tagIDs {
-			parts = append(parts, tagExists(entityType, idColumn, []ids.UUID{id}, arg))
+			parts = append(parts, tagExists(taggableType, idColumn, []ids.UUID{id}, arg))
 		}
 		return "(" + strings.Join(parts, " AND ") + ")"
 	case TagModeNone:
-		return "NOT " + tagExists(entityType, idColumn, tagIDs, arg)
+		return "NOT " + tagExists(taggableType, idColumn, tagIDs, arg)
 	default:
-		return tagExists(entityType, idColumn, tagIDs, arg)
+		return tagExists(taggableType, idColumn, tagIDs, arg)
 	}
 }
 
 // tagExists renders one EXISTS over the taggable link for these ids.
-func tagExists(entityType, idColumn string, tagIDs []ids.UUID, arg func(any) int) string {
+func tagExists(taggableType, idColumn string, tagIDs []ids.UUID, arg func(any) int) string {
 	return fmt.Sprintf(`EXISTS (
 		SELECT 1 FROM taggable tg
 		  JOIN tag t ON t.id = tg.tag_id
 		WHERE tg.entity_type = $%d AND tg.entity_id = %s
 		  AND tg.tag_id = ANY($%d) AND t.archived_at IS NULL)`,
-		arg(entityType), idColumn, arg(tagIDs))
+		arg(taggableType), idColumn, arg(tagIDs))
 }

--- a/backend/migrations/core/1788346200_a_tag_is_findable_by_name.down.sql
+++ b/backend/migrations/core/1788346200_a_tag_is_findable_by_name.down.sql
@@ -1,0 +1,7 @@
+-- The column is generated, so nothing is lost by dropping it: every value it
+-- held is recomputable from the name it was derived from.
+SET LOCAL lock_timeout = '3s';
+
+DROP INDEX IF EXISTS idx_tag_search;
+
+ALTER TABLE tag DROP COLUMN IF EXISTS search_tsv;

--- a/backend/migrations/core/1788346200_a_tag_is_findable_by_name.up.sql
+++ b/backend/migrations/core/1788346200_a_tag_is_findable_by_name.up.sql
@@ -1,0 +1,26 @@
+-- A tag is findable by name.
+--
+-- Search reaches a record type through a generated `search_tsv` column and a
+-- GIN index over it — that is the shape every searchable table already has, and
+-- the branch added for tags fails without it because the column does not exist.
+--
+-- Finding the WORD is the step before finding the records that carry it. A
+-- reader who cannot search the vocabulary has to know it already, which is
+-- exactly the position a shared vocabulary exists to get people out of.
+--
+-- Weighted 'A' and unaccented the way the other name columns are: a tag is one
+-- short label, so there is no body text to weigh against it, and "Kärcher" has
+-- to be found by somebody typing "Karcher".
+--
+-- Bounded: adding a generated column rewrites the table, which takes an ACCESS
+-- EXCLUSIVE lock, and the tag table is written whenever anybody coins a word.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE tag
+    ADD COLUMN search_tsv tsvector
+    GENERATED ALWAYS AS (
+        setweight(to_tsvector('simple', f_unaccent(COALESCE(name, ''))), 'A') ||
+        setweight(to_tsvector('simple', f_fold_apostrophes(COALESCE(name, ''))), 'A')
+    ) STORED;
+
+CREATE INDEX idx_tag_search ON tag USING gin (search_tsv);

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -2361,6 +2361,7 @@ public.idx_system_log_action CREATE INDEX idx_system_log_action ON public.system
 public.idx_system_log_actor CREATE INDEX idx_system_log_actor ON public.system_log USING btree (actor_id, occurred_at DESC)
 public.idx_system_log_mirror_conflict_class CREATE INDEX idx_system_log_mirror_conflict_class ON public.system_log USING btree (((detail ->> 'object_class'::text)), occurred_at DESC) WHERE (action = 'mirror.conflict'::text)
 public.idx_system_log_time CREATE INDEX idx_system_log_time ON public.system_log USING btree (occurred_at DESC)
+public.idx_tag_search CREATE INDEX idx_tag_search ON public.tag USING gin (search_tsv)
 public.idx_taggable_entity CREATE INDEX idx_taggable_entity ON public.taggable USING btree (entity_type, entity_id)
 public.idx_taggable_tag CREATE INDEX idx_taggable_tag ON public.taggable USING btree (tag_id)
 public.idx_team_membership_team CREATE INDEX idx_team_membership_team ON public.team_membership USING btree (team_id)
@@ -4429,6 +4430,7 @@ public.tag.created_at timestamp with time zone NOT NULL gen=- def=now()
 public.tag.description text gen=- def=-
 public.tag.id uuid NOT NULL gen=- def=uuidv7()
 public.tag.name text NOT NULL gen=- def=-
+public.tag.search_tsv tsvector gen=s def=(setweight(to_tsvector('simple'::regconfig, f_unaccent(COALESCE(name, ''::text))), 'A'::"char") || setweight(to_tsvector('simple'::regconfig, f_fold_apostrophes(COALESCE(name, ''::text))), 'A'::"char"))
 public.tag.tag_color_check CHECK (((color IS NULL) OR (color = ANY (ARRAY['teal'::text, 'amber'::text, 'rose'::text, 'slate'::text]))))
 public.tag.tag_pkey PRIMARY KEY (id)
 public.tag.trg_tag_updated CREATE TRIGGER trg_tag_updated BEFORE UPDATE ON public.tag FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version()

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,7 +5,7 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 61,
-    "tokens": 19258,
+    "tokens": 19280,
     "median_tool_tokens": 274,
     "mean_tool_tokens": 315
   },
@@ -20,9 +20,9 @@
         "read_brief",
         "read_record"
       ],
-      "tokens": 1666,
-      "percent_of_ceiling": 6,
-      "headroom_tokens": 15334,
+      "tokens": 1688,
+      "percent_of_ceiling": 7,
+      "headroom_tokens": 15312,
       "dangling_cross_references": [
         "annotate_brief → log_activity",
         "catch_me_up_on → prep_for_meeting",
@@ -45,9 +45,9 @@
         "review_commitments",
         "whats_slipping_this_week"
       ],
-      "tokens": 2514,
+      "tokens": 2535,
       "percent_of_ceiling": 10,
-      "headroom_tokens": 14486,
+      "headroom_tokens": 14465,
       "dangling_cross_references": [
         "at_risk_relationships → account_coverage",
         "at_risk_relationships → intro_path_to",
@@ -94,12 +94,12 @@
       "tokens": 513
     },
     {
-      "name": "query_workspace",
-      "tokens": 491
+      "name": "list_records",
+      "tokens": 501
     },
     {
-      "name": "list_records",
-      "tokens": 480
+      "name": "query_workspace",
+      "tokens": 491
     },
     {
       "name": "advance_deal",

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -5,7 +5,7 @@
   "whole_catalog_floor": 21000,
   "catalog": {
     "tools": 61,
-    "tokens": 19253,
+    "tokens": 19258,
     "median_tool_tokens": 274,
     "mean_tool_tokens": 315
   },
@@ -20,9 +20,9 @@
         "read_brief",
         "read_record"
       ],
-      "tokens": 1661,
+      "tokens": 1666,
       "percent_of_ceiling": 6,
-      "headroom_tokens": 15339,
+      "headroom_tokens": 15334,
       "dangling_cross_references": [
         "annotate_brief → log_activity",
         "catch_me_up_on → prep_for_meeting",
@@ -45,9 +45,9 @@
         "review_commitments",
         "whats_slipping_this_week"
       ],
-      "tokens": 2509,
+      "tokens": 2514,
       "percent_of_ceiling": 10,
-      "headroom_tokens": 14491,
+      "headroom_tokens": 14486,
       "dangling_cross_references": [
         "at_risk_relationships → account_coverage",
         "at_risk_relationships → intro_path_to",
@@ -99,7 +99,7 @@
     },
     {
       "name": "list_records",
-      "tokens": 475
+      "tokens": 480
     },
     {
       "name": "advance_deal",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -24,15 +24,15 @@ feature is expected to argue with.
 
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
-| `morning_brief` | 5 | 1666 | 6% | 15334 | 6 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2514 | 10% | 14486 | 15 | 8 |
-| _whole served catalog, for scale_ | 61 | 19258 | 80% | — | — | — |
+| `morning_brief` | 5 | 1688 | 7% | 15312 | 6 | 5 |
+| `overnight_at_risk_sweep` | 7 | 2535 | 10% | 14465 | 15 | 8 |
+| _whole served catalog, for scale_ | 61 | 19280 | 80% | — | — | — |
 
 ### `morning_brief`
 
 > Assemble the Morning Brief for this workspace: enumerate open deals, read the ones with recent activity, and produce a ranked list (at most 7) of deals the team can win this week. For each: why it is on the list, what changed recently, and one recommended next move — every claim grounded in a record you actually read, citing its id. A quiet day yields a short list; never pad it.
 
-Attaches 5 tools for 1666 tokens, leaving 15334 of its budget and 22334 tokens of the
+Attaches 5 tools for 1688 tokens, leaving 15312 of its budget and 22312 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `annotate_brief`
@@ -55,7 +55,7 @@ cannot call, so a run may spend a step discovering the refusal:
 
 > Sweep this workspace's open deals for risk: find deals with no activity in 14+ days, stakeholders gone quiet, or missing next steps. Log ONE note activity per at-risk deal summarizing the risk and the evidence (cite the records you read). Do not advance stages, send anything, or archive anything.
 
-Attaches 7 tools for 2514 tokens, leaving 14486 of its budget and 21486 tokens of the
+Attaches 7 tools for 2535 tokens, leaving 14465 of its budget and 21465 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `at_risk_relationships`
@@ -138,8 +138,8 @@ a term in an addition.
 | `update_record` | 603 | 4 scenarios |
 | `send_account_email` | 545 | — |
 | `resolve_entities` | 513 | — |
+| `list_records` | 501 | — |
 | `query_workspace` | 491 | 3 scenarios |
-| `list_records` | 480 | — |
 | `advance_deal` | 474 | 1 scenario |
 | `send_email` | 471 | 1 scenario |
 | `annotate_brief` | 456 | — |

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -24,15 +24,15 @@ feature is expected to argue with.
 
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
-| `morning_brief` | 5 | 1661 | 6% | 15339 | 6 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2509 | 10% | 14491 | 15 | 8 |
-| _whole served catalog, for scale_ | 61 | 19253 | 80% | — | — | — |
+| `morning_brief` | 5 | 1666 | 6% | 15334 | 6 | 5 |
+| `overnight_at_risk_sweep` | 7 | 2514 | 10% | 14486 | 15 | 8 |
+| _whole served catalog, for scale_ | 61 | 19258 | 80% | — | — | — |
 
 ### `morning_brief`
 
 > Assemble the Morning Brief for this workspace: enumerate open deals, read the ones with recent activity, and produce a ranked list (at most 7) of deals the team can win this week. For each: why it is on the list, what changed recently, and one recommended next move — every claim grounded in a record you actually read, citing its id. A quiet day yields a short list; never pad it.
 
-Attaches 5 tools for 1661 tokens, leaving 15339 of its budget and 22339 tokens of the
+Attaches 5 tools for 1666 tokens, leaving 15334 of its budget and 22334 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `annotate_brief`
@@ -55,7 +55,7 @@ cannot call, so a run may spend a step discovering the refusal:
 
 > Sweep this workspace's open deals for risk: find deals with no activity in 14+ days, stakeholders gone quiet, or missing next steps. Log ONE note activity per at-risk deal summarizing the risk and the evidence (cite the records you read). Do not advance stages, send anything, or archive anything.
 
-Attaches 7 tools for 2509 tokens, leaving 14491 of its budget and 21491 tokens of the
+Attaches 7 tools for 2514 tokens, leaving 14486 of its budget and 21486 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `at_risk_relationships`
@@ -139,7 +139,7 @@ a term in an addition.
 | `send_account_email` | 545 | — |
 | `resolve_entities` | 513 | — |
 | `query_workspace` | 491 | 3 scenarios |
-| `list_records` | 475 | — |
+| `list_records` | 480 | — |
 | `advance_deal` | 474 | 1 scenario |
 | `send_email` | 471 | 1 scenario |
 | `annotate_brief` | 456 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 61,
     "resources": 9,
-    "tool_catalog_bytes": 177739,
+    "tool_catalog_bytes": 177825,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 45313,
+    "approx_wire_tokens_total": 45334,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 41211,
-      "input_schema_bytes": 37806,
+      "input_schema_bytes": 37892,
       "output_schema_bytes": 85535,
-      "description_plus_input_schema_bytes": 79017
+      "description_plus_input_schema_bytes": 79103
     }
   },
   "tools": {
@@ -4620,7 +4620,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag_mode (any|all|none) organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other) deal — organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
+              "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag_id (a), tag_mode (any|all|none) organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other), tag_id (a), tag_mode (any|all|none) deal — organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost), tag_id (a), tag_mode (any|all|none) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
               "type": "object"
             },
             "limit": {

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 61,
     "resources": 9,
-    "tool_catalog_bytes": 177719,
+    "tool_catalog_bytes": 177739,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 45308,
+    "approx_wire_tokens_total": 45313,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 41211,
-      "input_schema_bytes": 37786,
+      "input_schema_bytes": 37806,
       "output_schema_bytes": 85535,
-      "description_plus_input_schema_bytes": 78997
+      "description_plus_input_schema_bytes": 79017
     }
   },
   "tools": {
@@ -4620,7 +4620,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other) deal — organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
+              "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag_mode (any|all|none) organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other) deal — organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
               "type": "object"
             },
             "limit": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 61 |
 | Resources | 9 |
-| Tool catalog | 173.6 KB |
+| Tool catalog | 173.7 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 45313 |
+| Approx. wire tokens | 45334 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -31,7 +31,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 |---|---:|---:|---|
 | Output schemas | 83.5 KB | 48% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 40.2 KB | 23% | Yes, every step |
-| Input schemas | 36.9 KB | 21% | Yes, every step |
+| Input schemas | 37.0 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.9 KB | 7% | Partly |
 | **Description + input schema** | **77.2 KB** | **44%** | **the recurring cost** |
 
@@ -89,7 +89,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`list_channel_providers`](#list_channel_providers) | List messaging transports | yes |  | 2.0 KB |
 | [`list_colleagues`](#list_colleagues) | List colleagues | yes |  | 1.9 KB |
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
-| [`list_records`](#list_records) | List records | yes |  | 3.1 KB |
+| [`list_records`](#list_records) | List records | yes |  | 3.2 KB |
 | [`list_tags`](#list_tags) | List tags | yes |  | 1.6 KB |
 | [`log_activity`](#log_activity) | Log an activity |  |  | 3.8 KB |
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
@@ -5177,7 +5177,7 @@ Enumerate the people, organizations, deals, leads or projects that meet exact co
       "additionalProperties": {
         "type": "string"
       },
-      "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag_mode (any|all|none) organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other) deal — organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
+      "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag_id (a), tag_mode (any|all|none) organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other), tag_id (a), tag_mode (any|all|none) deal — organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost), tag_id (a), tag_mode (any|all|none) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
       "type": "object"
     },
     "limit": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -15,7 +15,7 @@ receives it. This page is rendered from that file.
 | Resources | 9 |
 | Tool catalog | 173.6 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 45308 |
+| Approx. wire tokens | 45313 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -33,7 +33,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 | Descriptions (incl. governance clause) | 40.2 KB | 23% | Yes, every step |
 | Input schemas | 36.9 KB | 21% | Yes, every step |
 | _Names, annotations, punctuation_ | 12.9 KB | 7% | Partly |
-| **Description + input schema** | **77.1 KB** | **44%** | **the recurring cost** |
+| **Description + input schema** | **77.2 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -5177,7 +5177,7 @@ Enumerate the people, organizations, deals, leads or projects that meet exact co
       "additionalProperties": {
         "type": "string"
       },
-      "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other) deal — organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
+      "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag_mode (any|all|none) organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other) deal — organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
       "type": "object"
     },
     "limit": {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -15225,6 +15225,7 @@ export interface components {
         };
         /** @description A contact. Mirrors the `person` table. */
         Person: {
+            tags?: components["schemas"]["RowTag"][];
             /** Format: uuid */
             id: string;
             first_name?: string | null;
@@ -15460,6 +15461,7 @@ export interface components {
         };
         /** @description A company. Mirrors the `organization` table. */
         Organization: {
+            tags?: components["schemas"]["RowTag"][];
             /** @description Canonical LinkedIn company URL (PO-DDL-N-2, ADR-0085). A validated column rather than a governed custom field, because it bears identity semantics — matching, dedupe, enrichment — a custom field cannot express. Unique among live rows. */
             linkedin_url?: string | null;
             /** @description The company's readable website, DERIVED from its primary domain row. There is deliberately no website column — a second store for a fact organization_domain already owns is the duplication ADR-0085 closes. Not accepted on write. */
@@ -18639,6 +18641,7 @@ export interface components {
         };
         /** @description A deal. Mirrors the `deal` table. */
         Deal: {
+            tags?: components["schemas"]["RowTag"][];
             /** Format: uuid */
             id: string;
             name: string;
@@ -21431,6 +21434,18 @@ export interface components {
             /** @enum {string|null} */
             color?: "teal" | "amber" | "rose" | "slate" | null;
             description?: string | null;
+        };
+        /**
+         * @description A tag as a list ROW carries it: the word and its colour, nothing else. The full
+         *     assignment — who applied it, when — comes from the record's own tags read, because a
+         *     page of fifty rows does not need fifty assignments to draw a chip.
+         */
+        RowTag: {
+            /** Format: uuid */
+            tag_id: string;
+            name: string;
+            /** @enum {string|null} */
+            color?: "teal" | "amber" | "rose" | "slate" | null;
         };
         /**
          * @description What one record carries. `withheld` says the caller could not read the vocabulary,

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -27552,21 +27552,6 @@ export interface components {
          *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
          */
         Sort: string;
-        /**
-         * @description Narrow to the records carrying these tags. Repeat the parameter for several.
-         *
-         *     By ID, not by name: a name is what a person types and an admin can rename, so a saved
-         *     view holding one would silently start selecting a different slice the day somebody
-         *     corrects a spelling.
-         */
-        TagIDs: string[];
-        /**
-         * @description How several `tag_id` values combine. `any` selects a record carrying at least one of
-         *     them, `all` a record carrying every one, `none` a record carrying not one.
-         *
-         *     Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
-         */
-        TagMode: "any" | "all" | "none";
         /** @description Include soft-deleted (archived) rows. Default false. */
         IncludeArchived: boolean;
         /**
@@ -28280,18 +28265,18 @@ export interface operations {
                 /**
                  * @description Narrow to the records carrying these tags. Repeat the parameter for several.
                  *
-                 *     By ID, not by name: a name is what a person types and an admin can rename, so a saved
-                 *     view holding one would silently start selecting a different slice the day somebody
-                 *     corrects a spelling.
+                 *     By ID, not by name: a name is what a person types and an admin can rename, so a
+                 *     saved view holding one would silently start selecting a different slice the day
+                 *     somebody corrects a spelling.
                  */
-                tag_id?: components["parameters"]["TagIDs"];
+                tag_id?: string[];
                 /**
-                 * @description How several `tag_id` values combine. `any` selects a record carrying at least one of
-                 *     them, `all` a record carrying every one, `none` a record carrying not one.
+                 * @description How several `tag_id` values combine. `any` selects a record carrying at least one
+                 *     of them, `all` a record carrying every one, `none` a record carrying not one.
                  *
                  *     Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
                  */
-                tag_mode?: components["parameters"]["TagMode"];
+                tag_mode?: "any" | "all" | "none";
                 /**
                  * @description People who work at this account, by their CURRENT PRIMARY employment edge
                  *     (`relationship` kind `employment`, DM-VOCAB-1). A past employer does not match:
@@ -29713,18 +29698,18 @@ export interface operations {
                 /**
                  * @description Narrow to the records carrying these tags. Repeat the parameter for several.
                  *
-                 *     By ID, not by name: a name is what a person types and an admin can rename, so a saved
-                 *     view holding one would silently start selecting a different slice the day somebody
-                 *     corrects a spelling.
+                 *     By ID, not by name: a name is what a person types and an admin can rename, so a
+                 *     saved view holding one would silently start selecting a different slice the day
+                 *     somebody corrects a spelling.
                  */
-                tag_id?: components["parameters"]["TagIDs"];
+                tag_id?: string[];
                 /**
-                 * @description How several `tag_id` values combine. `any` selects a record carrying at least one of
-                 *     them, `all` a record carrying every one, `none` a record carrying not one.
+                 * @description How several `tag_id` values combine. `any` selects a record carrying at least one
+                 *     of them, `all` a record carrying every one, `none` a record carrying not one.
                  *
                  *     Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
                  */
-                tag_mode?: components["parameters"]["TagMode"];
+                tag_mode?: "any" | "all" | "none";
             };
             header?: never;
             path?: never;
@@ -31325,18 +31310,18 @@ export interface operations {
                 /**
                  * @description Narrow to the records carrying these tags. Repeat the parameter for several.
                  *
-                 *     By ID, not by name: a name is what a person types and an admin can rename, so a saved
-                 *     view holding one would silently start selecting a different slice the day somebody
-                 *     corrects a spelling.
+                 *     By ID, not by name: a name is what a person types and an admin can rename, so a
+                 *     saved view holding one would silently start selecting a different slice the day
+                 *     somebody corrects a spelling.
                  */
-                tag_id?: components["parameters"]["TagIDs"];
+                tag_id?: string[];
                 /**
-                 * @description How several `tag_id` values combine. `any` selects a record carrying at least one of
-                 *     them, `all` a record carrying every one, `none` a record carrying not one.
+                 * @description How several `tag_id` values combine. `any` selects a record carrying at least one
+                 *     of them, `all` a record carrying every one, `none` a record carrying not one.
                  *
                  *     Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
                  */
-                tag_mode?: components["parameters"]["TagMode"];
+                tag_mode?: "any" | "all" | "none";
             };
             header?: never;
             path?: never;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -27552,6 +27552,21 @@ export interface components {
          *     an out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
          */
         Sort: string;
+        /**
+         * @description Narrow to the records carrying these tags. Repeat the parameter for several.
+         *
+         *     By ID, not by name: a name is what a person types and an admin can rename, so a saved
+         *     view holding one would silently start selecting a different slice the day somebody
+         *     corrects a spelling.
+         */
+        TagIDs: string[];
+        /**
+         * @description How several `tag_id` values combine. `any` selects a record carrying at least one of
+         *     them, `all` a record carrying every one, `none` a record carrying not one.
+         *
+         *     Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
+         */
+        TagMode: "any" | "all" | "none";
         /** @description Include soft-deleted (archived) rows. Default false. */
         IncludeArchived: boolean;
         /**
@@ -28262,8 +28277,21 @@ export interface operations {
                 unassigned?: boolean;
                 /** @description Full-text query over name/title (tsvector). */
                 q?: string;
-                /** @description Filter by tag name. */
-                tag?: string;
+                /**
+                 * @description Narrow to the records carrying these tags. Repeat the parameter for several.
+                 *
+                 *     By ID, not by name: a name is what a person types and an admin can rename, so a saved
+                 *     view holding one would silently start selecting a different slice the day somebody
+                 *     corrects a spelling.
+                 */
+                tag_id?: components["parameters"]["TagIDs"];
+                /**
+                 * @description How several `tag_id` values combine. `any` selects a record carrying at least one of
+                 *     them, `all` a record carrying every one, `none` a record carrying not one.
+                 *
+                 *     Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
+                 */
+                tag_mode?: components["parameters"]["TagMode"];
                 /**
                  * @description People who work at this account, by their CURRENT PRIMARY employment edge
                  *     (`relationship` kind `employment`, DM-VOCAB-1). A past employer does not match:
@@ -29682,6 +29710,21 @@ export interface operations {
                 /** @description How many people work there (DM-VOCAB-2). */
                 size_band?: "1-10" | "11-50" | "51-200" | "201-500" | "501-1000" | "1001-5000" | "5000+";
                 q?: string;
+                /**
+                 * @description Narrow to the records carrying these tags. Repeat the parameter for several.
+                 *
+                 *     By ID, not by name: a name is what a person types and an admin can rename, so a saved
+                 *     view holding one would silently start selecting a different slice the day somebody
+                 *     corrects a spelling.
+                 */
+                tag_id?: components["parameters"]["TagIDs"];
+                /**
+                 * @description How several `tag_id` values combine. `any` selects a record carrying at least one of
+                 *     them, `all` a record carrying every one, `none` a record carrying not one.
+                 *
+                 *     Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
+                 */
+                tag_mode?: components["parameters"]["TagMode"];
             };
             header?: never;
             path?: never;
@@ -31279,6 +31322,21 @@ export interface operations {
                 partner_sourced?: boolean;
                 /** @description Deals a partner brought (`sourced`) or merely helped (`influenced`). */
                 partner_attribution?: "sourced" | "influenced";
+                /**
+                 * @description Narrow to the records carrying these tags. Repeat the parameter for several.
+                 *
+                 *     By ID, not by name: a name is what a person types and an admin can rename, so a saved
+                 *     view holding one would silently start selecting a different slice the day somebody
+                 *     corrects a spelling.
+                 */
+                tag_id?: components["parameters"]["TagIDs"];
+                /**
+                 * @description How several `tag_id` values combine. `any` selects a record carrying at least one of
+                 *     them, `all` a record carrying every one, `none` a record carrying not one.
+                 *
+                 *     Ignored when no `tag_id` is given — a mode with nothing to combine is not a filter.
+                 */
+                tag_mode?: components["parameters"]["TagMode"];
             };
             header?: never;
             path?: never;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22476,7 +22476,7 @@ export interface components {
         };
         SearchResult: {
             /** @enum {string} */
-            type: "person" | "organization" | "deal" | "activity" | "lead" | "project";
+            type: "person" | "organization" | "deal" | "activity" | "lead" | "project" | "tag";
             /** Format: uuid */
             id: string;
             /** @description Display label (name/subject). */
@@ -36822,7 +36822,7 @@ export interface operations {
                 /** @description The search query. */
                 q: string;
                 /** @description Restrict to these object types (default all). */
-                types?: ("person" | "organization" | "deal" | "activity" | "lead" | "project")[];
+                types?: ("person" | "organization" | "deal" | "activity" | "lead" | "project" | "tag")[];
                 /**
                  * @description Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
                  *     effective `sort` of the originating request (field + direction) plus the last row's keyset

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -219,6 +219,7 @@ export const de = {
   "search.group.deal": "Deals",
   "search.group.activity": "Aktivitäten",
   "search.group.lead": "Leads",
+  "search.group.tag": "Tags",
   "search.tier.mirrored": "aus einem verbundenen System",
   "search.tier.unverified": "nicht verifiziert",
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -239,6 +239,7 @@ export const en = {
   "search.group.deal": "Deals",
   "search.group.activity": "Activities",
   "search.group.lead": "Leads",
+  "search.group.tag": "Tags",
   "search.tier.mirrored": "from a connected system",
   "search.tier.unverified": "unverified",
 

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -224,6 +224,7 @@ export const vi = {
   "search.group.deal": "Deal",
   "search.group.activity": "Hoạt động",
   "search.group.lead": "Lead",
+  "search.group.tag": "Tag",
   "search.tier.mirrored": "từ hệ thống đã kết nối",
   "search.tier.unverified": "chưa xác minh",
 

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -121,7 +121,10 @@ function useSearchTargets() {
       if (error) throwProblem(error);
       const out: RecordPickerCandidate[] = [];
       for (const result of data.data) {
-        if (result.type === "activity") continue;
+        // Neither is a record this can be filed against: an activity is the
+        // message itself, and a tag is a word rather than something a message
+        // can be about.
+        if (result.type === "activity" || result.type === "tag") continue;
         kindById.current.set(result.id, result.type);
         out.push({ id: result.id, name: result.title ?? result.id });
       }

--- a/frontend/src/screens/search.tsx
+++ b/frontend/src/screens/search.tsx
@@ -25,6 +25,10 @@ const GROUP_ORDER = [
   "deal",
   "activity",
   "lead",
+  // Last: a tag is a WORD, and somebody searching a name is usually after the
+  // records rather than the label. It sits below them and is how they get to
+  // the rest of the slice.
+  "tag",
 ] as const;
 const GROUP_KEY: Record<string, MessageKey> = {
   person: "search.group.person",
@@ -32,6 +36,7 @@ const GROUP_KEY: Record<string, MessageKey> = {
   deal: "search.group.deal",
   activity: "search.group.activity",
   lead: "search.group.lead",
+  tag: "search.group.tag",
 };
 // Only these hit types have a 360 to route to (the app-wide ENTITY registry).
 // `activity` is a valid SearchResult type but has no record route, so it


### PR DESCRIPTION
Three pieces, each useless without the others: filter by tag, see the tags on a row, and find a tag by name.

## Filtering

`tag_id` (repeatable) and `tag_mode` (any / all / none) on people, companies and deals. Only "any" existed before, only on people, and only by tag NAME — a saved view holding a name would silently start selecting a different slice the day an admin corrected a spelling, so the wire takes ids.

The predicate is written once in storekit and called from three places. Three copies is three chances for one mode to drift, and the one that drifts first is `none` — nobody notices it is wrong until a rep is looking at a record they filtered out. Mutation-checked by negating inside the subquery instead of around the EXISTS, which two tests catch.

## Rows

Each row in those three lists carries a small tag summary, so a table can draw a chip. Shipping the filter alone would have hidden tags on exactly the screens where they explain why a row is in the list.

One batched query per page, not one per row. A window function keeps the cap per record — a plain LIMIT would hand every tag to the first row and none to the rest.

## Search

A tag branch, plus a migration adding the generated search column and GIN index every searchable table has. Finding the WORD is the step before finding the records that carry it.

A tag is not a record, and that mattered in eight places: the branch list also feeds a structured query planner, a graph walk, an embedding search, a published vocabulary, an anchor list and two gates. The branch is marked text-only and each of those skips it — a word has no fields to plan over, no neighbours to walk, and no prose to embed.

## What review caught

**A blocker.** List rows handed out tag ids, names and colours with no permission check, while the record's own tags read withholds them from a caller who may not read the vocabulary. A list giving away the same words makes that withholding pointless. Both the row summary and the filter now ask for `tag.read`, and the filter refuses by selecting nothing rather than by rendering no predicate — an unrendered clause WIDENS the answer.

**The filters were still unreachable by agents** after I thought I had fixed that. Inlining the parameters fixed what the contract publishes; the saved-view binding still keyed on `tag` while the contract said `tag_id`, so the intersection was empty, and organizations and deals bound neither.

**Search results reached a screen with no group for them**, so tag hits rendered into an empty container.

**One finding I did not act on.** An archived tag id behaves differently per mode: `any` and `all` narrow to nothing, `none` keeps everything. Both follow from one rule — a retired word is not part of the vocabulary a filter can name — and honouring it instead would let a saved view keep selecting by a word an admin retired precisely to stop that. The rule is now stated where it acts.

## Checks

`make check` green after rebase. Integration lanes green. `make craft-static` clean, RLS and jurisdiction gates pass. Two frontend suites failed and passed unchanged on rerun, in routing and onboarding — neither touches tags.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tags become a way to find records: people, companies and deals now filter by tag in any/all/none modes, each list row carries a tag summary, and search finds tags by name.

**Filtering and row tags**
- The person list's old `tag` name parameter is replaced by repeatable `tag_id` plus `tag_mode` on all three list surfaces.
- Row summaries are fetched in one batched query per page, capped per record.
- Both the filter and row summaries require `tag.read`; an unauthorized filter selects nothing rather than widening.

**Search and agents**
- Tags get a generated search column and GIN index, searchable by name.
- The tag branch is text-only, so structured planning, graph walks, and embedding search skip it.
- The agent tool schema publishes the new filters; saved-view bindings use tag ids.

<sup>Written for commit 4715ba84594ed3cb52decace558449f9f85c0226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter people, organizations, and deals by one or more tag IDs using “any,” “all,” or “none” matching.
  * View live tags, including names, IDs, and optional colors, on record list results.
  * Search for tags by name, with archived tags excluded from results.
  * Tag results are now grouped and labeled in supported languages.

* **Bug Fixes**
  * Unsupported tag filters now return clear validation errors instead of being silently ignored.
  * Text-only search entries no longer appear as context anchors or relinking targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->