### PR TITLE
A found email is the same message the timeline shows

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31900,6 +31900,17 @@ components:
             filters offer, not every type `taggable` admits. It is what tells a searcher
             whether the word is worth opening before they open it. Null on every other hit
             type, and null when no count was taken.
+        email_summary:
+          allOf: [{ $ref: '#/components/schemas/EmailSummary' }]
+          readOnly: true
+          nullable: true
+          description: >-
+            The canonical email row, on an `activity` hit whose activity is an email THIS
+            caller may read. Null on every other hit type, and null for a non-email activity
+            — a call, a note, a task and a meeting are activities too, and each keeps its
+            generic hit. An email whose content is not this caller's produces no hit at all,
+            because the activity branch is content-gated. A client renders the canonical row
+            when this is present and falls back to `title`/`snippet` when it is not.
         trust_tier:
           type: [string, 'null']
           enum: [authoritative, external, unverified, null]

--- a/backend/internal/compose/integration/searchemailsummary_integration_test.go
+++ b/backend/internal/compose/integration/searchemailsummary_integration_test.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A search hit on an email carries the canonical email row, so the result
+// looks like the same message the timeline shows rather than a second
+// rendering of it. The row is admitted by the SAME content gate the hit is,
+// which is what keeps a limited conversation out of search entirely — hit and
+// summary alike.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/search"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// searchEmailStore is the search store wired the way compose wires it: with
+// the activities reader behind an email hit's summary. A test that built the
+// store bare would prove nothing about the surface a person searches.
+func searchEmailStore(e *Env) *search.Store {
+	return search.NewStore(e.DB()).WithEmailSummaries(activities.EmailSummariesByIDBatch)
+}
+
+func hitFor(page search.Page, id ids.UUID) *search.Hit {
+	for i := range page.Hits {
+		if page.Hits[i].ID == id {
+			return &page.Hits[i]
+		}
+	}
+	return nil
+}
+
+// An email hit carries the canonical row: the subject, a body preview and the
+// access badge, all from the activities projection rather than from a second
+// one built here.
+func TestAnEmailSearchHitCarriesTheCanonicalRow(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	subject, body := "Rennsteig renewal terms", "The quote is attached, and it holds until Friday."
+	logged, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+		Kind: "email", Subject: &subject, Body: &body, Direction: strPtr("inbound"),
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+	})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	id := ids.UUID(logged.Id)
+
+	page, err := searchEmailStore(e).Search(author, search.Input{
+		Query: "Rennsteig", Types: []string{"activity"},
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	hit := hitFor(page, id)
+	if hit == nil {
+		t.Fatalf("the author's own mail did not appear in search: %+v", page.Hits)
+	}
+	if hit.EmailSummary == nil {
+		t.Fatal("an email hit carried no email_summary; the canonical row is what the client renders")
+	}
+	got := *hit.EmailSummary
+	if got.Subject == nil || *got.Subject != subject {
+		t.Errorf("summary subject = %v, want %q", got.Subject, subject)
+	}
+	if got.Preview == nil || *got.Preview == "" {
+		t.Error("summary carried no preview; the row shows one and the hit must show the same one")
+	}
+	if got.DisplayStatus != crmcontracts.EmailAccessStatusTeam {
+		t.Errorf("display_status = %q, want team for an unlimited mail", got.DisplayStatus)
+	}
+	if got.Direction == nil || *got.Direction != crmcontracts.EmailSummaryDirectionInbound {
+		t.Errorf("summary direction = %v, want inbound", got.Direction)
+	}
+	if got.ActivityId != logged.Id {
+		t.Errorf("summary names activity %v, want the hit's own %v", got.ActivityId, logged.Id)
+	}
+	if got.Version == 0 {
+		t.Error("summary carried no version; the audience write needs it for If-Match")
+	}
+}
+
+// The privacy behaviour search already had does not change. A limited
+// conversation produces NO hit for a colleague outside its audience — not a
+// withheld one — because the activity branch is content-gated. Moving it to
+// the discover gate would leak what the body says through hit existence,
+// score, ordering and the page boundary.
+func TestAWithheldEmailProducesNoSearchHit(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	colleague := e.As(e.Rep3, []ids.UUID{e.Team2}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	subject, body := "Rennsteig severance package", "the agreed figure is confidential"
+	logged, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+		Kind: "email", Subject: &subject, Body: &body, Direction: strPtr("outbound"),
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+	})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	id := ids.UUID(logged.Id)
+	store := searchEmailStore(e)
+
+	// Before limiting, the colleague finds it — which is what makes the
+	// disappearance below the audience's doing rather than the query's.
+	before, err := e.Activities.GetActivity(colleague, ids.From[ids.ActivityKind](id), storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("colleague reading before limiting: %v", err)
+	}
+	if before.Subject == nil {
+		t.Fatal("the colleague could not read the mail before it was limited; the fixture proves nothing")
+	}
+	openPage, err := store.Search(colleague, search.Input{Query: "Rennsteig", Types: []string{"activity"}})
+	if err != nil {
+		t.Fatalf("search before limiting: %v", err)
+	}
+	if hitFor(openPage, id) == nil {
+		t.Fatal("the colleague did not find an unlimited mail; the fixture proves nothing")
+	}
+
+	if _, err := e.Activities.SetAudience(author, ids.From[ids.ActivityKind](id),
+		activities.SetAudienceInput{Audience: "participants"}); err != nil {
+		t.Fatalf("limiting: %v", err)
+	}
+
+	// A search over the SUBJECT and one over the BODY, because either matching
+	// would disclose what the message says.
+	for _, q := range []string{"Rennsteig", "severance", "confidential"} {
+		page, err := store.Search(colleague, search.Input{Query: q, Types: []string{"activity"}})
+		if err != nil {
+			t.Fatalf("search %q: %v", q, err)
+		}
+		if hit := hitFor(page, id); hit != nil {
+			t.Errorf("a limited mail surfaced in a colleague's search for %q: %+v", q, *hit)
+		}
+	}
+
+	// The author is in its audience and keeps finding it, whole.
+	mine, err := store.Search(author, search.Input{Query: "Rennsteig", Types: []string{"activity"}})
+	if err != nil {
+		t.Fatalf("author search: %v", err)
+	}
+	hit := hitFor(mine, id)
+	if hit == nil || hit.EmailSummary == nil {
+		t.Fatalf("the author lost their own limited mail from search: %+v", mine.Hits)
+	}
+	if hit.EmailSummary.DisplayStatus != crmcontracts.EmailAccessStatusParticipants {
+		t.Errorf("display_status = %q, want participants — the badge says the mail is limited",
+			hit.EmailSummary.DisplayStatus)
+	}
+}
+
+// A call, a note, a task and a meeting are activities too. Each keeps the
+// generic hit it has always had, so a client branching on email_summary's
+// presence renders them the way it did before.
+func TestANonEmailActivityHitKeepsItsGenericTreatment(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+	store := searchEmailStore(e)
+
+	for _, kind := range []string{"call", "note", "task", "meeting"} {
+		subject := "Rennsteig " + kind + " follow-up"
+		body := "what we agreed on the " + kind
+		logged, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+			Kind: kind, Subject: &subject, Body: &body,
+			Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+		})
+		if err != nil {
+			t.Fatalf("log %s: %v", kind, err)
+		}
+		page, err := store.Search(author, search.Input{Query: "Rennsteig", Types: []string{"activity"}})
+		if err != nil {
+			t.Fatalf("search after %s: %v", kind, err)
+		}
+		hit := hitFor(page, ids.UUID(logged.Id))
+		if hit == nil {
+			t.Fatalf("a %s did not appear in search at all", kind)
+		}
+		if hit.EmailSummary != nil {
+			t.Errorf("a %s hit carried an email_summary: %+v — only an email has an email's shape",
+				kind, *hit.EmailSummary)
+		}
+		if hit.Title == "" {
+			t.Errorf("a %s hit lost its generic title", kind)
+		}
+	}
+}
+
+// The batch enriches EVERY email on a full page, not just the first. It is
+// one statement over the page's ids, and the failure this catches is a batch
+// that quietly reads a prefix — which on a page of one looks exactly right.
+func TestEveryEmailOnAFullPageCarriesItsRow(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	const mails = 12
+	for i := range mails {
+		subject := "Rennsteig thread message"
+		body := "line one of message"
+		if _, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+			Kind: "email", Subject: &subject, Body: &body, Direction: strPtr("inbound"),
+			Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+		}); err != nil {
+			t.Fatalf("log %d: %v", i, err)
+		}
+	}
+
+	page, err := searchEmailStore(e).Search(author, search.Input{
+		Query: "Rennsteig", Types: []string{"activity"}, Limit: mails,
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(page.Hits) < mails {
+		t.Fatalf("found %d of %d seeded mails", len(page.Hits), mails)
+	}
+	for i := range page.Hits {
+		if page.Hits[i].EmailSummary == nil {
+			t.Fatalf("hit %d of a page of %d carried no summary; the batch missed a row",
+				i, len(page.Hits))
+		}
+	}
+}
+
+// The batch reader carries its OWN content gate, proven here rather than
+// through search: search's activity branch is content-gated too, so a test
+// that goes through search passes even when this gate is weakened. Two guards
+// that both hold are one guard until each is asked separately, and this reader
+// is exported — a future caller reaching it through a discover-gated list would
+// otherwise print a limited conversation's subject to a colleague.
+func TestTheEmailSummaryBatchRefusesAWithheldRowOnItsOwn(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	colleague := e.As(e.Rep3, []ids.UUID{e.Team2}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	subject, body := "Severance figures", "the agreed figure is confidential"
+	logged, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+		Kind: "email", Subject: &subject, Body: &body, Direction: strPtr("outbound"),
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+	})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	id := ids.UUID(logged.Id)
+
+	read := func(ctx context.Context) map[ids.UUID]crmcontracts.EmailSummary {
+		t.Helper()
+		var got map[ids.UUID]crmcontracts.EmailSummary
+		if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+			var readErr error
+			got, readErr = activities.EmailSummariesByIDBatch(ctx, tx, []ids.UUID{id})
+			return readErr
+		}); err != nil {
+			t.Fatalf("batch read: %v", err)
+		}
+		return got
+	}
+
+	// Unlimited: the colleague reads the row, which is what makes its absence
+	// below the audience's doing.
+	if _, ok := read(colleague)[id]; !ok {
+		t.Fatal("the colleague got no row for an unlimited mail; the fixture proves nothing")
+	}
+
+	if _, err := e.Activities.SetAudience(author, ids.From[ids.ActivityKind](id),
+		activities.SetAudienceInput{Audience: "participants"}); err != nil {
+		t.Fatalf("limiting: %v", err)
+	}
+
+	if row, ok := read(colleague)[id]; ok {
+		t.Errorf("the batch handed a colleague a limited mail's row: %+v", row)
+	}
+	if _, ok := read(author)[id]; !ok {
+		t.Error("the batch withheld the author's own mail from them")
+	}
+}

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/briefs"
 	"github.com/margince/margince/backend/internal/compose/weekly"
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents/runner"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/aiactivity"
@@ -118,7 +119,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		dealroomsHandlers:   dealrooms.NewHandlers(InstallationDB(pool)),
 		commissionsHandlers: commissions.NewHandlers(InstallationDB(pool)),
 		activitiesHandlers:  newActivitiesHandlers(pool).WithUploadLimit(limits.Attachment),
