### PR TITLE
A tag found in search reaches the records carrying it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31029,10 +31029,11 @@ components:
         carried_by:
           type: [integer, 'null']
           description: >
-            For a `tag` hit only: how many records across every taggable type carry this word,
-            as the caller's own row scope counts them. It is what tells a searcher whether the
-            word is worth opening before they open it. Null on every other hit type, and null
-            when the caller may not read the vocabulary.
+            For a `tag` hit only: how many people, companies and deals carry this word, as
+            THIS caller may see them — the same three types the tag page counts and the
+            filters offer, not every type `taggable` admits. It is what tells a searcher
+            whether the word is worth opening before they open it. Null on every other hit
+            type, and null when no count was taken.
         trust_tier:
           type: [string, 'null']
           enum: [authoritative, external, unverified, null]

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31026,6 +31026,13 @@ components:
         title: { type: [string, 'null'], description: Display label (name/subject). }
         snippet: { type: [string, 'null'] }
         score: { type: [number, 'null'], description: Relevance score. }
+        carried_by:
+          type: [integer, 'null']
+          description: >
+            For a `tag` hit only: how many records across every taggable type carry this word,
+            as the caller's own row scope counts them. It is what tells a searcher whether the
+            word is worth opening before they open it. Null on every other hit type, and null
+            when the caller may not read the vocabulary.
         trust_tier:
           type: [string, 'null']
           enum: [authoritative, external, unverified, null]

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/aiactivity"
 	"github.com/margince/margince/backend/internal/modules/automation"
+	"github.com/margince/margince/backend/internal/modules/collections"
 	"github.com/margince/margince/backend/internal/modules/commissions"
 	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/modules/contracts"
@@ -115,7 +116,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		dealroomsHandlers:   dealrooms.NewHandlers(InstallationDB(pool)),
 		commissionsHandlers: commissions.NewHandlers(InstallationDB(pool)),
 		activitiesHandlers:  newActivitiesHandlers(pool).WithUploadLimit(limits.Attachment),
-		searchHandlers:      search.NewHandlers(InstallationDB(pool)),
+		searchHandlers:      search.NewHandlers(InstallationDB(pool), collections.CountTagReach),
 		// Constructed, not merely embedded: the handler carries no nil-pool
 		// branch, so the zero value would panic on the first authenticated
 		// read rather than answer anything at all.

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -116,7 +116,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		dealroomsHandlers:   dealrooms.NewHandlers(InstallationDB(pool)),
 		commissionsHandlers: commissions.NewHandlers(InstallationDB(pool)),
 		activitiesHandlers:  newActivitiesHandlers(pool).WithUploadLimit(limits.Attachment),
