### PR TITLE
The address you sign in with is one of your own

### DIFF
--- a/backend/gates/livemember_test.go
+++ b/backend/gates/livemember_test.go
@@ -76,15 +76,16 @@ const (
 // keying on statement text, which changes with every whitespace edit and
 // ratifies nothing stable.
 var cannotReachIdentity = gatekit.Waive(map[string]string{
-	"internal/modules/activities/audience.go":     "activities cannot import identity (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/activities/lifecycle.go":    "activities cannot import identity (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/dealrooms/store_public.go":  "dealrooms cannot import identity (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/people/counterpartyname.go": "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/people/leadrouting.go":      "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/people/linkedinmatch.go":    "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/projects/surface.go":        "projects cannot import identity (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/projects/transfer.go":       "projects cannot import identity (ADR-0054 §3); the predicate must move tier first",
-	"internal/modules/search/graphedge.go":        "search cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/activities/audience.go":        "activities cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/activities/lifecycle.go":       "activities cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/dealrooms/store_public.go":     "dealrooms cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/capture/owneridentitystore.go": "capture cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/people/counterpartyname.go":    "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/people/leadrouting.go":         "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/people/linkedinmatch.go":       "people cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/projects/surface.go":           "projects cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/projects/transfer.go":          "projects cannot import identity (ADR-0054 §3); the predicate must move tier first",
+	"internal/modules/search/graphedge.go":           "search cannot import identity (ADR-0054 §3); the predicate must move tier first",
 })
 
 // deliberatelyNotLiveness ratifies the half-spellings that are not answering

--- a/backend/internal/compose/integration/capture/capture_owner_identity_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_owner_identity_integration_test.go
@@ -385,3 +385,42 @@ func TestAClaimSettlesNoColleaguesOpenQuestion(t *testing.T) {
 			"must not answer a colleague's pending decision")
 	}
 }
