### PR TITLE
The weekly reads as one answer

### DIFF
--- a/frontend/e2e/brief.spec.ts
+++ b/frontend/e2e/brief.spec.ts
@@ -92,6 +92,14 @@ async function openBrief(page: Page) {
  * so waiting on it would time out on every call. Excluded by name rather than
  * by giving up on the check, which would also excuse a panel still sliding in.
  */
+/** Open the Brief on its weekly view, settled the same way the morning is. */
+async function openWeekly(page: Page) {
+  await page.goto("/#/home?view=weekly", { waitUntil: "networkidle" });
+  await expect(page.locator(GLANCE)).toBeVisible();
+  await expect(page.locator("#home-weekly")).toBeVisible();
+  await settled(page);
+}
+
 async function settled(page: Page) {
   await page.waitForFunction(
     (ambient) =>
@@ -233,24 +241,29 @@ test.describe("the Brief — page shape", () => {
   // The retrospective is LAST, under the work. It is what a rep reads once on
   // Monday, after the work waiting on them today; above either of those it puts
   // last week ahead of this morning.
-  test("keeps last week below today's work", async ({ page }) => {
-    await openBrief(page);
-    await expectShellRendered(page);
-
-    expect(await topOf(page.locator("#home-today"))).toBeLessThan(
-      await topOf(page.locator("#home-weekly")),
-    );
-  });
-
+  // The week lives behind the Weekly dial, not at the foot of the morning. It
+  // moved there when the dials shipped, and these two assertions kept opening
+  // the morning and waiting for a section that is no longer on it.
+  //
   // Frozen past above, live future below: a rep decides what next week holds by
   // reading what this one did.
   test("puts the week's plan under the week's review", async ({ page }) => {
-    await openBrief(page);
+    await openWeekly(page);
     await expectShellRendered(page);
 
     expect(await topOf(page.locator("#home-weekly"))).toBeLessThan(
       await topOf(page.locator("#brief-plan")),
     );
+  });
+
+  // And the morning shows the morning's work — the weekly is a dial away, not
+  // a section further down the same page.
+  test("keeps the week off the morning", async ({ page }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    await expect(page.locator("#home-focus")).toBeVisible();
+    await expect(page.locator("#home-weekly")).toHaveCount(0);
   });
 
   // At desktop the rail is BESIDE the work, not under it. This is the assertion

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2533,6 +2533,7 @@ export const de = {
   "home.glance.eveningAnon": "Guten Abend.",
   "home.glance.night": "Noch im Einsatz, {name}.",
   "home.glance.nightAnon": "Noch im Einsatz.",
+  "home.glance.introWeekly": "Das ist deine abgeschlossene Woche.",
   "home.glance.intro": "Das ist dein Tag.",
   "home.glance.decisionsClear": "Es wartet nichts auf dich.",
   "home.glance.decisions_one": "Entscheidung wartet auf dich.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2580,6 +2580,7 @@ export const en = {
   "home.glance.eveningAnon": "Good evening.",
   "home.glance.night": "Still at it, {name}.",
   "home.glance.nightAnon": "Still at it.",
+  "home.glance.introWeekly": "This is the week you just closed.",
   "home.glance.intro": "Here is your day.",
   "home.glance.decisionsClear": "Nothing is waiting on you.",
   "home.glance.decisions_one": "decision is waiting on you.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2510,6 +2510,7 @@ export const vi = {
   "home.glance.eveningAnon": "Chào buổi tối.",
   "home.glance.night": "Vẫn đang làm việc, {name}.",
   "home.glance.nightAnon": "Vẫn đang làm việc.",
+  "home.glance.introWeekly": "Đây là tuần bạn vừa khép lại.",
   "home.glance.intro": "Đây là ngày của bạn.",
   "home.glance.decisionsClear": "Không có gì đang chờ bạn.",
   "home.glance.decisions_one": "quyết định đang chờ bạn.",

--- a/frontend/src/screens/home.dials.test.tsx
+++ b/frontend/src/screens/home.dials.test.tsx
@@ -142,6 +142,12 @@ describe("the Brief's dials", () => {
     expect(await screen.findByText(en["brief.eyebrow.weekly"])).toBeTruthy();
     expect(screen.queryByText(en["brief.eyebrow"])).toBeNull();
     expect(screen.queryByTestId("glance-sentence")).toBeNull();
+    // And the line that stands in for it belongs to the week too. The weekly
+    // NEVER composes a sentence, so the fallback is the only line under its
+    // heading — and the morning's "this is your day" read as the wrong week
+    // entirely beneath "YOUR WEEK".
+    expect(screen.getByText(en["home.glance.introWeekly"])).toBeTruthy();
+    expect(screen.queryByText(en["home.glance.intro"])).toBeNull();
   });
 
   // The morning shows what waits; the weekly shows the week. Neither shows the

--- a/frontend/src/screens/home.glance.tsx
+++ b/frontend/src/screens/home.glance.tsx
@@ -237,7 +237,14 @@ export function HomeGlance({
           {t(sentence.key, sentence.values)}
         </p>
       ) : (
-        <p className="glance-intro t-caption">{t("home.glance.intro")}</p>
+        // The weekly has no composed sentence, so the fallback is the only line
+        // under its heading — and the morning's "this is your day" read as the
+        // wrong week entirely beneath "YOUR WEEK". Each view says its own.
+        <p className="glance-intro t-caption">
+          {t(
+            view === "weekly" ? "home.glance.introWeekly" : "home.glance.intro",
+          )}
+        </p>
       )}
       <div className="glance-lines">
         {decisions !== null && decisions.pending === 0 && (

--- a/frontend/src/screens/home.weekly.css
+++ b/frontend/src/screens/home.weekly.css
@@ -56,3 +56,36 @@
 .home-weekly-narrative-absent {
   color: var(--textMeta);
 }
+
+/* ── The week's workings ───────────────────────────────────────────────────
+ * Slots six to ten of what used to be one ten-slot strip. A strip is read
+ * ACROSS as a single comparison and ten slots folded into two ranks, which is
+ * a table wearing a strip's clothes; these five are looked up ONE at a time by
+ * somebody who already read the outcomes, so they draw as a definition list.
+ *
+ * Wrapping pairs rather than a grid of fixed columns: the labels differ in
+ * length across three languages, and a fixed track that fits "Decided" leaves
+ * "Zusagen, eingelöst" clipped. */
+
+.home-weekly-workings {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-6);
+  margin: var(--space-4) 0 0;
+}
+
+.home-weekly-working {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.home-weekly-working dt {
+  color: var(--textSecondary);
+}
+
+/* The browser's own indent on a `dd` would stagger every pair by 40px. */
+.home-weekly-working dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/screens/home.weekly.test.tsx
+++ b/frontend/src/screens/home.weekly.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { cleanup, screen } from "@testing-library/react";
+import { cleanup, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { en } from "../i18n/en";
 import { HomeScreen } from "./home";
@@ -281,5 +281,55 @@ describe("HomeScreen — the week against the one before", () => {
 
     const marker = en["home.weekly.sincePrior"].replace("{delta}", "").trim();
     expect(strip.textContent).not.toContain(marker);
+  });
+
+  // ── Five outcomes, and the workings under them ──
+
+  // The strip is read ACROSS as one comparison, so its width is the claim. At
+  // ten slots it folded into two ranks at 1280 and stopped being one reading —
+  // which is what #3709 reported.
+  it("draws five slots, not the ten the week has figures for", async () => {
+    const strip = await mount(withPrior);
+
+    expect(strip.querySelectorAll(".stat-card")).toHaveLength(5);
+  });
+
+  // The five are the week's OUTCOMES: what was promised and kept, what closed,
+  // how fast new business was answered, whether meetings led anywhere, and what
+  // did not get finished.
+  it("gives the strip the week's outcomes", async () => {
+    const strip = await mount(withPrior);
+
+    for (const key of [
+      "home.weekly.promisesKept",
+      "home.weekly.dealsWon",
+      "home.weekly.leadsAnswered",
+      "home.weekly.meetingsHeld",
+      "home.weekly.carriedOver",
+    ] as const) {
+      expect(within(strip).getByText(en[key])).toBeTruthy();
+    }
+  });
+
+  // Narrowing the strip must not LOSE the other five. They are still the week's
+  // figures and a reader who wants them has to be able to find them — a strip
+  // that got shorter by dropping readings would be a worse answer than the row
+  // that folded.
+  it("keeps the other five figures, under the strip", async () => {
+    const strip = await mount(withPrior);
+
+    for (const key of [
+      "home.weekly.promised",
+      "home.weekly.dealsMoved",
+      "home.weekly.dealsLost",
+      "home.weekly.decided",
+      "home.weekly.queueWorked",
+    ] as const) {
+      const reading = screen.getByText(en[key]);
+      expect(reading).toBeTruthy();
+      // Under the strip, not in it: in a slot they would be back to competing
+      // with the outcomes for the one comparison the row makes.
+      expect(strip.contains(reading)).toBe(false);
+    }
   });
 });

--- a/frontend/src/screens/home.weekly.tsx
+++ b/frontend/src/screens/home.weekly.tsx
@@ -84,6 +84,69 @@ export function WeeklySection() {
 }
 
 /**
+ * The week's workings, under the strip.
+ *
+ * Five readings that answer "how did the week go" rather than "what did the week
+ * produce" — how much of the queue was worked, how proposals were decided, how
+ * many deals moved without closing. They were slots six to ten of a ten-slot
+ * strip, where they made the row fold into two ranks and cost the outcomes their
+ * one-comparison reading.
+ *
+ * A definition list, not more cards: these are looked up one at a time by
+ * somebody who already read the strip, which is the opposite of the strip's
+ * read-across claim.
+ */
+function WeeklyWorkings({
+  counts,
+}: Readonly<{ counts: WeeklyReview["counts"] }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const n = (value: number) => formatNumber(value, locale);
+  return (
+    <dl className="home-weekly-workings">
+      <Working
+        label={t("home.weekly.promised")}
+        value={t("home.weekly.ofDue", {
+          done: n(counts.tasks_done),
+          due: n(counts.tasks_due),
+        })}
+      />
+      <Working
+        label={t("home.weekly.dealsMoved")}
+        value={n(counts.deals_moved)}
+      />
+      <Working
+        label={t("home.weekly.dealsLost")}
+        value={n(counts.deals_lost)}
+      />
+      <Working
+        label={t("home.weekly.decided")}
+        value={t("home.weekly.acceptedRejected", {
+          accepted: n(counts.proposals_accepted),
+          rejected: n(counts.proposals_rejected),
+        })}
+      />
+      <Working
+        label={t("home.weekly.queueWorked")}
+        value={t("home.weekly.actedDismissed", {
+          acted: n(counts.brief_items_acted),
+          dismissed: n(counts.brief_items_dismissed),
+        })}
+      />
+    </dl>
+  );
+}
+
+function Working({ label, value }: Readonly<{ label: string; value: string }>) {
+  return (
+    <div className="home-weekly-working">
+      <dt className="t-caption">{label}</dt>
+      <dd className="t-body">{value}</dd>
+    </div>
+  );
+}
+
+/**
  * The sentence about the week, above its numbers.
  *
  * THREE STATES, and the third is the one worth the code. A review with no
@@ -192,29 +255,28 @@ function WeeklyBody({
   return (
     <>
       <WeeklyNarrative review={review} />
+      {/* FIVE slots, because a strip is read ACROSS as one comparison and ten
+          is a table wearing a strip's clothes — at 1280 the row folded to two
+          ranks of five and stopped being one reading at all (#3709).
+          These five are the week's outcomes: what was promised and kept, what
+          closed, how fast new business was answered, whether meetings led
+          anywhere, and what did not get finished. The other five are workings
+          — how the queue was worked, how proposals were decided — and they
+          read as a list under the strip, where they are still available to
+          anyone who wants them and no longer compete with the outcomes. */}
       <StatStrip testId="weekly-strip">
         <StatCard
-          label={t("home.weekly.promised")}
+          label={t("home.weekly.promisesKept")}
           value={t("home.weekly.ofDue", {
-            done: formatNumber(c.tasks_done, locale),
-            due: formatNumber(c.tasks_due, locale),
+            done: formatNumber(c.commitments_kept, locale),
+            due: formatNumber(c.commitments_due, locale),
           })}
-          detail={since(c.tasks_done, prior?.tasks_done)}
+          detail={since(c.commitments_kept, prior?.commitments_kept)}
         />
         <StatCard
           label={t("home.weekly.dealsWon")}
           value={formatNumber(c.deals_won, locale)}
           detail={since(c.deals_won, prior?.deals_won)}
-        />
-        <StatCard
-          label={t("home.weekly.dealsLost")}
-          value={formatNumber(c.deals_lost, locale)}
-          detail={since(c.deals_lost, prior?.deals_lost)}
-        />
-        <StatCard
-          label={t("home.weekly.dealsMoved")}
-          value={formatNumber(c.deals_moved, locale)}
-          detail={since(c.deals_moved, prior?.deals_moved)}
         />
         <StatCard
           label={t("home.weekly.leadsAnswered")}
@@ -228,14 +290,6 @@ function WeeklyBody({
           )}
         />
         <StatCard
-          label={t("home.weekly.promisesKept")}
-          value={t("home.weekly.ofDue", {
-            done: formatNumber(c.commitments_kept, locale),
-            due: formatNumber(c.commitments_due, locale),
-          })}
-          detail={since(c.commitments_kept, prior?.commitments_kept)}
-        />
-        <StatCard
           label={t("home.weekly.meetingsHeld")}
           value={t("home.weekly.ofMeetings", {
             withStep: formatNumber(c.meetings_with_next_step, locale),
@@ -244,24 +298,12 @@ function WeeklyBody({
           detail={since(c.meetings_held, prior?.meetings_held)}
         />
         <StatCard
-          label={t("home.weekly.decided")}
-          value={t("home.weekly.acceptedRejected", {
-            accepted: formatNumber(c.proposals_accepted, locale),
-            rejected: formatNumber(c.proposals_rejected, locale),
-          })}
-        />
-        <StatCard
-          label={t("home.weekly.queueWorked")}
-          value={t("home.weekly.actedDismissed", {
-            acted: formatNumber(c.brief_items_acted, locale),
-            dismissed: formatNumber(c.brief_items_dismissed, locale),
-          })}
-        />
-        <StatCard
           label={t("home.weekly.carriedOver")}
           value={formatNumber(c.tasks_carried_over, locale)}
+          detail={since(c.tasks_carried_over, prior?.tasks_carried_over)}
         />
       </StatStrip>
+      <WeeklyWorkings counts={c} />
       {review.deals.length > 0 && (
         <ul className="home-weekly-deals">
           {review.deals.map((deal) => (


### PR DESCRIPTION
The weekly's readings strip carried ten slots. A strip is read ACROSS as one
comparison — that is the whole difference between it and a row of cards — and at
1280 ten folded into two ranks, which is a table wearing a strip's clothes. That
was issue #3709.

Five slots now, and they are the week's OUTCOMES: what was promised and kept,
what closed, how fast new business was answered, whether meetings led anywhere,
and what did not get finished. The other five are workings — how the queue was
worked, how proposals were decided, how many deals moved without closing — and
they draw as a definition list under the strip. Nothing is lost: a reading
dropped to make the row shorter would be a worse answer than the row that
folded, so the test asserts both halves and mutation-checks in both directions.

The Brief plan asks for "New pipeline" and "Quota pace" in this strip. Neither
has data: `weekly_review` carries no money columns — PR 4 specified them and
shipped without them — and quotas were retired by #3625. Drawing a slot with
nothing behind it is the failure the morning strip's em dashes exist to avoid,
so these five are what the week can honestly report.

Two defects found by looking at the page rather than the tests:

The weekly's sub-sentence read "Das ist dein Tag." under a heading saying DEINE
WOCHE. The weekly never composes a sentence, so the fallback line is the only
one under its heading, and the fallback was the morning's. Each view says its
own now.

Both weekly layout assertions in the e2e spec had been failing since before this
session, for two different stale reasons: they opened the MORNING and waited for
a section that moved behind the Weekly dial, and one of them looked for
`#home-today`, an id renamed to `#home-focus`. There is an `openWeekly` helper
now, and a second test asserting the week stays OFF the morning — the claim the
dial actually makes. All 13 brief specs pass, where 11 did before.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrinks the weekly readings strip from ten slots to five so it reads as one comparison at any width, and moves the remaining five figures into a definition list under the strip.

**Bug Fixes**

- The weekly view now shows its own fallback sentence ("This is the week you just closed") instead of the morning's "Here is your day."
- Fixes two e2e assertions that had been failing: they opened the morning view and waited for a section that moved behind the Weekly dial, and one looked for an id renamed to `#home-focus`. Adds an `openWeekly` helper and a test asserting the week stays off the morning.

<sup>Written for commit 1ca2d217ba13ab9384caee10b3d181d76a00fc82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the weekly briefing with five focused outcome metrics: promises kept, deals won, leads answered, meetings held, and tasks carried over.
  * Added a detailed workings section below the metrics for task, proposal, queue, deal, and scheduling activity.
  * Added a dedicated weekly introduction message, with English, German, and Vietnamese translations.
* **Updates**
  * Weekly and morning briefings now use distinct introductory content, keeping weekly details out of the morning view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->