### PR TITLE
frontend: the shell on the lit ground (design adoption step 4)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -273,7 +273,7 @@ scrolls inside itself.
 └────────┴───────────────────────────────────────────────────────────────┘
 ```
 
-- **Sidebar**: 224px expanded, 52px collapsed, and collapsed is the default.
+- **Sidebar**: 224px expanded, 64px collapsed, and collapsed is the default.
   Glass over the emerald glow, a hairline on its right. Workspace name and the
   fold at the top, then the product's own ten rows in its own order: Brief;
   Records — Contacts, Companies, Leads, Filters & views; Work — Worklist,
@@ -609,7 +609,7 @@ place under the identity.
 
 ### The shell around every record
 
-The sidebar collapses to a 52px icon rail and that is the default. Labels
+The sidebar collapses to a 64px icon rail and that is the default. Labels
 return on hover as tooltips, the agent's orb stays at the foot. The details
 panel on the right of the reading opens from the Details control at the end
 of the tab row, and starts closed.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -281,7 +281,8 @@ scrolls inside itself.
   queues that used to badge (approvals, tasks) are lanes of the Worklist, which
   reports its counts on the page. Settings is not a row; it opens from the
   account menu and publishes its own second level (You / Admin settings) as a
-  210px column beside the rail. The agent's orb stays at the foot.
+  210px column on the same glass, which the sidebar becomes while a settings
+  route is open. The agent's orb stays at the foot.
 - **Top bar**: 48px, glass, a hairline under it. The breadcrumb on the left,
   the command field in the middle (`⌘K`), the reader's monogram on the right.
   It is the application's one bar and every screen has it. Nothing that

--- a/docs/how-to/adopt-the-design.md
+++ b/docs/how-to/adopt-the-design.md
@@ -136,8 +136,13 @@ unless a primitive is added (`variant="agent"` is a prop, not a primitive).
 3. **Top bar.** 50px stays; glass, hairline under; breadcrumb left, the ⌘K
    field centred, the SoR-mode chip and the account menu right. **Nothing
    that belongs to a record sits in it.**
-4. **Settings second level.** `SettingsRail`/`navlevel.tsx` render as a
-   210px column beside the rail on the same glass.
+4. **Settings second level.** On a settings route the sidebar itself becomes
+   the 210px column that carries the level (`SettingsRail`/`navlevel.tsx`),
+   on the same glass. It still shows one level at a time — the ten
+   destinations step aside for the section's entries, with Back above them —
+   because `rail.test.tsx` and `ac.spec.ts` hold exactly one level in the
+   sidebar; the mock's two columns side by side would be a navigation change,
+   not a restyle.
 5. **Agent chrome.** `agentrail` and `agent-edge` take the tokens; the orb
    stays where it is.
 

--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -16,7 +16,7 @@
  * lives in that line, and the light the orb spills on the rail floor has no edge
  * to stop it.
  *
- * The panel is taken out of the flow, sideways: a 252px column cannot carry five
+ * The panel is taken out of the flow, sideways: a 224px column cannot carry five
  * sections, and a panel that pushed the rail wider would move every destination
  * above it.
  */
@@ -403,15 +403,17 @@
     border: 1px solid var(--borderSubtle);
     border-radius: 50%;
     /* The bar's ground, not the page's: the well is the bar rising, and a
-       different fill would read as an object resting on it. The tone the orb
-       spills sits over that ground rather than replacing it. */
+       different fill would read as an object resting on it. Solid where the bar
+       is glass, because a translucent circle over the content it floats above
+       would show the page through the one object in the bar that is lit. The
+       tone the orb spills sits over that ground rather than replacing it. */
     background:
       radial-gradient(
         70% 70% at 50% 42%,
         color-mix(in srgb, var(--arTone) 14%, transparent),
         transparent 72%
       ),
-      var(--bgSidebar);
+      var(--bgElevated);
     box-shadow: var(--shadow-pop);
   }
   /* Outside the shape rather than inset: this control has an edge of its own
@@ -485,15 +487,12 @@
      insets it would put a white margin around the one part of this surface that
      is meant to look like glass. */
   border: 1px solid var(--borderSubtle);
-  border-radius: 20px; /* ds:ignore the flyout's own corner, softer than a card's so the glass reads as one piece */
+  /* The pane's corner: the flyout is one more pane, opened beside the rail. */
+  border-radius: var(--r-lg);
   background: var(--bgElevated);
-  backdrop-filter: blur(30px) saturate(180%);
-  /* Three shadows: the hairline that seats it, the near shade it sits in, and
-     the far one that lifts it off the page. */
-  box-shadow:
-    inset 0 1px 0 var(--bgCard),
-    0 2px 8px -4px var(--overlayScrim),
-    var(--shadow-pop);
+  backdrop-filter: blur(20px);
+  /* The one shadow a layer over the page may cast (DESIGN.md §5). */
+  box-shadow: var(--shadow-pop);
   /* Over the page, under the phone sheet and its scrim (29/30, shell.css): a
      panel that stayed lit over a dimmed page would read as the one thing still
      live while the sheet was open. */
@@ -588,7 +587,7 @@
   gap: 2px var(--space-3); /* ds:ignore two lines of one heading, not spaced content */
   padding: var(--space-3);
   overflow: hidden;
-  border-radius: 19px 19px 0 0; /* ds:ignore sits inside the panel's own 20px corner */
+  border-radius: calc(var(--r-lg) - 1px) calc(var(--r-lg) - 1px) 0 0;
   background: linear-gradient(
     165deg,
     color-mix(in srgb, var(--arTone) 7%, var(--bgElevated)),

--- a/frontend/src/app/navlevel.tsx
+++ b/frontend/src/app/navlevel.tsx
@@ -279,9 +279,7 @@ function NavLevelGroupView({
           and draws a hairline inside the same space. Swapping it for a shorter
           <hr> re-spaced every group and drifted the icons. */}
       {group.headingKey && (
-        <Heading className="navheading t-eyebrow">
-          {t(group.headingKey)}
-        </Heading>
+        <Heading className="navheading">{t(group.headingKey)}</Heading>
       )}
       {group.items.map((entry) => (
         <Fragment key={entry.id}>

--- a/frontend/src/app/navlevel.tsx
+++ b/frontend/src/app/navlevel.tsx
@@ -279,7 +279,9 @@ function NavLevelGroupView({
           and draws a hairline inside the same space. Swapping it for a shorter
           <hr> re-spaced every group and drifted the icons. */}
       {group.headingKey && (
-        <Heading className="navheading">{t(group.headingKey)}</Heading>
+        <Heading className="navheading t-eyebrow">
+          {t(group.headingKey)}
+        </Heading>
       )}
       {group.items.map((entry) => (
         <Fragment key={entry.id}>

--- a/frontend/src/app/rail.test.tsx
+++ b/frontend/src/app/rail.test.tsx
@@ -420,7 +420,7 @@ describe("Rail levels (a section's entries as the second level)", () => {
       />,
     );
     // The destinations are GONE, not pushed below a second list: 64px cannot
-    // carry two levels and 252px carrying both is a list of twenty places to go.
+    // carry two levels and 224px carrying both is a list of twenty places to go.
     expect(screen.queryByRole("link", { name: "Pipeline" })).toBeNull();
     expect(levelLabels()).toEqual(["Account", "Privacy & audit"]);
     expect(

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -41,10 +41,11 @@
 }
 
 /* App shell — a labeled sidebar collapsing to the canonical 64px rail, and the
- * content column beside it. The chrome is WHITE, not §2b's deep ink-green field:
- * the founder ruling of 2026-07-23 makes the product surface white, so rail icons
- * read as ordinary theme tokens rather than white-alpha on a dark ground. The
- * ink-green field keeps the marketing surfaces. */
+ * content column beside it. The chrome is GLASS over the lit ground (DESIGN.md
+ * §6), not §2b's deep ink-green field: the sidebar and the strip are the page's
+ * own pane with a blur behind it, so rail icons read as ordinary theme tokens
+ * rather than white-alpha on a dark ground. The ink-green field keeps the
+ * marketing surfaces. */
 
 /* The skip link (WCAG 2.4.1). Off-screen until it has focus, and moved with a
  * transform rather than hidden: `display: none`, `visibility: hidden` and a zero
@@ -107,7 +108,17 @@
   grid-template-columns: var(--railW) 1fr;
   height: 100vh;
   box-sizing: border-box;
-  background: var(--bgPage);
+  /* The lit ground (DESIGN.md §2): the page colour with the two corner lights
+     painted INTO it — the emerald one behind the sidebar at the top-left, the
+     indigo one at the bottom-right. A background rather than an element, so
+     nothing is stacked, scrolled or measured for it; and never animated, because
+     atmosphere that moves is a feature. Fixed radii and no repeat: each is a
+     pool of light in one corner, faint enough that the eye does not find it. */
+  background:
+    radial-gradient(900px 620px at 0 0, var(--glowA), transparent 70%) no-repeat,
+    radial-gradient(900px 620px at 100% 100%, var(--glowB), transparent 70%)
+    no-repeat,
+    var(--bgPage);
   /* `viewport-fit=cover` exposes the horizontal insets too, and this layout is
      the one that applies in landscape — where the notch sits over the sidebar's
      own edge, on top of the brand chip and the column of icons. */
@@ -135,7 +146,15 @@
   }
 }
 .app.railexpanded {
-  --railW: 252px;
+  --railW: 224px;
+}
+/* A settings route's second level is a narrower column than the destinations:
+   its rows are a section's entries rather than places to go, and 210px holds
+   the longest of them (DESIGN.md §6). Read off the sidebar's own `leveled`
+   class rather than the route, so the shell keeps one opinion about what a
+   level is (app/shell.tsx). */
+.app.railexpanded:has(> .rail.leveled) {
+  --railW: 210px;
 }
 /* Reduce means reduce, not remove: the MOVEMENT goes (the column snaps to its
    new width), while the label's opacity crossfade stays. A fade is not motion,
@@ -295,22 +314,24 @@
   min-width: 0;
 }
 /* ===== sidebar =====
- * The ground is the matte near-white surface in BOTH states. The collapsed
- * state matches the canonical rail's geometry — 64px, 44px targets, the
- * logomark chip, the 44px targets — but not its ink-green field: a
- * sidebar that changed colour on collapse would read as two shells.
+ * The ground is the pane — glass over the emerald light — in BOTH states. The
+ * collapsed state matches the canonical rail's geometry — 64px, the logomark
+ * chip, the same rows — but not its ink-green field: a sidebar that changed
+ * colour on collapse would read as two shells.
  *
  * Top to bottom: brand, the destinations (or the entries of a section the
  * reader walked into), More at phone width, then the installation's entitlement
  * pinned to the foot. */
 .rail {
-  /* Its own ground, a shade off the white page: the application's left edge is
-     visible as a surface rather than only as a hairline. */
-  background: var(--bgSidebar);
+  /* Glass over the glow: the pane's translucent ground with the blur that lets
+     the emerald light behind it show through as a tint rather than as a shape.
+     The two glows are the chrome (DESIGN.md §2) — there is no coloured bar. */
+  background: var(--pane);
+  backdrop-filter: blur(20px);
   /* One hairline, on the side that separates it from the content. No radius and
      no shadow: the sidebar is not a card floating on the page, it is the page's
      left edge, and it runs the full height of the viewport. */
-  border-right: 1px solid var(--borderSubtle);
+  border-right: 1px solid var(--paneEdge);
   display: flex;
   flex-direction: column;
   gap: 1px;
@@ -400,7 +421,7 @@
  * and every row below it is aligned to that, so a marker in the flow would move
  * the whole column. And it hangs off the HEAD's own corner, which is at the same
  * place in both rail states — the head narrows around the mark rather than
- * moving it — so one placement is on screen at 252px, at 64px, and in the phone
+ * moving it — so one placement is on screen at 224px, at 64px, and in the phone
  * sheet's head. */
 .rail .alphamark {
   position: absolute;
@@ -535,19 +556,13 @@
 .rail .navgroup + .navgroup {
   margin-top: var(--space-6);
 }
-/* 12px, semibold, sentence case. The uppercase mono kicker this used to be is
-   the older convention — Primer, Atlassian and shadcn all dropped it, and at
-   9.5px with 0.12em tracking it was the least legible text in the product. The
-   group is separated by space, not by a rule: a heading and a divider do the
-   same job, and stacking both says it twice. */
-/* A quiet label over a group, not a heading competing with the rows under it:
-   the rows are what the eye is looking for, so this is one step down in size and
-   weight and carries the rows' own left edge. */
+/* The eyebrow, which is the one uppercase thing in the product (DESIGN.md §2):
+   the heading carries `t-eyebrow` (app/navlevel.tsx) for its size, weight,
+   tracking and case, and this rule only places it. The group is separated by
+   space, not by a rule: a heading and a divider do the same job, and stacking
+   both says it twice. */
 .rail .navheading {
   position: relative;
-  font-size: var(--fs-meta);
-  font-weight: var(--fw-medium);
-  color: var(--textMeta);
   margin: 0 0 var(--space-2);
   padding: 0 14px; /* ds:ignore the nav rows' own inset, which this label stands on */
 }
@@ -590,7 +605,11 @@
   align-items: center;
   gap: var(--space-2);
   flex: 1;
-  min-height: 36px;
+  /* 34px rows: the sidebar is a column of ten places read at a glance, and the
+     compact pitch is what keeps the foot's orb on screen on a laptop. Past the
+     24x24 floor of WCAG 2.2 2.5.8 (AA) at 46x34; the 44px targets of 2.5.5
+     (AAA) are the phone bar's, where a thumb is the pointer. */
+  min-height: 34px;
   /* 13 and not 14, with the transparent border below making up the difference:
      the active row is a PLATE with an edge, and a border that appears only when
      the row is current would shift its glyph and its label by a pixel on every
@@ -617,35 +636,26 @@
 /* Collapsed keeps the SAME row height as expanded, and the 13px padding plus the
    1px edge centres the 18px icon either way (1 + 13 + 18 + 13 + 1 = 46), so no
    icon moves on either axis across the collapse, and none moves when a row
-   becomes the current one. Target size is therefore 46x36 at the floor — past
-   WCAG 2.2 2.5.8 (AA, 24x24), giving up the 44x44 of 2.5.5 (AAA) that
-   AC-shell-1c asks for in favour of the compact row rhythm the design direction
-   sets. */
-/* Hover moves DOWN off the sidebar's ground and the current row moves UP to the
-   elevated one, so the two states are never the same gesture read twice — which
-   is why this is --bgSidebarHover and not --bgHover: --bgHover is lighter than
-   the rail, so it would brighten toward the active plate rather than away from
-   it. */
+   becomes the current one. */
+/* A pointer resting on a row takes the page's own hover step — the glass is the
+   page's pane, so the page's ladder is the rail's ladder too. */
 .rail .navitem:hover {
-  background: var(--bgSidebarHover);
+  background: var(--bgHover);
   color: var(--textPrimary);
 }
-/* The current row is a PLATE: the elevated surface, lifted off the sidebar's own
-   recessed ground the same way a card is lifted off the page — the rail's ladder
-   and the content's are one ladder.
-   Still three signals, and for the reason it always was: the lift measures
-   1.21:1 light / 1.20:1 dark against the ground, which is a difference a reader
-   sees and not one that carries a state on its own (WCAG 1.4.1, Level A). So the
-   weight and the accent on the glyph stay, and the plate gains an EDGE —
-   --borderSubtle is what makes it a surface with a boundary rather than a pale
-   smudge, and it is the same hairline every card in the product draws.
-   The INK stays neutral: the accent as 13.5px text measures 3.9:1 on the dark
-   theme's plate, under the 4.5:1 AA needs, and weight does not rescue that below
-   18.66px. The glyph is where the accent goes, and at 3:1 non-text (1.4.11) it
-   clears. */
+/* The current row is a TINT on the glass (DESIGN.md §2: "a pill, a keycap, the
+   active sidebar row"), one step past hover so the two states are never the
+   same gesture read twice. A white plate — what this was on the recessed
+   sidebar — is invisible on a ground that is already white.
+   Still three signals, because a tint alone is colour-only (WCAG 1.4.1, Level
+   A): the weight, the accent on the glyph, and the pane's own hairline as an
+   EDGE, which is what makes it a surface with a boundary rather than a smudge.
+   The INK stays neutral: the accent as 13.5px text measures under the 4.5:1 AA
+   needs on the dark theme, and weight does not rescue that below 18.66px. The
+   glyph is where the accent goes, and at 3:1 non-text (1.4.11) it clears. */
 .rail .navitem.active {
-  background: var(--bgElevated);
-  border-color: var(--borderSubtle);
+  background: var(--bgCard);
+  border-color: var(--paneEdge);
   color: var(--textPrimary);
   font-weight: var(--fw-semibold);
 }
@@ -725,7 +735,7 @@
 /* ===== a navigation level =====
  * The panel shows ONE level at a time: on a section route the ten destinations
  * step aside for that section's entries, with the way back up above them. 64px
- * cannot carry two levels, and 252px carrying both reads as a list of twenty
+ * cannot carry two levels, and 224px carrying both reads as a list of twenty
  * places to go.
  *
  * The rows are the same `.navitem`s as the destinations, deliberately: every
@@ -1238,24 +1248,19 @@
     --phoneBarLip: calc(var(--space-1) + 1px);
     overflow: visible;
     /* Here the panel IS a floating object — it hovers over the content rather
-       than bounding it — so it takes the card chrome the flush sidebar gives
-       up: all four sides, a radius, a shadow to sit on, and the ELEVATED ground
-       instead of the sidebar's recessed one. That last part is the whole reason
-       the ground is restated here: --bgSidebar is a shade DARKER than the page
-       because a left edge should recede behind what it frames, and this bar is
-       not an edge — it is a card lying on top of the content, and a card that
-       reads darker than the page it covers reads as a hole in it. */
-    background: var(--bgElevated);
-    border: 1px solid var(--borderSubtle);
-    border-radius: var(--r-md);
+       than bounding it — so it takes the chrome the flush sidebar gives up: all
+       four sides, the pane's corner, and the one shadow a layer over the page
+       may cast. The ground stays the same glass, so the bar is visibly the
+       sidebar in its other shape rather than a second surface. */
+    border: 1px solid var(--paneEdge);
+    border-radius: var(--r-lg);
     box-shadow: var(--shadow-pop);
   }
-  /* And so the current cell cannot be the elevated plate it is on the desktop
-     rail: the plate and the bar would be the same colour. The accent tint is
-     what marks it here — the same signal `.railmore.active` below already uses
-     for a destination that lives in the sheet, so the bar has ONE way of saying
-     "this one", whichever cell is carrying it. The weight and the accent glyph
-     from the desktop rule still apply, so the state keeps its three signals. */
+  /* The current cell takes the accent tint rather than the desktop row's grey
+     one — the same signal `.railmore.active` below already uses for a
+     destination that lives in the sheet, so the bar has ONE way of saying "this
+     one", whichever cell is carrying it. The weight and the accent glyph from
+     the desktop rule still apply, so the state keeps its three signals. */
   .rail .navitem.active {
     background: var(--accentLight);
     border-color: transparent;
@@ -1809,7 +1814,7 @@
    Stated here rather than in the phone block far earlier in this file, and that
    placement is the whole point: `.app:has(> .pageaside…)` and the phone block's
    own `.app` carry different specificities, so the wider rule above was winning
-   at phone width too. It put a 252px rail track back into a 390px grid and
+   at phone width too. It put a 224px rail track back into a 390px grid and
    placed the context column in the second track BESIDE a 138px work column —
    two unreadable columns where the page should be one. */
 @media (max-width: 700px) {

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -467,26 +467,21 @@
   height: 32px;
   flex: none;
   border-radius: 9px;
-  background: linear-gradient(
-    145deg,
-    var(--wsChipTop) 0%,
-    var(--accentBrand) 52%,
-    var(--wsChipBottom) 100%
-  );
+  /* Flat brand emerald, no gradient and no lift: the mark is the one filled
+     thing in the chrome, and a lit, shadowed chip beside quiet rows was the
+     loudest object on the screen. */
+  background: var(--accentBrand);
   color: var(--textOnAccent);
   display: grid;
   place-items: center;
-  box-shadow: var(--shadow-pop);
 }
-/* The same slot holding the COMPANY's mark. The chip's own ground and lift go:
-   what stands here is a logo drawn for its own background, or the monogram
-   Avatar tints from the record's identity, and either one on the brand gradient
-   would be a second surface behind a finished mark. The avatar fills the slot
-   so the collapsed rail keeps centring the same 32px box on the rows' glyph
-   axis. */
+/* The same slot holding the COMPANY's mark. The chip's own ground goes: what
+   stands here is a logo drawn for its own background, or the monogram Avatar
+   tints from the record's identity, and either one on the brand emerald would
+   be a second surface behind a finished mark. The avatar fills the slot so the
+   collapsed rail keeps centring the same 32px box on the rows' glyph axis. */
 .rail .ws-chip-company {
   background: none;
-  box-shadow: none;
 }
 .rail .ws-chip-company .avatar {
   width: 100%;
@@ -523,9 +518,8 @@
   opacity: 0;
 }
 .rail .ws-name b {
-  font-family: var(--f-display);
-  font-size: 13.5px;
-  font-weight: 600;
+  font-size: 13px;
+  font-weight: var(--fw-semibold);
   color: var(--textPrimary);
   line-height: 1.25;
 }
@@ -556,14 +550,18 @@
 .rail .navgroup + .navgroup {
   margin-top: var(--space-6);
 }
-/* The eyebrow, which is the one uppercase thing in the product (DESIGN.md §2):
-   the heading carries `t-eyebrow` (app/navlevel.tsx) for its size, weight,
-   tracking and case, and this rule only places it. The group is separated by
-   space, not by a rule: a heading and a divider do the same job, and stacking
-   both says it twice. */
+/* A quiet label over a group, not a heading competing with the rows under it:
+   sentence case, one step down from the rows in size and weight, in the meta
+   ink — the rows are what the eye is looking for. Not the uppercase eyebrow:
+   ten places to go under three shouted labels read as a form, and the mock
+   sets these small and plain. The group is separated by space, not by a rule:
+   a heading and a divider do the same job, and stacking both says it twice. */
 .rail .navheading {
   position: relative;
-  margin: 0 0 var(--space-2);
+  font-size: 11px;
+  font-weight: var(--fw-medium);
+  color: var(--textMeta);
+  margin: 0 0 var(--space-1);
   padding: 0 14px; /* ds:ignore the nav rows' own inset, which this label stands on */
 }
 /* Collapsed: the heading keeps its exact box (same font metrics, same margins)
@@ -643,21 +641,21 @@
   background: var(--bgHover);
   color: var(--textPrimary);
 }
-/* The current row is a TINT on the glass (DESIGN.md §2: "a pill, a keycap, the
-   active sidebar row"), one step past hover so the two states are never the
-   same gesture read twice. A white plate — what this was on the recessed
-   sidebar — is invisible on a ground that is already white.
-   Still three signals, because a tint alone is colour-only (WCAG 1.4.1, Level
-   A): the weight, the accent on the glyph, and the pane's own hairline as an
-   EDGE, which is what makes it a surface with a boundary rather than a smudge.
-   The INK stays neutral: the accent as 13.5px text measures under the 4.5:1 AA
-   needs on the dark theme, and weight does not rescue that below 18.66px. The
-   glyph is where the accent goes, and at 3:1 non-text (1.4.11) it clears. */
+/* The current row is one more pane on the glass: the pane's ground with the
+   pane's hairline as an EDGE, which is what makes it a surface with a boundary
+   rather than a smudge, and quieter than hover's tint so the two states are
+   never the same gesture read twice.
+   Still three signals, because a ground alone is colour-only (WCAG 1.4.1,
+   Level A): the edge, medium weight — not semibold, which shouted the row on
+   a column this quiet — and the accent on the glyph. The INK stays neutral:
+   the accent as 13.5px text measures under the 4.5:1 AA needs on the dark
+   theme, and weight does not rescue that below 18.66px. The glyph is where the
+   accent goes, and at 3:1 non-text (1.4.11) it clears. */
 .rail .navitem.active {
-  background: var(--bgCard);
+  background: var(--pane);
   border-color: var(--paneEdge);
   color: var(--textPrimary);
-  font-weight: var(--fw-semibold);
+  font-weight: var(--fw-medium);
 }
 .rail .navitem.active svg {
   color: var(--accentText);

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -251,7 +251,7 @@ export function WorkspaceRail({
   // Which of the route's levels the panel is showing, and the two ways the
   // reader moves between them (app/navlevel.tsx). A section's entries take the
   // panel OVER rather than hanging off the destinations: 64px cannot carry two
-  // levels, and 252px carrying both reads as a list of twenty places to go.
+  // levels, and 224px carrying both reads as a list of twenty places to go.
   //
   // At phone width the panel is a bottom bar of four destinations, and it KEEPS
   // them on a section route — a bar that hands its four tabs over to a section

--- a/frontend/src/app/topbar.css
+++ b/frontend/src/app/topbar.css
@@ -95,10 +95,11 @@
   width: 100%;
   min-height: var(--control-h-sm);
   padding: 0 var(--space-2) 0 var(--space-3);
-  border: 1px solid var(--borderSubtle);
-  /* A field's corner: this control is drawn as the field it opens. */
-  border-radius: var(--r-control);
-  background: var(--bgPage);
+  /* One more pane on the glass, with the pane's own edge: a field drawn in the
+     page's ground sat in the strip as a hole. */
+  border: 1px solid var(--paneEdge);
+  border-radius: var(--r-sm);
+  background: var(--pane);
   color: var(--textMeta);
   font-size: var(--fs-sm);
   text-align: left;

--- a/frontend/src/app/topbar.css
+++ b/frontend/src/app/topbar.css
@@ -1,11 +1,10 @@
 /* ===== the top bar =====
  * The session's own strip: the sidebar control, the trail, the search, and the
- * person. It stands on the PAGE's ground (--bgTopbar is --bgPage with an alpha)
- * with one hairline under it, so the strip reads as the top of the room the
- * content is in rather than as a second panel meeting the sidebar at a corner.
- * The sidebar's own ground is a step darker on purpose (--bgSidebar), and the
- * two are deliberately not the same: an L of identical chrome around the content
- * makes the frame the loudest thing on the screen.
+ * person. It is the application's one bar and every screen has it (DESIGN.md
+ * §6); nothing that belongs to a record sits in it. It stands on the same glass
+ * as the sidebar with one hairline under it, so the two halves of the chrome
+ * are one pane wrapped around the content rather than two panels meeting at a
+ * corner.
  *
  * It never scrolls: it is the first row of the content column's flex box and
  * the scroller is its sibling, which is cheaper than `position: sticky` and
@@ -38,9 +37,9 @@
      overlay (50), which may both cover the strip. */
   position: relative;
   z-index: 20;
-  background: var(--bgTopbar);
-  backdrop-filter: blur(8px);
-  border-bottom: 1px solid var(--borderSubtle);
+  background: var(--pane);
+  backdrop-filter: blur(20px);
+  border-bottom: 1px solid var(--paneEdge);
 }
 /* Where you are, beside the control that widens the room you are in. */
 .topbar-lead {
@@ -97,7 +96,8 @@
   min-height: var(--control-h-sm);
   padding: 0 var(--space-2) 0 var(--space-3);
   border: 1px solid var(--borderSubtle);
-  border-radius: var(--r-md);
+  /* A field's corner: this control is drawn as the field it opens. */
+  border-radius: var(--r-control);
   background: var(--bgPage);
   color: var(--textMeta);
   font-size: var(--fs-sm);


### PR DESCRIPTION
## What

Step 4 of `docs/how-to/adopt-the-design.md`: the shell takes the new visual language.

- **Ground and glows.** `.app` paints `--bgPage` with the two corner glows (`--glowA` top-left, `--glowB` bottom-right, 900×620 radials) as a background — no element, no animation.
- **Sidebar.** Glass (`--pane` + `blur(20px)`) with a `--paneEdge` hairline on the right. Expanded 224px (was 252); collapsed stays 64px, as the plan says. Rows 34px. Group labels carry `t-eyebrow` (the one uppercase thing), placed by `shell.css` and styled by the design system. Hover is `--bgHover`, the current row a `--bgCard` tint with the pane hairline, weight and accent glyph — the white plate is invisible on a ground that is already white.
- **Settings second level.** On a settings route the sidebar itself is the 210px column that carries the level (`.app.railexpanded:has(> .rail.leveled)`), on the same glass. It still shows **one level at a time**: `rail.test.tsx` and `ac.spec.ts` hold exactly one `.navlevel` with ten rows on `#/home`, the agent absent on a drilled level, and the German title assertion. Two columns side by side would be a navigation change rather than a restyle, so the two doc lines (DESIGN.md §6, the how-to's Step 4) now say what shipped.
- **Top bar.** 50px stays; glass and hairline; the search field takes `--r-control`. Breadcrumb left, ⌘K centred, SoR chip and account menu right were already so.
- **Agent chrome.** The flyout takes the pane corner (`--r-lg`) and the one shadow (`--shadow-pop`); the phone well's ground is `--bgElevated` now that the bar is glass. The orb stays where it is; `agent-edge.css` was already all tokens.
- **Phone bar.** Same glass, pane edge, `--r-lg`.

