### PR TITLE
The tool catalog lists every verb the surface serves

### DIFF
--- a/backend/gates/agenttoolcatalogtiers_test.go
+++ b/backend/gates/agenttoolcatalogtiers_test.go
@@ -165,43 +165,19 @@ func TestTheToolCatalogsTiersAreTheContractsTiers(t *testing.T) {
 	}
 }
 
-// absentFromTheCatalog ratifies the governed verbs the page did not list when
-// this gate landed. Shrinking is the point; a NEW one fails.
+// absentFromTheCatalog is EMPTY, and that is the state to keep it in.
 //
-// A ratchet rather than a sweep, because filling a row in means writing its
-// overlay-mode behaviour — what the verb does when the records live in somebody
-// else's CRM — and that is a per-verb answer read out of the code, not
-// something a gate landing should guess at nineteen times.
+// It carried nineteen entries when this gate landed — governed verbs the
+// hand-kept page had never listed — ratcheted rather than swept because filling
+// a row in means writing the verb's overlay-mode behaviour, which is read out
+// of the code per verb rather than guessed at nineteen times. They have since
+// been read and written, and the backlog is gone.
 //
-// One reason for all of them, because it is one fact: each is declared in
-// crm.yaml with a tier, the catalog is hand-kept, and none of them was ever
-// added. That is the same drift this gate exists to stop, caught in the other
-// direction.
-var absentFromTheCatalog = gatekit.Waive(map[string]string{
-	"annotate_brief":         catalogNeverListedIt,
-	"apply_tag":              catalogNeverListedIt,
-	"commit_import":          catalogNeverListedIt,
-	"create_task":            catalogNeverListedIt,
-	"decide_approval":        catalogNeverListedIt,
-	"decide_approval_bundle": catalogNeverListedIt,
-	"list_approvals":         catalogNeverListedIt,
-	"list_channel_providers": catalogNeverListedIt,
-	"list_colleagues":        catalogNeverListedIt,
-	"list_tags":              catalogNeverListedIt,
-	"preview_import":         catalogNeverListedIt,
-	"read_approval":          catalogNeverListedIt,
-	"read_import_report":     catalogNeverListedIt,
-	"read_import_run":        catalogNeverListedIt,
-	"read_project_360":       catalogNeverListedIt,
-	"relink_activities":      catalogNeverListedIt,
-	"relink_thread":          catalogNeverListedIt,
-	"remove_tag":             catalogNeverListedIt,
-	"send_account_email":     catalogNeverListedIt,
-})
-
-const catalogNeverListedIt = "declared in crm.yaml with a tier and absent from the hand-kept catalog when " +
-	"this gate landed. Writing its row means answering what the verb does in overlay mode, which is read " +
-	"out of the code per verb — so these are counted rather than guessed at, and the count only falls"
+// So a new entry here is not a smaller version of that backlog: it is one verb
+// whose row somebody did not write, on the page a reader consults before
+// granting a passport. Write the row instead. If a verb genuinely cannot have
+// one, the reason belongs here in its own words, not a shared constant.
+var absentFromTheCatalog = gatekit.Waive(map[string]string{})
 
 // markFor is how the page must write a tool whose policies carry these tiers.
 //

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -55,11 +55,15 @@ the credential: [how-to/mint-a-passport.md](../how-to/mint-a-passport.md).
 
 ## The catalog
 
-The **35 core tools**, listed in the order `Registry.Specs()` sorts them — which
-is the order `tools/list` returns. An enabled extension unit adds its own verbs
-to the same listing, so a vanilla install answers 42: these plus
-`openchannel`'s seven verbs, which are not tabled here because the catalog
+Every core verb the surface serves. An enabled extension unit adds its own to
+the same listing — `openchannel`'s seven are not tabled here, because this page
 tracks the core surface.
+
+The count is deliberately not written down. It said 35 while the surface served
+69, and a number in prose that nothing checks is one more thing to go quietly
+wrong; `TestTheToolCatalogsTiersAreTheContractsTiers` holds the membership
+instead, in both directions. For the live figure read
+[reference/mcp-info.md](mcp-info.md), which is generated.
 
 This table and `api/crm.yaml` cannot disagree: every operation carrying
 `x-mcp-tool` has a registered tool of that verb, and every registered tool is
