### PR TITLE
The harness's admin can see the words a rep can see

### DIFF
--- a/backend/internal/compose/integration/capture/capture_tiergate_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_tiergate_integration_test.go
@@ -377,9 +377,19 @@ func TestCaptureTierGateHonorsCorrespondenceFromACRMOriginatedSend(t *testing.T)
 		WHERE pe.email = 'team@news.prospect.example'`); n != 1 {
 		t.Fatalf("%d persons for a sender the CRM had written to, want 1 — a CRM send must count as correspondence", n)
 	}
+	// A ledger row here is expected, and it is not a deferral. #3719 made both
+	// create tiers open the same question the deferred tier opens, because a
+	// sender created on sight and never judged stayed the mailbox owner's
+	// permanently. T1 still decides STORAGE — the person above exists, which is
+	// what "nothing defers" was ever about. What the row asks is whose record it
+	// is, and `advisor` is a legitimate answer that keeps it private, so the
+	// question cannot be skipped for a corresponded-with sender either.
 	if n := countRows(t, e, `
-		SELECT count(*) FROM capture_pending_counterparty WHERE email = 'team@news.prospect.example'`); n != 0 {
-		t.Fatalf("%d ledger rows for a corresponded-with sender, want 0 — T1 decides, nothing defers", n)
+		SELECT count(*) FROM capture_pending_counterparty
+		WHERE email = 'team@news.prospect.example'
+		  AND status = 'pending' AND resolved_at IS NULL`); n != 1 {
+		t.Fatalf("%d open visibility questions for a corresponded-with sender, want 1 — "+
+			"T1 creates the record on sight and still asks whose it is", n)
 	}
 }
 

--- a/backend/internal/compose/integration/harnessperms.go
+++ b/backend/internal/compose/integration/harnessperms.go
@@ -199,6 +199,15 @@ var (
 			objInstallSettings: {Read: true, Update: true},
 			"project":          {Create: true, Read: true, Update: true, Delete: true},
 			objRelationship:    {Create: true, Read: true, Update: true, Delete: true},
+			// tag and list are crud for admin in the real seed
+			// (identity/internal/policy's admin row), and this fixture had
+			// neither. That drift was not inert: the tag FILTER refuses a
+			// caller without tag.read by rendering FALSE rather than by
+			// erroring, so an admin missing the grant asked "who carries
+			// VIP" and was answered "nobody" — and this fixture was
+			// narrower than AccountRepPerms, which already carries both.
+			"tag":  {Create: true, Read: true, Update: true, Delete: true},
+			"list": {Create: true, Read: true, Update: true, Delete: true},
 		},
 		RowScope: principal.RowScopeAll,
 	}

--- a/backend/internal/compose/integration/harnesspermsparity_integration_test.go
+++ b/backend/internal/compose/integration/harnesspermsparity_integration_test.go
@@ -136,13 +136,54 @@ func declaredSeatFixtures(t *testing.T) []string {
 			if !ok {
 				continue
 			}
+			if !mayBeASeatFixture(value) {
+				continue
+			}
 			for _, name := range value.Names {
+				// The blank identifier names nothing a suite can act
+				// through, so it is not a fixture whatever it is assigned.
+				if name.Name == "_" {
+					continue
+				}
 				names = append(names, name.Name)
 			}
 		}
 	}
 	sort.Strings(names)
 	return names
+}
+
+// mayBeASeatFixture reports whether a var declaration in harnessperms.go could
+// be a seat fixture, which is not the same question as whether it IS one.
+//
+// It answers by EXCLUSION — a composite literal of some other type is not a
+// fixture, so a shared ObjectGrant parked in this file does not have to be
+// registered — and everything else has to be. That asymmetry is the point.
+// AdminWithSignals is `withFullSignalGrant(AdminPerms)`, a call and not a
+// literal, and admitting only literals would have exempted the one fixture in
+// the file that is assembled rather than written out. Deciding this properly
+// needs the type checker, and the package does not depend on one; excluding
+// what is provably not a fixture is what can be done without it, and it errs
+// toward demanding registration rather than toward granting exemption.
+func mayBeASeatFixture(spec *ast.ValueSpec) bool {
+	if spec.Type != nil {
+		return isPermissionsType(spec.Type)
+	}
+	for _, value := range spec.Values {
+		if literal, ok := value.(*ast.CompositeLit); ok && !isPermissionsType(literal.Type) {
+			return false
+		}
+	}
+	return true
+}
+
+func isPermissionsType(expr ast.Expr) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && pkg.Name == "principal" && selector.Sel.Name == "Permissions"
 }
 
 // seatRole is the seeded role a fixture stands in for. A fixture naming none

