### PR TITLE
A half-saved week says so, instead of reporting success

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2476,6 +2476,10 @@ export const de = {
   "plan.none": "Du hast diese Woche noch nicht geplant.",
   "plan.start": "Meine Woche planen",
   "plan.add": "Vorhaben hinzufügen",
+  "plan.saveRefused_one":
+    "Eine Zusage konnte nicht gespeichert werden. Sie ist weiterhin angehakt — bitte erneut versuchen.",
+  "plan.saveRefused_other":
+    "{count} Zusagen konnten nicht gespeichert werden. Sie sind weiterhin angehakt — bitte erneut versuchen.",
   "plan.save_one": "{count} Änderung speichern",
   "plan.save_other": "{count} Änderungen speichern",
   "plan.due": "bis {day}",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2525,6 +2525,10 @@ export const en = {
   "plan.none": "You have not planned this week yet.",
   "plan.start": "Plan my week",
   "plan.add": "Add commitment",
+  "plan.saveRefused_one":
+    "One commitment could not be saved. It is still ticked — try again.",
+  "plan.saveRefused_other":
+    "{count} commitments could not be saved. They are still ticked — try again.",
   "plan.save_one": "Save {count} change",
   "plan.save_other": "Save {count} changes",
   "plan.due": "due {day}",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2452,6 +2452,10 @@ export const vi = {
   "plan.none": "Bạn chưa lập kế hoạch cho tuần này.",
   "plan.start": "Lập kế hoạch tuần của tôi",
   "plan.add": "Thêm cam kết",
+  "plan.saveRefused_one":
+    "Không lưu được một cam kết. Mục này vẫn được tick — hãy thử lại.",
+  "plan.saveRefused_other":
+    "Không lưu được {count} cam kết. Các mục này vẫn được tick — hãy thử lại.",
   "plan.save_one": "Lưu {count} thay đổi",
   "plan.save_other": "Lưu {count} thay đổi",
   "plan.due": "hạn {day}",

--- a/frontend/src/screens/brief.plan.test.tsx
+++ b/frontend/src/screens/brief.plan.test.tsx
@@ -124,6 +124,63 @@ describe("the week ahead", () => {
     expect(writes(calls)[0].body).toEqual({ state: "done" });
   });
 
+  // A save that fails halfway must not leave the panel lying about it.
+  //
+  // Save settles each staged row in its own request, so a refusal on the second
+  // one leaves the first written and the rest not. What the reader must not be
+  // told is that nothing happened, or that everything did: the rows that landed
+  // have to stop being staged, and the one that failed has to still say so.
+  it("keeps the unsaved rows staged when one write is refused", async () => {
+    const calls = stubApi({
+      "GET /weekly-plans/current": () =>
+        jsonResponse(
+          plan({
+            commitments: [
+              commitment(),
+              commitment({ id: "c2", label: "Send the Weber quote" }),
+            ],
+          }),
+        ),
+      "PUT /weekly-plans/commitments/c1/state": () =>
+        new Response(null, { status: 204 }),
+      "PUT /weekly-plans/commitments/c2/state": () =>
+        jsonResponse({ title: "Conflict" }, 409),
+    });
+    render(<PlanSection />);
+
+    await userEvent.click(
+      await screen.findByRole("checkbox", {
+        name: "Call the Aster buyer back",
+      }),
+    );
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Send the Weber quote" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: en["plan.save_other"].replace("{count}", "2"),
+      }),
+    );
+
+    // BOTH are attempted. A loop that threw on the first refusal would leave
+    // the second row unwritten with nothing having asked it to stop.
+    await waitFor(() => expect(writes(calls)).toHaveLength(2));
+    // The refusal is SAID. A panel that swallows it tells a rep their week is
+    // recorded when half of it is not.
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    // And exactly ONE row is still staged: the refused one. Leaving both staged
+    // invites a second Save that re-sends a write which already succeeded;
+    // clearing both loses the reader's own unsaved intent. The Save button
+    // counts the staged set, so its label is where that count is readable.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: en["plan.save_one"].replace("{count}", "1"),
+        }),
+      ).toBeTruthy(),
+    );
+  });
+
   // `missed` is what the week's close writes over a commitment left open. A box
   // that reopened it would let one click undo the close, and the review's counts
   // would stop agreeing with the rows they were counted from.

--- a/frontend/src/screens/brief.plan.tsx
+++ b/frontend/src/screens/brief.plan.tsx
@@ -10,6 +10,7 @@ import {
   Field,
   TextInput,
 } from "../design-system/atoms";
