### PR TITLE
No message reaches a provider without a decision recorded for that attempt

### DIFF
--- a/backend/internal/modules/comms/dispatcher.go
+++ b/backend/internal/modules/comms/dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -171,7 +172,8 @@ func (d *Dispatcher) DispatchWithWait(ctx context.Context, id ids.UUID) (Outcome
 	// Gate: suppression and consent, which are one step — one-click
 	// unsubscribe writes a per-purpose consent withdrawal, so this gate IS
 	// the suppression mechanism.
-	if outcome, wait, err := d.gateConsent(ctx, del); outcome != outcomeUndecided {
+	ticket, outcome, wait, err := d.gateConsent(ctx, del)
+	if outcome != outcomeUndecided {
 		return outcome, wait, err
 	}
 
@@ -204,7 +206,7 @@ func (d *Dispatcher) DispatchWithWait(ctx context.Context, id ids.UUID) (Outcome
 		return d.park(ctx, del.ID, fmt.Sprintf("the retry ladder is exhausted after %d attempts", del.Attempts))
 	}
 
-	return d.transmit(ctx, del, seam)
+	return d.transmit(ctx, del, seam, ticket)
 }
 
 // pace applies the policy chain. The chain is ordered and the first non-zero
@@ -234,7 +236,15 @@ func (d *Dispatcher) pace(ctx context.Context, del Delivery) (Outcome, time.Dura
 // transmit hands the message to the provider and records what came back. The
 // seam already carries the shape-specific half (sendseam.go), so what follows is
 // the same for a mail message and a channel one.
-func (d *Dispatcher) transmit(ctx context.Context, del Delivery, seam sendSeam) (Outcome, time.Duration, error) {
+func (d *Dispatcher) transmit(ctx context.Context, del Delivery, seam sendSeam, ticket commsauthz.TransmitTicket) (Outcome, time.Duration, error) {
+	// The last thing checked before the wire, and the reason the ticket is
+	// threaded down here rather than trusted from three frames up: a send that
+	// reaches a provider without a decision recorded for THIS delivery and THIS
+	// attempt is a send nobody can account for afterwards. A stale attempt is
+	// as bad as none — it belongs to a try whose world may already have moved.
+	if !ticket.Current(del.ID, del.Attempts) {
+		return d.park(ctx, del.ID, "no current authorization decision covers this attempt")
+	}
 	// The attachment BYTES, resolved before the marker below and not inside the
 	// provider call.
 	//

--- a/backend/internal/modules/comms/dispatcher_harness_test.go
+++ b/backend/internal/modules/comms/dispatcher_harness_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -195,6 +196,17 @@ func (f fakeResolver) ResolveChannel(context.Context, ids.UserID, string) (conne
 type stubConsent struct {
 	err   error
 	asked []string
+	// ticket is what AuthorizeTransmit hands back. The zero value is a
+	// DELIBERATE default of "no decision recorded", so a test that forgets to
+	// arm it sees transmit refuse rather than silently sending — the harness
+	// arms a current ticket in armTicket below.
+	ticket commsauthz.TransmitTicket
+	// armed says the test set ticket deliberately, including to a zero-valued
+	// one. Without it a test pinning "no decision was recorded" is
+	// indistinguishable from a test that armed nothing.
+	armed     bool
+	authzErr  error
+	authzSeen int
 }
 
 func (s *stubConsent) RequireGrantedForRecipients(_ context.Context, recipients []connector.Recipient, _ string) error {
@@ -328,6 +340,42 @@ func dispatch(ctx context.Context, d *Dispatcher, id ids.UUID) (Outcome, error) 
 
 type consentFunc func(context.Context, []connector.Recipient, string) error
 
+// AuthorizeTransmit hands back a ticket covering exactly the attempt it was
+// asked about, so a test using this shorthand double is testing the gate it
+// named and not the ticket check beside it.
+func (f consentFunc) AuthorizeTransmit(_ context.Context, req commsauthz.TransmitRequest) (commsauthz.TransmitTicket, error) {
+	return commsauthz.TransmitTicket{
+		DeliveryID:    req.DeliveryID,
+		Attempt:       req.Attempt,
+		DecisionSetID: ids.NewV7(),
+		Allowed:       true,
+	}, nil
+}
+
 func (f consentFunc) RequireGrantedForRecipients(ctx context.Context, r []connector.Recipient, p string) error {
 	return f(ctx, r, p)
+}
+
+// AuthorizeTransmit stands in for the engine. It returns whatever the test
+// armed, so a test can pin the two cases that matter here: a ticket for the
+// wrong attempt, and no ticket at all.
+func (s *stubConsent) AuthorizeTransmit(_ context.Context, req commsauthz.TransmitRequest) (commsauthz.TransmitTicket, error) {
+	s.authzSeen++
+	if s.authzErr != nil {
+		return commsauthz.TransmitTicket{}, s.authzErr
+	}
+	if s.armed {
+		return s.ticket, nil
+	}
+	// Unarmed, the stub behaves as the engine does in observe mode: it records
+	// a decision and permits the send, leaving the legacy gate to rule. It must
+	// NOT mirror s.err — that field is the LEGACY gate's answer, and a stub
+	// that refused here too would make every legacy test pass for the engine's
+	// reason instead of its own.
+	return commsauthz.TransmitTicket{
+		DeliveryID:    req.DeliveryID,
+		Attempt:       req.Attempt,
+		DecisionSetID: ids.NewV7(),
+		Allowed:       true,
+	}, nil
 }

--- a/backend/internal/modules/comms/dispatcher_ticket_test.go
+++ b/backend/internal/modules/comms/dispatcher_ticket_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package comms
+
+// What stands between a delivery and a provider: a decision recorded for THIS
+// delivery and THIS attempt.
+//
+// The check exists because a send that reaches a provider without one is a
+// send nobody can account for afterwards — the installation cannot say what
+// rule permitted it or what evidence stood behind it. These tests hold the two
+// ways that could happen quietly: no decision at all, and a decision belonging
+// to an earlier attempt whose world may already have moved.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// No ticket, no wire. A zero decision-set id means the engine recorded nothing.
+func TestTransmitRefusesWhenNoDecisionWasRecorded(t *testing.T) {
+	sender := &fakeSender{}
+	store := &fakeStore{delivery: liveDelivery()}
+	// Everything present EXCEPT the decision-set id, so this test fails on the
+	// one thing it is about: nothing was recorded.
+	consent := &stubConsent{armed: true, ticket: commsauthz.TransmitTicket{
+		DeliveryID: store.delivery.ID,
+		Attempt:    store.delivery.Attempts,
+		Allowed:    true,
+	}}
+	d := newTestDispatcher(store, fakeResolver{sender: sender, granted: []string{sendScope}}, consent)
+
+	got, err := dispatch(context.Background(), d, store.delivery.ID)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if got != OutcomeParked {
+		t.Errorf("outcome = %v, want OutcomeParked — an unrecorded send must not reach a provider", got)
+	}
+	if sender.calls != 0 {
+		t.Errorf("provider called %d time(s) with no decision on record", sender.calls)
+	}
+}
+
+// A ticket for a DIFFERENT attempt is not a ticket for this one. The delivery
+// it names was authorized against a world that may since have changed — a
+// withdrawal, an objection, a bounce — which is the whole reason the recheck
+// runs per attempt rather than once.
+func TestTransmitRefusesATicketFromAnotherAttempt(t *testing.T) {
+	sender := &fakeSender{}
+	store := &fakeStore{delivery: liveDelivery()}
+	consent := &stubConsent{armed: true, ticket: commsauthz.TransmitTicket{
+		DeliveryID:    store.delivery.ID,
+		DecisionSetID: ids.NewV7(),
+		// Any attempt but the one being dispatched.
+		Attempt: store.delivery.Attempts + 41,
+		Allowed: true,
+	}}
+	d := newTestDispatcher(store, fakeResolver{sender: sender, granted: []string{sendScope}}, consent)
+
+	got, err := dispatch(context.Background(), d, store.delivery.ID)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if got != OutcomeParked {
+		t.Errorf("outcome = %v, want OutcomeParked — a stale decision authorizes nothing", got)
+	}
+	if sender.calls != 0 {
+		t.Errorf("provider called %d time(s) on a stale decision", sender.calls)
+	}
+}
+
+// The engine refusing is an ANSWER and parks. This is the observe-mode path
+// that must still hold: the four absolute refusals deny whatever the legacy
+// gate says.
+func TestTransmitParksWhenTheEngineRefuses(t *testing.T) {
+	sender := &fakeSender{}
+	store := &fakeStore{delivery: liveDelivery()}
+	consent := &stubConsent{armed: true, ticket: commsauthz.TransmitTicket{
+		DecisionSetID: ids.NewV7(),
+		Allowed:       false,
+		Reason:        "1 of 1 recipients are not authorized for this message (marketing_objection)",
+	}}
+	d := newTestDispatcher(store, fakeResolver{sender: sender, granted: []string{sendScope}}, consent)
+
+	got, err := dispatch(context.Background(), d, store.delivery.ID)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if got != OutcomeParked || sender.calls != 0 {
+		t.Errorf("outcome=%v calls=%d, want parked/0 on an engine refusal", got, sender.calls)
+	}
+}
+
+// An engine that could not answer is an OUTAGE, not a verdict. Reading it as a
+// refusal would park legitimate mail permanently every time the database
+// hiccuped — the same mistake the legacy gate's own branch guards against.
+func TestTransmitRetriesWhenTheEngineCannotAnswer(t *testing.T) {
+	sender := &fakeSender{}
+	store := &fakeStore{delivery: liveDelivery()}
+	consent := &stubConsent{authzErr: errors.New("connection refused")}
+	d := newTestDispatcher(store, fakeResolver{sender: sender, granted: []string{sendScope}}, consent)
+
+	got, err := dispatch(context.Background(), d, store.delivery.ID)
+	if err == nil && got != OutcomeRetry {
+		t.Errorf("outcome = %v, want OutcomeRetry — an outage is not a refusal", got)
+	}
+	if sender.calls != 0 {
+		t.Errorf("provider called %d time(s) while the engine was unreachable", sender.calls)
+	}
+}
+
+// And the converse, or every test above would pass with the wire disconnected:
+// an ordinary delivery with a current ticket does reach the provider.
+func TestTransmitProceedsOnACurrentTicket(t *testing.T) {
+	sender := &fakeSender{}
+	store := &fakeStore{delivery: liveDelivery()}
+	consent := &stubConsent{}
+	d := newTestDispatcher(store, fakeResolver{sender: sender, granted: []string{sendScope}}, consent)
+
+	got, err := dispatch(context.Background(), d, store.delivery.ID)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if got != OutcomeSent || sender.calls != 1 {
+		t.Errorf("outcome=%v calls=%d, want sent/1 on a current decision", got, sender.calls)
+	}
+	if consent.authzSeen != 1 {
+		t.Errorf("the engine was asked %d time(s), want exactly 1 per attempt", consent.authzSeen)
+	}
+}

--- a/backend/internal/modules/comms/gates.go
+++ b/backend/internal/modules/comms/gates.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -233,15 +234,42 @@ func (d *Dispatcher) gateSeat(ctx context.Context, del Delivery) (Outcome, time.
 	return outcomeUndecided, 0, nil
 }
 
-// gateConsent asks the authoritative suppression question and returns
-// outcomeUndecided when every addressee may still be mailed.
-func (d *Dispatcher) gateConsent(ctx context.Context, del Delivery) (Outcome, time.Duration, error) {
+// gateConsent is suppression and consent, and now also the point at which the
+// engine records why this attempt was permitted.
+//
+// Two authorities run here, deliberately, while the rollout is in observe
+// mode: the engine writes its own per-recipient decision and applies only the
+// refusals no mode may soften, and the legacy purpose gate still rules
+// everything else. The engine's ticket is what transmit demands, so a provider
+// call without one cannot happen.
+func (d *Dispatcher) gateConsent(ctx context.Context, del Delivery) (commsauthz.TransmitTicket, Outcome, time.Duration, error) {
+	var none commsauthz.TransmitTicket
 	if d.consent == nil {
 		// A send path with no consent authority wired is a deployment defect.
 		// Retrying would hide the misconfiguration behind a delivery that
 		// quietly never goes out.
-		return d.park(ctx, del.ID, "no consent authority is configured on this send path")
+		o, w, err := d.park(ctx, del.ID, "no consent authority is configured on this send path")
+		return none, o, w, err
 	}
+	ticket, terr := d.consent.AuthorizeTransmit(ctx, commsauthz.TransmitRequest{
+		DeliveryID: del.ID,
+		Attempt:    del.Attempts,
+		Recipients: consentRecipients(del),
+		PurposeKey: del.ConsentPurpose,
+		Subject:    del.Subject,
+		Body:       del.Body,
+	})
+	if terr != nil {
+		// The question could not be asked. A consent service that is merely
+		// down must not permanently destroy a legitimate send.
+		o, w, err := d.retry(ctx, del.ID, terr)
+		return none, o, w, err
+	}
+	if !ticket.Allowed {
+		o, w, err := d.park(ctx, del.ID, ticket.Reason)
+		return ticket, o, w, err
+	}
+
 	// EVERY subject this delivery reaches is asked about, not just the To line:
 	// a Cc'd person is owed the same suppression, and this call is the only one
 	// that runs after they could have withdrawn. consentRecipients is what makes
@@ -249,16 +277,17 @@ func (d *Dispatcher) gateConsent(ctx context.Context, del Delivery) (Outcome, ti
 	// recipient arrive here as the same list.
 	switch err := d.consent.RequireGrantedForRecipients(ctx, consentRecipients(del), del.ConsentPurpose); {
 	case errors.Is(err, apperrors.ErrConsentNotGranted):
-		// An answer: consent is absent, and no amount of waiting brings it
-		// back.
-		return d.park(ctx, del.ID, fmt.Sprintf(
+		// An answer: consent is absent, and no amount of waiting brings it back.
+		o, w, perr := d.park(ctx, del.ID, fmt.Sprintf(
 			"consent for purpose %q is not granted for these recipients", del.ConsentPurpose,
 		))
+		return ticket, o, w, perr
 	case err != nil:
 		// NOT an answer. A consent service that is merely down must not
 		// permanently destroy a consented send — getting this branch backwards
 		// silently kills legitimate mail.
-		return d.retry(ctx, del.ID, err)
+		o, w, rerr := d.retry(ctx, del.ID, err)
+		return ticket, o, w, rerr
 	}
-	return outcomeUndecided, 0, nil
+	return ticket, outcomeUndecided, 0, nil
 }

--- a/backend/internal/modules/comms/seams.go
+++ b/backend/internal/modules/comms/seams.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -88,6 +89,11 @@ type MessageIdentityReconciler interface {
 // asked. The dispatcher parks on the first and retries on the second.
 type ConsentGate interface {
 	RequireGrantedForRecipients(ctx context.Context, recipients []connector.Recipient, purposeKey string) error
+	// AuthorizeTransmit answers whether this delivery may go out NOW and
+	// records the answer per recipient before any provider I/O. The ticket it
+	// returns is what transmit demands: a send with no current ticket is a
+	// send nobody can account for.
+	AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitRequest) (commsauthz.TransmitTicket, error)
 }
 
 // SeatAuthority answers whether the human whose mailbox is about to transmit

--- a/backend/internal/modules/consent/authorizetransmit.go
+++ b/backend/internal/modules/consent/authorizetransmit.go
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The decision taken immediately before a message reaches a provider, and the
+// record of it.
+//
+// A staging decision answers "may this be written down and queued". It cannot
+// answer "may this go out NOW", because the two are separated by a queue: a
+// person can withdraw consent, object, or have their address hard-bounce in
+// between, and a delivery that waited a day on a retry ladder was authorized
+// against a world that no longer exists. So the question is asked again here,
+// and the answer is persisted before any provider I/O rather than after — a
+// decision written afterwards records what was sent, not what permitted it.
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// AuthorizeTransmit answers whether this delivery may go out now, and writes
+// the answer down.
+//
+// It runs in its own short transaction, which commits BEFORE the provider is
+// called. That ordering is the point: the row says "this was permitted at
+// attempt N", and a send that happens without one is a send nobody can account
+// for. The transaction is its own rather than the caller's because there is no
+// caller transaction to join — provider I/O cannot sit inside one.
+func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitRequest) (commsauthz.TransmitTicket, error) {
+	for _, r := range req.Recipients {
+		if err := r.Validate(); err != nil {
+			// A malformed recipient is a caller DEFECT, not an answer about
+			// anybody. The legacy gate refuses the same shape for the same
+			// reason: a recipient carrying both an address and a channel
+			// identity would be answered about on the channel arm alone, and
+			// the address — which may be the one that objected — would never
+			// be looked at.
+			return commsauthz.TransmitTicket{}, fmt.Errorf(
+				"consent: this recipient cannot be put to the engine: %w", err)
+		}
+	}
+	if len(req.Recipients) == 0 {
+		// A caller fault, not an answer about anybody: reported as the defect
+		// it is rather than dressed up as a suppression.
+		return commsauthz.TransmitTicket{}, fmt.Errorf("consent: a transmit decision needs at least one recipient: %w",
+			apperrors.ErrInvalidArgument)
+	}
+	setID := ids.NewV7()
+	ticket := commsauthz.TransmitTicket{DeliveryID: req.DeliveryID, Attempt: req.Attempt, DecisionSetID: setID}
+
+	// The legacy gate still rules while the engine is in observe mode, so its
+	// answer is taken first and carried onto every row. A disagreement is then
+	// readable in the record rather than only in a counter that dies with the
+	// process.
+	legacyErr := g.RequireGrantedForRecipients(ctx, req.Recipients, req.PurposeKey)
+	switch {
+	case legacyErr == nil:
+	case errors.Is(legacyErr, apperrors.ErrConsentNotGranted):
+	default:
+		// NOT an answer. The question could not be asked, so nothing has been
+		// learned and nothing is recorded — the dispatcher retries.
+		return commsauthz.TransmitTicket{}, legacyErr
+	}
+	legacyAllowed := legacyErr == nil
+
+	err := g.store.db.Tx(ctx, func(tx pgx.Tx) error {
+		set, err := g.decideRecipients(ctx, tx, req, legacyAllowed)
+		if err != nil {
+			return err
+		}
+		if err := g.recordDecisions(ctx, tx, req, setID, set); err != nil {
+			return err
+		}
+		ticket.Allowed = set.Effective(commsauthz.ModeObserve, legacyAllowed)
+		ticket.Reason = refusalReason(set, legacyAllowed)
+		return nil
+	})
+	if err != nil {
+		return commsauthz.TransmitTicket{}, err
+	}
+	return ticket, nil
+}
+
+// decideRecipients asks the engine about every addressee.
+//
+// Every recipient is asked even once one has refused, because the record is
+// per recipient: an operator answering "why did this not go" is owed the whole
+// answer, not the first line of it.
+func (g *Gate) decideRecipients(ctx context.Context, tx pgx.Tx, req commsauthz.TransmitRequest, legacyAllowed bool) (commsauthz.DecisionSet, error) {
+	legacy := commsauthz.VerdictDeny
+	if legacyAllowed {
+		legacy = commsauthz.VerdictAllow
+	}
+	set := commsauthz.DecisionSet{}
+	for _, r := range req.Recipients {
+		d, err := g.decideOne(ctx, tx, r, req.PurposeKey)
+		if err != nil {
+			return commsauthz.DecisionSet{}, err
+		}
+		d.Phase = commsauthz.PhaseTransmit
+		d.Mode = commsauthz.ModeObserve
+		d.LegacyVerdict = string(legacy)
+		set.Decisions = append(set.Decisions, d)
+	}
+	return set, nil
+}
+
+// decideOne answers about a single recipient: who they are, whether anything
+// suppresses them, and what the purpose class says.
+func (g *Gate) decideOne(ctx context.Context, tx pgx.Tx, r connector.Recipient, purposeKey string) (commsauthz.Decision, error) {
+	d := commsauthz.Decision{Recipient: r, Resolved: commsauthz.CategoryMarketing}
+	personID, found, err := resolvePerson(ctx, tx, r)
+	if err != nil {
+		// Ambiguity refuses rather than picking, and that is an ANSWER about
+		// this send: no verdict can be about one person.
+		if errors.Is(err, apperrors.ErrConsentNotGranted) {
+			d.Verdict = commsauthz.VerdictDeny
+			d.ReasonCode = commsauthz.ReasonNoSubject
+			return d, nil
+		}
+		return commsauthz.Decision{}, err
+	}
+	if !found {
+		d.Verdict = commsauthz.VerdictReview
+		d.ReasonCode = commsauthz.ReasonNoSubject
+		return d, nil
+	}
+	parsed, err := ids.Parse(personID)
+	if err != nil {
+		return commsauthz.Decision{}, fmt.Errorf("consent: the resolved subject is not an id: %w", err)
+	}
+	d.SubjectKind, d.SubjectID = entityPerson, parsed
+
+	suppressed, kind, err := liveSuppression(ctx, tx, personID, r)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	if suppressed {
+		d.Verdict = commsauthz.VerdictDeny
+		d.ReasonCode = kind
+		d.Suppression = kind
+		return d, nil
+	}
+	return classVerdict(ctx, tx, personID, purposeKey, d)
+}
+
+// classVerdict reads the purpose the delivery was staged under and answers in
+// the engine's vocabulary.
+//
+// It calls VerdictForPerson rather than reimplementing the class model, which
+// is what keeps the engine, the legacy transmit gate and the guard endpoint
+// answering with one body of code about one person. A second implementation
+// here would be a second answer, and the one that stopped matching would look
+// exactly like the one that still did.
+func classVerdict(ctx context.Context, tx pgx.Tx, personID, purposeKey string, d commsauthz.Decision) (commsauthz.Decision, error) {
+	var purpose PurposeRow
+	err := tx.QueryRow(ctx,
+		`SELECT id, key, label, class, requires_double_opt_in
+		   FROM consent_purpose WHERE key = $1 AND archived_at IS NULL`,
+		normalizedPurposeKey(purposeKey)).Scan(
+		&purpose.ID, &purpose.Key, &purpose.Label, &purpose.Class, &purpose.RequiresDOI)
+	if errors.Is(err, pgx.ErrNoRows) {
+		d.Verdict = commsauthz.VerdictDeny
+		d.ReasonCode = commsauthz.ReasonUnknownPurpose
+		return d, nil
+	}
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	d.Resolved = categoryForClass(purpose.Class)
+
+	verdict, err := VerdictForPerson(ctx, tx, personID, purpose)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	switch verdict.State {
+	case VerdictAllowed:
+		d.Verdict = commsauthz.VerdictAllow
+		d.ReasonCode = commsauthz.ReasonAllowed
+		d.Basis = basisForClass(purpose.Class)
+	case VerdictBlocked:
+		d.Verdict = commsauthz.VerdictDeny
+		d.ReasonCode = blockedReasonCode(verdict)
+	default:
+		d.Verdict = commsauthz.VerdictReview
+		d.ReasonCode = commsauthz.ReasonNoMarketingConsent
+	}
+	return d, nil
+}
+
+// blockedReasonCode translates the verdict's own code into the engine's
+// vocabulary.
+//
+// It reads Verdict.Code and never the operator sentence beside it. Matching on
+// prose meant an ordinary copy edit in verdict.go could silently reclassify a
+// legal fact, and it collapsed three different blocks into "objection" — a
+// withdrawal under Art. 7(3), and a purpose class this installation has no
+// transport for, both recorded as though the person had objected. A subject
+// access request discloses these rows, so a wrong label there is a false
+// statement about somebody.
+//
+// The default is the STRONGEST code, not the weakest: an unrecognised block is
+// a block this function has not been taught about, and guessing leniently is
+// how a new refusal becomes the one that sends.
+func blockedReasonCode(v Verdict) string {
+	switch v.Code {
+	case BlockUnconfirmedDOI:
+		return commsauthz.ReasonUnconfirmedDOI
+	case BlockWithdrawn:
+		return commsauthz.ReasonConsentWithdrawn
+	case BlockNoChannel:
+		return commsauthz.ReasonNoEvidence
+	default:
+		return commsauthz.ReasonObjection
+	}
+}
+
+// categoryForClass maps the legacy purpose class onto the closed vocabulary,
+// conservatively. The old transactional class becomes account_notice rather
+// than anything broader: it is the narrowest member that can carry a genuine
+// operational message, and the engine records what it was ASKED alongside it.
+func categoryForClass(class Class) commsauthz.Category {
+	switch class {
+	case ClassBusinessCorrespondence:
+		return commsauthz.CategoryReplyToInbound
+	case ClassTransactional:
+		return commsauthz.CategoryAccountNotice
+	default:
+		return commsauthz.CategoryMarketing
+	}
+}
+
+func basisForClass(class Class) commsauthz.Basis {
+	switch class {
+	case ClassBusinessCorrespondence:
+		return commsauthz.BasisSubjectInitiatedCorrespondence
+	case ClassTransactional:
+		return commsauthz.BasisContract
+	default:
+		return commsauthz.BasisConsent
+	}
+}
+
+// refusalReason renders the operator-facing sentence for a parked delivery. It
+// names the category and the reason code, never the recipient's consent
+// history: the caller supplied the addresses, so nothing here discloses
+// anything they did not already hold.
+func refusalReason(set commsauthz.DecisionSet, legacyAllowed bool) string {
+	denied := set.Denied()
+	if len(denied) == 0 {
+		if legacyAllowed {
+			return ""
+		}
+		return "the consent gate refused this delivery"
+	}
+	return fmt.Sprintf("%d of %d recipients are not authorized for this message (%s)",
+		len(denied), len(set.Decisions), denied[0].ReasonCode)
+}
+
+// recordDecisions writes one immutable row per recipient.
+//
+// The content fingerprint is a hash of subject and body, never the text: it
+// exists so a later reader can tell whether the message that went is the
+// message that was authorized, and storing the words themselves would make the
+// decision a second copy of the mail.
+func (g *Gate) recordDecisions(ctx context.Context, tx pgx.Tx, req commsauthz.TransmitRequest, setID ids.UUID, set commsauthz.DecisionSet) error {
+	sum := sha256.Sum256([]byte(req.Subject + "\x00" + req.Body))
+	by, err := storekit.CapturedBy(ctx)
+	if err != nil {
+		return err
+	}
+	for _, d := range set.Decisions {
+		// Both or neither, which the table's own CHECK also demands: a
+		// subject_kind naming a row with no id describes nothing.
+		subjectKind := nullableText(d.SubjectKind)
+		var subjectID *ids.UUID
+		if d.SubjectKind != "" {
+			id := d.SubjectID
+			subjectID = &id
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO communication_decision
+			  (delivery_id, attempt, decision_set_id, recipient_address, subject_kind, subject_id,
+			   phase, resolved_category, verdict, reason_code, basis, suppression,
+			   content_fingerprint, legacy_verdict, mode, actor)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+			ON CONFLICT (decision_set_id, recipient_address, phase) DO NOTHING`,
+			req.DeliveryID, req.Attempt, setID, decisionRecipientKey(d.Recipient),
+			subjectKind, subjectID, string(d.Phase), string(d.Resolved), string(d.Verdict),
+			d.ReasonCode, nullableBasis(d.Basis), nullableText(d.Suppression),
+			sum[:], d.LegacyVerdict, string(d.Mode), by); err != nil {
+			return fmt.Errorf("consent: record the transmit decision: %w", err)
+		}
+	}
+	return nil
+}
+
+// nullableBasis and nullableText carry the difference between "no value" and
+// "the empty string" to Postgres. A *string is what pgx reads as NULL, and the
+// distinction matters on both columns: a decision with no basis recorded is not
+// the same fact as one whose basis is blank.
+func nullableBasis(b commsauthz.Basis) *string {
+	if b == "" {
+		return nil
+	}
+	v := string(b)
+	return &v
+}
+
+func nullableText(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// liveSuppression reads what stops a message reaching this recipient
+// independently of any consent grant.
+//
+// Two shapes, and the address arm matters as much as the person arm: a hard
+// bounce is a fact about a MAILBOX, so it is recorded against the address and
+// keeps applying when the same address later appears on a different record.
+// The person arm carries objections and restrictions, which follow the human.
+func liveSuppression(ctx context.Context, tx pgx.Tx, personID string, r connector.Recipient) (bool, string, error) {
+	var kind string
+	// STRONGEST first, not newest. Ordering by time would let a weaker
+	// suppression recorded later mask an objection recorded earlier, and the
+	// reason code is what decides whether a refusal survives observe mode — so
+	// a masked objection is a message that goes out to somebody who said stop.
+	// This is also the only reader in the tree that applies these rows: the
+	// legacy gate reads person_consent and never looks here.
+	err := tx.QueryRow(ctx, `
+		SELECT kind FROM communication_suppression
+		 WHERE revoked_at IS NULL
+		   AND (person_id = $1
+		        OR lead_id = $1
+		        OR (address IS NOT NULL AND $2 <> '' AND lower(address) = lower($2)))
+		 ORDER BY CASE kind
+		            WHEN 'marketing_objection'    THEN 0
+		            WHEN 'processing_restriction' THEN 1
+		            WHEN 'subject_request'        THEN 2
+		            WHEN 'hard_bounce'            THEN 3
+		            ELSE 4
+		          END, recorded_at DESC
+		 LIMIT 1`, personID, r.Email).Scan(&kind)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", fmt.Errorf("consent: read the recipient's suppressions: %w", err)
+	}
+	switch kind {
+	case "marketing_objection":
+		return true, commsauthz.ReasonObjection, nil
+	case "processing_restriction":
+		return true, commsauthz.ReasonRestricted, nil
+	case "hard_bounce":
+		return true, commsauthz.ReasonHardBounce, nil
+	default:
+		// A kind this code does not recognise still SUPPRESSES, and absolutely.
+		// Somebody added a row shape to the constraint and not to this switch;
+		// treating the unknown case as the weaker one would let the next kind
+		// added to the table be the one that sends.
+		return true, commsauthz.ReasonRestricted, nil
+	}
+}
+
+// decisionRecipientKey is the stored identity of one recipient, and it is
+// deliberately NOT recipientLabel.
+//
+// recipientLabel exists to name a refused recipient in an operator's error
+// message, where a channel account id is withheld on purpose — the caller never
+// supplied it, so a refusal must not hand it back. That is right for a sentence
+// and wrong for a key: every channel recipient would store the same words, so
+// two recipients on one delivery would collide on the uniqueness index and the
+// second decision — possibly the refusal — would be dropped.
+//
+// A channel identity is therefore stored structurally. It stays inside the
+// installation, where the timeline already holds the same id.
+func decisionRecipientKey(r connector.Recipient) string {
+	if r.Channel != nil {
+		return r.Channel.Provider + ":" + r.Channel.ChannelUserID
+	}
+	return r.Email
+}

--- a/backend/internal/modules/consent/blockcodes.go
+++ b/backend/internal/modules/consent/blockcodes.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Why a verdict blocked, in a form code can act on.
+//
+// Its own file because the sentence a rep reads and the fact a caller branches
+// on are two different things, and keeping them together is what let an engine
+// match on prose: an ordinary copy edit to an operator message then silently
+// reclassified a legal fact, and three distinct blocks — an Art. 21 objection,
+// an Art. 7(3) withdrawal, and a purpose class this installation has no
+// transport for — were all recorded as the first one.
+
+// The machine-readable reasons a verdict blocks. They exist so a caller can
+// act on WHICH block happened without matching on the sentence a rep reads.
+const (
+	// BlockObjection is Art. 21: the subject objected to direct marketing.
+	BlockObjection = "objection"
+	// BlockWithdrawn is Art. 7(3): they took a consent back. A different legal
+	// fact from an objection, with different obligations.
+	BlockWithdrawn = "withdrawn"
+	// BlockUnconfirmedDOI is a grant whose round trip never completed.
+	BlockUnconfirmedDOI = "unconfirmed_double_opt_in"
+	// BlockNoChannel is a fact about this INSTALLATION, not about the subject:
+	// no transport is wired for that purpose class.
+	BlockNoChannel = "no_channel_configured"
+)

--- a/backend/internal/modules/consent/verdict.go
+++ b/backend/internal/modules/consent/verdict.go
@@ -62,6 +62,11 @@ type Verdict struct {
 	// one did. Recording WHICH event is what makes the Art 6(1)(f) balancing
 	// accountable rather than merely asserted.
 	Qualifying *QualifyingEvent
+	// Code names the block in a form code can read, because the engine has to
+	// tell an Art. 21 objection from a withdrawal from a deployment fact — and
+	// matching on Reason, which is an operator-facing sentence, means an
+	// ordinary copy edit silently reclassifies a legal fact.
+	Code string
 	// QualifyingDerived marks a Qualifying that was READ OFF the timeline
 	// rather than read from a stored row.
 	//
@@ -118,7 +123,7 @@ func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose P
 		return Verdict{}, err
 	}
 	if suppressed {
-		return Verdict{State: VerdictBlocked, Reason: objectionReason(at)}, nil
+		return Verdict{State: VerdictBlocked, Reason: objectionReason(at), Code: BlockObjection}, nil
 	}
 
 	switch purpose.Class {
@@ -150,7 +155,7 @@ func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose P
 	case ClassPhoneOutreach:
 		// Dormant by decision: the purpose exists so the model is complete. A
 		// surface that offered it would offer a path nothing implements.
-		return Verdict{State: VerdictBlocked, Reason: "no call path is configured"}, nil
+		return Verdict{State: VerdictBlocked, Reason: "no call path is configured", Code: BlockNoChannel}, nil
 
 	default:
 		return marketingVerdict(ctx, tx, personID, purpose)
@@ -171,7 +176,7 @@ func marketingVerdict(ctx context.Context, tx pgx.Tx, personID string, purpose P
 		return Verdict{State: VerdictAllowed, Reason: "they gave consent, with the confirmation on file"}, nil
 	}
 	if state == string(StateWithdrawn) {
-		return Verdict{State: VerdictBlocked, Reason: "they withdrew consent for this purpose"}, nil
+		return Verdict{State: VerdictBlocked, Reason: "they withdrew consent for this purpose", Code: BlockWithdrawn}, nil
 	}
 	if state == string(StateGranted) && purpose.RequiresDOI {
 		// Granted but never confirmed. The BGH evidence standard is the whole
@@ -180,6 +185,7 @@ func marketingVerdict(ctx context.Context, tx pgx.Tx, personID string, purpose P
 		return Verdict{
 			State:  VerdictBlocked,
 			Reason: "consent was recorded but never confirmed by the double opt-in",
+			Code:   BlockUnconfirmedDOI,
 		}, nil
 	}
 	flagged, err := existingCustomerFlag(ctx, tx, personID)

--- a/backend/internal/shared/ports/commsauthz/absolute.go
+++ b/backend/internal/shared/ports/commsauthz/absolute.go
@@ -26,11 +26,18 @@ const (
 	ReasonNoSubject = "recipient_resolves_to_no_single_subject"
 	// ReasonNoMarketingConsent is marketing without a grant or an exception.
 	ReasonNoMarketingConsent = "no_marketing_consent"
+	// ReasonConsentWithdrawn is Art. 7(3): the subject took a consent back.
+	// Distinct from an objection because they are different legal facts, and a
+	// proof row that called one the other would misstate what somebody did.
+	ReasonConsentWithdrawn = "consent_withdrawn"
 	// ReasonAllowed is the allow path's own code, so every row has one.
 	ReasonAllowed = "allowed"
 )
 
 // absoluteDenials are the refusals no rollout mode may soften.
+//
+// Held by: TestAbsoluteDenialsSurviveEveryMode (commsauthz_test.go), which
+// fails if any member stops denying under observe or warn.
 //
 // Observe mode exists so a new engine can be measured against the old gate
 // without blocking legitimate mail while the two are compared. It does NOT
@@ -43,6 +50,18 @@ var absoluteDenials = map[string]bool{
 	ReasonRestricted:     true,
 	ReasonHardBounce:     true,
 	ReasonUnconfirmedDOI: true,
+	// A recipient the engine cannot resolve to exactly one subject is the
+	// fifth, and it belongs here for a different reason than the other four:
+	// they are refusals ABOUT somebody, this one is the admission that nobody
+	// knows who the message is going to. No suppression, objection or consent
+	// state can be read for a subject that was never identified, so letting a
+	// rollout mode soften it would send precisely the messages nothing was
+	// able to check.
+	ReasonNoSubject: true,
+	// A withdrawal is the subject saying stop. It is a different act from an
+	// objection and gets its own code, but it binds exactly as hard: no
+	// rollout mode may send to somebody who took their consent back.
+	ReasonConsentWithdrawn: true,
 }
 
 // Absolute reports whether this reason denies regardless of Mode.

--- a/backend/internal/shared/ports/commsauthz/commsauthz_test.go
+++ b/backend/internal/shared/ports/commsauthz/commsauthz_test.go
@@ -34,6 +34,7 @@ func TestAnEmptySetIsNotAllowed(t *testing.T) {
 func TestAbsoluteDenialsSurviveEveryMode(t *testing.T) {
 	for _, reason := range []string{
 		ReasonObjection, ReasonRestricted, ReasonHardBounce, ReasonUnconfirmedDOI,
+		ReasonNoSubject, ReasonConsentWithdrawn,
 	} {
 		set := DecisionSet{Decisions: []Decision{{Verdict: VerdictDeny, ReasonCode: reason}}}
 		for _, mode := range []Mode{ModeObserve, ModeWarn, ModeEnforce} {

--- a/backend/internal/shared/ports/commsauthz/decision.go
+++ b/backend/internal/shared/ports/commsauthz/decision.go
@@ -164,3 +164,35 @@ func (s DecisionSet) Denied() []Decision {
 	}
 	return out
 }
+
+// TransmitRequest is one delivery, about to reach a provider.
+type TransmitRequest struct {
+	DeliveryID ids.UUID
+	// Attempt is the dispatcher's own counter, already incremented for this
+	// try. It is the freshness clock: a ticket is current only for the attempt
+	// that wrote it, so a crash between the decision and the provider call
+	// leaves a row that cannot be mistaken for the next attempt's.
+	Attempt    int
+	Recipients []connector.Recipient
+	// PurposeKey is the legacy consent purpose the delivery was staged with.
+	PurposeKey string
+	Subject    string
+	Body       string
+}
+
+// TransmitTicket is what a dispatcher must hold before it calls a provider.
+type TransmitTicket struct {
+	DeliveryID    ids.UUID
+	Attempt       int
+	DecisionSetID ids.UUID
+	Allowed       bool
+	Reason        string
+}
+
+// Current reports whether this ticket authorizes THIS attempt of THIS
+// delivery. A zero set id means no decision was ever recorded; a stale attempt
+// means the decision belongs to an earlier try. Both are refusals, and the
+// dispatcher asks before it transmits.
+func (t TransmitTicket) Current(deliveryID ids.UUID, attempt int) bool {
+	return t.DecisionSetID != ids.UUID{} && t.DeliveryID == deliveryID && t.Attempt == attempt
+}

--- a/backend/migrations/core/1788407500_a_send_records_why_it_was_allowed.up.sql
+++ b/backend/migrations/core/1788407500_a_send_records_why_it_was_allowed.up.sql
@@ -75,11 +75,19 @@ CREATE TABLE communication_decision (
         ]))
 );
 
--- One authoritative row per recipient per phase per attempt. Without this a
--- retry could write a second staging answer and leave two rows disagreeing
--- about the same moment, with nothing to say which one the send relied on.
-CREATE UNIQUE INDEX communication_decision_one_per_attempt
-    ON communication_decision (delivery_id, recipient_address, phase, attempt);
+-- One authoritative row per recipient per DECISION, not per attempt.
+--
+-- Keying on the attempt looks right and is not: a pacing policy that postpones
+-- a delivery hands the attempt number back (RecordDeferral decrements it), so
+-- the next dispatch re-authorizes under the same number. A uniqueness key on
+-- attempt would make that second, fresher decision collide with the first and
+-- be silently dropped — leaving the record asserting that an older verdict,
+-- taken before somebody objected, is what permitted the send.
+--
+-- The decision set is minted per evaluation, so it separates two answers about
+-- the same attempt while still refusing a duplicate row inside one evaluation.
+CREATE UNIQUE INDEX communication_decision_one_per_decision
+    ON communication_decision (decision_set_id, recipient_address, phase);
 CREATE INDEX communication_decision_by_subject
     ON communication_decision (subject_id) WHERE subject_id IS NOT NULL;
 CREATE INDEX communication_decision_disagreements

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -1358,7 +1358,7 @@ public.communication_decision.suppression text gen=- def=-
 public.communication_decision.verdict text NOT NULL gen=- def=-
 public.communication_decision_by_subject CREATE INDEX communication_decision_by_subject ON public.communication_decision USING btree (subject_id) WHERE (subject_id IS NOT NULL)
 public.communication_decision_disagreements CREATE INDEX communication_decision_disagreements ON public.communication_decision USING btree (decided_at) WHERE ((legacy_verdict IS NOT NULL) AND (legacy_verdict <> verdict))
-public.communication_decision_one_per_attempt CREATE UNIQUE INDEX communication_decision_one_per_attempt ON public.communication_decision USING btree (delivery_id, recipient_address, phase, attempt)
+public.communication_decision_one_per_decision CREATE UNIQUE INDEX communication_decision_one_per_decision ON public.communication_decision USING btree (decision_set_id, recipient_address, phase)
 public.communication_decision_pkey CREATE UNIQUE INDEX communication_decision_pkey ON public.communication_decision USING btree (id)
 public.communication_suppression acl=margince_owner=arwdDxt/margince_owner,margince_app=arwd/margince_owner rls=false force=false
 public.communication_suppression.address text gen=- def=-


### PR DESCRIPTION
The staging half of an authorization answers "may this be written down and queued". It cannot answer "may this go out now", because the two are separated by a queue: a person can withdraw consent, object, or have their address hard-bounce in between, and a delivery that waited a day on the retry ladder was authorized against a world that no longer exists.

So the engine is asked again immediately before transmission, and the answer is written down **before** any provider I/O rather than after. A decision recorded afterwards says what was sent, not what permitted it.

`Gate.AuthorizeTransmit` writes one immutable row per recipient and returns a ticket. `Dispatcher.transmit` refuses unless that ticket covers this delivery and this attempt. A mutation test proves the guard: remove it and two tests fail.

Two authorities run in parallel during observe mode, deliberately. The engine records its decision and applies only the refusals no rollout mode may soften; the legacy purpose gate rules everything else, and its answer is stored as `legacy_verdict` so a disagreement is readable in the record rather than only in a counter that dies with the process.

## What the security review changed

Six findings, all fixed here. Three affected whether a message could go out:

- **Suppressions were read newest-first.** A weaker suppression recorded later masked an objection recorded earlier, and the reason code is what decides whether a refusal survives observe mode. They are now ranked by strength, the unknown kind is treated as absolute, and the lead arm was missing entirely.
- **An unidentifiable recipient sent.** A recipient the engine could not resolve to exactly one subject returned a non-absolute review, so observe mode let it through — precisely the messages nothing was able to check. That reason is now absolute.
- **A withdrawal was labelled an objection** and mapped to a non-absolute code. It is now its own absolute code: an Art. 7(3) withdrawal and an Art. 21 objection are different legal facts, and a proof row that called one the other misstates what somebody did.

Three affected the integrity of the record:

- The block reason was decided by string-matching an operator-facing sentence, so a copy edit would silently reclassify a legal fact. `Verdict` now carries a machine-readable code.
- A pacing deferral hands the attempt number back, so keying uniqueness on the attempt made the second, fresher decision collide and be dropped. It is keyed on the decision set instead.
- A channel recipient wrote a prose sentence into the address column, which is also the uniqueness key. Channel identities are now stored structurally.

Recipient shape is validated as the legacy gate validates it: a recipient carrying both an address and a channel identity was answered about on the channel arm alone, and the address, which may be the one that objected, was never looked at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rechecks authorization immediately before transmission and records the decision before any provider I/O, so no message reaches a provider without a decision covering that exact delivery and attempt. The staging check alone goes stale — consent can be withdrawn, an objection filed, or an address hard-bounced while a delivery waits in the retry ladder.

`Gate.AuthorizeTransmit` writes one immutable row per recipient and hands back a ticket the dispatcher demands before transmitting. During observe mode the legacy purpose gate still rules, and its answer is stored as `legacy_verdict` on each row.

**Security review fixes**

- Suppressions are ranked by strength instead of recency; the unknown kind and unresolvable recipients are now absolute denials.
- A withdrawal (Art. 7(3)) has its own absolute code, distinct from an objection (Art. 21).
- Block reasons are machine-readable codes instead of matched operator-facing sentences.
- Decision rows are keyed on the decision set rather than the attempt, so a pacing deferral can't drop a fresher decision.
- Channel identities are stored structurally, and recipients carrying both an address and a channel identity are validated so both are checked.

<sup>Written for commit 46c1487b9b75d35a68be8b652c13d95985c3e0f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added transmission authorization checks before messages are sent.
  - Added machine-readable reasons for consent-related delivery blocks.

- **Bug Fixes**
  - Prevented unauthorized, withdrawn, unresolved, or stale deliveries from reaching providers.
  - Deliveries now retry when authorization services are temporarily unavailable.
  - Valid authorization permits each delivery attempt to be sent only once.

- **Reliability**
  - Improved handling of recipient consent, communication-channel availability, and suppression decisions before transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->