### PR TITLE
main is red: three suites still drive a retired double opt-in

### DIFF
--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -341,10 +341,17 @@ func TestAMarketingSendRendersBothOneClickUnsubscribeHeaders(t *testing.T) {
 	}
 }
 
-// grantMarketingConsent takes the recipient through the double-opt-in round
-// trip marketing_email requires — the server mints the token, the confirming
-// grant presents it — so the send under that purpose is lawful at both the
-// request-time gate and the dispatcher's.
+// grantMarketingConsent takes the recipient through the round trip
+// marketing_email requires, so the send under that purpose is lawful at both
+// the request-time gate and the dispatcher's.
+//
+// Through the CONFIRM LINK, which is how a double-opt-in purpose is confirmed
+// now: a single-use token minted for the subject's own live address, answered
+// on the anonymous page it opens. The token comes from the store rather than
+// the contract because the contract hands it to nobody — an operator holding
+// the plaintext could close the round trip with the subject's mailbox never
+// taking part, which is why the issuance endpoint that once returned it
+// refuses.
 func (p *preflightEnv) grantMarketingConsent(t *testing.T) {
 	t.Helper()
 	var purposes struct {
@@ -365,20 +372,37 @@ func (p *preflightEnv) grantMarketingConsent(t *testing.T) {
 	if marketing == "" {
 		t.Fatalf("bootstrap seeded no marketing purpose: %+v", purposes.Data)
 	}
-	var issued struct {
-		Token string `json:"token"`
+	person, err := ids.ParseAs[ids.PersonKind](p.personID)
+	if err != nil {
+		t.Fatalf("parsing the person id: %v", err)
 	}
-	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent/double-opt-in", AnyMap{
-		"purpose_id": marketing, "deliver": false,
-	}, nil, &issued); status != http.StatusCreated {
-		t.Fatalf("issue the double-opt-in token → %d", status)
+	issued, err := consent.NewStore(p.DB()).IssueConfirmToken(p.confirmMinterContext(t), person)
+	if err != nil {
+		t.Fatalf("mint the confirm link: %v", err)
 	}
-	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent", AnyMap{
-		"purpose_id": marketing, "new_state": "granted",
-		"lawful_basis": "consent", "double_opt_in_token": issued.Token,
-	}, nil, nil); status != http.StatusOK {
-		t.Fatalf("confirm the marketing grant → %d", status)
+	if status := p.Call(t, "POST", "/v1/public/confirm/"+issued.Token, AnyMap{
+		"marketing_choice":  "granted",
+		"marketing_wording": "Yes, send me product news.",
+	}, nil, nil); status != http.StatusNoContent {
+		t.Fatalf("answer the confirm page → %d, want 204", status)
 	}
+}
+
+// confirmMinterContext is the seat the mail path would mint under: a human who
+// may update the person the link is for, which is what IssueConfirmToken asks.
+func (p *preflightEnv) confirmMinterContext(t *testing.T) context.Context {
+	t.Helper()
+	wsID := apptest.InstallationWorkspaceUUID(context.Background(), t, p.Pool)
+	ctx := principal.WithWorkspaceID(context.Background(), wsID)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	user := ids.NewV7()
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"person": {Read: true, Update: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
 }
 
 // Revocation binds mid-flight on the one lane that reaches a real external

--- a/backend/internal/compose/integration/consent_integration_test.go
+++ b/backend/internal/compose/integration/consent_integration_test.go
@@ -15,10 +15,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 type consentEnv struct {
@@ -113,13 +116,7 @@ func TestConsentDefaultDenySuppressesSends(t *testing.T) {
 
 	// Grant marketing through the round-trip its purpose demands; the send
 	// under THAT purpose then flows.
-	token := c.issueDOIToken(t, c.purposes["marketing_email"])
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
-		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"lawful_basis": "consent", "double_opt_in_token": token,
-	}, nil, nil); status != http.StatusOK {
-		t.Fatalf("record consent → %d", status)
-	}
+	c.grantMarketingThroughTheConfirmLink(t)
 	if status, code := c.send(t, "marketing_email"); status != http.StatusAccepted {
 		t.Fatalf("granted send → %d %q, want 202", status, code)
 	}
@@ -322,24 +319,18 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 	if status != 422 {
 		t.Fatalf("DOI-less marketing grant → %d, want 422", status)
 	}
-	// A fabricated token proves nothing: only a server-issued one confirms.
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
-		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"double_opt_in_token": "doi-token-forged",
-	}, nil, nil); status != 422 {
-		t.Fatalf("forged DOI grant → %d, want 422", status)
+	// AND NO OPERATOR CAN CLOSE IT FOR THEM. The endpoint that once handed the
+	// caller a plaintext token refuses now, because holding it meant the round
+	// trip could complete without the subject's mailbox ever taking part.
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", AnyMap{
+		"purpose_id": c.purposes["marketing_email"],
+	}, nil, nil); status != http.StatusConflict {
+		t.Fatalf("operator-held DOI issuance → %d, want 409 — the token must reach the subject, not the caller", status)
 	}
 
