### PR TITLE
Route the draft-email probe through the catalog/instance path

### DIFF
--- a/backend/internal/compose/integration/no_activity_reminder_workqueue_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_reminder_workqueue_integration_test.go
@@ -57,6 +57,7 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -93,7 +94,9 @@ func TestNoActivityReminderReachesTheOwnersTasksScreenThroughTheRealRiverJob(t *
 	backdateCreatedAt(t, owner, "deal", dealID, staleTouch)
 
 	seedTaskCreatePermission(t, owner, e.WS, sam)
-	seedOwnedNoActivityReminder(t, owner, e.WS, sam, noActivityDays)
+	params := json.RawMessage(fmt.Sprintf(`{"no_activity_days":%d}`, noActivityDays))
+	seedOwnedAutomation(t, owner, "no_activity_reminder", "No Activity Reminder",
+		`{"schedule":"clock"}`, `{"kind":"create_task"}`, params, sam)
 
 	ApplyRiverSchema(t)
 	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -194,19 +197,20 @@ func seedTaskCreatePermission(t *testing.T, owner *pgx.Conn, ws, user ids.UUID) 
 	}
 }
 
-// seedOwnedNoActivityReminder enrolls one enabled no_activity_reminder
-// instance OWNED BY A HUMAN — unlike seedNoActivityReminder's ownerless
-// system-seed shape (timescan_integration_test.go), a non-null owner_id
-// routes every firing through the Task-13 match-time gate, which is
-// exactly the path AUTO-AC-6 exercises: Sam turned this rule on himself.
-func seedOwnedNoActivityReminder(t *testing.T, owner *pgx.Conn, ws, ownerID ids.UUID, days int) {
+// seedOwnedAutomation enrolls one enabled automation instance OWNED BY A
+// HUMAN: a non-null owner_id routes every firing through the match-time gate
+// (automation/gate.go), which re-resolves that owner's LIVE RBAC through
+// identity.Service — the real resolver compose.NewWorkflowEngine wires in,
+// never the harness's synthetic principal.Permissions used elsewhere for
+// read-side scope tests. One writer for this shape, so a new required
+// column or default is maintained once rather than drifting between callers.
+func seedOwnedAutomation(t *testing.T, owner *pgx.Conn, key, name, trigger, action string, params json.RawMessage, ownerID ids.UUID) {
 	t.Helper()
-	params := fmt.Sprintf(`{"no_activity_days":%d}`, days)
 	if _, err := owner.Exec(context.Background(),
 		`INSERT INTO automation (id, key, name, trigger, action, params, owner_id, enabled)
-		 VALUES ($1, 'no_activity_reminder', 'No Activity Reminder', '{"schedule":"clock"}', '{"kind":"create_task"}', $2::jsonb, $3, true)`,
-		ids.NewV7(), params, ownerID); err != nil {
-		t.Fatalf("seeding the owner-authored no_activity_reminder instance: %v", err)
+		 VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7, true)`,
+		ids.NewV7(), key, name, trigger, action, params, ownerID); err != nil {
+		t.Fatalf("seeding the owner-authored %s instance: %v", key, err)
 	}
 }
 

--- a/backend/internal/compose/integration/workflow_action_executors_integration_test.go
+++ b/backend/internal/compose/integration/workflow_action_executors_integration_test.go
@@ -186,10 +186,35 @@ func TestDraftEmailFiringLandsTheComposedDraftOnTheRunRecord(t *testing.T) {
 	dealID := e.SeedDeal(t, "Draft Email Probe Deal", pipeline, open, nil)
 
 	engine := compose.NewWorkflowEngine(e.DB())
-	engine.RegisterSystemWorkflow(draftEmailProbe{
+	// RegisterWorkflow, not RegisterSystemWorkflow: a draft_email action now
+	// refuses at compose time with no owner behind the firing
+	// (MissingDraftOwnerError), and a system handler's firing carries no
+	// owner by contract (workflow.Event.OwnerID's own doc) — there is no
+	// instance behind it to read one from. The catalog/instance path below
+	// is what every drafting automation in production actually runs
+	// through, Rep1 owning it is what makes principal.SendingHuman resolve.
+	engine.RegisterWorkflow(draftEmailProbe{
 		comms:     draftingComms{subject: "Re: next step", body: "Following up on our last conversation."},
 		approvals: stagingApprovals{svc: approvals.NewService(e.DB())},
 	})
+	// The match-time gate (gate.go) resolves the owner's authority through
+	// identity.Service reading the REAL role/role_assignment tables, not the
+	// harness's in-memory permission fixtures e.As() uses — so a
+	// human-authored firing needs an actual role row or the gate blocks it
+	// as a lost permission, the same requirement
+	// no_activity_reminder_workqueue_integration_test.go's
+	// seedTaskCreatePermission documents for its own owned automation.
+	seedTaskCreatePermission(t, OwnerConn(t), e.WS, e.Rep1)
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO automation (key, name, trigger, action, params, owner_id, enabled)
+			VALUES ('task11a_draft_email_probe', 'Draft Email Probe',
+			        '{"event_type":"deal.stage_changed"}', '{"kind":"draft_email"}', '{}'::jsonb, $1, true)`,
+			e.Rep1)
+		return err
+	}); err != nil {
+		t.Fatalf("enrolling the draft-email probe instance: %v", err)
+	}
 
 	ctx := context.Background()
 	if err := engine.HandleEvent(ctx, kevents.Envelope{

--- a/backend/internal/compose/integration/workflow_action_executors_integration_test.go
+++ b/backend/internal/compose/integration/workflow_action_executors_integration_test.go
@@ -204,17 +204,10 @@ func TestDraftEmailFiringLandsTheComposedDraftOnTheRunRecord(t *testing.T) {
 	// as a lost permission, the same requirement
 	// no_activity_reminder_workqueue_integration_test.go's
 	// seedTaskCreatePermission documents for its own owned automation.
-	seedTaskCreatePermission(t, OwnerConn(t), e.WS, e.Rep1)
-	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(context.Background(), `
-			INSERT INTO automation (key, name, trigger, action, params, owner_id, enabled)
-			VALUES ('task11a_draft_email_probe', 'Draft Email Probe',
-			        '{"event_type":"deal.stage_changed"}', '{"kind":"draft_email"}', '{}'::jsonb, $1, true)`,
-			e.Rep1)
-		return err
-	}); err != nil {
-		t.Fatalf("enrolling the draft-email probe instance: %v", err)
-	}
+	owner := OwnerConn(t)
+	seedTaskCreatePermission(t, owner, e.WS, e.Rep1)
+	seedOwnedAutomation(t, owner, "task11a_draft_email_probe", "Draft Email Probe",
+		`{"event_type":"deal.stage_changed"}`, `{"kind":"draft_email"}`, json.RawMessage(`{}`), e.Rep1)
 
 	ctx := context.Background()
 	if err := engine.HandleEvent(ctx, kevents.Envelope{


### PR DESCRIPTION
## Summary

Fixes #3736 — `TestDraftEmailFiringLandsTheComposedDraftOnTheRunRecord` fails
deterministically on `main`, blocking the shared `ci` required check for every
open PR.

#3727 ("A held draft is released by the person it goes out as") made any
`draft_email` firing with no owner refuse at compose time
(`MissingDraftOwnerError`) — a message drafted under nobody's name is exactly
the case that PR closed.

The failing test registered its synthetic `draftEmailProbe` via
`RegisterSystemWorkflow`, which runs with no automation instance behind it at
all — `workflow.Event.OwnerID`'s own doc already names this as always-zero for
a system handler. The test's premise (a bare system handler successfully
drafting email) is exactly the case #3727 made impossible. It was **not** a
missing fixture value on the deal — I first tried seeding a deal owner and
confirmed that path is never even read for a `RegisterSystemWorkflow` handler,
before finding the actual cause (see #3736 for the full trace).

## Fix

Switched the probe's registration to `RegisterWorkflow` plus a seeded, enabled
`automation` instance row carrying `owner_id` — the same catalog/instance path
every drafting automation in production actually runs through, and the shape
#3727's own commit routed the *other* `draft_email` fixtures through
(`ownedFiring()`, in the `automation` package — unexported there, so this
integration-level test needed its own instance rather than reusing it).

The match-time gate (`gate.go`) resolves the owner's live RBAC through the
real `role`/`role_assignment` tables rather than the harness's in-memory
permission fixtures, so the owner also needs an actual grant — reused
`seedTaskCreatePermission`, already established by
`no_activity_reminder_workqueue_integration_test.go` for exactly this
requirement.

## Testing

- `make test-it DIR=backend/internal/compose/integration RUN=TestDraftEmailFiringLandsTheComposedDraftOnTheRunRecord` — passes
- `make test-it DIR=backend/internal/compose/integration` (whole package) — passes
- `craft static --strict` on the changed file — clean

Test-only change, no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the draft-email probe through the catalog/instance path so `TestDraftEmailFiringLandsTheComposedDraftOnTheRunRecord` passes again on `main`, unblocking the shared `ci` check. Fixes #3736.

- Registers the probe with `RegisterWorkflow` instead of `RegisterSystemWorkflow`, since #3727 made `draft_email` firing without an owner refuse at compose time.
- Seeds an enabled `automation` instance row with `owner_id` set, matching how production drafting automations run.
- Grants the owner `seedTaskCreatePermission` because the match-time gate reads real `role`/`role_assignment` tables, not the harness's in-memory fixtures.
- Generalizes the owned-automation seeding into `seedOwnedAutomation` and points this test and `no_activity_reminder_workqueue_integration_test.go` at it.
- Test-only change; no production code touched.

<sup>Written for commit ae9a272e5ba38eb3d05767c9bb01a7199a7a6f09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded integration coverage for draft email workflows using owned workflow instances and configured permissions.
  * Added validation for automation ownership, authorization, draft persistence, and approval staging.
  * Improved coverage for no-activity reminders, including owner-authored automation configuration and task visibility during scheduled scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->