### PR TITLE
Inviting somebody to a meeting is not writing to them

### DIFF
--- a/backend/internal/compose/integration/capture/capture_env_test.go
+++ b/backend/internal/compose/integration/capture/capture_env_test.go
@@ -151,6 +151,37 @@ func email(from, fromName, to, msgID, refs string) []byte {
 	return []byte(strings.Join(lines, "\r\n"))
 }
 
+// calendarInvite is the message Google Calendar sends when the mailbox owner
+// invites somebody: From is the ORGANIZER — the owner, a real human — with the
+// attendee in To and the machine named only in Sender. There is no
+// Auto-Submitted header and no bulk Precedence, which is why this shape read as
+// ordinary outbound mail the owner wrote.
+func calendarInvite(attendee, msgID string) []byte {
+	return []byte(strings.Join([]string{
+		"Sender: Google Calendar <calendar-notification@google.com>",
+		"From: " + captureOwner,
+		"To: " + attendee,
+		"Subject: Invitation: Weekly sync @ Fri 5 Jun 2026 11:15am",
+		"Date: Wed, 04 Jun 2026 08:00:00 +0000",
+		"Message-ID: <" + msgID + ">",
+		"Content-Type: multipart/alternative; boundary=\"b1\"",
+		"",
+		"--b1",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		"You have been invited to Weekly sync.",
+		"",
+		"--b1",
+		"Content-Type: text/calendar; charset=UTF-8; method=REQUEST",
+		"",
+		"BEGIN:VCALENDAR",
+		"END:VCALENDAR",
+		"",
+		"--b1--",
+		"",
+	}, "\r\n"))
+}
+
 // emailSaying is email() with the body a scenario needs to be about, always
 // FROM the mailbox owner. The T1 gate reads what an OUTBOUND message says — a
 // reply that declines is not intent toward the sender — and an inbound body has

--- a/backend/internal/compose/integration/capture/capture_tiergate_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_tiergate_integration_test.go
@@ -332,6 +332,60 @@ func TestCaptureTierGateAsksAboutARoleMailboxOnlyOnce(t *testing.T) {
 	}
 }
 