@@ -102,11 +106,19 @@ Columns:
 | `advance_project_phase` | 🟢 | `write` | — | Runs: a project is native-only, so its table is the live one in either mode |
 | `archive_record` | 🟢 | `write` | — | Seam-routed: write-back through the incumbent |
 | `at_risk_relationships` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
+| `annotate_brief` | 🟢 | `write` | — | `unsupported_by_sor` (native-only guard): the brief is Margince's own, and the incumbent holds nothing to annotate |
+| `apply_tag` | 🟢 | `write` | — | Writes the native tag-application table; `tag` is not a mirrored type, so it runs in either mode |
 | `book_meeting` | 🟢 | `send` | yes | Staging refuses a mirror-held link |
 | `catch_me_up_on` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `check_availability` | 🟢 | `read` | — | Calendar seam; not mode-routed |
-| `create_record` | 🟢 / 🟡 | `write` | — | Seam-routed: write-back through the incumbent |
+| `check_location_support` | 🟢 | `read` | — | Constant metadata about the host's geolocation permission; no store, no mode guard |
+| `commit_import` | 🟢 | `write` | — | Margince's own import tables. Deliberately mode-independent: import is the machinery that flips an overlay installation to native |
+| `create_record` | 🟢 / 🟡 | `write` | — | `unsupported_by_sor`: `overlay.SupportsWrite` serves no CREATE for any type, so a create never reaches the incumbent |
 | `create_tag` | 🟢 | `write` | — | Coins a word in the workspace vocabulary; native, not mode-routed. Needs `tag.create`, which the seeded roles give Admin and Ops alone |
+| `create_task` | 🟢 | `write` | — | `unsupported_by_sor`: the provider serves no CREATE for any type, so a task cannot be written to the incumbent |
+| `decide_approval` | 🟢 | `write` | — | Decides a row in Margince's own approvals queue; the incumbent holds none |
+| `decide_approval_bundle` | 🟢 | `write` | — | As `decide_approval`, for several at once |
+| `describe_query_vocabulary` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard): it describes the native query surface, which is not what a mirrored read answers |
 | `disqualify_lead` | 🟢 | `write` | — | `unsupported_by_sor`: a lead is mirrored and the provider cannot serve this write, so the native table is empty |
 | `draft_email` | 🟢 | `draft` | — | Activities seam; not mode-routed |
 | `draft_follow_ups_for` | 🟢 | `draft` | — | `unsupported_by_sor` (native-only guard) |
@@ -115,19 +127,33 @@ Columns:
 | `get_tag` | 🟢 | `read` | — | Reads one tag and how much of the workspace carries it; native vocabulary, not mode-routed |
 | `intro_path_to` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `list_pipelines` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
+| `list_approvals` | 🟢 | `read` | — | Reads Margince's own approvals queue; carries no mode guard |
+| `list_channel_providers` | 🟢 | `read` | — | Reads the installation's composed transport directory, not workspace data |
+| `list_colleagues` | 🟢 | `read` | — | Reads the seat roster; a seat is not a record, so no seam is involved |
 | `list_records` | 🟢 | `read` | — | Mirror-backed unfiltered; a FILTERED call is `unsupported_by_sor` (see below) |
-| `log_activity` | 🟢 | `write` | — | Seam-routed: write-back through the incumbent |
+| `log_activity` | 🟢 | `write` | — | `unsupported_by_sor`: it creates an activity, and CREATE is the verb the provider serves for no type |
 | `merge_records` | 🟢 | `write` | — | `unsupported_by_sor` (no atomic incumbent projection) |
