### PR TITLE
The deal's tags ride in the context rail

### DIFF
--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -11,6 +11,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
+import { PageAsideProvider, PageAsideRegion } from "../app/pageaside";
 import { pickOption } from "../design-system/select-testing";
 import { ToastProvider, ToastRegion } from "../design-system/toast";
 import { formatMoney } from "../format/format";
@@ -1921,15 +1922,26 @@ describe("DealScreen — the stage stepper advances the deal", () => {
 
   // A control that can only fail is worse than none: an archived deal is not
   // moved through the pipeline, it is restored first.
-  // The deal's tags ride in the OVERVIEW pane, not in a rail: this record page
-  // hands RecordView neither rail nor aside, so it collapses to one column and
-  // there is no side column for a card to sit in.
-  it("draws the deal's tags on the overview", async () => {
+  // The deal's tags ride in the CONTEXT rail, beside the seats, the deal room
+  // and the mail card — the same column a person and a company draw theirs in.
+  // They sat in the overview pane once, full-width between the readings and the
+  // stage stepper, on the belief that this page had no side column; it fills one
+  // through `PageAside`, which portals into the shell's rail.
+  it("draws the deal's tags in the context rail", async () => {
     const d = deal({ id: "x" });
     vi.stubGlobal("fetch", stubBackend([d], { single: d }));
-    render(<DealScreen id="x" />);
+    // The provider and the region together, because `PageAside` is a PORTAL:
+    // without a mounted host it renders null, and a bare screen would report
+    // the card missing whichever column it was written into.
+    render(
+      <PageAsideProvider>
+        <DealScreen id="x" />
+        <PageAsideRegion />
+      </PageAsideProvider>,
+    );
 
-    expect(await screen.findByText("Renewal")).toBeTruthy();
+    const tag = await screen.findByText("Renewal");
+    expect(tag.closest("aside")).not.toBeNull();
   });
 
   it("offers no move on an archived deal", async () => {

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -3693,11 +3693,6 @@ function DealOverviewPane({
       {/* A won deal with no project, on a company with exactly one open
           project, is offered that project once. Nothing else here asks. */}
       {!overlay && <StartDeliveryPrompt deal={deal} />}
-      {/* How this deal is filed. It rides in the overview rather than in a
-          rail, because this record page has no rail column: RecordView
-          collapses to one column when it is handed neither, and giving the
-          deal a rail for one card would move every block on the page. */}
-      <DealTagsSection deal={deal} />
       {/* A group, not a nav: these buttons move the deal, they do not take the
           reader anywhere, and a landmark in the navigation list that writes
           when you press it misdescribes what it does. */}
@@ -4025,6 +4020,13 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                   pending={coverageRead.pending}
                   overlay={overlay}
                 />
+                {/* How this deal is filed, in the rail with the rest of its
+                    context — the same card a person and a company draw, in the
+                    same column of their pages. It sat full-width in the
+                    overview before, between the readings and the stage
+                    stepper, where a reader looking for the record's context
+                    was not looking. */}
+                <DealTagsSection deal={deal} />
                 {!overlay && (
                   <>
                     <DealRoomAside dealId={id} dealName={deal.name} />


### PR DESCRIPTION
The tags card sat full-width in the deal's overview, between the readings and the stage stepper. Two comments and a test asserted that was forced — "this record page hands RecordView neither rail nor aside, so it collapses to one column". That is wrong: the deal page fills the shell's **Context** rail through `PageAside`, which already carries "Who is on this deal", the Deal Room card and the mail card.

The card moves into that rail, unchanged, so a deal files itself in the same column a person and a company do.

## The test

The old test was named "draws the deal's tags on the overview" and asserted only that the tag text appeared anywhere. It now asserts the tag's `closest("aside")` is not null, and renders through `PageAsideProvider` + `PageAsideRegion` — `PageAside` is a portal that renders null without a mounted host, so a bare screen render reports the card missing whichever column it is written into.

Mutation-checked: moving the card back to the overview fails this test alone.

## Verified running

On a dev stack: Tags is the second card in the Context rail, between "Who is on this deal" and "Deal Room"; the main column goes readings → stage stepper with no gap; applying a word from the rail writes and renders the chip.

`make check-fe` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the deal's tags card from the overview pane to the context rail, so it sits alongside the seats, deal room, and mail card—matching how people and companies display their tags.

Updates the test to assert the tags render inside an `aside` element, and wraps the screen in `PageAsideProvider` and `PageAsideRegion` so the portal-based `PageAside` actually mounts during testing.

<sup>Written for commit 6f7075a55af5725ffe5f78e0fd26a7ebccfd458e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Deal tags now appear in the deal page’s context rail alongside related deal information, rather than in the overview pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->