### PR TITLE
The morning's eyebrow says when its queue was read

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2399,6 +2399,7 @@ export const de = {
   // Seite zeigt — nie von einem Modell geschrieben.
   "brief.eyebrow": "Dein Morgen",
   "brief.eyebrow.weekly": "Deine Woche",
+  "brief.eyebrow.asOf": "{scope} · Stand {at}",
   // Die zwei Regler des Briefings: welches, und für wen.
   "brief.view.label": "Welches Briefing",
   "brief.view.morning": "Morgen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2448,6 +2448,7 @@ export const en = {
   // never model-written, so it cannot say what the rows contradict.
   "brief.eyebrow": "Your morning",
   "brief.eyebrow.weekly": "Your week",
+  "brief.eyebrow.asOf": "{scope} · as of {at}",
   // The Brief's two dials. Which brief, and whose.
   "brief.view.label": "Which brief",
   "brief.view.morning": "Morning",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2375,6 +2375,7 @@ export const vi = {
   // không do mô hình viết.
   "brief.eyebrow": "Buổi sáng của bạn",
   "brief.eyebrow.weekly": "Tuần của bạn",
+  "brief.eyebrow.asOf": "{scope} · tính đến {at}",
   // Hai nút chuyển của bản tóm tắt: bản nào, và của ai.
   "brief.view.label": "Bản tóm tắt nào",
   "brief.view.morning": "Buổi sáng",

--- a/frontend/src/screens/home.dials.test.tsx
+++ b/frontend/src/screens/home.dials.test.tsx
@@ -2,6 +2,8 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatTimeOfDay } from "../format/format";
+import { viewerZone } from "../format/timezone";
 import { en } from "../i18n/en";
 import { HomeScreen } from "./home";
 import { readingsDay, waitingRow } from "./home.fixtures";
@@ -128,7 +130,17 @@ describe("the Brief's dials", () => {
   it("names the view in the eyebrow, and keeps the sentence to the morning", async () => {
     stubHome(["mine"]);
     render(<HomeScreen />);
-    expect(await screen.findByText(en["brief.eyebrow"])).toBeTruthy();
+    // The expected time is DERIVED, not written down: the runner's zone is not
+    // the fixture's, so a literal "07:00" here passes in Berlin and fails in CI.
+    expect(
+      await screen.findByText(
+        `${en["brief.eyebrow"]} · as of ${formatTimeOfDay(
+          readingsDay({}).as_of,
+          "en",
+          viewerZone(),
+        )}`,
+      ),
+    ).toBeTruthy();
     // findBy: the sentence is composed from the worklist read, so it appears
     // when that lands rather than on the first paint.
     expect(await screen.findByTestId("glance-sentence")).toBeTruthy();
@@ -140,7 +152,12 @@ describe("the Brief's dials", () => {
     render(<HomeScreen />);
 
     expect(await screen.findByText(en["brief.eyebrow.weekly"])).toBeTruthy();
-    expect(screen.queryByText(en["brief.eyebrow"])).toBeNull();
+    // Exact match: the morning's eyebrow now composes the scope with an as-of,
+    // so a substring read would call the weekly clean while the morning's own
+    // words were on the page.
+    expect(
+      screen.queryByText((text) => text === en["brief.eyebrow"]),
+    ).toBeNull();
     expect(screen.queryByTestId("glance-sentence")).toBeNull();
     // And the line that stands in for it belongs to the week too. The weekly
     // NEVER composes a sentence, so the fallback is the only line under its

--- a/frontend/src/screens/home.glance.tsx
+++ b/frontend/src/screens/home.glance.tsx
@@ -2,9 +2,9 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import { Eyebrow } from "../design-system/eyebrow";
-import { hourInZone } from "../format/format";
+import { formatTimeOfDay, hourInZone } from "../format/format";
 import { viewerZone } from "../format/timezone";
-import { useLocale, useT } from "../i18n";
+import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { briefSentence } from "./brief.sentence";
 import type { BriefView } from "./brief.view";
@@ -78,6 +78,30 @@ export type GlanceFacts = Readonly<{
 
 export type GlanceProps = GlanceFacts;
 
+// The eyebrow names the view and, for the morning, the moment the queue below
+// was read. The as-of is the morning's alone: the weekly's numbers were frozen
+// when the week closed, and a time-of-day against them would date the reading
+// rather than the week. A morning whose queue has not arrived yet says the
+// scope by itself instead of naming a moment it does not know.
+function eyebrowText(
+  view: BriefView,
+  day: Worklist | undefined,
+  t: Translator,
+  locale: Locale,
+): string {
+  if (view === "weekly") {
+    return t("brief.eyebrow.weekly");
+  }
+  const scope = t("brief.eyebrow");
+  if (day === undefined) {
+    return scope;
+  }
+  return t("brief.eyebrow.asOf", {
+    scope,
+    at: formatTimeOfDay(day.as_of, locale, viewerZone()),
+  });
+}
+
 export function HomeGlance({ firstName, now, day, view }: GlanceProps) {
   const t = useT();
   const hour = hourInZone(now, viewerZone());
@@ -101,7 +125,7 @@ export function HomeGlance({ firstName, now, day, view }: GlanceProps) {
       {/* Scope and date, above the greeting. A span rather than a heading: the
           page has ONE h1 and this is its label, not a level of its own. */}
       <Eyebrow className="glance-eyebrow">
-        {t(view === "weekly" ? "brief.eyebrow.weekly" : "brief.eyebrow")}
+        {eyebrowText(view, day, t, locale)}
       </Eyebrow>
       <h1 className="glance-greeting t-display">{greeting}</h1>
       {sentence ? (

--- a/frontend/src/screens/home.test.tsx
+++ b/frontend/src/screens/home.test.tsx
@@ -8,9 +8,11 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { MONEY_ABSENT } from "../format/format";
+import { formatTimeOfDay, MONEY_ABSENT } from "../format/format";
+import { viewerZone } from "../format/timezone";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
+import type { BriefView } from "./brief.view";
 import { HomeScreen } from "./home";
 import { overnightRow, readingsDay } from "./home.fixtures";
 import { HomeGlance } from "./home.glance";
@@ -28,6 +30,7 @@ import {
   writeRoutes,
   writes,
 } from "./home.testkit";
+import type { Worklist } from "./worklist.queries";
 
 afterEach(() => {
   cleanup();
@@ -373,6 +376,48 @@ describe("HomeGlance — the greeting follows the reader's own hour", () => {
     // panels — so an unread queue leaves the header saying only the greeting.
     expect(screen.queryByTestId("glance-sentence")).toBeNull();
     expect(screen.queryByText("Nothing is waiting on you.")).toBeNull();
+  });
+});
+
+// ── The eyebrow dates the morning's reading, and only the morning's ──
+
+describe("HomeGlance — the eyebrow says when the queue was read", () => {
+  function eyebrowOf(view: BriefView, day: Worklist | undefined): string {
+    const rendered = rtlRender(
+      <LocaleProvider initial="en">
+        <HomeGlance
+          view={view}
+          firstName="Ada"
+          now={new Date(2026, 6, 5, 9, 0, 0)}
+          day={day}
+        />
+      </LocaleProvider>,
+    );
+    const text =
+      screen.getByTestId("home-glance").firstChild?.textContent ?? "";
+    rendered.unmount();
+    return text;
+  }
+
+  // Derived from the fixture and the runner's own zone. A literal time here
+  // would pin the test to whichever machine wrote it.
+  it("names the moment the morning's queue was read", () => {
+    const day = readingsDay({});
+    expect(eyebrowOf("morning", day)).toBe(
+      `Your morning · as of ${formatTimeOfDay(day.as_of, "en", viewerZone())}`,
+    );
+  });
+
+  // The weekly's numbers were frozen when the week closed. A time of day
+  // against them dates the reading rather than the week.
+  it("gives the weekly no as-of at all", () => {
+    expect(eyebrowOf("weekly", readingsDay({}))).toBe("Your week");
+  });
+
+  // A queue still in flight has no moment to name, and inventing one would
+  // date a reading that has not happened.
+  it("says the scope alone while the morning's queue is unread", () => {
+    expect(eyebrowOf("morning", undefined)).toBe("Your morning");
   });
 });
 


### PR DESCRIPTION
The Brief's eyebrow was a static scope word — "Your morning" — while `Worklist.as_of` sat unread on the wire. A reader coming back at 11:00 had no way to tell whether the queue below was minutes or hours old.

It now composes scope and as-of for the morning, in the reader's own locale and zone, through the existing `formatTimeOfDay`.

Two cases keep the scope word alone, and each is a deliberate refusal rather than a gap:

- **The weekly.** Its numbers were frozen when the week closed, so a time of day against them dates the reading rather than the week.
- **A morning whose queue has not arrived.** There is no moment to name yet, and inventing one would date a reading that has not happened.

All three behaviours are mutation-checked one clause at a time — removing either guard, or reverting to the static string, fails the matching test and nothing else.

The expected time in both tests is **derived** from the fixture and the runner's own zone rather than written down. A literal "07:00" passes in Berlin and fails in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The morning's eyebrow now shows when its queue was read, formatted in the reader's own locale and time zone, so returning readers can tell how fresh the briefing is.

- Composes the scope and the as-of time from the queue's `as_of` field.
- The weekly keeps its static scope; a morning queue that hasn't arrived yet also shows only the scope.
- Adds the `brief.eyebrow.asOf` translation key to `en`, `de`, and `vi`.
- Tests now derive expected times from the fixture and runner's zone, with mutation checks on the guards.

<sup>Written for commit e9abb5b47b31a0efffb022e078eee152f1811261. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Morning briefings now show a localized “as of” timestamp alongside the briefing scope when available.
  * Added English, German, and Vietnamese translations for the updated briefing label.

* **Bug Fixes**
  * Weekly briefings continue to display without a morning timestamp.
  * Unread morning briefings show only their scope when a timestamp is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->