### PR TITLE
Every row says the decisive thing about itself

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -35956,8 +35956,9 @@ components:
 
             The idle window here is DELIBERATELY shorter than the product-wide `stalled`
             threshold: a queue that only speaks once a deal meets the stalled bar is
-            reporting a two-month-old fact rather than warning. `detail` names the window
-            actually used, so the card never implies a patience the server did not apply.
+            reporting a two-month-old fact rather than warning. `quiet_days` carries the
+            window actually used, so the card never implies a patience the server did not
+            apply.
 
             Absent — not empty — on an installation whose feed does not read deals.
         relationship_decay:
@@ -35969,9 +35970,9 @@ components:
 
             A fact about a PERSON rather than a deal, which is why it is not on `at_risk`:
             a contact carrying no open deal never reaches that lane, and those are exactly
-            the relationships that lapse unnoticed. `detail` carries the silence in days,
-            from the same §4 derivation the contact's own page shows, so the two surfaces
-            cannot come to disagree about when somebody went quiet.
+            the relationships that lapse unnoticed. `quiet_days` carries the silence, from
+            the same §4 derivation the contact's own page shows, so the two surfaces cannot
+            come to disagree about when somebody went quiet.
 
             Only relationships this reader actually had: a contact nobody here ever spoke
             to has not gone quiet, and a lane that said otherwise would report every
@@ -36302,7 +36303,41 @@ components:
             ABSENT where the sentence would have to be invented: the product ships
             three languages, so a duplicate pair sends its `kind` and `confidence`
             and the client writes the line in the reader's own.
-        detail: { type: string, description: "One supporting line: what changed, or what the evidence said." }
+        detail:
+          type: string
+          description: |
+            One supporting line: what changed, or what the evidence said. PROSE, in a
+            language a reader reads — a bounce reason, a park reason, the mailbox that
+            stopped syncing, what an AI task was about.
+
+            It is not a channel for anything else. Three producers used the field as one,
+            each with its own reader parsing the value back out: two wrote a bare day count
+            and one wrote internal marker words. So the field meant "a sentence" on twelve
+            sources and something else on three, and a client drawing it faithfully printed
+            a naked "90" under one title and "machine_sender" under another.
+
+            Both now travel typed — `quiet_days` and `staged` below — and the client writes
+            the sentence in the reader's own language.
+
+            ONE source is still an exception, and a client must know it: `sync_health` fills
+            this field with its own vocabulary — the affected object classes, the failure
+            class, or the budget band — for a client to write a sentence from. Those are
+            words like `shed` and `deal, person`. A client that has not written that
+            sentence draws nothing for that source rather than the value.
+        staged:
+          $ref: '#/components/schemas/AttentionStagedFacts'
+        quiet_days:
+          type: [integer, 'null']
+          minimum: 0
+          description: |
+            How many days a deal or a relationship has been idle, where the producing lane
+            measures one. Sent by `deal_at_risk` and `relationship_decay`.
+
+            Typed rather than written into `detail` because it is a number the queue READS
+            and not only something it shows: it becomes the row's `quiet_days` reason, the
+            deal card's own figure, and the age each row carries into the ordering. A number
+            parsed back out of a sentence reads as zero the day somebody rewords the
+            sentence, and every one of those uses would go quietly wrong together.
         cause_ref:
           type: string
           description: |
@@ -36314,6 +36349,28 @@ components:
             meaning. A row that reports no shared condition omits it. Present only on the
             system-health sources, where "the same thing broke again" is a question a reader
             has.
+
+            `cause_label` is the half a reader sees. The two are separate because they must
+            be able to disagree: a rule's NAME is mutable and not unique, so an identity
+            built from it would merge two rules that happen to share a name and split one
+            that was renamed, while a reader shown `automation_run:01a0…` learns nothing.
+        cause_label:
+          type: string
+          description: |
+            What `cause_ref` identifies, in words — the automation's name, the mailbox that
+            stopped.
+
+            Minted by the LANE that mints the cause, because only that lane knows which of
+            the records it read is the condition's name. It is deliberately not derived from
+            a sampled member's title: the members of a group are alike, not identical, and
+            one member's subject describes that member rather than the thing they share.
+
+            ABSENT is a real answer, not a gap. A lane whose only candidate is a vocabulary
+            key sends nothing rather than a plausible-looking one — the AI-work lane is that
+            case, since its task kinds are generated enum keys, and a rep reading
+            "site_triage failed 8 times" is being shown the vocabulary this field exists to
+            replace. A group with no words is named by its kind alone, and a client never
+            falls back to rendering `cause_ref`.
         rank: { type: integer, minimum: 1, description: "Position in its producer's own ordering, where the producer ranks (the briefing queue). 1 is first." }
         confidence:
           type: number
@@ -36367,6 +36424,27 @@ components:
             print: a reader asked to compare `full_name` is being shown the
             database rather than their own records.
           items: { $ref: '#/components/schemas/AttentionPairEvidence' }
+    AttentionStagedFacts:
+      type: object
+      description: |
+        What the verdict engine already worked out about a staged contact decision, so a
+        surface can group alike questions without reading the proposal a second time.
+
+        Read from the payload the engine staged rather than re-derived, because a second
+        opinion would put one decision in two groups across two reads.
+
+        Typed because these are FLAGS a client tests, not words a reader sees. They used to
+        ride inside `detail` as the marker words `machine_sender` and `known_company`, with
+        a reader doing a substring match to get them back — which made the supporting line
+        undrawable on this source and would have shown a rep an internal token.
+      properties:
+        machine_sender:
+          type: boolean
+          description: 'The address is a sending system rather than a person.'
+        known_company:
+          type: boolean
+          description: "The address's domain already names a company in this workspace."
+
     AttentionDealFacts:
       type: object
       description: |
@@ -36951,7 +37029,28 @@ components:
             Which underlying CONDITION this row reports, so a surface can group repeated
             failures of one thing into one row. Opaque identity, never rendered and never
             parsed. Absent on a row that reports no shared condition.
-        detail: { type: string, description: 'One supporting line.' }
+        cause_label:
+          type: string
+          description: |
+            What `cause_ref` identifies, in words — the automation's name, the mailbox that
+            stopped. This is the half a reader sees; the identity beside it is not drawable.
+
+            Present wherever the producing lane named the condition. A row whose lane named
+            none is described by its kind alone.
+        detail:
+          type: string
+          description: |
+            One supporting line, in PROSE — a bounce reason, a park reason, the mailbox that
+            stopped, what an AI task was about.
+
+            Not a channel for anything else. A value the queue itself reads travels typed
+            beside this field, never inside it: a figure parsed back out of a sentence reads
+            as zero the day somebody rewords the sentence.
+
+            ONE source is an exception a client must know: `sync_health` fills this with its
+            own vocabulary — the affected object classes, the failure class, the budget band
+            — for a client to write a sentence from. Those are words like `shed`. A client
+            that has not written that sentence draws nothing for that source.
         because:
           type: array
           items: { $ref: '#/components/schemas/WorklistReason' }
@@ -37202,9 +37301,23 @@ components:
         cause:
           type: string
           description: |
-            What the members have in common, for a `system_incident`: the rule's name,
-            the AI task's kind, the mailbox. Named so a reader knows WHAT is broken
-            rather than only how often.
+            WHICH condition the members share, for a `system_incident` — the identity the
+            group was formed on, carried so a client can tell two groups apart and find
+            the same row again on a re-read.
+
+            An opaque identity, never rendered. It is a `cause_ref` and reads like one
+            (`automation_run:<uuid>`), so a client that put it on screen would show a rep
+            "automation_run:01a0… failed 12 times". `label` is the half to draw.
+        label:
+          type: string
+          description: |
+            What `cause` identifies, in words — the automation's name, the mailbox that
+            stopped. This is what a row says.
+
+            Absent where the lane that formed the group minted no name for the condition.
+            A client then names the group by its kind alone and NEVER falls back to
+            `cause`, because an identity on screen is worse than a vaguer sentence: the
+            reader cannot act on it and cannot tell it from a bug.
 
     WorklistDealFacts:
       type: object

--- a/backend/internal/compose/attention/batches.go
+++ b/backend/internal/compose/attention/batches.go
@@ -136,6 +136,26 @@ func systemCause(row ranked) (string, bool) {
 	return *row.item.CauseRef, true
 }
 
+// causeLabelOf is the words for the condition a group was formed on.
+//
+// The members share one cause, so they carry one label, and the first that has
+// it answers for all. It walks rather than reading members[0] because a lane can
+// name the condition on some of its rows and not others — an automation run
+// whose rule was deleted between firings has the id and no name — and taking the
+// first row's absence for the group's would leave a named condition unnamed.
+//
+// An empty answer is a group with no name of its own, which the client draws by
+// its kind. It never falls back to the cause: that is an identity, and putting
+// it on screen is the defect this pair of fields exists to prevent.
+func causeLabelOf(members []ranked) string {
+	for _, member := range members {
+		if member.item.CauseLabel != nil && *member.item.CauseLabel != "" {
+			return *member.item.CauseLabel
+		}
+	}
+	return ""
+}
+
 // batchKeyOf says which group a row belongs to, and whether it may be grouped
 // at all.
 //
