### PR TITLE
Focus when time opens, and the night's pick is drawn once

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2494,6 +2494,8 @@ export const de = {
   "home.weekly.outcome.moved": "bewegt",
   "home.weekly.outcome.won": "gewonnen",
   "home.weekly.outcome.lost": "verloren",
+  "home.focus.allAbove":
+    "Alles aus der Nacht steht schon oben, bei dem, was auf dich wartet.",
   "home.quietRun":
     "Heute Morgen hat nichts die Schwelle geschafft. Keine erfundene Dringlichkeit — genieß die Ruhe.",
   "home.act": "Erledigt",
@@ -2551,7 +2553,7 @@ export const de = {
   "home.glance.goDuplicates": "Zur Duplikate-Warteschlange",
   "home.glance.goWatch": "Zu den Deals, die still geworden sind",
   "home.panel.decisions": "Wartet auf dich",
-  "home.panel.today": "Heute",
+  "home.panel.focus": "Wenn Zeit bleibt",
   "home.panel.overnight": "Über Nacht",
   "home.panel.position": "Bestand",
   "home.panel.watch": "Still geworden",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2541,6 +2541,8 @@ export const en = {
   "home.weekly.outcome.moved": "moved",
   "home.weekly.outcome.won": "won",
   "home.weekly.outcome.lost": "lost",
+  "home.focus.allAbove":
+    "Everything the night suggested is already above, in what waits on you.",
   "home.quietRun":
     "Nothing cleared the bar this morning. No invented urgency — enjoy the quiet.",
   "home.act": "Done",
@@ -2598,7 +2600,7 @@ export const en = {
   "home.glance.goDuplicates": "Go to the duplicates queue",
   "home.glance.goWatch": "Go to the deals that have gone quiet",
   "home.panel.decisions": "Waiting on you",
-  "home.panel.today": "Today",
+  "home.panel.focus": "Focus when time opens",
   "home.panel.overnight": "Overnight",
   "home.panel.position": "Position",
   "home.panel.watch": "Gone quiet",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2471,6 +2471,8 @@ export const vi = {
   "home.weekly.outcome.moved": "đã chuyển",
   "home.weekly.outcome.won": "thắng",
   "home.weekly.outcome.lost": "thua",
+  "home.focus.allAbove":
+    "Mọi gợi ý từ đêm qua đã nằm ở trên, trong phần đang chờ bạn.",
   "home.quietRun":
     "Sáng nay không có gì vượt ngưỡng. Không bịa ra việc gấp — hãy tận hưởng sự yên tĩnh.",
   "home.act": "Đánh dấu xong",
@@ -2528,7 +2530,7 @@ export const vi = {
   "home.glance.goDuplicates": "Đến hàng chờ bản trùng",
   "home.glance.goWatch": "Đến các giao dịch đã im ắng",
   "home.panel.decisions": "Đang chờ bạn",
-  "home.panel.today": "Hôm nay",
+  "home.panel.focus": "Khi có thời gian",
   "home.panel.overnight": "Qua đêm",
   "home.panel.position": "Vị thế",
   "home.panel.watch": "Đã im ắng",

--- a/frontend/src/screens/brief.donext.tsx
+++ b/frontend/src/screens/brief.donext.tsx
@@ -5,7 +5,7 @@ import { Panel } from "../design-system/panel";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
-import { waitingRows } from "./brief.sentence";
+import { leadRows, waitingRows } from "./brief.sentence";
 import type { Worklist } from "./worklist.queries";
 import { WorklistRow } from "./worklist.row";
 
@@ -28,9 +28,6 @@ import "./brief.donext.css";
 // base-currency conversion and a materiality threshold the browser does not
 // hold — so this takes a prefix of the queue and nothing else.
 
-/** How many rows lead the page. */
-const LEAD = 3;
-
 /**
  * The head of the ranked queue, expanded.
  *
@@ -52,7 +49,7 @@ export function DoNext({
   // "what this page is answerable for", so the sentence cannot name a row this
   // section did not draw.
   const waiting = waitingRows(day);
-  const rows = waiting.slice(0, LEAD);
+  const rows = leadRows(day);
   return (
     <section id="brief-donext" aria-label={t("brief.donext.title")}>
       <Panel

--- a/frontend/src/screens/brief.sentence.test.ts
+++ b/frontend/src/screens/brief.sentence.test.ts
@@ -3,7 +3,14 @@ import { de } from "../i18n/de";
 import type { MessageKey } from "../i18n/en";
 import { en } from "../i18n/en";
 import { vi } from "../i18n/vi";
-import { briefSentence, leadOf, waitingRows } from "./brief.sentence";
+import {
+  briefSentence,
+  leadOf,
+  leadRows,
+  ledAlready,
+  waitingRows,
+} from "./brief.sentence";
+import { overnightRow } from "./home.fixtures";
 import { itemTitle } from "./worklist.copy";
 import type { Worklist, WorklistItem } from "./worklist.queries";
 
@@ -143,5 +150,49 @@ describe("the opening sentence", () => {
   it("names no remainder when the lead is the only row", () => {
     const sentence = briefSentence(day([item()]), t, "en");
     expect(sentence?.key).toMatch(/^brief\.sentence\.one/);
+  });
+});
+
+// Which overnight suggestions the section BELOW must leave out.
+//
+// The Brief reads one brief run through two endpoints, so a suggestion that
+// ranks into the lead is on the page twice unless the lower section skips it —
+// once as a worklist row with its own controls, once as a card with its own.
+// That is the same duplication the decisions deck exclusion exists to stop, one
+// section further down.
+describe("what already leads the page", () => {
+  it("names the overnight rows Do next drew", () => {
+    const today = day([
+      overnightRow("bi-1", "d-1"),
+      overnightRow("bi-2", "d-2"),
+    ]);
+
+    expect([...ledAlready(today)]).toEqual(["bi-1", "bi-2"]);
+  });
+
+  // The lead is a prefix of ONE order, so a suggestion ranked below it is not
+  // on the page yet and the section below is the only place it appears.
+  it("leaves out an overnight row that ranked past the lead", () => {
+    const today = day([
+      item({ id: "w1" }),
+      item({ id: "w2" }),
+      item({ id: "w3" }),
+      overnightRow("bi-9", "d-9"),
+    ]);
+
+    expect(ledAlready(today).has("bi-9")).toBe(false);
+    expect(leadRows(today).map((row) => row.id)).toEqual(["w1", "w2", "w3"]);
+  });
+
+  // Only overnight rows can collide: a waiting customer has no card below to be
+  // drawn as, so naming it here would hide nothing and cost the reader a row.
+  it("names nothing for a lead made of ordinary waiting work", () => {
+    const today = day([item({ id: "w1" }), item({ id: "w2" })]);
+
+    expect(ledAlready(today).size).toBe(0);
+  });
+
+  it("names nothing when the day could not be read", () => {
+    expect(ledAlready(undefined).size).toBe(0);
   });
 });

--- a/frontend/src/screens/brief.sentence.ts
+++ b/frontend/src/screens/brief.sentence.ts
@@ -105,6 +105,40 @@ export function briefSentence(
   };
 }
 
+/** How many rows lead the page — what "Do next" draws. */
+export const LEAD = 3;
+
+/** The rows "Do next" draws: the head of the one ranked order. */
+export function leadRows(day: Worklist | undefined): readonly WorklistItem[] {
+  return waitingRows(day).slice(0, LEAD);
+}
+
+/**
+ * Which overnight suggestions "Do next" has ALREADY drawn.
+ *
+ * The Brief reads the same brief run through two endpoints. `GET /worklist`
+ * ranks each suggestion into the one order as a `brief_item` row, and
+ * `GET /brief` serves the same records with the factors behind them — same ids,
+ * because `briefItem` sends the entry's own id (`attention/render.go`). So a
+ * suggestion that ranks into the lead is on the page twice unless the section
+ * below leaves out what the section above took: once as a worklist row, once as
+ * a card, each offering its own controls over one record.
+ *
+ * The split lives HERE rather than in either section because both must read the
+ * same answer. Kept in one of them, the other would drift the first time `LEAD`
+ * moved, and the duplicate would come back silently.
+ */
+export function ledAlready(day: Worklist | undefined): ReadonlySet<string> {
+  return new Set(
+    leadRows(day)
+      .filter((item) => item.source === OVERNIGHT)
+      .map((item) => item.id),
+  );
+}
+
+/** The source a row carries when it came from the overnight run. */
+const OVERNIGHT = "brief_item";
+
 /**
  * The row the page opens with.
  *

--- a/frontend/src/screens/home.fixtures.ts
+++ b/frontend/src/screens/home.fixtures.ts
@@ -266,6 +266,26 @@ export function meetingRow(id: string, prepared: boolean): WorklistItem {
 
 type WorklistItem = components["schemas"]["WorklistItem"];
 
+/**
+ * The overnight run's suggestion as the WORKLIST carries it.
+ *
+ * Same id as the `MorningBrief` item it came from — `briefItem` in
+ * `attention/render.go` sends the entry's own id — which is what lets the Focus
+ * section leave out whatever Do next already drew.
+ */
+export function overnightRow(id: string, dealId: string): WorklistItem {
+  return {
+    id,
+    source: "brief_item",
+    level: 3,
+    category: "deals_at_risk",
+    because: [],
+    consequence: "deal_drifts",
+    actions: ["act", "set_aside", "dismiss"],
+    subject: { type: "deal", id: dealId },
+  };
+}
+
 /** One customer waiting on an answer — the row Do next leads with. */
 export function waitingRow(): WorklistItem {
   return {

--- a/frontend/src/screens/home.parts.stories.tsx
+++ b/frontend/src/screens/home.parts.stories.tsx
@@ -19,7 +19,7 @@ import {
 import { HomeGlance } from "./home.glance";
 import { OvernightPanel, PositionPanel, WatchPanel } from "./home.rail";
 import { HomeReadingsStrip } from "./home.readings";
-import { TodaySection } from "./home.today";
+import { FocusSection } from "./home.today";
 import {
   installFetchStub,
   jsonResponse,
@@ -27,6 +27,9 @@ import {
   type RouteMap,
   StoryProviders,
 } from "./story-utils";
+
+// A story draws one section on its own, so nothing leads the page above it.
+const NOTHING_ABOVE: ReadonlySet<string> = new Set();
 
 // Home, one part at a time.
 //
@@ -273,27 +276,45 @@ export const DecisionsRefused: Story = {
 // The ranked queue: the composite as the first row of the same axis its five
 // factors are drawn on, and the factors in a softer fill so the row that leads
 // reads first.
-export const Today: Story = {
+export const Focus: Story = {
   render: part(
-    <TodaySection brief={ranked} deals={deals} nowMs={NOW} state="ready" />,
+    <FocusSection
+      brief={ranked}
+      deals={deals}
+      nowMs={NOW}
+      state="ready"
+      drawnAbove={NOTHING_ABOVE}
+    />,
     { ...RAIL_ROUTES, "POST /brief": () => jsonResponse(ranked) },
   ),
 };
 
 // A run that ranked nothing, with the candidate count under it. Honest quiet,
 // and no invented urgency.
-export const TodayQuietRun: Story = {
+export const FocusQuietRun: Story = {
   render: part(
-    <TodaySection brief={quietRun} deals={deals} nowMs={NOW} state="ready" />,
+    <FocusSection
+      brief={quietRun}
+      deals={deals}
+      nowMs={NOW}
+      state="ready"
+      drawnAbove={NOTHING_ABOVE}
+    />,
     { ...RAIL_ROUTES, "POST /brief": () => jsonResponse(quietRun) },
   ),
 };
 
 // No run has ever been made. The panel offers to make one instead of drawing an
 // empty queue that looks like a failure.
-export const TodayNoRun: Story = {
+export const FocusNoRun: Story = {
   render: part(
-    <TodaySection brief={null} deals={deals} nowMs={NOW} state="ready" />,
+    <FocusSection
+      brief={null}
+      deals={deals}
+      nowMs={NOW}
+      state="ready"
+      drawnAbove={NOTHING_ABOVE}
+    />,
     {
       ...RAIL_ROUTES,
       "POST /brief": () => jsonResponse(ranked),
@@ -304,9 +325,15 @@ export const TodayNoRun: Story = {
 // The read behind the queue failed. The panel says so where the cards would be,
 // rather than drawing the empty plate a morning with no run would show — the two
 // are different facts and used to look identical.
-export const TodayRefused: Story = {
+export const FocusRefused: Story = {
   render: part(
-    <TodaySection brief={null} deals={deals} nowMs={NOW} state="failed" />,
+    <FocusSection
+      brief={null}
+      deals={deals}
+      nowMs={NOW}
+      state="failed"
+      drawnAbove={NOTHING_ABOVE}
+    />,
   ),
 };
 

--- a/frontend/src/screens/home.test.tsx
+++ b/frontend/src/screens/home.test.tsx
@@ -12,6 +12,7 @@ import { MONEY_ABSENT } from "../format/format";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
 import { HomeScreen } from "./home";
+import { overnightRow, readingsDay } from "./home.fixtures";
 import { HomeGlance } from "./home.glance";
 import {
   fleetDeal,
@@ -22,6 +23,7 @@ import {
   render,
   run,
   stubApi,
+  threeRanked,
   workOrder,
   writeRoutes,
   writes,
@@ -295,7 +297,7 @@ describe("HomeScreen — the order of the page follows the day", () => {
     render(<HomeScreen />);
 
     await screen.findByText("Send the Weber follow-up");
-    expect(workOrder()).toEqual(["home-decisions", "home-today"]);
+    expect(workOrder()).toEqual(["home-decisions", "home-focus"]);
   });
 
   it("leads with the ranked queue once the deck is clear", async () => {
@@ -306,7 +308,7 @@ describe("HomeScreen — the order of the page follows the day", () => {
     render(<HomeScreen />);
 
     await screen.findByText("Fleet retrofit");
-    expect(workOrder()).toEqual(["home-today", "home-decisions"]);
+    expect(workOrder()).toEqual(["home-focus", "home-decisions"]);
   });
 });
 
@@ -547,6 +549,70 @@ describe("HomeScreen — a reading in flight is absent, not zero", () => {
 // ── The ranked queue ──
 
 describe("HomeScreen — the ranked queue", () => {
+  // ONE brief run reaches this page through TWO endpoints: `GET /worklist`
+  // ranks each suggestion into the one order as a `brief_item` row, and
+  // `GET /brief` serves the same records with the factors behind them, under the
+  // same ids. So a suggestion that ranks into "Do next" is on the page twice
+  // unless "Focus when time opens" leaves out what the lead already drew — once
+  // as a worklist row and once as a card, each offering its own controls over
+  // the same deal.
+  it("draws an overnight suggestion once, even when it also leads the page", async () => {
+    stubApi({
+      "GET /brief": () => jsonResponse(threeRanked),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+      "GET /worklist": () =>
+        jsonResponse(readingsDay({}, [overnightRow("bi-1", "d-1")])),
+    });
+    render(<HomeScreen />);
+
+    // The suggestions that did not lead are drawn as cards, so the section is
+    // skipping ONE record rather than going quiet. Awaited first: it is the
+    // slowest of the reads this assertion depends on.
+    expect(await screen.findByTestId("brief-item-bi-2")).toBeTruthy();
+    expect(screen.getByTestId("brief-item-bi-3")).toBeTruthy();
+    // The one that leads is drawn ONCE — as a worklist row, not again as a card.
+    const lead = screen.getByRole("region", {
+      name: en["brief.donext.title"],
+    });
+    expect(within(lead).getAllByRole("listitem")).toHaveLength(1);
+    expect(screen.queryByTestId("brief-item-bi-1")).toBeNull();
+  });
+
+  // The other half of the same rule. Nothing led the page, so the section below
+  // owns every suggestion — a filter that dropped one here would hide work.
+  it("draws every suggestion when none of them leads the page", async () => {
+    stubApi({
+      "GET /brief": () => jsonResponse(threeRanked),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    render(<HomeScreen />);
+
+    expect(await screen.findByTestId("brief-item-bi-1")).toBeTruthy();
+    expect(screen.getByTestId("brief-item-bi-2")).toBeTruthy();
+    expect(screen.getByTestId("brief-item-bi-3")).toBeTruthy();
+  });
+
+  // A morning whose every suggestion already leads. "Nothing cleared the bar"
+  // would contradict the rows the reader can see directly above.
+  it("says the work is above rather than that the night found nothing", async () => {
+    stubApi({
+      "GET /brief": () => jsonResponse(threeRanked),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+      "GET /worklist": () =>
+        jsonResponse(
+          readingsDay({}, [
+            overnightRow("bi-1", "d-1"),
+            overnightRow("bi-2", "d-2"),
+            overnightRow("bi-3", "d-3"),
+          ]),
+        ),
+    });
+    render(<HomeScreen />);
+
+    expect(await screen.findByText(en["home.focus.allAbove"])).toBeTruthy();
+    expect(screen.queryByText(en["home.quietRun"])).toBeNull();
+  });
+
   it("renders the run: the deal, its money, the decomposition, the evidence and the honest-short line", async () => {
     stubApi({
       "GET /brief": () => jsonResponse(run),

--- a/frontend/src/screens/home.testkit.tsx
+++ b/frontend/src/screens/home.testkit.tsx
@@ -176,7 +176,7 @@ export function writeRoutes(calls: readonly Call[]): string[] {
 
 /** Home's two work sections, in the order the document holds them. */
 export function workOrder(): string[] {
-  return [...document.querySelectorAll("#home-decisions, #home-today")].map(
+  return [...document.querySelectorAll("#home-decisions, #home-focus")].map(
     (section) => section.id,
   );
 }
@@ -219,6 +219,20 @@ export const run: MorningBrief = {
       state: "new",
       state_at: null,
     },
+  ],
+};
+
+/**
+ * The same run with three suggestions, for the cases about which section owns
+ * which. One item cannot show a section SKIPPING one and keeping the rest.
+ */
+export const threeRanked: MorningBrief = {
+  ...run,
+  candidate_count: 3,
+  items: [
+    run.items[0],
+    { ...run.items[0], id: "bi-2", deal_id: "d-2", rank: 2, composite: 0.61 },
+    { ...run.items[0], id: "bi-3", deal_id: "d-3", rank: 3, composite: 0.44 },
   ],
 };
 

--- a/frontend/src/screens/home.today.tsx
+++ b/frontend/src/screens/home.today.tsx
@@ -19,19 +19,33 @@ import {
   useBriefRefresh,
 } from "./home.queries";
 
-// The ranked half of Home: what the run thinks the day is for, and the three
-// verbs that move an entry off it.
+// The opportunity half of Home: what the overnight run thinks is worth pursuing
+// once the waiting work is answered, and the three verbs that move an entry off
+// it.
+//
+// It sits BELOW "Do next" and answers a different question. Do next is what is
+// already waiting on this rep; this is where to spend the hour that opens up
+// after — which is why the section is named for the time rather than for the
+// day, and why leading with it was leading with the wrong half.
+//
+// The two sections read ONE brief run through two endpoints, so this leaves out
+// whatever Do next already drew (`ledAlready`). Without that a suggestion
+// ranking into the lead appeared twice on one page — once as a worklist row and
+// once as a card, each with its own controls over the same record.
 
-/** The ranked queue: what the run thinks the day is for. */
-export function TodaySection({
+/** What the run thinks the day is for, minus what already leads the page. */
+export function FocusSection({
   brief,
   deals,
   nowMs,
   state,
+  drawnAbove,
 }: Readonly<{
   brief: MorningBrief | null;
   deals: readonly Deal[];
   nowMs: number;
+  /** The overnight suggestions "Do next" has already drawn, by id. */
+  drawnAbove: ReadonlySet<string>;
   /** What the read behind the queue says. Before it has answered the panel
    *  holds its shape, and a FAILED read says so — `ready` as a boolean could
    *  only tell the two apart by drawing a failure as an empty queue. */
@@ -43,9 +57,9 @@ export function TodaySection({
   const mark = useBriefItemMark();
 
   return (
-    <section id="home-today" aria-label={t("home.panel.today")}>
+    <section id="home-focus" aria-label={t("home.panel.focus")}>
       <Panel
-        title={t("home.panel.today")}
+        title={t("home.panel.focus")}
         sub={
           brief
             ? t("home.asOf", {
@@ -85,12 +99,13 @@ export function TodaySection({
         }
       >
         <PanelBody className="home-today-list">
-          <TodayBody
+          <FocusBody
             brief={brief}
             deals={deals}
             nowMs={nowMs}
             state={state}
             mark={mark}
+            drawnAbove={drawnAbove}
           />
         </PanelBody>
         {refresh.isError && (
@@ -106,18 +121,20 @@ export function TodaySection({
 }
 
 /** The queue's four readings: in flight, no run, a quiet run, or the items. */
-function TodayBody({
+function FocusBody({
   brief,
   deals,
   nowMs,
   state,
   mark,
+  drawnAbove,
 }: Readonly<{
   brief: MorningBrief | null;
   deals: readonly Deal[];
   nowMs: number;
   state: SectionState;
   mark: ReturnType<typeof useBriefItemMark>;
+  drawnAbove: ReadonlySet<string>;
 }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -129,7 +146,7 @@ function TodayBody({
       <SurfaceState
         state={state}
         emptyLabel={t("home.noneBody")}
-        loadingLabel={t("home.panel.today")}
+        loadingLabel={t("home.panel.focus")}
       >
         {null}
       </SurfaceState>
@@ -138,15 +155,25 @@ function TodayBody({
   if (brief === null) {
     return <EmptyState>{t("home.noneBody")}</EmptyState>;
   }
-  if (brief.items.length === 0) {
+  const items = brief.items.filter((item) => !drawnAbove.has(item.id));
+  if (items.length === 0) {
     // The narrative still belongs here. A run that ranked nothing is exactly
     // when the night's sentence carries the most — "nothing needs you today"
     // and "nobody looked" are different mornings, and the empty state alone
     // cannot tell them apart.
+    //
+    // Two ways to reach this and they read differently. A run that ranked
+    // nothing is a quiet morning; a run whose every suggestion already leads the
+    // page is a morning where the work is simply above, and saying "nothing
+    // cleared the bar" there would contradict the rows the reader can see.
     return (
       <>
         <TodayNarrative brief={brief} />
-        <EmptyState>{t("home.quietRun")}</EmptyState>
+        <EmptyState>
+          {brief.items.length > 0
+            ? t("home.focus.allAbove")
+            : t("home.quietRun")}
+        </EmptyState>
       </>
     );
   }
@@ -156,7 +183,7 @@ function TodayBody({
   return (
     <>
       <TodayNarrative brief={brief} />
-      {brief.items.map((item) => (
+      {items.map((item) => (
         <BriefQueueItem
           key={item.id}
           item={item}

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -15,6 +15,7 @@ import { usePendingApprovals } from "./approvals.queries";
 import { BriefDials } from "./brief.dials";
 import { DoNext } from "./brief.donext";
 import { PlanSection } from "./brief.plan";
+import { ledAlready } from "./brief.sentence";
 import { TeamWeeklyPanel } from "./brief.teamweekly";
 import { addressFrom, type BriefAddress, paramsFor } from "./brief.view";
 import { BriefCoverage } from "./briefcoverage";
@@ -37,7 +38,7 @@ import {
 import { OvernightPanel, PositionPanel, WatchPanel } from "./home.rail";
 import { HomeReadingsStrip } from "./home.readings";
 import { HomeTeamBoard } from "./home.teamboard";
-import { TodaySection } from "./home.today";
+import { FocusSection } from "./home.today";
 import { WeeklySection } from "./home.weekly";
 import { useWorklist, type Worklist } from "./worklist.queries";
 import "./home.css";
@@ -219,13 +220,16 @@ function HomeWork({
       onAlreadyDecided={onAlreadyDecided}
     />
   );
-  const today = (
-    <TodaySection
-      key="today"
+  const focus = (
+    <FocusSection
+      key="focus"
       brief={brief}
       deals={deals}
       nowMs={nowMs}
       state={briefState}
+      // What "Do next" already drew, so one brief run reaching the page through
+      // two endpoints does not put the same suggestion on it twice.
+      drawnAbove={ledAlready(day)}
     />
   );
   // A KEYED array, not two fragments. Positional children of a fragment are
@@ -272,8 +276,8 @@ function HomeWork({
     return [lastWeek, nextWeek];
   }
   return items.length > 0
-    ? [decisions, doNext, today]
-    : [doNext, today, decisions];
+    ? [decisions, doNext, focus]
+    : [doNext, focus, decisions];
 }
 
 /**
@@ -407,7 +411,7 @@ export function HomeScreen() {
         overnight={overnightGlance(digestQuery.isSuccess, digest)}
         stalled={quietReading}
         onGoToDecisions={() => goToSection("home-decisions")}
-        onGoToToday={() => goToSection("home-today")}
+        onGoToToday={() => goToSection("home-focus")}
         onGoToDuplicates={() => navigate({ screen: "worklist" })}
         onGoToWatch={() => goToSection("home-watch")}
       />


### PR DESCRIPTION
The Brief showed the overnight run twice. `GET /worklist` ranks each suggestion
into the one order as a `brief_item` row, and `GET /brief` serves the same
records with the factors behind them, under the same ids — `briefItem` in
`attention/render.go` sends the entry's own id. So a suggestion that ranked into
the top three appeared once as a worklist row in "Do next" and again as a card
below, each offering its own controls over one deal.

The lower panel is now "Focus when time opens" and draws what the lead did not.
The split lives in `brief.sentence.ts` beside the deck exclusion it mirrors,
because both sections have to read one answer: kept in either of them, the other
would drift the first time LEAD moved and the duplicate would come back quietly.

It also renames the section for what it is. "Today" said nothing about which of
the two questions it answered — Do next is what is already waiting, this is
where the hour that opens up afterwards goes, which is why it sits below.

The empty state now has two readings. A run that ranked nothing is a quiet
morning; a run whose every suggestion already leads the page is a morning whose
work is simply above, and "nothing cleared the bar this morning" there would
contradict the rows the reader can see.

Tested both ways round, because a filter has two failure directions and only one
of them is visible. Dropping the exclusion fails the duplication test; widening
it to drop everything fails the tests that prove the section still draws the
suggestions nobody took. Before this the exclusion could be deleted with all
3961 screen tests still green.

The section keeps its own id (`home-focus`), so the glance's jump link, the work
order assertions and the testkit's section reader move with it.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the home screen from showing the same overnight suggestion twice. A suggestion that ranked into the top three appeared once as a "Do next" worklist row and again as a card below, each offering its own controls over the same deal.

- Renames the lower panel from "Today" to "Focus when time opens"; it now draws only suggestions the lead did not take.
- The empty state now distinguishes a run that ranked nothing from one whose every suggestion already leads the page.
- The exclusion logic lives in `brief.sentence.ts` so both sections read the same answer; the section keeps its own `home-focus` id, moving the jump link, work order assertions, and testkit reader with it.

<sup>Written for commit 11bf9cadb50d734c596f03aa48fa137eb3032410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a ranked “Do Next” section showing up to three priority suggestions.
  - Prevented suggestions already shown in “Do Next” from being repeated in the Focus section.
  - Added clearer empty-state messaging when all suggestions are already displayed above.
- **Changes**
  - Renamed the home section from “Today” to “Focus,” including navigation labels.
  - Updated English, German, and Vietnamese translations for the new labels and messages.
- **Tests**
  - Added coverage for ranking, duplicate prevention, and empty-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->