### PR TITLE
The meeting brief reads what was said last

### DIFF
--- a/backend/internal/compose/meetingbrief/excerpts.go
+++ b/backend/internal/compose/meetingbrief/excerpts.go
@@ -23,6 +23,8 @@ package meetingbrief
 import (
 	"context"
 	"fmt"
+	"slices"
+	"sort"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -113,12 +115,21 @@ func (s *Service) readExcerpts(
 // excerptTargets picks which activities are worth a body read: the first and
 // last of each ranked moment's threads, which between them carry how a
 // conversation opened and where it landed.
+//
+// NEWEST THREAD FIRST within a moment, because the budget is six threads and a
+// moment can hold more. Threads reach here oldest-first — threadsOf sorts by
+// First and clusterThreads keeps that order — so the cap used to spend itself
+// on the oldest conversations present: an account touched anywhere inside
+// arcGapDays collapses into ONE moment, and a note written minutes before the
+// meeting sat thirteenth in that walk with its body never read. The model was
+// handed four fortnight-old invitation threads and the new note's subject line
+// alone, which reads exactly like a brief that ignored it.
 func excerptTargets(moments []ArcMoment) []string {
 	var wanted []string
 	seen := map[string]bool{}
 	threadsTaken := 0
 	for _, moment := range moments {
-		for _, current := range moment.Threads {
+		for _, current := range threadsNewestFirst(moment.Threads) {
 			if len(current.IDs) == 0 {
 				continue
 			}
@@ -135,6 +146,18 @@ func excerptTargets(moments []ArcMoment) []string {
 		}
 	}
 	return wanted
+}
+
+// threadsNewestFirst orders a moment's threads by their last message, latest
+// first, on a COPY: the arc renders the same moments in their own order, and
+// sorting in place would reorder the story a reader is shown to suit this
+// budget.
+func threadsNewestFirst(threads []thread) []thread {
+	ordered := slices.Clone(threads)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Last.After(ordered[j].Last)
+	})
+	return ordered
 }
 
 // pickRows takes the ends of a thread and, when there is room, the messages

--- a/backend/internal/compose/meetingbrief/excerpts_test.go
+++ b/backend/internal/compose/meetingbrief/excerpts_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package meetingbrief
+
+import (
+	"slices"
+	"testing"
+)
+
+// The excerpt budget is six threads, and a moment can hold more. What a reader
+// preparing for a meeting needs is what was said LAST, so the six that get
+// their bodies read are the six most recent.
+//
+// The shape here is the one that produced the bug: a fortnight of calendar
+// invitations, then a note written minutes before the meeting. Every row sits
+// inside arcGapDays, so clusterThreads folds them into ONE moment and the cap
+// is decided purely by walk order.
+func TestTheNewestConversationIsExcerptedBeforeTheOldest(t *testing.T) {
+	var history []HistoryIn
+	for i := range 8 {
+		history = append(history, mail(
+			"invite-"+string(rune('a'+i)), i+1,
+			"Invitation: Forum "+string(rune('a'+i)), "inbound"))
+	}
+	note := HistoryIn{ID: "the-note", Kind: "note", Subject: "CRM", At: at(9)}
+	history = append(history, note)
+
+	moments := clusterThreads(threadsOf(history))
+	if len(moments) != 1 {
+		t.Fatalf("moments = %d, want 1 — every row is inside arcGapDays", len(moments))
+	}
+	targets := excerptTargets(moments)
+	if !slices.Contains(targets, note.ID) {
+		t.Errorf("the note's body was never read: targets = %v", targets)
+	}
+	if len(targets) > excerptThreads*excerptRowsPerThread {
+		t.Errorf("targets = %d, want at most %d — the budget still binds",
+			len(targets), excerptThreads*excerptRowsPerThread)
+	}
+}
+
+// The cap is what makes the order matter: with more threads than budget, the
+// oldest are the ones dropped, not the newest.
+func TestTheOldestConversationsAreWhatTheBudgetDrops(t *testing.T) {
+	var history []HistoryIn
+	for i := range excerptThreads + 2 {
+		history = append(history, mail(
+			"thread-"+string(rune('a'+i)), i+1,
+			"Subject "+string(rune('a'+i)), "inbound"))
+	}
+	targets := excerptTargets(clusterThreads(threadsOf(history)))
+	if slices.Contains(targets, "thread-a") {
+		t.Errorf("the oldest thread was excerpted over a newer one: %v", targets)
+	}
+	if !slices.Contains(targets, "thread-h") {
+		t.Errorf("the newest thread was not excerpted: %v", targets)
+	}
+}
+
+// Ordering for the budget must not reorder the arc a reader is shown. The
+// moment keeps the threads in the order it was built with.
+func TestPickingExcerptsLeavesTheMomentsOwnOrderAlone(t *testing.T) {
+	history := []HistoryIn{
+		mail("older", 1, "First", "inbound"),
+		mail("newer", 5, "Second", "outbound"),
+	}
+	moments := clusterThreads(threadsOf(history))
+	before := make([]string, 0, len(moments[0].Threads))
+	for _, current := range moments[0].Threads {
+		before = append(before, current.Key)
+	}
+	excerptTargets(moments)
+	for i, current := range moments[0].Threads {
+		if current.Key != before[i] {
+			t.Fatalf("moment thread %d = %q, want %q — the arc's order moved",
+				i, current.Key, before[i])
+		}
+	}
+}


### PR DESCRIPTION
## What was wrong

The meeting brief's excerpt pass picked which conversations get their bodies read by walking each moment's threads in order and stopping at six. Threads arrive oldest-first (`threadsOf` sorts on `First`, `clusterThreads` preserves it), and any account touched anywhere inside `arcGapDays=21` folds into a single moment — so the six *oldest* conversations spent the whole budget.

Found on a real contact: a note written minutes before the meeting, saying what the other side wanted to discuss, sat thirteenth in that walk. The model received four fortnight-old Google Calendar invitation threads and the note's subject line ("CRM") with none of its body. The brief read exactly as though the note had been ignored, which is how it was reported.

## The fix

`excerptTargets` now orders each moment's threads newest-first (by `thread.Last`) before applying the `excerptThreads` cap. The sort runs on a `slices.Clone` copy, because the arc renders the same moments in their own order and sorting in place would reorder the story a reader is shown to suit this budget.

`rankMoments` was considered and deliberately not added here: it reorders whole moments, and the starvation is *within* one moment. It also cannot be called at this site — `readExcerpts` runs inside the transaction, before `Input` exists.

## Tests

Three, in a new `excerpts_test.go`, driven through the real pipeline (`threadsOf` → `clusterThreads` → `excerptTargets`) rather than hand-built moments:

- the newest conversation is excerpted, on the exact shape that produced the bug
- the budget drops the oldest threads, not the newest
- picking excerpts leaves the moment's own order alone

Mutation-checked: reverting the sort fails the first two, and the failure output reproduces the original bug (six invite threads, note absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the meeting brief's excerpt pass reading threads oldest-first, so a note written minutes before the meeting was never read because the six-thread budget went to older conversations. Excerpts now take the six newest threads per moment, on a copy so the arc a reader sees keeps its own order.

**Bug Fixes**
- Orders each moment's threads by last message before the six-thread cap.
- Adds tests through the real pipeline covering the reported bug, the oldest threads being dropped, and order preservation.

<sup>Written for commit 961aa1562b374b4ce88d227d86a093dd65f1bde6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Meeting briefs now prioritize the most recent conversations when selecting excerpts.
  * Conversation ordering remains unchanged in the displayed meeting brief.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->