### PR TITLE
The weekly message opens the week it is about

### DIFF
--- a/backend/gates/mailbrieflink_test.go
+++ b/backend/gates/mailbrieflink_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H1
+
+package gates
+
+// The Brief's address is spelled twice: the frontend routes it
+// (frontend/src/screens/brief.view.ts) and outbound mail links to it
+// (internal/platform/mailcopy/link.go), because a message has to name a view
+// before the app it opens is running.
+//
+// This pair drifts SILENTLY, and in the one direction nobody notices. The app
+// is hash-routed and resolves an unknown view by FALLING BACK to the morning —
+// brief.view.ts's `viewFrom` ends `?? DEFAULT_ADDRESS.view`, on purpose, so a
+// stale bookmark opens a working page instead of an error. A mail carrying a
+// renamed view therefore keeps working: every reader lands on the morning, the
+// weekly message opens today's queue, and no test on either side fails. That is
+// exactly the defect this gate exists for — it is the one the weekly mail
+// shipped with, linking to the bare origin and landing a Monday summary of last
+// week on this morning's work.
+//
+// WHAT IT HOLDS: every view word the mail fragments name is a view the frontend
+// still offers, and the morning — the Brief's default — carries no parameter,
+// because the frontend's own writer emits only what DIFFERS from the default.
+//
+// WHAT IT CANNOT SEE: whether the app's route table still answers to "home", or
+// whether the parameter is still called "view". Both are read off the frontend
+// as literals here rather than derived, so a rename of either passes this and
+// is caught by frontend/src/screens/brief.view.test.ts round-tripping every
+// combination it offers.
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	frontendBriefView = "../frontend/src/screens/brief.view.ts"
+	backendMailLink   = "internal/platform/mailcopy/link.go"
+)
+
+// viewsOffered reads the frontend's own VIEWS list rather than restating it.
+// A gate that hard-codes part of its subject has become a second copy of it.
+func viewsOffered(t *testing.T, source string) []string {
+	t.Helper()
+	list := regexp.MustCompile(`VIEWS\s*=\s*\[([^\]]*)\]`).FindStringSubmatch(source)
+	if list == nil {
+		t.Fatal("no VIEWS list in " + frontendBriefView + " — this gate can no longer see its subject")
+	}
+	views := regexp.MustCompile(`"([a-z_]+)"`).FindAllStringSubmatch(list[1], -1)
+	if len(views) == 0 {
+		t.Fatalf("the VIEWS list in %s named no views: %q", frontendBriefView, list[1])
+	}
+	out := make([]string, 0, len(views))
+	for _, view := range views {
+		out = append(out, view[1])
+	}
+	return out
+}
+
+func TestEveryMailedBriefLinkNamesAViewTheAppStillOffers(t *testing.T) {
+	t.Parallel()
+	front := readFiscalSource(t, frontendBriefView)
+	back := readFiscalSource(t, backendMailLink)
+
+	offered := viewsOffered(t, front)
+	// The fragments as the mail actually spells them, read out of the source so
+	// a fragment added later is covered without editing this gate.
+	fragments := regexp.MustCompile(`Brief\w+Fragment\s*=\s*"([^"]*)"`).FindAllStringSubmatch(back, -1)
+	if len(fragments) == 0 {
+		t.Fatal("no Brief*Fragment constants in " + backendMailLink + " — this gate can no longer see its subject")
+	}
+
+	named := regexp.MustCompile(`view=([a-z_]+)`)
+	for _, fragment := range fragments {
+		address := fragment[1]
+		asked := named.FindStringSubmatch(address)
+		if asked == nil {
+			// No parameter means the DEFAULT view, which is what the frontend's
+			// writer emits for it. Nothing to check against the list.
+			continue
+		}
+		if !contains(offered, asked[1]) {
+			t.Errorf(
+				"a mailed link names view %q, which %s no longer offers (%v). "+
+					"The app falls back to the morning silently, so every reader "+
+					"of that message lands on the wrong page and nothing fails.",
+				asked[1], frontendBriefView, offered)
+		}
+	}
+}
+
+// The morning is the Brief's default view, so its link carries no parameter.
+//
+// Not cosmetic: brief.view.ts's `paramsFor` writes only what DIFFERS from
+// DEFAULT_ADDRESS, so a mail naming the default would be a second spelling of
+// an address the app itself never produces — and the day the default moves, the
+// mail would keep asking for a view the product no longer opens on.
+func TestTheMorningsMailedLinkAsksForNoView(t *testing.T) {
+	t.Parallel()
+	back := readFiscalSource(t, backendMailLink)
+
+	morning := regexp.MustCompile(`BriefMorningFragment\s*=\s*"([^"]*)"`).FindStringSubmatch(back)
+	if morning == nil {
+		t.Fatal("no BriefMorningFragment in " + backendMailLink)
+	}
+	if strings.Contains(morning[1], "view=") {
+		t.Errorf(
+			"the morning's mailed link is %q, which names a view. The morning is "+
+				"the default, and the frontend writes only what differs from it.",
+			morning[1])
+	}
+}