@@ -271,6 +291,14 @@ func batchRow(key crmcontracts.WorklistBatchKey, cause string, members []ranked,
 	}
 	if cause != "" {
 		row.Batch.Cause = &cause
+		// And the words for it. The members of a group share their condition, so
+		// they share its name — this is a lookup among rows already in hand, not
+		// a second read, and NOT the sampled member's own title: the members are
+		// alike rather than identical, and one member's subject describes that
+		// member instead of the thing they have in common.
+		if label := causeLabelOf(members); label != "" {
+			row.Batch.Label = &label
+		}
 	}
 	if bounded {
 		atLeast := true

--- a/backend/internal/compose/attention/causeref_test.go
+++ b/backend/internal/compose/attention/causeref_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// An identity never reaches a field a reader is shown.
+//
+// `cause_ref` groups repeated failures of one thing, and it has to be an
+// IDENTITY to do that: a rule's name is mutable and not unique, so a cause built
+// from names would merge two rules that happen to share one and split a rule
+// somebody renamed. Its own contract says it is "never rendered".
+//
+// The client rendered it anyway, and a rep read "automation_run:01a05500-…
+// failed 12 times". Fixing the client is half: the other half is making sure the
+// server never puts a value of that shape somewhere the client is SUPPOSED to
+// draw, because then every client is wrong and none of them can tell.
+//
+// This runs the real renderers over the awkward inputs rather than reading their
+// source, so a renderer that starts composing its title out of a cause fails
+// here even though the source never spells one.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// causeShaped matches the vocabulary the producers actually mint: a lowercase
+// snake_case word, a colon, and something after it. Deliberately not "contains a
+// colon" — a bounce reason may legitimately read "Rejected: no such mailbox",
+// and a gate that failed on prose would be turned off rather than fixed.
+var causeShaped = regexp.MustCompile(`\b[a-z][a-z0-9_]*:[^\s]`)
+
+// renderedFields are the strings a client puts on screen. `cause_ref` is
+// deliberately absent from this list — it is the identity, and carrying it is
+// the whole point.
+func renderedFields(item crmcontracts.AttentionItem) map[string]*string {
+	return map[string]*string{
+		"title":       item.Title,
+		"detail":      item.Detail,
+		"cause_label": item.CauseLabel,
+	}
+}
+
+func causeRefRenderers(t *testing.T) map[string]crmcontracts.AttentionItem {
+	t.Helper()
+	at := time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC)
+	return map[string]crmcontracts.AttentionItem{
+		"capture_health": captureItem(CaptureConcern{
+			ConnectionID: ids.NewV7(),
+			Kind:         "disconnected",
+			Provider:     "gmail",
+			AccountLabel: "lena.fischer@margince.test",
+		}),
+		"ai_work_health": aiWorkItem(TroubledRun{
+			ID:           ids.NewV7(),
+			Kind:         "meeting_recap",
+			State:        "failed",
+			Summary:      "A recap did not generate",
+			SubjectLabel: "Acme Renewal",
+			OccurredAt:   at,
+		}),
+		"automation_run": automationItem(TroubledAutomationRun{
+			ID:           ids.NewV7(),
+			AutomationID: ids.New[ids.AutomationKind](),
+			Name:         "Notify sales on a new lead",
+			Outcome:      "failed",
+			Reason:       "The webhook target answered 500 five times.",
+			OccurredAt:   at,
+		}),
+	}
+}
+
+// The fixtures above are hand-written, because each renderer takes a different
+// input and no scan can invent one. What CAN be derived is the census: which
+// functions assign a CauseRef at all. A fourth producer added tomorrow joins
+// this list by existing, and fails here until somebody gives it a fixture —
+// which is the only way the tests above can be known to cover the tree.
+//
+// The failure mode this exists for is the quiet one: a new producer leaks an
+// identity into a rendered field, and the gate reports PASS because it never
+// heard of it.
+func TestEveryCauseProducerHasAFixture(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the attention package directory: %v", err)
+	}
+	producers := map[string]bool{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		parsed, parseErr := parser.ParseFile(fset, name, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", name, parseErr)
+		}
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			if assignsCauseRef(fn.Body) {
+				producers[fn.Name.Name] = true
+			}
+		}
+	}
+	if len(producers) == 0 {
+		t.Fatal("found no CauseRef producer in the package at all — the scan is looking in " +
+			"the wrong place, and would report PASS over a tree where every one leaked")
+	}
+	// The fixture map is keyed by SOURCE; the census is keyed by function. Both
+	// are small and the mapping is stated once, here, so a new producer fails
+	// with a sentence saying what to do rather than a missing-key panic.
+	fixtured := map[string]string{
+		"captureItem":    "capture_health",
+		"aiWorkItem":     "ai_work_health",
+		"automationItem": "automation_run",
+	}
+	items := causeRefRenderers(t)
+	for producer := range producers {
+		source, known := fixtured[producer]
+		if !known {
+			t.Errorf("%s assigns a cause_ref and no fixture drives it, so the gates in this "+
+				"file never judge what it renders. Add it to causeRefRenderers and to the "+
+				"map above.", producer)
+			continue
+		}
+		if _, built := items[source]; !built {
+			t.Errorf("%s is mapped to the source %q, which causeRefRenderers does not build",
+				producer, source)
+		}
+	}
+}
+
+// assignsCauseRef reports whether a function body assigns to a CauseRef field.
+func assignsCauseRef(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for _, target := range assign.Lhs {
+			if sel, ok := target.(*ast.SelectorExpr); ok && sel.Sel.Name == "CauseRef" {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// Every renderer that mints a cause, over inputs that fill each of its fields.
+func TestNoRenderedFieldCarriesACauseIdentity(t *testing.T) {
+	for source, item := range causeRefRenderers(t) {
+		t.Run(source, func(t *testing.T) {
+			// The renderer must actually have minted one, or this proves nothing:
+			// a fixture that produced no cause would pass every assertion below
+			// while testing a row this gate does not care about.
+			if item.CauseRef == nil || *item.CauseRef == "" {
+				t.Fatalf("%s minted no cause_ref for this input, so the case below is vacuous", source)
+			}
+			for name, value := range renderedFields(item) {
+				if value == nil {
+					continue
+				}
+				if causeShaped.MatchString(*value) {
+					t.Errorf("%s.%s = %q, which reads like an identity. The contract says a "+
+						"cause_ref is never rendered, and a reader shown one learns nothing "+
+						"they can act on and cannot tell it from a bug.", source, name, *value)
+				}
+			}
+		})
+	}
+}
+
+// A label that IS sent must be words a reader reads.
+//
+// Not "must be sent". A lane with no reader-facing name for its condition mints
+// none, and the group says what KIND of thing broke instead. The AI lane is
+// exactly that: its only candidate is a generated task enum, and sending
+// `site_triage` as the words would move the leak rather than close it.
+//
+// So this judges what a lane does send, in both directions a label goes wrong —
+// the identity spelled twice, or a bare vocabulary key wearing the label's
+// clothes. The second is the one that reads as a label until you look at it.
+func TestAMintedLabelIsWordsAndNotVocabulary(t *testing.T) {
+	// A key: lowercase snake_case, no spaces. A real label is a mailbox address
+	// or a rule's name — something with a space, a dot or an at-sign in it.
+	bareKey := regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)+$`)
+	labelled := 0
+	for source, item := range causeRefRenderers(t) {
+		t.Run(source, func(t *testing.T) {
+			if item.CauseLabel == nil || *item.CauseLabel == "" {
+				return
+			}
+			labelled++
+			label := *item.CauseLabel
+			if label == *item.CauseRef {
+				t.Errorf("%s carries the identity as its own label (%q): the two exist "+
+					"because one groups and the other is read", source, label)
+			}
+			if bareKey.MatchString(label) {
+				t.Errorf("%s's label %q is a vocabulary key rather than words. A reader "+
+					"shown it learns as little as from the identity — a lane with no name "+
+					"for its condition sends none, and the group says its kind instead.",
+					source, label)
+			}
+		})
+	}
+	// Under-recognition guard: were every lane to stop labelling, the loop above
+	// would judge nothing and still report PASS.
+	if labelled == 0 {
+		t.Fatal("no renderer minted a label at all, so this test judged nothing — either " +
+			"the labels were dropped or the fixtures stopped producing them")
+	}
+}
+
+// The gate's own reach, checked from the other end.
+//
+// A regex that matched nothing would report PASS over a tree where every
+// renderer leaked, and nothing would fail to say so. So the pattern is asserted
+// against the values these renderers really mint, and against the prose it must
+// NOT fire on — a bounce reason with a colon in it is a sentence, and a gate
+// that failed on those would be waived rather than fixed.
+func TestTheIdentityPatternSeesRealCausesAndSparesRealProse(t *testing.T) {
+	for source, item := range causeRefRenderers(t) {
+		if !causeShaped.MatchString(*item.CauseRef) {
+			t.Errorf("the pattern does not recognise %s's own cause %q — it would report "+
+				"PASS over a renderer leaking exactly that shape", source, *item.CauseRef)
+		}
+	}
+	prose := []string{
+		"Rejected: no such mailbox at that domain.",
+		"Held: the recipient has not consented to marketing mail.",
+		"They asked to be introduced to the buyer at Turbinenbau.",
+		"lena.fischer@margince.test",
+		"Notify sales on a new lead",
+	}
+	for _, line := range prose {
+		if causeShaped.MatchString(line) {
+			t.Errorf("the pattern fires on the sentence %q — a gate that fails on prose "+
+				"gets turned off rather than fixed", line)
+		}
+	}
+	// A guard against the pattern being loosened into "anything with a colon":
+	// the sentences above already cover that, and this names why they are there.
+	if !strings.Contains(prose[0], ":") {
+		t.Fatal("the prose corpus lost its colon case, which is the whole distinction")
+	}
+}
+
+// A contact decision's supporting line, which used to be marker words.
+//
+// The queue groups these questions by two facts the verdict engine already
+// decided, and those facts travelled as the words "machine_sender" and
+// "known_company" inside `detail` — with a substring match to read them back.
+// That is why this source's supporting line could not be drawn: any client
+// rendering the field faithfully would have shown a rep an internal token.
+//
+// Now the facts are typed and the field is free to hold a sentence, or nothing.
+// What it must never hold again is a marker.
+func TestAContactDecisionsDetailCarriesNoMarkerWords(t *testing.T) {
+	change := map[string]any{"email": "noreply@newsletter.example"}
+	summary := "Is noreply@newsletter.example a contact worth keeping?"
+	approval := crmcontracts.Approval{
+		Id:             openapi_types.UUID(ids.NewV7()),
+		Kind:           "capture_counterparty",
+		Summary:        &summary,
+		ProposedChange: &change,
+	}
+
+	item := approvalItem(approval, func(string) bool { return true })
+
+	// The fact still reaches the queue — asserted first, so the absence below
+	// cannot pass because nothing was computed at all.
+	if item.Staged == nil || item.Staged.MachineSender == nil || !*item.Staged.MachineSender {
+		t.Fatalf("the machine-sender fact did not reach the row: %+v", item.Staged)
+	}
+	if item.Detail != nil {
+		t.Errorf("detail = %q on a contact decision, want none: this field is drawn to a "+
+			"reader now, and a marker word here reaches them as %q", *item.Detail, *item.Detail)
+	}
+}

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -113,8 +113,12 @@ func base(
 		Title:       item.Title,
 		Detail:      item.Detail,
 		CauseRef:    item.CauseRef,
-		Subject:     item.Subject,
-		Deal:        dealFactsOf(item),
+		// The identity AND the words for it. The identity groups the row; the
+		// label is what the group says. Forwarding only the first is how the
+		// client came to interpolate an identity into a sentence.
+		CauseLabel: item.CauseLabel,
+		Subject:    item.Subject,
+		Deal:       dealFactsOf(item),
 		// Forwarded, never re-derived here. The lane already applied the
 		// both-sides-visible rule and set `merge` only where it held, so
 		// carrying the payload keeps the verb and the records it acts on
@@ -467,19 +471,18 @@ func occurredOf(item crmcontracts.AttentionItem, asOf time.Time) time.Time {
 	return asOf
 }
 
-// quietDaysOf reads the idle count the risk and decay cards carry as their
-// detail. A detail that is not a number is a different kind of supporting line,
-// and reading it as zero is the honest answer rather than a guess.
+// quietDaysOf reads the idle count the risk and decay lanes measure.
+//
+// From the TYPED field, not parsed out of the supporting sentence. It used to
+// read `detail` a digit at a time and answer zero for anything else, which made
+// the ordering depend on a display string: a lane that made its sentence
+// friendlier — "quiet for 90 days" instead of "90" — would have dropped every
+// such row to the bottom of the queue, and nothing would have failed.
+//
+// A lane that measures no idle time sends none, and zero is what that means.
 func quietDaysOf(item crmcontracts.AttentionItem) int {
-	if item.Detail == nil {
+	if item.QuietDays == nil {
 		return 0
 	}
-	days := 0
-	for _, r := range *item.Detail {
-		if r < '0' || r > '9' {
-			return 0
-		}
-		days = days*10 + int(r-'0')
-	}
-	return days
+	return *item.QuietDays
 }

--- a/backend/internal/compose/attention/classifydecision.go
+++ b/backend/internal/compose/attention/classifydecision.go
@@ -11,7 +11,6 @@ package attention
 // decision holds up a person, or is the routine tidying that groups.
 
 import (
-	"strings"
 	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -31,10 +30,10 @@ func classifyDecision(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	}
 	row := base(item, level, "decisions", consequence)
 	row.Because = []crmcontracts.WorklistReason{reason(crmcontracts.WorklistReasonKind(why), nil)}
-	// The two facts a routine contact decision is grouped by. They ride on the
-	// wire item's `detail`, which the feed fills from the staged payload — the
-	// verdict engine already decided who the address belongs to, and deriving
-	// it again here would put one decision in two groups across two reads.
+	// The two facts a routine contact decision is grouped by, from the typed
+	// field the feed fills out of the staged payload — the verdict engine
+	// already decided who the address belongs to, and deriving it again here
+	// would put one decision in two groups across two reads.
 	facts := stagedFactsOf(item)
 	return ranked{
 		item:          row,
@@ -44,23 +43,25 @@ func classifyDecision(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	}
 }
 
-// The markers the feed stamps on a contact decision's detail, so the queue can
-// group it without reading the payload a second time. Two words rather than a
-// structure, because `detail` is one line on the wire and this is all it needs
-// to carry.
-const (
-	stagedMachineSender = "machine_sender"
-	stagedKnownCompany  = "known_company"
-)
-
-// stagedFactsOf reads those markers back.
+// stagedFactsOf reads what the feed already worked out about a contact
+// decision, so the queue groups it without reading the proposal a second time.
+//
+// From the TYPED field. These were two marker words written into `detail` and a
+// substring match to read them back, which cost this source its supporting line
+// entirely: a client drawing that field faithfully would have shown a rep
+// "machine_sender".
+//
+// An item carrying none is not "not a machine sender" — it is a decision of a
+// kind this question is never asked about. Both read false here, which is the
+// same answer for grouping and the safe direction: an ungrouped question is
+// still shown, where a wrongly grouped one disappears behind a fold.
 func stagedFactsOf(item crmcontracts.AttentionItem) StagedFacts {
-	if item.Detail == nil {
+	if item.Staged == nil {
 		return StagedFacts{}
 	}
 	return StagedFacts{
-		MachineSender: strings.Contains(*item.Detail, stagedMachineSender),
-		KnownCompany:  strings.Contains(*item.Detail, stagedKnownCompany),
+		MachineSender: item.Staged.MachineSender != nil && *item.Staged.MachineSender,
+		KnownCompany:  item.Staged.KnownCompany != nil && *item.Staged.KnownCompany,
 	}
 }
 

--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -83,7 +83,7 @@ func dealFactsOf(item crmcontracts.AttentionItem) *crmcontracts.WorklistDealFact
 		Currency:    item.Deal.Currency,
 	}
 	// The close date rides on the lane item's own due moment, and the idle
-	// count on its detail. Both were already resolved; only this projection
+	// count on its own typed field. Both were already resolved; only this projection
 	// dropped them, so the card could state money and never say when the deal
 	// was meant to land.
 	if item.DueAt != nil {

--- a/backend/internal/compose/attention/quietdays_test.go
+++ b/backend/internal/compose/attention/quietdays_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The idle count, from the lane to everything that uses it.
+//
+// It travels typed now, and that is only worth doing if something downstream
+// actually depends on the number. Three things do — the sentence the row says,
+// the figure the deal card draws, and the age the ordering carries — and none of
+// them was held: `quietDaysOf` could be made to answer zero for every row and
+// the whole package stayed green, which is a defect that would reach a rep as
+// "quiet 0 days" beside a deal nobody has touched since spring.
+//
+// These run the classifiers directly rather than through a lane, because the
+// question is what the number becomes, not how it was measured.
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func quietDealItem(days int) crmcontracts.AttentionItem {
+	dealID := ids.NewV7()
+	name := "Fleet retrofit"
+	item := crmcontracts.AttentionItem{
+		Id:      dealID.String(),
+		Source:  sourceAtRisk,
+		Title:   &name,
+		Subject: subjectOf(subjectDeal, dealID),
+		Actions: []crmcontracts.AttentionItemActions{},
+	}
+	if days > 0 {
+		quiet := days
+		item.QuietDays = &quiet
+	}
+	return item
+}
+
+func quietPersonItem(days int) crmcontracts.AttentionItem {
+	personID := ids.NewV7()
+	name := "Dana Weiss"
+	item := crmcontracts.AttentionItem{
+		Id:      personID.String(),
+		Source:  "relationship_decay",
+		Title:   &name,
+		Subject: subjectOf("person", personID),
+		Actions: []crmcontracts.AttentionItemActions{},
+	}
+	if days > 0 {
+		quiet := days
+		item.QuietDays = &quiet
+	}
+	return item
+}
+
+func quietReasonOf(t *testing.T, row crmcontracts.WorklistItem) *crmcontracts.WorklistValue {
+	t.Helper()
+	for _, reason := range row.Because {
+		if reason.Kind == "quiet_days" {
+			return reason.Value
+		}
+	}
+	return nil
+}
+
+// The sentence the row says. A rep reads "quiet 90 days" and checks it against
+// what they know about the account, so the figure has to be the one the lane
+// measured rather than a default that survived a lost field.
+func TestAQuietDealsOwnCountReachesTheReasonItStates(t *testing.T) {
+	row := classifyRisk(quietDealItem(90), rankInstant, materialBar{}, dayMoney{})
+
+	value := quietReasonOf(t, row.item)
+	if value == nil {
+		t.Fatal("a deal quiet for 90 days says nothing about how long — the reason is absent")
+	}
+	if value.Days == nil || *value.Days != 90 {
+		t.Fatalf("the row says %v days, want the 90 the lane measured", value.Days)
+	}
+}
+
+// The same count on a decay row, which has no deal facts to carry it: this is
+// the source that would lose the number entirely if it rode on the deal.
+func TestALapsedRelationshipsCountReachesTheReasonItStates(t *testing.T) {
+	row := classifyDecay(quietPersonItem(63), rankInstant)
+
+	value := quietReasonOf(t, row.item)
+	if value == nil {
+		t.Fatal("a relationship quiet for 63 days says nothing about how long")
+	}
+	if value.Days == nil || *value.Days != 63 {
+		t.Fatalf("the row says %v days, want the 63 the lane measured", value.Days)
+	}
+}
+
+// The figure the deal's own card draws, beside the sentence. Both come from one
+// number, so a reader comparing the card against the line cannot find them
+// disagreeing.
+func TestTheDealCardsFigureIsTheSameCountTheRowStates(t *testing.T) {
+	// A deal whose lane resolved its figures, which is what makes there be a
+	// card at all: a row naming a deal and carrying none of its numbers draws
+	// no card, and the idle count has nowhere to sit.
+	item := quietDealItem(45)
+	amount := int64(160_100_00)
+	currency := "EUR"
+	item.Deal = &crmcontracts.AttentionDealFacts{AmountMinor: &amount, Currency: &currency}
+	row := classifyRisk(item, rankInstant, materialBar{}, dayMoney{})
+
+	if row.item.Deal == nil || row.item.Deal.QuietDays == nil {
+		t.Fatalf("the deal card carries no idle figure: %+v", row.item.Deal)
+	}
+	if *row.item.Deal.QuietDays != 45 {
+		t.Fatalf("the card says %d and the lane measured 45", *row.item.Deal.QuietDays)
+	}
+}
+
+// The AGE each row carries into the ordering. The hardest use to see, and the
+// reason the count is typed: `ranked.waitingDays` is not drawn anywhere, so a
+// wrong value here is invisible on screen.
+//
+// It is what the waiting-days step REPORTS — the "12 against 30" a reader
+// checks the order against. That step decides on `waitingRank`, which these two
+// sources do not yet set, so today a wrong value here misexplains the order
+// rather than changing it. Both are the row lying about itself, and both are
+// fixed by the count being right.
+func TestTheIdleCountBecomesTheAgeTheOrderingCarries(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		row  ranked
+	}{
+		{"a drifting deal", classifyRisk(quietDealItem(90), rankInstant, materialBar{}, dayMoney{})},
+		{"a lapsed relationship", classifyDecay(quietPersonItem(90), rankInstant)},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if c.row.waitingDays != 90 {
+				t.Fatalf("the ordering carries an age of %d, want the 90 days the lane measured — "+
+					"this value is never drawn, so a wrong one silently reorders the queue",
+					c.row.waitingDays)
+			}
+		})
+	}
+}
+
+// A lane that measured no idle time says nothing about it. Zero is a real
+// answer here — "not measured" — and printing "quiet 0 days" would be the row
+// inventing a fact rather than omitting one.
+func TestARowWithNoMeasuredIdleTimeSaysNothingAboutIt(t *testing.T) {
+	row := classifyRisk(quietDealItem(0), rankInstant, materialBar{}, dayMoney{})
+
+	if value := quietReasonOf(t, row.item); value != nil {
+		t.Fatalf("a deal with no measured idle time still says %v days", value.Days)
+	}
+	item := quietDealItem(0)
+	amount := int64(160_100_00)
+	item.Deal = &crmcontracts.AttentionDealFacts{AmountMinor: &amount}
+	priced := classifyRisk(item, rankInstant, materialBar{}, dayMoney{})
+	if priced.item.Deal == nil {
+		t.Fatal("a priced deal drew no card at all")
+	}
+	if priced.item.Deal.QuietDays != nil {
+		t.Fatalf("the card drew an idle figure of %d from nothing", *priced.item.Deal.QuietDays)
+	}
+}

--- a/backend/internal/compose/attention/quietlanes_test.go
+++ b/backend/internal/compose/attention/quietlanes_test.go
@@ -63,8 +63,17 @@ func TestAQuietDealSaysHowLongItHasBeenQuiet(t *testing.T) {
 	if items[0].Title == nil || *items[0].Title != "Fleet retrofit" {
 		t.Errorf("title = %v, want the deal name", items[0].Title)
 	}
-	if items[0].Detail == nil || *items[0].Detail != "19" {
-		t.Errorf("detail = %s, want the idle day count", stringOr(items[0].Detail))
+	// TYPED, and not in `detail`. The ordering READS this number, so it travels
+	// as one: parsed back out of a sentence it reads as zero the day somebody
+	// rewords the sentence, and the queue stops ranking by age with every test
+	// still green.
+	if items[0].QuietDays == nil || *items[0].QuietDays != 19 {
+		t.Errorf("quiet_days = %v, want the idle day count 19", items[0].QuietDays)
+	}
+	if items[0].Detail != nil {
+		t.Errorf("detail = %q, want no supporting sentence here — a bare number in this "+
+			"field is what made it mean prose on ten sources and an integer on two",
+			*items[0].Detail)
 	}
 	if items[0].Kind == nil || *items[0].Kind != "quiet" {
 		t.Errorf("kind = %s, want the ground it was admitted on", stringOr(items[0].Kind))
@@ -174,8 +183,13 @@ func TestALapsedRelationshipCarriesItsSpanAndItsLastExchange(t *testing.T) {
 	if item.Title == nil || *item.Title != "Dana Weiss" {
 		t.Errorf("title = %s, want the contact's name", stringOr(item.Title))
 	}
-	if item.Detail == nil || *item.Detail != "63" {
-		t.Errorf("detail = %s, want the derived silence in days", stringOr(item.Detail))
+	// Typed here for the reason the at-risk lane's is: the derived silence is a
+	// number the ordering weighs, not a sentence.
+	if item.QuietDays == nil || *item.QuietDays != 63 {
+		t.Errorf("quiet_days = %v, want the derived silence 63", item.QuietDays)
+	}
+	if item.Detail != nil {
+		t.Errorf("detail = %q, want no supporting sentence on a decay row", *item.Detail)
 	}
 	if item.OccurredAt == nil || !item.OccurredAt.Equal(spoke) {
 		t.Errorf("occurred_at = %v, want the last exchange %v", item.OccurredAt, spoke)

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -6,8 +6,6 @@ package attention
 import (
 	"context"
 	"errors"
-	"strconv"
-	"strings"
 	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -181,29 +179,37 @@ func approvalItem(approval crmcontracts.Approval, machine MachineSender) crmcont
 	if approval.TargetEntityType != nil && approval.TargetEntityId != nil {
 		item.Subject = subjectOf(*approval.TargetEntityType, ids.UUID(*approval.TargetEntityId))
 	}
-	if markers := stagedMarkers(approval, machine); markers != "" {
-		item.Detail = &markers
+	if staged, ok := stagedFacts(approval, machine); ok {
+		item.Staged = &staged
 	}
 	return item
 }
 
-// stagedMarkers says what a routine contact decision is ABOUT, for the group it
+// stagedFacts says what a routine contact decision is ABOUT, for the group it
 // will join.
 //
 // Read from the payload the verdict engine staged — the address it is asking
 // about, and whether that address's domain already names a company here. Both
 // are facts the engine had; re-deriving them in the queue would be a second
 // opinion, and one decision would land in two groups across two reads.
-func stagedMarkers(approval crmcontracts.Approval, machine MachineSender) string {
+//
+// TYPED on the item rather than written into `detail` as marker words. They were
+// words because `detail` was the only line on the wire and this was all they
+// needed to carry — but that made a supporting line undrawable on this source,
+// and any client rendering it faithfully showed a rep "machine_sender".
+func stagedFacts(
+	approval crmcontracts.Approval, machine MachineSender,
+) (crmcontracts.AttentionStagedFacts, bool) {
 	if approval.Kind != "capture_counterparty" || approval.ProposedChange == nil {
-		return ""
+		return crmcontracts.AttentionStagedFacts{}, false
 	}
 	change := *approval.ProposedChange
-	markers := make([]string, 0, 2)
+	facts := crmcontracts.AttentionStagedFacts{}
 	if address, ok := change["email"].(string); ok && machine != nil && machine(address) {
-		markers = append(markers, stagedMachineSender)
+		sender := true
+		facts.MachineSender = &sender
 	}
-	// There is no company marker here, and the reason is worth stating: the
+	// KnownCompany is left UNSET here, and the reason is worth stating: the
 	// only company-ish field the staged payload carries is `display_name`,
 	// which capture labels "untrusted header text — for display, never
 	// matching" (modules/capture/pending.go). A sender types it, so
@@ -212,7 +218,7 @@ func stagedMarkers(approval crmcontracts.Approval, machine MachineSender) string
 	// A real match needs a lookup against the organizations this workspace has,
 	// which is a read this assembler does not make. Until it does, a contact
 	// question is either from a machine or is the honest remainder.
-	return strings.Join(markers, " ")
+	return facts, true
 }
 
 // taskItem renders one open task.
@@ -333,11 +339,15 @@ func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
 		Deal:    dealFacts(deal),
 		Actions: []crmcontracts.AttentionItemActions{actionOpen},
 	}
-	// The idle count rides as the detail's own number, so the card can say the
-	// window the server actually applied instead of implying one.
+	// The idle count travels TYPED, so the card can say the window the server
+	// actually applied instead of implying one — and so `detail` stays the
+	// supporting sentence it is everywhere else. It used to ride as the detail's
+	// own decimal, which made one field mean a sentence on ten sources and an
+	// integer on two, and any client rendering it faithfully printed a naked
+	// "90" under the title.
 	if deal.QuietDays > 0 {
-		days := strconv.Itoa(deal.QuietDays)
-		item.Detail = &days
+		days := deal.QuietDays
+		item.QuietDays = &days
 	}
 	if deal.ExpectedCloseDate != nil {
 		due := *deal.ExpectedCloseDate
@@ -349,9 +359,9 @@ func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
 // lapsedItem renders one relationship this reader has stopped talking to.
 //
 // The contact's NAME travels as the title because a person's name is a
-// sentence in every language, and the silence rides as the detail's own
-// number, the way the risk card carries its idle count — so the client writes
-// "quiet 63 days" and the server implies no window it did not apply.
+// sentence in every language, and the silence rides as a typed count, the way
+// the risk card carries its idle days — so the client writes "quiet 63 days"
+// and the server implies no window it did not apply.
 //
 // `occurred_at` is the last time they spoke. It is the fact the card dates
 // itself from, and it lets the lane be read as a chronology rather than only
@@ -362,13 +372,16 @@ func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
 // answered it here would be deciding rather than warning.
 func lapsedItem(quiet QuietRelationship) crmcontracts.AttentionItem {
 	name := quiet.Name
-	days := strconv.Itoa(quiet.QuietDays)
+	days := quiet.QuietDays
 	lastAt := quiet.LastAt
 	return crmcontracts.AttentionItem{
-		Id:         quiet.PersonID.String(),
-		Source:     crmcontracts.AttentionItemSource("relationship_decay"),
-		Title:      &name,
-		Detail:     &days,
+		Id:     quiet.PersonID.String(),
+		Source: crmcontracts.AttentionItemSource("relationship_decay"),
+		Title:  &name,
+		// Typed, for the reason riskItem's is: `detail` is a sentence on every
+		// other source, and the client writes "quiet N days" in the reader's
+		// own language rather than rendering a decimal the server chose.
+		QuietDays:  &days,
 		Subject:    subjectOf("person", quiet.PersonID),
 		OccurredAt: &lastAt,
 		Actions:    []crmcontracts.AttentionItemActions{},

--- a/backend/internal/compose/attention/renderhealthlanes.go
+++ b/backend/internal/compose/attention/renderhealthlanes.go
@@ -67,6 +67,11 @@ func captureItem(concern CaptureConcern) crmcontracts.AttentionItem {
 		item.Detail = &mailbox
 		cause := "capture_health:" + kind + ":" + mailbox
 		item.CauseRef = &cause
+		// The mailbox is the condition's NAME as well as part of its identity,
+		// and both travel. A group formed on the identity draws from the label;
+		// a reader shown the identity reads "capture_health:disconnected:…".
+		label := mailbox
+		item.CauseLabel = &label
 	}
 	return item
 }
@@ -92,6 +97,23 @@ func aiWorkItem(run TroubledRun) crmcontracts.AttentionItem {
 	if run.Kind != "" {
 		cause := "ai_work_health:" + run.Kind
 		item.CauseRef = &cause
+		// And NO label. This lane has no reader-facing name for its condition,
+		// so it mints none rather than a plausible-looking one.
+		//
+		// The task kind is the obvious candidate and it is a generated enum key
+		// — `site_triage`, `signal_extract`, a hundred and sixty of them. A rep
+		// reading "site_triage failed 8 times" is being shown the vocabulary,
+		// which is the defect the label exists to remove; sending it would move
+		// the leak rather than close it. Translating them client-side would be a
+		// hand-kept list of 162 keys in three languages, silently rotting as the
+		// generator adds more.
+		//
+		// The run's own summary is not it either: it is written per run, so a
+		// group of twelve failures would be named after whichever was sampled.
+		//
+		// So the group says what KIND of thing broke and how often, which is
+		// what a row with no named condition is supposed to say. Naming the AI
+		// task properly is issue #3870.
 	}
 	if run.Summary != "" {
 		summary := run.Summary
@@ -182,6 +204,14 @@ func automationItem(run TroubledAutomationRun) crmcontracts.AttentionItem {
 	if !run.AutomationID.IsZero() {
 		cause := "automation_run:" + run.AutomationID.String()
 		item.CauseRef = &cause
+		// And the NAME travels beside it, for the reader. This is the case the
+		// split exists for: the identity a group is formed on has to be the id
+		// for the reason above, and a rep shown "automation_run:01a0…" learns
+		// nothing about which rule stopped working.
+		if name != "" {
+			label := name
+			item.CauseLabel = &label
+		}
 	}
 	if run.Reason != "" {
 		reason := run.Reason

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -642,7 +642,7 @@ func TestASendersOwnDisplayNameIsNotACompanyMatch(t *testing.T) {
 
 	item := approvalItem(approval, func(string) bool { return false })
 
-	if item.Detail != nil && strings.Contains(*item.Detail, stagedKnownCompany) {
+	if item.Staged != nil && item.Staged.KnownCompany != nil && *item.Staged.KnownCompany {
 		t.Fatal("a sender's own display name was taken for a company we know")
 	}
 }

--- a/backend/internal/compose/attention/worklistincidents_test.go
+++ b/backend/internal/compose/attention/worklistincidents_test.go
@@ -204,3 +204,48 @@ func aiFailure(seq int, taskKind string) crmcontracts.AttentionItem {
 		OccurredAt: rankInstant,
 	})
 }
+
+// The words the group is drawn from, through the whole path a row travels.
+//
+// The renderer mints the label, base() forwards it, and batchRow lifts it onto
+// the group. Every step is a place it can be dropped or replaced, and the
+// per-renderer test cannot see any of them: it stops at the item. A gate that
+// judged only the renderer stayed green while batchRow assigned the identity.
+//
+// The automation lane, because it is the one that HAS a name to mint — the
+// rule's own — and it is the case the whole split exists for: the identity must
+// be the immutable id, so without the label the group can only be drawn from
+// "automation_run:<uuid>".
+func TestAnIncidentGroupIsDrawnFromTheRulesNameNotItsIdentity(t *testing.T) {
+	automationID := ids.New[ids.AutomationKind]()
+	failures := []crmcontracts.AttentionItem{}
+	for i := 0; i < 6; i++ {
+		failures = append(failures, automationItem(TroubledAutomationRun{
+			ID:           ids.MustParse(fmt.Sprintf("01a05500-0000-7000-8000-0000000%05x", i)),
+			AutomationID: automationID,
+			Name:         "Notify sales on a new lead",
+			Outcome:      "failed",
+			Reason:       "The webhook target answered 500.",
+			OccurredAt:   rankInstant,
+		}))
+	}
+	day := crmcontracts.Attention{AsOf: rankInstant, AutomationHealth: &failures}
+
+	got := rankAll(foldRoutineDecisions(classifyDay(day, rankInstant, dayMoney{})))
+
+	if len(got) != 1 || got[0].Batch == nil {
+		t.Fatalf("six failures of one rule drew %d rows, want one group", len(got))
+	}
+	// The identity still groups them — that is what it is for, and asserting it
+	// here keeps the label from being "fixed" by making the cause readable.
+	if got[0].Batch.Cause == nil || *got[0].Batch.Cause != "automation_run:"+automationID.String() {
+		t.Fatalf("the group's identity is %v, want the rule's id", got[0].Batch.Cause)
+	}
+	if got[0].Batch.Label == nil {
+		t.Fatal("the group carries no words, so a client can only draw it from the identity — " +
+			"which is a uuid in front of a rep")
+	}
+	if *got[0].Batch.Label != "Notify sales on a new lead" {
+		t.Fatalf("the group is named %q, want the rule's own name", *got[0].Batch.Label)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -16227,8 +16227,9 @@ type Attention struct {
 	//
 	// The idle window here is DELIBERATELY shorter than the product-wide `stalled`
 	// threshold: a queue that only speaks once a deal meets the stalled bar is
-	// reporting a two-month-old fact rather than warning. `detail` names the window
-	// actually used, so the card never implies a patience the server did not apply.
+	// reporting a two-month-old fact rather than warning. `quiet_days` carries the
+	// window actually used, so the card never implies a patience the server did not
+	// apply.
 	//
 	// Absent — not empty — on an installation whose feed does not read deals.
 	AtRisk *[]AttentionItem `json:"at_risk,omitempty"`
@@ -16392,9 +16393,9 @@ type Attention struct {
 	//
 	// A fact about a PERSON rather than a deal, which is why it is not on `at_risk`:
 	// a contact carrying no open deal never reaches that lane, and those are exactly
-	// the relationships that lapse unnoticed. `detail` carries the silence in days,
-	// from the same §4 derivation the contact's own page shows, so the two surfaces
-	// cannot come to disagree about when somebody went quiet.
+	// the relationships that lapse unnoticed. `quiet_days` carries the silence, from
+	// the same §4 derivation the contact's own page shows, so the two surfaces cannot
+	// come to disagree about when somebody went quiet.
 	//
 	// Only relationships this reader actually had: a contact nobody here ever spoke
 	// to has not gone quiet, and a lane that said otherwise would report every
@@ -16567,6 +16568,22 @@ type AttentionItem struct {
 	// handles `snooze` generically write the wrong endpoint.
 	Actions []AttentionItemActions `json:"actions"`
 
+	// CauseLabel What `cause_ref` identifies, in words — the automation's name, the mailbox that
+	// stopped.
+	//
+	// Minted by the LANE that mints the cause, because only that lane knows which of
+	// the records it read is the condition's name. It is deliberately not derived from
+	// a sampled member's title: the members of a group are alike, not identical, and
+	// one member's subject describes that member rather than the thing they share.
+	//
+	// ABSENT is a real answer, not a gap. A lane whose only candidate is a vocabulary
+	// key sends nothing rather than a plausible-looking one — the AI-work lane is that
+	// case, since its task kinds are generated enum keys, and a rep reading
+	// "site_triage failed 8 times" is being shown the vocabulary this field exists to
+	// replace. A group with no words is named by its kind alone, and a client never
+	// falls back to rendering `cause_ref`.
+	CauseLabel *string `json:"cause_label,omitempty"`
+
 	// CauseRef Which underlying CONDITION this row reports, for a surface that groups repeated
 	// failures of one thing into one row. Two failures of one broken automation carry
 	// the same value; a failure of a different rule carries a different one.
@@ -16575,6 +16592,11 @@ type AttentionItem struct {
 	// meaning. A row that reports no shared condition omits it. Present only on the
 	// system-health sources, where "the same thing broke again" is a question a reader
 	// has.
+	//
+	// `cause_label` is the half a reader sees. The two are separate because they must
+	// be able to disagree: a rule's NAME is mutable and not unique, so an identity
+	// built from it would merge two rules that happen to share a name and split one
+	// that was renamed, while a reader shown `automation_run:01a0…` learns nothing.
 	CauseRef *string `json:"cause_ref,omitempty"`
 
 	// Confidence How sure the detector was, 0..1, where an item rests on a detection rather than a rule.
@@ -16587,7 +16609,24 @@ type AttentionItem struct {
 	// reader's own language; a label composed server-side would not be.
 	Deal *AttentionDealFacts `json:"deal,omitempty"`
 
-	// Detail One supporting line: what changed, or what the evidence said.
+	// Detail One supporting line: what changed, or what the evidence said. PROSE, in a
+	// language a reader reads — a bounce reason, a park reason, the mailbox that
+	// stopped syncing, what an AI task was about.
+	//
+	// It is not a channel for anything else. Three producers used the field as one,
+	// each with its own reader parsing the value back out: two wrote a bare day count
+	// and one wrote internal marker words. So the field meant "a sentence" on twelve
+	// sources and something else on three, and a client drawing it faithfully printed
+	// a naked "90" under one title and "machine_sender" under another.
+	//
+	// Both now travel typed — `quiet_days` and `staged` below — and the client writes
+	// the sentence in the reader's own language.
+	//
+	// ONE source is still an exception, and a client must know it: `sync_health` fills
+	// this field with its own vocabulary — the affected object classes, the failure
+	// class, or the budget band — for a client to write a sentence from. Those are
+	// words like `shed` and `deal, person`. A client that has not written that
+	// sentence draws nothing for that source rather than the value.
 	Detail *string `json:"detail,omitempty"`
 
 	// DueAt When this is due (tasks), or when it lapses (approvals).
@@ -16615,11 +16654,33 @@ type AttentionItem struct {
 	// item the reader may not fully see is not offered as a decision at all.
 	Pair *AttentionPair `json:"pair,omitempty"`
 
+	// QuietDays How many days a deal or a relationship has been idle, where the producing lane
+	// measures one. Sent by `deal_at_risk` and `relationship_decay`.
+	//
+	// Typed rather than written into `detail` because it is a number the queue READS
+	// and not only something it shows: it becomes the row's `quiet_days` reason, the
+	// deal card's own figure, and the age each row carries into the ordering. A number
+	// parsed back out of a sentence reads as zero the day somebody rewords the
+	// sentence, and every one of those uses would go quietly wrong together.
+	QuietDays *int `json:"quiet_days,omitempty"`
+
 	// Rank Position in its producer's own ordering, where the producer ranks (the briefing queue). 1 is first.
 	Rank *int `json:"rank,omitempty"`
 
 	// Source Which producer raised it, and therefore which endpoint its verbs go to.
 	Source AttentionItemSource `json:"source"`
+
+	// Staged What the verdict engine already worked out about a staged contact decision, so a
+	// surface can group alike questions without reading the proposal a second time.
+	//
+	// Read from the payload the engine staged rather than re-derived, because a second
+	// opinion would put one decision in two groups across two reads.
+	//
+	// Typed because these are FLAGS a client tests, not words a reader sees. They used to
+	// ride inside `detail` as the marker words `machine_sender` and `known_company`, with
+	// a reader doing a substring match to get them back — which made the supporting line
+	// undrawable on this source and would have shown a rep an internal token.
+	Staged *AttentionStagedFacts `json:"staged,omitempty"`
 
 	// Subject The record this item is about, named so a reader knows who it concerns before opening anything.
 	Subject *AttentionSubject `json:"subject,omitempty"`
@@ -16698,6 +16759,24 @@ type AttentionPairSide struct {
 	// send none today. Zero would claim the side carries nothing, which is a
 	// different fact from not having asked.
 	RelatedCount *int `json:"related_count,omitempty"`
+}
+
+// AttentionStagedFacts What the verdict engine already worked out about a staged contact decision, so a
+// surface can group alike questions without reading the proposal a second time.
+//
+// Read from the payload the engine staged rather than re-derived, because a second
+// opinion would put one decision in two groups across two reads.
+//
+// Typed because these are FLAGS a client tests, not words a reader sees. They used to
+// ride inside `detail` as the marker words `machine_sender` and `known_company`, with
+// a reader doing a substring match to get them back — which made the supporting line
+// undrawable on this source and would have shown a rep an internal token.
+type AttentionStagedFacts struct {
+	// KnownCompany The address's domain already names a company in this workspace.
+	KnownCompany *bool `json:"known_company,omitempty"`
+
+	// MachineSender The address is a sending system rather than a person.
+	MachineSender *bool `json:"machine_sender,omitempty"`
 }
 
 // AttentionSubject The record this item is about, named so a reader knows who it concerns before opening anything.
@@ -31244,9 +31323,13 @@ type WorklistBatch struct {
 	// bound printed as a total is a wrong number rather than a bounded one.
 	AtLeast *bool `json:"at_least,omitempty"`
 
-	// Cause What the members have in common, for a `system_incident`: the rule's name,
-	// the AI task's kind, the mailbox. Named so a reader knows WHAT is broken
-	// rather than only how often.
+	// Cause WHICH condition the members share, for a `system_incident` — the identity the
+	// group was formed on, carried so a client can tell two groups apart and find
+	// the same row again on a re-read.
+	//
+	// An opaque identity, never rendered. It is a `cause_ref` and reads like one
+	// (`automation_run:<uuid>`), so a client that put it on screen would show a rep
+	// "automation_run:01a0… failed 12 times". `label` is the half to draw.
 	Cause *string `json:"cause,omitempty"`
 
 	// Count How many decisions this row stands for.
@@ -31264,6 +31347,15 @@ type WorklistBatch struct {
 	// is broken, and repeating it eight times is aggregation failure rather than
 	// urgency.
 	Key WorklistBatchKey `json:"key"`
+
+	// Label What `cause` identifies, in words — the automation's name, the mailbox that
+	// stopped. This is what a row says.
+	//
+	// Absent where the lane that formed the group minted no name for the condition.
+	// A client then names the group by its kind alone and NEVER falls back to
+	// `cause`, because an identity on screen is worse than a vaguer sentence: the
+	// reader cannot act on it and cannot tell it from a bug.
+	Label *string `json:"label,omitempty"`
 
 	// Sample A few members, named, so the group can be checked before it is answered.
 	Sample *[]string `json:"sample,omitempty"`
@@ -31419,6 +31511,13 @@ type WorklistItem struct {
 	// Category The badge, and the filter it answers to. A reader groups by this; the ORDER never does.
 	Category WorklistItemCategory `json:"category"`
 
+	// CauseLabel What `cause_ref` identifies, in words — the automation's name, the mailbox that
+	// stopped. This is the half a reader sees; the identity beside it is not drawable.
+	//
+	// Present wherever the producing lane named the condition. A row whose lane named
+	// none is described by its kind alone.
+	CauseLabel *string `json:"cause_label,omitempty"`
+
 	// CauseRef Which underlying CONDITION this row reports, so a surface can group repeated
 	// failures of one thing into one row. Opaque identity, never rendered and never
 	// parsed. Absent on a row that reports no shared condition.
@@ -31434,7 +31533,17 @@ type WorklistItem struct {
 	// the only figure by which two deals in different currencies may be compared.
 	Deal *WorklistDealFacts `json:"deal,omitempty"`
 
-	// Detail One supporting line.
+	// Detail One supporting line, in PROSE — a bounce reason, a park reason, the mailbox that
+	// stopped, what an AI task was about.
+	//
+	// Not a channel for anything else. A value the queue itself reads travels typed
+	// beside this field, never inside it: a figure parsed back out of a sentence reads
+	// as zero the day somebody rewords the sentence.
+	//
+	// ONE source is an exception a client must know: `sync_health` fills this with its
+	// own vocabulary — the affected object classes, the failure class, the budget band
+	// — for a client to write a sentence from. Those are words like `shed`. A client
+	// that has not written that sentence draws nothing for that source.
 	Detail *string `json:"detail,omitempty"`
 
 	// Dispositions The ways this row can be PUT DOWN, as the server declares them. A client

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -27001,8 +27001,9 @@ export interface components {
              *
              *     The idle window here is DELIBERATELY shorter than the product-wide `stalled`
              *     threshold: a queue that only speaks once a deal meets the stalled bar is
-             *     reporting a two-month-old fact rather than warning. `detail` names the window
-             *     actually used, so the card never implies a patience the server did not apply.
+             *     reporting a two-month-old fact rather than warning. `quiet_days` carries the
+             *     window actually used, so the card never implies a patience the server did not
+             *     apply.
              *
              *     Absent — not empty — on an installation whose feed does not read deals.
              */
@@ -27013,9 +27014,9 @@ export interface components {
              *
              *     A fact about a PERSON rather than a deal, which is why it is not on `at_risk`:
              *     a contact carrying no open deal never reaches that lane, and those are exactly
-             *     the relationships that lapse unnoticed. `detail` carries the silence in days,
-             *     from the same §4 derivation the contact's own page shows, so the two surfaces
-             *     cannot come to disagree about when somebody went quiet.
+             *     the relationships that lapse unnoticed. `quiet_days` carries the silence, from
+             *     the same §4 derivation the contact's own page shows, so the two surfaces cannot
+             *     come to disagree about when somebody went quiet.
              *
              *     Only relationships this reader actually had: a contact nobody here ever spoke
              *     to has not gone quiet, and a lane that said otherwise would report every
@@ -27268,8 +27269,39 @@ export interface components {
              *     and the client writes the line in the reader's own.
              */
             title?: string;
-            /** @description One supporting line: what changed, or what the evidence said. */
+            /**
+             * @description One supporting line: what changed, or what the evidence said. PROSE, in a
+             *     language a reader reads — a bounce reason, a park reason, the mailbox that
+             *     stopped syncing, what an AI task was about.
+             *
+             *     It is not a channel for anything else. Three producers used the field as one,
+             *     each with its own reader parsing the value back out: two wrote a bare day count
+             *     and one wrote internal marker words. So the field meant "a sentence" on twelve
+             *     sources and something else on three, and a client drawing it faithfully printed
+             *     a naked "90" under one title and "machine_sender" under another.
+             *
+             *     Both now travel typed — `quiet_days` and `staged` below — and the client writes
+             *     the sentence in the reader's own language.
+             *
+             *     ONE source is still an exception, and a client must know it: `sync_health` fills
+             *     this field with its own vocabulary — the affected object classes, the failure
+             *     class, or the budget band — for a client to write a sentence from. Those are
+             *     words like `shed` and `deal, person`. A client that has not written that
+             *     sentence draws nothing for that source rather than the value.
+             */
             detail?: string;
+            staged?: components["schemas"]["AttentionStagedFacts"];
+            /**
+             * @description How many days a deal or a relationship has been idle, where the producing lane
+             *     measures one. Sent by `deal_at_risk` and `relationship_decay`.
+             *
+             *     Typed rather than written into `detail` because it is a number the queue READS
+             *     and not only something it shows: it becomes the row's `quiet_days` reason, the
+             *     deal card's own figure, and the age each row carries into the ordering. A number
+             *     parsed back out of a sentence reads as zero the day somebody rewords the
+             *     sentence, and every one of those uses would go quietly wrong together.
+             */
+            quiet_days?: number | null;
             /**
              * @description Which underlying CONDITION this row reports, for a surface that groups repeated
              *     failures of one thing into one row. Two failures of one broken automation carry
@@ -27279,8 +27311,30 @@ export interface components {
              *     meaning. A row that reports no shared condition omits it. Present only on the
              *     system-health sources, where "the same thing broke again" is a question a reader
              *     has.
+             *
+             *     `cause_label` is the half a reader sees. The two are separate because they must
+             *     be able to disagree: a rule's NAME is mutable and not unique, so an identity
+             *     built from it would merge two rules that happen to share a name and split one
+             *     that was renamed, while a reader shown `automation_run:01a0…` learns nothing.
              */
             cause_ref?: string;
+            /**
+             * @description What `cause_ref` identifies, in words — the automation's name, the mailbox that
+             *     stopped.
+             *
+             *     Minted by the LANE that mints the cause, because only that lane knows which of
+             *     the records it read is the condition's name. It is deliberately not derived from
+             *     a sampled member's title: the members of a group are alike, not identical, and
+             *     one member's subject describes that member rather than the thing they share.
+             *
+             *     ABSENT is a real answer, not a gap. A lane whose only candidate is a vocabulary
+             *     key sends nothing rather than a plausible-looking one — the AI-work lane is that
+             *     case, since its task kinds are generated enum keys, and a rep reading
+             *     "site_triage failed 8 times" is being shown the vocabulary this field exists to
+             *     replace. A group with no words is named by its kind alone, and a client never
+             *     falls back to rendering `cause_ref`.
+             */
+            cause_label?: string;
             /** @description Position in its producer's own ordering, where the producer ranks (the briefing queue). 1 is first. */
             rank?: number;
             /** @description How sure the detector was, 0..1, where an item rests on a detection rather than a rule. */
@@ -27334,6 +27388,24 @@ export interface components {
              *     database rather than their own records.
              */
             evidence: components["schemas"]["AttentionPairEvidence"][];
+        };
+        /**
+         * @description What the verdict engine already worked out about a staged contact decision, so a
+         *     surface can group alike questions without reading the proposal a second time.
+         *
+         *     Read from the payload the engine staged rather than re-derived, because a second
+         *     opinion would put one decision in two groups across two reads.
+         *
+         *     Typed because these are FLAGS a client tests, not words a reader sees. They used to
+         *     ride inside `detail` as the marker words `machine_sender` and `known_company`, with
+         *     a reader doing a substring match to get them back — which made the supporting line
+         *     undrawable on this source and would have shown a rep an internal token.
+         */
+        AttentionStagedFacts: {
+            /** @description The address is a sending system rather than a person. */
+            machine_sender?: boolean;
+            /** @description The address's domain already names a company in this workspace. */
+            known_company?: boolean;
         };
         /**
          * @description The deal behind a `deal_at_risk` item: the facts its card states, so a client
@@ -27906,7 +27978,27 @@ export interface components {
              *     parsed. Absent on a row that reports no shared condition.
              */
             cause_ref?: string;
-            /** @description One supporting line. */
+            /**
+             * @description What `cause_ref` identifies, in words — the automation's name, the mailbox that
+             *     stopped. This is the half a reader sees; the identity beside it is not drawable.
+             *
+             *     Present wherever the producing lane named the condition. A row whose lane named
+             *     none is described by its kind alone.
+             */
+            cause_label?: string;
+            /**
+             * @description One supporting line, in PROSE — a bounce reason, a park reason, the mailbox that
+             *     stopped, what an AI task was about.
+             *
+             *     Not a channel for anything else. A value the queue itself reads travels typed
+             *     beside this field, never inside it: a figure parsed back out of a sentence reads
+             *     as zero the day somebody rewords the sentence.
+             *
+             *     ONE source is an exception a client must know: `sync_health` fills this with its
+             *     own vocabulary — the affected object classes, the failure class, the budget band
+             *     — for a client to write a sentence from. Those are words like `shed`. A client
+             *     that has not written that sentence draws nothing for that source.
+             */
             detail?: string;
             /** @description The facts that put this item at this level, in the order they were weighed. */
             because: components["schemas"]["WorklistReason"][];
@@ -28145,11 +28237,25 @@ export interface components {
             /** @description A few members, named, so the group can be checked before it is answered. */
             sample?: string[];
             /**
-             * @description What the members have in common, for a `system_incident`: the rule's name,
-             *     the AI task's kind, the mailbox. Named so a reader knows WHAT is broken
-             *     rather than only how often.
+             * @description WHICH condition the members share, for a `system_incident` — the identity the
+             *     group was formed on, carried so a client can tell two groups apart and find
+             *     the same row again on a re-read.
+             *
+             *     An opaque identity, never rendered. It is a `cause_ref` and reads like one
+             *     (`automation_run:<uuid>`), so a client that put it on screen would show a rep
+             *     "automation_run:01a0… failed 12 times". `label` is the half to draw.
              */
             cause?: string;
+            /**
+             * @description What `cause` identifies, in words — the automation's name, the mailbox that
+             *     stopped. This is what a row says.
+             *
+             *     Absent where the lane that formed the group minted no name for the condition.
+             *     A client then names the group by its kind alone and NEVER falls back to
+             *     `cause`, because an identity on screen is worse than a vaguer sentence: the
+             *     reader cannot act on it and cannot tell it from a bug.
+             */
+            label?: string;
         };
         /**
          * @description The deal behind an item, with the facts its card states. `expected_minor_base` is

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -465,10 +465,16 @@ export function itemTitle(item: WorklistItem, t: T, locale: Locale): string {
       ? `${formatNumber(item.batch.count, locale)}+`
       : formatNumber(item.batch.count, locale);
     // An incident names WHAT is broken; a hygiene group names its kind.
+    //
+    // From `label`, never from `cause`. The cause is the identity the group was
+    // formed on and reads like one — interpolating it printed
+    // "automation_run:01a0…-… failed 12 times" at a rep, which names nothing
+    // they can act on and cannot be told from a bug. A group whose lane minted
+    // no name falls back to the generic phrase rather than to the identity.
     if (item.batch.key === "system_incident") {
       return t("worklist.batch.system_incident", {
         count,
-        cause: item.batch.cause ?? t("worklist.batch.unnamedCause"),
+        cause: item.batch.label ?? t("worklist.batch.unnamedCause"),
       });
     }
     return t(`worklist.batch.${item.batch.key}` as const, { count });

--- a/frontend/src/screens/worklist.detail.test.tsx
+++ b/frontend/src/screens/worklist.detail.test.tsx
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { ToastProvider, ToastRegion } from "../design-system/toast";
+import { LocaleProvider } from "../i18n";
+import { WorklistScreen } from "./worklist";
+
+// The supporting line, and the words for a group's cause.
+//
+// Twelve sources send a sentence saying the decisive thing about their row —
+// which mailbox stopped, why a message bounced, why a send was held, which rule
+// failed and how — and the row drew it for exactly one of them. A rep looking at
+// "Automation failed" learned nothing about which rule or why, and the answer
+// was already on the wire.
+//
+// The reason it was gated is real and now fixed on the other side: three sources
+// used the field as a typed channel — two wrote a bare day count, one wrote the
+// marker words the queue groups by — so drawing it would have printed "90" under
+// one title and "machine_sender" under another. Those three send their values
+// typed now.
+//
+// The cases below are a SAMPLE of the sources that send prose, not a census: one
+// per shape of sentence, plus the one source still held back. What holds the
+// whole set is the server-side gate, which walks the renderers themselves
+// (backend/internal/compose/attention/causeref_test.go).
+
+type Worklist = components["schemas"]["Worklist"];
+type WorklistItem = components["schemas"]["WorklistItem"];
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function day(queue: WorklistItem[]): Worklist {
+  return {
+    as_of: "2026-08-31T09:00:00Z",
+    scope: "mine",
+    scope_options: ["mine"],
+    queue,
+    summary: {
+      urgent: 0,
+      due: queue.length,
+      lower_priority: 0,
+      total: queue.length,
+    },
+    sources_unavailable: [],
+    readings: {
+      revenue_at_risk_minor: null,
+      buyer_replies: 0,
+      prospecting: 0,
+      review: 0,
+      more_available: false,
+    },
+    reach: [],
+    counts: [],
+  };
+}
+
+function draw(queue: WorklistItem[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => jsonResponse(day(queue))),
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <ToastProvider>
+          <WorklistScreen />
+          <ToastRegion />
+        </ToastProvider>
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+// One case per source that sends prose, each asserting the DECISIVE line — the
+// half a rep needs to know what happened, which is the half they could not see.
+const sourcesWithProse: ReadonlyArray<{
+  name: string;
+  row: WorklistItem;
+  says: string;
+}> = [
+  {
+    name: "a mailbox that stopped capturing",
+    says: "lena.fischer@margince.test",
+    row: {
+      id: "c1",
+      source: "capture_health",
+      category: "system",
+      level: 6,
+      consequence: "data_drifts",
+      kind: "disconnected",
+      title: "A mailbox stopped syncing",
+      detail: "lena.fischer@margince.test",
+      because: [],
+      actions: [],
+    },
+  },
+  {
+    name: "a message that bounced",
+    says: "The address does not exist at that domain.",
+    row: {
+      id: "b1",
+      source: "bounce",
+      category: "customer_waiting",
+      level: 3,
+      consequence: "buyer_waits",
+      title: "Your quote never arrived",
+      detail: "The address does not exist at that domain.",
+      because: [],
+      actions: [],
+    },
+  },
+  {
+    name: "a send that was held",
+    says: "Held: the recipient has not consented to marketing mail.",
+    row: {
+      id: "u1",
+      source: "undelivered",
+      category: "customer_waiting",
+      level: 3,
+      consequence: "buyer_waits",
+      title: "A message never left",
+      detail: "Held: the recipient has not consented to marketing mail.",
+      because: [],
+      actions: [],
+    },
+  },
+  {
+    name: "an automation that failed",
+    says: "The webhook target answered 500 five times.",
+    row: {
+      id: "a1",
+      source: "automation_run",
+      category: "system",
+      level: 6,
+      consequence: "data_drifts",
+      title: "Notify sales on a new lead",
+      detail: "The webhook target answered 500 five times.",
+      because: [],
+      actions: [],
+    },
+  },
+  {
+    name: "an AI task that broke",
+    says: "Acme Renewal",
+    row: {
+      id: "w1",
+      source: "ai_work_health",
+      category: "system",
+      level: 6,
+      consequence: "data_drifts",
+      title: "A recap did not generate",
+      detail: "Acme Renewal",
+      because: [],
+      actions: [],
+    },
+  },
+  {
+    name: "a colleague waiting on an introduction",
+    says: "They asked to be introduced to the buyer at Turbinenbau.",
+    row: {
+      id: "i1",
+      source: "introduction_request",
+      category: "decisions",
+      level: 5,
+      consequence: "work_blocked",
+      title: "Katrin asked for an introduction",
+      detail: "They asked to be introduced to the buyer at Turbinenbau.",
+      because: [],
+      actions: [],
+    },
+  },
+];
+
+describe("the supporting line each source sends", () => {
+  it.each(sourcesWithProse)(
+    "says the decisive thing about $name",
+    async ({ row, says }) => {
+      draw([row]);
+      expect(await screen.findByText(says)).toBeTruthy();
+    },
+  );
+
+  // The one source still held back. Its renderer says in as many words that the
+  // field carries "that condition's facts in the producer's own vocabulary" —
+  // the affected object classes, the failure class, the budget band — and that
+  // the CLIENT writes the sentence. The client never wrote it, so drawing the
+  // field raw puts `shed` or `deal, person` in front of a rep.
+  //
+  // This is the case that keeps "render every source" honest: the rule is prose,
+  // not "whatever a source happens to send".
+  it("draws no supporting line for a source that sends its own vocabulary", async () => {
+    draw([
+      {
+        id: "s1",
+        source: "sync_health",
+        category: "system",
+        level: 6,
+        consequence: "data_drifts",
+        kind: "budget_degraded",
+        detail: "shed",
+        because: [],
+        actions: [],
+      },
+    ]);
+
+    // The row is drawn — this is not passing because the page is empty.
+    expect(
+      await screen.findByText("The CRM sync needs attention"),
+    ).toBeTruthy();
+    expect(screen.queryByText("shed")).toBeNull();
+  });
+});
+
+describe("a group names what is broken", () => {
+  // THE defect: `cause` is the identity the group was formed on, and reads like
+  // one. Interpolated into the sentence it put "automation_run:<uuid> failed 12
+  // times" in front of a rep — a string they cannot act on and cannot tell from
+  // a bug.
+  it("draws the label and never the identity behind it", async () => {
+    draw([
+      {
+        id: "g1",
+        source: "automation_run",
+        category: "system",
+        level: 6,
+        consequence: "data_drifts",
+        because: [],
+        actions: [],
+        batch: {
+          key: "system_incident",
+          count: 12,
+          cause: "automation_run:01a05500-0000-7000-8000-0000000000a1",
+          label: "Notify sales on a new lead",
+        },
+      },
+    ]);
+
+    expect(
+      await screen.findByText(/Notify sales on a new lead failed 12 times/),
+    ).toBeTruthy();
+    // Asserted over the WHOLE rendered page rather than the one line, because
+    // an identity is a defect wherever it surfaces — and a uuid is the shape
+    // that gives it away.
+    expect(document.body.textContent ?? "").not.toMatch(
+      /[0-9a-f]{8}-[0-9a-f]{4}-/,
+    );
+    expect(document.body.textContent ?? "").not.toContain("automation_run:");
+  });
+
+  // A lane that minted no name for the condition. The row says what KIND of
+  // thing broke and stops — it must not fall back to the identity, which is the
+  // one string worse than a vague sentence.
+  it("falls back to a generic phrase, never to the identity", async () => {
+    draw([
+      {
+        id: "g2",
+        source: "automation_run",
+        category: "system",
+        level: 6,
+        consequence: "data_drifts",
+        because: [],
+        actions: [],
+        batch: {
+          key: "system_incident",
+          count: 8,
+          cause: "automation_run:01a05500-0000-7000-8000-0000000000b2",
+        },
+      },
+    ]);
+
+    expect(await screen.findByText(/failed 8 times/)).toBeTruthy();
+    expect(document.body.textContent ?? "").not.toContain("automation_run:");
+    expect(document.body.textContent ?? "").not.toMatch(
+      /[0-9a-f]{8}-[0-9a-f]{4}-/,
+    );
+  });
+});

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -110,14 +110,30 @@ export function WorklistRow({
             <Badge tone="warn">{t("worklist.needsPrep")}</Badge>
           )}
         </p>
-        {/* `detail` is not prose on every source: a relationship-decay row
-            carries a bare day COUNT there (attention/render.go's lapsedItem,
-            "the client writes 'quiet N days'"), which this row already says
-            properly through `because`. Only the `notice` source's detail is
-            a full sentence — the server sets it from the notice's own body,
-            the deal's name included — so only that source renders it here
-            rather than every source that happens to send one. */}
-        {item.source === "notice" && item.detail && (
+        {/* The supporting line, from every source that sends PROSE.
+
+            It was drawn for `notice` alone, because three sources used this
+            field as a typed channel — two wrote a bare day count, one wrote the
+            marker words the queue groups by — and drawing it would have printed
+            "90" under one title and "machine_sender" under another. Those three
+            send their values typed now, so the twelve sources that were already
+            writing sentences get to say them: which mailbox stopped, why a
+            message bounced, why a send was held, what an AI task was about,
+            which rule failed and how. That is the decisive line on most of these
+            rows, and a reader was reading around it.
+
+            `sync_health` is the one still held back, and deliberately. Its own
+            renderer says it carries "that condition's facts in the producer's
+            own vocabulary — the affected object classes, the failure class, or
+            the budget band — and the client writes the sentence": internal words
+            like `shed` or `deal, person`. The client never wrote that sentence,
+            so drawing the field raw would put the vocabulary on screen. Writing
+            it is real work on a lane this change is not about; until then the
+            row says its title, which is what it said before.
+
+            Held by: "draws no supporting line for a source that sends its own
+            vocabulary" (worklist.detail.test.tsx). */}
+        {item.detail && item.source !== "sync_health" && (
           <p className="t-caption worklist-row-detail">{item.detail}</p>
         )}
         {item.batch?.sample && item.batch.sample.length > 0 && (

--- a/frontend/src/screens/worklist.stories.tsx
+++ b/frontend/src/screens/worklist.stories.tsx
@@ -324,3 +324,114 @@ export const ATeamBiggerThanTheBoardCanCount: Story = {
     );
   },
 };
+
+// A day of things that went wrong, each saying WHAT went wrong.
+//
+// The story worth looking at for this change: six system rows whose supporting
+// line was on the wire all along and drawn for none of them. A rep reading
+// "A mailbox stopped syncing" could not tell which mailbox, and "Automation
+// failed" named neither the rule nor the reason.
+//
+// The group row is the other half. Its `cause` is the identity twelve failures
+// were folded on and reads like one; the sentence is written from `label`, so
+// the row says which rule broke rather than "automation_run:01a0… failed 12
+// times".
+export const WhatWentWrong: Story = {
+  render: () => {
+    stubDay({
+      as_of: "2026-08-31T09:00:00Z",
+      scope: "mine",
+      scope_options: ["mine"],
+      summary: { urgent: 0, due: 2, lower_priority: 4, total: 6 },
+      sources_unavailable: [],
+      reach: [],
+      readings: {
+        revenue_at_risk_minor: 0,
+        revenue_currency: "EUR",
+        buyer_replies: 0,
+        prospecting: 0,
+        review: 0,
+        more_available: false,
+      },
+      counts: [],
+      queue: [
+        {
+          id: "b1",
+          source: "bounce",
+          category: "customer_waiting",
+          level: 3,
+          consequence: "buyer_waits",
+          title: "Your quote never arrived",
+          detail: "The address does not exist at that domain.",
+          because: [],
+          actions: [],
+        },
+        {
+          id: "u1",
+          source: "undelivered",
+          category: "customer_waiting",
+          level: 3,
+          consequence: "buyer_waits",
+          title: "A message never left",
+          detail: "Held: the recipient has not consented to marketing mail.",
+          because: [],
+          actions: [],
+        },
+        {
+          id: "g1",
+          source: "automation_run",
+          category: "system",
+          level: 6,
+          consequence: "data_drifts",
+          because: [],
+          actions: [],
+          batch: {
+            key: "system_incident",
+            count: 12,
+            cause: "automation_run:01a05500-0000-7000-8000-0000000000a1",
+            label: "Notify sales on a new lead",
+          },
+        },
+        {
+          id: "c1",
+          source: "capture_health",
+          category: "system",
+          level: 6,
+          consequence: "data_drifts",
+          kind: "disconnected",
+          title: "A mailbox stopped syncing",
+          detail: "lena.fischer@margince.test",
+          because: [],
+          actions: [],
+        },
+        {
+          id: "w1",
+          source: "ai_work_health",
+          category: "system",
+          level: 6,
+          consequence: "data_drifts",
+          title: "A recap did not generate",
+          detail: "Acme Renewal",
+          because: [],
+          actions: [],
+        },
+        {
+          id: "i1",
+          source: "introduction_request",
+          category: "decisions",
+          level: 5,
+          consequence: "work_blocked",
+          title: "Katrin asked for an introduction",
+          detail: "They asked to be introduced to the buyer at Turbinenbau.",
+          because: [],
+          actions: [],
+        },
+      ],
+    });
+    return (
+      <StoryProviders>
+        <WorklistScreen />
+      </StoryProviders>
+    );
+  },
+};


### PR DESCRIPTION
A Worklist row drew its supporting line for exactly one source. Twelve others were sending the sentence a rep actually needs — which mailbox stopped, why a message bounced, why a send was held, which rule failed and how — and none of it reached the screen. A rep read "Automation failed" and could not tell which rule or why, while the answer sat on the wire.

## Why it was gated, and what changed

The gate was there for a real reason: three producers used `detail` as a typed channel, each with its own reader parsing the value back out. Two wrote a bare day count, one wrote the marker words the queue groups contact decisions by. Drawing the field would have printed "90" under one title and "machine_sender" under another.

All three now travel typed. `quiet_days` carries the idle count, `staged` carries the two grouping flags, and `detail` is prose everywhere it is drawn.

The day count turned out to be load-bearing in four places — the row's `quiet_days` reason, the deal card's figure, the age each row carries into the ordering, and the "not measured" case — and **none of them was held**. `quietDaysOf` could be made to answer zero for every row and the whole package stayed green; that would have reached a rep as "quiet 0 days" beside a deal nobody had touched since spring. Four tests hold it now.

## A group names what broke

`cause_ref` is an identity and its own contract says it is never rendered, but the client interpolated it: "automation_run:01a0… failed 12 times".

The identity has to stay an identity — a rule's name is mutable and not unique, so a cause built from names would merge two rules sharing one and split a rule somebody renamed. So the words travel beside it as `cause_label`, minted by the lane that mints the cause.

**The AI lane mints none, deliberately.** Its only candidate is a generated task enum (`site_triage`, and 161 siblings), and sending that as the words would move the leak rather than close it. That group says what kind of thing broke and how often, which is what a row with no named condition is supposed to say. Naming the task properly is #3870.

**`sync_health` keeps the gate, also deliberately.** Its renderer says it fills `detail` with "that condition's facts in the producer's own vocabulary" for a client to write a sentence from, and the client never wrote it. Drawing it raw would put `shed` or `deal, person` in front of a rep. That is #3865.

## Three gates, each catching what the others cannot

- `causeref_test.go` runs the real renderers and refuses an identity-shaped string in any rendered field, refuses a label that is a bare vocabulary key, and **derives its own producer census from the source** — so a fourth producer added later fails until somebody gives it a fixture.
- `worklistincidents_test.go` asserts the group's words through the whole path a row travels: renderer → classifier → batch. The per-renderer gate stops at the item, and stayed green while `batchRow` assigned the identity.
- The reach check holds the identity pattern against the causes the producers really mint and against prose it must not fire on, because a blind pattern reports PASS over a tree where everything leaks.

## Contract

Purely additive: `quiet_days`, `staged` and `cause_label` on `AttentionItem`, `cause_label` on `WorklistItem`, `label` on `WorklistBatch`, and the new `AttentionStagedFacts`. No existing field or `required` array changed; the breaking-change gate reports none.

## Verification

`make check-backend` and `make check-fe` (6051 tests) green. Every guard mutation-checked one clause at a time: `quietDaysOf`→0 (4 fail), the notice-only gate restored (6 fail), label falling back to the identity (1 fails), labelling with the identity (2 fail), labelling with the raw enum (1 fails), the identity assigned into `Batch.Label` (1 fails), a marker word back in `detail` (1 fails), an unfixtured producer added (1 fails), and a blinded regex (the reach check fails).

No user-visible strings changed — only which existing fields render — so the German e2e specs are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Worklist row now draws its supporting sentence from every source that sends prose, instead of only `notice` — twelve sources were already sending the line a rep needs (which mailbox stopped, why a message bounced, which rule failed and how) and the row showed none of it. Three sources that used `detail` as a typed channel — two bare day counts, one marker word — now send `quiet_days`, `staged`, and `cause_label` instead, so `detail` is a sentence everywhere it renders. The API change is purely additive.

**Typed fields**
- `quiet_days` carries the idle count the queue reads — the row's reason, the deal card's figure, the ordering age — where a number parsed out of a sentence would read as zero the day the sentence is reworded.
- `staged` (`AttentionStagedFacts`) carries the two contact-decision grouping flags that used to ride in `detail` as marker words matched by substring.

**Group labels**
- Incident groups are drawn from the new `label`/`cause_label`, never from the `cause_ref` identity the client was interpolating as "automation_run:01a0… failed 12 times"; a group with no label falls back to its kind, not the identity.
- The AI-work lane mints no label deliberately — its only candidate is a generated task enum key (proper naming is #3870) — and `sync_health` keeps its gate because its `detail` is producer vocabulary the client never renders (#3865).

<sup>Written for commit 547757e95a7cb5df41089968f542e25013439ce6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worklist items now show readable cause labels, such as mailbox or automation rule names, instead of exposing internal identifiers.
  - Attention data now provides structured idle-day counts and contact-decision indicators.
  - Worklist rows display supporting details more consistently, while sensitive internal vocabulary remains hidden.
  - Grouped incidents use human-readable labels with a clear fallback when no label is available.

- **Bug Fixes**
  - Improved consistency between displayed idle durations, deal-card figures, and worklist ordering.
  - Prevented internal cause references and identifiers from appearing in user-facing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->