### PR TITLE
The lead lane's three unproven paths get their tests

### DIFF
--- a/backend/internal/compose/attention/leadlane_test.go
+++ b/backend/internal/compose/attention/leadlane_test.go
@@ -8,6 +8,7 @@ package attention
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -51,6 +52,18 @@ func rowFor(t *testing.T, day crmcontracts.Worklist, title string) crmcontracts.
 	}
 	t.Fatalf("no row titled %q on the queue", title)
 	return crmcontracts.WorklistItem{}
+}
+
+// The band a named row landed in. A band is optional on the wire, and an absent
+// one is not "now" — it is a row that made no claim, so the caller must not read
+// a missing band as the unpromoted case.
+func bandOf(t *testing.T, day crmcontracts.Worklist, title string) string {
+	t.Helper()
+	row := rowFor(t, day, title)
+	if row.Band == nil {
+		t.Fatalf("row %q carries no band at all", title)
+	}
+	return string(*row.Band)
 }
 
 func kindsOf(row crmcontracts.WorklistItem) []string {
@@ -245,5 +258,134 @@ func TestAnUntrackedLanePublishesNoReachRow(t *testing.T) {
 			t.Fatalf("the lane published a reach row (considered=%d shown=%d) with nothing measuring first response",
 				reach.Considered, reach.Shown)
 		}
+	}
+}
+
+// One late reply is ONE row.
+//
+// The SLA escalation writes a task about the lead as well, and both reached the
+// page before this lane existed. Without the fold a rep who missed one deadline
+// meets the same fact twice — the lead, and a task describing the lead — and
+// the second one carries neither the deadline nor a verb that opens the record.
+func TestTheEscalationTaskForAnOwedLeadFoldsIntoTheLeadRow(t *testing.T) {
+	lead := ids.NewV7()
+	tasks := &stubTasks{rows: []Task{{
+		ID: ids.NewV7(), Subject: "Follow up with the new lead",
+		LinkType: string(subjectLead), LinkID: lead,
+	}}}
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, tasks, stubReceipts{},
+		stubBriefing{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		fixedClock).WithLeadResponses(&stubLeads{tracked: true, rows: []OwedLead{
+		{ID: lead, Name: "the late one", DeadlineAt: readInstant.Add(-time.Hour), State: "breached"},
+	}})
+
+	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("worklist: %v", err)
+	}
+
+	rowFor(t, day, "the late one")
+	for _, row := range day.Queue {
+		if row.Source == sourceTask {
+			t.Errorf("the escalation's own task about an owed lead stayed on the page as %q", *row.Title)
+		}
+	}
+}
+
+// And a task about a lead the queue is NOT showing survives.
+//
+// The fold matches on the link, so a rule that dropped every lead-linked task
+// would take the ordinary follow-up somebody filed by hand along with the
+// escalation's. Without this half the test above passes over a lane that
+// silences lead work generally.
+func TestATaskAboutALeadTheQueueDoesNotShowSurvives(t *testing.T) {
+	tasks := &stubTasks{rows: []Task{{
+		ID: ids.NewV7(), Subject: "Ring the other lead back",
+		LinkType: string(subjectLead), LinkID: ids.NewV7(),
+	}}}
+	svc := NewService(
+		stubApprovals{}, stubDuplicates{}, tasks, stubReceipts{},
+		stubBriefing{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		fixedClock).WithLeadResponses(&stubLeads{tracked: true, rows: []OwedLead{
+		{ID: ids.NewV7(), Name: "the owed one", DeadlineAt: readInstant.Add(-time.Hour), State: "breached"},
+	}})
+
+	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("worklist: %v", err)
+	}
+
+	rowFor(t, day, "Ring the other lead back")
+}
+
+// Past the eighth, an overdue lead sorts BELOW the other kinds without ceasing
+// to be one.
+//
+// leadLead is not a cap on the source — every lead stays on the page and keeps
+// its level. It bounds how much of ONE kind a reader meets before they see the
+// others, so a morning of nine late leads does not bury the meeting that starts
+// in ten minutes.
+//
+// The lane sorts by deadline ASCENDING, so the LONGEST wait sorts first and the
+// SHORTEST is ninth. Seeded backwards from that: "lead 0" is the oldest.
+func TestPastTheEighthAnOverdueLeadStopsLeadingThePage(t *testing.T) {
+	rows := make([]OwedLead, 0, leadLead+1)
+	for i := range leadLead + 1 {
+		rows = append(rows, OwedLead{
+			ID: ids.NewV7(), Name: fmt.Sprintf("lead %d", i),
+			DeadlineAt: readInstant.Add(-time.Duration(leadLead+1-i) * time.Hour),
+			State:      "breached",
+		})
+	}
+	svc := leadLaneService(&stubLeads{tracked: true, rows: rows})
+
+	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("worklist: %v", err)
+	}
+
+	// All nine are still on the page — the cut demotes, it does not drop.
+	if got := len(day.Queue); got != leadLead+1 {
+		t.Fatalf("the page carried %d rows, wanted all %d leads", got, leadLead+1)
+	}
+	// The BAND is what crowding decides: a crowded row stops claiming to need
+	// answering today. Asserting position instead proves nothing here — nine
+	// leads alike differ in nothing else, so their order is unchanged either
+	// way and the test passes with the cut deleted.
+	if got := bandOf(t, day, fmt.Sprintf("lead %d", leadLead-1)); got != bandNow {
+		t.Errorf("the eighth lead landed in band %q, wanted %q — it still leads the page", got, bandNow)
+	}
+	if got := bandOf(t, day, fmt.Sprintf("lead %d", leadLead)); got != bandKeepMomentum {
+		t.Errorf("the ninth lead landed in band %q, wanted %q — the crowding cut did not bite", got, bandKeepMomentum)
+	}
+}
+
+// A read that came back FULL says so, so the page can tell a reader it is not
+// showing everything. Without it a rep reads eight of ninety late leads as
+// eight late leads.
+func TestALeadReadAtItsBoundReportsMoreAvailable(t *testing.T) {
+	rows := make([]OwedLead, 0, leadResponseBound)
+	for i := range leadResponseBound {
+		rows = append(rows, OwedLead{
+			ID: ids.NewV7(), Name: fmt.Sprintf("lead %d", i),
+			DeadlineAt: readInstant.Add(-time.Hour), State: "breached",
+		})
+	}
+	svc := leadLaneService(&stubLeads{tracked: true, rows: rows})
+
+	day, err := svc.Worklist(leadReader(), "", "", ids.UUID{}, 25, "")
+	if err != nil {
+		t.Fatalf("worklist: %v", err)
+	}
+
+	reach := slices.IndexFunc(day.Reach, func(r crmcontracts.WorklistReach) bool {
+		return string(r.Source) == sourceLeadResponse
+	})
+	if reach < 0 {
+		t.Fatalf("no reach row for %s at all", sourceLeadResponse)
+	}
+	if !day.Reach[reach].MoreAvailable {
+		t.Error("a lead read that filled its bound reported more_available false — the page would claim to show every late lead")
 	}
 }


