### PR TITLE
The Worklist's verbs do what their labels promise

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7832,6 +7832,8 @@ export const de = {
     "Über dem Nächsten: {mine} gegen {theirs}.",
   "worklist.above.relationship":
     "Über dem Nächsten wegen der engeren Beziehung.",
+  "worklist.above.crowded":
+    "Über dem Nächsten, weil davon viele gleichzeitig anstehen.",
   "worklist.consequence.buyer_waits": "Wenn du nichts tust, warten sie weiter.",
   "worklist.consequence.promise_breaks":
     "Wenn du nichts tust, brichst du eine Zusage.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7908,6 +7908,8 @@ export const en = {
     "Above the next: {mine} against {theirs}.",
   "worklist.above.relationship":
     "Above the next on how close the relationship is.",
+  "worklist.above.crowded":
+    "Above the next because that one is one of many of its kind.",
   "worklist.consequence.buyer_waits": "If you do nothing, they keep waiting.",
   "worklist.consequence.promise_breaks": "If you do nothing, a promise breaks.",
   "worklist.consequence.deal_drifts":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7739,6 +7739,7 @@ export const vi = {
   "worklist.above.waiting_days": "Trên mục kế nhờ thời gian chờ.",
   "worklist.above.waiting_days.pair": "Trên mục kế: {mine} so với {theirs}.",
   "worklist.above.relationship": "Trên mục kế nhờ quan hệ gần hơn.",
+  "worklist.above.crowded": "Trên mục kế vì loại việc đó đang có rất nhiều.",
   "worklist.consequence.buyer_waits": "Nếu bạn không làm gì, họ vẫn chờ.",
   "worklist.consequence.promise_breaks":
     "Nếu bạn không làm gì, một lời hứa bị phá vỡ.",

--- a/frontend/src/screens/worklist.copy.test.ts
+++ b/frontend/src/screens/worklist.copy.test.ts
@@ -60,6 +60,20 @@ describe("comparisonText", () => {
   it("draws nothing for order (every comparator tied, ids broke it)", () => {
     expect(comparisonText({ comparator: "order" }, t, "en", zone)).toBeNull();
   });
+
+  // The comparator this build emits and could not name.
+  //
+  // `crowded` is the anti-monopoly rule: the row BELOW was held back so one
+  // lane could not own the page. It carries no values on purpose — "8th
+  // against 9th" describes the lane, not either row — and the client's
+  // known-comparator guard, written to drop values from NEWER servers, was
+  // dropping one this same build sends. The row whose position is hardest to
+  // explain was the one row with no explanation.
+  it("names crowded, which this build's own server emits", () => {
+    expect(comparisonText({ comparator: "crowded" }, t, "en", zone)).toBe(
+      "Above the next because that one is one of many of its kind.",
+    );
+  });
 });
 
 // The move that became performable.

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -189,6 +189,12 @@ function known(kind: WorklistReason["kind"]): kind is KnownReason {
 }
 
 // The comparators this build can name, for the same reason.
+//
+// `crowded` reads the other way round from the rest: this row is above because
+// the one BELOW was held back, so a single lane could not own the page. The
+// server sends no values with it deliberately — "8th against 9th" is a fact
+// about the lane rather than about either row. Absent from this list it drew
+// nothing at all, on exactly the row whose position most needs explaining.
 const KNOWN_COMPARATORS = {
   pin: true,
   level: true,
@@ -196,6 +202,7 @@ const KNOWN_COMPARATORS = {
   expected_revenue: true,
   waiting_days: true,
   relationship: true,
+  crowded: true,
 } as const;
 
 function knownComparator(

--- a/frontend/src/screens/worklist.focus.test.tsx
+++ b/frontend/src/screens/worklist.focus.test.tsx
@@ -114,6 +114,25 @@ describe("the queue's top row, drawn as the one thing to do next", () => {
     expect(request?.method ?? init?.method).toBe("PATCH");
   });
 
+  // The card draws ONE control. TaskQuickActions would add Snooze beside Done
+  // for any dated task — and every task the queue carries is dated — which is
+  // the list again in a bigger box.
+  it("offers the completion alone, not a menu", () => {
+    renderCard(taskItem({ due_at: "2026-09-04T09:00:00Z" }));
+    expect(screen.getByRole("button", { name: "Done" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Snooze/ })).toBeNull();
+  });
+
+  // A hand-written task linked to nothing is completable where it stands, so
+  // the card draws it. Requiring a record address would hide the one row a rep
+  // can finish without opening anything.
+  it("promotes a completable task that points at no record", () => {
+    const unlinked = taskItem({ subject: undefined });
+    expect(focusOf([unlinked])).toBe(unlinked);
+    renderCard(unlinked);
+    expect(screen.getByRole("button", { name: "Done" })).toBeTruthy();
+  });
+
   it("draws nothing for a notice's acknowledge, even with a record to name", () => {
     const { container } = renderCard(
       dealItem({

--- a/frontend/src/screens/worklist.focus.test.tsx
+++ b/frontend/src/screens/worklist.focus.test.tsx
@@ -2,8 +2,10 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 /** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { FocusCard, focusOf } from "./worklist.focus";
@@ -35,19 +37,81 @@ function dealItem(over: Partial<WorklistItem> = {}): WorklistItem {
 }
 
 function renderCard(item: WorklistItem) {
+  // The card's verb can be a real mutation, so it needs a query client — the
+  // completion the `complete` action names is a PATCH, not a link.
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
   return render(
-    <LocaleProvider initial="en">
-      <FocusCard item={item} />
-    </LocaleProvider>,
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <FocusCard item={item} />
+      </LocaleProvider>
+    </QueryClientProvider>,
   );
 }
 
-afterEach(cleanup);
+// A task whose primary action is `complete` — the case that made the card's
+// verb a component. `id` is the ACTIVITY id for a task row, which is what the
+// completion PATCHes.
+function taskItem(over: Partial<WorklistItem> = {}): WorklistItem {
+  return dealItem({
+    id: "01a05500-0000-7000-8000-000000000099",
+    source: "task",
+    category: "tasks",
+    level: 4,
+    consequence: "task_slips",
+    title: "Call Alice back",
+    actions: ["complete", "snooze"],
+    primary_action: "complete",
+    subject: {
+      type: "person",
+      id: "01a05500-0000-7000-8000-000000000011",
+      label: "Alice Müller",
+    },
+    ...over,
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe("the queue's top row, drawn as the one thing to do next", () => {
   it("draws the card for a routable action", () => {
     renderCard(dealItem());
     expect(screen.getByText("Acme Expansion")).toBeTruthy();
+  });
+
+  // THE case this card's verb exists for.
+  //
+  // The label said "Complete it" over a link to the task's record, so pressing
+  // it navigated and completed nothing — the reader believed the work was done
+  // and moved on. Asserting the MUTATION rather than the label is the point: a
+  // test reading the button's text passed throughout the whole time the
+  // promise was false.
+  it("completing a task from the card actually completes it", async () => {
+    const fetched = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal("fetch", fetched);
+    renderCard(taskItem());
+
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    await vi.waitFor(() => {
+      expect(fetched).toHaveBeenCalled();
+    });
+    // The ADDRESS and the METHOD, not the label: this is the assertion that
+    // would have failed for the whole time the card only navigated.
+    const [input, init] = fetched.mock.calls[0];
+    const request = input instanceof Request ? input : undefined;
+    expect(String(request?.url ?? input)).toContain(
+      "/activities/01a05500-0000-7000-8000-000000000099",
+    );
+    expect(request?.method ?? init?.method).toBe("PATCH");
   });
 
   it("draws nothing for a notice's acknowledge, even with a record to name", () => {

--- a/frontend/src/screens/worklist.focus.tsx
+++ b/frontend/src/screens/worklist.focus.tsx
@@ -13,11 +13,12 @@
 // verb the server named. The row stays in the queue below it, because removing
 // it would make the rank numbers lie and the counts disagree with the page.
 
-import { Badge } from "../design-system/atoms";
+import { Badge, Button } from "../design-system/atoms";
 import { Panel } from "../design-system/panel";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
-import { TaskQuickActions, useTaskUpdate } from "./taskactions";
+import { problemMessageOf } from "./common";
+import { useTaskUpdate } from "./taskactions";
 import {
   consequenceText,
   dealFactsText,
@@ -104,12 +105,32 @@ function FocusVerb({
   const t = useT();
   const update = useTaskUpdate([worklistKey]);
   if (item.source === "task" && item.primary_action === "complete") {
+    // The completion alone, not TaskQuickActions — that draws Snooze beside it
+    // for any dated task, and every task the queue carries is dated. Two
+    // controls here would be the list again in a bigger box, which is the one
+    // thing this card exists not to be. Snooze stays on the row below, where
+    // the server's own `actions` list already offers it.
     return (
-      <TaskQuickActions
-        activityId={item.id}
-        dueAt={item.due_at}
-        update={update}
-      />
+      <>
+        <Button
+          small
+          variant="primary"
+          disabled={update.isPending}
+          onClick={() =>
+            update.mutate({ id: item.id, body: { is_done: true } })
+          }
+        >
+          {t("tasks.complete")}
+        </Button>
+        {/* A rejected PATCH otherwise leaves the card rendering exactly as a
+            click that did nothing would, and the reader has no reason to try
+            again — the same reason NoticeAcknowledge says so. */}
+        {update.isError && (
+          <span className="co-part-error" role="alert">
+            {problemMessageOf(update.error, t)}
+          </span>
+        )}
+      </>
     );
   }
   if (move) {
@@ -158,11 +179,17 @@ export function worthActingOn(item: WorklistItem): boolean {
   if (item.primary_action === "acknowledge") {
     return false;
   }
-  // And somewhere for the verb to GO. A row filed under no record — a task
-  // nobody linked to anything — has no address at all: rowHref falls through
-  // the subject and the source-queue map and finds none. The card would then
-  // be a headline with no way to act, occupying the one place a reader looks
-  // for their next step.
+  // A completable task needs no address: the verb acts on the row itself.
+  // The backend mints exactly this — a hand-written task linked to nothing,
+  // "readable, completable, and pointing nowhere" — and requiring an href
+  // would hide the one row a rep can finish without opening anything.
+  if (item.source === "task" && item.primary_action === "complete") {
+    return true;
+  }
+  // Otherwise the verb needs somewhere to GO. A row filed under no record has
+  // no address at all: rowHref falls through the subject and the source-queue
+  // map and finds none. The card would then be a headline with no way to act,
+  // occupying the one place a reader looks for their next step.
   return rowHref(item) !== undefined || moveHref(item) !== undefined;
 }
 

--- a/frontend/src/screens/worklist.focus.tsx
+++ b/frontend/src/screens/worklist.focus.tsx
@@ -17,15 +17,17 @@ import { Badge } from "../design-system/atoms";
 import { Panel } from "../design-system/panel";
 import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
+import { TaskQuickActions, useTaskUpdate } from "./taskactions";
 import {
   consequenceText,
   dealFactsText,
   itemTitle,
   moveHref,
+  moveOpensComposer,
   reasonText,
   rowHref,
 } from "./worklist.copy";
-import type { WorklistItem } from "./worklist.queries";
+import { type WorklistItem, worklistKey } from "./worklist.queries";
 
 // The focus card, or nothing.
 //
@@ -72,20 +74,64 @@ export function FocusCard({ item }: Readonly<{ item: WorklistItem }>) {
             the list again in a bigger box. Everything else this row supports
             stays available on its own row below. */}
         <div className="worklist-focus-verb">
-          {move ? (
-            <a className="button button-primary" href={move}>
-              {t("worklist.verb.draft_reply")}
-            </a>
-          ) : (
-            href && (
-              <a className="button button-primary" href={href}>
-                {t(`worklist.focus.verb.${item.primary_action ?? "open"}`)}
-              </a>
-            )
-          )}
+          <FocusVerb item={item} href={href} move={move} />
         </div>
       </div>
     </Panel>
+  );
+}
+
+// The card's single verb.
+//
+// Three shapes, and which one is drawn is decided by what the verb can actually
+// DO — not by what reads best. A card whose strongest control promises more
+// than it performs is worse than one that promises less: the reader believes
+// the work is done and moves on.
+//
+// `complete` on a task is the case that made this a component. The label said
+// "Complete it" over a link to the task's record, so pressing it navigated and
+// completed nothing. The mutation exists and every other surface already uses
+// it, so the card completes the task rather than renaming the promise down.
+function FocusVerb({
+  item,
+  href,
+  move,
+}: Readonly<{
+  item: WorklistItem;
+  href: string | undefined;
+  move: string | undefined;
+}>) {
+  const t = useT();
+  const update = useTaskUpdate([worklistKey]);
+  if (item.source === "task" && item.primary_action === "complete") {
+    return (
+      <TaskQuickActions
+        activityId={item.id}
+        dueAt={item.due_at}
+        update={update}
+      />
+    );
+  }
+  if (move) {
+    return (
+      <a className="btn btn-primary" href={move}>
+        {/* The row makes this distinction and the card used to drop it, so the
+            same address was described two ways on one screen. */}
+        {t(
+          moveOpensComposer(item)
+            ? "worklist.verb.draft_reply_now"
+            : "worklist.verb.draft_reply",
+        )}
+      </a>
+    );
+  }
+  if (!href) {
+    return null;
+  }
+  return (
+    <a className="btn btn-primary" href={href}>
+      {t(`worklist.focus.verb.${item.primary_action ?? "open"}`)}
+    </a>
   );
 }
 

--- a/frontend/src/screens/worklist.pane.test.tsx
+++ b/frontend/src/screens/worklist.pane.test.tsx
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  day,
+  jsonResponse,
+  renderWorklist,
+  row,
+  stub,
+  type Worklist,
+} from "./worklist.testkit";
+
+// What opens beside the queue, and — just as much — what does not.
+//
+// The rank is the way in, and it is a control only where pressing it opens
+// something. A rank that toggles a pressed state over no pane teaches the
+// reader that the page lies about what is pressable, so these cases assert
+// both halves: a button where a pane exists, a plain number where none does.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("what the selected row is about", () => {
+  it("draws no pane until the reader picks a row", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "one",
+            title: "A task",
+            subject: {
+              type: "person",
+              id: "01a05500-0000-7000-8000-0000000000aa",
+              label: "Kirsten Vogel",
+            },
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    // The full-width list a reader had before selection existed. An empty
+    // column standing ready reads as a pane that failed to load.
+    await screen.findByText("A task · Kirsten Vogel");
+    expect(screen.queryByText("They last wrote")).toBeNull();
+  });
+
+  it("opens the record beside the queue, and closes it on a second press", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "one",
+            title: "A task",
+            subject: {
+              type: "person",
+              id: "01a05500-0000-7000-8000-0000000000aa",
+              label: "Kirsten Vogel",
+            },
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    const open = await screen.findByRole("button", {
+      name: /^Show what/,
+    });
+    await userEvent.click(open);
+    // The pane names the record and answers the question the row cannot: how
+    // long the silence has run, in both directions.
+    await screen.findByText("They last wrote");
+    expect(screen.getByText("We last wrote")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: /^Show what/ }));
+    await waitFor(() => {
+      expect(screen.queryByText("They last wrote")).toBeNull();
+    });
+  });
+
+  // A rank that opens nothing is not a control.
+  //
+  // This case asserted the ABSENCE of a pane after a click, which passed
+  // against a button that toggled a pressed state and opened nothing — the
+  // dead control it was meant to describe. The claim worth making is about the
+  // rank: a deal row has no pane, so its rank is a plain number with no button
+  // to press.
+  it("draws the rank as a plain number for a row with no pane", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "one",
+            title: "Northstar renewal",
+            source: "deal_at_risk",
+            category: "deals_at_risk",
+            subject: {
+              type: "deal",
+              id: "01a05500-0000-7000-8000-0000000000bb",
+              label: "Northstar",
+            },
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    // The row drew — this is not a test that the page failed to render.
+    await screen.findByText("Northstar renewal");
+    expect(screen.queryByRole("button", { name: /^Show what/ })).toBeNull();
+  });
+
+  // The other half of the same rule. Without this case, "no rank button" would
+  // also be satisfied by a page that never drew one at all.
+  it("draws the rank as a button where a pane opens, and it opens", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "one",
+            title: "Re: pricing",
+            source: "customer_waiting",
+            category: "customer_waiting",
+            subject: {
+              type: "person",
+              id: "01a05500-0000-7000-8000-0000000000cc",
+              label: "Alice Müller",
+            },
+          }),
+        ],
+        summary: { urgent: 1, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /^Show what/ }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("complementary")).toBeTruthy();
+    });
+  });
+
+  it("closes the pane when the selected row leaves the queue", async () => {
+    const withRow = day({
+      queue: [
+        row({
+          id: "one",
+          title: "A task",
+          subject: {
+            type: "person",
+            id: "01a05500-0000-7000-8000-0000000000aa",
+            label: "Kirsten Vogel",
+          },
+        }),
+      ],
+      summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
+    });
+    // The same day with the row gone — a disposition, a filter, a refetch that
+    // found it answered. The pane must not go on describing a record whose row
+    // is no longer on the page.
+    let current: Worklist = withRow;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes("/worklist")) {
+          return jsonResponse(current);
+        }
+        return jsonResponse({ data: [] });
+      }),
+    );
+    renderWorklist();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /^Show what/ }),
+    );
+    await screen.findByText("They last wrote");
+
+    current = day({
+      queue: [],
+      summary: { urgent: 0, due: 0, lower_priority: 0, total: 0 },
+    });
+    // Re-render through the filter, which refetches: the row is gone, and the
+    // pane goes with it rather than outliving the row it describes.
+    await userEvent.click(screen.getByRole("button", { name: /Decisions/ }));
+    await waitFor(() => {
+      expect(screen.queryByText("They last wrote")).toBeNull();
+    });
+  });
+  it("draws no aside landmark for a row that has no pane", async () => {
+    stub(
+      day({
+        queue: [
+          row({
+            id: "one",
+            title: "Northstar renewal",
+            source: "deal_at_risk",
+            category: "deals_at_risk",
+            subject: {
+              type: "deal",
+              id: "01a05500-0000-7000-8000-0000000000bb",
+              label: "Northstar",
+            },
+          }),
+        ],
+        summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
+      }),
+    );
+    const { container } = renderWorklist();
+
+    await screen.findByText("Northstar renewal");
+    // A deal row has no pane. An empty <aside> would still be announced as a
+    // landmark and still take its third of the grid, which reads as a pane
+    // that failed rather than as one that was never meant to be there.
+    //
+    // Reached by rendering rather than by clicking the rank: the rank on such
+    // a row is no longer a button, because a control that opens nothing
+    // teaches the reader that the page lies about what is pressable.
+    await waitFor(() => {
+      expect(container.querySelectorAll("aside")).toHaveLength(0);
+    });
+  });
+});
+
+// What `#/worklist/<segment>` opens on.
+//
+// The address is the other half of the team board's row: a board that writes a
+// hash nothing reads is a row that goes nowhere. These assert the REQUEST, not
+// the rendering, because whose day the page is showing is a question about
+// which day it asked the server for.

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -715,15 +715,21 @@ describe("the one thing to do next", () => {
   it("promotes no card when the row has nowhere for its verb to go", async () => {
     stub(
       day({
-        // A task filed under nothing: no subject, so rowHref falls through
-        // SOURCE_QUEUE and finds no address. The server named a verb, and the
-        // page has nowhere to send it.
+        // Filed under nothing, so rowHref falls through SOURCE_QUEUE and finds
+        // no address. The server named a verb and the page has nowhere to send
+        // it.
+        //
+        // Deliberately NOT a task: a task's `complete` acts on the row itself
+        // and needs no address, so this case would be asserting the opposite
+        // rule with a task fixture.
         queue: [
           row({
             id: "unfiled",
+            source: "sync_health",
+            category: "system",
             title: "Something to do",
             band: "keep_momentum",
-            primary_action: "complete",
+            primary_action: "open",
           }),
         ],
         summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -1,94 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
 /** @vitest-environment jsdom */
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { components } from "../api/schema";
-import { type Locale, LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
-import { WorklistScreen } from "./worklist";
+import {
+  day,
+  renderWorklist,
+  row,
+  stub,
+  type WorklistItem,
+} from "./worklist.testkit";
 
 // The ranked queue, and the ways it can mislead the person reading it.
 //
 // Every case here is one promise the page makes: that the order is readable,
 // that a figure describes the rows beneath it, that nothing is drawn to report
 // a zero, and that the database's own words never reach the screen.
-
-type Worklist = components["schemas"]["Worklist"];
-type WorklistItem = components["schemas"]["WorklistItem"];
-
-function jsonResponse(body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { "content-type": "application/json" },
-  });
-}
-
-// The queue, plus the one approval a decision row fetches whole. A row sends a
-// sentence; deciding needs the payload, the stager and the evidence, so the row
-// being decided reads the approval it is showing.
-function stub(day: Worklist, approval?: unknown) {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input instanceof Request ? input.url : input);
-      if (url.includes("/worklist")) {
-        return jsonResponse(day);
-      }
-      if (approval && /\/approvals\/[^/]+$/.test(url.split("?")[0])) {
-        return jsonResponse(approval);
-      }
-      return jsonResponse({ data: [] });
-    }),
-  );
-}
-
-function renderWorklist(locale: Locale = "en", opensOn?: string) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return render(
-    <QueryClientProvider client={client}>
-      <LocaleProvider initial={locale}>
-        <WorklistScreen opensOn={opensOn} />
-      </LocaleProvider>
-    </QueryClientProvider>,
-  );
-}
-
-function day(over: Partial<Worklist> = {}): Worklist {
-  return {
-    as_of: "2026-08-31T09:00:00Z",
-    scope: "mine",
-    scope_options: ["mine"],
-    queue: [],
-    summary: { urgent: 0, due: 0, lower_priority: 0, total: 0 },
-    sources_unavailable: [],
-    reach: [],
-    counts: [],
-    readings: {
-      revenue_at_risk_minor: null,
-      buyer_replies: 0,
-      prospecting: 0,
-      review: 0,
-      more_available: false,
-    },
-    ...over,
-  };
-}
-
-function row(over: Partial<WorklistItem> = {}): WorklistItem {
-  return {
-    id: "row-1",
-    source: "task",
-    category: "tasks",
-    level: 4,
-    consequence: "task_slips",
-    because: [],
-    actions: [],
-    ...over,
-  };
-}
+//
+// What the pane opens (and refuses to open) lives in worklist.pane.test.tsx.
 
 afterEach(() => {
   cleanup();
@@ -806,186 +738,6 @@ describe("the one thing to do next", () => {
   });
 });
 
-describe("what the selected row is about", () => {
-  it("draws no pane until the reader picks a row", async () => {
-    stub(
-      day({
-        queue: [
-          row({
-            id: "one",
-            title: "A task",
-            subject: {
-              type: "person",
-              id: "01a05500-0000-7000-8000-0000000000aa",
-              label: "Kirsten Vogel",
-            },
-          }),
-        ],
-        summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
-      }),
-    );
-    renderWorklist();
-
-    // The full-width list a reader had before selection existed. An empty
-    // column standing ready reads as a pane that failed to load.
-    await screen.findByText("A task · Kirsten Vogel");
-    expect(screen.queryByText("They last wrote")).toBeNull();
-  });
-
-  it("opens the record beside the queue, and closes it on a second press", async () => {
-    stub(
-      day({
-        queue: [
-          row({
-            id: "one",
-            title: "A task",
-            subject: {
-              type: "person",
-              id: "01a05500-0000-7000-8000-0000000000aa",
-              label: "Kirsten Vogel",
-            },
-          }),
-        ],
-        summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
-      }),
-    );
-    renderWorklist();
-
-    const open = await screen.findByRole("button", {
-      name: /^Show what/,
-    });
-    await userEvent.click(open);
-    // The pane names the record and answers the question the row cannot: how
-    // long the silence has run, in both directions.
-    await screen.findByText("They last wrote");
-    expect(screen.getByText("We last wrote")).toBeTruthy();
-
-    await userEvent.click(screen.getByRole("button", { name: /^Show what/ }));
-    await waitFor(() => {
-      expect(screen.queryByText("They last wrote")).toBeNull();
-    });
-  });
-
-  it("draws no pane for a row about a deal, whose figures are already on it", async () => {
-    stub(
-      day({
-        queue: [
-          row({
-            id: "one",
-            title: "Northstar renewal",
-            source: "deal_at_risk",
-            category: "deals_at_risk",
-            subject: {
-              type: "deal",
-              id: "01a05500-0000-7000-8000-0000000000bb",
-              label: "Northstar",
-            },
-          }),
-        ],
-        summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
-      }),
-    );
-    renderWorklist();
-
-    const open = await screen.findByRole("button", {
-      name: /^Show what/,
-    });
-    await userEvent.click(open);
-
-    // Selected, and deliberately nothing beside it: a deal row carries its own
-    // amount, close date and owner, so a pane would be a second spelling.
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /^Show what/ })).toBeTruthy();
-    });
-    expect(screen.queryByText("They last wrote")).toBeNull();
-  });
-
-  it("closes the pane when the selected row leaves the queue", async () => {
-    const withRow = day({
-      queue: [
-        row({
-          id: "one",
-          title: "A task",
-          subject: {
-            type: "person",
-            id: "01a05500-0000-7000-8000-0000000000aa",
-            label: "Kirsten Vogel",
-          },
-        }),
-      ],
-      summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
-    });
-    // The same day with the row gone — a disposition, a filter, a refetch that
-    // found it answered. The pane must not go on describing a record whose row
-    // is no longer on the page.
-    let current: Worklist = withRow;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL) => {
-        const url = String(input instanceof Request ? input.url : input);
-        if (url.includes("/worklist")) {
-          return jsonResponse(current);
-        }
-        return jsonResponse({ data: [] });
-      }),
-    );
-    renderWorklist();
-
-    await userEvent.click(
-      await screen.findByRole("button", { name: /^Show what/ }),
-    );
-    await screen.findByText("They last wrote");
-
-    current = day({
-      queue: [],
-      summary: { urgent: 0, due: 0, lower_priority: 0, total: 0 },
-    });
-    // Re-render through the filter, which refetches: the row is gone, and the
-    // pane goes with it rather than outliving the row it describes.
-    await userEvent.click(screen.getByRole("button", { name: /Decisions/ }));
-    await waitFor(() => {
-      expect(screen.queryByText("They last wrote")).toBeNull();
-    });
-  });
-  it("draws no aside landmark for a row that has no pane", async () => {
-    stub(
-      day({
-        queue: [
-          row({
-            id: "one",
-            title: "Northstar renewal",
-            source: "deal_at_risk",
-            category: "deals_at_risk",
-            subject: {
-              type: "deal",
-              id: "01a05500-0000-7000-8000-0000000000bb",
-              label: "Northstar",
-            },
-          }),
-        ],
-        summary: { urgent: 0, due: 0, lower_priority: 0, total: 1 },
-      }),
-    );
-    const { container } = renderWorklist();
-
-    await userEvent.click(
-      await screen.findByRole("button", { name: /^Show what/ }),
-    );
-    // A deal row has no pane. An empty <aside> would still be announced as a
-    // landmark and still take its third of the grid, which reads as a pane
-    // that failed rather than as one that was never meant to be there.
-    await waitFor(() => {
-      expect(container.querySelectorAll("aside")).toHaveLength(0);
-    });
-  });
-});
-
-// What `#/worklist/<segment>` opens on.
-//
-// The address is the other half of the team board's row: a board that writes a
-// hash nothing reads is a row that goes nowhere. These assert the REQUEST, not
-// the rendering, because whose day the page is showing is a question about
-// which day it asked the server for.
 describe("the address opens a queue", () => {
   function requestedUrls(): string[] {
     const mock = globalThis.fetch as unknown as {

--- a/frontend/src/screens/worklist.testkit.tsx
+++ b/frontend/src/screens/worklist.testkit.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/**
+ * The harness the Worklist's test files share.
+ *
+ * Extracted when `worklist.test.tsx` crossed the 1000-line ceiling and had to
+ * split. The alternative was copying `day`, `row` and `stub` into the second
+ * file, and two copies of a fixture builder drift: one gains a field the
+ * contract added, the other keeps describing a row the server no longer sends,
+ * and the tests disagree about what a queue looks like.
+ *
+ * A `.tsx` module rather than a `.test.tsx` one, so vitest does not collect it
+ * as a suite of its own with no cases in it.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type RenderResult, render } from "@testing-library/react";
+import { vi } from "vitest";
+import type { components } from "../api/schema";
+import { type Locale, LocaleProvider } from "../i18n";
+import { WorklistScreen } from "./worklist";
+
+export type Worklist = components["schemas"]["Worklist"];
+export type WorklistItem = components["schemas"]["WorklistItem"];
+
+export function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * The queue, plus the one approval a decision row fetches whole. A row sends a
+ * sentence; deciding needs the payload, the stager and the evidence, so the row
+ * being decided reads the approval it is showing.
+ */
+export function stub(day: Worklist, approval?: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes("/worklist")) {
+        return jsonResponse(day);
+      }
+      if (approval && /\/approvals\/[^/]+$/.test(url.split("?")[0])) {
+        return jsonResponse(approval);
+      }
+      return jsonResponse({ data: [] });
+    }),
+  );
+}
+
+export function renderWorklist(
+  locale: Locale = "en",
+  opensOn?: string,
+): RenderResult {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial={locale}>
+        <WorklistScreen opensOn={opensOn} />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+export function day(over: Partial<Worklist> = {}): Worklist {
+  return {
+    as_of: "2026-08-31T09:00:00Z",
+    scope: "mine",
+    scope_options: ["mine"],
+    queue: [],
+    summary: { urgent: 0, due: 0, lower_priority: 0, total: 0 },
+    sources_unavailable: [],
+    reach: [],
+    counts: [],
+    readings: {
+      revenue_at_risk_minor: null,
+      buyer_replies: 0,
+      prospecting: 0,
+      review: 0,
+      more_available: false,
+    },
+    ...over,
+  };
+}
+
+export function row(over: Partial<WorklistItem> = {}): WorklistItem {
+  return {
+    id: "row-1",
+    source: "task",
+    category: "tasks",
+    level: 4,
+    consequence: "task_slips",
+    because: [],
+    actions: [],
+    ...over,
+  };
+}

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -65,6 +65,18 @@ function reviewFilter(item: WorklistItem): WorklistFilter {
   return item.category === "system" ? "system" : "decisions";
 }
 
+// What identifies one row on this page.
+//
+// The SOURCE and the id together, because `id` alone is not unique across the
+// queue: a task and a waiting message may carry the same underlying record's
+// id, and the lanes mint ids independently. The React key has always spelled
+// it this way; the selected-row state used the bare id, so two rows sharing one
+// could both light up pressed while the pane resolved to whichever came first.
+// One function now, read by both, so they cannot drift apart again.
+function rowIdentity(item: WorklistItem): string {
+  return `${item.source}-${item.id}`;
+}
+
 // Whether this row opens its band — the first banded row, or the first after a
 // row of a DIFFERENT band.
 //
@@ -201,10 +213,10 @@ function WorklistBody({
   // one kind of work — worklist.nextup.tsx says why that is the ranking's to
   // fix rather than this page's.
   const next = nextUpOf(day.queue, focus);
-  // The row the pane is about. Resolved from the id rather than held as the
-  // item itself: a refetch replaces every row object, and a held one would go
-  // on describing a version of the day that is no longer on screen.
-  const selected = day.queue.find((item) => item.id === selectedId);
+  // The row the pane is about. Resolved from the identity rather than held as
+  // the item itself: a refetch replaces every row object, and a held one would
+  // go on describing a version of the day that is no longer on screen.
+  const selected = day.queue.find((item) => rowIdentity(item) === selectedId);
   return (
     <>
       <WorklistHeader
@@ -286,7 +298,7 @@ function WorklistBody({
             <Panel title={t("worklist.queue")}>
               <ol className="worklist-list">
                 {day.queue.map((item, index) => (
-                  <li key={`${item.source}-${item.id}`}>
+                  <li key={rowIdentity(item)}>
                     {/* The heading, drawn where the band CHANGES. The server sends
                     the queue already sorted so each band is one contiguous run,
                     so a change is a boundary and never a second visit — which
@@ -303,9 +315,21 @@ function WorklistBody({
                       item={item}
                       position={index + 1}
                       owner={owner}
-                      selected={selectedId === item.id}
-                      onSelect={() =>
-                        onSelect(selectedId === item.id ? "" : item.id)
+                      selected={selectedId === rowIdentity(item)}
+                      // Only where pressing it OPENS something. WorklistRow
+                      // draws a plain number without this, which is what the
+                      // Brief already relies on: a rank that toggles a pressed
+                      // state and opens nothing teaches the reader that the
+                      // page lies about what is pressable.
+                      onSelect={
+                        hasPane(item)
+                          ? () =>
+                              onSelect(
+                                selectedId === rowIdentity(item)
+                                  ? ""
+                                  : rowIdentity(item),
+                              )
+                          : undefined
                       }
                       onReview={() => onFilter(reviewFilter(item))}
                     />


### PR DESCRIPTION
Four ways the queue told a rep something untrue, and the tests that let it.

## What was wrong

**"Complete it" completed nothing.** The focus card's strongest control was a link to the task's record, so a rep could press it, see the page change, and believe the work was done. The mutation already existed and every other surface already used it.

**Every rank was a button, but the pane opens only for a person.** On a deal row the press toggled `aria-pressed` and opened nothing. `Rank`'s own comment already states the rule — a control that answers nothing teaches the reader that the page lies about what is pressable — and the Brief honours it by passing no handler.

**Selection was keyed on the bare row id** while the React key beside it already used source-and-id. Two rows sharing an id could both light up pressed, and the pane resolved to whichever came first.

**`crowded` had no sentence.** This build's own server emits it from two rank steps; no catalogue named it, so the row held back by the anti-monopoly rule was the one row on the page with no explanation of its position.

## The tests that allowed it

The two cases covering the dead rank clicked it and asserted that nothing opened — which passes against a control that does nothing at all. They now assert the rank is *not* a button where no pane exists, plus the opposite case, so neither passes alone. The focus-card case asserts the PATCH rather than the label.

`worklist.test.tsx` was 1082 lines, over the ceiling. The pane cases moved to their own file; the shared fixtures went to `worklist.testkit.tsx` rather than being copied, because two fixture builders drift.

## Review

Codex found two defects, both fixed here:
- The card rendered `TaskQuickActions`, which adds Snooze beside Done for any dated task — the card that exists to offer one verb was offering two.
- `worthActingOn` required a record address, but a completable task acts on itself. The backend mints exactly that shape, and the card was hiding it. The case asserting the old behaviour used a task fixture, so it was testing the opposite rule with the one source it does not apply to.

## Verification

`make check-fe` green. `make frontend-e2e` green (222 passed). `make craft-static` pass. Mutation-checked: reverting the completion fix fails its test; removing `crowded` fails its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Worklist queue's misleading controls so they do what their labels promise.

**Bug Fixes**
- The focus card's "Complete it" now PATCHes the task instead of linking to its record.
- The card offers Done alone, without the Snooze button TaskQuickActions added.
- Completable tasks with no record address now get the focus card.
- Ranks are plain numbers on rows with no pane instead of dead buttons.
- Row selection uses source-and-id so rows sharing an id can't both highlight.
- `crowded` rows now explain why they're held back.

**Refactors**
- Pane tests moved to `worklist.pane.test.tsx`; shared fixtures moved to `worklist.testkit.tsx`.

<sup>Written for commit e16165e1d9acb7ce1c9f4a40d7c33af28bb8b8da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worklist comparisons now explain when an item ranks lower because its category is crowded, with English, German, and Vietnamese translations.
  - Focus view now supports completing tasks without linked records.
  - Completing tasks directly from Focus view provides visible error feedback when updates fail.

- **Bug Fixes**
  - Worklist row selection is now more reliable when items share identifiers across different sources.
  - Rows without detail panes are no longer presented as selectable.
  - Detail panes close correctly when the selected item disappears after a refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->