+| `list_tags` | 🟢 | `read` | — | Reads the tag vocabulary; `tag` is not a mirrored type |
 | `merge_tags` | 🟡 | `write` | — | Folds one vocabulary word into another; native, not mode-routed. 🟡 where `merge_records` is 🟢 because it releases the source's name and keeps no pointer home. Needs `tag.update`, and a human releases it |
 | `prep_for_meeting` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `progress_deal` | dynamic | `write` | — | `unsupported_by_sor` (shares `advance_deal`'s seam) |
+| `prepare_handoff` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard): a project has no incumbent analogue |
+| `preview_import` | 🟢 | `write` | — | Margince's own import tables; mode-independent for the reason `commit_import` gives |
 | `promote_lead` | 🟢 | `write` | — | `unsupported_by_sor` (no atomic incumbent projection) |
 | `qualify_lead` | 🟢 | `write` | — | Seam-routed: read + patch through the provider |
 | `read_brief` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `read_record` | 🟢 | `read` | — | Mirror-backed; result carries `trust_tier: external` |
+| `read_approval` | 🟢 | `read` | — | Reads one row of Margince's own approvals queue |
+| `read_import_report` | 🟢 | `read` | — | Margince's own import tables |
+| `read_import_run` | 🟢 | `read` | — | Margince's own import tables |
+| `read_project_360` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard). The REST twin refuses too, but answers `unsupported_in_overlay_mode` — a different code for the same fact |
 | `query_workspace` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `relink_activity` | dynamic | `write` | — | Runs: a link row is not an SoR record write, so it is available in either mode |
 | `resolve_entities` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
+| `relink_activities` | dynamic | `write` | — | Native activity-link write, carrying no mode guard — see the note below |
+| `relink_thread` | dynamic | `write` | — | Native activity-link write, carrying no mode guard — see the note below |
+| `remove_tag` | 🟢 | `write` | — | Takes a tag off a record; native, for the reason `apply_tag` gives |
+| `review_commitments` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard): the mirror holds no task projection |
 | `run_report` | 🟢 | `read` | — | `unsupported_by_sor` (no incumbent analogue) |
 | `forecast_readings` | 🟢 | `read` | — | Reads deals, stages and the installation's fiscal settings, so it answers only where those live |
 | `forecast_movement` | 🟢 | `read` | — | Diffs two stored snapshots, so it answers only where snapshots exist |
@@ -137,11 +163,13 @@ Columns:
 | `search_context` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `search_records` | 🟢 | `read` | — | Mirror-backed; results carry `trust_tier: external` |
 | `send_email` | 🟢 | `send` | yes | Staging refuses a mirror-held anchor |
+| `send_account_email` | 🟢 | `send` | yes | `unsupported_by_sor`: its required record links are held in the incumbent, and staging refuses a link it cannot govern |
 | `send_message` | 🟢 | `send` | yes | Staging refuses a mirror-held anchor |
 | `update_record` | 🟢 / 🟡 | `write` | — | Seam-routed; see the per-field split below |
 | `update_tag` | 🟢 | `write` | — | Renames, recolours or describes an existing word; native, not mode-routed |
 | `whats_slipping_this_week` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard) |
 | `who_knows` | 🟢 | `read` | — | Native relationship read; carries no mode guard |
+| `whoami` | 🟢 | `read` | — | Identity metadata about the passport itself; no record, no seam, no guard |
 
 Five rows deserve their footnote:
 
@@ -186,6 +214,24 @@ Five rows deserve their footnote:
   rival survives, because collapsing it would settle a disagreement using the
   caller's own blindness. The narrowing is reported once per call, without a
   count.
+
+### The relink verbs carry no overlay guard
+
+`relink_activities` and `relink_thread` write the native activity-link tables
+directly: `compose/registry.go` wires the bare relinker, with none of the
+`nativeOnly*` wrappers the other native-only capabilities get, and neither verb
+is named in `overlayRecordWriteTools`.
+
+For a `project` destination that is moot — the tier resolves to confirm-first,
+and staging refuses a destination the seam does not hold. For the auto-execute
+destinations it is not: in overlay mode the activity rows live in the incumbent,
+so the write lands on native tables that are empty and answers successfully
+having moved nothing. That is the well-formed-but-meaningless answer the
+native-only guards exist to prevent, and the two verbs do not have one.
+
+Recorded rather than fixed: whether these should refuse, or should route to the
+seam, is a question about what a link row means in overlay mode, and the answer
+belongs with whoever owns the overlay contract.
 
 ## What each scope buys
 


