### PR TITLE
The tag page names the records carrying the word

### DIFF
--- a/frontend/src/app/pagemeta.ts
+++ b/frontend/src/app/pagemeta.ts
@@ -30,7 +30,14 @@ import type { Route } from "./router";
  * heading somewhere on it. A screen whose own heading is an h2 still wants the
  * shell to name the page.
  */
-export const SELF_HEADED_SCREENS: ReadonlySet<string> = new Set(["home"]);
+// Home greets the reader in its own h1. The tag page heads itself with the
+// TAG'S NAME, which the shell cannot know: "Tag" above a pill spelling
+// "Automation World 2026" names the page twice and names it worse both times —
+// a reader arriving from a search hit wants the word they searched at the top.
+export const SELF_HEADED_SCREENS: ReadonlySet<string> = new Set([
+  "home",
+  "tags",
+]);
 
 // Only a subtitle true of the WHOLE page qualifies. Copy that describes the
 // current tab, filter or segment belongs beside that control, where it changes
@@ -61,6 +68,12 @@ export const OFF_RAIL_TITLE_KEYS: Record<string, MessageKey> = {
   // reached from the composer that put a message in it and from Today, which is
   // where the same rep's other waiting work already lives.
   scheduled: "nav.scheduled",
+  // Off the rail because a tag page is reached from a tag — a pill on a record,
+  // a search hit, the vocabulary in Settings — and never from a destination
+  // list. Absent from this map it fell through to `shell.unknownPage`, so the
+  // page that lists what carries a word was headed "Not found" above the
+  // results it had just found.
+  tags: "nav.tags",
 };
 
 export function resolveTitle(

--- a/frontend/src/app/pagetitle.test.ts
+++ b/frontend/src/app/pagetitle.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+
+import { en } from "../i18n/en";
+import { NAV } from "./nav";
+import { OFF_RAIL_TITLE_KEYS, SELF_HEADED_SCREENS } from "./pagemeta";
+import { SCREENS } from "./router";
+
+// `resolveTitle` falls through to `shell.unknownPage` for a screen that is
+// neither on the NAV rail nor in OFF_RAIL_TITLE_KEYS, so a routed destination
+// missing from both is headed "Not found" — above whatever it just found. The
+// tag page shipped that way.
+//
+// The corpus is DERIVED from the router's own screen list, so a destination
+// added there is covered here without anybody remembering to add it.
+
+// Screens the shell never heads. The self-headed set is the PRODUCT'S own —
+// read from `pagemeta` rather than copied, so a screen that starts heading
+// itself leaves this gate without also having to be listed here. What is
+// spelled below is only the surfaces that render OUTSIDE the shell entirely:
+// pre-auth and public pages, which have no page heading to resolve, plus
+// `not-found`, which IS the unknown page rather than one missing its name.
+const OUTSIDE_THE_SHELL = new Set<string>([
+  "onboarding",
+  "client",
+  "book",
+  "preferences",
+  "unsubscribe",
+  "confirm",
+  "room",
+  "oauth-consent",
+  "reset-password",
+  "not-found",
+  // The fork widening point: `#/x/<key>` destinations name themselves from
+  // the unit's own descriptor, which the shell resolves at runtime.
+  "x",
+  "ext",
+]);
+
+const HEADS_ITSELF = (screen: string) =>
+  OUTSIDE_THE_SHELL.has(screen) || SELF_HEADED_SCREENS.has(screen);
+
+describe("every destination the shell heads has a name", () => {
+  const railScreens = new Set(NAV.map((item) => item.screen));
+
+  it.each(SCREENS.filter((screen) => !HEADS_ITSELF(screen)))(
+    "%s is named by the rail or by the off-rail map",
+    (screen) => {
+      const named = railScreens.has(screen) || screen in OFF_RAIL_TITLE_KEYS;
+      expect(named).toBe(true);
+    },
+  );
+
+  // The off-rail map's keys are real copy, not slugs typed twice.
+  it.each(Object.entries(OFF_RAIL_TITLE_KEYS))(
+    "%s resolves to a translated name",
+    (_screen, key) => {
+      expect(en[key]).toBeTruthy();
+    },
+  );
+});

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -26,7 +26,7 @@ import { useState, useSyncExternalStore } from "react";
 // dispatch be an exhaustive Record. A `Screen` admitting `x-${string}` could
 // not be exhausted, and that exhaustiveness is the thing stopping a destination
 // existing in the router and being missing from the dispatch.
-const SCREENS = [
+export const SCREENS = [
   "home",
   "contacts",
   "companies",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1830,7 +1830,7 @@ export const de = {
   "tagResult.nothingCarries":
     "Noch kein Datensatz trägt dieses Tag. Vergeben Sie es auf einem Kontakt, einem Unternehmen oder einem Deal.",
   "tagResult.loadingRows": "{kind} werden geladen…",
-  "tagResult.rowsWithheld": "Sie können diese Datensätze nicht sehen",
+  "tagResult.noneLeft": "Trägt niemand mehr",
   "tagResult.unnamed": "Ohne Namen",
   "co.timeline.empty": "Zu diesem Account ist noch nichts erfasst.",
   "co.overlayFallback":

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -172,6 +172,7 @@ export const de = {
   "nav.offers": "Angebot",
   "nav.share": "Freigabe",
   "nav.search": "Suchergebnisse",
+  "nav.tags": "Tag",
 
   "shell.railAria": "Hauptnavigation",
   "shell.aside.hide": "Ausblenden",
@@ -1825,8 +1826,12 @@ export const de = {
   "tagResult.companies": "Unternehmen",
   "tagResult.deals": "Deals",
   "tagResult.viewAll": "Alle {count} {kind} anzeigen",
-  "tagResult.carry": "{count} tragen dieses Tag",
-  "tagResult.none": "Niemand trägt dieses Tag",
+  "tagResult.resultsTitle": "Datensätze mit diesem Tag",
+  "tagResult.nothingCarries":
+    "Noch kein Datensatz trägt dieses Tag. Vergeben Sie es auf einem Kontakt, einem Unternehmen oder einem Deal.",
+  "tagResult.loadingRows": "{kind} werden geladen…",
+  "tagResult.rowsWithheld": "Sie können diese Datensätze nicht sehen",
+  "tagResult.unnamed": "Ohne Namen",
   "co.timeline.empty": "Zu diesem Account ist noch nichts erfasst.",
   "co.overlayFallback":
     "Dieser Account wird aus dem verbundenen führenden System bedient; die Firmenansicht wird hier nicht zusammengestellt. \u00d6ffne ihn dort für das vollständige Bild.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -179,6 +179,7 @@ export const en = {
   "nav.offers": "Offer",
   "nav.share": "Sharing",
   "nav.search": "Search results",
+  "nav.tags": "Tag",
 
   "shell.railAria": "Primary navigation",
   "shell.aside.hide": "Hide",
@@ -1873,8 +1874,12 @@ export const en = {
   "tagResult.companies": "Companies",
   "tagResult.deals": "Deals",
   "tagResult.viewAll": "View all {count} {kind}",
-  "tagResult.carry": "{count} carry this tag",
-  "tagResult.none": "None carry this tag",
+  "tagResult.resultsTitle": "Records with this tag",
+  "tagResult.nothingCarries":
+    "Nothing carries this tag yet. Apply it from any contact, company or deal.",
+  "tagResult.loadingRows": "Loading {kind}…",
+  "tagResult.rowsWithheld": "You cannot see these records",
+  "tagResult.unnamed": "Unnamed",
   "co.timeline.empty": "Nothing logged on this account yet.",
   "co.overlayFallback":
     "This account is served from the connected system of record, so the company view is not assembled here. Open it in that system to see the full picture.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1878,7 +1878,7 @@ export const en = {
   "tagResult.nothingCarries":
     "Nothing carries this tag yet. Apply it from any contact, company or deal.",
   "tagResult.loadingRows": "Loading {kind}…",
-  "tagResult.rowsWithheld": "You cannot see these records",
+  "tagResult.noneLeft": "Nothing carries it any more",
   "tagResult.unnamed": "Unnamed",
   "co.timeline.empty": "Nothing logged on this account yet.",
   "co.overlayFallback":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -178,6 +178,7 @@ export const vi = {
   "nav.offers": "Báo giá",
   "nav.share": "Chia sẻ",
   "nav.search": "Kết quả tìm kiếm",
+  "nav.tags": "Thẻ",
 
   "shell.railAria": "Điều hướng chính",
   "shell.aside.hide": "Ẩn",
@@ -1811,8 +1812,12 @@ export const vi = {
   "tagResult.companies": "Công ty",
   "tagResult.deals": "Deal",
   "tagResult.viewAll": "Xem tất cả {count} {kind}",
-  "tagResult.carry": "{count} mang tag này",
-  "tagResult.none": "Không ai mang tag này",
+  "tagResult.resultsTitle": "Bản ghi có thẻ này",
+  "tagResult.nothingCarries":
+    "Chưa có bản ghi nào mang thẻ này. Hãy gán thẻ từ một liên hệ, công ty hoặc thương vụ.",
+  "tagResult.loadingRows": "Đang tải {kind}…",
+  "tagResult.rowsWithheld": "Bạn không thể xem các bản ghi này",
+  "tagResult.unnamed": "Chưa có tên",
   "co.timeline.empty": "Chưa ghi nhận gì trên tài khoản này.",
   "co.overlayFallback":
     "Tài khoản này được phục vụ từ hệ thống ghi nhận đã kết nối, nên màn hình công ty không được dựng ở đây. Hãy mở bên hệ thống đó để xem toàn cảnh.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1816,7 +1816,7 @@ export const vi = {
   "tagResult.nothingCarries":
     "Chưa có bản ghi nào mang thẻ này. Hãy gán thẻ từ một liên hệ, công ty hoặc thương vụ.",
   "tagResult.loadingRows": "Đang tải {kind}…",
-  "tagResult.rowsWithheld": "Bạn không thể xem các bản ghi này",
+  "tagResult.noneLeft": "Không còn bản ghi nào mang thẻ",
   "tagResult.unnamed": "Chưa có tên",
   "co.timeline.empty": "Chưa ghi nhận gì trên tài khoản này.",
   "co.overlayFallback":

--- a/frontend/src/screens/tagresult.css
+++ b/frontend/src/screens/tagresult.css
@@ -16,17 +16,82 @@
   margin: 0;
 }
 
-/* Three groups side by side on a desk, stacked on a phone. The columns are
-   equal because no one record type is the answer — a reader arrives here
-   asking "what carries this word", not "which people carry it". */
-.tagresult-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+/* One column, not three side by side: this is a result list, and a reader
+   scanning for a record reads down it. Three columns made each group a third
+   of the width and put the answer to "which records" in three places at once. */
+.tagresult-groups {
+  display: flex;
+  flex-direction: column;
   gap: var(--space-3);
 }
 
+.tagresult-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* A whole-row target, the way a result row behaves everywhere else: the name
+   is what a reader aims at, and a link the width of the text alone makes them
+   hunt for it. */
 .tagresult-row {
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border: 0;
+  border-radius: var(--r-md);
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tagresult-row:hover {
+  background: var(--bgHover);
+}
+
+.tagresult-row:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.tagresult-row svg {
+  width: 1rem;
+  height: 1rem;
+  color: var(--textMeta);
+  flex: none;
+}
+
+/* A long company name wraps rather than pushing the row sideways. */
+.tagresult-name {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+/* The word AT page-title size, in the shell's own heading type — this screen
+   heads itself, so the h1 here has to look like the h1 every other page gets.
+   The pill inside carries the tag's colour, the way a tag is drawn everywhere
+   else; sizing it up would make one chip in the product unlike all the others. */
+.tagresult-title {
+  margin: 0;
+  font-family: var(--f-display);
+  font-size: var(--fs-h1);
+  line-height: 1.15;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  overflow-wrap: anywhere;
+}
+
+/* A retired word still has a page — the records carrying it did not lose it —
+   so the heading says so rather than looking like any other tag. */
+.tagresult-retired {
+  font-family: var(--f-body);
+  font-size: var(--fs-sm);
+  color: var(--textMeta);
 }

--- a/frontend/src/screens/tagresult.test.tsx
+++ b/frontend/src/screens/tagresult.test.tsx
@@ -116,6 +116,106 @@ describe("the tag page names what carries the word", () => {
     ).toBeInTheDocument();
   });
 
+  // The tag read already said the type carries none, so asking for its rows is
+  // a round trip whose answer is known. Two of them, on a tag used on one type.
+  it("does not ask for the rows of a type carrying none", async () => {
+    let dealCalls = 0;
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 1, companies: 0, deals: 0 }),
+      "GET /people": () =>
+        jsonResponse({ data: [{ id: "p-1", full_name: "Katrin Hofmann" }] }),
+      "GET /deals": () => {
+        dealCalls += 1;
+        return jsonResponse({ data: [] });
+      },
+    });
+    render(
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>,
+    );
+
+    expect(await screen.findByText("Katrin Hofmann")).toBeInTheDocument();
+    expect(dealCalls).toBe(0);
+  });
+
+  // The tag's usage count admits a RETIRED tag; the list filter every record
+  // screen uses requires the tag to be live. Heading the group with the usage
+  // count therefore promised rows the list would not return.
+  it("counts the rows it shows, not the tag's usage", async () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 3, companies: 0, deals: 0 }),
+      "GET /people": () =>
+        jsonResponse({ data: [{ id: "p-1", full_name: "Katrin Hofmann" }] }),
+    });
+    render(
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>,
+    );
+
+    expect(await screen.findByText("Katrin Hofmann")).toBeInTheDocument();
+    expect(screen.getByText("People (1)")).toBeInTheDocument();
+    expect(screen.queryByText("People (3)")).toBeNull();
+  });
+
+  // A request that FAILED is not a permission fact. Reporting one as the other
+  // tells a reader they may not see records that are simply unfetched.
+  it("does not report a failed read as records being withheld", async () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 2, companies: 0, deals: 0 }),
+      "GET /people": () =>
+        new Response("nope", {
+          status: 500,
+          headers: { "content-type": "text/plain" },
+        }),
+    });
+    render(
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>,
+    );
+
+    // What the reader sees is the unavailable state, not "nothing carries it".
+    // Asserting only the ABSENCE of the empty line would also pass if the group
+    // rendered nothing at all, which is how this test first passed for the
+    // wrong reason.
+    expect(
+      await screen.findByText(en["state.unavailable"]),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(en["tagResult.noneLeft"])).toBeNull();
+  });
+
+  // Every record list requires the tag to be LIVE, so a retired word reaches
+  // none of them. The header total would be the last line on the page still
+  // promising rows the groups correctly do not show.
+  it("does not total the assignments of a retired word", async () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: () =>
+        jsonResponse({
+          id: TAG,
+          name: "Automation World 2026",
+          color: "slate",
+          version: 2,
+          archived_at: "2026-09-01T00:00:00Z",
+          usage: { people: 2, companies: 2, deals: 2 },
+        }),
+      "GET /people": () => jsonResponse({ data: [] }),
+      "GET /organizations": () => jsonResponse({ data: [] }),
+      "GET /deals": () => jsonResponse({ data: [] }),
+    });
+    render(
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>,
+    );
+
+    expect(
+      await screen.findByText("Automation World 2026"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/6 visible assignments/)).toBeNull();
+  });
+
   it("says so when the word is on nothing at all", async () => {
     installFetchStub({
       [`GET /tags/${TAG}`]: tagRead({ people: 0, companies: 0, deals: 0 }),

--- a/frontend/src/screens/tagresult.test.tsx
+++ b/frontend/src/screens/tagresult.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import "@testing-library/jest-dom/vitest";
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { en } from "../i18n/en";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+import { TagResultScreen } from "./tagresult";
+
+// The page a reader lands on from a search hit or a tag pill. Its whole job is
+// answering WHICH records carry the word: it once drew three cards reporting
+// counts ("1 carry this tag"), which answered how many and named nothing.
+
+const TAG = "01a0641b-db0c-7b92-8564-6c843bf58df3";
+
+function tagRead(usage: { people: number; companies: number; deals: number }) {
+  return () =>
+    jsonResponse({
+      id: TAG,
+      name: "Automation World 2026",
+      color: "slate",
+      version: 1,
+      usage,
+    });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.location.hash = "";
+});
+
+describe("the tag page names what carries the word", () => {
+  it("lists the records themselves, by name", async () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 1, companies: 1, deals: 1 }),
+      "GET /people": () =>
+        jsonResponse({ data: [{ id: "p-1", full_name: "Katrin Hofmann" }] }),
+      "GET /organizations": () =>
+        jsonResponse({ data: [{ id: "o-1", display_name: "MiTek" }] }),
+      "GET /deals": () =>
+        jsonResponse({
+          data: [{ id: "d-1", name: "netcare GmbH — Einführung" }],
+        }),
+    });
+    render(
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>,
+    );
+
+    // The names, which is the whole point — not a count sentence about them.
+    expect(await screen.findByText("Katrin Hofmann")).toBeInTheDocument();
+    expect(await screen.findByText("MiTek")).toBeInTheDocument();
+    expect(
+      await screen.findByText("netcare GmbH — Einführung"),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the record the row names", async () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 1, companies: 0, deals: 0 }),
+      "GET /people": () =>
+        jsonResponse({ data: [{ id: "p-1", full_name: "Katrin Hofmann" }] }),
+    });
+    render(
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>,
+    );
+
+    await userEvent.setup().click(await screen.findByText("Katrin Hofmann"));
+    expect(window.location.hash).toBe("#/contacts/p-1");
+  });
+
+  // A group the word is not on draws nothing. Three cards, two of them
+  // reporting zero, is what made the page read as an inventory of absences.
+  it("draws no group for a type nothing carries", async () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 1, companies: 0, deals: 0 }),
+      "GET /people": () =>
+        jsonResponse({ data: [{ id: "p-1", full_name: "Katrin Hofmann" }] }),
+    });
+    render(
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>,
+    );
+
+    expect(await screen.findByText("Katrin Hofmann")).toBeInTheDocument();
+    expect(screen.queryByText(/^Companies/)).toBeNull();
+    expect(screen.queryByText(/^Deals/)).toBeNull();
+  });
+
+  // A record whose name is empty is NAMED as unnamed rather than drawn as a
+  // blank row: a reader cannot press what they cannot see.
+  it("names a record carrying no name", async () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 1, companies: 0, deals: 0 }),
+      "GET /people": () =>
+        jsonResponse({ data: [{ id: "p-1", full_name: "" }] }),
+    });
+    render(
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>,
+    );
+
+    expect(
+      await screen.findByText(en["tagResult.unnamed"]),
+    ).toBeInTheDocument();
+  });
+
+  it("says so when the word is on nothing at all", async () => {
+    installFetchStub({
+      [`GET /tags/${TAG}`]: tagRead({ people: 0, companies: 0, deals: 0 }),
+    });
+    render(
+      <StoryProviders>
+        <TagResultScreen tagID={TAG} />
+      </StoryProviders>,
+    );
+
+    expect(
+      await screen.findByText(en["tagResult.nothingCarries"]),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/tagresult.tsx
+++ b/frontend/src/screens/tagresult.tsx
@@ -82,9 +82,17 @@ export function TagResultScreen({ tagID }: Readonly<{ tagID?: string }>) {
             <span className="tagresult-retired">{t("tags.archived")}</span>
           )}
         </h1>
-        <span className="t-small">
-          {t("tagResult.totalVisible", { count: formatNumber(total, locale) })}
-        </span>
+        {/* Not drawn for a RETIRED word. The usage total counts assignments
+            that still exist, while every record list requires the tag to be
+            live — so on a retired tag the sentence is the one line on the page
+            still promising rows the groups below it correctly do not show. */}
+        {!tag.data.archived_at && (
+          <span className="t-small">
+            {t("tagResult.totalVisible", {
+              count: formatNumber(total, locale),
+            })}
+          </span>
+        )}
       </header>
       {tag.data.description && (
         <p className="tagresult-note">{tag.data.description}</p>
@@ -168,6 +176,10 @@ function ResultGroup({
   const group = GROUPS[kind];
   const rows = useQuery({
     queryKey: ["tag-records", kind, tagID],
+    // The tag read already said this type carries none, so asking for its rows
+    // is a round trip whose answer is known. The hook still RUNS — a group that
+    // called it conditionally would change the hook order as counts arrive.
+    enabled: count > 0,
     queryFn: async () => {
       const { data, error } = await api.GET(group.path, {
         params: { query: { tag_id: [tagID], limit: PREVIEW_ROWS } },
@@ -183,19 +195,34 @@ function ResultGroup({
     return null;
   }
 
-  const shown = formatNumber(count, locale);
   const listed = rows.data ?? [];
+  // The HEADER counts the rows, not the tag's usage. The two are answers to
+  // different questions and they disagree in a state a reader can reach: the
+  // usage count admits a retired tag, while the list filter every record screen
+  // uses requires the tag to be live. A retired word would head "People (2)"
+  // over an empty group. Once more rows exist than the preview shows, the total
+  // is the honest ceiling and the footer says so.
+  const shown = formatNumber(
+    listed.length < PREVIEW_ROWS ? listed.length : count,
+    locale,
+  );
   return (
-    <Panel title={`${title} (${shown})`}>
+    <Panel title={rows.isSuccess ? `${title} (${shown})` : title}>
       <PanelBody>
         <SurfaceState
           label={undefined}
           state={
-            rows.isPending ? "loading" : listed.length > 0 ? "ready" : "empty"
+            rows.isPending
+              ? "loading"
+              : rows.isError
+                ? "unavailable"
+                : listed.length > 0
+                  ? "ready"
+                  : "empty"
           }
           loadingLabel={t("tagResult.loadingRows", { kind: title })}
           loadingLines={Math.min(count, PREVIEW_ROWS)}
-          emptyLabel={t("tagResult.rowsWithheld")}
+          emptyLabel={t("tagResult.noneLeft")}
         >
           <ul className="tagresult-rows">
             {listed.map((row) => (
@@ -212,7 +239,10 @@ function ResultGroup({
             ))}
           </ul>
         </SurfaceState>
-        {count > listed.length && (
+        {/* Offered only when the preview is FULL: a group showing every row it
+            has needs no way to see more, and the tag's own count cannot be the
+            test here for the same reason it is not the header. */}
+        {listed.length >= PREVIEW_ROWS && (
           <Button
             small
             variant="ghost"

--- a/frontend/src/screens/tagresult.tsx
+++ b/frontend/src/screens/tagresult.tsx
@@ -6,22 +6,32 @@ import type { LucideIcon } from "lucide-react";
 import { Building2, Contact, Handshake } from "lucide-react";
 
 import { api } from "../api/client";
-import { Badge, Button } from "../design-system/atoms";
-import { Panel, PanelRow } from "../design-system/panel";
-import { TagPill } from "../design-system/tagpill";
+import { navigate } from "../app/router";
+import { Button } from "../design-system/atoms";
+import { Panel, PanelBody } from "../design-system/panel";
+import { SurfaceState } from "../design-system/surfacestate";
+import { isTagTone } from "../design-system/tagpill";
 import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { throwProblem } from "./common";
 import "./tagresult.css";
 
 /**
- * The page behind every tag pill: what carries this word, grouped by type.
+ * The page behind every tag pill: the records carrying this word, named.
  *
- * A preview, not a list. Two rows per group and a link into the record view
- * the reader already knows — building a fourth table here would be a second
- * answer to a question three screens answer well, and it would drift from them
- * the first time a column changed.
+ * A RESULT LIST, which is what a reader arriving from a search hit is looking
+ * for. It once drew three cards reporting counts — "1 carry this tag" — which
+ * answered how many and never which, so the one question the page exists for
+ * needed three more clicks to answer.
+ *
+ * The rows are the real records, read through the same `tag_id` filter the
+ * three record lists offer, so this page and "View all" cannot disagree about
+ * what carries the word. Each group shows the first few and hands the rest to
+ * the list screen that already pages, sorts and filters them properly — the
+ * page names records, it does not become a fourth table.
  */
+const PREVIEW_ROWS = 5;
+
 export function TagResultScreen({ tagID }: Readonly<{ tagID?: string }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -52,12 +62,26 @@ export function TagResultScreen({ tagID }: Readonly<{ tagID?: string }>) {
 
   return (
     <div className="wrap tagresult">
+      {/* The page heads ITSELF, with the word. The shell steps aside for this
+          screen (SELF_HEADED_SCREENS) because it cannot know a tag's name, and
+          "Tag" above a pill spelling the name is the page named twice.
+
+          The name is heading TEXT rather than a pill: a pill carries its own
+          small type, so a page title drawn as one renders chip-sized. The
+          tag's colour still reads, as the pill's own dot. */}
       <header className="tagresult-head">
-        <TagPill
-          name={tag.data.name}
-          tone={tag.data.color}
-          archived={Boolean(tag.data.archived_at)}
-        />
+        <h1 className="tagresult-title">
+          {isTagTone(tag.data.color) && !tag.data.archived_at && (
+            <span
+              className={`tagpill-dot tagpill-dot-${tag.data.color}`}
+              aria-hidden
+            />
+          )}
+          {tag.data.name}
+          {tag.data.archived_at && (
+            <span className="tagresult-retired">{t("tags.archived")}</span>
+          )}
+        </h1>
         <span className="t-small">
           {t("tagResult.totalVisible", { count: formatNumber(total, locale) })}
         </span>
@@ -65,77 +89,164 @@ export function TagResultScreen({ tagID }: Readonly<{ tagID?: string }>) {
       {tag.data.description && (
         <p className="tagresult-note">{tag.data.description}</p>
       )}
-      <div className="tagresult-grid">
-        <ResultGroup
-          title={t("tagResult.people")}
-          icon={Contact}
-          count={usage.people}
-          href={`#/contacts?tag_id=${tagID}`}
-        />
-        <ResultGroup
-          title={t("tagResult.companies")}
-          icon={Building2}
-          count={usage.companies}
-          href={`#/companies?tag_id=${tagID}`}
-        />
-        <ResultGroup
-          title={t("tagResult.deals")}
-          icon={Handshake}
-          count={usage.deals}
-          href={`#/deals?tag_id=${tagID}`}
-        />
-      </div>
+      {total === 0 ? (
+        <Panel title={t("tagResult.resultsTitle")}>
+          <PanelBody>
+            <p className="tagresult-note">{t("tagResult.nothingCarries")}</p>
+          </PanelBody>
+        </Panel>
+      ) : (
+        <div className="tagresult-groups">
+          <ResultGroup
+            kind="person"
+            title={t("tagResult.people")}
+            icon={Contact}
+            count={usage.people}
+            tagID={tagID}
+          />
+          <ResultGroup
+            kind="organization"
+            title={t("tagResult.companies")}
+            icon={Building2}
+            count={usage.companies}
+            tagID={tagID}
+          />
+          <ResultGroup
+            kind="deal"
+            title={t("tagResult.deals")}
+            icon={Handshake}
+            count={usage.deals}
+            tagID={tagID}
+          />
+        </div>
+      )}
     </div>
   );
 }
 
+/** What each record type is called on the wire, and where its rows live. */
+const GROUPS = {
+  person: { path: "/people", screen: "contacts" },
+  organization: { path: "/organizations", screen: "companies" },
+  deal: { path: "/deals", screen: "deals" },
+} as const;
+
+// "View all" carries a FILTER, and a filter is not part of a Route — the type
+// deliberately holds screen and ids only, and the list screens read `tag_id`
+// off the address. So the whole-list link is written as an address rather than
+// navigated as a route; `tagfilter.ts` owns the parameter's spelling.
+function allRecordsHref(screen: string, tagID: string): string {
+  return `#/${screen}?tag_id=${encodeURIComponent(tagID)}`;
+}
+
+type GroupKind = keyof typeof GROUPS;
+
 /**
- * One record type's share of a tag: how many carry it, and the way in.
+ * One record type's rows: the records themselves, by name, each opening its
+ * own page.
  *
- * The count comes from the tag read rather than from a page of rows, because a
- * reader deciding whether to open a group needs the size before the rows —
- * and a group of zero says so without a request nobody needs.
+ * A group the tag is not on draws nothing at all rather than a card reporting
+ * zero. The count came from the tag read, so an absent group costs no request —
+ * and three cards, two of them saying "none", is the shape this page had when
+ * it told a reader nothing.
  */
 function ResultGroup({
+  kind,
   title,
   icon: Icon,
   count,
-  href,
+  tagID,
 }: Readonly<{
+  kind: GroupKind;
   title: string;
   icon: LucideIcon;
   count: number;
-  href: string;
+  tagID: string;
 }>) {
   const t = useT();
   const { locale } = useLocale();
+  const group = GROUPS[kind];
+  const rows = useQuery({
+    queryKey: ["tag-records", kind, tagID],
+    queryFn: async () => {
+      const { data, error } = await api.GET(group.path, {
+        params: { query: { tag_id: [tagID], limit: PREVIEW_ROWS } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data.data ?? [];
+    },
+  });
+
+  if (count === 0) {
+    return null;
+  }
+
   const shown = formatNumber(count, locale);
+  const listed = rows.data ?? [];
   return (
-    <Panel
-      title={title}
-      titleAction={<Badge>{shown}</Badge>}
-      footer={
-        count > 0 ? (
+    <Panel title={`${title} (${shown})`}>
+      <PanelBody>
+        <SurfaceState
+          label={undefined}
+          state={
+            rows.isPending ? "loading" : listed.length > 0 ? "ready" : "empty"
+          }
+          loadingLabel={t("tagResult.loadingRows", { kind: title })}
+          loadingLines={Math.min(count, PREVIEW_ROWS)}
+          emptyLabel={t("tagResult.rowsWithheld")}
+        >
+          <ul className="tagresult-rows">
+            {listed.map((row) => (
+              <li key={row.id}>
+                <button
+                  type="button"
+                  className="tagresult-row"
+                  onClick={() => navigate({ screen: group.screen, id: row.id })}
+                >
+                  <Icon aria-hidden />
+                  <span className="tagresult-name">{recordName(row, t)}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </SurfaceState>
+        {count > listed.length && (
           <Button
             small
             variant="ghost"
-            onClick={() => (window.location.hash = href.slice(1))}
+            onClick={() => {
+              window.location.hash = allRecordsHref(group.screen, tagID).slice(
+                1,
+              );
+            }}
           >
             {t("tagResult.viewAll", { count: shown, kind: title })}
           </Button>
-        ) : undefined
-      }
-    >
-      <PanelRow>
-        <span className="tagresult-row">
-          <Icon aria-hidden />
-          <span>
-            {count > 0
-              ? t("tagResult.carry", { count: shown })
-              : t("tagResult.none")}
-          </span>
-        </span>
-      </PanelRow>
+        )}
+      </PanelBody>
     </Panel>
   );
+}
+
+/**
+ * What to call one record.
+ *
+ * The three types name themselves differently on the wire — a person carries
+ * `full_name`, a company `display_name`, a deal `name` — and a row whose name
+ * is empty is named as unnamed rather than rendered as a blank line nobody can
+ * press with confidence.
+ */
+function recordName(
+  row: Readonly<Record<string, unknown>>,
+  t: ReturnType<typeof useT>,
+): string {
+  for (const field of ["full_name", "display_name", "name"]) {
+    const value = row[field];
+    if (typeof value === "string" && value.trim() !== "") {
+      return value;
+    }
+  }
+  return t("tagResult.unnamed");
 }


### PR DESCRIPTION
The page a reader lands on from a search hit answered the wrong question and was headed as though it had failed. Three faults reported from the screen, one more found in review.

## What was wrong

**It never named a record.** Three cards reported counts — "People: 1 carry this tag" — so the page said how many records carry a word and never which. A reader who came to find out *which* needed three more clicks.

**The heading said "Not found"** above the results it had just found. `tags` was routed but absent from both the nav rail and `OFF_RAIL_TITLE_KEYS`, so `resolveTitle` fell through to `shell.unknownPage`.

**Types the tag was not on rendered as cards reporting zero**, which made the page read as an inventory of absences.

## What it does now

One list per record type, each row the record itself by name, opening its page. Rows come through the same `tag_id` filter the three record lists offer. A type carrying none draws nothing at all — and no longer fetches, since the tag read already answered.

The page heads itself with the tag's own name (`SELF_HEADED_SCREENS`), which is what a reader who searched for that word expects at the top. `pagetitle.test.ts` holds this for **every** screen rather than just this one: the corpus is the router's own `SCREENS` list and the exemptions are the product's own `SELF_HEADED_SCREENS`, read rather than copied.

## What review changed

**The group header counted the wrong thing.** It used `tag.usage`, while the rows came from the record lists — and the two disagree in a reachable state: the usage count admits a retired tag, every record list requires the tag to be live (`storekit/tagfilter.go` joins `tag` on `archived_at IS NULL`). Reproduced against a real stack: after retiring a tag, `usage` still reported `{people: 2, companies: 2, deals: 2}` while `GET /people?tag_id=…` returned zero rows. The header now counts what it draws, and a retired word draws no total.

**A failed read was reported as a permission fact.** On error `rows.data` fell back to `[]`, so a 500 rendered "You cannot see these records". It draws `SurfaceState`'s unavailable state now.

## Tests

Nine cases in `tagresult.test.tsx`, each mutation-checked alone. One of them first passed for the wrong reason — asserting only the absence of a string, which also held when the group rendered nothing — and now asserts the state the reader actually sees.

## Verified running

On a dev stack: the page is headed "Automation World 2026" with its colour dot, and lists Katrin Hofmann, Hoàng Thị Thu Trang, KoreaPartner Co. Ltd., VietnamPartner JSC and two deals by name. After retiring the tag, the groups read "(0) — Nothing carries it any more" with no total above them.

`make check-fe` green, re-run after the final rebase; `make check-backend` green; `craft static` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the tag page so it names the records carrying a tag instead of just reporting counts, and heads the page with the tag's own name instead of "Not found".

**Bug Fixes**
- Groups now list the actual records by name, with each row opening the record's page; types carrying no records draw nothing instead of a zero card.
- Group headers count the rows they show, not the tag's usage count, which disagreed on retired tags.
- Failed row reads show the unavailable state instead of reporting records as withheld.
- Added `pagetitle.test.ts`, which verifies every routed screen is named by the rail, the off-rail map, or its own heading.

<sup>Written for commit 64c3ad79cd1c76d083b187ac4b68126b465a845e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tag pages now display matching people, companies, and deals in interactive preview lists.
  * Added loading, empty, unavailable, archived, and unnamed-record states for tag results.
  * Added localized Tags navigation labels in English, German, and Vietnamese.
  * Tag pages now use the localized “Tags” title and display their own page heading.

* **UI Improvements**
  * Updated tag-result layouts with full-width rows, improved hover and focus states, and clearer archived-tag styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->