### PR TITLE
An email shows the files that came with it

### DIFF
--- a/backend/internal/compose/integration/emailattachmentcount_integration_test.go
+++ b/backend/internal/compose/integration/emailattachmentcount_integration_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// What a list row says about the files that came with a message.
+//
+// The count was hardcoded to zero on every list projection, so the paperclip
+// the canonical row draws could never appear — on a timeline, in Search or on
+// the Worklist. These are the two claims that replaced it: a readable email
+// reports what it carries, and a withheld one reports nothing, because knowing
+// a contract arrived is knowing something about a message.
+
+import (
+	"context"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// seedAttachment files one document against a message, the way capture leaves
+// it. Written through the owner connection because the caller under test is a
+// READER — a test that wrote its fixture as the reader would prove the reader
+// can see its own writes and nothing about the projection.
+func seedAttachment(t *testing.T, activity ids.UUID, filename string) {
+	t.Helper()
+	if _, err := OwnerConn(t).Exec(context.Background(), `
+		INSERT INTO attachment (entity_type, entity_id, filename, storage_key, source, captured_by)
+		VALUES ('activity', $1, $2, $3, 'imap', 'connector:imap')`,
+		activity, filename, "seed/"+filename+"/"+activity.String()); err != nil {
+		t.Fatalf("seeding %s: %v", filename, err)
+	}
+}
+
+func rowFor(page []crmcontracts.Activity, id ids.UUID) *crmcontracts.EmailSummary {
+	for i := range page {
+		if ids.UUID(page[i].Id) == id {
+			return page[i].EmailSummary
+		}
+	}
+	return nil
+}
+
+// A readable email reports what came with it, and a message with nothing
+// attached reports zero rather than nothing at all.
+func TestAListRowCarriesItsRealAttachmentCount(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	subject, body := "The signed contract", "Attached, as agreed."
+	withFiles, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+		Kind: "email", Subject: &subject, Body: &body, Direction: strPtr("inbound"),
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+	})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	bare := "Just a note"
+	noFiles, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+		Kind: "email", Subject: &bare, Body: &body, Direction: strPtr("inbound"),
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+	})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	seedAttachment(t, ids.UUID(withFiles.Id), "contract.pdf")
+	seedAttachment(t, ids.UUID(withFiles.Id), "annex.pdf")
+
+	page, _, err := e.Activities.ListActivities(author, activities.ListActivitiesInput{
+		EntityType: strPtr("person"), EntityID: &contact,
+	})
+	if err != nil {
+		t.Fatalf("listing the timeline: %v", err)
+	}
+
+	carried := rowFor(page, ids.UUID(withFiles.Id))
+	if carried == nil {
+		t.Fatal("the message with files carried no email row at all")
+	}
+	if carried.AttachmentCount != 2 {
+		t.Errorf("attachment_count = %d, want 2 — the paperclip on the row is drawn from this, "+
+			"so a wrong number here is a badge that never appears", carried.AttachmentCount)
+	}
+	empty := rowFor(page, ids.UUID(noFiles.Id))
+	if empty == nil {
+		t.Fatal("the message without files carried no email row at all")
+	}
+	if empty.AttachmentCount != 0 {
+		t.Errorf("a message with nothing attached reported %d files", empty.AttachmentCount)
+	}
+}
+
+// A withheld row reports NO attachments, whatever came with the message.
+//
+// The file list is refused to a reader outside the audience, and the fact that
+// files exist is the same fact in smaller print: a colleague who sees "2 files"
+// beside a message they may not open has learned that a contract was exchanged.
+func TestAWithheldRowReportsNoAttachments(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	colleague := e.As(e.Rep3, []ids.UUID{e.Team2}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	subject, body := "Severance agreement", "The signed copy is attached."
+	logged, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+		Kind: "email", Subject: &subject, Body: &body, Direction: strPtr("outbound"),
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+	})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	id := ids.UUID(logged.Id)
+	seedAttachment(t, id, "severance.pdf")
+	seedAttachment(t, id, "annex.pdf")
+
+	// Admitted first, so the zero below is the audience's doing rather than a
+	// count that never worked.
+	open, _, err := e.Activities.ListActivities(colleague, activities.ListActivitiesInput{
+		EntityType: strPtr("person"), EntityID: &contact,
+	})
+	if err != nil {
+		t.Fatalf("colleague listing before limiting: %v", err)
+	}
+	if before := rowFor(open, id); before == nil || before.AttachmentCount != 2 {
+		t.Fatalf("the colleague saw %v before limiting; the withheld case below would prove nothing",
+			before)
+	}
+
+	if _, err := e.Activities.SetAudience(author, ids.From[ids.ActivityKind](id),
+		activities.SetAudienceInput{Audience: "participants"}); err != nil {
+		t.Fatalf("limiting: %v", err)
+	}
+
+	after, _, err := e.Activities.ListActivities(colleague, activities.ListActivitiesInput{
+		EntityType: strPtr("person"), EntityID: &contact,
+	})
+	if err != nil {
+		t.Fatalf("colleague listing after limiting: %v", err)
+	}
+	held := rowFor(after, id)
+	if held == nil {
+		t.Fatal("the withheld row vanished; it stays discoverable with its content removed")
+	}
+	if held.DisplayStatus != crmcontracts.EmailAccessStatusWithheld {
+		t.Fatalf("display_status = %q, want withheld", held.DisplayStatus)
+	}
+	if held.AttachmentCount != 0 {
+		t.Errorf("a withheld row told the colleague that %d files came with a message they may "+
+			"not read", held.AttachmentCount)
+	}
+
+	// The author is in the audience and still sees what they sent.
+	mine, _, err := e.Activities.ListActivities(author, activities.ListActivitiesInput{
+		EntityType: strPtr("person"), EntityID: &contact,
+	})
+	if err != nil {
+		t.Fatalf("author listing: %v", err)
+	}
+	if own := rowFor(mine, id); own == nil || own.AttachmentCount != 2 {
+		t.Errorf("the author lost the count on their own message: %v", own)
+	}
+}
+
+// The single read agrees with the list. Two projections of one row that
+// disagree about what came with a message is the drift this arc exists to
+// remove — a reader opening a record from two directions must see one answer.
+func TestTheSingleReadAgreesWithTheListAboutAttachments(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	subject, body := "The signed contract", "Attached, as agreed."
+	logged, _, err := e.Activities.LogActivity(author, activities.LogActivityInput{
+		Kind: "email", Subject: &subject, Body: &body, Direction: strPtr("inbound"),
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: contact}},
+	})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	id := ids.UUID(logged.Id)
+	seedAttachment(t, id, "contract.pdf")
+
+	one, err := e.Activities.GetActivity(author, ids.From[ids.ActivityKind](id), storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("single read: %v", err)
+	}
+	if one.EmailSummary == nil || one.EmailSummary.AttachmentCount != 1 {
+		t.Errorf("the single read reported %v, want one file", one.EmailSummary)
+	}
+}

