### PR TITLE
The Brief's e2e suite reads the page, not only its boxes

### DIFF
--- a/frontend/e2e/brief.spec.ts
+++ b/frontend/e2e/brief.spec.ts
@@ -1,4 +1,6 @@
 import { expect, type Locator, type Page, test } from "@playwright/test";
+import { de } from "../src/i18n/de";
+import type { MessageKey } from "../src/i18n/en";
 
 /**
  * The Brief — the page a rep and a lead open first.
@@ -37,6 +39,19 @@ const SHOTS = process.env.E2E_BRIEF_SHOT_DIR ?? "/tmp/e2e-brief";
 // The readings row, by the test id HomeReadingsStrip hands its StatStrip. Not
 // by class: the plate is the shared primitive's, so a class selector would
 // match every other StatStrip in the app.
+/**
+ * A string the app actually renders, read from the catalog the component reads.
+ *
+ * The app renders GERMAN. Writing the words here would put a second copy of
+ * them in the tree, and a translator improving one would fail a layout suite —
+ * which is why the rest of this file asserts structure. The two cases below
+ * name copy because they are about a reader FINDING the page, and a heading
+ * nobody can read is a defect no box measurement can see.
+ */
+function copy(key: MessageKey): string {
+  return de[key];
+}
+
 const STRIP = '[data-testid="home-readings"]';
 const GLANCE = '[data-testid="home-glance"]';
 
@@ -227,6 +242,79 @@ test.describe("the Brief — page shape", () => {
     );
   });
 
+  // The headline outranks what is under it, in the product's OWN scale.
+  //
+  // The concept pack asks for a 30px floor. The design system's `--fs-h1` is
+  // 24px and every h1 in the product is drawn at it (base.css `.t-display`),
+  // so a 30px floor here would either fail forever or force the Brief to a size
+  // no other page uses — a second type scale, to satisfy a number taken from a
+  // mockup rather than from this system. Whether the product's h1 should grow
+  // is a design-system decision, and it is not the Brief's to take alone.
+  //
+  // What IS this page's to hold is that the greeting still READS as a headline:
+  // a ratio against body text, so a change to the scale moves both ends and
+  // only a collapse fails.
+  //
+  // The sentence under the greeting is NOT compared here. It carries no size of
+  // its own (home.css `.glance-sentence` sets colour, margin and measure) and
+  // inherits one LARGER than a panel title — the lede treatment the concept
+  // asks for. An assertion that it ranks below a section heading would encode
+  // the opposite of what the page deliberately does.
+  test("draws the headline at headline scale, not body scale", async ({
+    page,
+  }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    const headline = await px(page.locator("main h1"), "font-size");
+    const body = await px(
+      page.locator('[data-testid="glance-sentence"]'),
+      "font-size",
+    );
+    // A RATIO, not "bigger than". Panel titles are 13px and body is 13.5, so a
+    // headline shrunk all the way to body size still measures larger than a
+    // section heading — a greater-than comparison passes on a page whose
+    // headline has stopped being one. 1.5x is comfortably under the shipped
+    // step (24 over 13.5) and comfortably over any collapse of it.
+    expect(headline / body).toBeGreaterThanOrEqual(1.5);
+  });
+
+  // Inside the glance, top to bottom: the eyebrow labels the page, the heading
+  // greets, the sentence says what the morning holds. The block-level assertion
+  // above places the glance against the strip and cannot see this order at all,
+  // so a sentence rendered above its own heading would pass every other test
+  // here.
+  test("orders the eyebrow above the heading above the sentence", async ({
+    page,
+  }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    const eyebrow = await topOf(page.locator(`${GLANCE} .glance-eyebrow`));
+    const heading = await topOf(page.locator("main h1"));
+    expect(eyebrow).toBeLessThan(heading);
+    expect(heading).toBeLessThan(
+      await topOf(page.locator('[data-testid="glance-sentence"]')),
+    );
+  });
+
+  // ONE paragraph, and all of it visible.
+  //
+  // The sentence the Brief opens with was a STACK of one-fact lines before
+  // #3801 — a list wearing a sentence's position. Two assertions, because they
+  // fail for different reasons: a second <p> is the stack coming back, and a
+  // clipped one is a sentence the reader cannot finish.
+  test("says the morning in one paragraph, unclipped", async ({ page }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    await expect(page.locator(`${GLANCE} p`)).toHaveCount(1);
+    const clipped = await page
+      .locator('[data-testid="glance-sentence"]')
+      .evaluate((el) => el.scrollHeight > el.clientHeight);
+    expect(clipped).toBe(false);
+  });
+
   // The strip is five slots on EVERY morning, including a quiet one. A row that
   // shrank when a reading had nothing in it would be compared against a fuller
   // one and read as fewer questions asked, which is why the two slots the
