### PR TITLE
The contract for one email, read once

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -20280,15 +20280,19 @@ components:
       type: string
       x-email-presentation: exempt
       x-email-presentation-reason: A status word, not email content.
-      enum: [team, participants, selected, private_pending, private_by_you, still_held, withheld]
+      enum: [team, participants, selected, withheld]
       description: |
         What a reader is allowed to know about who else reads this message, in one word the
         badge can print. `team` never means the whole workspace: the linked record's own scope
         still decides who may discover the row at all.
 
-        `still_held` is the honest half of a share — you released your hold and somebody else
-        has not. `withheld` is the only value that says the content is not this caller's, and
-        it never travels with a reason: why a message is private describes what it is about.
+        `withheld` is the only value that says the content is not this caller's, and it never
+        travels with a reason: why a message is private describes what it is about.
+
+        The captured-mail states a mailbox owner sees — held until classified, private by you,
+        shared but still held by another seat — are not here yet. They arrive with the thread
+        contribution editor that can act on them; a value no server can emit is one a client
+        would branch on and never reach.
 
     EmailParty:
       type: object
@@ -20358,11 +20362,6 @@ components:
           type: string
           enum: [thread, message, none]
           description: What the editor must say it is about to change, in the words the user reads.
-        held_by_others:
-          type: [integer, 'null']
-          description: |
-            After a share, how many other seats still hold this thread. A count and never a
-            name. Null when the question does not apply.
         explanation:
           type: [string, 'null']
           description: |
@@ -20401,11 +20400,11 @@ components:
         id: { type: string, format: uuid }
         lifecycle:
           type: string
-          enum: [delivered, scheduled, approval_draft]
+          enum: [delivered]
           description: |
-            Whether this is correspondence or something not yet sent. A scheduled send and a
-            draft awaiting approval borrow the frame; their operational verbs stay with the
-            workflow that owns them.
+            What kind of message this is. One value today: this read serves delivered
+            correspondence. A scheduled send and a draft awaiting approval will borrow the
+            frame when the reads that serve them land, and they are not listed until then.
         occurred_at: { type: string, format: date-time }
         summary:
           $ref: '#/components/schemas/EmailSummary'

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -4935,6 +4935,37 @@ paths:
         '404': { $ref: '#/components/responses/NotFound' }
         '409': { $ref: '#/components/responses/Conflict' }
 
+  /activities/{id}/email-presentation:
+    parameters:
+      - $ref: '#/components/parameters/Id'
+    get:
+      tags: [Activities]
+      operationId: getEmailPresentation
+      summary: Everything one email needs to be read and acted on, in one read.
+      description: |
+        The composed read behind the canonical email viewer: the message, who it went to,
+        what came with it, and what this caller may do about who else reads it.
+
+        It answers 404 for an activity that is not `kind=email`, and for one held under a
+        statutory retention obligation — a held row is outside every ordinary read, so there
+        is no presentation of it to refuse. A caller who may discover the row but stands
+        outside its audience gets `content_state: withheld`: the markers, and nothing said.
+      x-mcp-tool: { verb: read_record, record_type: activity, tier: auto_execute, scope: read }
+      parameters:
+        - name: thread_cursor
+          in: query
+          required: false
+          schema: { type: string }
+          description: |
+            Continue the thread's member page from a previous response's `thread.next_cursor`.
+      responses:
+        '200':
+          description: The email.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EmailPresentation' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
   /activities/{id}/audience:
     parameters:
       - $ref: '#/components/parameters/Id'
@@ -20197,6 +20228,230 @@ components:
             deciding this sender is business cancels the deletion. Later mail from the same sender
             runs its own window, so this date names the next message to go rather than all of them.
 
+    EmailSummary:
+      type: object
+      x-email-presentation: entry
+      description: |
+        One retained email, reduced to what a row shows without opening it. Present on an
+        activity only when `kind=email`; every other kind carries none, and a reader that
+        branches on this field is asking the one question that decides the canonical row.
+
+        The preview is normalised by the server with the same splitter the detail uses, so a
+        row and the message it opens never disagree about where the sender's own words end.
+        A withheld email carries a summary whose `subject` and `preview` are null and whose
+        `display_status` says so — the row stays, the words do not.
+      required: [activity_id, occurred_at, display_status, attachment_count, move, version]
+      properties:
+        activity_id: { type: string, format: uuid }
+        subject:
+          type: [string, 'null']
+          description: Null when the message has none, and when the content is withheld.
+        preview:
+          type: [string, 'null']
+          description: |
+            One line of the sender's own text, signature and quoted history already removed.
+            Null when withheld, and when the message has no text of its own.
+        occurred_at: { type: string, format: date-time }
+        direction: { type: [string, 'null'], enum: [null, inbound, outbound] }
+        counterparty:
+          type: [string, 'null']
+          description: |
+            Who the message was with, named for the row: "Ana Sommer", or "Ana Sommer +2" when
+            the exchange had more. Null when no participant resolves to a name this caller may
+            see — the row then says the direction alone rather than inventing a stranger.
+        attachment_count:
+          type: integer
+          description: How many files came with it. Zero when withheld, like every other count.
+        move:
+          type: string
+          enum: [needs_reply, waiting_for_them, none]
+          description: |
+            Whose move it is, derived from what this reader can see of the thread. `none` when
+            the question cannot be answered honestly — an unanswerable move is not a claim.
+        display_status:
+          $ref: '#/components/schemas/EmailAccessStatus'
+        version:
+          allOf: [{ $ref: '#/components/schemas/RowVersion' }]
+          description: |
+            The activity's version, carried so a row can open an editor that writes with
+            If-Match. A row without it can only read.
+
+    EmailAccessStatus:
+      type: string
+      x-email-presentation: exempt
+      x-email-presentation-reason: A status word, not email content.
+      enum: [team, participants, selected, private_pending, private_by_you, still_held, withheld]
+      description: |
+        What a reader is allowed to know about who else reads this message, in one word the
+        badge can print. `team` never means the whole workspace: the linked record's own scope
+        still decides who may discover the row at all.
+
+        `still_held` is the honest half of a share — you released your hold and somebody else
+        has not. `withheld` is the only value that says the content is not this caller's, and
+        it never travels with a reason: why a message is private describes what it is about.
+
+    EmailParty:
+      type: object
+      x-email-presentation: exempt
+      x-email-presentation-reason: A participant identity, gated with the content it belongs to.
+      description: One address on a message, resolved to a person or a seat when it is one.
+      required: [address]
+      properties:
+        address: { type: string }
+        display_name: { type: [string, 'null'] }
+        person_id:
+          type: [string, 'null']
+          format: uuid
+          description: Set when the address belongs to a contact this caller may see.
+        user_id:
+          type: [string, 'null']
+          format: uuid
+          description: Set when the address belongs to a seat in this workspace.
+
+    EmailAttachmentSummary:
+      type: object
+      x-email-presentation: exempt
+      x-email-presentation-reason: File metadata, gated with the message it came on.
+      description: One file that came with the message. Metadata only; bytes are fetched separately.
+      required: [id, filename]
+      properties:
+        id: { type: string, format: uuid }
+        filename: { type: string }
+        byte_size: { type: [integer, 'null'] }
+        content_type: { type: [string, 'null'] }
+
+    EmailAccess:
+      type: object
+      x-email-presentation: exempt
+      x-email-presentation-reason: The access block, which is about the message rather than in it.
+      description: |
+        Who reads this message, and what this caller may do about that. `can_change` and
+        `change_mode` are decided by the same authority that would execute the write, so a
+        control this block offers is a control the write will accept.
+      required: [content_state, display_status, can_change, change_mode]
+      properties:
+        content_state:
+          type: string
+          enum: [available, withheld]
+        display_status:
+          $ref: '#/components/schemas/EmailAccessStatus'
+        audience:
+          allOf: [{ $ref: '#/components/schemas/ActivityAudience' }]
+          nullable: true
+        selected_members:
+          type: array
+          description: |
+            Who is named on a `selected` audience. Returned only to a caller who may both read
+            the content and change it — a reader with no standing to edit the set has no
+            standing to enumerate it either.
+          items: { $ref: '#/components/schemas/AudienceMember' }
+        can_change: { type: boolean }
+        change_mode:
+          type: string
+          enum: [thread_contribution, message_audience, none]
+          description: |
+            Which write this caller's Access control performs. `thread_contribution` changes
+            only this owner's contribution to a captured thread; `message_audience` sets a
+            hand-logged message's own audience. The browser never decides this by reading
+            `captured_by` — the server knows which write it would accept.
+        change_scope:
+          type: string
+          enum: [thread, message, none]
+          description: What the editor must say it is about to change, in the words the user reads.
+        held_by_others:
+          type: [integer, 'null']
+          description: |
+            After a share, how many other seats still hold this thread. A count and never a
+            name. Null when the question does not apply.
+        explanation:
+          type: [string, 'null']
+          description: |
+            Why the message is limited, when the caller may know. Always null while the content
+            is withheld: the reason describes the message.
+
+    EmailThreadPage:
+      type: object
+      x-email-presentation: exempt
+      x-email-presentation-reason: A page of EmailSummary, each of which carries its own annotation.
+      description: |
+        The rest of the conversation, newest first, as summaries. Bounded and paged rather
+        than whole: a thread has no ceiling, and a drawer that fetched every message would
+        make opening the newest one cost the whole history.
+      required: [members]
+      properties:
+        members:
+          type: array
+          items: { $ref: '#/components/schemas/EmailSummary' }
+        next_cursor:
+          type: [string, 'null']
+          description: Pass back as `thread_cursor` for the next page. Null when this is the last.
+
+    EmailPresentation:
+      type: object
+      x-email-presentation: entry
+      description: |
+        One email, composed for reading. The message and its parties come from the activity's
+        own store; the access block is assembled from the same authority that performs the
+        write, so what this says a caller may do is what the caller may do.
+
+        A withheld presentation carries the markers and refuses the rest: no subject, no body,
+        no parties, no attachments, no thread, no reason, no member names.
+      required: [id, lifecycle, occurred_at, summary, access, version, from, to, cc, bcc, attachments, links, bcc_withheld, can_reply, can_relink]
+      properties:
+        id: { type: string, format: uuid }
+        lifecycle:
+          type: string
+          enum: [delivered, scheduled, approval_draft]
+          description: |
+            Whether this is correspondence or something not yet sent. A scheduled send and a
+            draft awaiting approval borrow the frame; their operational verbs stay with the
+            workflow that owns them.
+        occurred_at: { type: string, format: date-time }
+        summary:
+          $ref: '#/components/schemas/EmailSummary'
+        body:
+          type: [string, 'null']
+          description: |
+            The message as plain text, normalised. Null when withheld. Provider payloads are
+            never handed to a browser to parse.
+        thread_key: { type: [string, 'null'] }
+        from:
+          type: array
+          items: { $ref: '#/components/schemas/EmailParty' }
+        to:
+          type: array
+          items: { $ref: '#/components/schemas/EmailParty' }
+        cc:
+          type: array
+          items: { $ref: '#/components/schemas/EmailParty' }
+        bcc:
+          type: array
+          description: |
+            Empty for every caller but the seat that sent or imported the message. Being
+            allowed to read what was written does not disclose who was copied blind.
+          items: { $ref: '#/components/schemas/EmailParty' }
+        bcc_withheld:
+          type: boolean
+          description: |
+            True when the message has blind recipients this caller may not see. The viewer says
+            that they exist rather than showing an empty list that reads as none.
+        attachments:
+          type: array
+          items: { $ref: '#/components/schemas/EmailAttachmentSummary' }
+        links:
+          type: array
+          description: What the message is filed against, named for a reader.
+          items: { $ref: '#/components/schemas/ActivityLink' }
+        thread:
+          $ref: '#/components/schemas/EmailThreadPage'
+        access:
+          $ref: '#/components/schemas/EmailAccess'
+        can_reply: { type: boolean }
+        can_relink: { type: boolean }
+        version:
+          allOf: [{ $ref: '#/components/schemas/RowVersion' }]
+          description: The activity's version, for the If-Match its own actions send.
+
     ThreadAudienceOutcome:
       type: object
       description: What an owner's decision about a thread reached.
@@ -27637,6 +27892,14 @@ components:
             and the mailbox behind it is not on the row. Null on every other kind, and on a
             meeting nobody was recorded as hosting.
         direction: { type: [string, 'null'], enum: [null, inbound, outbound], description: 'inbound/outbound for email/call; null for note/task.' }
+        email_summary:
+          allOf: [{ $ref: '#/components/schemas/EmailSummary' }]
+          readOnly: true
+          nullable: true
+          description: >-
+            Present exactly when `kind=email`. What the canonical email row renders, so a list
+            does not have to fetch a message per visible line to draw one. Every other kind
+            carries none, and a reader branches on its presence rather than on the kind word.
         thread_key:
           type: [string, 'null']
           readOnly: true
@@ -27914,6 +28177,17 @@ components:
             A moment already past is refused rather than stored: it would write a row that hides
             nothing, and read to the rep as a snooze that did not take.
 
+    AudienceMember:
+      type: object
+      description: |
+        One user or team admitted to a message besides its participants. The same shape the
+        audience write takes and the presentation reads back, so an editor that renders the
+        current set submits it in the vocabulary it received.
+      required: [subject_type, subject_id]
+      properties:
+        subject_type: { type: string, enum: [user, team] }
+        subject_id: { type: string, format: uuid }
+
     SetActivityAudienceRequest:
       type: object
       required: [audience]
@@ -27925,12 +28199,7 @@ components:
           description: >-
             The users and teams admitted besides the participants. Read only when `audience` is
             `selected`; replaces the previous set.
