### PR TITLE
Source health is an operator's view, and the grant says so

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -15905,6 +15905,34 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404':
           description: No run has completed yet. A fresh installation has not been checked.
+  /analytics/coverage:
+    get:
+      tags: [Reports]
+      operationId: getDataCoverage
+      summary: How current the sources behind the numbers are.
+      description: |
+        Source health: which connectors the nightly check could read, how far back each
+        reaches, and what it could not open.
+
+        Gated on `data_coverage`, which admin and ops hold and nobody else does. That is a
+        decision rather than an oversight: a rep shown their installation's connector
+        health has been handed somebody else's job, and a screen reporting a problem they
+        cannot act on teaches them to ignore the screen.
+
+        Only a `checked` source carries `checked_through`. A date on a stale or unavailable
+        one would read as "checked up to then" when nothing was read at all — which is the
+        difference between a quiet week and a broken connector.
+      x-mcp-tool: { verb: data_coverage, tier: auto_execute, scope: read }
+      responses:
+        '200':
+          description: The most recent run's source health.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DataCoverage' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404':
+          description: No run has completed yet. A fresh installation has not been checked.
   /forecast/assurance/exceptions:
     get:
       tags: [Reports]
@@ -30858,6 +30886,21 @@ components:
             When a suppressing answer stops holding. Omitted, it is the 90-day ceiling;
             beyond the ceiling it is refused rather than shortened.
       additionalProperties: false
+    DataCoverage:
+      type: object
+      description: How current the sources behind the forecast's numbers are.
+      required: [run_id, as_of, sources]
+      properties:
+        run_id: { type: string, format: uuid }
+        as_of: { type: string, format: date-time }
+        sources:
+          type: array
+          description: >-
+            The sources the run tried, and how far it reached into each. A source absent
+            from this list is one the run did not attempt — different from one it
+            attempted and could not read, which the state field says.
+          items: { $ref: '#/components/schemas/ForecastAssuranceSource' }
+      additionalProperties: false
     ForecastAssurance:
       type: object
       description: >-
@@ -31108,7 +31151,7 @@ components:
          webhook_subscription, fx_rate, ai_model_rate, capture_settings, project,
          channel_connection, import_run, installation_settings, finance, integrations,
          retention_policy, capture_trace, license, contract, ai_routing, commission, deal_room,
