### PR TITLE
docs(gates): update stale EnsureLinkTarget exclusion comment

### DIFF
--- a/backend/gates/writeauthority_test.go
+++ b/backend/gates/writeauthority_test.go
@@ -41,8 +41,21 @@ package gates
 // an oversight: auth.EnsureLinkTarget. It asks whether the caller may REFERENCE
 // a record — attach an activity, name a parent org, add a list member — and
 // whether "add" needs write authority on the thing added TO is a product
-// question UC-E11-08 E2 raises rather than settles. It is tracked as its own
-// issue rather than decided inside a security sweep.
+// question UC-E11-08 E2 raises rather than settles PER CALL SITE — a security
+// sweep is the wrong place to answer it for all of them at once, and members.go
+// (collections) is the worked counterexample: list membership is not rendered
+// as an attribute of the added record, so EnsureLinkTarget is the right gate
+// there, not a gap.
+//
+// One instance IS decided: applying a tag DOES need write authority on the
+// target (a tag steers a filter and an automation, so tagging changes the
+// record), fixed by moving ApplyTag/RemoveTag/EnsureTaggable in
+// internal/modules/collections/tags.go onto EnsureWritableLive — which is why
+// tags.go earns no waiver here, having left the excluded spelling behind
+// entirely. Every other EnsureLinkTarget site still carries the unresolved
+// question and this exclusion still hides it from the census by construction;
+// closing that per-site, or ruling the current behavior acceptable and saying
+// so here instead of "tracked as its own issue", is tracked separately.
 //
 // The LIST predicates (auth.ScopeClauseFor, auth.VisiblePredicate) are IN the
 // census, and that is a correction rather than a flourish. A first draft left

--- a/backend/gates/writeauthority_test.go
+++ b/backend/gates/writeauthority_test.go
@@ -41,21 +41,15 @@ package gates
 // an oversight: auth.EnsureLinkTarget. It asks whether the caller may REFERENCE
 // a record — attach an activity, name a parent org, add a list member — and
 // whether "add" needs write authority on the thing added TO is a product
-// question UC-E11-08 E2 raises rather than settles PER CALL SITE — a security
-// sweep is the wrong place to answer it for all of them at once, and members.go
-// (collections) is the worked counterexample: list membership is not rendered
-// as an attribute of the added record, so EnsureLinkTarget is the right gate
-// there, not a gap.
-//
-// One instance IS decided: applying a tag DOES need write authority on the
-// target (a tag steers a filter and an automation, so tagging changes the
-// record), fixed by moving ApplyTag/RemoveTag/EnsureTaggable in
-// internal/modules/collections/tags.go onto EnsureWritableLive — which is why
-// tags.go earns no waiver here, having left the excluded spelling behind
-// entirely. Every other EnsureLinkTarget site still carries the unresolved
-// question and this exclusion still hides it from the census by construction;
-// closing that per-site, or ruling the current behavior acceptable and saying
-// so here instead of "tracked as its own issue", is tracked separately.
+// question UC-E11-08 E2 raises rather than settles, decided per call site
+// rather than all at once by this gate. internal/modules/collections shows
+// both answers: applying a tag DOES need it, so tags.go probes the target with
+// EnsureWritableLive; adding a list member does NOT
+// (internal/modules/collections/members.go says why). The excluded spelling
+// still reads green here either way — this gate cannot tell tags.go's fix from
+// a revert of it, which collections/tagauthz_integration_test.go holds
+// instead. Every other EnsureLinkTarget site remains unjudged, invisible to
+// this census by construction, tracked at #3797.
 //
 // The LIST predicates (auth.ScopeClauseFor, auth.VisiblePredicate) are IN the
 // census, and that is a correction rather than a flourish. A first draft left


### PR DESCRIPTION
## Summary

Flagged by the peer QC session's control census: `backend/gates/writeauthority_test.go`'s comment described the tag-application write-authority question as an open product question "tracked as its own issue" — but margince#3755 (merged in #3768) decided and fixed exactly that instance. The gate has been green over this class the whole time by an explicit, wholesale exclusion of `auth.EnsureLinkTarget`; the comment now says which instance is decided (tags) and which counterexample proves the exclusion isn't just a gap (`members.go` — list membership isn't a record attribute, so visibility-only is the right gate there).

Every other `EnsureLinkTarget` call site still carries the same unresolved question with no gate watching it. That's tracked as margince#3797 rather than left as something only this comment's staleness would eventually surface — deciding each site is a separate, larger effort out of scope here.

No behavior change: `EnsureLinkTarget` stays excluded from the census everywhere except `tags.go`, which needs no waiver because it no longer calls that spelling at all (confirmed: `TestEveryMutationOfAShareableRecordProbesForWriteAuthority` passes with zero waiver entries for `tags.go`'s functions — they clear the gate on their own merits now that they call `EnsureWritableLive` directly).

## Test plan

- [x] `go test ./gates/... -run TestEveryMutationOfAShareableRecordProbesForWriteAuthority` passes
- [x] `craft static --strict` clean
- [x] `make check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oooEFASw2gFLzM2uAb64A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the stale comment on the write-authority census's `EnsureLinkTarget` exclusion to reflect that the tag-application question is now decided: applying a tag requires write authority, so `tags.go` probes the target with `EnsureWritableLive`, while `members.go` is the counterexample where visibility-only gating is correct. The comment now states the gate cannot distinguish the `tags.go` fix from a revert of it (that invariant lives in `collections/tagauthz_integration_test.go`) and cites #3797 for the remaining unjudged call sites. No behavior changes; the gate and waivers stay as before.

<sup>Written for commit 51b200c518de40fd05426cfd8dc45722ce373416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that authority decisions are made per call site.
  * Documented writable-live validation for tag operations and read-only authority for list membership.
  * Added references to integration-test coverage for tag behavior and tracking for other call sites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->