### PR TITLE
The weekly message closes by asking, not just reporting

### DIFF
--- a/backend/gates/mailcopy_test.go
+++ b/backend/gates/mailcopy_test.go
@@ -54,6 +54,10 @@ var mailLabelPairs = []struct {
 	{"home.weekly.decided", func(c mailcopy.Copy) string { return c.WeeklyDecided }},
 	{"home.weekly.queueWorked", func(c mailcopy.Copy) string { return c.WeeklyQueue }},
 	{"home.weekly.carriedOver", func(c mailcopy.Copy) string { return c.WeeklyCarried }},
+	// The planning question is the PANEL's heading. The mail asks it and the
+	// screen answers it, so two spellings would have the message invite
+	// something the page it opens does not offer under that name.
+	{"plan.title", func(c mailcopy.Copy) string { return c.WeeklyPlanAhead }},
 	{"home.weekly.outcome.won", func(c mailcopy.Copy) string { return c.WeeklyOutcomeWon }},
 	{"home.weekly.outcome.lost", func(c mailcopy.Copy) string { return c.WeeklyOutcomeLost }},
 	{"home.weekly.outcome.moved", func(c mailcopy.Copy) string { return c.WeeklyOutcomeMoved }},

--- a/backend/internal/compose/weekly/weeklymail.go
+++ b/backend/internal/compose/weekly/weeklymail.go
@@ -109,6 +109,17 @@ func MailBody(review Review, homeURL string, words mailcopy.Copy) string {
 
 	writeDealLines(&b, review.Deals, words)
 
+	// The message closes forward, not back.
+	//
+	// Everything above it reports a week that is over. Without a question the
+	// mail is a receipt — a rep reads their numbers, agrees with them and does
+	// nothing, while the panel the link opens is asking them to plan the next
+	// week. Asked in the PANEL's own words (mailcopy pairs it to plan.title),
+	// so the message invites exactly what the page it opens offers.
+	//
+	// It sits above the archive link because it is what the reader is being
+	// asked to do; the archive is where they go if they want the week before.
+	b.WriteString("\n" + words.WeeklyPlanAhead + "\n")
 	// The WEEKLY view, not the bare origin: this message is about a week, and
 	// the page it opened without the fragment was showing this morning.
 	mailcopy.Link(&b, homeURL, mailcopy.BriefWeeklyFragment, words.WeeklyFullWeek)

--- a/backend/internal/compose/weekly/weeklymail_test.go
+++ b/backend/internal/compose/weekly/weeklymail_test.go
@@ -295,3 +295,28 @@ func TestTheWeeklyOmitsTheLinkLineWithNoOrigin(t *testing.T) {
 		t.Errorf("the weekly wrote its link label with no address under it:\n%s", body)
 	}
 }
+
+// The message closes by asking, not just reporting.
+//
+// Every line above it is a week that is over. Without the question the mail is
+// a receipt: a rep reads their numbers, agrees with them, and does nothing —
+// while the panel behind the link is asking them to plan the next week.
+//
+// Asserted ABOVE the link, because the order is the argument: the question is
+// what the reader is being asked to do, and the archive line is where they go
+// if they want the week before instead.
+func TestTheWeeklyAsksAboutTheWeekAhead(t *testing.T) {
+	body := MailBody(mailFixture(), "https://crm.example.test", english)
+
+	asked := strings.Index(body, english.WeeklyPlanAhead)
+	if asked < 0 {
+		t.Fatalf("the weekly message never asks about the week ahead:\n%s", body)
+	}
+	link := strings.Index(body, english.WeeklyFullWeek)
+	if link < 0 {
+		t.Fatalf("the weekly message lost its archive line:\n%s", body)
+	}
+	if asked > link {
+		t.Errorf("the planning question sits below the archive link:\n%s", body)
+	}
+}

--- a/backend/internal/platform/mailcopy/catalog.go
+++ b/backend/internal/platform/mailcopy/catalog.go
@@ -163,6 +163,10 @@ func weeklyLines(line writeLine) {
 		"… and %d more, on Home",
 		"… weitere auf Home: %d",
 		"… và %d mục nữa, trên Home")
+	line(func(c *Copy) *string { return &c.WeeklyPlanAhead },
+		"Plan next week",
+		"Nächste Woche planen",
+		"Lập kế hoạch tuần tới")
 	line(func(c *Copy) *string { return &c.WeeklyFullWeek },
 		"The full week, and the ones before it:",
 		"Die ganze Woche, und die davor:",

--- a/backend/internal/platform/mailcopy/mailcopy.go
+++ b/backend/internal/platform/mailcopy/mailcopy.go
@@ -123,6 +123,11 @@ type Copy struct {
 	WeeklyWhatMoved string
 	WeeklyAndMore   string
 	WeeklyFullWeek  string
+	// The question the message closes on, in the panel's own words. The weekly
+	// mail reported the week and asked nothing, so it read as a receipt for
+	// work already done — while the screen it links to opens with a panel
+	// inviting the reader to plan the next one.
+	WeeklyPlanAhead string
 	// The three outcomes a deal line reports, lower-case because they are read
 	// inside a sentence rather than as a label.
 	WeeklyOutcomeWon   string


### PR DESCRIPTION
Every line of the weekly mail was a week that is over. Without a question it is a **receipt**: a rep reads their numbers, agrees with them, and does nothing — while the panel behind the link is asking them to plan the next week.

It now closes on that question, **above** the archive line, because the question is what the reader is being asked to do and the archive is where they go if they want the week before instead.

### Asked in the panel's own words

`mailcopy` pairs the new field to the frontend's `plan.title`, so the two cannot drift — the message invites exactly what the page it opens offers, in all three languages. That pairing is enforced by the existing `mailcopy_test.go` gate; mutation-checked by changing the German to "Woche planen", which fails naming both spellings.

### The ordering is asserted, not just the presence

Moving the question below the archive link fails the test. Removing it fails differently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The weekly mail now closes by asking the rep to plan the next week, instead of ending as a receipt of the week that just passed.

The question sits above the archive link and is worded identically to the planning panel's title, so the message invites exactly what the page it opens offers.

- Adds the `WeeklyPlanAhead` copy field, paired with the frontend's `plan.title` and covered by the existing `mailcopy_test.go` parity gate.
- The mail body and its test assert the question's position above the archive link, not just its presence.

<sup>Written for commit c49682f84e6860d0c3533a3d52ee100f9f26239e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly retrospective emails now include a localized prompt encouraging users to plan the upcoming week.
  * The prompt appears before the weekly archive link.
  * Added English, German, and Vietnamese translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->