### PR TITLE
QC Wave 3 — worklist/attention backend cleanup

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -37332,15 +37332,19 @@ components:
       type: object
       description: |
         The deal behind an item, with the facts its card states. `expected_minor_base` is
-        `amount_minor × win_probability`, converted to the installation's base currency —
-        the only figure by which two deals in different currencies may be compared.
+        `amount_minor` converted to the installation's base currency — the only figure by
+        which two deals in different currencies may be compared. It does not yet weight by
+        `win_probability`: the pipeline this row comes from does not read a deal's stage
+        today, so the two fields are independent facts rather than one computed from the
+        other, and a reader must not multiply them together expecting the product to equal
+        a risk-adjusted figure the API does not compute.
       properties:
         stage_id: { type: [string, 'null'], format: uuid }
         amount_minor: { type: [integer, 'null'], format: int64 }
         currency: { type: [string, 'null'], pattern: '^[A-Z]{3}$' }
         owner_id: { type: [string, 'null'], format: uuid }
         win_probability: { type: [integer, 'null'], minimum: 0, maximum: 100 }
-        expected_minor_base: { type: [integer, 'null'], format: int64, description: 'Expected revenue in the base currency. Null when the amount or the rate is unknown.' }
+        expected_minor_base: { type: [integer, 'null'], format: int64, description: 'The deal amount converted to the base currency, NOT weighted by win_probability. Null when the amount or the conversion rate is unknown.' }
         expected_close_date: { type: [string, 'null'], format: date }
         quiet_days: { type: [integer, 'null'], minimum: 0 }
 

--- a/backend/internal/compose/attention/basemoney_test.go
+++ b/backend/internal/compose/attention/basemoney_test.go
@@ -274,3 +274,60 @@ func TestADayOfUnitlessDealsIsConvertedWithNothingPriced(t *testing.T) {
 		t.Fatalf("a bar of %d was taken from amounts in no currency", *out.Summary.MaterialThresholdMinor)
 	}
 }
+
+// The contract promises a per-row base-currency figure
+// (WorklistDealFacts.ExpectedMinorBase) and the projection must actually send
+// one: a client wanting to show or total the converted amount otherwise finds
+// null and either shows nothing or re-derives the conversion itself, a second
+// answer to "what is this deal worth here" of exactly the kind this seam
+// exists to prevent.
+func TestTheDealFactsCarryTheConvertedExpectedRevenue(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("yen", "deal_at_risk", withPricedDeal(fiveMillionYen))),
+	}
+	fx := stubFX{base: "EUR", answers: map[CurrencyAmount]int64{fiveMillionYen: 3_000_000}}
+
+	out := pricedWorklist(t, fx, day)
+
+	deal := out.Queue[0].Deal
+	if deal == nil {
+		t.Fatal("the row carries no deal facts at all")
+	}
+	if deal.ExpectedMinorBase == nil || *deal.ExpectedMinorBase != 3_000_000 {
+		t.Fatalf("expected_minor_base = %v, wanted 3000000 (the converted €30,000)", deal.ExpectedMinorBase)
+	}
+}
+
+// A deal the estate cannot price states no base-currency figure: null means
+// "could not be priced", the same null a client already reads for an unpriced
+// deal's other money fields, not a second and different meaning of null.
+func TestAnUnpricedDealCarriesNoExpectedMinorBase(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("no-rate", "deal_at_risk", withPricedDeal(CurrencyAmount{Minor: 9_000_000, Currency: "GBP"}))),
+	}
+	fx := stubFX{base: "EUR", answers: map[CurrencyAmount]int64{}}
+
+	out := pricedWorklist(t, fx, day)
+
+	if deal := out.Queue[0].Deal; deal != nil && deal.ExpectedMinorBase != nil {
+		t.Fatalf("expected_minor_base = %v on a deal the estate holds no rate for", *deal.ExpectedMinorBase)
+	}
+}
+
+// Without the FX seam bound there is no base currency at all, so the raw
+// amount must never be sent AS IF it were a base-currency figure — that would
+// silently misprice every currency but the base's own.
+func TestAnUnboundSeamCarriesNoExpectedMinorBase(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("d", "deal_at_risk", withDeal(40_000))),
+	}
+
+	out := (&Service{}).worklistFrom(t.Context(), day, scopeAll, "", 25, waitingRead{}, leadRead{}, worklistCursor{}, nil)
+
+	if deal := out.Queue[0].Deal; deal != nil && deal.ExpectedMinorBase != nil {
+		t.Fatalf("expected_minor_base = %v with no FX seam bound at all", *deal.ExpectedMinorBase)
+	}
+}

