### PR TITLE
An audience change reaches every record the message is filed against

### DIFF
--- a/frontend/src/screens/activitykeys.test.ts
+++ b/frontend/src/screens/activitykeys.test.ts
@@ -4,6 +4,7 @@ import {
   dealWinKeys,
   derivedRecordKeys,
   entityTimelineKeys,
+  showsAMessage,
   taskWriteKeys,
 } from "./activitykeys";
 
@@ -87,5 +88,51 @@ describe("which reads a write to the record itself invalidates", () => {
 
   it("names nothing for a record kind with no derived read", () => {
     expect(derivedRecordKeys("person", "p1")).toEqual([]);
+  });
+});
+
+// A message is filed against several records, and the client is never told
+// which: the audience answer names activities, not the records they hang off.
+// So the reads that could be drawing a changed message are found by SHAPE, and
+// the shape has to be wide enough to catch every timeline and narrow enough not
+// to re-read the whole app.
+describe("which reads could be showing a message", () => {
+  const matches = (key: unknown[]) => showsAMessage({ queryKey: key });
+
+  it("matches every record's timeline, not only the one on screen", () => {
+    expect(matches(["activities", "deal", "d1"])).toBe(true);
+    expect(matches(["activities", "person", "p1"])).toBe(true);
+    // Narrowed and paged reads hang further keys off the same prefix, and they
+    // draw the same messages.
+    expect(matches(["activities", "person", "p1", { kind: "email" }])).toBe(
+      true,
+    );
+  });
+
+  it("matches the composite reads that carry a timeline's first page", () => {
+    expect(matches(["organization360", "o1"])).toBe(true);
+    expect(matches(["person360", "p1"])).toBe(true);
+    expect(matches(["project", "j1", "360"])).toBe(true);
+  });
+
+  it("matches the canonical email read, which a drawer's thread page also carries", () => {
+    // The anchor message may not be the one that changed: a presentation
+    // embeds a page of thread-member summaries, and one of those can be.
+    expect(matches(["email-presentation", "a1"])).toBe(true);
+  });
+
+  it("matches what a timeline is derived into", () => {
+    expect(matches(["deal-status", "d1"])).toBe(true);
+  });
+
+  it("leaves reads that carry no message alone", () => {
+    // The project RECORD, which is the same head as its 360 payload and two
+    // segments long. Matching it would re-read every project page in the cache
+    // for a change that cannot have touched one.
+    expect(matches(["project", "j1"])).toBe(false);
+    expect(matches(["deal", "d1"])).toBe(false);
+    expect(matches(["deals"])).toBe(false);
+    expect(matches(["tasks"])).toBe(false);
+    expect(matches(["held-threads"])).toBe(false);
   });
 });

--- a/frontend/src/screens/activitykeys.ts
+++ b/frontend/src/screens/activitykeys.ts
@@ -127,6 +127,58 @@ export function dealWinKeys(
   return keys;
 }
 
+// ── Every timeline, not one record's ────────────────────────────────────────
+
+// A change to who may read a MESSAGE reaches every record the message is filed
+// against, and the client is not told which those are: the server names the
+// activities a decision touched, and `Activity.links` is not on that answer —
+// putting a record list on a privacy response for the sake of a cache is the
+// wrong trade. So the reads that could be showing the old audience are found by
+// their SHAPE instead of by their record.
+//
+// It is a wide invalidation and that is affordable here, not everywhere: an
+// audience change is a deliberate, rare human act, and react-query refetches
+// only the queries that are actually mounted — the rest are marked stale and
+// re-read when something asks for them.
+//
+// The shapes are derived from the tables above rather than listed again, so a
+// record kind that grows a timeline read joins this by being added there. A
+// second list would go stale exactly the way the record-scoped invalidation it
+// replaces did, and just as quietly.
+const SHAPE_ID = "\u0000id";
+
+// Every key shape that draws a message: the per-record timelines, the composite
+// 360 payloads that carry their first page, the reads derived from a timeline,
+// and the canonical email read itself — a drawer's thread-member page can carry
+// a message the reader did not open and did not change.
+function messageBearingShapes(): unknown[][] {
+  const shapes: unknown[][] = [["activities"], ["email-presentation"]];
+  for (const seed of Object.values(TIMELINE_SEED_KEYS)) {
+    shapes.push(seed(SHAPE_ID) as unknown[]);
+  }
+  for (const derived of Object.values(DERIVED_FROM_TIMELINE)) {
+    shapes.push(derived(SHAPE_ID) as unknown[]);
+  }
+  return shapes;
+}
+
+/**
+ * Whether a cached read could be showing a message whose audience just changed.
+ *
+ * Matched as a PREFIX with the id position wild, so `["activities", …]` covers
+ * every record's timeline while `["project", id, "360"]` covers the project
+ * 360 payload without also matching `["project", id]` — the project record
+ * itself, which carries no message and does not need re-reading.
+ */
+export function showsAMessage(query: { queryKey: QueryKey }): boolean {
+  const key = query.queryKey as unknown[];
+  return messageBearingShapes().some(
+    (shape) =>
+      key.length >= shape.length &&
+      shape.every((segment, at) => segment === SHAPE_ID || segment === key[at]),
+  );
+}
+
 // The canonical email read's key belongs to the component that reads under it,
 // so this is a re-export rather than a second spelling. Two copies of a cache
 // key do not fail loudly: they fail as a drawer that quietly stops refreshing