-		searchHandlers:      search.NewHandlers(InstallationDB(pool), collections.CountTagReach),
+		searchHandlers:      search.NewHandlers(InstallationDB(pool), collections.CountTagReachBatch),
 		// Constructed, not merely embedded: the handler carries no nil-pool
 		// branch, so the zero value would panic on the first authenticated
 		// read rather than answer anything at all.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -27744,7 +27744,7 @@ type SearchResponse struct {
 
 // SearchResult defines model for SearchResult.
 type SearchResult struct {
-	// CarriedBy For a `tag` hit only: how many records across every taggable type carry this word, as the caller's own row scope counts them. It is what tells a searcher whether the word is worth opening before they open it. Null on every other hit type, and null when the caller may not read the vocabulary.
+	// CarriedBy For a `tag` hit only: how many people, companies and deals carry this word, as THIS caller may see them — the same three types the tag page counts and the filters offer, not every type `taggable` admits. It is what tells a searcher whether the word is worth opening before they open it. Null on every other hit type, and null when no count was taken.
 	CarriedBy *int               `json:"carried_by,omitempty"`
 	Id        openapi_types.UUID `json:"id"`
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -27744,7 +27744,9 @@ type SearchResponse struct {
 
 // SearchResult defines model for SearchResult.
 type SearchResult struct {
-	Id openapi_types.UUID `json:"id"`
+	// CarriedBy For a `tag` hit only: how many records across every taggable type carry this word, as the caller's own row scope counts them. It is what tells a searcher whether the word is worth opening before they open it. Null on every other hit type, and null when the caller may not read the vocabulary.
+	CarriedBy *int               `json:"carried_by,omitempty"`
+	Id        openapi_types.UUID `json:"id"`
 
 	// Score Relevance score.
 	Score   *float32 `json:"score,omitempty"`

--- a/backend/internal/modules/collections/tagreach_test.go
+++ b/backend/internal/modules/collections/tagreach_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package collections
+
+// `carried_by` on a search hit is this counter, so what it refuses is what a
+// searcher is not told. The count is per-caller by construction — it totals
+// tagUsage, whose per-type queries each carry that type's row-scope clause —
+// and the door in front of it is the vocabulary read: a caller who may not
+// read tags learns nothing about them, including how many records carry one.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// A count is a fact about the vocabulary, so it asks the same grant reading the
+// vocabulary asks. The refusal lands before any query, which is why a nil
+// transaction is enough to prove it: reaching the database would panic.
+func TestCountingATagsReachNeedsTheVocabularyRead(t *testing.T) {
+	t.Parallel()
+	ctx := taggerWith(map[string]principal.ObjectGrant{
+		"person":       {Read: true},
+		"organization": {Read: true},
+		"deal":         {Read: true},
+	})
+
+	_, err := CountTagReachBatch(ctx, nil, []ids.TagID{ids.New[ids.TagKind]()})
+
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a seat without tag.read counted a tag's reach: %v", err)
+	}
+}
+
+// The disclosure case Codex named, and the reason the object grant is asked
+// per counted type: ScopeClauseFor renders a ROW predicate and is not a gate,
+// so a seat holding tag.read and no person.read would be counted the people it
+// may not list — and a count of rows a caller cannot open tells them those rows
+// exist. The refusal lands before any query here too, so a nil transaction is
+// the proof: reaching the database would panic instead.
+func TestATypeTheCallerMayNotReadIsNotCounted(t *testing.T) {
+	t.Parallel()
+	ctx := taggerWith(map[string]principal.ObjectGrant{
+		"tag": {Read: true},
+	})
+
+	if _, err := countVisibleTaggedBatch(ctx, nil, []ids.TagID{ids.New[ids.TagKind]()}, "person"); !errors.Is(
+		err, apperrors.ErrPermissionDenied,
+	) {
+		t.Fatalf("counted a type the seat may not read: %v", err)
+	}
+}
+
+// The admit case, and it is not decoration: without it a counter that refused
+// EVERY caller would pass the refusal above and report nothing to anybody.
+// Holding the grant must get PAST the door — it then fails on the nil
+// transaction, which is the proof it got that far.
+func TestTheVocabularyReadGetsPastTheDoor(t *testing.T) {
+	t.Parallel()
+	ctx := taggerWith(map[string]principal.ObjectGrant{
+		"tag":          {Read: true},
+		"person":       {Read: true},
+		"organization": {Read: true},
+		"deal":         {Read: true},
+	})
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected the nil transaction to panic once the door admitted")
+		}
+	}()
+	if _, err := CountTagReachBatch(ctx, nil, []ids.TagID{ids.New[ids.TagKind]()}); err != nil {
+		t.Fatalf("the door refused a seat holding tag.read: %v", err)
+	}
+}

--- a/backend/internal/modules/collections/tagvocab.go
+++ b/backend/internal/modules/collections/tagvocab.go
@@ -145,6 +145,25 @@ func countVisibleTagged(ctx context.Context, tx pgx.Tx, id ids.TagID, entityType
 	return n, nil
 }
 
