### PR TITLE
The tag panel carries its own add verb

### DIFF
--- a/frontend/src/screens/companyrailtags.tsx
+++ b/frontend/src/screens/companyrailtags.tsx
@@ -1,28 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-import { useState } from "react";
 import type { components } from "../api/schema";
 import { useCan } from "../app/capability";
 import { useCompanyReadOnlyReason } from "./companyheader";
-import { AddTagDialog } from "./tagpicker";
-import { useRecordTags } from "./tags.queries";
-import { AddTagButton, TagsPanel } from "./tagspanel";
-import "./company360.css";
+import { TagsPanel } from "./tagspanel";
 
 type Organization = components["schemas"]["Organization"];
 
 /**
  * The company's tags, drawn by the SHARED panel.
  *
- * This file used to hold a panel of its own, reading the tag names off the
- * account's 360 response. That block carried no assigner, so the menu could
- * not say who applied a word — and a person and a deal had no panel at all.
- * One component for all three answers those together.
- *
- * What stays here is the mount: the add-tag verb needs a resolved
- * Organization to ask `useCompanyReadOnlyReason` about, so the wrapper waits
- * for one rather than calling the hook conditionally.
+ * What stays here is the mount: the write gate needs a resolved Organization to
+ * ask `useCompanyReadOnlyReason` about, so the wrapper waits for one rather
+ * than calling the hook conditionally.
  */
 export function CompanyTagsSection({
   organization,
@@ -39,37 +30,15 @@ function CompanyTags({
   orgId,
 }: Readonly<{ organization: Organization; orgId: string }>) {
   const readOnlyReason = useCompanyReadOnlyReason(organization);
-  const [adding, setAdding] = useState(false);
-  const read = useRecordTags("organization", orgId);
-  // The verb answers to the same read the panel does. The panel draws nothing
-  // until the read lands, and says "hidden" when the vocabulary is withheld —
-  // so a button gated on permission alone floats above no panel at all, and on
-  // a withheld record it opens a picker whose apply the server refuses.
-  // Three questions, all of which the server asks before it writes: the object
-  // grant, this row's own writability, and whether the vocabulary is visible at
-  // all. `useCompanyReadOnlyReason` answers only the row — its own comment says
-  // every mount ANDs it with the grant — and apply refuses without `tag.read`,
-  // which is what `withheld` reports.
+  // The two questions a MOUNT can answer: the object grant, and this row's own
+  // writability. `useCompanyReadOnlyReason` answers only the row — its own
+  // comment says every mount ANDs it with the grant. The third question, whether
+  // the vocabulary is visible at all, belongs to the panel: it draws the
+  // withheld state instead of the words, and its verb never reaches that path.
   const canUpdate = useCan("organization", "update");
-  const canEdit =
-    canUpdate && !readOnlyReason && read.isSuccess && !read.data.withheld;
+  const canEdit = canUpdate && !readOnlyReason;
 
   return (
-    <>
-      <TagsPanel entityType="organization" entityID={orgId} canEdit={canEdit} />
-      {canEdit && (
-        <div className="co-card-actions">
-          <AddTagButton onOpen={() => setAdding(true)} />
-        </div>
-      )}
-      {adding && (
-        <AddTagDialog
-          entityType="organization"
-          entityID={orgId}
-          current={read.data?.data ?? []}
-          onClose={() => setAdding(false)}
-        />
-      )}
-    </>
+    <TagsPanel entityType="organization" entityID={orgId} canEdit={canEdit} />
   );
 }

--- a/frontend/src/screens/companyrailtags.tsx
+++ b/frontend/src/screens/companyrailtags.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import type { components } from "../api/schema";
-import { useCan } from "../app/capability";
+import { useCanWriteRecord } from "../app/capability";
 import { useCompanyReadOnlyReason } from "./companyheader";
 import { TagsPanel } from "./tagspanel";
 
@@ -29,13 +29,14 @@ function CompanyTags({
   organization,
   orgId,
 }: Readonly<{ organization: Organization; orgId: string }>) {
+  // useCanWriteRecord, not useCan: applying a tag is a WRITE to the record, so
+  // it owes the same three axes every other company control derives — the
+  // object grant, the licensing seat, and the server's own `writable` for this
+  // row. `useCompanyReadOnlyReason` adds the reason worth SAYING (archived, or
+  // an overlay installation); it deliberately stays quiet about an ownerless
+  // record, which `writable` is what answers.
+  const canUpdate = useCanWriteRecord("organization", organization);
   const readOnlyReason = useCompanyReadOnlyReason(organization);
-  // The two questions a MOUNT can answer: the object grant, and this row's own
-  // writability. `useCompanyReadOnlyReason` answers only the row — its own
-  // comment says every mount ANDs it with the grant. The third question, whether
-  // the vocabulary is visible at all, belongs to the panel: it draws the
-  // withheld state instead of the words, and its verb never reaches that path.
-  const canUpdate = useCan("organization", "update");
   const canEdit = canUpdate && !readOnlyReason;
 
   return (

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -20,7 +20,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
 import { approvalDotTier, useAgentTierMap, verbTier } from "../app/autonomy";
-import { useCan } from "../app/capability";
+import { useCanWriteRecord } from "../app/capability";
 import { PageAside, PageAsideToggle } from "../app/pageaside";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
@@ -3600,7 +3600,11 @@ function DealLead({
  * may see the vocabulary at all.
  */
 function DealTagsSection({ deal }: Readonly<{ deal: Deal }>) {
-  const canUpdate = useCan("deal", "update");
+  // useCanWriteRecord, not useCan: applying a tag writes to the deal, so the
+  // verb owes the seat ceiling and this row's own `writable` alongside the
+  // object grant — a grant by itself would offer the picker on a colleague's
+  // deal, and to a read seat the server refuses before RBAC is consulted.
+  const canUpdate = useCanWriteRecord("deal", deal);
   const overlay = useSorMode() === "overlay";
   return (
     <TagsPanel

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -184,7 +184,7 @@ function PersonHoldSection({ view }: Readonly<{ view: Person360 }>) {
 // --- How this contact is filed -----------------------------------------
 
 /**
- * The contact's tags, drawn by the SHARED panel in the rail's section chrome.
+ * The contact's tags, drawn by the SHARED panel.
  *
  * The three questions the server asks before it writes are asked here too: the
  * object grant, this record's own editability, and — inside the panel — whether
@@ -202,7 +202,6 @@ function PersonTagsSection({ view }: Readonly<{ view: Person360 }>) {
       entityType="person"
       entityID={person.id}
       canEdit={canUpdate && !readOnlyReason}
-      chrome="section"
     />
   );
 }

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
-import { useCan } from "../app/capability";
+import { useCan, useCanWriteRecord } from "../app/capability";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import {
@@ -189,11 +189,20 @@ function PersonHoldSection({ view }: Readonly<{ view: Person360 }>) {
  * The three questions the server asks before it writes are asked here too: the
  * object grant, this record's own editability, and — inside the panel — whether
  * the vocabulary is visible at all.
+ *
+ * Exported for its own test: mounting the whole rail to ask whether the tag
+ * verb appears would fail for eight unrelated reasons, and a test that instead
+ * passed `canEdit` straight to the panel would prove only that the panel obeys
+ * its prop — never that this mount computes it.
  */
-function PersonTagsSection({ view }: Readonly<{ view: Person360 }>) {
+export function PersonTagsSection({ view }: Readonly<{ view: Person360 }>) {
   const person = view.person;
   const readOnlyReason = usePersonReadOnlyReason(person);
-  const canUpdate = useCan("person", "update");
+  // useCanWriteRecord, not useCan: applying a tag writes to the record, so the
+  // verb owes the seat ceiling and this row's own `writable` as well as the
+  // object grant. A rep holding `person.update` still may not tag a colleague's
+  // contact, and the read-only reason above does not answer that half.
+  const canUpdate = useCanWriteRecord("person", person);
   if (!person.id) {
     return null;
   }

--- a/frontend/src/screens/tagspanel.css
+++ b/frontend/src/screens/tagspanel.css
@@ -60,3 +60,12 @@
   margin: 0;
   font-weight: 500;
 }
+
+/* The verb under the words it adds to, spaced off them so it reads as an
+   action rather than as one more chip in the strip. */
+.tagspanel-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}

--- a/frontend/src/screens/tagspanel.test.tsx
+++ b/frontend/src/screens/tagspanel.test.tsx
@@ -215,3 +215,50 @@ describe("the company mount's add-tag verb", () => {
     expect(screen.queryByRole("button", { name: en["tags.add"] })).toBeNull();
   });
 });
+
+// The verb belongs to the PANEL, not to each host that mounts it. A person page
+// once shipped with tags a reader could see and no way to add one, because the
+// add button lived in the company wrapper and the person mount never placed it.
+// These assert the shared component carries it, whatever record it is drawn on.
+describe("the add verb travels with the panel", () => {
+  const PERSON = "01a06151-0000-7000-8000-000000000002";
+
+  function mountFor(entityType: "person" | "deal", canEdit: boolean) {
+    installFetchStub({
+      [`GET /records/${entityType}/${PERSON}/tags`]: () =>
+        jsonResponse({ data: [], withheld: false }),
+    });
+    render(
+      <StoryProviders>
+        <TagsPanel
+          entityType={entityType}
+          entityID={PERSON}
+          canEdit={canEdit}
+        />
+      </StoryProviders>,
+    );
+  }
+
+  it.each(["person", "deal"] as const)(
+    "offers the verb on a %s a seat may write",
+    async (entityType) => {
+      mountFor(entityType, true);
+      expect(
+        await screen.findByRole("button", { name: en["tags.add"] }),
+      ).toBeInTheDocument();
+    },
+  );
+
+  // The other half of the same rule: a reader who may not write the record sees
+  // the words and no verb, so the panel is not simply always offering one.
+  it.each(["person", "deal"] as const)(
+    "offers no verb on a %s the seat may only read",
+    async (entityType) => {
+      mountFor(entityType, false);
+      expect(
+        await screen.findByText(en["tags.emptyTitle"]),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: en["tags.add"] })).toBeNull();
+    },
+  );
+});

--- a/frontend/src/screens/tagspanel.test.tsx
+++ b/frontend/src/screens/tagspanel.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { en } from "../i18n/en";
 import { CompanyTagsSection } from "./companyrailtags";
+import { PersonTagsSection } from "./personrail";
 import {
   installFetchStub,
   jsonResponse,
@@ -179,15 +180,20 @@ describe("the company mount's add-tag verb", () => {
   function mountCompany(
     withheld: boolean,
     grants: Record<string, string[]> = { organization: ["update"] },
+    row: { writable: boolean } = { writable: true },
+    seat: "full" | "read" = "full",
   ) {
     installFetchStub({
-      "GET /me": meRoute(grants as never),
+      "GET /me": meRoute(grants as never, { seat }),
       [`GET /records/organization/${ORG}/tags`]: () =>
         jsonResponse({ data: [], withheld }),
     });
     render(
       <StoryProviders>
-        <CompanyTagsSection organization={ORG_ROW as never} orgId={ORG} />
+        <CompanyTagsSection
+          organization={{ ...ORG_ROW, ...row } as never}
+          orgId={ORG}
+        />
       </StoryProviders>,
     );
   }
@@ -209,6 +215,27 @@ describe("the company mount's add-tag verb", () => {
 
   // Applying writes to the RECORD, so the server asks for `organization.update`
   // as well. A seat without it would be offered a picker whose apply is refused.
+  // The row axis. A rep holding `organization.update` on the OBJECT still may
+  // not write a colleague's company, and the server stamps that as `writable`.
+  it("offers no verb on a company this reader may not write", async () => {
+    mountCompany(false, { organization: ["update"] }, { writable: false });
+    expect(await screen.findByText(en["tags.emptyTitle"])).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: en["tags.add"] })).toBeNull();
+  });
+
+  // The seat axis. A read seat is refused by the licensing middleware before
+  // RBAC is consulted, so a verb offered to one cannot lead to a saved tag.
+  it("offers no verb on a company to a read seat", async () => {
+    mountCompany(
+      false,
+      { organization: ["update"] },
+      { writable: true },
+      "read",
+    );
+    expect(await screen.findByText(en["tags.emptyTitle"])).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: en["tags.add"] })).toBeNull();
+  });
+
   it("offers no verb to a seat holding no update grant", async () => {
     mountCompany(false, {});
     expect(await screen.findByText(en["tags.emptyTitle"])).toBeInTheDocument();
@@ -219,46 +246,61 @@ describe("the company mount's add-tag verb", () => {
 // The verb belongs to the PANEL, not to each host that mounts it. A person page
 // once shipped with tags a reader could see and no way to add one, because the
 // add button lived in the company wrapper and the person mount never placed it.
-// These assert the shared component carries it, whatever record it is drawn on.
-describe("the add verb travels with the panel", () => {
+// These drive the REAL mount, so they fail if it stops computing `canEdit`
+// correctly — a literal prop would only prove the panel obeys whatever it gets.
+describe("the person mount offers the verb the panel draws", () => {
   const PERSON = "01a06151-0000-7000-8000-000000000002";
 
-  function mountFor(entityType: "person" | "deal", canEdit: boolean) {
+  function mountPerson(
+    person: Record<string, unknown>,
+    grants: Record<string, string[]> = { person: ["update"] },
+    seat: "full" | "read" = "full",
+  ) {
     installFetchStub({
-      [`GET /records/${entityType}/${PERSON}/tags`]: () =>
+      "GET /me": meRoute(grants as never, { seat }),
+      [`GET /records/person/${PERSON}/tags`]: () =>
         jsonResponse({ data: [], withheld: false }),
     });
     render(
       <StoryProviders>
-        <TagsPanel
-          entityType={entityType}
-          entityID={PERSON}
-          canEdit={canEdit}
+        <PersonTagsSection
+          view={{ person: { id: PERSON, ...person } } as never}
         />
       </StoryProviders>,
     );
   }
 
-  it.each(["person", "deal"] as const)(
-    "offers the verb on a %s a seat may write",
-    async (entityType) => {
-      mountFor(entityType, true);
-      expect(
-        await screen.findByRole("button", { name: en["tags.add"] }),
-      ).toBeInTheDocument();
-    },
-  );
+  // The control: without it, a verb that never renders would pass every test
+  // below for the wrong reason.
+  it("offers the verb on a contact the seat may write", async () => {
+    mountPerson({ writable: true });
+    expect(
+      await screen.findByRole("button", { name: en["tags.add"] }),
+    ).toBeInTheDocument();
+  });
 
-  // The other half of the same rule: a reader who may not write the record sees
-  // the words and no verb, so the panel is not simply always offering one.
-  it.each(["person", "deal"] as const)(
-    "offers no verb on a %s the seat may only read",
-    async (entityType) => {
-      mountFor(entityType, false);
-      expect(
-        await screen.findByText(en["tags.emptyTitle"]),
-      ).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: en["tags.add"] })).toBeNull();
-    },
-  );
+  // The row axis. A rep holding `person.update` on the OBJECT still may not
+  // write a colleague's contact, and the server stamps that as `writable`.
+  it("offers no verb on a contact this reader may not write", async () => {
+    mountPerson({ writable: false });
+    expect(await screen.findByText(en["tags.emptyTitle"])).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: en["tags.add"] })).toBeNull();
+  });
+
+  // The seat axis. A read seat is refused by the licensing middleware before
+  // RBAC is consulted, so a verb offered to one is a control whose save cannot
+  // succeed.
+  it("offers no verb to a read seat", async () => {
+    mountPerson({ writable: true }, { person: ["update"] }, "read");
+    expect(await screen.findByText(en["tags.emptyTitle"])).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: en["tags.add"] })).toBeNull();
+  });
+
+  // The object axis, for completeness: all three are necessary and none of the
+  // others would catch a mount that dropped this one.
+  it("offers no verb to a seat holding no update grant", async () => {
+    mountPerson({ writable: true }, {});
+    expect(await screen.findByText(en["tags.emptyTitle"])).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: en["tags.add"] })).toBeNull();
+  });
 });

