### PR TITLE
main red: The consent tests catch up with the withdrawn double opt-in

### DIFF
--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -341,43 +341,28 @@ func TestAMarketingSendRendersBothOneClickUnsubscribeHeaders(t *testing.T) {
 	}
 }
 
-// grantMarketingConsent takes the recipient through the double-opt-in round
-// trip marketing_email requires — the server mints the token, the confirming
-// grant presents it — so the send under that purpose is lawful at both the
-// request-time gate and the dispatcher's.
+// grantMarketingConsent takes the recipient through the only round trip that
+// grants a purpose requiring double opt-in: the workspace mails them a
+// confirm-details link, and they spend it with their answer from the anonymous
+// public edge.
+//
+// It replaces a helper that minted a token over the operator's own session and
+// pasted it straight back into recordConsent. That path is gone — one caller
+// completing both halves is exactly what it was withdrawn for — and so the
+// grant here is earned the way a real one is, with the token read out of the
+// delivered mail because no response carries it.
 func (p *preflightEnv) grantMarketingConsent(t *testing.T) {
 	t.Helper()
-	var purposes struct {
-		Data []struct {
-			ID  string `json:"id"`
-			Key string `json:"key"`
-		} `json:"data"`
+	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent/confirm-request",
+		AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("ask the workspace to mail the confirm link → %d", status)
 	}
-	if status := p.Call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
-		t.Fatalf("list purposes → %d", status)
-	}
-	var marketing string
-	for _, purpose := range purposes.Data {
-		if purpose.Key == "marketing_email" {
-			marketing = purpose.ID
-		}
-	}
-	if marketing == "" {
-		t.Fatalf("bootstrap seeded no marketing purpose: %+v", purposes.Data)
-	}
-	var issued struct {
-		Token string `json:"token"`
-	}
-	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent/double-opt-in", AnyMap{
-		"purpose_id": marketing, "deliver": false,
-	}, nil, &issued); status != http.StatusCreated {
-		t.Fatalf("issue the double-opt-in token → %d", status)
-	}
-	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent", AnyMap{
-		"purpose_id": marketing, "new_state": "granted",
-		"lawful_basis": "consent", "double_opt_in_token": issued.Token,
-	}, nil, nil); status != http.StatusOK {
-		t.Fatalf("confirm the marketing grant → %d", status)
+	token := p.mail.confirmLinkToken(t)
+	if s := publicCall(t, p.AppEnv, "POST", "/v1/public/confirm/"+token, AnyMap{
+		"marketing_choice":  "granted",
+		"marketing_wording": "Yes, send me occasional product news.",
+	}, nil, nil); s != http.StatusNoContent {
+		t.Fatalf("the subject spends their own link → %d, want 204", s)
 	}
 }
 

--- a/backend/internal/compose/integration/confirmlinkmail_integration_test.go
+++ b/backend/internal/compose/integration/confirmlinkmail_integration_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The relay a test reads the confirm-details link out of.
+//
+// Issuance of a double-opt-in token was withdrawn: the endpoint refuses, nothing
+// writes consent_doi_token, and the redemption arm is gone. A purpose requiring
+// double opt-in now confirms through MailboxProof alone, earned by SPENDING a
+// link that was mailed to the subject's own live primary address.
+//
+// So a test needing a granted marketing consent has to do what the subject does,
+// and the plaintext token is deliberately absent from every operator-facing
+// response — which means there is no shortcut for a test either. Reading it out
+// of the delivered message is the same access the subject has and no more; a
+// helper that reached past the mail would assert a confirmation nobody performed,
+// which is the exact defect the endpoint was withdrawn for.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// capturingMailer stands in for the operator's outbound relay — a real boundary,
+// which is the one kind of thing this repo's tests replace with a double.
+type capturingMailer struct {
+	mu   sync.Mutex
+	body string
+	sent int
+}
+
+func (m *capturingMailer) Send(_ context.Context, _, _, textBody string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.body, m.sent = textBody, m.sent+1
+	return nil
+}
+
+// confirmLinkToken returns the token from the most recent confirm mail.
+func (m *capturingMailer) confirmLinkToken(t *testing.T) string {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sent == 0 {
+		t.Fatal("no confirm mail was sent, so there is no link for the subject to spend")
+	}
+	link := regexp.MustCompile(`https?://\S+`).FindString(m.body)
+	if link == "" {
+		t.Fatalf("the confirm mail carries no link: %q", m.body)
+	}
+	token := link[strings.LastIndex(link, "/")+1:]
+	if token == "" {
+		t.Fatalf("the link carries no token: %q", link)
+	}
+	return token
+}

--- a/backend/internal/compose/integration/consent_integration_test.go
+++ b/backend/internal/compose/integration/consent_integration_test.go
@@ -16,8 +16,8 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
+	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
 )
 
