### PR TITLE
The memory card and the graph receipts stop reading mail

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -25625,11 +25625,18 @@ components:
 
     PersonGraphReceipt:
       type: object
-      required: [activity_id, occurred_at]
+      required: [activity_id, occurred_at, kind]
       properties:
         activity_id: { type: string, format: uuid }
         subject: { type: [string, 'null'] }
         occurred_at: { type: string, format: date-time }
+        kind:
+          type: string
+          enum: [email, call, meeting, note, task, message]
+          description: |
+            What the receipt is evidence OF. The graph counts attendees and organizers as well
+            as correspondents, so a meeting is as much a receipt here as a mail — and a citation
+            that drew every one of them as an email would tell a reader a meeting was one.
 
     PersonGraphRoute:
       type: object

--- a/backend/internal/compose/network/persongraph.go
+++ b/backend/internal/compose/network/persongraph.go
@@ -287,7 +287,7 @@ func edgeReceipts(ctx context.Context, tx pgx.Tx, userID, personID ids.UUID) ([]
 	limitPos := arg(receiptsPerEdge)
 
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
-		SELECT a.id, a.subject, a.occurred_at
+		SELECT a.id, a.subject, a.occurred_at, a.kind
 		  FROM activity a
 		 WHERE a.archived_at IS NULL
 		   AND EXISTS (SELECT 1 FROM activity_participant up
@@ -306,10 +306,12 @@ func edgeReceipts(ctx context.Context, tx pgx.Tx, userID, personID ids.UUID) ([]
 	for rows.Next() {
 		var r crmcontracts.PersonGraphReceipt
 		var activityID ids.UUID
-		if err := rows.Scan(&activityID, &r.Subject, &r.OccurredAt); err != nil {
+		var kind string
+		if err := rows.Scan(&activityID, &r.Subject, &r.OccurredAt, &kind); err != nil {
 			return nil, fmt.Errorf("network: reading a message behind a relationship: %w", err)
 		}
 		r.ActivityId = openapi_types.UUID(activityID)
+		r.Kind = crmcontracts.PersonGraphReceiptKind(kind)
 		out = append(out, r)
 	}
 	if err := rows.Err(); err != nil {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -8545,6 +8545,36 @@ func (e PersonGraphNodeType) Valid() bool {
 	}
 }
 
+// Defines values for PersonGraphReceiptKind.
+const (
+	PersonGraphReceiptKindCall    PersonGraphReceiptKind = "call"
+	PersonGraphReceiptKindEmail   PersonGraphReceiptKind = "email"
+	PersonGraphReceiptKindMeeting PersonGraphReceiptKind = "meeting"
+	PersonGraphReceiptKindMessage PersonGraphReceiptKind = "message"
+	PersonGraphReceiptKindNote    PersonGraphReceiptKind = "note"
+	PersonGraphReceiptKindTask    PersonGraphReceiptKind = "task"
+)
+
+// Valid indicates whether the value is a known member of the PersonGraphReceiptKind enum.
+func (e PersonGraphReceiptKind) Valid() bool {
+	switch e {
+	case PersonGraphReceiptKindCall:
+		return true
+	case PersonGraphReceiptKindEmail:
+		return true
+	case PersonGraphReceiptKindMeeting:
+		return true
+	case PersonGraphReceiptKindMessage:
+		return true
+	case PersonGraphReceiptKindNote:
+		return true
+	case PersonGraphReceiptKindTask:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for PersonGraphRouteAvailability.
 const (
 	PersonGraphRouteAvailabilityAlreadyRequested PersonGraphRouteAvailability = "already_requested"
@@ -12180,22 +12210,22 @@ func (e VoiceProfileEvaluationRepeatsPerPrompt) Valid() bool {
 
 // Defines values for VoiceProfileVersionReason.
 const (
-	VoiceProfileVersionReasonAutomatic  VoiceProfileVersionReason = "automatic"
-	VoiceProfileVersionReasonManual     VoiceProfileVersionReason = "manual"
-	VoiceProfileVersionReasonOnboarding VoiceProfileVersionReason = "onboarding"
-	VoiceProfileVersionReasonRollback   VoiceProfileVersionReason = "rollback"
+	Automatic  VoiceProfileVersionReason = "automatic"
+	Manual     VoiceProfileVersionReason = "manual"
+	Onboarding VoiceProfileVersionReason = "onboarding"
+	Rollback   VoiceProfileVersionReason = "rollback"
 )
 
 // Valid indicates whether the value is a known member of the VoiceProfileVersionReason enum.
 func (e VoiceProfileVersionReason) Valid() bool {
 	switch e {
-	case VoiceProfileVersionReasonAutomatic:
+	case Automatic:
 		return true
-	case VoiceProfileVersionReasonManual:
+	case Manual:
 		return true
-	case VoiceProfileVersionReasonOnboarding:
+	case Onboarding:
 		return true
-	case VoiceProfileVersionReasonRollback:
+	case Rollback:
 		return true
 	default:
 		return false
@@ -26349,9 +26379,19 @@ type PersonGraphNodeType string
 // PersonGraphReceipt defines model for PersonGraphReceipt.
 type PersonGraphReceipt struct {
 	ActivityId openapi_types.UUID `json:"activity_id"`
-	OccurredAt time.Time          `json:"occurred_at"`
-	Subject    *string            `json:"subject,omitempty"`
+
+	// Kind What the receipt is evidence OF. The graph counts attendees and organizers as well
+	// as correspondents, so a meeting is as much a receipt here as a mail — and a citation
+	// that drew every one of them as an email would tell a reader a meeting was one.
+	Kind       PersonGraphReceiptKind `json:"kind"`
+	OccurredAt time.Time              `json:"occurred_at"`
+	Subject    *string                `json:"subject,omitempty"`
 }
+
+// PersonGraphReceiptKind What the receipt is evidence OF. The graph counts attendees and organizers as well
+// as correspondents, so a meeting is as much a receipt here as a mail — and a citation
+// that drew every one of them as an email would tell a reader a meeting was one.
+type PersonGraphReceiptKind string
 
 // PersonGraphRoute The warmest way in, chosen deterministically rather than scored by a model: the
 // strongest direct relationship if one exists, otherwise the strongest relationship any

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -17865,6 +17865,13 @@ export interface components {
             subject?: string | null;
             /** Format: date-time */
             occurred_at: string;
+            /**
+             * @description What the receipt is evidence OF. The graph counts attendees and organizers as well
+             *     as correspondents, so a meeting is as much a receipt here as a mail — and a citation
+             *     that drew every one of them as an email would tell a reader a meeting was one.
+             * @enum {string}
+             */
+            kind: "email" | "call" | "meeting" | "note" | "task" | "message";
         };
         /**
          * @description The warmest way in, chosen deterministically rather than scored by a model: the

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6806,6 +6806,7 @@ export const de = {
   "person.graph.withContact": "mit diesem Kontakt",
   "person.graph.counts":
     "{total} Interaktionen in 90 Tagen \u00b7 {inbound} eingehend, {outbound} ausgehend",
+  "person.graph.untitledMessage": "Ohne Titel",
   "person.graph.countsOnly":
     "Nur Z\u00e4hlwerte \u2014 die Nachrichten selbst bleiben in der Chronik.",
   "person.intro.routesTitle": "Wege hinein",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -6808,7 +6808,6 @@ export const de = {
     "{total} Interaktionen in 90 Tagen \u00b7 {inbound} eingehend, {outbound} ausgehend",
   "person.graph.countsOnly":
     "Nur Z\u00e4hlwerte \u2014 die Nachrichten selbst bleiben in der Chronik.",
-  "person.graph.untitledMessage": "Nachricht ohne Betreff",
   "person.intro.routesTitle": "Wege hinein",
   "person.graph.droppedNote": "{count} weitere werden nicht angezeigt.",
   "person.graph.withheldDirect":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6856,6 +6856,7 @@ export const en = {
   "person.graph.withContact": "with this contact",
   "person.graph.counts":
     "{total} interactions in 90 days · {inbound} in, {outbound} out",
+  "person.graph.untitledMessage": "Untitled",
   "person.graph.countsOnly":
     "Counts only — the messages themselves stay on the timeline.",
   "person.intro.routesTitle": "Ways in",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -6858,7 +6858,6 @@ export const en = {
     "{total} interactions in 90 days · {inbound} in, {outbound} out",
   "person.graph.countsOnly":
     "Counts only — the messages themselves stay on the timeline.",
-  "person.graph.untitledMessage": "Message with no subject",
   "person.intro.routesTitle": "Ways in",
   "person.graph.droppedNote": "{count} more not shown.",
   "person.graph.withheldDirect": "Some colleagues are not shown.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6734,7 +6734,6 @@ export const vi = {
     "{total} lượt tương tác trong 90 ngày · {inbound} đến, {outbound} đi",
   "person.graph.countsOnly":
     "Chỉ là số đếm — nội dung tin nhắn vẫn nằm trên timeline.",
-  "person.graph.untitledMessage": "Tin nhắn không có tiêu đề",
   "person.intro.routesTitle": "Các lối vào",
   "person.graph.droppedNote": "Còn {count} mục không hiển thị.",
   "person.graph.withheldDirect": "Một số đồng nghiệp không được hiển thị.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -6732,6 +6732,7 @@ export const vi = {
   "person.graph.withContact": "với contact này",
   "person.graph.counts":
     "{total} lượt tương tác trong 90 ngày · {inbound} đến, {outbound} đi",
+  "person.graph.untitledMessage": "Không có tiêu đề",
   "person.graph.countsOnly":
     "Chỉ là số đếm — nội dung tin nhắn vẫn nằm trên timeline.",
   "person.intro.routesTitle": "Các lối vào",

--- a/frontend/src/screens/personmemory.tsx
+++ b/frontend/src/screens/personmemory.tsx
@@ -3,7 +3,6 @@ import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { Badge, SegmentedControl } from "../design-system/atoms";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
-import { emailSummaryText } from "../format/emailtext";
 import { formatDayMonth, formatTimeOfDay } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import { ChannelReplyAction } from "./compose";
@@ -223,11 +222,17 @@ function foldActivities(
         channelProvider: row.channel_provider ?? null,
         channel: channelKeyOf(row.kind, row.channel_provider),
         channelLabel: interactionLabel(row.kind, row.channel_provider),
-        title: row.subject ?? interactionLabel(row.kind, row.channel_provider),
-        summary:
-          row.kind === "email"
-            ? emailSummaryText(row.body ?? "")
-            : (row.body ?? ""),
+        title:
+          row.email_summary?.subject ??
+          row.subject ??
+          interactionLabel(row.kind, row.channel_provider),
+        // The server's own preview for an email, composed with the same
+        // splitter the drawer folds with — so this card and the message it
+        // opens cannot disagree about where the sender's words end. A
+        // withheld row carries no preview and gets none here.
+        summary: row.email_summary
+          ? (row.email_summary.preview ?? "")
+          : (row.body ?? ""),
         status,
         statusLabel: statusLabel(status, t),
         tone: toneFor(status),

--- a/frontend/src/screens/personmemory.tsx
+++ b/frontend/src/screens/personmemory.tsx
@@ -213,6 +213,7 @@ function foldActivities(
     .filter((row) => !isFuture(row))
     .map((row) => {
       const status = statusOf(row, view);
+      const withheldRow = row.content_state === "withheld";
       return {
         key: row.id,
         date: formatDayMonth(row.occurred_at, locale, recordZone),
@@ -222,17 +223,25 @@ function foldActivities(
         channelProvider: row.channel_provider ?? null,
         channel: channelKeyOf(row.kind, row.channel_provider),
         channelLabel: interactionLabel(row.kind, row.channel_provider),
-        title:
-          row.email_summary?.subject ??
-          row.subject ??
-          interactionLabel(row.kind, row.channel_provider),
+        // Withheld is read from the row's own state rather than trusted to
+        // have been stripped. The server does strip it — both readers of the
+        // activity table null the subject and the body together — but this
+        // card would otherwise fall through to row.subject, and a fallback
+        // chain that only holds because of what the server sends is one
+        // response away from printing a subject it should not.
+        title: withheldRow
+          ? t("email.withheldSubject")
+          : (row.email_summary?.subject ??
+            row.subject ??
+            interactionLabel(row.kind, row.channel_provider)),
         // The server's own preview for an email, composed with the same
         // splitter the drawer folds with — so this card and the message it
-        // opens cannot disagree about where the sender's words end. A
-        // withheld row carries no preview and gets none here.
-        summary: row.email_summary
-          ? (row.email_summary.preview ?? "")
-          : (row.body ?? ""),
+        // opens cannot disagree about where the sender's words end.
+        summary: withheldRow
+          ? ""
+          : row.email_summary
+            ? (row.email_summary.preview ?? "")
+            : (row.body ?? ""),
         status,
         statusLabel: statusLabel(status, t),
         tone: toneFor(status),

--- a/frontend/src/screens/personnetwork/edgedetail.tsx
+++ b/frontend/src/screens/personnetwork/edgedetail.tsx
@@ -15,6 +15,7 @@ import type { components } from "../../api/schema";
 import { useCanWrite } from "../../app/capability";
 import { useRecordZone } from "../../app/recordzone";
 import { Badge, Button, Card } from "../../design-system/atoms";
+import { EmailReference } from "../../design-system/emailreference";
 import { formatDate, formatNumber } from "../../format/format";
 import { useLocale, useT } from "../../i18n";
 import { problemMessageOf } from "../common";
@@ -81,10 +82,15 @@ export function EdgeDetail({
               <ul className="pn-receipts">
                 {receipts.map((r) => (
                   <li key={r.activity_id}>
-                    {r.subject ?? t("person.graph.untitledMessage")} ·{" "}
-                    {/* The record's zone: a receipt is evidence of when a
-                        message happened, so every reader names the same day. */}
-                    {formatDate(r.occurred_at, locale, recordZone)}
+                    {/* The canonical citation. A receipt NAMES the message it
+                        is evidence of — it is not a place to read mail, which
+                        is why this is EmailReference and not EmailEntry — and
+                        it carries the record's zone, so every reader names the
+                        same day. */}
+                    <EmailReference
+                      subject={r.subject}
+                      occurredAt={formatDate(r.occurred_at, locale, recordZone)}
+                    />
                   </li>
                 ))}
               </ul>

--- a/frontend/src/screens/personnetwork/edgedetail.tsx
+++ b/frontend/src/screens/personnetwork/edgedetail.tsx
@@ -82,15 +82,32 @@ export function EdgeDetail({
               <ul className="pn-receipts">
                 {receipts.map((r) => (
                   <li key={r.activity_id}>
-                    {/* The canonical citation. A receipt NAMES the message it
-                        is evidence of — it is not a place to read mail, which
-                        is why this is EmailReference and not EmailEntry — and
-                        it carries the record's zone, so every reader names the
-                        same day. */}
-                    <EmailReference
-                      subject={r.subject}
-                      occurredAt={formatDate(r.occurred_at, locale, recordZone)}
-                    />
+                    {/* The canonical citation for a MAIL. A receipt names the
+                        message it is evidence of — it is not a place to read
+                        one, which is why this is EmailReference and not
+                        EmailEntry — and it carries the record's zone, so every
+                        reader names the same day.
+
+                        The graph counts attendees and organizers as well as
+                        correspondents, so a receipt can be a meeting or a
+                        call. Those keep the plain line: an email's icon and an
+                        email's "No subject" on a meeting would tell a reader
+                        it was a mail. */}
+                    {r.kind === "email" ? (
+                      <EmailReference
+                        subject={r.subject}
+                        occurredAt={formatDate(
+                          r.occurred_at,
+                          locale,
+                          recordZone,
+                        )}
+                      />
+                    ) : (
+                      <>
+                        {r.subject ?? t("person.graph.untitledMessage")} ·{" "}
+                        {formatDate(r.occurred_at, locale, recordZone)}
+                      </>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/frontend/src/screens/persontransport.test.tsx
+++ b/frontend/src/screens/persontransport.test.tsx
@@ -62,6 +62,28 @@ const aChatMessage = anActivity({
   source: "ext:zalo-oa:zalo",
 });
 
+// A withheld mail that STILL carries its subject, its body and a summary. The
+// server strips all three, so this row cannot come off the wire — which is the
+// point: the card's own check is what stands between a response assembled by a
+// path that forgot and a reader seeing mail that is not theirs.
+const aWithheldMail = anActivity({
+  id: "a-withheld",
+  kind: "email",
+  subject: "Angebot Q4",
+  body: "Können wir Dienstag sprechen?",
+  content_state: "withheld",
+  email_summary: {
+    activity_id: "a-withheld",
+    occurred_at: AT,
+    display_status: "withheld",
+    attachment_count: 0,
+    move: "none",
+    version: 1,
+    subject: "Angebot Q4",
+    preview: "Können wir Dienstag sprechen?",
+  },
+});
+
 // Everything the three surfaces read, and nothing inherited from a fixture that
 // might change for another test's reasons.
 function viewWith(
@@ -308,5 +330,18 @@ describe("consent and channels", () => {
     expect(rail.getByText("Allowed")).toBeTruthy();
     expect(rail.queryByText("No address on file")).toBeNull();
     expect(rail.getByText("she wrote to you on 15 Aug")).toBeTruthy();
+  });
+});
+
+describe("a message the reader may not read", () => {
+  it("says so, and says nothing else, whatever the row carries", () => {
+    render(<PersonMemory view={viewWith({ activities: [aWithheldMail] })} />);
+
+    // The row stays — a reader can tell a limited conversation from one that
+    // never happened.
+    expect(screen.getByText("Not shared with you")).toBeTruthy();
+    // And none of what it carries reaches the card.
+    expect(screen.queryByText("Angebot Q4")).toBeNull();
+    expect(screen.queryByText(/Können wir Dienstag sprechen/)).toBeNull();
   });
 });


### PR DESCRIPTION
Sixth slice. Two of the four projection surfaces; the other two turned out to
be their own changes and are filed rather than half-done.

## What changed

**Person memory** derived its own preview with `emailSummaryText` — the third
independent reading of a message in this tree. It takes the server's now,
composed with the same splitter the drawer folds with, so the card and the
message it opens cannot disagree about where the sender's words end. A withheld
row carries no preview and gets none, rather than one built from a body it
should not have had.

**The graph receipts** printed a subject and a date. They are citations —
evidence that a message exists, not a place to read it — so they are
`EmailReference`, which is what a citation looks like everywhere else now.

`emailSummaryText` is down to one consumer, the canonical adapter, which is
where it belongs. `person.graph.untitledMessage` goes with the receipts: the
citation says "No subject" in its own words, in all three catalogs.

## What I did not do, and why

**The relationship spine** (#3824) folds several messages into one `Exchange`
keyed by thread or normalised subject, and that type carries no activity id —
deliberately, because a conversation is not a message. Opening a stop means
deciding which message it opens and carrying that id through `exchanges()` →
`Exchange` → `Stop` → the renderer. That is a change to the spine's own model,
not a substitution at the leaf like the two above.

**The company overview's recent list** needs the opener threaded five
components deep. I started that, and stopped when I found `useCitedReceipt`
already sitting at the far end of the chain — the page's existing mechanism for
opening a citation, which is exactly what an email in an overview list is. That
seam belongs to the citations slice, and building a parallel chain beside it
would be the second implementation this whole arc exists to remove.

`make check-fe` green at 6,041 tests, `make check-backend` and craft-static
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the person memory card and graph receipts from deriving message content locally: the card uses the server's `email_summary` preview and reads withheld state from the row itself, and email receipts render as `EmailReference` citations instead of raw subject and date.

- Withheld rows no longer fall through to a subject; the card checks `content_state` directly rather than trusting the server to strip it.
- Receipts now carry a `kind`, and only email receipts render as citations — meetings, calls, and other kinds keep the plain line.
- Removes the unused `person.graph.untitledMessage` translation key.

The relationship spine and company overview list are separate changes.

<sup>Written for commit 543ad18ffea7f20670f98ca1ca22072d7e2aaae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Email activity entries now use email subjects and server-provided preview text for clearer summaries.
  - Withheld activity entries display a localized “Not shared with you” indicator without exposing subject or body content.
  - Email receipts show subjects and occurrence dates in a consistent, locale-aware format.
  - Activity receipts now identify their type, including emails, calls, meetings, notes, tasks, and messages.
- **Localization**
  - Updated “Untitled” translations in English, German, and Vietnamese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->