### PR TITLE
Classify the send-authorization tables' row-scoped FKs

### DIFF
--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -157,6 +157,30 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"conversation_claim.person_id":          "gated: RecordConversationClaim opens with auth.RequireHuman + auth.Require(person, update), then auth.EnsureWritableLive on the person inside the write's own transaction — a claim may only be recorded against a person the caller could already change",
 	"conversation_claim.source_activity_id": "gated: the same writer takes auth.EnsureActivityContentVisibleLive on the cited activity in that transaction, so a claim can never quote a message the caller may not open — and LIVE rather than merely visible, because a claim must not outlive its evidence",
 	"conversation_claim.task_activity_id":   "PENDING WRITER: the column has no writer. The task an extracted commitment creates is written through the tasks substrate's own gated path, and this entry is replaced with that gate when the routing edge lands",
+	// The send-authorization record's two capability tables (core 1788407500)
+	// are SCHEMA ONLY: nothing in the tree inserts a row into either. What
+	// exists today READS them — consent's liveSuppression, which its own
+	// comment names as the only reader that applies a suppression — and
+	// REMOVES them, on privacy's erasure and retention paths, which null the
+	// subject link or delete the row and never create a reference. So the five
+	// entries below are the obligation on whoever writes the first row rather
+	// than a record of a gate already taken, and each names the sibling whose
+	// shape that writer has to match.
+	//
+	// The subject columns are one fact spelled twice, because the CHECKs make
+	// them alternatives: communication_basis_one_subject admits a person XOR a
+	// lead, and communication_suppression_names_a_target admits either, or
+	// neither when the row is scoped to a bare address. An address is a fact
+	// about a MAILBOX and names no row-scoped record, so it is outside this
+	// gate rather than exempted by it.
+	"communication_basis.person_id": "PENDING WRITER: the obligation on whoever writes it — a basis recorded from a path that already holds the subject (a captured inbound, an inquiry) carries that path's gate, as consent_qualifying_event.person_id does; a basis whose subject a CALLER names takes auth.EnsureVisibleLive on that person in the insert's own transaction, as lead_manual_signal.lead_id does, because recording why writing to somebody is lawful would otherwise confirm they exist",
+	"communication_basis.lead_id":   "PENDING WRITER: the lead arm of the entry above, under the same obligation — the CHECK makes the two exclusive, so a writer fills exactly one and the arm it fills carries that arm's probe",
+	// LIVE rather than merely visible, for the reason conversation_claim's
+	// evidence column is: a basis that outlived its evidence would keep
+	// authorizing sends on the strength of a message nobody can now open.
+	"communication_basis.source_activity_id": "PENDING WRITER: the obligation is conversation_claim.source_activity_id's — auth.EnsureActivityContentVisibleLive on the cited message, in the same transaction as the insert, so a basis can never rest on a thread the writer's caller may not read",
+	"communication_suppression.person_id":    "PENDING WRITER: the subject arm of a suppression, under communication_basis.person_id's obligation — with one difference worth writing down rather than rediscovering: a hard bounce arrives from a provider and not from a caller, and a system writer that names no principal takes no row-scope probe because there is no scope to probe. It is the CALLER-named row this binds",
+	"communication_suppression.lead_id":      "PENDING WRITER: the lead arm of the entry above; the target CHECK admits a row naming only an address, so a writer may fill neither subject column and the probe binds only the arm it fills",
 	// Owned child rows: the row is an attribute of its visible parent,
 	// written only through the parent's own gated paths.
 	"organization_geocode_state.organization_id": "child row: the sidecar for an organization's own coordinate lookup, and no caller ever names the organization it keys on. " +

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -224,8 +224,15 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// to gate: nothing outside the triage resolve ever writes this column, and
 	// no human surface reads the row.
 	"organization_domain_disposition.organization_id": "server-derived: set only by ResolveDomainTriage, to the organization that same transaction created or adopted through the gated dedupe chokepoint",
