### PR TITLE
fe: the three families, the type scale and the pane tokens (design step 1)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -149,7 +149,7 @@ default.
 ## The gates (all run by `pnpm check` / `pnpm e2e`)
 
 1. Token canon — every §2 Ledger-Green value pinned to the design canon.
-2. Three type families only (Outfit / DM Sans / JetBrains Mono).
+2. Three type families only (Bricolage Grotesque / Geist / Geist Mono).
 3. Literal colours live only in `tokens.css`.
 4. No hard-coded user-facing copy — JSX text and user-facing attributes
    must come from the i18n catalogs (TS AST walk).

--- a/frontend/e2e/meeting-brief.spec.ts
+++ b/frontend/e2e/meeting-brief.spec.ts
@@ -30,22 +30,44 @@ function copy(key: MessageKey): string {
 // also excuse a drawer still sliding in.
 const AMBIENT = ["core-rim", "core-glass"];
 
+// A CSS transition of one of these properties cannot move a box either: the
+// button the reader just pressed is still fading its hover colour off when the
+// drawer is already standing, and a measurement taken through that fade is in
+// the right place. A transition of anything else — transform, width, inset —
+// is exactly what this check exists to catch, so the list is closed.
+const PAINT_ONLY = [
+  "background-color",
+  "border-color",
+  "box-shadow",
+  "color",
+  "filter",
+  "opacity",
+  "outline-color",
+];
+
 async function settleAnimations(page: Page) {
-  const running = await page.evaluate((ambient) => {
-    const named = (element: Element) =>
-      `${element.tagName.toLowerCase()}.${element.className}`;
-    return document
-      .getAnimations()
-      .filter((animation) => animation.playState === "running")
-      .map((animation) => {
-        const effect = animation.effect;
-        return effect instanceof KeyframeEffect &&
-          effect.target instanceof Element
-          ? named(effect.target)
-          : "an element the effect does not name";
-      })
-      .filter((name) => !ambient.some((mark) => name.includes(mark)));
-  }, AMBIENT);
+  const running = await page.evaluate(
+    ({ ambient, paintOnly }) => {
+      const named = (element: Element) =>
+        `${element.tagName.toLowerCase()}.${element.className}`;
+      const paintsOnly = (animation: Animation) =>
+        animation instanceof CSSTransition &&
+        paintOnly.includes(animation.transitionProperty);
+      return document
+        .getAnimations()
+        .filter((animation) => animation.playState === "running")
+        .filter((animation) => !paintsOnly(animation))
+        .map((animation) => {
+          const effect = animation.effect;
+          return effect instanceof KeyframeEffect &&
+            effect.target instanceof Element
+            ? named(effect.target)
+            : "an element the effect does not name";
+        })
+        .filter((name) => !ambient.some((mark) => name.includes(mark)));
+    },
+    { ambient: AMBIENT, paintOnly: PAINT_ONLY },
+  );
   expect(
     running,
     "an animation was still running when a box was measured, so the box is where the element passed through rather than where it rests",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Outfit:wght@600&family=DM+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@600&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/frontend/scripts/check-font-lock.sh
+++ b/frontend/scripts/check-font-lock.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Font-lock gate: the three-family type
 # rule (design §2) — every font-family declaration under frontend/src or an
-# extension unit's frontend names only Outfit (display), DM Sans (body), or
-# JetBrains Mono (mono).
+# extension unit's frontend names only Bricolage Grotesque (display), Geist
+# (body), or Geist Mono (mono).
 #
 # Allowed besides the three families: the generic stack fallbacks the §2
 # token definitions name (system-ui, sans-serif, ui-monospace, monospace) and
@@ -57,9 +57,9 @@ while IFS= read -r hit; do
   stripped=$(echo "$value" \
     | sed -E 's/font-family\s*://g' \
     | sed -E 's/var\(--[A-Za-z0-9-]+\)//g' \
-    | sed -E 's/JetBrains Mono//g' \
-    | sed -E 's/DM Sans//g' \
-    | sed -E 's/Outfit//g' \
+    | sed -E 's/Geist Mono//g' \
+    | sed -E 's/Bricolage Grotesque//g' \
+    | sed -E 's/Geist//g' \
     | sed -E 's/system-ui//g' \
     | sed -E 's/sans-serif//g' \
     | sed -E 's/ui-monospace//g' \
@@ -76,10 +76,10 @@ done < <(
 )
 
 if [[ "$EXIT" == "0" ]]; then
-  echo "PASS — only Outfit / DM Sans / JetBrains Mono (+ generic fallbacks)"
+  echo "PASS — only Bricolage Grotesque / Geist / Geist Mono (+ generic fallbacks)"
 else
   echo ""
-  echo "Allowed: Outfit, DM Sans, JetBrains Mono; generics system-ui,"
+  echo "Allowed: Bricolage Grotesque, Geist, Geist Mono; generics system-ui,"
   echo "sans-serif, ui-monospace, monospace; var(--f-*) token references."
 fi
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -22,8 +22,8 @@ html {
 
 body {
   font-family: var(--f-body);
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: var(--fs-body);
+  line-height: var(--lh-normal);
   color: var(--textContent);
   background: var(--bgPage);
   -webkit-font-smoothing: antialiased;

--- a/frontend/src/design-system/base.css
+++ b/frontend/src/design-system/base.css
@@ -494,7 +494,7 @@ a:not([class]):focus-visible {
 }
 
 .t-small {
-  font-size: 12px;
+  font-size: var(--fs-meta);
   color: var(--textMeta);
 }
 
@@ -536,38 +536,43 @@ a:not([class]):focus-visible {
  * across the app (record headings, field labels, captions, mono figures) —
  * no new sizes invented, just named. */
 .t-display {
-  font-size: 22px;
-  font-weight: 700;
+  font-family: var(--f-display);
+  font-size: var(--fs-h1);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--tracking-display);
   color: var(--textPrimary);
 }
 .t-h2 {
-  font-size: 18px;
-  font-weight: 600;
+  font-family: var(--f-display);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--tracking-display);
   color: var(--textPrimary);
 }
 /* The step between a heading and body text, which StatCard's reading has asked
    for since it was written — the class was named there but never declared, so
    the figure a tile exists to show was rendering at body size. */
 .t-h3 {
-  font-size: 16px;
-  font-weight: 600;
+  font-family: var(--f-display);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-semibold);
   color: var(--textPrimary);
 }
 .t-label {
-  font-size: 12.5px;
+  font-size: var(--fs-meta);
   font-weight: 600;
   color: var(--textMeta);
 }
 .t-caption {
-  font-size: 12.5px;
+  font-size: var(--fs-meta);
   color: var(--textMeta);
 }
 .t-sub {
-  font-size: 13px;
+  font-size: var(--fs-sm);
   color: var(--textMeta);
 }
 .t-body {
-  font-size: 14px;
+  font-size: var(--fs-body);
   color: var(--textContent);
 }
 .t-mono {

--- a/frontend/src/design-system/base.css
+++ b/frontend/src/design-system/base.css
@@ -560,7 +560,7 @@ a:not([class]):focus-visible {
 }
 .t-label {
   font-size: var(--fs-meta);
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
   color: var(--textMeta);
 }
 .t-caption {

--- a/frontend/src/design-system/conformance.test.ts
+++ b/frontend/src/design-system/conformance.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, it } from "vitest";
 
 // The two source-wide design gates from B-EP09.1, derived from the tree so a
 // new file is enrolled the moment it exists:
-//  - exactly three type families (Outfit / DM Sans / JetBrains Mono, §2) — any
+//  - exactly three type families (Bricolage Grotesque / Geist / Geist Mono, §2) — any
 //    other font-family fails the build;
 //  - every colour reads from a token — literal colours live only in tokens.css.
 
@@ -52,9 +52,9 @@ const files = sourceFiles(join(frontendRoot, "src"))
   .concat(extensionFrontends());
 
 const allowedFamilies = new Set([
-  "Outfit",
-  "DM Sans",
-  "JetBrains Mono",
+  "Bricolage Grotesque",
+  "Geist",
+  "Geist Mono",
   // stack fallbacks named in the §2 token definitions
   "system-ui",
   "sans-serif",

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -76,6 +76,15 @@
    * ground is see-through, and the alpha is what makes the strip show the
    * content sliding past it. */
   --bgTopbar: rgba(244, 248, 246, 0.9);
+  /* One translucent pane per zone (DESIGN.md §5): white over the lit ground
+   * with a blur behind it, and a hairline for its edge. The two glows are the
+   * chrome — an emerald light at the top-left corner behind the sidebar and an
+   * indigo one at the bottom-right — faint enough that the eye does not find
+   * them; they are atmosphere, not a feature. */
+  --pane: rgba(255, 255, 255, 0.72);
+  --paneEdge: rgba(16, 26, 21, 0.08);
+  --glowA: rgba(24, 190, 120, 0.06);
+  --glowB: rgba(91, 97, 214, 0.1);
 
   --accent: #0b7a53;
   /* The accent as TEXT, split from the accent as a FILL, and now diverging from
@@ -251,8 +260,8 @@
   --dangerBg: rgba(239, 68, 68, 0.1);
 
   --r-sm: 8px;
-  --r-md: 12px;
-  --r-lg: 20px;
+  --r-md: 14px;
+  --r-lg: 18px; /* the pane */
   --r-full: 9999px;
 
   /* The height of an interactive control, in its two sizes. A button, a text
@@ -316,9 +325,13 @@
    * is, and the two went out of step by 60px of viewport width. */
   --stickyBottomInset: var(--space-2);
 
-  --f-display: "Outfit", system-ui, sans-serif;
-  --f-body: "DM Sans", system-ui, sans-serif;
-  --f-mono: "JetBrains Mono", ui-monospace, monospace;
+  /* Three families (DESIGN.md §4): a display face with character for the one
+   * line a reader identifies a record by, a quiet grotesk for everything read,
+   * and a mono with tabular figures for every number, so figures align in a
+   * column and never look like words. */
+  --f-display: "Bricolage Grotesque", system-ui, sans-serif;
+  --f-body: "Geist", system-ui, sans-serif;
+  --f-mono: "Geist Mono", ui-monospace, monospace;
 
   /*
    * Type scale (design §2 three-family rule, this file's numeric half).
@@ -338,12 +351,12 @@
   --fs-eyebrow: 11px; /* uppercase kickers, section labels */
   --fs-meta: 12px; /* counts, provenance, timestamps */
   --fs-sm: 13px; /* dense UI: chips, table cells, helper text */
-  --fs-body: 14px; /* the default reading size */
+  --fs-body: 13.5px; /* the default reading size */
   --fs-lead: 15px; /* the one paragraph under a heading; inputs */
   --fs-h3: 17px; /* card title */
   --fs-h2: 20px; /* section title */
   --fs-h1: 24px; /* the title of a step */
-  --fs-display: 30px; /* the title of a full-viewport moment */
+  --fs-display: 32px; /* a record's name; the title of a full-viewport moment */
   /* Two fluid rungs, for the two surfaces that own a whole viewport and
      therefore have room to answer to it: the gate and the handoff scene. */
   --fs-display-fluid: clamp(24px, 2.6vw, 32px);
@@ -361,13 +374,13 @@
      is read as a shape, relaxed for prose that is read as sentences. */
   --lh-tight: 1.15;
   --lh-snug: 1.3;
-  --lh-normal: 1.45;
+  --lh-normal: 1.55;
   --lh-relaxed: 1.6;
 
   /* Tracking. Only two directions matter: display type set large enough that
      the default spacing reads loose, and uppercase micro-type where the
      default reads cramped. Everything else is 0 and says so. */
-  --tracking-display: -0.02em;
+  --tracking-display: -0.03em;
   --tracking-normal: 0;
   --tracking-eyebrow: 0.08em;
 
@@ -392,7 +405,9 @@
    *
    * Read by every panel and card in the tree through this one token, so the
    * elevation of a card is not a decision any screen gets to make. */
-  --shadow-card: 0 2px 4px -1px #0000000f;
+  /* A pane is separated by its ground and its hairline (--paneEdge), not by a
+   * drop shadow; the card shadow is kept as a hairline so nothing floats. */
+  --shadow-card: 0 0 0 1px #0000000a;
   --shadow-pop: 0 8px 30px rgba(41, 37, 36, 0.14);
 
   /*
@@ -509,6 +524,10 @@
      theme's page colour. It used to be the ELEVATED ground, which made the
      strip read as a card laid over the top of the window. */
   --bgTopbar: rgba(14, 27, 22, 0.9);
+  --pane: rgba(20, 36, 32, 0.72);
+  --paneEdge: rgba(255, 255, 255, 0.08);
+  --glowA: rgba(24, 190, 120, 0.1);
+  --glowB: rgba(91, 97, 214, 0.2);
 
   --accent: #16a34a;
   /* --textOnAccent stays light in dark mode: it is the shared ink for every
@@ -631,6 +650,10 @@
     --bgSidebar: #06100d;
     --bgSidebarHover: #0c1814;
     --bgTopbar: rgba(14, 27, 22, 0.9);
+    --pane: rgba(20, 36, 32, 0.72);
+    --paneEdge: rgba(255, 255, 255, 0.08);
+    --glowA: rgba(24, 190, 120, 0.1);
+    --glowB: rgba(91, 97, 214, 0.2);
 
     --accent: #16a34a;
 

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -589,15 +589,13 @@
      control boundary, held to the same 1.4.11 floor. */
   --borderControl: #5f7a6e;
 
-  /* Themed, because the light value is a 6% black — invisible on #0e1b16. Any
-     card whose separation depends on its shadow simply lost its edge in dark,
-     and the login surface's brand pane is exactly that case: its fill sits
-     within a couple of ΔE of the pane behind it, so with no shadow the two-pane
-     split had no visible boundary at all. The GEOMETRY is the light theme's,
-     because a card sits the same distance off the page in either theme; only the
-     alpha is a theme's decision, and on a dark ground it has to be most of the
-     way to opaque to read at all. */
-  --shadow-card: 0 2px 4px -1px rgba(0, 0, 0, 0.5);
+  /* Themed, because the light hairline is a 4% black — invisible on #0e1b16.
+     Any card whose separation depends on it simply lost its edge in dark, and
+     the login surface's brand pane is exactly that case: its fill sits within
+     a couple of ΔE of the pane behind it. The GEOMETRY is the light theme's
+     (a hairline, not a drop shadow); only the ink is a theme's decision, and
+     on a dark ground the edge is a faint white rather than a faint black. */
+  --shadow-card: 0 0 0 1px #ffffff14;
   --shadow-pop: 0 8px 30px rgba(0, 0, 0, 0.55);
 
   /* higher alpha so the teal read-pill fill stays legible on the darker card
@@ -690,7 +688,7 @@
 
     --borderControl: #5f7a6e;
 
-    --shadow-card: 0 2px 4px -1px rgba(0, 0, 0, 0.5);
+    --shadow-card: 0 0 0 1px #ffffff14;
     --shadow-pop: 0 8px 30px rgba(0, 0, 0, 0.55);
 
     --tealLight: rgba(14, 116, 144, 0.28);

--- a/frontend/src/design-system/tokens.test.ts
+++ b/frontend/src/design-system/tokens.test.ts
@@ -69,12 +69,12 @@ const canonical: Record<string, string> = {
   "--danger": "#b91c1c",
   "--dangerBg": "rgba(239,68,68,.1)",
   "--r-sm": "8px",
-  "--r-md": "12px",
-  "--r-lg": "20px",
+  "--r-md": "14px",
+  "--r-lg": "18px",
   "--r-full": "9999px",
-  "--f-display": '"Outfit",system-ui,sans-serif',
-  "--f-body": '"DM Sans",system-ui,sans-serif',
-  "--f-mono": '"JetBrains Mono",ui-monospace,monospace',
+  "--f-display": '"Bricolage Grotesque",system-ui,sans-serif',
+  "--f-body": '"Geist",system-ui,sans-serif',
+  "--f-mono": '"Geist Mono",ui-monospace,monospace',
 };
 
 function normalize(value: string): string {


### PR DESCRIPTION
## What

Step 1 of the design adoption plan (`docs/how-to/adopt-the-design.md`, arriving in #3833): the token layer only, no component or page changes.

- **Fonts.** Bricolage Grotesque for display, Geist for body, Geist Mono for figures. Changed in the four places the font lock checks: `tokens.css` (`--f-*`), the Google Fonts link in `index.html`, the `allowedFamilies` list in `conformance.test.ts`, and the strip list in `scripts/check-font-lock.sh`.
- **Type scale.** Body 13.5px at 1.55 line height; display 32px with -0.03em tracking. The `.t-*` classes in `base.css` now read the scale (`.t-display`/`.t-h2`/`.t-h3` take the display face), and `body` in `app.css` reads the body tokens.
- **Radii and card edge.** `--r-md` 14px, `--r-lg` 18px; `--shadow-card` becomes a hairline instead of a drop shadow.
- **Pane tokens.** New `--pane`, `--paneEdge`, `--glowA`, `--glowB` in the light arm and byte-equal in both dark arms, for the translucent panes the later steps build on.
- `frontend/README.md` names the new families.

## Why

The visual language in `DESIGN.md` starts from the tokens: everything above them (atoms, record primitives, shell, then the record pages) is a separate PR each so review stays small and each step lands green on its own.

## How verified

- [x] `make fe-ds-gates` green: font lock, purity, spacing, `tokens.test.ts` (pin table, luminance ladders, AA contrast, dark arms byte-equal), conformance, catalog, eyebrow and one-card tests.
- [x] `make fe-lint` green.
- [x] Full unit suite: 5812 of 5816 pass. The four failures (`aiusage`, `buyerroom`, `personstrip`) fail identically on `origin/main` or on this branch's base in a clean worktree, so they are not caused by this change.

## AI involvement

Written by Claude Code with the author reviewing every hunk.

## Accountability

The author has read the diff and takes responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC

---
_Generated by [Claude Code](https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Step 1 of the design adoption plan: the token layer only, no component or page changes. Swaps the three font families for Bricolage Grotesque, Geist, and Geist Mono, updates the type scale and radii, and adds pane tokens for the translucent panes later steps build on.

- Font lock updated in all four places it checks, so the new families pass the gate.
- Type classes read the scale from tokens instead of hard-coded pixels; display, h2, and h3 use the display face and its tracking, and `.t-label` takes its weight from `--fw-semibold`.
- Body text moves to 13.5px at 1.55 line height; display to 32px with -0.03em tracking.
- `--r-md` and `--r-lg` move to 14px and 18px; the card shadow becomes a hairline in the light and both dark arms.
- New `--pane`, `--paneEdge`, `--glowA`, and `--glowB` tokens in the light arm and both dark arms.
- The meeting-brief settle check now ignores paint-only transitions, which cannot move a box.
- All gates pass: font lock, purity, spacing, token tests, conformance, catalog, and the eyebrow and one-card tests.

<sup>Written for commit 9458af50f6a3e538e8144d66cb0849960e7778d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated interface typography to use Bricolage Grotesque, Geist, and Geist Mono.
  - Refined font sizing, line heights, letter spacing, and heading styles for more consistent readability.
  - Updated corner radii and card shadow styling.
  - Added light and dark glass-pane styling tokens for themed surfaces.
  - Improved typography and spacing consistency across interface elements.

- **Documentation**
  - Updated frontend documentation to reflect the current typeface families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->