--- a/backend/internal/compose/attention/classifybrief.go
+++ b/backend/internal/compose/attention/classifybrief.go
@@ -29,13 +29,12 @@ import (
 // deal-figures read that supplied DueAt (applyDealFigures, dealfacts.go),
 // which states deals.CloseIsOverdue's verdict — a CALENDAR-DATE comparison in
 // the workspace zone, the same rule the sibling "deals_at_risk" row for the
-// identical deal is judged by. Recomputing an instant comparison here instead
-// (as this once did, via overdueAt) is exactly what let the two rows disagree
-// for a deal due today: a close date round-trips as UTC midnight, so an
-// instant read calls it overdue from 00:00 UTC onward on the due day itself,
-// up to a whole local day before the calendar-date verdict agrees.
-// base() already carries item.Overdue onto row.Overdue; there is nothing left
-// to set here.
+// identical deal is judged by. A close date round-trips as UTC midnight, so
+// an INSTANT comparison here would call a deal overdue from 00:00 UTC onward
+// on the due day itself — up to a whole local day before the calendar-date
+// verdict agrees, and the two rows for one deal would disagree over exactly
+// that window. base() already carries item.Overdue onto row.Overdue; there
+// is nothing left to set here.
 func classifyBriefItem(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	row := base(item, levelAgreed, "deals_at_risk", "deal_drifts")
 	if item.DueAt != nil {

--- a/backend/internal/compose/attention/classifybrief.go
+++ b/backend/internal/compose/attention/classifybrief.go
@@ -25,22 +25,26 @@ import (
 // due date: closing_soon whenever a date is set, never due_today, because a
 // close date three months out is a forecast and not work owed for today.
 //
-// Overdue is set directly here rather than through stampDeadline: that
-// helper's own contract is a date the READER owes, which a forecast close
-// date is not — this computes the identical overdueAt the ordering already
-// uses, so a passed close date still orders and badges as overdue, just
-// without invoking a helper whose documented purpose is the opposite case.
+// Overdue is never recomputed here. It arrives on item.Overdue from the SAME
+// deal-figures read that supplied DueAt (applyDealFigures, dealfacts.go),
+// which states deals.CloseIsOverdue's verdict — a CALENDAR-DATE comparison in
+// the workspace zone, the same rule the sibling "deals_at_risk" row for the
+// identical deal is judged by. Recomputing an instant comparison here instead
+// (as this once did, via overdueAt) is exactly what let the two rows disagree
+// for a deal due today: a close date round-trips as UTC midnight, so an
+// instant read calls it overdue from 00:00 UTC onward on the due day itself,
+// up to a whole local day before the calendar-date verdict agrees.
+// base() already carries item.Overdue onto row.Overdue; there is nothing left
+// to set here.
 func classifyBriefItem(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	row := base(item, levelAgreed, "deals_at_risk", "deal_drifts")
 	if item.DueAt != nil {
 		row.Because = append(row.Because, reason("closing_soon", nil))
-		past := overdueAt(item.DueAt, asOf)
-		row.Overdue = &past
 	}
 	return ranked{
 		item:       row,
 		deadlineAt: deadlineOf(item.DueAt),
-		overdue:    overdueAt(item.DueAt, asOf),
+		overdue:    item.Overdue != nil && *item.Overdue,
 		occurredAt: occurredOf(item, asOf),
 	}
 }

--- a/backend/internal/compose/attention/classifybrief_test.go
+++ b/backend/internal/compose/attention/classifybrief_test.go
@@ -36,15 +36,14 @@ func TestClassifyBriefItemStampsItsDeadline(t *testing.T) {
 	}
 }
 
-// margince#3749: the brief row and the at-risk row for the SAME deal must
-// never disagree about whether it is late. The at-risk lane compares calendar
-// dates in the workspace zone (deals.CloseIsOverdue) — a deal due TODAY is not
-// overdue — and that verdict now arrives pre-computed on item.Overdue
-// (deals.Store.Figures, threaded through applyDealFigures). Before this fix,
-// classifyBriefItem recomputed its own answer from the INSTANT the close date
-// round-trips as (UTC midnight of the due day), which reads "overdue" from
-// 00:00 UTC onward on the due day itself — a whole local day out of step with
-// the sibling lane, for a deal due today.
+// The brief row and the at-risk row for the SAME deal must never disagree
+// about whether it is late. The at-risk lane compares calendar dates in the
+// workspace zone (deals.CloseIsOverdue) — a deal due TODAY is not overdue —
+// and classifyBriefItem trusts the identical pre-computed verdict rather
+// than recomputing one from the INSTANT the close date round-trips as (UTC
+// midnight of the due day), which would read "overdue" from 00:00 UTC onward
+// on the due day itself — a whole local day out of step with the sibling
+// lane, for a deal due today.
 func TestClassifyBriefItemTrustsTheDealsCalendarOverdueVerdictOverAnInstantComparison(t *testing.T) {
 	// The close date's UTC-midnight round-trip is already behind rankInstant
 	// (09:00 UTC on the same day), so an instant comparison would call this

--- a/backend/internal/compose/attention/classifybrief_test.go
+++ b/backend/internal/compose/attention/classifybrief_test.go
@@ -15,10 +15,12 @@ import (
 
 func TestClassifyBriefItemStampsItsDeadline(t *testing.T) {
 	closes := rankInstant.Add(-24 * time.Hour)
+	overdue := true
 	item := crmcontracts.AttentionItem{
-		Id:     "brief-1",
-		Source: "brief_item",
-		DueAt:  &closes,
+		Id:      "brief-1",
+		Source:  "brief_item",
+		DueAt:   &closes,
+		Overdue: &overdue,
 	}
 
 	got := classifyBriefItem(item, rankInstant)
@@ -31,6 +33,39 @@ func TestClassifyBriefItemStampsItsDeadline(t *testing.T) {
 	}
 	if !got.overdue {
 		t.Fatal("a close date in the past was not marked overdue")
+	}
+}
+
+// margince#3749: the brief row and the at-risk row for the SAME deal must
+// never disagree about whether it is late. The at-risk lane compares calendar
+// dates in the workspace zone (deals.CloseIsOverdue) — a deal due TODAY is not
+// overdue — and that verdict now arrives pre-computed on item.Overdue
+// (deals.Store.Figures, threaded through applyDealFigures). Before this fix,
+// classifyBriefItem recomputed its own answer from the INSTANT the close date
+// round-trips as (UTC midnight of the due day), which reads "overdue" from
+// 00:00 UTC onward on the due day itself — a whole local day out of step with
+// the sibling lane, for a deal due today.
+func TestClassifyBriefItemTrustsTheDealsCalendarOverdueVerdictOverAnInstantComparison(t *testing.T) {
+	// The close date's UTC-midnight round-trip is already behind rankInstant
+	// (09:00 UTC on the same day), so an instant comparison would call this
+	// overdue — but the deal's own calendar-date verdict, from the SAME lane's
+	// deal-figures read, says it is due today and not yet late.
+	closesToday := time.Date(rankInstant.Year(), rankInstant.Month(), rankInstant.Day(), 0, 0, 0, 0, time.UTC)
+	notOverdue := false
+	item := crmcontracts.AttentionItem{
+		Id:      "brief-due-today",
+		Source:  "brief_item",
+		DueAt:   &closesToday,
+		Overdue: &notOverdue,
+	}
+
+	got := classifyBriefItem(item, rankInstant)
+
+	if got.overdue {
+		t.Fatal("a deal due TODAY was marked overdue — the brief row disagrees with the at-risk row for the identical deal")
+	}
+	if got.item.Overdue == nil || *got.item.Overdue {
+		t.Fatalf("item.Overdue = %v, wanted the deal's own false to reach the card's badge too", got.item.Overdue)
 	}
 }
 

--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -37,6 +37,13 @@ func classifyRisk(item crmcontracts.AttentionItem, asOf time.Time, bar materialB
 		level = levelMaterialRisk
 	}
 	row := base(item, level, "deals_at_risk", consequence)
+	// The contract's own per-row figure, sent rather than left for a client to
+	// re-derive from `because`/`above_next` — set only once conversion actually
+	// ran and priced this item, so a raw amount (no FX seam bound) or an
+	// unpriced deal never claims to be a base-currency figure it is not.
+	if row.Deal != nil && money.converted() && known {
+		row.Deal.ExpectedMinorBase = &expected
+	}
 	// The reason carries the figure the verdict actually weighed, in the units
 	// it was weighed in — the base currency once conversion ran — so a reader
 	// comparing it against the summary's threshold compares like with like.

--- a/backend/internal/compose/attention/dealfacts.go
+++ b/backend/internal/compose/attention/dealfacts.go
@@ -29,7 +29,8 @@ import (
 )
 
 // nameTheMoney puts a deal's figures on every lane item that names one and
-// carries none.
+// carries none — and drops the item where Figures cannot answer for it at
+// all (margince#3800), since a row that can name nothing is not a suggestion.
 //
 // Items that already have facts are left alone: the lane that produced them
 // read the deal under this same reader, and asking again could only produce a
@@ -59,20 +60,28 @@ func (s *Service) nameTheMoney(ctx context.Context, day *crmcontracts.Attention)
 		return err
 	}
 	for _, lane := range lanes {
+		kept := make([]crmcontracts.AttentionItem, 0, len(*lane))
 		for i := range *lane {
-			id, ok := needsDealFigures((*lane)[i])
-			if !ok {
+			item := (*lane)[i]
+			id, needsFigures := needsDealFigures(item)
+			if !needsFigures {
+				kept = append(kept, item)
 				continue
 			}
 			found, ok := figures[id]
 			if !ok {
-				// The reader may not see this deal, or it is gone. The row
-				// keeps its name and says no more, which is the shape an
-				// unnamed subject already has.
+				// The deal is gone (archived, deleted) or the reader can no
+				// longer see it — Figures answers the same absence either
+				// way, and a row that can name nothing is not a suggestion:
+				// dropped here rather than left on the page with no amount,
+				// no close date and no reason, still offering act/set_aside/
+				// dismiss over a deal that no longer resolves (margince#3800).
 				continue
 			}
-			applyDealFigures(&(*lane)[i], found)
+			applyDealFigures(&item, found)
+			kept = append(kept, item)
 		}
+		*lane = kept
 	}
 	return nil
 }
@@ -91,6 +100,12 @@ func needsDealFigures(item crmcontracts.AttentionItem) (ids.UUID, bool) {
 // The close date lands on DueAt as well as on the deal facts, because that is
 // where the projection reads a row's deadline from — a date set only on the
 // facts would print on the card and order nothing.
+//
+// The overdue verdict lands on Overdue for the same reason, and it is the
+// SAME verdict deals.CloseIsOverdue gives the at-risk lane's identical deal
+// (deals.Store.Figures computes it calendar-date, workspace-zone aware) —
+// never classifyBriefItem's own instant comparison, which is what let the two
+// lanes disagree about a deal due today.
 func applyDealFigures(item *crmcontracts.AttentionItem, figures DealFigures) {
 	facts := &crmcontracts.AttentionDealFacts{AmountMinor: figures.AmountMinor}
 	if !figures.StageID.IsZero() {
@@ -109,5 +124,9 @@ func applyDealFigures(item *crmcontracts.AttentionItem, figures DealFigures) {
 	if figures.ExpectedCloseDate != nil && item.DueAt == nil {
 		closes := *figures.ExpectedCloseDate
 		item.DueAt = &closes
+	}
+	if figures.ExpectedCloseDate != nil && item.Overdue == nil {
+		overdue := figures.CloseOverdue
+		item.Overdue = &overdue
 	}
 }

--- a/backend/internal/compose/attention/dealfacts.go
+++ b/backend/internal/compose/attention/dealfacts.go
@@ -30,7 +30,7 @@ import (
 
 // nameTheMoney puts a deal's figures on every lane item that names one and
 // carries none — and drops the item where Figures cannot answer for it at
-// all (margince#3800), since a row that can name nothing is not a suggestion.
+// all, since a row that can name nothing is not a suggestion.
 //
 // Items that already have facts are left alone: the lane that produced them
 // read the deal under this same reader, and asking again could only produce a
@@ -75,7 +75,7 @@ func (s *Service) nameTheMoney(ctx context.Context, day *crmcontracts.Attention)
 				// way, and a row that can name nothing is not a suggestion:
 				// dropped here rather than left on the page with no amount,
 				// no close date and no reason, still offering act/set_aside/
-				// dismiss over a deal that no longer resolves (margince#3800).
+				// dismiss over a deal that no longer resolves.
 				continue
 			}
 			applyDealFigures(&item, found)

--- a/backend/internal/compose/attention/dealfacts_test.go
+++ b/backend/internal/compose/attention/dealfacts_test.go
@@ -72,8 +72,8 @@ func TestABriefRowGainsItsDealsFigures(t *testing.T) {
 	}
 }
 
-// margince#3800: a deal Figures cannot answer for — gone (archived, deleted)
-// or no longer visible to this reader — drops the row entirely, rather than
+// A deal Figures cannot answer for — gone (archived, deleted) or no longer
+// visible to this reader — drops the row entirely, rather than
 // leaving an unidentifiable one on the page: no amount, no close date, no
 // reason, yet still offering act/set_aside/dismiss over a deal that no longer
 // resolves. A row that can name nothing is not a suggestion, and the refusal

--- a/backend/internal/compose/attention/dealfacts_test.go
+++ b/backend/internal/compose/attention/dealfacts_test.go
@@ -72,19 +72,48 @@ func TestABriefRowGainsItsDealsFigures(t *testing.T) {
 	}
 }
 
-// A deal the reader may not see leaves the row as it was. The refusal is an
-// absent answer, not an error, so one withheld deal cannot take the page down.
-func TestAWithheldDealLeavesTheRowUnchanged(t *testing.T) {
+// margince#3800: a deal Figures cannot answer for — gone (archived, deleted)
+// or no longer visible to this reader — drops the row entirely, rather than
+// leaving an unidentifiable one on the page: no amount, no close date, no
+// reason, yet still offering act/set_aside/dismiss over a deal that no longer
+// resolves. A row that can name nothing is not a suggestion, and the refusal
+// is an absent answer rather than an error, so one unresolved deal cannot take
+// the whole read down.
+func TestABriefRowWhoseDealCannotBeResolvedIsDropped(t *testing.T) {
 	dealID := ids.NewV7()
 	svc := (&Service{}).WithDealFacts(&stubDealFacts{figures: map[ids.UUID]DealFigures{}})
 	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{briefRow(dealID)}}
 
 	if err := svc.nameTheMoney(context.Background(), &day); err != nil {
-		t.Fatalf("a deal the reader may not see failed the whole read: %v", err)
+		t.Fatalf("an unresolved deal failed the whole read: %v", err)
 	}
 
-	if day.ThisMorning[0].Deal != nil {
-		t.Fatal("a withheld deal put figures on the row anyway")
+	if len(day.ThisMorning) != 0 {
+		t.Fatalf("ThisMorning still carries %d row(s); an unresolved deal's row should have been dropped", len(day.ThisMorning))
+	}
+}
+
+// A row beside an unresolved one is untouched: dropping one deal's row is not
+// a reason to drop, reorder or otherwise disturb its neighbours.
+func TestABriefRowBesideAnUnresolvedOneIsUntouched(t *testing.T) {
+	resolved, unresolved := ids.NewV7(), ids.NewV7()
+	amount := int64(50_00)
+	svc := (&Service{}).WithDealFacts(&stubDealFacts{figures: map[ids.UUID]DealFigures{
+		resolved: {AmountMinor: &amount, Currency: "EUR"},
+	}})
+	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{
+		briefRow(unresolved), briefRow(resolved),
+	}}
+
+	if err := svc.nameTheMoney(context.Background(), &day); err != nil {
+		t.Fatalf("naming the money: %v", err)
+	}
+
+	if len(day.ThisMorning) != 1 {
+		t.Fatalf("ThisMorning carries %d row(s), wanted exactly the resolved one", len(day.ThisMorning))
+	}
+	if day.ThisMorning[0].Id != resolved.String() {
+		t.Fatalf("the surviving row is %q, wanted the resolved deal %q", day.ThisMorning[0].Id, resolved.String())
 	}
 }
 
@@ -142,5 +171,48 @@ func TestAnUnboundReaderLeavesEveryRowAlone(t *testing.T) {
 	}
 	if day.ThisMorning[0].Deal != nil {
 		t.Fatal("an unbound reader invented figures")
+	}
+}
+
+// A brief row carries the SAME overdue verdict the at-risk lane gives the
+// identical deal — deals.Store.Figures now answers it calendar-date, workspace-
+// zone aware, the same way deals.CloseIsOverdue does for that sibling lane, so
+// the two rows for one deal state one verdict about whether it is late.
+func TestABriefRowCarriesTheDealsOverdueVerdict(t *testing.T) {
+	dealID := ids.NewV7()
+	closes := time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC)
+	svc := (&Service{}).WithDealFacts(&stubDealFacts{figures: map[ids.UUID]DealFigures{
+		dealID: {ExpectedCloseDate: &closes, CloseOverdue: true},
+	}})
+	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{briefRow(dealID)}}
+
+	if err := svc.nameTheMoney(context.Background(), &day); err != nil {
+		t.Fatalf("naming the money: %v", err)
+	}
+
+	got := day.ThisMorning[0]
+	if got.Overdue == nil || !*got.Overdue {
+		t.Fatalf("Overdue = %v, wanted the deal's own overdue verdict (true)", got.Overdue)
+	}
+}
+
+// A close date that has not passed carries no overdue verdict — the false is
+// as load-bearing as the true, and a row that always answered true once a close
+// date existed would badge every dated deal late.
+func TestABriefRowCarriesAFutureCloseDateAsNotOverdue(t *testing.T) {
+	dealID := ids.NewV7()
+	closes := time.Date(2027, 3, 1, 0, 0, 0, 0, time.UTC)
+	svc := (&Service{}).WithDealFacts(&stubDealFacts{figures: map[ids.UUID]DealFigures{
+		dealID: {ExpectedCloseDate: &closes, CloseOverdue: false},
+	}})
+	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{briefRow(dealID)}}
+
+	if err := svc.nameTheMoney(context.Background(), &day); err != nil {
+		t.Fatalf("naming the money: %v", err)
+	}
+
+	got := day.ThisMorning[0]
+	if got.Overdue == nil || *got.Overdue {
+		t.Fatalf("Overdue = %v, wanted false for a close date that has not passed", got.Overdue)
 	}
 }

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -386,6 +386,11 @@ type DealFigures struct {
 	AmountMinor       *int64
 	Currency          string
 	ExpectedCloseDate *time.Time
+	// CloseOverdue is the SAME calendar-date, workspace-zone verdict
+	// deals.CloseIsOverdue gives the at-risk lane's identical deal. Meaningless
+	// where ExpectedCloseDate is nil — a deal with no close date is not late by
+	// one, it has none to be late by.
+	CloseOverdue bool
 }
 
 // Meetings is today's booked meetings that have not happened yet.

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -257,6 +257,7 @@ func (f attentionDealFacts) Figures(
 			AmountMinor:       figures.AmountMinor,
 			Currency:          figures.Currency,
 			ExpectedCloseDate: figures.ExpectedCloseDate,
+			CloseOverdue:      figures.CloseOverdue,
 		}
 	}
 	return out, nil