### PR DESCRIPTION
The lane shipped in #3582 and its integration cover landed in #3785. Three behaviours were still unproven, and each is a way the page misleads a rep.

### The dedupe — two halves that fail for opposite reasons

One late reply is **one** row. Without the fold a rep meets the same fact twice: as the lead, and as the escalation's task about the lead. The second carries neither the deadline nor a verb that opens the record.

The second half seeds a task about a lead the queue is **not** showing and proves it survives. The fold matches on the link, so a rule that dropped every lead-linked task would also take the ordinary follow-up somebody filed by hand — and the first test alone passes over that.

### The crowding cut at `leadLead = 8`

`leadLead` is not a cap: every lead stays on the page and keeps its level. What changes past the eighth is the claim that it needs answering *today*.

### The reach bound

A read that came back full says so — otherwise a rep reads eight of ninety late leads as eight late leads.

### The crowding test was wrong first, and passed for the wrong reason

It compared **queue positions**, and stayed green with the cut deleted. Nine leads alike differ in nothing else, so their relative order is identical either way — the assertion could not fail.

`crowded` is read by `bandOfRow`, so the **band** is the observable claim: a crowded row stops being "now" work. Mutation-checked both directions now — deleting the cut and moving its boundary by one each fail it, naming the band that landed.

All five mutations were checked one clause at a time, and each failed only its own test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests for three unproven lead lane behaviors, each a way the page could mislead a rep.

**Bug Fixes**
- Fixes the crowding test, which passed for the wrong reason: it compared queue positions, which don't change when the cut is deleted. It now asserts on the band, which is the observable claim.
- Covers the dedupe fold in two directions: an owed lead's escalation task folds into the lead row, while a task about a lead the queue doesn't show survives.
- Verifies a lead read that fills its bound reports `more_available`, so a rep doesn't read eight of ninety late leads as eight.

<sup>Written for commit e3d96be91557db70ac7ff4f27389994de4e8ed4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for combining escalation tasks with their associated lead rows.
  * Verified that unrelated lead tasks remain visible in the queue.
  * Added checks for how overdue leads are prioritized after the first eight items.
  * Confirmed that lead results correctly report when additional items are available beyond the read limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->