### PR TITLE
Wave 4 follow-up: scope vcard_create's identity to close a same-tenant cross-subject gap

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -745,9 +745,11 @@ kinds:
     timeout:
       value: 5m
       reason: >-
-        Parsing a handful of small text files and writing at most five people.
-        No model call and no network read is in it, so anything past this is a
-        stuck database handle rather than a large card.
+        Fetching a handful of small attachments from blob storage and writing
+        at most five people. No model call is in it, and the one dependency
+        read is scoped to this message's own attachments, so anything past
+        this is a stuck database handle or an unreachable store rather than
+        a large card.
     opts_owner: caller
     cadence: on_demand
     args:

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "cc0508aa4201841e43826e2e824e02354b75b567add7d526a6757bf30d1f5d01"
+const jobContractHash = "951f9851b633a7ea201a8c1374cda5ad3b917bc9fcf8e33606f2373b1c3a2a81"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it

--- a/backend/internal/compose/linkedinmatchproposal.go
+++ b/backend/internal/compose/linkedinmatchproposal.go
@@ -62,13 +62,18 @@ type linkedInMatchProposal struct {
 // withGhostOwnerAsSubject records the acting member as the subject the
 // proposals are staged for. A context with no human actor cannot stage: a
 // self-only proposal nobody is recorded for is one nobody can ever decide.
-func withGhostOwnerAsSubject(ctx context.Context) (context.Context, error) {
+//
+// Returns the stamped subject alongside the context so a caller that needs
+// it (to fold into an identity, say) reads back the exact id just recorded
+// rather than asking principal.Actor a second time for an answer this
+// function already computed and cannot itself have gotten wrong.
+func withGhostOwnerAsSubject(ctx context.Context) (context.Context, ids.UUID, error) {
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.UserID == ids.Nil {
-		return nil, apperrors.ErrPermissionDenied
+		return nil, ids.Nil, apperrors.ErrPermissionDenied
 	}
 	actor.OnBehalfOf = actor.UserID
-	return principal.WithActor(ctx, actor), nil
+	return principal.WithActor(ctx, actor), actor.OnBehalfOf, nil
 }
 
 // linkedInMatchStager is the seam people.Handlers calls after an import. It
@@ -123,7 +128,7 @@ func stagePendingLinkedInMatches(ctx context.Context, svc *approvals.Service, pe
 	// about. ADR-0078/A123 settles that deliberately: who-knows-whom is
 	// workspace-shared metadata, guarded by "you only see edges for a person
 	// you can see at all", which is exactly what that rule already applies.
-	ctx, err := withGhostOwnerAsSubject(ctx)
+	ctx, _, err := withGhostOwnerAsSubject(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/compose/linkedinmatchproposal_test.go
+++ b/backend/internal/compose/linkedinmatchproposal_test.go
@@ -78,19 +78,22 @@ func TestStagingRefusesAContextWithNoHumanBehindIt(t *testing.T) {
 	// what the audit trail answers "who asked" with. A context carrying no
 	// human cannot stage: writing the proposal anyway would put a question in
 	// somebody's inbox that no trail attributes to anyone.
-	if _, err := withGhostOwnerAsSubject(context.Background()); !errors.Is(err, apperrors.ErrPermissionDenied) {
+	if _, _, err := withGhostOwnerAsSubject(context.Background()); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("staging without an actor answered %v, want a permission refusal", err)
 	}
 
 	// With a member bound, the subject IS that member.
 	me := ids.NewV7()
-	ctx, err := withGhostOwnerAsSubject(principal.WithActor(context.Background(),
+	ctx, subject, err := withGhostOwnerAsSubject(principal.WithActor(context.Background(),
 		principal.Principal{Type: principal.PrincipalHuman, UserID: me}))
 	if err != nil {
 		t.Fatalf("staging as a member: %v", err)
 	}
+	if subject != me {
+		t.Errorf("the staging subject is %v, want the acting member %s", subject, me)
+	}
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.OnBehalfOf != me {
-		t.Errorf("the staging subject is %v, want the acting member %s", actor.OnBehalfOf, me)
+		t.Errorf("the context's own actor is %v, want the acting member %s", actor.OnBehalfOf, me)
 	}
 }

--- a/backend/internal/compose/vcardcreateproposal.go
+++ b/backend/internal/compose/vcardcreateproposal.go
@@ -13,14 +13,12 @@ package compose
 // is somebody else, create them", reject means the card stays uncreated, and
 // a decline is remembered so re-importing the same file does not re-ask.
 //
-// The proposal deliberately carries NO target. The decline memory is keyed on
-// (kind, target, identity), and the candidate's visibility differs per
-// importer — person rows are scoped, with capture privacy on top — so a
-// candidate-targeted proposal would put the same card in a different bucket
-// per importer, and a decline in one would be invisible to the others. One
-// bucket, one memory: the candidate travels in the payload for display, and
-// deciding is gated on the create grants alone, which is exactly what the
-// approval spends.
+// The proposal deliberately carries NO target — the candidate travels in the
+// payload for display only, and deciding is gated on the create grants
+// alone, which is exactly what the approval spends. The decline memory is
+// keyed on (kind, target, identity) and the identity carries the staging
+// subject, so the memory is per-importer by design: a self-only kind's
+// declines are one member's own answers, never another member's.
 
 import (
 	"context"
@@ -72,6 +70,21 @@ type vcardCreateProposal struct {
 	// importer could see it too. Informational for the decider; the create
 	// itself does not read it.
 	CandidatePersonID *openapi_types.UUID `json:"candidate_person_id,omitempty"`
+	// StagedBy is the importer's own user id. vcard_create is self-only — one
+	// member's own uploaded address book — but neither the identity-keyed
+	// supersession nor the diff-hash join/decline-memory the engine runs for
+	// EVERY kind carries a subject filter of its own; both trust a caller's
+	// discriminator to already be collision-proof. A card is otherwise
+	// addressed by facts a stranger can read off a business card or simply
+	// guess (a name, a company), so without this a second member staging a
+	// same-named — or even a same-named-and-same-company — card could
+	// silently withdraw or answer a colleague's unrelated pending review.
+	// Folding the subject in here, in BOTH the identity and (because it is a
+	// plain field with no omitempty) the hashed payload, makes every one of
+	// this kind's proposals inherently per-importer no matter which fields
+	// the card itself states. Not offered to a decider (no DISPLAY_FIELDS
+	// entry) — a self-only proposal's importer already knows their own id.
+	StagedBy string `json:"staged_by"`
 }
 
 // vcardCreateStager builds the people module's review port: one card's
@@ -83,8 +96,9 @@ func vcardCreateStager(pool *pgxpool.Pool) func(ctx context.Context, entry peopl
 		// member's own uploaded address book, so the importer is recorded as
 		// the proposal's subject and is the only person who can read or
 		// decide it. Without the stamp a self-only row is decidable by
-		// nobody, so the two halves land together.
-		ctx, err := withGhostOwnerAsSubject(ctx)
+		// nobody, so the two halves land together. subject is the exact id
+		// the approval row itself will carry as on_behalf_of.
+		ctx, subject, err := withGhostOwnerAsSubject(ctx)
 		if err != nil {
 			return err
 		}
@@ -106,6 +120,7 @@ func vcardCreateStager(pool *pgxpool.Pool) func(ctx context.Context, entry peopl
 			Phones:       strings.Join(phones, ", "),
 			URL:          strings.TrimSpace(entry.URL),
 			Address:      strings.TrimSpace(entry.Address),
+			StagedBy:     subject.String(),
 		}
 		if candidate != nil {
 			id := openapi_types.UUID(candidate.UUID)
@@ -119,14 +134,22 @@ func vcardCreateStager(pool *pgxpool.Pool) func(ctx context.Context, entry peopl
 		// not the whole payload: a re-export that reorders phone numbers or
 		// tweaks a title is still the same question, and a decline keyed on
 		// the full payload would be forgotten the first time a field moved.
-		// Organization joins the identity as the discriminator for the card
-		// with no address at all — the name-collision lane's common case. Two
-		// emailless cards naming the same person at the same company are ONE
-		// question; at different companies they are two.
+		// staged_by joins it for a different reason than the card fields do:
+		// full_name, emails and organization say WHICH card; staged_by says
+		// WHOSE — and without it, two members' cards naming the same person
+		// (or, for a bare name with no other addressing at all, simply
+		// sharing one) would be one question in the engine's eyes, answerable
+		// and withdrawable by either member's stager.
+		//
+		// Every field named here must carry no `omitempty` on the struct
+		// above: the engine refuses an identity asserting a key the payload's
+		// JSON omits, and a card whose value is legitimately empty (no email,
+		// no company) is not exempt from being asked about.
 		identity, err := json.Marshal(map[string]any{
 			fieldFullName:                  proposal.FullName,
 			"emails":                       proposal.Emails,
 			string(recordTypeOrganization): proposal.Organization,
+			"staged_by":                    proposal.StagedBy,
 		})
 		if err != nil {
 			return fmt.Errorf("compose: encoding the vCard proposal identity: %w", err)

--- a/backend/internal/compose/vcardingest.go
+++ b/backend/internal/compose/vcardingest.go
@@ -53,14 +53,16 @@ import (
 // past a limit of five.
 const vcardIngestMaxCards = 5
 
-// vcardIngestMaxAttempts bounds the retry: parsing a handful of local files
-// and writing at most vcardIngestMaxCards people touches no model and no
-// network (api/jobs.yaml's timeout says so), so a failure here is either a
-// transient database hiccup, worth one or two more tries, or a defect in the
-// card or the code — neither of which a 25th identical attempt fixes. River's
-// own default would keep retrying a deterministic refusal for hours across an
-// exponential ladder, for no different an answer than the first attempt gave.
-const vcardIngestMaxAttempts = 3
+// vcardIngestMaxAttempts bounds the retry. This kind is on-demand — nothing
+// re-enqueues a message the trigger already fired for — so the ladder has to
+// carry BOTH failure shapes alone: a blob-store read that is down for a
+// minute (worth the retries) and a malformed card or a code defect (worth
+// none, since River's own default would answer no differently on its 25th
+// identical attempt). Five, not three: unlike a lookup this job can retry
+// freely (geocodeMaxAttempts, vatCheckMaxAttempts), it is never re-swept, so
+// it needs the same headroom scheduledSendMaxAttempts and
+// embedReindexMaxAttempts carry for a dependency with no second chance.
+const vcardIngestMaxAttempts = 5
 
 // vcardIngestInsertOpts is the trigger's insert, spelled here beside the worker
 // whose queue and attempt cap it names.
@@ -126,9 +128,11 @@ func (w *vcardIngestWorker) Work(ctx context.Context, job *river.Job[VCardIngest
 			"activity", job.Args.Activity, "workspace", job.Args.Workspace)
 		return nil
 	default:
-		// River owns the attempt cap, from the contract's own max_attempts.
-		// A second ceiling counted here would be a copy of that number, and the
-		// two would drift the first time either moved.
+		// River retries this against vcardIngestMaxAttempts, declared beside
+		// vcardIngestInsertOpts — this kind is opts_owner: caller, so nothing
+		// reads a bound from api/jobs.yaml for it the way workspaceSweepOpts
+		// reads one for a fan_out kind; the cap has to live at the insert
+		// site instead.
 		return jobs.FaultContext(ctx, err)
 	}
 }

--- a/backend/internal/compose/vcardingest_integration_test.go
+++ b/backend/internal/compose/vcardingest_integration_test.go
@@ -120,16 +120,22 @@ func TestAMailedCardQueuesItsImport(t *testing.T) {
 		t.Fatalf("handling the capture event: %v", err)
 	}
 
-	var queued int
+	var queued, maxAttempts int
 	if err := e.Pool.QueryRow(ctx, `
-		SELECT count(*) FROM river_job
+		SELECT count(*), coalesce(max(max_attempts), 0) FROM river_job
 		 WHERE kind = 'vcard_ingest' AND args->>'activity_id' = $1`,
-		activity.String()).Scan(&queued); err != nil {
+		activity.String()).Scan(&queued, &maxAttempts); err != nil {
 		t.Fatalf("counting the queued imports: %v", err)
 	}
 	if queued != 1 {
 		t.Fatalf("the trigger queued %d imports for a message carrying a card, want 1 — "+
 			"a card that reaches the mailbox and no job is the feature doing nothing", queued)
+	}
+	// The bound River actually persisted, not the InsertOpts value this
+	// package hands it — proof the cap survives insertion rather than being
+	// silently dropped for the default.
+	if maxAttempts != vcardIngestMaxAttempts {
+		t.Errorf("river_job.max_attempts = %d, want the declared ladder %d", maxAttempts, vcardIngestMaxAttempts)
 	}
 }
 

--- a/backend/internal/compose/vcardingest_test.go
+++ b/backend/internal/compose/vcardingest_test.go
@@ -3,19 +3,22 @@
 
 package compose
 
-import "testing"
+import (
+	"testing"
 
-// A mailed card's import touches no model and no network, so a failure is
-// either a transient database hiccup or a deterministic refusal — a
-// malformed card, a bug — that answers identically on every attempt. River's
-// own default would retry the deterministic case 25 times across hours of
-// exponential backoff for no different an answer than the first attempt gave.
+	"github.com/riverqueue/river"
+)
+
+// The insert carries the declared constant, and that constant is itself a
+// sane bound — an unset MaxAttempts is silently River's own default with no
+// other symptom, which is what the second check would catch even if the
+// first held by coincidence.
 func TestVCardIngestDeclaresABoundedRetryLadder(t *testing.T) {
 	got := vcardIngestInsertOpts().MaxAttempts
 	if got != vcardIngestMaxAttempts {
 		t.Fatalf("enqueued MaxAttempts = %d, want the declared ladder %d", got, vcardIngestMaxAttempts)
 	}
-	if got <= 0 || got >= 25 {
-		t.Fatalf("MaxAttempts = %d, want a positive bound well below River's own default of 25", got)
+	if got <= 0 || got >= river.MaxAttemptsDefault {
+		t.Fatalf("MaxAttempts = %d, want a positive bound well below River's own default of %d", got, river.MaxAttemptsDefault)
 	}
 }

--- a/backend/internal/compose/vcardproposal_integration_test.go
+++ b/backend/internal/compose/vcardproposal_integration_test.go
@@ -39,8 +39,9 @@ func reviewedCard() people.VCardEntry {
 }
 
 // seedNearMatch writes the existing contact through the real writer and
-// answers the import's review verdict for the card that resembles them.
-func seedNearMatch(ctx context.Context, t *testing.T, e *integration.Env) *ids.PersonID {
+// answers the import's review verdict for the given card, which must
+// resemble them by name.
+func seedNearMatch(ctx context.Context, t *testing.T, e *integration.Env, card people.VCardEntry) *ids.PersonID {
 	t.Helper()
 	if _, err := e.People.CreatePerson(ctx, people.CreatePersonInput{
 		FullName: "Anna Weber", Source: "ui",
@@ -48,7 +49,7 @@ func seedNearMatch(ctx context.Context, t *testing.T, e *integration.Env) *ids.P
 	}); err != nil {
 		t.Fatalf("seeding the existing contact: %v", err)
 	}
-	results, err := e.People.ImportVCards(ctx, []people.VCardEntry{reviewedCard()})
+	results, err := e.People.ImportVCards(ctx, []people.VCardEntry{card})
 	if err != nil {
 		t.Fatalf("importing the near-match card: %v", err)
 	}
@@ -61,7 +62,7 @@ func seedNearMatch(ctx context.Context, t *testing.T, e *integration.Env) *ids.P
 func TestAVCardNearMatchBecomesOneDurableProposal(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.Admin()
-	candidate := seedNearMatch(ctx, t, e)
+	candidate := seedNearMatch(ctx, t, e, reviewedCard())
 	if candidate == nil {
 		t.Fatal("the import named no visible candidate for an admin importer")
 	}
@@ -126,10 +127,10 @@ func TestAVCardNearMatchBecomesOneDurableProposal(t *testing.T) {
 	}
 }
 
-// orgLessReviewedCard is the shape margince#3410 refused forever: no ORG
-// line at all, so the card's identity asserts organization: "" while the
-// payload's omitempty dropped the key entirely — staging's containment check
-// refused the mismatch on every attempt, and re-importing failed identically.
+// orgLessReviewedCard is a near-match with no ORG line at all — an email
+// still gives it real addressing, but the identity asserts organization too
+// (as the empty string), and the staged payload must carry that same key or
+// the engine's containment check refuses the mismatch.
 func orgLessReviewedCard() people.VCardEntry {
 	return people.VCardEntry{
 		FullName: "Anna Weber",
@@ -140,30 +141,208 @@ func orgLessReviewedCard() people.VCardEntry {
 func TestACardNamingNoCompanyCanStillBeStaged(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.Admin()
-	if _, err := e.People.CreatePerson(ctx, people.CreatePersonInput{
-		FullName: "Anna Weber", Source: "ui",
-		Emails: []people.PersonEmailInput{{Email: existingContactEmail, EmailType: "work", IsPrimary: true}},
-	}); err != nil {
-		t.Fatalf("seeding the existing contact: %v", err)
-	}
-	results, err := e.People.ImportVCards(ctx, []people.VCardEntry{orgLessReviewedCard()})
-	if err != nil {
-		t.Fatalf("importing the near-match card: %v", err)
-	}
-	if len(results) != 1 || results[0].Outcome != people.VCardNeedsReview {
-		t.Fatalf("import outcome = %+v, want the one needs_review refusal", results)
-	}
+	candidate := seedNearMatch(ctx, t, e, orgLessReviewedCard())
 
 	stage := vcardCreateStager(e.Pool)
-	if err := stage(ctx, orgLessReviewedCard(), results[0].PersonID); err != nil {
+	if err := stage(ctx, orgLessReviewedCard(), candidate); err != nil {
 		t.Fatalf("staging a card naming no company: %v", err)
+	}
+
+	// A staging error nil does not, by itself, prove a decidable row exists —
+	// StageUnlessDeclined can also settle onto a prior decline with no new
+	// row. The reader this bug affected needs the review IN THEIR QUEUE.
+	svc := approvalsServiceWithEffects(e.Pool)
+	status, kind := "pending", vcardCreateKind
+	rows, _, err := svc.ListWire(ctx, approvals.ListInput{Status: &status, Kind: &kind, Limit: 10})
+	if err != nil {
+		t.Fatalf("listing the staged review: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("pending vcard_create proposals = %d, want the one org-less review", len(rows))
+	}
+
+	// The release half is the one org-less cards exercise differently: no
+	// company to attach means no employment edge, which is a distinct code
+	// path from the org-present create the sibling test already covers.
+	if _, err := svc.Decide(ctx, ids.From[ids.ApprovalKind](ids.UUID(rows[0].Id)), true, nil); err != nil {
+		t.Fatalf("approving the org-less create: %v", err)
+	}
+	var created, employed int
+	if err := e.Pool.QueryRow(ctx,
+		`SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+		  WHERE lower(pe.email) = $1`, reviewedCardEmail).Scan(&created); err != nil {
+		t.Fatalf("counting people holding the card's address: %v", err)
+	}
+	if created != 1 {
+		t.Errorf("people holding %s = %d, want exactly the approved create", reviewedCardEmail, created)
+	}
+	if err := e.Pool.QueryRow(ctx, `
+		SELECT count(*) FROM relationship r
+		  JOIN person_email pe ON pe.person_id = r.person_id
+		 WHERE r.kind = 'employment' AND lower(pe.email) = $1`, reviewedCardEmail).Scan(&employed); err != nil {
+		t.Fatalf("counting employment edges: %v", err)
+	}
+	if employed != 0 {
+		t.Errorf("employment edges for a card naming no company = %d, want none", employed)
+	}
+}
+
+// vacuousReviewedCard names a person and nothing else — no email, no
+// organization. Without a subject folded into the identity, this would
+// collapse to the bare name alone — exactly what two DIFFERENT workspace
+// members could independently produce for two DIFFERENT people who share
+// that name.
+func vacuousReviewedCard() people.VCardEntry {
+	return people.VCardEntry{FullName: "Priya Raghunathan"}
+}
+
+// A card's identity is scoped to the SUBJECT who staged it (vcard_create is
+// self-only: nobody but the importer may read or decide their own upload),
+// and the engine's identity-keyed supersession carries no subject filter of
+// its own — it trusts the caller's identity to already be collision-proof.
+// A name-only card is the sharpest version of that trust failing: nothing
+// but staged_by distinguishes "Priya Raghunathan, no email, no company" in
+// one member's address book from another member's. Two members staging
+// that same bare name must not see one of their reviews withdrawn out from
+// under them.
+//
+// The two cards also carry different candidates, so their PAYLOADS differ
+// (and so join on neither the same diff hash nor the same row) independent
+// of staged_by — isolating the identity-keyed supersession path this test
+// is actually about from the engine's separate diff-hash join step, which
+// this kind's staged_by field also happens to disambiguate but which no
+// self-only kind's join is scoped by on its own.
+func TestAVacuousCardDoesNotSupersedeAnotherSubjectsPendingReview(t *testing.T) {
+	e := integration.Setup(t)
+	adminCtx := e.Admin()
+	repCtx := e.As(e.Rep1, nil, integration.AdminPerms)
+
+	adminCandidate, err := e.People.CreatePerson(adminCtx, people.CreatePersonInput{FullName: "A Different Priya", Source: "ui"})
+	if err != nil {
+		t.Fatalf("seeding the admin's candidate: %v", err)
+	}
+	adminCandidateID := ids.From[ids.PersonKind](ids.UUID(adminCandidate.Id))
+
+	stage := vcardCreateStager(e.Pool)
+	if err := stage(adminCtx, vacuousReviewedCard(), &adminCandidateID); err != nil {
+		t.Fatalf("admin staging the vacuous card: %v", err)
+	}
+	if err := stage(repCtx, vacuousReviewedCard(), nil); err != nil {
+		t.Fatalf("rep staging the same vacuous card: %v", err)
+	}
+
+	svc := approvalsServiceWithEffects(e.Pool)
+	status, kind := "pending", vcardCreateKind
+	adminRows, _, err := svc.ListWire(adminCtx, approvals.ListInput{Status: &status, Kind: &kind, Limit: 10})
+	if err != nil {
+		t.Fatalf("listing the admin's reviews: %v", err)
+	}
+	if len(adminRows) != 1 {
+		t.Errorf("admin's pending vcard_create reviews = %d, want the one they staged — a colleague's later upload must not withdraw it", len(adminRows))
+	}
+	repRows, _, err := svc.ListWire(repCtx, approvals.ListInput{Status: &status, Kind: &kind, Limit: 10})
+	if err != nil {
+		t.Fatalf("listing the rep's reviews: %v", err)
+	}
+	if len(repRows) != 1 {
+		t.Errorf("rep's pending vcard_create reviews = %d, want the one they staged", len(repRows))
+	}
+}
+
+// The two tests above give each member a different candidate so their
+// PAYLOADS differ regardless of staged_by, isolating the identity-keyed
+// supersession path. This one closes the gap that leaves: the SAME
+// candidate (both nil — neither importer sees a near-match) means the only
+// thing that can still make two members' payloads diverge is staged_by
+// itself, which is exactly what the engine's separate diff-hash JOIN step
+// would otherwise ignore.
+func TestATwoMembersCardsWithNoCandidateDoNotJoinIntoOneReview(t *testing.T) {
+	e := integration.Setup(t)
+	adminCtx := e.Admin()
+	repCtx := e.As(e.Rep1, nil, integration.AdminPerms)
+
+	stage := vcardCreateStager(e.Pool)
+	if err := stage(adminCtx, coworkerNamedCard(), nil); err != nil {
+		t.Fatalf("admin staging their card: %v", err)
+	}
+	if err := stage(repCtx, coworkerNamedCard(), nil); err != nil {
+		t.Fatalf("rep staging the identical card: %v", err)
+	}
+
+	svc := approvalsServiceWithEffects(e.Pool)
+	status, kind := "pending", vcardCreateKind
+	adminRows, _, err := svc.ListWire(adminCtx, approvals.ListInput{Status: &status, Kind: &kind, Limit: 10})
+	if err != nil {
+		t.Fatalf("listing the admin's reviews: %v", err)
+	}
+	if len(adminRows) != 1 {
+		t.Errorf("admin's pending vcard_create reviews = %d, want the one they staged — the rep's identical upload must not join it", len(adminRows))
+	}
+	repRows, _, err := svc.ListWire(repCtx, approvals.ListInput{Status: &status, Kind: &kind, Limit: 10})
+	if err != nil {
+		t.Fatalf("listing the rep's reviews: %v", err)
+	}
+	if len(repRows) != 1 {
+		t.Errorf("rep's pending vcard_create reviews = %d, want their own review, not the admin's joined row (which self-only hides from them)", len(repRows))
+	}
+}
+
+// coworkerNamedCard names a person AND a company — real addressing, not the
+// bare-name shape above — because the fix under test is not "vacuous cards
+// get special treatment", it is "every card's identity is subject-scoped".
+// A name and an employer are both facts a coworker could read off a business
+// card or a signature block, so a value-derived identity built from card
+// fields alone is guessable no matter how many of them are populated.
+func coworkerNamedCard() people.VCardEntry {
+	return people.VCardEntry{FullName: "Jan Kowalski", Organization: "Acme GmbH"}
+}
+
+// The harder case behind the one above: two DIFFERENT people who both work
+// at the same company and share a name are not a hypothetical the fix
+// happens to miss — they are exactly what an attacker with person:create
+// need only observe (or guess) to reproduce another member's card byte for
+// byte, if organization alone still discriminated the identity.
+func TestATwoFieldCardDoesNotSupersedeAnotherSubjectsPendingReview(t *testing.T) {
+	e := integration.Setup(t)
+	adminCtx := e.Admin()
+	repCtx := e.As(e.Rep1, nil, integration.AdminPerms)
+
+	adminCandidate, err := e.People.CreatePerson(adminCtx, people.CreatePersonInput{FullName: "A Different Jan Kowalski", Source: "ui"})
+	if err != nil {
+		t.Fatalf("seeding the admin's candidate: %v", err)
+	}
+	adminCandidateID := ids.From[ids.PersonKind](ids.UUID(adminCandidate.Id))
+
+	stage := vcardCreateStager(e.Pool)
+	if err := stage(adminCtx, coworkerNamedCard(), &adminCandidateID); err != nil {
+		t.Fatalf("admin staging their card: %v", err)
+	}
+	if err := stage(repCtx, coworkerNamedCard(), nil); err != nil {
+		t.Fatalf("rep staging the same name-and-company card: %v", err)
+	}
+
+	svc := approvalsServiceWithEffects(e.Pool)
+	status, kind := "pending", vcardCreateKind
+	adminRows, _, err := svc.ListWire(adminCtx, approvals.ListInput{Status: &status, Kind: &kind, Limit: 10})
+	if err != nil {
+		t.Fatalf("listing the admin's reviews: %v", err)
+	}
+	if len(adminRows) != 1 {
+		t.Errorf("admin's pending vcard_create reviews = %d, want the one they staged — a coworker sharing this card's name and company must not withdraw it", len(adminRows))
+	}
+	repRows, _, err := svc.ListWire(repCtx, approvals.ListInput{Status: &status, Kind: &kind, Limit: 10})
+	if err != nil {
+		t.Fatalf("listing the rep's reviews: %v", err)
+	}
+	if len(repRows) != 1 {
+		t.Errorf("rep's pending vcard_create reviews = %d, want the one they staged", len(repRows))
 	}
 }
 
 func TestADeclinedVCardReviewIsNotReAsked(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.Admin()
-	candidate := seedNearMatch(ctx, t, e)
+	candidate := seedNearMatch(ctx, t, e, reviewedCard())
 
 	stage := vcardCreateStager(e.Pool)
 	if err := stage(ctx, reviewedCard(), candidate); err != nil {
@@ -201,7 +380,7 @@ func TestADeclinedVCardReviewIsNotReAsked(t *testing.T) {
 func TestAnEditThatDropsTheCardIsRefusedWhileStillPending(t *testing.T) {
 	e := integration.Setup(t)
 	ctx := e.Admin()
-	candidate := seedNearMatch(ctx, t, e)
+	candidate := seedNearMatch(ctx, t, e, reviewedCard())
 	stage := vcardCreateStager(e.Pool)
 	if err := stage(ctx, reviewedCard(), candidate); err != nil {
 		t.Fatalf("staging the review: %v", err)

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "cc0508aa4201841e43826e2e824e02354b75b567add7d526a6757bf30d1f5d01"
+const JobContractHash = "951f9851b633a7ea201a8c1374cda5ad3b917bc9fcf8e33606f2373b1c3a2a81"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it

--- a/frontend/src/screens/approvalkind.test.ts
+++ b/frontend/src/screens/approvalkind.test.ts
@@ -75,6 +75,10 @@ describe("what a reader may change before accepting", () => {
     expect(stage.options).toContain("customer");
   });
 
+  it("offers nothing on a vcard_create — the accept effect reads only the nested Entry, so an edited flattened field would silently do nothing", () => {
+    expect(EDITABLE_FIELDS.vcard_create).toEqual([]);
+  });
+
   it("never offers an identifier, on any kind that declares a policy", () => {
     for (const [kind, fields] of Object.entries(EDITABLE_FIELDS)) {
       for (const entry of fields) {

--- a/frontend/src/screens/approvalkind.ts
+++ b/frontend/src/screens/approvalkind.ts
@@ -195,6 +195,12 @@ export const EDITABLE_FIELDS: Readonly<
       label: "approval.field.expected_close_date",
     },
   ],
+  // Every flattened field here is a display copy of the card the server
+  // parsed (vcardCreateProposal's Entry), and the create reads only that
+  // nested struct — never the flattened strings a generic editor would offer
+  // back. An edit to any of them would silently do nothing, so none is
+  // offered rather than each looking like a live field that quietly is not.
+  vcard_create: [],
 };
 
 // What a reader SEES of a proposal, per kind — the read-side counterpart of


### PR DESCRIPTION
## Summary

Follow-up to #3757, which merged before this session's own mandatory review round (craft-reviewer + security-redteam) finished — auto-merge was armed too early and fired on green CI while the review agents were still running. **This PR went through two rounds of that review itself before landing**, and the second round found the first fix here was still incomplete — details below. Process note at the end.

### Round 1: the gap #3757 introduced

`vcardcreateproposal.go`'s fix for margince#3410 (org-less cards) made `organization` always present in the staged identity. For a card with **neither an email nor an organization**, that identity collapsed to the bare full name alone — which any workspace member could independently produce for a *different* person sharing that name. `vcard_create` is self-only (nobody but the importer may read or decide their own upload), but the approvals engine's identity-keyed supersession carries no subject filter of its own. First fix: give a bare-name card no identity at all.

### Round 2: that fix was too narrow

The identity built for every *other* card was still purely value-derived (full name, emails, organization) — and a name plus an employer is exactly the pair a coworker can read off a business card or a signature block. `TestATwoFieldCardDoesNotSupersedeAnotherSubjectsPendingReview` proves it: two different members, two different people who happen to share a name *and* a company, no email — the identical byte-for-byte identity, and the second member's stage silently expires the first member's pending review.

**The actual fix**: fold the staging subject (`StagedBy`, the importer's own user id) into every card's identity, and — because it's a plain field with no `omitempty` — into the hashed payload too. Every `vcard_create` proposal is now inherently per-importer regardless of which card fields are present. This also incidentally closes the diff-hash join/decline-memory cross-subject paths *for this caller specifically* (they were already subject-blind engine-wide, but now hash differently per subject regardless of card content).

**Still not fixed here, filed instead**: the underlying engine gap — no self-only kind's identity-keyed *or* diff-hash paths are subject-scoped by the shared staging code itself, LinkedIn match included — is bigger than one caller and wants its own review: margince#3758. margince#3759 is an unrelated sibling census gap surfaced in the same round (no gate ensures every `opts_owner: caller` job declares a retry bound).

### Also from this review round
- `vcard_create`'s flattened display fields (`approvalkind.ts`) were generically offered as editable text boxes with no effect — the accept effect reads only the nested `Entry`, never a flattened edit. Declared `vcard_create: []` in `EDITABLE_FIELDS` (the pattern `org_name_promotion` already uses) and pinned it with a dedicated test.
- `vcardIngestMaxAttempts` raised from 3 to 5 and its rationale corrected in both Go and `api/jobs.yaml` — the worker's `Work()` does call `blob.Get` (a real dependency), and this on-demand, never-re-swept job needs the same headroom as other dependency-bound on-demand kinds, not the lookup-job precedent (3) the first version of this comment cited.
- Comment fixes: a now-false claim about River reading `api/jobs.yaml`'s `max_attempts`, a ticket-number/fix-narration comment, a stale card description, a hardcoded `25` replaced with `river.MaxAttemptsDefault`, and a dropped equality assertion restored alongside the bound check.
- `seedNearMatch` parametrized instead of duplicated across two tests.

## Process note
Auto-merge should never be armed before this session's own mandatory craft-reviewer/security-redteam pass completes — arming it right after opening the PR let CI-green merge #3757 while those agents (and Fable/Codex) were still running, landing an unreviewed cross-subject gap. For this PR, reviews ran and were triaged fully — twice — before auto-merge is armed.

## Test plan
- [x] TDD: `TestAVacuousCardDoesNotSupersedeAnotherSubjectsPendingReview`, `TestATwoFieldCardDoesNotSupersedeAnotherSubjectsPendingReview`, and `TestATwoMembersCardsWithNoCandidateDoNotJoinIntoOneReview` (the last added after Fable/Codex found the first two only proved the identity path, not the diff-hash join path, since they used different candidates per member) each written RED-first against the real approvals engine, now green
- [x] Full vCard suite (17 tests) green on top of current `main`, including the strengthened `TestACardNamingNoCompanyCanStillBeStaged` and `TestAMailedCardQueuesItsImport`, plus `withGhostOwnerAsSubject`'s signature simplified to return its stamped subject directly (closing an unreachable-error-branch finding)
- [x] `go build`, `go vet`, `gofmt -l .` clean; `make test-it DIR=backend/internal/compose` green (real Postgres)
- [x] `craft static --strict`: 0/0/0
- [x] Frontend: `make fe-typecheck-composed` clean, `approvalkind.test.ts` (19 tests) green
- [x] Rebased onto latest `origin/main` (which includes #3757)
- [x] Filed margince#3758 and margince#3759 for out-of-scope findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oooEFASw2gFLzM2uAb64A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes `vcard_create` review identity and diff hashes to the importing member, preventing one member’s card from superseding, joining, or remembering a decline for another member’s review. Re-uploads by the same member still join by diff hash and retain decline memory.

- Adds regression coverage for bare-name, name-and-organization, and identical no-candidate cards.
- Removes ineffective `vcard_create` fields from the approval editor.
- Raises `vcardIngestMaxAttempts` from 3 to 5 for blob-storage failures in the on-demand worker.
- Tracks the shared engine subject-scoping gap in `margince#3758` and the retry-bound census gap in `margince#3759`.

<sup>Written for commit ab372bf6f4e963414ac2c25ca415d0be8806cb14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Name-only contact cards can be staged and approved without creating an employment relationship.
  * Reviews for similar contact cards remain separate when submitted by different people.

* **Bug Fixes**
  * Contact-card processing now makes additional retry attempts for transient failures.
  * Unsupported vCard fields no longer appear in the editing interface.
  * Contact-card review status remains scoped to the person who submitted it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