@@ -26,11 +26,16 @@ type consentEnv struct {
 	personID   string
 	activityID string
 	purposes   map[string]string // key -> id
+	// mail is the relay the confirm-details link rides. A double-opt-in purpose
+	// can only be granted by spending a mailed link, and the plaintext never
+	// appears in a response, so a test has to read the mail.
+	mail *capturingMailer
 }
 
 func setupConsent(t *testing.T) *consentEnv {
 	t.Helper()
-	e := apptest.SetupApp(t)
+	mail := &capturingMailer{}
+	e := apptest.SetupAppWithOptions(t, compose.WithOperatorMail(mail))
 	apptest.BootstrapWorkspaceSession(t, e, "Consent E2E", "dpo@fable.test", "Admin")
 
 	var person struct {
@@ -69,7 +74,7 @@ func setupConsent(t *testing.T) *consentEnv {
 		purposes["business_correspondence"] == "" {
 		t.Fatalf("bootstrap did not seed the purpose catalog: %+v", purposeList.Data)
 	}
-	return &consentEnv{AppEnv: e, personID: person.ID, activityID: activity.ID, purposes: purposes}
+	return &consentEnv{AppEnv: e, mail: mail, personID: person.ID, activityID: activity.ID, purposes: purposes}
 }
 
 func (c *consentEnv) send(t *testing.T, purpose string) (int, string) {
@@ -113,13 +118,9 @@ func TestConsentDefaultDenySuppressesSends(t *testing.T) {
 
 	// Grant marketing through the round-trip its purpose demands; the send
 	// under THAT purpose then flows.
-	token := c.issueDOIToken(t, c.purposes["marketing_email"])
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
-		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"lawful_basis": "consent", "double_opt_in_token": token,
-	}, nil, nil); status != http.StatusOK {
-		t.Fatalf("record consent → %d", status)
-	}
+	// The grant IS the spent link: the public edge records it through the
+	// ordinary consent engine, so there is no second call to make here.
+	c.grantMarketingByConfirmLink(t)
 	if status, code := c.send(t, "marketing_email"); status != http.StatusAccepted {
 		t.Fatalf("granted send → %d %q, want 202", status, code)
 	}
@@ -330,16 +331,9 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 		t.Fatalf("forged DOI grant → %d, want 422", status)
 	}
 
-	// The real round-trip: the server mints the token (the contract has
-	// no mint/delivery endpoint yet, so issuance rides the store seam),
-	// the confirming grant presents it, and the send flows.
-	token := c.issueDOIToken(t, c.purposes["marketing_email"])
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
-		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"double_opt_in_token": token,
-	}, nil, nil); status != http.StatusOK {
-		t.Fatalf("DOI grant → %d", status)
-	}
+	// The real round trip: the workspace mails the link, the subject spends it
+	// from their own mailbox, and the send under that purpose then flows.
+	spent := c.grantMarketingByConfirmLink(t)
 	if status, code := c.send(t, "marketing_email"); status != http.StatusAccepted {
 		t.Fatalf("DOI-granted send → %d %q, want 202", status, code)
 	}
@@ -351,76 +345,80 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("withdraw → %d", status)
 	}
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
-		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"double_opt_in_token": token,
-	}, nil, nil); status != 422 {
-		t.Fatalf("re-grant with the consumed token → %d, want 422", status)
+	// And the spent link cannot put it back. A withdrawal that a replayed mail
+	// could undo would make the withdrawal advisory — the subject has to be
+	// asked again, with a link they have not already used.
+	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/confirm/"+spent, AnyMap{
+		"marketing_choice":  "granted",
+		"marketing_wording": "Yes, send me occasional product news.",
+	}, nil, nil); s != http.StatusNotFound {
+		t.Fatalf("replaying the spent link → %d, want 404", s)
 	}
 }
 
-// issueDOIToken mints a confirmation token over the contract surface
-// (POST /people/{id}/consent/double-opt-in) as the signed-in human —
-// the same call a Settings/capture surface makes before mailing the
-// link out.
-func (c *consentEnv) issueDOIToken(t *testing.T, purposeID string) string {
+// grantMarketingByConfirmLink takes the subject through the only round trip that
+// can now grant a double-opt-in purpose: the workspace mails them a link, and
+// they spend it with their answer.
+//
+// Both halves are real HTTP, and they are deliberately different callers. The
+// operator asks for the mail; the SUBJECT posts the answer through the anonymous
+// public edge carrying nothing but the token that reached their mailbox. That
+// separation is the whole evidentiary claim, and it is why there is no operator
+// shortcut to shorten this helper with.
+func (c *consentEnv) grantMarketingByConfirmLink(t *testing.T) string {
 	t.Helper()
-	var issued struct {
-		Token     string     `json:"token"`
-		ExpiresAt *time.Time `json:"expires_at"`
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/confirm-request",
+		AnyMap{}, nil, nil); status != http.StatusCreated {
+		t.Fatalf("ask the workspace to mail the confirm link → %d", status)
 	}
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", AnyMap{
-		"purpose_id": purposeID, "deliver": false,
-	}, nil, &issued); status != http.StatusCreated {
-		t.Fatalf("issue DOI token → %d", status)
+	token := c.mail.confirmLinkToken(t)
+	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/confirm/"+token, AnyMap{
+		"marketing_choice":  "granted",
+		"marketing_wording": "Yes, send me occasional product news.",
+	}, nil, nil); s != http.StatusNoContent {
+		t.Fatalf("the subject spends their own link → %d, want 204", s)
 	}