+
+// The address a seat SIGNS IN with is one of their own addresses, and nobody
+// should have to declare who they are to the product they are signed in to.
+//
+// It is a different address from the connected mailbox in the ordinary case: a
+// person signs in with their work address and connects a mailbox, and the two
+// often agree — but when they do not, the login address was unknown here. It
+// then stood in as a counterparty to itself, which is how a founder's own
+// address became a contact in his own workspace.
+func TestTheSeatsLoginAddressIsNeverACounterparty(t *testing.T) {
+	env := newCaptureEnv(t)
+	e := env.e
+
+	// The seat's login address, which the harness sets and no fixture declares.
+	var login string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT email FROM app_user WHERE id = $1`, e.Rep1).Scan(&login)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if login == captureOwner {
+		t.Fatalf("the fixture's login address is the connected mailbox (%s) — the case under test needs them to differ", login)
+	}
+
+	// Mail from the seat's own login address into the connected mailbox.
+	env.sync(t, email(login, "Lars Himself", captureOwner, "login1@authz.test", ""))
+
+	if n := countRows(t, e, `
+		SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		WHERE pe.email = '`+login+`'`); n != 0 {
+		t.Errorf("%d person(s) for the seat's own login address, want 0", n)
+	}
+	if n := countRows(t, e, `
+		SELECT count(*) FROM capture_pending_counterparty WHERE email = '`+login+`'`); n != 0 {
+		t.Errorf("%d ledger question(s) about the seat's own login address, want 0 — "+
+			"a seat is not a first-time sender to themselves", n)
+	}
+}

--- a/backend/internal/modules/capture/owndomains.go
+++ b/backend/internal/modules/capture/owndomains.go
@@ -251,16 +251,51 @@ func (d InternalDomains) Domains() []string {
 // everything — which leaves every gate reading it exactly where it was.
 type SelfSet struct {
 	addresses map[string]struct{}
-	domains   InternalDomains
+	// identityOnly are addresses that say WHO the seat is without proving what
+	// reached their mailbox. They answer Covers and never CoversAddressExactly —
+	// see that method for why the two questions cannot share one set.
+	identityOnly map[string]struct{}
+	domains      InternalDomains
 }
 
 // NewSelfSet folds and de-duplicates a seat's declared addresses and domains.
 func NewSelfSet(addresses, domains []string) SelfSet {
-	set := SelfSet{addresses: make(map[string]struct{}, len(addresses)), domains: NewInternalDomains(domains)}
+	return NewSelfSetWithIdentityOnly(addresses, nil, domains)
+}
+
+// NewSelfSetWithIdentityOnly separates the addresses that PROVE DELIVERY from
+// the ones that merely name the seat.
+//
+// The distinction is not a nicety. An address in the first group is either the
+// mailbox a provider attested at grant or one the seat declared about
+// themselves; an address in the second is one the product knows belongs to them
+// for another reason — the address they sign in with — which nobody proved they
+// control as a mailbox. Only the first can answer "did this message reach me",
+// because that answer grants read access to an incumbent message a colleague
+// may have captured first.
+func NewSelfSetWithIdentityOnly(addresses, identityOnly, domains []string) SelfSet {
+	set := SelfSet{
+		addresses:    make(map[string]struct{}, len(addresses)),
+		identityOnly: make(map[string]struct{}, len(identityOnly)),
+		domains:      NewInternalDomains(domains),
+	}
 	for _, address := range addresses {
 		if folded := foldAddress(address); folded != "" {
 			set.addresses[folded] = struct{}{}
 		}
+	}
+	for _, address := range identityOnly {
+		folded := foldAddress(address)
+		if folded == "" {
+			continue
+		}
+		if _, proven := set.addresses[folded]; proven {
+			// The same address arrived both ways. The stronger claim stands:
+			// listing it here as well would not weaken it, but keeping one
+			// address in two sets invites a later reader to ask which wins.
+			continue
+		}
+		set.identityOnly[folded] = struct{}{}
 	}
 	return set
 }
@@ -299,6 +334,13 @@ func foldAddress(address string) string {
 // address as delivered to them. An exact address is different in kind — it is
 // either the mailbox the provider attested at grant, or one the seat declared
 // about themselves, and neither names a colleague.
+//
+// The seat's LOGIN address is deliberately not among them, for the same reason
+// in a different shape. It says who the seat is and proves nothing about what
+// their mailbox received, so admitting it here would let a message that merely
+// NAMES that address stand as proof of delivery — and a message's identity is a
+// Message-ID the sender types. A colleague's held mail would then be reachable
+// by anybody who could get their own capture to name the right address.
 func (s SelfSet) CoversAddressExactly(address string) bool {
 	folded := foldAddress(address)
 	if folded == "" {
@@ -316,12 +358,17 @@ func (s SelfSet) Covers(address string) bool {
 	if _, ok := s.addresses[folded]; ok {
 		return true
 	}
+	if _, ok := s.identityOnly[folded]; ok {
+		return true
+	}
 	return s.domains.Covers(folded)
 }
 
 // Empty reports whether the seat declared nothing, which lets a caller skip
 // work rather than test every address against an empty set.
-func (s SelfSet) Empty() bool { return len(s.addresses) == 0 && s.domains.empty() }
+func (s SelfSet) Empty() bool {
+	return len(s.addresses) == 0 && len(s.identityOnly) == 0 && s.domains.empty()
+}
 
 // WithoutSelf is the addresses that are NOT the seat's own, order preserved.
 // The gates need the remainder rather than a yes/no: what makes a message

--- a/backend/internal/modules/capture/owneridentitystore.go
+++ b/backend/internal/modules/capture/owneridentitystore.go
@@ -262,11 +262,22 @@ func ownerIdentitiesTx(ctx context.Context, tx pgx.Tx) (SelfSet, error) {
 	// SQL: a display-form label compared as a whole address matches no header,
 	// and the seat's primary address would be missing from the set with nothing
 	// to say so.
+	// The seat's LOGIN address belongs to the set for the same reason the
+	// connection label does, and it is a different address in the ordinary case:
+	// somebody signs in as themselves and connects a mailbox that is also
+	// theirs, and the two agree — but a seat who signs in with a work address
+	// and connects a second mailbox has two addresses, both of them their own,
+	// and only one of them was known here. The other stood in as a counterparty
+	// to itself, and a founder's own address became a contact in his workspace.
+	//
+	// It is read rather than declared because nobody should have to declare who
+	// they are to the product they are signed in to.
 	rows, err := tx.Query(ctx, `
 		SELECT kind, value FROM capture_owner_identity WHERE user_id = $1
 		 UNION ALL
 		SELECT 'address', account_label FROM capture_connection
-		 WHERE user_id = $1 AND coalesce(account_label, '') <> '' AND archived_at IS NULL`, user)
+		 WHERE user_id = $1 AND coalesce(account_label, '') <> '' AND archived_at IS NULL
+`, user)
 	if err != nil {
 		return SelfSet{}, fmt.Errorf("capture: reading the mailbox owner's identities: %w", err)
 	}
