### PR TITLE
The Generate button says it is assembling, not ranking

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2377,7 +2377,7 @@ export const de = {
     "{count} Deals fehlen in diesen Zahlen – Ihre Berechtigung deckt sie nicht ab.",
   "home.pipelineUnavailable": "Diese Zahl konnte nicht geladen werden.",
   "home.asOf": "Stand {at}",
-  "home.refreshing": "Sortiere neu…",
+  "home.generating": "Stelle zusammen…",
   "home.generate": "Briefing jetzt holen",
   "home.noneBody":
     "Dein Morgenbriefing sortiert die Deals, die deine erste Stunde verdienen — Gewinnchance, Umsatz, Timing, Momentum und Nähe, jeder Faktor mit Beleg. Es entsteht über Nacht und liegt morgen früh bereit, sobald offene Deals da sind.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2421,7 +2421,7 @@ export const en = {
     "{count} deals are not in these figures — your access does not cover them.",
   "home.pipelineUnavailable": "This figure could not be loaded.",
   "home.asOf": "as of {at}",
-  "home.refreshing": "Ranking…",
+  "home.generating": "Assembling…",
   "home.generate": "Get today's brief now",
   "home.noneBody":
     "Your morning brief ranks the deals worth your first hour — winnability, revenue, timing, momentum, and warmth, each factor with its evidence. It is assembled overnight, so it is waiting for you tomorrow morning once you have open deals.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2353,7 +2353,7 @@ export const vi = {
     "{count} deal không nằm trong các số này — quyền của bạn không bao gồm chúng.",
   "home.pipelineUnavailable": "Không tải được số liệu này.",
   "home.asOf": "tính đến {at}",
-  "home.refreshing": "Đang xếp hạng…",
+  "home.generating": "Đang tổng hợp…",
   "home.generate": "Lấy tóm tắt hôm nay",
   "home.noneBody":
     "Tóm tắt buổi sáng xếp hạng những deal đáng dành giờ đầu tiên — khả năng thắng, doanh thu, thời điểm, đà tiến và độ thân thiết, mỗi yếu tố kèm bằng chứng của nó. Bản tóm tắt được dựng qua đêm nên sẽ sẵn sàng vào sáng mai, khi bạn đã có deal đang mở.",

--- a/frontend/src/screens/home.test.tsx
+++ b/frontend/src/screens/home.test.tsx
@@ -901,4 +901,34 @@ describe("HomeScreen — the brief is generated, never re-ranked", () => {
     const generate = await screen.findByTestId("brief-refresh");
     expect(generate.textContent).toContain(en["home.generate"]);
   });
+
+  // And what it says WHILE it works names the same act. The button assembles a
+  // first run; a pending label reading "Ranking…" describes re-ordering one
+  // that already exists, which is the confusion the button's own wording was
+  // changed to avoid. Nothing asserted this label, so the two drifted.
+  it("names assembling, not ranking, while the run is being built", async () => {
+    let releasePost: (() => void) | undefined;
+    const posted = new Promise<void>((resolve) => {
+      releasePost = resolve;
+    });
+    stubApi({
+      "GET /brief": () => jsonResponse({ title: "Not Found" }, 404),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+      "POST /brief": async () => {
+        await posted;
+        return jsonResponse(run, 201);
+      },
+    });
+    const user = userEvent.setup();
+    render(<HomeScreen />);
+
+    // Deliberately NOT awaited: the click's promise settles only once the write
+    // does, and the pending label is what the button says in between.
+    void user.click(await screen.findByTestId("brief-refresh"));
+    expect(
+      (await screen.findByText(en["home.generating"])).textContent,
+    ).toContain(en["home.generating"]);
+
+    releasePost?.();
+  });
 });

--- a/frontend/src/screens/home.today.tsx
+++ b/frontend/src/screens/home.today.tsx
@@ -82,7 +82,7 @@ export function FocusSection({
             <Button
               small
               pending={refresh.isPending}
-              busyLabel={t("home.refreshing")}
+              busyLabel={t("home.generating")}
               onClick={() => refresh.mutate()}
               data-testid="brief-refresh"
             >


### PR DESCRIPTION
The button that fetches a first brief showed **"Ranking…"** while it worked. In German it was worse: **"Sortiere neu…"** — literally *re-sorting* — under a button reading *"Briefing jetzt holen"*.

`POST /brief` assembles a run where none exists and re-ranks nothing. The button's own label was already changed to say so, and a nine-line comment above it explains why: a control promising a re-rank the click cannot perform makes a rep who presses it and sees the same order conclude the ranking is stuck. The pending label was left behind saying exactly that.

`home.refreshing` becomes `home.generating` in en/de/vi.

**Nothing asserted the busy label**, which is why the two could drift. A test now holds the write open — the click deliberately not awaited — and reads what the button says in between. Mutation-checked: pointing `busyLabel` at any other key fails that test and nothing else.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the Generate button's busy label from "Ranking…" to "Assembling…" so the pending state matches what the click actually does. `POST /brief` builds a first run; the old label (German: "Sortiere neu…") promised a re-rank that never happens.

**Bug Fixes**
- Adds a test that holds the POST open and reads the button label while the request is pending, so the busy label can't drift from the button's intent again.

<sup>Written for commit 2868e9f81872a20ab3a5b5e636abc19f32743b35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the home screen’s progress message to indicate when content is being assembled.
  * Added Vietnamese and German translations for the updated status message.

* **Bug Fixes**
  * Improved the refresh button’s pending-state label so it accurately reflects brief generation in progress.

* **Tests**
  * Added coverage verifying the generation status remains visible while the request is pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->