### PR TITLE
Search matches the word a reader is still typing

### DIFF
--- a/backend/danglingcitations.txt
+++ b/backend/danglingcitations.txt
@@ -173,7 +173,6 @@ backend/internal/modules/search/queryjoins_test.go core 0195
 backend/internal/modules/search/querysql_test.go core 0007
 backend/internal/modules/search/querysql_test.go core 0131
 backend/internal/modules/search/querystorage.go migration 0051
-backend/internal/modules/search/store.go migration 0077
 backend/internal/modules/signals/audiencerescope.go migration 0208
 backend/internal/platform/auth/auditgrant_test.go migration 0133
 backend/internal/platform/auth/auditgrant_test.go migration 0287

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -250,8 +250,11 @@ var searchBranches = []searchBranch{
 // keyset pagination orders (score DESC, type, id) so the cursor is
 // stable under concurrent writes.
 func (s *Store) Search(ctx context.Context, in Input) (Page, error) {
-	query := strings.TrimSpace(in.Query)
-	if query == "" {
+	// normalizeQuery, not TrimSpace: a TRAILING separator is what says the
+	// reader finished a word, and trimming it turned every completed search
+	// into a prefix search.
+	query := normalizeQuery(in.Query)
+	if strings.TrimSpace(query) == "" {
 		return Page{}, &BadQueryError{Field: "q", Reason: "q is required"}
 	}
 	limit := clampLimit(in.Limit)
@@ -280,9 +283,20 @@ func (s *Store) Search(ctx context.Context, in Input) (Page, error) {
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
-		qPos := arg(query)
 
-		branches, err := admittedBranchSQL(ctx, types, qPos, arg)
+		// The query split at the last separator: the words the reader FINISHED,
+		// and the fragment they are still typing. The two are matched
+		// differently — finished words whole, the fragment as a prefix.
+		head, tail := splitTypedQuery(query)
+		headPos := arg(head)
+		// Bound only when there IS a fragment: a parameter no SQL references
+		// cannot have its type inferred, and Postgres fails the whole statement.
+		tailPos := 0
+		if tail != "" {
+			tailPos = arg(tail)
+		}
+
+		branches, err := admittedBranchSQL(ctx, types, headPos, tailPos, tail != "", arg)
 		if err != nil {
 			return err
 		}
@@ -323,7 +337,7 @@ func (s *Store) Search(ctx context.Context, in Input) (Page, error) {
 // entity type. A hit is a read twice over: object RBAC first (a role
 // without person.read gets no person hits — search must not out-see the
 // entity lists), then the row scope.
-func admittedBranchSQL(ctx context.Context, types []string, qPos int, arg func(any) int) ([]string, error) {
+func admittedBranchSQL(ctx context.Context, types []string, headPos, tailPos int, hasFragment bool, arg func(any) int) ([]string, error) {
 	var branches []string
 	for _, branch := range searchBranches {
 		if !slices.Contains(types, branch.entity) {
@@ -336,21 +350,11 @@ func admittedBranchSQL(ctx context.Context, types []string, qPos int, arg func(a
 		if !admitted {
 			continue
 		}
-		// Name entities parse the query 'simple' (unaccented — Muller
-		// finds Müller), OR-ed with the apostrophe-collapsed parse so
-		// "o'reilly" also reaches a row stored as "OReilly" (the index
-		// side carries the collapsed tokens, migration 0077); the
-		// activity branch additionally ORs the German/English stemmed
-		// parses so "Vertrag" reaches rows whose tsvector stemmed
-		// "Verträge" under their captured language.
-		tsquery := fmt.Sprintf(
-			`(websearch_to_tsquery('simple', f_unaccent($%[1]d)) || websearch_to_tsquery('simple', f_fold_apostrophes($%[1]d)))`,
-			qPos)
-		if branch.entity == "activity" {
-			tsquery = fmt.Sprintf(
-				`(websearch_to_tsquery('simple', f_unaccent($%[1]d)) || websearch_to_tsquery('simple', f_fold_apostrophes($%[1]d)) || websearch_to_tsquery('german', f_unaccent($%[1]d)) || websearch_to_tsquery('english', f_unaccent($%[1]d)))`,
-				qPos)
-		}
+		// What this branch matches, and why it is shaped that way, lives with
+		// the expression in typedquery.go — including the parse configurations
+		// each entity uses and the rule that only the fragment widens.
+		tsquery := matchExpression(branch.entity, headPos, tailPos, hasFragment)
+
 		snippet, err := branch.excerpt(ctx, arg)
 		if err != nil {
 			return nil, err

--- a/backend/internal/modules/search/typedquery.go
+++ b/backend/internal/modules/search/typedquery.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// normalizeQuery is what Search hands the splitter.
+//
+// Leading whitespace is the reader's slip; TRAILING whitespace is a statement —
+// it is what says a word is finished. Trimming both, which Search did, made
+// "a finished word" unreachable: "ann " became "ann", read as a fragment, and
+// searched as `ann:*`, so a completed search silently reached "annual".
+//
+// Spelled here rather than at the call site so a test can drive the same
+// normalisation the product does; asserting against its own copy is how the
+// trailing-space case passed while the product had already erased it.
+func normalizeQuery(raw string) string {
+	return strings.TrimLeft(raw, " \t\r\n")
+}
+
+// splitTypedQuery divides a query into the words the reader FINISHED and the
+// fragment they are still typing.
+//
+// Only the fragment is offered as a prefix. "automation wor" reaches a record
+// carrying the whole word "automation" and something starting with "wor";
+// loosening the earlier word too would return records the reader had already
+// ruled out by finishing it.
+//
+// THE WHOLE QUERY IS THE HEAD when there is nothing to complete, and there are
+// three such cases. A query ending in a space is a reader who finished a word.
+// A closing quote says the same more strongly: the quotes mean those words
+// entire. And a query using the websearch OPERATORS is one the reader is
+// composing rather than typing a name into — `websearch_to_tsquery` gives them
+// `or`, `-term` and quoted phrases, and splitting the string underneath that
+// grammar tears an operator off its operand: "automation or katrin" would ask
+// for the whole words "automation or" AND anything starting with "katrin",
+// which is neither what they typed nor what they meant.
+//
+// The cost of the operator rule is that a reader mid-word in an operator query
+// waits for the space, which is the same wait every query had before.
+func splitTypedQuery(query string) (head, tail string) {
+	if strings.HasSuffix(query, `"`) || carriesOperators(query) {
+		return query, ""
+	}
+	i := strings.LastIndexFunc(query, func(r rune) bool {
+		return unicode.IsSpace(r) || r == '"'
+	})
+	if i < 0 {
+		return "", query
+	}
+	return query[:i], query[i+1:]
+}
+
+// carriesOperators reports whether the query uses the websearch grammar rather
+// than being a run of plain words. `websearch_to_tsquery` reads a bare `or`
+// between words as a disjunction, a leading `-` as a negation, and a quote as
+// the start of a phrase — each of which binds to the words around it and so
+// must not be cut in half.
+func carriesOperators(query string) bool {
+	if strings.Contains(query, `"`) {
+		return true
+	}
+	for _, field := range strings.Fields(query) {
+		if strings.HasPrefix(field, "-") || strings.EqualFold(field, "or") {
+			return true
+		}
+	}
+	return false
+}
+
+// prefixArmSQL matches the fragment the reader is still typing as a PREFIX.
+//
+// `plainto_tsquery` is the escaper, NOT `quote_literal`. The latter quotes for
+// SQL, not for tsquery: given a fragment carrying a backslash it emits an
+// E-string, and the `E` is then parsed as a lexeme of its own — "ACME\Sales"
+// searched for a phantom `e` alongside the words the reader typed.
+// `plainto_tsquery` renders the same input as `'acme' & 'sales'`, sanitized
+// into lexemes with every operator already neutralized, and it never raises on
+// text off a request.
+//
+// `:*` is appended to the rendered TEXT, so it marks the final lexeme. A
+// fragment is one word by construction and usually renders one lexeme; when a
+// separator inside it yields more ("ACME\Sales" → two), marking the last is
+// exactly right — those are words the reader finished typing and the last is
+// the one still under the cursor.
+//
+// An EMPTY fragment renders an empty tsquery, and `”:*` would be a syntax
+// error, so the caller omits the arm entirely rather than building one. That is
+// also what makes a finished query match exactly what it matched before.
+func prefixArmSQL(tailPos int) string {
+	return fmt.Sprintf(
+		`(plainto_tsquery('simple', f_unaccent($%d))::text || ':*')::tsquery`,
+		tailPos)
+}
+
+// matchExpression is the tsquery one branch matches against: the words the
+// reader FINISHED, whole, AND the fragment they are still typing, as a prefix.
+//
+// AND rather than OR is the correctness of it. OR-ed, the prefix alone
+// satisfies the match, so "zebra wor" reaches a record carrying neither word
+// and typing MORE widens the answer instead of narrowing it.
+//
+// The `simple` parse is unaccented, so "Muller" finds "Müller", and it is
+// OR-ed with the apostrophe-collapsed parse so "o'reilly" reaches a row stored
+// as "OReilly". Both halves rest on the same invariant: every searchable table's
+// `search_tsv` carries the unaccented and apostrophe-collapsed tokens, so a
+// query parsed either way meets an index that speaks it.
+//
+// The activity branch parses German and English as well as `simple`, so rows
+// whose tsvector stemmed "Verträge" answer a search for "Vertrag". Both halves
+// carry those parses: a prefix compares `simple` lexemes while the index stores
+// stems, so a fragment offered as `study:*` reaches neither the stored `studi`
+// nor the simple `studies` — and every search is a fragment as it is typed.
+func matchExpression(entity string, headPos, tailPos int, hasFragment bool) string {
+	wholeWords := fmt.Sprintf(
+		`websearch_to_tsquery('simple', f_unaccent($%[1]d)) || websearch_to_tsquery('simple', f_fold_apostrophes($%[1]d))`,
+		headPos)
+	if entity == entityActivity {
+		wholeWords += fmt.Sprintf(
+			` || websearch_to_tsquery('german', f_unaccent($%[1]d)) || websearch_to_tsquery('english', f_unaccent($%[1]d))`,
+			headPos)
+	}
+	if !hasFragment {
+		return fmt.Sprintf(`(%s)`, wholeWords)
+	}
+	fragment := prefixArmSQL(tailPos)
+	if entity == entityActivity {
+		fragment = fmt.Sprintf(
+			`(%s || websearch_to_tsquery('german', f_unaccent($%[2]d)) || websearch_to_tsquery('english', f_unaccent($%[2]d)))`,
+			fragment, tailPos)
+	}
+	return fmt.Sprintf(`((%s) && %s)`, wholeWords, fragment)
+}

--- a/backend/internal/modules/search/typedquery_test.go
+++ b/backend/internal/modules/search/typedquery_test.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Which part of a query is matched whole, and which is offered as a prefix.
+//
+// Only the fragment the reader is still typing widens. The words behind it are
+// ones they finished and meant, and the two halves are AND-ed: a prefix that
+// stood alone would let "zebra wor" reach a record carrying neither word, so
+// typing more would widen the answer instead of narrowing it.
+func TestSplitTypedQuerySeparatesFinishedWordsFromTheOneBeingTyped(t *testing.T) {
+	t.Parallel()
+	for _, c := range []struct {
+		name     string
+		query    string
+		wantHead string
+		wantTail string
+	}{
+		{"one unfinished word", "automa", "", "automa"},
+		{"the last of several", "automation wor", "automation", "wor"},
+		{
+			"a trailing space means the word is finished",
+			"automation ",
+			"automation",
+			"",
+		},
+		{
+			"a closing quote means the reader meant those words entire",
+			`"automation world"`,
+			`"automation world"`,
+			"",
+		},
+		// A quote ANYWHERE means the reader is writing a phrase, so the string
+		// stays whole even when a bare word trails it. Completing that word
+		// would mean reasoning about which side of the quotes it falls on, and
+		// getting that wrong tears an operator off its operand.
+		{
+			"a bare word after a quoted phrase still does not split",
+			`"key account" ber`,
+			`"key account" ber`,
+			"",
+		},
+		{"a tab separates as a space does", "automation\twor", "automation", "wor"},
+		{"an accented fragment survives whole", "Müll", "", "Müll"},
+		{
+			"three words: only the third is a fragment",
+			"acme gmbh ein",
+			"acme gmbh",
+			"ein",
+		},
+		// The websearch operators bind to the words around them, so the string
+		// under that grammar must not be cut. "automation or katrin" split
+		// would ask for the whole words "automation or" AND a prefix "katrin",
+		// which is neither what was typed nor what was meant — and it silently
+		// returned nothing.
+		{
+			"a disjunction is composed, not typed",
+			"automation or katrin",
+			"automation or katrin",
+			"",
+		},
+		{"OR in any case", "automation OR katrin", "automation OR katrin", ""},
+		{"a negated term", "automation -world", "automation -world", ""},
+		{
+			"a quote anywhere means a phrase is being written",
+			`"automation world" x`,
+			`"automation world" x`,
+			"",
+		},
+		{"a lone word that merely contains or", "corridor", "", "corridor"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			head, tail := splitTypedQuery(c.query)
+			if head != c.wantHead || tail != c.wantTail {
+				t.Fatalf("splitTypedQuery(%q) = (%q, %q), want (%q, %q)",
+					c.query, head, tail, c.wantHead, c.wantTail)
+			}
+		})
+	}
+}
+
+// Every parameter Search BINDS must be USED by the SQL it builds.
+//
+// Postgres infers a parameter's type from where it appears; one that is bound
+// and never referenced cannot be inferred, and the whole statement fails with
+// "could not determine data type of parameter $1". That is exactly what this
+// change first did: the prefix arm replaced the whole-query parameter in every
+// branch while Search still bound it, so every search answered 500 — and the
+// frontend rendered the failure as "no results", which reads like the feature
+// simply not working.
+//
+// The binding order lives in `Search`, not in `admittedBranchSQL`, so this
+// mirrors what Search binds before its branches: a test that bound its own
+// parameters would prove nothing about the caller that actually has the bug.
+func TestSearchBindsNoParameterItsSQLDoesNotUse(t *testing.T) {
+	t.Parallel()
+	ctx := teamReaderFor("organization")
+
+	var bound []any
+	arg := func(v any) int { bound = append(bound, v); return len(bound) }
+
+	// The same split, in the same order, as Search performs.
+	head, tail := splitTypedQuery("acme ein")
+	headPos, tailPos := arg(head), arg(tail)
+
+	branches, err := admittedBranchSQL(ctx, []string{"organization"}, headPos, tailPos, true, arg)
+	if err != nil {
+		t.Fatalf("building the branch SQL: %v", err)
+	}
+	if len(branches) == 0 {
+		t.Fatal("no branch was admitted, so this proves nothing about the SQL")
+	}
+
+	sql := strings.Join(branches, " ")
+	for i := range bound {
+		placeholder := fmt.Sprintf("$%d", i+1)
+		if !strings.Contains(sql, placeholder) {
+			t.Fatalf("parameter %s is bound and never used; Postgres cannot infer its type, so the statement fails at run time", placeholder)
+		}
+	}
+}
+
+// The reader-facing half of the same rule, and the reason it matters: the query
+// Search hands Postgres has to name every parameter Search bound. This asserts
+// the SQL text itself carries both halves of the split — the finished words and
+// the fragment — because a branch that dropped one would still build valid SQL
+// and quietly stop matching.
+func TestTheBranchSQLCarriesBothHalvesOfTheQuery(t *testing.T) {
+	t.Parallel()
+	ctx := teamReaderFor("organization")
+	var bound []any
+	arg := func(v any) int { bound = append(bound, v); return len(bound) }
+	headPos, tailPos := arg("acme"), arg("ein")
+
+	branches, err := admittedBranchSQL(ctx, []string{"organization"}, headPos, tailPos, true, arg)
+	if err != nil {
+		t.Fatalf("building the branch SQL: %v", err)
+	}
+	sql := strings.Join(branches, " ")
+
+	if !strings.Contains(sql, "websearch_to_tsquery") {
+		t.Fatal("the finished words are no longer matched whole")
+	}
+	if !strings.Contains(sql, "':*'") {
+		t.Fatal("the fragment is no longer offered as a prefix")
+	}
+	// AND, not OR: OR-ed, the prefix alone satisfies the match and typing more
+	// words widens the answer instead of narrowing it.
+	if !strings.Contains(sql, "&&") {
+		t.Fatal("the two halves are not AND-ed, so a prefix can match on its own")
+	}
+}
+
+// A finished query gets NO prefix arm, and that is not an optimisation.
+//
+// `quote_literal("")` renders `”`, and `”:*` is a tsquery syntax error, so an
+// arm built for an absent fragment answered 500 on every finished query — a
+// quoted phrase, a trailing space, an operator query. The arm is omitted
+// instead, which also makes those queries match exactly what they matched
+// before this change.
+func TestAQueryWithNoFragmentGetsNoPrefixArm(t *testing.T) {
+	t.Parallel()
+	ctx := teamReaderFor("organization")
+	var bound []any
+	arg := func(v any) int { bound = append(bound, v); return len(bound) }
+
+	head, tail := splitTypedQuery(`"automation world"`)
+	if tail != "" {
+		t.Fatalf("a quoted phrase left a fragment %q", tail)
+	}
+	headPos := arg(head)
+
+	branches, err := admittedBranchSQL(ctx, []string{"organization"}, headPos, 0, false, arg)
+	if err != nil {
+		t.Fatalf("building the branch SQL: %v", err)
+	}
+	sql := strings.Join(branches, " ")
+
+	if strings.Contains(sql, "':*'") {
+		t.Fatal("a prefix arm was built for a query with no fragment; it renders '':* and raises a tsquery syntax error")
+	}
+	if !strings.Contains(sql, "websearch_to_tsquery") {
+		t.Fatal("the finished words are no longer matched at all")
+	}
+}
+
+// A trailing separator survives as far as the split.
+//
+// `Search` trims its input, and trimming the separator BEFORE the split is what
+// makes "a finished word" unreachable: "ann " becomes "ann", which the splitter
+// reads as a fragment and searches as `ann:*`, so a completed search silently
+// widened to reach "annual". A unit test on the splitter alone cannot see this —
+// it never runs the trim — so this asserts the shape `Search` actually produces.
+func TestATrailingSpaceStillMarksTheWordFinished(t *testing.T) {
+	t.Parallel()
+	for _, c := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"a trailing space is kept", "ann ", ""},
+		{"leading space is not the reader's", "  ann", "ann"},
+		{"both, and only the leading one goes", "  ann ", ""},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			// The PRODUCT'S normalisation, not a copy of it: a test that
+			// trimmed for itself would pass while Search erased the separator.
+			if _, tail := splitTypedQuery(normalizeQuery(c.input)); tail != c.want {
+				t.Fatalf("after Search's trim, splitTypedQuery(%q) tail = %q, want %q",
+					c.input, tail, c.want)
+			}
+		})
+	}
+}
+
+// The fragment keeps the activity branch's stemming.
+//
+// A prefix compares `simple` lexemes while the activity index stores stems, so
+// "study" as `study:*` reaches neither the stored `studi` nor the simple
+// `studies`. Every search is a fragment as it is typed, so without this the
+// branch's whole reason for existing — reaching "Verträge" from "Vertrag" —
+// stopped applying to exactly the case a reader hits first.
+func TestTheActivityFragmentKeepsItsStemming(t *testing.T) {
+	t.Parallel()
+	ctx := teamReaderFor("activity")
+	var bound []any
+	arg := func(v any) int { bound = append(bound, v); return len(bound) }
+	headPos, tailPos := arg(""), arg("study")
+
+	branches, err := admittedBranchSQL(ctx, []string{"activity"}, headPos, tailPos, true, arg)
+	if err != nil {
+		t.Fatalf("building the branch SQL: %v", err)
+	}
+	sql := strings.Join(branches, " ")
+
+	if !strings.Contains(sql, "':*'") {
+		t.Fatal("the fragment is no longer offered as a prefix")
+	}
+	// The FRAGMENT'S parameter has to appear inside a stemmed arm. Counting
+	// occurrences of the stemmed parse is not enough: the finished-words half of
+	// an activity branch already carries them, so a fragment that dropped its
+	// own still left the count satisfied.
+	for _, config := range []string{"german", "english"} {
+		stemmedFragment := fmt.Sprintf(
+			"websearch_to_tsquery('%s', f_unaccent($%d))", config, tailPos)
+		if !strings.Contains(sql, stemmedFragment) {
+			t.Fatalf("the fragment does not carry the %s parse, so a single-word search loses stemming", config)
+		}
+	}
+}
+
+// The fragment is escaped as a tsquery, not as a SQL literal.
+//
+// `quote_literal` emits an E-string for text carrying a backslash, and the `E`
+// is then read as a lexeme of its own: "ACME\Sales" searched for a phantom `e`.
+// `plainto_tsquery` renders the same input into sanitized lexemes and never
+// raises on text off a request.
+func TestTheFragmentIsEscapedAsATsqueryNotASQLLiteral(t *testing.T) {
+	t.Parallel()
+	sql := prefixArmSQL(7)
+	if strings.Contains(sql, "quote_literal") {
+		t.Fatal("quote_literal quotes for SQL, not for tsquery: a backslash in the fragment becomes an E-string and the E is parsed as a lexeme")
+	}
+	if !strings.Contains(sql, "plainto_tsquery") {
+		t.Fatal("the fragment is not sanitized into lexemes")
+	}
+}


### PR DESCRIPTION
The search box found nothing until a word was finished. Typing "automa" returned nothing; "automation" returned the tag. `websearch_to_tsquery` matches whole words only, so the lexeme `automa` never matched an indexed `automation` — and the ⌘K palette beside it, which is an autocomplete, behaved like a search engine.

## What changed

A query is matched in two halves, AND-ed: the words the reader finished, whole, and the fragment they are still typing, as a prefix. Only the fragment widens.

`splitTypedQuery` decides where that boundary is; `matchExpression` builds the tsquery. Both live in the new `typedquery.go` with the reasoning beside them.

## Five defects found and fixed before merge

**AND, not OR** — the first attempt OR-ed the halves, so the prefix alone satisfied the match: "zebra wor" reached a record carrying neither word, and typing *more* widened the answer. Caught in psql before it reached a branch.

**Operator queries are not split** — cutting "automation or katrin" at the last space asks for the whole words "automation or" AND a prefix, which is neither what was typed nor what it meant. The disjunction returned nothing.

**No fragment, no arm** — an empty fragment renders `'':*`, itself a tsquery syntax error, so every quoted phrase answered **500** and the screen showed it as "no results".

**`plainto_tsquery`, not `quote_literal`** — the latter quotes for SQL: given a backslash it emits an E-string, and the `E` is then read as a lexeme, so "ACME\Sales" searched for a word nobody typed.

**A trailing separator survives to the split** — `Search` trimmed it, which made "a finished word" unreachable and quietly widened every completed search. "automa " now returns 0 where "automa" returns 13.

**The fragment keeps the activity branch's stemming** — a prefix compares `simple` lexemes while that index stores stems, so "study" as `study:*` reached neither the stored `studi` nor the simple `studies`. A single word is what every search is as it is typed, so this was the common case.

## Tests

Nine cases in `typedquery_test.go`, each mutation-checked alone. Two first passed for the wrong reason and were rewritten: one asserted against its own copy of the trim rather than the product's, and one counted parse occurrences that the finished-words half already satisfied.

## Verified running

On a dev stack, typed letter by letter: "au" → 50 hits, "automa" → 13, "automation" → 12. "automation wor" narrows to 1; "zebra wor" is 0. Quoted phrases, `or`, `-term` and backslashes all answer 200.

`make check-backend`, the search integration lane, `craft static`, `rls-store-path` and `no-jurisdiction` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Search now matches the word a reader is still typing: the last word of a query is treated as a prefix while finished words are matched whole, so "automa" finds "automation" as it is typed.

The query is split at the last separator into finished words and the active fragment, then AND-ed in the tsquery. Only the fragment widens; finished words still match exactly.

- Operator queries (`or`, `-term`, quoted phrases) are not split, since splitting tears an operator off its operand.
- Queries with no fragment get no prefix arm; an empty one rendered `'':*`, a tsquery syntax error that answered 500.
- The fragment is escaped with `plainto_tsquery`, not `quote_literal`, which turned backslashes into a phantom lexeme.
- A trailing space is preserved through normalization, so "automa " still means a finished word.
- The activity branch's German/English stemming now applies to the fragment as well, not just the whole-word half.
- Postgres parameter binding matches the SQL; a bound-but-unused parameter fails the whole statement.

Tests in `typedquery_test.go` cover the split, the parameter binding, the absent-fragment arm, escaping, and stemming.

<sup>Written for commit 50be7e81bec9afa9bbf742bb5f3511b97c97ae07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Search Improvements**
  - Search now preserves trailing spaces and distinguishes completed words from the fragment currently being typed.
  - Completed terms are matched as whole words, while the active fragment uses prefix matching.
  - Quoted phrases and search operators are handled consistently.
  - Activity searches retain language-aware stemming for English and German terms.

- **Bug Fixes**
  - Improved search query escaping and matching behavior for partial and multi-term queries.

- **Tests**
  - Added coverage for query splitting, trailing spaces, prefix matching, stemming, and safe query handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->