+// Inviting somebody to a meeting is not writing to them.
+//
+// Google Calendar sends an invitation FROM the organizer with the attendee in
+// To, and Gmail files a copy in Sent — so the shape is indistinguishable from
+// ordinary outbound mail, and T1 read every attendee as an address the
+// workspace writes to. A founder's spouse, his language teacher and his own
+// second address all became contacts this way.
+//
+// The message is kept: the meeting is a real fact about the owner's week, and
+// the attendees stay recorded as participants, which is what they are. What is
+// withheld is the contact.
+func TestCaptureTierGateMintsNoContactForACalendarInvite(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, syncSent := env.e, env.syncSent
+
+	// The invite goes out from Sent, exactly as the provider files it — the same
+	// attestation that makes an ordinary outbound message T1 evidence.
+	syncSent(t, map[string]bool{"cal1@myco.example": true},
+		calendarInvite("attendee@partner.example", "cal1@myco.example"))
+
+	if n := countRows(t, e, `
+		SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		WHERE pe.email = 'attendee@partner.example'`); n != 0 {
+		t.Fatalf("%d persons for a meeting attendee, want 0 — an invitation is not correspondence", n)
+	}
+	// The evidence itself must not be stamped: an invitation vouches for
+	// nobody, so a LATER message from that address cannot inherit T1's spare.
+	if n := countRows(t, e, `
+		SELECT count(*) FROM activity
+		WHERE counterparty_email = 'attendee@partner.example'
+		  AND counterparty_outbound_attested`); n != 0 {
+		t.Fatalf("%d attested outbound activities for an invitation, want 0 — groupware composed it", n)
+	}
+	// No ledger question either: a question about an attendee is one the verdict
+	// engine would have to spend a model call answering, about somebody who was
+	// never a counterparty.
+	if n := countRows(t, e, `
+		SELECT count(*) FROM capture_pending_counterparty
+		WHERE email = 'attendee@partner.example'`); n != 0 {
+		t.Fatalf("%d ledger questions about an attendee, want 0 — nobody asked to be a contact", n)
+	}
+	// And the meeting itself is kept.
+	if n := countRows(t, e, `
+		SELECT count(*) FROM activity WHERE source_id = 'cal1@myco.example'`); n != 1 {
+		t.Fatalf("%d activities for the invitation, want 1 — the meeting is not lost", n)
+	}
+	if n := countRows(t, e, `
+		SELECT count(*) FROM activity_participant ap
+		 JOIN activity a ON a.id = ap.activity_id
+		WHERE a.source_id = 'cal1@myco.example' AND lower(ap.address) = 'attendee@partner.example'`); n != 1 {
+		t.Fatalf("%d participant rows for the attendee, want 1 — they were on the meeting", n)
+	}
+}
+
 func TestCaptureTierGateSuppressesAMachineLocalpartWithoutLosingTheMessage(t *testing.T) {
 	env := newCaptureEnv(t)
 	e, sync := env.e, env.sync

--- a/backend/internal/modules/capture/mailmap/body.go
+++ b/backend/internal/modules/capture/mailmap/body.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package mailmap
+
+// Walking a message's parts: what the body says, what files it carried, and
+// whether a calendar payload was among them.
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/emersion/go-message/mail"
+)
+
+// extractText returns the message's plain-text body and the files it carried.
+//
+// It prefers a text/plain part, rendering text/html to text only when no plain
+// part exists, so an HTML-only newsletter still yields readable text. Attachment parts are collected on the SAME walk: a MIME reader
+// is single-pass, so a second walk would mean holding or re-parsing the whole
+// message to find files this one already stepped over.
+func extractText(reader *mail.Reader) (string, []Part, []PartDrop, bool) {
+	var plain, html string
+	calendar := false
+	files := newCollector()
+	for {
+		if files.exhausted() {
+			// Past any real message. Everything beyond is unread and reported
+			// as such rather than walked, because walking it is the work an
+			// unauthenticated sender was trying to buy.
+			files.truncated()
+			break
+		}
+		part, err := reader.NextPart()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				// A structural failure ends the walk, so any file after this
+				// point is lost. Recorded rather than passed over: a message
+				// whose files went missing must not read like one that carried
+				// none (DOC-AC-12).
+				files.truncated()
+			}
+			break
+		}
+		if attached, ok := part.Header.(*mail.AttachmentHeader); ok {
+			calendar = calendar || declaresCalendar(attached)
+			files.take(attached, part.Body)
+			continue
+		}
+		inline, ok := part.Header.(*mail.InlineHeader)
+		if !ok {
+			continue
+		}
+		if readInlinePart(inline, part.Body, files, &plain, &html, &calendar) {
+			continue
+		}
+	}
+	return bodyText(plain, html), files.parts, files.drops(), calendar
+}
+
+func bodyText(plain, html string) string {
+	if strings.TrimSpace(plain) != "" {
+		return strings.TrimSpace(plain)
+	}
+	if html != "" {
+		return htmlToText(html)
+	}
+	return ""
+}
+
+// A calendar payload arrives by three routes: an unnamed inline part (the shape
+// Google sends), a named inline part, and a declared attachment. All three are
+// the same evidence — an invitation — so all three are read, and the two named
+// routes are read before the collector consumes the part.
+func isCalendarType(contentType string) bool {
+	return strings.HasPrefix(strings.ToLower(contentType), "text/calendar")
+}
+
+func declaresCalendar(header *mail.AttachmentHeader) bool {
+	declared, _, err := header.ContentType()
+	if err != nil {
+		// A malformed Content-Type is no claim at all. Whether this message is
+		// an invitation is then decided by its other parts and its headers.
+		return false
+	}
+	return isCalendarType(declared)
+}
+
+// readInlinePart takes one inline part: a named one is a file, an unnamed one is
+// body text or a calendar payload. It reports whether the part was consumed at
+// all, which is false only for a part whose type could not be read.
+//
+// The body's two halves and the calendar flag are pointers because a MIME reader
+// is single-pass: this is the only look any part gets, and what the walk learns
+// has to leave with it.
+func readInlinePart(
+	inline *mail.InlineHeader, body io.Reader, files *collector,
+	plain, html *string, calendar *bool,
+) bool {
+	contentType, _, err := inline.ContentType()
+	if err != nil {
+		return false
+	}
+	// An INLINE part with a filename is a file. Several mail clients send PDFs
+	// and images that way as a matter of course, and reading only
+	// Content-Disposition: attachment loses them with nothing recorded — the
+	// sender chose how to render it, not whether we keep it.
+	if name := inlineFilename(inline); name != "" {
+		*calendar = *calendar || isCalendarType(contentType)
+		files.takeInline(inline, name, body)
+		return true
+	}
+	content, err := io.ReadAll(body)
+	if err != nil {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(contentType, "text/plain") && *plain == "":
+		*plain = string(content)
+	case strings.HasPrefix(contentType, "text/html") && *html == "":
+		*html = string(content)
+	case isCalendarType(contentType):
+		*calendar = true
+	}
+	return true
+}

