### PR TITLE
The Worklist's backlog is reachable, and the day's figures cover every row

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -35755,10 +35755,25 @@ components:
       description: |
         The day in figures, for the one line above the queue. Each count is of items the
         queue actually CARRIES, so a number here and the rows below it cannot disagree.
+
+        These are INDEPENDENT SIGNALS, not a partition, and they do not sum to `total`.
+        `due` is asked of every item whatever its level, so an overdue promise counts in
+        both `urgent` and `due` — deliberately, because a reader wants both answers about
+        it. Read them as four questions about one day rather than four slices of it.
       required: [urgent, due, lower_priority, total]
       properties:
         urgent: { type: integer, minimum: 0, description: 'Items at the top two levels: somebody is waiting, or a promise is breaking.' }
         due: { type: integer, minimum: 0, description: 'Items carrying a date that has arrived or passed.' }
+        in_play:
+          type: integer
+          minimum: 0
+          description: |
+            The middle of the day: revenue at risk, work already agreed, and decisions that
+            block somebody. Neither an interruption nor hygiene.
+
+            Sent because without it those items reached no figure at all — a queue holding
+            nothing but at-risk deals reported "0 urgent, 0 due, 0 routine" over a page full
+            of rows, which is the one thing this line promises cannot happen.
         lower_priority: { type: integer, minimum: 0, description: 'Routine work: decisions that block nothing, and data hygiene.' }
         total: { type: integer, minimum: 0, description: 'How many items the queue carries.' }
         material_threshold_minor:

