### PR TITLE
The week says what its wins were worth

### DIFF
--- a/frontend/src/screens/home.weekly.test.tsx
+++ b/frontend/src/screens/home.weekly.test.tsx
@@ -81,6 +81,53 @@ describe("HomeScreen — the weekly retrospective", () => {
     expect(screen.getByText(en["home.weekly.promised"])).toBeTruthy();
   });
 
+  // What the wins were WORTH, beside how many there were.
+  //
+  // The count alone says a week of five small renewals and a week of one
+  // company-making deal are the same week. The money was computed, converted
+  // and stored — and read by no screen until now.
+  it("says what the week's wins were worth", async () => {
+    stubApi({
+      "GET /weekly-reviews/latest": () =>
+        jsonResponse({
+          ...review,
+          pipeline: {
+            created_minor: 4500000,
+            won_minor: 1250000,
+            lost_minor: 0,
+            currency: "EUR",
+          },
+        }),
+      "GET /weekly-reviews": () => jsonResponse({ weeks: ["2026-06-29"] }),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    render(<HomeScreen />);
+
+    // The review's OWN currency, not the installation's current setting: base
+    // currency is operator-mutable, and re-reading it would re-label an old
+    // week with a currency its numbers were never in.
+    expect(await screen.findByText(/12.500,00\s*€|€12,500\.00/)).toBeTruthy();
+  });
+
+  // And a week with no pipeline block draws no money at all.
+  //
+  // The block is optional on the wire — a week assembled before the money
+  // columns existed, or one whose FX rate was missing, has no honest figure.
+  // "0 €" is a claim about a week nobody measured.
+  it("draws no money for a week that carries none", async () => {
+    stubApi({
+      "GET /weekly-reviews/latest": () => jsonResponse(review),
+      "GET /weekly-reviews": () => jsonResponse({ weeks: ["2026-06-29"] }),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    render(<HomeScreen />);
+
+    await screen.findByText("Weber Rahmenvertrag");
+    const strip = document.querySelector('[data-testid="weekly-strip"]');
+    expect(strip).not.toBeNull();
+    expect(strip?.textContent ?? "").not.toMatch(/€|EUR/);
+  });
+
   it("says there is no review yet rather than drawing a week of zeroes", async () => {
     stubApi({
       "GET /weekly-reviews/latest": () =>

--- a/frontend/src/screens/home.weekly.tsx
+++ b/frontend/src/screens/home.weekly.tsx
@@ -9,8 +9,13 @@ import { Select } from "../design-system/select";
 import { StatStrip } from "../design-system/statstrip";
 import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { ProvenanceTag } from "../design-system/trust";
-import { formatDate, formatNumber, formatSignedNumber } from "../format/format";
-import { useLocale, useT } from "../i18n";
+import {
+  formatDate,
+  formatMoney,
+  formatNumber,
+  formatSignedNumber,
+} from "../format/format";
+import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
   useWeeklyReview,
@@ -207,6 +212,27 @@ function readState(
   return query.isPending ? "loading" : "ready";
 }
 
+/**
+ * What the week's wins were worth, or nothing.
+ *
+ * NOTHING, not a zero, when the review carries no pipeline block. That block is
+ * optional on the wire: a week assembled before the money columns existed, or
+ * one where an FX rate was missing, has no honest figure — and "€0 won" is a
+ * claim about a week nobody measured, which is the opposite of what happened.
+ *
+ * The currency comes from the review, never from the installation's current
+ * setting. Base currency is operator-mutable, so re-reading it later would
+ * re-label an old week with a currency its numbers were never in. The contract
+ * stores it beside the figures for exactly this reason.
+ */
+function wonValue(review: WeeklyReview, locale: Locale): string | undefined {
+  const pipeline = review.pipeline;
+  if (pipeline === undefined) {
+    return undefined;
+  }
+  return formatMoney(pipeline.won_minor, pipeline.currency, locale);
+}
+
 function WeeklyBody({
   review,
   state,
@@ -276,7 +302,21 @@ function WeeklyBody({
         <StatCard
           label={t("home.weekly.dealsWon")}
           value={formatNumber(c.deals_won, locale)}
-          detail={since(c.deals_won, prior?.deals_won)}
+          // What those wins were WORTH, at each deal's own close-time rate.
+          //
+          // The count alone says a week of five small renewals and a week of
+          // one company-making deal are the same week. The money was computed,
+          // FX-converted, stored with the currency it is in, and served — and
+          // read by nothing until now.
+          //
+          // It rides the won slot rather than taking a sixth: five is what a
+          // strip can be read across as one comparison, and a tenth slot folded
+          // the row into two ranks at 1280 (#3709). The delta line gives way to
+          // it, because "what it was worth" is the fact a reader wants first
+          // and the strip has one detail line to give.
+          detail={
+            wonValue(review, locale) ?? since(c.deals_won, prior?.deals_won)
+          }
         />
         <StatCard
           label={t("home.weekly.leadsAnswered")}


### PR DESCRIPTION
`WeeklyReview.pipeline` is computed, FX-converted, stored with the currency it is in, served on the wire, and present in the generated frontend types — and was **read by no screen at all**.

So the weekly strip reported "Deals won: 1", which says a week of five small renewals and a week of one company-making deal are the same week.

### Where it goes

The won slot now carries the money beneath its count. It rides that slot rather than taking a sixth: five is what a strip can be read across as one comparison, and a tenth slot folded the row into two ranks at 1280 (#3709). The delta line gives way to it — what a win was worth is the fact a reader wants first, and the strip has one detail line to give.

### Two honesty rules

**A review with no pipeline block draws no money, not a zero.** The block is optional on the wire: a week assembled before the money columns existed, or one whose FX rate was missing, has no honest figure. "0 EUR won" is a claim about a week nobody measured.

**The currency comes from the review, never from the installation's current setting.** Base currency is operator-mutable, so re-reading it later would re-label an old week with a currency its numbers were never in. The contract stores it beside the figures for exactly that reason.

### Proof

Both mutation-checked. Dropping the money fails the money test. Rendering a zero-with-guessed-currency instead of nothing fails the absence test **and** the pre-existing delta test — which is what proves the fallback still reaches `since()` when there is no money to show.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the weekly “Deals won” card to show the review’s won pipeline value beneath the count instead of the period delta when pipeline data is available. Reviews without pipeline data keep the existing delta fallback and never display a fabricated zero.

- Uses the currency stored on each review rather than the installation’s current setting.
- Adds coverage for displayed won value and missing pipeline data.

<sup>Written for commit c4241c4e08d1c272647d3eaae929f6c91d86a552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Weekly review deal-won statistics now display the total pipeline value won, formatted in the review’s currency.
  - When pipeline value isn’t available, the statistic falls back to the change in deals won from the previous week.

- **Bug Fixes**
  - Monetary output is now omitted when no pipeline data exists.
  - Added localized currency formatting for weekly review values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->