--- a/frontend/src/screens/audienceservice.test.tsx
+++ b/frontend/src/screens/audienceservice.test.tsx
@@ -10,13 +10,13 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { emailPresentationKey } from "./activitykeys";
 import { useThreadAudience } from "./audienceservice";
 
 // A thread decision changes several messages at once, and they are filed
 // against whatever records each one touches. The caller names what its own
-// screen has to refresh; the service refreshes the messages the server says
-// were reached, because no caller can know that list and every caller needs it.
+// screen has to refresh; the service refreshes every read that could be drawing
+// one of those messages, because no caller can know which records they are on —
+// the answer names ACTIVITIES, and `Activity.links` is deliberately not on it.
 //
 // The failure this guards is quiet: the row you pressed updates, the same
 // message on another record keeps showing the audience it had before, and the
@@ -42,6 +42,18 @@ function Harness({ onDone }: Readonly<{ onDone?: () => void }>) {
   );
 }
 
+// The reads a reader could have open elsewhere while they press release here:
+// another record's timeline, the composite payload that carries a contact's
+// first page, and a drawer anchored on a message this decision never named.
+const ELSEWHERE = [
+  ["activities", "deal", "d-1"],
+  ["person360", "p-9"],
+  ["email-presentation", "33333333-3333-4333-8333-333333333333"],
+];
+
+// And the reads that carry no message, which a release must leave alone.
+const UNTOUCHED = [["project", "j-1"], ["deals"]];
+
 function renderHarness(body: unknown) {
   vi.stubGlobal(
     "fetch",
@@ -56,13 +68,19 @@ function renderHarness(body: unknown) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  // Cached rather than spied on: what matters is that these reads end up
+  // needing to be re-read, not which call did it. A spy on invalidateQueries
+  // would pass for a predicate that matched nothing.
+  for (const key of [...ELSEWHERE, ...UNTOUCHED]) {
+    client.setQueryData(key, { drawn: "before the release" });
+  }
   const spy = vi.spyOn(client, "invalidateQueries");
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
   const done = vi.fn();
   render(<Harness onDone={done} />, { wrapper });
-  return { spy, done };
+  return { spy, done, client };
 }
 
 afterEach(() => {
@@ -72,9 +90,9 @@ afterEach(() => {
 });
 
 describe("useThreadAudience", () => {
-  it("refreshes every message the decision reached, not only the caller's own screen", async () => {
+  it("refreshes other records' timelines, not only the caller's own screen", async () => {
     const user = userEvent.setup();
-    const { spy, done } = renderHarness({
+    const { spy, done, client } = renderHarness({
       messages: 2,
       shared: true,
       held_by_others: 0,
@@ -84,14 +102,21 @@ describe("useThreadAudience", () => {
     await user.click(screen.getByRole("button", { name: "release" }));
     await waitFor(() => expect(done).toHaveBeenCalled());
 
+    // The caller's own key, because the queue it sits in has to reload.
     const invalidated = spy.mock.calls.map(([arg]) =>
       JSON.stringify(arg?.queryKey),
     );
-    // The caller's own key, because the queue it sits in has to reload.
     expect(invalidated).toContain(JSON.stringify(["held-threads"]));
-    // And every message the server named, wherever else it is mounted.
-    for (const id of REACHED) {
-      expect(invalidated).toContain(JSON.stringify(emailPresentationKey(id)));
+
+    // And every read that could be drawing one of the changed messages,
+    // whichever record it is filed against. None of these is the screen the
+    // press happened on, and none of them is named by the answer.
+    for (const key of ELSEWHERE) {
+      expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+    }
+    // A release is not a reason to re-read the whole cache.
+    for (const key of UNTOUCHED) {
+      expect(client.getQueryState(key)?.isInvalidated).toBe(false);
     }
   });
 

--- a/frontend/src/screens/audienceservice.ts
+++ b/frontend/src/screens/audienceservice.ts
@@ -19,7 +19,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
-import { emailPresentationKey } from "./activitykeys";
+import { showsAMessage } from "./activitykeys";
 import { throwProblem } from "./common";
 
 type ThreadAudienceOutcome = components["schemas"]["ThreadAudienceOutcome"];
@@ -47,11 +47,13 @@ export type ThreadAudienceResult = {
  * held-threads queue refreshes the queue. The WRITE is the same either way,
  * which is why it is here and that is not.
  *
- * What every caller shares is the messages the decision actually reached — the
- * server names them — so those are refreshed here rather than left to each
- * caller to remember. A thread decision changes several messages filed against
- * several records, and refreshing only the one on screen leaves the rest
- * showing the audience they had before the press.
+ * What every caller shares is that a decision reaches messages filed against
+ * records this screen is not on — so every read that could be drawing one is
+ * refreshed here rather than left to each caller to remember. Refreshing only
+ * the record on screen left the same message on a colleague's contact page, or
+ * on the deal it also hangs off, still saying "Everyone in the organization"
+ * until a reload: the change did happen, and the second page was quietly wrong
+ * about it, which is the harder version to trust.
  */
 export function useThreadAudience(options: {
   invalidate: (result: ThreadAudienceResult) => QueryKey[];
@@ -77,11 +79,10 @@ export function useThreadAudience(options: {
       for (const queryKey of options.invalidate(result)) {
         queryClient.invalidateQueries({ queryKey });
       }
-      for (const activityId of result.outcome?.activity_ids ?? []) {
-        queryClient.invalidateQueries({
-          queryKey: emailPresentationKey(activityId),
-        });
-      }
+      // Every read that could be drawing one of the changed messages, not the
+      // ones the answer names: the outcome names ACTIVITIES and the client is
+      // never told which records they are filed against.
+      queryClient.invalidateQueries({ predicate: showsAMessage });
       options.onSettled?.(result);
     },
   });
@@ -123,16 +124,14 @@ export function useMessageAudience(options: {
       if (error) throwProblem(error);
       return data;
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: () => {
       for (const queryKey of options.invalidate()) {
         queryClient.invalidateQueries({ queryKey });
       }
-      // The message's own canonical read, wherever it is mounted. The caller
-      // names its screen's keys; this one is the same for every caller, so it
-      // is not theirs to remember.
-      queryClient.invalidateQueries({
-        queryKey: emailPresentationKey(variables.activityId),
-      });
+      // The message's own canonical read and every timeline it appears on. One
+      // message is filed against several records, so the caller's screen is
+      // never the whole answer — and it is not the caller's to remember either.
+      queryClient.invalidateQueries({ predicate: showsAMessage });
       options.onSettled?.();
     },
   });


### PR DESCRIPTION
Closes #3789.

One message is filed against several records — a deal, the contact on it, the project it belongs to — and each of those pages caches its own timeline. Narrowing a message from the deal page left the contact page showing *"Everyone in the organization"* until a reload. The change did happen; the second page was quietly wrong about it, which is the harder version to trust.

A second, narrower case the ticket names: `EmailPresentation` embeds a page of thread-member summaries, so a drawer anchored on a message that did **not** change can contain one that did, and nothing invalidated the anchor.

## Why it is a predicate and not a key

The ticket states the constraint precisely: the server names the *messages* a decision reached, and nothing tells the client which **records** those messages are filed against. `Activity.links` is not on the thread outcome, and putting a record list on a privacy response for the sake of a cache is the wrong trade.

It offers two ways out — an activity-scoped key the record timelines also carry, or a predicate over the timeline key space. This is the second, and it is much the smaller change: the first would mean every timeline read growing a second key and every writer maintaining it, for a case that arises on one deliberate, rare human act.

`showsAMessage` matches by key **shape**, and the shapes are derived from the same `TIMELINE_SEED_KEYS` / `DERIVED_FROM_TIMELINE` tables `entityTimelineKeys` already reads — so a record kind that grows a timeline joins this by being added there. A second hand-kept list would go stale exactly the way the record-scoped invalidation it replaces did, and just as quietly.

Matched as a prefix with the id position wild, so:

- `["activities", …]` covers every record's timeline, including narrowed and paged reads that hang further segments off it;
- `["project", id, "360"]` covers the project's composite payload **without** matching `["project", id]` — the project record itself carries no message, and re-reading every cached project page for an audience change would be the over-correction.

## Affordable, and only here

It is a wide invalidation. That is fine for this write and would not be for a common one: react-query refetches only the queries actually mounted, and the rest are marked stale and re-read when something asks. An audience change is a deliberate act somebody performs a handful of times a day.

Both writes take it — `useThreadAudience` and `useMessageAudience` — because both change who may read a message, and a message-scoped change is filed against exactly as many records as a thread-scoped one.

## Tests

- `activitykeys.test.ts` pins the predicate itself: every timeline, the three composite 360 payloads, the canonical email read, the deal status card derived from a timeline — and, in its own case, the reads it must leave alone (`["project", id]`, `["deal", id]`, `["deals"]`, `["tasks"]`, `["held-threads"]`).
- `audienceservice.test.tsx`'s first test was rewritten from spying on `invalidateQueries` arguments to **caching real reads and asserting they end up needing re-reading**. A spy on the call would pass for a predicate that matched nothing, which is precisely the failure mode being fixed. It seeds three reads a reader could have open elsewhere — another record's timeline, a contact's 360 payload, a drawer on a message the answer never named — plus two that carry no message, and asserts the first three are invalidated and the last two are not.

Mutation-checked in both directions:

- `predicate: () => false` → the test fails (nothing elsewhere refreshed).
- `predicate: () => true` → the test fails too (the reads that carry no message were re-read).

**Verification.** `make check-fe` green (6,078 tests). `make check-backend` green. No backend or contract change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message visibility updates after audience changes.
  * Refreshes affected activity timelines, composite views, email presentations, and related record views.
  * Ensures cached views update even when activity identifiers are unavailable.
  * Prevents unrelated queries from being refreshed unnecessarily.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->