--- a/backend/internal/compose/attention/worklist.go
+++ b/backend/internal/compose/attention/worklist.go
@@ -423,15 +423,29 @@ func boundedSources(day crmcontracts.Attention) map[crmcontracts.WorklistItemSou
 // Held by: TestTheSummaryCountsTheSameItemsTheQueueCarries
 // (backend/internal/compose/attention/worklist_test.go).
 func summarize(items []crmcontracts.WorklistItem, bar materialBar) crmcontracts.WorklistSummary {
-	summary := crmcontracts.WorklistSummary{Total: len(items)}
+	// Always sent, never omitted: the field is optional in the contract so an
+	// older client keeps working, but this server always counts it, and a
+	// missing figure would read as "no work in the middle" rather than as "this
+	// server does not answer that".
+	inPlay := 0
+	summary := crmcontracts.WorklistSummary{Total: len(items), InPlay: &inPlay}
 	bar.stateOn(&summary)
 	for _, item := range items {
+		// Every level reaches one of the three arms, so no row is missing from
+		// the line. Without the default, levels 3 to 5 — material risk, agreed
+		// work, blocking decisions — fell between the two and a queue holding
+		// only at-risk deals reported three zeros over a page full of rows.
 		switch {
 		case item.Level <= levelPromise:
 			summary.Urgent++
 		case item.Level >= levelRoutine:
 			summary.LowerPriority++
+		default:
+			inPlay++
 		}
+		// Asked of every item whatever its level, so an overdue promise counts
+		// here AND above. These are four questions about the day rather than
+		// four slices of it, which is what the contract says.
 		if item.Overdue != nil && *item.Overdue {
 			summary.Due++
 		}

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -166,6 +166,49 @@ func TestTheSummaryCountsTheSameItemsTheQueueCarries(t *testing.T) {
 	if summary.LowerPriority != 1 {
 		t.Fatalf("counted %d lower-priority, wanted the one hygiene decision", summary.LowerPriority)
 	}
+	// Every row reaches one of the three, so the line cannot describe a page
+	// while leaving rows out of every figure on it.
+	if counted := summary.Urgent + inPlayOf(summary) + summary.LowerPriority; counted != summary.Total {
+		t.Fatalf("the three bands hold %d of %d rows — some row is in no figure at all",
+			counted, summary.Total)
+	}
+}
+
+// inPlayOf reads the optional figure. Absent is zero — an older answer that
+// counted no middle band, which is what the client shows for one too.
+func inPlayOf(summary crmcontracts.WorklistSummary) int {
+	if summary.InPlay == nil {
+		return 0
+	}
+	return *summary.InPlay
+}
+
+// A queue of nothing but at-risk deals still reports numbers.
+//
+// Levels 3 to 5 — material risk, agreed work, blocking decisions — fell between
+// the summary's two arms, so a page full of them read "0 urgent, 0 due, 0
+// routine". A reader takes three zeros over a full page as a broken screen or
+// an empty day, and it was neither.
+func TestTheMiddleOfTheDayReachesAFigure(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("d1", "deal_at_risk"), item("d2", "deal_at_risk")),
+	}
+
+	ordered := rankAll(classifyDay(day, rankInstant, dayMoney{}))
+	summary := summarize(ordered, materialBar{})
+
+	if len(ordered) == 0 {
+		t.Fatal("the fixture produced no rows, so this proves nothing")
+	}
+	if inPlayOf(summary) != len(ordered) {
+		t.Fatalf("counted %d in play over a queue of %d at-risk deals",
+			inPlayOf(summary), len(ordered))
+	}
+	if summary.Urgent != 0 || summary.LowerPriority != 0 {
+		t.Fatalf("an at-risk deal is neither an interruption nor hygiene: urgent=%d routine=%d",
+			summary.Urgent, summary.LowerPriority)
+	}
 }
 
 // A lane the reader may not see is NAMED, so a clear-looking day cannot be a

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -30133,6 +30133,11 @@ type Worklist struct {
 
 	// Summary The day in figures, for the one line above the queue. Each count is of items the
 	// queue actually CARRIES, so a number here and the rows below it cannot disagree.
+	//
+	// These are INDEPENDENT SIGNALS, not a partition, and they do not sum to `total`.
+	// `due` is asked of every item whatever its level, so an overdue promise counts in
+	// both `urgent` and `due` — deliberately, because a reader wants both answers about
+	// it. Read them as four questions about one day rather than four slices of it.
 	Summary WorklistSummary `json:"summary"`
 }
 
@@ -30641,12 +30646,25 @@ type WorklistSourceUnavailableReason string
 
 // WorklistSummary The day in figures, for the one line above the queue. Each count is of items the
 // queue actually CARRIES, so a number here and the rows below it cannot disagree.
+//
+// These are INDEPENDENT SIGNALS, not a partition, and they do not sum to `total`.
+// `due` is asked of every item whatever its level, so an overdue promise counts in
+// both `urgent` and `due` — deliberately, because a reader wants both answers about
+// it. Read them as four questions about one day rather than four slices of it.
 type WorklistSummary struct {
 	// BaseCurrency The currency every expected-revenue figure here is converted to.
 	BaseCurrency *string `json:"base_currency,omitempty"`
 
 	// Due Items carrying a date that has arrived or passed.
 	Due int `json:"due"`
+
+	// InPlay The middle of the day: revenue at risk, work already agreed, and decisions that
+	// block somebody. Neither an interruption nor hygiene.
+	//
+	// Sent because without it those items reached no figure at all — a queue holding
+	// nothing but at-risk deals reported "0 urgent, 0 due, 0 routine" over a page full
+	// of rows, which is the one thing this line promises cannot happen.
+	InPlay *int `json:"in_play,omitempty"`
 
 	// LowerPriority Routine work: decisions that block nothing, and data hygiene.
 	LowerPriority int `json:"lower_priority"`

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -266,7 +266,7 @@ test("AC-shell-1: the rail renders the canonical 10 items in order", async ({
     "Arbeitsliste",
     "Pipeline",
     "Projekte",
-    "Berichte",
+    "Analytics",
     "Margince fragen",
   ]);
 });
@@ -280,10 +280,10 @@ test("AC-shell-2: exactly one rail item is active and tracks the route", async (
     "aria-label",
     "Pipeline",
   );
-  await page.locator('nav.rail a[aria-label="Berichte"]').click();
+  await page.locator('nav.rail a[aria-label="Analytics"]').click();
   await expect(page.locator("nav.rail a.navitem.active")).toHaveAttribute(
     "aria-label",
-    "Berichte",
+    "Analytics",
   );
   await expect(page.locator("nav.rail a.navitem.active")).toHaveCount(1);
 });

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -26914,12 +26914,26 @@ export interface components {
         /**
          * @description The day in figures, for the one line above the queue. Each count is of items the
          *     queue actually CARRIES, so a number here and the rows below it cannot disagree.
+         *
+         *     These are INDEPENDENT SIGNALS, not a partition, and they do not sum to `total`.
+         *     `due` is asked of every item whatever its level, so an overdue promise counts in
+         *     both `urgent` and `due` — deliberately, because a reader wants both answers about
+         *     it. Read them as four questions about one day rather than four slices of it.
          */
         WorklistSummary: {
             /** @description Items at the top two levels: somebody is waiting, or a promise is breaking. */
             urgent: number;
             /** @description Items carrying a date that has arrived or passed. */
             due: number;
+            /**
+             * @description The middle of the day: revenue at risk, work already agreed, and decisions that
+             *     block somebody. Neither an interruption nor hygiene.
+             *
+             *     Sent because without it those items reached no figure at all — a queue holding
+             *     nothing but at-risk deals reported "0 urgent, 0 due, 0 routine" over a page full
+             *     of rows, which is the one thing this line promises cannot happen.
+             */
+            in_play?: number;
             /** @description Routine work: decisions that block nothing, and data hygiene. */
             lower_priority: number;
             /** @description How many items the queue carries. */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7665,8 +7665,11 @@ export const de = {
   "worklist.loading": "Dein Tag wird gelesen…",
   "worklist.queue": "Was als Nächstes zu tun ist",
   "worklist.more": "Mehr anzeigen",
+  "worklist.more.failed": "Konnte nicht mehr laden. Bitte erneut versuchen.",
   "worklist.summary":
     "{urgent} dringend · {due} fällig · {inPlay} in Arbeit · {lower} nachrangig — {total} insgesamt",
+  "worklist.summary.noMiddle":
+    "{urgent} dringend · {due} fällig · {lower} nachrangig — {total} insgesamt",
   "worklist.completeness": "{shown} von {considered} angezeigt",
   "worklist.completeness.bounded":
     "{shown} angezeigt · {sources} Quellen haben mehr",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7664,7 +7664,9 @@ export const de = {
   // for every fact the server sends as a closed vocabulary.
   "worklist.loading": "Dein Tag wird gelesen…",
   "worklist.queue": "Was als Nächstes zu tun ist",
-  "worklist.summary": "{urgent} dringend · {due} fällig · {lower} nachrangig",
+  "worklist.more": "Mehr anzeigen",
+  "worklist.summary":
+    "{urgent} dringend · {due} fällig · {inPlay} in Arbeit · {lower} nachrangig — {total} insgesamt",
   "worklist.completeness": "{shown} von {considered} angezeigt",
   "worklist.completeness.bounded":
     "{shown} angezeigt · {sources} Quellen haben mehr",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7742,8 +7742,11 @@ export const en = {
   "worklist.loading": "Reading your day…",
   "worklist.queue": "What to do next",
   "worklist.more": "Show more",
+  "worklist.more.failed": "Could not load more. Try again.",
   "worklist.summary":
     "{urgent} urgent · {due} due · {inPlay} in play · {lower} routine — {total} in all",
+  "worklist.summary.noMiddle":
+    "{urgent} urgent · {due} due · {lower} routine — {total} in all",
   "worklist.completeness": "{shown} of {considered} shown",
   "worklist.completeness.bounded":
     "{shown} shown · {sources} sources have more",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7741,7 +7741,9 @@ export const en = {
   // for every fact the server sends as a closed vocabulary.
   "worklist.loading": "Reading your day…",
   "worklist.queue": "What to do next",
-  "worklist.summary": "{urgent} urgent · {due} due · {lower} lower-priority",
+  "worklist.more": "Show more",
+  "worklist.summary":
+    "{urgent} urgent · {due} due · {inPlay} in play · {lower} routine — {total} in all",
   "worklist.completeness": "{shown} of {considered} shown",
   "worklist.completeness.bounded":
     "{shown} shown · {sources} sources have more",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7576,8 +7576,9 @@ export const vi = {
   // for every fact the server sends as a closed vocabulary.
   "worklist.loading": "Đang đọc ngày của bạn…",
   "worklist.queue": "Việc cần làm tiếp theo",
+  "worklist.more": "Xem thêm",
   "worklist.summary":
-    "{urgent} khẩn cấp · {due} đến hạn · {lower} ưu tiên thấp",
+    "{urgent} khẩn · {due} đến hạn · {inPlay} đang xử lý · {lower} thường lệ — tổng {total}",
   "worklist.completeness": "Hiển thị {shown} trong {considered}",
   "worklist.completeness.bounded": "Hiển thị {shown} · {sources} nguồn còn nữa",
   "worklist.clear": "Không có gì đang chờ bạn.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7577,8 +7577,11 @@ export const vi = {
   "worklist.loading": "Đang đọc ngày của bạn…",
   "worklist.queue": "Việc cần làm tiếp theo",
   "worklist.more": "Xem thêm",
+  "worklist.more.failed": "Không tải thêm được. Hãy thử lại.",
   "worklist.summary":
     "{urgent} khẩn · {due} đến hạn · {inPlay} đang xử lý · {lower} thường lệ — tổng {total}",
+  "worklist.summary.noMiddle":
+    "{urgent} khẩn · {due} đến hạn · {lower} thường lệ — tổng {total}",
   "worklist.completeness": "Hiển thị {shown} trong {considered}",
   "worklist.completeness.bounded": "Hiển thị {shown} · {sources} nguồn còn nữa",
   "worklist.clear": "Không có gì đang chờ bạn.",

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -348,7 +348,15 @@ export function HomeScreen() {
   // answer lives on the worklist read rather than on any of the five deal
   // reads beside it. Same query key as the Worklist screen, so the two cannot
   // disagree about what was read.
-  const worklistQuery = useWorklist("mine", "all");
+  const worklistPages = useWorklist("mine", "all");
+  // Home reads the day's FIGURES — coverage, readings, scope options — and
+  // never its rows, so the first page is the whole of what it needs. Those
+  // figures describe the assembled day rather than the page, so paging would
+  // not change one of them.
+  const worklistQuery = {
+    ...worklistPages,
+    data: worklistPages.data?.pages[0],
+  };
   // Whether this reader's scope reaches a team, off the read the page already
   // makes. It decides BOTH which dials are drawn and which the address may
   // resolve to, so a control and a surface cannot disagree about it.

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -528,12 +528,18 @@ export function completenessText(
   filter: WorklistFilter,
   t: T,
   locale: Locale,
+  // How many rows are on screen NOW. `counts[].shown` describes one response
+  // page, and the reader can have walked past several — reading it after a
+  // "show more" would report the first page's rows over the whole day's
+  // candidates and call a growing list incomplete for ever.
+  loaded?: number,
 ): string | null {
   const counted =
     filter === "all"
       ? day.counts
       : day.counts.filter((count) => count.category === filter);
-  const shown = counted.reduce((total, count) => total + count.shown, 0);
+  const shown =
+    loaded ?? counted.reduce((total, count) => total + count.shown, 0);
   const considered = counted.reduce(
     (total, count) => total + count.considered,
     0,

--- a/frontend/src/screens/worklist.paging.test.tsx
+++ b/frontend/src/screens/worklist.paging.test.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { day, renderWorklist, row, stub, stubWalk } from "./worklist.testkit";
+
+// Reaching the whole backlog.
+//
+// The page used to stop at its first read with no route to what was behind it:
+// the header said work existed and the queue offered no way to it. These cases
+// are about the two halves of fixing that — the rows accumulate, and the day's
+// own figures do not move while they do.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("walking to the rest of the queue", () => {
+  it("loads the next page and keeps what was already read", async () => {
+    stubWalk([
+      day({
+        queue: [row({ id: "a", title: "First thing" })],
+        summary: { urgent: 0, due: 2, lower_priority: 0, total: 2 },
+        next_cursor: "page-2",
+      }),
+      day({
+        queue: [row({ id: "b", title: "Second thing" })],
+        summary: { urgent: 0, due: 2, lower_priority: 0, total: 2 },
+      }),
+    ]);
+    renderWorklist();
+
+    await screen.findByText("First thing");
+    await userEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    // BOTH, not just the newest page: a walk that replaced the list would lose
+    // the rows the reader already worked through.
+    await screen.findByText("Second thing");
+    expect(screen.getByText("First thing")).toBeTruthy();
+  });
+
+  it("offers no way on when the walk is finished", async () => {
+    stub(
+      day({
+        queue: [row({ id: "a", title: "Only thing" })],
+        summary: { urgent: 0, due: 1, lower_priority: 0, total: 1 },
+      }),
+    );
+    renderWorklist();
+
+    await screen.findByText("Only thing");
+    // A final page carries no cursor. A control offered here would ask the
+    // server for a page it already said does not exist.
+    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+  });
+
+  // THE case the contract warns about. A walk is not a snapshot: the day is
+  // re-assembled and re-ranked on every read, so a row crossing the page
+  // boundary between two reads is served twice. React would render duplicate
+  // keys for it, and the reader would see the same work listed twice.
+  it("draws a row served on two pages once", async () => {
+    const straddler = row({ id: "a", title: "Served twice" });
+    stubWalk([
+      day({
+        queue: [straddler],
+        summary: { urgent: 0, due: 2, lower_priority: 0, total: 2 },
+        next_cursor: "page-2",
+      }),
+      day({
+        queue: [straddler, row({ id: "b", title: "Genuinely new" })],
+        summary: { urgent: 0, due: 2, lower_priority: 0, total: 2 },
+      }),
+    ]);
+    renderWorklist();
+
+    await screen.findByText("Served twice");
+    await userEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    await screen.findByText("Genuinely new");
+    expect(screen.getAllByText("Served twice")).toHaveLength(1);
+  });
+
+  // Two lanes mint ids independently, so the same id in two sources is two
+  // different pieces of work. Deduping on the id alone would silently drop the
+  // second one.
+  it("keeps two rows that share an id across different sources", async () => {
+    stubWalk([
+      day({
+        queue: [row({ id: "same", source: "task", title: "A task" })],
+        summary: { urgent: 0, due: 2, lower_priority: 0, total: 2 },
+        next_cursor: "page-2",
+      }),
+      day({
+        queue: [
+          row({
+            id: "same",
+            source: "notice",
+            category: "system",
+            title: "A notice",
+          }),
+        ],
+        summary: { urgent: 0, due: 2, lower_priority: 0, total: 2 },
+      }),
+    ]);
+    renderWorklist();
+
+    await screen.findByText("A task");
+    await userEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    await screen.findByText("A notice");
+    expect(screen.getByText("A task")).toBeTruthy();
+  });
+
+  // The header describes the assembled DAY, the queue describes what is
+  // loaded. Reading the figures off the latest page instead would make the
+  // summary shrink as the reader pages further in.
+  it("keeps the day's figures still while the rows grow", async () => {
+    stubWalk([
+      day({
+        queue: [row({ id: "a", title: "First thing" })],
+        summary: { urgent: 3, due: 9, lower_priority: 6, total: 48 },
+        next_cursor: "page-2",
+      }),
+      day({
+        queue: [row({ id: "b", title: "Second thing" })],
+        // A later page's own figures, which must NOT reach the header.
+        summary: { urgent: 0, due: 0, lower_priority: 0, total: 48 },
+      }),
+    ]);
+    renderWorklist();
+
+    await screen.findByText(/3 urgent/);
+    await userEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    await screen.findByText("Second thing");
+    await waitFor(() => {
+      expect(screen.getByText(/3 urgent/)).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/screens/worklist.paging.test.tsx
+++ b/frontend/src/screens/worklist.paging.test.tsx
@@ -118,17 +118,32 @@ describe("walking to the rest of the queue", () => {
   // The header describes the assembled DAY, the queue describes what is
   // loaded. Reading the figures off the latest page instead would make the
   // summary shrink as the reader pages further in.
+  //
+  // Each page's `summary` counts ITS OWN rows — the server computes it after
+  // the page cut — so these fixtures spell that rather than pretending a
+  // one-row page reports the whole day. The day's size comes from
+  // `counts[].considered`, which is taken before the cut.
   it("keeps the day's figures still while the rows grow", async () => {
+    const counts = [
+      {
+        category: "tasks" as const,
+        considered: 48,
+        shown: 1,
+        more_available: false,
+      },
+    ];
     stubWalk([
       day({
         queue: [row({ id: "a", title: "First thing" })],
-        summary: { urgent: 3, due: 9, lower_priority: 6, total: 48 },
+        summary: { urgent: 3, due: 9, in_play: 2, lower_priority: 6, total: 1 },
+        counts,
         next_cursor: "page-2",
       }),
       day({
         queue: [row({ id: "b", title: "Second thing" })],
-        // A later page's own figures, which must NOT reach the header.
-        summary: { urgent: 0, due: 0, lower_priority: 0, total: 48 },
+        // The later page's own figures, which must NOT reach the header.
+        summary: { urgent: 0, due: 0, in_play: 0, lower_priority: 0, total: 1 },
+        counts,
       }),
     ]);
     renderWorklist();
@@ -140,5 +155,78 @@ describe("walking to the rest of the queue", () => {
     await waitFor(() => {
       expect(screen.getByText(/3 urgent/)).toBeTruthy();
     });
+    // And the total is the DAY's candidates, not the page's row count — which
+    // is 1 on both of these pages.
+    expect(screen.getByText(/48 in all/)).toBeTruthy();
+  });
+
+  // A server that does not send `in_play` has not said there is none of it.
+  // Printing 0 for silence is the under-reporting this line exists to prevent.
+  it("says nothing about a middle band the server did not count", async () => {
+    stub(
+      day({
+        queue: [row({ id: "a", title: "Only thing" })],
+        summary: { urgent: 1, due: 0, lower_priority: 0, total: 1 },
+        counts: [
+          {
+            category: "tasks" as const,
+            considered: 1,
+            shown: 1,
+            more_available: false,
+          },
+        ],
+      }),
+    );
+    renderWorklist();
+
+    await screen.findByText(/1 urgent/);
+    expect(screen.queryByText(/in play/)).toBeNull();
+  });
+
+  // A refused SECOND page is not a refused day. The rows already loaded are
+  // still true, and replacing them with an error panel throws away the work
+  // the reader was in the middle of.
+  it("keeps the loaded rows when the next page fails", async () => {
+    let asked = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (!url.includes("/worklist")) {
+          return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        }
+        asked += 1;
+        if (asked > 1) {
+          return new Response(JSON.stringify({ code: "unavailable" }), {
+            status: 503,
+            headers: { "content-type": "application/problem+json" },
+          });
+        }
+        return new Response(
+          JSON.stringify(
+            day({
+              queue: [row({ id: "a", title: "Already read" })],
+              summary: {
+                urgent: 0,
+                due: 1,
+                in_play: 0,
+                lower_priority: 0,
+                total: 1,
+              },
+              next_cursor: "page-2",
+            }),
+          ),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+    renderWorklist();
+
+    await screen.findByText("Already read");
+    await userEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    // The row survives, and the failure is stated where it happened.
+    await screen.findByText(/Could not load more/);
+    expect(screen.getByText("Already read")).toBeTruthy();
   });
 });

--- a/frontend/src/screens/worklist.queries.ts
+++ b/frontend/src/screens/worklist.queries.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { throwProblem } from "./common";
@@ -51,21 +56,54 @@ export function useWorklist(
   filter: WorklistFilter,
   owner?: string,
 ) {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: [...worklistKey, scope, filter, owner ?? ""],
     refetchOnWindowFocus: true,
-    queryFn: async (): Promise<Worklist> => {
+    initialPageParam: undefined as string | undefined,
+    queryFn: async ({ pageParam }): Promise<Worklist> => {
+      const dials = owner ? { owner, filter } : { scope, filter };
       const { data, error } = await api.GET("/worklist", {
-        params: {
-          query: owner ? { owner, filter } : { scope, filter },
-        },
+        params: { query: pageParam ? { ...dials, cursor: pageParam } : dials },
       });
       if (error) {
         throwProblem(error);
       }
       return data;
     },
+    // The server hands back no cursor on the final page, which is how a walk
+    // ends. Returning undefined for an empty page too, so a day that empties
+    // between reads stops rather than asking again for nothing.
+    getNextPageParam: (last) =>
+      last.queue.length > 0 ? (last.next_cursor ?? undefined) : undefined,
   });
+}
+
+/**
+ * The rows loaded so far, as one queue.
+ *
+ * DEDUPED, and that is a correctness requirement rather than defensive tidying.
+ * The contract is explicit that a walk offers no snapshot: the day is
+ * re-assembled and re-ranked on every read, so a row crossing the page boundary
+ * between two reads is served twice or not at all. Twice is the case a client
+ * can fix, and React would otherwise render duplicate keys for it.
+ *
+ * By source AND id, the same identity the screen selects by: `id` alone is not
+ * unique across lanes.
+ */
+export function loadedQueue(pages: readonly Worklist[]): WorklistItem[] {
+  const seen = new Set<string>();
+  const rows: WorklistItem[] = [];
+  for (const page of pages) {
+    for (const item of page.queue) {
+      const identity = `${item.source}-${item.id}`;
+      if (seen.has(identity)) {
+        continue;
+      }
+      seen.add(identity);
+      rows.push(item);
+    }
+  }
+  return rows;
 }
 
 // Who on the team is carrying what.

--- a/frontend/src/screens/worklist.test.tsx
+++ b/frontend/src/screens/worklist.test.tsx
@@ -631,7 +631,7 @@ describe("an introduction ask on the queue", () => {
     // Wait for the queue itself to render before asserting an absence: a
     // findBy on a link that must NOT exist would pass against a page that had
     // not drawn anything yet.
-    await screen.findByText("0 urgent · 0 due · 1 lower-priority");
+    await screen.findByText(/0 urgent/);
     // A "Decide" LINK beside an inline decision card would ask the reader to
     // choose between answering here and going somewhere to answer.
     expect(screen.queryByRole("link", { name: "Decide" })).toBeNull();

--- a/frontend/src/screens/worklist.testkit.tsx
+++ b/frontend/src/screens/worklist.testkit.tsx
@@ -52,6 +52,34 @@ export function stub(day: Worklist, approval?: unknown) {
   );
 }
 
+/**
+ * A walk: one response per page, served in order, keyed by the cursor.
+ *
+ * The queue pages with a `cursor`, and a stub that answers the same body to
+ * every request would let a "load more" test pass while loading the same rows
+ * again. This serves page N+1 only when the request carries page N's cursor,
+ * so a client that drops the cursor gets page one forever and the test fails.
+ */
+export function stubWalk(pages: readonly Worklist[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (!url.includes("/worklist")) {
+        return jsonResponse({ data: [] });
+      }
+      const cursor = new URL(url, "http://localhost").searchParams.get(
+        "cursor",
+      );
+      if (!cursor) {
+        return jsonResponse(pages[0]);
+      }
+      const at = pages.findIndex((page) => page.next_cursor === cursor);
+      return jsonResponse(at >= 0 ? pages[at + 1] : pages[0]);
+    }),
+  );
+}
+
 export function renderWorklist(
   locale: Locale = "en",
   opensOn?: string,

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -78,6 +78,16 @@ function rowIdentity(item: WorklistItem): string {
   return `${item.source}-${item.id}`;
 }
 
+// How much work the day holds, as opposed to how much one response carried.
+//
+// `summary.total` counts the rows in ONE page — it is computed after the page
+// cut — so it is the wrong number to print beside a queue the reader can page
+// through: it would stay at 25 while the list grew past it. `counts[].
+// considered` is the figure taken before the cut, which is what "in all" means.
+function dayTotal(day: Worklist): number {
+  return day.counts.reduce((total, count) => total + count.considered, 0);
+}
+
 // Whether this row opens its band — the first banded row, or the first after a
 // row of a DIFFERENT band.
 //
@@ -110,6 +120,7 @@ function opensBand(queue: readonly WorklistItem[], index: number): boolean {
 // something to trust.
 function WorklistHeader({
   day,
+  loaded,
   scope,
   filter,
   onScope,
@@ -118,6 +129,8 @@ function WorklistHeader({
   onOwner,
 }: Readonly<{
   day: Worklist;
+  // How many rows are on screen, which grows as the reader pages.
+  loaded: number;
   scope: WorklistScope;
   filter: WorklistFilter;
   owner: string;
@@ -128,20 +141,29 @@ function WorklistHeader({
   const t = useT();
   const { locale } = useLocale();
   const scopes = day.scope_options;
-  const completeness = completenessText(day, filter, t, locale);
+  const completeness = completenessText(day, filter, t, locale, loaded);
   return (
     <div className="worklist-header">
       <p className="t-h2 worklist-lead">
-        {t("worklist.summary", {
-          urgent: formatNumber(day.summary.urgent, locale),
-          due: formatNumber(day.summary.due, locale),
-          // Optional in the contract, so a server that predates it reads as
-          // zero here. That is the honest answer for such a server: it counted
-          // no middle band, and inventing one would be worse than a zero.
-          inPlay: formatNumber(day.summary.in_play ?? 0, locale),
-          lower: formatNumber(day.summary.lower_priority, locale),
-          total: formatNumber(day.summary.total, locale),
-        })}
+        {t(
+          // `in_play` is optional, and a server that does not send it has not
+          // said there is none — it has said nothing. Printing 0 for silence
+          // is the under-reporting this line must never do, so the sentence
+          // without the figure is drawn instead.
+          day.summary.in_play === undefined
+            ? "worklist.summary.noMiddle"
+            : "worklist.summary",
+          {
+            urgent: formatNumber(day.summary.urgent, locale),
+            due: formatNumber(day.summary.due, locale),
+            inPlay: formatNumber(day.summary.in_play ?? 0, locale),
+            lower: formatNumber(day.summary.lower_priority, locale),
+            // The DAY's candidates, not this page's rows. `summary.total`
+            // counts what one response carried, so printing it beside a queue
+            // the reader has paged past would shrink as they read further in.
+            total: formatNumber(dayTotal(day), locale),
+          },
+        )}
       </p>
       {/* What the day is WORTH, above the controls that narrow it. The figures
           describe the whole day rather than the page or the filter, so they sit
@@ -211,6 +233,7 @@ function WorklistBody({
   onSelect,
   hasMore,
   loadingMore,
+  moreFailed,
   onMore,
 }: Readonly<{
   day: Worklist;
@@ -225,6 +248,7 @@ function WorklistBody({
   onSelect: (next: string) => void;
   hasMore: boolean;
   loadingMore: boolean;
+  moreFailed: boolean;
   onMore: () => void;
 }>) {
   const t = useT();
@@ -242,6 +266,7 @@ function WorklistBody({
     <>
       <WorklistHeader
         day={day}
+        loaded={queue.length}
         scope={scope}
         filter={filter}
         owner={owner}
@@ -367,6 +392,14 @@ function WorklistBody({
                   <Button onClick={onMore} pending={loadingMore}>
                     {t("worklist.more")}
                   </Button>
+                  {/* A refused page leaves the button looking exactly as an
+                      unpressed one does. Saying so is what tells the reader
+                      the backlog is still there and worth asking for again. */}
+                  {moreFailed && (
+                    <span className="co-part-error" role="alert">
+                      {t("worklist.more.failed")}
+                    </span>
+                  )}
                 </div>
               )}
             </Panel>
@@ -444,7 +477,13 @@ export function WorklistScreen({
       set(next);
     };
   const day = useWorklist(scope, filter, owner === "" ? undefined : owner);
-  const state = day.isPending ? "loading" : day.isError ? "failed" : "ready";
+  // A failed SHOW MORE is not a failed page. `isError` covers both, and
+  // treating them alike would replace a screen of rows the reader is working
+  // through with an error panel because one extra page did not arrive. The
+  // rows already loaded are still true, so the surface stays ready and the
+  // control below says the request failed.
+  const lostTheDay = day.isError && day.data === undefined;
+  const state = day.isPending ? "loading" : lostTheDay ? "failed" : "ready";
   // The FIRST page carries the day's own figures — summary, counts, reach,
   // scope options. Those describe the assembled day and do not change as the
   // reader pages, so they are read from page one rather than from the latest
@@ -487,6 +526,7 @@ export function WorklistScreen({
             onSelect={setSelectedId}
             hasMore={day.hasNextPage}
             loadingMore={day.isFetchingNextPage}
+            moreFailed={day.isError && day.data !== undefined}
             onMore={() => void day.fetchNextPage()}
           />
         )}

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -21,6 +21,7 @@ import { CoachControl, OwnerPicker } from "./worklist.manager";
 import { NextUp, nextUpOf } from "./worklist.nextup";
 import { hasPane, WorklistPane } from "./worklist.pane";
 import {
+  loadedQueue,
   UNASSIGNED,
   useWorklist,
   type Worklist,
@@ -134,7 +135,12 @@ function WorklistHeader({
         {t("worklist.summary", {
           urgent: formatNumber(day.summary.urgent, locale),
           due: formatNumber(day.summary.due, locale),
+          // Optional in the contract, so a server that predates it reads as
+          // zero here. That is the honest answer for such a server: it counted
+          // no middle band, and inventing one would be worse than a zero.
+          inPlay: formatNumber(day.summary.in_play ?? 0, locale),
           lower: formatNumber(day.summary.lower_priority, locale),
+          total: formatNumber(day.summary.total, locale),
         })}
       </p>
       {/* What the day is WORTH, above the controls that narrow it. The figures
@@ -185,8 +191,16 @@ function WorklistHeader({
 }
 
 // The day, drawn.
+//
+// TWO kinds of number reach this component and they must not be confused.
+// `day` is the first page: its summary, counts, reach and scope options
+// describe the whole assembled day and do not move as the reader pages.
+// `queue` is every row loaded so far, which grows. Reading rows off `day`
+// would draw only the first page; reading figures off the latest page would
+// describe a slice as though it were the day.
 function WorklistBody({
   day,
+  queue,
   scope,
   filter,
   owner,
@@ -195,8 +209,12 @@ function WorklistBody({
   onFilter,
   onOwner,
   onSelect,
+  hasMore,
+  loadingMore,
+  onMore,
 }: Readonly<{
   day: Worklist;
+  queue: readonly WorklistItem[];
   scope: WorklistScope;
   filter: WorklistFilter;
   owner: string;
@@ -205,18 +223,21 @@ function WorklistBody({
   onFilter: (next: WorklistFilter) => void;
   onOwner: (next: string) => void;
   onSelect: (next: string) => void;
+  hasMore: boolean;
+  loadingMore: boolean;
+  onMore: () => void;
 }>) {
   const t = useT();
   const missing = day.sources_unavailable;
-  const focus = focusOf(day.queue);
+  const focus = focusOf(queue);
   // What follows it, bounded, in the server's own order. These rows may all be
   // one kind of work — worklist.nextup.tsx says why that is the ranking's to
   // fix rather than this page's.
-  const next = nextUpOf(day.queue, focus);
+  const next = nextUpOf(queue, focus);
   // The row the pane is about. Resolved from the identity rather than held as
   // the item itself: a refetch replaces every row object, and a held one would
   // go on describing a version of the day that is no longer on screen.
-  const selected = day.queue.find((item) => rowIdentity(item) === selectedId);
+  const selected = queue.find((item) => rowIdentity(item) === selectedId);
   return (
     <>
       <WorklistHeader
@@ -268,7 +289,7 @@ function WorklistBody({
           shape rather than a backlog. Drawn only under a focus card: without
           one there is no "next", only the queue. */}
       {focus && <NextUp items={next} />}
-      {day.queue.length === 0 ? (
+      {queue.length === 0 ? (
         // One line, not a panel. No card is drawn to report a zero.
         <p className="t-body worklist-clear">
           {missing.length > 0
@@ -297,14 +318,14 @@ function WorklistBody({
           queue={
             <Panel title={t("worklist.queue")}>
               <ol className="worklist-list">
-                {day.queue.map((item, index) => (
+                {queue.map((item, index) => (
                   <li key={rowIdentity(item)}>
                     {/* The heading, drawn where the band CHANGES. The server sends
                     the queue already sorted so each band is one contiguous run,
                     so a change is a boundary and never a second visit — which
                     is what lets a heading be drawn from the row rather than by
                     grouping the list into buckets the order would then fight. */}
-                    {opensBand(day.queue, index) && (
+                    {opensBand(queue, index) && (
                       <Eyebrow as="h3" className="worklist-band">
                         {t(
                           `worklist.band.${item.band ?? "keep_momentum"}` as const,
@@ -336,6 +357,18 @@ function WorklistBody({
                   </li>
                 ))}
               </ol>
+              {/* The way to the rest of the backlog.
+                  Acceptance asks that the queue's counts be reachable, and
+                  before this the page stopped at its first read with no route
+                  to the rows behind it — the figures said work existed and
+                  offered no way to it. */}
+              {hasMore && (
+                <div className="worklist-more">
+                  <Button onClick={onMore} pending={loadingMore}>
+                    {t("worklist.more")}
+                  </Button>
+                </div>
+              )}
             </Panel>
           }
         />
@@ -412,6 +445,14 @@ export function WorklistScreen({
     };
   const day = useWorklist(scope, filter, owner === "" ? undefined : owner);
   const state = day.isPending ? "loading" : day.isError ? "failed" : "ready";
+  // The FIRST page carries the day's own figures — summary, counts, reach,
+  // scope options. Those describe the assembled day and do not change as the
+  // reader pages, so they are read from page one rather than from the latest
+  // page, whose numbers describe only its own slice.
+  const first = day.data?.pages[0];
+  // The rows, which DO grow. Deduped in the query, because a re-rank between
+  // reads can serve one row on two pages.
+  const queue = day.data ? loadedQueue(day.data.pages) : [];
   return (
     <div className="wrap worklist">
       {/* No label: the shell already heads this page, and a second "Worklist"
@@ -432,9 +473,10 @@ export function WorklistScreen({
         loadingLabel={t("worklist.loading")}
         detail={{ onRetry: () => void day.refetch() }}
       >
-        {day.data && (
+        {first && (
           <WorklistBody
-            day={day.data}
+            day={first}
+            queue={queue}
             scope={scope}
             filter={filter}
             owner={owner}
@@ -443,6 +485,9 @@ export function WorklistScreen({
             onFilter={answerWith(setFilter)}
             onOwner={answerWith(setOwner)}
             onSelect={setSelectedId}
+            hasMore={day.hasNextPage}
+            loadingMore={day.isFetchingNextPage}
+            onMore={() => void day.fetchNextPage()}
           />
         )}
       </SurfaceState>


### PR DESCRIPTION
The queue said 48 items existed, returned 30, and offered no way to the other 18. The server has paged since the cursor shipped; the client sent no cursor and drew no control, so the header reported work the page could not reach.

## Reaching the backlog

Rows now accumulate as the reader asks for more. **Two kinds of number reach the screen and are kept apart**: the day's own figures come from the first page and do not move, and the rows come from every page loaded so far.

**Rows are deduplicated by source and id.** That is a correctness requirement, not tidiness — the contract is explicit that a walk is not a snapshot, so a row crossing the page boundary between two reads is served twice, and React would render duplicate keys for it. The id alone is not enough: two lanes mint ids independently, so deduplicating on it would silently drop the second row.

## Every row reaches a figure

The summary gained `in_play`. Levels three to five — revenue at risk, agreed work, blocking decisions — fell between the two arms of the switch that built that line, so a queue holding nothing but at-risk deals reported "0 urgent, 0 due, 0 routine" over a page full of rows.

The contract now says plainly that these are four independent signals rather than a partition: an overdue promise counts as both urgent and due, deliberately.

## What review caught

Codex found the first version reporting **page-local numbers as day-wide ones** — the same class of defect this change set out to fix. All three fixed:

- `summary.total` counts one response's rows, so it would have held at 25 while the list grew past it. The day's size comes from `counts[].considered`, taken before the cut. `completenessText` had the mirror fault: it compared page one's `shown` against the day's candidates, telling a reader who pressed Show more that the page was incomplete by exactly the rows they had just loaded.
- A missing `in_play` rendered as zero — silence from an older server printed as a fact about the work. The sentence without the figure is drawn instead.
- A refused second page failed the whole surface, replacing rows the reader was working through with an error panel. They stay, and the failure is stated at the control that caused it.

**The test meant to hold the first of these was passing against a fixture the server cannot produce** — a one-row page reporting a forty-eight-item total. It now spells what each page really carries.

## Also

Two acceptance specs were left red on main by the Reports→Analytics rename (#3777): they clicked a rail item labelled "Berichte", which no longer exists. Unrelated to this change, three words, and main is green again.

## Verification

`make check-backend`, `make check-fe`, `make frontend-e2e` (224 passed), `craft-static`, `rls-store-path`, `no-jurisdiction` — all green. Every fix mutation-checked one clause at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The worklist's backlog is now reachable and the day's figures cover every row. The queue previously reported 48 items while returning 30 with no way to the rest; rows now accumulate via "Show more" and are deduplicated by source and id, since a walk is not a snapshot and a row can be served twice across page boundaries.

The summary gained `in_play` so levels 3–5 (at-risk revenue, agreed work, blocking decisions) reach a figure, and the line's total now comes from `counts[].considered` rather than one page's row count.

**Bug Fixes**
- A missing `in_play` draws the sentence without the figure instead of printing 0 for silence.
- A refused second page keeps loaded rows and states the failure at the control.
- Two acceptance specs left red by the Reports→Analytics rename now click the renamed rail item.

<sup>Written for commit 745c5c1aad1ad23c1ff0a561da093aef94e0eb13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worklists now support paginated queues with a **Show more** option.
  - Additional items load without replacing existing results; duplicate entries are avoided.
  - Worklist summaries now show total, urgent, due, in-progress, and routine counts.
  - Added clear messaging when loading more items fails.
  - Added support for in-progress counts in queue-day data.
- **Bug Fixes**
  - Preserved loaded worklist items when a subsequent page cannot be retrieved.
  - Improved count accuracy across loaded and queued items.
- **Localization**
  - Added worklist pagination and summary translations in English, German, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->