-          items:
-            type: object
-            required: [subject_type, subject_id]
-            properties:
-              subject_type: { type: string, enum: [user, team] }
-              subject_id: { type: string, format: uuid }
+          items: { $ref: '#/components/schemas/AudienceMember' }
     UpdateActivityRequest:
       type: object
       properties:

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -154,6 +154,7 @@ var agentPolicies = map[string]agentPolicy{
 	"DELETE /v1/webhook-subscriptions/{id}":                              {Op: "archiveWebhookSubscription", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/activities":                                                 {Op: "listActivities", Access: "tool", Tool: "search_records", RecordType: "activity", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/activities/{id}":                                            {Op: "getActivity", Access: "tool", Tool: "read_record", RecordType: "activity", Tier: "auto_execute", Scope: "read"},
+	"GET /v1/activities/{id}/email-presentation":                         {Op: "getEmailPresentation", Access: "tool", Tool: "read_record", RecordType: "activity", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/activities/{id}/pipeline":                                   {Op: "readActivityPipelineTrace", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/activities/{id}/transcript-proposals/latest":                {Op: "getLatestTranscriptRead", Access: "tool", Tool: "read_record", RecordType: "activity", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/activities/{id}/transcript-proposals/{readId}":              {Op: "getTranscriptRead", Access: "tool", Tool: "read_record", RecordType: "activity", Tier: "auto_execute", Scope: "read"},

--- a/backend/internal/compose/integration/emailpresentation_integration_test.go
+++ b/backend/internal/compose/integration/emailpresentation_integration_test.go
@@ -56,8 +56,9 @@ func TestEmailPresentationAccessMatrix(t *testing.T) {
 		audience string
 		// readers that must read the content whole.
 		available []struct {
-			name string
-			ctx  context.Context
+			name   string
+			ctx    context.Context
+			writer bool
 		}
 		// readers that must see the row and none of its words.
 		withheld []struct {
@@ -68,20 +69,22 @@ func TestEmailPresentationAccessMatrix(t *testing.T) {
 		{
 			audience: "workspace",
 			available: []struct {
-				name string
-				ctx  context.Context
+				name   string
+				ctx    context.Context
+				writer bool
 			}{
-				{"the author", author},
-				{"a colleague in another team", colleague},
-				{"an unbounded admin", e.Admin()},
+				{"the author", author, true},
+				{"a colleague in another team", colleague, false},
+				{"an unbounded admin", e.Admin(), true},
 			},
 		},
 		{
 			audience: "participants",
 			available: []struct {
-				name string
-				ctx  context.Context
-			}{{"the author", author}},
+				name   string
+				ctx    context.Context
+				writer bool
+			}{{"the author", author, true}},
 			withheld: []struct {
 				name string
 				ctx  context.Context
@@ -114,6 +117,14 @@ func TestEmailPresentationAccessMatrix(t *testing.T) {
 				if got.Body == nil {
 					t.Errorf("%s: no body on a message they may read", reader.name)
 				}
+				// Replying needs only the message; relinking is a write, so it
+				// is offered to a writer and to nobody else.
+				if !got.CanReply {
+					t.Errorf("%s: cannot reply to a message they may read", reader.name)
+				}
+				if got.CanRelink != reader.writer {
+					t.Errorf("%s: can_relink=%v, want %v — relinking is a write", reader.name, got.CanRelink, reader.writer)
+				}
 			}
 			for _, reader := range tc.withheld {
 				got, err := e.Activities.GetEmailPresentation(reader.ctx, id, nil)
@@ -123,6 +134,59 @@ func TestEmailPresentationAccessMatrix(t *testing.T) {
 				assertWithholdsEverything(t, reader.name, got)
 			}
 		})
+	}
+}
+
+// TestSelectedAudienceReadsBackItsMembers is the admit case for the withheld
+// matrix's member check, which would otherwise pass on a field nothing ever
+// fills. It proves the positive arm: a caller who may change the set reads it,
+// and one who may only read the message does not.
+func TestSelectedAudienceReadsBackItsMembers(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+	id := logEmailActivity(author, t, e, contact, "Q3 renewal terms", "confidential pricing")
+
+	if _, err := e.Activities.SetAudience(author, id, activities.SetAudienceInput{
+		Audience: "selected",
+		Members:  []activities.AudienceMember{{SubjectType: "user", SubjectID: e.Rep3}},
+	}); err != nil {
+		t.Fatalf("limiting to selected: %v", err)
+	}
+
+	// The author may change the set, so the author may see it.
+	got, err := e.Activities.GetEmailPresentation(author, id, nil)
+	if err != nil {
+		t.Fatalf("author reading: %v", err)
+	}
+	if got.Access.DisplayStatus != crmcontracts.EmailAccessStatusSelected {
+		t.Errorf("display_status=%v, want selected", got.Access.DisplayStatus)
+	}
+	if got.Access.SelectedMembers == nil || len(*got.Access.SelectedMembers) != 1 {
+		t.Fatalf("selected_members=%v, want the one named member — an editor cannot submit a set it was never shown", got.Access.SelectedMembers)
+	}
+	if member := (*got.Access.SelectedMembers)[0]; ids.UUID(member.SubjectId) != e.Rep3 {
+		t.Errorf("selected_members named %v, want the member that was set", member.SubjectId)
+	}
+
+	// A named member from ANOTHER team reads the message and is offered no
+	// editor: they were let in to read it, and the set stays the row writer's.
+	// The team matters — a colleague sharing the contact's team holds write
+	// authority through the linked record, which is a different question from
+	// having been named on this message.
+	named := e.As(e.Rep3, []ids.UUID{e.Team2}, activityLifecyclePerms)
+	asMember, err := e.Activities.GetEmailPresentation(named, id, nil)
+	if err != nil {
+		t.Fatalf("named member reading: %v", err)
+	}
+	if asMember.Access.ContentState != crmcontracts.EmailAccessContentStateAvailable {
+		t.Errorf("a named member cannot read the message they were named on")
+	}
+	if asMember.Access.CanChange {
+		t.Errorf("a named member is offered the editor; the set belongs to a writer of the row")
+	}
+	if asMember.Access.SelectedMembers != nil && len(*asMember.Access.SelectedMembers) != 0 {
+		t.Errorf("a reader with no standing to change the set enumerated it: %v", asMember.Access.SelectedMembers)
 	}
 }
 

--- a/backend/internal/compose/integration/emailpresentation_integration_test.go
+++ b/backend/internal/compose/integration/emailpresentation_integration_test.go
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// The email viewer's read is the one place a reader meets a message whole, so
+// it is the one place every arm of the audience model has to answer the same
+// way the timeline does. These tests are the matrix: each audience against
+// each kind of reader, and then the state machines that are not audiences at
+// all — statutory retention, a non-email row, blind recipients — kept separate
+// because folding them into the matrix would multiply cases that share no rule.
+
+// logEmailActivity logs one email against a contact and answers its id.
+func logEmailActivity(author context.Context, t *testing.T, e *Env, contact ids.UUID, subject, body string) ids.ActivityID {
+	t.Helper()
+	logged, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+		Kind: "email", Subject: &subject, Body: &body, Direction: strPtr("inbound"),
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+	})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	return ids.From[ids.ActivityKind](ids.UUID(logged.Id))
+}
+
+// TestEmailPresentationAccessMatrix walks every audience against every reader.
+//
+// The rule it holds: an audience decides who reads CONTENT, and row scope
+// decides who discovers the row at all. They are separate gates, so a reader
+// can be admitted by one and refused by the other — and an unbounded admin is
+// admitted by scope and still refused by the audience, because an admin
+// reading a colleague's limited mail is the disclosure the limit exists to
+// prevent.
+func TestEmailPresentationAccessMatrix(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	participant := e.As(e.Rep2, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	colleague := e.As(e.Rep3, []ids.UUID{e.Team2}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	for _, tc := range []struct {
+		audience string
+		// readers that must read the content whole.
+		available []struct {
+			name string
+			ctx  context.Context
+		}
+		// readers that must see the row and none of its words.
+		withheld []struct {
+			name string
+			ctx  context.Context
+		}
+	}{
+		{
+			audience: "workspace",
+			available: []struct {
+				name string
+				ctx  context.Context
+			}{
+				{"the author", author},
+				{"a colleague in another team", colleague},
+				{"an unbounded admin", e.Admin()},
+			},
+		},
+		{
+			audience: "participants",
+			available: []struct {
+				name string
+				ctx  context.Context
+			}{{"the author", author}},
+			withheld: []struct {
+				name string
+				ctx  context.Context
+			}{
+				{"a colleague in another team", colleague},
+				// The one that matters most: scope admits the admin, the
+				// audience does not, and the audience wins.
+				{"an unbounded admin", e.Admin()},
+				{"a colleague who is not a participant", participant},
+			},
+		},
+	} {
+		t.Run(tc.audience, func(t *testing.T) {
+			id := logEmailActivity(author, t, e, contact, "Q3 renewal terms", "confidential pricing")
+			if _, err := e.Activities.SetAudience(author, id,
+				activities.SetAudienceInput{Audience: tc.audience}); err != nil {
+				t.Fatalf("limiting to %s: %v", tc.audience, err)
+			}
+			for _, reader := range tc.available {
+				got, err := e.Activities.GetEmailPresentation(reader.ctx, id, nil)
+				if err != nil {
+					t.Fatalf("%s reading a %s message: %v", reader.name, tc.audience, err)
+				}
+				if got.Access.ContentState != crmcontracts.EmailAccessContentStateAvailable {
+					t.Errorf("%s: content_state=%v, want available", reader.name, got.Access.ContentState)
+				}
+				if got.Summary.Subject == nil || *got.Summary.Subject != "Q3 renewal terms" {
+					t.Errorf("%s: subject %v, want the subject", reader.name, got.Summary.Subject)
+				}
+				if got.Body == nil {
+					t.Errorf("%s: no body on a message they may read", reader.name)
+				}
+			}
+			for _, reader := range tc.withheld {
+				got, err := e.Activities.GetEmailPresentation(reader.ctx, id, nil)
+				if err != nil {
+					t.Fatalf("%s reading a %s message: %v — a discoverable row is read, withheld", reader.name, tc.audience, err)
+				}
+				assertWithholdsEverything(t, reader.name, got)
+			}
+		})
+	}
+}
+
+// assertWithholdsEverything is the leak check every withheld case runs, so
+// each of them is held to the same list. A field added to the presentation
+// that carries content is a field this has to learn about.
+func assertWithholdsEverything(t *testing.T, who string, got crmcontracts.EmailPresentation) {
+	t.Helper()
+	if got.Access.ContentState != crmcontracts.EmailAccessContentStateWithheld {
+		t.Errorf("%s: content_state=%v, want withheld", who, got.Access.ContentState)
+	}
+	if got.Summary.DisplayStatus != crmcontracts.EmailAccessStatusWithheld {
+		t.Errorf("%s: display_status=%v, want withheld", who, got.Summary.DisplayStatus)
+	}
+	if got.Summary.Subject != nil {
+		t.Errorf("%s: subject %q leaked", who, *got.Summary.Subject)
+	}
+	if got.Summary.Preview != nil {
+		t.Errorf("%s: preview %q leaked", who, *got.Summary.Preview)
+	}
+	if got.Body != nil {
+		t.Errorf("%s: body %q leaked", who, *got.Body)
+	}
+	if got.ThreadKey != nil {
+		t.Errorf("%s: thread_key %q leaked", who, *got.ThreadKey)
+	}
+	if len(got.From) != 0 || len(got.To) != 0 || len(got.Cc) != 0 || len(got.Bcc) != 0 {
+		t.Errorf("%s: participants leaked (from=%d to=%d cc=%d bcc=%d)",
+			who, len(got.From), len(got.To), len(got.Cc), len(got.Bcc))
+	}
+	if len(got.Attachments) != 0 {
+		t.Errorf("%s: %d attachment(s) leaked", who, len(got.Attachments))
+	}
+	if got.Thread != nil {
+		t.Errorf("%s: the thread leaked", who)
+	}
+	if got.Access.Explanation != nil {
+		// The reason describes what the message is about, so it is withheld
+		// with the content.
+		t.Errorf("%s: the reason %q leaked", who, *got.Access.Explanation)
+	}
+	if got.Access.SelectedMembers != nil && len(*got.Access.SelectedMembers) != 0 {
+		t.Errorf("%s: selected-member identities leaked", who)
+	}
+	if got.Access.CanChange {
+		t.Errorf("%s: offered a control over a message they may not read", who)
+	}
+	// The row itself survives: a withheld message is visibly withheld rather
+	// than absent, or a reader cannot tell it from a conversation that never
+	// happened.
+	if got.Summary.OccurredAt.IsZero() {
+		t.Errorf("%s: no occurred_at — a withheld row still says when", who)
+	}
+}
+
+// TestEmailPresentationRefusesWhatIsNotAnEmail holds the kind boundary. An
+// activity is not a synonym for an email: a call, a note and a task are
+// activities too, and none of them has an email's shape.
+func TestEmailPresentationRefusesWhatIsNotAnEmail(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	for _, kind := range []string{"call", "note", "meeting", "task"} {
+		t.Run(kind, func(t *testing.T) {
+			subject := "not an email"
+			logged, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+				Kind: kind, Subject: &subject,
+				Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+			})
+			if err != nil {
+				t.Fatalf("log a %s: %v", kind, err)
+			}
+			id := ids.From[ids.ActivityKind](ids.UUID(logged.Id))
+			// Not-found rather than a wrong-kind error: naming the kind would
+			// answer a question about a row the caller may only discover.
+			if _, err := e.Activities.GetEmailPresentation(author, id, nil); !errors.Is(err, apperrors.ErrNotFound) {
+				t.Errorf("presentation of a %s → %v, want ErrNotFound", kind, err)
+			}
+		})
+	}
+}
+
+// TestEmailSummaryRidesEveryActivityRow holds the field a canonical row reads.
+// Present exactly when kind=email, so a reader branches on the field rather
+// than on the kind word.
+func TestEmailSummaryRidesEveryActivityRow(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	id := logEmailActivity(author, t, e, contact, "Q3 renewal terms",
+		"Können wir Dienstag sprechen?\n\nViele Grüße\nAna")
+	got, err := e.Activities.GetActivity(author, id, storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.EmailSummary == nil {
+		t.Fatal("an email row carries no email_summary; every canonical row reads it")
+	}
+	// The preview is the sender's own words: the sign-off is not the message.
+	if got.EmailSummary.Preview == nil || *got.EmailSummary.Preview != "Können wir Dienstag sprechen?" {
+		t.Errorf("preview = %v, want the sentence without the sign-off", got.EmailSummary.Preview)
+	}
+	if got.EmailSummary.Move != crmcontracts.EmailSummaryMoveNeedsReply {
+		t.Errorf("move = %v on an inbound message, want needs_reply", got.EmailSummary.Move)
+	}
+
+	subject := "a call"
+	call, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+		Kind: "call", Subject: &subject,
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+	})
+	if err != nil {
+		t.Fatalf("log a call: %v", err)
+	}
+	if call.EmailSummary != nil {
+		t.Error("a call carries an email_summary; only an email has an email's shape")
+	}
+}

--- a/backend/internal/compose/person360/sectionstimeline.go
+++ b/backend/internal/compose/person360/sectionstimeline.go
@@ -254,6 +254,14 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 			a.Subject, a.Body, a.ThreadKey, a.AudienceReason = nil, nil, nil, nil
 		}
 		a.ContentState = &state
+		// Composed from the shared helper rather than spelled again here. The
+		// contract says an email row carries a summary exactly when kind=email,
+		// and this hand-written twin of the projection is the one read that
+		// could make that false — a person page whose mail rows came back
+		// summary-less would render every one of them degraded while the same
+		// rows off /activities rendered whole. Set AFTER the withholding above,
+		// so a withheld row's summary is the withheld one.
+		a.EmailSummary = activities.RowEmailSummary(a)
 		// Links say how the message is FILED, and a row can reach this page
 		// without being filed here: a contact who was CC'd or who attended is on
 		// the message through their participant row, while the filing belongs to

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -71,6 +71,10 @@ func (stubs) DraftEmail(w nethttp.ResponseWriter, r *nethttp.Request, id crmcont
 	httperr.NotImplemented(w, r, "DraftEmail")
 }
 
+func (stubs) GetEmailPresentation(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.GetEmailPresentationParams) {
+	httperr.NotImplemented(w, r, "GetEmailPresentation")
+}
+
 func (stubs) GetMeetingBrief(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.GetMeetingBriefParams) {
 	httperr.NotImplemented(w, r, "GetMeetingBrief")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -4953,13 +4953,10 @@ func (e EmailAccessContentState) Valid() bool {
 
 // Defines values for EmailAccessStatus.
 const (
-	EmailAccessStatusParticipants   EmailAccessStatus = "participants"
-	EmailAccessStatusPrivateByYou   EmailAccessStatus = "private_by_you"
-	EmailAccessStatusPrivatePending EmailAccessStatus = "private_pending"
-	EmailAccessStatusSelected       EmailAccessStatus = "selected"
-	EmailAccessStatusStillHeld      EmailAccessStatus = "still_held"
-	EmailAccessStatusTeam           EmailAccessStatus = "team"
-	EmailAccessStatusWithheld       EmailAccessStatus = "withheld"
+	EmailAccessStatusParticipants EmailAccessStatus = "participants"
+	EmailAccessStatusSelected     EmailAccessStatus = "selected"
+	EmailAccessStatusTeam         EmailAccessStatus = "team"
+	EmailAccessStatusWithheld     EmailAccessStatus = "withheld"
 )
 
 // Valid indicates whether the value is a known member of the EmailAccessStatus enum.
@@ -4967,13 +4964,7 @@ func (e EmailAccessStatus) Valid() bool {
 	switch e {
 	case EmailAccessStatusParticipants:
 		return true
-	case EmailAccessStatusPrivateByYou:
-		return true
-	case EmailAccessStatusPrivatePending:
-		return true
 	case EmailAccessStatusSelected:
-		return true
-	case EmailAccessStatusStillHeld:
 		return true
 	case EmailAccessStatusTeam:
 		return true
@@ -4986,19 +4977,13 @@ func (e EmailAccessStatus) Valid() bool {
 
 // Defines values for EmailPresentationLifecycle.
 const (
-	EmailPresentationLifecycleApprovalDraft EmailPresentationLifecycle = "approval_draft"
-	EmailPresentationLifecycleDelivered     EmailPresentationLifecycle = "delivered"
-	EmailPresentationLifecycleScheduled     EmailPresentationLifecycle = "scheduled"
+	EmailPresentationLifecycleDelivered EmailPresentationLifecycle = "delivered"
 )
 
 // Valid indicates whether the value is a known member of the EmailPresentationLifecycle enum.
 func (e EmailPresentationLifecycle) Valid() bool {
 	switch e {
-	case EmailPresentationLifecycleApprovalDraft:
-		return true
 	case EmailPresentationLifecycleDelivered:
-		return true
-	case EmailPresentationLifecycleScheduled:
 		return true
 	default:
 		return false
@@ -20158,18 +20143,18 @@ type EmailAccess struct {
 	// badge can print. `team` never means the whole workspace: the linked record's own scope
 	// still decides who may discover the row at all.
 	//
-	// `still_held` is the honest half of a share — you released your hold and somebody else
-	// has not. `withheld` is the only value that says the content is not this caller's, and
-	// it never travels with a reason: why a message is private describes what it is about.
+	// `withheld` is the only value that says the content is not this caller's, and it never
+	// travels with a reason: why a message is private describes what it is about.
+	//
+	// The captured-mail states a mailbox owner sees — held until classified, private by you,
+	// shared but still held by another seat — are not here yet. They arrive with the thread
+	// contribution editor that can act on them; a value no server can emit is one a client
+	// would branch on and never reach.
 	DisplayStatus EmailAccessStatus `json:"display_status"`
 
 	// Explanation Why the message is limited, when the caller may know. Always null while the content
 	// is withheld: the reason describes the message.
 	Explanation *string `json:"explanation,omitempty"`
-
-	// HeldByOthers After a share, how many other seats still hold this thread. A count and never a
-	// name. Null when the question does not apply.
-	HeldByOthers *int `json:"held_by_others,omitempty"`
 
 	// SelectedMembers Who is named on a `selected` audience. Returned only to a caller who may both read
 	// the content and change it — a reader with no standing to edit the set has no
@@ -20193,9 +20178,13 @@ type EmailAccessContentState string
 // badge can print. `team` never means the whole workspace: the linked record's own scope
 // still decides who may discover the row at all.
 //
-// `still_held` is the honest half of a share — you released your hold and somebody else
-// has not. `withheld` is the only value that says the content is not this caller's, and
-// it never travels with a reason: why a message is private describes what it is about.
+// `withheld` is the only value that says the content is not this caller's, and it never
+// travels with a reason: why a message is private describes what it is about.
+//
+// The captured-mail states a mailbox owner sees — held until classified, private by you,
+// shared but still held by another seat — are not here yet. They arrive with the thread
+// contribution editor that can act on them; a value no server can emit is one a client
+// would branch on and never reach.
 type EmailAccessStatus string
 
 // EmailAttachmentSummary One file that came with the message. Metadata only; bytes are fetched separately.
@@ -20267,9 +20256,9 @@ type EmailPresentation struct {
 	From      []EmailParty       `json:"from"`
 	Id        openapi_types.UUID `json:"id"`
 
-	// Lifecycle Whether this is correspondence or something not yet sent. A scheduled send and a
-	// draft awaiting approval borrow the frame; their operational verbs stay with the
-	// workflow that owns them.
+	// Lifecycle What kind of message this is. One value today: this read serves delivered
+	// correspondence. A scheduled send and a draft awaiting approval will borrow the
+	// frame when the reads that serve them land, and they are not listed until then.
 	Lifecycle EmailPresentationLifecycle `json:"lifecycle"`
 
 	// Links What the message is filed against, named for a reader.
@@ -20297,9 +20286,9 @@ type EmailPresentation struct {
 	Version RowVersion `json:"version"`
 }
 
-// EmailPresentationLifecycle Whether this is correspondence or something not yet sent. A scheduled send and a
-// draft awaiting approval borrow the frame; their operational verbs stay with the
-// workflow that owns them.
+// EmailPresentationLifecycle What kind of message this is. One value today: this read serves delivered
+// correspondence. A scheduled send and a draft awaiting approval will borrow the
+// frame when the reads that serve them land, and they are not listed until then.
 type EmailPresentationLifecycle string
 
 // EmailSignature defines model for EmailSignature.
@@ -20335,9 +20324,13 @@ type EmailSummary struct {
 	// badge can print. `team` never means the whole workspace: the linked record's own scope
 	// still decides who may discover the row at all.
 	//
-	// `still_held` is the honest half of a share — you released your hold and somebody else
-	// has not. `withheld` is the only value that says the content is not this caller's, and
-	// it never travels with a reason: why a message is private describes what it is about.
+	// `withheld` is the only value that says the content is not this caller's, and it never
+	// travels with a reason: why a message is private describes what it is about.
+	//
+	// The captured-mail states a mailbox owner sees — held until classified, private by you,
+	// shared but still held by another seat — are not here yet. They arrive with the thread
+	// contribution editor that can act on them; a value no server can emit is one a client
+	// would branch on and never reach.
 	DisplayStatus EmailAccessStatus `json:"display_status"`
 
 	// Move Whose move it is, derived from what this reader can see of the thread. `none` when

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1507,6 +1507,24 @@ func (e AttentionSubjectType) Valid() bool {
 	}
 }
 
+// Defines values for AudienceMemberSubjectType.
+const (
+	AudienceMemberSubjectTypeTeam AudienceMemberSubjectType = "team"
+	AudienceMemberSubjectTypeUser AudienceMemberSubjectType = "user"
+)
+
+// Valid indicates whether the value is a known member of the AudienceMemberSubjectType enum.
+func (e AudienceMemberSubjectType) Valid() bool {
+	switch e {
+	case AudienceMemberSubjectTypeTeam:
+		return true
+	case AudienceMemberSubjectTypeUser:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AuditHistoryEntryActorType.
 const (
 	AuditHistoryEntryActorTypeAgent     AuditHistoryEntryActorType = "agent"
@@ -4867,6 +4885,159 @@ func (e DemoteLeadResponseUnwind) Valid() bool {
 	case DemoteUnwindMergeLineageOnly:
 		return true
 	case DemoteUnwindReversed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EmailAccessChangeMode.
+const (
+	EmailAccessChangeModeMessageAudience    EmailAccessChangeMode = "message_audience"
+	EmailAccessChangeModeNone               EmailAccessChangeMode = "none"
+	EmailAccessChangeModeThreadContribution EmailAccessChangeMode = "thread_contribution"
+)
+
+// Valid indicates whether the value is a known member of the EmailAccessChangeMode enum.
+func (e EmailAccessChangeMode) Valid() bool {
+	switch e {
+	case EmailAccessChangeModeMessageAudience:
+		return true
+	case EmailAccessChangeModeNone:
+		return true
+	case EmailAccessChangeModeThreadContribution:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EmailAccessChangeScope.
+const (
+	EmailAccessChangeScopeMessage EmailAccessChangeScope = "message"
+	EmailAccessChangeScopeNone    EmailAccessChangeScope = "none"
+	EmailAccessChangeScopeThread  EmailAccessChangeScope = "thread"
+)
+
+// Valid indicates whether the value is a known member of the EmailAccessChangeScope enum.
+func (e EmailAccessChangeScope) Valid() bool {
+	switch e {
+	case EmailAccessChangeScopeMessage:
+		return true
+	case EmailAccessChangeScopeNone:
+		return true
+	case EmailAccessChangeScopeThread:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EmailAccessContentState.
+const (
+	EmailAccessContentStateAvailable EmailAccessContentState = "available"
+	EmailAccessContentStateWithheld  EmailAccessContentState = "withheld"
+)
+
+// Valid indicates whether the value is a known member of the EmailAccessContentState enum.
+func (e EmailAccessContentState) Valid() bool {
+	switch e {
+	case EmailAccessContentStateAvailable:
+		return true
+	case EmailAccessContentStateWithheld:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EmailAccessStatus.
+const (
+	EmailAccessStatusParticipants   EmailAccessStatus = "participants"
+	EmailAccessStatusPrivateByYou   EmailAccessStatus = "private_by_you"
+	EmailAccessStatusPrivatePending EmailAccessStatus = "private_pending"
+	EmailAccessStatusSelected       EmailAccessStatus = "selected"
+	EmailAccessStatusStillHeld      EmailAccessStatus = "still_held"
+	EmailAccessStatusTeam           EmailAccessStatus = "team"
+	EmailAccessStatusWithheld       EmailAccessStatus = "withheld"
+)
+
+// Valid indicates whether the value is a known member of the EmailAccessStatus enum.
+func (e EmailAccessStatus) Valid() bool {
+	switch e {
+	case EmailAccessStatusParticipants:
+		return true
+	case EmailAccessStatusPrivateByYou:
+		return true
+	case EmailAccessStatusPrivatePending:
+		return true
+	case EmailAccessStatusSelected:
+		return true
+	case EmailAccessStatusStillHeld:
+		return true
+	case EmailAccessStatusTeam:
+		return true
+	case EmailAccessStatusWithheld:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EmailPresentationLifecycle.
+const (
+	EmailPresentationLifecycleApprovalDraft EmailPresentationLifecycle = "approval_draft"
+	EmailPresentationLifecycleDelivered     EmailPresentationLifecycle = "delivered"
+	EmailPresentationLifecycleScheduled     EmailPresentationLifecycle = "scheduled"
+)
+
+// Valid indicates whether the value is a known member of the EmailPresentationLifecycle enum.
+func (e EmailPresentationLifecycle) Valid() bool {
+	switch e {
+	case EmailPresentationLifecycleApprovalDraft:
+		return true
+	case EmailPresentationLifecycleDelivered:
+		return true
+	case EmailPresentationLifecycleScheduled:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EmailSummaryDirection.
+const (
+	EmailSummaryDirectionInbound  EmailSummaryDirection = "inbound"
+	EmailSummaryDirectionOutbound EmailSummaryDirection = "outbound"
+)
+
+// Valid indicates whether the value is a known member of the EmailSummaryDirection enum.
+func (e EmailSummaryDirection) Valid() bool {
+	switch e {
+	case EmailSummaryDirectionInbound:
+		return true
+	case EmailSummaryDirectionOutbound:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EmailSummaryMove.
+const (
+	EmailSummaryMoveNeedsReply     EmailSummaryMove = "needs_reply"
+	EmailSummaryMoveNone           EmailSummaryMove = "none"
+	EmailSummaryMoveWaitingForThem EmailSummaryMove = "waiting_for_them"
+)
+
+// Valid indicates whether the value is a known member of the EmailSummaryMove enum.
+func (e EmailSummaryMove) Valid() bool {
+	switch e {
+	case EmailSummaryMoveNeedsReply:
+		return true
+	case EmailSummaryMoveNone:
+		return true
+	case EmailSummaryMoveWaitingForThem:
 		return true
 	default:
 		return false
@@ -9811,24 +9982,6 @@ func (e SearchResultType) Valid() bool {
 	}
 }
 
-// Defines values for SetActivityAudienceRequestMembersSubjectType.
-const (
-	SetActivityAudienceRequestMembersSubjectTypeTeam SetActivityAudienceRequestMembersSubjectType = "team"
-	SetActivityAudienceRequestMembersSubjectTypeUser SetActivityAudienceRequestMembersSubjectType = "user"
-)
-
-// Valid indicates whether the value is a known member of the SetActivityAudienceRequestMembersSubjectType enum.
-func (e SetActivityAudienceRequestMembersSubjectType) Valid() bool {
-	switch e {
-	case SetActivityAudienceRequestMembersSubjectTypeTeam:
-		return true
-	case SetActivityAudienceRequestMembersSubjectTypeUser:
-		return true
-	default:
-		return false
-	}
-}
-
 // Defines values for SetActivityDispositionRequestDisposition.
 const (
 	SetActivityDispositionRequestDispositionNotMine  SetActivityDispositionRequestDisposition = "not_mine"
@@ -13089,25 +13242,25 @@ func (e StartOidcSignInParamsProvider) Valid() bool {
 
 // Defines values for ListAutomationRunsParamsOutcome.
 const (
-	ListAutomationRunsParamsOutcomeBlocked           ListAutomationRunsParamsOutcome = "blocked"
-	ListAutomationRunsParamsOutcomeFailed            ListAutomationRunsParamsOutcome = "failed"
-	ListAutomationRunsParamsOutcomeFired             ListAutomationRunsParamsOutcome = "fired"
-	ListAutomationRunsParamsOutcomeQueuedForApproval ListAutomationRunsParamsOutcome = "queued_for_approval"
-	ListAutomationRunsParamsOutcomeSkipped           ListAutomationRunsParamsOutcome = "skipped"
+	Blocked           ListAutomationRunsParamsOutcome = "blocked"
+	Failed            ListAutomationRunsParamsOutcome = "failed"
+	Fired             ListAutomationRunsParamsOutcome = "fired"
+	QueuedForApproval ListAutomationRunsParamsOutcome = "queued_for_approval"
+	Skipped           ListAutomationRunsParamsOutcome = "skipped"
 )
 
 // Valid indicates whether the value is a known member of the ListAutomationRunsParamsOutcome enum.
 func (e ListAutomationRunsParamsOutcome) Valid() bool {
 	switch e {
-	case ListAutomationRunsParamsOutcomeBlocked:
+	case Blocked:
 		return true
-	case ListAutomationRunsParamsOutcomeFailed:
+	case Failed:
 		return true
-	case ListAutomationRunsParamsOutcomeFired:
+	case Fired:
 		return true
-	case ListAutomationRunsParamsOutcomeQueuedForApproval:
+	case QueuedForApproval:
 		return true
-	case ListAutomationRunsParamsOutcomeSkipped:
+	case Skipped:
 		return true
 	default:
 		return false
@@ -13803,22 +13956,22 @@ func (e ListOrganizationDocumentsParamsCategory) Valid() bool {
 
 // Defines values for ListOrganizationDocumentsParamsDocState.
 const (
-	Current    ListOrganizationDocumentsParamsDocState = "current"
-	Draft      ListOrganizationDocumentsParamsDocState = "draft"
-	Final      ListOrganizationDocumentsParamsDocState = "final"
-	Superseded ListOrganizationDocumentsParamsDocState = "superseded"
+	ListOrganizationDocumentsParamsDocStateCurrent    ListOrganizationDocumentsParamsDocState = "current"
+	ListOrganizationDocumentsParamsDocStateDraft      ListOrganizationDocumentsParamsDocState = "draft"
+	ListOrganizationDocumentsParamsDocStateFinal      ListOrganizationDocumentsParamsDocState = "final"
+	ListOrganizationDocumentsParamsDocStateSuperseded ListOrganizationDocumentsParamsDocState = "superseded"
 )
 
 // Valid indicates whether the value is a known member of the ListOrganizationDocumentsParamsDocState enum.
 func (e ListOrganizationDocumentsParamsDocState) Valid() bool {
 	switch e {
-	case Current:
+	case ListOrganizationDocumentsParamsDocStateCurrent:
 		return true
-	case Draft:
+	case ListOrganizationDocumentsParamsDocStateDraft:
 		return true
-	case Final:
+	case ListOrganizationDocumentsParamsDocStateFinal:
 		return true
-	case Superseded:
+	case ListOrganizationDocumentsParamsDocStateSuperseded:
 		return true
 	default:
 		return false
@@ -14594,6 +14747,9 @@ type Activity struct {
 
 	// DurationSeconds Meeting/call only.
 	DurationSeconds *int `json:"duration_seconds,omitempty"`
+
+	// EmailSummary Present exactly when `kind=email`. What the canonical email row renders, so a list does not have to fetch a message per visible line to draw one. Every other kind carries none, and a reader branches on its presence rather than on the kind word.
+	EmailSummary *EmailSummary `json:"email_summary,omitempty"`
 
 	// HostUserId Meeting only: the member of this organization who held it. It is the one place an activity names OUR side of an exchange — a mail says only which contact it was with, and the mailbox behind it is not on the row. Null on every other kind, and on a meeting nobody was recorded as hosting.
 	HostUserId *openapi_types.UUID `json:"host_user_id,omitempty"`
@@ -16117,6 +16273,17 @@ type AttentionSubject struct {
 
 // AttentionSubjectType defines model for AttentionSubject.Type.
 type AttentionSubjectType string
+
+// AudienceMember One user or team admitted to a message besides its participants. The same shape the
+// audience write takes and the presentation reads back, so an editor that renders the
+// current set submits it in the vocabulary it received.
+type AudienceMember struct {
+	SubjectId   openapi_types.UUID        `json:"subject_id"`
+	SubjectType AudienceMemberSubjectType `json:"subject_type"`
+}
+
+// AudienceMemberSubjectType defines model for AudienceMember.SubjectType.
+type AudienceMemberSubjectType string
 
 // AuditHistoryEntry One rendered history line for a record mutation. `before`/`after` are
 // masked to the viewer's readable fields — an absent key was hidden, not null.
@@ -19970,6 +20137,75 @@ type DisqualifyLeadRequest struct {
 	ReasonId *openapi_types.UUID `json:"reason_id,omitempty"`
 }
 
+// EmailAccess Who reads this message, and what this caller may do about that. `can_change` and
+// `change_mode` are decided by the same authority that would execute the write, so a
+// control this block offers is a control the write will accept.
+type EmailAccess struct {
+	Audience  *ActivityAudience `json:"audience,omitempty"`
+	CanChange bool              `json:"can_change"`
+
+	// ChangeMode Which write this caller's Access control performs. `thread_contribution` changes
+	// only this owner's contribution to a captured thread; `message_audience` sets a
+	// hand-logged message's own audience. The browser never decides this by reading
+	// `captured_by` — the server knows which write it would accept.
+	ChangeMode EmailAccessChangeMode `json:"change_mode"`
+
+	// ChangeScope What the editor must say it is about to change, in the words the user reads.
+	ChangeScope  *EmailAccessChangeScope `json:"change_scope,omitempty"`
+	ContentState EmailAccessContentState `json:"content_state"`
+
+	// DisplayStatus What a reader is allowed to know about who else reads this message, in one word the
+	// badge can print. `team` never means the whole workspace: the linked record's own scope
+	// still decides who may discover the row at all.
+	//
+	// `still_held` is the honest half of a share — you released your hold and somebody else
+	// has not. `withheld` is the only value that says the content is not this caller's, and
+	// it never travels with a reason: why a message is private describes what it is about.
+	DisplayStatus EmailAccessStatus `json:"display_status"`
+
+	// Explanation Why the message is limited, when the caller may know. Always null while the content
+	// is withheld: the reason describes the message.
+	Explanation *string `json:"explanation,omitempty"`
+
+	// HeldByOthers After a share, how many other seats still hold this thread. A count and never a
+	// name. Null when the question does not apply.
+	HeldByOthers *int `json:"held_by_others,omitempty"`
+
+	// SelectedMembers Who is named on a `selected` audience. Returned only to a caller who may both read
+	// the content and change it — a reader with no standing to edit the set has no
+	// standing to enumerate it either.
+	SelectedMembers *[]AudienceMember `json:"selected_members,omitempty"`
+}
+
+// EmailAccessChangeMode Which write this caller's Access control performs. `thread_contribution` changes
+// only this owner's contribution to a captured thread; `message_audience` sets a
+// hand-logged message's own audience. The browser never decides this by reading
+// `captured_by` — the server knows which write it would accept.
+type EmailAccessChangeMode string
+
+// EmailAccessChangeScope What the editor must say it is about to change, in the words the user reads.
+type EmailAccessChangeScope string
+
+// EmailAccessContentState defines model for EmailAccess.ContentState.
+type EmailAccessContentState string
+
+// EmailAccessStatus What a reader is allowed to know about who else reads this message, in one word the
+// badge can print. `team` never means the whole workspace: the linked record's own scope
+// still decides who may discover the row at all.
+//
+// `still_held` is the honest half of a share — you released your hold and somebody else
+// has not. `withheld` is the only value that says the content is not this caller's, and
+// it never travels with a reason: why a message is private describes what it is about.
+type EmailAccessStatus string
+
+// EmailAttachmentSummary One file that came with the message. Metadata only; bytes are fetched separately.
+type EmailAttachmentSummary struct {
+	ByteSize    *int               `json:"byte_size,omitempty"`
+	ContentType *string            `json:"content_type,omitempty"`
+	Filename    string             `json:"filename"`
+	Id          openapi_types.UUID `json:"id"`
+}
+
 // EmailDraft A drafted email (never sent by drafting). Send via /activities/{id}/send-email (🟡).
 type EmailDraft struct {
 	// AiDisclosure The machine-readable Art. 50 disclosure line; non-null iff ai_generated=true.
@@ -19989,6 +20225,83 @@ type EmailDraft struct {
 	VoiceProfileVersion *int `json:"voice_profile_version,omitempty"`
 }
 
+// EmailParty One address on a message, resolved to a person or a seat when it is one.
+type EmailParty struct {
+	Address     string  `json:"address"`
+	DisplayName *string `json:"display_name,omitempty"`
+
+	// PersonId Set when the address belongs to a contact this caller may see.
+	PersonId *openapi_types.UUID `json:"person_id,omitempty"`
+
+	// UserId Set when the address belongs to a seat in this workspace.
+	UserId *openapi_types.UUID `json:"user_id,omitempty"`
+}
+
+// EmailPresentation One email, composed for reading. The message and its parties come from the activity's
+// own store; the access block is assembled from the same authority that performs the
+// write, so what this says a caller may do is what the caller may do.
+//
+// A withheld presentation carries the markers and refuses the rest: no subject, no body,
+// no parties, no attachments, no thread, no reason, no member names.
+type EmailPresentation struct {
+	// Access Who reads this message, and what this caller may do about that. `can_change` and
+	// `change_mode` are decided by the same authority that would execute the write, so a
+	// control this block offers is a control the write will accept.
+	Access      EmailAccess              `json:"access"`
+	Attachments []EmailAttachmentSummary `json:"attachments"`
+
+	// Bcc Empty for every caller but the seat that sent or imported the message. Being
+	// allowed to read what was written does not disclose who was copied blind.
+	Bcc []EmailParty `json:"bcc"`
+
+	// BccWithheld True when the message has blind recipients this caller may not see. The viewer says
+	// that they exist rather than showing an empty list that reads as none.
+	BccWithheld bool `json:"bcc_withheld"`
+
+	// Body The message as plain text, normalised. Null when withheld. Provider payloads are
+	// never handed to a browser to parse.
+	Body      *string            `json:"body,omitempty"`
+	CanRelink bool               `json:"can_relink"`
+	CanReply  bool               `json:"can_reply"`
+	Cc        []EmailParty       `json:"cc"`
+	From      []EmailParty       `json:"from"`
+	Id        openapi_types.UUID `json:"id"`
+
+	// Lifecycle Whether this is correspondence or something not yet sent. A scheduled send and a
+	// draft awaiting approval borrow the frame; their operational verbs stay with the
+	// workflow that owns them.
+	Lifecycle EmailPresentationLifecycle `json:"lifecycle"`
+
+	// Links What the message is filed against, named for a reader.
+	Links      []ActivityLink `json:"links"`
+	OccurredAt time.Time      `json:"occurred_at"`
+
+	// Summary One retained email, reduced to what a row shows without opening it. Present on an
+	// activity only when `kind=email`; every other kind carries none, and a reader that
+	// branches on this field is asking the one question that decides the canonical row.
+	//
+	// The preview is normalised by the server with the same splitter the detail uses, so a
+	// row and the message it opens never disagree about where the sender's own words end.
+	// A withheld email carries a summary whose `subject` and `preview` are null and whose
+	// `display_status` says so — the row stays, the words do not.
+	Summary EmailSummary `json:"summary"`
+
+	// Thread The rest of the conversation, newest first, as summaries. Bounded and paged rather
+	// than whole: a thread has no ceiling, and a drawer that fetched every message would
+	// make opening the newest one cost the whole history.
+	Thread    *EmailThreadPage `json:"thread,omitempty"`
+	ThreadKey *string          `json:"thread_key,omitempty"`
+	To        []EmailParty     `json:"to"`
+
+	// Version The activity's version, for the If-Match its own actions send.
+	Version RowVersion `json:"version"`
+}
+
+// EmailPresentationLifecycle Whether this is correspondence or something not yet sent. A scheduled send and a
+// draft awaiting approval borrow the frame; their operational verbs stay with the
+// workflow that owns them.
+type EmailPresentationLifecycle string
+
 // EmailSignature defines model for EmailSignature.
 type EmailSignature struct {
 	// Body The sign-off appended below every message this member sends, plain text.
@@ -19996,6 +20309,69 @@ type EmailSignature struct {
 	// written one.
 	Body      string     `json:"body"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+// EmailSummary One retained email, reduced to what a row shows without opening it. Present on an
+// activity only when `kind=email`; every other kind carries none, and a reader that
+// branches on this field is asking the one question that decides the canonical row.
+//
+// The preview is normalised by the server with the same splitter the detail uses, so a
+// row and the message it opens never disagree about where the sender's own words end.
+// A withheld email carries a summary whose `subject` and `preview` are null and whose
+// `display_status` says so — the row stays, the words do not.
+type EmailSummary struct {
+	ActivityId openapi_types.UUID `json:"activity_id"`
+
+	// AttachmentCount How many files came with it. Zero when withheld, like every other count.
+	AttachmentCount int `json:"attachment_count"`
+
+	// Counterparty Who the message was with, named for the row: "Ana Sommer", or "Ana Sommer +2" when
+	// the exchange had more. Null when no participant resolves to a name this caller may
+	// see — the row then says the direction alone rather than inventing a stranger.
+	Counterparty *string                `json:"counterparty,omitempty"`
+	Direction    *EmailSummaryDirection `json:"direction,omitempty"`
+
+	// DisplayStatus What a reader is allowed to know about who else reads this message, in one word the
+	// badge can print. `team` never means the whole workspace: the linked record's own scope
+	// still decides who may discover the row at all.
+	//
+	// `still_held` is the honest half of a share — you released your hold and somebody else
+	// has not. `withheld` is the only value that says the content is not this caller's, and
+	// it never travels with a reason: why a message is private describes what it is about.
+	DisplayStatus EmailAccessStatus `json:"display_status"`
+
+	// Move Whose move it is, derived from what this reader can see of the thread. `none` when
+	// the question cannot be answered honestly — an unanswerable move is not a claim.
+	Move       EmailSummaryMove `json:"move"`
+	OccurredAt time.Time        `json:"occurred_at"`
+
+	// Preview One line of the sender's own text, signature and quoted history already removed.
+	// Null when withheld, and when the message has no text of its own.
+	Preview *string `json:"preview,omitempty"`
+
+	// Subject Null when the message has none, and when the content is withheld.
+	Subject *string `json:"subject,omitempty"`
+
+	// Version The activity's version, carried so a row can open an editor that writes with
+	// If-Match. A row without it can only read.
+	Version RowVersion `json:"version"`
+}
+
+// EmailSummaryDirection defines model for EmailSummary.Direction.
+type EmailSummaryDirection string
+
+// EmailSummaryMove Whose move it is, derived from what this reader can see of the thread. `none` when
+// the question cannot be answered honestly — an unanswerable move is not a claim.
+type EmailSummaryMove string
+
+// EmailThreadPage The rest of the conversation, newest first, as summaries. Bounded and paged rather
+// than whole: a thread has no ceiling, and a drawer that fetched every message would
+// make opening the newest one cost the whole history.
+type EmailThreadPage struct {
+	Members []EmailSummary `json:"members"`
+
+	// NextCursor Pass back as `thread_cursor` for the next page. Null when this is the last.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // EmbedReindexPreview The scope before the spend (ADR-0020 preview-before-spend obligation): what running the reindex now would touch and roughly cost. MUST precede the confirm route — the estimate is what the operator consents to. An estimate, labeled as such — actual spend is metered per embed call.
@@ -28002,14 +28378,8 @@ type SetActivityAudienceRequest struct {
 	Audience ActivityAudience `json:"audience"`
 
 	// Members The users and teams admitted besides the participants. Read only when `audience` is `selected`; replaces the previous set.
-	Members *[]struct {
-		SubjectId   openapi_types.UUID                           `json:"subject_id"`
-		SubjectType SetActivityAudienceRequestMembersSubjectType `json:"subject_type"`
-	} `json:"members,omitempty"`
+	Members *[]AudienceMember `json:"members,omitempty"`
 }
-
-// SetActivityAudienceRequestMembersSubjectType defines model for SetActivityAudienceRequest.Members.SubjectType.
-type SetActivityAudienceRequestMembersSubjectType string
 
 // SetActivityDispositionRequest defines model for SetActivityDispositionRequest.
 type SetActivityDispositionRequest struct {
@@ -31017,6 +31387,12 @@ type ClearActivityDispositionParamsScope string
 type DraftEmailJSONBody struct {
 	// Intent Optional steering, e.g. "polite follow-up referencing Friday".
 	Intent *string `json:"intent,omitempty"`
+}
+
+// GetEmailPresentationParams defines parameters for GetEmailPresentation.
+type GetEmailPresentationParams struct {
+	// ThreadCursor Continue the thread's member page from a previous response's `thread.next_cursor`.
+	ThreadCursor *string `form:"thread_cursor,omitempty" json:"thread_cursor,omitempty"`
 }
 
 // GetMeetingBriefParams defines parameters for GetMeetingBrief.
@@ -43751,6 +44127,9 @@ type ServerInterface interface {
 	// Draft a reply/follow-up email for context (the `draft_email` MCP verb).
 	// (POST /activities/{id}/draft-email)
 	DraftEmail(w http.ResponseWriter, r *http.Request, id Id)
+	// Everything one email needs to be read and acted on, in one read.
+	// (GET /activities/{id}/email-presentation)
+	GetEmailPresentation(w http.ResponseWriter, r *http.Request, id Id, params GetEmailPresentationParams)
 	// The pre-meeting brief for one booked meeting — goal, commitments, where the deal stands.
 	// (GET /activities/{id}/meeting-brief)
 	GetMeetingBrief(w http.ResponseWriter, r *http.Request, id Id, params GetMeetingBriefParams)
@@ -45458,6 +45837,12 @@ func (_ Unimplemented) SetActivityDisposition(w http.ResponseWriter, r *http.Req
 // Draft a reply/follow-up email for context (the `draft_email` MCP verb).
 // (POST /activities/{id}/draft-email)
 func (_ Unimplemented) DraftEmail(w http.ResponseWriter, r *http.Request, id Id) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Everything one email needs to be read and acted on, in one read.
+// (GET /activities/{id}/email-presentation)
+func (_ Unimplemented) GetEmailPresentation(w http.ResponseWriter, r *http.Request, id Id, params GetEmailPresentationParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -49466,6 +49851,56 @@ func (siw *ServerInterfaceWrapper) DraftEmail(w http.ResponseWriter, r *http.Req
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.DraftEmail(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetEmailPresentation operation middleware
+func (siw *ServerInterfaceWrapper) GetEmailPresentation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetEmailPresentationParams
+
+	// ------------- Optional query parameter "thread_cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "thread_cursor", r.URL.Query(), &params.ThreadCursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "thread_cursor"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "thread_cursor", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetEmailPresentation(w, r, id, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -72968,6 +73403,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/activities/{id}/draft-email", wrapper.DraftEmail)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/activities/{id}/email-presentation", wrapper.GetEmailPresentation)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/activities/{id}/meeting-brief", wrapper.GetMeetingBrief)

--- a/backend/internal/modules/activities/activityprojection.go
+++ b/backend/internal/modules/activities/activityprojection.go
@@ -166,5 +166,53 @@ func (s *activityScan) record() crmcontracts.Activity {
 	a.BulkMailAttested = &bulk
 	version := s.version
 	a.Version = &version
+	// What a canonical email row draws, composed here so every reader of an
+	// activity carries it: a list that had to fetch a message per visible line
+	// to draw one would be the N+1 this field exists to avoid. Attached from
+	// the row's own columns only — the counterparty and the attachment count
+	// need joins this scan does not have, and the detail read fills them in.
+	a.EmailSummary = rowEmailSummary(a)
 	return a
+}
+
+// rowEmailSummary is the email row's fields, for the kind that has them.
+//
+// Present exactly when kind=email, so a reader branches on the field rather
+// than on the kind word: a call and a note are activities too, and neither has
+// an email's shape. A withheld row still gets a summary — the status says the
+// content is not this caller's, which is what keeps a withheld row visibly
+// withheld rather than absent.
+func rowEmailSummary(a crmcontracts.Activity) *crmcontracts.EmailSummary {
+	if a.Kind != crmcontracts.ActivityKindEmail {
+		return nil
+	}
+	withheld := a.ContentState != nil && *a.ContentState == crmcontracts.ActivityContentStateWithheld
+	summary := crmcontracts.EmailSummary{
+		ActivityId:    a.Id,
+		OccurredAt:    a.OccurredAt,
+		DisplayStatus: crmcontracts.EmailAccessStatusWithheld,
+		Move:          crmcontracts.EmailSummaryMoveNone,
+	}
+	if a.Version != nil {
+		summary.Version = *a.Version
+	}
+	if a.Direction != nil {
+		d := crmcontracts.EmailSummaryDirection(*a.Direction)
+		summary.Direction = &d
+	}
+	if withheld {
+		return &summary
+	}
+	summary.DisplayStatus = crmcontracts.EmailAccessStatusTeam
+	if a.Audience != nil {
+		summary.DisplayStatus = statusForAudience(*a.Audience)
+	}
+	summary.Subject = a.Subject
+	if a.Body != nil {
+		if preview := EmailSummaryText(*a.Body); preview != "" {
+			summary.Preview = &preview
+		}
+	}
+	summary.Move = moveOf(a)
+	return &summary
 }

--- a/backend/internal/modules/activities/activityprojection.go
+++ b/backend/internal/modules/activities/activityprojection.go
@@ -171,18 +171,24 @@ func (s *activityScan) record() crmcontracts.Activity {
 	// to draw one would be the N+1 this field exists to avoid. Attached from
 	// the row's own columns only — the counterparty and the attachment count
 	// need joins this scan does not have, and the detail read fills them in.
-	a.EmailSummary = rowEmailSummary(a)
+	a.EmailSummary = RowEmailSummary(a)
 	return a
 }
 
-// rowEmailSummary is the email row's fields, for the kind that has them.
+// RowEmailSummary is the email row's fields, for the kind that has them.
+//
+// Exported because compose/person360 assembles its own Activity from a
+// hand-written twin of this projection and cannot reach record(). That twin is
+// why this is exported rather than private: it has gone missing a column twice
+// before, and a summary it did not carry would make the contract's "present
+// exactly when kind=email" false on the person page alone.
 //
 // Present exactly when kind=email, so a reader branches on the field rather
 // than on the kind word: a call and a note are activities too, and neither has
 // an email's shape. A withheld row still gets a summary — the status says the
 // content is not this caller's, which is what keeps a withheld row visibly
 // withheld rather than absent.
-func rowEmailSummary(a crmcontracts.Activity) *crmcontracts.EmailSummary {
+func RowEmailSummary(a crmcontracts.Activity) *crmcontracts.EmailSummary {
 	if a.Kind != crmcontracts.ActivityKindEmail {
 		return nil
 	}

--- a/backend/internal/modules/activities/audience.go
+++ b/backend/internal/modules/activities/audience.go
@@ -335,18 +335,33 @@ func (e *InvalidAudienceError) FieldFault() (field, code, message string) {
 	return "audience", "invalid_audience", e.Error()
 }
 
-// refuseCapturedAudienceWrite stops a direct audience write on a message a
-// mailbox brought in.
+// activityWasImported answers whether a mailbox brought this message in.
 //
 // The test is whether any seat has an import row: that is what makes the
 // audience derived rather than declared. A row with none was hand-logged, and
 // its audience is exactly what somebody set.
-func refuseCapturedAudienceWrite(ctx context.Context, tx pgx.Tx, id ids.ActivityID) error {
+//
+// One definition, because two callers act on it and they must not disagree:
+// refuseCapturedAudienceWrite turns it into the write's refusal, and
+// readEmailAccess turns it into the change_mode the viewer offers. A read that
+// asked the question its own way would offer a control the write then refuses,
+// and the difference would show up as a dialog that does nothing.
+func activityWasImported(ctx context.Context, tx pgx.Tx, id ids.ActivityID) (bool, error) {
 	var imported bool
 	if err := tx.QueryRow(ctx, `
 		SELECT EXISTS (SELECT 1 FROM capture_import WHERE activity_id = $1)`,
 		id.UUID).Scan(&imported); err != nil {
-		return fmt.Errorf("activities: reading whether a message was imported: %w", err)
+		return false, fmt.Errorf("activities: reading whether a message was imported: %w", err)
+	}
+	return imported, nil
+}
+
+// refuseCapturedAudienceWrite stops a direct audience write on a message a
+// mailbox brought in.
+func refuseCapturedAudienceWrite(ctx context.Context, tx pgx.Tx, id ids.ActivityID) error {
+	imported, err := activityWasImported(ctx, tx, id)
+	if err != nil {
+		return err
 	}
 	if imported {
 		return &CapturedAudienceError{}

--- a/backend/internal/modules/activities/emailaccess.go
+++ b/backend/internal/modules/activities/emailaccess.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// Who reads one email, and what this caller may do about that.
+//
+// Kept beside the presentation rather than in it because the question is
+// about the message rather than in it, and because the answer has to agree
+// with the write: the mode this reports is decided by the same test
+// refuseCapturedAudienceWrite applies.
+
+// readEmailAccess assembles who reads this message and what this caller may do
+// about it.
+//
+// change_mode is decided here, by the same test the write itself applies:
+// refuseCapturedAudienceWrite refuses a direct audience write on a message any
+// mailbox brought in, because a captured message's audience is derived from
+// its importers rather than declared. The browser has been guessing this from
+// the "connector:" prefix on captured_by, which puts a backend ownership rule
+// in display code and gets a hand-typed threaded reply wrong. The server knows
+// which write it would accept, so the server says.
+func readEmailAccess(
+	ctx context.Context,
+	tx pgx.Tx,
+	id ids.ActivityID,
+	activity crmcontracts.Activity,
+) (crmcontracts.EmailAccess, error) {
+	out := crmcontracts.EmailAccess{
+		ContentState:  crmcontracts.EmailAccessContentStateAvailable,
+		ChangeMode:    crmcontracts.EmailAccessChangeModeNone,
+		ChangeScope:   ptr(crmcontracts.EmailAccessChangeScopeNone),
+		DisplayStatus: crmcontracts.EmailAccessStatusTeam,
+	}
+	if activity.Audience != nil {
+		aud := crmcontracts.ActivityAudience(*activity.Audience)
+		out.Audience = &aud
+		out.DisplayStatus = statusForAudience(aud)
+	}
+	// The reason is content: it describes what the message is about. It travels
+	// only with a message the caller may read, which is the branch this is in.
+	out.Explanation = activity.AudienceReason
+
+	var imported bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM capture_import WHERE activity_id = $1)`,
+		id.UUID).Scan(&imported); err != nil {
+		return crmcontracts.EmailAccess{}, fmt.Errorf("activities: reading whether a message was imported: %w", err)
+	}
+
+	writable := auth.EnsureActivityWritable(ctx, tx, id.UUID) == nil
+	switch {
+	case imported:
+		// A captured message: the caller changes their own contribution to the
+		// thread, and only their own. Every importing seat holds one, so this
+		// is offered to an importer rather than to a writer of the row.
+		sender, err := callerIsSenderSeat(ctx, tx, id)
+		if err != nil {
+			return crmcontracts.EmailAccess{}, err
+		}
+		out.CanChange = sender
+		if sender {
+			out.ChangeMode = crmcontracts.EmailAccessChangeModeThreadContribution
+			out.ChangeScope = ptr(crmcontracts.EmailAccessChangeScopeThread)
+		}
+	case writable:
+		// Hand-logged: its audience is exactly what somebody set, so a writer
+		// of the row sets it.
+		out.CanChange = true
+		out.ChangeMode = crmcontracts.EmailAccessChangeModeMessageAudience
+		out.ChangeScope = ptr(crmcontracts.EmailAccessChangeScopeMessage)
+	}
+
+	// Who is named on a selected audience, read back only for the caller who
+	// may change the set. A reader with no standing to edit it has none to
+	// enumerate it either.
+	if out.CanChange && activity.Audience != nil && *activity.Audience == crmcontracts.ActivityAudienceSelected {
+		members, err := readSelectedMembers(ctx, tx, id)
+		if err != nil {
+			return crmcontracts.EmailAccess{}, err
+		}
+		out.SelectedMembers = &members
+	}
+	return out, nil
+}
+
+// statusForAudience is the word the badge prints for a message the caller can
+// read. "team" never means the whole workspace: the linked record's own scope
+// still decides who may discover the row at all.
+func statusForAudience(aud crmcontracts.ActivityAudience) crmcontracts.EmailAccessStatus {
+	switch aud {
+	case crmcontracts.ActivityAudienceParticipants:
+		return crmcontracts.EmailAccessStatusParticipants
+	case crmcontracts.ActivityAudienceSelected:
+		return crmcontracts.EmailAccessStatusSelected
+	default:
+		return crmcontracts.EmailAccessStatusTeam
+	}
+}
+
+func readSelectedMembers(ctx context.Context, tx pgx.Tx, id ids.ActivityID) ([]crmcontracts.AudienceMember, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT subject_type, subject_id
+		  FROM activity_audience_member
+		 WHERE activity_id = $1
+		 ORDER BY subject_type, subject_id`, id.UUID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []crmcontracts.AudienceMember{}
+	for rows.Next() {
+		var subjectType string
+		var subjectID ids.UUID
+		if err := rows.Scan(&subjectType, &subjectID); err != nil {
+			return nil, err
+		}
+		out = append(out, crmcontracts.AudienceMember{
+			SubjectType: crmcontracts.AudienceMemberSubjectType(subjectType),
+			SubjectId:   openapi_types.UUID(subjectID),
+		})
+	}
+	return out, rows.Err()
+}

--- a/backend/internal/modules/activities/emailaccess.go
+++ b/backend/internal/modules/activities/emailaccess.go
@@ -5,13 +5,14 @@ package activities
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/jackc/pgx/v5"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -25,8 +26,9 @@ import (
 // readEmailAccess assembles who reads this message and what this caller may do
 // about it.
 //
-// change_mode is decided here, by the same test the write itself applies:
-// refuseCapturedAudienceWrite refuses a direct audience write on a message any
+// change_mode is decided by activityWasImported — the same helper the write
+// calls, not a second copy of its question. refuseCapturedAudienceWrite
+// refuses a direct audience write on a message any
 // mailbox brought in, because a captured message's audience is derived from
 // its importers rather than declared. The browser has been guessing this from
 // the "connector:" prefix on captured_by, which puts a backend ownership rule
@@ -53,14 +55,25 @@ func readEmailAccess(
 	// only with a message the caller may read, which is the branch this is in.
 	out.Explanation = activity.AudienceReason
 
-	var imported bool
-	if err := tx.QueryRow(ctx, `
-		SELECT EXISTS (SELECT 1 FROM capture_import WHERE activity_id = $1)`,
-		id.UUID).Scan(&imported); err != nil {
-		return crmcontracts.EmailAccess{}, fmt.Errorf("activities: reading whether a message was imported: %w", err)
+	imported, err := activityWasImported(ctx, tx, id)
+	if err != nil {
+		return crmcontracts.EmailAccess{}, err
 	}
 
-	writable := auth.EnsureActivityWritable(ctx, tx, id.UUID) == nil
+	// Denial and failure are different answers and must not collapse into one.
+	// A == nil test would report can_change:false on a transient database
+	// error, which reaches the reader as the Access control quietly not being
+	// there — indistinguishable from the product deciding they lack authority.
+	writable := false
+	switch err := auth.EnsureActivityWritable(ctx, tx, id.UUID); {
+	case err == nil:
+		writable = true
+	case errors.Is(err, apperrors.ErrNotFound), errors.Is(err, apperrors.ErrPermissionDenied):
+		// Denied. Not an error to report: the caller may read this message and
+		// simply may not change who else does.
+	default:
+		return crmcontracts.EmailAccess{}, err
+	}
 	switch {
 	case imported:
 		// A captured message: the caller changes their own contribution to the

--- a/backend/internal/modules/activities/emailpresentation.go
+++ b/backend/internal/modules/activities/emailpresentation.go
@@ -93,13 +93,7 @@ func readEmailPresentation(ctx context.Context, tx pgx.Tx, id ids.ActivityID, th
 	out.Links = []crmcontracts.ActivityLink{}
 
 	if withheld {
-		// Markers and nothing said. No parties, no files, no thread, no
-		// reason: each of those describes the message this caller may not
-		// read, and an empty list is a different statement from a refused one
-		// only if the status says which.
-		out.Summary = withheldSummary(activity)
-		out.Access = withheldAccess()
-		return out, nil
+		return withheldPresentation(out, activity), nil
 	}
 
 	parties, err := readEmailParties(ctx, tx, id)
@@ -108,9 +102,13 @@ func readEmailPresentation(ctx context.Context, tx pgx.Tx, id ids.ActivityID, th
 	}
 	out.From, out.To, out.Cc = parties.from, parties.to, parties.cc
 	// Blind recipients are disclosed only to the seat that sent or imported the
-	// message. Being allowed to read what was written is not standing to learn
-	// who was copied without the others knowing — the audience gate answers the
-	// first question and has no arm for the second.
+	// message. Being allowed to read what was written is not, in general,
+	// standing to learn who was copied without the others knowing.
+	//
+	// The one caller for whom this is the SAME question rather than a narrower
+	// one is an importing seat: a capture_import row already grants the whole
+	// audience arm, so it grants this too. That is the reach of the forged
+	// Message-ID path importrow.go documents, not a door opened here.
 	if sender, err := callerIsSenderSeat(ctx, tx, id); err != nil {
 		return crmcontracts.EmailPresentation{}, err
 	} else if sender {
@@ -142,10 +140,26 @@ func readEmailPresentation(ctx context.Context, tx pgx.Tx, id ids.ActivityID, th
 	}
 	out.Thread = &thread
 
-	// Both actions are the caller's because the content is: a reader inside the
-	// audience may answer the message and may correct what it is filed against.
-	out.CanReply, out.CanRelink = true, true
+	// Replying needs only the message: a reader inside the audience may answer
+	// it. Relinking is a WRITE — it changes what the message is filed against —
+	// so it follows the same writability the access block just decided, rather
+	// than being promised to every reader and refused on click.
+	out.CanReply = true
+	out.CanRelink = access.CanChange && access.ChangeMode == crmcontracts.EmailAccessChangeModeMessageAudience
 	return out, nil
+}
+
+// withheldPresentation is the whole answer for a caller who may know the
+// message exists and may not read it: markers, and nothing said.
+//
+// Its own function because it shares nothing with the available path below —
+// no parties, no files, no thread, no reason. Each of those describes the
+// message, and an empty list is a different statement from a refused one only
+// if the status says which.
+func withheldPresentation(out crmcontracts.EmailPresentation, activity crmcontracts.Activity) crmcontracts.EmailPresentation {
+	out.Summary = withheldSummary(activity)
+	out.Access = withheldAccess()
+	return out
 }
 
 // availableSummary is the row for a message this caller may read.
@@ -186,11 +200,13 @@ func availableSummary(
 	return summary
 }
 
-// moveOf says whose turn it is, from what this reader can see of the message
-// itself. An inbound message nobody has answered is the reader's move; one we
-// sent is theirs. Anything else makes no claim: a move nobody can derive
-// honestly is worse on a row than no move at all, because a rep works the row
-// that says they owe a reply.
+// moveOf says whose turn it is, from the message's DIRECTION alone.
+//
+// It does not ask whether anyone answered, so an inbound mail the rep replied
+// to a month ago still reads needs_reply. That is the limit of one row read by
+// itself: the answer lives on a later message, which this function is not
+// given. Named rather than dressed up, because a rep works their day from this
+// field — reading the thread is what would close it (margince#3784).
 func moveOf(activity crmcontracts.Activity) crmcontracts.EmailSummaryMove {
 	if activity.Direction == nil {
 		return crmcontracts.EmailSummaryMoveNone
@@ -292,10 +308,12 @@ func withheldAccess() crmcontracts.EmailAccess {
 // first. Bounded and paged: a thread has no ceiling, and a drawer that fetched
 // every message would make opening the newest one cost the whole history.
 //
-// It runs the same gated list every timeline runs, so a member the caller may
-// not read comes back withheld rather than missing — the drawer says a message
-// is there and not theirs, which is the honest shape of a conversation with a
-// limited message in it.
+// It runs the same gated list every timeline runs. Narrowing to a thread_key
+// upgrades that list to the CONTENT gate, so a member the caller may not read
+// is absent rather than withheld: the drawer shows the conversation this
+// reader is party to, not its true length. That is the existing behaviour of
+// a thread-narrowed list and not a choice made here, but it means the member
+// count is the reader's own and no one else's.
 func readThreadPage(
 	ctx context.Context,
 	tx pgx.Tx,

--- a/backend/internal/modules/activities/emailpresentation.go
+++ b/backend/internal/modules/activities/emailpresentation.go
@@ -10,13 +10,14 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 // The composed read behind the canonical email viewer.
@@ -37,6 +38,15 @@ import (
 // — a support exchange runs to hundreds — and a drawer that fetched every
 // message would make opening the newest one cost the whole history.
 const maxThreadMembers = 20
+
+// The participant roles this viewer reads. A closed set, named so the query
+// and the scan cannot spell one of them differently.
+const (
+	roleFrom = "from"
+	roleTo   = "to"
+	roleCc   = "cc"
+	roleBcc  = "bcc"
+)
 
 // GetEmailPresentation composes one email for reading.
 func (s *Store) GetEmailPresentation(ctx context.Context, id ids.ActivityID, threadCursor *string) (crmcontracts.EmailPresentation, error) {
@@ -130,7 +140,7 @@ func readEmailPresentation(ctx context.Context, tx pgx.Tx, id ids.ActivityID, th
 	if err != nil {
 		return crmcontracts.EmailPresentation{}, err
 	}
-	out.Thread = thread
+	out.Thread = &thread
 
 	// Both actions are the caller's because the content is: a reader inside the
 	// audience may answer the message and may correct what it is filed against.
@@ -278,119 +288,6 @@ func withheldAccess() crmcontracts.EmailAccess {
 	}
 }
 
-// readEmailAccess assembles who reads this message and what this caller may do
-// about it.
-//
-// change_mode is decided here, by the same test the write itself applies:
-// refuseCapturedAudienceWrite refuses a direct audience write on a message any
-// mailbox brought in, because a captured message's audience is derived from
-// its importers rather than declared. The browser has been guessing this from
-// the "connector:" prefix on captured_by, which puts a backend ownership rule
-// in display code and gets a hand-typed threaded reply wrong. The server knows
-// which write it would accept, so the server says.
-func readEmailAccess(
-	ctx context.Context,
-	tx pgx.Tx,
-	id ids.ActivityID,
-	activity crmcontracts.Activity,
-) (crmcontracts.EmailAccess, error) {
-	out := crmcontracts.EmailAccess{
-		ContentState:  crmcontracts.EmailAccessContentStateAvailable,
-		ChangeMode:    crmcontracts.EmailAccessChangeModeNone,
-		ChangeScope:   ptr(crmcontracts.EmailAccessChangeScopeNone),
-		DisplayStatus: crmcontracts.EmailAccessStatusTeam,
-	}
-	if activity.Audience != nil {
-		aud := crmcontracts.ActivityAudience(*activity.Audience)
-		out.Audience = &aud
-		out.DisplayStatus = statusForAudience(aud)
-	}
-	// The reason is content: it describes what the message is about. It travels
-	// only with a message the caller may read, which is the branch this is in.
-	out.Explanation = activity.AudienceReason
-
-	var imported bool
-	if err := tx.QueryRow(ctx, `
-		SELECT EXISTS (SELECT 1 FROM capture_import WHERE activity_id = $1)`,
-		id.UUID).Scan(&imported); err != nil {
-		return crmcontracts.EmailAccess{}, fmt.Errorf("activities: reading whether a message was imported: %w", err)
-	}
-
-	writable := auth.EnsureActivityWritable(ctx, tx, id.UUID) == nil
-	switch {
-	case imported:
-		// A captured message: the caller changes their own contribution to the
-		// thread, and only their own. Every importing seat holds one, so this
-		// is offered to an importer rather than to a writer of the row.
-		sender, err := callerIsSenderSeat(ctx, tx, id)
-		if err != nil {
-			return crmcontracts.EmailAccess{}, err
-		}
-		out.CanChange = sender
-		if sender {
-			out.ChangeMode = crmcontracts.EmailAccessChangeModeThreadContribution
-			out.ChangeScope = ptr(crmcontracts.EmailAccessChangeScopeThread)
-		}
-	case writable:
-		// Hand-logged: its audience is exactly what somebody set, so a writer
-		// of the row sets it.
-		out.CanChange = true
-		out.ChangeMode = crmcontracts.EmailAccessChangeModeMessageAudience
-		out.ChangeScope = ptr(crmcontracts.EmailAccessChangeScopeMessage)
-	}
-
-	// Who is named on a selected audience, read back only for the caller who
-	// may change the set. A reader with no standing to edit it has none to
-	// enumerate it either.
-	if out.CanChange && activity.Audience != nil && *activity.Audience == crmcontracts.ActivityAudienceSelected {
-		members, err := readSelectedMembers(ctx, tx, id)
-		if err != nil {
-			return crmcontracts.EmailAccess{}, err
-		}
-		out.SelectedMembers = &members
-	}
-	return out, nil
-}
-
-// statusForAudience is the word the badge prints for a message the caller can
-// read. "team" never means the whole workspace: the linked record's own scope
-// still decides who may discover the row at all.
-func statusForAudience(aud crmcontracts.ActivityAudience) crmcontracts.EmailAccessStatus {
-	switch aud {
-	case crmcontracts.ActivityAudienceParticipants:
-		return crmcontracts.EmailAccessStatusParticipants
-	case crmcontracts.ActivityAudienceSelected:
-		return crmcontracts.EmailAccessStatusSelected
-	default:
-		return crmcontracts.EmailAccessStatusTeam
-	}
-}
-
-func readSelectedMembers(ctx context.Context, tx pgx.Tx, id ids.ActivityID) ([]crmcontracts.AudienceMember, error) {
-	rows, err := tx.Query(ctx, `
-		SELECT subject_type, subject_id
-		  FROM activity_audience_member
-		 WHERE activity_id = $1
-		 ORDER BY subject_type, subject_id`, id.UUID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	out := []crmcontracts.AudienceMember{}
-	for rows.Next() {
-		var subjectType string
-		var subjectID ids.UUID
-		if err := rows.Scan(&subjectType, &subjectID); err != nil {
-			return nil, err
-		}
-		out = append(out, crmcontracts.AudienceMember{
-			SubjectType: crmcontracts.AudienceMemberSubjectType(subjectType),
-			SubjectId:   openapi_types.UUID(subjectID),
-		})
-	}
-	return out, rows.Err()
-}
-
 // readThreadPage reads the rest of the conversation as summaries, newest
 // first. Bounded and paged: a thread has no ceiling, and a drawer that fetched
 // every message would make opening the newest one cost the whole history.
@@ -404,9 +301,13 @@ func readThreadPage(
 	tx pgx.Tx,
 	activity crmcontracts.Activity,
 	cursor *string,
-) (*crmcontracts.EmailThreadPage, error) {
+) (crmcontracts.EmailThreadPage, error) {
+	empty := crmcontracts.EmailThreadPage{Members: []crmcontracts.EmailSummary{}}
+	// A message the provider gave no conversation key is its own whole
+	// conversation: an empty page rather than an absent one, so the drawer
+	// renders one message instead of deciding what a missing thread means.
 	if activity.ThreadKey == nil || *activity.ThreadKey == "" {
-		return nil, nil
+		return empty, nil
 	}
 	key := *activity.ThreadKey
 	limit := maxThreadMembers
@@ -416,7 +317,7 @@ func readThreadPage(
 		Limit:     &limit,
 	})
 	if err != nil {
-		return nil, err
+		return empty, err
 	}
 	out := crmcontracts.EmailThreadPage{Members: []crmcontracts.EmailSummary{}}
 	for _, member := range members {
@@ -430,7 +331,7 @@ func readThreadPage(
 	if page.NextCursor != "" {
 		out.NextCursor = &page.NextCursor
 	}
-	return &out, nil
+	return out, nil
 }
 
 func ptr[T any](v T) *T { return &v }
@@ -489,13 +390,13 @@ func readEmailParties(ctx context.Context, tx pgx.Tx, id ids.ActivityID) (emailP
 			party.UserId = &uid
 		}
 		switch role {
-		case "from":
+		case roleFrom:
 			out.from = append(out.from, party)
-		case "to":
+		case roleTo:
 			out.to = append(out.to, party)
-		case "cc":
+		case roleCc:
 			out.cc = append(out.cc, party)
-		case "bcc":
+		case roleBcc:
 			out.bcc = append(out.bcc, party)
 		}
 	}

--- a/backend/internal/modules/activities/emailpresentation.go
+++ b/backend/internal/modules/activities/emailpresentation.go
@@ -1,0 +1,529 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+// The composed read behind the canonical email viewer.
+//
+// It reads through readActivity rather than writing a third SELECT over
+// activity: the withholding rule already exists twice in this tree, and the
+// file comment on compose/person360's hand-written sibling records that the
+// duplicate went missing a column for a whole slice, twice. What this file
+// adds is what a single Activity row cannot carry — who the message went to,
+// what came with it, and which write the caller's Access control performs.
+//
+// Every relation is read as its own bounded statement against the same
+// transaction. One flat join would multiply participants by attachments by
+// members, and a per-row read would be the N+1 the summary field exists to
+// avoid.
+
+// maxThreadMembers bounds one page of a conversation. A thread has no ceiling
+// — a support exchange runs to hundreds — and a drawer that fetched every
+// message would make opening the newest one cost the whole history.
+const maxThreadMembers = 20
+
+// GetEmailPresentation composes one email for reading.
+func (s *Store) GetEmailPresentation(ctx context.Context, id ids.ActivityID, threadCursor *string) (crmcontracts.EmailPresentation, error) {
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return crmcontracts.EmailPresentation{}, err
+	}
+	var out crmcontracts.EmailPresentation
+	err := s.tx(ctx, func(tx pgx.Tx) (err error) {
+		out, err = readEmailPresentation(ctx, tx, id, threadCursor)
+		return err
+	})
+	return out, err
+}
+
+func readEmailPresentation(ctx context.Context, tx pgx.Tx, id ids.ActivityID, threadCursor *string) (crmcontracts.EmailPresentation, error) {
+	// The same discover gate and per-row audience test every activity read
+	// carries: a caller who may know the row exists reads it, and the audience
+	// decides whether its content comes along.
+	activity, err := readActivity(ctx, tx, id, storekit.LiveOnly)
+	if err != nil {
+		return crmcontracts.EmailPresentation{}, err
+	}
+	// Not an email, so there is no email to present. Answered as not-found
+	// rather than as a wrong-kind error: the caller asked for a resource that
+	// does not exist at this address, and saying which kind it actually is
+	// would answer a question about a row they may only discover.
+	if activity.Kind != crmcontracts.ActivityKindEmail {
+		return crmcontracts.EmailPresentation{}, apperrors.ErrNotFound
+	}
+
+	withheld := activity.ContentState != nil && *activity.ContentState == crmcontracts.ActivityContentStateWithheld
+	out := crmcontracts.EmailPresentation{
+		Id:         activity.Id,
+		Lifecycle:  crmcontracts.EmailPresentationLifecycleDelivered,
+		OccurredAt: activity.OccurredAt,
+		ThreadKey:  activity.ThreadKey,
+		Body:       activity.Body,
+	}
+	if activity.Version != nil {
+		out.Version = *activity.Version
+	}
+	out.From, out.To, out.Cc, out.Bcc = emptyParties(), emptyParties(), emptyParties(), emptyParties()
+	out.Attachments = []crmcontracts.EmailAttachmentSummary{}
+	out.Links = []crmcontracts.ActivityLink{}
+
+	if withheld {
+		// Markers and nothing said. No parties, no files, no thread, no
+		// reason: each of those describes the message this caller may not
+		// read, and an empty list is a different statement from a refused one
+		// only if the status says which.
+		out.Summary = withheldSummary(activity)
+		out.Access = withheldAccess()
+		return out, nil
+	}
+
+	parties, err := readEmailParties(ctx, tx, id)
+	if err != nil {
+		return crmcontracts.EmailPresentation{}, err
+	}
+	out.From, out.To, out.Cc = parties.from, parties.to, parties.cc
+	// Blind recipients are disclosed only to the seat that sent or imported the
+	// message. Being allowed to read what was written is not standing to learn
+	// who was copied without the others knowing — the audience gate answers the
+	// first question and has no arm for the second.
+	if sender, err := callerIsSenderSeat(ctx, tx, id); err != nil {
+		return crmcontracts.EmailPresentation{}, err
+	} else if sender {
+		out.Bcc = parties.bcc
+	}
+	// Said rather than shown: an empty list reads as "nobody was blind-copied",
+	// which is a different fact from "you may not see who was".
+	out.BccWithheld = len(parties.bcc) > 0 && len(out.Bcc) == 0
+
+	attachments, err := readEmailAttachments(ctx, tx, id)
+	if err != nil {
+		return crmcontracts.EmailPresentation{}, err
+	}
+	out.Attachments = attachments
+	if activity.Links != nil {
+		out.Links = *activity.Links
+	}
+
+	access, err := readEmailAccess(ctx, tx, id, activity)
+	if err != nil {
+		return crmcontracts.EmailPresentation{}, err
+	}
+	out.Access = access
+	out.Summary = availableSummary(activity, parties, len(attachments), access.DisplayStatus)
+
+	thread, err := readThreadPage(ctx, tx, activity, threadCursor)
+	if err != nil {
+		return crmcontracts.EmailPresentation{}, err
+	}
+	out.Thread = thread
+
+	// Both actions are the caller's because the content is: a reader inside the
+	// audience may answer the message and may correct what it is filed against.
+	out.CanReply, out.CanRelink = true, true
+	return out, nil
+}
+
+// availableSummary is the row for a message this caller may read.
+func availableSummary(
+	activity crmcontracts.Activity,
+	parties emailParties,
+	attachments int,
+	status crmcontracts.EmailAccessStatus,
+) crmcontracts.EmailSummary {
+	summary := crmcontracts.EmailSummary{
+		ActivityId:      activity.Id,
+		OccurredAt:      activity.OccurredAt,
+		DisplayStatus:   status,
+		AttachmentCount: attachments,
+		Move:            crmcontracts.EmailSummaryMoveNone,
+		Subject:         activity.Subject,
+	}
+	if activity.Version != nil {
+		summary.Version = *activity.Version
+	}
+	if activity.Direction != nil {
+		d := crmcontracts.EmailSummaryDirection(*activity.Direction)
+		summary.Direction = &d
+	}
+	if activity.Body != nil {
+		if preview := EmailSummaryText(*activity.Body); preview != "" {
+			summary.Preview = &preview
+		}
+	}
+	// Who it was with: the far side of the exchange, which is the sender on a
+	// message that came in and the recipients on one that went out.
+	far := parties.to
+	if activity.Direction != nil && *activity.Direction == crmcontracts.ActivityDirectionInbound {
+		far = parties.from
+	}
+	summary.Counterparty = counterpartyOf(far)
+	summary.Move = moveOf(activity)
+	return summary
+}
+
+// moveOf says whose turn it is, from what this reader can see of the message
+// itself. An inbound message nobody has answered is the reader's move; one we
+// sent is theirs. Anything else makes no claim: a move nobody can derive
+// honestly is worse on a row than no move at all, because a rep works the row
+// that says they owe a reply.
+func moveOf(activity crmcontracts.Activity) crmcontracts.EmailSummaryMove {
+	if activity.Direction == nil {
+		return crmcontracts.EmailSummaryMoveNone
+	}
+	switch *activity.Direction {
+	case crmcontracts.ActivityDirectionInbound:
+		return crmcontracts.EmailSummaryMoveNeedsReply
+	case crmcontracts.ActivityDirectionOutbound:
+		return crmcontracts.EmailSummaryMoveWaitingForThem
+	default:
+		return crmcontracts.EmailSummaryMoveNone
+	}
+}
+
+// callerIsSenderSeat answers whether this caller is the seat the message went
+// out as, or the mailbox owner who brought it in.
+func callerIsSenderSeat(ctx context.Context, tx pgx.Tx, id ids.ActivityID) (bool, error) {
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID == (ids.UUID{}) {
+		return false, nil
+	}
+	var sender bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		       SELECT 1 FROM capture_import ci
+		        WHERE ci.activity_id = $1 AND ci.user_id = $2
+		       UNION ALL
+		       SELECT 1 FROM activity a
+		        WHERE a.id = $1 AND a.captured_by LIKE '%:' || $2::text)`,
+		id.UUID, actor.UserID).Scan(&sender); err != nil {
+		return false, fmt.Errorf("activities: reading whether the caller sent this message: %w", err)
+	}
+	return sender, nil
+}
+
+// readEmailAttachments reads what came with the message. Reached only after
+// the content gate above admitted the caller, so it carries no second gate of
+// its own — the parent decided, exactly as ListAttachments' parent check does.
+func readEmailAttachments(ctx context.Context, tx pgx.Tx, id ids.ActivityID) ([]crmcontracts.EmailAttachmentSummary, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT at.id, at.filename, at.byte_size, at.content_type
+		  FROM attachment at
+		 WHERE at.entity_type = 'activity' AND at.entity_id = $1 AND at.archived_at IS NULL
+		 ORDER BY at.created_at, at.id`, id.UUID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []crmcontracts.EmailAttachmentSummary{}
+	for rows.Next() {
+		var a crmcontracts.EmailAttachmentSummary
+		var raw ids.UUID
+		if err := rows.Scan(&raw, &a.Filename, &a.ByteSize, &a.ContentType); err != nil {
+			return nil, err
+		}
+		a.Id = openapi_types.UUID(raw)
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// emptyParties is an empty list rather than a nil one: a viewer that sees no
+// `to` array cannot tell "nobody" from "the field was not sent", and the
+// difference decides whether it renders a recipient row at all.
+func emptyParties() []crmcontracts.EmailParty {
+	return []crmcontracts.EmailParty{}
+}
+
+// withheldSummary is the row a caller outside the audience still sees: when it
+// happened and that it happened, with the words removed.
+func withheldSummary(activity crmcontracts.Activity) crmcontracts.EmailSummary {
+	summary := crmcontracts.EmailSummary{
+		ActivityId:      activity.Id,
+		OccurredAt:      activity.OccurredAt,
+		DisplayStatus:   crmcontracts.EmailAccessStatusWithheld,
+		AttachmentCount: 0,
+		Move:            crmcontracts.EmailSummaryMoveNone,
+	}
+	if activity.Version != nil {
+		summary.Version = *activity.Version
+	}
+	if activity.Direction != nil {
+		d := crmcontracts.EmailSummaryDirection(*activity.Direction)
+		summary.Direction = &d
+	}
+	return summary
+}
+
+func withheldAccess() crmcontracts.EmailAccess {
+	return crmcontracts.EmailAccess{
+		ContentState:  crmcontracts.EmailAccessContentStateWithheld,
+		DisplayStatus: crmcontracts.EmailAccessStatusWithheld,
+		CanChange:     false,
+		ChangeMode:    crmcontracts.EmailAccessChangeModeNone,
+	}
+}
+
+// readEmailAccess assembles who reads this message and what this caller may do
+// about it.
+//
+// change_mode is decided here, by the same test the write itself applies:
+// refuseCapturedAudienceWrite refuses a direct audience write on a message any
+// mailbox brought in, because a captured message's audience is derived from
+// its importers rather than declared. The browser has been guessing this from
+// the "connector:" prefix on captured_by, which puts a backend ownership rule
+// in display code and gets a hand-typed threaded reply wrong. The server knows
+// which write it would accept, so the server says.
+func readEmailAccess(
+	ctx context.Context,
+	tx pgx.Tx,
+	id ids.ActivityID,
+	activity crmcontracts.Activity,
+) (crmcontracts.EmailAccess, error) {
+	out := crmcontracts.EmailAccess{
+		ContentState:  crmcontracts.EmailAccessContentStateAvailable,
+		ChangeMode:    crmcontracts.EmailAccessChangeModeNone,
+		ChangeScope:   ptr(crmcontracts.EmailAccessChangeScopeNone),
+		DisplayStatus: crmcontracts.EmailAccessStatusTeam,
+	}
+	if activity.Audience != nil {
+		aud := crmcontracts.ActivityAudience(*activity.Audience)
+		out.Audience = &aud
+		out.DisplayStatus = statusForAudience(aud)
+	}
+	// The reason is content: it describes what the message is about. It travels
+	// only with a message the caller may read, which is the branch this is in.
+	out.Explanation = activity.AudienceReason
+
+	var imported bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM capture_import WHERE activity_id = $1)`,
+		id.UUID).Scan(&imported); err != nil {
+		return crmcontracts.EmailAccess{}, fmt.Errorf("activities: reading whether a message was imported: %w", err)
+	}
+
+	writable := auth.EnsureActivityWritable(ctx, tx, id.UUID) == nil
+	switch {
+	case imported:
+		// A captured message: the caller changes their own contribution to the
+		// thread, and only their own. Every importing seat holds one, so this
+		// is offered to an importer rather than to a writer of the row.
+		sender, err := callerIsSenderSeat(ctx, tx, id)
+		if err != nil {
+			return crmcontracts.EmailAccess{}, err
+		}
+		out.CanChange = sender
+		if sender {
+			out.ChangeMode = crmcontracts.EmailAccessChangeModeThreadContribution
+			out.ChangeScope = ptr(crmcontracts.EmailAccessChangeScopeThread)
+		}
+	case writable:
+		// Hand-logged: its audience is exactly what somebody set, so a writer
+		// of the row sets it.
+		out.CanChange = true
+		out.ChangeMode = crmcontracts.EmailAccessChangeModeMessageAudience
+		out.ChangeScope = ptr(crmcontracts.EmailAccessChangeScopeMessage)
+	}
+
+	// Who is named on a selected audience, read back only for the caller who
+	// may change the set. A reader with no standing to edit it has none to
+	// enumerate it either.
+	if out.CanChange && activity.Audience != nil && *activity.Audience == crmcontracts.ActivityAudienceSelected {
+		members, err := readSelectedMembers(ctx, tx, id)
+		if err != nil {
+			return crmcontracts.EmailAccess{}, err
+		}
+		out.SelectedMembers = &members
+	}
+	return out, nil
+}
+
+// statusForAudience is the word the badge prints for a message the caller can
+// read. "team" never means the whole workspace: the linked record's own scope
+// still decides who may discover the row at all.
+func statusForAudience(aud crmcontracts.ActivityAudience) crmcontracts.EmailAccessStatus {
+	switch aud {
+	case crmcontracts.ActivityAudienceParticipants:
+		return crmcontracts.EmailAccessStatusParticipants
+	case crmcontracts.ActivityAudienceSelected:
+		return crmcontracts.EmailAccessStatusSelected
+	default:
+		return crmcontracts.EmailAccessStatusTeam
+	}
+}
+
+func readSelectedMembers(ctx context.Context, tx pgx.Tx, id ids.ActivityID) ([]crmcontracts.AudienceMember, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT subject_type, subject_id
+		  FROM activity_audience_member
+		 WHERE activity_id = $1
+		 ORDER BY subject_type, subject_id`, id.UUID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []crmcontracts.AudienceMember{}
+	for rows.Next() {
+		var subjectType string
+		var subjectID ids.UUID
+		if err := rows.Scan(&subjectType, &subjectID); err != nil {
+			return nil, err
+		}
+		out = append(out, crmcontracts.AudienceMember{
+			SubjectType: crmcontracts.AudienceMemberSubjectType(subjectType),
+			SubjectId:   openapi_types.UUID(subjectID),
+		})
+	}
+	return out, rows.Err()
+}
+
+// readThreadPage reads the rest of the conversation as summaries, newest
+// first. Bounded and paged: a thread has no ceiling, and a drawer that fetched
+// every message would make opening the newest one cost the whole history.
+//
+// It runs the same gated list every timeline runs, so a member the caller may
+// not read comes back withheld rather than missing — the drawer says a message
+// is there and not theirs, which is the honest shape of a conversation with a
+// limited message in it.
+func readThreadPage(
+	ctx context.Context,
+	tx pgx.Tx,
+	activity crmcontracts.Activity,
+	cursor *string,
+) (*crmcontracts.EmailThreadPage, error) {
+	if activity.ThreadKey == nil || *activity.ThreadKey == "" {
+		return nil, nil
+	}
+	key := *activity.ThreadKey
+	limit := maxThreadMembers
+	members, page, err := ListActivitiesTx(ctx, tx, ListActivitiesInput{
+		ThreadKey: &key,
+		Cursor:    cursor,
+		Limit:     &limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := crmcontracts.EmailThreadPage{Members: []crmcontracts.EmailSummary{}}
+	for _, member := range members {
+		if member.Kind != crmcontracts.ActivityKindEmail {
+			continue
+		}
+		if member.EmailSummary != nil {
+			out.Members = append(out.Members, *member.EmailSummary)
+		}
+	}
+	if page.NextCursor != "" {
+		out.NextCursor = &page.NextCursor
+	}
+	return &out, nil
+}
+
+func ptr[T any](v T) *T { return &v }
+
+type emailParties struct {
+	from, to, cc, bcc []crmcontracts.EmailParty
+}
+
+// readEmailParties reads the message's normalised recipients. They are stored
+// as activity_participant rows with a role, which is why the viewer never has
+// to parse a provider payload to learn who was on a message.
+//
+// A person's name is resolved only through the caller's own row scope: an
+// address the caller may not see a contact for stays an address, which is the
+// truth rather than a blank.
+func readEmailParties(ctx context.Context, tx pgx.Tx, id ids.ActivityID) (emailParties, error) {
+	args := []any{id}
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	scope, err := auth.ScopeClauseFor(ctx, "person", "p", arg)
+	if err != nil {
+		return emailParties{}, err
+	}
+	personJoin := `LEFT JOIN person p ON p.id = ap.person_id AND p.archived_at IS NULL`
+	if scope != "" {
+		personJoin += ` AND (` + scope + `)`
+	}
+	rows, err := tx.Query(ctx, `
+		SELECT ap.role, coalesce(ap.address, ''), p.id, p.full_name, ap.user_id
+		  FROM activity_participant ap
+		  `+personJoin+`
+		 WHERE ap.activity_id = $1
+		   AND ap.role IN ('from', 'to', 'cc', 'bcc')
+		 ORDER BY CASE ap.role
+		            WHEN 'from' THEN 1 WHEN 'to' THEN 2 WHEN 'cc' THEN 3 ELSE 4
+		          END, ap.created_at, ap.id`, args...)
+	if err != nil {
+		return emailParties{}, err
+	}
+	defer rows.Close()
+
+	var out emailParties
+	for rows.Next() {
+		var role, address string
+		var personID, userID *ids.UUID
+		var fullName *string
+		if err := rows.Scan(&role, &address, &personID, &fullName, &userID); err != nil {
+			return emailParties{}, err
+		}
+		party := crmcontracts.EmailParty{Address: address, DisplayName: fullName}
+		if personID != nil {
+			pid := openapi_types.UUID(*personID)
+			party.PersonId = &pid
+		}
+		if userID != nil {
+			uid := openapi_types.UUID(*userID)
+			party.UserId = &uid
+		}
+		switch role {
+		case "from":
+			out.from = append(out.from, party)
+		case "to":
+			out.to = append(out.to, party)
+		case "cc":
+			out.cc = append(out.cc, party)
+		case "bcc":
+			out.bcc = append(out.bcc, party)
+		}
+	}
+	return out, rows.Err()
+}
+
+// counterpartyOf names the other side for a row: the first party the caller
+// can name, and how many more there were. A message whose participants all
+// resolve to nothing gets no counterparty rather than an invented stranger.
+func counterpartyOf(parties []crmcontracts.EmailParty) *string {
+	if len(parties) == 0 {
+		return nil
+	}
+	var named string
+	for _, p := range parties {
+		if p.DisplayName != nil && strings.TrimSpace(*p.DisplayName) != "" {
+			named = *p.DisplayName
+			break
+		}
+		if named == "" && p.Address != "" {
+			named = p.Address
+		}
+	}
+	if named == "" {
+		return nil
+	}
+	if extra := len(parties) - 1; extra > 0 {
+		named += " +" + strconv.Itoa(extra)
+	}
+	return &named
+}

--- a/backend/internal/modules/activities/emailtext.go
+++ b/backend/internal/modules/activities/emailtext.go
@@ -14,12 +14,30 @@ import (
 // What a row shows is the sentence the sender wrote, and that is what this
 // file finds.
 //
-// This is the declared mirror of frontend/src/format/emailtext.ts. The two
+// This is a deliberate mirror of frontend/src/format/emailtext.ts. The two
 // exist because the row's preview is now composed by the server while the
 // drawer still folds the tail in the browser, and a preview that disagreed
 // with the message it opens would be a row lying about its own mail.
-// gates/frontendemailtext_test.go holds them to the same tables in both
-// directions, and emailtext_parity_test.go runs both over shared fixtures.
+//
+// Nothing yet FAILS when they drift: emailtext_test.go's table was checked by
+// hand against the TypeScript on the same twelve bodies, which proves they
+// agree today and not that they will tomorrow. The gate that reads both
+// tables and fails in either direction is owed (margince#3782), and until it
+// exists a change to either side has to be made to both by whoever makes it.
+//
+// Why not textlang.NewTextOnly, which also finds where a message ends: it
+// answers a different question and its answer is wrong for a row. Asked for
+// "Danke für das Angebot.\n\nViele Grüße\nAna" it returns the whole thing —
+// it cuts on the RFC 3676 sig-dash and on legal-footer leads, and knows no
+// sign-off vocabulary, no mobile-client boilerplate and not the From:/To:
+// preamble capture prepends. A preview built on it would print the sender's
+// closing and their signature block as though they were the message.
+//
+// The two also owe opposite guarantees. NewTextOnly feeds language detection,
+// where cutting too much is safe and a short remainder is fine; a preview must
+// never come back empty, because a body that is nothing but a greeting is a
+// real message and a row that renders it as blank has hidden the mail. That
+// floor is why this splitter falls back to the whole body twice.
 
 // preamblePattern is what the capture mail mapper prepends verbatim. Peeled
 // before any heuristic runs, or the `From:` line reads as an Outlook reply

--- a/backend/internal/modules/activities/emailtext.go
+++ b/backend/internal/modules/activities/emailtext.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Server-side reading of a captured mail body. The stored body is the whole
+// message — signature, quoted history and all — because the enrichment pass
+// mines the sign-off for contact details, so nothing may be trimmed at rest.
+// What a row shows is the sentence the sender wrote, and that is what this
+// file finds.
+//
+// This is the declared mirror of frontend/src/format/emailtext.ts. The two
+// exist because the row's preview is now composed by the server while the
+// drawer still folds the tail in the browser, and a preview that disagreed
+// with the message it opens would be a row lying about its own mail.
+// gates/frontendemailtext_test.go holds them to the same tables in both
+// directions, and emailtext_parity_test.go runs both over shared fixtures.
+
+// preamblePattern is what the capture mail mapper prepends verbatim. Peeled
+// before any heuristic runs, or the `From:` line reads as an Outlook reply
+// header and folds the entire message.
+var preamblePattern = regexp.MustCompile(`^From:[^\n]*\nTo:[^\n]*\n\n`)
+
+// signatureDelimiter is RFC 3676 §4.3: a line of exactly two hyphens.
+// Trailing whitespace is allowed because mail clients strip it inconsistently.
+var signatureDelimiter = regexp.MustCompile(`^--\s*$`)
+
+// attributionPatterns introduce a quoted reply. Bounded repetition keeps a
+// pathological body from backtracking.
+var attributionPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`^On\s.{1,200}\swrote:\s*$`),
+	regexp.MustCompile(`^Am\s.{1,200}\sschrieb\s?.{0,120}:\s*$`),
+	regexp.MustCompile(`(?i)^-{2,}\s*(Original Message|Ursprüngliche Nachricht|Forwarded message|Weitergeleitete Nachricht)`),
+	regexp.MustCompile(`(?i)^Anfang der weitergeleiteten (E-Mail|Nachricht)`),
+	regexp.MustCompile(`^_{5,}\s*$`),
+}
+
+// The Outlook top-reply block: a From:/Von: line whose neighbours carry the
+// sent-date field. Recognised as a pair because "Von:" alone is ordinary prose
+// in German mail.
+var (
+	replyHeaderFrom = regexp.MustCompile(`^(Von|From):\s`)
+	replyHeaderSent = regexp.MustCompile(`^(Gesendet|Sent|Datum|Date):\s`)
+)
+
+// signOffPrefixes may open a line, since a name usually follows on the same one.
+var signOffPrefixes = []string{
+	"mit freundlichen grüßen",
+	"mit freundlichem gruß",
+	"mit besten grüßen",
+	"freundliche grüße",
+	"viele grüße",
+	"beste grüße",
+	"herzliche grüße",
+	"liebe grüße",
+	"schöne grüße",
+	"best regards",
+	"kind regards",
+	"warm regards",
+	"many thanks",
+	"thanks and regards",
+	"diese e-mail wurde von avast",
+}
+
+// signOffLines is mobile-client boilerplate, matched against the WHOLE line
+// rather than as a prefix: "Sent from my perspective, the contract is not
+// ready" opens a sentence with the same three words and is the message.
+var signOffLines = []*regexp.Regexp{
+	regexp.MustCompile(`^von meinem (iphone|ipad|android|mobilteil|samsung)\b.*gesendet$`),
+	regexp.MustCompile(`^sent from my \w[\w\s]{0,30}$`),
+	regexp.MustCompile(`^gesendet mit \w[\w\s]{0,30}$`),
+	regexp.MustCompile(`^get outlook for \w+$`),
+}
+
+// signOffExact are the short forms, whole-line only: "LG" opens a sentence
+// about a washing machine as readily as it closes a mail.
+var signOffExact = map[string]bool{
+	"mfg": true, "vg": true, "lg": true, "vlg": true,
+	"best": true, "regards": true, "cheers": true, "thanks": true,
+	"thank you": true, "danke": true, "gruß": true, "grüße": true, "bg": true,
+}
+
+// trailingScanLines is how far up from the end a sign-off is looked for. The
+// same words in an opening paragraph are prose, and scanning the whole body
+// folds the message away on the strength of one line.
+const trailingScanLines = 15
+
+// EmailBodyParts is a mail body read for display.
+type EmailBodyParts struct {
+	// Header is the From:/To: preamble capture folds into the body, when present.
+	Header string
+	// Main is what the sender actually wrote. Never empty when the body was not.
+	Main string
+	// Trimmed is the signature and quoted history, kept but not shown.
+	Trimmed string
+}
+
+func isSignOff(line string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(line))
+	normalized = strings.TrimRight(normalized, ",.!")
+	if normalized == "" {
+		return false
+	}
+	if signOffExact[normalized] {
+		return true
+	}
+	for _, pattern := range signOffLines {
+		if pattern.MatchString(normalized) {
+			return true
+		}
+	}
+	for _, prefix := range signOffPrefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isQuoteStart(lines []string, index int) bool {
+	line := lines[index]
+	if strings.HasPrefix(line, ">") {
+		return true
+	}
+	for _, pattern := range attributionPatterns {
+		if pattern.MatchString(line) {
+			return true
+		}
+	}
+	// The Outlook block: the sent-date field within the next few lines is what
+	// separates a reply header from a sentence that opens "Von:".
+	if index > 0 && replyHeaderFrom.MatchString(line) {
+		end := min(index+5, len(lines))
+		for _, next := range lines[index+1 : end] {
+			if replyHeaderSent.MatchString(next) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// boundaryIndex is the first line belonging to the tail rather than the
+// message: a quote marker anywhere, or a sign-off near the end. Returns -1
+// when the whole body is the message.
+func boundaryIndex(lines []string) int {
+	signOffFloor := max(0, len(lines)-trailingScanLines)
+	for i, line := range lines {
+		if signatureDelimiter.MatchString(line) {
+			return i
+		}
+		if isQuoteStart(lines, i) {
+			// The attribution line directly above a quoted block introduces it,
+			// so it travels with the quote rather than trailing the message.
+			if strings.HasPrefix(line, ">") && i > 0 && strings.HasSuffix(strings.TrimSpace(lines[i-1]), ":") {
+				return i - 1
+			}
+			return i
+		}
+		if i >= signOffFloor && isSignOff(line) {
+			return i
+		}
+	}
+	return -1
+}
+
+// SplitEmailBody separates a stored mail body into the part worth reading on a
+// row and the tail worth keeping but not showing.
+//
+// The message is never allowed to become empty: a body that is nothing but a
+// greeting is a real message, and a heuristic that folds it away has hidden the
+// mail rather than tidied it.
+func SplitEmailBody(body string) EmailBodyParts {
+	if strings.TrimSpace(body) == "" {
+		return EmailBodyParts{}
+	}
+	var header, rest string
+	if loc := preamblePattern.FindString(body); loc != "" {
+		header = strings.TrimSpace(loc)
+		rest = body[len(loc):]
+	} else {
+		rest = body
+	}
+
+	// A body that is only a preamble has no message under it. The header is the
+	// whole of what was captured, so it IS the message: the invariant is that a
+	// non-empty body never renders as nothing.
+	if strings.TrimSpace(rest) == "" {
+		return EmailBodyParts{Main: strings.TrimSpace(body)}
+	}
+
+	lines := strings.Split(rest, "\n")
+	cut := boundaryIndex(lines)
+	if cut < 0 {
+		return EmailBodyParts{Header: header, Main: strings.TrimSpace(rest)}
+	}
+	main := strings.TrimSpace(strings.Join(lines[:cut], "\n"))
+	if main == "" {
+		return EmailBodyParts{Header: header, Main: strings.TrimSpace(rest)}
+	}
+	return EmailBodyParts{
+		Header:  header,
+		Main:    main,
+		Trimmed: strings.TrimSpace(strings.Join(lines[cut:], "\n")),
+	}
+}
+
+// collapseWhitespace is the one-line form: every run of whitespace becomes a
+// single space.
+var collapseWhitespace = regexp.MustCompile(`\s+`)
+
+// EmailSummaryText is the message on one line, for a row preview: the sender's
+// own words, never their sign-off and never the `From:` preamble.
+func EmailSummaryText(body string) string {
+	collapsed := strings.TrimSpace(collapseWhitespace.ReplaceAllString(SplitEmailBody(body).Main, " "))
+	// A body that is only a quoted forward has no message of its own. The whole
+	// text is a better preview than an empty one.
+	if collapsed != "" {
+		return collapsed
+	}
+	return strings.TrimSpace(collapseWhitespace.ReplaceAllString(body, " "))
+}

--- a/backend/internal/modules/activities/emailtext_test.go
+++ b/backend/internal/modules/activities/emailtext_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import "testing"
+
+// The cases here are the shared fixtures the frontend splitter is held to as
+// well. A case added on one side and not the other is the drift this file and
+// gates/frontendemailtext_test.go exist to catch, so the table is written to be
+// read from both languages: one body in, one main and one trimmed out.
+
+func TestSplitEmailBodyFindsWhatTheSenderWrote(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		body    string
+		main    string
+		trimmed string
+	}{
+		{
+			name: "a plain body is all message",
+			body: "Können wir Dienstag sprechen?",
+			main: "Können wir Dienstag sprechen?",
+		},
+		{
+			name:    "the RFC 3676 delimiter opens the signature",
+			body:    "Passt bei mir.\n\n--\nAna Sommer\nGeschäftsführerin",
+			main:    "Passt bei mir.",
+			trimmed: "--\nAna Sommer\nGeschäftsführerin",
+		},
+		{
+			name:    "a German sign-off near the end closes the message",
+			body:    "Danke für das Angebot.\n\nViele Grüße\nAna",
+			main:    "Danke für das Angebot.",
+			trimmed: "Viele Grüße\nAna",
+		},
+		{
+			name:    "an attribution line travels with the quote it introduces",
+			body:    "Ja, gerne.\n\nAm 1. September schrieb Ana:\n> Passt Dienstag?",
+			main:    "Ja, gerne.",
+			trimmed: "Am 1. September schrieb Ana:\n> Passt Dienstag?",
+		},
+		{
+			name:    "the Outlook block needs its sent-date neighbour",
+			body:    "Siehe unten.\n\nVon: Ana Sommer\nGesendet: Montag, 1. September\nAn: Lars\n\nPasst Dienstag?",
+			main:    "Siehe unten.",
+			trimmed: "Von: Ana Sommer\nGesendet: Montag, 1. September\nAn: Lars\n\nPasst Dienstag?",
+		},
+		{
+			name: "a Von: line without a sent-date is prose",
+			body: "Von: uns beiden kam bisher keine Antwort.",
+			main: "Von: uns beiden kam bisher keine Antwort.",
+		},
+		{
+			name: "mobile boilerplate matches the whole line, not a prefix",
+			body: "Sent from my perspective the contract is not ready",
+			main: "Sent from my perspective the contract is not ready",
+		},
+		{
+			name:    "and folds when it is the whole line",
+			body:    "Passt.\n\nSent from my iPhone",
+			main:    "Passt.",
+			trimmed: "Sent from my iPhone",
+		},
+		{
+			name: "a greeting alone is still a message",
+			body: "Danke!",
+			main: "Danke!",
+		},
+		{
+			name: "a body that is only a quote keeps the quote as its text",
+			body: "> Passt Dienstag?",
+			main: "> Passt Dienstag?",
+		},
+		{
+			name: "the capture preamble is peeled and does not fold the message",
+			body: "From: ana@example.test\nTo: lars@example.test\n\nPasst Dienstag?",
+			main: "Passt Dienstag?",
+		},
+		{
+			name: "an empty body stays empty",
+			body: "   \n\n ",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := SplitEmailBody(tc.body)
+			if got.Main != tc.main {
+				t.Errorf("main:\n got %q\nwant %q", got.Main, tc.main)
+			}
+			if got.Trimmed != tc.trimmed {
+				t.Errorf("trimmed:\n got %q\nwant %q", got.Trimmed, tc.trimmed)
+			}
+		})
+	}
+}
+
+func TestEmailSummaryTextIsOneLineOfTheSendersOwnWords(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "newlines collapse to single spaces",
+			body: "Passt Dienstag?\n\nOder Mittwoch?\n\nViele Grüße\nAna",
+			want: "Passt Dienstag? Oder Mittwoch?",
+		},
+		{
+			name: "a body that is only a forward previews the forward",
+			body: "> Passt Dienstag?",
+			want: "> Passt Dienstag?",
+		},
+		{
+			name: "an empty body previews nothing",
+			body: "",
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := EmailSummaryText(tc.body); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/activities/handlers_emailpresentation.go
+++ b/backend/internal/modules/activities/handlers_emailpresentation.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"net/http"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// GetEmailPresentation serves the canonical email viewer's one read.
+func (h Handlers) GetEmailPresentation(
+	w http.ResponseWriter,
+	r *http.Request,
+	id crmcontracts.Id,
+	params crmcontracts.GetEmailPresentationParams,
+) {
+	presentation, err := h.store.GetEmailPresentation(r.Context(),
+		pathID[ids.ActivityKind](id), params.ThreadCursor)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, presentation)
+}

--- a/backend/pkg/extension/crm/crm_gen.go
+++ b/backend/pkg/extension/crm/crm_gen.go
@@ -30,16 +30,16 @@ func (e ActivityCaptureLabel) Valid() bool {
 
 // Defines values for ActivityContentState.
 const (
-	Available ActivityContentState = "available"
-	Withheld  ActivityContentState = "withheld"
+	ActivityContentStateAvailable ActivityContentState = "available"
+	ActivityContentStateWithheld  ActivityContentState = "withheld"
 )
 
 // Valid indicates whether the value is a known member of the ActivityContentState enum.
 func (e ActivityContentState) Valid() bool {
 	switch e {
-	case Available:
+	case ActivityContentStateAvailable:
 		return true
-	case Withheld:
+	case ActivityContentStateWithheld:
 		return true
 	default:
 		return false
@@ -265,6 +265,78 @@ func (e CreateActivityRequestMeetingStatus) Valid() bool {
 	}
 }
 
+// Defines values for EmailAccessStatus.
+const (
+	EmailAccessStatusParticipants   EmailAccessStatus = "participants"
+	EmailAccessStatusPrivateByYou   EmailAccessStatus = "private_by_you"
+	EmailAccessStatusPrivatePending EmailAccessStatus = "private_pending"
+	EmailAccessStatusSelected       EmailAccessStatus = "selected"
+	EmailAccessStatusStillHeld      EmailAccessStatus = "still_held"
+	EmailAccessStatusTeam           EmailAccessStatus = "team"
+	EmailAccessStatusWithheld       EmailAccessStatus = "withheld"
+)
+
+// Valid indicates whether the value is a known member of the EmailAccessStatus enum.
+func (e EmailAccessStatus) Valid() bool {
+	switch e {
+	case EmailAccessStatusParticipants:
+		return true
+	case EmailAccessStatusPrivateByYou:
+		return true
+	case EmailAccessStatusPrivatePending:
+		return true
+	case EmailAccessStatusSelected:
+		return true
+	case EmailAccessStatusStillHeld:
+		return true
+	case EmailAccessStatusTeam:
+		return true
+	case EmailAccessStatusWithheld:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EmailSummaryDirection.
+const (
+	Inbound  EmailSummaryDirection = "inbound"
+	Outbound EmailSummaryDirection = "outbound"
+)
+
+// Valid indicates whether the value is a known member of the EmailSummaryDirection enum.
+func (e EmailSummaryDirection) Valid() bool {
+	switch e {
+	case Inbound:
+		return true
+	case Outbound:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EmailSummaryMove.
+const (
+	NeedsReply     EmailSummaryMove = "needs_reply"
+	None           EmailSummaryMove = "none"
+	WaitingForThem EmailSummaryMove = "waiting_for_them"
+)
+
+// Valid indicates whether the value is a known member of the EmailSummaryMove enum.
+func (e EmailSummaryMove) Valid() bool {
+	switch e {
+	case NeedsReply:
+		return true
+	case None:
+		return true
+	case WaitingForThem:
+		return true
+	default:
+		return false
+	}
+}
+
 // Activity A polymorphic timeline item. Mirrors the `activity` table + `activity_link`.
 // **Per-kind field constraints** (enforced server-side to match the DB `activity_task_fields`
 // CHECK; the OpenAPI cannot express these conditionally): `due_at`/`assignee_id`/`is_done`/
@@ -314,6 +386,9 @@ type Activity struct {
 
 	// DurationSeconds Meeting/call only.
 	DurationSeconds *int `json:"duration_seconds,omitempty"`
+
+	// EmailSummary Present exactly when `kind=email`. What the canonical email row renders, so a list does not have to fetch a message per visible line to draw one. Every other kind carries none, and a reader branches on its presence rather than on the kind word.
+	EmailSummary *EmailSummary `json:"email_summary,omitempty"`
 
 	// HostUserId Meeting only: the member of this organization who held it. It is the one place an activity names OUR side of an exchange — a mail says only which contact it was with, and the mailbox behind it is not on the row. Null on every other kind, and on a meeting nobody was recorded as hosting.
 	HostUserId *string `json:"host_user_id,omitempty"`
@@ -424,6 +499,68 @@ type CreateActivityRequestLinksEntityType string
 
 // CreateActivityRequestMeetingStatus defines model for CreateActivityRequest.MeetingStatus.
 type CreateActivityRequestMeetingStatus string
+
+// EmailAccessStatus What a reader is allowed to know about who else reads this message, in one word the
+// badge can print. `team` never means the whole workspace: the linked record's own scope
+// still decides who may discover the row at all.
+//
+// `still_held` is the honest half of a share — you released your hold and somebody else
+// has not. `withheld` is the only value that says the content is not this caller's, and
+// it never travels with a reason: why a message is private describes what it is about.
+type EmailAccessStatus string
+
+// EmailSummary One retained email, reduced to what a row shows without opening it. Present on an
+// activity only when `kind=email`; every other kind carries none, and a reader that
+// branches on this field is asking the one question that decides the canonical row.
+//
+// The preview is normalised by the server with the same splitter the detail uses, so a
+// row and the message it opens never disagree about where the sender's own words end.
+// A withheld email carries a summary whose `subject` and `preview` are null and whose
+// `display_status` says so — the row stays, the words do not.
+type EmailSummary struct {
+	ActivityId string `json:"activity_id"`
+
+	// AttachmentCount How many files came with it. Zero when withheld, like every other count.
+	AttachmentCount int `json:"attachment_count"`
+
+	// Counterparty Who the message was with, named for the row: "Ana Sommer", or "Ana Sommer +2" when
+	// the exchange had more. Null when no participant resolves to a name this caller may
+	// see — the row then says the direction alone rather than inventing a stranger.
+	Counterparty *string                `json:"counterparty,omitempty"`
+	Direction    *EmailSummaryDirection `json:"direction,omitempty"`
+
+	// DisplayStatus What a reader is allowed to know about who else reads this message, in one word the
+	// badge can print. `team` never means the whole workspace: the linked record's own scope
+	// still decides who may discover the row at all.
+	//
+	// `still_held` is the honest half of a share — you released your hold and somebody else
+	// has not. `withheld` is the only value that says the content is not this caller's, and
+	// it never travels with a reason: why a message is private describes what it is about.
+	DisplayStatus EmailAccessStatus `json:"display_status"`
+
+	// Move Whose move it is, derived from what this reader can see of the thread. `none` when
+	// the question cannot be answered honestly — an unanswerable move is not a claim.
+	Move       EmailSummaryMove `json:"move"`
+	OccurredAt time.Time        `json:"occurred_at"`
+
+	// Preview One line of the sender's own text, signature and quoted history already removed.
+	// Null when withheld, and when the message has no text of its own.
+	Preview *string `json:"preview,omitempty"`
+
+	// Subject Null when the message has none, and when the content is withheld.
+	Subject *string `json:"subject,omitempty"`
+
+	// Version The activity's version, carried so a row can open an editor that writes with
+	// If-Match. A row without it can only read.
+	Version RowVersion `json:"version"`
+}
+
+// EmailSummaryDirection defines model for EmailSummary.Direction.
+type EmailSummaryDirection string
+
+// EmailSummaryMove Whose move it is, derived from what this reader can see of the thread. `none` when
+// the question cannot be answered honestly — an unanswerable move is not a claim.
+type EmailSummaryMove string
 
 // ProviderRef A reference to a messaging transport registered in THIS installation
 // (ADR-0107/A158). Deliberately a pattern-constrained string rather than an enum:

--- a/backend/pkg/extension/crm/crm_gen.go
+++ b/backend/pkg/extension/crm/crm_gen.go
@@ -267,13 +267,10 @@ func (e CreateActivityRequestMeetingStatus) Valid() bool {
 
 // Defines values for EmailAccessStatus.
 const (
-	EmailAccessStatusParticipants   EmailAccessStatus = "participants"
-	EmailAccessStatusPrivateByYou   EmailAccessStatus = "private_by_you"
-	EmailAccessStatusPrivatePending EmailAccessStatus = "private_pending"
-	EmailAccessStatusSelected       EmailAccessStatus = "selected"
-	EmailAccessStatusStillHeld      EmailAccessStatus = "still_held"
-	EmailAccessStatusTeam           EmailAccessStatus = "team"
-	EmailAccessStatusWithheld       EmailAccessStatus = "withheld"
+	EmailAccessStatusParticipants EmailAccessStatus = "participants"
+	EmailAccessStatusSelected     EmailAccessStatus = "selected"
+	EmailAccessStatusTeam         EmailAccessStatus = "team"
+	EmailAccessStatusWithheld     EmailAccessStatus = "withheld"
 )
 
 // Valid indicates whether the value is a known member of the EmailAccessStatus enum.
@@ -281,13 +278,7 @@ func (e EmailAccessStatus) Valid() bool {
 	switch e {
 	case EmailAccessStatusParticipants:
 		return true
-	case EmailAccessStatusPrivateByYou:
-		return true
-	case EmailAccessStatusPrivatePending:
-		return true
 	case EmailAccessStatusSelected:
-		return true
-	case EmailAccessStatusStillHeld:
 		return true
 	case EmailAccessStatusTeam:
 		return true
@@ -504,9 +495,13 @@ type CreateActivityRequestMeetingStatus string
 // badge can print. `team` never means the whole workspace: the linked record's own scope
 // still decides who may discover the row at all.
 //
-// `still_held` is the honest half of a share — you released your hold and somebody else
-// has not. `withheld` is the only value that says the content is not this caller's, and
-// it never travels with a reason: why a message is private describes what it is about.
+// `withheld` is the only value that says the content is not this caller's, and it never
+// travels with a reason: why a message is private describes what it is about.
+//
+// The captured-mail states a mailbox owner sees — held until classified, private by you,
+// shared but still held by another seat — are not here yet. They arrive with the thread
+// contribution editor that can act on them; a value no server can emit is one a client
+// would branch on and never reach.
 type EmailAccessStatus string
 
 // EmailSummary One retained email, reduced to what a row shows without opening it. Present on an
@@ -533,9 +528,13 @@ type EmailSummary struct {
 	// badge can print. `team` never means the whole workspace: the linked record's own scope
 	// still decides who may discover the row at all.
 	//
-	// `still_held` is the honest half of a share — you released your hold and somebody else
-	// has not. `withheld` is the only value that says the content is not this caller's, and
-	// it never travels with a reason: why a message is private describes what it is about.
+	// `withheld` is the only value that says the content is not this caller's, and it never
+	// travels with a reason: why a message is private describes what it is about.
+	//
+	// The captured-mail states a mailbox owner sees — held until classified, private by you,
+	// shared but still held by another seat — are not here yet. They arrive with the thread
+	// contribution editor that can act on them; a value no server can emit is one a client
+	// would branch on and never reach.
 	DisplayStatus EmailAccessStatus `json:"display_status"`
 
 	// Move Whose move it is, derived from what this reader can see of the thread. `none` when

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3176,6 +3176,35 @@ export interface paths {
         patch: operations["updateActivity"];
         trace?: never;
     };
+    "/activities/{id}/email-presentation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /**
+         * Everything one email needs to be read and acted on, in one read.
+         * @description The composed read behind the canonical email viewer: the message, who it went to,
+         *     what came with it, and what this caller may do about who else reads it.
+         *
+         *     It answers 404 for an activity that is not `kind=email`, and for one held under a
+         *     statutory retention obligation — a held row is outside every ordinary read, so there
+         *     is no presentation of it to refuse. A caller who may discover the row but stands
+         *     outside its audience gets `content_state: withheld`: the markers, and nothing said.
+         */
+        get: operations["getEmailPresentation"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/activities/{id}/audience": {
         parameters: {
             query?: never;
@@ -13552,6 +13581,186 @@ export interface components {
              */
             deletes_at?: string;
         };
+        /**
+         * @description One retained email, reduced to what a row shows without opening it. Present on an
+         *     activity only when `kind=email`; every other kind carries none, and a reader that
+         *     branches on this field is asking the one question that decides the canonical row.
+         *
+         *     The preview is normalised by the server with the same splitter the detail uses, so a
+         *     row and the message it opens never disagree about where the sender's own words end.
+         *     A withheld email carries a summary whose `subject` and `preview` are null and whose
+         *     `display_status` says so — the row stays, the words do not.
+         */
+        EmailSummary: {
+            /** Format: uuid */
+            activity_id: string;
+            /** @description Null when the message has none, and when the content is withheld. */
+            subject?: string | null;
+            /**
+             * @description One line of the sender's own text, signature and quoted history already removed.
+             *     Null when withheld, and when the message has no text of its own.
+             */
+            preview?: string | null;
+            /** Format: date-time */
+            occurred_at: string;
+            /** @enum {string|null} */
+            direction?: null | "inbound" | "outbound";
+            /**
+             * @description Who the message was with, named for the row: "Ana Sommer", or "Ana Sommer +2" when
+             *     the exchange had more. Null when no participant resolves to a name this caller may
+             *     see — the row then says the direction alone rather than inventing a stranger.
+             */
+            counterparty?: string | null;
+            /** @description How many files came with it. Zero when withheld, like every other count. */
+            attachment_count: number;
+            /**
+             * @description Whose move it is, derived from what this reader can see of the thread. `none` when
+             *     the question cannot be answered honestly — an unanswerable move is not a claim.
+             * @enum {string}
+             */
+            move: "needs_reply" | "waiting_for_them" | "none";
+            display_status: components["schemas"]["EmailAccessStatus"];
+            /**
+             * @description The activity's version, carried so a row can open an editor that writes with
+             *     If-Match. A row without it can only read.
+             */
+            version: components["schemas"]["RowVersion"];
+        };
+        /**
+         * @description What a reader is allowed to know about who else reads this message, in one word the
+         *     badge can print. `team` never means the whole workspace: the linked record's own scope
+         *     still decides who may discover the row at all.
+         *
+         *     `still_held` is the honest half of a share — you released your hold and somebody else
+         *     has not. `withheld` is the only value that says the content is not this caller's, and
+         *     it never travels with a reason: why a message is private describes what it is about.
+         * @enum {string}
+         */
+        EmailAccessStatus: "team" | "participants" | "selected" | "private_pending" | "private_by_you" | "still_held" | "withheld";
+        /** @description One address on a message, resolved to a person or a seat when it is one. */
+        EmailParty: {
+            address: string;
+            display_name?: string | null;
+            /**
+             * Format: uuid
+             * @description Set when the address belongs to a contact this caller may see.
+             */
+            person_id?: string | null;
+            /**
+             * Format: uuid
+             * @description Set when the address belongs to a seat in this workspace.
+             */
+            user_id?: string | null;
+        };
+        /** @description One file that came with the message. Metadata only; bytes are fetched separately. */
+        EmailAttachmentSummary: {
+            /** Format: uuid */
+            id: string;
+            filename: string;
+            byte_size?: number | null;
+            content_type?: string | null;
+        };
+        /**
+         * @description Who reads this message, and what this caller may do about that. `can_change` and
+         *     `change_mode` are decided by the same authority that would execute the write, so a
+         *     control this block offers is a control the write will accept.
+         */
+        EmailAccess: {
+            /** @enum {string} */
+            content_state: "available" | "withheld";
+            display_status: components["schemas"]["EmailAccessStatus"];
+            audience?: components["schemas"]["ActivityAudience"] | null;
+            /**
+             * @description Who is named on a `selected` audience. Returned only to a caller who may both read
+             *     the content and change it — a reader with no standing to edit the set has no
+             *     standing to enumerate it either.
+             */
+            selected_members?: components["schemas"]["AudienceMember"][];
+            can_change: boolean;
+            /**
+             * @description Which write this caller's Access control performs. `thread_contribution` changes
+             *     only this owner's contribution to a captured thread; `message_audience` sets a
+             *     hand-logged message's own audience. The browser never decides this by reading
+             *     `captured_by` — the server knows which write it would accept.
+             * @enum {string}
+             */
+            change_mode: "thread_contribution" | "message_audience" | "none";
+            /**
+             * @description What the editor must say it is about to change, in the words the user reads.
+             * @enum {string}
+             */
+            change_scope?: "thread" | "message" | "none";
+            /**
+             * @description After a share, how many other seats still hold this thread. A count and never a
+             *     name. Null when the question does not apply.
+             */
+            held_by_others?: number | null;
+            /**
+             * @description Why the message is limited, when the caller may know. Always null while the content
+             *     is withheld: the reason describes the message.
+             */
+            explanation?: string | null;
+        };
+        /**
+         * @description The rest of the conversation, newest first, as summaries. Bounded and paged rather
+         *     than whole: a thread has no ceiling, and a drawer that fetched every message would
+         *     make opening the newest one cost the whole history.
+         */
+        EmailThreadPage: {
+            members: components["schemas"]["EmailSummary"][];
+            /** @description Pass back as `thread_cursor` for the next page. Null when this is the last. */
+            next_cursor?: string | null;
+        };
+        /**
+         * @description One email, composed for reading. The message and its parties come from the activity's
+         *     own store; the access block is assembled from the same authority that performs the
+         *     write, so what this says a caller may do is what the caller may do.
+         *
+         *     A withheld presentation carries the markers and refuses the rest: no subject, no body,
+         *     no parties, no attachments, no thread, no reason, no member names.
+         */
+        EmailPresentation: {
+            /** Format: uuid */
+            id: string;
+            /**
+             * @description Whether this is correspondence or something not yet sent. A scheduled send and a
+             *     draft awaiting approval borrow the frame; their operational verbs stay with the
+             *     workflow that owns them.
+             * @enum {string}
+             */
+            lifecycle: "delivered" | "scheduled" | "approval_draft";
+            /** Format: date-time */
+            occurred_at: string;
+            summary: components["schemas"]["EmailSummary"];
+            /**
+             * @description The message as plain text, normalised. Null when withheld. Provider payloads are
+             *     never handed to a browser to parse.
+             */
+            body?: string | null;
+            thread_key?: string | null;
+            from: components["schemas"]["EmailParty"][];
+            to: components["schemas"]["EmailParty"][];
+            cc: components["schemas"]["EmailParty"][];
+            /**
+             * @description Empty for every caller but the seat that sent or imported the message. Being
+             *     allowed to read what was written does not disclose who was copied blind.
+             */
+            bcc: components["schemas"]["EmailParty"][];
+            /**
+             * @description True when the message has blind recipients this caller may not see. The viewer says
+             *     that they exist rather than showing an empty list that reads as none.
+             */
+            bcc_withheld: boolean;
+            attachments: components["schemas"]["EmailAttachmentSummary"][];
+            /** @description What the message is filed against, named for a reader. */
+            links: components["schemas"]["ActivityLink"][];
+            thread?: components["schemas"]["EmailThreadPage"];
+            access: components["schemas"]["EmailAccess"];
+            can_reply: boolean;
+            can_relink: boolean;
+            /** @description The activity's version, for the If-Match its own actions send. */
+            version: components["schemas"]["RowVersion"];
+        };
         /** @description What an owner's decision about a thread reached. */
         ThreadAudienceOutcome: {
             /** @description How many of the thread's messages you imported, and the decision reached. */
@@ -19703,6 +19912,8 @@ export interface components {
              * @enum {string|null}
              */
             direction?: null | "inbound" | "outbound";
+            /** @description Present exactly when `kind=email`. What the canonical email row renders, so a list does not have to fetch a message per visible line to draw one. Every other kind carries none, and a reader branches on its presence rather than on the kind word. */
+            readonly email_summary?: components["schemas"]["EmailSummary"] | null;
             /** @description The provider's own conversation id (Gmail threadId, Graph conversationId, the RFC822 References root), stamped by capture. It is what makes a thread a thread: grouping by subject would merge two unrelated "Re: Update" exchanges and split one that was renamed mid-conversation. Null on anything capture did not thread — a note, a task, a message whose provider offered none. */
             readonly thread_key?: string | null;
             /**
@@ -19938,15 +20149,21 @@ export interface components {
              */
             snoozed_until?: string;
         };
+        /**
+         * @description One user or team admitted to a message besides its participants. The same shape the
+         *     audience write takes and the presentation reads back, so an editor that renders the
+         *     current set submits it in the vocabulary it received.
+         */
+        AudienceMember: {
+            /** @enum {string} */
+            subject_type: "user" | "team";
+            /** Format: uuid */
+            subject_id: string;
+        };
         SetActivityAudienceRequest: {
             audience: components["schemas"]["ActivityAudience"];
             /** @description The users and teams admitted besides the participants. Read only when `audience` is `selected`; replaces the previous set. */
-            members?: {
-                /** @enum {string} */
-                subject_type: "user" | "team";
-                /** Format: uuid */
-                subject_id: string;
-            }[];
+            members?: components["schemas"]["AudienceMember"][];
         };
         UpdateActivityRequest: {
             subject?: string | null;
@@ -32996,6 +33213,33 @@ export interface operations {
             };
             404: components["responses"]["NotFound"];
             422: components["responses"]["ValidationError"];
+        };
+    };
+    getEmailPresentation: {
+        parameters: {
+            query?: {
+                /** @description Continue the thread's member page from a previous response's `thread.next_cursor`. */
+                thread_cursor?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The email. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EmailPresentation"];
+                };
+            };
+            404: components["responses"]["NotFound"];
         };
     };
     setActivityAudience: {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -13631,12 +13631,16 @@ export interface components {
          *     badge can print. `team` never means the whole workspace: the linked record's own scope
          *     still decides who may discover the row at all.
          *
-         *     `still_held` is the honest half of a share — you released your hold and somebody else
-         *     has not. `withheld` is the only value that says the content is not this caller's, and
-         *     it never travels with a reason: why a message is private describes what it is about.
+         *     `withheld` is the only value that says the content is not this caller's, and it never
+         *     travels with a reason: why a message is private describes what it is about.
+         *
+         *     The captured-mail states a mailbox owner sees — held until classified, private by you,
+         *     shared but still held by another seat — are not here yet. They arrive with the thread
+         *     contribution editor that can act on them; a value no server can emit is one a client
+         *     would branch on and never reach.
          * @enum {string}
          */
-        EmailAccessStatus: "team" | "participants" | "selected" | "private_pending" | "private_by_you" | "still_held" | "withheld";
+        EmailAccessStatus: "team" | "participants" | "selected" | "withheld";
         /** @description One address on a message, resolved to a person or a seat when it is one. */
         EmailParty: {
             address: string;
@@ -13691,11 +13695,6 @@ export interface components {
              */
             change_scope?: "thread" | "message" | "none";
             /**
-             * @description After a share, how many other seats still hold this thread. A count and never a
-             *     name. Null when the question does not apply.
-             */
-            held_by_others?: number | null;
-            /**
              * @description Why the message is limited, when the caller may know. Always null while the content
              *     is withheld: the reason describes the message.
              */
@@ -13723,12 +13722,12 @@ export interface components {
             /** Format: uuid */
             id: string;
             /**
-             * @description Whether this is correspondence or something not yet sent. A scheduled send and a
-             *     draft awaiting approval borrow the frame; their operational verbs stay with the
-             *     workflow that owns them.
+             * @description What kind of message this is. One value today: this read serves delivered
+             *     correspondence. A scheduled send and a draft awaiting approval will borrow the
+             *     frame when the reads that serve them land, and they are not listed until then.
              * @enum {string}
              */
-            lifecycle: "delivered" | "scheduled" | "approval_draft";
+            lifecycle: "delivered";
             /** Format: date-time */
             occurred_at: string;
             summary: components["schemas"]["EmailSummary"];


### PR DESCRIPTION
The first slice of the email-display unification: the read every canonical
email surface will use. No screen changes yet — this is the contract and the
engine behind it.

## What it adds

**`EmailSummary`, riding every `Activity`.** What a row draws without opening
the message: subject, a server-composed preview, direction, counterparty,
attachment count, move state, access status, version. Composed in
`activityprojection.go`'s `record()`, so every reader of an activity carries
it and a twenty-row timeline stays one request. Present exactly when
`kind=email` — a reader branches on the field, not on the kind word, because
a call and a note are activities too and neither has an email's shape.

**`EmailPresentation`,** served by `GET /activities/{id}/email-presentation`:
the message, its normalised recipients, its attachments, a bounded page of its
thread, and the access block.

## What it does not do

It reads THROUGH `readActivity` rather than adding a third SELECT over
`activity`. The withholding rule already exists twice here, and the comment on
`compose/person360`'s hand-written sibling records that the duplicate went
missing a column for a whole slice, twice.

## Three decisions worth review

**`change_mode` is the server's answer, not the browser's guess.** The UI has
been reading the `connector:` prefix off `captured_by` to choose between the
thread and message audience writes — a backend ownership rule living in
display code, which reads a hand-typed threaded reply wrong. `readEmailAccess`
decides it with the same `capture_import` existence test
`refuseCapturedAudienceWrite` applies, so what the read offers is what the
write accepts.

**BCC has its own gate.** It is an ordinary `activity_participant` role, and
`ActivityContentClause` has no arm for it: being allowed to read what was
written is not standing to learn who was copied blind. Only the sending or
importing seat sees it; everyone else gets `bcc_withheld: true`, because an
empty list reads as "nobody" rather than "not yours".

**A non-email id answers 404** rather than naming the kind it actually is,
which would answer a question about a row the caller may only discover.

## Tests

`TestEmailPresentationAccessMatrix` walks each audience against each reader.
The case that matters is the unbounded admin on a participants-only message:
row scope admits them, the audience does not, and the audience wins.
Mutation-checked — forcing `withheld=false` fails it on all three refused
readers rather than passing quietly.

`make check-backend` and `make check-fe` both green; craft-static,
rls-store-path and no-jurisdiction clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the contract behind the email-display unification: every `Activity` now carries an `EmailSummary`, and `GET /activities/{id}/email-presentation` serves the full read. No screen changes yet.

**New Features**
- `EmailSummary` is composed in the activity projection, so a 20-row timeline stays one request; it appears only when `kind=email`.
- `EmailPresentation` returns normalized recipients, attachment metadata, a bounded cursored thread page, and the access block, reading through `readActivity`.
- A Go body splitter mirrors the frontend preview splitter, with shared fixtures keeping the two in parity.
- `TestEmailPresentationAccessMatrix` walks every audience against every reader, including an unbounded admin on a participants-only message.

**Behavior**
- `change_mode` is decided by the same captured-audience check the write path uses, instead of the UI parsing the `connector:` prefix from `captured_by`.
- BCC recipients are hidden from all but the sending or importing seat, surfaced as `bcc_withheld: true` rather than an empty list.
- Non-email and retention-held ids return 404; readers outside the audience get `content_state: withheld`.
- The person360 twin of the projection composes the summary after withholding, so the contract holds there too.
- `can_relink` follows the access block's writability; a database failure in the probe returns an error, not a denial.
- The import check is one shared helper, `activityWasImported`; the contract shed five enum values nothing can emit.

<sup>Written for commit c48ae6adcbc9b755930f7784b74ceb69c249c567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added email presentation retrieval with optional thread pagination.
  * Added email summaries to activity listings, including subject, preview, direction, status, and move state.
  * Added access-aware email views with participants, attachments, access controls, and restricted-content handling.
  * Added cleaner email previews and readable message content through email body parsing.
  * Added support for audience members in activity audience updates.
  * Added reply and relinking permissions based on email access.

* **Bug Fixes**
  * Non-email activities are rejected when requesting email presentations.
  * Sensitive details, including restricted content and unauthorized BCC information, are hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->