### PR TITLE
The conformance lane's admin holds the grants its real seed gives

### DIFF
--- a/backend/internal/compose/integration/harnessperms.go
+++ b/backend/internal/compose/integration/harnessperms.go
@@ -208,6 +208,15 @@ var (
 			// narrower than AccountRepPerms, which already carries both.
 			"tag":  {Create: true, Read: true, Update: true, Delete: true},
 			"list": {Create: true, Read: true, Update: true, Delete: true},
+			// forecast is create+read for admin in the real seed and
+			// data_coverage is read (identity/internal/policy/defaults.go's
+			// admin row). The same drift the tag and list entries above record,
+			// and no more inert: every forecast tool on the agent surface came
+			// back `permission denied` in the conformance lane, which reads as
+			// "this lane cannot reach them" rather than as "this fixture is
+			// short a grant production gives".
+			"forecast":      {Create: true, Read: true},
+			"data_coverage": {Read: true},
 		},
 		RowScope: principal.RowScopeAll,
 	}

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -225,6 +225,20 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 		// Renaming the word coined above. Both tag-vocabulary writes are reachable
 		// here: AdminPerms carries tag create/read/update/delete.
 		{"update_tag", `{"tag_id":"` + tag.String() + `","name":"conformance-renamed","color":"amber"}`},
+		// The rest of the tag family, reachable for the same reason: the
+		// fixture carries tag read as well as the writes. apply_tag leads and
+		// remove_tag follows, so the middle two read a record that is actually
+		// carrying the word rather than an empty answer that would keep its
+		// shape whatever the read did.
+		{"list_tags", `{}`},
+		{"get_tag", `{"tag_id":"` + tag.String() + `"}`},
+		{"apply_tag", `{"tag_id":"` + tag.String() + `","record_type":"person","record_id":"` + person.String() + `"}`},
+		{"get_record_tags", `{"record_type":"person","record_id":"` + person.String() + `"}`},
+		{"remove_tag", `{"tag_id":"` + tag.String() + `","record_type":"person","record_id":"` + person.String() + `"}`},
+		// The forecast reads, reachable now that the fixture holds the forecast
+		// grant its real seed gives. Both take no arguments.
+		{"forecast_readings", `{}`},
+		{"list_input_checks", `{}`},
 		// The confirm-first queue read back through its own doors.
 		{"list_approvals", `{}`},
 		{"read_approval", `{"staged_action_id":"` + waiting.String() + `"}`},
