### PR TITLE
The report fixtures can reach the settings a report reads

### DIFF
--- a/backend/internal/compose/integration/report_project_integration_test.go
+++ b/backend/internal/compose/integration/report_project_integration_test.go
@@ -55,7 +55,15 @@ func (e *SearchEnv) scopedReaderOf(object string, user *ids.UUID, team *ids.UUID
 	actor := principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
 		Permissions: principal.Permissions{
-			Objects:  map[string]principal.ObjectGrant{object: {Read: true}},
+			// The record type under test, and the installation's own settings
+			// beside it: a report resolves the basis it reports money in, so
+			// this read is held by every seeded role and refusing it stops the
+			// caller before any row-scope rule is reached. Same pairing
+			// searchReadGrants makes, for the same reason.
+			Objects: map[string]principal.ObjectGrant{
+				object:             {Read: true},
+				objInstallSettings: {Read: true},
+			},
 			RowScope: scope,
 		},
 	}

--- a/backend/internal/compose/integration/searchenv.go
+++ b/backend/internal/compose/integration/searchenv.go
@@ -77,6 +77,11 @@ func SetupSearch(t *testing.T) *SearchEnv {
 	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id) VALUES ($1)`, e.WS); err != nil {
 		t.Fatal(err)
 	}
+	// This harness builds its installation by raw SQL, so bootstrap never wrote
+	// the settings rows — the case seedInstallationIdentity exists for. A report
+	// resolves the basis it reports money in, and the zone it buckets dates by,
+	// so a suite without them is refused before any rule under test is reached.
+	seedInstallationIdentity(ctx, t, owner)
 	for i, u := range []ids.UUID{e.Rep1, e.Rep3} {
 		if _, err := owner.Exec(ctx, `INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Rep')`, u, fmt.Sprintf("rep%d@search.test", i)); err != nil {
 			t.Fatal(err)
@@ -135,7 +140,15 @@ func (e *SearchEnv) SeedID(t *testing.T, sql string, args ...any) ids.UUID {
 // principal without it sees no employer-derived account at all, which is a
 // different suite's question (TestASubjectTypeTheCallerMayNotReadIsNeverNamed
 // asks it deliberately, by naming its own grants).
-var searchObjects = []string{objPerson, objOrg, objDeal, "lead", objActivity, objRelationship}
+// installation_settings joins the record types, and it is not a record type:
+// a report resolves the basis it reports money in, so every seeded role holds
+// this read and every other report suite's fixture already grants it
+// (report_fieldmask, report_forecast, report_projectgrant). Without it a
+// principal here is refused before any row-scope rule is reached, which is a
+// fixture that cannot ask the question its suite exists to ask.
+var searchObjects = []string{
+	objPerson, objOrg, objDeal, "lead", objActivity, objRelationship, objInstallSettings,
+}
 
 // searchReadGrants is read on every record type this fixture's principals can
 // reach. Read-only on purpose: the suites riding it assert what a caller may SEE,


### PR DESCRIPTION
Two integration tests have been failing on main: TestAdHocReportPlanCountsUnderRowScope
and TestAdHocProjectReportCountsUnderRowScope. Both are privacy tests — they prove an
aggregate cannot count rows the lists hide — so a red main here means the leak guard
has not actually run since it broke.

Neither is a behaviour regression. A report resolves the basis it reports money in and
the zone it buckets dates by, so it reads installation_settings; every seeded role holds
that grant, and every other report suite's fixture already gives it
(report_fieldmask, report_forecast, report_projectgrant). The two SearchEnv fixtures were
the ones that fell behind, and they failed before any rule under test was reached.

Two omissions of the same thing, fixed in both places rather than in the one that was
reported: searchReadGrants gains installation_settings, and scopedReaderOf's one-object
map gains it too. Fixing only the first would have left the project suite red for the
identical reason a week later.

SetupSearch also never wrote the settings ROWS. It builds its installation by raw SQL,
which is the exact case seedInstallationIdentity documents itself for, so it now calls
that helper instead of growing a second copy of the four INSERTs.

Verified the fixtures did not paper over the assertion: pointing the colleague's read at
the captor makes the leak assertion fail with the rows it leaked
("row scope leaked into the aggregate: [[manual 3]]"), so the guard is live and the
change restored its ability to run rather than weakening what it proves.

195 tests across the Report, Search, Schema, Graph and Project suites now pass.

Found while running an unrelated branch's integration lane. Filed as #3773 before the
cause was known; the issue blamed #3770, which was wrong — the grant requirement is
older than that PR.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

---

Local gate: `make check-backend` green, `make craft-static` clean, `scripts/check-rls-store-path.sh` OK. 195 tests green across Report / Search / Schema / Graph / Project.

Closes #3773.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two failing privacy integration tests by granting the `SearchEnv` fixtures read access to `installation_settings`, which reports need to resolve their reporting basis and date zone.

**Bug Fixes**
- Adds the `installation_settings` read grant to both `searchReadGrants` and `scopedReaderOf`.
- Calls `seedInstallationIdentity` in `SetupSearch` so the settings rows are written when the installation is built by raw SQL.
- Verified the leak guard is still live: pointing the colleague's read at the captor still fails the assertion.

<sup>Written for commit f5d9076047309329db8957454ec0762793a4a6ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Project reports now correctly resolve reporting configuration while preserving existing object-level permissions and row-level access controls.
  - Search-related setup now supports permission checks involving installation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->