### PR TITLE
Restore the response-metrics read that a stale rebase removed

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -10031,6 +10031,52 @@ paths:
               schema: { $ref: '#/components/schemas/HiddenBacklog' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /worklist/response:
+    get:
+      tags: [Brief]
+      operationId: getResponseMetrics
+      summary: How fast the workspace answers, and how much of the queue it puts down.
+      description: |
+        The hidden-backlog guardrail says what the queue is NOT showing. This says what
+        happens to the work it does show, which is the other half of the same question: a
+        queue can be honest about its contents and still be a queue nobody answers.
+
+        Read over a WINDOW rather than at an instant, because neither figure is a fact
+        about right now — "we answer in four hours" is a claim about a fortnight, and a
+        number taken from today would swing on one slow afternoon. The window defaults to
+        the last 14 days.
+
+        Counted under the CALLER's own visibility — but only on the INBOUND side, and the
+        difference is worth stating rather than glossing. A message the caller may not read
+        contributes to no figure here. The REPLY that answered it is not gated: the waiting
+        lane deliberately ignores the audience arm on its own reply anti-join, because a
+        reply somebody else may see still answered the customer, and skipping it would
+        report an answered message as waiting.
+
+        So a caller who can read an inbound but not the audience-limited reply to it learns
+        WHEN a colleague answered, to the minute, folded into the median. That is a
+        timestamp rather than content, and it is the price of the two readers agreeing
+        about which threads were answered — but it is a real disclosure and this is where
+        it is written down.
+      x-agent-access: human-only
+      parameters:
+        - name: days
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 90, default: 14 }
+          description: |
+            How many days back the window reaches. Capped at 90: past that the figure stops
+            describing how the workspace works now and starts averaging over a change in
+            how it works.
+      responses:
+        '200':
+          description: What the workspace did with its waiting work.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ResponseMetrics' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '422': { $ref: '#/components/responses/ValidationError' }
   /digest:
     get:
       tags: [Capture]
@@ -35823,6 +35869,54 @@ components:
             True when nothing is being held back AND the reads were complete. The
             guardrail's target, sent as its own field because a number only ever read beside
             other numbers becomes decoration — this is what a check asserts on.