@@ -264,6 +352,41 @@ test.describe("the Brief — page shape", () => {
 
     await expect(page.locator("#home-focus")).toBeVisible();
     await expect(page.locator("#home-weekly")).toHaveCount(0);
+  });
+
+  // The page a German reader arrives at is in German, and says what it is.
+  //
+  // Every other assertion here is geometry, which a page rendering raw message
+  // KEYS would satisfy completely — five boxes in a row is five boxes whether
+  // they read "Als Nächstes" or "brief.donext.title". One catalog read is what
+  // separates a rendered page from a rendered skeleton.
+  test("greets a German reader in German", async ({ page }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    await expect(
+      page.getByRole("heading", { name: copy("brief.donext.title") }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("group", { name: copy("brief.view.label") }),
+    ).toBeVisible();
+  });
+
+  // The dial PRESSED, not the address typed.
+  //
+  // openWeekly() navigates straight to ?view=weekly, which proves the address
+  // resolves and nothing about the control. A dial wired to the wrong writer —
+  // or to none — leaves every other test in this file green while the button a
+  // reader actually presses does nothing.
+  test("switches to the week when the dial is pressed", async ({ page }) => {
+    await openBrief(page);
+    await expectShellRendered(page);
+
+    await page.getByRole("button", { name: copy("brief.view.weekly") }).click();
+
+    await expect(page.locator("#home-weekly")).toBeVisible();
+    await expect(page.locator("#home-focus")).toHaveCount(0);
+    expect(page.url()).toContain("view=weekly");
   });
 
   // At desktop the rail is BESIDE the work, not under it. This is the assertion


### PR DESCRIPTION
Five assertions the suite could not make. All verified against a running stack, each mutation-checked separately.

### Geometry

- **The eyebrow, heading and sentence in that order, inside the glance.** The existing block-level assertion places the whole glance against the strip and cannot see this — a sentence rendered above its own heading passed everything.
- **One paragraph, unclipped.** The opening sentence was a stack of one-fact lines before #3801; a second `<p>` is that coming back.
- **The headline still reads as a headline**, as a ratio against body text.

### Copy and interaction — what no box measurement can reach

- **The page a German reader arrives at is in German.** Every other assertion in this file is satisfied by a page rendering raw message *keys*: five boxes in a row is five boxes whether they read "Als Nächstes" or `brief.donext.title`.
- **The weekly dial pressed.** `openWeekly()` navigates straight to `?view=weekly`, which proves the address resolves and nothing about the control. Mutation-checked by wiring the dial's `onChange` to a no-op — the whole suite stayed green except this test.

### Two assertions were wrong first, and both are recorded in the file

**The concept pack's 30px h1 floor fails against the tree: `--fs-h1` is 24px** and every h1 in the product is drawn at it. A 30px floor would either fail forever or force the Brief to a size no other page uses — a second type scale, to satisfy a number taken from a mockup rather than from this design system. Whether the product's h1 should grow is a design-system decision, not the Brief's.

**The replacement was also wrong, and passed for the wrong reason.** It compared the headline against a panel title, and stayed green with the headline shrunk to body size: panel titles are 13px and body is 13.5, so a collapsed headline still measured "larger". It is a ratio against body text now, which fails at 1.0 where the greater-than passed.

### Not included

The plan also asks for a coverage-line assertion. The e2e seed sends no `sources_unavailable`, so the callout never renders — asserting it needs a fixture change beyond this item's scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Brief's e2e suite now verifies the page renders real content and responds to interaction, not just that its boxes exist.

- Adds five assertions: eyebrow/heading/sentence order, single unclipped paragraph, headline-to-body ratio, German copy from the i18n catalog, and the weekly dial pressed via click.
- Drops the concept pack's 30px h1 floor — the design system's `--fs-h1` is 24px, so the floor would force a second type scale onto the Brief alone.
- Compares the headline to body text as a ratio instead of against panel titles, which passed with a headline shrunk to body size.

<sup>Written for commit 0e31929195248c6a5cbf731f0007272dbd62321d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for the Brief experience.
  - Added checks for headline sizing, content ordering, paragraph rendering, German labels, and greeting text.
  - Added coverage for switching to the weekly view using the dial control.
  - Updated tests to use German labels from the translation catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->