--- a/backend/internal/compose/person360/sectionstimeline.go
+++ b/backend/internal/compose/person360/sectionstimeline.go
@@ -283,6 +283,14 @@ func (s *Service) readActivities(ctx context.Context, tx pgx.Tx, personID ids.Pe
 	if hasMore {
 		out = out[:sectionCap]
 	}
+	// AFTER the cap, so the statement counts the rows this page returns rather
+	// than the extra one read to detect hasMore. Same reason the summary above
+	// is composed from the shared helper: a person page whose mail showed no
+	// paperclip while the same rows off /activities showed one is the drift
+	// this twin exists to avoid.
+	if err := activities.WithAttachmentCounts(ctx, tx, out); err != nil {
+		return nil, false, err
+	}
 	return out, hasMore, nil
 }
 

--- a/backend/internal/modules/activities/activityread.go
+++ b/backend/internal/modules/activities/activityread.go
@@ -226,6 +226,11 @@ func ListActivitiesTx(ctx context.Context, tx pgx.Tx, in ListActivitiesInput) ([
 		// no way to act on. Rows beyond the cap still exist; CountOpenForViewer
 		// is the query that answers how many.
 	}
+	// What came with each message, on the same transaction and in one
+	// statement — the batching rule attachLinks above already follows.
+	if err := WithAttachmentCounts(ctx, tx, activities); err != nil {
+		return nil, storekit.Page{}, err
+	}
 	if err := attachLinks(ctx, tx, activities); err != nil {
 		return nil, storekit.Page{}, err
 	}
@@ -293,6 +298,9 @@ func readActivityRow(ctx context.Context, tx pgx.Tx, id ids.ActivityID, archived
 		return crmcontracts.Activity{}, err
 	}
 	one := []crmcontracts.Activity{a}
+	if err := WithAttachmentCounts(ctx, tx, one); err != nil {
+		return crmcontracts.Activity{}, err
+	}
 	if err := attachLinks(ctx, tx, one); err != nil {
 		return crmcontracts.Activity{}, err
 	}

--- a/backend/internal/modules/activities/attachmentcounts.go
+++ b/backend/internal/modules/activities/attachmentcounts.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// AttachmentCountsFor counts what came with each of these messages, in ONE
+// statement over the whole page.
+//
+// A count per row cost a round trip per visible line, which a timeline of
+// twenty turns into twenty statements and a search page of two hundred into
+// two hundred. The same batching rule the email-row reader follows.
+//
+// It carries NO gate of its own, and must only be called with ids a
+// content-gated read already admitted. The count is content: knowing that a
+// contract arrived with a message is knowing something about the message, so
+// the caller's own gate is what decides, exactly as readEmailAttachments is
+// reached only after its parent admitted the caller.
+//
+// An id absent from the map had no attachments, which is a count of zero.
+func AttachmentCountsFor(
+	ctx context.Context, tx pgx.Tx, activityIDs []ids.UUID,
+) (map[ids.UUID]int, error) {
+	if len(activityIDs) == 0 {
+		return map[ids.UUID]int{}, nil
+	}
+	rows, err := tx.Query(ctx, `
+		SELECT at.entity_id, count(*)
+		  FROM attachment at
+		 WHERE at.entity_type = 'activity' AND at.entity_id = ANY($1) AND at.archived_at IS NULL
+		 GROUP BY at.entity_id`, activityIDs)
+	if err != nil {
+		return nil, fmt.Errorf("activities: counting what came with a page of messages: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[ids.UUID]int, len(activityIDs))
+	for rows.Next() {
+		var id ids.UUID
+		var n int
+		if err := rows.Scan(&id, &n); err != nil {
+			return nil, fmt.Errorf("activities: scanning an attachment count: %w", err)
+		}
+		out[id] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("activities: counting what came with a page of messages: %w", err)
+	}
+	return out, nil
+}
+
+// applyAttachmentCounts stamps the counts onto the email rows of a page.
+//
+// WITHHELD ROWS ARE SKIPPED, and that is the whole reason this is a separate
+// pass rather than a field RowEmailSummary fills. A withheld summary returns
+// early with the content stripped, and a count written over it afterwards
+// would tell a colleague that a contract came with a message they may not
+// read — the file list is refused to them, and the fact that files exist is
+// the same fact in smaller print.
+func applyAttachmentCounts(page []crmcontracts.Activity, counts map[ids.UUID]int) {
+	for i := range page {
+		summary := page[i].EmailSummary
+		if summary == nil || summary.DisplayStatus == crmcontracts.EmailAccessStatusWithheld {
+			continue
+		}
+		summary.AttachmentCount = counts[ids.UUID(page[i].Id)]
+	}
+}
+
+// emailIDsOf answers the ids of the email rows on a page, which are the only
+// ones an attachment count is asked for: a call and a note carry no email row
+// to stamp, and a withheld one must not be stamped.
+func emailIDsOf(page []crmcontracts.Activity) []ids.UUID {
+	var out []ids.UUID
+	for i := range page {
+		summary := page[i].EmailSummary
+		if summary == nil || summary.DisplayStatus == crmcontracts.EmailAccessStatusWithheld {
+			continue
+		}
+		out = append(out, ids.UUID(page[i].Id))
+	}
+	return out
+}
+
+// WithAttachmentCounts fills the attachment count on every email row of a page
+// the caller's own gate already admitted.
+//
+// One statement, and none at all when the page carries no readable email.
+func WithAttachmentCounts(ctx context.Context, tx pgx.Tx, page []crmcontracts.Activity) error {
+	emailIDs := emailIDsOf(page)
+	if len(emailIDs) == 0 {
+		return nil
+	}
+	counts, err := AttachmentCountsFor(ctx, tx, emailIDs)
+	if err != nil {
+		return err
+	}
+	applyAttachmentCounts(page, counts)
+	return nil
+}

--- a/backend/internal/modules/activities/emailsummarybatch.go
+++ b/backend/internal/modules/activities/emailsummarybatch.go
@@ -91,22 +91,35 @@ func EmailSummariesByIDBatch(
 	}
 	defer rows.Close()
 
-	out := make(map[ids.UUID]crmcontracts.EmailSummary, len(activityIDs))
+	admitted := make([]crmcontracts.Activity, 0, len(activityIDs))
 	for rows.Next() {
 		var scan activityScan
 		if err := rows.Scan(activityScanTargets(&scan)...); err != nil {
 			return nil, fmt.Errorf("activities: scanning an email summary: %w", err)
 		}
-		activity := scan.record()
-		// RowEmailSummary rather than a second assembler: the row a search hit
-		// shows and the row a timeline shows are the same row, and two
-		// projections of it would drift the moment either grew a field.
-		if summary := RowEmailSummary(activity); summary != nil {
-			out[scan.id] = *summary
-		}
+		admitted = append(admitted, scan.record())
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("activities: reading email summaries for a page: %w", err)
+	}
+	// Collected first: the count runs a second statement on this transaction,
+	// which needs the cursor above already closed.
+	rows.Close()
+	if err := WithAttachmentCounts(ctx, tx, admitted); err != nil {
+		return nil, err
+	}
+
+	out := make(map[ids.UUID]crmcontracts.EmailSummary, len(activityIDs))
+	for _, activity := range admitted {
+		// RowEmailSummary rather than a second assembler: the row a search hit
+		// shows and the row a timeline shows are the same row, and two
+		// projections of it would drift the moment either grew a field.
+		// The summary the page carries is the row RECORD() already built,
+		// counts and all — not a second call to RowEmailSummary, which would
+		// rebuild it from the activity and drop the count just applied.
+		if activity.EmailSummary != nil {
+			out[ids.UUID(activity.Id)] = *activity.EmailSummary
+		}
 	}
 	return out, nil
 }

--- a/frontend/src/design-system/emaildetail.css
+++ b/frontend/src/design-system/emaildetail.css
@@ -70,3 +70,50 @@
   gap: var(--space-2);
   justify-content: space-between;
 }
+
+/* What came with the message. A list, not a grid: filenames run to very
+   different lengths and a column would either truncate the long ones or leave
+   a gutter beside the short ones. */
+.emaildetail__files {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--borderSubtle);
+}
+.emaildetail__filesLabel {
+  font-size: var(--fs-meta);
+  color: var(--textSecondary);
+}
+.emaildetail__fileList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  list-style: none;
+}
+.emaildetail__file {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+.emaildetail__file svg {
+  flex: none;
+  width: 14px;
+  height: 14px;
+  color: var(--textTertiary);
+}
+/* The filename truncates, the size does not: a size is four characters and
+   losing them tells the reader nothing, while a long filename is the thing
+   the row is about. */
+.emaildetail__file a {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.emaildetail__fileSize {
+  flex: none;
+  font-size: var(--fs-meta);
+  color: var(--textTertiary);
+}

--- a/frontend/src/design-system/emaildetail.test.tsx
+++ b/frontend/src/design-system/emaildetail.test.tsx
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+// What the email drawer shows about the files that came with a message.
+//
+// The server had been sending them all along and the drawer drew none of them:
+// a rep reading a message in the product could see that a contract was
+// mentioned and had no way to open it. These are the claims that replaced that.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { EmailDetail } from "./emaildetail";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const ACTIVITY = "01a05500-0000-7000-8000-0000000000a1";
+
+function presentation(over: Record<string, unknown> = {}) {
+  return {
+    id: ACTIVITY,
+    lifecycle: "delivered",
+    occurred_at: "2026-09-01T09:15:00Z",
+    summary: {
+      activity_id: ACTIVITY,
+      occurred_at: "2026-09-01T09:15:00Z",
+      version: 3,
+      subject: "The signed contract",
+      preview: "Attached, as agreed.",
+      display_status: "team",
+      move: "none",
+      attachment_count: 2,
+    },
+    body: "Attached, as agreed.",
+    thread_key: "t1",
+    from: [{ address: "dana@acme.test", display_name: "Dana Buyer" }],
+    to: [],
+    cc: [],
+    bcc: [],
+    bcc_withheld: false,
+    attachments: [
+      {
+        id: "01a05500-0000-7000-8000-0000000000f1",
+        filename: "contract.pdf",
+        byte_size: 248000,
+        content_type: "application/pdf",
+      },
+      {
+        id: "01a05500-0000-7000-8000-0000000000f2",
+        filename: "annex.pdf",
+        byte_size: null,
+        content_type: "application/pdf",
+      },
+    ],
+    links: [],
+    thread: { members: [], next_cursor: null },
+    access: {
+      content_state: "available",
+      audience: "workspace",
+      selected_members: [],
+      display_status: "team",
+      can_change: false,
+      change_mode: "message",
+      held_by_others: false,
+    },
+    can_reply: true,
+    can_relink: false,
+    version: 3,
+    ...over,
+  };
+}
+
+function stubRead(body: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ),
+  );
+}
+
+function draw(node: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{node}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function open() {
+  return (
+    <EmailDetail
+      activityId={ACTIVITY}
+      onClose={() => {}}
+      formatWhen={(iso) => iso}
+    />
+  );
+}
+
+describe("the email drawer's attachments", () => {
+  it("names each file and downloads it from the attachment endpoint", async () => {
+    stubRead(presentation());
+    draw(open());
+
+    await waitFor(() => expect(screen.getByText("contract.pdf")).toBeTruthy());
+    expect(screen.getByText("2 attachments")).toBeTruthy();
+
+    // The NAME is the download — the pattern the contact and account file
+    // lists already use, rather than a second action word at the end of a row.
+    const link = screen.getByText("contract.pdf") as HTMLAnchorElement;
+    expect(link.tagName).toBe("A");
+    expect(link.getAttribute("href")).toBe(
+      "/v1/attachments/01a05500-0000-7000-8000-0000000000f1",
+    );
+    expect(link.getAttribute("download")).toBe("contract.pdf");
+
+    // formatBytes' own scale: decimal units, so 248000 bytes is 248 kB. The
+    // second file's size was never recorded and is absent rather than drawn as
+    // zero bytes, which would be a claim about the file.
+    expect(screen.getByText("248 kB")).toBeTruthy();
+    expect(screen.queryByText(/0 byte/)).toBeNull();
+  });
+
+  it("draws no region for a message that carried nothing", async () => {
+    stubRead(
+      presentation({
+        attachments: [],
+        summary: {
+          ...presentation().summary,
+          attachment_count: 0,
+        },
+      }),
+    );
+    draw(open());
+
+    await waitFor(() =>
+      expect(screen.getByText("Attached, as agreed.")).toBeTruthy(),
+    );
+    // A heading over nothing says the message had files and they are missing,
+    // which is a different claim from having had none.
+    expect(screen.queryByText(/attachment/i)).toBeNull();
+  });
+
+  // The count is content. A reader outside the audience is told neither what
+  // the files are nor that any arrived — knowing a contract was exchanged is
+  // knowing something about the message.
+  it("tells a reader outside the audience nothing about the files", async () => {
+    // A HOSTILE fixture: withheld access alongside a full file list, which the
+    // server does not send. That is the point — the drawer's own check is what
+    // must refuse it, and a fixture that arrived already stripped would pass
+    // with no check at all.
+    stubRead(
+      presentation({
+        access: {
+          ...presentation().access,
+          content_state: "withheld",
+          display_status: "withheld",
+        },
+      }),
+    );
+    draw(open());
+
+    // Waits for the READ to land, not for the Modal: the dialog renders before
+    // the fetch resolves, so a wait on it asserts against a loading state and
+    // would pass however badly the loaded one behaved.
+    await waitFor(() =>
+      expect(screen.getByText("Not shared with you")).toBeTruthy(),
+    );
+    // Asked of document.body, NOT of render()'s container: Modal renders into
+    // a PORTAL, so the container is empty and every assertion made against it
+    // passes whatever the drawer draws. That mistake hid this very mutation.
+    expect(document.body.textContent).not.toContain("contract.pdf");
+    expect(document.body.textContent).not.toContain("annex.pdf");
+    expect(document.body.querySelector(".emaildetail__files")).toBeNull();
+    // Fails loudly if the fixture ever stops carrying files: this test's whole
+    // claim is that a PRESENT list is refused, and a fixture that quietly lost
+    // its attachments would assert nothing.
+    if (presentation().attachments.length === 0) {
+      throw new Error(
+        "the hostile fixture carries no files; the claim is vacuous",
+      );
+    }
+  });
+});

--- a/frontend/src/design-system/emaildetail.tsx
+++ b/frontend/src/design-system/emaildetail.tsx
@@ -2,13 +2,14 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import { useQuery } from "@tanstack/react-query";
-import { X } from "lucide-react";
+import { Paperclip, X } from "lucide-react";
 import { useId } from "react";
 
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { splitEmailBody } from "../format/emailtext";
-import { useT } from "../i18n";
+import { formatBytes, formatNumber } from "../format/format";
+import { translatePlural, useLocale, useT } from "../i18n";
 import { Button, Modal } from "./atoms";
 import { SurfaceState } from "./surfacestate";
 import "./emaildetail.css";
@@ -26,6 +27,7 @@ import "./emaildetail.css";
 
 type EmailPresentation = components["schemas"]["EmailPresentation"];
 type EmailParty = components["schemas"]["EmailParty"];
+type EmailAttachmentSummary = components["schemas"]["EmailAttachmentSummary"];
 
 /**
  * The key a message's canonical read is cached under. Exported because the
@@ -177,9 +179,61 @@ function EmailBody({
           <p>{parts.trimmed}</p>
         </details>
       )}
+      <Attachments files={presentation.attachments} />
       <p className="emaildetail__when">
         {formatWhen(presentation.occurred_at)}
       </p>
+    </div>
+  );
+}
+
+/**
+ * What came with the message.
+ *
+ * Reached only from the body above, which returns early for a withheld
+ * message — so a reader outside the audience is never told that a contract
+ * arrived, which is a fact about the message like any other.
+ *
+ * The NAME is the download, the pattern the account and contact file lists
+ * already use: a separate action word at the far end of the row is a second
+ * thing to find for the only thing this row does. The href is the attachment
+ * endpoint that has always served these bytes; nothing new is fetched here.
+ */
+function Attachments({ files }: Readonly<{ files: EmailAttachmentSummary[] }>) {
+  const { locale } = useLocale();
+  if (files.length === 0) {
+    // No empty region: a heading over nothing says the message had files and
+    // they are missing, which is a different claim from having had none.
+    return null;
+  }
+  return (
+    <div className="emaildetail__files">
+      <p className="emaildetail__filesLabel">
+        {translatePlural(locale, "email.detail.attachments", files.length, {
+          count: formatNumber(files.length, locale),
+        })}
+      </p>
+      <ul className="emaildetail__fileList">
+        {files.map((file) => (
+          <li key={file.id} className="emaildetail__file">
+            <Paperclip aria-hidden="true" />
+            <a
+              className="link-button"
+              href={`/v1/attachments/${file.id}`}
+              download={file.filename}
+            >
+              {file.filename}
+            </a>
+            {/* Absent rather than zero when the server sent no size: a size it
+                could not record is not a file of no bytes. */}
+            {file.byte_size != null && (
+              <span className="emaildetail__fileSize">
+                {formatBytes(file.byte_size, locale)}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1509,6 +1509,8 @@ export const de = {
   "email.move.waitingForThem": "Warten auf Antwort",
   "email.detail.loading": "Nachricht wird geöffnet",
   "email.detail.none": "Diese Nachricht",
+  "email.detail.attachments_one": "{count} Anhang",
+  "email.detail.attachments_other": "{count} Anhänge",
   "email.detail.showQuoted": "Zitierten Verlauf anzeigen",
   "email.detail.close": "Schließen",
   "email.detail.withheldReason":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1563,6 +1563,8 @@ export const en = {
   "email.move.waitingForThem": "Waiting for them",
   "email.detail.loading": "Opening the message",
   "email.detail.none": "This message",
+  "email.detail.attachments_one": "{count} attachment",
+  "email.detail.attachments_other": "{count} attachments",
   "email.detail.showQuoted": "Show quoted history",
   "email.detail.close": "Close",
   "email.detail.withheldReason": "This message is not shared with you",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1503,6 +1503,8 @@ export const vi = {
   "email.move.waitingForThem": "Đang chờ họ",
   "email.detail.loading": "Đang mở thư",
   "email.detail.none": "Thư này",
+  "email.detail.attachments_one": "{count} tệp đính kèm",
+  "email.detail.attachments_other": "{count} tệp đính kèm",
   "email.detail.showQuoted": "Hiện phần trích dẫn",
   "email.detail.close": "Đóng",
   "email.detail.withheldReason": "Thư này không được chia sẻ với bạn",


### PR DESCRIPTION
Ninth slice of the email display unification arc — added at Lars's request after he noticed attachments were nowhere in the product.

## The gap

Attachments were nowhere on a message, and the reason was not that the plumbing was missing. Capture stores them (`activities/capturedfiles.go`), `/attachments/{id}` serves the bytes, `EmailPresentation` already carried `filename`, `byte_size` and `content_type` over the wire — and `emaildetail.tsx` rendered none of it. A rep could read that a contract was attached and had no way to open it.

## The dead badge

Worse, and mine: **`AttachmentCount` was set only by the detail read.** `RowEmailSummary` — the projection behind every list row — never set it, so the paperclip I put on `EmailEntry` in #3804 could not appear on a timeline, in Search or on the Worklist.

The row's own unit test fixtured `attachment_count: 2` and passed the whole time. Green gates over unreachable code, which is exactly the pattern the rulebook's "a census that can fail short has already failed" warns about.

## What changed

- **`activities/attachmentcounts.go`** (new) — one statement per page, beside the `attachLinks` query that already batches this way. Wired into `ListActivitiesTx`, the single read, the email-row batch reader (Search + Worklist) and `person360`'s hand-written timeline twin, which the file's own comment warns is the one read that can make the contract false.
- **`emaildetail.tsx`** — an attachments region. The **name is the download**, reusing the pattern from `personfiles.tsx:150` rather than inventing a path. `formatBytes` already existed. A message with nothing attached draws no region, because a heading over nothing claims the files are missing.
- Three i18n catalogs, pluralised through the existing `translatePlural`.

## Privacy: the count is content

A withheld row reports **zero**, however many files came with the message. A colleague who sees "2 files" beside a severance agreement they may not open has learned that a contract was exchanged. Refused in two places — the projection skips withheld rows, the drawer returns before the body — and both refusals are mutation-checked.

The drawer test uses a **hostile fixture**: withheld access alongside a full file list, a shape the server never sends. That is the point — the drawer's own check must refuse it, and a fixture that arrived already stripped would pass with no check at all.

## A test lesson worth keeping

The first version of that privacy test **passed with the guard deleted**. `Modal` renders through a portal, so the `container` that `render()` returns is empty and every assertion made against it passes whatever the drawer draws. It asks `document.body` now. Recorded because the same mistake is available to anyone testing a modal in this tree.

## Tests

Integration: `TestAListRowCarriesItsRealAttachmentCount` (mutation-checked against the old hardcoded zero — the badge goes from unreachable to reachable), `TestAWithheldRowReportsNoAttachments` (admitted first, so the zero is the audience's doing), `TestTheSingleReadAgreesWithTheListAboutAttachments`.

Frontend: each file named and downloadable, a recorded size shown and an unrecorded one absent rather than "0 bytes", no region when nothing came, and nothing at all disclosed to a reader outside the audience.

## Deliberately not here

Inline preview of images and PDFs. What renders inline versus downloads is a design question rather than a gap, and it would have made this a different change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the files that came with an email for the first time and makes the attachment-count badge on list rows real — it was only set by the detail read, so it never appeared on a timeline, in Search, or on the Worklist.

**Backend**
- Adds a batched, one-statement-per-page count query wired into every read path, including `person360`'s timeline twin.
- Withheld rows report zero attachments: the count is content, so knowing a contract arrived is never disclosed.

**Frontend**
- The message drawer lists each file with the filename as the download link and the recorded size.
- Draws no attachments region when nothing came, and shows nothing at all to a reader outside the audience.

<sup>Written for commit 01ee3d56f7156210df5506dd8202ff26540aae64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Email details now display attachment counts, filenames, download links, file icons, and sizes.
  - Attachment information is available in activity lists and individual activity views when permitted.
  - Added localized attachment-count text in English, German, and Vietnamese.
- **Bug Fixes**
  - Attachment counts now accurately reflect available files across activity views.
  - Restricted email rows and details no longer expose attachment information to unauthorized viewers.
  - Empty emails correctly show no attachment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->