### PR TITLE
The schedule panel draws each meeting's start time

### DIFF
--- a/frontend/src/screens/home.fixtures.ts
+++ b/frontend/src/screens/home.fixtures.ts
@@ -250,14 +250,26 @@ export const NOT_FOUND = { title: "Not Found", code: "no_digest_yet" };
 export type Worklist = components["schemas"]["Worklist"];
 type Readings = components["schemas"]["WorklistReadings"];
 
-/** One meeting row, prepared or not, as the queue would carry it. */
-export function meetingRow(id: string, prepared: boolean): WorklistItem {
+/**
+ * One meeting row, prepared or not, as the queue would carry it.
+ *
+ * `due_at` is the start, and it is not optional in the fixture because it is
+ * not optional on the wire: the meeting lane sets it on every row it produces.
+ * A fixture that left it off was the reason a panel which could never draw a
+ * time had a green test suite.
+ */
+export function meetingRow(
+  id: string,
+  prepared: boolean,
+  startsAt = "2026-09-03T09:30:00Z",
+): WorklistItem {
   return {
     id,
     source: "meeting",
     level: 3,
     category: "meetings",
     title: "Weber GmbH · quarterly review",
+    due_at: startsAt,
     because: prepared ? [] : [{ kind: "meeting_unprepared" }],
     consequence: prepared ? "none" : "meeting_unprepared",
     actions: ["open"],

--- a/frontend/src/screens/home.schedule.test.tsx
+++ b/frontend/src/screens/home.schedule.test.tsx
@@ -1,6 +1,8 @@
 /** @vitest-environment jsdom */
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
+import { formatTimeOfDay } from "../format/format";
+import { viewerZone } from "../format/timezone";
 import { LocaleProvider } from "../i18n";
 import { en } from "../i18n/en";
 import { meetingRow, readingsDay } from "./home.fixtures";
@@ -58,6 +60,36 @@ describe("the schedule panel", () => {
     draw(<SchedulePanel day={day} state="ready" />);
 
     expect(screen.getAllByText(en["worklist.needsPrep"])).toHaveLength(1);
+  });
+
+  // The panel is a list of TIMES. Without them it is the meetings count from
+  // the readings strip again, in a wider column — and a rep is told they have a
+  // meeting today and never told when.
+  //
+  // The start rides `due_at`, which is where the meeting lane puts it; the rows
+  // carry no `occurred_at` at all, because a meeting on today's schedule has
+  // not occurred yet. Reading that field drew every row with a blank gutter,
+  // and no fixture gave a meeting a time, so the panel's own suite rendered the
+  // empty branch and asserted around it.
+  it("draws each meeting's start time", () => {
+    const zone = viewerZone();
+    const day = readingsDay({}, [
+      meetingRow("m1", true, "2026-09-03T03:40:00Z"),
+      meetingRow("m2", true, "2026-09-03T13:15:00Z"),
+    ]);
+    draw(<SchedulePanel day={day} state="ready" />);
+
+    const times = screen
+      .getByRole("region")
+      .querySelectorAll(".rail-schedule-when");
+    expect(Array.from(times, (cell) => cell.textContent)).toEqual([
+      formatTimeOfDay("2026-09-03T03:40:00Z", "en", zone),
+      formatTimeOfDay("2026-09-03T13:15:00Z", "en", zone),
+    ]);
+    // Two DIFFERENT times, so a cell that rendered a constant — or the same
+    // row twice — cannot pass the comparison above.
+    expect(times[0].textContent).not.toBe(times[1].textContent);
+    expect(times[0].textContent).not.toBe("");
   });
 
   it("says the day is clear rather than drawing an empty panel", () => {

--- a/frontend/src/screens/home.schedule.tsx
+++ b/frontend/src/screens/home.schedule.tsx
@@ -127,13 +127,16 @@ function Title({ item }: Readonly<{ item: WorklistItem }>) {
 /**
  * When a meeting starts, or nothing.
  *
- * `occurred_at` is when it is, and a meeting the server sent without one is
- * drawn without a time rather than with an invented one.
+ * The start is on `due_at`. The meeting lane puts it there deliberately — it is
+ * the deadline a reader is racing (attention/meeting.go) — and sets no
+ * `occurred_at` at all, because a meeting on today's schedule has not occurred
+ * yet. Reading the other field drew every row with a blank time.
+ *
+ * A row the server sent without one is still drawn without a time rather than
+ * with an invented one.
  */
 function whenOf(item: WorklistItem, locale: Locale, zone: string): string {
-  return item.occurred_at
-    ? formatTimeOfDay(item.occurred_at, locale, zone)
-    : "";
+  return item.due_at ? formatTimeOfDay(item.due_at, locale, zone) : "";
 }
 
 /** One source's rows, in the server's order. */


### PR DESCRIPTION
Closes #3792.

Home's **Today's schedule** drew every meeting with an empty time cell. The panel is a list of times; without them it is the meetings count from the readings strip again, in a wider column — and a rep is told they have a meeting today and never told when. (The *Do next* card says *"starting shortly"*, which is a relative phrase, not the 10:40 the meeting is at.)

**The field, not the format.** `whenOf` read `occurred_at`. The meeting lane puts the start on `due_at` and says why — it is the deadline a reader is racing (`attention/meeting.go`) — and sets no `occurred_at` at all, because a meeting on today's schedule has not occurred yet. So the fallback branch was the only branch a meeting row could take, and it draws nothing by design. The guard was on the wrong field.

**Why nothing caught it.** `meetingRow` in `home.fixtures.ts` built rows with neither field, so the panel's own suite rendered the empty branch and asserted around it. There was no fixture in which a meeting had a time, which is how a panel that could never show one stayed green.

The fixture now carries `due_at`, and not as an option: the lane sets it on every row it produces, so a fixture without one is not a row the server can send. A third parameter lets a test name the instant.

**The test.** `draws each meeting's start time` renders two meetings at different instants and compares the two `.rail-schedule-when` cells against `formatTimeOfDay(..., viewerZone())` — the pattern `home.dials.test.tsx` and `home.readings.test.tsx` already use, so it holds under any viewer zone and under `fe-clock-drift`'s +200 days (the instants are absolute). It then asserts the two differ and neither is empty, so a cell rendering a constant, or the same row twice, cannot pass the comparison.

Mutation-checked: putting `item.occurred_at` back in `whenOf` fails the new test and nothing else.

**Verification.** `make check-fe` green (6,056 tests). `make check-backend` green. No contract or backend change — `due_at` was already on the wire, correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Meeting start times in the schedule panel now display correctly according to the viewer’s local timezone.
  - Different scheduled meetings now show their respective start times instead of identical or missing values.
  - Meetings without a scheduled timestamp continue to display no time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->