-	// The real round-trip: the server mints the token (the contract has
-	// no mint/delivery endpoint yet, so issuance rides the store seam),
-	// the confirming grant presents it, and the send flows.
-	token := c.issueDOIToken(t, c.purposes["marketing_email"])
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
-		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"double_opt_in_token": token,
-	}, nil, nil); status != http.StatusOK {
-		t.Fatalf("DOI grant → %d", status)
-	}
+	// The round trip as it works now: a single-use link to the subject's own
+	// address, answered on the anonymous page it opens.
+	c.grantMarketingThroughTheConfirmLink(t)
 	if status, code := c.send(t, "marketing_email"); status != http.StatusAccepted {
 		t.Fatalf("DOI-granted send → %d %q, want 202", status, code)
 	}
@@ -351,76 +342,87 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("withdraw → %d", status)
 	}
+	// A bare re-grant is refused for the same reason the first one was: the
+	// purpose requires the subject's own confirmation, and a withdrawal does
+	// not leave one lying around to reuse.
 	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"double_opt_in_token": token,
 	}, nil, nil); status != 422 {
-		t.Fatalf("re-grant with the consumed token → %d, want 422", status)
+		t.Fatalf("re-grant with no fresh confirmation → %d, want 422", status)
 	}
 }
 
-// issueDOIToken mints a confirmation token over the contract surface
-// (POST /people/{id}/consent/double-opt-in) as the signed-in human —
-// the same call a Settings/capture surface makes before mailing the
-// link out.
-func (c *consentEnv) issueDOIToken(t *testing.T, purposeID string) string {
+// grantMarketingThroughTheConfirmLink takes the subject through the round trip
+// marketing_email requires, as it works now: a single-use link is minted for
+// their own live address, and the answer arrives on the anonymous page that
+// link opens.
+//
+// The token is minted through the STORE rather than the contract, because the
+// contract deliberately never returns it — `confirm-request` mails it and hands
+// the caller nothing. That is the security property the old double-opt-in
+// issuance lacked: an operator who holds the plaintext can close the round trip
+// without the subject's mailbox taking part, which is why that endpoint now
+// refuses. A test needs the seam the mailer would read.
+func (c *consentEnv) grantMarketingThroughTheConfirmLink(t *testing.T) {
 	t.Helper()
-	var issued struct {
-		Token     string     `json:"token"`
-		ExpiresAt *time.Time `json:"expires_at"`
+	person, err := ids.ParseAs[ids.PersonKind](c.personID)
+	if err != nil {
+		t.Fatalf("parsing the person id: %v", err)
 	}
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", AnyMap{
-		"purpose_id": purposeID, "deliver": false,
-	}, nil, &issued); status != http.StatusCreated {
-		t.Fatalf("issue DOI token → %d", status)
+	issued, err := consent.NewStore(c.DB()).IssueConfirmToken(c.confirmMinterContext(t), person)
+	if err != nil {
+		t.Fatalf("mint the confirm link: %v", err)
 	}
-	if issued.Token == "" || issued.ExpiresAt == nil {
-		t.Fatalf("DOI issuance response incomplete: %+v", issued)
+	if status := c.Call(t, "POST", "/v1/public/confirm/"+issued.Token, AnyMap{
+		"marketing_choice":  "granted",
+		"marketing_wording": "Yes, send me product news.",
+	}, nil, nil); status != http.StatusNoContent {
+		t.Fatalf("answer the confirm page → %d, want 204", status)
 	}
-	return issued.Token
 }
 
-// The issuance half of the DOI round-trip (feedback/11): a purpose that
-// does not require DOI refuses issuance, and a fresh token supersedes
-// the unredeemed prior one — an old confirmation link in a stale mail
-// can no longer confirm anything.
-func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
+// OPERATOR-HELD ISSUANCE IS RETIRED, and the endpoint says so rather than
+// disappearing.
+//
+// It once minted a plaintext token and returned it to the authenticated caller.
+// A double opt-in is evidence only because the data subject completed it from
+// their own mailbox, and a caller holding the token could close that round trip
+// with the mailbox never taking part — recording a confirmation that had not
+// happened. So it refuses for every purpose now, DOI-requiring or not, and the
+// answer names why. The replacement is the confirm-details link, whose token is
+// mailed to the subject's own live address and returned to nobody.
+//
+// It refuses rather than 404ing because the operation is in the public
+// contract: an integrator who calls it deserves the reason, not the suggestion
+// that they got the path wrong.
+func TestOperatorHeldDoubleOptInIssuanceRefuses(t *testing.T) {
 	c := setupConsent(t)
 
-	// transactional does not require double opt-in → 422.
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", AnyMap{
-		"purpose_id": c.purposes["transactional"],
-	}, nil, nil); status != 422 {
-		t.Fatalf("DOI issuance for a non-DOI purpose → %d, want 422", status)
+	for name, purpose := range map[string]string{
+		"a purpose that requires double opt-in": c.purposes["marketing_email"],
+		"one that does not":                     c.purposes["transactional"],
+	} {
+		t.Run(name, func(t *testing.T) {
+			var problem struct {
+				Detail string `json:"detail"`
+			}
+			if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", AnyMap{
+				"purpose_id": purpose,
+			}, nil, &problem); status != http.StatusConflict {
+				t.Fatalf("issuance → %d, want 409", status)
+			}
+			if !strings.Contains(problem.Detail, "data subject") {
+				t.Errorf("the refusal reads %q, want it to say the subject must complete it", problem.Detail)
+			}
+		})
 	}
 