+// CountTagReach totals the records one tag is on, for THIS caller, inside a
+// transaction the caller already holds.
+//
+// The search module's `carried_by` is this number: search shows a word, and the
+// count is how a reader tells a word worth opening from one nobody used. It is
+// `tagUsage` totalled rather than a count of its own, so the figure beside a
+// search hit and the per-type figures on the tag page are the same read of the
+// same rule — including the rule that a caller counts only what they may see.
+func CountTagReach(ctx context.Context, tx pgx.Tx, tagID ids.TagID) (int, error) {
+	if err := auth.Require(ctx, "tag", principal.ActionRead); err != nil {
+		return 0, err
+	}
+	usage, err := tagUsage(ctx, tx, tagID)
+	if err != nil {
+		return 0, err
+	}
+	return usage.People + usage.Companies + usage.Deals, nil
+}
+
 // TagUpdate is the partial a rename carries. A nil field is left alone; a
 // non-nil one holding a nil pointer clears the column.
 type TagUpdate struct {

--- a/backend/internal/modules/collections/tagvocab.go
+++ b/backend/internal/modules/collections/tagvocab.go
@@ -108,6 +108,13 @@ func tagUsage(ctx context.Context, tx pgx.Tx, id ids.TagID) (TagUsage, error) {
 		{typeDeal, &out.Deals},
 	} {
 		n, err := countVisibleTagged(ctx, tx, id, c.entityType)
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			// No grant on that type is not "none of them carry it": the caller
+			// may not read the type at all, and a number covering rows they
+			// cannot list would tell them those rows exist. Zero is the honest
+			// answer to a caller who is not admitted to look.
+			continue
+		}
 		if err != nil {
 			return TagUsage{}, err
 		}
@@ -119,6 +126,13 @@ func tagUsage(ctx context.Context, tx pgx.Tx, id ids.TagID) (TagUsage, error) {
 // countVisibleTagged counts one type's tagged records under that type's own
 // row-scope predicate.
 func countVisibleTagged(ctx context.Context, tx pgx.Tx, id ids.TagID, entityType string) (int, error) {
+	// The OBJECT grant first. ScopeClauseFor renders a row predicate and is not
+	// a gate: a seat holding tag.read and no person.read would otherwise be
+	// counted the people it may not list, and a count of rows a caller cannot
+	// open discloses that they exist.
+	if err := auth.Require(ctx, entityType, principal.ActionRead); err != nil {
+		return 0, err
+	}
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	tagPos, typePos := arg(id), arg(entityType)
@@ -145,23 +159,83 @@ func countVisibleTagged(ctx context.Context, tx pgx.Tx, id ids.TagID, entityType
 	return n, nil
 }
 
-// CountTagReach totals the records one tag is on, for THIS caller, inside a
-// transaction the caller already holds.
+// CountTagReachBatch totals, per tag, the records THIS caller may see carrying
+// it — one statement per record type for the whole page rather than three per
+// hit, which is what a search page of tag hits would otherwise cost.
 //
-// The search module's `carried_by` is this number: search shows a word, and the
-// count is how a reader tells a word worth opening from one nobody used. It is
-// `tagUsage` totalled rather than a count of its own, so the figure beside a
-// search hit and the per-type figures on the tag page are the same read of the
-// same rule — including the rule that a caller counts only what they may see.
-func CountTagReach(ctx context.Context, tx pgx.Tx, tagID ids.TagID) (int, error) {
+// The per-type structure is kept, not flattened: each type carries its own
+// object grant and its own row-scope predicate, and a single query across
+// types could honour neither. What is batched is the tags, not the rules.
+//
+// A tag absent from the returned map is one nothing visible carries; the
+// caller decides whether that reads as zero or as unknown.
+func CountTagReachBatch(ctx context.Context, tx pgx.Tx, tagIDs []ids.TagID) (map[ids.TagID]int, error) {
 	if err := auth.Require(ctx, "tag", principal.ActionRead); err != nil {
-		return 0, err
+		return nil, err
 	}
-	usage, err := tagUsage(ctx, tx, tagID)
+	out := make(map[ids.TagID]int, len(tagIDs))
+	if len(tagIDs) == 0 {
+		return out, nil
+	}
+	for _, entityType := range []string{typePerson, typeOrganization, typeDeal} {
+		counts, err := countVisibleTaggedBatch(ctx, tx, tagIDs, entityType)
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			// Same rule as tagUsage: a type this caller may not read
+			// contributes nothing rather than disclosing that its rows exist.
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		for tagID, n := range counts {
+			out[tagID] += n
+		}
+	}
+	return out, nil
+}
+
+// countVisibleTaggedBatch is countVisibleTagged over many tags at once, under
+// the same object grant and the same row-scope predicate.
+func countVisibleTaggedBatch(ctx context.Context, tx pgx.Tx, tagIDs []ids.TagID, entityType string) (map[ids.TagID]int, error) {
+	if err := auth.Require(ctx, entityType, principal.ActionRead); err != nil {
+		return nil, err
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idsPos, typePos := arg(tagIDs), arg(entityType)
+	scope, err := auth.ScopeClauseFor(ctx, entityType, "r", arg)
 	if err != nil {
-		return 0, err
+		return nil, fmt.Errorf("collections: scoping %s tag usage: %w", entityType, err)
 	}
-	return usage.People + usage.Companies + usage.Deals, nil
+	if scope == "" {
+		scope = "TRUE"
+	}
+	query := fmt.Sprintf(`
+		SELECT tg.tag_id, count(*)
+		  FROM taggable tg
+		  JOIN %s r ON r.id = tg.entity_id
+		 WHERE tg.tag_id = ANY($%d) AND tg.entity_type = $%d
+		   AND r.archived_at IS NULL
+		   AND (%s)
+		 GROUP BY tg.tag_id`, pgx.Identifier{entityType}.Sanitize(), idsPos, typePos, scope)
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("collections: counting %s tag usage: %w", entityType, err)
+	}
+	defer rows.Close()
+	out := make(map[ids.TagID]int, len(tagIDs))
+	for rows.Next() {
+		var tagID ids.TagID
+		var n int
+		if err := rows.Scan(&tagID, &n); err != nil {
+			return nil, fmt.Errorf("collections: reading %s tag usage: %w", entityType, err)
+		}
+		out[tagID] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("collections: reading %s tag usage: %w", entityType, err)
+	}
+	return out, nil
 }
 
 // TagUpdate is the partial a rename carries. A nil field is left alone; a

--- a/backend/internal/modules/search/handlers.go
+++ b/backend/internal/modules/search/handlers.go
@@ -21,8 +21,11 @@ type Handlers struct {
 }
 
 // NewHandlers builds the module's HTTP surface over a workspace-bound handle.
-func NewHandlers(db *database.DB) Handlers {
-	store := NewStore(db)
+// NewHandlers binds the HTTP search surface. `tagReach` counts what a tag hit
+// is on for the asking caller; compose supplies the collections store's own
+// counter, and a nil one leaves every hit's count absent rather than zero.
+func NewHandlers(db *database.DB, tagReach TagReachCounter) Handlers {
+	store := NewStore(db).WithTagReach(tagReach)
 	// Embedder is nil, and stays nil: the only thing this retriever serves is
 	// AssembleContext, which walks the context graph and never embeds. The
 	// request-path embed lane compose binds is for the RANKED half, and
@@ -63,6 +66,11 @@ func (h Handlers) Search(w http.ResponseWriter, r *http.Request, params crmcontr
 		}
 		if hit.Snippet != "" {
 			result.Snippet = ptr(hit.Snippet)
+		}
+		// Copied, not aliased: `hit` is the loop's own variable and taking its
+		// address would give every result the last hit's number.
+		if hit.CarriedBy != nil {
+			result.CarriedBy = ptr(*hit.CarriedBy)
 		}
 		// native records are authoritative
 		result.TrustTier = ptr(crmcontracts.SearchResultTrustTierAuthoritative)

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -24,12 +24,33 @@ import (
 type Store struct {
 	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
 	db *database.DB
+	// carriedBy counts the records one tag is on, for THIS caller. It is the
+	// collections store's own counter, injected by compose because a module
+	// never imports a sibling. Calling that counter rather than writing a
+	// second one here is what keeps the figure beside a search hit derived
+	// from the same rule as the figures on the tag page — including the rule
+	// that a caller counts only the records they may see.
+	//
+	// Nil where nothing supplied it (a worker's store, a test that does not
+	// ask): a tag hit then carries no count, which reads as "not known" and
+	// never as zero.
+	carriedBy TagReachCounter
 }
+
+// TagReachCounter counts, inside the caller's own transaction, how many records
+// carry one tag under that caller's row scope.
+type TagReachCounter func(ctx context.Context, tx pgx.Tx, tagID ids.TagID) (int, error)
 
 // NewStore opens this module's store on a handle already bound to the
 // workspace it serves.
 func NewStore(db *database.DB) *Store {
 	return &Store{db: db}
+}
+
+// WithTagReach binds the counter behind a tag hit's `carried_by`.
+func (s *Store) WithTagReach(count TagReachCounter) *Store {
+	s.carriedBy = count
+	return s
 }
 
 // bounded is this store with a time ceiling on every statement it runs.
@@ -39,7 +60,9 @@ func NewStore(db *database.DB) *Store {
 // one, and a ceiling armed at a single call site would leave the other lane as
 // unbounded as it was before anybody thought about it.
 func (s *Store) bounded(budget time.Duration) *Store {
-	return &Store{db: s.db.Bounded(budget)}
+	// Every field travels, not just the handle: this rebuilds the store, so a
+	// field left out here is one the bounded lane silently does without.
+	return &Store{db: s.db.Bounded(budget), carriedBy: s.carriedBy}
 }
 
 // forWorkspace is this store re-bound to one tenant of the fleet enumeration.
@@ -58,6 +81,9 @@ type Hit struct {
 	Title   string
 	Snippet string
 	Score   float64
+	// CarriedBy is set on a `tag` hit alone: how many records the caller may
+	// see carry this word. Nil elsewhere, and nil when no counter is bound.
+	CarriedBy *int
 }
 
 type Page struct {
@@ -282,13 +308,42 @@ func (s *Store) Search(ctx context.Context, in Input) (Page, error) {
 			return fmt.Errorf("search: query: %w", err)
 		}
 		defer rows.Close()
-		page, err = scanRankedPage(rows, limit)
-		return err
+		if page, err = scanRankedPage(rows, limit); err != nil {
+			return err
+		}
+		return s.countTagReach(ctx, tx, page.Hits)
 	})
 	if err != nil {
 		return Page{}, err
 	}
 	return page, nil
+}
+
+// countTagReach fills CarriedBy on the tag hits of one page.
+//
+// It runs in the SAME transaction as the ranking query, so the number a hit
+// reports and the rows the search admitted are one consistent read: counting
+// afterwards could answer from a tree somebody changed in between.
+//
+// A counting failure fails the search rather than answering with a silent
+// gap. The counter runs the caller's own row scope, so an error here is that
+// scope refusing to render — and a page that quietly drops the number in that
+// case would show a searcher a smaller world without saying so.
+func (s *Store) countTagReach(ctx context.Context, tx pgx.Tx, hits []Hit) error {
+	if s.carriedBy == nil {
+		return nil
+	}
+	for i := range hits {
+		if hits[i].Type != "tag" {
+			continue
+		}
+		n, err := s.carriedBy(ctx, tx, ids.From[ids.TagKind](hits[i].ID))
+		if err != nil {
+			return fmt.Errorf("search: counting what tag %s is on: %w", hits[i].ID, err)
+		}
+		hits[i].CarriedBy = &n
+	}
+	return nil
 }
 
 // admittedBranchSQL builds one ranked SELECT per requested-and-admitted

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -37,10 +37,6 @@ type Store struct {
 	carriedBy TagReachCounter
 }
 
-// TagReachCounter counts, inside the caller's own transaction, how many records
-// carry one tag under that caller's row scope.
-type TagReachCounter func(ctx context.Context, tx pgx.Tx, tagID ids.TagID) (int, error)
-
 // NewStore opens this module's store on a handle already bound to the
 // workspace it serves.
 func NewStore(db *database.DB) *Store {
@@ -69,6 +65,10 @@ func (s *Store) bounded(budget time.Duration) *Store {
 // Only the index-maintenance passes that walk every workspace use it; a
 // request-path caller already holds the handle for the tenant it serves.
 func (s *Store) forWorkspace(ws ids.WorkspaceID) *Store {
+	// carriedBy is deliberately NOT carried across: these passes rebuild the
+	// index and answer nobody, so there is no caller whose row scope a count
+	// would be taken under. A lane that starts serving hits from here owes
+	// itself the counter, and would otherwise report every tag as uncounted.
 	return &Store{db: s.db.ForWorkspace(ws)}
 }
 
@@ -317,33 +317,6 @@ func (s *Store) Search(ctx context.Context, in Input) (Page, error) {
 		return Page{}, err
 	}
 	return page, nil
-}
-
-// countTagReach fills CarriedBy on the tag hits of one page.
-//
-// It runs in the SAME transaction as the ranking query, so the number a hit
-// reports and the rows the search admitted are one consistent read: counting
-// afterwards could answer from a tree somebody changed in between.
-//
-// A counting failure fails the search rather than answering with a silent
-// gap. The counter runs the caller's own row scope, so an error here is that
-// scope refusing to render — and a page that quietly drops the number in that
-// case would show a searcher a smaller world without saying so.
-func (s *Store) countTagReach(ctx context.Context, tx pgx.Tx, hits []Hit) error {
-	if s.carriedBy == nil {
-		return nil
-	}
-	for i := range hits {
-		if hits[i].Type != "tag" {
-			continue
-		}
-		n, err := s.carriedBy(ctx, tx, ids.From[ids.TagKind](hits[i].ID))
-		if err != nil {
-			return fmt.Errorf("search: counting what tag %s is on: %w", hits[i].ID, err)
-		}
-		hits[i].CarriedBy = &n
-	}
-	return nil
 }
 
 // admittedBranchSQL builds one ranked SELECT per requested-and-admitted

--- a/backend/internal/modules/search/tagreach.go
+++ b/backend/internal/modules/search/tagreach.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// hitTypeTag is the `type` a tag hit carries on the wire, and the same word
+// the tag branch declares in searchBranches. Named because the count path
+// tests it twice and a typo in either would silently count nothing.
+const hitTypeTag = "tag"
+
+// TagReachCounter counts, inside the caller's own transaction, how many records
+// carry each of these tags under that caller's row scope. It takes the whole
+// page's tags at once: a per-hit counter cost a round trip per record type per
+// hit, which a page of 200 turns into hundreds.
+//
+// A tag missing from the returned map is one nothing visible carries.
+type TagReachCounter func(ctx context.Context, tx pgx.Tx, tagIDs []ids.TagID) (map[ids.TagID]int, error)
+
+// countTagReach fills CarriedBy on the tag hits of one page.
+//
+// It runs in the ranking query's transaction so the counts are taken under the
+// same connection and the same actor, not because that freezes them: the
+// handle runs READ COMMITTED, so each count still sees its own committed
+// snapshot. A number one write out of date is the right trade here — this is
+// a hint about whether a word is worth opening, and the tag page behind it
+// re-counts on arrival.
+//
+// A counting failure fails the search rather than answering with a silent
+// gap. The counter runs the caller's own row scope, so an error here is that
+// scope refusing to render — and a page that quietly drops the number in that
+// case would show a searcher a smaller world without saying so.
+func (s *Store) countTagReach(ctx context.Context, tx pgx.Tx, hits []Hit) error {
+	if s.carriedBy == nil {
+		return nil
+	}
+	var tagIDs []ids.TagID
+	for i := range hits {
+		if hits[i].Type == hitTypeTag {
+			tagIDs = append(tagIDs, ids.From[ids.TagKind](hits[i].ID))
+		}
+	}
+	if len(tagIDs) == 0 {
+		return nil
+	}
+	counts, err := s.carriedBy(ctx, tx, tagIDs)
+	if err != nil {
+		return fmt.Errorf("search: counting what this page's tags are on: %w", err)
+	}
+	for i := range hits {
+		if hits[i].Type != hitTypeTag {
+			continue
+		}
+		// Absent from the map means nothing VISIBLE carries the word, which is
+		// a count of zero rather than a count nobody took — the counter ran and
+		// this tag matched no row the caller may see.
+		n := counts[ids.From[ids.TagKind](hits[i].ID)]
+		hits[i].CarriedBy = &n
+	}
+	return nil
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22546,6 +22546,8 @@ export interface components {
             snippet?: string | null;
             /** @description Relevance score. */
             score?: number | null;
+            /** @description For a `tag` hit only: how many records across every taggable type carry this word, as the caller's own row scope counts them. It is what tells a searcher whether the word is worth opening before they open it. Null on every other hit type, and null when the caller may not read the vocabulary. */
+            carried_by?: number | null;
             /**
              * @description Provenance tier of the underlying record. In native mode every stored record is `authoritative`; `external`/`unverified` are reserved for overlay/connector-sourced rows (not emitted until overlay adapters land). Never guessed — null when unknown.
              * @enum {string|null}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -22546,7 +22546,7 @@ export interface components {
             snippet?: string | null;
             /** @description Relevance score. */
             score?: number | null;
-            /** @description For a `tag` hit only: how many records across every taggable type carry this word, as the caller's own row scope counts them. It is what tells a searcher whether the word is worth opening before they open it. Null on every other hit type, and null when the caller may not read the vocabulary. */
+            /** @description For a `tag` hit only: how many people, companies and deals carry this word, as THIS caller may see them — the same three types the tag page counts and the filters offer, not every type `taggable` admits. It is what tells a searcher whether the word is worth opening before they open it. Null on every other hit type, and null when no count was taken. */
             carried_by?: number | null;
             /**
              * @description Provenance tier of the underlying record. In native mode every stored record is `authoritative`; `external`/`unverified` are reserved for overlay/connector-sourced rows (not emitted until overlay adapters land). Never guessed — null when unknown.

--- a/frontend/src/app/palette.test.tsx
+++ b/frontend/src/app/palette.test.tsx
@@ -240,6 +240,28 @@ describe("CommandPalette (AC-shell-3/4/5/6)", () => {
     await userEvent.click(screen.getByText("ACME-CRM"));
     expect(window.location.hash).toBe("#/projects/pr-1");
   });
+
+  // Typing a word and being taken to what carries it is the whole point of a
+  // tag. The palette used to drop tag hits with the types that have no page —
+  // a tag has one, so a searcher was left with no autocomplete for the
+  // vocabulary at all.
+  it("offers a tag hit and opens its page", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          data: [{ type: "tag", id: "t-1", title: "Key Account" }],
+          page: { next_cursor: null, has_more: false },
+        }),
+      ),
+    );
+    render(<CommandPalette open onClose={() => {}} commands={commands} />);
+    await userEvent.type(screen.getByRole("textbox"), "key");
+    await waitFor(() => expect(screen.getByText("Key Account")).toBeTruthy());
+
+    await userEvent.click(screen.getByText("Key Account"));
+    expect(window.location.hash).toBe("#/tags/t-1");
+  });
 });
 
 // The builtin set is DERIVED from the rail's destinations, so a screen with a

--- a/frontend/src/app/palette.tsx
+++ b/frontend/src/app/palette.tsx
@@ -187,8 +187,12 @@ function useSearchCommands(query: string): Command[] {
       return data.data;
     },
   });
-  const hits = (result.data ?? []).filter((hit) =>
-    RECORD_KINDS.has(hit.type as EntityKind),
+  // A tag rides alongside the records rather than being filtered out with the
+  // types that have no page. It is not an ENTITY kind — there is no tag 360 —
+  // but it has a page of its own, and reaching it is the point of typing a word
+  // into the palette: the tag page is where the records carrying it are listed.
+  const hits = (result.data ?? []).filter(
+    (hit) => RECORD_KINDS.has(hit.type as EntityKind) || hit.type === "tag",
   );
   const projectLines = useProjectHitLines(
     hits.filter((hit) => hit.type === "project").map((hit) => hit.id),
@@ -205,7 +209,12 @@ function useSearchCommands(query: string): Command[] {
         ? (projectLines.get(hit.id) ?? hit.type)
         : hit.type,
     type: "record" as const,
-    route: ENTITY[hit.type as EntityKind].route(hit.id),
+    // A tag's page is not in the ENTITY registry, which maps record kinds to
+    // their 360; reading it for a tag would throw on a missing entry.
+    route:
+      hit.type === "tag"
+        ? { screen: "tags" as const, id: hit.id }
+        : ENTITY[hit.type as EntityKind].route(hit.id),
   }));
 }
 

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -220,6 +220,7 @@ export const de = {
   "search.group.activity": "Aktivitäten",
   "search.group.lead": "Leads",
   "search.group.tag": "Tags",
+  "search.tag.carriedBy": "Auf {count} Datensätzen",
   "search.tier.mirrored": "aus einem verbundenen System",
   "search.tier.unverified": "nicht verifiziert",
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -240,6 +240,7 @@ export const en = {
   "search.group.activity": "Activities",
   "search.group.lead": "Leads",
   "search.group.tag": "Tags",
+  "search.tag.carriedBy": "On {count} records",
   "search.tier.mirrored": "from a connected system",
   "search.tier.unverified": "unverified",
 

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -225,6 +225,7 @@ export const vi = {
   "search.group.activity": "Hoạt động",
   "search.group.lead": "Lead",
   "search.group.tag": "Tag",
+  "search.tag.carriedBy": "Trên {count} bản ghi",
   "search.tier.mirrored": "từ hệ thống đã kết nối",
   "search.tier.unverified": "chưa xác minh",
 

--- a/frontend/src/screens/search.test.tsx
+++ b/frontend/src/screens/search.test.tsx
@@ -9,6 +9,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
@@ -191,5 +192,66 @@ describe("SearchScreen", () => {
     );
     render(<SearchScreen q="zzz" />);
     await waitFor(() => expect(screen.getByText(/No matches/)).toBeTruthy());
+  });
+  // Finding the WORD is the step before finding the records carrying it, so a
+  // tag hit has to be openable. It shipped as plain text — the group rendered,
+  // and the result was a dead end.
+  it("opens the tag page from a tag hit, and says what the word is on", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          data: [
+            {
+              type: "tag",
+              id: "01a05ebd-b03d-7183-b2fb-c00bcb58b419",
+              title: "Key Account",
+              snippet: null,
+              score: 2,
+              carried_by: 7,
+              trust_tier: "authoritative",
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+      ),
+    );
+    render(<SearchScreen q="key" />);
+
+    const hit = await screen.findByText("Key Account");
+    expect(hit.tagName).toBe("BUTTON");
+    expect(screen.getByText("On 7 records")).toBeTruthy();
+
+    await userEvent.setup().click(hit);
+    expect(window.location.hash).toBe(
+      "#/tags/01a05ebd-b03d-7183-b2fb-c00bcb58b419",
+    );
+  });
+
+  // Absent is not zero. A server that sent no number has not said the word is
+  // unused, and printing "On 0 records" would be a claim nobody made.
+  it("prints no count when the answer carried none", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          data: [
+            {
+              type: "tag",
+              id: "01a05ebd-b03d-7183-b2fb-c00bcb58b419",
+              title: "Key Account",
+              snippet: null,
+              score: 2,
+              trust_tier: "authoritative",
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+      ),
+    );
+    render(<SearchScreen q="key" />);
+
+    expect(await screen.findByText("Key Account")).toBeTruthy();
+    expect(screen.queryByText(/On \d+ records/)).toBeNull();
   });
 });

--- a/frontend/src/screens/search.tsx
+++ b/frontend/src/screens/search.tsx
@@ -8,7 +8,8 @@ import type { components } from "../api/schema";
 import { ENTITY, ENTITY_KINDS, type EntityKind } from "../app/entity";
 import { navigate } from "../app/router";
 import { Badge, Card, EmptyState, SearchField } from "../design-system/atoms";
-import { useT } from "../i18n";
+import { formatNumber } from "../format/format";
+import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { QueryGate, throwProblem } from "./common";
 import "./search.css";
@@ -125,11 +126,25 @@ function SearchGroups({ results }: Readonly<{ results: SearchResult[] }>) {
 
 function SearchHit({ hit }: Readonly<{ hit: SearchResult }>) {
   const t = useT();
+  const { locale } = useLocale();
+  // A tag is not an ENTITY kind — it has no 360 — but it does have a page, and
+  // it is the whole point of finding one: the word is the way to the records
+  // carrying it. Routed on its own rather than by widening ENTITY_KINDS, which
+  // drives record routing everywhere else and would claim a tag is a record.
+  const isTag = hit.type === "tag";
   const isLinkable = LINKABLE_KINDS.has(hit.type as EntityKind);
   return (
     <li className="search-hit">
       <div className="search-hit-title">
-        {isLinkable ? (
+        {isTag ? (
+          <button
+            type="button"
+            className="entity-link"
+            onClick={() => navigate({ screen: "tags", id: hit.id })}
+          >
+            {hit.title ?? hit.id}
+          </button>
+        ) : isLinkable ? (
           // The search API already returns the hit's display name as
           // `title` — routing through EntityRef here would re-fetch the
           // same record per hit (an N+1 GET per result) just to re-derive
@@ -171,6 +186,16 @@ function SearchHit({ hit }: Readonly<{ hit: SearchResult }>) {
           reached the page as "relevance 280%" — a percentage of nothing, which
           a reader can neither act on nor disbelieve. It still does its job in
           the ordering the results arrive in. */}
+      {/* What the word is on, so a reader can tell a live tag from one nobody
+          used without opening it. Absent rather than zero when the server sent
+          no number: a count it could not take is not a count of none. */}
+      {isTag && hit.carried_by != null && (
+        <p className="search-hit-snippet">
+          {t("search.tag.carriedBy", {
+            count: formatNumber(hit.carried_by, locale),
+          })}
+        </p>
+      )}
       {hit.snippet && <p className="search-hit-snippet">“{hit.snippet}”</p>}
     </li>
   );


### PR DESCRIPTION
Searching a tag name found the word and stopped there. The hit rendered as plain text — `tag` is not an ENTITY kind, so the search screen fell to its non-linkable branch — and the ⌘K palette dropped tag hits entirely, filtering on the same set. Finding the word is the step before finding the records on it, and neither surface took the second step.

## What changed

Both surfaces now route a tag hit to its page, which already lists every record carrying the word. Routed explicitly rather than by widening `ENTITY_KINDS`: that set drives 360 routing, and a tag has no 360.

A hit also says what the word is on. `carried_by` is the collections store's own counter injected through compose rather than a second count, so the figure beside a search hit is derived from the same rule as the figures on the tag page.

## What review changed

Codex found the count reaching past the caller's grants, and it was right. `ScopeClauseFor` renders a row predicate and is **not** an object gate, so a seat holding `tag.read` and no `person.read` was counted the people it may not list — and a count of rows somebody cannot open tells them those rows exist. Each counted type now asks its own read grant. **That hole predates this branch**, in the count behind the tag page; it is fixed there, at the invariant, rather than at the new call site.

Counting is also batched now: one statement per record type for a whole page rather than three per hit, which a 200-hit page turned into hundreds of round trips. The per-type structure stays — each type carries its own grant and its own scope clause, and one query across types could honour neither.

Two claims were corrected rather than kept. The contract said "every taggable type" while the product deliberately counts the three it shows and filters (leads and projects are taggable and uncounted, per the note in `tagvocab.go`). And a comment claimed one consistent read from sharing a transaction, which READ COMMITTED does not give.

## Tests

Three door tests in `tagreach_test.go`, each mutation-checked alone: the vocabulary read is required, a type the caller may not read is refused, and an admit case so the gate cannot pass by refusing everyone. Frontend: the tag hit is a button that lands on `#/tags/<id>`, the count renders, and an absent count renders nothing rather than zero — reverting each clause fails exactly its own test.

## Verified running

On a dev stack: search "K5" shows the Tags group with "K5 Summit / On 2 records", clicking opens the tag page listing the records; ⌘K offers the tag and lands on the same page. A tag nothing carries reports `carried_by: 0`. Measured 60 tag hits at 58ms before batching, so the change is a headroom fix rather than a live regression.

`make check-backend`, `make check-fe` and the integration lanes for both modules are green, re-run after the final rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search results for tags now show how many records carry each tag when available.
  - Selecting a tag search result opens its tag page.
  - Tag results are supported in the command palette and localized in English, German, and Vietnamese.
  - Search APIs now provide optional tag usage counts.

- **Bug Fixes**
  - Tag usage counts now respect visibility permissions and omit inaccessible records without failing the search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, tag matches in the search screen were plain text and the ⌘K palette discarded them. They now open the tag page, and each search hit can show how many visible people, companies, and deals carry the tag; unavailable counts remain hidden instead of appearing as zero.

**Implementation**

- Routes tags explicitly instead of widening `ENTITY_KINDS`, since tags have a page but no 360 route.
- Reuses the collections store’s counter so search results follow the tag page’s visibility rules.
- Requires `tag.read` and each counted record type’s read grant to prevent disclosure through counts.
- Batches counting into one query per record type for the entire result page.

<sup>Written for commit 7d4eda6eeaf366742922478c77aa0c7f688472f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

