### PR TITLE
An at-risk lead says when the reply is due

### DIFF
--- a/backend/internal/compose/attention/lead.go
+++ b/backend/internal/compose/attention/lead.go
@@ -135,7 +135,19 @@ func leadStanding(lead OwedLead, asOf time.Time) (int, []crmcontracts.WorklistRe
 		}
 		return levelWaiting, because
 	case string(crmcontracts.LeadSlaStateAtRisk):
-		return levelPromise, []crmcontracts.WorklistReason{reason("response_due_soon", nil)}
+		// The deadline travels with the reason, because "reply due soon" alone
+		// asks the rep to guess how soon. Its breached sibling above already
+		// carries a figure (the days it has been overdue); this is the same
+		// courtesy on the side of the clock where it can still be met.
+		//
+		// A row whose deadline is missing says the plain sentence rather than a
+		// zero time: absent is honest, 1 January 1 is not.
+		if lead.DeadlineAt.IsZero() {
+			return levelPromise, []crmcontracts.WorklistReason{reason("response_due_soon", nil)}
+		}
+		return levelPromise, []crmcontracts.WorklistReason{
+			reason("response_due_soon", deadlineValue(lead.DeadlineAt)),
+		}
 	default:
 		return levelAgreed, []crmcontracts.WorklistReason{}
 	}

--- a/backend/internal/compose/attention/leadlane_test.go
+++ b/backend/internal/compose/attention/leadlane_test.go
@@ -98,6 +98,68 @@ func TestABreachedLeadRanksAboveOneMerelyAtRisk(t *testing.T) {
 	}
 }
 
+// An at-risk lead says WHEN, not merely that something is due.
+//
+// "reply due soon" alone asks the rep to guess how soon, while its breached
+// sibling already carries a figure. The moment travels as a date value and the
+// client formats it — nothing here composes a date into words, because the
+// product ships three languages and a zone per reader.
+func TestAnAtRiskLeadCarriesTheDeadlineItIsMeasuredAgainst(t *testing.T) {
+	due := readInstant.Add(30 * time.Minute)
+	svc := leadLaneService(&stubLeads{tracked: true, rows: []OwedLead{
+		{ID: ids.NewV7(), Name: "at risk", DeadlineAt: due, State: "at_risk", OwnerID: ids.NewV7()},
+	}})
+
+	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("worklist: %v", err)
+	}
+
+	row := rowFor(t, day, "at risk")
+	for _, because := range row.Because {
+		if because.Kind != "response_due_soon" {
+			continue
+		}
+		if because.Value == nil {
+			t.Fatal("the at-risk reason carries no value, so the row says a reply is due " +
+				"soon without saying by when")
+		}
+		if because.Value.Kind != "date" || because.Value.Date == nil {
+			t.Fatalf("the value is %+v, wanted a date — the client renders a date in the "+
+				"reader's own locale and zone, and no other kind reaches that path",
+				because.Value)
+		}
+		if !because.Value.Date.Equal(due) {
+			t.Errorf("the deadline reads %s, wanted the lead's own %s",
+				because.Value.Date, due)
+		}
+		return
+	}
+	t.Fatalf("no response_due_soon reason on the row: %v", kindsOf(row))
+}
+
+// A lead with no deadline says the plain sentence rather than a zero time.
+//
+// The honest absence: a date value built from an unset time would render as
+// 1 January, year 1, which is a worse answer than not naming a moment at all.
+func TestAnAtRiskLeadWithNoDeadlineNamesNoMoment(t *testing.T) {
+	svc := leadLaneService(&stubLeads{tracked: true, rows: []OwedLead{
+		{ID: ids.NewV7(), Name: "at risk", State: "at_risk", OwnerID: ids.NewV7()},
+	}})
+
+	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("worklist: %v", err)
+	}
+
+	row := rowFor(t, day, "at risk")
+	for _, because := range row.Because {
+		if because.Kind == "response_due_soon" && because.Value != nil {
+			t.Errorf("a lead with no deadline still carried a value: %+v", because.Value)
+		}
+	}
+}
+
 // The policy question is not a filter. With no target set nothing is late, so
 // the source is ABSENT — a page reporting zero overdue leads would be stating a
 // number nothing measures.

--- a/backend/internal/compose/attention/rank.go
+++ b/backend/internal/compose/attention/rank.go
@@ -304,6 +304,14 @@ func daysSince(from, asOf time.Time) int {
 	return days
 }
 