@@ -289,7 +300,49 @@ func ownerIdentitiesTx(ctx context.Context, tx pgx.Tx) (SelfSet, error) {
 	if err := rows.Err(); err != nil {
 		return SelfSet{}, fmt.Errorf("capture: reading the mailbox owner's identities: %w", err)
 	}
+	login, err := seatLoginAddressTx(ctx, tx, user)
+	if err != nil {
+		return SelfSet{}, err
+	}
+	if login != "" {
+		addresses = append(addresses, login)
+	}
 	return NewSelfSet(addresses, domains), nil
+}
+
+// seatLoginAddressTx is the address this seat signs in with.
+//
+// It is read on its own rather than UNIONed into the query above, because it
+// asks a different question of a different table: that query is about what a
+// seat has DECLARED and what their connection reports, and neither has a
+// liveness condition. This one reads app_user, where "still works here" is
+// status AND archived_at together — deactivation sets the status and leaves
+// archived_at NULL, so either half alone goes on offering a departed
+// colleague's address as somebody's own.
+//
+// A seat whose account is no longer live yields nothing, which is the safe
+// direction: their address then falls to the ordinary ladder, where it is
+// judged like any other rather than silently treated as the caller's. In
+// practice a deactivated seat cannot reach the sink at all — the grant dies
+// with them, and capture refuses the message before this is read — so the
+// liveness condition here is a second lock on a door that is already shut, and
+// it is spelled correctly so that it stays one if that ever changes.
+//
+// The liveness predicate is spelled out rather than calling identity's helper:
+// identity owns app_user and capture may not import a sibling module. Both
+// halves are named, which is the thing that matters — either alone would go on
+// offering a departed colleague's address.
+func seatLoginAddressTx(ctx context.Context, tx pgx.Tx, user ids.UUID) (string, error) {
+	var email string
+	if err := tx.QueryRow(ctx, `
+		SELECT coalesce(email, '') FROM app_user
+		 WHERE id = $1 AND status = 'active' AND archived_at IS NULL`, user).Scan(&email); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("capture: reading the seat's own login address: %w", err)
+	}
+	return bareAddress(email), nil
 }
 
 // retirePendingForIdentityTx settles the seat's own open questions about an

--- a/backend/internal/modules/capture/owneridentitystore.go
+++ b/backend/internal/modules/capture/owneridentitystore.go
@@ -304,10 +304,17 @@ func ownerIdentitiesTx(ctx context.Context, tx pgx.Tx) (SelfSet, error) {
 	if err != nil {
 		return SelfSet{}, err
 	}
+	// The login address goes in IDENTITY-ONLY, never among the proven ones. It
+	// says who the seat is; it does not say that their mailbox received
+	// anything, and one reader of this set treats an exact address as proof of
+	// delivery in order to grant read access to an incumbent message. Proving
+	// identity and proving delivery are two questions and this address answers
+	// only the first.
+	var identityOnly []string
 	if login != "" {
-		addresses = append(addresses, login)
+		identityOnly = append(identityOnly, login)
 	}
-	return NewSelfSet(addresses, domains), nil
+	return NewSelfSetWithIdentityOnly(addresses, identityOnly, domains), nil
 }
 
 // seatLoginAddressTx is the address this seat signs in with.

