### PR TITLE
Reports is now Analytics, and the old address still answers

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -92,7 +92,7 @@ const CORE_SCREENS = [
   // second level of nesting indents it again.
   "filters",
   "worklist",
-  "reports",
+  "analytics",
   "settings",
   // The automations editor is configuration on the AI settings page now, not a
   // destination of its own. Sweeping `#/automations` after the route retired
@@ -1360,7 +1360,7 @@ async function expectNoAaViolations(page: Page, screen: string) {
 const ADDRESSED_VIEWS = [
   "companies?q=brandt&sort=name",
   "companies/o-brandt/tasks",
-  "reports/forecast",
+  "analytics/forecast",
   // The three record headers whose verbs are icon-only: the name a sighted
   // reader gets on hover is not the name axe checks, so what is swept here is
   // the other half — that every square carries an accessible name at all, and

--- a/frontend/e2e/history.spec.ts
+++ b/frontend/e2e/history.spec.ts
@@ -165,12 +165,12 @@ test("a linked tab opens on that tab, not on the overview", async ({
 test("a report is an address, and Back steps between reports", async ({
   page,
 }) => {
-  await page.goto("/#/reports");
-  await page.getByRole("button", { name: "Forecast" }).click();
-  await expect(page).toHaveURL(/#\/reports\/forecast$/);
+  await page.goto("/#/analytics");
+  await page.getByRole("button", { name: "Forecast-Kategorien" }).click();
+  await expect(page).toHaveURL(/#\/analytics\/forecast$/);
 
   await page.goBack();
-  await expect(page).toHaveURL(/#\/reports$/);
+  await expect(page).toHaveURL(/#\/analytics$/);
 });
 
 test("the deals board remembers its pipeline and its view in the address", async ({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -219,9 +219,9 @@ const ConfirmDetailsScreen = lazy(
     })),
   ),
 );
-const ReportsScreen = lazy(
+const AnalyticsScreen = lazy(
   routed(() =>
-    import("./screens/reports").then((m) => ({ default: m.ReportsScreen })),
+    import("./screens/analytics").then((m) => ({ default: m.AnalyticsScreen })),
   ),
 );
 const ScheduledSendsScreen = lazy(
@@ -461,7 +461,7 @@ const SCREEN_VIEWS: Readonly<Record<Screen, (args: ScreenArgs) => ReactNode>> =
     // other three dials stay state: putting one of four in the address would
     // make it describe a fraction of what the reader is looking at.
     worklist: ({ id }) => <WorklistScreen opensOn={id} />,
-    reports: () => <ReportsScreen />,
+    analytics: () => <AnalyticsScreen />,
     ai: () => <AskAiScreen />,
     // The screen resolves its own address, because which entry an address names
     // is the settings IA's question: the admin half lives a segment deeper, and

--- a/frontend/src/app/nav.ts
+++ b/frontend/src/app/nav.ts
@@ -113,7 +113,7 @@ export const NAV_GROUPS: readonly NavGroup[] = [
   {
     headingKey: "nav.group.intelligence",
     items: [
-      { screen: "reports", labelKey: "nav.reports", icon: BarChart3 },
+      { screen: "analytics", labelKey: "nav.analytics", icon: BarChart3 },
       { screen: "ai", labelKey: "nav.ai", icon: Sparkles },
     ],
   },

--- a/frontend/src/app/rail.test.tsx
+++ b/frontend/src/app/rail.test.tsx
@@ -98,7 +98,7 @@ const CANONICAL_ORDER = [
   "Worklist",
   "Pipeline",
   "Projects",
-  "Reports",
+  "Analytics",
   "Ask Margince",
 ];
 
@@ -263,7 +263,7 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
   // in the More sheet has nothing to carry the current-destination state. More
   // carries it instead, or the bar shows no active tab at all.
   it("marks More as the active tab for a destination the phone bar hides", () => {
-    const sheeted = render(<WorkspaceRail route={{ screen: "reports" }} />);
+    const sheeted = render(<WorkspaceRail route={{ screen: "analytics" }} />);
     const more = sheeted.container.querySelector(".railmore.active");
     expect(more).not.toBeNull();
     // Announced, not merely tinted: the hidden route's own link is out of the
@@ -287,7 +287,7 @@ describe("WorkspaceRail (AC-shell-1/2)", () => {
     // itself holding there.
     stubPhoneViewport();
     const { container } = render(
-      <WorkspaceRail route={{ screen: "reports" }} />,
+      <WorkspaceRail route={{ screen: "analytics" }} />,
     );
     await user.click(screen.getByRole("button", { name: "More" }));
     expect(
@@ -492,15 +492,15 @@ describe("Rail levels (a section's entries as the second level)", () => {
   // which is the case below and would hide this one.
   it("walks out of the section to the route the reader came from", async () => {
     const user = userEvent.setup();
-    window.location.hash = "#/reports";
+    window.location.hash = "#/analytics";
     render(<Shell onOpenSearch={ignoreSearch}>{null}</Shell>);
-    expect(screen.getByRole("link", { name: "Reports" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Analytics" })).toBeTruthy();
 
     navigate({ screen: "settings", id: "account" });
     await user.click(
       await screen.findByRole("button", { name: "Back to Destinations" }),
     );
-    expect(window.location.hash).toBe("#/reports");
+    expect(window.location.hash).toBe("#/analytics");
     // The panel is derived from the address, so the destinations arrive with it —
     // and they take the focus the level's own rows gave up rather than leaving
     // the document on <body>.
@@ -518,7 +518,7 @@ describe("Rail levels (a section's entries as the second level)", () => {
   // <body> with the sidebar lost. The re-render below is that gap, made
   // deterministic.
   it("keeps the arriving level's focus when the section re-renders mid-walk", async () => {
-    window.location.hash = "#/reports";
+    window.location.hash = "#/analytics";
     render(<Shell onOpenSearch={ignoreSearch}>{null}</Shell>);
     navigate({ screen: "settings", id: "account" });
     const back = await screen.findByRole("button", {

--- a/frontend/src/app/router.test.ts
+++ b/frontend/src/app/router.test.ts
@@ -179,3 +179,22 @@ describe("routeIdentity", () => {
 it("answers the old day address with the page that replaced it", () => {
   expect(parseHash("#/today")).toEqual({ screen: "worklist" });
 });
+
+// Reports became Analytics. Same argument as the day address above, with one
+// more thing to get right: the segment has to ride along. A bookmark of
+// #/reports/forecast that lands on the default section has kept the reader on
+// the product and still lost their page.
+it("answers the old reports address, carrying the segment across", () => {
+  expect(parseHash("#/reports")).toEqual({
+    screen: "analytics",
+    id: undefined,
+    id2: undefined,
+    id3: undefined,
+  });
+  expect(parseHash("#/reports/forecast")).toEqual({
+    screen: "analytics",
+    id: "forecast",
+    id2: undefined,
+    id3: undefined,
+  });
+});

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -35,7 +35,7 @@ const SCREENS = [
   "deals",
   "projects",
   "worklist",
-  "reports",
+  "analytics",
   "ai",
   "settings",
   "filters",
@@ -102,6 +102,12 @@ export function parseHash(hash: string): Route {
   // lost their page.
   if (screen === "today") {
     return { screen: "worklist" };
+  }
+  // Reports became Analytics, and the same argument applies: a bookmark and
+  // every link already sent outlive the rename. The segment rides along, so
+  // #/reports/forecast lands on the forecast section rather than the default.
+  if (screen === "reports") {
+    return { screen: "analytics", id, id2, id3 };
   }
   if (!isScreen(screen)) {
     // A hash comes out of the URL bar, so its first segment is text a human
@@ -170,9 +176,9 @@ const IDENTITY_DEPTH: Readonly<Record<Screen, number>> = {
   // state and never touches the address, which is what makes lowering this look
   // free — the pane is not what the depth is protecting.
   worklist: WHOLE_ADDRESS,
-  // #/reports/<report> — the picker chooses a view of one screen, so switching
-  // reports re-renders the panel instead of throwing the screen away.
-  reports: 1,
+  // #/analytics/<section> — the picker chooses a view of one screen, so
+  // switching sections re-renders the panel instead of throwing the screen away.
+  analytics: 1,
   ai: WHOLE_ADDRESS,
   // Not a tab, however much the sidebar looks like one: every settings entry is
   // its own page, and the admin half is a segment deeper.

--- a/frontend/src/app/shell.stories.tsx
+++ b/frontend/src/app/shell.stories.tsx
@@ -630,7 +630,7 @@ export const SectionPhone: Story = {
  * it, or a keyboard reader is left tabbing through a page they can no longer see.
  */
 function PhoneSheetExample() {
-  const route: Route = { screen: "reports" };
+  const route: Route = { screen: "analytics" };
   const { openSearch, palette } = usePaletteSeam();
   return (
     <div className="app railexpanded">

--- a/frontend/src/app/shell.test.tsx
+++ b/frontend/src/app/shell.test.tsx
@@ -347,9 +347,9 @@ describe("Section switcher (the page title at phone width)", () => {
 
 describe("Shell", () => {
   it("stamps body[data-screen] from the route", () => {
-    window.location.hash = "#/reports";
+    window.location.hash = "#/analytics";
     render(<Shell onOpenSearch={ignoreSearch}>{null}</Shell>);
-    expect(document.body.dataset.screen).toBe("reports");
+    expect(document.body.dataset.screen).toBe("analytics");
   });
 
   // ONE element claims the page, on every route — and where two elements could

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -162,7 +162,7 @@ export const de = {
   "nav.leads": "Leads",
   "nav.deals": "Pipeline",
   "nav.today": "Arbeitsliste",
-  "nav.reports": "Berichte",
+  "nav.analytics": "Analytics",
   "nav.ai": "Margince fragen",
   "nav.settings": "Einstellungen",
   "nav.automations": "Automatisierungen",
@@ -3123,20 +3123,20 @@ export const de = {
   "tasks.isDone": "Abgeschlossen",
   "tasks.logged": "Erfasst",
 
-  "reports.sub": "Deals je Phase — ungewichtet neben gewichtet",
-  "reports.currency": "Währung",
-  "reports.count": "Deals",
-  "reports.unweighted": "Ungewichtet",
-  "reports.weighted": "Gewichtet",
-  "reports.planNote":
+  "analytics.sub": "Deals je Phase — ungewichtet neben gewichtet",
+  "analytics.currency": "Währung",
+  "analytics.count": "Deals",
+  "analytics.unweighted": "Ungewichtet",
+  "analytics.weighted": "Gewichtet",
+  "analytics.planNote":
     "der ausgeführte Plan und die Zeilen, auf die sich die Zahl zurückrechnet",
-  "reports.reportDeals": "Deals nach Phase",
-  "reports.reportForecast": "Forecast",
-  "reports.reportOpenByCompany": "Offene Deals pro Firma",
-  "reports.forecastBanner":
+  "analytics.reportDeals": "Deals nach Phase",
+  "analytics.reportForecast": "Forecast-Kategorien",
+  "analytics.reportOpenByCompany": "Offene Deals pro Firma",
+  "analytics.forecastBanner":
     "Jede Kachel zeigt die Rohsumme und darunter die gewichtete Summe — pro Deal gerundet, sodass sie immer mit „Diese Zahl erklären“ übereinstimmt.",
-  "reports.company": "Firma",
-  "reports.openDeals": "Offene Deals",
+  "analytics.company": "Firma",
+  "analytics.openDeals": "Offene Deals",
   "explain.sources": "Quellzeilen",
 
   "ai.sub": "bring deinen eigenen Agenten mit — geregelt über die zwei Stufen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -169,7 +169,7 @@ export const en = {
   // The merge decision. Both values survive a merge — choosing a side decides
   // which record stands and which value is shown first — so the copy never says
   // "delete", because nothing is deleted.
-  "nav.reports": "Reports",
+  "nav.analytics": "Analytics",
   "nav.ai": "Ask Margince",
   "nav.settings": "Settings",
   "nav.automations": "Automations",
@@ -3170,20 +3170,20 @@ export const en = {
   "tasks.isDone": "Completed",
   "tasks.logged": "Logged",
 
-  "reports.sub": "deals by stage — unweighted next to weighted",
-  "reports.currency": "Currency",
-  "reports.count": "Deals",
-  "reports.unweighted": "Unweighted",
-  "reports.weighted": "Weighted",
-  "reports.planNote":
+  "analytics.sub": "deals by stage — unweighted next to weighted",
+  "analytics.currency": "Currency",
+  "analytics.count": "Deals",
+  "analytics.unweighted": "Unweighted",
+  "analytics.weighted": "Weighted",
+  "analytics.planNote":
     "the executed plan and the rows this number reconciles to",
-  "reports.reportDeals": "Deals by stage",
-  "reports.reportForecast": "Forecast",
-  "reports.reportOpenByCompany": "Open deals per company",
-  "reports.forecastBanner":
+  "analytics.reportDeals": "Deals by stage",
+  "analytics.reportForecast": "Forecast categories",
+  "analytics.reportOpenByCompany": "Open deals per company",
+  "analytics.forecastBanner":
     "Each tile shows the raw total and, beneath it, the probability-weighted total — rounded per deal, so it always reconciles to Explain This Number.",
-  "reports.company": "Company",
-  "reports.openDeals": "Open deals",
+  "analytics.company": "Company",
+  "analytics.openDeals": "Open deals",
   "explain.sources": "Source rows",
 
   "ai.sub": "bring your own agent — governed by the two-tier contract",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -22,6 +22,11 @@ import { vi as viCatalog } from "./vi";
 const KEPT_IN_ENGLISH = new Set<string>([
   // The product name of the buyer surface.
   "room.card.title",
+  // The area's name, which is the same word in all three catalogs by decision:
+  // "Analytics" is what the product calls this surface, and both German and
+  // Vietnamese borrow it as a term of art rather than translating it. The
+  // section labels UNDER it are translated normally.
+  "nav.analytics",
   // Two placeholders and a dash. Every word in the line comes from elsewhere —
   // the dimension's own label and the sentence the server wrote — so there is
   // nothing here for a locale to translate.

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -168,7 +168,7 @@ export const vi = {
   "nav.leads": "Lead",
   "nav.deals": "Pipeline",
   "nav.today": "Danh sách việc",
-  "nav.reports": "Báo cáo",
+  "nav.analytics": "Analytics",
   "nav.ai": "Hỏi Margince",
   "nav.settings": "Cài đặt",
   "nav.automations": "Tự động hoá",
@@ -3090,20 +3090,20 @@ export const vi = {
   "tasks.isDone": "Đã hoàn thành",
   "tasks.logged": "Đã ghi nhận",
 
-  "reports.sub": "deal theo giai đoạn — chưa trọng số cạnh có trọng số",
-  "reports.currency": "Tiền tệ",
-  "reports.count": "Deal",
-  "reports.unweighted": "Chưa trọng số",
-  "reports.weighted": "Có trọng số",
-  "reports.planNote":
+  "analytics.sub": "deal theo giai đoạn — chưa trọng số cạnh có trọng số",
+  "analytics.currency": "Tiền tệ",
+  "analytics.count": "Deal",
+  "analytics.unweighted": "Chưa trọng số",
+  "analytics.weighted": "Có trọng số",
+  "analytics.planNote":
     "kế hoạch đã chạy và những dòng mà con số này đối chiếu về",
-  "reports.reportDeals": "Deal theo giai đoạn",
-  "reports.reportForecast": "Dự báo",
-  "reports.reportOpenByCompany": "Deal đang mở theo công ty",
-  "reports.forecastBanner":
+  "analytics.reportDeals": "Deal theo giai đoạn",
+  "analytics.reportForecast": "Nhóm dự báo",
+  "analytics.reportOpenByCompany": "Deal đang mở theo công ty",
+  "analytics.forecastBanner":
     'Mỗi ô hiển thị tổng chưa trọng số, và bên dưới là tổng có trọng số — được làm tròn theo từng deal, nên luôn khớp với "Giải thích con số này".',
-  "reports.company": "Công ty",
-  "reports.openDeals": "Deal đang mở",
+  "analytics.company": "Công ty",
+  "analytics.openDeals": "Deal đang mở",
   "explain.sources": "Các dòng nguồn",
 
   "ai.sub": "mang Agent của riêng bạn — được quản trị bằng hợp đồng hai bậc",

--- a/frontend/src/screens/analytics.stories.tsx
+++ b/frontend/src/screens/analytics.stories.tsx
@@ -4,7 +4,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within } from "storybook/test";
 import { StatStrip } from "../design-system/statstrip";
-import { ForecastTile, ReportsScreen } from "./reports";
+import { AnalyticsScreen, ForecastTile } from "./analytics";
 import {
   installFetchStub,
   jsonResponse,
@@ -151,7 +151,7 @@ function screenStory() {
   installFetchStub(routes);
   return (
     <StoryProviders>
-      <ReportsScreen />
+      <AnalyticsScreen />
     </StoryProviders>
   );
 }

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -16,10 +16,10 @@ import { LocaleProvider } from "../i18n";
 type Stage = components["schemas"]["Stage"];
 
 import {
+  AnalyticsScreen,
   buildStageAggregates,
   parseDerivationQuery,
-  ReportsScreen,
-} from "./reports";
+} from "./analytics";
 
 // D2 acceptance: a report picker over deals-by-stage (unchanged), forecast
 // (unweighted category tiles + a weighted-vs-unweighted banner), and
@@ -122,10 +122,10 @@ function reportsStub(opts: ReportsStubOpts = {}) {
   });
 }
 
-describe("ReportsScreen", () => {
+describe("AnalyticsScreen", () => {
   it("defaults to deals-by-stage and renders unweighted/weighted columns", async () => {
     vi.stubGlobal("fetch", reportsStub());
-    render(<ReportsScreen />);
+    render(<AnalyticsScreen />);
     await waitFor(() => expect(screen.getByText("Qualify")).toBeTruthy());
   });
 
@@ -146,9 +146,9 @@ describe("ReportsScreen", () => {
         ],
       }),
     );
-    render(<ReportsScreen />);
+    render(<AnalyticsScreen />);
     await userEvent.click(
-      await screen.findByRole("button", { name: "Forecast" }),
+      await screen.findByRole("button", { name: "Forecast categories" }),
     );
     await waitFor(() => expect(screen.getByText("Commit")).toBeTruthy());
     expect(
@@ -188,9 +188,9 @@ describe("ReportsScreen", () => {
         ],
       }),
     );
-    render(<ReportsScreen />);
+    render(<AnalyticsScreen />);
     await userEvent.click(
-      await screen.findByRole("button", { name: "Forecast" }),
+      await screen.findByRole("button", { name: "Forecast categories" }),
     );
     await waitFor(() => expect(screen.getByText("Slipped")).toBeTruthy());
   });
@@ -214,7 +214,7 @@ describe("ReportsScreen", () => {
         ],
       }),
     );
-    render(<ReportsScreen />);
+    render(<AnalyticsScreen />);
     await waitFor(() => expect(screen.getByText("Qualify")).toBeTruthy());
     expect(
       bodies.some(
@@ -244,7 +244,7 @@ describe("ReportsScreen", () => {
         ],
       }),
     );
-    render(<ReportsScreen />);
+    render(<AnalyticsScreen />);
     await userEvent.click(
       await screen.findByRole("button", { name: "Open deals per company" }),
     );
@@ -266,7 +266,7 @@ describe("ReportsScreen", () => {
         },
       }),
     );
-    render(<ReportsScreen />);
+    render(<AnalyticsScreen />);
     await userEvent.click(
       await screen.findByRole("button", { name: /Explain/ }),
     );
@@ -319,7 +319,7 @@ describe("reports never sum money across currencies", () => {
       "fetch",
       reportsStub({ onRun: (key, body) => bodies.push({ key, body }) }),
     );
-    render(<ReportsScreen />);
+    render(<AnalyticsScreen />);
     await waitFor(() => expect(screen.getByText("Qualify")).toBeTruthy());
     const stagePlan = bodies.find((sent) => sent.key === "deals-by-stage");
     expect(stagePlan?.body).toMatchObject({
@@ -349,7 +349,7 @@ describe("reports never sum money across currencies", () => {
         ],
       }),
     );
-    render(<ReportsScreen />);
+    render(<AnalyticsScreen />);
     expect(
       await screen.findByText(formatMoney(100_000, "EUR", "en")),
     ).toBeTruthy();
@@ -380,7 +380,7 @@ describe("reports never sum money across currencies", () => {
         ],
       }),
     );
-    render(<ReportsScreen />);
+    render(<AnalyticsScreen />);
     await waitFor(() => expect(screen.getByText("Qualify")).toBeTruthy());
     // The count is real and stays; only the money is unknown.
     expect(screen.getByText("4")).toBeTruthy();
@@ -390,8 +390,10 @@ describe("reports never sum money across currencies", () => {
 
   it("renders a forecast category with no deals as absent rather than as zero euros", async () => {
     vi.stubGlobal("fetch", reportsStub({ forecastRows: [] }));
-    render(<ReportsScreen />);
-    await userEvent.setup().click(await screen.findByText("Forecast"));
+    render(<AnalyticsScreen />);
+    await userEvent
+      .setup()
+      .click(await screen.findByText("Forecast categories"));
     await waitFor(() =>
       expect(screen.getAllByText(MONEY_ABSENT).length).toBeGreaterThan(0),
     );
@@ -476,8 +478,10 @@ describe("reports never sum money across currencies", () => {
         ],
       }),
     );
-    render(<ReportsScreen />);
-    await userEvent.setup().click(await screen.findByText("Forecast"));
+    render(<AnalyticsScreen />);
+    await userEvent
+      .setup()
+      .click(await screen.findByText("Forecast categories"));
     // Both currencies of the uncategorised pipeline, each in its own unit.
     expect(
       await screen.findByText(formatMoney(202_720_000, "EUR", "en")),
@@ -508,8 +512,10 @@ describe("reports never sum money across currencies", () => {
         ],
       }),
     );
-    render(<ReportsScreen />);
-    await userEvent.setup().click(await screen.findByText("Forecast"));
+    render(<AnalyticsScreen />);
+    await userEvent
+      .setup()
+      .click(await screen.findByText("Forecast categories"));
     await waitFor(() =>
       expect(screen.getByText(formatMoney(1000, "EUR", "en"))).toBeTruthy(),
     );

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -28,7 +28,7 @@ import {
 } from "./common";
 import { EntityRef } from "./entityref";
 
-// Reports (B-EP09.12c, D-11): a picker over three reports — deals-by-stage
+// Analytics (B-EP09.12c, D-11): a picker over three reports — deals-by-stage
 // (unweighted next to weighted), forecast (category readings, each showing
 // unweighted and weighted, plus the server-derived "slipped" bucket), and
 // open deals per company. "Explain this number" opens the executed plan +
@@ -135,16 +135,16 @@ function byCurrency(
 // card that segment opens read the same key, so the tab and the surface behind
 // it cannot drift into two names for one report.
 const REPORT_LABEL_KEY = {
-  "deals-by-stage": "reports.reportDeals",
-  forecast: "reports.reportForecast",
-  "open-deals-per-company": "reports.reportOpenByCompany",
+  "deals-by-stage": "analytics.reportDeals",
+  forecast: "analytics.reportForecast",
+  "open-deals-per-company": "analytics.reportOpenByCompany",
 } as const satisfies Record<ReportKey, string>;
 
 // The line under the segment picker, for the two segments whose copy says
 // something the card's own title does not. A segment absent from here gets no
 // caption: an explanation of the report beside it is worse than none.
 const segmentSub: Partial<Record<Segment, MessageKey>> = {
-  "deals-by-stage": "reports.sub",
+  "deals-by-stage": "analytics.sub",
 };
 
 type ReportAggregate = NonNullable<
@@ -239,7 +239,7 @@ export function ForecastTile({
       detail={
         weightedMinor == null
           ? undefined
-          : `${t("reports.weighted")}: ${formatMoneyOrAbsent(weightedMinor, currency, locale)}`
+          : `${t("analytics.weighted")}: ${formatMoneyOrAbsent(weightedMinor, currency, locale)}`
       }
     />
   );
@@ -270,7 +270,7 @@ function ForecastStrip({
   const t = useT();
   return (
     <>
-      <Callout tone="info">{t("reports.forecastBanner")}</Callout>
+      <Callout tone="info">{t("analytics.forecastBanner")}</Callout>
       {/* ONE STRIP PER CURRENCY. A slot carries a single figure, so a category
           holding euros and dong cannot state one — and adding them would be the
           unit-less total data-semantics §1 r4 forbids. Banding by currency keeps
@@ -328,11 +328,11 @@ function CompanyTable({
   const t = useT();
   return (
     <DataTable
-      label={t("reports.reportOpenByCompany")}
+      label={t("analytics.reportOpenByCompany")}
       columns={[
         {
           key: "company",
-          header: t("reports.company"),
+          header: t("analytics.company"),
           // The report answers with an organization id and nothing else, so the
           // column read `01a0131c-3154-74cb-…` for every row — a company report
           // nobody could read. One record lookup per row, cached by id for a
@@ -348,19 +348,19 @@ function CompanyTable({
         },
         {
           key: FIELD_CURRENCY,
-          header: t("reports.currency"),
+          header: t("analytics.currency"),
           render: (row: ReportRow) => (
             <span className="t-mono">{rowCurrency(row) ?? MONEY_ABSENT}</span>
           ),
         },
         {
           key: "count",
-          header: t("reports.openDeals"),
+          header: t("analytics.openDeals"),
           render: (row: ReportRow) => String(rowCount(row, "deal_count")),
         },
         {
           key: "raw",
-          header: t("reports.unweighted"),
+          header: t("analytics.unweighted"),
           render: (row: ReportRow) => (
             <span className="t-mono">
               {formatMoneyOrAbsent(
@@ -429,7 +429,7 @@ function StageTable({
   const aggregates = buildStageAggregates(rows, stages);
   return (
     <DataTable
-      label={t("reports.reportDeals")}
+      label={t("analytics.reportDeals")}
       columns={[
         {
           key: "stage",
@@ -438,19 +438,19 @@ function StageTable({
         },
         {
           key: FIELD_CURRENCY,
-          header: t("reports.currency"),
+          header: t("analytics.currency"),
           render: (row: StageAgg) => (
             <span className="t-mono">{row.currency ?? MONEY_ABSENT}</span>
           ),
         },
         {
           key: "count",
-          header: t("reports.count"),
+          header: t("analytics.count"),
           render: (row: StageAgg) => String(row.count),
         },
         {
           key: "raw",
-          header: t("reports.unweighted"),
+          header: t("analytics.unweighted"),
           render: (row: StageAgg) => (
             <span className="t-mono">
               {formatMoneyOrAbsent(row.rawMinor, row.currency, locale)}
@@ -459,7 +459,7 @@ function StageTable({
         },
         {
           key: "weighted",
-          header: t("reports.weighted"),
+          header: t("analytics.weighted"),
           render: (row: StageAgg) => (
             <span className="t-mono">
               {formatMoneyOrAbsent(row.weightedMinor, row.currency, locale)}
@@ -520,7 +520,7 @@ function ExplainCard({
       id={id}
       ariaLabel={t("explain.title")}
       title={t("explain.title")}
-      sub={query.data?.definition ?? t("reports.planNote")}
+      sub={query.data?.definition ?? t("analytics.planNote")}
     >
       {url == null && <p className="t-caption">{t("common.empty")}</p>}
       {url != null && query.isPending && (
@@ -550,7 +550,7 @@ function ExplainCard({
   );
 }
 
-export function ReportsScreen() {
+export function AnalyticsScreen() {
   const t = useT();
   const { locale } = useLocale();
   const [explain, setExplain] = useState(false);
@@ -561,11 +561,11 @@ export function ReportsScreen() {
   // own: a suite that renders it directly goes on pressing the picker.
   const route = useRoute();
   const segment: Segment =
-    route.screen === "reports" && isSegment(route.id)
+    route.screen === "analytics" && isSegment(route.id)
       ? route.id
       : "deals-by-stage";
   const setSegment = (next: Segment) =>
-    navigate({ screen: "reports", id: next });
+    navigate({ screen: "analytics", id: next });
   const report: ReportKey = segment;
   // Deal reports aggregate over the pipeline/stage structure the overlay mirror
   // does not hold (the report endpoints answer 422 unsupported_by_sor in
@@ -649,7 +649,7 @@ export function ReportsScreen() {
           ),
         }}
       />
-      {/* Only where the copy is true of the SELECTED segment. `reports.sub`
+      {/* Only where the copy is true of the SELECTED segment. `analytics.sub`
           explains deals-by-stage's two money columns; printed over the forecast
           or the per-company table it described a report the reader was not
           looking at. The others are named by their card's own title. */}


### PR DESCRIPTION
The area the product calls Reports becomes Analytics: screen files, route id, nav entry, and the i18n keys under it. The forecast report is relabelled "Forecast categories" — it categorises open pipeline and is not a period forecast, and the old label had readers expecting the second thing.

**The old address keeps working.** `#/reports` lands on `#/analytics`, and the segment rides along, so a bookmark of `#/reports/forecast` opens the forecast section rather than the default one. This follows the `today` -> `worklist` redirect already in `parseHash`, for the reason recorded there: a rename outlives nobody's bookmarks, and answering an old link with Not Found teaches the reader the product lost their page. The redirect has its own test, mutation-checked — removing the redirect fails it.

**Locales.** `nav.analytics` is the same word in all three catalogs, which the vi untranslated-copy gate refuses by default, so it is allowlisted with its reason. The section labels under it are translated normally: "Forecast-Kategorien" in German, "Nhóm dự báo" in Vietnamese.

**Not changed:** the API path. This is a screen and route rename; the endpoint is still `/reports/{report}`.

One test in `shell.test.tsx` navigated to `#/reports` and would have silently become a redirect test while still claiming to test hash stamping. It now uses the real route, and the redirect is tested on its own.

`make check-fe` green; the diff is frontend-only. A pre-existing intermittent failure in `organizations.header.test.tsx` surfaced once during a gate run and is filed as #3776 — it passes in isolation on `origin/main` and contains no reference to anything this branch touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the Reports area to Analytics across navigation, routes, screens, and i18n keys, and relabels the forecast report as "Forecast categories" since it categorizes open pipeline rather than forecasting a period. The old `#/reports` address redirects to `#/analytics` and carries its segment along, so existing bookmarks like `#/reports/forecast` still open the forecast section.

**Notes**
- The API path is unchanged; endpoints remain under `/reports/{report}`.
- `nav.analytics` is identical across all three locale catalogs, so the i18n test allowlists it with a comment.
- Tests now navigate to `#/analytics` directly, and the redirect has its own mutation-checked test.

<sup>Written for commit 5b3c208e23894ff83cf5944d911dbf2530e2ab9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation**
  * Renamed the Reports area to **Analytics** across the app.
  * Existing `/reports` links now redirect to the corresponding Analytics views.
  * Route sections and navigation behavior are preserved.

* **Analytics**
  * Updated screen labels and forecast terminology to **Forecast categories**.
  * Added consistent Analytics translations in English, German, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->