### PR TITLE
Wave 4: a vCard naming no company can be staged, and its import stops retrying forever

### DIFF
--- a/backend/internal/compose/vcardcreateproposal.go
+++ b/backend/internal/compose/vcardcreateproposal.go
@@ -58,8 +58,12 @@ type vcardCreateProposal struct {
 	// The rest of what an approval RELEASES, flattened for the card: the
 	// decider is shown every field the create will write, or they are
 	// approving more than they were asked. Empty fields are omitted so the
-	// card carries facts, not blanks.
-	Organization string `json:"organization,omitempty"`
+	// card carries facts, not blanks — Organization is the one exception:
+	// it also joins the identity below, and the engine's containment check
+	// refuses an identity asserting a field the payload omits. A card
+	// naming no company still displays as nothing; omitempty just cannot
+	// be the reason it does, or that card can never be staged at all.
+	Organization string `json:"organization"`
 	Title        string `json:"title,omitempty"`
 	Phones       string `json:"phones,omitempty"`
 	URL          string `json:"url,omitempty"`

--- a/backend/internal/compose/vcardingest.go
+++ b/backend/internal/compose/vcardingest.go
@@ -53,6 +53,15 @@ import (
 // past a limit of five.
 const vcardIngestMaxCards = 5
 
+// vcardIngestMaxAttempts bounds the retry: parsing a handful of local files
+// and writing at most vcardIngestMaxCards people touches no model and no
+// network (api/jobs.yaml's timeout says so), so a failure here is either a
+// transient database hiccup, worth one or two more tries, or a defect in the
+// card or the code — neither of which a 25th identical attempt fixes. River's
+// own default would keep retrying a deterministic refusal for hours across an
+// exponential ladder, for no different an answer than the first attempt gave.
+const vcardIngestMaxAttempts = 3
+
 // vcardIngestInsertOpts is the trigger's insert, spelled here beside the worker
 // whose queue and attempt cap it names.
 //
@@ -68,8 +77,9 @@ const vcardIngestMaxCards = 5
 // their own.
 func vcardIngestInsertOpts() *river.InsertOpts {
 	return &river.InsertOpts{
-		Queue:      aiCaptureQueue,
-		UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+		Queue:       aiCaptureQueue,
+		MaxAttempts: vcardIngestMaxAttempts,
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
 	}
 }
 

--- a/backend/internal/compose/vcardingest_test.go
+++ b/backend/internal/compose/vcardingest_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import "testing"
+
+// A mailed card's import touches no model and no network, so a failure is
+// either a transient database hiccup or a deterministic refusal — a
+// malformed card, a bug — that answers identically on every attempt. River's
+// own default would retry the deterministic case 25 times across hours of
+// exponential backoff for no different an answer than the first attempt gave.
+func TestVCardIngestDeclaresABoundedRetryLadder(t *testing.T) {
+	got := vcardIngestInsertOpts().MaxAttempts
+	if got != vcardIngestMaxAttempts {
+		t.Fatalf("enqueued MaxAttempts = %d, want the declared ladder %d", got, vcardIngestMaxAttempts)
+	}
+	if got <= 0 || got >= 25 {
+		t.Fatalf("MaxAttempts = %d, want a positive bound well below River's own default of 25", got)
+	}
+}

--- a/backend/internal/compose/vcardproposal_integration_test.go
+++ b/backend/internal/compose/vcardproposal_integration_test.go
@@ -126,6 +126,40 @@ func TestAVCardNearMatchBecomesOneDurableProposal(t *testing.T) {
 	}
 }
 
+// orgLessReviewedCard is the shape margince#3410 refused forever: no ORG
+// line at all, so the card's identity asserts organization: "" while the
+// payload's omitempty dropped the key entirely — staging's containment check
+// refused the mismatch on every attempt, and re-importing failed identically.
+func orgLessReviewedCard() people.VCardEntry {
+	return people.VCardEntry{
+		FullName: "Anna Weber",
+		Emails:   []people.VCardChannel{{Value: reviewedCardEmail, Kind: "work"}},
+	}
+}
+
+func TestACardNamingNoCompanyCanStillBeStaged(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+	if _, err := e.People.CreatePerson(ctx, people.CreatePersonInput{
+		FullName: "Anna Weber", Source: "ui",
+		Emails: []people.PersonEmailInput{{Email: existingContactEmail, EmailType: "work", IsPrimary: true}},
+	}); err != nil {
+		t.Fatalf("seeding the existing contact: %v", err)
+	}
+	results, err := e.People.ImportVCards(ctx, []people.VCardEntry{orgLessReviewedCard()})
+	if err != nil {
+		t.Fatalf("importing the near-match card: %v", err)
+	}
+	if len(results) != 1 || results[0].Outcome != people.VCardNeedsReview {
+		t.Fatalf("import outcome = %+v, want the one needs_review refusal", results)
+	}
+
+	stage := vcardCreateStager(e.Pool)
+	if err := stage(ctx, orgLessReviewedCard(), results[0].PersonID); err != nil {
+		t.Fatalf("staging a card naming no company: %v", err)
+	}
+}
+
 func TestADeclinedVCardReviewIsNotReAsked(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.Admin()


### PR DESCRIPTION
## Summary

margince#3410 bundled two fixes to the vCard import lane, per the QC plan's own scoping (same code path).

### The rule that bent: a card's identity may assert an empty string that the payload doesn't literally carry

Three individually-correct decisions contradicted each other:
1. The staged identity always asserts `organization` — including as `""` — because organization discriminates two same-named cards from different companies (`vcardcreateproposal.go:114`).
2. The staged payload struct tagged `Organization` as `json:"organization,omitempty"`, so an org-less card dropped the key entirely.
3. The approvals engine's containment check deliberately refuses an identity asserting a field the payload doesn't carry (`staging.go`) — a real invariant protecting every other `Stage` caller in the codebase from a silent future containment-match failure.

**The call made**: bend (2). `omitempty` was serving a genuine display purpose ("empty fields are omitted so the card carries facts, not blanks"), but that purpose is already satisfied at the *display* layer — `resolveDisplay`/`displayValue` in `approvalkind.ts` already treats an empty string identically to an absent key (`if (raw.trim() === "") return null`). So dropping `omitempty` from just this one field (the only payload field that also doubles as an identity discriminator) fixes the mismatch with zero UI change: an org-less card's review still shows no Company row.

I didn't touch the staging engine's containment check (3) — it's a load-bearing invariant shared by every `Stage` caller in the tree, not something specific to vCards, and weakening it would reopen exactly the class of bug it exists to prevent.

### Bundled: `vcard_ingest`'s retry ceiling

Same job's insert site, same issue. `vcardIngestInsertOpts` carried no `MaxAttempts`, so a deterministic failure (this bug, or any other) rode River's own 25-attempt exponential ladder for an answer that never changes — the job parses local files with no model call and no network read, so a repeat attempt against the same bytes can only repeat the same verdict.

`api/jobs.yaml`'s `max_attempts` field turned out to be the wrong place for this: that field only governs `opts_owner: fan_out` jobs (`compose.workspaceSweepOpts` is its only reader, per the YAML's own comment), and `vcard_ingest` is `opts_owner: caller`. The bound belongs at the insert site instead — matched the existing pattern in `commsjobs.go`/`geocodejobs.go` (a named `const` on the `*river.InsertOpts`).

## Test plan
- [x] TDD: `TestACardNamingNoCompanyCanStillBeStaged` (integration) written RED-first against the real approvals engine, now green; `TestVCardIngestDeclaresABoundedRetryLadder` (unit, 100% coverage on the new line)
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `make test-it DIR=backend/internal/compose` green (real Postgres), full existing vCard suite unaffected
- [x] `craft static --strict`: 0 blocker/major/minor
- [x] Live UAT: uploaded an org-less near-match card through the actual Contacts → Import cards flow on a real dev stack, confirmed the review appears with no phantom Company row, and approved it into a real contact — video attached below
- [x] No AI prompt touched, no aicert re-run needed
- [x] `make check` green before push, rebased onto latest `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oooEFASw2gFLzM2uAb64A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes margince#3410: previously, org-less vCard near-matches could not be staged because their empty organization field was omitted; now they can stage without showing a Company row. `vcard_ingest` now stops after 3 attempts instead of River’s default 25, limiting repeated retries for deterministic failures.

- Leaves the approvals containment check unchanged and preserves the empty organization value in the staged payload.
- Adds integration coverage for staging and unit coverage for the retry limit.

<sup>Written for commit 58c4b117a1ecce5a15ee81eeb0416af887af470f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * vCard imports with missing organization information can now be staged for review successfully.
  * vCard import jobs are limited to three retry attempts, reducing repeated processing of failed imports.
  * Staged vCard proposals consistently include organization information, including when the value is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->