+
+    ResponseMetrics:
+      type: object
+      description: |
+        What the workspace did with its waiting work over one window. Two questions: how
+        fast it answered what it answered, and how much it put down instead.
+      required: [from, to, answered, median_minutes, disposed, disposed_not_sales]
+      properties:
+        from: { type: string, format: date-time, description: 'The start of the window, inclusive.' }
+        to: { type: string, format: date-time, description: 'The end of the window, exclusive — so consecutive windows partition time and a message on a boundary is counted once.' }
+        answered:
+          type: integer
+          minimum: 0
+          description: |
+            How many inbound sales messages got a reply in the window. It is the
+            denominator `median_minutes` is worth reading against: a fast median over three
+            answered messages says less about the workspace than a slower one over three
+            hundred.
+        median_minutes:
+          type: integer
+          minimum: 0
+          description: |
+            How long the middle answered message waited, in minutes.
+
+            The MEDIAN rather than the mean, for the reason the material bar takes one: a
+            single message answered after three weeks drags an average past every figure a
+            reader would recognise, and the question is what a customer TYPICALLY waits.
+
+            Zero when nothing was answered, which `answered` tells apart from a genuine
+            zero-minute median.
+        disposed:
+          type: integer
+          minimum: 0
+          description: |
+            How many rows a reader put DOWN in the window — snoozed, marked not theirs, or
+            judged not sales.
+
+            Counted from the audit record rather than from what is set aside now. A snooze
+            that lifted and a not_mine somebody withdrew leave no trace in the current
+            state, so a figure read from there would FALL as readers tidied up — reporting
+            less judgement the more of it happened.
+        disposed_not_sales:
+          type: integer
+          minimum: 0
+          description: |
+            How many of those were the workspace-wide judgement. Its own figure because it
+            is the one that costs everybody: the other two hide a row from one reader, this
+            one hides the conversation from all of them and does not lift.
 
     WorklistItem:
       type: object

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -314,6 +314,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/weekly-reviews/team":                                        {Op: "getTeamWeeklyReview", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/worklist":                                                   {Op: "getWorklist", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/worklist/hidden":                                            {Op: "getHiddenBacklog", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/worklist/response":                                          {Op: "getResponseMetrics", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/worklist/team":                                              {Op: "getTeamBoard", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"PATCH /v1/activities/{id}":                                          {Op: "updateActivity", Access: "tool", Tool: "update_record", RecordType: "activity", Tier: "auto_execute", Scope: "write"},
 	"PATCH /v1/activities/{id}/audience":                                 {Op: "setActivityAudience", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/attention/handlers.go
+++ b/backend/internal/compose/attention/handlers.go
@@ -4,6 +4,7 @@
 package attention
 
 import (
+	"fmt"
 	"net/http"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -57,6 +58,43 @@ func (h Handlers) GetTeamBoard(w http.ResponseWriter, r *http.Request) {
 // somebody else.
 func (h Handlers) GetHiddenBacklog(w http.ResponseWriter, r *http.Request) {
 	out, err := h.svc.HiddenBacklog(r.Context())
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, out)
+}
+
+// GetResponseMetrics answers how fast the workspace replies over a window.
+//
+// The window is the ONE parameter, and it is a length rather than a pair of
+// instants: a caller naming both ends could ask for a window the figures were
+// never meant to describe, and every reader of this endpoint wants "the last N
+// days" rather than an arbitrary fortnight in the past.
+func (h Handlers) GetResponseMetrics(
+	w http.ResponseWriter, r *http.Request, params crmcontracts.GetResponseMetricsParams,
+) {
+	days := 0
+	if params.Days != nil {
+		// Refused rather than clamped, which is this tree's convention for a
+		// published range (automations_preview.go and filterpreview.go both say
+		// so in their own words). A caller asking for a window the reading does
+		// not cover has made a mistake, and answering a different window than
+		// they asked for hands them a figure they will read as the one they
+		// requested.
+		//
+		// Enforced HERE because nothing else does: the generated parameter is a
+		// bare *int, so the contract's minimum and maximum are documentation the
+		// router never applies. Left unchecked, `days=3650000` reaches the store
+		// and scans every message the installation has ever held.
+		if *params.Days < 1 || *params.Days > responseWindowMaxDays {
+			httperr.Write(w, r, httperr.Validation("days", "out_of_range",
+				fmt.Sprintf("the window must be between 1 and %d days", responseWindowMaxDays)))
+			return
+		}
+		days = *params.Days
+	}
+	out, err := h.svc.ResponseMetrics(r.Context(), days)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return

--- a/backend/internal/compose/attention/hiddenbacklog_test.go
+++ b/backend/internal/compose/attention/hiddenbacklog_test.go
@@ -16,6 +16,10 @@ func (h hidingWork) Unanswered(context.Context, time.Time) ([]WaitingCustomer, b
 	return nil, false, nil
 }
 
+func (h hidingWork) Answered(context.Context, time.Time, time.Time) (AnsweredWork, error) {
+	return AnsweredWork{}, nil
+}
+
 func (h hidingWork) Hidden(context.Context, time.Time) (HiddenWork, error) {
 	return HiddenWork(h), nil
 }

--- a/backend/internal/compose/attention/ownerqueue_test.go
+++ b/backend/internal/compose/attention/ownerqueue_test.go
@@ -49,6 +49,13 @@ func (w waitingOwnedBy) Unanswered(context.Context, time.Time) ([]WaitingCustome
 // Nothing hidden: these tests are about WHOSE rows the queue carries, and a
 // fake that also invented a backlog would let a projection defect show up as a
 // guardrail figure instead of as a missing row.
+// Nothing measured: these tests are about which rows the queue carries, and a
+// fake answering a response time would let a projection defect read as a
+// timing figure.
+func (w waitingOwnedBy) Answered(context.Context, time.Time, time.Time) (AnsweredWork, error) {
+	return AnsweredWork{}, nil
+}
+
 func (w waitingOwnedBy) Hidden(context.Context, time.Time) (HiddenWork, error) {
 	return HiddenWork{Shown: len(w)}, nil
 }

--- a/backend/internal/compose/attention/responsemetrics_test.go
+++ b/backend/internal/compose/attention/responsemetrics_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// answering is the who-is-waiting seam reporting a window's figures, and
+// recording the window it was asked for.
+type answering struct {
+	work AnsweredWork
+	from *time.Time
+	to   *time.Time
+}
+
+func (a *answering) Unanswered(context.Context, time.Time) ([]WaitingCustomer, bool, error) {
+	return nil, false, nil
+}
+
+func (a *answering) Hidden(context.Context, time.Time) (HiddenWork, error) {
+	return HiddenWork{}, nil
+}
+
+func (a *answering) Answered(
+	_ context.Context, from, to time.Time,
+) (AnsweredWork, error) {
+	a.from, a.to = &from, &to
+	return a.work, nil
+}
+
+// The window a caller names is the window the read gets.
+//
+// A projection that ignored the parameter would answer the default for every
+// request, so a reader asking about last week and a reader asking about last
+// quarter would be shown the same figure and have no way to tell.
+func TestTheWindowAskedForIsTheWindowRead(t *testing.T) {
+	t.Parallel()
+
+	seam := &answering{}
+	svc := unboundService()
+	svc.waiting = seam
+
+	got, err := svc.ResponseMetrics(context.Background(), 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if seam.from == nil || seam.to == nil {
+		t.Fatal("the seam was never asked")
+	}
+	if days := seam.to.Sub(*seam.from).Hours() / 24; days < 29 || days > 31 {
+		t.Fatalf("read a window of %.0f days, wanted the 30 asked for", days)
+	}
+	// The window travels to the READER too, or a figure arrives with no way to
+	// know what span it describes.
+	if !got.From.Equal(*seam.from) || !got.To.Equal(*seam.to) {
+		t.Fatalf("the answer names %s–%s over a read of %s–%s",
+			got.From, got.To, *seam.from, *seam.to)
+	}
+}
+
+// A caller naming no window gets the default rather than a zero-length one.
+//
+// Zero days would make `from` and `to` the same instant, and every figure would
+// come back zero — a workspace that answers nothing, reported over a window
+// nothing could have happened in.
+func TestNoWindowAskedForReadsTheDefaultFortnight(t *testing.T) {
+	t.Parallel()
+
+	seam := &answering{}
+	svc := unboundService()
+	svc.waiting = seam
+
+	if _, err := svc.ResponseMetrics(context.Background(), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if seam.from == nil {
+		t.Fatal("the seam was never asked")
+	}
+	if days := seam.to.Sub(*seam.from).Hours() / 24; days < 13 || days > 15 {
+		t.Fatalf("read a window of %.0f days, wanted the default fortnight", days)
+	}
+}
+
+// The service holds the bound even when nothing above it did.
+//
+// The handler refuses an out-of-range window, which is the tree's convention
+// for a published range. This is the second line: a caller reaching the service
+// directly — a future job, another seam — gets the widest honest window rather
+// than an unbounded scan over every message the installation has ever held.
+//
+// Worth its own case because the contract's `maximum` enforces nothing: the
+// generated parameter is a bare *int, so a bound that lives only in YAML is a
+// bound that does not exist.
+func TestTheServiceHoldsTheWindowBoundOnItsOwn(t *testing.T) {
+	t.Parallel()
+
+	seam := &answering{}
+	svc := unboundService()
+	svc.waiting = seam
+
+	if _, err := svc.ResponseMetrics(context.Background(), 100_000); err != nil {
+		t.Fatal(err)
+	}
+
+	if seam.from == nil {
+		t.Fatal("the seam was never asked")
+	}
+	if days := seam.to.Sub(*seam.from).Hours() / 24; days > 91 {
+		t.Fatalf("read a window of %.0f days — the contract's cap is not enforced "+
+			"anywhere the router can see, so the service is what has to hold it", days)
+	}
+}
+
+// Every figure crosses the seam. A projection that dropped one would publish a
+// zero, and a zero here reads as a workspace answering instantly or judging
+// nothing — both flattering, both wrong.
+func TestEveryResponseFigureReachesTheWire(t *testing.T) {
+	t.Parallel()
+
+	svc := unboundService()
+	svc.waiting = &answering{work: AnsweredWork{
+		Answered: 40, MedianMinutes: 95, Disposed: 12, DisposedNotSales: 3,
+	}}
+
+	got, err := svc.ResponseMetrics(context.Background(), 14)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, pair := range map[string][2]int{
+		"answered":           {got.Answered, 40},
+		"median_minutes":     {got.MedianMinutes, 95},
+		"disposed":           {got.Disposed, 12},
+		"disposed_not_sales": {got.DisposedNotSales, 3},
+	} {
+		if pair[0] != pair[1] {
+			t.Fatalf("%s reached the wire as %d, wanted %d", name, pair[0], pair[1])
+		}
+	}
+}
+
+// An installation with no mail stream has nothing to have answered slowly, so
+// an empty window is the true answer rather than a refusal.
+func TestAnUnboundWaitingLaneAnswersAnEmptyWindow(t *testing.T) {
+	t.Parallel()
+
+	got, err := unboundService().ResponseMetrics(context.Background(), 14)
+	if err != nil {
+		t.Fatalf("an unbound lane should answer, not refuse: %v", err)
+	}
+
+	if got.Answered != 0 || got.Disposed != 0 {
+		t.Fatalf("a lane that never ran reported work: %+v", got)
+	}
+	// The window is still named, so a reader is not handed figures with no span.
+	if !got.To.After(got.From) {
+		t.Fatalf("the empty answer names no window: %s–%s", got.From, got.To)
+	}
+}

--- a/backend/internal/compose/attention/teamboard_test.go
+++ b/backend/internal/compose/attention/teamboard_test.go
@@ -47,6 +47,13 @@ func (w waitingSaying) Unanswered(context.Context, time.Time) ([]WaitingCustomer
 
 // Nothing hidden: the board is about who is CARRYING what, and a fake that also
 // invented a backlog would let a counting defect read as hidden work.
+// Nothing measured: these tests are about which rows the queue carries, and a
+// fake answering a response time would let a projection defect read as a
+// timing figure.
+func (w waitingSaying) Answered(context.Context, time.Time, time.Time) (AnsweredWork, error) {
+	return AnsweredWork{}, nil
+}
+
 func (w waitingSaying) Hidden(context.Context, time.Time) (HiddenWork, error) {
 	return HiddenWork{Shown: len(w.rows)}, nil
 }

--- a/backend/internal/compose/attention/waitinglane.go
+++ b/backend/internal/compose/attention/waitinglane.go
@@ -46,6 +46,21 @@ type Waiting interface {
 	// so a second seam would let an installation bind a queue and a guardrail
 	// that disagree about who is waiting.
 	Hidden(ctx context.Context, asOf time.Time) (HiddenWork, error)
+	// Answered says how fast the workspace replied over a window, and how much
+	// of the queue it put down instead.
+	//
+	// On this seam for the reason Hidden is: both are questions about the same
+	// waiting work, and a seam of their own would let an installation bind a
+	// queue and a measurement that disagree about which threads are sales.
+	Answered(ctx context.Context, from, to time.Time) (AnsweredWork, error)
+}
+
+// AnsweredWork is what the workspace did with its waiting work over a window.
+type AnsweredWork struct {
+	Answered         int
+	MedianMinutes    int
+	Disposed         int
+	DisposedNotSales int
 }
 
 // HiddenWork is how much waiting work each rule is holding back, and whether
@@ -174,4 +189,59 @@ func (s *Service) HiddenBacklog(ctx context.Context) (crmcontracts.HiddenBacklog
 		// non-zero counts is the one lie this endpoint must not tell.
 		Clear: work.Clear(),
 	}, nil
+}
+
+// responseWindowDays is how far back the reading looks when a caller names no
+// window. A fortnight: long enough that one slow afternoon does not decide the
+// figure, short enough that it still describes how the workspace works now.
+const responseWindowDays = 14
+
+// responseWindowMaxDays is the widest window this reading answers.
+//
+// Clamped HERE and not only in the contract. The generated parameter is a bare
+// *int — OpenAPI's `maximum` is documentation the router does not enforce — so a
+// caller asking for a hundred thousand days would reach the store and scan every
+// message the workspace has ever held. Past ninety days the figure also stops
+// describing how the workspace works now and starts averaging over a change in
+// how it works, so the bound is the same number for both reasons.
+//
+// The HANDLER refuses a window outside 1..this, which is the tree's convention
+// for a published range. This constant is also the service's own last line: a
+// caller reaching the service directly — a future job, a seam — gets the widest
+// honest window rather than an unbounded scan.
+const responseWindowMaxDays = 90
+
+// ResponseMetrics answers how fast the workspace replies, over a window.
+//
+// A projection over the seam, like HiddenBacklog: the arithmetic is a median
+// and a filtered count in SQL, and computing either here would need this
+// package to hold a second definition of what a sales thread is.
+//
+// An unbound seam answers an empty window rather than an error, for the reason
+// the guardrail does: an installation that reads no mail has nothing to have
+// answered slowly.
+func (s *Service) ResponseMetrics(
+	ctx context.Context, days int,
+) (crmcontracts.ResponseMetrics, error) {
+	if days <= 0 {
+		days = responseWindowDays
+	}
+	if days > responseWindowMaxDays {
+		days = responseWindowMaxDays
+	}
+	to := s.now()
+	from := to.AddDate(0, 0, -days)
+	out := crmcontracts.ResponseMetrics{From: from, To: to}
+	if s.waiting == nil {
+		return out, nil
+	}
+	work, err := s.waiting.Answered(ctx, from, to)
+	if err != nil {
+		return crmcontracts.ResponseMetrics{}, err
+	}
+	out.Answered = work.Answered
+	out.MedianMinutes = work.MedianMinutes
+	out.Disposed = work.Disposed
+	out.DisposedNotSales = work.DisposedNotSales
+	return out, nil
 }

--- a/backend/internal/compose/attentionwaitingseam.go
+++ b/backend/internal/compose/attentionwaitingseam.go
@@ -31,6 +31,23 @@ type attentionWaiting struct {
 // The instant comes from the caller so the whole read is one snapshot. Asking
 // the clock again here would let the anti-joins judge against a moment the rest
 // of the day was not read at.
+// Answered asks the module how fast it replied over a window. A pass-through,
+// like Hidden: the median and the counts are SQL and belong beside the query.
+func (w attentionWaiting) Answered(
+	ctx context.Context, from, to time.Time,
+) (attention.AnsweredWork, error) {
+	got, err := w.store.ResponseWindow(ctx, from, to)
+	if err != nil {
+		return attention.AnsweredWork{}, err
+	}
+	return attention.AnsweredWork{
+		Answered:         got.Answered,
+		MedianMinutes:    got.MedianMinutes,
+		Disposed:         got.Disposed,
+		DisposedNotSales: got.DisposedNotSales,
+	}, nil
+}
+
 // Hidden asks the module what its own hiding rules are keeping off the queue.
 //
 // A pass-through: the arithmetic is five reads of the eligibility query and

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -439,6 +439,13 @@ func (s Server) GetWorklist(w http.ResponseWriter, r *http.Request, params crmco
 	s.attentionHandlers.GetWorklist(w, r, params)
 }
 
+// GetResponseMetrics forwards the reading of how fast the workspace replies.
+func (s Server) GetResponseMetrics(
+	w http.ResponseWriter, r *http.Request, params crmcontracts.GetResponseMetricsParams,
+) {
+	s.attentionHandlers.GetResponseMetrics(w, r, params)
+}
+
 // GetHiddenBacklog forwards the guardrail over the queue's own hiding rules.
 func (s Server) GetHiddenBacklog(w http.ResponseWriter, r *http.Request) {
 	s.attentionHandlers.GetHiddenBacklog(w, r)

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -2239,6 +2239,10 @@ func (stubs) GetHiddenBacklog(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetHiddenBacklog")
 }
 
+func (stubs) GetResponseMetrics(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.GetResponseMetricsParams) {
+	httperr.NotImplemented(w, r, "GetResponseMetrics")
+}
+
 func (stubs) GetTeamBoard(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetTeamBoard")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -27356,6 +27356,46 @@ type RescheduleSendRequest struct {
 	ScheduledTz string    `json:"scheduled_tz"`
 }
 
+// ResponseMetrics What the workspace did with its waiting work over one window. Two questions: how
+// fast it answered what it answered, and how much it put down instead.
+type ResponseMetrics struct {
+	// Answered How many inbound sales messages got a reply in the window. It is the
+	// denominator `median_minutes` is worth reading against: a fast median over three
+	// answered messages says less about the workspace than a slower one over three
+	// hundred.
+	Answered int `json:"answered"`
+
+	// Disposed How many rows a reader put DOWN in the window — snoozed, marked not theirs, or
+	// judged not sales.
+	//
+	// Counted from the audit record rather than from what is set aside now. A snooze
+	// that lifted and a not_mine somebody withdrew leave no trace in the current
+	// state, so a figure read from there would FALL as readers tidied up — reporting
+	// less judgement the more of it happened.
+	Disposed int `json:"disposed"`
+
+	// DisposedNotSales How many of those were the workspace-wide judgement. Its own figure because it
+	// is the one that costs everybody: the other two hide a row from one reader, this
+	// one hides the conversation from all of them and does not lift.
+	DisposedNotSales int `json:"disposed_not_sales"`
+
+	// From The start of the window, inclusive.
+	From time.Time `json:"from"`
+
+	// MedianMinutes How long the middle answered message waited, in minutes.
+	//
+	// The MEDIAN rather than the mean, for the reason the material bar takes one: a
+	// single message answered after three weeks drags an average past every figure a
+	// reader would recognise, and the question is what a customer TYPICALLY waits.
+	//
+	// Zero when nothing was answered, which `answered` tells apart from a genuine
+	// zero-minute median.
+	MedianMinutes int `json:"median_minutes"`
+
+	// To The end of the window, exclusive — so consecutive windows partition time and a message on a boundary is counted once.
+	To time.Time `json:"to"`
+}
+
 // RestrictedRecord defines model for RestrictedRecord.
 type RestrictedRecord struct {
 	ActivityId openapi_types.UUID `json:"activity_id"`
@@ -35252,6 +35292,14 @@ type GetWorklistParamsScope string
 
 // GetWorklistParamsFilter defines parameters for GetWorklist.
 type GetWorklistParamsFilter string
+
+// GetResponseMetricsParams defines parameters for GetResponseMetrics.
+type GetResponseMetricsParams struct {
+	// Days How many days back the window reaches. Capped at 90: past that the figure stops
+	// describing how the workspace works now and starts averaging over a change in
+	// how it works.
+	Days *int `form:"days,omitempty" json:"days,omitempty"`
+}
 
 // LogActivityJSONRequestBody defines body for LogActivity for application/json ContentType.
 type LogActivityJSONRequestBody = CreateActivityRequest
@@ -45290,6 +45338,9 @@ type ServerInterface interface {
 	// What the queue is not showing, and which rule is holding it back.
 	// (GET /worklist/hidden)
 	GetHiddenBacklog(w http.ResponseWriter, r *http.Request)
+	// How fast the workspace answers, and how much of the queue it puts down.
+	// (GET /worklist/response)
+	GetResponseMetrics(w http.ResponseWriter, r *http.Request, params GetResponseMetricsParams)
 	// One row per teammate — who is carrying what, so a lead can see where to help.
 	// (GET /worklist/team)
 	GetTeamBoard(w http.ResponseWriter, r *http.Request)
@@ -48620,6 +48671,12 @@ func (_ Unimplemented) GetWorklist(w http.ResponseWriter, r *http.Request, param
 // What the queue is not showing, and which rule is holding it back.
 // (GET /worklist/hidden)
 func (_ Unimplemented) GetHiddenBacklog(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// How fast the workspace answers, and how much of the queue it puts down.
+// (GET /worklist/response)
+func (_ Unimplemented) GetResponseMetrics(w http.ResponseWriter, r *http.Request, params GetResponseMetricsParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -72661,6 +72718,47 @@ func (siw *ServerInterfaceWrapper) GetHiddenBacklog(w http.ResponseWriter, r *ht
 	handler.ServeHTTP(w, r)
 }
 
+// GetResponseMetrics operation middleware
+func (siw *ServerInterfaceWrapper) GetResponseMetrics(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetResponseMetricsParams
+
+	// ------------- Optional query parameter "days" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "days", r.URL.Query(), &params.Days, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "days"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "days", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetResponseMetrics(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetTeamBoard operation middleware
 func (siw *ServerInterfaceWrapper) GetTeamBoard(w http.ResponseWriter, r *http.Request) {
 
@@ -74457,6 +74555,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/worklist/hidden", wrapper.GetHiddenBacklog)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/worklist/response", wrapper.GetResponseMetrics)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/worklist/team", wrapper.GetTeamBoard)

--- a/backend/internal/modules/activities/responsemetrics.go
+++ b/backend/internal/modules/activities/responsemetrics.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// How fast the workspace answers, and how much of the queue is being worked
+// rather than put down.
+//
+// The hidden-backlog guardrail says what the queue is NOT showing. These two say
+// what happens to the work it does show, which is the other half of the same
+// question: a queue can be honest about its contents and still be a queue nobody
+// answers.
+//
+// Both are read over a WINDOW rather than at an instant, because neither is a
+// fact about right now — "we answer in four hours" is a claim about a fortnight,
+// and a figure taken from today would swing on one slow afternoon.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// ResponseMetrics is what the workspace did with its waiting work over a window.
+type ResponseMetrics struct {
+	// Answered is how many inbound sales messages got a reply in the window.
+	Answered int
+	// MedianMinutes is how long the middle one waited, in minutes. The MEDIAN
+	// rather than the mean, for the reason the material bar takes one: a single
+	// message answered after three weeks drags an average past every figure a
+	// reader would recognise, and the question here is "what does a customer
+	// typically wait", not "what is the arithmetic mean of our failures".
+	//
+	// Zero when nothing was answered, which the Answered count tells apart from
+	// a genuine zero-minute median.
+	MedianMinutes int
+	// Disposed is how many rows a reader put DOWN in the window — snoozed,
+	// marked not theirs, or judged not sales.
+	Disposed int
+	// DisposedNotSales is how many of those were the workspace-wide judgement.
+	// Its own figure because it is the one that costs everybody: the other two
+	// hide a row from one reader, this one hides the conversation from all of
+	// them and does not lift.
+	DisposedNotSales int
+}
+
+// firstResponseSQL measures the wait on threads that WERE answered.
+//
+// The mirror of waitingRepliesSQL, which finds the newest inbound with no later
+// outbound. This finds the newest inbound that HAS one, and how long it took —
+// so the two together cover every sales thread: answered, and not yet.
+//
+// Deliberately NOT sharing that constant. The anti-join is the whole of what
+// this differs by, and forcing one statement to express both questions would
+// mean a flag deciding whether a NOT EXISTS is an EXISTS — the shape where a
+// reader can no longer tell what either caller runs. What the two DO share is
+// the definition of a sales thread, and that is stated here as the same three
+// clauses rather than inherited: see the comment on the sales link below.
+//
+// The window is bounded by the caller. An unbounded read would answer "how fast
+// have we ever been", which no reader is asking and which grows without limit.
+const firstResponseSQL = `
+	SELECT count(*),
+	       COALESCE(
+	         percentile_cont(0.5) WITHIN GROUP (
+	           ORDER BY EXTRACT(EPOCH FROM (reply.occurred_at - inbound.occurred_at)) / 60
+	         )::bigint, 0)
+	  FROM activity inbound
+	  -- The FIRST reply after it, not the newest: what a customer waited is the
+	  -- time to the answer they actually got, and taking the latest outbound on
+	  -- the thread would report the wait as the length of the whole conversation.
+	  JOIN LATERAL (
+	         SELECT a.occurred_at
+	           FROM activity a
+	          -- Matched within ONE medium, on the same triple every other thread
+	          -- reader in this tree matches on, and it is a SECURITY control
+	          -- rather than a convenience.
+	          --
+	          -- thread_key is one flat namespace holding both a mail thread root
+	          -- and a channel's provider:bot:chat key, and the mail half
+	          -- is attacker-supplied: it is the message's own References root, so
+	          -- a sender chooses it verbatim. Matching on the key alone lets a
+	          -- forged References header naming a Telegram conversation — a bot
+	          -- id is public and a private chat's id is the target's own — count
+	          -- somebody else's channel reply as the answer to that mail. The
+	          -- published median then carries a data point a stranger chose, in
+	          -- whichever direction they chose it.
+	          --
+	          -- It also keeps the two readers of "was this answered" agreeing:
+	          -- waitingSQL's anti-join matches this same triple, so without it a
+	          -- thread would be answered here and still waiting there.
+	          WHERE a.thread_key = inbound.thread_key
+	            AND a.kind = inbound.kind
+	            AND a.channel_provider IS NOT DISTINCT FROM inbound.channel_provider
+	            AND a.direction = 'outbound'
+	            AND a.archived_at IS NULL
+	            AND a.occurred_at > inbound.occurred_at
+	          ORDER BY a.occurred_at
+	          LIMIT 1) reply ON TRUE
+	 WHERE inbound.kind IN ('email', 'message')
+	   AND inbound.direction = 'inbound'
+	   AND inbound.archived_at IS NULL
+	   AND inbound.thread_key IS NOT NULL
+	   AND inbound.occurred_at >= $1
+	   AND inbound.occurred_at < $2
+	   AND %[1]s
+	   -- A SALES thread, by the same three arms waitingRepliesSQL qualifies on.
+	   -- Restated rather than shared because this query has no wl join to hang
+	   -- them off; what must not drift is the DEFINITION, and a test feeding
+	   -- both readers one timeline holds that better than a shared fragment
+	   -- neither could read.
+	   AND EXISTS (
+	         SELECT 1 FROM activity_link sales
+	          WHERE sales.activity_id = inbound.id
+	            AND (sales.person_id IS NOT NULL
+	              OR sales.organization_id IS NOT NULL
+	              OR EXISTS (SELECT 1 FROM deal d
+	                          WHERE d.id = sales.deal_id AND %[2]s)
+	              OR EXISTS (SELECT 1 FROM lead ld
+	                          WHERE ld.id = sales.lead_id AND %[3]s)))`
+
+// dispositionsSQL counts what readers put down in the window.
+//
+// From audit_log rather than from the state tables, and that is the whole point
+// of reading it here: activity_reader_state holds what is set aside NOW, so a
+// snooze that lifted and a not_mine somebody withdrew have left no trace in it.
+// The audit row is the only record that the judgement was ever made, which is
+// what a rate over a window needs.
+const dispositionsSQL = `
+	SELECT count(*) FILTER (WHERE a.after->>'disposition' IS NOT NULL),
+	       count(*) FILTER (WHERE a.after->>'disposition' = 'not_sales')
+	  FROM audit_log a
+	 WHERE a.entity_type = 'activity'
+	   AND a.action = 'update'
+	   AND a.occurred_at >= $1
+	   AND a.occurred_at < $2`
+
+// ResponseWindow reads both figures over one window.
+//
+// The window is half-open — from inclusive, to exclusive — so consecutive
+// windows partition time and a message on a boundary is counted once.
+func (s *Store) ResponseWindow(ctx context.Context, from, to time.Time) (ResponseMetrics, error) {
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return ResponseMetrics{}, err
+	}
+	if !to.After(from) {
+		// A window that ends before it starts is a caller mistake, and answering
+		// zeros would let it read as a quiet fortnight.
+		return ResponseMetrics{}, fmt.Errorf(
+			"activities: response window ends at %s, before it starts at %s",
+			to.Format(time.RFC3339), from.Format(time.RFC3339))
+	}
+	var out ResponseMetrics
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		args := []any{from, to}
+		arg := func(v any) int { args = append(args, v); return len(args) }
+		// The same content gate the waiting lane composes. A message this reader
+		// may not read contributes to no figure here: a median over rows they
+		// cannot open would publish the timing of somebody else's conversations.
+		// The INBOUND side only, and the asymmetry is deliberate rather than an
+		// oversight. The waiting lane ignores the audience arm on its own reply
+		// anti-join for a stated reason — a reply this reader may not see still
+		// answered the customer — and gating the reply here would make the two
+		// readers disagree about which threads were answered.
+		//
+		// What it costs is stated in the contract rather than hidden: a caller
+		// who can read an inbound but not the limited reply to it learns when a
+		// colleague answered, folded into the median. A timestamp, not content.
+		content, err := auth.ActivityContentClause(ctx, "inbound", arg)
+		if err != nil {
+			return err
+		}
+		if err := tx.QueryRow(ctx, fmt.Sprintf(firstResponseSQL,
+			content,
+			liveRecord(openDealPredicate, "d"),
+			liveRecord(workingLeadPredicate, "ld")),
+			args...).Scan(&out.Answered, &out.MedianMinutes); err != nil {
+			return fmt.Errorf("activities: reading first-response times: %w", err)
+		}
+		// The audit read carries no content clause, and that is deliberate: an
+		// audit row records that a JUDGEMENT was made, not what the message
+		// said, and the count is over the workspace's own bookkeeping. The
+		// workspace binding is the transaction's.
+		if err := tx.QueryRow(ctx, dispositionsSQL, from, to).
+			Scan(&out.Disposed, &out.DisposedNotSales); err != nil {
+			return fmt.Errorf("activities: reading disposition counts: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return ResponseMetrics{}, err
+	}
+	return out, nil
+}

--- a/backend/internal/modules/activities/responsemetrics_integration_test.go
+++ b/backend/internal/modules/activities/responsemetrics_integration_test.go
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package activities
+
+// How fast the workspace answers, and how much of the queue it puts down,
+// against a real database.
+//
+// Both figures are SQL — a LATERAL join for the first reply, a percentile for
+// the median, and a filtered count over audit_log — and none of it is visible
+// to the unit lane: a wrong join direction, a median over the wrong column, or
+// a disposition read off the state table instead of the audit row all compile
+// and simply report a different number.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func metricsStore(e *loadEnv) *Store {
+	return NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
+}
+
+// window is a fortnight around now, wide enough for the fixtures below and
+// bounded so the read is over a window rather than over all history.
+func window() (time.Time, time.Time) {
+	now := time.Now()
+	return now.Add(-14 * 24 * time.Hour), now.Add(time.Hour)
+}
+
+// seedAnswered writes an inbound and the reply it got, `after` later.
+//
+// Through the same columns seedWait uses, so what varies between this file's
+// fixtures and the waiting lane's is only whether a reply exists.
+func seedAnswered(t *testing.T, e *loadEnv, person ids.UUID, ago, after time.Duration) {
+	t.Helper()
+	inbound, thread := ids.NewV7(), "thread-"+ids.NewV7().String()
+	e.exec(t, `INSERT INTO activity (id, kind, direction, subject, occurred_at, thread_key, source, captured_by)
+		VALUES ($1, 'email', 'inbound', 'Question', now() - $2::interval, $3, 'seed', 'system')`,
+		inbound, ago.String(), thread)
+	e.exec(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), inbound, person)
+	e.exec(t, `INSERT INTO activity (id, kind, direction, subject, occurred_at, thread_key, source, captured_by)
+		VALUES ($1, 'email', 'outbound', 'Re: Question', now() - $2::interval, $3, 'seed', 'system')`,
+		ids.NewV7(), (ago - after).String(), thread)
+}
+
+// The median is the MIDDLE wait, not the average of them.
+//
+// One message answered after a week drags a mean past every figure a reader
+// would recognise, and the question is what a customer typically waits. Three
+// answered messages with one outlier is the smallest fixture where the two
+// answers differ enough to tell apart.
+func TestTheResponseTimeIsTheMedianRatherThanTheMean(t *testing.T) {
+	e := setupLoad(t)
+	person := ids.NewV7()
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Buyer Person', $2, 'seed', 'system')`, person, e.rep)
+	// Waits of 1h, 2h and 100h. Median 2h = 120 minutes; the mean would be
+	// roughly 34 hours, which describes nobody's experience.
+	seedAnswered(t, e, person, 48*time.Hour, time.Hour)
+	seedAnswered(t, e, person, 47*time.Hour, 2*time.Hour)
+	seedAnswered(t, e, person, 46*time.Hour, 100*time.Hour)
+
+	from, to := window()
+	got, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Answered < 3 {
+		t.Fatalf("counted %d answered, wanted at least the three seeded", got.Answered)
+	}
+	// Asserted as a RANGE because the lane template is shared: another test's
+	// answered thread shifts the median, and a fixed number would pass or fail
+	// on which tests ran. The mean of this fixture is ~2000 minutes, so any
+	// figure this low proves the percentile is what ran.
+	if got.MedianMinutes > 400 {
+		t.Fatalf("the median came back %d minutes — a mean over these waits would be "+
+			"about 2000, so this is not a median", got.MedianMinutes)
+	}
+}
+
+// The wait is measured to the FIRST reply, not the newest one.
+//
+// Taking the latest outbound on the thread would report the wait as the length
+// of the whole conversation, so a customer answered in an hour and talked to
+// for a week would read as a week-long wait.
+func TestTheWaitIsMeasuredToTheFirstReplyNotTheLast(t *testing.T) {
+	e := setupLoad(t)
+	person := ids.NewV7()
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Buyer Person', $2, 'seed', 'system')`, person, e.rep)
+	inbound, thread := ids.NewV7(), "thread-"+ids.NewV7().String()
+	e.exec(t, `INSERT INTO activity (id, kind, direction, subject, occurred_at, thread_key, source, captured_by)
+		VALUES ($1, 'email', 'inbound', 'Question', now() - interval '10 days', $2, 'seed', 'system')`,
+		inbound, thread)
+	e.exec(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), inbound, person)
+	// Answered in an hour, then talked to for another nine days.
+	for _, at := range []string{"10 days", "1 day"} {
+		e.exec(t, `INSERT INTO activity (id, kind, direction, subject, occurred_at, thread_key, source, captured_by)
+			VALUES ($1, 'email', 'outbound', 'Re', now() - $2::interval + interval '1 hour', $3, 'seed', 'system')`,
+			ids.NewV7(), at, thread)
+	}
+
+	from, to := window()
+	got, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Answered == 0 {
+		t.Fatal("the answered thread was not counted at all")
+	}
+	// Nine days is 12960 minutes. Anything near that means the LAST reply was
+	// measured, which is the defect this case exists for.
+	if got.MedianMinutes > 5000 {
+		t.Fatalf("the wait came back %d minutes over a thread answered in one hour — "+
+			"the last reply was measured, not the first", got.MedianMinutes)
+	}
+}
+
+// An unanswered thread is not a fast one.
+//
+// The waiting lane's own subject, and the failure worth guarding: a query that
+// admitted threads with no reply at all would count them at some default and
+// report the workspace as answering everything.
+func TestAnUnansweredThreadIsNotCountedAsAnswered(t *testing.T) {
+	e := setupLoad(t)
+	person := ids.NewV7()
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Buyer Person', $2, 'seed', 'system')`, person, e.rep)
+	from, to := window()
+	before, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A wait with no reply — exactly what the Worklist queue is made of.
+	e.seedWait(t, "Nobody answered this", "person_id", person)
+
+	after, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if after.Answered != before.Answered {
+		t.Fatalf("an unanswered wait moved the answered count from %d to %d",
+			before.Answered, after.Answered)
+	}
+}
+
+// Dispositions are counted from the AUDIT row, not from the state table.
+//
+// activity_reader_state holds what is set aside NOW, so a snooze that lifted
+// and a not_mine somebody withdrew have left no trace in it. The audit row is
+// the only record the judgement was ever made, which is what a rate over a
+// window needs — and a metric read off the state table would fall as readers
+// tidied up, reporting less judgement the more of it happened.
+func TestDispositionsAreCountedFromTheAuditRowRatherThanTheStateTable(t *testing.T) {
+	e := setupLoad(t)
+	person := ids.NewV7()
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Buyer Person', $2, 'seed', 'system')`, person, e.rep)
+	activity := e.seedWait(t, "Set aside then withdrawn", "person_id", person)
+	from, to := window()
+	before, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The judgement, audited the way recordDisposition writes it.
+	e.exec(t, `INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id, after)
+		VALUES ('human', 'human:seed', 'update', 'activity', $1, '{"disposition":"not_sales"}'::jsonb)`,
+		activity)
+	// And the reader withdrawing it, so the state table holds nothing.
+	e.exec(t, `DELETE FROM activity_reader_state WHERE activity_id = $1`, activity)
+
+	after, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if after.Disposed != before.Disposed+1 {
+		t.Fatalf("the disposition count moved %d → %d over one audited judgement — "+
+			"a read off the state table loses it the moment the reader withdraws",
+			before.Disposed, after.Disposed)
+	}
+	if after.DisposedNotSales != before.DisposedNotSales+1 {
+		t.Fatalf("not_sales moved %d → %d, wanted the one judgement",
+			before.DisposedNotSales, after.DisposedNotSales)
+	}
+}
+
+// A snooze is a disposition but not the workspace-wide one.
+//
+// not_sales gets its own figure because it is the judgement that costs
+// everybody: the other two hide a row from one reader, this one hides the
+// conversation from all of them and does not lift. A metric that folded them
+// together would make a fortnight of ordinary tidying look like a fortnight of
+// customers being written off.
+func TestOnlyTheWorkspaceWideJudgementCountsAsNotSales(t *testing.T) {
+	e := setupLoad(t)
+	person := ids.NewV7()
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Buyer Person', $2, 'seed', 'system')`, person, e.rep)
+	activity := e.seedWait(t, "Snoozed", "person_id", person)
+	from, to := window()
+	before, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.exec(t, `INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id, after)
+		VALUES ('human', 'human:seed', 'update', 'activity', $1, '{"disposition":"snoozed"}'::jsonb)`,
+		activity)
+
+	after, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if after.Disposed != before.Disposed+1 {
+		t.Fatalf("a snooze did not count as a disposition: %d → %d",
+			before.Disposed, after.Disposed)
+	}
+	if after.DisposedNotSales != before.DisposedNotSales {
+		t.Fatalf("a snooze was counted as the workspace-wide judgement: %d → %d",
+			before.DisposedNotSales, after.DisposedNotSales)
+	}
+}
+
+// An update that is not a disposition is not one.
+//
+// audit_log's `update` on `activity` is written by anything that changes a
+// message, so counting the action alone would report every edit as a rep putting
+// work down.
+func TestAnOrdinaryActivityUpdateIsNotADisposition(t *testing.T) {
+	e := setupLoad(t)
+	person := ids.NewV7()
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Buyer Person', $2, 'seed', 'system')`, person, e.rep)
+	activity := e.seedWait(t, "Edited", "person_id", person)
+	from, to := window()
+	before, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.exec(t, `INSERT INTO audit_log (actor_type, actor_id, action, entity_type, entity_id, after)
+		VALUES ('human', 'human:seed', 'update', 'activity', $1, '{"subject":"Renamed"}'::jsonb)`,
+		activity)
+
+	after, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if after.Disposed != before.Disposed {
+		t.Fatalf("an ordinary edit counted as a disposition: %d → %d",
+			before.Disposed, after.Disposed)
+	}
+}
+
+// A window that ends before it starts is refused rather than answered.
+//
+// Zeros would read as a quiet fortnight, which is the under-reporting direction
+// every figure in this family has to fail away from.
+func TestABackwardsWindowIsRefusedRatherThanAnsweredWithZeros(t *testing.T) {
+	e := setupLoad(t)
+	now := time.Now()
+
+	_, err := metricsStore(e).ResponseWindow(e.as(), now, now.Add(-time.Hour))
+
+	if err == nil {
+		t.Fatal("a window ending before it starts answered instead of refusing")
+	}
+}
+
+// A forged thread key cannot manufacture an answer from another medium.
+//
+// thread_key is one flat namespace holding both a mail thread root and a
+// channel's provider:bot:chat key, and the mail half is attacker-supplied — it
+// is the message's own References root, chosen verbatim by the sender. Matching
+// a reply on the key alone lets a stranger name a Telegram conversation whose
+// parts are both discoverable, and have somebody else's channel reply counted as
+// the answer to their mail.
+//
+// Two things break if it does. The published median absorbs a data point the
+// attacker chose, in whichever direction they chose it. And this reader would
+// call the thread answered while waitingSQL — which does apply the medium match
+// — still shows it waiting, so the two readers of one question disagree.
+//
+// Every other thread reader in the tree matches the triple and says in its own
+// comment that this is a security control. This case is what keeps the
+// restatement here honest.
+func TestAReplyOnAnotherMediumDoesNotAnswerAForgedMailThread(t *testing.T) {
+	e := setupLoad(t)
+	person := ids.NewV7()
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Buyer Person', $2, 'seed', 'system')`, person, e.rep)
+	from, to := window()
+	before, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The key a channel conversation already lives under.
+	forged := "telegram:bot-7:chat-42"
+	// The colleague's channel reply on it, which the attacker was never part of.
+	e.exec(t, `INSERT INTO activity (id, kind, direction, subject, occurred_at, thread_key, channel_provider, source, captured_by)
+		VALUES ($1, 'message', 'outbound', 'Sure, sending now', now() - interval '1 hour', $2, 'telegram', 'seed', 'system')`,
+		ids.NewV7(), forged)
+	// The stranger's mail, carrying that key as its References root.
+	inbound := ids.NewV7()
+	e.exec(t, `INSERT INTO activity (id, kind, direction, subject, occurred_at, thread_key, source, captured_by)
+		VALUES ($1, 'email', 'inbound', 'Forged root', now() - interval '2 hours', $2, 'seed', 'system')`,
+		inbound, forged)
+	e.exec(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), inbound, person)
+
+	after, err := metricsStore(e).ResponseWindow(e.as(), from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if after.Answered != before.Answered {
+		t.Fatalf("the answered count moved %d → %d over a mail nobody replied to — "+
+			"a channel reply on a forged thread key was counted as its answer",
+			before.Answered, after.Answered)
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -6732,6 +6732,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/worklist/response": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * How fast the workspace answers, and how much of the queue it puts down.
+         * @description The hidden-backlog guardrail says what the queue is NOT showing. This says what
+         *     happens to the work it does show, which is the other half of the same question: a
+         *     queue can be honest about its contents and still be a queue nobody answers.
+         *
+         *     Read over a WINDOW rather than at an instant, because neither figure is a fact
+         *     about right now — "we answer in four hours" is a claim about a fortnight, and a
+         *     number taken from today would swing on one slow afternoon. The window defaults to
+         *     the last 14 days.
+         *
+         *     Counted under the CALLER's own visibility — but only on the INBOUND side, and the
+         *     difference is worth stating rather than glossing. A message the caller may not read
+         *     contributes to no figure here. The REPLY that answered it is not gated: the waiting
+         *     lane deliberately ignores the audience arm on its own reply anti-join, because a
+         *     reply somebody else may see still answered the customer, and skipping it would
+         *     report an answered message as waiting.
+         *
+         *     So a caller who can read an inbound but not the audience-limited reply to it learns
+         *     WHEN a colleague answered, to the minute, folded into the median. That is a
+         *     timestamp rather than content, and it is the price of the two readers agreeing
+         *     about which threads were answered — but it is a real disclosure and this is where
+         *     it is written down.
+         */
+        get: operations["getResponseMetrics"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/digest": {
         parameters: {
             query?: never;
@@ -27015,6 +27055,56 @@ export interface components {
             clear: boolean;
         };
         /**
+         * @description What the workspace did with its waiting work over one window. Two questions: how
+         *     fast it answered what it answered, and how much it put down instead.
+         */
+        ResponseMetrics: {
+            /**
+             * Format: date-time
+             * @description The start of the window, inclusive.
+             */
+            from: string;
+            /**
+             * Format: date-time
+             * @description The end of the window, exclusive — so consecutive windows partition time and a message on a boundary is counted once.
+             */
+            to: string;
+            /**
+             * @description How many inbound sales messages got a reply in the window. It is the
+             *     denominator `median_minutes` is worth reading against: a fast median over three
+             *     answered messages says less about the workspace than a slower one over three
+             *     hundred.
+             */
+            answered: number;
+            /**
+             * @description How long the middle answered message waited, in minutes.
+             *
+             *     The MEDIAN rather than the mean, for the reason the material bar takes one: a
+             *     single message answered after three weeks drags an average past every figure a
+             *     reader would recognise, and the question is what a customer TYPICALLY waits.
+             *
+             *     Zero when nothing was answered, which `answered` tells apart from a genuine
+             *     zero-minute median.
+             */
+            median_minutes: number;
+            /**
+             * @description How many rows a reader put DOWN in the window — snoozed, marked not theirs, or
+             *     judged not sales.
+             *
+             *     Counted from the audit record rather than from what is set aside now. A snooze
+             *     that lifted and a not_mine somebody withdrew leave no trace in the current
+             *     state, so a figure read from there would FALL as readers tidied up — reporting
+             *     less judgement the more of it happened.
+             */
+            disposed: number;
+            /**
+             * @description How many of those were the workspace-wide judgement. Its own figure because it
+             *     is the one that costs everybody: the other two hide a row from one reader, this
+             *     one hides the conversation from all of them and does not lift.
+             */
+            disposed_not_sales: number;
+        };
+        /**
          * @description One thing to do, with the reason it sits where it sits.
          *
          *     `level` is the hard product rule and `score` orders inside it; a client renders
@@ -38555,6 +38645,36 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+        };
+    };
+    getResponseMetrics: {
+        parameters: {
+            query?: {
+                /**
+                 * @description How many days back the window reaches. Capped at 90: past that the figure stops
+                 *     describing how the workspace works now and starts averaging over a change in
+                 *     how it works.
+                 */
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description What the workspace did with its waiting work. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResponseMetrics"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            422: components["responses"]["ValidationError"];
         };
     };
     getMorningDigest: {


### PR DESCRIPTION
`GET /worklist/response` answers 404 on a running stack. The feature merged in #3716 and is not in the tree.

## What happened

#3718 merged ten minutes after #3716, off a base that predated it. Its squash reintroduced the older state of every file the two changes had in common, which deleted the response-metrics feature: the contract path, the handler, the compose seam, the store read and all eight integration tests.

The two changes never overlapped. #3718's own work is the Brief's dials, entirely under `frontend/src/screens/`, and nothing here touches it.

## What this does

Restores the fifteen files to the content #3716 merged, and regenerates both contract artifacts.

- Five files restored whole; the three Go ones are byte-identical to the merged version.
- Six partial files re-applied as patches, each without conflict. `crm.yaml` keeps #3722's later tag-contract changes.

## Verification

- `make check-backend`, `make check-fe` — green
- All eight integration tests pass against real Postgres, including the forged-`References`-header case that holds the `(thread_key, kind, channel_provider)` match as a security control
- `craft-static`, `rls-store-path`, `no-jurisdiction` — pass
- Codex review: no findings

Found by testing the merged worklist rework on a dev stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `GET /worklist/response` response-metrics read that a stale rebase deleted, so the endpoint answers instead of 404ing on a running stack. The feature was lost when a squash merged off a base that predated it; that change's own work is untouched.

**Restore scope**
- Fifteen files restored, with the three Go files byte-identical to the merged version.
- Six partial files re-applied as patches without conflict; `crm.yaml` keeps later tag-contract changes.
- Both contract artifacts regenerated.

**Verification**
- `make check-backend` and `make check-fe` pass.
- All eight integration tests pass against real Postgres, including the forged-`References`-header security case.
- `craft-static`, `rls-store-path`, and `no-jurisdiction` pass.

<sup>Written for commit e892af20ba89a2db9b0c56f53a7a768080ca0994. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added response metrics reporting through a human-only endpoint.
  * Reports answered messages, median first-response time, total dispositions, and non-sales dispositions.
  * Supports customizable reporting windows from 1 to 90 days, defaulting to 14 days.
  * Returns an empty metrics result when no waiting source is configured.

* **Tests**
  * Added coverage for reporting windows, response calculations, disposition tracking, authorization, and invalid date ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->