--- a/frontend/src/screens/tagspanel.tsx
+++ b/frontend/src/screens/tagspanel.tsx
@@ -121,7 +121,10 @@ export function TagsPanel({
           <AddTagButton onOpen={() => setAdding(true)} />
         </div>
       )}
-      {adding && (
+      {/* `canEdit` again, not `adding` alone: a seat downgrade, an archive or an
+          ownership change while the picker is open takes the button away, and a
+          dialog that outlived it would still submit. */}
+      {canEdit && adding && (
         <AddTagDialog
           entityType={entityType}
           entityID={entityID}

--- a/frontend/src/screens/tagspanel.tsx
+++ b/frontend/src/screens/tagspanel.tsx
@@ -12,6 +12,7 @@ import { TagPill } from "../design-system/tagpill";
 import { formatDate, formatNumber } from "../format/format";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
+import { AddTagDialog } from "./tagpicker";
 import type { RecordTag, TaggableType } from "./tags.queries";
 import { useRecordTags, useRemoveTag } from "./tags.queries";
 import "./tagspanel.css";
@@ -23,6 +24,9 @@ import "./tagspanel.css";
  * Four visible, then "+N more". A record with twenty tags would otherwise push
  * everything below it off the screen, and the rail is where a reader looks for
  * the things they can act on rather than for a full inventory.
+ *
+ * The panel carries its own add verb rather than leaving it to each host, so a
+ * record type cannot ship with tags a reader can see and no way to add one.
  */
 const VISIBLE_TAGS = 4;
 
@@ -30,21 +34,17 @@ export function TagsPanel({
   entityType,
   entityID,
   canEdit,
-  chrome = "card",
 }: Readonly<{
   entityType: TaggableType;
   entityID: string;
   /** Whether this reader may change the record. Applying a tag writes to the
    * RECORD, so a reader who may only look at it sees the words and no verbs. */
   canEdit: boolean;
-  /** The frame this host draws its rail in. The company rail is a column of
-   * cards, the person rail is ONE card of sections — the same tags inside two
-   * different chromes rather than two components that drift. */
-  chrome?: "card" | "section";
 }>) {
   const t = useT();
   const { locale } = useLocale();
   const [expanded, setExpanded] = useState(false);
+  const [adding, setAdding] = useState(false);
   const read = useRecordTags(entityType, entityID);
 
   // The frame stands while the read is in flight. This panel sits in the record
@@ -58,7 +58,7 @@ export function TagsPanel({
   }
   if (read.isPending) {
     return (
-      <TagsFrame chrome={chrome} title={t("tags.panelTitle")}>
+      <TagsFrame title={t("tags.panelTitle")}>
         <p className="tagspanel-note">{t("tags.loading")}</p>
       </TagsFrame>
     );
@@ -69,7 +69,7 @@ export function TagsPanel({
   // fact about the record that nobody established.
   if (read.data.withheld) {
     return (
-      <TagsFrame chrome={chrome} title={t("tags.panelTitle")}>
+      <TagsFrame title={t("tags.panelTitle")}>
         <p className="tagspanel-note">{t("tags.withheld")}</p>
       </TagsFrame>
     );
@@ -85,7 +85,6 @@ export function TagsPanel({
 
   return (
     <TagsFrame
-      chrome={chrome}
       title={t("tags.panelTitle")}
       sub={tags.length > 0 ? t("tags.panelSub") : undefined}
     >
@@ -117,38 +116,40 @@ export function TagsPanel({
           )}
         </div>
       )}
+      {canEdit && (
+        <div className="tagspanel-actions">
+          <AddTagButton onOpen={() => setAdding(true)} />
+        </div>
+      )}
+      {adding && (
+        <AddTagDialog
+          entityType={entityType}
+          entityID={entityID}
+          current={tags}
+          onClose={() => setAdding(false)}
+        />
+      )}
     </TagsFrame>
   );
 }
 
 /**
- * The frame around the tags, in whichever shape the host rail uses.
+ * The frame around the tags: a rail card, the same as every card beside it.
  *
- * The company rail is a column of sibling cards, so the tags are one more card.
- * The person rail is ONE card whose contents are headed sections, so a second
- * card inside it would draw a box in a box. Same contents either way — the
- * alternative was a second panel component, and the two would have drifted the
- * first time an empty state changed.
+ * The person rail once drew these as a bare headed section instead. It sat
+ * between two cards — the correspondence control above, recent activity below —
+ * so the one section in the column read as unstyled rather than as a deliberate
+ * second shape.
  */
 function TagsFrame({
-  chrome,
   title,
   sub,
   children,
 }: Readonly<{
-  chrome: "card" | "section";
   title: string;
   sub?: string;
   children: ReactNode;
 }>) {
-  if (chrome === "section") {
-    return (
-      <section className="pe-rail-section">
-        <h3 className="pe-rail-heading">{title}</h3>
-        {children}
-      </section>
-    );
-  }
   return (
     <Panel title={title} sub={sub}>
       <PanelBody>{children}</PanelBody>
@@ -229,8 +230,15 @@ function TagOnRecord({
   );
 }
 
-/** The add-tag verb, which the caller places where the record page wants it. */
-export function AddTagButton({ onOpen }: Readonly<{ onOpen: () => void }>) {
+/**
+ * The add-tag verb.
+ *
+ * Private to this file. Applying a word needs the record's CURRENT tags, so the
+ * dialog can offer each one once — and this panel is what holds that read. A
+ * caller placing the verb itself had to fetch the same list a second time to
+ * feed the dialog, and a caller that forgot placed no verb at all.
+ */
+function AddTagButton({ onOpen }: Readonly<{ onOpen: () => void }>) {
   const t = useT();
   return (
     <Button small variant="ghost" onClick={onOpen}>


### PR DESCRIPTION
A contact page shipped with tags a reader could see and no way to add one. The add button was exported from `tagspanel.tsx` and only the company wrapper imported it, so the person and deal mounts drew the words and no verb. The person mount also asked for a bare headed section, which read as unstyled between the two cards either side of it.

## What changed

`TagsPanel` now renders the add verb itself and owns the dialog. It already holds the read the picker needs to offer each word once, so a host placing the button had to fetch the same list a second time — the company wrapper did exactly that, and is now the mount alone. `AddTagButton` is file-private and the `chrome` prop is gone: its one non-default caller was the bug.

Review then found the gate itself was wrong on all three mounts. They asked `useCan`, which answers the object grant and deliberately not the licensing seat or the row, so a read seat or a rep looking at a colleague's record was offered a picker the server would refuse. They now use `useCanWriteRecord`, which folds all three axes and is what every other record control on these pages already uses. The dialog checks `canEdit` too, so a seat downgrade or an archive while it is open cannot leave a live dialog that still submits.

## Tests

Seven cases across the person and company mounts, one per axis, driving the real mount rather than passing a literal prop — a literal would prove only that the panel obeys what it is given. Each was mutation-checked alone: reverting a mount to `useCan` fails exactly its row and seat tests, and removing the verb fails exactly the three positive cases.

## Verified running

On a dev stack: the person rail now draws Tags as a card between "Private correspondence" and "Recent activity" with an "+ Add tag" button, the company keeps its verb, and applying a word writes and renders the chip.

## Left alone

Applying a tag gates on `auth.EnsureLinkTarget`, which is visibility, not writability. That is pre-existing, outside this diff, and shared with nine other modules that link a reference to a record — whether a tag is that kind of reference or a write that owes `EnsureWritableLive` is a product call, not one to make in passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`TagsPanel` now renders its own add-tag button and dialog, so every record type gets a way to add tags instead of only companies. The write gate also covers the object grant, licensing seat, and row writability, so the button only appears when the server would accept the write.

**What changed**
- Person and deal pages previously showed tags with no way to add one; they now get the same verb as companies.
- The person rail's tags are a card like its neighbors instead of an unstyled bare section.
- Hosts no longer fetch the tag list twice or place a button; the `chrome` prop and exported `AddTagButton` are gone.
- All three mounts use `useCanWriteRecord` instead of `useCan`, so read seats and reps viewing colleagues' records no longer see a refused picker.
- The dialog re-checks `canEdit` while open, so a downgrade or archive can't leave a live dialog that still submits.

**Tests**
- Seven tests across company and person mounts cover object, row, and seat axes and drive the real mounts instead of passing a literal prop.

<sup>Written for commit 76ca2c89b9e61e9b7968984dc3e7710587e50865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tag panels now use a consistent card-style layout across company and person views.
  * Tag editing controls are shown only when the specific record can be edited, including seat and row restrictions.
  * Add-tag actions and dialogs are managed consistently within the tag panel.
  * Tag-panel actions now wrap neatly and include improved spacing on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->