+// deadlineValue is a moment a reader still has time to act on, for the reasons
+// that name one. The client formats it in its own locale and zone; nothing here
+// composes a date into words.
+func deadlineValue(at time.Time) *crmcontracts.WorklistValue {
+	when := at
+	return &crmcontracts.WorklistValue{Kind: "date", Date: &when}
+}
+
 func daysValue(days int) *crmcontracts.WorklistValue {
 	value := days
 	return &crmcontracts.WorklistValue{Kind: "days", Days: &value}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7827,6 +7827,7 @@ export const de = {
   "worklist.because.meeting_unprepared": "nichts vorbereitet",
   "worklist.because.response_overdue": "Antwort überfällig",
   "worklist.because.response_due_soon": "Antwort bald fällig",
+  "worklist.because.response_due_soon.value": "Antwort fällig bis {value}",
   "worklist.because.unassigned": "niemand zuständig",
   "worklist.because.stale": "wartet schon lange",
   "worklist.above.pin": "Über dem Nächsten, weil du es angeheftet hast.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7903,6 +7903,7 @@ export const en = {
   "worklist.because.meeting_unprepared": "nothing prepared",
   "worklist.because.response_overdue": "reply overdue",
   "worklist.because.response_due_soon": "reply due soon",
+  "worklist.because.response_due_soon.value": "reply due by {value}",
   "worklist.because.unassigned": "nobody owns it",
   "worklist.because.stale": "waiting a long time",
   "worklist.above.pin": "Above the next because you pinned it.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7736,6 +7736,7 @@ export const vi = {
   "worklist.because.meeting_unprepared": "chưa chuẩn bị gì",
   "worklist.because.response_overdue": "quá hạn trả lời",
   "worklist.because.response_due_soon": "sắp đến hạn trả lời",
+  "worklist.because.response_due_soon.value": "cần trả lời trước {value}",
   "worklist.because.unassigned": "chưa có ai phụ trách",
   "worklist.because.stale": "đã chờ rất lâu",
   "worklist.above.pin": "Trên mục kế vì bạn đã ghim.",

--- a/frontend/src/screens/worklist.copy.test.ts
+++ b/frontend/src/screens/worklist.copy.test.ts
@@ -169,3 +169,32 @@ describe("reasonText — day-count plural", () => {
     expect(reasonText(many, t, "en", zone)).toBe("quiet for 14 days");
   });
 });
+
+// The lead's deadline is a MOMENT, and the sentence has to put it somewhere.
+//
+// Both halves of this live on opposite sides of the wire: the backend attaches
+// the date (attention/lead.go leadStanding), and VALUED_REASONS here decides
+// whether it reaches a sentence at all. A value can travel for a reason whose
+// copy has nowhere to put it, and that combination renders the plain phrase
+// while the figure is silently dropped — so the two are one change, and this is
+// the half that fails if only the backend lands.
+describe("reasonText — the lead's own deadline", () => {
+  it("names when the reply is due", () => {
+    const reason: WorklistReason = {
+      kind: "response_due_soon",
+      value: { kind: "date", date: "2026-09-03T14:30:00Z" },
+    };
+    const got = reasonText(reason, t, "en", zone);
+    expect(got).not.toBeNull();
+    // The formatted moment, not the raw ISO string: valueText renders it in the
+    // reader's locale and zone, and asserting the literal would pin a format
+    // this file does not own.
+    expect(got).not.toBe("reply due soon");
+    expect(got).toContain("reply due by");
+  });
+
+  it("falls back to the plain phrase when no deadline travelled", () => {
+    const reason: WorklistReason = { kind: "response_due_soon" };
+    expect(reasonText(reason, t, "en", zone)).toBe("reply due soon");
+  });
+});

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -128,6 +128,10 @@ const VALUED_REASONS = {
   expected_revenue: true,
   material: true,
   below_material: true,
+  // The lead's own deadline, which is a MOMENT rather than a figure: valueText
+  // renders a date value in the reader's locale and zone, so the sentence says
+  // when without this file composing one.
+  response_due_soon: true,
 } as const;
 
 type ValuedReason = keyof typeof VALUED_REASONS;


### PR DESCRIPTION
"reply due soon" asked the rep to guess how soon. Its breached sibling already
carries a figure — the days it has been overdue — and this is the same courtesy
on the side of the clock where the deadline can still be met.

The moment travels as a date value and the client formats it in the reader's own
locale and zone. Nothing on the backend composes a date into words; the product
ships three languages and a zone per reader, so a sentence built server-side
would reach a German reader in English.

BOTH SIDES IN ONE CHANGE, because either half alone is a defect rather than
half a fix. The backend attaches the value in leadStanding; VALUED_REASONS in
worklist.copy.ts decides whether a value reaches a sentence at all. A reason not
in that set renders its plain phrase and drops the figure silently — so a
backend-only landing would ship a deadline nobody sees, with every test green.
The frontend test is the half that fails if only the backend lands, and it was
mutation-checked that way: removing the registry entry fails with the exact
defect, "reply due soon" where the deadline should be.

A lead with no deadline keeps the plain phrase. A date value built from an unset
time renders as 1 January, year 1 — worse than not naming a moment at all — and
the guard is mutation-checked in that direction too, which is what the second
test exists for.

No contract change: WorklistValue already carries `date`, and valueText already
renders it. The i18n key is new rather than changed, so the existing
"reply due soon" phrase and every spec that reads it are untouched.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

---

Local gate: `make check-backend` and `make check-fe` both green, `make craft-static` clean, `scripts/check-rls-store-path.sh` OK.

Both guards mutation-checked in both directions: drop the value and the backend test fails; drop the zero-guard and the absence test fails with the year-1 date; drop the VALUED_REASONS entry and the frontend test fails with the deadline silently missing.

No Playwright run: the i18n key is added, not changed, so no spec asserts it (grepped `frontend/e2e/`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
At-risk leads now show when the reply is due, instead of just "reply due soon" with no date.

- The backend attaches the deadline as a date value; the frontend renders it in the reader's locale and zone.
- Leads with no deadline keep the plain phrase.
- The backend and frontend changes land together, since either half alone silently drops the date.
- No contract change; a new i18n key was added, so the existing phrase and its specs are untouched.

<sup>Written for commit d6945cbe9475f8c13fee7bf6ddfad4f526dadcb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * At-risk leads now show the deadline for an upcoming response when available.
  * Worklist explanations display localized “reply due by” dates in English, German, and Vietnamese.
  * Leads without a deadline continue to show a general “reply due soon” explanation without an empty date.

* **Bug Fixes**
  * Prevented missing deadlines from displaying as an invalid zero timestamp.

* **Tests**
  * Added coverage for deadline display and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->