### PR TITLE
The Brief says when it was read

### DIFF
--- a/backend/api/internal-events.yaml
+++ b/backend/api/internal-events.yaml
@@ -148,3 +148,58 @@ components:
           maxLength: 2000
           description: The occurrence's own prose. Never the status line.
       additionalProperties: false
+    InternalEventBriefOpened:
+      type: object
+      x-event-type: brief.opened
+      x-entity-type: ""
+
+      description: >-
+        Payload for brief.opened — a rep read their morning Brief. The product
+        question behind it is whether the thing gets opened at all, and on the
+        days it says something worth acting on.
+
+        Emitted on the READ of an existing run, never on the pass that
+        assembles one: a night that ranked a queue nobody looked at is exactly
+        the case this event exists to make visible, and counting the assembly
+        as an open would hide it.
+
+        Counts only, no prose and no record data. What a rep's morning HOLDS is
+        already recoverable from the run itself, and what they DID with it from
+        the audit rows brief_item marks write. This payload answers one
+        question the other two cannot: whether they came and looked.
+
+        Entity-less, and that is what keeps it internal. Every catalogued type
+        that is NOT in the entity-less pipeline class is subscribable by an
+        outside consumer — publicevents_test.go derives the set exactly as
+        webhooks.validateEventTypes does — so naming brief_run here would make
+        "this rep opened their Brief at 06:42" a webhook anyone may select. The
+        run id stays on the system_log row the emit writes, where it is
+        attributable without being deliverable.
+      required:
+        - local_day
+        - items
+        - unread
+      properties:
+        local_day:
+          type: string
+          format: date
+          description: >-
+            The run's own local day, which is its identity — one run per rep per
+            day. Carried so a consumer can tell today's first open from a
+            re-open of yesterday's without reaching back into brief_run.
+        items:
+          type: integer
+          minimum: 0
+          description: >-
+            How many items the run held when it was opened, AFTER expired
+            snoozes resurfaced — what the rep actually saw, not what the night
+            ranked. Zero is a real and interesting reading: a quiet morning
+            that was still opened.
+        unread:
+          type: integer
+          minimum: 0
+          description: >-
+            How many of those carried no act, dismiss or snooze mark yet.
+            Together with items it separates a first open from a return visit
+            without needing a second event type for the difference.
+      additionalProperties: false