--- a/backend/internal/modules/capture/selfsetproof_test.go
+++ b/backend/internal/modules/capture/selfsetproof_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+import "testing"
+
+// The self set answers two questions and only one of them grants anything.
+//
+// "Is this me" settles filing: a seat's own address is not their own
+// counterparty. "Did this reach my mailbox" settles whether an incumbent
+// activity — possibly a COLLEAGUE's held message — may be written against, and
+// a message's identity is a Message-ID the sender types. So the second question
+// may only be answered by an address somebody proved control of: the mailbox a
+// provider attested at grant, or one the seat declared about themselves.
+//
+// The seat's login address is neither. Nobody proves control of it; the product
+// knows it because that is who signed in. Admitting it to the delivery question
+// would let a message that merely NAMES it stand as proof of delivery.
+func TestALoginAddressNamesTheSeatWithoutProvingDelivery(t *testing.T) {
+	t.Parallel()
+	const (
+		mailbox = "owner@myco.example"
+		login   = "owner@corp.example"
+	)
+	self := NewSelfSetWithIdentityOnly([]string{mailbox}, []string{login}, nil)
+
+	if !self.Covers(login) {
+		t.Error("the login address must read as the seat: it is who they signed in as")
+	}
+	if self.CoversAddressExactly(login) {
+		t.Error("the login address must NOT prove delivery — nobody proved the seat controls that mailbox")
+	}
+	// The attested mailbox answers both, which is what makes it different in
+	// kind rather than merely different in origin.
+	if !self.Covers(mailbox) || !self.CoversAddressExactly(mailbox) {
+		t.Error("the connected mailbox answers both questions")
+	}
+}
+
+// A seat whose only address is their login is not an empty set. Reading it as
+// empty would skip every gate that guards on it, which fails in the direction
+// that files a person as their own counterparty again.
+func TestASeatKnownOnlyByTheirLoginIsNotAnEmptySet(t *testing.T) {
+	t.Parallel()
+	self := NewSelfSetWithIdentityOnly(nil, []string{"owner@corp.example"}, nil)
+	if self.Empty() {
+		t.Error("a seat with a login address is somebody, and the gates must run for them")
+	}
+}
+
+// The same address arriving both ways keeps the stronger claim. Holding one
+// address in two sets would leave a later reader asking which wins.
+func TestAnAddressProvenAndAlsoTheLoginStaysProven(t *testing.T) {
+	t.Parallel()
+	const both = "owner@myco.example"
+	self := NewSelfSetWithIdentityOnly([]string{both}, []string{both}, nil)
+	if !self.CoversAddressExactly(both) {
+		t.Error("an address the provider attested does not stop being proof because it is also the login")
+	}
+}


### PR DESCRIPTION
A founder's own address was a contact in his own workspace.

The set of addresses treated as "the caller's own" held two things: what a seat has **declared** on the owner-identities card, and the address their connected mailbox reports. It did not hold the address they **sign in with**.

Those agree in the ordinary case — somebody signs in as themselves and connects a mailbox that is also theirs. When they do not agree, the login address was unknown here. It then stood in as a counterparty to itself, opened a ledger question about the person asking it, and became a record.

Nobody should have to declare who they are to the product they are signed in to, so it is read rather than declared.

## Why it is a separate statement

It asks a different question of a different table. The query beside it is about what a seat declared and what their connection reports, and neither carries a liveness condition. `app_user` does: "still works here" is `status` **and** `archived_at` together, and deactivation sets the status while leaving `archived_at` NULL — so either half alone would go on offering a departed colleague's address as somebody's own.

The liveness gate caught exactly that ambiguity the moment `app_user` joined the original statement. The predicate is spelled out rather than calling identity's helper, because capture may not import a sibling module, and the file is ratified in that gate the way the other seven such statements already are.

In practice a deactivated seat cannot reach the sink at all — the grant dies with them and capture refuses the message first. The condition here is a second lock on a door that is already shut, spelled correctly so it stays one if that ever changes.

## Scope

Two of this item's three parts were already done. The owner-identities settings card shipped in #3713, so the API is reachable. Automatic alias discovery is deliberately **not** here — see the issue linked below.

Mutation-checked: without the fix the seat's own login address opens a ledger question. `make check-backend` green, capture integration lane green, craft static clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a seat's own login address from being treated as a counterparty in their own workspace. The address they sign in with is now read from `app_user` and recognized as their own, but only as identity — it no longer stands as proof that a message reached their mailbox.

**Details**
- Reads the login address separately from declared and connected addresses, with a liveness gate: a seat is live only when `status = 'active'` and `archived_at IS NULL`, so deactivated seats yield no login address.
- Splits the self set into identity-only addresses and delivery-proven addresses; `Covers` reads both, while `CoversAddressExactly` reads only the proven ones, so a message that merely names the login address cannot grant access to a colleague's held mail.
- Keeps the stronger delivery-proven claim when an address is both the login address and a connected mailbox.
- Adds integration and unit tests for a seat whose login address differs from their connected mailbox, plus the proof distinction.

<sup>Written for commit 31dc3e1254809269960c388d8dabbfba03a5c627. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login email addresses are now recognized as the account owner’s identity, alongside connected mailbox identities.
  * Messages sent from an account’s own login address no longer create an incorrect person record or pending counterparty decision.
  * Identity recognition applies only to active, non-archived accounts, helping prevent inactive or unavailable account details from being treated as current identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->