### PR TITLE
A dial turn on the Brief leaves Back where it was

### DIFF
--- a/frontend/src/screens/home.dials.test.tsx
+++ b/frontend/src/screens/home.dials.test.tsx
@@ -97,6 +97,38 @@ describe("the Brief's dials", () => {
     );
   });
 
+  // And it REPLACES the entry rather than pushing one.
+  //
+  // Back is the key a reader presses to get out of where they are. A reader
+  // turns several dials to reach one view, so pushing per turn would bury the
+  // screen they arrived from under a stack of near-identical entries and Back
+  // would walk them through it one dial at a time instead of out.
+  //
+  // app/addressstate.test.ts holds this for replaceParams itself. That proves
+  // the mechanism, not that the Brief's dials go through it — a screen writing
+  // location.hash directly would satisfy every other assertion in this file
+  // while quietly pushing an entry per press.
+  it("turns a dial without adding a history entry to press Back through", async () => {
+    stubHome(["mine", "team"]);
+    render(<HomeScreen />);
+
+    const before = globalThis.history.length;
+    await userEvent.click(
+      await screen.findByRole("button", { name: en["brief.view.weekly"] }),
+    );
+    await waitFor(() =>
+      expect(globalThis.location.hash).toContain("view=weekly"),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: en["brief.scope.team"] }),
+    );
+    await waitFor(() =>
+      expect(globalThis.location.hash).toContain("scope=team"),
+    );
+
+    expect(globalThis.history.length).toBe(before);
+  });
+
   // DECISION 5, ON THE PAGE. Every combination the dials offer must draw
   // something. An empty work column under a selectable dial is the defect the
   // rule exists to prevent, and it is invisible to a test that only checks the


### PR DESCRIPTION
The Brief's two dials write the address. Nothing proved they **replace** the history entry rather than pushing one.

Back is the key a reader presses to get out of where they are. A reader turns several dials to reach one view, so pushing per turn would bury the screen they arrived from under a stack of near-identical entries — and Back would walk them through it one dial at a time instead of out.

`app/addressstate.test.ts` holds this for `replaceParams` itself. That proves the *mechanism*, not that the Brief goes through it: a screen assigning `location.hash` directly would satisfy every other assertion in `home.dials.test.tsx` while quietly pushing an entry per press.

Mutation-checked — switching `replaceParams` to `pushState` fails this test and nothing else, reporting 5 entries where 3 were expected (both dial turns pushing).

### Four other claims under this ledger item turned out already covered

Checked before writing anything, and none needed work:

- **`clearOfWhatWasRead` vs `clear`** — `worklist.test.tsx:527`, both directions.
- **Sorted key order** — `brief.view.test.ts:69`, "writes only what differs from the default".
- **Nav order and label** — `app/rail.test.tsx:149`, the canonical 13 items in order.
- **The unmatched `brief_item` fallback** — describes a composition that was built differently. The two endpoints are deduped by id through `ledAlready`, which has four tests including the empty and undefined cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a test proving the Brief's dials replace the history entry instead of pushing one, so Back exits the screen rather than walking through each dial turn.

- Asserts `history.length` stays unchanged after turning both dials.
- Switching `replaceParams` to `pushState` fails only this test.
- Four related claims were already covered: `clearOfWhatWasRead` vs `clear`, sorted key order, nav order and label, and the `brief_item` fallback.

<sup>Written for commit 4007c8cbf667ed094bce84203aa2928939cf768e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that changing both Home screen dials updates the URL without adding browser history entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->