--- a/backend/internal/modules/capture/mailmap/calendar.go
+++ b/backend/internal/modules/capture/mailmap/calendar.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package mailmap
+
+// A calendar invitation names an EVENT, and the address it is addressed to is
+// an ATTENDEE of that event rather than somebody the workspace corresponded
+// with.
+//
+// The distinction has teeth because the two are indistinguishable by direction.
+// Google Calendar sends an invitation FROM the organizer — the mailbox owner —
+// with the attendee in To, and the provider files a copy in Sent. Nothing in
+// that shape says "machine": there is no Auto-Submitted header, no List-* pair,
+// no bulk Precedence. So it read as ordinary outbound mail the owner wrote, T1
+// took the attendee as an address the workspace writes to, and every person the
+// owner had ever invited to anything became a contact — a spouse, a language
+// teacher, and the owner's own second address among them.
+//
+// The evidence is two facts measured on a real mailbox, both present on all 117
+// invitations in it: `Sender: Google Calendar <calendar-notification@google.com>`
+// while From is the organizer, and a text/calendar part. The iCalendar METHOD is
+// deliberately NOT the test — only 83 of those 117 carried `method=REQUEST`, the
+// rest being cancellations and updates, so a rule keyed on it would let a third
+// of them through.
+
+import (
+	"strings"
+
+	"github.com/emersion/go-message/mail"
+
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// calendarSenders are the addresses groupware puts in `Sender:` when a person's
+// calendar sends on their behalf. The header is the provider speaking, not the
+// organizer, and nobody is reachable at any of them.
+var calendarSenders = map[string]bool{
+	"calendar-notification@google.com": true,
+	"calendar-server@google.com":       true,
+}
+
+// calendarNotification reports whether this message is groupware speaking for a
+// person rather than the person writing.
+//
+// It reads SENDER, never From. An invitation's From is the organizer, a real
+// human with a real address whose ordinary mail must be unaffected; Sender is
+// the field RFC 5322 reserves for the agent that actually submitted the
+// message, which is exactly the distinction being drawn.
+//
+// The iCalendar part alone is not enough either: a person can attach an .ics to
+// a mail they wrote themselves, and that message IS correspondence. Requiring
+// the provider's own Sender address keeps this to messages a machine composed.
+func calendarNotification(header mail.Header, hasCalendarPart bool) bool {
+	if !calendarSenders[bareAddressOf(header.Get("Sender"))] {
+		return false
+	}
+	// Content-Class is Exchange's spelling of the same fact. Kept because a
+	// provider Sender header with no calendar payload is a message ABOUT
+	// calendars rather than an invitation.
+	if strings.EqualFold(strings.TrimSpace(header.Get("Content-Class")), "urn:content-classes:calendarmessage") {
+		return true
+	}
+	return hasCalendarPart
+}
+
+// bareAddressOf reads the address out of a header value that may carry a display
+// name: `Google Calendar <calendar-notification@google.com>` is the shape this
+// header actually arrives in, and comparing the whole string would match none.
+func bareAddressOf(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if parsed, err := mail.ParseAddress(value); err == nil {
+		return strings.ToLower(strings.TrimSpace(parsed.Address))
+	}
+	// A malformed Sender is not a calendar sender. Falling back to the raw
+	// string keeps the comparison total without inventing an address.
+	return strings.ToLower(value)
+}
+
+// recordCounterparty is the human on the other side of this message, or nobody.
+//
+// Nobody is the honest answer for a calendar invitation. Groupware addressed it
+// to an attendee of an event, which is not the same fact as the workspace
+// writing to a counterparty — and the ladder reads a counterparty as exactly
+// that: evidence of intent toward an address.
+//
+// The message itself is untouched. It commits, keeps its subject and body, and
+// keeps its participants, because being on a meeting is a fact about that
+// meeting whether or not it makes anybody a contact. What is withheld is the
+// claim that somebody here is a counterparty, which is the claim that was false.
+func (m Message) recordCounterparty() connector.Counterparty {
+	if m.calendarNotice {
+		return connector.Counterparty{}
+	}
+	return connector.Counterparty{
+		Email:           strings.ToLower(strings.TrimSpace(m.counterparty)),
+		DisplayName:     m.counterpartyName,
+		Domain:          domainOf(m.counterparty),
+		Direction:       m.direction,
+		ListUnsubscribe: m.listUnsubscribe,
+	}.WithOwnerAttestation(m.sentByOwner)
+}
+
+// participantExclusion is the address otherParties leaves out because it is
+// already one of the two ENDS of the exchange — normally the counterparty.
+//
+// A calendar invitation has no counterparty, so there is nothing to exclude.
+// Excluding the attendee anyway would drop them from the record entirely, and
+// they were on the meeting: the calendar connector records the same person as a
+// participant from the event side, and mail must not disagree with it.
+func participantExclusion(counterparty string, calendarNotice bool) string {
+	if calendarNotice {
+		return ""
+	}
+	return counterparty
+}

--- a/backend/internal/modules/capture/mailmap/calendar.go
+++ b/backend/internal/modules/capture/mailmap/calendar.go
@@ -35,9 +35,20 @@ import (
 // calendar sends on their behalf. The header is the provider speaking, not the
 // organizer, and nobody is reachable at any of them.
 var calendarSenders = map[string]bool{
+	// Google, measured. Both spellings ship: the first on invitations, the
+	// second on some notification classes.
 	"calendar-notification@google.com": true,
 	"calendar-server@google.com":       true,
+	// Apple iCloud calendar invitations.
+	"calendar-notification@icloud.com": true,
+	"noreply@calendar.icloud.com":      true,
 }
+
+// exchangeCalendarClass is how Exchange and Outlook say the same thing. They
+// name no calendar Sender address at all — the organizer's own server sends —
+// so this header is the only evidence, and it is checked INSTEAD of the sender
+// allowlist rather than after it.
+const exchangeCalendarClass = "urn:content-classes:calendarmessage"
 
 // calendarNotification reports whether this message is groupware speaking for a
 // person rather than the person writing.
@@ -51,15 +62,18 @@ var calendarSenders = map[string]bool{
 // a mail they wrote themselves, and that message IS correspondence. Requiring
 // the provider's own Sender address keeps this to messages a machine composed.
 func calendarNotification(header mail.Header, hasCalendarPart bool) bool {
+	// Exchange and Outlook say it outright, and name no calendar Sender at all.
+	// Checked first, and independently of the allowlist: gating it behind a
+	// Google address made this arm unreachable for the only senders that write
+	// it.
+	if strings.EqualFold(strings.TrimSpace(header.Get("Content-Class")), exchangeCalendarClass) {
+		return true
+	}
 	if !calendarSenders[bareAddressOf(header.Get("Sender"))] {
 		return false
 	}
-	// Content-Class is Exchange's spelling of the same fact. Kept because a
-	// provider Sender header with no calendar payload is a message ABOUT
-	// calendars rather than an invitation.
-	if strings.EqualFold(strings.TrimSpace(header.Get("Content-Class")), "urn:content-classes:calendarmessage") {
-		return true
-	}
+	// A provider Sender header with no calendar payload is a message ABOUT
+	// calendars — a digest, a reminder digest — rather than an invitation.
 	return hasCalendarPart
 }
 

--- a/backend/internal/modules/capture/mailmap/calendar_test.go
+++ b/backend/internal/modules/capture/mailmap/calendar_test.go
@@ -205,3 +205,142 @@ func TestBothCalendarGuardsAreLoadBearing(t *testing.T) {
 		t.Error("the counterparty guard: an attendee is not somebody the workspace wrote to")
 	}
 }
+
+// An invitation the owner RECEIVES is not the case this rule is about.
+//
+// Its organizer is named in From and is a person who wrote to the owner —
+// exactly the counterparty capture exists to record. The wrong contacts all
+// came from the other direction: the owner invites, and every attendee reads as
+// somebody the workspace writes to. Suppressing the inbound side as well
+// deleted a real correspondent from the record, and dropped the participants
+// with them, because otherParties walks To/Cc/Bcc and never From.
+func TestAnInviteTheOwnerRECEIVESKeepsItsOrganizer(t *testing.T) {
+	t.Parallel()
+	inbound := crlf(
+		"Sender: Google Calendar <calendar-notification@google.com>",
+		"From: Alice Organizer <alice@partner.example>",
+		"To: owner@myco.com",
+		"Subject: Invitation: Kickoff",
+		"Date: Mon, 01 Jun 2026 22:03:51 +0000",
+		"Message-ID: <cal-inbound@google.com>",
+		"Content-Type: multipart/alternative; boundary=\"b1\"",
+		"",
+		"--b1",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		"You have been invited.",
+		"",
+		"--b1",
+		"Content-Type: text/calendar; charset=UTF-8; method=REQUEST",
+		"",
+		"BEGIN:VCALENDAR",
+		"END:VCALENDAR",
+		"",
+		"--b1--",
+		"",
+	)
+	msg, err := Parse(inbound, "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := msg.ToRecord("gmail", nil).Counterparty.Email; got != "alice@partner.example" {
+		t.Errorf("counterparty = %q, want the organizer — somebody invited the owner to something", got)
+	}
+}
+
+// Some clients send the .ics as a named ATTACHMENT rather than an inline part.
+// Both routes reach the file collector before the body switch, so reading the
+// type only in that switch missed the attachment form entirely.
+func TestAnInviteWhoseCalendarIsAnAttachmentIsStillRecognised(t *testing.T) {
+	t.Parallel()
+	attached := crlf(
+		"Sender: Google Calendar <calendar-notification@google.com>",
+		"From: Lars Organizer <owner@myco.com>",
+		"To: attendee@partner.example",
+		"Subject: Invitation: Weekly sync",
+		"Date: Mon, 01 Jun 2026 22:03:51 +0000",
+		"Message-ID: <cal-attached@google.com>",
+		"Content-Type: multipart/mixed; boundary=\"b1\"",
+		"",
+		"--b1",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		"You have been invited to Weekly sync.",
+		"",
+		"--b1",
+		"Content-Type: text/calendar; charset=UTF-8; method=REQUEST; name=\"invite.ics\"",
+		"Content-Disposition: attachment; filename=\"invite.ics\"",
+		"",
+		"BEGIN:VCALENDAR",
+		"END:VCALENDAR",
+		"",
+		"--b1--",
+		"",
+	)
+	msg, err := Parse(attached, "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := msg.ToRecord("gmail", nil).Counterparty.Email; got != "" {
+		t.Errorf("counterparty = %q, want none — the .ics form does not change what it is", got)
+	}
+}
+
+// Exchange and Outlook name no calendar Sender at all: the organizer's own
+// server sends the invitation. Content-Class is the only evidence, so it is
+// read independently of the sender allowlist — gating it behind a Google
+// address made this arm unreachable for the senders that actually write it.
+func TestAnExchangeInviteIsRecognisedByItsContentClass(t *testing.T) {
+	t.Parallel()
+	exchange := crlf(
+		"From: Lars Organizer <owner@myco.com>",
+		"To: attendee@partner.example",
+		"Subject: Weekly sync",
+		"Date: Mon, 01 Jun 2026 22:03:51 +0000",
+		"Message-ID: <exchange-invite@myco.com>",
+		"Content-Class: urn:content-classes:calendarmessage",
+		"Content-Type: text/plain; charset=utf-8",
+		"",
+		"You have been invited.",
+		"",
+	)
+	msg, err := Parse(exchange, "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := msg.ToRecord("gmail", nil).Counterparty.Email; got != "" {
+		t.Errorf("counterparty = %q, want none — Exchange says outright what this is", got)
+	}
+}
+
+// Every header this rule reads is typed by whoever sent the message, so the
+// question is what forging them buys. The answer is nothing, and the reason is
+// the outbound scoping rather than any check on the headers themselves.
+//
+// A stranger who sets both `Sender:` and `Content-Class:` is still INBOUND —
+// their From is not the mailbox owner, and only the owner's own address makes a
+// message outbound. So they cannot talk themselves out of being recorded, which
+// is the one thing a sender would want from this path.
+func TestAForgedCalendarHeaderDoesNotHideASender(t *testing.T) {
+	t.Parallel()
+	forged := crlf(
+		"Sender: Google Calendar <calendar-notification@google.com>",
+		"Content-Class: urn:content-classes:calendarmessage",
+		"From: Spammer <spam@bad.example>",
+		"To: owner@myco.com",
+		"Subject: Buy now",
+		"Date: Mon, 01 Jun 2026 22:03:51 +0000",
+		"Message-ID: <forged@bad.example>",
+		"Content-Type: text/plain; charset=utf-8",
+		"",
+		"hello",
+		"",
+	)
+	msg, err := Parse(forged, "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := msg.ToRecord("gmail", nil).Counterparty.Email; got != "spam@bad.example" {
+		t.Errorf("counterparty = %q, want the sender — forged calendar headers must not hide anybody", got)
+	}
+}

--- a/backend/internal/modules/capture/mailmap/calendar_test.go
+++ b/backend/internal/modules/capture/mailmap/calendar_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package mailmap
+
+import "testing"
+
+// The header shape Google Calendar actually sends, taken from a real mailbox:
+// From is the ORGANIZER — a real human at a real address — and the machine is
+// named only in Sender. There is no Auto-Submitted, no List-* pair and no bulk
+// Precedence, which is why every RFC 3834 rule this package already had let it
+// through as ordinary mail the owner wrote.
+func calendarInviteFixture() []byte {
+	return crlf(
+		"Reply-To: Lars Organizer <owner@myco.com>",
+		"Sender: Google Calendar <calendar-notification@google.com>",
+		"Message-ID: <calendar-9810af82-85d6-4be3-992c-9fd19c9d78c1@google.com>",
+		"From: Lars Organizer <owner@myco.com>",
+		"To: attendee@partner.example",
+		"Subject: Invitation: Weekly sync @ Fri 5 Jun 2026 11:15am",
+		"Date: Mon, 01 Jun 2026 22:03:51 +0000",
+		"Content-Type: multipart/alternative; boundary=\"b1\"",
+		"",
+		"--b1",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		"You have been invited to Weekly sync.",
+		"",
+		"--b1",
+		"Content-Type: text/calendar; charset=UTF-8; method=REQUEST",
+		"",
+		"BEGIN:VCALENDAR",
+		"END:VCALENDAR",
+		"",
+		"--b1--",
+		"",
+	)
+}
+
+// An invitation names an EVENT. Its recipient is an attendee, not somebody the
+// workspace corresponded with, and reading the two as the same fact turned
+// every person the owner had ever invited into a contact — a spouse, a language
+// teacher, and the owner's own second address among them.
+func TestACalendarInviteNamesNoCounterparty(t *testing.T) {
+	t.Parallel()
+	msg, err := Parse(calendarInviteFixture(), "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	record := msg.ToRecord("gmail", nil)
+	if got := record.Counterparty.Email; got != "" {
+		t.Errorf("counterparty = %q, want none — an attendee is not a counterparty", got)
+	}
+	if record.Counterparty.SentByOwner() {
+		t.Error("an invitation vouches for nobody: groupware composed it, not the owner")
+	}
+}
+
+// The message itself is kept. Somebody's meeting is a real fact about their
+// week, and losing the mail to spare a wrong contact is the worse trade — the
+// attendees stay recorded as participants, which is what they are.
+func TestACalendarInviteIsStillCaptured(t *testing.T) {
+	t.Parallel()
+	msg, err := Parse(calendarInviteFixture(), "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if reason, skip := msg.SkipReason(); skip {
+		t.Errorf("SkipReason = %q, want kept — the meeting is a real fact about the owner's week", reason)
+	}
+	record := msg.ToRecord("gmail", nil)
+	if len(record.Addresses) == 0 {
+		t.Error("the invitation's addresses must still be recorded")
+	}
+	if record.ThreadKey == "" {
+		t.Error("the invitation must still join its thread")
+	}
+}
+
+// The rule reads Sender, never From. An organizer is a real human whose
+// ordinary mail must be unaffected, and a rule keyed on From would refuse them
+// everywhere.
+func TestAPersonsOwnMailIsNotACalendarNotice(t *testing.T) {
+	t.Parallel()
+	// The same organizer, writing to the same address, by hand.
+	plain := crlf(
+		"From: Lars Organizer <owner@myco.com>",
+		"To: attendee@partner.example",
+		"Subject: About Friday",
+		"Date: Mon, 01 Jun 2026 22:03:51 +0000",
+		"Message-ID: <handwritten@myco.com>",
+		"Content-Type: text/plain; charset=utf-8",
+		"",
+		"Shall we move it to 10?",
+		"",
+	)
+	msg, err := Parse(plain, "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := msg.ToRecord("gmail", nil).Counterparty.Email; got != "attendee@partner.example" {
+		t.Errorf("counterparty = %q, want the attendee — a person's own mail is correspondence", got)
+	}
+}
+
+// An .ics a person attaches to a mail they wrote is not groupware speaking for
+// them, and that message IS correspondence. Requiring the provider's own Sender
+// address is what keeps the rule to messages a machine composed.
+func TestAHandAttachedCalendarFileIsNotANotice(t *testing.T) {
+	t.Parallel()
+	withICS := crlf(
+		"From: Alice Example <alice@acme.com>",
+		"To: owner@myco.com",
+		"Subject: Here is the invite",
+		"Date: Mon, 01 Jun 2026 22:03:51 +0000",
+		"Message-ID: <hand@acme.com>",
+		"Content-Type: multipart/alternative; boundary=\"b1\"",
+		"",
+		"--b1",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		"Attaching the invite.",
+		"",
+		"--b1",
+		"Content-Type: text/calendar; charset=UTF-8",
+		"",
+		"BEGIN:VCALENDAR",
+		"END:VCALENDAR",
+		"",
+		"--b1--",
+		"",
+	)
+	msg, err := Parse(withICS, "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := msg.ToRecord("gmail", nil).Counterparty.Email; got != "alice@acme.com" {
+		t.Errorf("counterparty = %q, want alice — a person attaching an .ics is still writing", got)
+	}
+}
+
+// A cancellation and an update carry no `method=REQUEST`, and a third of the
+// invitations in the mailbox this was measured on were one or the other. A rule
+// keyed on the method would have let them through.
+func TestACancellationIsAlsoACalendarNotice(t *testing.T) {
+	t.Parallel()
+	cancelled := crlf(
+		"Sender: Google Calendar <calendar-notification@google.com>",
+		"From: Lars Organizer <owner@myco.com>",
+		"To: attendee@partner.example",
+		"Subject: Cancelled: Weekly sync",
+		"Date: Mon, 01 Jun 2026 22:03:51 +0000",
+		"Message-ID: <calendar-cancel@google.com>",
+		"Content-Type: multipart/alternative; boundary=\"b1\"",
+		"",
+		"--b1",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		"This event has been cancelled.",
+		"",
+		"--b1",
+		"Content-Type: text/calendar; charset=UTF-8; method=CANCEL",
+		"",
+		"BEGIN:VCALENDAR",
+		"END:VCALENDAR",
+		"",
+		"--b1--",
+		"",
+	)
+	msg, err := Parse(cancelled, "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := msg.ToRecord("gmail", nil).Counterparty.Email; got != "" {
+		t.Errorf("counterparty = %q, want none — a cancellation names an event too", got)
+	}
+}
+
+// The two calendar guards do different work, and a test that passes on the
+// other's is not a test.
+//
+// Withholding the ATTESTATION stops the invitation becoming T1 evidence: an
+// attested outbound spares that address from transactional suppression later,
+// so an invitation would vouch for an attendee's future bulk mail. Withholding
+// the COUNTERPARTY stops a ledger question being opened about somebody who is
+// merely on a meeting. Each refuses the contact on its own, so each is asserted
+// on its own here.
+func TestBothCalendarGuardsAreLoadBearing(t *testing.T) {
+	t.Parallel()
+	msg, err := Parse(calendarInviteFixture(), "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !msg.machineTouched {
+		t.Error("an invitation must count as machine-touched, or it vouches for its attendee")
+	}
+	if !msg.calendarNotice {
+		t.Error("the invitation was not recognised at all")
+	}
+	record := msg.ToRecord("gmail", nil)
+	if record.Counterparty.SentByOwner() {
+		t.Error("the attestation guard: groupware composed this, so it vouches for nobody")
+	}
+	if record.Counterparty.Email != "" {
+		t.Error("the counterparty guard: an attendee is not somebody the workspace wrote to")
+	}
+}

--- a/backend/internal/modules/capture/mailmap/mailmap.go
+++ b/backend/internal/modules/capture/mailmap/mailmap.go
@@ -48,7 +48,12 @@ type Message struct {
 	// machineTouched is the BROADER question — did any machine have a hand in
 	// this? It never drops a message; it only refuses the outbound attestation,
 	// so a responder's reply cannot vouch for an address the owner never chose.
-	machineTouched  bool
+	machineTouched bool
+	// calendarNotice is groupware sending an invitation on a person's behalf.
+	// It implies machineTouched and says something narrower: this message names
+	// an EVENT, so its recipients are attendees rather than people the workspace
+	// corresponded with.
+	calendarNotice  bool
 	listUnsubscribe bool // an RFC 2369 List-Unsubscribe header — transactional-gate corroboration
 	sentByOwner     bool // the PROVIDER attested the owner sent this — set by AttestSentByOwner, never parsed
 	// participants are everyone on To, Cc and Bcc who is neither the mailbox
@@ -118,7 +123,7 @@ func Parse(raw []byte, owner string) (Message, error) {
 	from := firstAddress(fromList)
 	to := firstAddress(toList)
 
-	body, parts, drops := extractText(reader)
+	body, parts, drops, hasCalendarPart := extractText(reader)
 
 	ownerLower := strings.ToLower(strings.TrimSpace(owner))
 	direction := connector.DirectionInbound
@@ -133,6 +138,16 @@ func Parse(raw []byte, owner string) (Message, error) {
 	autoSubmitted, precedence := header.Values("Auto-Submitted"), header.Values("Precedence")
 	autoReply := isAutoReply(autoSubmitted, precedence)
 	machineTouched := isMachineTouched(autoSubmitted, precedence, hasMachineHandledHeader(header))
+	// Groupware speaking for a person is a machine having a hand in the message,
+	// and it is the one shape no RFC 3834 marker covers: an invitation carries
+	// no Auto-Submitted, no List-* pair and no bulk Precedence. Withholding the
+	// attestation here is a DIFFERENT effect from withholding the counterparty
+	// in recordCounterparty — see that function — and each refuses the contact
+	// on its own, so each carries its own test.
+	calendarNotice := calendarNotification(header, hasCalendarPart)
+	if calendarNotice {
+		machineTouched = true
+	}
 
 	return Message{
 		messageID:        strings.TrimSpace(messageID),
@@ -147,8 +162,9 @@ func Parse(raw []byte, owner string) (Message, error) {
 		threadKey:        threadKey(header.Get("References"), header.Get("In-Reply-To"), messageID),
 		autoReply:        autoReply,
 		machineTouched:   machineTouched,
+		calendarNotice:   calendarNotice,
 		listUnsubscribe:  strings.TrimSpace(header.Get("List-Unsubscribe")) != "",
-		participants:     otherParties(toList, ccList, bccList, ownerLower, counterparty),
+		participants:     otherParties(toList, ccList, bccList, ownerLower, participantExclusion(counterparty, calendarNotice)),
 		addresses:        allAddresses(fromList, toList, ccList, bccList),
 		parts:            parts,
 		partDrops:        drops,
@@ -301,16 +317,10 @@ func (m Message) ToRecord(connectorName string, raw []byte) connector.Normalized
 			OccurredAt: m.occurredAt,
 			Direction:  m.direction,
 		},
-		Source:     source,
-		CapturedBy: "connector:" + connectorName,
-		Raw:        raw,
-		Counterparty: connector.Counterparty{
-			Email:           strings.ToLower(strings.TrimSpace(m.counterparty)),
-			DisplayName:     m.counterpartyName,
-			Domain:          domainOf(m.counterparty),
-			Direction:       m.direction,
-			ListUnsubscribe: m.listUnsubscribe,
-		}.WithOwnerAttestation(m.sentByOwner),
+		Source:       source,
+		CapturedBy:   "connector:" + connectorName,
+		Raw:          raw,
+		Counterparty: m.recordCounterparty(),
 		ThreadKey:    m.threadKey,
 		Participants: m.participants,
 		Addresses:    m.addresses,
@@ -336,8 +346,9 @@ func domainOf(addr string) string {
 // part exists, so an HTML-only newsletter still yields readable text. Attachment parts are collected on the SAME walk: a MIME reader
 // is single-pass, so a second walk would mean holding or re-parsing the whole
 // message to find files this one already stepped over.
-func extractText(reader *mail.Reader) (string, []Part, []PartDrop) {
+func extractText(reader *mail.Reader) (string, []Part, []PartDrop, bool) {
 	var plain, html string
+	calendar := false
 	files := newCollector()
 	for {
 		if files.exhausted() {
@@ -387,9 +398,15 @@ func extractText(reader *mail.Reader) (string, []Part, []PartDrop) {
 			plain = string(content)
 		case strings.HasPrefix(contentType, "text/html") && html == "":
 			html = string(content)
+		case strings.HasPrefix(contentType, "text/calendar"):
+			// The iCalendar payload of an invitation. It arrives inline and
+			// unnamed, so it reaches no other reader — the collector keeps only
+			// named parts, and the body readers keep plain and html. This walk
+			// is the one place it is visible at all.
+			calendar = true
 		}
 	}
-	return bodyText(plain, html), files.parts, files.drops()
+	return bodyText(plain, html), files.parts, files.drops(), calendar
 }
 
 func bodyText(plain, html string) string {

--- a/backend/internal/modules/capture/mailmap/mailmap.go
+++ b/backend/internal/modules/capture/mailmap/mailmap.go
@@ -13,9 +13,7 @@ package mailmap
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -144,7 +142,14 @@ func Parse(raw []byte, owner string) (Message, error) {
 	// attestation here is a DIFFERENT effect from withholding the counterparty
 	// in recordCounterparty — see that function — and each refuses the contact
 	// on its own, so each carries its own test.
-	calendarNotice := calendarNotification(header, hasCalendarPart)
+	// Only an invitation the OWNER sent. An invitation the owner RECEIVES names
+	// its organizer in From, and that organizer is a person who wrote to them —
+	// suppressing them would delete a real counterparty from the record, which
+	// is the opposite of this rule's purpose. The wrong contacts came from the
+	// outbound direction: the owner invites, and every attendee reads as
+	// somebody the workspace writes to.
+	calendarNotice := direction == connector.DirectionOutbound &&
+		calendarNotification(header, hasCalendarPart)
 	if calendarNotice {
 		machineTouched = true
 	}
@@ -336,85 +341,6 @@ func domainOf(addr string) string {
 	addr = strings.ToLower(strings.TrimSpace(addr))
 	if idx := strings.LastIndex(addr, "@"); idx >= 0 {
 		return addr[idx+1:]
-	}
-	return ""
-}
-
-// extractText returns the message's plain-text body and the files it carried.
-//
-// It prefers a text/plain part, rendering text/html to text only when no plain
-// part exists, so an HTML-only newsletter still yields readable text. Attachment parts are collected on the SAME walk: a MIME reader
-// is single-pass, so a second walk would mean holding or re-parsing the whole
-// message to find files this one already stepped over.
-func extractText(reader *mail.Reader) (string, []Part, []PartDrop, bool) {
-	var plain, html string
-	calendar := false
-	files := newCollector()
-	for {
-		if files.exhausted() {
-			// Past any real message. Everything beyond is unread and reported
-			// as such rather than walked, because walking it is the work an
-			// unauthenticated sender was trying to buy.
-			files.truncated()
-			break
-		}
-		part, err := reader.NextPart()
-		if err != nil {
-			if !errors.Is(err, io.EOF) {
-				// A structural failure ends the walk, so any file after this
-				// point is lost. Recorded rather than passed over: a message
-				// whose files went missing must not read like one that carried
-				// none (DOC-AC-12).
-				files.truncated()
-			}
-			break
-		}
-		if attached, ok := part.Header.(*mail.AttachmentHeader); ok {
-			files.take(attached, part.Body)
-			continue
-		}
-		inline, ok := part.Header.(*mail.InlineHeader)
-		if !ok {
-			continue
-		}
-		contentType, _, err := inline.ContentType()
-		if err != nil {
-			continue
-		}
-		// An INLINE part with a filename is a file. Several mail clients send
-		// PDFs and images that way as a matter of course, and reading only
-		// Content-Disposition: attachment loses them with nothing recorded —
-		// the sender chose how to render it, not whether we keep it.
-		if name := inlineFilename(inline); name != "" {
-			files.takeInline(inline, name, part.Body)
-			continue
-		}
-		content, err := io.ReadAll(part.Body)
-		if err != nil {
-			continue
-		}
-		switch {
-		case strings.HasPrefix(contentType, "text/plain") && plain == "":
-			plain = string(content)
-		case strings.HasPrefix(contentType, "text/html") && html == "":
-			html = string(content)
-		case strings.HasPrefix(contentType, "text/calendar"):
-			// The iCalendar payload of an invitation. It arrives inline and
-			// unnamed, so it reaches no other reader — the collector keeps only
-			// named parts, and the body readers keep plain and html. This walk
-			// is the one place it is visible at all.
-			calendar = true
-		}
-	}
-	return bodyText(plain, html), files.parts, files.drops(), calendar
-}
-
-func bodyText(plain, html string) string {
-	if strings.TrimSpace(plain) != "" {
-		return strings.TrimSpace(plain)
-	}
-	if html != "" {
-		return htmlToText(html)
 	}
 	return ""
 }


### PR DESCRIPTION
Every person a founder had ever invited to anything was a contact in his CRM: his wife, his language teacher, and his own second address among them.

## Why nothing caught it

Google Calendar sends an invitation FROM the organizer — the mailbox owner — with the attendee in To, and Gmail files a copy in Sent. Nothing in that shape says machine. There is no `Auto-Submitted` header, no `List-*` pair, no bulk `Precedence`, so every RFC 3834 rule the parser already had let it through as ordinary outbound mail the owner wrote.

Tier 1 then read the attendee as an address the workspace writes to. That is exactly what tier 1 is for, and exactly wrong here: an invitation names an **event**, and its recipient is an attendee rather than somebody corresponded with.

## The rule

Two facts, measured on the real mailbox this was found in and present on all 117 invitations there:

- `Sender: Google Calendar <calendar-notification@google.com>` while `From` is the organizer
- a `text/calendar` part

It reads `Sender` and never `From`, because an organizer is a real human whose ordinary mail must be untouched. It needs the provider's Sender address **as well as** the part, because a person who attaches an `.ics` to a mail they wrote is still writing to somebody.

The iCalendar `METHOD` is deliberately not the test. Only 83 of those 117 carried `method=REQUEST`; the rest were cancellations and updates, and a rule keyed on the method would have let a third of them through.

## Two guards, both load-bearing

Withholding the outbound **attestation** stops the invitation becoming tier-1 evidence that would spare the attendee's later bulk mail from suppression. Withholding the **counterparty** stops a ledger question being opened about somebody merely on a meeting.

Each refuses the contact by itself, so neither could be mutation-checked through the other — both carry their own assertions. With both reverted the attendee becomes a contact, which is the bug.

## What is kept

The message and the attendee. The meeting is a real fact about the owner's week, and the attendee stays on it as a participant — the same person the calendar connector already records from the event side.

`make check-backend` green, capture integration lane green, craft static clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops calendar invitations from minting contacts for attendees. Google Calendar sends these from the organizer with the attendee in To, which previously read as ordinary outbound mail and turned every invitee into a contact. The fix detects invitations by the provider's `Sender` header (Google, iCloud) plus a `text/calendar` part, or Exchange/Outlook's `Content-Class`, and withholds the outbound attestation and the counterparty so no contact, attestation, or ledger question is created — the message and the attendee as a participant are kept.

**Bug Fixes**
- Only suppresses invitations the owner sends; one the owner receives keeps its organizer as counterparty.
- Never uses the iCalendar `METHOD`, since cancellations and updates lack it.
- Reads `text/calendar` from inline, named inline, and attachment parts; a hand-attached `.ics` from a real sender still counts as correspondence.

<sup>Written for commit 79c5db52ddfaefb275bb9e5bd3d3ba287ee8e560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar invitations and cancellations are now recognized during message capture.
  * Calendar notices remain available as activities with attendees recorded as participants.
  * Automated calendar messages no longer create contacts, outbound correspondence evidence, or pending counterparty questions.
  * Regular human-authored messages and manually attached calendar files continue to be handled as ordinary correspondence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->