### PR DESCRIPTION
`docs/reference/agent-tools.md` is the inventory a reader consults before granting an agent passport. It listed **45 of the 69 served verbs**, and nothing failed — a nineteen-entry waiver in `TestTheToolCatalogsTiersAreTheContractsTiers` ratified exactly that gap when the gate landed.

Found while answering "can an agent attach and detach a tag over MCP?" — the answer is yes, and `apply_tag` / `remove_tag` were both absent from the page.

## What was missing

24 verbs, including the ones you would most want to look up: `decide_approval`, `decide_approval_bundle`, `commit_import`, `preview_import`, `send_account_email`, `apply_tag`, `remove_tag`, `list_approvals`, `read_project_360`.

The waiver was honest about why they were counted rather than filled in: writing a row means answering what the verb does in **overlay mode**, which is read out of the code per verb and not something a gate landing should guess at nineteen times.

So they were read. Of the 24:

- **6 refuse** with `unsupported_by_sor` — `annotate_brief`, `describe_query_vocabulary`, `prepare_handoff`, `read_project_360`, `review_commitments` via `nativeOnly*` guards, and `create_task` via the provider serving no CREATE.
- **1 refuses conditionally** — `send_account_email`, because its required record links are held in the incumbent and staging refuses a link it cannot govern.
- **17 are native** — they touch Margince's own tables (approvals, imports, the tag vocabulary, the seat roster, the transport directory) which no incumbent CRM holds.

The waiver list is now empty. Both directions were mutation-checked: deleting a row and giving one a wrong tier each fail the gate.

## Two existing rows were wrong

The page calls a wrong tier "worse than an absent one", and two rows were wrong in exactly that way:

| Verb | Said | Actually |
|---|---|---|
| `create_record` | Seam-routed: write-back through the incumbent | `unsupported_by_sor` |
| `log_activity` | Seam-routed: write-back through the incumbent | `unsupported_by_sor` |

`overlay.SupportsWrite` returns `false` for `WriteCreate` for **every** type (`provider_writes.go:399-411`), and `Provider.Create` is a bare `requireSupportedWrite` (`provider_writes.go:196-197`). Anyone planning an overlay integration around those rows planned around a write that never happens.

## Recorded, not fixed

**`relink_activities` and `relink_thread` carry no overlay guard.** `compose/registry.go` wires the bare relinker with none of the `nativeOnly*` wrappers, and neither verb is in `overlayRecordWriteTools`. For a `project` destination that is moot — staging refuses a destination the seam does not hold. For the auto-execute destinations it is not: the write lands on native tables that are empty in overlay mode and answers successfully having moved nothing, which is the well-formed-but-meaningless answer the native-only guards exist to prevent.

Whether they should refuse or route to the seam is a question about what a link row means in overlay mode, so it is written into the page under its own heading rather than guessed at here.

**The prose said "35 core tools"** while the surface served 69. It now points at the generated `mcp-info.md` instead of carrying a number nothing checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fills in the missing tool catalog rows so the page lists all 69 served verbs, and corrects two rows that documented a write path that doesn't exist.

- Adds rows for 24 previously missing verbs, including `decide_approval`, `commit_import`, `apply_tag`, and `send_account_email`, with per-verb overlay behavior.
- Corrects `create_record` and `log_activity` from "seam-routed" to `unsupported_by_sor`; the gate's waiver list is now empty and fails on any missing or wrong row.
- Replaces the hardcoded "35 core tools" count with a link to the generated `mcp-info.md`.
- Notes that `relink_activities` and `relink_thread` lack overlay guards, so writes can silently no-op in overlay mode; recorded as a known issue.

<sup>Written for commit df59f482c15bf1729b7ed14a81bde41de1ad5f6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the agent tools catalog with approval, import, channel, tagging, relinking, identity, and account-email tools.
  - Documented overlay-mode behavior, including unsupported operations, native-only restrictions, and relinking behavior.
  - Removed the fixed core-tool count so the catalog reflects its documented contents.

- **Tests**
  - Strengthened catalog validation to require newly missing governed tools to be documented or individually justified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->