### PR TITLE
test(authz): dedupe tag-write test setup

### DIFF
--- a/backend/internal/compose/integration/collections/tagauthz_integration_test.go
+++ b/backend/internal/compose/integration/collections/tagauthz_integration_test.go
@@ -17,7 +17,6 @@ package collections
 // Postgres row-scope predicate can arbitrate.
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -30,8 +29,11 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
-// seedTag mints a live tag as admin, in the caller's shape (ids.TagID).
-func seedTag(t *testing.T, e *integration.Env, tags *collectionsmod.Store, name string) ids.TagID {
+// createTagViaStore is createTag's store-path counterpart: this package's
+// createTag (tagvocab_integration_test.go) goes through the HTTP handler and
+// answers a string id; the tests here exercise the store directly and need
+// the typed ids.TagID its own methods take.
+func createTagViaStore(t *testing.T, e *integration.Env, tags *collectionsmod.Store, name string) ids.TagID {
 	t.Helper()
 	tag, err := tags.NewTag(e.Admin(), name, "")
 	if err != nil {
@@ -40,21 +42,15 @@ func seedTag(t *testing.T, e *integration.Env, tags *collectionsmod.Store, name 
 	return ids.From[ids.TagKind](tag.TagID)
 }
 
-// repCtx is the one seat every test in this file probes: Rep1 on Team1,
-// holding AccountRepPerms — read-all on person, write bounded to their team.
-func repCtx(e *integration.Env) context.Context {
-	return e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
-}
-
 func TestATagWriteOnAForeignOwnedRecordIsRefused(t *testing.T) {
 	e := integration.Setup(t)
 	tags := collectionsmod.NewStore(e.DB())
 
 	own := e.SeedPerson(t, "Own", &e.Rep1)
 	foreign := e.SeedPerson(t, "Foreign", &e.Rep3)
-	tagID := seedTag(t, e, tags, "Key Account")
+	tagID := createTagViaStore(t, e, tags, "Key Account")
 
-	rep := repCtx(e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	// The admit arm first: this seat CAN read the foreign contact (person is
 	// read-all), which is the exact condition an object grant alone cannot
@@ -111,13 +107,13 @@ func TestATagWriteOnAnArchivedRecordIsRefused(t *testing.T) {
 	tags := collectionsmod.NewStore(e.DB())
 
 	own := e.SeedPerson(t, "Own", &e.Rep1)
-	tagID := seedTag(t, e, tags, "Archived Target")
+	tagID := createTagViaStore(t, e, tags, "Archived Target")
 
 	if _, err := e.People.ArchivePerson(e.Admin(), integration.PersonIDOf(own), nil); err != nil {
 		t.Fatalf("archiving the fixture: %v", err)
 	}
 
-	rep := repCtx(e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	if _, err := tags.ApplyTag(rep, tagID, "person", own); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("applying a tag to an archived record this seat owns → %v, want ErrNotFound", err)
 	}
@@ -145,9 +141,9 @@ func TestATagWriteOnAnOwnerlessRecordIsRefusedBelowRowScopeAll(t *testing.T) {
 	tags := collectionsmod.NewStore(e.DB())
 
 	unowned := e.SeedPerson(t, "Unclaimed", nil)
-	tagID := seedTag(t, e, tags, "Ownerless Target")
+	tagID := createTagViaStore(t, e, tags, "Ownerless Target")
 
-	rep := repCtx(e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	if _, err := e.People.GetPerson(rep, integration.PersonIDOf(unowned), storekit.LiveOnly); err != nil {
 		t.Fatalf("reading an unowned contact: %v, want success — read-all covers ownerless rows too", err)
 	}
@@ -188,7 +184,7 @@ func TestEnsureTaggableRefusesTheSameForeignOwnedRecordApplyDoes(t *testing.T) {
 
 	own := e.SeedPerson(t, "Own", &e.Rep1)
 	foreign := e.SeedPerson(t, "Foreign", &e.Rep3)
-	rep := repCtx(e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	if err := tags.EnsureTaggable(rep, "person", own); err != nil {
 		t.Errorf("EnsureTaggable on this seat's own contact: %v, want success", err)
@@ -208,9 +204,9 @@ func TestTheImportersTagWriteRefusesAForeignOwnedRecordToo(t *testing.T) {
 
 	own := e.SeedPerson(t, "Own", &e.Rep1)
 	foreign := e.SeedPerson(t, "Foreign", &e.Rep3)
-	tagID := seedTag(t, e, tags, "Imported")
+	tagID := createTagViaStore(t, e, tags, "Imported")
 
-	rep := repCtx(e)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	tx, err := e.Pool.Begin(rep)
 	if err != nil {

--- a/backend/internal/compose/integration/collections/tagauthz_integration_test.go
+++ b/backend/internal/compose/integration/collections/tagauthz_integration_test.go
@@ -37,7 +37,7 @@ func createTagViaStore(t *testing.T, e *integration.Env, tags *collectionsmod.St
 	t.Helper()
 	tag, err := tags.NewTag(e.Admin(), name, "")
 	if err != nil {
-		t.Fatalf("seeding the tag: %v", err)
+		t.Fatalf("seeding the tag %q: %v", name, err)
 	}
 	return ids.From[ids.TagKind](tag.TagID)
 }

--- a/backend/internal/compose/integration/collections/tagauthz_integration_test.go
+++ b/backend/internal/compose/integration/collections/tagauthz_integration_test.go
@@ -17,6 +17,7 @@ package collections
 // Postgres row-scope predicate can arbitrate.
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -29,19 +30,31 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
+// seedTag mints a live tag as admin, in the caller's shape (ids.TagID).
+func seedTag(t *testing.T, e *integration.Env, tags *collectionsmod.Store, name string) ids.TagID {
+	t.Helper()
+	tag, err := tags.NewTag(e.Admin(), name, "")
+	if err != nil {
+		t.Fatalf("seeding the tag: %v", err)
+	}
+	return ids.From[ids.TagKind](tag.TagID)
+}
+
+// repCtx is the one seat every test in this file probes: Rep1 on Team1,
+// holding AccountRepPerms — read-all on person, write bounded to their team.
+func repCtx(e *integration.Env) context.Context {
+	return e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+}
+
 func TestATagWriteOnAForeignOwnedRecordIsRefused(t *testing.T) {
 	e := integration.Setup(t)
 	tags := collectionsmod.NewStore(e.DB())
 
 	own := e.SeedPerson(t, "Own", &e.Rep1)
 	foreign := e.SeedPerson(t, "Foreign", &e.Rep3)
-	tag, err := tags.NewTag(e.Admin(), "Key Account", "")
-	if err != nil {
-		t.Fatalf("seeding the tag: %v", err)
-	}
-	tagID := ids.From[ids.TagKind](tag.TagID)
+	tagID := seedTag(t, e, tags, "Key Account")
 
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+	rep := repCtx(e)
 
 	// The admit arm first: this seat CAN read the foreign contact (person is
 	// read-all), which is the exact condition an object grant alone cannot
@@ -98,17 +111,13 @@ func TestATagWriteOnAnArchivedRecordIsRefused(t *testing.T) {
 	tags := collectionsmod.NewStore(e.DB())
 
 	own := e.SeedPerson(t, "Own", &e.Rep1)
-	tag, err := tags.NewTag(e.Admin(), "Archived Target", "")
-	if err != nil {
-		t.Fatalf("seeding the tag: %v", err)
-	}
-	tagID := ids.From[ids.TagKind](tag.TagID)
+	tagID := seedTag(t, e, tags, "Archived Target")
 
 	if _, err := e.People.ArchivePerson(e.Admin(), integration.PersonIDOf(own), nil); err != nil {
 		t.Fatalf("archiving the fixture: %v", err)
 	}
 
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+	rep := repCtx(e)
 	if _, err := tags.ApplyTag(rep, tagID, "person", own); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("applying a tag to an archived record this seat owns → %v, want ErrNotFound", err)
 	}
@@ -136,13 +145,9 @@ func TestATagWriteOnAnOwnerlessRecordIsRefusedBelowRowScopeAll(t *testing.T) {
 	tags := collectionsmod.NewStore(e.DB())
 
 	unowned := e.SeedPerson(t, "Unclaimed", nil)
-	tag, err := tags.NewTag(e.Admin(), "Ownerless Target", "")
-	if err != nil {
-		t.Fatalf("seeding the tag: %v", err)
-	}
-	tagID := ids.From[ids.TagKind](tag.TagID)
+	tagID := seedTag(t, e, tags, "Ownerless Target")
 
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+	rep := repCtx(e)
 	if _, err := e.People.GetPerson(rep, integration.PersonIDOf(unowned), storekit.LiveOnly); err != nil {
 		t.Fatalf("reading an unowned contact: %v, want success — read-all covers ownerless rows too", err)
 	}
@@ -183,7 +188,7 @@ func TestEnsureTaggableRefusesTheSameForeignOwnedRecordApplyDoes(t *testing.T) {
 
 	own := e.SeedPerson(t, "Own", &e.Rep1)
 	foreign := e.SeedPerson(t, "Foreign", &e.Rep3)
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+	rep := repCtx(e)
 
 	if err := tags.EnsureTaggable(rep, "person", own); err != nil {
 		t.Errorf("EnsureTaggable on this seat's own contact: %v, want success", err)
@@ -203,13 +208,9 @@ func TestTheImportersTagWriteRefusesAForeignOwnedRecordToo(t *testing.T) {
 
 	own := e.SeedPerson(t, "Own", &e.Rep1)
 	foreign := e.SeedPerson(t, "Foreign", &e.Rep3)
-	tag, err := tags.NewTag(e.Admin(), "Imported", "")
-	if err != nil {
-		t.Fatalf("seeding the tag: %v", err)
-	}
-	tagID := ids.From[ids.TagKind](tag.TagID)
+	tagID := seedTag(t, e, tags, "Imported")
 
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+	rep := repCtx(e)
 
 	tx, err := e.Pool.Begin(rep)
 	if err != nil {


### PR DESCRIPTION
## Summary

SonarCloud flagged 15.9% duplication on the new code in #3768 (threshold ≤3%) — not a required check for this repo, but real duplication worth fixing on its own merits.

`backend/internal/compose/integration/collections/tagauthz_integration_test.go`'s tag-seeding block (mint via `NewTag`, check the error, convert to `ids.TagID`) and the one `Rep1`/`Team1`/`AccountRepPerms` reader context repeated near-verbatim across all five tests in the file. Extracted two small helpers, `seedTag` and `repCtx`.

No behavior change — every test asserts exactly what it did before; this is a pure DRY pass.

## Test plan

- [x] `make test-it DIR=backend/internal/compose/integration/collections` — all 12 tests in the package pass, unchanged assertions
- [x] `craft static --strict` clean
- [x] `make check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oooEFASw2gFLzM2uAb64A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the tag-seeding block repeated across the tag-authz integration tests by extracting it into a single `createTagViaStore` helper, resolving the SonarCloud duplication flag. No behavior change — every test asserts exactly what it did before.

- Drops the initial `seedTag`/`repCtx` split; only the tag-seeding extraction remains.
- Names the helper `createTagViaStore` to sit alongside the package's existing `createTag` (HTTP-handler path).

<sup>Written for commit 006268f74ce86983c7973646dfe7e70ecf318055. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined integration test setup for clearer, more localized authorization context handling.
  * Centralized tag creation through a shared store-based test utility.
  * Improved test setup error details by identifying the affected tag.
  * Existing test behavior and assertions remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->