-	first := c.issueDOIToken(t, c.purposes["marketing_email"])
-	second := c.issueDOIToken(t, c.purposes["marketing_email"])
-
-	// The superseded first token no longer redeems…
-	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
-		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"double_opt_in_token": first,
-	}, nil, nil); status != 422 {
-		t.Fatalf("superseded token redeemed → %d, want 422", status)
-	}
-	// …the fresh one does.
-	if c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", AnyMap{
-		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
-		"double_opt_in_token": second,
-	}, nil, nil) != http.StatusOK {
-		t.Fatalf("fresh token refused")
-	}
-
-	// Issuance is an audited fact.
-	var audit struct {
-		Data []AnyMap `json:"data"`
-	}
-	if status := c.Call(t, "GET", "/v1/audit-log?entity_type=consent_doi_token", nil, nil, &audit); status != http.StatusOK {
-		t.Fatalf("audit read → %d", status)
-	}
-	if len(audit.Data) != 2 {
-		t.Fatalf("DOI issuances audited %d times, want exactly the 2 mints (a refused issuance writes nothing)", len(audit.Data))
+	// A malformed request is still malformed. The handler probes the required
+	// id BEFORE refusing for its own reasons, so an endpoint that says no does
+	// not become the one place a missing purpose goes unnamed.
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in",
+		AnyMap{}, nil, nil); status != 422 {
+		t.Fatalf("issuance with no purpose → %d, want 422", status)
 	}
 }
 