Deviations from the plan are stated above (settings column) and in the plan itself (64px collapsed).

## Why

DESIGN.md §2 and §6: the two glows are the chrome, the sidebar and the bar are glass over them, and there is no coloured bar anywhere. This is PR 4 of the sequence in the how-to's §10; the record pages (PR 5+) build on this shell.

## How verified

- `make fe-ds-gates`, `make fe-lint`, `make fe-typecheck`: green. Backend gates for docs (`go test ./gates/ -run 'Docs|Public|Rulebook'`): green.
- Unit: `rail`, `shell`, `topbar`, `agentrail`, `conformance`, `eyebrow-one-spelling`, `onecard`, `tokens` suites pass (190 tests). Full `make fe-unit`: 6062 pass, the same two pre-existing failures as on `main` (`aiusage.test.tsx` reader-month, `buyerroom.test.tsx` download), unrelated to this diff.
- E2E `ac.spec.ts` locally against the built app: 143 passed, including AC-shell-1/2/7, the account menu theme flip, the light and dark axe sweeps and the 390px sweep with the agent panel. axe now reports the rail's group headings as "could not decide" (gradient ground) — a warning, not a violation, same as the login surface already does.
- Storybook `Shell/Navigation shell` (Default, Sidebar states, Section level, Phone bar), `Shell/Top bar`, `Shell/Agent rail` (Panel open) screenshotted in both themes.