--- a/backend/internal/compose/integration/dealfigures_integration_test.go
+++ b/backend/internal/compose/integration/dealfigures_integration_test.go
@@ -166,7 +166,7 @@ func TestDealFiguresApplyTheRolesFieldMask(t *testing.T) {
 	}
 }
 
-// margince#3749: a close date already behind today's calendar date, in the
+// A close date already behind today's calendar date, in the
 // workspace's own zone (UTC — this harness's fresh-installation default),
 // answers overdue — the same verdict deals.CloseIsOverdue gives the at-risk
 // lane over the identical deal, so the Worklist's two rows for one deal state

--- a/backend/internal/compose/integration/dealfigures_integration_test.go
+++ b/backend/internal/compose/integration/dealfigures_integration_test.go
@@ -196,7 +196,15 @@ func TestDealFiguresFlagsAPastCloseDateAsOverdue(t *testing.T) {
 // comparison, and a deal due today is due today, not late.
 func TestDealFiguresDoesNotFlagATodayOrFutureCloseDateAsOverdue(t *testing.T) {
 	e := Setup(t)
-	today := time.Now().UTC()
+	// The DB's own "today", not Go's: Figures compares against Postgres's
+	// now() in the installation's zone, and seeding from the wall clock this
+	// process reads would race a UTC-midnight rollover between the seed and
+	// the query.
+	var today time.Time
+	if err := OwnerConn(t).QueryRow(context.Background(),
+		`SELECT (timezone('UTC', now()))::date`).Scan(&today); err != nil {
+		t.Fatalf("reading the database's own today: %v", err)
+	}
 	dealID := seedFiguresDealClosing(t, e.Rep1, 50_000_00, today)
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
 

--- a/backend/internal/compose/integration/dealfigures_integration_test.go
+++ b/backend/internal/compose/integration/dealfigures_integration_test.go
@@ -15,6 +15,7 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -24,6 +25,14 @@ import (
 // card states.
 func seedFiguresDeal(t *testing.T, owner ids.UUID, amount int64) ids.UUID {
 	t.Helper()
+	return seedFiguresDealClosing(t, owner, amount, time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC))
+}
+
+// seedFiguresDealClosing writes one deal with the given expected close date —
+// the workspace's own timezone setting is what Figures reads it against
+// (UTC, the fresh-installation default this harness never overrides).
+func seedFiguresDealClosing(t *testing.T, owner ids.UUID, amount int64, closes time.Time) ids.UUID {
+	t.Helper()
 	conn := OwnerConn(t)
 	pipeline := SeedIDRow(t, conn, `INSERT INTO pipeline (id, name, is_default, position)
 		VALUES ($1, 'Sales', true, 0)`)
@@ -32,8 +41,8 @@ func seedFiguresDeal(t *testing.T, owner ids.UUID, amount int64) ids.UUID {
 	return SeedIDRow(t, conn, `INSERT INTO deal
 		(id, owner_id, name, pipeline_id, stage_id, amount_minor, currency, expected_close_date,
 		 source, captured_by)
-		VALUES ($1, $2, 'Northstar renewal', $3, $4, $5, 'EUR', DATE '2026-08-28', 'manual', 'human:x')`,
-		owner, pipeline, stage, amount)
+		VALUES ($1, $2, 'Northstar renewal', $3, $4, $5, 'EUR', $6, 'manual', 'human:x')`,
+		owner, pipeline, stage, amount, closes)
 }
 
 // A deal the reader may see comes back with the figures a card states.
@@ -117,7 +126,14 @@ func TestDealFiguresApplyTheRolesFieldMask(t *testing.T) {
 		e.WsExec(t, `UPDATE deal SET amount_minor = $2, currency = 'EUR' WHERE id = $1`, id, amount)
 	}
 	perms := activityLifecyclePerms
-	perms.Objects = map[string]principal.ObjectGrant{"deal": {Read: true, Update: true}, "pipeline": {Read: true}}
+	perms.Objects = map[string]principal.ObjectGrant{
+		"deal": {Read: true, Update: true}, "pipeline": {Read: true},
+		// Figures reads the installation's timezone to state each deal's own
+		// overdue verdict — installation_settings mirrors 0191's real seed,
+		// readable by every seeded role, so a narrow test fixture needs it
+		// stated explicitly the way dozens of others in this package already do.
+		"installation_settings": {Read: true},
+	}
 	perms.FieldMasks = []principal.FieldMask{
 		{Object: "deal", Field: "amount_minor", Condition: principal.MaskOutsideWriteAuthority},
 	}
@@ -147,5 +163,53 @@ func TestDealFiguresApplyTheRolesFieldMask(t *testing.T) {
 	}
 	if other.Currency != "" {
 		t.Fatalf("another team's currency reached the Worklist as %q — a currency alone says the deal is priced and in what units", other.Currency)
+	}
+}
+
+// margince#3749: a close date already behind today's calendar date, in the
+// workspace's own zone (UTC — this harness's fresh-installation default),
+// answers overdue — the same verdict deals.CloseIsOverdue gives the at-risk
+// lane over the identical deal, so the Worklist's two rows for one deal state
+// one verdict about whether it is late.
+func TestDealFiguresFlagsAPastCloseDateAsOverdue(t *testing.T) {
+	e := Setup(t)
+	yesterday := time.Now().UTC().AddDate(0, 0, -1)
+	dealID := seedFiguresDealClosing(t, e.Rep1, 50_000_00, yesterday)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+
+	figures, err := e.Deals.Figures(rep, []ids.UUID{dealID})
+	if err != nil {
+		t.Fatalf("reading the deal's figures: %v", err)
+	}
+
+	got, ok := figures[dealID]
+	if !ok {
+		t.Fatal("the deal did not come back at all")
+	}
+	if !got.CloseOverdue {
+		t.Fatal("a close date already behind today's calendar date came back not overdue")
+	}
+}
+
+// A close date that has not yet arrived — today's or later — is not overdue.
+// Today itself is the boundary this asserts: CloseIsOverdue is a calendar-date
+// comparison, and a deal due today is due today, not late.
+func TestDealFiguresDoesNotFlagATodayOrFutureCloseDateAsOverdue(t *testing.T) {
+	e := Setup(t)
+	today := time.Now().UTC()
+	dealID := seedFiguresDealClosing(t, e.Rep1, 50_000_00, today)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+
+	figures, err := e.Deals.Figures(rep, []ids.UUID{dealID})
+	if err != nil {
+		t.Fatalf("reading the deal's figures: %v", err)
+	}
+
+	got, ok := figures[dealID]
+	if !ok {
+		t.Fatal("the deal did not come back at all")
+	}
+	if got.CloseOverdue {
+		t.Fatal("a deal due TODAY came back overdue")
 	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -31458,14 +31458,18 @@ type WorklistCount struct {
 type WorklistCountCategory string
 
 // WorklistDealFacts The deal behind an item, with the facts its card states. `expected_minor_base` is
-// `amount_minor × win_probability`, converted to the installation's base currency —
-// the only figure by which two deals in different currencies may be compared.
+// `amount_minor` converted to the installation's base currency — the only figure by
+// which two deals in different currencies may be compared. It does not yet weight by
+// `win_probability`: the pipeline this row comes from does not read a deal's stage
+// today, so the two fields are independent facts rather than one computed from the
+// other, and a reader must not multiply them together expecting the product to equal
+// a risk-adjusted figure the API does not compute.
 type WorklistDealFacts struct {
 	AmountMinor       *int64              `json:"amount_minor,omitempty"`
 	Currency          *string             `json:"currency,omitempty"`
 	ExpectedCloseDate *openapi_types.Date `json:"expected_close_date,omitempty"`
 
-	// ExpectedMinorBase Expected revenue in the base currency. Null when the amount or the rate is unknown.
+	// ExpectedMinorBase The deal amount converted to the base currency, NOT weighted by win_probability. Null when the amount or the conversion rate is unknown.
 	ExpectedMinorBase *int64              `json:"expected_minor_base,omitempty"`
 	OwnerId           *openapi_types.UUID `json:"owner_id,omitempty"`
 	QuietDays         *int                `json:"quiet_days,omitempty"`
@@ -31537,8 +31541,12 @@ type WorklistItem struct {
 	Consequence WorklistItemConsequence `json:"consequence"`
 
 	// Deal The deal behind an item, with the facts its card states. `expected_minor_base` is
-	// `amount_minor × win_probability`, converted to the installation's base currency —
-	// the only figure by which two deals in different currencies may be compared.
+	// `amount_minor` converted to the installation's base currency — the only figure by
+	// which two deals in different currencies may be compared. It does not yet weight by
+	// `win_probability`: the pipeline this row comes from does not read a deal's stage
+	// today, so the two fields are independent facts rather than one computed from the
+	// other, and a reader must not multiply them together expecting the product to equal
+	// a risk-adjusted figure the API does not compute.
 	Deal *WorklistDealFacts `json:"deal,omitempty"`
 
 	// Detail One supporting line, in PROSE — a bounce reason, a park reason, the mailbox that

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -161,16 +161,27 @@ func (w followUpAutoResolve) Apply(ctx context.Context, ev workflow.Event, eff w
 	// transaction that emits this event — so the lead-keyed completion above
 	// never finds it once a lead has genuinely promoted; only the payload
 	// still names where the task went.
+	//
+	// Only for a FRESH person (dedupe_outcome "created"). A promotion that
+	// MERGES into an existing survivor carries the same task, but the
+	// survivor can already carry its own open system-minted reminders —
+	// no_activity_reminder and check_in_cadence anchor on a person the same
+	// way a lead's follow-up does — and completing every open system task on
+	// the person would tick off work this promotion has nothing to do with.
+	// A newly minted person cannot yet carry anything else, so completing by
+	// person id is exact there and only there.
 	if w.trigger == leadPromotedTrigger {
-		personID, err := promotedPersonID(ev.Payload)
+		promoted, err := decodeLeadPromoted(ev.Payload)
 		if err != nil {
 			return workflow.RunResult{}, fmt.Errorf("decoding the promoted person: %w", err)
 		}
-		done, err := w.store.CompleteOpenSystemTasksForPerson(ctx, personID)
-		if err != nil {
-			return workflow.RunResult{}, fmt.Errorf("resolving follow-ups on person %s: %w", personID, err)
+		if promoted.DedupeOutcome == dedupeOutcomeCreated {
+			done, err := w.store.CompleteOpenSystemTasksForPerson(ctx, promoted.PersonID)
+			if err != nil {
+				return workflow.RunResult{}, fmt.Errorf("resolving follow-ups on person %s: %w", promoted.PersonID, err)
+			}
+			completed += done
 		}
-		completed += done
 	}
 	if completed == 0 {
 		return workflow.RunResult{}, nil
@@ -178,15 +189,30 @@ func (w followUpAutoResolve) Apply(ctx context.Context, ev workflow.Event, eff w
 	return workflow.RunResult{Applied: eff.Actions}, nil
 }
 
-// promotedPersonID reads the person a lead.promoted payload names — the only
-// place, once carryLeadActivities has run, that still says where its tasks
-// went.
-func promotedPersonID(payload json.RawMessage) (ids.PersonID, error) {
+// dedupeOutcomeCreated is people.QualifyLead's own spelling
+// (promote.go) for "a fresh person, not a merge into a survivor" — the one
+// outcome where completing every open system task on the person cannot reach
+// anything this promotion did not itself just carry there.
+const dedupeOutcomeCreated = "created"
+
+// promotedLead is what a lead.promoted payload says about where a lead's
+// tasks went, and whether that person existed before this promotion.
+type promotedLead struct {
+	PersonID      ids.PersonID
+	DedupeOutcome string
+}
+
+// decodeLeadPromoted reads a lead.promoted payload — the only place, once
+// carryLeadActivities has run, that still says where its tasks went.
+func decodeLeadPromoted(payload json.RawMessage) (promotedLead, error) {
 	var body crmcontracts.PublicEventLeadPromoted
 	if err := json.Unmarshal(payload, &body); err != nil {
-		return ids.PersonID{}, fmt.Errorf("activities: decoding lead.promoted's payload: %w", err)
+		return promotedLead{}, fmt.Errorf("activities: decoding lead.promoted's payload: %w", err)
 	}
-	return ids.From[ids.PersonKind](ids.UUID(body.PromotedPersonId)), nil
+	return promotedLead{
+		PersonID:      ids.From[ids.PersonKind](ids.UUID(body.PromotedPersonId)),
+		DedupeOutcome: body.DedupeOutcome,
+	}, nil
 }
 
 func (w followUpAutoResolve) IdempotencyKey(ev workflow.Event) string {
@@ -245,7 +271,7 @@ func (w followUpAutoResolve) linkedLeads(ctx context.Context, activityID ids.Act
 // leaves a call that takes no read gate of its own; each completion's
 // write is gated inside UpdateActivity.
 func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.LeadID) (int, error) {
-	return s.completeOpenSystemTasksLinkedBy(ctx, "l.lead_id = $1", leadID.UUID)
+	return s.completeOpenSystemTasksLinkedBy(ctx, "lead_id", leadID.UUID)
 }
 
 // CompleteOpenSystemTasksForPerson is CompleteOpenSystemTasksForLead's
@@ -254,14 +280,16 @@ func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.L
 // in the same transaction that emits lead.promoted, so a lead id can no
 // longer find it — only the person id it was carried to can.
 func (s *Store) CompleteOpenSystemTasksForPerson(ctx context.Context, personID ids.PersonID) (int, error) {
-	return s.completeOpenSystemTasksLinkedBy(ctx, "l.person_id = $1", personID.UUID)
+	return s.completeOpenSystemTasksLinkedBy(ctx, "person_id", personID.UUID)
 }
 
-// completeOpenSystemTasksLinkedBy is the one query and completion loop both
-// callers above share, differing only in which activity_link column names
-// the subject. `linkClause` is always a caller-supplied compile-time literal
-// ("l.lead_id = $1" / "l.person_id = $1"), never a value off a request body.
-func (s *Store) completeOpenSystemTasksLinkedBy(ctx context.Context, linkClause string, linkValue ids.UUID) (int, error) {
+// completeOpenSystemTasksLinkedBy is the query and completion loop both
+// callers above share, differing only in which activity_link column names the
+// subject. `column` is unexported and passed only by the two callers above,
+// each a compile-time literal ("lead_id" / "person_id") — never a value off a
+// request body. Its placeholder is spelled right here, beside the argument
+// that fills it, rather than split across a call boundary.
+func (s *Store) completeOpenSystemTasksLinkedBy(ctx context.Context, column string, linkValue ids.UUID) (int, error) {
 	type openTask struct {
 		id      ids.ActivityID
 		version int64
@@ -271,10 +299,10 @@ func (s *Store) completeOpenSystemTasksLinkedBy(ctx context.Context, linkClause 
 		rows, err := tx.Query(ctx, storekit.SQLf(`
 			SELECT a.id, a.version FROM activity a
 			JOIN activity_link l ON l.activity_id = a.id
-			WHERE %s AND a.kind = $2 AND a.source = $3
+			WHERE l.%s = $1 AND a.kind = $2 AND a.source = $3
 			  AND (a.captured_by = $4 OR a.captured_by LIKE $5)
 			  AND a.is_done = false AND a.archived_at IS NULL
-			ORDER BY a.id`, linkClause), linkValue, string(crmcontracts.ActivityKindTask), systemSource,
+			ORDER BY a.id`, column), linkValue, string(crmcontracts.ActivityKindTask), systemSource,
 			systemCapturedBy, systemCapturedByPattern)
 		if err != nil {
 			return err

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -155,8 +155,8 @@ func (w followUpAutoResolve) Apply(ctx context.Context, ev workflow.Event, eff w
 		}
 		completed += done
 	}
-	// margince#3764: a PROMOTED lead is a different shape from a disqualified
-	// one. carryLeadActivities (people/promote.go) moves the follow-up task's
+	// A PROMOTED lead is a different shape from a disqualified one.
+	// carryLeadActivities (people/promote.go) moves the follow-up task's
 	// link from the lead onto the person it became, inside the SAME
 	// transaction that emits this event — so the lead-keyed completion above
 	// never finds it once a lead has genuinely promoted; only the payload
@@ -169,7 +169,8 @@ func (w followUpAutoResolve) Apply(ctx context.Context, ev workflow.Event, eff w
 	// way a lead's follow-up does — and completing every open system task on
 	// the person would tick off work this promotion has nothing to do with.
 	// A newly minted person cannot yet carry anything else, so completing by
-	// person id is exact there and only there.
+	// person id is exact there and only there. A MERGED promotion's carried
+	// follow-up is left open by this arm; nothing else resolves it either.
 	if w.trigger == leadPromotedTrigger {
 		promoted, err := decodeLeadPromoted(ev.Payload)
 		if err != nil {

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -77,10 +77,14 @@ const systemCapturedByPattern = systemCapturedBy + ":%"
 func FollowUpWorkflows(store *Store) []workflow.Handler {
 	return []workflow.Handler{
 		followUpAutoResolve{store: store, name: "follow_up_auto_resolve", trigger: "activity.captured", leadsFromLinks: true},
-		followUpAutoResolve{store: store, name: "follow_up_auto_resolve_on_promoted", trigger: "lead.promoted"},
+		followUpAutoResolve{store: store, name: "follow_up_auto_resolve_on_promoted", trigger: leadPromotedTrigger},
 		followUpAutoResolve{store: store, name: "follow_up_auto_resolve_on_disqualified", trigger: "lead.disqualified"},
 	}
 }
+
+// leadPromotedTrigger names the one trigger whose Apply also has to resolve
+// by PERSON rather than by lead — see the comment on Apply for why.
+const leadPromotedTrigger = "lead.promoted"
 
 // followUpAutoResolve is one trigger's arm of the auto-resolve invariant.
 // leadsFromLinks says the fired entity is an ACTIVITY whose linked leads
@@ -151,10 +155,38 @@ func (w followUpAutoResolve) Apply(ctx context.Context, ev workflow.Event, eff w
 		}
 		completed += done
 	}
+	// margince#3764: a PROMOTED lead is a different shape from a disqualified
+	// one. carryLeadActivities (people/promote.go) moves the follow-up task's
+	// link from the lead onto the person it became, inside the SAME
+	// transaction that emits this event — so the lead-keyed completion above
+	// never finds it once a lead has genuinely promoted; only the payload
+	// still names where the task went.
+	if w.trigger == leadPromotedTrigger {
+		personID, err := promotedPersonID(ev.Payload)
+		if err != nil {
+			return workflow.RunResult{}, fmt.Errorf("decoding the promoted person: %w", err)
+		}
+		done, err := w.store.CompleteOpenSystemTasksForPerson(ctx, personID)
+		if err != nil {
+			return workflow.RunResult{}, fmt.Errorf("resolving follow-ups on person %s: %w", personID, err)
+		}
+		completed += done
+	}
 	if completed == 0 {
 		return workflow.RunResult{}, nil
 	}
 	return workflow.RunResult{Applied: eff.Actions}, nil
+}
+
+// promotedPersonID reads the person a lead.promoted payload names — the only
+// place, once carryLeadActivities has run, that still says where its tasks
+// went.
+func promotedPersonID(payload json.RawMessage) (ids.PersonID, error) {
+	var body crmcontracts.PublicEventLeadPromoted
+	if err := json.Unmarshal(payload, &body); err != nil {
+		return ids.PersonID{}, fmt.Errorf("activities: decoding lead.promoted's payload: %w", err)
+	}
+	return ids.From[ids.PersonKind](ids.UUID(body.PromotedPersonId)), nil
 }
 
 func (w followUpAutoResolve) IdempotencyKey(ev workflow.Event) string {
@@ -213,19 +245,36 @@ func (w followUpAutoResolve) linkedLeads(ctx context.Context, activityID ids.Act
 // leaves a call that takes no read gate of its own; each completion's
 // write is gated inside UpdateActivity.
 func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.LeadID) (int, error) {
+	return s.completeOpenSystemTasksLinkedBy(ctx, "l.lead_id = $1", leadID.UUID)
+}
+
+// CompleteOpenSystemTasksForPerson is CompleteOpenSystemTasksForLead's
+// sibling for a lead that PROMOTED: carryLeadActivities (people/promote.go)
+// re-points a follow-up task's link from the lead onto the person it became,
+// in the same transaction that emits lead.promoted, so a lead id can no
+// longer find it — only the person id it was carried to can.
+func (s *Store) CompleteOpenSystemTasksForPerson(ctx context.Context, personID ids.PersonID) (int, error) {
+	return s.completeOpenSystemTasksLinkedBy(ctx, "l.person_id = $1", personID.UUID)
+}
+
+// completeOpenSystemTasksLinkedBy is the one query and completion loop both
+// callers above share, differing only in which activity_link column names
+// the subject. `linkClause` is always a caller-supplied compile-time literal
+// ("l.lead_id = $1" / "l.person_id = $1"), never a value off a request body.
+func (s *Store) completeOpenSystemTasksLinkedBy(ctx context.Context, linkClause string, linkValue ids.UUID) (int, error) {
 	type openTask struct {
 		id      ids.ActivityID
 		version int64
 	}
 	var open []openTask
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, `
+		rows, err := tx.Query(ctx, storekit.SQLf(`
 			SELECT a.id, a.version FROM activity a
 			JOIN activity_link l ON l.activity_id = a.id
-			WHERE l.lead_id = $1 AND a.kind = $2 AND a.source = $3
+			WHERE %s AND a.kind = $2 AND a.source = $3
 			  AND (a.captured_by = $4 OR a.captured_by LIKE $5)
 			  AND a.is_done = false AND a.archived_at IS NULL
-			ORDER BY a.id`, leadID, string(crmcontracts.ActivityKindTask), systemSource,
+			ORDER BY a.id`, linkClause), linkValue, string(crmcontracts.ActivityKindTask), systemSource,
 			systemCapturedBy, systemCapturedByPattern)
 		if err != nil {
 			return err

--- a/backend/internal/modules/activities/followupresolve_integration_test.go
+++ b/backend/internal/modules/activities/followupresolve_integration_test.go
@@ -125,11 +125,12 @@ func (e *resolveEnv) seedTaskLinkedToPerson(t *testing.T, source, capturedBy str
 // leadPromotedEvent is the real shape people.QualifyLead emits — the payload
 // names the person the lead became, which is the only place, once
 // carryLeadActivities has run, that a caller can still learn where the lead's
-// tasks went.
-func leadPromotedEvent(t *testing.T, lead, person ids.UUID) workflow.Event {
+// tasks went. dedupeOutcome is "created" for a fresh person, "merged" for an
+// existing survivor — see promotedPersonID's doc for why the resolver reads it.
+func leadPromotedEvent(t *testing.T, lead, person ids.UUID, dedupeOutcome string) workflow.Event {
 	t.Helper()
 	payload, err := json.Marshal(map[string]string{
-		"promoted_person_id": person.String(), "dedupe_outcome": "created", "trigger": "human_qualify",
+		"promoted_person_id": person.String(), "dedupe_outcome": dedupeOutcome, "trigger": "human_qualify",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -298,7 +299,7 @@ func TestAPromotedLeadCompletesItsSystemTasksCarriedToThePerson(t *testing.T) {
 
 	ctx := e.systemCtx()
 	h := handlerFor(t, store, "lead.promoted")
-	result := fire(ctx, t, h, leadPromotedEvent(t, e.lead, person))
+	result := fire(ctx, t, h, leadPromotedEvent(t, e.lead, person, "created"))
 
 	if len(result.Applied) == 0 {
 		t.Fatal("a promoted lead resolved nothing — the follow-up loop stays open forever")
@@ -308,6 +309,32 @@ func TestAPromotedLeadCompletesItsSystemTasksCarriedToThePerson(t *testing.T) {
 	}
 	if e.isDone(t, humanTask) {
 		t.Error("the HUMAN's task was completed — the system claimed work a person may not consider done")
+	}
+}
+
+// A lead promoted into an EXISTING person (dedupe_outcome "merged") must not
+// claim work the person's own history already carries. promoteTarget only
+// merges into a survivor that could easily have its own open system-minted
+// reminder already (no_activity_reminder/check_in_cadence anchor on a person
+// the same way) — completing every open system task on the person, rather
+// than only the one this promotion carried, would tick off a reminder this
+// promotion has nothing to do with, with an audit row claiming the follow-up
+// happened. The resolver only completes the carried task on a genuinely NEW
+// person, where nothing else could exist to collide with yet.
+func TestAMergedPromotionDoesNotClaimThePersonsUnrelatedTasks(t *testing.T) {
+	e := setupResolve(t)
+	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
+	person := e.seedPerson(t)
+	// Pre-existing, unrelated to this promotion: a check-in reminder the
+	// system minted against the SURVIVOR long before this lead ever promoted.
+	unrelatedReminder := e.seedTaskLinkedToPerson(t, "system", "system", person)
+
+	ctx := e.systemCtx()
+	h := handlerFor(t, store, "lead.promoted")
+	fire(ctx, t, h, leadPromotedEvent(t, e.lead, person, "merged"))
+
+	if e.isDone(t, unrelatedReminder) {
+		t.Error("a merge completed a person's pre-existing system reminder that this promotion never touched")
 	}
 }
 

--- a/backend/internal/modules/activities/followupresolve_integration_test.go
+++ b/backend/internal/modules/activities/followupresolve_integration_test.go
@@ -284,7 +284,7 @@ func TestADisqualifiedLeadCompletesItsSystemTasks(t *testing.T) {
 	}
 }
 
-// margince#3764: a lead PROMOTED is a different shape. carryLeadActivities
+// A lead PROMOTED is a different shape. carryLeadActivities
 // (people/promote.go) moves the follow-up task's link from the lead onto the
 // person it became — entity_type 'person', person_id set, lead_id NULL —
 // inside the SAME transaction that emits lead.promoted, so the resolver never

--- a/backend/internal/modules/activities/followupresolve_integration_test.go
+++ b/backend/internal/modules/activities/followupresolve_integration_test.go
@@ -97,6 +97,52 @@ func (e *resolveEnv) seedTask(t *testing.T, source, capturedBy string) ids.UUID 
 	return id
 }
 
+// seedPerson writes a bare person row, the target a promotion carries the
+// lead's activities onto.
+func (e *resolveEnv) seedPerson(t *testing.T) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Resolve Person', $2, 'manual', $3)`, id, e.rep, "human:"+e.rep.String())
+	return id
+}
+
+// seedTaskLinkedToPerson writes one open task linked to a person — the shape
+// carryLeadActivities (people/promote.go) leaves a lead's follow-up task in,
+// inside the SAME transaction that promotes the lead: entity_type 'person',
+// person_id set, lead_id NULL. A resolver that still looks this task up by
+// the lead id finds nothing.
+func (e *resolveEnv) seedTaskLinkedToPerson(t *testing.T, source, capturedBy string, person ids.UUID) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	e.exec(t, `INSERT INTO activity (id, kind, subject, occurred_at, due_at, source, captured_by)
+		VALUES ($1, 'task', 'Follow up with the new lead', now(), now() + interval '1 day', $2, $3)`,
+		id, source, capturedBy)
+	e.exec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id) VALUES ($1, 'person', $2)`, id, person)
+	return id
+}
+
+// leadPromotedEvent is the real shape people.QualifyLead emits — the payload
+// names the person the lead became, which is the only place, once
+// carryLeadActivities has run, that a caller can still learn where the lead's
+// tasks went.
+func leadPromotedEvent(t *testing.T, lead, person ids.UUID) workflow.Event {
+	t.Helper()
+	payload, err := json.Marshal(map[string]string{
+		"promoted_person_id": person.String(), "dedupe_outcome": "created", "trigger": "human_qualify",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return workflow.Event{
+		ID:         ids.NewV7(),
+		Type:       "lead.promoted",
+		OccurredAt: time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC),
+		Entity:     datasource.EntityRef{Type: "lead", ID: lead},
+		Payload:    payload,
+	}
+}
+
 func (e *resolveEnv) isDone(t *testing.T, id ids.UUID) bool {
 	t.Helper()
 	var done bool
@@ -216,21 +262,52 @@ func TestACapturedTaskResolvesNothing(t *testing.T) {
 	}
 }
 
-func TestALeadLeavingTheOpenPoolCompletesItsSystemTasks(t *testing.T) {
+// A lead DISQUALIFIED leaves the open pool without moving anything: it never
+// becomes a person, so its follow-up task's link keeps its lead_id, and the
+// resolver's original lead-keyed lookup still finds it.
+func TestADisqualifiedLeadCompletesItsSystemTasks(t *testing.T) {
 	e := setupResolve(t)
 	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
 	systemTask := e.seedTask(t, "system", "system")
 
 	ctx := e.systemCtx()
-	h := handlerFor(t, store, "lead.promoted")
+	h := handlerFor(t, store, "lead.disqualified")
 	fire(ctx, t, h, workflow.Event{
 		ID:         ids.NewV7(),
-		Type:       "lead.promoted",
+		Type:       "lead.disqualified",
 		OccurredAt: time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC),
 		Entity:     datasource.EntityRef{Type: "lead", ID: e.lead},
 	})
 	if !e.isDone(t, systemTask) {
-		t.Error("the promoted lead's system follow-up is still open — a reminder chasing a closed loop")
+		t.Error("the disqualified lead's system follow-up is still open — a reminder chasing a closed loop")
+	}
+}
+
+// margince#3764: a lead PROMOTED is a different shape. carryLeadActivities
+// (people/promote.go) moves the follow-up task's link from the lead onto the
+// person it became — entity_type 'person', person_id set, lead_id NULL —
+// inside the SAME transaction that emits lead.promoted, so the resolver never
+// sees a lead-linked row for a genuinely promoted lead. It has to complete the
+// task through the person the event names instead.
+func TestAPromotedLeadCompletesItsSystemTasksCarriedToThePerson(t *testing.T) {
+	e := setupResolve(t)
+	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
+	person := e.seedPerson(t)
+	systemTask := e.seedTaskLinkedToPerson(t, "system", "system", person)
+	humanTask := e.seedTaskLinkedToPerson(t, "web", "human:"+e.rep.String(), person)
+
+	ctx := e.systemCtx()
+	h := handlerFor(t, store, "lead.promoted")
+	result := fire(ctx, t, h, leadPromotedEvent(t, e.lead, person))
+
+	if len(result.Applied) == 0 {
+		t.Fatal("a promoted lead resolved nothing — the follow-up loop stays open forever")
+	}
+	if !e.isDone(t, systemTask) {
+		t.Error("the promoted lead's system follow-up is still open — its task carried to the person, and the resolver looked it up by the lead id promotion just nulled")
+	}
+	if e.isDone(t, humanTask) {
+		t.Error("the HUMAN's task was completed — the system claimed work a person may not consider done")
 	}
 }
 

--- a/backend/internal/modules/deals/dealfigures.go
+++ b/backend/internal/modules/deals/dealfigures.go
@@ -92,6 +92,15 @@ type DealFigures struct {
 	AmountMinor       *int64
 	Currency          string
 	ExpectedCloseDate *time.Time
+	// CloseOverdue is the SAME calendar-date, workspace-zone verdict
+	// CloseIsOverdue gives elsewhere (closedatesweep.go, slipping.go): the
+	// close date's own calendar day is before today's, in the installation's
+	// zone. Computed in SQL rather than by calling CloseIsOverdue in Go — this
+	// read already opens one transaction, and `timezone($1, now())::date` asks
+	// Postgres the identical question without a second round trip to resolve
+	// the zone through identity.TimezoneOf and a fresh Go-side comparison.
+	// Meaningless where ExpectedCloseDate is nil.
+	CloseOverdue bool
 }
 
 // figuresScanCap bounds one read. A page names as many deals as it has rows,
@@ -124,17 +133,31 @@ func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]D
 			len(dealIDs), figuresScanCap)
 	}
 	err := s.Tx(ctx, func(tx pgx.Tx) error {
+		// The SAME question CloseIsOverdue asks elsewhere (closedatesweep.go,
+		// slipping.go), asked in SQL instead of resolved through a second
+		// transaction: this read is already inside one, and `timezone($1,
+		// now())::date` is Postgres's own answer to "what is today, in this
+		// zone" — the identical rule the at-risk lane's identical deal is
+		// judged by, so this read's caller states the same overdue verdict
+		// for both rows of one deal.
+		tzName, err := s.installation.Timezone(ctx, tx)
+		if err != nil {
+			return fmt.Errorf("read the installation's timezone: %w", err)
+		}
 		args := []any{}
 		arg := func(v any) int { args = append(args, v); return len(args) }
+		tzPos := arg(tzName)
 		idsPos := arg(dealIDs)
 		scope, err := auth.ScopeClauseFor(ctx, dealTable, "d", arg)
 		if err != nil {
 			return err
 		}
 		query := storekit.SQLf(
-			`SELECT d.id, d.stage_id, d.owner_id, d.amount_minor, d.currency, d.expected_close_date
+			`SELECT d.id, d.stage_id, d.owner_id, d.amount_minor, d.currency, d.expected_close_date,
+			        d.expected_close_date IS NOT NULL
+			          AND d.expected_close_date < (timezone($%d, now()))::date
 			   FROM deal d
-			  WHERE d.id = ANY($%d) AND d.archived_at IS NULL`, idsPos)
+			  WHERE d.id = ANY($%d) AND d.archived_at IS NULL`, tzPos, idsPos)
 		if scope != "" {
 			query += storekit.SQLf(" AND %s", scope)
 		}
@@ -145,17 +168,18 @@ func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]D
 		defer rows.Close()
 		for rows.Next() {
 			var (
-				id     ids.UUID
-				stage  *ids.UUID
-				owner  *ids.UUID
-				amount *int64
-				code   *string
-				closes *time.Time
+				id      ids.UUID
+				stage   *ids.UUID
+				owner   *ids.UUID
+				amount  *int64
+				code    *string
+				closes  *time.Time
+				overdue bool
 			)
-			if err := rows.Scan(&id, &stage, &owner, &amount, &code, &closes); err != nil {
+			if err := rows.Scan(&id, &stage, &owner, &amount, &code, &closes, &overdue); err != nil {
 				return err
 			}
-			figures := DealFigures{AmountMinor: amount, ExpectedCloseDate: closes}
+			figures := DealFigures{AmountMinor: amount, ExpectedCloseDate: closes, CloseOverdue: overdue}
 			if stage != nil {
 				figures.StageID = *stage
 			}

--- a/backend/internal/platform/netguard/publicorigin.go
+++ b/backend/internal/platform/netguard/publicorigin.go
@@ -51,14 +51,12 @@ var ErrOriginNotPublic = errors.New("public origin is not reachable by a recipie
 // including an unrecognised one, which runtimeenv parses as production —
 // gets the full rule, so the carve-out fails closed.
 //
-// The development/test exemption is checked BEFORE bareOrigin for an
-// UNSET value specifically (margince#3457): a caller that never wired an
-// origin at all is not a broken configuration under a posture that needs no
-// real link to work, and refusing it before the posture was even consulted
-// once left a worker process unable to start while the api process (which
-// did receive a value) came up fine beside it. A NON-empty value still goes
-// through the full shape check in every posture — only genuine absence is
-// exempt, so a real but malformed origin is still caught.
+// The development/test exemption is checked BEFORE bareOrigin for an UNSET
+// value specifically: a caller that never wired an origin at all is not a
+// broken configuration under a posture that needs no real link to work. A
+// NON-empty value still goes through the full shape check in every posture
+// — only genuine absence is exempt, so a real but malformed origin is still
+// caught.
 func RequirePublicOrigin(label, raw string, env runtimeenv.Environment) error {
 	devOrTest := env == runtimeenv.Development || env == runtimeenv.Test
 	if devOrTest && strings.TrimSpace(raw) == "" {

--- a/backend/internal/platform/netguard/publicorigin.go
+++ b/backend/internal/platform/netguard/publicorigin.go
@@ -50,12 +50,25 @@ var ErrOriginNotPublic = errors.New("public origin is not reachable by a recipie
 // stack's http://localhost default keeps working. Any other posture —
 // including an unrecognised one, which runtimeenv parses as production —
 // gets the full rule, so the carve-out fails closed.
+//
+// The development/test exemption is checked BEFORE bareOrigin for an
+// UNSET value specifically (margince#3457): a caller that never wired an
+// origin at all is not a broken configuration under a posture that needs no
+// real link to work, and refusing it before the posture was even consulted
+// once left a worker process unable to start while the api process (which
+// did receive a value) came up fine beside it. A NON-empty value still goes
+// through the full shape check in every posture — only genuine absence is
+// exempt, so a real but malformed origin is still caught.
 func RequirePublicOrigin(label, raw string, env runtimeenv.Environment) error {
+	devOrTest := env == runtimeenv.Development || env == runtimeenv.Test
+	if devOrTest && strings.TrimSpace(raw) == "" {
+		return nil
+	}
 	parsed, err := bareOrigin(label, raw)
 	if err != nil {
 		return err
 	}
-	if env == runtimeenv.Development || env == runtimeenv.Test {
+	if devOrTest {
 		return nil
 	}
 	if parsed.Scheme != "https" {

--- a/backend/internal/platform/netguard/publicorigin_test.go
+++ b/backend/internal/platform/netguard/publicorigin_test.go
@@ -89,13 +89,10 @@ func TestAnEmptyOriginIsRefused(t *testing.T) {
 	}
 }
 
-// margince#3457: a caller that has not wired a public origin at all is not a
-// broken configuration under development or test — those postures need no
-// real link to work, and the refusal used to run before the posture was even
-// consulted, so a worker started with no origin flag could not start at all
-// while the api process (which did receive one) came up fine beside it.
-// Production and every OTHER posture — an unrecognised one included — still
-// refuse below, through TestAnEmptyOriginIsRefused and
+// A caller that has not wired a public origin at all is not a broken
+// configuration under development or test — those postures need no real
+// link to work. Production and every OTHER posture — an unrecognised one
+// included — still refuse below, through TestAnEmptyOriginIsRefused and
 // TestAnUnknownPostureIsTreatedAsProduction.
 func TestAnUnsetOriginInDevelopmentOrTestIsNotRefused(t *testing.T) {
 	for _, env := range []runtimeenv.Environment{runtimeenv.Development, runtimeenv.Test} {

--- a/backend/internal/platform/netguard/publicorigin_test.go
+++ b/backend/internal/platform/netguard/publicorigin_test.go
@@ -89,6 +89,31 @@ func TestAnEmptyOriginIsRefused(t *testing.T) {
 	}
 }
 
+// margince#3457: a caller that has not wired a public origin at all is not a
+// broken configuration under development or test — those postures need no
+// real link to work, and the refusal used to run before the posture was even
+// consulted, so a worker started with no origin flag could not start at all
+// while the api process (which did receive one) came up fine beside it.
+// Production and every OTHER posture — an unrecognised one included — still
+// refuse below, through TestAnEmptyOriginIsRefused and
+// TestAnUnknownPostureIsTreatedAsProduction.
+func TestAnUnsetOriginInDevelopmentOrTestIsNotRefused(t *testing.T) {
+	for _, env := range []runtimeenv.Environment{runtimeenv.Development, runtimeenv.Test} {
+		if err := RequirePublicOrigin("--public-base-url", "", env); err != nil {
+			t.Errorf("posture %v refused an unset origin: %v", env, err)
+		}
+	}
+}
+
+// A malformed, non-empty origin is still refused under development or test —
+// only genuine ABSENCE is exempt, so a real but broken value is still caught
+// rather than reaching a dev stack's own link-building code unchecked.
+func TestAMalformedOriginInDevelopmentIsStillRefused(t *testing.T) {
+	if err := RequirePublicOrigin("--public-base-url", "https://user:secret@example.com", runtimeenv.Development); err == nil {
+		t.Error("posture Development admitted a malformed, non-empty origin")
+	}
+}
+
 // Every one of these was admitted by a first version of this guard that
 // delegated shape validation to a caller which does not always run.
 func TestAMalformedOriginIsRefusedBySendersOwnGuard(t *testing.T) {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28262,8 +28262,12 @@ export interface components {
         };
         /**
          * @description The deal behind an item, with the facts its card states. `expected_minor_base` is
-         *     `amount_minor × win_probability`, converted to the installation's base currency —
-         *     the only figure by which two deals in different currencies may be compared.
+         *     `amount_minor` converted to the installation's base currency — the only figure by
+         *     which two deals in different currencies may be compared. It does not yet weight by
+         *     `win_probability`: the pipeline this row comes from does not read a deal's stage
+         *     today, so the two fields are independent facts rather than one computed from the
+         *     other, and a reader must not multiply them together expecting the product to equal
+         *     a risk-adjusted figure the API does not compute.
          */
         WorklistDealFacts: {
             /** Format: uuid */
@@ -28276,7 +28280,7 @@ export interface components {
             win_probability?: number | null;
             /**
              * Format: int64
-             * @description Expected revenue in the base currency. Null when the amount or the rate is unknown.
+             * @description The deal amount converted to the base currency, NOT weighted by win_probability. Null when the amount or the conversion rate is unknown.
              */
             expected_minor_base?: number | null;
             /** Format: date */


### PR DESCRIPTION
## Summary

Five independently-verified QC findings, one review surface (`compose/attention`, `modules/deals`, `modules/activities`, `platform/netguard`):

- **margince#3315** — `WorklistDealFacts.expected_minor_base` was declared in the contract and never populated. `classifyRisk` now sets it from the FX-converted expected-revenue figure, only once the seam actually priced the deal. Also corrected the field's contract description, which claimed a `amount_minor × win_probability` formula this pipeline does not compute (nothing reads a deal's stage win_probability here — `expectedRevenue`'s own comment already said so). Shipping the raw amount under a wrong formula would have been worse than the field staying absent.
- **margince#3749** — the brief lane and the at-risk lane disagreed about whether a deal due *today* was overdue: the brief lane compared instants, the at-risk lane compares calendar dates in the workspace zone (`deals.CloseIsOverdue`). `deals.Store.Figures` now computes the same calendar-date verdict in SQL and threads it onto `item.Overdue`, so both lanes state one answer for one deal.
- **margince#3800** — deleting a deal left its overnight-brief row on the Worklist with no amount, no close date and no reason, still offering `act`/`set_aside`/`dismiss`. `nameTheMoney` now drops a brief row whose deal `Figures` can't answer for, instead of leaving an unidentifiable one on the page.
- **margince#3764** — promoting a lead strands its "Follow up with the new lead" task. `carryLeadActivities` re-points the task's `activity_link` from the lead onto the person it became, inside the promotion's own transaction — so the `lead.promoted` resolver's lead-keyed lookup always found nothing. It now also resolves by the person the event payload names, **for a fresh person only** (`dedupe_outcome == "created"`); completing by person id on a *merged* promotion risked ticking off the survivor's own unrelated open reminders (`no_activity_reminder`/`check_in_cadence`), so that narrower case is filed as a follow-up: margince#3843.
- **margince#3457** — `make dev` could not start a worker because `RequirePublicOrigin` refused an empty origin before checking whether the posture was development/test at all. The exemption is now checked first for a genuinely unset value; a non-empty malformed one is still refused in every posture.

## Review

Two independent reviews (Fable model, Codex) ran against the diff before push. Findings addressed:
- MAJOR (Fable): person-keyed follow-up completion on a merged promotion could complete unrelated tasks — fixed by gating on `dedupe_outcome`, guarded by a new test.
- Contract mismatch (Codex): `expected_minor_base`'s declared formula didn't match what's computed — fixed the contract description rather than the wrong alternative (implementing win-probability weighting is separate, larger work; shipping the mismatch was worse than leaving the field absent).
- Ticket references and fix-narration in comments — reworded per AGENTS.md's "history belongs to git" rule.
- SQL clause placeholder now spelled beside its own argument instead of split across a call boundary; test seeded from the DB's own clock instead of Go's wall clock to remove a UTC-midnight race.

## Test plan

- [x] `make check` — full local gate, green (backend build/vet/lint/arch-lint/tests, contract drift, composition reproducibility, frontend typecheck/lint/build/unit).
- [x] `craft static --strict` (diff-scoped) — 0 blocker/major/minor.
- [x] `make test-it DIR=backend/internal/modules/activities` and `DIR=backend/internal/compose/integration RUN=TestDealFigures` — real-Postgres integration lanes, all green, including the new `TestAMergedPromotionDoesNotClaimThePersonsUnrelatedTasks` regression guard.
- [x] New code coverage: 75–100% across all touched functions (measured via `-coverpkg` against the integration lanes for the DB-dependent paths).
- [ ] Live dev-stack UAT was attempted but hit a port collision with another user's stack on this shared machine (`:18083` already held by a different `make dev` instance); relying on the real-Postgres integration suite above as the equivalent evidence for backend-only, no-UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzkBShFNemkBKN3h5faNxf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five backend edge cases where Worklist data, promotion follow-ups, and development startup could produce inconsistent or unusable behavior.

**Bug Fixes**

- Populates `expected_minor_base` with the converted deal amount after successful pricing and documents that it is not win-probability weighted.
- Uses the workspace calendar date for overdue status in both brief and at-risk lanes, so deals due today are not marked late.
- Drops brief rows when their deal can no longer be resolved instead of leaving actions for an unidentified deal.
- Resolves follow-up tasks moved to newly created people during lead promotion, while merged promotions do not claim the survivor’s existing tasks.
- Allows an unset public origin in development and test while still rejecting non-empty malformed origins in every posture.

<sup>Written for commit 6f4f3090f5c7589127810d9c50bcb766c5b3b342. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deal insights now show whether expected close dates are overdue using the workspace’s local calendar date.
  - Expected revenue is displayed in base currency when conversion is available.
  - Promoting a lead now completes applicable open system follow-up tasks for the associated person.

- **Bug Fixes**
  - Deals without resolvable figures are no longer shown without details.
  - Overdue indicators remain consistent across deal cards and attention views.
  - Unrelated tasks are protected during merged-lead promotions.
  - Development and test environments now accept unset origins while still rejecting malformed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->