@@ -474,4 +476,23 @@ func TestConsentProofLogIsAppendOnlyAndIdempotent(t *testing.T) {
 	if audits != 1 || events != 1 {
 		t.Fatalf("audit/event counts = %d/%d, want 1/1", audits, events)
 	}
+}
+
+// confirmMinterContext is the seat the MAIL PATH would mint under — a human who
+// may update the person the link is for, which is what IssueConfirmToken
+// requires. Built here rather than borrowed from a request because the contract
+// route deliberately hands the token to nobody.
+func (c *consentEnv) confirmMinterContext(t *testing.T) context.Context {
+	t.Helper()
+	wsID := apptest.InstallationWorkspaceUUID(context.Background(), t, c.Pool)
+	ctx := principal.WithWorkspaceID(context.Background(), wsID)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	user := ids.NewV7()
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"person": {Read: true, Update: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
 }

--- a/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
+++ b/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
@@ -119,6 +119,16 @@ type requiredIDCase struct {
 	method, path      string
 	omitted, supplied AnyMap
 	field             string
+	// suppliedStatus overrides the 404 the invisible-id arm expects, for an
+	// endpoint that refuses BEFORE it looks anything up. Zero means 404.
+	//
+	// The property this suite defends is that a caller cannot tell an id that
+	// names nothing from one they may not see. A uniform refusal satisfies that
+	// more completely than a 404 does — every id gets the same answer, so there
+	// is nothing to compare — but it cannot answer 404 without inventing a
+	// lookup it does not perform. Naming the status keeps the arm honest
+	// instead of exempting the endpoint from the sweep.
+	suppliedStatus int
 }
 
 // requiredIDCases is every body this suite drives, keyed by the field under
@@ -163,6 +173,11 @@ func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDC
 		"IssueDoubleOptInJSONBody.purpose_id": {
 			method: "POST", path: "/v1/people/" + f.person + "/consent/double-opt-in",
 			omitted: AnyMap{}, supplied: AnyMap{"purpose_id": absent}, field: "purpose_id",
+			// Operator-held issuance is retired: it refuses every purpose,
+			// visible or not, because a token handed to the caller lets the
+			// round trip close without the subject's mailbox. So there is no
+			// lookup to 404 on, and one uniform answer enumerates nothing.
+			suppliedStatus: http.StatusConflict,
 		},
 		"ApplyTagRequest.entity_id": {
 			method: "POST", path: "/v1/tags/" + f.tag + "/apply",
@@ -221,10 +236,14 @@ func TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden(t *testing.T) {
 		})
 		t.Run(name+"/supplied but invisible stays a 404", func(t *testing.T) {
 			var problem problemBody
+			want := tc.suppliedStatus
+			if want == 0 {
+				want = http.StatusNotFound
+			}
 			status := e.Call(t, tc.method, tc.path, tc.supplied, nil, &problem)
-			if status != http.StatusNotFound {
-				t.Fatalf("→ %d, want 404: a well-formed id that names nothing must not be distinguishable "+
-					"from one the caller may not see, or the status code enumerates rows: %+v", status, problem)
+			if status != want {
+				t.Fatalf("→ %d, want %d: a well-formed id that names nothing must not be distinguishable "+
+					"from one the caller may not see, or the status code enumerates rows: %+v", status, want, problem)
 			}
 			// And it must not name the field either: a 404 that said "purpose_id"
 			// would confirm the caller's id was structurally accepted and only

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -269,6 +269,17 @@ var unreachableInThisLane = gatekit.Waive(map[string]string{
 		"granting it here would widen the authority every other tool in the sweep runs under, " +
 		"and the answer shape it would prove is the one remove_tag already shares",
 	"remove_tag": "same missing tag.read as apply_tag above",
+	"create_tag": "naming the vocabulary is admin/ops work, and this lane's seat holds no tag " +
+		"write — granting it would widen the authority every other tool in the sweep runs under",
+	"update_tag": "same missing tag write as create_tag above; it renames or recolours a row " +
+		"that tool would have had to make",
+	"forecast_readings": "needs a seat holding forecast.read, which this lane's seat does not " +
+		"carry — the forecast is an installation-wide figure and granting it here would widen " +
+		"the authority every other tool in the sweep runs under",
+	"forecast_movement": "the same missing forecast.read as forecast_readings above, and it " +
+		"additionally needs two SNAPSHOTS to sit between — a snapshot is minted by the period's " +
+		"own producer rather than by a caller, so standing one up would make this sweep a " +
+		"forecast test",
 	"list_tags": "same missing tag.read as apply_tag above — and unlike remove_tag it shares its " +
 		"answer shape with nothing else here, so this waiver leaves that shape unproven rather " +
 		"than proven elsewhere",


### PR DESCRIPTION
The real-Postgres lane has been red on the tip for days. [#3605](https://github.com/margince/margince/issues/3605) recorded a different cause each time it recurred; this is the one that is actually failing now.

```
consent_integration_test.go:336: issue DOI token → 422
consent_integration_test.go:394: DOI issuance for a non-DOI purpose → 409, want 422
```

## What happened

Operator-held double-opt-in issuance was **retired**, and for a real reason — `MissingDraftOwnerError`'s neighbour in `consent/handlers.go` says it plainly:

> "This endpoint returned the plaintext token to the authenticated operator, who could paste it back into RecordConsent — so the round trip the proof stands on could be closed without the subject's mailbox ever taking part, and the resulting consent_event recorded a confirmation that had not happened."

The endpoint refuses for every purpose now, and `double_opt_in_token` is gone from the contract entirely. Three test sites still drove it: two in `consent_integration_test.go`, and `grantMarketingConsent` in `comms_send_integration_test.go`.

## What they do now

They take the round trip as it actually works — the **confirm-details link**: a single-use token minted for the subject's own live primary address, answered on the anonymous page it opens.

The token is read from the store seam rather than the contract, deliberately. The contract hands it to nobody, and that IS the property the retired endpoint lacked — a test that could ask for the plaintext over the wire would be exercising exactly the hole this change closed.

The issuance test now asserts the **retirement**: it refuses whether or not the purpose requires double opt-in, and the answer names why. A malformed request is still malformed, because the handler probes the required id before refusing for its own reasons — an endpoint that says no must not become the one place a missing purpose goes unnamed.

## The required-body-id sweep

`TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden` failed on the same endpoint, and the honest answer is not to exempt it.

That suite defends the property that a caller cannot distinguish an id naming nothing from one they may not see. A uniform refusal satisfies that **more** completely than a 404 does — every id gets the same answer, so there is nothing to compare — but it cannot answer 404 without inventing a lookup it does not perform. Making it 404 for invisible ids and 409 for visible ones is what would enumerate. So the case carries an explicit `suppliedStatus` and stays in the sweep.

## Four uncovered tools

The conformance sweep refuses a registered tool it never invokes, and four had arrived:

- `create_tag`, `update_tag` — need tag writes this lane's seat does not hold;
- `forecast_readings`, `forecast_movement` — need `forecast.read`, which it also does not hold. I tried invoking `forecast_readings` first (all its arguments are optional) and it answered `forecast.read: permission denied`, so it is waived with that reason rather than a guessed one. `forecast_movement` additionally needs two snapshots, which only the period's own producer mints.

Granting any of those here would widen the authority every other tool in the sweep runs under, which is the reason the existing tag waivers give.

## On the `uat` lane

[#3504](https://github.com/margince/margince/issues/3504) is **already fixed** — the 04:38 scheduled run has `uat (main): success`, and all five AC-shell specs pass locally. Only the 00:15 run failed. That issue can be closed; nothing here touches it.

## Verification

```
ok  github.com/margince/margince/backend/internal/compose/integration  292.038s
```

Whole package, plus `make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated marketing consent flows to use confirmation links and require fresh confirmation after withdrawal.
  * Operator-issued double opt-in requests now return clearer conflict responses when unsupported.
  * Refined validation for supplied but inaccessible identifiers to return endpoint-appropriate status codes.

* **Tests**
  * Expanded integration coverage for consent confirmation, identifier handling, and tool-schema behavior.
  * Documented supported exceptions for tools requiring additional setup or permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->