+import { Callout } from "../design-system/callout";
 import { DateInput, type ISODate, isISODate } from "../design-system/dateinput";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { SurfaceState } from "../design-system/surfacestate";
@@ -92,6 +93,10 @@ export function PlanSection() {
   // honest rather than a decoration on an immediate write.
   const [staged, setStaged] = useState<ReadonlySet<string>>(new Set());
   const [adding, setAdding] = useState(false);
+  // How many rows the last Save could not write. Zero is the ordinary state and
+  // draws nothing; anything else is said out loud, because a half-written week
+  // that reports success is worse than one that fails outright.
+  const [unsaved, setUnsaved] = useState(0);
 
   const state = plan.isPending
     ? "loading"
@@ -128,10 +133,24 @@ export function PlanSection() {
         (write): write is { id: string; state: SettableState } =>
           write.state !== null,
       );
+    // Each row is attempted even after one is refused, and only the rows that
+    // LANDED stop being staged.
+    //
+    // The loop used to throw on the first refusal, which left the writes after
+    // it unattempted and — because clearing the staged set came after the loop
+    // — left every row still ticked, including the ones already written. A rep
+    // pressing Save again then re-sent a write that had already succeeded, and
+    // nothing on the panel said any of it had gone wrong.
+    const refused: string[] = [];
     for (const write of writes) {
-      await setState.mutateAsync(write);
+      try {
+        await setState.mutateAsync(write);
+      } catch {
+        refused.push(write.id);
+      }
     }
-    setStaged(new Set());
+    setStaged(new Set(refused));
+    setUnsaved(refused.length);
   }
 
   return (
@@ -148,12 +167,30 @@ export function PlanSection() {
           // Save appears only once a box has changed. A save bar standing in the
           // resting layout would say there is something to save on a week nobody
           // has touched.
-          staged.size > 0 ? (
-            <Button onClick={() => void save()} disabled={setState.isPending}>
-              {plural("plan.save", staged.size, {
-                count: formatNumber(staged.size, locale),
-              })}
-            </Button>
+          //
+          // The refusal sits beside it rather than at the top of the panel: it
+          // is about the press the reader just made, and the rows it names are
+          // the ones still ticked under it.
+          staged.size > 0 || unsaved > 0 ? (
+            <>
+              {unsaved > 0 && (
+                <Callout tone="warn" live="alert">
+                  {plural("plan.saveRefused", unsaved, {
+                    count: formatNumber(unsaved, locale),
+                  })}
+                </Callout>
+              )}
+              {staged.size > 0 && (
+                <Button
+                  onClick={() => void save()}
+                  disabled={setState.isPending}
+                >
+                  {plural("plan.save", staged.size, {
+                    count: formatNumber(staged.size, locale),
+                  })}
+                </Button>
+              )}
+            </>
           ) : undefined
         }
       >


### PR DESCRIPTION
Ticking boxes on the week's plan and pressing Save wrote each staged row in its own request, awaited in a loop **with no error handling**.

A refusal on the second of five rows threw. The three after it were never attempted — and because `setStaged(new Set())` came *after* the loop, that line never ran either.

The reader was left with two commitments written, three not, **every row still ticked, and nothing on the panel saying anything had gone wrong**. Pressing Save again re-sent the writes that had already succeeded.

### The fix

Each row is attempted now even after one is refused. Only the rows that **landed** stop being staged, and the refused count is said out loud in a warn `Callout` with `role="alert"` beside the Save button.

### The per-row calls stay

The ledger item asked for Save to become one call. The endpoint settles a single commitment and no batch endpoint exists, so that means a contract change and a new handler. More to the point, the existing comment was right: failing them one at a time is what keeps a refusal attributable to its own row. What was missing was **surviving** the refusal, not avoiding it.

### Proof

The new test seeds a 204 and a 409, and asserts three things: both writes are attempted, the alert is drawn, and exactly one row is still staged. Mutation-checked both ways — clearing the whole staged set, and restoring the throwing loop, each fail it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plan save so a partially failed save no longer leaves the UI lying about what got saved. Previously, a refused write stopped the loop, leaving later writes unattempted and all rows ticked; now each row is attempted, only failed rows remain staged, and a warning callout appears.

<sup>Written for commit 70b8315fc6948fb896ed7d98609ff801b9e4f3b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Saving weekly plan commitments now continues across all selected items, even if one fails.
  * Failed commitments remain selected for retry, while successfully saved items are cleared.
  * A warning indicates how many commitments could not be saved, with singular and plural messaging in English, German, and Vietnamese.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->