--- a/backend/internal/compose/briefs/briefopened.go
+++ b/backend/internal/compose/briefs/briefopened.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package briefs
+
+// The one thing the Brief's own tables cannot answer: whether anybody looked.
+//
+// What a run HELD is in brief_run and brief_item, and what a rep DID with it is
+// in the audit rows the marks write. Neither records a morning the rep opened,
+// read and closed — which is the reading the product most wants, because a
+// night that ranked a queue nobody opened looks exactly like a night that
+// ranked nothing worth opening.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+)
+
+// briefOpenedAction is the system_log action the open is recorded under. The
+// ledger row is what makes the event attributable — Validate refuses an
+// envelope with no trace link — and system_log rather than audit_log because
+// reading a Brief mutates no record, which is the line LogSystem's own contract
+// draws.
+const briefOpenedAction = "brief.opened"
+
+// emitBriefOpened records that this rep read this run.
+//
+// Inside the caller's transaction, which is the read's OWN transaction rather
+// than a second one opened to write telemetry: LatestRun already writes there
+// (expired snoozes resurface on read), so the counts below are the ones the rep
+// is about to be shown and the event cannot describe a page that failed to
+// render. A telemetry write that could commit while the read it reports rolled
+// back would report opens that never happened.
+//
+// Counts only. The run's contents are the rep's own queue and are recoverable
+// from brief_item under the reader's scope; copying any of it into an event
+// payload would put deal names on a bus for a question that is answered by
+// three integers.
+//
+// Entity-less, through EmitPipelinePayload: the subject of this event is the
+// READING rather than the run, and there is nothing for a consumer to read
+// back under its own scope, which is what an entity ref is for. It is also
+// what keeps the type internal — every catalogued type outside the entity-less
+// class is selectable by a webhook subscription. The run id rides the ledger
+// row below instead, attributable without being deliverable.
+func emitBriefOpened(ctx context.Context, tx pgx.Tx, run BriefRun) error {
+	unread := 0
+	for _, item := range run.Items {
+		if item.State == briefStateNew {
+			unread++
+		}
+	}
+	// The ledger row first: it is the id the envelope's trace points at, so
+	// there is no ordering in which an event exists without one.
+	ledgerID, err := storekit.LogSystem(ctx, tx, briefOpenedAction, map[string]any{
+		"brief_run_id": run.ID.String(),
+		"local_day":    run.LocalDay.Format("2006-01-02"),
+	})
+	if err != nil {
+		return fmt.Errorf("briefs: logging the brief open: %w", err)
+	}
+	payload := crmcontracts.InternalEventBriefOpened{
+		LocalDay: openapi_types.Date{Time: run.LocalDay},
+		Items:    len(run.Items),
+		Unread:   unread,
+	}
+	if err := storekit.EmitPipelinePayload(ctx, tx, ledgerID, payload); err != nil {
+		return fmt.Errorf("briefs: publishing the brief open: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/compose/briefs/briefstore.go
+++ b/backend/internal/compose/briefs/briefstore.go
@@ -278,7 +278,13 @@ func (e *BriefEngine) LatestRun(ctx context.Context, now time.Time) (BriefRun, e
 		}
 
 		run.Items, err = readRunItems(ctx, tx, run.ID)
-		return err
+		if err != nil {
+			return err
+		}
+		// The open is recorded here and not in the handler, so it rides the
+		// same transaction as the read and counts what the rep is actually
+		// about to see (briefopened.go).
+		return emitBriefOpened(ctx, tx, run)
 	})
 	if err != nil {
 		return BriefRun{}, err

--- a/backend/internal/compose/integration/briefopened_integration_test.go
+++ b/backend/internal/compose/integration/briefopened_integration_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The one product reading the Brief's own tables cannot give: whether anybody
+// looked at it.
+//
+// Driven through the real HTTP stack rather than the engine, because the claim
+// is about what a REP's morning does — GET /v1/brief is the open, POST is not —
+// and a test calling LatestRun directly would prove the function emits while
+// saying nothing about which route a rep's browser takes.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+)
+
+// briefOpenEnvelope is the part of a staged brief.opened this suite reads.
+type briefOpenEnvelope struct {
+	Type   string `json:"type"`
+	Entity *struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+	} `json:"entity"`
+	Trace struct {
+		AuditLogID string `json:"audit_log_id"`
+	} `json:"trace"`
+	Payload struct {
+		LocalDay string `json:"local_day"`
+		Items    int    `json:"items"`
+		Unread   int    `json:"unread"`
+	} `json:"payload"`
+}
+
+// openEvents returns every brief.opened staged so far, oldest first.
+func openEvents(t *testing.T, e *apptest.AppEnv) []briefOpenEnvelope {
+	t.Helper()
+	var out []briefOpenEnvelope
+	if err := e.DB().Tx(context.Background(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(context.Background(), `
+			SELECT envelope FROM event_outbox
+			 WHERE envelope->>'type' = 'brief.opened'
+			 ORDER BY seq`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var raw []byte
+			if err := rows.Scan(&raw); err != nil {
+				return err
+			}
+			var env briefOpenEnvelope
+			if err := json.Unmarshal(raw, &env); err != nil {
+				return err
+			}
+			out = append(out, env)
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// A read of the Brief says so on the bus, and says what was there to read.
+//
+// The counts are asserted against the run the SAME call returned rather than
+// against a literal, so a fixture that ranks a different number of deals moves
+// both together and the test keeps meaning what it says.
+func TestReadingTheBriefEmitsTheOpen(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	stages := apptest.DiscoverSeededPipeline(t, e)
+	createDealClosingThisWeek(t, e, stages, "Closing this week")
+	createDealClosingThisWeek(t, e, stages, "Also closing")
+
+	var generated briefResponse
+	if status := e.Call(t, "POST", "/v1/brief", nil, nil, &generated); status != http.StatusCreated {
+		t.Fatalf("POST /v1/brief = %d, want 201", status)
+	}
+
+	// Generating is not opening. The night assembles a run nobody has looked
+	// at yet, and counting that as an open would hide the exact case this
+	// event exists to make visible: a queue that was ranked and never read.
+	if staged := openEvents(t, e); len(staged) != 0 {
+		t.Fatalf("POST /v1/brief staged %d brief.opened event(s), want none — "+
+			"assembling a run is not a rep reading it", len(staged))
+	}
+
+	var read briefResponse
+	if status := e.Call(t, "GET", "/v1/brief", nil, nil, &read); status != http.StatusOK {
+		t.Fatalf("GET /v1/brief = %d, want 200", status)
+	}
+
+	staged := openEvents(t, e)
+	if len(staged) != 1 {
+		t.Fatalf("the read staged %d brief.opened event(s), want exactly one", len(staged))
+	}
+	got := staged[0]
+
+	if got.Payload.Items != len(read.Items) {
+		t.Errorf("the event says %d items and the rep was shown %d — the count must be "+
+			"what the page rendered, not what the night ranked",
+			got.Payload.Items, len(read.Items))
+	}
+	// Nothing has been marked yet, so every item the rep sees is unread. This
+	// is what separates a first open from a return visit.
+	if got.Payload.Unread != len(read.Items) {
+		t.Errorf("unread = %d on a run nobody has marked, want %d", got.Payload.Unread, len(read.Items))
+	}
+	if got.Payload.LocalDay == "" {
+		t.Error("the event carries no local_day, so a consumer cannot tell today's " +
+			"first open from a re-open of yesterday's run")
+	}
+
+	// The trace link is what makes the event attributable, and Validate refuses
+	// an envelope without one. Asserted rather than assumed: a staged event
+	// with no ledger row behind it is an open nobody can attribute.
+	if got.Trace.AuditLogID == "" {
+		t.Error("the event carries no trace link to its ledger row")
+	}
+	assertSystemLogRow(t, e, got.Trace.AuditLogID)
+}
+
+// The event names no entity, and that is what keeps it internal.
+//
+// Every catalogued type outside the entity-less pipeline class is selectable by
+// a webhook subscription — publicevents_test.go derives that set exactly as
+// webhooks.validateEventTypes does. So an entity ref here would turn "this rep
+// opened their Brief at 06:42" into a delivery an outside consumer may ask for.
+// The gate proves the type is in the right class; this proves the ENVELOPE the
+// emit actually stages agrees with it.
+func TestTheBriefOpenNamesNoEntity(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	stages := apptest.DiscoverSeededPipeline(t, e)
+	createDealClosingThisWeek(t, e, stages, "Closing this week")
+
+	var generated briefResponse
+	if status := e.Call(t, "POST", "/v1/brief", nil, nil, &generated); status != http.StatusCreated {
+		t.Fatalf("POST /v1/brief = %d, want 201", status)
+	}
+	if status := e.Call(t, "GET", "/v1/brief", nil, nil, nil); status != http.StatusOK {
+		t.Fatalf("GET /v1/brief = %d, want 200", status)
+	}
+
+	staged := openEvents(t, e)
+	if len(staged) != 1 {
+		t.Fatalf("staged %d brief.opened event(s), want one", len(staged))
+	}
+	if ent := staged[0].Entity; ent != nil && ent.Type != "" {
+		t.Errorf("the open names entity %s/%s — an entity ref makes the type "+
+			"subscribable, and a rep's reading habits are not a webhook",
+			ent.Type, ent.ID)
+	}
+}
+
+// Reading twice says so twice.
+//
+// The obvious wrong implementation records the first open and then treats the
+// run as seen — which would answer "did they ever look" while losing "do they
+// come back", and the second is the one a product decision turns on.
+func TestEveryReadOfTheBriefIsItsOwnOpen(t *testing.T) {
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	stages := apptest.DiscoverSeededPipeline(t, e)
+	createDealClosingThisWeek(t, e, stages, "Closing this week")
+
+	var generated briefResponse
+	if status := e.Call(t, "POST", "/v1/brief", nil, nil, &generated); status != http.StatusCreated {
+		t.Fatalf("POST /v1/brief = %d, want 201", status)
+	}
+	for i := range 2 {
+		if status := e.Call(t, "GET", "/v1/brief", nil, nil, nil); status != http.StatusOK {
+			t.Fatalf("read %d: GET /v1/brief = %d, want 200", i+1, status)
+		}
+	}
+
+	if staged := openEvents(t, e); len(staged) != 2 {
+		t.Fatalf("two reads staged %d open(s), want 2 — a run is not 'seen once'", len(staged))
+	}
+}
+
+// assertSystemLogRow proves the trace points at a real system_log row.
+//
+// system_log rather than audit_log, and that is the ruling rather than an
+// incidental choice: reading a Brief mutates no record, and audit_log is the
+// record-mutation spine. A telemetry row filed there would put a page view in
+// the same ledger a reviewer reads to answer "what changed about this deal".
+func assertSystemLogRow(t *testing.T, e *apptest.AppEnv, id string) {
+	t.Helper()
+	var action string
+	if err := e.DB().Tx(context.Background(), func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT action FROM system_log WHERE id = $1`, id).Scan(&action)
+	}); err != nil {
+		t.Fatalf("the trace id names no system_log row (%v) — if it was filed in "+
+			"audit_log instead, a page view is sitting in the record-mutation spine", err)
+	}
+	if action != "brief.opened" {
+		t.Errorf("the ledger row's action is %q, want brief.opened", action)
+	}
+}

--- a/backend/internal/contracts/internalevents_gen.go
+++ b/backend/internal/contracts/internalevents_gen.go
@@ -64,6 +64,25 @@ type InternalEventAiTaskStateChanged struct {
 	Summary *string `json:"summary,omitempty"`
 }
 
+// InternalEventBriefOpened Payload for brief.opened — a rep read their morning Brief. The product question behind it is whether the thing gets opened at all, and on the days it says something worth acting on.
+// Emitted on the READ of an existing run, never on the pass that assembles one: a night that ranked a queue nobody looked at is exactly the case this event exists to make visible, and counting the assembly as an open would hide it.
+// Counts only, no prose and no record data. What a rep's morning HOLDS is already recoverable from the run itself, and what they DID with it from the audit rows brief_item marks write. This payload answers one question the other two cannot: whether they came and looked.
+// Entity-less, and that is what keeps it internal. Every catalogued type that is NOT in the entity-less pipeline class is subscribable by an outside consumer — publicevents_test.go derives the set exactly as webhooks.validateEventTypes does — so naming brief_run here would make "this rep opened their Brief at 06:42" a webhook anyone may select. The run id stays on the system_log row the emit writes, where it is attributable without being deliverable.
+type InternalEventBriefOpened struct {
+	// Items How many items the run held when it was opened, AFTER expired snoozes resurfaced — what the rep actually saw, not what the night ranked. Zero is a real and interesting reading: a quiet morning that was still opened.
+	Items int `json:"items"`
+
+	// LocalDay The run's own local day, which is its identity — one run per rep per day. Carried so a consumer can tell today's first open from a re-open of yesterday's without reaching back into brief_run.
+	LocalDay openapi_types.Date `json:"local_day"`
+
+	// Unread How many of those carried no act, dismiss or snooze mark yet. Together with items it separates a first open from a return visit without needing a second event type for the difference.
+	Unread int `json:"unread"`
+}
+
 func (InternalEventAiTaskStateChanged) EventType() string { return "ai_task.state_changed" }
 
 func (InternalEventAiTaskStateChanged) EntityType() string { return "" }
+
+func (InternalEventBriefOpened) EventType() string { return "brief.opened" }
+
+func (InternalEventBriefOpened) EntityType() string { return "" }

--- a/backend/internal/shared/kernel/events/catalog.go
+++ b/backend/internal/shared/kernel/events/catalog.go
@@ -53,6 +53,17 @@ const extensionStreamEntity = "extension"
 // purge does not unlink is one that outlives a data reset.
 const aiTaskStreamEntity = "aitask"
 
+// briefStreamEntity is the stream every brief.* product-telemetry event rides.
+//
+// Out of streamEntities for the same three reasons aiTaskStreamEntity is, and
+// they hold one at a time: the automation engine has no trigger for "a rep
+// opened their Brief", the webhook deliverer has no public type to name it by,
+// and the audit stream already carries what the rep DID — brief_item marks
+// write audit rows — so an all-stream consumer would gain nothing but volume.
+// What this stream answers is the one thing those cannot: whether the page was
+// opened at all. Enumerated by Streams() all the same, so the purge unlinks it.
+const briefStreamEntity = "brief"
+
 // ExtensionEventVersion is the payload schema version every extension event
 // carries, and it is 1 forever.
 //
@@ -108,11 +119,12 @@ var streamEntities = []string{
 // left out here is one the data reset does not unlink and no operator can see,
 // which is a worse outcome than the entries it would leave behind.
 func Streams() []string {
-	out := make([]string, 0, len(streamEntities)+2)
+	out := make([]string, 0, len(streamEntities)+3)
 	for _, e := range streamEntities {
 		out = append(out, StreamPrefix+e)
 	}
-	out = append(out, StreamPrefix+extensionStreamEntity, StreamPrefix+aiTaskStreamEntity)
+	out = append(out, StreamPrefix+extensionStreamEntity, StreamPrefix+aiTaskStreamEntity,
+		StreamPrefix+briefStreamEntity)
 	sort.Strings(out)
 	return out
 }
@@ -382,6 +394,10 @@ var catalog = map[string]struct {
 	// The AI-activity projection feed (ai_task_run). One type with the state
 	// inside, like voice.build_changed: a new state must never need a new type.
 	"ai_task.state_changed": {aiTaskStreamEntity, 1},
+
+	// Product telemetry: the morning Brief was read. Internal only — nothing
+	// subscribes to it, and api/internal-events.yaml says why that file exists.
+	"brief.opened": {briefStreamEntity, 1},
 }
 
 // pipelineEventTypes are the events that may ride the bus WITHOUT a subject
@@ -404,6 +420,11 @@ var pipelineEventTypes = map[string]struct{}{
 	"capture.failed":        {},
 	"capture.skipped":       {},
 	"ai_task.state_changed": {},
+	// A Brief open names no record it could hand a consumer: the subject is the
+	// READING, not the run, and the run is the reader's own queue. Entity-less
+	// is also what keeps it off the subscribable set — see its schema in
+	// api/internal-events.yaml.
+	"brief.opened": {},
 }
 
 // IsPipelineEvent reports whether an event type is an entity-less

--- a/backend/internal/shared/kernel/events/events_test.go
+++ b/backend/internal/shared/kernel/events/events_test.go
@@ -43,8 +43,12 @@ func TestStreamsMatchSpecList(t *testing.T) {
 	// missing from it is one a reset silently leaves behind.
 	// The aitask stream joins them for the same reason and only that reason:
 	// it is enumerable and resettable, while staying outside coreStreams() so
-	// no all-stream group subscribes to an internal projection feed.
-	want := append(append([]string{}, coreFamilyStreams...), "gw:events:crm:extension", "gw:events:crm:aitask")
+	// no all-stream group subscribes to an internal projection feed. The brief
+	// stream is the second of that kind — product telemetry, not a family — and
+	// belongs here for the resettability half: a reset that left a rep's
+	// reading history behind would outlive the data it describes.
+	want := append(append([]string{}, coreFamilyStreams...),
+		"gw:events:crm:extension", "gw:events:crm:aitask", "gw:events:crm:brief")
 	sort.Strings(want)
 	if got := Streams(); !reflect.DeepEqual(got, want) {
 		t.Errorf("Streams() = %v, want the events.md stream set plus the extension stream %v", got, want)


### PR DESCRIPTION
brief.opened is the one product reading the Brief's own tables cannot give.
What a run HELD is in brief_run and brief_item; what a rep DID with it is in the
audit rows the act/dismiss/snooze marks already write. Neither records a morning
the rep opened, read and closed — and a night that ranked a queue nobody looked
at is indistinguishable, in the data, from a night that ranked nothing worth
opening.

Emitted on GET /v1/brief and NOT on the POST that assembles a run. Counting the
assembly as an open would hide exactly the case the event exists to make
visible, so it is a test rather than a comment: staging on the generate path
fails TestReadingTheBriefEmitsTheOpen with the reason spelled out.

It rides the read's own transaction. LatestRun already writes there — expired
snoozes resurface on read — so the counts are the ones the rep is about to be
shown, and a telemetry row cannot commit describing a page that failed to
render. Three integers, no prose and no record data: items as rendered, how many
were still unmarked, and the run's local day.

ENTITY-LESS, and that is what keeps it internal rather than a stylistic choice.
Every catalogued type outside the entity-less pipeline class is selectable by a
webhook subscription — publicevents_test.go derives that set exactly as
webhooks.validateEventTypes does. The first version named brief_run and the gate
correctly refused it: it would have made "this rep opened their Brief at 06:42" a
delivery an outside consumer may ask for. The run id rides the system_log row
instead, attributable without being deliverable.

system_log rather than audit_log, which is the ruling and not an incidental
choice: reading a Brief mutates no record, and audit_log is the record-mutation
spine. A page view filed there would sit in the same ledger a reviewer reads to
answer "what changed about this deal". LogSystem's own contract draws that line
and names login and bulk export as the class.

The stream stays outside coreStreams() so no all-stream consumer subscribes to a
rep's reading habits, and inside Streams() so a data reset unlinks it — the same
two properties aitask was given, verified in both directions before pushing.

SCOPE, and it is narrower than #3679 asks. The issue names three events; only
this one is buildable server-side.

  brief.item_opened — opening an item is a client navigation. No request
  distinguishes it from any other. The adjacent fact is that brief_item marks
  already write audit_log and emit nothing, so "which items did a rep act on" is
  already answerable from the audit spine.

  brief.coverage_viewed — no request exists at all. briefcoverage.tsx uses a
  native Disclosure; expanding it is local component state.

Both need a client-to-server telemetry ingest, and this product has none: no
endpoint, no track() anywhere in frontend/src. That is a new product surface
carrying its own consent, rate-limiting and privacy questions, so it is a
decision to take rather than something to infer from a plan bullet. #3679 stays
open with the finding.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

---

Local gate: `make check-backend` green, `make craft-static` clean, `scripts/check-rls-store-path.sh` OK, 31 brief integration tests green.

Two gates shaped this rather than merely passing it: `publicevents_test.go` refused the first version's entity ref (which would have made the event webhook-subscribable), and `TestStreamsMatchSpecList` required the new stream be declared resettable.

Partial fix for #3679 — the other two events are blocked on a client telemetry ingest that does not exist. Reasoning in the commit body; the issue stays open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `brief.opened` telemetry for #3679 so the system can distinguish a generated Brief nobody read from one a rep opened. Previously neither route recorded a read; now each successful `GET /v1/brief` emits one event, while `POST /v1/brief` emits none.

- Includes the rendered item count, unread count, and run local day without record data.
- Writes the event and its `system_log` trace in the read transaction, so failed reads do not leave telemetry.
- Keeps the event entity-less and internal, while making its stream resettable with workspace data.
- Adds integration coverage for route behavior, repeated reads, payload counts, traceability, and entity scope.
- Implements only `brief.opened` from #3679; item and coverage events still require client telemetry ingestion.

<sup>Written for commit 5d6c735845c4aeac345017788d2de8c61e384919. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added telemetry for when users open a Brief, including the local day, total item count, and unread count.
  * Each Brief view now records a corresponding system log entry.
  * Repeated Brief views generate separate open events.

* **Bug Fixes**
  * Brief-open events are emitted reliably within the same transaction, with failures reported to the caller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->