-	"person_email.person_id":                          "child row: written through the person's own gated paths",
-	"person_phone.person_id":                          "child row: written through the person's own gated paths",
+	// Why a contact exists at all, written where the contact is. There is no
+	// client-supplied reference to gate: recordAcquisition takes the id
+	// createPerson has just minted, on that same transaction, so no caller can
+	// name a subject here at all. The one other writer is the merge relink,
+	// which MOVES the rows onto a survivor mergePair has already gated — it
+	// supplies neither id from a request body either.
+	"person_acquisition_evidence.person_id": "child row: written only by recordAcquisition, inside createPerson's own transaction, for the person that transaction just created; the merge relink is the only other writer and moves the rows onto an already-gated survivor",
+	"person_email.person_id":                "child row: written through the person's own gated paths",
+	"person_phone.person_id":                "child row: written through the person's own gated paths",
 	// The licensed-data-provider platform (ADR-0101). A run names the subject
 	// it spends credits on, so admitting one IS a read of that person: QueueRun
 	// takes auth.EnsureVisible inside the queueing transaction, before any


### PR DESCRIPTION
Closes #3818. **This unblocks the integration lane on `main`** — `TestFK_rowScopedTargetsHaveVisibilityDecision` fails on a clean `origin/main`, so any branch running `make test-it DIR=backend/migrations` is red through no fault of its own.

**What the gate found.** `communication_basis` and `communication_suppression` arrived with the send-authorization record (core `1788407500`, #3815) carrying five FK columns that name a row-scoped record and no entry in `rowScopedFKDecisions`. The ticket named six; the gate names five — `communication_suppression` has no activity column, so its FKs are `person_id` and `lead_id` only.

**What the research found.** The ticket was filed rather than fixed because "the author of #3815 knows whether those references are gated; I would be guessing." The answer turns out not to need that knowledge, because there is nothing to know yet: **nothing in the tree inserts a row into either table.** Every Go statement that names them is one of

- a READ — consent's `liveSuppression`, whose own comment says it is "the only reader in the tree that applies these rows";
- a REMOVAL — privacy's erasure and retention paths, which delete the row or null the subject link (`retentionactions.go`, `erasure_consent.go`, `erasure_leadtwins.go`). None of them ever creates a reference.

So the honest classification is the one this map already spells twice — `conversation_claim.task_activity_id` and `provider_applied_field.person_id` — `PENDING WRITER`: the entry states the obligation on whoever writes the first row, and names the sibling whose shape that writer has to match.

**The five entries**

| column | obligation |
| --- | --- |
| `communication_basis.person_id` | a path that already holds the subject carries that path's gate (`consent_qualifying_event.person_id`'s shape); a caller-named subject takes `auth.EnsureVisibleLive` in the insert's transaction (`lead_manual_signal.lead_id`'s shape) |
| `communication_basis.lead_id` | the lead arm of the same; `communication_basis_one_subject` makes the two exclusive |
| `communication_basis.source_activity_id` | `conversation_claim.source_activity_id`'s obligation — `auth.EnsureActivityContentVisibleLive`, and **live** rather than merely visible, because a basis that outlived its evidence would keep authorizing sends on a message nobody can now open |
| `communication_suppression.person_id` | the subject arm, with the difference written down rather than rediscovered: a hard bounce arrives from a provider and not from a caller, and a system writer that names no principal has no scope to probe |
| `communication_suppression.lead_id` | the lead arm; the target CHECK admits an address-only row, so the probe binds only the arm a writer fills |

The address column is deliberately not classified: an address is a fact about a mailbox and names no row-scoped record, so it is outside this gate rather than exempted by it. That is said in the block comment so the next reader does not look for the missing entry.

**Mutation-checked, both directions**

- deleting the `source_activity_id` entry → `FK communication_basis.source_activity_id -> activity has no visibility decision`
- adding a `communication_basis.no_such_column` entry → `waiver communication_basis.no_such_column matched no subject: delete it, or correct the key if the subject was renamed`

**Verification.** `make test-it DIR=backend/migrations` green (all five tests). `make check-backend` green.

**Known limitation, filed as #3831.** A `PENDING WRITER` entry is a claim that no writer exists, and nothing fails when one appears — the classification just goes quietly false. That is AGENTS.md's "a census that can fail short has already failed". The holder belongs in `backend/gates`, where `collectTableWrites` already walks every SQL write target in the tree, so it is that gate's corpus rather than this one's and would roughly double this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data integrity checks for communication preferences and suppression records across visibility, activity, system-generated, provider-generated, and address-only scenarios.
  - Added more precise classification for person acquisition evidence and related records, including system-originated suppression handling and server-derived write paths.
  - Added safeguards to ensure these records are correctly classified during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->