--- a/backend/internal/compose/integration/harnesspermsparity_integration_test.go
+++ b/backend/internal/compose/integration/harnesspermsparity_integration_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The harness's admin is the seat a suite acts through when the seat is not
+// what it is testing, and one narrower than production's admin does not fail —
+// it answers.
+//
+// AdminPerms carried no `tag` grant while AccountRepPerms, a REP fixture,
+// carried tag.read. Nothing erred: the tag filter refuses a caller without
+// tag.read by rendering FALSE (storekit.TagFilterClause — an error would tell
+// an outsider that the tag exists), so the admin asked "who carries VIP" and
+// was told "nobody", and the suite read that as the store's answer.
+//
+// So the claim here is the one harnessperms.go already makes in prose — "the
+// harness's admin stands in for every seat in most suites" — and the check is
+// its contrapositive: no fixture for a seat the SEED grants strictly less than
+// admin may hold a grant AdminPerms lacks. Seats, not fixtures. A fixture is
+// often narrower than its own seat on purpose, and several here say so where
+// they are declared; what cannot happen is the widest stand-in being narrower
+// than something it stands in for.
+//
+// It compares against migrations/testdata/rbac_seeded_defaults.json, which is
+// policy's own value: policy sits behind identity/internal/, and
+// identity/rbacfixture_test.go lives inside that fence and pins the file to
+// policy.MustDefaultJSON on every unit pass.
+//
+// WHAT IT DOES NOT REACH: a seat the seed grants exactly what it grants admin.
+// ops holds the admin grid, so OpsPerms is never compared, and neither is
+// AdminWithSignals — an admin fixture carrying a signal grant AdminPerms
+// lacks. That narrowing is deliberate and documented where it is declared, but
+// this gate is not what keeps it so; nothing is.
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// harnessPermsFile is the file whose fixtures this gate governs. The census
+// below reads it rather than trusting the map: a fixture added to it and not
+// registered here would otherwise be exempt by omission.
+const harnessPermsFile = "harnessperms.go"
+
+// adminFixture is the fixture the harness reaches for when a suite wants a
+// seat that is not what it is testing. harnessperms.go says so where it grants
+// weekly_plan: "the harness's admin stands in for every seat in most suites".
+const adminFixture = "AdminPerms"
+
+// harnessSeatFixtures is every permission fixture harnessperms.go declares, by
+// name.
+//
+// Held by: TestEverySeatFixtureIsRegisteredWithTheParityGate
+// (backend/internal/compose/integration/harnesspermsparity_integration_test.go)
+var harnessSeatFixtures = map[string]principal.Permissions{
+	"RepPerms":         RepPerms,
+	"ContractRepPerms": ContractRepPerms,
+	"AccountRepPerms":  AccountRepPerms,
+	"ReadOnlyPerms":    ReadOnlyPerms,
+	"OpsPerms":         OpsPerms,
+	"AdminWithSignals": AdminWithSignals,
+	"AdminPerms":       AdminPerms,
+}
+
+func TestEverySeatFixtureIsRegisteredWithTheParityGate(t *testing.T) {
+	declared := declaredSeatFixtures(t)
+	for _, name := range declared {
+		if _, ok := harnessSeatFixtures[name]; !ok {
+			t.Errorf("harnessperms.go declares %s, which harnessSeatFixtures does not name — "+
+				"an unregistered fixture is exempt from the parity gate by omission", name)
+		}
+	}
+	for name := range harnessSeatFixtures {
+		if !slices.Contains(declared, name) {
+			t.Errorf("harnessSeatFixtures names %s, which harnessperms.go no longer declares", name)
+		}
+	}
+}
+
+func TestTheAdminFixtureHoldsEveryGrantANarrowerSeatFixtureDoes(t *testing.T) {
+	seed := seededRoleGrants(t)
+	names := make([]string, 0, len(harnessSeatFixtures))
+	for name := range harnessSeatFixtures {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		role := seatRole(t, name)
+		// STRICTLY narrower only. A fixture may be narrower than its own
+		// seat on purpose — several here are, and say so where they are
+		// declared — so this compares seats, not fixtures. ops holds the
+		// admin grid and is therefore not narrower; nor is AdminWithSignals,
+		// which is this fixture plus a delta.
+		if !strictlyWider(seed, seatRole(t, adminFixture), role) {
+			continue
+		}
+		for object, grant := range harnessSeatFixtures[name].Objects {
+			for _, verb := range grantDiff(grant, AdminPerms.Objects[object]) {
+				t.Errorf("%s (%s) holds %s.%s and %s does not, though the seed grants "+
+					"admin strictly more than %s — a surface production admits to both "+
+					"answers the admin as though it were refused",
+					name, role, object, verb, adminFixture, role)
+			}
+		}
+	}
+}
+
+// declaredSeatFixtures reads the package-level var names out of
+// harnessperms.go. It parses rather than greps because a fixture is declared
+// inside a var block, where a name is a token and not a line.
+func declaredSeatFixtures(t *testing.T) []string {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), harnessPermsFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", harnessPermsFile, err)
+	}
+	var names []string
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, name := range value.Names {
+				names = append(names, name.Name)
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// seatRole is the seeded role a fixture stands in for. A fixture naming none
+// cannot be placed against the seed at all, so it fails rather than passing
+// unexamined.
+func seatRole(t *testing.T, fixture string) string {
+	t.Helper()
+	keys := harnessSeatFixtures[fixture].RoleKeys
+	if len(keys) != 1 {
+		t.Fatalf("%s names %d role keys, want exactly one — the gate places a fixture "+
+			"against one seeded role", fixture, len(keys))
+	}
+	return keys[0]
+}
+
+// seededRoleGrants is the matrix identity seeds, as role → object → verb.
+func seededRoleGrants(t *testing.T) map[string]map[string]principal.ObjectGrant {
+	t.Helper()
+	raw, err := os.ReadFile(seededDefaults)
+	if err != nil {
+		t.Fatalf("reading the seeded defaults: %v", err)
+	}
+	var documents map[string]struct {
+		Objects map[string]principal.ObjectGrant `json:"objects"`
+	}
+	if err := json.Unmarshal(raw, &documents); err != nil {
+		t.Fatalf("decoding the seeded defaults: %v", err)
+	}
+	out := make(map[string]map[string]principal.ObjectGrant, len(documents))
+	for role, doc := range documents {
+		out[role] = doc.Objects
+	}
+	return out
+}
+
+// strictlyWider reports whether the seed grants `wide` everything it grants
+// `narrow`, and something more.
+func strictlyWider(seed map[string]map[string]principal.ObjectGrant, wide, narrow string) bool {
+	wideGrants, ok := seed[wide]
+	if !ok {
+		return false
+	}
+	narrowGrants, ok := seed[narrow]
+	if !ok {
+		return false
+	}
+	for object, grant := range narrowGrants {
+		if len(grantDiff(grant, wideGrants[object])) > 0 {
+			return false
+		}
+	}
+	for object, grant := range wideGrants {
+		if len(grantDiff(grant, narrowGrants[object])) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// grantDiff names the verbs `held` grants that `against` does not.
+func grantDiff(held, against principal.ObjectGrant) []string {
+	var missing []string
+	for _, verb := range []struct {
+		name      string
+		held, has bool
+	}{
+		{"create", held.Create, against.Create},
+		{"read", held.Read, against.Read},
+		{"update", held.Update, against.Update},
+		{"delete", held.Delete, against.Delete},
+	} {
+		if verb.held && !verb.has {
+			missing = append(missing, verb.name)
+		}
+	}
+	return missing
+}

--- a/backend/internal/compose/integration/harnesspermsparity_integration_test.go
+++ b/backend/internal/compose/integration/harnesspermsparity_integration_test.go
@@ -42,6 +42,7 @@ import (
 	"os"
 	"slices"
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -125,6 +126,7 @@ func declaredSeatFixtures(t *testing.T) []string {
 	if err != nil {
 		t.Fatalf("parsing %s: %v", harnessPermsFile, err)
 	}
+	pkg := principalIdent(t, file)
 	var names []string
 	for _, decl := range file.Decls {
 		gen, ok := decl.(*ast.GenDecl)
@@ -136,13 +138,10 @@ func declaredSeatFixtures(t *testing.T) []string {
 			if !ok {
 				continue
 			}
-			if !mayBeASeatFixture(value) {
-				continue
-			}
-			for _, name := range value.Names {
+			for i, name := range value.Names {
 				// The blank identifier names nothing a suite can act
 				// through, so it is not a fixture whatever it is assigned.
-				if name.Name == "_" {
+				if name.Name == "_" || !mayBeASeatFixture(value, i, pkg) {
 					continue
 				}
 				names = append(names, name.Name)
@@ -153,8 +152,8 @@ func declaredSeatFixtures(t *testing.T) []string {
 	return names
 }
 
-// mayBeASeatFixture reports whether a var declaration in harnessperms.go could
-// be a seat fixture, which is not the same question as whether it IS one.
+// mayBeASeatFixture reports whether one NAME in a var declaration could be a
+// seat fixture, which is not the same question as whether it IS one.
 //
 // It answers by EXCLUSION — a composite literal of some other type is not a
 // fixture, so a shared ObjectGrant parked in this file does not have to be
@@ -163,27 +162,67 @@ func declaredSeatFixtures(t *testing.T) []string {
 // literal, and admitting only literals would have exempted the one fixture in
 // the file that is assembled rather than written out. Deciding this properly
 // needs the type checker, and the package does not depend on one; excluding
-// what is provably not a fixture is what can be done without it, and it errs
-// toward demanding registration rather than toward granting exemption.
-func mayBeASeatFixture(spec *ast.ValueSpec) bool {
+// what is provably not a fixture is what can be done without it, and every
+// judgement below errs toward demanding registration.
+//
+// PER NAME, not per declaration: `var A, B = principal.Permissions{…},
+// principal.ObjectGrant{…}` declares one fixture and one thing that is not,
+// and excluding the whole spec would drop A silently — an exemption by
+// omission, which is what this census exists to refuse.
+func mayBeASeatFixture(spec *ast.ValueSpec, index int, principalPkg string) bool {
 	if spec.Type != nil {
-		return isPermissionsType(spec.Type)
+		return isPermissionsType(spec.Type, principalPkg)
 	}
-	for _, value := range spec.Values {
-		if literal, ok := value.(*ast.CompositeLit); ok && !isPermissionsType(literal.Type) {
-			return false
-		}
+	// The multi-return form (`var a, b = f()`) has no per-name value to
+	// inspect, so it is asked for.
+	if len(spec.Values) != len(spec.Names) {
+		return true
 	}
-	return true
+	literal, ok := spec.Values[index].(*ast.CompositeLit)
+	return !ok || isPermissionsType(literal.Type, principalPkg)
 }
 
-func isPermissionsType(expr ast.Expr) bool {
+func isPermissionsType(expr ast.Expr, principalPkg string) bool {
 	selector, ok := expr.(*ast.SelectorExpr)
 	if !ok {
 		return false
 	}
 	pkg, ok := selector.X.(*ast.Ident)
-	return ok && pkg.Name == "principal" && selector.Sel.Name == "Permissions"
+	return ok && pkg.Name == principalPkg && selector.Sel.Name == "Permissions"
+}
+
+// principalPackage is the import path of the package whose Permissions type
+// every fixture here has.
+const principalPackage = "github.com/margince/margince/backend/internal/shared/kernel/principal"
+
+// principalIdent is the identifier harnessperms.go qualifies that package by.
+//
+// Resolved rather than assumed. Matching the bare name `principal` would read
+// an aliased import as some other package, and every Permissions literal in
+// the file would then be excluded — silently, with no test failing, which is
+// exactly the escape this census exists to close. A file that does not import
+// the package at all, or that dot-imports it so no qualifier survives to
+// match, is not a file this gate can reason about, and it says so rather than
+// passing on an empty census.
+func principalIdent(t *testing.T, file *ast.File) string {
+	t.Helper()
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || path != principalPackage {
+			continue
+		}
+		if spec.Name == nil {
+			return "principal"
+		}
+		if name := spec.Name.Name; name != "." && name != "_" {
+			return name
+		}
+		t.Fatalf("%s imports %s as %q, which leaves no qualifier to match — this gate "+
+			"reads the fixtures' type off the source", harnessPermsFile, principalPackage, spec.Name.Name)
+	}
+	t.Fatalf("%s does not import %s, whose Permissions type every fixture in it has — "+
+		"an empty census would pass while governing nothing", harnessPermsFile, principalPackage)
+	return ""
 }
 
 // seatRole is the seeded role a fixture stands in for. A fixture naming none

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -200,7 +200,14 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// many there are — the same statement the next-steps section already ran,
 	// asked a second time at a different bound. Flat in the size of the
 	// account, like every section above.
-	const budget = 43
+	// 44 since the harness's admin gained the `tag` grant the real seed
+	// always gave it: one read of the account's tag chips. The section is
+	// not new — assemble.readTags has always run for a caller holding
+	// tag.read, which every production admin does — so this line records a
+	// cost the budget had been blind to rather than a cost just added. One
+	// statement for the account's own chips, flat in the size of the
+	// account like every section above.
+	const budget = 44
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}


### PR DESCRIPTION
`main` is red: `integration / integration shard (4/6)` fails on `TestThePersonListNarrowsByTagID` — "the tag filter returned 0 people, want only the tagged one". Reproduced on plain `origin/main` and at `edd89a55e`, the commit that added the test.

## Cause

`AdminPerms` in the integration harness carries no `tag` grant. `storekit.TagFilterClause` refuses a caller without `tag.read` by rendering `FALSE` rather than by erroring — deliberately, since an error would tell an outsider the tag exists — so `e.Admin()` asked "who carries VIP" and was answered "nobody". The suite read that as the store's answer.

The real seed (`identity/internal/policy`'s admin row) grants admin `crud` on both `tag` and `list`. The fixture was narrower than `AccountRepPerms`, a **rep** fixture, which already carries `tag.read` and `list.read`.

## Fix

`AdminPerms` gains the `tag` and `list` grants the seed gives it.

## Gate

`harnessperms.go` already says in prose that "the harness's admin stands in for every seat in most suites". The new gate is its contrapositive: no fixture for a seat the **seed** grants strictly less than admin may hold a grant `AdminPerms` lacks. It compares *seats*, not fixtures — a fixture is often deliberately narrower than its own seat, and several here say so where they are declared. A companion census parses the fixture names out of `harnessperms.go`, so an unregistered fixture fails rather than being exempt by omission.

It reads `migrations/testdata/rbac_seeded_defaults.json`, which `identity/rbacfixture_test.go` pins to `policy.MustDefaultJSON` on every unit pass — `policy` itself sits behind `identity/internal/`.

**Stated limit, in the doc comment:** a seat the seed grants exactly what it grants admin is never compared. `OpsPerms` holds the admin grid, and `AdminWithSignals` is an admin fixture carrying a `signal` grant `AdminPerms` lacks. Nothing holds that narrowing honest.

## Evidence

- `TestThePersonListNarrowsByTagID` — fails on `origin/main`, passes here.
- Mutation: drop `tag` from `AdminPerms` → the gate names it (`AccountRepPerms (rep) holds tag.read and AdminPerms does not`).
- Mutation: unregister `AccountRepPerms` → the census names it.
- `make check-backend` exit 0; the whole `compose/integration` package green (135s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Administrators now have consistent create, view, update, and delete access for tags and lists.
  * Tag-filtered results now correctly reflect administrator permissions.
  * CRM-originated correspondence records unresolved sender visibility questions while still creating the associated person record.

* **Tests**
  * Added checks to keep administrator permissions aligned with configured policies.
  * Expanded integration coverage for correspondence processing, organization tags, query budgets, and permission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->