### PR TITLE
The leads reading says when the nearest answer is due

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2587,6 +2587,7 @@ export const de = {
   "home.readings.promisesBasis": "Zusagen werden noch nicht erfasst",
   "home.readings.leads": "Erstkontakt",
   "home.readings.leadsBasis": "warten auf die erste Antwort",
+  "home.readings.leadsDue": "nächste fällig {value}",
   "home.readings.quota": "Ziel-Tempo",
   "home.readings.quotaBasis": "kein Ziel hinterlegt",
   "home.rail": "Kontext",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2634,6 +2634,7 @@ export const en = {
   "home.readings.promisesBasis": "promises are not tracked yet",
   "home.readings.leads": "Lead response",
   "home.readings.leadsBasis": "owed a first answer",
+  "home.readings.leadsDue": "next due {value}",
   "home.readings.quota": "Quota pace",
   "home.readings.quotaBasis": "no target is set",
   "home.rail": "Context",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2564,6 +2564,7 @@ export const vi = {
   "home.readings.promisesBasis": "cam kết chưa được theo dõi",
   "home.readings.leads": "Phản hồi khách mới",
   "home.readings.leadsBasis": "đang chờ câu trả lời đầu tiên",
+  "home.readings.leadsDue": "tiếp theo đến hạn {value}",
   "home.readings.quota": "Nhịp chỉ tiêu",
   "home.readings.quotaBasis": "chưa đặt chỉ tiêu",
   "home.rail": "Ngữ cảnh",

--- a/frontend/src/screens/home.fixtures.ts
+++ b/frontend/src/screens/home.fixtures.ts
@@ -264,6 +264,56 @@ export function meetingRow(id: string, prepared: boolean): WorklistItem {
   };
 }
 
+/**
+ * A lead owed a first answer, optionally naming when that answer is due.
+ *
+ * `due` undefined is the breached case: the moment has already passed, so the
+ * row carries `response_overdue` and names no future deadline.
+ */
+export function leadRow(id: string, due?: string): WorklistItem {
+  return {
+    id,
+    source: "lead_response",
+    level: due === undefined ? 1 : 2,
+    category: "leads",
+    title: "Weber GmbH · inbound enquiry",
+    because:
+      due === undefined
+        ? // A breached lead the way the lane really builds one: the overdue
+          // reason plus how long it has been waiting. The second reason CARRIES
+          // A VALUE, which is what makes this fixture able to tell a slot that
+          // filters on the reason kind from one that merely takes the first
+          // value it meets.
+          [
+            { kind: "response_overdue" },
+            { kind: "waiting_days", value: { kind: "days", days: 3 } },
+          ]
+        : [{ kind: "response_due_soon", value: { kind: "date", date: due } }],
+    consequence: "buyer_waits",
+    actions: ["open"],
+  };
+}
+
+/** A leads count the page carries whole — considered, shown and read to the end. */
+export function wholeLeads(n: number): WorklistCount {
+  return {
+    category: "leads",
+    considered: n,
+    shown: n,
+    more_available: false,
+  };
+}
+
+/** A leads count whose read stopped at its bound: more exist than the page shows. */
+export function boundedLeads(considered: number, shown: number): WorklistCount {
+  return {
+    category: "leads",
+    considered,
+    shown,
+    more_available: true,
+  };
+}
+
 type WorklistItem = components["schemas"]["WorklistItem"];
 
 /**

--- a/frontend/src/screens/home.readings.test.tsx
+++ b/frontend/src/screens/home.readings.test.tsx
@@ -1,9 +1,18 @@
 /** @vitest-environment jsdom */
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
+import { formatDateTime } from "../format/format";
+import { viewerZone } from "../format/timezone";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
-import { boundedMeetings, meetingRow, readingsDay } from "./home.fixtures";
+import {
+  boundedLeads,
+  boundedMeetings,
+  leadRow,
+  meetingRow,
+  readingsDay,
+  wholeLeads,
+} from "./home.fixtures";
 import { HomeReadingsStrip } from "./home.readings";
 
 // The Brief's readings strip, and the one claim it makes that the Worklist's
@@ -150,5 +159,79 @@ describe("the brief readings strip", () => {
     draw();
 
     expect(screen.queryByText(en["home.readings.truncated"])).toBeNull();
+  });
+});
+
+// The leads slot carries a second fact for the same reason the meetings slot
+// does: how many are owed an answer does not tell a rep whether one is due
+// before lunch.
+describe("the leads reading", () => {
+  function leadsCard(): HTMLElement {
+    const card = screen
+      .getByText(en["home.readings.leads"])
+      .closest(".stat-card");
+    if (!(card instanceof HTMLElement)) {
+      throw new Error("the leads reading is not on the page");
+    }
+    return card;
+  }
+
+  it("names when the nearest answer is due", () => {
+    draw(
+      { prospecting: 2 },
+      [leadRow("l1", "2026-08-31T15:00:00Z"), leadRow("l2")],
+      [wholeLeads(2)],
+    );
+
+    expect(leadsCard().textContent).toContain("2");
+    // The formatted moment, not the ISO string: the slot renders it in the
+    // reader's own zone and this file does not own that format.
+    expect(leadsCard().textContent).not.toContain("2026-08-31T15:00:00Z");
+    expect(screen.queryByText(en["home.readings.leadsBasis"])).toBeNull();
+  });
+
+  it("names the earliest of several, not the first it meets", () => {
+    draw(
+      { prospecting: 2 },
+      [
+        leadRow("late", "2026-08-31T18:00:00Z"),
+        leadRow("soon", "2026-08-31T09:00:00Z"),
+      ],
+      [wholeLeads(2)],
+    );
+
+    // Asserted by DIFFERENCE rather than by a literal clock reading: the two
+    // moments are nine hours apart, so whichever zone the runtime is in, the
+    // card must carry the earlier one's rendering and not the later one's. A
+    // hard-coded hour would pin the test to the runner's own zone — the first
+    // version of this line did, and read 09:00 as 16:00 under Asia/Ho_Chi_Minh.
+    const earlier = formatDateTime("2026-08-31T09:00:00Z", "en", viewerZone());
+    const later = formatDateTime("2026-08-31T18:00:00Z", "en", viewerZone());
+    expect(leadsCard().textContent).toContain(earlier);
+    expect(leadsCard().textContent).not.toContain(later);
+  });
+
+  // The defect this slot is shaped around, and the same one the meetings slot
+  // guards: a cut read means an unshown lead could be due sooner than every one
+  // the reader can see, so naming the earliest visible deadline states a "next"
+  // that is not next.
+  it("refuses a deadline when the page carries fewer leads than it counted", () => {
+    draw(
+      { prospecting: 9 },
+      [leadRow("l1", "2026-08-31T15:00:00Z")],
+      [boundedLeads(9, 1)],
+    );
+
+    expect(leadsCard().textContent).toContain("9");
+    expect(screen.getByText(en["home.readings.leadsBasis"])).toBeTruthy();
+  });
+
+  // Every lead already overdue. There is no NEXT moment to name — they have all
+  // passed — so the slot says what it counts rather than a date behind it.
+  it("names no deadline when every lead is already overdue", () => {
+    draw({ prospecting: 2 }, [leadRow("l1"), leadRow("l2")], [wholeLeads(2)]);
+
+    expect(leadsCard().textContent).toContain("2");
+    expect(screen.getByText(en["home.readings.leadsBasis"])).toBeTruthy();
   });
 });