--- a/backend/internal/compose/briefs/briefmailrender.go
+++ b/backend/internal/compose/briefs/briefmailrender.go
@@ -142,8 +142,5 @@ func waitingItems(run BriefRun) []BriefRunItem {
 
 // writeLink closes with the way in, when there is a usable one.
 func writeLink(b *strings.Builder, homeURL string, words mailcopy.Copy) {
-	if homeURL == "" {
-		return
-	}
-	b.WriteString("\n" + words.MorningOpenDay + "\n  " + homeURL + "\n")
+	mailcopy.Link(b, homeURL, mailcopy.BriefMorningFragment, words.MorningOpenDay)
 }

--- a/backend/internal/compose/briefs/briefmailrender_test.go
+++ b/backend/internal/compose/briefs/briefmailrender_test.go
@@ -144,8 +144,17 @@ func TestTheLinkIsOmittedRatherThanMailedBroken(t *testing.T) {
 	if strings.Contains(body, english().MorningOpenDay) {
 		t.Errorf("the closing line was drawn over an empty origin:\n%s", body)
 	}
+	// The WHOLE address, not the origin: the origin alone appears in every
+	// wrong answer too, so a substring check cannot tell the morning's link
+	// from one pointing at a view this message is not about.
 	withLink := MailBody(run(item(briefStateNew, "x")), "https://crm.example", english())
-	if !strings.Contains(withLink, "https://crm.example") {
+	if !strings.Contains(withLink, "https://crm.example/#/home") {
 		t.Errorf("the link is missing when there is a usable one:\n%s", withLink)
+	}
+	// And the morning is the Brief's DEFAULT view, so its address carries no
+	// parameter. One that named a view would be a second spelling of the
+	// default, which the frontend's own writer refuses to produce.
+	if strings.Contains(withLink, "view=") {
+		t.Errorf("the morning link named a view it did not need:\n%s", withLink)
 	}
 }

--- a/backend/internal/compose/weekly/weeklymail.go
+++ b/backend/internal/compose/weekly/weeklymail.go
@@ -109,9 +109,9 @@ func MailBody(review Review, homeURL string, words mailcopy.Copy) string {
 
 	writeDealLines(&b, review.Deals, words)
 
-	if homeURL != "" {
-		b.WriteString("\n" + words.WeeklyFullWeek + "\n  " + homeURL + "\n")
-	}
+	// The WEEKLY view, not the bare origin: this message is about a week, and
+	// the page it opened without the fragment was showing this morning.
+	mailcopy.Link(&b, homeURL, mailcopy.BriefWeeklyFragment, words.WeeklyFullWeek)
 	return b.String()
 }
 

--- a/backend/internal/compose/weekly/weeklymail_test.go
+++ b/backend/internal/compose/weekly/weeklymail_test.go
@@ -256,3 +256,42 @@ func TestTheLabelColumnIsSizedToTheLabelsItHas(t *testing.T) {
 func countLeadingSpaces(s string) int {
 	return len(s) - len(strings.TrimLeft(s, " "))
 }
+
+// The link opens the WEEK, not the morning.
+//
+// The app is one hash-routed page, so the view a link means lives after the
+// '#'. This message sent the reader to the bare origin, which opens the Brief
+// on its default view — so a Monday summary of last week landed them on today's
+// queue, with nothing on either page saying they had been sent to the wrong one.
+//
+// Asserted as the WHOLE closing address rather than as a substring: the origin
+// alone appears in both the right answer and the wrong one, which is why the
+// test above passed either way.
+func TestTheWeeklyLinkOpensTheWeek(t *testing.T) {
+	body := MailBody(mailFixture(), "https://crm.example.test", english)
+
+	const want = "https://crm.example.test/#/home?view=weekly"
+	if !strings.Contains(body, want) {
+		t.Errorf("the weekly message does not link to %q:\n%s", want, body)
+	}
+}
+
+// A trailing slash on the configured origin does not become a double one.
+func TestTheWeeklyLinkSurvivesATrailingSlash(t *testing.T) {
+	body := MailBody(mailFixture(), "https://crm.example.test/", english)
+
+	if strings.Contains(body, "test//#/") {
+		t.Errorf("the weekly link doubled the separator:\n%s", body)
+	}
+}
+
+// No origin, no line. An installation that has not been told its own public
+// address cannot produce a working link, and a label over an empty indent reads
+// as one that failed to render.
+func TestTheWeeklyOmitsTheLinkLineWithNoOrigin(t *testing.T) {
+	body := MailBody(mailFixture(), "", english)
+
+	if strings.Contains(body, english.WeeklyFullWeek) {
+		t.Errorf("the weekly wrote its link label with no address under it:\n%s", body)
+	}
+}

--- a/backend/internal/platform/mailcopy/link.go
+++ b/backend/internal/platform/mailcopy/link.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package mailcopy
+
+import "strings"
+
+// Link is the closing line every message ends with: a label, and the address it
+// names on its own indented line.
+//
+// ONE writer for both senders. The morning and the weekly each had their own
+// copy of the same four-part shape — blank line, label, two spaces, address —
+// differing only in which label they reached for, which is two answers to one
+// question and the thing this package exists to prevent.
+//
+// A blank base omits the whole line rather than writing a label over nothing.
+// An installation that has not been told its own public origin cannot produce a
+// working link, and a label followed by an empty indent reads as a link that
+// failed to render.
+//
+// FRAGMENT, NOT PATH. The app is a hash-routed single page, so the address of a
+// view lives after the '#'. Both mails linked to the bare origin before this,
+// which meant a rep opening the WEEKLY message landed on the morning — the
+// message is about a week the page it opened was not showing.
+func Link(b *strings.Builder, base, fragment, label string) {
+	if base == "" {
+		return
+	}
+	b.WriteString("\n" + label + "\n  " + strings.TrimSuffix(base, "/") + fragment + "\n")
+}
+
+// The Brief's two addresses, as a message must spell them.
+//
+// The morning is the view the Brief opens on, so it needs no parameter — its
+// address is the page itself, and frontend/src/screens/brief.view.ts writes
+// only what DIFFERS from that default. The weekly names itself.
+//
+// Held by backend/gates/mailbrieflink_test.go, which reads the view words out
+// of the frontend's own VIEWS list: a rename there without one here would leave
+// these links pointing at a view the app no longer answers to, and the app
+// falls back to the morning silently rather than erroring.
+const (
+	BriefMorningFragment = "/#/home"
+	BriefWeeklyFragment  = "/#/home?view=weekly"
+)

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (63)
+## Parity (64)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -60,6 +60,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `inboundsigningrecipe_test.go` | H3 | The signing scope is ONE invariant spelled on both sides of a wire. |
 | `issuelabels_test.go` | H3 | The label taxonomy is written down once and read from there. |
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |
+| `mailbrieflink_test.go` | H1 | The Brief's address is spelled twice: the frontend routes it (frontend/src/screens/brief.view.ts) and outbound mail links to it (internal/platform/mailcopy/link.go), because a message has to name a view before the app it opens is running. |
 | `mailcopy_test.go` | H2 | The weekly message's labels are the weekly PANEL's labels. |
 | `minorunitscale_test.go` | H3 | A currency's minor-unit scale — 100 for EUR, 1000 for KWD, 1 for VND — is one fact, and the table that holds it lives in shared/kernel/values. |
 | `modulecatalogtables_test.go` | H2 | The module catalog's Owns-tables column is the ownership map. |


### PR DESCRIPTION
Both mails linked to the **bare origin**. The app is one hash-routed page, so a link with no fragment opens the Brief on its *default* view — and a Monday summary of last week therefore landed the reader on this morning's queue, with nothing on either page saying they had been sent somewhere else.

The morning was right by accident: its view *is* the default. The weekly has been wrong every week since the dials shipped.

### The duplicated renderer

The link line was written twice, once in each sender, differing only in which label it reached for: blank line, label, two-space indent, address. It moves to `platform/mailcopy`, which exists precisely so senders do not each invent their own — its package comment says as much.

A trailing slash on the configured origin no longer produces a double separator.

### A new gate, because this pair drifts silently

`brief.view.ts` resolves an unknown view by **falling back to the morning**, deliberately, so a stale bookmark opens a working page rather than an error. A mail naming a renamed view therefore keeps "working": every reader lands on the morning, no test on either side fails, and nobody finds out.

`mailbrieflink_test.go` reads the frontend's own `VIEWS` list rather than restating it, and is mutation-checked in **both** directions — renaming the view in the mail, and renaming it in the frontend, each fail it. A third case holds that the morning's link names no view, since the frontend's own writer emits only what differs from the default.

### Why the existing tests missed it

They asserted that the **origin** appeared in the body — a substring the wrong answer satisfies too. That is why they passed identically before and after the fragment was added. They assert the whole address now.

### Not changed

`mailItemCap = 5`. The ledger item wanted the plan's 3, but 5 is an argued choice with its reasoning written beside it, and the plan's number is arbitrary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the weekly email link so it opens the weekly view instead of the default morning view. The link now includes the `view=weekly` fragment, and both senders use a shared helper in `mailcopy` to write the link line consistently.

**Bug Fixes**
- Fixes a trailing slash on the origin producing a double separator.
- Adds a gate test that ensures mailed view names still exist in the frontend's `VIEWS` list.

<sup>Written for commit 122c1ee029eb2bed5a2dd128e0d2f5589542fc67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email links to morning and weekly briefs now open the correct views.
  * Links remain valid when the application URL includes a trailing slash.
  * Email link lines are omitted when no application URL is configured.

* **Tests**
  * Added coverage to detect incorrect or outdated brief links in mailed content.

* **Documentation**
  * Updated the gate inventory to include the new link validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->