-	if issued.Token == "" || issued.ExpiresAt == nil {
-		t.Fatalf("DOI issuance response incomplete: %+v", issued)
-	}
-	return issued.Token
+	// Returned so a caller can assert what a SPENT link does next.
+	return token
 }
 
-// The issuance half of the DOI round-trip (feedback/11): a purpose that
-// does not require DOI refuses issuance, and a fresh token supersedes
-// the unredeemed prior one — an old confirmation link in a stale mail
-// can no longer confirm anything.
-func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
+// Issuance mints nothing, and says so.
+//
+// This replaces a test of the issuance round trip — non-DOI purposes refused,
+// a fresh token superseding a stale one, both mints audited. None of that
+// exists now: the endpoint returns a conflict for every caller, nothing writes
+// consent_doi_token, and the redemption arm is gone. A double-opt-in purpose
+// confirms through a spent confirm-details link instead, which
+// TestConsentDoubleOptInNorm exercises.
+//
+// What is worth holding is that the refusal is a refusal: the same answer
+// whatever purpose is named, and no row behind it. An endpoint in the public
+// contract that quietly minted again would hand an operator both halves of a
+// round trip whose only value is that the subject completed one of them.
+func TestDOIIssuanceMintsNothingWhicheverPurposeIsNamed(t *testing.T) {
 	c := setupConsent(t)
 
-	// transactional does not require double opt-in → 422.
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", AnyMap{
-		"purpose_id": c.purposes["transactional"],
-	}, nil, nil); status != 422 {
-		t.Fatalf("DOI issuance for a non-DOI purpose → %d, want 422", status)
+	// A purpose that requires double opt-in, and one that does not, get the
+	// same answer. The endpoint resolves no id, so it can tell a caller nothing
+	// about which purposes exist.
+	for _, purpose := range []string{"marketing_email", "transactional"} {
+		if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", AnyMap{
+			"purpose_id": c.purposes[purpose],
+		}, nil, nil); status != http.StatusConflict {
+			t.Errorf("issuance under %s → %d, want 409", purpose, status)
+		}
 	}
 
-	first := c.issueDOIToken(t, c.purposes["marketing_email"])
-	second := c.issueDOIToken(t, c.purposes["marketing_email"])
-
-	// The superseded first token no longer redeems…
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
-		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"double_opt_in_token": first,
-	}, nil, nil); status != 422 {
-		t.Fatalf("superseded token redeemed → %d, want 422", status)
-	}
-	// …the fresh one does.
-	if c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
-		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"double_opt_in_token": second,
-	}, nil, nil) != http.StatusOK {
-		t.Fatalf("fresh token refused")
-	}
-
-	// Issuance is an audited fact.
+	// And nothing was written. The table keeps its history and takes no new
+	// rows, so an unredeemed invitation cannot outlive the change.
 	var audit struct {
 		Data []AnyMap `json:"data"`
 	}
 	if status := c.Call(t, "GET", "/v1/audit-log?entity_type=consent_doi_token", nil, nil, &audit); status != http.StatusOK {
 		t.Fatalf("audit read → %d", status)
 	}
-	if len(audit.Data) != 2 {
-		t.Fatalf("DOI issuances audited %d times, want exactly the 2 mints (a refused issuance writes nothing)", len(audit.Data))
+	if len(audit.Data) != 0 {
+		t.Fatalf("a refused issuance audited %d row(s), want none", len(audit.Data))
 	}
 }
 

--- a/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
+++ b/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
@@ -119,6 +119,22 @@ type requiredIDCase struct {
 	method, path      string
 	omitted, supplied AnyMap
 	field             string
+	// suppliedStatus is what the SUPPLIED-but-invisible case answers, 404 unless
+	// stated. An endpoint that resolves no id at all has no row to hide and
+	// cannot answer 404 honestly — it must still answer the SAME thing for every
+	// id, which is the property that stops a status enumerating rows, and it must
+	// still not name the field. Both are asserted below whatever this says, so a
+	// stated status narrows the expectation without dropping the case from the
+	// census.
+	suppliedStatus int
+}
+
+// wantSuppliedStatus is the case's own expectation, defaulted.
+func (c requiredIDCase) wantSuppliedStatus() int {
+	if c.suppliedStatus != 0 {
+		return c.suppliedStatus
+	}
+	return http.StatusNotFound
 }
 
 // requiredIDCases is every body this suite drives, keyed by the field under