-         knowledge_corpus, knowledge_document, introduction, weekly_plan, forecast]
+         knowledge_corpus, knowledge_document, introduction, weekly_plan, forecast, data_coverage]
 
     RbacAction:
       type: string

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -168,6 +168,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/ai/provider-keys":                                           {Op: "listAiProviderKeys", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/routing":                                                 {Op: "getAiRouting", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/usage":                                                   {Op: "getAiUsage", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/analytics/coverage":                                         {Op: "getDataCoverage", Access: "tool", Tool: "data_coverage", RecordType: "", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/approvals":                                                  {Op: "listApprovals", Access: "tool", Tool: "list_approvals", RecordType: "", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/approvals/{id}":                                             {Op: "getApproval", Access: "tool", Tool: "read_approval", RecordType: "", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/assistant/profile":                                          {Op: "getAssistantProfile", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/forecasttool.go
+++ b/backend/internal/compose/forecasttool.go
@@ -23,6 +23,8 @@ import (
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/modules/assurance"
 	"github.com/margince/margince/backend/internal/modules/forecasting"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
@@ -320,4 +322,39 @@ func storedSlots(raw []byte) json.RawMessage {
 		return json.RawMessage(`{}`)
 	}
 	return json.RawMessage(raw)
+}
+
+// coverageToolReader answers data_coverage, through the same store the endpoint
+// reads. The grant is checked in the store's own read, so a seller reaching
+// this tool is refused by the same boundary the screen uses.
+func coverageToolReader(pool *pgxpool.Pool) agents.SourceCoverageReader {
+	store := assurance.NewStore(InstallationDB(pool))
+	return func(ctx context.Context) (json.RawMessage, error) {
+		if err := auth.Require(ctx, "data_coverage", principal.ActionRead); err != nil {
+			return nil, err
+		}
+		run, err := store.LatestRun(ctx)
+		if err != nil {
+			return nil, err
+		}
+		coverage, err := store.CoverageFor(ctx, run.ID)
+		if err != nil {
+			return nil, err
+		}
+		out := agents.DataCoverageResult{
+			RunID: run.ID.String(),
+			AsOf:  run.AsOf.UTC().Format(time.RFC3339),
+			// Empty, never nil: null reads as "unknown" to a model, which here
+			// is a different claim from "nothing was tried".
+			Sources: []agents.ForecastAssuranceSourceResult{},
+		}
+		for _, c := range coverage {
+			source := agents.ForecastAssuranceSourceResult{Source: c.Source, State: c.State}
+			if c.State == assurance.CoverageChecked && c.CheckedThrough != nil {
+				source.CheckedThrough = c.CheckedThrough.UTC().Format(time.RFC3339)
+			}
+			out.Sources = append(out.Sources, source)
+		}
+		return json.Marshal(out)
+	}
 }

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -176,6 +176,7 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 	agents.RegisterMovementTool(registry, movementToolReader(pool))
 	agents.RegisterAssuranceTool(registry, assuranceToolReader(pool))
 	agents.RegisterInputChecksTool(registry, inputChecksToolReader(pool))
+	agents.RegisterCoverageTool(registry, coverageToolReader(pool))
 	// The governed workspace query. It takes the provider as well as the runner
 	// because the two halves of an answer come from different places: the plan
 	// selects records through the search module, and each selected record is

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -183,6 +183,10 @@ func (stubs) GetAiUsage(w nethttp.ResponseWriter, r *nethttp.Request, params crm
 	httperr.NotImplemented(w, r, "GetAiUsage")
 }
 
+func (stubs) GetDataCoverage(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "GetDataCoverage")
+}
+
 func (stubs) ApproveApprovalBundle(w nethttp.ResponseWriter, r *nethttp.Request, bundleId crmcontracts.BundleId) {
 	httperr.NotImplemented(w, r, "ApproveApprovalBundle")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -19768,6 +19768,15 @@ type DataCompleteness struct {
 	Present int `json:"present"`
 }
 
+// DataCoverage How current the sources behind the forecast's numbers are.
+type DataCoverage struct {
+	AsOf  time.Time          `json:"as_of"`
+	RunId openapi_types.UUID `json:"run_id"`
+
+	// Sources The sources the run tried, and how far it reached into each. A source absent from this list is one the run did not attempt — different from one it attempted and could not read, which the state field says.
+	Sources []ForecastAssuranceSource `json:"sources"`
+}
+
 // DataSubjectRequest A GDPR data-subject request (Art. 15/16/17) tracked to completion (B-E11.30; data-model §12.5).
 type DataSubjectRequest struct {
 	AssigneeId *openapi_types.UUID `json:"assignee_id,omitempty"`
@@ -45000,6 +45009,9 @@ type ServerInterface interface {
 	// AI usage + budget — the spend is never invisible.
 	// (GET /ai/usage)
 	GetAiUsage(w http.ResponseWriter, r *http.Request, params GetAiUsageParams)
+	// How current the sources behind the numbers are.
+	// (GET /analytics/coverage)
+	GetDataCoverage(w http.ResponseWriter, r *http.Request)
 	// Approve every still-pending member of one bundle.
 	// (POST /approval-bundles/{bundle_id}/approve)
 	ApproveApprovalBundle(w http.ResponseWriter, r *http.Request, bundleId BundleId)
@@ -46812,6 +46824,12 @@ func (_ Unimplemented) ReplaceAiRouting(w http.ResponseWriter, r *http.Request) 
 // AI usage + budget — the spend is never invisible.
 // (GET /ai/usage)
 func (_ Unimplemented) GetAiUsage(w http.ResponseWriter, r *http.Request, params GetAiUsageParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// How current the sources behind the numbers are.
+// (GET /analytics/coverage)
+func (_ Unimplemented) GetDataCoverage(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -51735,6 +51753,28 @@ func (siw *ServerInterfaceWrapper) GetAiUsage(w http.ResponseWriter, r *http.Req
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetAiUsage(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetDataCoverage operation middleware
+func (siw *ServerInterfaceWrapper) GetDataCoverage(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetDataCoverage(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -74577,6 +74617,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/ai/usage", wrapper.GetAiUsage)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/analytics/coverage", wrapper.GetDataCoverage)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/approval-bundles/{bundle_id}/approve", wrapper.ApproveApprovalBundle)

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -182,6 +182,7 @@ func fullRegistry(t *testing.T) *Registry {
 	RegisterMovementTool(r, nil)
 	RegisterAssuranceTool(r, nil)
 	RegisterInputChecksTool(r, nil)
+	RegisterCoverageTool(r, nil)
 	RegisterIntentTools(r, inertRetriever{}, nil)
 	RegisterChannelProviderTools(r, inertChannelProviderDirectory{})
 	RegisterSlippingTools(r,

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -247,6 +247,9 @@ func idProbeDispatcher(t *testing.T) *Dispatcher {
 	RegisterInputChecksTool(r, func(context.Context) (json.RawMessage, error) {
 		return nil, errSeamReached
 	})
+	RegisterCoverageTool(r, func(context.Context) (json.RawMessage, error) {
+		return nil, errSeamReached
+	})
 	RegisterIntentTools(r, inertRetriever{}, nil)
 	RegisterChannelProviderTools(r, inertChannelProviderDirectory{})
 	RegisterSlippingTools(r,

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -1814,6 +1814,123 @@
       "warnings"
     ]
   },
+  "data_coverage": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "as_of": {
+            "type": "string"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "checked_through": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "source",
+                "state"
+              ]
+            }
+          }
+        },
+        "required": [
+          "as_of",
+          "run_id",
+          "sources"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "decide_approval": {
     "type": "object",
     "properties": {

--- a/backend/internal/modules/agents/tools_forecast.go
+++ b/backend/internal/modules/agents/tools_forecast.go
@@ -51,21 +51,15 @@ type forecastReadings struct {
 func (t forecastReadings) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "forecast_readings", Title: "Read the forecast", Version: toolVersionV1,
-		Description: "What a period is expected to close, in four readings, plus what the " +
-			"figures do not cover. " +
-			"`won` counts deals by the day they ACTUALLY closed, never the day they were " +
-			"expected to — a deal expected in March and won in April is April's. `evidence` " +
-			"is committed pipeline whose close date somebody confirmed; a provisional date " +
-			"is a guess, so it is excluded there and still counted in `open`. `weighted` " +
-			"applies each deal's stage probability, rounded per deal. " +
+		Description: "What a period is expected to close, in four readings. " +
+			"`won` counts deals by the day they ACTUALLY closed, not the day they were " +
+			"expected to. `evidence` is committed pipeline whose close date somebody " +
+			"confirmed; a provisional date stays in `open` and out of `evidence`. " +
 			"Read `eligible_count` against `priced_count` before quoting a total: an " +
-			"unpriced deal is real pipeline contributing zero money, and the gap is what " +
-			"the money readings leave out. `fx_missing_count` is priced deals no rate " +
-			"could convert — also absent from the totals rather than counted as zero. " +
-			"`scope_limited` true means deals the caller cannot read were left out; there " +
-			"is deliberately no count of them. " +
-			"Every figure carries the frame it was cut in: `as_of`, the installation's " +
-			"timezone, and the base currency. Quote them with the number — a total placed " +
+			"unpriced deal is real pipeline contributing zero money. `fx_missing_count` " +
+			"is priced deals no rate could convert — also absent from the totals rather " +
+			"than counted as zero. " +
+			"Quote `as_of`, `timezone` and `base_currency` with the number: a total placed " +
 			"in the reader's own zone is a different total.",
 		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
 		OpenAPIOp: "getForecast",
@@ -350,4 +344,46 @@ type InputCheckResult struct {
 	// LastSeenAt is the most recent run that still found it. Something seen for
 	// weeks is a different problem from something that appeared last night.
 	LastSeenAt string `json:"last_seen_at"`
+}
+
+// SourceCoverageReader answers how current the sources behind the numbers are.
+type SourceCoverageReader func(ctx context.Context) (json.RawMessage, error)
+
+// RegisterCoverageTool joins data_coverage to the surface.
+func RegisterCoverageTool(r *Registry, read SourceCoverageReader) {
+	r.Register(dataCoverage{read: read})
+}
+
+type dataCoverage struct {
+	read SourceCoverageReader
+}
+
+func (t dataCoverage) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "data_coverage", Title: "How current the sources are", Version: toolVersionV1,
+		Description: "Which connectors the nightly check could read, and how far back each " +
+			"reaches. Needs the data_coverage grant, which operators hold and sellers do " +
+			"not — a refusal here is a seat boundary, not a missing run. " +
+			"Only a `checked` source carries a date. On any other state nothing was read, " +
+			"and a quiet week is indistinguishable from a broken connector until somebody " +
+			"looks.",
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		OpenAPIOp:    "getDataCoverage",
+		InputSchema:  schema(`{"type":"object","properties":{},"additionalProperties":false}`),
+		OutputSchema: schemaFor[DataCoverageResult](),
+	}
+}
+
+func (t dataCoverage) Handle(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	noteDerivedContent(ctx)
+	return t.read(ctx)
+}
+
+// DataCoverageResult is what data_coverage answers with.
+type DataCoverageResult struct {
+	RunID string `json:"run_id"`
+	AsOf  string `json:"as_of"`
+	// Sources are the ones the run tried. One absent was not attempted, which
+	// is different from one attempted and unreadable — the state says which.
+	Sources []ForecastAssuranceSourceResult `json:"sources"`
 }

--- a/backend/internal/modules/assurance/coverage_test.go
+++ b/backend/internal/modules/assurance/coverage_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package assurance
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// seatWith builds a caller holding exactly the objects named.
+func seatWith(objects map[string]principal.ObjectGrant) context.Context {
+	user := ids.NewV7()
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"seat"}, Objects: objects,
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+// Source health is an operator's view, and reading the forecast does not buy
+// it.
+//
+// The two are separate objects on purpose: a rep or a manager shown their
+// installation's connector health has been handed somebody else's job, and a
+// screen reporting a problem they cannot act on teaches them to ignore the
+// screen. A gate on `forecast` would have given it to every seat that reads a
+// number.
+func TestReadingTheForecastDoesNotBuySourceHealth(t *testing.T) {
+	t.Parallel()
+
+	manager := seatWith(map[string]principal.ObjectGrant{
+		"forecast": {Read: true, Create: true},
+	})
+	if err := auth.Require(manager, "data_coverage", principal.ActionRead); err == nil {
+		t.Error("a seat holding forecast:read was admitted to source health — the two " +
+			"are different jobs, and one screen reports a problem the other cannot act on")
+	} else if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("the refusal was %v, want a permission denial", err)
+	}
+
+	// The admitting half. Without it a gate refusing EVERY caller would pass
+	// the assertion above while the screen sat unreachable for its own
+	// audience.
+	operator := seatWith(map[string]principal.ObjectGrant{
+		"forecast":      {Read: true},
+		"data_coverage": {Read: true},
+	})
+	if err := auth.Require(operator, "data_coverage", principal.ActionRead); err != nil {
+		t.Errorf("an operator holding data_coverage:read was refused: %v", err)
+	}
+}
+
+// Nobody writes coverage. It is OBSERVED — what the nightly run could reach —
+// and a grant for a verb the product does not offer reads as an oversight the
+// next author has to research.
+func TestSourceHealthHasNoWriteSurface(t *testing.T) {
+	t.Parallel()
+
+	operator := seatWith(map[string]principal.ObjectGrant{
+		"data_coverage": {Read: true},
+	})
+	for _, action := range []principal.Action{
+		principal.ActionCreate, principal.ActionUpdate, principal.ActionDelete,
+	} {
+		if err := auth.Require(operator, "data_coverage", action); err == nil {
+			t.Errorf("%s was admitted on data_coverage — coverage is observed, and there "+
+				"is nothing on this surface for anybody to write", action)
+		}
+	}
+}

--- a/backend/internal/modules/assurance/handlers.go
+++ b/backend/internal/modules/assurance/handlers.go
@@ -13,8 +13,10 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // ExceptionsFunc reads the open findings this caller may see.
@@ -182,4 +184,46 @@ func derefString(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// GetDataCoverage answers how current the sources behind the numbers are.
+//
+// Gated on `data_coverage` rather than on `forecast`: reading the pipeline's
+// numbers and reading the installation's connector health are different jobs,
+// and every seat that does the first does not do the second.
+func (h Handlers) GetDataCoverage(w http.ResponseWriter, r *http.Request) {
+	if err := auth.Require(r.Context(), "data_coverage", principal.ActionRead); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	run, err := h.store.LatestRun(r.Context())
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	coverage, err := h.store.CoverageFor(r.Context(), run.ID)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	out := crmcontracts.DataCoverage{
+		RunId: openapi_types.UUID(run.ID),
+		AsOf:  run.AsOf,
+		// Empty, never nil. A run that recorded no coverage is a real answer;
+		// null reads as "unknown", which on this surface is the difference
+		// between "nothing was tried" and "we cannot tell you".
+		Sources: []crmcontracts.ForecastAssuranceSource{},
+	}
+	for _, c := range coverage {
+		source := crmcontracts.ForecastAssuranceSource{
+			Source: crmcontracts.ForecastAssuranceSourceSource(c.Source),
+			State:  crmcontracts.ForecastAssuranceSourceState(c.State),
+		}
+		// Only a source actually read carries a date.
+		if c.State == CoverageChecked {
+			source.CheckedThrough = c.CheckedThrough
+		}
+		out.Sources = append(out.Sources, source)
+	}
+	httperr.WriteJSON(w, http.StatusOK, out)
 }

--- a/backend/internal/modules/identity/internal/policy/defaults.go
+++ b/backend/internal/modules/identity/internal/policy/defaults.go
@@ -83,11 +83,11 @@ var (
 // and migrate-in screens are admin surfaces.
 // managerObjects is the grid a team lead (`manager`) and the whole-organization
 // `management` seat share; only their row scope differs.
-var managerObjects = objects(crud, crud, crud, crud, crud, readOnly, crud, readOnly, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly, readOnly, crud, readOnly, grant{}, readOnly, grant{}, grant{}, grant{Create: true, Read: true}, crud, readOnly, grant{}, readOnly, readOnly, readOnly, grant{}, readOnly, grant{}, crud, grant{}, crud, crud, readOnly, readOnly, writeNoDelete, crud, createRead)
+var managerObjects = objects(crud, crud, crud, crud, crud, readOnly, crud, readOnly, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly, readOnly, crud, readOnly, grant{}, readOnly, grant{}, grant{}, grant{Create: true, Read: true}, crud, readOnly, grant{}, readOnly, readOnly, readOnly, grant{}, readOnly, grant{}, crud, grant{}, crud, crud, readOnly, readOnly, writeNoDelete, crud, createRead, grant{})
 
 var defaults = map[string]Document{
 	"admin": {
-		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, writeNoDelete, crud, crud, crud, readUpdate, crud, crud, crud, readOnly, readOnly, crud, readUpdate, crud, crud, crud, crud, writeNoDelete, crud, createRead),
+		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, writeNoDelete, crud, crud, crud, readUpdate, crud, crud, crud, readOnly, readOnly, crud, readUpdate, crud, crud, crud, crud, writeNoDelete, crud, createRead, readOnly),
 		RowScope: principal.RowScopeAll,
 	},
 	// management is the sales leader's seat (ADR-0110): the manager grid over
@@ -229,7 +229,13 @@ var defaults = map[string]Document{
 			// number, and a rep asserting one would be calling a figure they
 			// are not accountable for. The reading itself is derived, so there
 			// is no update or delete surface for any seat to hold.
-			readOnly),
+			readOnly,
+			// data_coverage — nothing. Source health is connector freshness,
+			// permission-limited checks and import backlog: an OPERATOR's
+			// view. A rep shown their installation's connector health has been
+			// handed somebody else's job, and the screen that would tell them
+			// is one they cannot act on.
+			grant{}),
 		// Own scope, not team: membership of a team is not by itself permission
 		// to rewrite a teammate's records. Writing somebody else's customer
 		// record takes an explicit share — a record_grant naming the user or
@@ -245,11 +251,11 @@ var defaults = map[string]Document{
 		// A read-only role still owns its personal view state: saved views
 		// are P1-exempt per-user prefs (runtime-config-surface.md §3), not
 		// shared records, so full self-service is correct even here.
-		Objects:  objects(readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, crud, readOnly, readOnly, readOnly, readOnly, grant{}, readOnly, grant{}, grant{}, readOnly, readOnly, readOnly, grant{}, readOnly, readOnly, readOnly, grant{}, grant{}, grant{}, readOnly, grant{}, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly),
+		Objects:  objects(readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, crud, readOnly, readOnly, readOnly, readOnly, grant{}, readOnly, grant{}, grant{}, readOnly, readOnly, readOnly, grant{}, readOnly, readOnly, readOnly, grant{}, grant{}, grant{}, readOnly, grant{}, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, grant{}),
 		RowScope: principal.RowScopeAll,
 	},
 	"ops": {
-		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, writeNoDelete, crud, crud, crud, readUpdate, crud, crud, crud, readOnly, readOnly, crud, readUpdate, crud, crud, crud, crud, writeNoDelete, crud, createRead),
+		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly, crud, crud, readUpdate, crud, writeNoDelete, writeNoDelete, writeNoDelete, crud, crud, crud, readUpdate, crud, crud, crud, readOnly, readOnly, crud, readUpdate, crud, crud, crud, crud, writeNoDelete, crud, createRead, readOnly),
 		RowScope: principal.RowScopeAll,
 	},
 }
@@ -262,7 +268,7 @@ var defaults = map[string]Document{
 // and rbacfixture_test.go holds the result to the matrix the server seeds. Five
 // map literals of every key is what this replaced. Shortening it is a refactor of
 // the seed rather than of this call.
-func objects(person, organization, deal, lead, activity, pipeline, list, tag, relationship, partner, automation, voiceProfile, product, offer, signal, savedView, customField, computedField, offerTemplate, overlayConnection, embeddingReindex, webhookSubscription, fxRate, aiModelRate, captureSettings, project, channelConnection, importRun, installationSettings, finance, integrations, retentionPolicy, captureTrace, license, contract, aiRouting, commission, dealRoom, knowledgeCorpus, knowledgeDocument, introduction, weeklyPlan, forecast grant) map[string]grant { // NOSONAR(go:S107) -- the parameter list is the mechanism; see above
+func objects(person, organization, deal, lead, activity, pipeline, list, tag, relationship, partner, automation, voiceProfile, product, offer, signal, savedView, customField, computedField, offerTemplate, overlayConnection, embeddingReindex, webhookSubscription, fxRate, aiModelRate, captureSettings, project, channelConnection, importRun, installationSettings, finance, integrations, retentionPolicy, captureTrace, license, contract, aiRouting, commission, dealRoom, knowledgeCorpus, knowledgeDocument, introduction, weeklyPlan, forecast, dataCoverage grant) map[string]grant { // NOSONAR(go:S107) -- the parameter list is the mechanism; see above
 	return map[string]grant{
 		"person": person, "organization": organization, "deal": deal,
 		"lead": lead, "activity": activity, "pipeline": pipeline,
@@ -378,9 +384,10 @@ func objects(person, organization, deal, lead, activity, pipeline, list, tag, re
 		// update are a rep's: asking is the job, and answering an ask made OF
 		// you is answering for yourself — the row's own party check decides
 		// which of the two you are, and a grant cannot substitute for it.
-		"introduction": introduction,
-		"weekly_plan":  weeklyPlan,
-		"forecast":     forecast,
+		"introduction":  introduction,
+		"weekly_plan":   weeklyPlan,
+		"forecast":      forecast,
+		"data_coverage": dataCoverage,
 	}
 }
 

--- a/backend/internal/modules/identity/internal/policy/policy.go
+++ b/backend/internal/modules/identity/internal/policy/policy.go
@@ -22,7 +22,7 @@ import (
 // (features/04 §1). A policy naming anything else is rejected — a typo'd
 // object would otherwise silently grant nothing and read as a bug in the
 // role, not the document.
-var coreObjects = []string{"person", "organization", "deal", "lead", "activity", "pipeline", "list", "tag", "relationship", "partner", "automation", "voice_profile", "product", "offer", "signal", "saved_view", "custom_field", "computed_field", "offer_template", "overlay_connection", "embedding_reindex", "webhook_subscription", "fx_rate", "ai_model_rate", "capture_settings", "project", "channel_connection", "import_run", "installation_settings", "finance", "integrations", "retention_policy", "capture_trace", "license", "contract", "ai_routing", "commission", "deal_room", "knowledge_corpus", "knowledge_document", "introduction", "weekly_plan", "forecast"}
+var coreObjects = []string{"person", "organization", "deal", "lead", "activity", "pipeline", "list", "tag", "relationship", "partner", "automation", "voice_profile", "product", "offer", "signal", "saved_view", "custom_field", "computed_field", "offer_template", "overlay_connection", "embedding_reindex", "webhook_subscription", "fx_rate", "ai_model_rate", "capture_settings", "project", "channel_connection", "import_run", "installation_settings", "finance", "integrations", "retention_policy", "capture_trace", "license", "contract", "ai_routing", "commission", "deal_room", "knowledge_corpus", "knowledge_document", "introduction", "weekly_plan", "forecast", "data_coverage"}
 
 // IsCoreObject reports whether an RBAC object is in the closed set a role
 // document may grant. Parse enforces it on stored documents; it is also the

--- a/backend/migrations/core/1788421500_source_health_is_an_operators_view.down.sql
+++ b/backend/migrations/core/1788421500_source_health_is_an_operators_view.down.sql
@@ -1,0 +1,7 @@
+-- Remove the object from the seeded roles. An operator who hand-set it after
+-- the fact loses that setting on a revert, which is the same trade every
+-- permission backfill in this tree makes.
+SET LOCAL lock_timeout = '5s';
+
+UPDATE role SET permissions = permissions #- '{objects,data_coverage}'
+    WHERE is_system AND permissions ? 'objects';

--- a/backend/migrations/core/1788421500_source_health_is_an_operators_view.up.sql
+++ b/backend/migrations/core/1788421500_source_health_is_an_operators_view.up.sql
@@ -1,0 +1,39 @@
+-- Who may read the installation's own source health.
+--
+-- Reach the installations that already exist. seedSystemRoles writes each role
+-- document once at workspace creation and never re-syncs, so an object added to
+-- the compiled defaults alone is granted to nobody who bootstrapped earlier — it
+-- works on a fresh database and 403s everywhere else, permanently.
+--
+-- One population needs reaching: `data_coverage` has never existed, so no role
+-- holds the key and the guard is absence. An operator who later hand-sets the
+-- object keeps their setting.
+SET LOCAL lock_timeout = '5s';
+
+-- Admin and ops read source health because it is their job: a connector that
+-- stopped, a mailbox the installation may not read, an import that never
+-- finished. Read only — coverage is OBSERVED, and there is nothing on this
+-- surface for anybody to write.
+UPDATE role SET permissions = jsonb_set(
+        permissions, '{objects,data_coverage}',
+        '{"create": false, "read": true, "update": false, "delete": false}'::jsonb, true)
+    WHERE is_system
+      AND key IN ('admin', 'ops')
+      AND permissions ? 'objects'
+      AND NOT (permissions -> 'objects') ? 'data_coverage';
+
+-- Everyone else: nothing, and the absence is the point. A rep or a manager
+-- shown their installation's connector health has been handed somebody else's
+-- job — and a screen reporting a problem they cannot act on teaches them to
+-- ignore the screen.
+--
+-- Written as an explicit zero grant rather than left out. A role with no key at
+-- all is indistinguishable from a role the backfill missed, and the next reader
+-- auditing this cannot tell a decision from an omission.
+UPDATE role SET permissions = jsonb_set(
+        permissions, '{objects,data_coverage}',
+        '{"create": false, "read": false, "update": false, "delete": false}'::jsonb, true)
+    WHERE is_system
+      AND key IN ('management', 'manager', 'rep', 'read_only')
+      AND permissions ? 'objects'
+      AND NOT (permissions -> 'objects') ? 'data_coverage';

--- a/backend/migrations/testdata/rbac_seeded_defaults.json
+++ b/backend/migrations/testdata/rbac_seeded_defaults.json
@@ -67,6 +67,12 @@
         "read": true,
         "update": true
       },
+      "data_coverage": {
+        "create": false,
+        "delete": false,
+        "read": true,
+        "update": false
+      },
       "deal": {
         "create": true,
         "delete": true,
@@ -328,6 +334,12 @@
         "create": false,
         "delete": false,
         "read": true,
+        "update": false
+      },
+      "data_coverage": {
+        "create": false,
+        "delete": false,
+        "read": false,
         "update": false
       },
       "deal": {
@@ -593,6 +605,12 @@
         "read": true,
         "update": false
       },
+      "data_coverage": {
+        "create": false,
+        "delete": false,
+        "read": false,
+        "update": false
+      },
       "deal": {
         "create": true,
         "delete": true,
@@ -855,6 +873,12 @@
         "delete": true,
         "read": true,
         "update": true
+      },
+      "data_coverage": {
+        "create": false,
+        "delete": false,
+        "read": true,
+        "update": false
       },
       "deal": {
         "create": true,
@@ -1119,6 +1143,12 @@
         "read": true,
         "update": false
       },
+      "data_coverage": {
+        "create": false,
+        "delete": false,
+        "read": false,
+        "update": false
+      },
       "deal": {
         "create": false,
         "delete": false,
@@ -1380,6 +1410,12 @@
         "create": false,
         "delete": false,
         "read": true,
+        "update": false
+      },
+      "data_coverage": {
+        "create": false,
+        "delete": false,
+        "read": false,
         "update": false
       },
       "deal": {

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -4,10 +4,10 @@
   "per_agent_listing_budget": 17000,
   "whole_catalog_floor": 21000,
   "catalog": {
-    "tools": 67,
-    "tokens": 20926,
-    "median_tool_tokens": 273,
-    "mean_tool_tokens": 311
+    "tools": 68,
+    "tokens": 20937,
+    "median_tool_tokens": 271,
+    "mean_tool_tokens": 307
   },
   "agents": [
     {
@@ -114,10 +114,6 @@
       "tokens": 456
     },
     {
-      "name": "forecast_readings",
-      "tokens": 441
-    },
-    {
       "name": "progress_deal",
       "tokens": 435
     },
@@ -148,6 +144,10 @@
     {
       "name": "search_context",
       "tokens": 352
+    },
+    {
+      "name": "forecast_readings",
+      "tokens": 335
     },
     {
       "name": "prep_for_meeting",
@@ -320,6 +320,10 @@
     {
       "name": "whoami",
       "tokens": 136
+    },
+    {
+      "name": "data_coverage",
+      "tokens": 116
     },
     {
       "name": "list_tags",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -26,7 +26,7 @@ feature is expected to argue with.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1688 | 7% | 15312 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2535 | 10% | 14465 | 15 | 8 |
-| _whole served catalog, for scale_ | 67 | 20926 | 87% | — | — | — |
+| _whole served catalog, for scale_ | 68 | 20937 | 87% | — | — | — |
 
 ### `morning_brief`
 
@@ -123,7 +123,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 273 tokens, mean 311, across 67 served tools.
+Median 271 tokens, mean 307, across 68 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -143,7 +143,6 @@ a term in an addition.
 | `advance_deal` | 474 | 1 scenario |
 | `send_email` | 471 | 1 scenario |
 | `annotate_brief` | 456 | — |
-| `forecast_readings` | 441 | — |
 | `progress_deal` | 435 | 3 scenarios |
 | `book_meeting` | 431 | — |
 | `create_record` | 429 | 1 scenario |
@@ -152,6 +151,7 @@ a term in an addition.
 | `search_records` | 392 | 6 scenarios |
 | `forecast_movement` | 358 | — |
 | `search_context` | 352 | — |
+| `forecast_readings` | 335 | — |
 | `prep_for_meeting` | 333 | — |
 | `merge_records` | 323 | — |
 | `draft_email` | 317 | — |
@@ -195,6 +195,7 @@ a term in an addition.
 | `get_record_tags` | 149 | — |
 | `list_colleagues` | 148 | — |
 | `whoami` | 136 | — |
+| `data_coverage` | 116 | — |
 | `list_tags` | 102 | — |
 | `get_tag` | 94 | — |
 | `read_import_report` | 80 | — |

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -132,6 +132,7 @@ Columns:
 | `forecast_movement` | 🟢 | `read` | — | Diffs two stored snapshots, so it answers only where snapshots exist |
 | `forecast_input_checks` | 🟢 | `read` | — | Reads the nightly run's own record, so it answers only where a run has completed |
 | `list_input_checks` | 🟢 | `read` | — | Scoped to the deals the caller can open, through the deal's own visibility |
+| `data_coverage` | 🟢 | `read` | — | Needs the data_coverage grant: operators hold it, sellers do not, so a refusal is a seat boundary rather than a missing run |
 | `search_context` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `search_records` | 🟢 | `read` | — | Mirror-backed; results carry `trust_tier: external` |
 | `send_email` | 🟢 | `send` | yes | Staging refuses a mirror-held anchor |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,18 +8,18 @@
     "enrich"
   ],
   "totals": {
-    "tools": 67,
+    "tools": 68,
     "resources": 9,
-    "tool_catalog_bytes": 193400,
+    "tool_catalog_bytes": 194750,
     "resource_catalog_bytes": 3513,
-    "approx_wire_tokens_total": 49228,
+    "approx_wire_tokens_total": 49565,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
-      "description_bytes": 45907,
-      "input_schema_bytes": 39927,
-      "output_schema_bytes": 93109,
-      "description_plus_input_schema_bytes": 85834
+      "description_bytes": 45913,
+      "input_schema_bytes": 39989,
+      "output_schema_bytes": 94182,
+      "description_plus_input_schema_bytes": 85902
     }
   },
   "tools": {
@@ -2522,6 +2522,138 @@
       {
         "annotations": {
           "openWorldHint": false,
+          "readOnlyHint": true,
+          "title": "How current the sources are"
+        },
+        "description": "Which connectors the nightly check could read, and how far back each reaches. Needs the data_coverage grant, which operators hold and sellers do not — a refusal here is a seat boundary, not a missing run. Only a `checked` source carries a date. On any other state nothing was read, and a quiet week is indistinguishable from a broken connector until somebody looks. (Governance: runs immediately; requires passport scope \"read\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {},
+          "type": "object"
+        },
+        "name": "data_coverage",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "as_of": {
+                  "type": "string"
+                },
+                "run_id": {
+                  "type": "string"
+                },
+                "sources": {
+                  "items": {
+                    "properties": {
+                      "checked_through": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      },
+                      "state": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "source",
+                      "state"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "as_of",
+                "run_id",
+                "sources"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "How current the sources are"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
           "readOnlyHint": false,
           "title": "Approve or reject one staged action"
         },
@@ -3994,7 +4126,7 @@
           "readOnlyHint": true,
           "title": "Read the forecast"
         },
-        "description": "What a period is expected to close, in four readings, plus what the figures do not cover. `won` counts deals by the day they ACTUALLY closed, never the day they were expected to — a deal expected in March and won in April is April's. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date is a guess, so it is excluded there and still counted in `open`. `weighted` applies each deal's stage probability, rounded per deal. Read `eligible_count` against `priced_count` before quoting a total: an unpriced deal is real pipeline contributing zero money, and the gap is what the money readings leave out. `fx_missing_count` is priced deals no rate could convert — also absent from the totals rather than counted as zero. `scope_limited` true means deals the caller cannot read were left out; there is deliberately no count of them. Every figure carries the frame it was cut in: `as_of`, the installation's timezone, and the base currency. Quote them with the number — a total placed in the reader's own zone is a different total. (Governance: runs immediately; requires passport scope \"read\".)",
+        "description": "What a period is expected to close, in four readings. `won` counts deals by the day they ACTUALLY closed, not the day they were expected to. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date stays in `open` and out of `evidence`. Read `eligible_count` against `priced_count` before quoting a total: an unpriced deal is real pipeline contributing zero money. `fx_missing_count` is priced deals no rate could convert — also absent from the totals rather than counted as zero. Quote `as_of`, `timezone` and `base_currency` with the number: a total placed in the reader's own zone is a different total. (Governance: runs immediately; requires passport scope \"read\".)",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -12785,7 +12917,7 @@
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":67,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"annotate_brief\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"create_record\",\"create_tag\",\"create_task\",\"decide_approval\",\"decide_approval_bundle\",\"describe_query_vocabulary\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"forecast_input_checks\",\"forecast_movement\",\"forecast_readings\",\"get_record_tags\",\"get_tag\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_input_checks\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"update_tag\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":68,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"annotate_brief\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"create_record\",\"create_tag\",\"create_task\",\"data_coverage\",\"decide_approval\",\"decide_approval_bundle\",\"describe_query_vocabulary\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"forecast_input_checks\",\"forecast_movement\",\"forecast_readings\",\"get_record_tags\",\"get_tag\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_input_checks\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"update_tag\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, channel_provider?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"message\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"|\\\"project\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, counterparty_person_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\"|\\\"works_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"A recording of a conversation is logged with `source_system: \\\"transcript\\\"` — that value is what has it read for next steps and commitments; any other value stores the text and reads nothing.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, source?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` on a lead is the administered lead-source key (see Settings › Data model); a patch corrects it, and the score follows.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
     "ui://margince/account-brief.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,11 +11,11 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 67 |
+| Tools | 68 |
 | Resources | 9 |
-| Tool catalog | 188.9 KB |
+| Tool catalog | 190.2 KB |
 | Resource catalog | 3.4 KB |
-| Approx. wire tokens | 49228 |
+| Approx. wire tokens | 49565 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 90.9 KB | 48% | **No** — a result's shape, never listed to a model |
+| Output schemas | 92.0 KB | 48% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 44.8 KB | 23% | Yes, every step |
-| Input schemas | 39.0 KB | 20% | Yes, every step |
-| _Names, annotations, punctuation_ | 14.1 KB | 7% | Partly |
-| **Description + input schema** | **83.8 KB** | **44%** | **the recurring cost** |
+| Input schemas | 39.1 KB | 20% | Yes, every step |
+| _Names, annotations, punctuation_ | 14.3 KB | 7% | Partly |
+| **Description + input schema** | **83.9 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -57,7 +57,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
 - [`ui://margince/geo-probe.html`](#geo_probe_view) — Location check
 
-### Tools (67)
+### Tools (68)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
@@ -76,6 +76,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`create_record`](#create_record) | Create a record |  |  | 3.3 KB |
 | [`create_tag`](#create_tag) | Create a tag |  |  | 1.9 KB |
 | [`create_task`](#create_task) | Create a task |  |  | 2.2 KB |
+| [`data_coverage`](#data_coverage) | How current the sources are | yes |  | 1.7 KB |
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 2.9 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 2.9 KB |
 | [`describe_query_vocabulary`](#describe_query_vocabulary) | Describe the query vocabulary | yes |  | 2.1 KB |
@@ -85,7 +86,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`enrich`](#enrich) | Enrich an organization from its website |  |  | 2.6 KB |
 | [`forecast_input_checks`](#forecast_input_checks) | What the forecast's inputs were checked against | yes |  | 2.4 KB |
 | [`forecast_movement`](#forecast_movement) | What moved the forecast | yes |  | 3.0 KB |
-| [`forecast_readings`](#forecast_readings) | Read the forecast | yes |  | 3.5 KB |
+| [`forecast_readings`](#forecast_readings) | Read the forecast | yes |  | 3.1 KB |
 | [`get_record_tags`](#get_record_tags) | Get a record's tags | yes |  | 1.9 KB |
 | [`get_tag`](#get_tag) | Get a tag | yes |  | 1.6 KB |
 | [`intro_path_to`](#intro_path_to) | Find a warm introduction path | yes |  | 2.3 KB |
@@ -2950,6 +2951,148 @@ Put a to-do on someone's list: what is owed, by whom, on which records. Creates 
 
 </details>
 
+### data_coverage
+
+**How current the sources are**
+
+Which connectors the nightly check could read, and how far back each reaches. Needs the data_coverage grant, which operators hold and sellers do not — a refusal here is a seat boundary, not a missing run. Only a `checked` source carries a date. On any other state nothing was read, and a quiet week is indistinguishable from a broken connector until somebody looks. (Governance: runs immediately; requires passport scope "read".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {},
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "as_of": {
+          "type": "string"
+        },
+        "run_id": {
+          "type": "string"
+        },
+        "sources": {
+          "items": {
+            "properties": {
+              "checked_through": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "source",
+              "state"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "as_of",
+        "run_id",
+        "sources"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
 ### decide_approval
 
 **Approve or reject one staged action**
@@ -4513,7 +4656,7 @@ The difference between two forecast snapshots, classified into named causes. Ope
 
 **Read the forecast**
 
-What a period is expected to close, in four readings, plus what the figures do not cover. `won` counts deals by the day they ACTUALLY closed, never the day they were expected to — a deal expected in March and won in April is April's. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date is a guess, so it is excluded there and still counted in `open`. `weighted` applies each deal's stage probability, rounded per deal. Read `eligible_count` against `priced_count` before quoting a total: an unpriced deal is real pipeline contributing zero money, and the gap is what the money readings leave out. `fx_missing_count` is priced deals no rate could convert — also absent from the totals rather than counted as zero. `scope_limited` true means deals the caller cannot read were left out; there is deliberately no count of them. Every figure carries the frame it was cut in: `as_of`, the installation's timezone, and the base currency. Quote them with the number — a total placed in the reader's own zone is a different total. (Governance: runs immediately; requires passport scope "read".)
+What a period is expected to close, in four readings. `won` counts deals by the day they ACTUALLY closed, not the day they were expected to. `evidence` is committed pipeline whose close date somebody confirmed; a provisional date stays in `open` and out of `evidence`. Read `eligible_count` against `priced_count` before quoting a total: an unpriced deal is real pipeline contributing zero money. `fx_missing_count` is priced deals no rate could convert — also absent from the totals rather than counted as zero. Quote `as_of`, `timezone` and `base_currency` with the number: a total placed in the reader's own zone is a different total. (Governance: runs immediately; requires passport scope "read".)
 
 <details><summary>Input schema</summary>
 

--- a/docs/reference/rbac-matrix.md
+++ b/docs/reference/rbac-matrix.md
@@ -74,6 +74,7 @@ changes none.
 | `computed_field` | -R-- | -R-- | -R-- | -R-- | -R-- | -R-- |
 | `contract` | CRUD | CRUD | CRUD | CRU- | -R-- | CRUD |
 | `custom_field` | CRUD | -R-- | -R-- | -R-- | -R-- | CRUD |
+| `data_coverage` | -R-- | ---- | ---- | ---- | ---- | -R-- |
 | `deal` | CRUD | CRUD | CRUD | CRU- | -R-- | CRUD |
 | `deal_room` | CRUD | CRUD | CRUD | CRU- | -R-- | CRUD |
 | `embedding_reindex` | -RU- | ---- | ---- | ---- | ---- | -RU- |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -10753,6 +10753,36 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/analytics/coverage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * How current the sources behind the numbers are.
+         * @description Source health: which connectors the nightly check could read, how far back each
+         *     reaches, and what it could not open.
+         *
+         *     Gated on `data_coverage`, which admin and ops hold and nobody else does. That is a
+         *     decision rather than an oversight: a rep shown their installation's connector
+         *     health has been handed somebody else's job, and a screen reporting a problem they
+         *     cannot act on teaches them to ignore the screen.
+         *
+         *     Only a `checked` source carries `checked_through`. A date on a stale or unavailable
+         *     one would read as "checked up to then" when nothing was read at all — which is the
+         *     difference between a quiet week and a broken connector.
+         */
+        get: operations["getDataCoverage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/forecast/assurance/exceptions": {
         parameters: {
             query?: never;
@@ -22506,6 +22536,15 @@ export interface components {
              */
             expires_at?: string;
         };
+        /** @description How current the sources behind the forecast's numbers are. */
+        DataCoverage: {
+            /** Format: uuid */
+            run_id: string;
+            /** Format: date-time */
+            as_of: string;
+            /** @description The sources the run tried, and how far it reached into each. A source absent from this list is one the run did not attempt — different from one it attempted and could not read, which the state field says. */
+            sources: components["schemas"]["ForecastAssuranceSource"][];
+        };
         /** @description What the most recent nightly input check found, and how much of the pipeline it was able to reach. */
         ForecastAssurance: {
             /** Format: uuid */
@@ -22703,7 +22742,7 @@ export interface components {
          *     The SERVER does not derive from it. `identity/internal/policy.coreObjects` is maintained separately (oapi-codegen emits nothing for a top-level standalone string enum, so there are no generated Go constants to derive from), and a typo there is an ordinary runtime value, not a compile error. What keeps the two honest is a merge-blocking parity test, `backend/gates/rbacvocabulary_test.go`, which holds this enum equal to that list. Editing this enum alone changes what clients can express, never what the server enforces — change both, and the gate will say so if you do not.
          * @enum {string}
          */
-        RbacObject: "person" | "organization" | "deal" | "lead" | "activity" | "pipeline" | "list" | "tag" | "relationship" | "partner" | "automation" | "voice_profile" | "product" | "offer" | "signal" | "saved_view" | "custom_field" | "computed_field" | "offer_template" | "overlay_connection" | "embedding_reindex" | "webhook_subscription" | "fx_rate" | "ai_model_rate" | "capture_settings" | "project" | "channel_connection" | "import_run" | "installation_settings" | "finance" | "integrations" | "retention_policy" | "capture_trace" | "license" | "contract" | "ai_routing" | "commission" | "deal_room" | "knowledge_corpus" | "knowledge_document" | "introduction" | "weekly_plan" | "forecast";
+        RbacObject: "person" | "organization" | "deal" | "lead" | "activity" | "pipeline" | "list" | "tag" | "relationship" | "partner" | "automation" | "voice_profile" | "product" | "offer" | "signal" | "saved_view" | "custom_field" | "computed_field" | "offer_template" | "overlay_connection" | "embedding_reindex" | "webhook_subscription" | "fx_rate" | "ai_model_rate" | "capture_settings" | "project" | "channel_connection" | "import_run" | "installation_settings" | "finance" | "integrations" | "retention_policy" | "capture_trace" | "license" | "contract" | "ai_routing" | "commission" | "deal_room" | "knowledge_corpus" | "knowledge_document" | "introduction" | "weekly_plan" | "forecast" | "data_coverage";
         /**
          * @description The four object-level verbs a grant carries (data-model §2.4). These are RBAC actions, not HTTP methods: the seat ceiling is clamped on the method independently, and the two diverge in both directions — a read-seat GET that the object grants, and a mutating route whose RBAC action is `read`.
          * @enum {string}
@@ -45867,6 +45906,35 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ForecastAssurance"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            /** @description No run has completed yet. A fresh installation has not been checked. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getDataCoverage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The most recent run's source health. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataCoverage"];
                 };
             };
             401: components["responses"]["Unauthorized"];


### PR DESCRIPTION
`data_coverage` is a new RBAC object, and the interesting part is who does **not** hold it. Admin and ops read source health because it is their job: a connector that stopped, a mailbox the installation may not read, an import that never finished. Everybody else gets nothing.

That is a decision rather than an omission. A rep or a manager shown their installation's connector health has been handed somebody else's job, and a screen reporting a problem they cannot act on teaches them to ignore the screen. Gating on `forecast` would have given it to every seat that reads a number — the test mutation-checks exactly that, by swapping the object and watching a manager pass.

**The backfill writes an explicit zero grant** for the roles that get nothing rather than leaving them out. A role with no key is indistinguishable from a role the backfill missed, and the next reader auditing this cannot tell a decision from an omission.

**No seat holds write on it either.** Coverage is *observed* — what the nightly run could reach — and a grant for a verb the product does not offer reads as an oversight somebody has to research.

This follows `docs/how-to/add-an-rbac-object.md` rather than being worked out from the gates. That page exists because six objects reached production ungranted, and it names them. All three seed-parity gates passed first try, including the one that composes every backfill from the oldest upgradable installation.

**Two collisions of the same kind, both caught rather than shipped:**

- `CoverageReader` already names a type in `tools_network.go`. Mine is `SourceCoverageReader`.
- My migration sorted *below* one main gained while this branch was open. It would still apply, but in a different position on each installation — before that migration on a fresh database, after it on one already past — and anything order-dependent then leaves two schemas different with nothing to report it.

The catalog's token budget went 43 over. `forecast_readings` was the wordiest of the five forecast tools and repeated what its own output schema says, so it is what got shorter.

`make check-backend`, `make check-fe`, craft, rls-store-path and no-jurisdiction green. The migrations lane's one failure is #3818, pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds source health (connector freshness) as a new `data_coverage` RBAC object, exposed through a `GET /analytics/coverage` endpoint and a `data_coverage` agent tool. Admin and ops can read it; every other seat gets an explicit zero grant, because a rep or manager shown connector health they cannot act on learns to ignore the screen. No seat holds write on it — coverage is observed, not edited.

**Migration**
- Backfills existing installations with read for admin and ops, and explicit zero grants for management, manager, rep, and read_only, so a missing key reads as a decision rather than a missed role.

Also shortens the `forecast_readings` description to stay within the catalog's token budget.

<sup>Written for commit d0e560e6ae83c4eca786ee1bfc0afc7c6e4d0d2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only data coverage view showing the latest run, source status, and coverage dates.
  - Added the `data_coverage` tool with structured coverage results.
  - Added a dedicated permission for data coverage access.

- **Access Control**
  - Administrators and Operations users receive read access by default.
  - Other seeded roles cannot access data coverage.

- **Documentation**
  - Updated tool catalogs, MCP references, budget reports, and the RBAC matrix.
  - Clarified forecast tool guidance and coverage-related output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->