### PR TITLE
A commitment's source opens the message it came from

### DIFF
--- a/frontend/src/screens/citationroute.test.ts
+++ b/frontend/src/screens/citationroute.test.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Where a cited record opens.
+//
+// The account page's commitment rows have passed `source_activity_id` into a
+// button since the day they were written, and pressing it did nothing: an
+// activity had no detail route, so it fell through the routing branch and the
+// receipt branch alike. The email drawer is that route now.
+
+import { describe, expect, it } from "vitest";
+import { citationOpensEmail } from "./organizations";
+
+describe("citationOpensEmail", () => {
+  it("opens the message for an activity", () => {
+    expect(citationOpensEmail("activity")).toBe(true);
+  });
+
+  // The kinds that route to a screen or a receipt keep doing so. An email
+  // drawer opened over a deal would put the reader on a message that has
+  // nothing to do with what they clicked.
+  it.each(["deal", "person", "fact", "profile_field", "organization"])(
+    "leaves %s to its own destination",
+    (kind) => {
+      expect(citationOpensEmail(kind)).toBe(false);
+    },
+  );
+});

--- a/frontend/src/screens/companywork.test.tsx
+++ b/frontend/src/screens/companywork.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
-
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import {
@@ -64,13 +64,15 @@ const project = {
   quiet: false,
 } as const;
 
-function draw(three60: Organization360) {
+function draw(three60: Organization360, onOpenRecord: OpenRecord = () => {}) {
   rtlRender(
     <LocaleProvider initial="en">
-      <CompanyWorkCard view={three60} onOpenRecord={() => {}} />
+      <CompanyWorkCard view={three60} onOpenRecord={onOpenRecord} />
     </LocaleProvider>,
   );
 }
+
+type OpenRecord = (entityType: string, entityId: string) => void;
 
 // What the header says BESIDE the card's own title: the count, and the
 // assertions below about what may not join it. Scoped past the title because
@@ -197,6 +199,43 @@ describe("the account's work in flight", () => {
         /Ida Keller said: ‘we'll confirm the depot slot once facilities sign off’/,
       ),
     ).toBeTruthy();
+  });
+
+  // The commitment's source is a MESSAGE, and pressing it must reach the
+  // handler as an activity. This button has existed since the row was written
+  // and did nothing: an activity had no detail route, so `useCitedReceipt`
+  // dropped it through both its branches. The email drawer is that route now,
+  // and this is the claim that says the button arrives.
+  it("routes a commitment's source to the message it came from", async () => {
+    const opened: Array<[string, string]> = [];
+    draw(
+      view({
+        deals: {
+          data: [
+            {
+              ...deal,
+              attention: {
+                kind: "commitment_theirs",
+                title: "we'll confirm the depot slot once facilities sign off",
+                who: "Ida Keller",
+                due_at: null,
+                source_activity_id: "a-1",
+              },
+            },
+          ],
+          page,
+          won_lifetime: { amount_minor: 0, currency: "EUR" },
+          lost_count: 0,
+        },
+      }),
+      (entityType, entityId) => opened.push([entityType, entityId]),
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Ida Keller said/ }),
+    );
+
+    expect(opened).toEqual([["activity", "a-1"]]);
   });
 
   it("shows the stall only when there is no reason that explains it", () => {

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1711,11 +1711,24 @@ function useChronologySlots({
 function useCitedReceipt() {
   const [cited, setCited] = useState<CitedRecord | null>(null);
   const [list, setList] = useState<readonly CitedRecord[]>([]);
+  // The message a citation opened, held HERE beside the receipt it opens for
+  // the other kinds: both answer "what did this chip open", and splitting them
+  // would leave a caller wiring two states for one question.
+  const [email, setEmail] = useState<string | null>(null);
   const open = (
     entityType: string,
     entityId: string,
     siblings?: readonly CitedRecord[],
   ) => {
+    // An activity opens the message itself. It used to fall through both
+    // branches below and land nowhere — the account's commitment rows have
+    // been passing `source_activity_id` into a button that did nothing since
+    // the day they were written, because an activity had no detail route.
+    // It has one now.
+    if (citationOpensEmail(entityType)) {
+      setEmail(entityId);
+      return;
+    }
     if (citationOpensRecord(entityType)) {
       openCitation(entityType, entityId);
       return;
@@ -1743,8 +1756,10 @@ function useCitedReceipt() {
   };
   return {
     cited,
+    email,
     open,
     close: () => setCited(null),
+    closeEmail: () => setEmail(null),
     step: list.length > 1 ? step : undefined,
   };
 }
@@ -2258,6 +2273,13 @@ function CompanyRecordBody({
           onStep={receipt.step}
         />
       )}
+      {/* The message a citation opened. Beside the receipt modal above and for
+          the same reason: both are what a chip on this page opens into. */}
+      <OpenEmailDrawer
+        activityId={receipt.email}
+        zone={viewerZone()}
+        onClose={receipt.closeEmail}
+      />
       {!overlay && (
         <CompanyProfileTab
           active={tab === "profile"}
@@ -2906,6 +2928,17 @@ function CompanyTasksTab({
 // what the reader wanted when they clicked the chip.
 function citationOpensRecord(entityType: string): boolean {
   return entityType === "deal" || entityType === "person";
+}
+
+// An activity opens the MESSAGE, in the account page's own email drawer.
+//
+// Its own named decision rather than a bare comparison inside the hook, so the
+// rule can be asserted without mounting the page: the account's commitment rows
+// have passed `source_activity_id` into a button since the day they were
+// written, and it did nothing because an activity fell through both branches
+// above. A rule with no name is a rule with no test.
+export function citationOpensEmail(entityType: string): boolean {
+  return entityType === "activity";
 }
 
 // The kinds a receipt can be written for. Narrowing HERE rather than asserting


### PR DESCRIPTION
Tenth slice of the email display unification arc.

## The dead button

`companywork.tsx:487` renders a live button that calls `onOpenRecord("activity", source)` on a commitment's source message. Pressing it did nothing.

`useCitedReceipt` routes a `deal` or `person` to its screen, and a `fact` or `profile_field` to its receipt. An activity matched neither and fell out of the function. The control was live, looked pressable, and answered nothing — since the day the row was written, because at that time an activity genuinely had no detail route.

It has one now: the email drawer this arc built.

## What changed

- `useCitedReceipt` gained the branch that opens a message, and holds it beside the receipt it already holds — both answer "what did this chip open", and splitting them would leave a caller wiring two states for one question.
- The account page mounts `OpenEmailDrawer` beside the receipt modal.
- `citations.tsx:158`'s comment said *"an activity has no detail route of its own"*. That premise is now false, and the comment is corrected rather than left to mislead the next reader.

## Why `ROUTABLE_CITATIONS` is unchanged

The plan said to add `activity` to that set. **I did, then reverted it**, because it would have shipped a new dead control.

Whether a message can be opened is the **host's** capability, not a global fact. The account page owns an email drawer; `compose.tsx`'s "why this draft?" chips have their own `openCited` handling only `deal` and `person`. Widening the shared set would have drawn a clickable chip in the composer that does nothing — the exact failure the set's own comment warns about.

Threading an `opensEmail` prop through `Citations` → `SentenceList` → six hosts was the alternative, and it spread across many files for one behaviour. The commitment button does not go through that set at all: it calls the handler directly. So the fix is the handler, and the set stays as it is.

## The rule has a name so it has a test

`citationOpensEmail` is exported rather than being a comparison inside the hook. The branch is one line, and covering it otherwise needs the whole account page mounted.

**That matters here specifically:** deleting the branch left **92 tests green**, including the commitments test that clicks the button — because that test proves the button *emits*, and the defect was in the handler that receives it. Mutation-checked both ways: the named rule fails when it stops answering true for an activity.

## Tests

`citationroute.test.ts` — an activity opens the message; deal, person, fact, profile_field and organization keep their own destinations.
`companywork.test.tsx` — the commitment's source arrives as `["activity", "a-1"]` rather than being dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the commitment source button on the account page so it opens the message the commitment came from, instead of doing nothing.

- Routes `activity` citations to the email drawer in `useCitedReceipt`, beside the receipt handling for the other kinds.
- Exports `citationOpensEmail` so the routing rule is testable without mounting the whole page.
- Leaves `ROUTABLE_CITATIONS` unchanged: the composer's chips don't own an email drawer, so opening emails there would create another dead control.
- Adds tests covering the new activity route and the commitment button's payload.

<sup>Written for commit e9121ece327f699f9c81634ec3bee13b1e234daf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Activity citations now open directly in an email drawer, with the viewer’s timezone applied.
  - Existing citation actions for deals, people, facts, profile fields, organizations, and receipts remain available.
  - Clicking a commitment row can now open its source activity for easier context and follow-up.

- **Tests**
  - Added coverage for citation behavior and commitment-row navigation across supported record types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->