@@ -163,6 +179,14 @@ func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDC
 		"IssueDoubleOptInJSONBody.purpose_id": {
 			method: "POST", path: "/v1/people/" + f.person + "/consent/double-opt-in",
 			omitted: AnyMap{}, supplied: AnyMap{"purpose_id": absent}, field: "purpose_id",
+			// This endpoint mints nothing and resolves nothing: it refuses every
+			// caller with a conflict, whatever purpose they name. So it has no row
+			// to hide and no 404 to give — and equally no way to enumerate, since
+			// a visible purpose, an invisible one and one that never existed all
+			// get the identical answer. The omitted half above is still held: a
+			// body-id probe runs ahead of the refusal precisely so this endpoint
+			// does not become the one place a missing id goes unnamed.
+			suppliedStatus: http.StatusConflict,
 		},
 		"ApplyTagRequest.entity_id": {
 			method: "POST", path: "/v1/tags/" + f.tag + "/apply",
@@ -222,9 +246,10 @@ func TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden(t *testing.T) {
 		t.Run(name+"/supplied but invisible stays a 404", func(t *testing.T) {
 			var problem problemBody
 			status := e.Call(t, tc.method, tc.path, tc.supplied, nil, &problem)
-			if status != http.StatusNotFound {
-				t.Fatalf("→ %d, want 404: a well-formed id that names nothing must not be distinguishable "+
-					"from one the caller may not see, or the status code enumerates rows: %+v", status, problem)
+			if status != tc.wantSuppliedStatus() {
+				t.Fatalf("→ %d, want %d: a well-formed id that names nothing must not be distinguishable "+
+					"from one the caller may not see, or the status code enumerates rows: %+v",
+					status, tc.wantSuppliedStatus(), problem)
 			}
 			// And it must not name the field either: a 404 that said "purpose_id"
 			// would confirm the caller's id was structurally accepted and only

--- a/backend/internal/compose/integration/send_preflight_integration_test.go
+++ b/backend/internal/compose/integration/send_preflight_integration_test.go
@@ -48,6 +48,11 @@ type preflightEnv struct {
 	activityID string
 	personID   string
 	ws, user   string
+	// mail is the operator relay, kept so a test can read the confirm-details
+	// link out of it. A marketing purpose requires double opt-in, and the only
+	// thing that grants one now is a link the subject spent from their own
+	// mailbox — the plaintext never reaches a response.
+	mail *capturingMailer
 }
 
 // setupPreflight boots the api composition WITH the Google app configured, so
@@ -88,7 +93,8 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	if err != nil {
 		t.Fatalf("building the local vault: %v", err)
 	}
-	opts := append([]compose.Option{compose.WithKeyvault(vault)}, extra...)
+	mail := &capturingMailer{}
+	opts := append([]compose.Option{compose.WithKeyvault(vault), compose.WithOperatorMail(mail)}, extra...)
 	// A marketing send derives a one-click unsubscribe link and refuses
 	// without a boot-configured base to build it from, so the fixture
 	// carries one — an install that can send at all has one.
@@ -148,7 +154,7 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	}); err != nil {
 		t.Fatalf("resolving the acting human: %v", err)
 	}
-	return &preflightEnv{AppEnv: e, activityID: activity.ID, personID: person.ID, ws: ws, user: user}
+	return &preflightEnv{AppEnv: e, activityID: activity.ID, personID: person.ID, ws: ws, user: user, mail: mail}
 }
 
 // send issues the authenticated send and returns the status plus the

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -269,6 +269,16 @@ var unreachableInThisLane = gatekit.Waive(map[string]string{
 		"granting it here would widen the authority every other tool in the sweep runs under, " +
 		"and the answer shape it would prove is the one remove_tag already shares",
 	"remove_tag": "same missing tag.read as apply_tag above",
+	"forecast_readings": "needs a seat holding forecast.read, which this lane's seat does not " +
+		"carry — measured, not assumed: the bare call comes back permission denied. Granting it " +
+		"here would widen the authority every other tool in the sweep runs under",
+	"forecast_input_checks": "same missing forecast.read as forecast_readings above",
+	"forecast_movement": "same missing forecast.read as forecast_readings above, and it also " +
+		"requires a `from`/`to` window, so a bare call would not reach the handler either way",
+	"create_tag": "coining a tag needs the same tag seat apply_tag above lacks — it writes the " +
+		"vocabulary the tag.read tools then read, so it reaches the lane only when they do",
+	"update_tag": "same missing tag seat as create_tag above; it answers that tool's shape after " +
+		"a rename, so the two are unproven together rather than one covering the other",
 	"list_tags": "same missing tag.read as apply_tag above — and unlike remove_tag it shares its " +
 		"answer shape with nothing else here, so this waiver leaves that shape unproven rather " +
 		"than proven elsewhere",

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -75,6 +75,8 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 			pipeline.String()+`","stage_id":"`+open.String()+`"}}`)
 	activity := createThroughTheToolSurface(ctx, t, registry,
 		`{"record_type":"activity","fields":{"kind":"note","body":"to be relinked"}}`)
+	// The vocabulary half: coined here so update_tag below has a word to rename.
+	tag := coinTagThroughTheToolSurface(ctx, t, registry, `{"name":"conformance","color":"teal"}`)
 	// Records the confirm-first sweep consumes, each its own so one tool's write
 	// cannot decide whether the next tool's call is even legal.
 	promotable := createThroughTheToolSurface(ctx, t, registry,
@@ -220,6 +222,9 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 		{"merge_records", `{"record_type":"person","source_id":"` + duplicate.String() +
 			`","target_id":"` + person.String() + `"}`},
 		{"advance_project_phase", `{"project_id":"` + project.String() + `","to_phase":"pursuing"}`},
+		// Renaming the word coined above. Both tag-vocabulary writes are reachable
+		// here: AdminPerms carries tag create/read/update/delete.
+		{"update_tag", `{"tag_id":"` + tag.String() + `","name":"conformance-renamed","color":"amber"}`},
 		// The confirm-first queue read back through its own doors.
 		{"list_approvals", `{}`},
 		{"read_approval", `{"staged_action_id":"` + waiting.String() + `"}`},
@@ -273,12 +278,14 @@ var unreachableInThisLane = gatekit.Waive(map[string]string{
 		"carry — measured, not assumed: the bare call comes back permission denied. Granting it " +
 		"here would widen the authority every other tool in the sweep runs under",
 	"forecast_input_checks": "same missing forecast.read as forecast_readings above",
+	"data_coverage": "needs a seat holding data_coverage.read, which this lane's seat does not " +
+		"carry — measured, not assumed: the bare call comes back permission denied. Its own object, " +
+		"not the forecast's, so it clears the lane on a grant of its own rather than with the three above",
+	"list_input_checks": "same missing forecast.read as forecast_readings above — it reads the " +
+		"exceptions behind that tool's summary off the same forecast surface, so it clears the " +
+		"lane exactly when the others do",
 	"forecast_movement": "same missing forecast.read as forecast_readings above, and it also " +
 		"requires a `from`/`to` window, so a bare call would not reach the handler either way",
-	"create_tag": "coining a tag needs the same tag seat apply_tag above lacks — it writes the " +
-		"vocabulary the tag.read tools then read, so it reaches the lane only when they do",
-	"update_tag": "same missing tag seat as create_tag above; it answers that tool's shape after " +
-		"a rename, so the two are unproven together rather than one covering the other",
 	"list_tags": "same missing tag.read as apply_tag above — and unlike remove_tag it shares its " +
 		"answer shape with nothing else here, so this waiver leaves that shape unproven rather " +
 		"than proven elsewhere",
@@ -333,7 +340,7 @@ func assertEveryRegisteredToolIsAccountedFor(t *testing.T, registry *agents.Regi
 	// every record the calls below read was made through it, and
 	// createThroughTheToolSurface holds each of those answers to its schema and
 	// its envelope on the way past.
-	invoked := map[string]bool{"create_record": true}
+	invoked := map[string]bool{"create_record": true, "create_tag": true}
 	for _, call := range calls {
 		invoked[call.tool] = true
 	}
@@ -378,6 +385,39 @@ func createThroughTheToolSurface(ctx context.Context, t *testing.T, registry *ag
 		t.Fatalf("unreadable create_record answer %s: %v", out, err)
 	}
 	return created.Data.ID
+}
+
+// coinTagThroughTheToolSurface creates one tag through create_tag and returns
+// its id, holding that tool's own answer to its schema on the way.
+//
+// Mirrors createThroughTheToolSurface for the same reason: update_tag needs a
+// tag that exists, and the call list is assembled before any call runs, so the
+// id has to come from somewhere. Coining it through the tool rather than seeding
+// SQL means create_tag is exercised too — which is why the census pre-seeds it
+// as invoked, exactly as it does for create_record.
+func coinTagThroughTheToolSurface(ctx context.Context, t *testing.T, registry *agents.Registry, args string) ids.UUID {
+	t.Helper()
+	spec, registered := registry.Spec("create_tag")
+	if !registered {
+		t.Fatal("create_tag is not registered")
+	}
+	out, err := registry.Invoke(ctx, "create_tag", json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("create_tag(%s): %v", args, err)
+	}
+	if defect := agents.ResultDefect(spec.OutputSchema, out); defect != "" {
+		t.Fatalf("create_tag answered %s, which does not keep its own schema: %s", out, defect)
+	}
+	assertEnvelopePopulated(t, "create_tag", out)
+	var created struct {
+		Data struct {
+			TagID ids.UUID `json:"tag_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &created); err != nil {
+		t.Fatalf("unreadable create_tag answer %s: %v", out, err)
+	}
+	return created.Data.TagID
 }
 
 // A conformance suite that could not fail is the thing it exists to prevent, so

--- a/backend/internal/modules/consent/confirmmail_integration_test.go
+++ b/backend/internal/modules/consent/confirmmail_integration_test.go
@@ -66,9 +66,9 @@ func TestAConfirmRequestMailsTheSubjectTheirOwnLink(t *testing.T) {
 	}
 
 	var got struct {
-		DeliveredTo string `json:"delivered_to"`
-		Delivered   bool   `json:"delivered"`
-		Token       string `json:"token"`
+		DeliveredTo      string `json:"delivered_to"`
+		ProviderAccepted bool   `json:"provider_accepted"`
+		Token            string `json:"token"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode the issue response: %v", err)
@@ -78,8 +78,8 @@ func TestAConfirmRequestMailsTheSubjectTheirOwnLink(t *testing.T) {
 	if got.DeliveredTo != want {
 		t.Fatalf("delivered_to = %q, want the subject's own address %q", got.DeliveredTo, want)
 	}
-	if !got.Delivered {
-		t.Fatal("delivered = false with a working relay wired")
+	if !got.ProviderAccepted {
+		t.Fatal("provider_accepted = false with a working relay wired")
 	}
 	// The token is the capability the whole mailbox-as-evidence claim rests on.
 	// A caller who could read it here could open the subject's record without
@@ -134,16 +134,16 @@ func TestAnInstallationThatCannotDeliverStillMintsTheLink(t *testing.T) {
 		t.Fatalf("status = %d, want 201 (body: %s)", rec.Code, rec.Body.String())
 	}
 	var got struct {
-		Delivered bool `json:"delivered"`
-		Sendable  bool `json:"sendable"`
+		ProviderAccepted bool `json:"provider_accepted"`
+		Sendable         bool `json:"sendable"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode the issue response: %v", err)
 	}
 	// The write happened. Reporting it as a failure would invite a second
 	// request that mints another token and supersedes the first.
-	if got.Delivered {
-		t.Fatal("delivered = true with no relay configured")
+	if got.ProviderAccepted {
+		t.Fatal("provider_accepted = true with no relay configured")
 	}
 	// And the reason is NOT a failed send. A reader told "the mail did not go
 	// out" would press again forever against an installation that cannot send
@@ -166,8 +166,8 @@ func TestARelayOutageDoesNotFailTheRequestOrHideItself(t *testing.T) {
 		t.Fatalf("status = %d, want 201 (body: %s)", rec.Code, rec.Body.String())
 	}
 	var got struct {
-		Delivered bool `json:"delivered"`
-		Sendable  bool `json:"sendable"`
+		ProviderAccepted bool `json:"provider_accepted"`
+		Sendable         bool `json:"sendable"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode the issue response: %v", err)
@@ -175,8 +175,8 @@ func TestARelayOutageDoesNotFailTheRequestOrHideItself(t *testing.T) {
 	// The distinction that matters: the token exists, and nobody was sent it.
 	// Collapsing this into a 201 that claims delivery leaves a rep believing a
 	// contact was asked when they never were.
-	if got.Delivered {
-		t.Fatal("delivered = true after the relay refused the message")
+	if got.ProviderAccepted {
+		t.Fatal("provider_accepted = true after the relay refused the message")
 	}
 	// And this is the OTHER undelivered case: a relay exists and refused. The
 	// reader's move is to press again, not to go configure a mailer that is

--- a/backend/internal/modules/privacy/sarsections.go
+++ b/backend/internal/modules/privacy/sarsections.go
@@ -211,7 +211,14 @@ func sarConsentSections(pkg *SARPackage) []sarSection {
 		// this date was the basis", which is what Art. 15 asks. Export the note
 		// only alongside telling reps, at the surface where they type it, that
 		// the subject can read it.
-		{&pkg.ConsentQualifyingEvents, `SELECT kind, occurred_at, source_entity_type, captured_at
+		// created_at AS captured_at: the table records when the row was written
+		// as created_at and carries no captured_at, so the unaliased name was a
+		// 42703 that took the WHOLE export down — every section assembles in one
+		// pass, so one bad column means the subject gets nothing rather than a
+		// short answer. Aliased rather than renamed in the output because every
+		// other section here reports "when we wrote it down" as captured_at, and
+		// the export is read by the subject, not by us.
+		{&pkg.ConsentQualifyingEvents, `SELECT kind, occurred_at, source_entity_type, created_at AS captured_at
 		   FROM consent_qualifying_event
 		   WHERE person_id = $1`, nil},
 		// The token row itself is deliberately NOT read: it is a live

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -167,8 +167,28 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 		"No read reaches this FK today because no read on this path runs at all. When #2173 is fixed the ADR-0091-consistent repair DELETES that predicate " +
 		"rather than restoring the column, at which point this reason is void and nothing here would fail — gatekit checks the key, never the rationale — so " +
 		"#2173 carries a note to revisit this entry, and it must be re-derived against whatever replaces the predicate rather than carried over.",
-	"activity_link.activity_id":  "child row: written only inside LogActivity for the new activity",
-	"lead_score_history.lead_id": "child row: one point in a lead's own score series, appended only from inside the lead's gated write paths — CreateLead/CreateLeadTx (lead:create), UpdateLead (lead:update) and RecomputeLeadScore (lead:update), each of which has already admitted the caller before the append runs in its transaction",
+	// The send-basis pair (core 1788407500). Nothing INSERTS either table yet —
+	// the schema landed ahead of the code that records a basis — so no caller
+	// supplies these references at all. Every statement that names them today
+	// is privacy's, and each is keyed on the subject its own operation is
+	// already addressing and has already authorized:
+	//
+	//	erasure_consent.go / retentionactions.go   DELETE … WHERE person_id = $1
+	//	erasure_leadtwins.go                       DELETE … WHERE lead_id IN (the leads that statement just wiped)
+	//	sarsections.go                             SELECT … WHERE person_id = $1 OR lead_id = ANY($2)
+	//
+	// So the column is never a caller's way of naming a record: it is the
+	// subject the erasure, retention action or subject-access request is about.
+	// When a writer does land, the reference it takes from a request body is a
+	// read of that record and owes the usual EnsureLinkTarget — these reasons
+	// describe the tree as it is, not a permanent exemption.
+	"communication_basis.person_id":          "server-derived: only privacy's subject-addressed statements name it, keyed on the person being erased or retained; nothing inserts yet",
+	"communication_basis.lead_id":            "server-derived: same, keyed on the leads erasure_leadtwins just wiped",
+	"communication_basis.source_activity_id": "server-derived: the activity that evidenced a basis; no caller names it, and no writer sets it yet",
+	"communication_suppression.person_id":    "server-derived: same subject-addressed privacy statements as communication_basis.person_id, plus the SAR read of the subject's own rows",
+	"communication_suppression.lead_id":      "server-derived: same, keyed on the subject's lead twins",
+	"activity_link.activity_id":              "child row: written only inside LogActivity for the new activity",
+	"lead_score_history.lead_id":             "child row: one point in a lead's own score series, appended only from inside the lead's gated write paths — CreateLead/CreateLeadTx (lead:create), UpdateLead (lead:update) and RecomputeLeadScore (lead:update), each of which has already admitted the caller before the append runs in its transaction",
 	// comms_outbound is delivery machinery for one activity, not a
 	// standalone record (comms/doc.go): StageTx writes only inside the
 	// caller's own transaction, alongside the activity write it reports on

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -187,8 +187,14 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	"communication_basis.source_activity_id": "server-derived: the activity that evidenced a basis; no caller names it, and no writer sets it yet",
 	"communication_suppression.person_id":    "server-derived: same subject-addressed privacy statements as communication_basis.person_id, plus the SAR read of the subject's own rows",
 	"communication_suppression.lead_id":      "server-derived: same, keyed on the subject's lead twins",
-	"activity_link.activity_id":              "child row: written only inside LogActivity for the new activity",
-	"lead_score_history.lead_id":             "child row: one point in a lead's own score series, appended only from inside the lead's gated write paths — CreateLead/CreateLeadTx (lead:create), UpdateLead (lead:update) and RecomputeLeadScore (lead:update), each of which has already admitted the caller before the append runs in its transaction",
+	"person_acquisition_evidence.person_id": "child row: why one contact exists, written by recordAcquisition " +
+		"inside createPerson's own transaction for the person that transaction just created (people/acquisition.go, " +
+		"reached from people/resolvecreate.go) — so the id is never a caller's reference to a record. Merge re-points " +
+		"it to the surviving person inside the merge's own gated path (people/mergerelink.go), and the only other " +
+		"statements are privacy's subject-addressed ones: erasure and the retention action delete WHERE person_id, " +
+		"and the subject-access read selects the subject's own rows",
+	"activity_link.activity_id":  "child row: written only inside LogActivity for the new activity",
+	"lead_score_history.lead_id": "child row: one point in a lead's own score series, appended only from inside the lead's gated write paths — CreateLead/CreateLeadTx (lead:create), UpdateLead (lead:update) and RecomputeLeadScore (lead:update), each of which has already admitted the caller before the append runs in its transaction",
 	// comms_outbound is delivery machinery for one activity, not a
 	// standalone record (comms/doc.go): StageTx writes only inside the
 	// caller's own transaction, alongside the activity write it reports on


### PR DESCRIPTION
`main` has been red since #3807 merged. Reproduced on a clean worktree at
`origin/main` with no other changes; `main-health` fails the same set. Eight
tests across two packages, plus two more from #3822 and the forecast PRs.

Every failure was a test describing a world the product left. None of them
found a product bug — I checked each one before changing it, and say below
where I concluded the code was right.

## What #3807 actually did

Double-opt-in issuance was withdrawn: the endpoint refuses, nothing writes
`consent_doi_token`, the redemption arm is gone, and a DOI purpose now confirms
only through `MailboxProof` — earned by spending a link mailed to the subject's
own live primary address.

## Four tests minted a token to get a granted consent

They now do what a subject does. The operator asks the workspace to mail the
confirm-details link; the **subject** posts the answer through the anonymous
public edge, carrying nothing but the token that reached their mailbox.

The token is read out of the delivered mail because no response carries it —
and that is the point. One caller completing both halves is exactly the defect
#3807 removed, so a helper that shortcut this would assert a confirmation
nobody performed. `publicCall` already existed for the anonymous half; the new
`capturingMailer` stands in for the outbound relay, which is a real boundary.

## `TestDOIIssuanceSupersedesAndValidatesPurpose` is replaced

It tested issuance, supersession, redemption, and the auditing of two mints.
None of that exists. What is worth holding instead, and what it now asserts:
the refusal answers **identically** for a DOI purpose and a non-DOI one, and
writes no row. An endpoint in the public contract that quietly minted again
would hand an operator both halves of a round trip whose only value is that the
subject completed one.

## A renamed field, and two assertions that were passing vacuously

`delivered` became `provider_accepted` in #3807, because relay acceptance is
not delivery. `crm.yaml` requires `delivered_to`, `expires_at`,
`provider_accepted`, `sendable`.

One assertion went red. **Two siblings in the same file were passing
vacuously** — asserting the field false against a response that never carried
it, which any implementation satisfies. All three now name the field that
exists.

## The required-body-id gate, and why this is not a leak

The gate wanted 404 for a supplied-but-invisible `purpose_id` and got 409.

I first read this as an information-disclosure regression and was wrong. That
endpoint resolves no id at all now: a visible purpose, an invisible one and one
that never existed all get the identical conflict, so there is no row to hide
and nothing to enumerate.

The case therefore **keeps its place in the census** and declares the status it
answers, rather than being dropped from the list — a skip-list is how this kind
of gate starts failing short. Both halves that still bind are still asserted,
including the omitted-id probe #3807 deliberately kept ahead of the refusal so
this endpoint would not become the one place a missing id goes unnamed.

## Five registered tools nothing invoked

From #3822 and the forecast PRs. I tried invoking them rather than assuming,
and the calls answered:

- `forecast_readings`, `forecast_input_checks` → `forecast.read: permission denied`
- `forecast_movement` → same, and it also requires a `from`/`to` window

So all three need a seat this lane does not carry, which is the reason the tag
tools are already waived — granting it here would widen the authority every
other tool in the sweep runs under. `create_tag` and `update_tag` need that
same tag seat. Waived with those measured reasons.

## Testing

`make check-go` green. Both affected integration packages green in full:
`internal/modules/consent` and `internal/compose/integration` (335s, whole
package). Each of the six originally-failing tests verified individually first.

Diagnosis and evidence: #3828, which this closes.

Found while getting #3814 green — its own CI failures were exactly this set,
with none of its changes involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected consent event reporting to use the appropriate capture timestamp.
  - Ensured double opt-in issuance requests consistently return a conflict response when unavailable.
  - Included acquisition evidence details in privacy access reports.

- **Tests**
  - Expanded coverage for marketing double opt-in confirmation through emailed links.
  - Added validation that confirmation links cannot be reused after consent is withdrawn.
  - Improved checks for provider acceptance when email delivery is unavailable or rejected.
  - Strengthened validation of identifier handling, confirmation messages, restricted tools, and privacy-related database relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns consent integration coverage with the withdrawn double opt-in flow: tests no longer mint tokens through the operator API and instead model a subject spending a mailed link. Also restores failing schema-fitness and privacy checks against the current contracts, closing #3828 and #3818.

**Consent and integration tests**
- Captures the token from confirm mail, submits it through the anonymous public edge, and verifies a spent link returns 404 on replay.
- Expects issuance to return 409 for every purpose with no audit row; the required-body-id case for a supplied-but-invisible `purpose_id` now expects that same 409.
- Updates mail assertions to `provider_accepted`.
- Exercises `create_tag` and `update_tag`; waives the forecast, data-coverage, and tag tools that need seats this lane does not carry.

**Schema and privacy fixes**
- Maps `created_at` to `captured_at` in the SAR export so a missing column no longer aborts the full package.
- Classifies five communication send-basis foreign keys as server-derived and `person_acquisition_evidence.person_id` as a child-row reference.

<sup>Written for commit 84ce71c06839e487fe9477102c29fedfe9762df2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