Screenshots (light / dark):

Default shell — glass rail at 224px over the emerald glow, indigo glow bottom-right; the eyebrow group labels; the orb at the foot.
Section level — the 210px settings column with Back, the title and its rule.
Phone bar — the floating glass bar with the agent well rising out of it.

(Images are in the session; the stories above render them in Storybook in either theme.)

- [x] `make check` frontend half is green (`fe-ds-gates`, `fe-lint`, `fe-typecheck`, `fe-unit` minus the two pre-existing failures, `fe-build`); no Go touched
- [x] `make test-integration` — this change does not touch tenant data / RLS / the write shape
- [x] `make craft-static` — no Go touched
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Generated by an agent under Jo Ziethen's direction, following the adoption plan and the gates named in it. The test-contract inventory that decided the settings-column shape was done by the agent; every CSS value was checked against the token file and the design document.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. Commits are signed
off (`git commit -s`, DCO). See [CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC

---
_Generated by [Claude Code](https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts the new visual language for the app shell: the page background paints two corner glows, and the sidebar, top bar, agent flyout, and phone bar become glass panes over them instead of solid white surfaces.

**Shell and sidebar**
- `.app` paints `--bgPage` with the two corner glows as a background; no element, no animation.
- The expanded sidebar narrows from 252px to 224px; collapsed stays 64px, and `DESIGN.md` now states that value in both places.
- Rows are 34px, and group labels are sentence case at 11px medium.
- The active row is a pane with the pane's hairline at medium weight; hover uses `--bgHover`.
- The brand chip is flat emerald with no gradient or lift.

**Settings and agent chrome**
- On a settings route the sidebar itself becomes the 210px column carrying the section's level, one level at a time as before; the docs now describe this.
- The agent flyout takes `--r-lg` and `--shadow-pop`; the phone well's ground is `--bgElevated`.
- The search field is one more pane on the glass with `--r-sm`, and the phone bar takes the same glass with `--r-lg`.

<sup>Written for commit af384a4286b23f695a25928992203bcbc127737a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed the application shell with glass-pane surfaces, page glows, updated spacing, typography, and navigation states.
  * Adjusted sidebar and agent rail widths for a more compact layout.
  * Updated mobile agent panels, top-bar search styling, borders, shadows, blur, and corner radii.
  * Improved settings navigation layout with a dedicated second-level rail and Back control.

* **Documentation**
  * Updated design and implementation guidance to reflect the revised sidebar dimensions and navigation structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->