-		searchHandlers:      search.NewHandlers(InstallationDB(pool), collections.CountTagReachBatch),
+		searchHandlers:      search.NewHandlers(InstallationDB(pool), collections.CountTagReachBatch, activities.EmailSummariesByIDBatch),
 		// Constructed, not merely embedded: the handler carries no nil-pool
 		// branch, so the zero value would panic on the first authenticated
 		// read rather than answer anything at all.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -28792,8 +28792,11 @@ type SearchResponse struct {
 // SearchResult defines model for SearchResult.
 type SearchResult struct {
 	// CarriedBy For a `tag` hit only: how many people, companies and deals carry this word, as THIS caller may see them — the same three types the tag page counts and the filters offer, not every type `taggable` admits. It is what tells a searcher whether the word is worth opening before they open it. Null on every other hit type, and null when no count was taken.
-	CarriedBy *int               `json:"carried_by,omitempty"`
-	Id        openapi_types.UUID `json:"id"`
+	CarriedBy *int `json:"carried_by,omitempty"`
+
+	// EmailSummary The canonical email row, on an `activity` hit whose activity is an email THIS caller may read. Null on every other hit type, and null for a non-email activity — a call, a note, a task and a meeting are activities too, and each keeps its generic hit. An email whose content is not this caller's produces no hit at all, because the activity branch is content-gated. A client renders the canonical row when this is present and falls back to `title`/`snippet` when it is not.
+	EmailSummary *EmailSummary      `json:"email_summary,omitempty"`
+	Id           openapi_types.UUID `json:"id"`
 
 	// Score Relevance score.
 	Score   *float32 `json:"score,omitempty"`

--- a/backend/internal/modules/activities/activityprojection.go
+++ b/backend/internal/modules/activities/activityprojection.go
@@ -101,6 +101,13 @@ var activityProjection = []activityColumn{
 	{"", func(s *activityScan) any { return &s.contentAvailable }},
 }
 
+// activityLive is the not-archived predicate, for the alias every read of this
+// table uses. One spelling, because three list builders composed it as a
+// string literal and a fourth would have been the fourth chance to type it
+// differently — a read that filtered on the wrong column would quietly serve
+// archived rows rather than fail.
+const activityLive = "a.archived_at IS NULL"
+
 // activityColumns renders the select list. contentArm is the predicate
 // auth.ActivityAudienceArm rendered for this query's arguments, which is why
 // the final column's SQL cannot be a constant.

--- a/backend/internal/modules/activities/commitments.go
+++ b/backend/internal/modules/activities/commitments.go
@@ -240,7 +240,7 @@ func openTasksFilter(ctx context.Context, in ListOpenTasksInput, arg func(any) i
 		// The definition of the set, and the partial index's own predicate.
 		sprintf("a.kind = $%d", arg(string(crmcontracts.ActivityKindTask))),
 		"a.is_done = false",
-		"a.archived_at IS NULL",
+		activityLive,
 	}
 	// The timeline's own scope rule: an activity carries no owner, so who may
 	// read one is decided by the records it links to. A task is the most

--- a/backend/internal/modules/activities/emailsummarybatch.go
+++ b/backend/internal/modules/activities/emailsummarybatch.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// EmailSummariesByIDBatch answers the email row of each of these activities,
+// for THIS caller, in the caller's own transaction. Ids that are not emails,
+// that the caller may not read, or that do not exist are simply absent from
+// the map — an absent id is one this caller gets no summary for, never an
+// error, because a batch enriching a page must not fail the page over one row
+// the reader was never entitled to.
+//
+// It takes the whole page at once. A per-id read cost a round trip per hit,
+// which a search page of 200 turns into 200 statements.
+//
+// The gate is auth.ActivityContentClause, not the timeline's discover clause.
+// A summary carries the subject and a body preview, so admitting a row here
+// is admitting its content: the discover gate would answer "you may know this
+// row exists", and then this function would print what it says.
+func EmailSummariesByIDBatch(
+	ctx context.Context, tx pgx.Tx, activityIDs []ids.UUID,
+) (map[ids.UUID]crmcontracts.EmailSummary, error) {
+	// An empty map rather than a nil one on both early exits: a caller reads
+	// this by key, and "no rows for you" and "no rows asked for" are the same
+	// answer to that question. Returning nil would make each call site decide
+	// again whether a nil map is safe to index.
+	none := map[ids.UUID]crmcontracts.EmailSummary{}
+	if len(activityIDs) == 0 {
+		return none, nil
+	}
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		// A seat with no activity.read reads no email rows, and a page of
+		// other records still renders. Same silent narrowing search itself
+		// gives a denied branch.
+		return none, nil
+	}
+	args := []any{}
+	arg := func(v any) int { args = append(args, v); return len(args) }
+
+	scope, err := auth.ActivityContentClause(ctx, "a", arg)
+	if err != nil {
+		return nil, err
+	}
+	contentArm, err := auth.ActivityAudienceArm(ctx, "a", arg)
+	if err != nil {
+		return nil, err
+	}
+	where := []string{
+		fmt.Sprintf("a.id = ANY($%d)", arg(activityIDs)),
+		"a.kind = 'email'",
+		activityLive,
+	}
+	if scope != "" {
+		where = append(where, scope)
+	}
+
+	sql := "SELECT " + activityColumns(contentArm) + " FROM activity a WHERE " +
+		strings.Join(where, " AND ")
+	rows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("activities: reading email summaries for a page: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[ids.UUID]crmcontracts.EmailSummary, len(activityIDs))
+	for rows.Next() {
+		var scan activityScan
+		if err := rows.Scan(activityScanTargets(&scan)...); err != nil {
+			return nil, fmt.Errorf("activities: scanning an email summary: %w", err)
+		}
+		activity := scan.record()
+		// RowEmailSummary rather than a second assembler: the row a search hit
+		// shows and the row a timeline shows are the same row, and two
+		// projections of it would drift the moment either grew a field.
+		if summary := RowEmailSummary(activity); summary != nil {
+			out[scan.id] = *summary
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("activities: reading email summaries for a page: %w", err)
+	}
+	return out, nil
+}

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -349,7 +349,7 @@ func listActivitiesFilter(ctx context.Context, in ListActivitiesInput) (join str
 		return "", nil, "", nil, err
 	}
 	if !in.IncludeArchived {
-		where = append(where, "a.archived_at IS NULL")
+		where = append(where, activityLive)
 	}
 	if in.Kind != nil {
 		where = append(where, sprintf("a.kind = $%d", arg(*in.Kind)))

--- a/backend/internal/modules/search/emailsummary.go
+++ b/backend/internal/modules/search/emailsummary.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// hitTypeActivity is the `type` an activity hit carries on the wire, and the
+// same word the activity branch declares in searchBranches.
+const hitTypeActivity = "activity"
+
+// EmailSummaryReader answers the email row of each of these activities, for
+// THIS caller, inside the caller's own transaction. It takes the whole page's
+// activity ids at once: a per-hit read cost a round trip per hit, which a page
+// of 200 turns into 200 statements.
+//
+// An id missing from the returned map is one this caller gets no email row
+// for — it is not an email, or its content is not theirs. Both are ordinary
+// answers, not failures.
+//
+// It is the activities store's own reader, injected by compose because a
+// module never imports a sibling. Calling that reader rather than projecting a
+// second email row here is what keeps a search hit and a timeline row the same
+// row, down to the preview text and the access badge.
+type EmailSummaryReader func(
+	ctx context.Context, tx pgx.Tx, activityIDs []ids.UUID,
+) (map[ids.UUID]crmcontracts.EmailSummary, error)
+
+// attachEmailSummaries fills EmailSummary on the email hits of one page.
+//
+// It changes nothing about WHICH rows are on the page. The activity branch is
+// already gated by auth.ActivityContentClause (branchScope), so a withheld
+// email produced no hit to enrich in the first place, and the reader runs that
+// same content gate a second time rather than trusting this one — the two
+// agree by construction, and the one that would matter if they ever did not is
+// the reader's, which is the one standing between a preview and a person who
+// may not read it.
+//
+// A read failure fails the search rather than answering with a silent gap. The
+// reader runs the caller's own gate, so an error here is that gate refusing to
+// render, and a page that quietly dropped the summaries would show a searcher
+// email hits stripped of their subject with no way to tell that from an email
+// that has none.
+func (s *Store) attachEmailSummaries(ctx context.Context, tx pgx.Tx, hits []Hit) error {
+	if s.emailSummaries == nil {
+		return nil
+	}
+	var activityIDs []ids.UUID
+	for i := range hits {
+		if hits[i].Type == hitTypeActivity {
+			activityIDs = append(activityIDs, hits[i].ID)
+		}
+	}
+	if len(activityIDs) == 0 {
+		return nil
+	}
+	summaries, err := s.emailSummaries(ctx, tx, activityIDs)
+	if err != nil {
+		return fmt.Errorf("search: reading this page's email rows: %w", err)
+	}
+	for i := range hits {
+		if hits[i].Type != hitTypeActivity {
+			continue
+		}
+		// Absent means this activity is not an email — a call, a note, a task
+		// and a meeting are activities too, and each keeps the generic hit it
+		// has always had.
+		summary, ok := summaries[hits[i].ID]
+		if !ok {
+			continue
+		}
+		// Copied into a local before its address is taken: `summary` is the
+		// loop's own variable and aliasing it would give every hit the last
+		// one's row.
+		row := summary
+		hits[i].EmailSummary = &row
+	}
+	return nil
+}

--- a/backend/internal/modules/search/handlers.go
+++ b/backend/internal/modules/search/handlers.go
@@ -24,8 +24,11 @@ type Handlers struct {
 // NewHandlers binds the HTTP search surface. `tagReach` counts what a tag hit
 // is on for the asking caller; compose supplies the collections store's own
 // counter, and a nil one leaves every hit's count absent rather than zero.
-func NewHandlers(db *database.DB, tagReach TagReachCounter) Handlers {
-	store := NewStore(db).WithTagReach(tagReach)
+// `emailRows` answers the canonical email row behind an activity hit; compose
+// supplies the activities store's own reader, and a nil one leaves every email
+// hit rendering the generic way.
+func NewHandlers(db *database.DB, tagReach TagReachCounter, emailRows EmailSummaryReader) Handlers {
+	store := NewStore(db).WithTagReach(tagReach).WithEmailSummaries(emailRows)
 	// Embedder is nil, and stays nil: the only thing this retriever serves is
 	// AssembleContext, which walks the context graph and never embeds. The
 	// request-path embed lane compose binds is for the RANKED half, and
@@ -71,6 +74,11 @@ func (h Handlers) Search(w http.ResponseWriter, r *http.Request, params crmcontr
 		// address would give every result the last hit's number.
 		if hit.CarriedBy != nil {
 			result.CarriedBy = ptr(*hit.CarriedBy)
+		}
+		// Same copy, same reason: the address of the loop's own variable would
+		// give every result the last hit's row.
+		if hit.EmailSummary != nil {
+			result.EmailSummary = ptr(*hit.EmailSummary)
 		}
 		// native records are authoritative
 		result.TrustTier = ptr(crmcontracts.SearchResultTrustTierAuthoritative)

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
@@ -35,6 +36,14 @@ type Store struct {
 	// ask): a tag hit then carries no count, which reads as "not known" and
 	// never as zero.
 	carriedBy TagReachCounter
+	// emailSummaries answers the email row behind an activity hit, for THIS
+	// caller. It is the activities store's own reader, injected by compose
+	// because a module never imports a sibling.
+	//
+	// Nil where nothing supplied it (a worker's store, a test that does not
+	// ask): an email hit then carries no row, and the frontend renders it the
+	// generic way rather than showing a blank canonical one.
+	emailSummaries EmailSummaryReader
 }
 
 // NewStore opens this module's store on a handle already bound to the
@@ -49,6 +58,12 @@ func (s *Store) WithTagReach(count TagReachCounter) *Store {
 	return s
 }
 
+// WithEmailSummaries binds the reader behind an email hit's `email_summary`.
+func (s *Store) WithEmailSummaries(read EmailSummaryReader) *Store {
+	s.emailSummaries = read
+	return s
+}
+
 // bounded is this store with a time ceiling on every statement it runs.
 //
 // The ceiling rides the HANDLE, so it reaches the lanes this store opens for
@@ -58,7 +73,7 @@ func (s *Store) WithTagReach(count TagReachCounter) *Store {
 func (s *Store) bounded(budget time.Duration) *Store {
 	// Every field travels, not just the handle: this rebuilds the store, so a
 	// field left out here is one the bounded lane silently does without.
-	return &Store{db: s.db.Bounded(budget), carriedBy: s.carriedBy}
+	return &Store{db: s.db.Bounded(budget), carriedBy: s.carriedBy, emailSummaries: s.emailSummaries}
 }
 
 // forWorkspace is this store re-bound to one tenant of the fleet enumeration.
@@ -84,6 +99,10 @@ type Hit struct {
 	// CarriedBy is set on a `tag` hit alone: how many records the caller may
 	// see carry this word. Nil elsewhere, and nil when no counter is bound.
 	CarriedBy *int
+	// EmailSummary is set on an `activity` hit whose activity is an email the
+	// caller may read. Nil on every other hit type, nil for a non-email
+	// activity, and nil when no reader is bound.
+	EmailSummary *crmcontracts.EmailSummary
 }
 
 type Page struct {
@@ -325,7 +344,10 @@ func (s *Store) Search(ctx context.Context, in Input) (Page, error) {
 		if page, err = scanRankedPage(rows, limit); err != nil {
 			return err
 		}
-		return s.countTagReach(ctx, tx, page.Hits)
+		if err := s.countTagReach(ctx, tx, page.Hits); err != nil {
+			return err
+		}
+		return s.attachEmailSummaries(ctx, tx, page.Hits)
 	})
 	if err != nil {
 		return Page{}, err

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -23229,6 +23229,8 @@ export interface components {
             score?: number | null;
             /** @description For a `tag` hit only: how many people, companies and deals carry this word, as THIS caller may see them — the same three types the tag page counts and the filters offer, not every type `taggable` admits. It is what tells a searcher whether the word is worth opening before they open it. Null on every other hit type, and null when no count was taken. */
             carried_by?: number | null;
+            /** @description The canonical email row, on an `activity` hit whose activity is an email THIS caller may read. Null on every other hit type, and null for a non-email activity — a call, a note, a task and a meeting are activities too, and each keeps its generic hit. An email whose content is not this caller's produces no hit at all, because the activity branch is content-gated. A client renders the canonical row when this is present and falls back to `title`/`snippet` when it is not. */
+            readonly email_summary?: components["schemas"]["EmailSummary"] | null;
             /**
              * @description Provenance tier of the underlying record. In native mode every stored record is `authoritative`; `external`/`unverified` are reserved for overlay/connector-sourced rows (not emitted until overlay adapters land). Never guessed — null when unknown.
              * @enum {string|null}

--- a/frontend/src/app/palette.tsx
+++ b/frontend/src/app/palette.tsx
@@ -164,6 +164,10 @@ export function useBuiltinCommands(): Command[] {
 
 // The record kinds a search hit can route to (activity is a valid
 // SearchResult type but has no 360 to land on — see entity.ts).
+//
+// An EMAIL hit is findable and openable on the search screen, which owns a
+// drawer. The palette owns no page and every Command must carry a route, so it
+// cannot open one; issue #3850 holds what that would take.
 const RECORD_KINDS = new Set<EntityKind>(ENTITY_KINDS);
 
 // Live record hits for the palette (RS-1): debounced via useDeferredValue

--- a/frontend/src/screens/search.css
+++ b/frontend/src/screens/search.css
@@ -33,3 +33,11 @@
   color: var(--textSecondary);
   font-size: 13px;
 }
+
+/* An email hit is the canonical row, which owns its own padding, typography
+   and focus treatment. The host supplies position and nothing else — the same
+   contract the timeline `<li>` and the company card give it. */
+.search-hit-email {
+  padding: 0;
+  gap: 0;
+}

--- a/frontend/src/screens/search.test.tsx
+++ b/frontend/src/screens/search.test.tsx
@@ -48,7 +48,145 @@ function hitRow(container: HTMLElement): HTMLElement {
   return row;
 }
 
+// One email hit, as the server sends it: the canonical row rides the hit and
+// the raw `snippet` is what the row REPLACES.
+const emailHit = {
+  type: "activity",
+  id: "a1",
+  title: "Rennsteig renewal terms",
+  snippet: "…a raw body slice the canonical row replaces…",
+  score: 0.88,
+  trust_tier: "authoritative",
+  email_summary: {
+    activity_id: "a1",
+    occurred_at: "2026-09-01T09:15:00Z",
+    version: 3,
+    subject: "Rennsteig renewal terms",
+    preview: "The quote holds until Friday.",
+    counterparty: "Dana Buyer",
+    direction: "inbound",
+    display_status: "team",
+    move: "needs_reply",
+    attachment_count: 1,
+  },
+};
+
+// The detail read, as the contract shapes it: the parties are flat on the
+// presentation and the access block is required. A fixture that omitted them
+// would model a response the server cannot send, and the drawer would throw on
+// a shape no user will ever meet.
+const emailPresentation = {
+  id: "a1",
+  lifecycle: "delivered",
+  occurred_at: "2026-09-01T09:15:00Z",
+  summary: emailHit.email_summary,
+  body: "The quote holds until Friday.",
+  thread_key: "t1",
+  from: [{ address: "dana@acme.test", display_name: "Dana Buyer" }],
+  to: [{ address: "rep@demo.test", display_name: "Lena Fischer" }],
+  cc: [],
+  bcc: [],
+  bcc_withheld: false,
+  attachments: [],
+  links: [],
+  thread: { members: [], next_cursor: null },
+  access: {
+    content_state: "available",
+    audience: "workspace",
+    selected_members: [],
+    display_status: "team",
+    can_change: false,
+    change_mode: "message",
+    held_by_others: false,
+  },
+  can_reply: true,
+  can_relink: false,
+  version: 3,
+};
+
 describe("SearchScreen", () => {
+  // An email hit is the canonical row, not a title and a raw body slice. The
+  // subject, the preview the server composed and the access badge all come
+  // from `email_summary`, and the row opens the same drawer every timeline
+  // opens.
+  it("renders an email hit as the canonical row and opens the drawer", async () => {
+    // The URL off the Request, not String(input): openapi-fetch hands fetch a
+    // Request object, whose String() is "[object Request]" and matches nothing.
+    const urlOf = (input: RequestInfo | URL) =>
+      input instanceof Request ? input.url : String(input);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (urlOf(input).includes("email-presentation")) {
+        return jsonResponse(emailPresentation);
+      }
+      return jsonResponse({
+        data: [emailHit],
+        page: { next_cursor: null, has_more: false },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<SearchScreen q="renewal" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Rennsteig renewal terms")).toBeTruthy(),
+    );
+    // The server's preview, not the raw `snippet`: the snippet is a
+    // 200-character slice of the body and drawing both would put two readings
+    // of one message on one line.
+    expect(screen.getByText("The quote holds until Friday.")).toBeTruthy();
+    expect(screen.queryByText(/raw body slice/)).toBeNull();
+    // The access badge rides the row, which is how a reader tells a limited
+    // conversation from an open one without opening it.
+    expect(screen.getByText("Team")).toBeTruthy();
+
+    // Clicking the row opens the drawer over the results — which is search's
+    // half of this. That it asks for THIS message's presentation is the claim;
+    // what the drawer then draws is emaildetail's own contract.
+    const row = screen.getByRole("button", { name: /Rennsteig renewal terms/ });
+    expect(row.getAttribute("aria-haspopup")).toBe("dialog");
+    await userEvent.click(row);
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some((call) =>
+          urlOf(call[0]).includes("/activities/a1/email-presentation"),
+        ),
+      ).toBe(true),
+    );
+  });
+
+  // A call, a note, a task and a meeting are activities too. The server sends
+  // no `email_summary` for them and the row keeps the generic treatment it has
+  // always had — the failure this catches is a screen branching on the KIND
+  // word rather than on the field.
+  it("leaves a non-email activity hit on its generic treatment", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          data: [
+            {
+              type: "activity",
+              id: "a2",
+              title: "Rennsteig kickoff call",
+              snippet: "…what we agreed on the call…",
+              score: 0.6,
+              trust_tier: "authoritative",
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+      ),
+    );
+    render(<SearchScreen q="rennsteig" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Rennsteig kickoff call")).toBeTruthy(),
+    );
+    expect(screen.getByText(/what we agreed on the call/)).toBeTruthy();
+    // Nothing openable: a row that looks like it opens a message and does not
+    // teaches a reader the product is broken.
+    expect(screen.queryByRole("button", { name: /kickoff call/ })).toBeNull();
+  });
+
   it("groups hits by type and shows the snippet", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/src/screens/search.tsx
+++ b/frontend/src/screens/search.tsx
@@ -6,12 +6,16 @@ import { type FormEvent, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ENTITY, ENTITY_KINDS, type EntityKind } from "../app/entity";
+import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Badge, Card, EmptyState, SearchField } from "../design-system/atoms";
-import { formatNumber } from "../format/format";
+import { EmailEntry } from "../design-system/emailentry";
+import { OpenEmailDrawer } from "../design-system/openemaildrawer";
+import { formatDateTime, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { QueryGate, throwProblem } from "./common";
+import { useOpenEmail } from "./openemail";
 import "./search.css";
 
 type SearchResult = components["schemas"]["SearchResult"];
@@ -47,6 +51,8 @@ const LINKABLE_KINDS = new Set<EntityKind>(ENTITY_KINDS);
 export function SearchScreen({ q }: Readonly<{ q: string }>) {
   const t = useT();
   const [draft, setDraft] = useState(q);
+  const [openEmail, setOpenEmail] = useOpenEmail();
+  const zone = useRecordZone();
   const query = useQuery({
     queryKey: ["search", q],
     enabled: q.trim().length > 0,
@@ -93,16 +99,30 @@ export function SearchScreen({ q }: Readonly<{ q: string }>) {
             data.data.length === 0 ? (
               <EmptyState>{t("search.empty", { q })}</EmptyState>
             ) : (
-              <SearchGroups results={data.data} />
+              <SearchGroups results={data.data} onOpenEmail={setOpenEmail} />
             )
           }
         </QueryGate>
       )}
+      {/* One drawer over the whole results page, at page level rather than
+          inside a group: two mounted dialogs would be two `aria-modal`
+          elements, and the results stay legible behind the one that is open. */}
+      <OpenEmailDrawer
+        activityId={openEmail}
+        zone={zone}
+        onClose={() => setOpenEmail(null)}
+      />
     </div>
   );
 }
 
-function SearchGroups({ results }: Readonly<{ results: SearchResult[] }>) {
+function SearchGroups({
+  results,
+  onOpenEmail,
+}: Readonly<{
+  results: SearchResult[];
+  onOpenEmail: (activityId: string) => void;
+}>) {
   const t = useT();
   return (
     <div className="search-groups arrive-stack">
@@ -114,7 +134,11 @@ function SearchGroups({ results }: Readonly<{ results: SearchResult[] }>) {
               {results
                 .filter((r) => r.type === type)
                 .map((hit) => (
-                  <SearchHit key={`${hit.type}:${hit.id}`} hit={hit} />
+                  <SearchHit
+                    key={`${hit.type}:${hit.id}`}
+                    hit={hit}
+                    onOpenEmail={onOpenEmail}
+                  />
                 ))}
             </ul>
           </Card>
@@ -124,9 +148,33 @@ function SearchGroups({ results }: Readonly<{ results: SearchResult[] }>) {
   );
 }
 
-function SearchHit({ hit }: Readonly<{ hit: SearchResult }>) {
+function SearchHit({
+  hit,
+  onOpenEmail,
+}: Readonly<{
+  hit: SearchResult;
+  onOpenEmail: (activityId: string) => void;
+}>) {
   const t = useT();
   const { locale } = useLocale();
+  const zone = useRecordZone();
+  // An email hit IS the canonical row — the same one the timeline draws, from
+  // the same server projection. It replaces the generic title-and-snippet
+  // rather than sitting beside it: the snippet was a raw 200-character slice
+  // of the body, and drawing both would put two readings of one message on one
+  // line. Every other hit type, activity or not, keeps what it had.
+  if (hit.email_summary) {
+    const summary = hit.email_summary;
+    return (
+      <li className="search-hit search-hit-email">
+        <EmailEntry
+          summary={summary}
+          timestamp={formatDateTime(summary.occurred_at, locale, zone)}
+          onOpen={() => onOpenEmail(summary.activity_id)}
+        />
+      </li>
+    );
+  }
   // A tag is not an ENTITY kind — it has no 360 — but it does have a page, and
   // it is the whole point of finding one: the word is the way to the records
   // carrying it. Routed on its own rather than by widening ENTITY_KINDS, which


### PR DESCRIPTION
Seventh slice of the email display unification arc (after #3779, #3786, #3804, #3812, #3819, #3826).

## What changed

Searching for a message returned a title and a raw 200-character slice of the body — a fifth reading of an email, beside the four the record pages had. An email hit now carries the server's own row and renders the canonical `EmailEntry`, and clicking it opens the same drawer every timeline opens.

- **`backend/internal/modules/activities/emailsummarybatch.go`** (new) — `EmailSummariesByIDBatch` reads a whole page's email rows in one statement, through the same `activityColumns`/`scan.record()`/`RowEmailSummary` path every other activity read uses.
- **`backend/internal/modules/search/emailsummary.go`** (new) — search declares an `EmailSummaryReader`; compose supplies the activities store's own reader at `server.go:121`. Search does not import activities. This mirrors the existing `TagReachCounter` wiring exactly.
- **`backend/api/crm.yaml`** — `email_summary` on `SearchResult`.
- **`frontend/src/screens/search.tsx`** — `SearchHit` early-returns the canonical row when `email_summary` is present; the search screen owns one page-level drawer.

## Privacy

**Unchanged, deliberately.** `search/store.go` composes `auth.ActivityContentClause` for the activity branch, so a limited conversation produces **no hit at all** — not a withheld one. Moving to the discover gate would leak that the body matched through hit existence, score, ordering and the page boundary.

The batch reader carries that same content gate a second time, and is tested **on its own** rather than only through search. That test exists because of what mutation testing showed: weakening the reader's gate does **not** fail a test that goes through search, since search's branch gate already covers the case. Two guards that both hold are one guard until each is asked separately — and the reader is exported, so a future caller reaching it from a discover-gated list would otherwise print a limited conversation's subject.

## Non-email activities

A call, a note, a task and a meeting are activities too. The server sends them no email row and each keeps the generic hit it had, so a client branches on the field rather than on the kind word. This is the defect Codex caught in #3826, guarded here from the start.

## Tests

Integration (`searchemailsummary_integration_test.go`):
- `TestAnEmailSearchHitCarriesTheCanonicalRow`
- `TestAWithheldEmailProducesNoSearchHit` — searches the subject **and** two body words, and proves the colleague found it *before* limiting so the disappearance is the audience's doing
- `TestANonEmailActivityHitKeepsItsGenericTreatment` — all four other kinds
- `TestEveryEmailOnAFullPageCarriesItsRow` — catches a batch that reads a prefix
- `TestTheEmailSummaryBatchRefusesAWithheldRowOnItsOwn` — the reader's own gate

Frontend (`search.test.tsx`): the canonical row renders and opens the drawer; a non-email activity hit keeps its snippet and is not openable.

All mutation-checked one clause at a time.

## Deliberately not here

**The palette cannot offer an email hit** — [#3850](https://github.com/margince/margince/issues/3850). A `Command` requires a `route` and an email opens a page-owned drawer; making it work needs either a global drawer host or a two-slot route, both of which reach every screen.

## Also

Three list builders each spelled `a.archived_at IS NULL` as their own string literal (`orgscope.go`, `commitments.go`, and this new reader). They share one `activityLive` constant now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Search results for emails now render the same canonical email row the timeline shows, instead of a title and raw body snippet. Clicking an email hit opens the same drawer every timeline opens.

- Email hits carry the server's `email_summary` and the search screen renders `EmailEntry`; non-email activity hits (calls, notes, tasks, meetings) keep their generic treatment.
- Privacy is unchanged: a limited conversation still produces no search hit at all, because the activity branch is content-gated; the new batch reader applies the same gate.
- The palette still cannot open email hits because it requires a route; tracked in issue #3850.
- Three list builders now share a single `activityLive` constant for the not-archived predicate.

<sup>Written for commit 6f3274af3accc1a7b5ad4128c077b8570263885e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email search results now display canonical email summaries, access status, and timestamps.
  * Selecting an email result opens its email drawer directly from the search screen.
  * Inaccessible emails are excluded from unauthorized search results.
  * Email summaries are included across full result pages.

* **Bug Fixes**
  * Non-email activity results retain their existing generic display and behavior.
  * Archived activities continue to be excluded from relevant results.

* **Tests**
  * Added coverage for email visibility, rendering, drawer opening, and mixed activity results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->