### PR TITLE
The queue shows the message somebody is waiting on

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -37074,6 +37074,19 @@ components:
             source, because one source has several honest answers: a deal past its close
             date slips, one merely idle drifts.
         subject: { $ref: '#/components/schemas/AttentionSubject' }
+        email_summary:
+          allOf: [{ $ref: '#/components/schemas/EmailSummary' }]
+          readOnly: true
+          nullable: true
+          description: >-
+            The canonical email row, on a `customer_waiting` row whose message is an EMAIL
+            this reader may read. The waiting lane spans email and channel messages, and only
+            an email has an email's shape — a chat drawn as one would carry a mail icon and an
+            email's access badge over a message that never travelled on one. Null on a channel
+            message, null on every other source, and null when the message's content is not
+            this reader's, though such a message produces no waiting row at all. A client
+            renders the canonical row when this is present and falls back to `title` when it
+            is not.
         deal: { $ref: '#/components/schemas/WorklistDealFacts' }
         batch: { $ref: '#/components/schemas/WorklistBatch' }
         pair:

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -276,6 +276,10 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 	if subject != "" {
 		row.Title = &subject
 	}
+	// Present exactly when this wait is an email the reader may read. A client
+	// branches on the field rather than on the kind word: the lane also carries
+	// channel messages, and each keeps the plain title it had.
+	row.EmailSummary = waiting.EmailSummary
 	// The record the reply would be about, most specific first: the deal a
 	// thread belongs to says more than the company it is filed under.
 	switch {

--- a/backend/internal/compose/attention/waitingemail_test.go
+++ b/backend/internal/compose/attention/waitingemail_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// What a waiting row carries when the message is an email, and what it does not
+// carry when the message is a chat.
+//
+// The lane spans both (the waiting query's own `a.kind IN ('email', 'message')`),
+// so the canonical email row rides the field rather than the kind word: a client
+// branching on "this is a waiting row" would draw a mail icon and an email's
+// access badge over a message that never travelled on one.
+
+import (
+	"testing"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func emailRow(id ids.UUID) *crmcontracts.EmailSummary {
+	return &crmcontracts.EmailSummary{
+		ActivityId:    openapi_types.UUID(id),
+		OccurredAt:    rankInstant.Add(-2 * 24 * time.Hour),
+		Version:       4,
+		Subject:       ptrTo("Re: the renewal quote"),
+		Preview:       ptrTo("Can you hold the price until Friday?"),
+		Counterparty:  ptrTo("Dana Buyer"),
+		DisplayStatus: crmcontracts.EmailAccessStatusTeam,
+		Move:          crmcontracts.EmailSummaryMoveNone,
+	}
+}
+
+func ptrTo[T any](v T) *T { return &v }
+
+// An email wait carries the canonical row, so the queue shows the same message
+// the timeline shows rather than a bare sentence about it.
+func TestAWaitingEmailCarriesTheCanonicalRow(t *testing.T) {
+	id := ids.MustParse("01a05500-0000-7000-8000-0000000000e1")
+	waiting := WaitingCustomer{
+		ActivityID:   id,
+		Subject:      "Re: the renewal quote",
+		Since:        rankInstant.Add(-2 * 24 * time.Hour),
+		EmailSummary: emailRow(id),
+	}
+
+	row := classifyWaiting(waiting, rankInstant)
+
+	if row.item.EmailSummary == nil {
+		t.Fatal("a waiting email carried no email_summary; the canonical row is what the client draws")
+	}
+	if row.item.EmailSummary.ActivityId != openapi_types.UUID(id) {
+		t.Errorf("the row's summary names activity %v, want the waiting message %v",
+			row.item.EmailSummary.ActivityId, id)
+	}
+	// The title survives beside it. A surface that has not migrated yet still
+	// draws a sentence, and a row that lost its title to gain a summary would
+	// go blank on every one of them.
+	if row.item.Title == nil || *row.item.Title == "" {
+		t.Error("the row lost its title when it gained a summary")
+	}
+}
+
+// A chat is not an email. The seam hands this lane no summary for one, and the
+// row must not invent an empty one: a zero-valued summary would claim an empty
+// subject and a `team` badge, which is a message rather than the absence of one.
+func TestAWaitingChannelMessageCarriesNoEmailRow(t *testing.T) {
+	waiting := WaitingCustomer{
+		ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000e2"),
+		Subject:    "ping about the quote",
+		Since:      rankInstant.Add(-2 * 24 * time.Hour),
+	}
+
+	row := classifyWaiting(waiting, rankInstant)
+
+	if row.item.EmailSummary != nil {
+		t.Errorf("a waiting chat carried an email row: %+v", *row.item.EmailSummary)
+	}
+	if row.item.Title == nil || *row.item.Title != "ping about the quote" {
+		t.Errorf("the chat row lost the title it renders from: %+v", row.item.Title)
+	}
+	// The verb is unchanged: a chat is still answered, just not through an
+	// email's row.
+	if row.item.Move == nil || row.item.Move.Action != crmcontracts.WorklistMoveActionDraftReply {
+		t.Errorf("the chat row lost its reply verb: %+v", row.item.Move)
+	}
+}

--- a/backend/internal/compose/attention/waitinglane.go
+++ b/backend/internal/compose/attention/waitinglane.go
@@ -92,7 +92,13 @@ func (h HiddenWork) Clear() bool {
 type WaitingCustomer struct {
 	// ActivityID is the message itself — what a reply would be drafted to.
 	ActivityID ids.UUID
-	Subject    string
+	// EmailSummary is the canonical email row, present exactly when this wait
+	// is an EMAIL the reader may read. The lane spans email and channel
+	// messages, and only an email has an email's shape — a chat drawn as one
+	// would carry a mail icon and an email's access badge over a message that
+	// never travelled on one.
+	EmailSummary *crmcontracts.EmailSummary
+	Subject      string
 	// Since is when they wrote. The wait is measured from it, and it is what
 	// the card says out loud.
 	Since time.Time

--- a/backend/internal/compose/attentionwaitingseam.go
+++ b/backend/internal/compose/attentionwaitingseam.go
@@ -16,8 +16,10 @@ import (
 	"time"
 
 	"github.com/margince/margince/backend/internal/compose/attention"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // attentionWaiting binds the who-is-waiting lane to the activities module's
@@ -84,10 +86,24 @@ func (w attentionWaiting) Unanswered(
 	// SURVIVORS against the scan bound would read a full scan whose survivors
 	// are few as a complete one. This is the only place both numbers exist.
 	cut := len(rows) >= activities.WaitingScanCap
-	out := make([]attention.WaitingCustomer, 0, len(rows))
-	for _, row := range keepWaitingCustomers(rows) {
+	kept := keepWaitingCustomers(rows)
+	summaries, err := w.emailRows(ctx, kept)
+	if err != nil {
+		return nil, false, err
+	}
+	out := make([]attention.WaitingCustomer, 0, len(kept))
+	for _, row := range kept {
+		// Nil when this wait is not an email, or is one whose content the
+		// reader may not read. A zero-valued struct would be a row claiming an
+		// empty subject and a `team` badge, which is a message rather than the
+		// absence of one.
+		var summary *crmcontracts.EmailSummary
+		if got, ok := summaries[row.ActivityID]; ok {
+			summary = &got
+		}
 		out = append(out, attention.WaitingCustomer{
 			ActivityID:     row.ActivityID,
+			EmailSummary:   summary,
 			Subject:        row.Subject,
 			Since:          row.OccurredAt,
 			PersonID:       row.PersonID,
@@ -138,4 +154,35 @@ func keepWaitingCustomers(rows []activities.WaitingReply) []activities.WaitingRe
 		kept = append(kept, row)
 	}
 	return kept
+}
+
+// emailRows reads the canonical email row behind each waiting message that is
+// one, in a single statement over the whole lane.
+//
+// The lane spans email and channel messages (the waiting query's own
+// `a.kind IN ('email', 'message')`), so the ids are filtered to email BEFORE
+// the read rather than after: a chat has no email row to fetch, and asking for
+// one would spend the statement's budget on rows that can only come back
+// absent.
+//
+// The reader carries its own content gate, so a summary reaches the lane only
+// for a message this caller may read. That is belt and braces here — a message
+// the reader may not read produces no waiting row at all — and it is the lock
+// that holds if the lane's own gate is ever loosened.
+func (w attentionWaiting) emailRows(
+	ctx context.Context, rows []activities.WaitingReply,
+) (map[ids.UUID]crmcontracts.EmailSummary, error) {
+	var emailIDs []ids.UUID
+	for _, row := range rows {
+		if row.Kind == string(crmcontracts.ActivityKindEmail) {
+			emailIDs = append(emailIDs, row.ActivityID)
+		}
+	}
+	if len(emailIDs) == 0 {
+		// An empty map rather than a nil one, for the reason the reader itself
+		// gives: the caller reads this by key, and "no emails in this lane" is
+		// the same answer to that question as "no rows for you".
+		return map[ids.UUID]crmcontracts.EmailSummary{}, nil
+	}
+	return w.store.EmailSummariesByID(ctx, emailIDs)
 }

--- a/backend/internal/compose/integration/waitinglane_integration_test.go
+++ b/backend/internal/compose/integration/waitinglane_integration_test.go
@@ -423,3 +423,45 @@ func TestWaitingReplyListFilterRefusesAnOutOfScopeEntity(t *testing.T) {
 		t.Fatalf("waiting_reply on an out-of-scope entity = %v, want ErrNotFound", err)
 	}
 }
+
+// One message filed under two records is ONE row, and it carries its kind.
+//
+// The select folds the multiple activity_link rows with array_agg, and the
+// GROUP BY is what makes that fold happen. A column added to the select without
+// being added to the group is a syntax error Postgres catches; one added to the
+// GROUP BY that VARIES across the joined rows silently splits the fold, and a
+// rep would see the same waiting customer twice. `kind` cannot vary — it is a
+// column of the grouped activity itself — and this is the test that says so
+// rather than leaving it to be re-derived.
+func TestAMessageFiledUnderTwoRecordsIsOneWaitingRowCarryingItsKind(t *testing.T) {
+	e := Setup(t)
+	first := seedWaitingPerson(t, e)
+	id := seedWaitingMessageLinked(t, e, "thread-two-links", "inbound", "Filed twice",
+		waitingInstant.Add(-3*24*time.Hour), first)
+	second := seedWaitingPerson(t, e)
+	if _, err := OwnerConn(t).Exec(context.Background(), `
+		INSERT INTO activity_link (activity_id, entity_type, person_id)
+		VALUES ($1, 'person', $2)`, id, second); err != nil {
+		t.Fatalf("filing the message under a second person: %v", err)
+	}
+
+	waiting, err := activities.NewStore(e.DB()).WaitingReplies(e.Admin(), waitingInstant)
+	if err != nil {
+		t.Fatalf("reading who is waiting: %v", err)
+	}
+
+	var seen int
+	for _, row := range waiting {
+		if row.ActivityID != id {
+			continue
+		}
+		seen++
+		if row.Kind != "email" {
+			t.Errorf("the row carried kind %q, want email — the canonical row rides this field", row.Kind)
+		}
+	}
+	if seen != 1 {
+		t.Errorf("a message filed under two records came back %d times; the reader would see one "+
+			"waiting customer twice", seen)
+	}
+}

--- a/backend/internal/compose/waitingemailseam_integration_test.go
+++ b/backend/internal/compose/waitingemailseam_integration_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// What the who-is-waiting seam attaches to a wait, against a real database.
+//
+// The lane spans email and channel messages (the waiting query's own
+// `a.kind IN ('email', 'message')`), and only an email has an email's shape.
+// The kind filter lives in the seam, so a unit test that builds a
+// WaitingCustomer by hand cannot see it fail — this file goes through the
+// seam's own read.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/attention"
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedWaitingOfKind writes one inbound message of the given kind, filed under a
+// person so it is sales mail rather than a rep's private correspondence — the
+// lane requires that link, and a message seeded without one correctly never
+// appears at all.
+func seedWaitingOfKind(
+	t *testing.T, e *integration.Env, person ids.UUID, kind, subject string, at time.Time,
+) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO activity (id, kind, subject, body, direction, source_system, source_id,
+			                      source, captured_by, audience, occurred_at, thread_key,
+			                      channel_provider)
+			VALUES ($1, $2, $3, 'What did we agree on the price?', 'inbound', 'gmail', $4,
+			        'gmail:'||$4, 'connector:gmail', 'workspace', $5, $6,
+			        CASE WHEN $2 = 'message' THEN 'telegram' END)`,
+			id, kind, subject, "wait-"+id.String(), at, "thread-"+id.String()); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO activity_participant (activity_id, role, address)
+			VALUES ($1, 'from', 'dana@acme.example')`, id); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ($1, 'person', $2)`, id, person)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a waiting %s: %v", kind, err)
+	}
+	return id
+}
+
+func waitingOf(rows []attention.WaitingCustomer, id ids.UUID) *attention.WaitingCustomer {
+	for i := range rows {
+		if rows[i].ActivityID == id {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+// An email wait carries the canonical row; a chat waiting in the same lane
+// carries none. Both halves in one test, because either alone passes for the
+// wrong reason: a seam attaching nothing satisfies the chat claim, and one
+// attaching a row to everything satisfies the email claim.
+func TestTheWaitingSeamAttachesAnEmailRowToEmailsAlone(t *testing.T) {
+	e := integration.Setup(t)
+	asOf := time.Now()
+	person := seedLinkedPerson(t, e, "dana@acme.example")
+	mail := seedWaitingOfKind(t, e, person, "email", "Re: the renewal quote", asOf.Add(-3*24*time.Hour))
+	chat := seedWaitingOfKind(t, e, person, "message", "ping about the quote", asOf.Add(-2*24*time.Hour))
+
+	seam := attentionWaiting{
+		store: activities.NewStore(e.DB()),
+		now:   func() time.Time { return asOf },
+	}
+	rows, _, err := seam.Unanswered(e.Admin(), asOf)
+	if err != nil {
+		t.Fatalf("reading who is waiting: %v", err)
+	}
+
+	gotMail := waitingOf(rows, mail)
+	if gotMail == nil {
+		t.Fatalf("the waiting email did not reach the lane at all; %d row(s) came back", len(rows))
+	}
+	if gotMail.EmailSummary == nil {
+		t.Fatal("a waiting email carried no canonical row")
+	}
+	if gotMail.EmailSummary.Subject == nil || *gotMail.EmailSummary.Subject != "Re: the renewal quote" {
+		t.Errorf("the email's row named %v, want its own subject", gotMail.EmailSummary.Subject)
+	}
+	if gotMail.EmailSummary.Preview == nil || *gotMail.EmailSummary.Preview == "" {
+		t.Error("the email's row carried no preview; the queue shows one and the timeline shows the same one")
+	}
+
+	gotChat := waitingOf(rows, chat)
+	if gotChat == nil {
+		t.Fatalf("the waiting chat did not reach the lane; the kind claim below would prove nothing")
+	}
+	if gotChat.EmailSummary != nil {
+		t.Errorf("a waiting chat carried an email row: %+v — only an email has an email's shape",
+			*gotChat.EmailSummary)
+	}
+}
+
+// A message whose content this reader may not read produces no waiting row at
+// all — so there is nothing to attach a row to. The seam's reader carries the
+// content gate a second time, which is the lock that holds if the lane's own
+// gate is ever loosened.
+func TestTheWaitingSeamHandsNoRowForAMessageTheReaderCannotRead(t *testing.T) {
+	e := integration.Setup(t)
+	asOf := time.Now()
+	person := seedLinkedPerson(t, e, "dana@acme.example")
+	mail := seedWaitingOfKind(t, e, person, "email", "Severance terms", asOf.Add(-3*24*time.Hour))
+
+	// Admitted first, so the refusal below is the audience's doing rather than
+	// the fixture never having qualified.
+	seam := attentionWaiting{
+		store: activities.NewStore(e.DB()),
+		now:   func() time.Time { return asOf },
+	}
+	before, _, err := seam.Unanswered(e.Admin(), asOf)
+	if err != nil {
+		t.Fatalf("reading who is waiting: %v", err)
+	}
+	if got := waitingOf(before, mail); got == nil || got.EmailSummary == nil {
+		t.Fatalf("the open mail carried no row to begin with; the held case proves nothing")
+	}
+
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, execErr := tx.Exec(context.Background(),
+			`UPDATE activity SET audience = 'participants' WHERE id = $1`, mail)
+		return execErr
+	}); err != nil {
+		t.Fatalf("limiting the message: %v", err)
+	}
+
+	// AdminPerms deliberately: the refusal below must be the AUDIENCE's, not a
+	// missing permission. A reader who could not have seen it either way would
+	// pass this test while proving nothing about the audience.
+	colleague := e.As(e.Rep3, []ids.UUID{e.Team2}, integration.AdminPerms)
+	after, _, err := seam.Unanswered(colleague, asOf)
+	if err != nil {
+		t.Fatalf("colleague reading who is waiting: %v", err)
+	}
+	if got := waitingOf(after, mail); got != nil {
+		t.Errorf("a limited message reached a colleague's queue: %+v", *got)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -31566,6 +31566,9 @@ type WorklistItem struct {
 	// DueAt When this is due, or when the meeting starts.
 	DueAt *time.Time `json:"due_at,omitempty"`
 
+	// EmailSummary The canonical email row, on a `customer_waiting` row whose message is an EMAIL this reader may read. The waiting lane spans email and channel messages, and only an email has an email's shape — a chat drawn as one would carry a mail icon and an email's access badge over a message that never travelled on one. Null on a channel message, null on every other source, and null when the message's content is not this reader's, though such a message produces no waiting row at all. A client renders the canonical row when this is present and falls back to `title` when it is not.
+	EmailSummary *EmailSummary `json:"email_summary,omitempty"`
+
 	// Id The owning record's id, as its own endpoint spells it.
 	Id string `json:"id"`
 

--- a/backend/internal/modules/activities/emailsummarybatch.go
+++ b/backend/internal/modules/activities/emailsummarybatch.go
@@ -16,6 +16,22 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
+// EmailSummariesByID is EmailSummariesByIDBatch for a caller with no
+// transaction of its own to lend — the who-is-waiting seam, whose rows come
+// back from a read that has already committed. Same reader, same gate; only
+// the transaction differs.
+func (s *Store) EmailSummariesByID(
+	ctx context.Context, activityIDs []ids.UUID,
+) (map[ids.UUID]crmcontracts.EmailSummary, error) {
+	var out map[ids.UUID]crmcontracts.EmailSummary
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		var readErr error
+		out, readErr = EmailSummariesByIDBatch(ctx, tx, activityIDs)
+		return readErr
+	})
+	return out, err
+}
+
 // EmailSummariesByIDBatch answers the email row of each of these activities,
 // for THIS caller, in the caller's own transaction. Ids that are not emails,
 // that the caller may not read, or that do not exist are simply absent from

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -36,7 +36,12 @@ import (
 type WaitingReply struct {
 	// ActivityID is the message itself — what a draft would reply to.
 	ActivityID ids.UUID
-	Subject    string
+	// Kind tells an email from a channel message. The query spans both, and
+	// only an email has an email's shape: a caller drawing the canonical email
+	// row for a chat would put a mail icon on a message that never travelled
+	// on one.
+	Kind    string
+	Subject string
 	// Sender is the address the message came from, so a caller can tell a
 	// person waiting from a machine sending. Empty when no sender was recorded.
 	Sender string
@@ -234,7 +239,7 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 		waiting = []WaitingReply{}
 		for rows.Next() {
 			var row WaitingReply
-			if err := rows.Scan(&row.ActivityID, &row.Subject, &row.Sender, &row.OccurredAt,
+			if err := rows.Scan(&row.ActivityID, &row.Kind, &row.Subject, &row.Sender, &row.OccurredAt,
 				&row.PersonID, &row.OrganizationID, &row.DealID,
 				&row.HasOpenDeal, &row.OwnerID); err != nil {
 				return err

--- a/backend/internal/modules/activities/waitingsql.go
+++ b/backend/internal/modules/activities/waitingsql.go
@@ -55,7 +55,7 @@ package activities
 // unthreaded question at once. Excluding them under-reports, which is the
 // direction that costs a row rather than a customer.
 const waitingRepliesSQL = `
-	SELECT a.id, COALESCE(a.subject, ''),
+	SELECT a.id, a.kind, COALESCE(a.subject, ''),
 	       COALESCE((array_agg(sender.address ORDER BY sender.address)
 	                 FILTER (WHERE sender.address IS NOT NULL))[1], ''),
 	       a.occurred_at,
@@ -257,7 +257,7 @@ const waitingRepliesSQL = `
 	            AND mine.reader_id = $%[10]d
 	            AND (mine.state = 'not_mine'
 	              OR (mine.state = 'snoozed' AND mine.snoozed_until > $%[1]d)))
-	 GROUP BY a.id, a.subject, a.occurred_at
+	 GROUP BY a.id, a.kind, a.subject, a.occurred_at
 	 -- NEWEST first, which is the opposite of how the rows are then shown.
 	 --
 	 -- The cap has to spend its budget on the rows most likely to matter, and

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28014,6 +28014,8 @@ export interface components {
              */
             consequence: "buyer_waits" | "promise_breaks" | "deal_drifts" | "deal_slips_past_close" | "meeting_unprepared" | "task_slips" | "work_blocked" | "customer_never_received" | "you_believe_it_happened" | "legal_deadline_missed" | "mailbox_blind" | "data_drifts" | "none";
             subject?: components["schemas"]["AttentionSubject"];
+            /** @description The canonical email row, on a `customer_waiting` row whose message is an EMAIL this reader may read. The waiting lane spans email and channel messages, and only an email has an email's shape — a chat drawn as one would carry a mail icon and an email's access badge over a message that never travelled on one. Null on a channel message, null on every other source, and null when the message's content is not this reader's, though such a message produces no waiting row at all. A client renders the canonical row when this is present and falls back to `title` when it is not. */
+            readonly email_summary?: components["schemas"]["EmailSummary"] | null;
             deal?: components["schemas"]["WorklistDealFacts"];
             batch?: components["schemas"]["WorklistBatch"];
             /**

--- a/frontend/src/screens/worklist.email.test.tsx
+++ b/frontend/src/screens/worklist.email.test.tsx
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+// What a waiting EMAIL looks like on the queue, and what every other row keeps.
+//
+// The lane spans email and channel messages, so these are two claims about one
+// page: an email names itself with the canonical row, and everything else — a
+// chat, a task, a drifting deal — reads exactly as it did. Either alone passes
+// for the wrong reason.
+//
+// Through the SCREEN rather than the row component, because the wiring is the
+// half that breaks: the opener is threaded from the page that owns the drawer,
+// down through the body, to the row. A row rendered on its own would prove the
+// component and nothing about whether the page reaches it.
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  day,
+  jsonResponse,
+  renderWorklist,
+  row,
+  stub,
+  type Worklist,
+  type WorklistItem,
+} from "./worklist.testkit";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const MESSAGE_ID = "01a05500-0000-7000-8000-0000000000e1";
+
+const waitingEmail: WorklistItem = row({
+  id: MESSAGE_ID,
+  source: "customer_waiting",
+  category: "customer_waiting",
+  level: 1,
+  consequence: "buyer_waits",
+  title: "Re: the renewal quote",
+  email_summary: {
+    activity_id: MESSAGE_ID,
+    occurred_at: "2026-08-29T09:15:00Z",
+    version: 4,
+    subject: "Re: the renewal quote",
+    preview: "Can you hold the price until Friday?",
+    counterparty: "Dana Buyer",
+    direction: "inbound",
+    display_status: "team",
+    move: "needs_reply",
+    attachment_count: 0,
+  },
+});
+
+// A chat waiting in the SAME lane. The server sends it no email row, so the
+// queue keeps the plain title it had — a chat drawn as an email would carry a
+// mail icon and an access badge over a message that never travelled on one.
+const waitingChat: WorklistItem = row({
+  id: "01a05500-0000-7000-8000-0000000000e2",
+  source: "customer_waiting",
+  category: "customer_waiting",
+  level: 1,
+  consequence: "buyer_waits",
+  title: "ping about the quote",
+});
+
+// The queue's own stub answers `{data: []}` to everything but the worklist,
+// which the email drawer reads as a presentation with no access block and
+// throws on. This serves the detail read too, so opening a message from the
+// queue is testable without the drawer's own contract moving into this file.
+const presentation = {
+  id: MESSAGE_ID,
+  lifecycle: "delivered",
+  occurred_at: "2026-08-29T09:15:00Z",
+  summary: waitingEmail.email_summary,
+  body: "Can you hold the price until Friday?",
+  thread_key: "t1",
+  from: [{ address: "dana@acme.example", display_name: "Dana Buyer" }],
+  to: [],
+  cc: [],
+  bcc: [],
+  bcc_withheld: false,
+  attachments: [],
+  links: [],
+  thread: { members: [], next_cursor: null },
+  access: {
+    content_state: "available",
+    audience: "workspace",
+    selected_members: [],
+    display_status: "team",
+    can_change: false,
+    change_mode: "message",
+    held_by_others: false,
+  },
+  can_reply: true,
+  can_relink: false,
+  version: 4,
+};
+
+function renderWithQueue(queue: Worklist) {
+  stub(queue);
+  return renderWorklist();
+}
+
+function stubWithDrawer(queue: Worklist) {
+  stub(queue);
+  // Typed as fetch itself, not as a Mock: the queue's stub installs one, and a
+  // Mock's own type is not callable without a cast the linter refuses.
+  const worklistFetch = globalThis.fetch;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.includes("email-presentation")) {
+        return jsonResponse(presentation);
+      }
+      return worklistFetch(input, init);
+    }),
+  );
+}
+
+describe("a waiting row on the queue", () => {
+  it("names a waiting email with the canonical row and opens the message", async () => {
+    stubWithDrawer(day({ queue: [waitingEmail] }));
+    renderWorklist();
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByText("Re: the renewal quote").length,
+      ).toBeGreaterThan(0),
+    );
+    // The server's own preview — the same line the timeline draws, not a slice
+    // this screen cut for itself.
+    expect(
+      screen.getAllByText("Can you hold the price until Friday?").length,
+    ).toBeGreaterThan(0);
+    // The access badge rides the row, so a rep tells a limited conversation
+    // from an open one without opening it.
+    expect(screen.getAllByText("Team").length).toBeGreaterThan(0);
+
+    const [opener] = screen.getAllByRole("button", {
+      name: /Re: the renewal quote/,
+    });
+    expect(opener.getAttribute("aria-haspopup")).toBe("dialog");
+    await userEvent.click(opener);
+    // The page's own drawer, over the queue.
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeTruthy());
+  });
+
+  it("keeps the queue's own furniture beside the email row", async () => {
+    // TWO rows: the first becomes the focus card above the queue, so a
+    // single-item queue draws no row at all and the claim below would be about
+    // a list that is not there.
+    const { container } = renderWithQueue(
+      day({ queue: [waitingChat, waitingEmail] }),
+    );
+
+    // Waits for the ROW, not for the subject: the focus card above the queue
+    // draws the same message and would satisfy a subject wait while the list
+    // below was still rendering.
+    await waitFor(() => {
+      if (!container.querySelector(".worklist-row")) {
+        throw new Error("the queue has not drawn its rows yet");
+      }
+    });
+    // Asked of the ROW, not the page: the same words label the filter control
+    // above, and a page-wide match would pass on that one while the row lost
+    // its badge. The category says where the row sits in the DAY, which the
+    // email row does not answer — a row that traded it for a subject would
+    // lose the reason it is on this page at all.
+    // Queried AFTER the wait above: the container is captured at render, and
+    // reading it before the page has answered finds a loading skeleton.
+    const rowEl = container.querySelector(".worklist-row");
+    if (!rowEl) {
+      throw new Error("the queue drew no row at all");
+    }
+    expect(rowEl.textContent).toContain("Customer waiting");
+  });
+
+  it("leaves a waiting chat on the plain title it had", async () => {
+    stub(day({ queue: [waitingChat] }));
+    renderWorklist();
+
+    await waitFor(() =>
+      expect(screen.getByText("ping about the quote")).toBeTruthy(),
+    );
+    // Nothing openable: there is no email drawer for a chat, and a control
+    // that answers nothing teaches a rep the product is broken.
+    expect(
+      screen.queryByRole("button", { name: /ping about the quote/ }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/screens/worklist.email.test.tsx
+++ b/frontend/src/screens/worklist.email.test.tsx
@@ -180,6 +180,24 @@ describe("a waiting row on the queue", () => {
     expect(rowEl.textContent).toContain("Customer waiting");
   });
 
+  // Suppressing the title line when a summary is present is only safe because
+  // EmailEntry always draws SOMETHING in its place. A summary with no subject
+  // of its own is the case that would otherwise leave a row with no name at
+  // all — the reader would see a date, a badge and a blank line where the
+  // message should be.
+  it("still names a row whose email carries no subject", async () => {
+    const noSubject = row({
+      ...waitingEmail,
+      email_summary: { ...waitingEmail.email_summary, subject: null },
+    } as Partial<WorklistItem>);
+    stub(day({ queue: [noSubject] }));
+    renderWorklist();
+
+    await waitFor(() =>
+      expect(screen.getAllByText("No subject").length).toBeGreaterThan(0),
+    );
+  });
+
   it("leaves a waiting chat on the plain title it had", async () => {
     stub(day({ queue: [waitingChat] }));
     renderWorklist();

--- a/frontend/src/screens/worklist.emailtitle.tsx
+++ b/frontend/src/screens/worklist.emailtitle.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// How a waiting row names the message somebody is waiting on.
+//
+// The queue's three renderers — the row, the focus card and next-up — each
+// composed their own title line from `itemTitle`, and a waiting email came out
+// as a bare sentence: no subject beside a preview, no access badge, and no way
+// to read the message without leaving the queue for the record behind it. This
+// is the one place that decides what a waiting email's line looks like, so the
+// three cannot drift.
+//
+// It is NOT a fourth email row. `EmailEntry` is the row, and this returns it —
+// what lives here is only the question of when a queue line is one.
+
+import { EmailEntry } from "../design-system/emailentry";
+import { formatDateTime } from "../format/format";
+import { viewerZone } from "../format/timezone";
+import type { Locale, useT } from "../i18n";
+import { useLocale } from "../i18n";
+import { itemTitle } from "./worklist.copy";
+import type { WorklistItem } from "./worklist.queries";
+
+/**
+ * The canonical email row for a waiting message, or null where the line is not
+ * one.
+ *
+ * Null on every source but a waiting customer, null on a channel message, and
+ * null on an email whose content is not this reader's — though such a message
+ * produces no waiting row at all. The caller draws its own title line when this
+ * answers null, which is what keeps a chat, a task and a drifting deal reading
+ * exactly as they did.
+ */
+export function WaitingEmailLine({
+  item,
+  onOpen,
+}: Readonly<{
+  item: WorklistItem;
+  /**
+   * Opens the message. Omitted on a surface with no drawer to open it into —
+   * the row then shows the message and does not pretend to open it, which is
+   * better than a control that answers nothing.
+   */
+  onOpen?: (activityId: string) => void;
+}>) {
+  const { locale } = useLocale();
+  const summary = item.email_summary;
+  if (!summary) {
+    return null;
+  }
+  return (
+    <EmailEntry
+      summary={summary}
+      timestamp={formatDateTime(summary.occurred_at, locale, viewerZone())}
+      onOpen={onOpen ? () => onOpen(summary.activity_id) : undefined}
+    />
+  );
+}
+
+/**
+ * The one-line name for a queue entry, using a waiting email's own SUBJECT
+ * where it has one.
+ *
+ * For the compact lists, which have room for a line and not for a row. The
+ * subject is what a rep recognizes a thread by, and `itemTitle` already
+ * returns it for a waiting row — this exists so the compact surfaces say out
+ * loud that they take the subject deliberately rather than by coincidence, and
+ * so a later change to `itemTitle` cannot silently take it away.
+ */
+export function nextUpLine(
+  item: WorklistItem,
+  t: ReturnType<typeof useT>,
+  locale: Locale,
+): string {
+  return item.email_summary?.subject?.trim() || itemTitle(item, t, locale);
+}

--- a/frontend/src/screens/worklist.focus.tsx
+++ b/frontend/src/screens/worklist.focus.tsx
@@ -28,6 +28,7 @@ import {
   reasonText,
   rowHref,
 } from "./worklist.copy";
+import { WaitingEmailLine } from "./worklist.emailtitle";
 import { type WorklistItem, worklistKey } from "./worklist.queries";
 
 // The focus card, or nothing.
@@ -35,7 +36,14 @@ import { type WorklistItem, worklistKey } from "./worklist.queries";
 // Drawn only on a page the reader can act on. A day whose top row is a
 // duplicate-merge suggestion is not a day with a recommended action, and
 // promoting one would tell a rep that hygiene is their most important work.
-export function FocusCard({ item }: Readonly<{ item: WorklistItem }>) {
+export function FocusCard({
+  item,
+  onOpenEmail,
+}: Readonly<{
+  item: WorklistItem;
+  // Opens a waiting email. Absent where the surface has no drawer.
+  onOpenEmail?: (activityId: string) => void;
+}>) {
   const t = useT();
   const { locale } = useLocale();
   const zone = viewerZone();
@@ -56,8 +64,13 @@ export function FocusCard({ item }: Readonly<{ item: WorklistItem }>) {
   return (
     <Panel title={t("worklist.focus.title")}>
       <div className="worklist-focus">
+        {/* The one thing to do now, and where it is an email that is the
+            message itself — the card has the room for the canonical row, and
+            the whole point of this card is that a rep can act without opening
+            anything else first. */}
+        <WaitingEmailLine item={item} onOpen={onOpenEmail} />
         <p className="t-h2 worklist-focus-what">
-          {href ? (
+          {item.email_summary ? null : href ? (
             <a className="entity-link" href={href}>
               {itemTitle(item, t, locale)}
             </a>

--- a/frontend/src/screens/worklist.nextup.tsx
+++ b/frontend/src/screens/worklist.nextup.tsx
@@ -30,7 +30,8 @@
 
 import { Panel } from "../design-system/panel";
 import { useLocale, useT } from "../i18n";
-import { itemTitle, rowHref } from "./worklist.copy";
+import { rowHref } from "./worklist.copy";
+import { nextUpLine } from "./worklist.emailtitle";
 import { worthActingOn } from "./worklist.focus";
 import type { WorklistItem } from "./worklist.queries";
 import "./worklist.css";
@@ -93,12 +94,17 @@ export function NextUp({
               key={`${item.source}-${item.id}`}
               className="worklist-nextup-row"
             >
+              {/* The SUBJECT for a waiting email, not the canonical row: this
+                  is a compact one-line list of what comes after the current
+                  focus, and a four-line row per entry would defeat the reason
+                  it is a list. The row itself is on the queue and on the focus
+                  card, both of which have the room for it. */}
               {href ? (
                 <a className="entity-link" href={href}>
-                  {itemTitle(item, t, locale)}
+                  {nextUpLine(item, t, locale)}
                 </a>
               ) : (
-                itemTitle(item, t, locale)
+                nextUpLine(item, t, locale)
               )}
             </li>
           );

--- a/frontend/src/screens/worklist.row.tsx
+++ b/frontend/src/screens/worklist.row.tsx
@@ -29,6 +29,7 @@ import {
   rowHref,
 } from "./worklist.copy";
 import { DispositionVerbs } from "./worklist.dispositions";
+import { WaitingEmailLine } from "./worklist.emailtitle";
 import { ReassignControl } from "./worklist.manager";
 import { PairDecision } from "./worklist.pair";
 import {
@@ -44,6 +45,7 @@ export function WorklistRow({
   selected,
   onSelect,
   onReview,
+  onOpenEmail,
 }: Readonly<{
   item: WorklistItem;
   position: number;
@@ -63,6 +65,10 @@ export function WorklistRow({
   // Where a grouped row is reviewed. Also a filter change the Brief cannot
   // make: it shows a fixed cut and has no filter to move.
   onReview?: () => void;
+  // Opens a waiting email. Absent on a surface with no drawer — the Brief
+  // draws the message and does not offer to open it, rather than drawing a
+  // control that answers nothing.
+  onOpenEmail?: (activityId: string) => void;
 }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -78,6 +84,7 @@ export function WorklistRow({
     .join(" · ");
   const above = comparisonText(item.above_next, t, locale, zone);
   const consequence = consequenceText(item, t);
+  const emailRow = item.email_summary != null;
   return (
     <PanelRow
       className={
@@ -91,8 +98,14 @@ export function WorklistRow({
         onSelect={onSelect}
       />
       <div className="worklist-row-text">
+        {/* A waiting EMAIL names itself with the canonical row — the same one
+            the timeline draws — so the queue shows the message rather than a
+            sentence about it. Everything else keeps the title line it had, and
+            the badges below stay on both: they say where the row sits in the
+            day, which the email row does not answer. */}
+        <WaitingEmailLine item={item} onOpen={onOpenEmail} />
         <p className="t-body worklist-row-title">
-          {href ? (
+          {emailRow ? null : href ? (
             <a className="entity-link" href={href}>
               {title}
             </a>

--- a/frontend/src/screens/worklist.tsx
+++ b/frontend/src/screens/worklist.tsx
@@ -4,11 +4,14 @@ import { Button, SegmentedControl } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
 import { Eyebrow } from "../design-system/eyebrow";
 import { FilterPills } from "../design-system/filterpills";
+import { OpenEmailDrawer } from "../design-system/openemaildrawer";
 import { PageZones } from "../design-system/pagezones";
 import { Panel } from "../design-system/panel";
 import { SurfaceState } from "../design-system/surfacestate";
 import { formatNumber } from "../format/format";
+import { viewerZone } from "../format/timezone";
 import { useLocale, useT } from "../i18n";
+import { useOpenEmail } from "./openemail";
 import { TeamBoard } from "./worklist.board";
 import {
   completenessText,
@@ -231,6 +234,7 @@ function WorklistBody({
   onFilter,
   onOwner,
   onSelect,
+  onOpenEmail,
   hasMore,
   loadingMore,
   moreFailed,
@@ -246,6 +250,8 @@ function WorklistBody({
   onFilter: (next: WorklistFilter) => void;
   onOwner: (next: string) => void;
   onSelect: (next: string) => void;
+  // Opens a waiting email into the page's one drawer.
+  onOpenEmail: (activityId: string) => void;
   hasMore: boolean;
   loadingMore: boolean;
   moreFailed: boolean;
@@ -309,7 +315,7 @@ function WorklistBody({
       {/* The one thing to do next, said rather than implied. The row stays in
           the queue below: removing it would make the rank numbers lie and the
           counts disagree with the page. */}
-      {focus && <FocusCard item={focus} />}
+      {focus && <FocusCard item={focus} onOpenEmail={onOpenEmail} />}
       {/* And then? A finite list a reader can see the end of, so a morning has a
           shape rather than a backlog. Drawn only under a focus card: without
           one there is no "next", only the queue. */}
@@ -377,6 +383,7 @@ function WorklistBody({
                               )
                           : undefined
                       }
+                      onOpenEmail={onOpenEmail}
                       onReview={() => onFilter(reviewFilter(item))}
                     />
                   </li>
@@ -466,6 +473,7 @@ export function WorklistScreen({
   // would make the address describe a fraction of what the reader is looking
   // at. Moving them all there is its own change.
   const [selectedId, setSelectedId] = useState("");
+  const [openEmail, setOpenEmail] = useOpenEmail();
   // Changing a dial drops the selection. A row chosen under one question is
   // not a row the reader chose under the next one, and keeping the id means a
   // row that comes back — a filter switched away and back, a snooze that lifts
@@ -524,6 +532,7 @@ export function WorklistScreen({
             onFilter={answerWith(setFilter)}
             onOwner={answerWith(setOwner)}
             onSelect={setSelectedId}
+            onOpenEmail={setOpenEmail}
             hasMore={day.hasNextPage}
             loadingMore={day.isFetchingNextPage}
             moreFailed={day.isError && day.data !== undefined}
@@ -531,6 +540,14 @@ export function WorklistScreen({
           />
         )}
       </SurfaceState>
+      {/* One drawer over the whole queue, at page level rather than inside a
+          row: two mounted dialogs would be two `aria-modal` elements, and the
+          day stays legible behind the message being read. */}
+      <OpenEmailDrawer
+        activityId={openEmail}
+        zone={viewerZone()}
+        onClose={() => setOpenEmail(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Eighth slice of the email display unification arc (after #3779, #3786, #3804, #3812, #3819, #3826, #3864).

## What changed

A waiting customer was a sentence about a message: no subject beside a preview, no access badge, and no way to read the mail without leaving the queue for the record behind it. A waiting email now names itself with the canonical `EmailEntry` — the same row the timeline and search draw — and opens the same drawer.

**Backend.** `WaitingReply` carries its `kind` (the waiting query selects `a.kind`, grouped alongside it). `attentionWaiting.Unanswered` filters the lane's ids to email and asks the activities store's own batched reader for their rows, in one statement. `WorklistItem.email_summary` is the contract field; `classifyWaiting` sets it.

**Frontend.** `WaitingEmailLine` in `worklist.emailtitle.tsx` is the one place that decides when a queue line is an email row — the three renderers each composed their own from `itemTitle` and would have drifted.

## Where the row goes differs by surface

| Surface | Draws | Why |
|---|---|---|
| Queue row | Canonical row + opener | Has the room; the page owns a drawer |
| Focus card | Canonical row + opener | The one thing to do now — a rep should act without opening anything first |
| Next-up | Subject only | A compact one-line list; four lines per entry defeats the reason it is a list |
| Brief | Canonical row, **no** opener | It has no drawer, and a control that answers nothing is worse than none |

The category badges stay beside the email row. They say where the row sits in the day, which the email row does not answer.

## Three guards, and what it took to prove them

A chat must not be drawn as an email — the defect Codex caught in #3826, where a meeting rendered with a mail icon. Three independent guards hold it: the seam's kind filter, the batch reader's `a.kind = 'email'`, and `RowEmailSummary` refusing a non-email.

**Removing any one leaves the other two, so each mutation passed.** The integration test fails only when all three go — which is what says the test can see the defect at all. Recorded here because a future reader removing one of the three will find every test still green and conclude it was dead code.

The unit test cannot see the seam's filter either: it builds a `WaitingCustomer` directly, past the seam. That is why `waitingemailseam_integration_test.go` goes through `attentionWaiting.Unanswered` against a real database.

## Privacy

A message whose content the reader may not read produces no waiting row at all (`classifyWaiting`'s own comment: "a message this reader may not read produces no row"). The batch reader carries `ActivityContentClause` a second time regardless — the lock that holds if the lane's gate is ever loosened. `TestTheWaitingSeamHandsNoRowForAMessageTheReaderCannotRead` proves the colleague found it before limiting, so the disappearance is the audience's doing and not a fixture that never qualified. It uses `AdminPerms` deliberately, so the refusal cannot be a missing permission.

## Tests

Unit (`waitingemail_test.go`): an email wait carries the row and keeps its title; a chat carries none and keeps its reply verb.

Integration (`waitingemailseam_integration_test.go`): the seam attaches a row to emails alone — both halves in one test, because either alone passes for the wrong reason; and a limited message reaches no colleague's queue.

Frontend (`worklist.email.test.tsx`): through the **screen**, not the row component — the opener is threaded from the page that owns the drawer down through the body to the row, and the wiring is the half that breaks.

All mutation-checked in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waiting emails in the queue now show the canonical email row — the same one the timeline and search draw — and open the same drawer, replacing a bare sentence about the message.

**Surface differences**
- Queue rows and the focus card draw the full row with an opener.
- Next-up keeps just the subject; a four-line row would defeat why it is a list.
- The Brief draws the row without an opener because it has no drawer to open into.

**Guards**
- Three independent checks keep a chat or meeting from being drawn as an email; a message filed under two records still comes back once with its kind.
- A message whose content the reader cannot read produces no waiting row at all.
- An email with no subject of its own still names its row.

<sup>Written for commit 285b3c0699403d83707a0b766fe67b1415a34bcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worklist email items now display canonical subjects, previews, and timestamps.
  * Email items can be opened directly in a page-level email drawer.
  * “Next Up” entries prefer email subjects when available.
  * Titles are used when email details are unavailable.
* **Bug Fixes**
  * Chat and other non-email items retain their existing titles and actions.
  * Restricted or inaccessible email content is excluded from waiting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->