@@ -270,31 +284,18 @@ var unreachableInThisLane = gatekit.Waive(map[string]string{
 		"authority every other tool in the sweep runs under",
 	"read_import_report": "needs a run that has been dry-run, which needs the object store above",
 	"commit_import":      "confirm-first, and needs the object store above to reach a committable run",
-	"apply_tag": "needs a seat holding tag.read, which this lane's seat does not carry — " +
-		"granting it here would widen the authority every other tool in the sweep runs under, " +
-		"and the answer shape it would prove is the one remove_tag already shares",
-	"remove_tag": "same missing tag.read as apply_tag above",
-	"forecast_readings": "needs a seat holding forecast.read, which this lane's seat does not " +
-		"carry — measured, not assumed: the bare call comes back permission denied. Granting it " +
-		"here would widen the authority every other tool in the sweep runs under",
-	"forecast_input_checks": "same missing forecast.read as forecast_readings above",
-	"data_coverage": "needs a seat holding data_coverage.read, which this lane's seat does not " +
-		"carry — measured, not assumed: the bare call comes back permission denied. Its own object, " +
-		"not the forecast's, so it clears the lane on a grant of its own rather than with the three above",
-	"list_input_checks": "same missing forecast.read as forecast_readings above — it reads the " +
-		"exceptions behind that tool's summary off the same forecast surface, so it clears the " +
-		"lane exactly when the others do",
-	"forecast_movement": "same missing forecast.read as forecast_readings above, and it also " +
-		"requires a `from`/`to` window, so a bare call would not reach the handler either way",
-	"list_tags": "same missing tag.read as apply_tag above — and unlike remove_tag it shares its " +
-		"answer shape with nothing else here, so this waiver leaves that shape unproven rather " +
-		"than proven elsewhere",
-	"get_tag": "same missing tag.read as apply_tag above. It answers ONE row of the shape list_tags " +
-		"answers many of, so the two are unproven together rather than one covering the other — " +
-		"whichever seat eventually carries tag.read reaches both",
-	"get_record_tags": "same missing tag.read as apply_tag above. Its answer shape IS held, " +
-		"against a real database, by the record-tags integration suite — including the withheld " +
-		"case, which is the one a schema alone could not prove",
+	// The two that still cannot answer, and neither reason is a grant. Both read
+	// last night's input-check RUN before anything else, and this lane stands up
+	// no scheduler, so the store answers not-found — which is a different shape
+	// from the empty-findings case list_input_checks proves above.
+	"forecast_input_checks": "needs a completed input-check run to read; the nightly pass is the " +
+		"producer, and this lane composes no scheduler",
+	"data_coverage": "same missing input-check run as forecast_input_checks above — source health " +
+		"is a projection of that run, so it cannot answer before one exists",
+	"forecast_movement": "needs a pair of stored snapshots to difference: its two required ids name " +
+		"snapshot rows, so a call without a snapshot producer would exercise the not-found path " +
+		"rather than the waterfall this schema describes. Its siblings are called above, so the " +
+		"grant is not what stops this one",
 	"book_meeting":         "needs a live calendar provider",
 	"send_email":           "needs an outbound mail provider",
 	"send_account_email":   "needs an outbound mail provider, and a send-capable mailbox for its pre-flight",


### PR DESCRIPTION
Seven agent tools were waived out of `TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas` for want of grants the seeded admin role actually holds. Nothing was checking their schemas or their envelopes, and the reason recorded for that was wrong.

`harnessperms.go` opens by saying exactly what it is for:

> They live beside the environment rather than inside it because they are the one part of the harness that has to mirror something outside the test tree: identity's seeded role documents. **A fixture that drifts from that seed still passes, while proving nothing about production.**

It had drifted. `identity/internal/policy/defaults.go`'s admin row grants `forecast` create+read and `data_coverage` read; `AdminPerms` held neither. The `tag` and `list` entries a few lines above record the same drift with the same consequence — that one was found when an admin missing `tag.read` asked "who carries VIP" and was answered "nobody".

## What that cost

The waivers read as facts about the lane and were facts about the fixture:

> "needs a seat holding forecast.read, which this lane's seat does not carry — measured, not assumed: the bare call comes back permission denied. **Granting it here would widen the authority every other tool in the sweep runs under**"

The measurement was right and the conclusion was not: granting it does not widen anything, it matches production. The tag family carried the same reasoning about `tag.read` — which the fixture has held since that earlier drift was corrected, so those five waivers were describing a seat that no longer existed.

## What is called now

With the two grants, **seven tools move from waived to invoked**, so their declared output schema and envelope are held against a live handler for the first time:

- `list_tags`, `get_tag`, `apply_tag`, `get_record_tags`, `remove_tag` — ordered so `apply_tag` leads and `remove_tag` follows, and the two reads in between see a record actually carrying the word. An empty answer keeps its shape whatever the read did, which is the case worth not proving.
- `forecast_readings`, `list_input_checks` — both take no arguments.

## What is still waived, and why it is not the grant

Three remain, each with the reason that actually stops it:

- `forecast_input_checks` and `data_coverage` read last night's input-check **run** before anything else, and this lane composes no scheduler, so the store answers not-found. That is a different shape from the empty-findings case `list_input_checks` proves above it — measured after the grant landed, not assumed.
- `forecast_movement` needs two stored snapshots to difference. Its siblings are called above, so the grant is not what stops this one.

## Verification

- `make test-it DIR=backend/internal/compose/integration` green, full package (139s).
- `make check-backend` green.
- Mutation-checked: setting `"forecast": {Create: true, Read: false}` fails `forecast_readings` and `list_input_checks` with `forecast.read: permission denied`, and nothing else.

Found while chasing the repeated conformance failures on `main` — every new forecast tool was landing straight into a waiver, because the first one had. The fixture was the reason, and it will keep producing them until it mirrors the seed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded integration coverage for tag management and forecasting workflows.
  - Added validation for forecast readings, input checks, data coverage, and forecast movement scenarios.
  - Updated test fixtures to reflect current access requirements for forecasting and data coverage features.
  - Refined test handling for scenarios where input-check runs or snapshot data are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->