--- a/frontend/src/screens/home.readings.tsx
+++ b/frontend/src/screens/home.readings.tsx
@@ -3,7 +3,8 @@
 
 import { StatCard } from "../design-system/atoms";
 import { StatStrip } from "../design-system/statstrip";
-import { formatNumber } from "../format/format";
+import { formatDateTime, formatNumber } from "../format/format";
+import { viewerZone } from "../format/timezone";
 import {
   type Locale,
   type Translator,
@@ -12,7 +13,7 @@ import {
   useT,
 } from "../i18n";
 import { isUnprepared } from "./worklist.copy";
-import type { Worklist } from "./worklist.queries";
+import type { Worklist, WorklistItem } from "./worklist.queries";
 
 // The day's readings, on one plate.
 //
@@ -35,12 +36,14 @@ import type { Worklist } from "./worklist.queries";
 // invite the reading where the others are exact.
 
 const MEETINGS = "meetings";
+const LEADS = "leads";
 
 export function HomeReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
   const t = useT();
   const { locale } = useLocale();
   const readings = day.readings;
   const meetings = meetingsReading(day);
+  const soonest = soonestLeadDeadline(day);
   return (
     <section className="home-readings" aria-label={t("home.readings.label")}>
       <StatStrip
@@ -69,12 +72,11 @@ export function HomeReadingsStrip({ day }: Readonly<{ day: Worklist }>) {
           label={t("home.readings.promises")}
           detail={t("home.readings.promisesBasis")}
         />
-        <StatCard
-          numeric
-          label={t("home.readings.leads")}
-          value={formatNumber(readings.prospecting, locale)}
-          tone={readings.prospecting > 0 ? "warn" : undefined}
-          detail={t("home.readings.leadsBasis")}
+        <LeadsStat
+          leads={readings.prospecting}
+          soonest={soonest}
+          locale={locale}
+          t={t}
         />
         <Untracked
           label={t("home.readings.quota")}
@@ -136,6 +138,92 @@ function meetingsDetail(
   return meetings === 0
     ? t("home.readings.meetingsBasis")
     : t("home.readings.prepared");
+}
+
+// How much new business is owed a first answer, and when the nearest one is due.
+//
+// The deadline is the fact that changes what a reader does before lunch, so it
+// takes the same shape readiness takes on the meetings slot beside it: a second
+// fact in the detail line, and NULL rather than a guess where the page cannot
+// honestly compute one.
+function LeadsStat({
+  leads,
+  soonest,
+  locale,
+  t,
+}: Readonly<{
+  leads: number;
+  // Null when no honest nearest deadline exists — either nothing on the page
+  // names one, or the leads read was cut short and an unshown lead could be
+  // sooner than every one the reader can see.
+  soonest: string | null;
+  locale: Locale;
+  t: Translator;
+}>) {
+  return (
+    <StatCard
+      numeric
+      label={t("home.readings.leads")}
+      value={formatNumber(leads, locale)}
+      tone={leads > 0 ? "warn" : undefined}
+      detail={
+        soonest === null
+          ? t("home.readings.leadsBasis")
+          : t("home.readings.leadsDue", {
+              value: formatDateTime(soonest, locale, viewerZone()),
+            })
+      }
+    />
+  );
+}
+
+// The nearest deadline among the lead rows the page is SHOWING, or none.
+//
+// None in two cases that are one rule: the page cannot see the whole lane, or no
+// row on it names a moment. A cut read is the interesting one — an unshown lead
+// could be due sooner than every one the reader can see, so naming the earliest
+// visible deadline would state a "next" that is not next. The slot falls back to
+// its plain basis line, which is what the meetings slot does with readiness for
+// the same reason.
+function soonestLeadDeadline(day: Worklist): string | null {
+  const entry = day.counts.find((count) => count.category === LEADS);
+  if (entry === undefined) {
+    // No lead was read at all: nothing to be nearest, and nothing missing.
+    return null;
+  }
+  if (entry.shown !== entry.considered || entry.more_available) {
+    return null;
+  }
+  let soonest: string | null = null;
+  for (const item of day.queue) {
+    const at = item.category === LEADS ? replyDueAt(item) : undefined;
+    if (at !== undefined && (soonest === null || at < soonest)) {
+      soonest = at;
+    }
+  }
+  return soonest;
+}
+
+// When this row says a reply is due, or nothing.
+//
+// The moment is read off the at-risk reason BY NAME rather than by taking
+// whatever date the row carries. An overdue lead has already missed its moment,
+// so it is not the next one due — and no test here can hold that distinction,
+// because a breached lead's other reason (`waiting_days`) carries a DAYS value,
+// which a filter reading "any date value" would skip anyway. The kind check is
+// what keeps this right when a lead row grows a second date-valued reason, a
+// first-contact date or a routing moment, that would otherwise read as a reply
+// deadline.
+function replyDueAt(item: WorklistItem): string | undefined {
+  for (const because of item.because) {
+    if (
+      because.kind === "response_due_soon" &&
+      because.value?.kind === "date"
+    ) {
+      return because.value.date;
+    }
+  }
+  return undefined;
 }
 
 // The count slots call `StatCard` straight rather than through a shared tile


### PR DESCRIPTION
How many leads are owed a first answer does not tell a rep whether one is due
before lunch. The slot now carries that second fact the way the meetings slot
beside it carries readiness: in the detail line, derived from the rows the page
is actually showing.

It refuses to name a moment when the page cannot honestly compute one. A leads
read cut at its bound means an unshown lead could be due sooner than every one
the reader can see, so naming the earliest visible deadline would state a "next"
that is not next — the slot falls back to its plain basis line instead. Same
ruling the meetings slot makes about readiness, and mutation-checked: removing
the guard fails that test and only that test.

The deadline is read off the at-risk reason BY NAME rather than by taking
whatever date the row carries. That distinction is not testable here and the
code says so: a breached lead's other reason carries a DAYS value, so a filter
reading "any date value" behaves identically today. The kind check is what keeps
it right when a lead row grows a second date-valued reason — a first-contact
date, a routing moment — that would otherwise read as a reply deadline.

HALF THE LEDGER ITEM WAS WRONG, and I checked before building rather than after.
It claimed the slot reads `readings.prospecting` instead of the `leads` count
category. Not a defect: readings.go:62 increments Prospecting on `case
categoryLeads`, the same category countsOf buckets, and both are computed from
the same `considered` slice — they cannot disagree on the number. Readings also
carries its own more_available, which the strip already renders through
StatStrip's floor slot. Nothing there needed changing, so nothing was changed.

The breached-lead fixture now carries the reasons the lane really builds
(response_overdue plus waiting_days with its value) rather than a lone kindless
reason, so a fixture that could not tell two filters apart no longer stands in
for one that can.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

---

Local gate: `make check-fe` green (re-run after rebasing onto #3768), `make check-backend` green (the i18n catalogs are read by a backend gate), `make craft-static` clean.

The honesty guard is mutation-checked: removing the cut-read check fails "refuses a deadline when the page carries fewer leads than it counted" and nothing else.

No Playwright run: the fallback phrase is unchanged and no e2e spec pins the leads slot (grepped `frontend/e2e/`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The leads reading now shows when the nearest first answer is due, so a rep can tell whether one is due before lunch.

- Adds the earliest deadline to the detail line, formatted in the viewer's timezone.
- Falls back to the plain basis line when the read was cut short or every lead is already overdue.
- Reads the deadline off the `response_due_soon` reason by kind, so future date-valued reasons won't read as reply deadlines.
- Updates the breached-lead fixture to carry the reasons the lane really builds.

<sup>Written for commit cbd5b93bc53dcb24b4cf2ad2ad989e401b0b2f31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The home readings screen now shows the next lead-response due date when a reliable deadline is available.
  * Due dates are selected chronologically and formatted safely across time zones.
  * When no reliable deadline exists, the leads card displays the available basis text instead.

* **Localization**
  * Added English, German, and Vietnamese translations for the lead-response due-time message.

* **Tests**
  * Added coverage for overdue leads, incomplete counts, due-soon responses, and date formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->