### PR TITLE
A site that builds itself in the browser is read, not written off

### DIFF
--- a/backend/internal/compose/deepreadreport.go
+++ b/backend/internal/compose/deepreadreport.go
@@ -37,7 +37,7 @@ func (w *siteDeepReadWorker) reportRead(ctx context.Context, args SiteDeepReadAr
 	if err != nil {
 		return w.fail(ctx, args.SiteReadID, fmt.Errorf("site deep read %s: %w", args.SiteReadID, err))
 	}
-	warnings := readWarnings(legalWarning, extraction.err)
+	warnings := readWarnings(legalWarning, extraction.err, seedIsJSShell(readPages))
 	draftFields := deepReadFields(mergedFields)
 	draftPeople := siteReadPeople(extraction.merged.people)
 	draftEntities := siteReadLegalEntities(extraction.merged.entities)
@@ -127,13 +127,27 @@ func (w *siteDeepReadWorker) landFindings(ctx context.Context, args SiteDeepRead
 // not settle, so a confirmation is never made on an unstated assumption. The
 // legal caveat arrives already spelled for the cause that fired; empty means the
 // legal gate settled and there is nothing to caveat.
-func readWarnings(legalWarning string, extractErr error) []string {
-	warnings := make([]string, 0, 2)
+func readWarnings(legalWarning string, extractErr error, jsShell bool) []string {
+	warnings := make([]string, 0, 3)
 	if legalWarning != "" {
 		warnings = append(warnings, legalWarning)
 	}
 	if extractErr != nil {
 		warnings = append(warnings, "Some pages could not be extracted; the grounded findings that completed are still available.")
 	}
+	if jsShell {
+		// Said out loud, because the dossier otherwise looks like a thin
+		// company rather than a thin READ: this site assembles its words in
+		// the browser, so what was found came from what the pages declare
+		// about themselves and not from their content.
+		warnings = append(warnings, "This site builds its pages in the browser, so only what they declare about themselves could be read. A person opening it will see more.")
+	}
 	return warnings
+}
+
+// seedIsJSShell answers whether the LANDING page was a client-rendered shell.
+// The seed rather than any page: it is the one every read starts from, and a
+// site that serves a shell there serves one everywhere.
+func seedIsJSShell(pages []crawlPage) bool {
+	return len(pages) > 0 && pages[0].isJSShell()
 }

--- a/backend/internal/compose/deepreadreport_test.go
+++ b/backend/internal/compose/deepreadreport_test.go
@@ -19,17 +19,17 @@ func TestReadWarningsStateTheCauseTheLegalGateReported(t *testing.T) {
 		{Name: "Acme Pte. Ltd.", SourceURL: seedURL + "/impressum"},
 	}
 
-	incomplete := readWarnings(legalAbstentionOf(one, true).warning(), nil)
+	incomplete := readWarnings(legalAbstentionOf(one, true).warning(), nil, false)
 	if len(incomplete) != 1 || incomplete[0] != legalWarningCensusIncomplete {
 		t.Fatalf("a failed legal page must be reported as one, not as a multi-entity domain: %v", incomplete)
 	}
 
-	multiple := readWarnings(legalAbstentionOf(two, false).warning(), nil)
+	multiple := readWarnings(legalAbstentionOf(two, false).warning(), nil, false)
 	if len(multiple) != 1 || multiple[0] != legalWarningMultipleEntities {
 		t.Fatalf("a domain that publishes two entities must still say so: %v", multiple)
 	}
 
-	if settled := readWarnings(legalAbstentionOf(one, false).warning(), nil); len(settled) != 0 {
+	if settled := readWarnings(legalAbstentionOf(one, false).warning(), nil, false); len(settled) != 0 {
 		t.Fatalf("a settled census has nothing to caveat: %v", settled)
 	}
 }
@@ -41,7 +41,7 @@ func TestReadWarningsKeepTheExtractionCaveatAlongsideTheLegalOne(t *testing.T) {
 		{Name: "Acme GmbH", SourceURL: seedURL + "/impressum"},
 		{Name: "Acme Pte. Ltd.", SourceURL: seedURL + "/impressum"},
 	}
-	got := readWarnings(legalAbstentionOf(two, true).warning(), errors.New("lane died"))
+	got := readWarnings(legalAbstentionOf(two, true).warning(), errors.New("lane died"), false)
 	if len(got) != 2 || got[0] != legalWarningMultipleEntities {
 		t.Fatalf("both caveats must reach the dossier, legal first: %v", got)
 	}

--- a/backend/internal/compose/deepreadtriage.go
+++ b/backend/internal/compose/deepreadtriage.go
@@ -290,7 +290,7 @@ const (
 
 // classifySeed runs the one classification call over the landing page.
 func (w *siteDeepReadWorker) classifySeed(ctx context.Context, seed crawlPage) (siteTriageVerdict, error) {
-	if strings.TrimSpace(seed.Text) == "" {
+	if strings.TrimSpace(seed.Text) == "" && len(seed.HeadText) == 0 {
 		if seed.UnresolvedForward {
 			// This page named the site's real address and the crawl could not
 			// reach it. The emptiness is a gap in the read, not the site
@@ -300,6 +300,18 @@ func (w *siteDeepReadWorker) classifySeed(ctx context.Context, seed crawlPage) (
 			return siteTriageVerdict{
 				Kind:   siteKindUnclear,
 				Reason: "the landing page forwards to an address that could not be read",
+			}, nil
+		}
+		if seed.isJSShell() {
+			// A client-rendered shell that declared nothing about itself. The
+			// words exist — a browser would assemble them — so this reader
+			// having none is a gap in the read, exactly as an unfollowable
+			// forward is. Settling `parked` with confidence 1 would put a real
+			// company on file as an empty address, with no model call made and
+			// nothing later to reopen it.
+			return siteTriageVerdict{
+				Kind:   siteKindUnclear,
+				Reason: "the landing page is a JavaScript application shell this reader cannot render",
 			}, nil
 		}
 		// A page with no readable text identifies nobody. That IS the parked

--- a/backend/internal/compose/sitecrawl.go
+++ b/backend/internal/compose/sitecrawl.go
@@ -61,9 +61,12 @@ type crawlPage struct {
 	// only prose the server sends. Kept out of Text because stored evidence
 	// snippets are matched against Text.
 	HeadText []string
-	// ExternalScripts counts the page's <script src=…> tags, which together
-	// with the text floor tells an application shell from an empty document.
+	// ExternalScripts counts the page's <script src=…> tags and ModuleScripts
+	// how many of those are ES modules. The MODULE count is what tells an
+	// application shell from an empty document — a parked domain carries
+	// analytics and registrar scripts just as readily as a real site does.
 	ExternalScripts int
+	ModuleScripts   int
 }
 
 type crawlSkip struct {
@@ -388,7 +391,7 @@ func newCrawlRun(c *siteCrawler, pacer crawlPacer, seedURL string, seedPage webr
 			SeedURL:    seedURL,
 		},
 		visited:       visited,
-		seenText:      map[string]bool{seedPage.Text: true},
+		seenText:      map[string]bool{bodyIdentity(seedPage.Text, seedPage.HeadText): true},
 		canonicalDone: map[string]bool{localeCanonical(seedURL): true},
 		probeKindDone: map[crmcontracts.SiteReadPageKind]bool{},
 		totalBytes:    seedPage.Bytes,

--- a/backend/internal/compose/sitecrawl.go
+++ b/backend/internal/compose/sitecrawl.go
@@ -56,6 +56,14 @@ type crawlPage struct {
 	// and could not be followed, and only the first is evidence of a parked
 	// domain.
 	UnresolvedForward bool
+	// HeadText is what the page's <head> says it is about — the meta
+	// description and the Open Graph pair. On a client-rendered site it is the
+	// only prose the server sends. Kept out of Text because stored evidence
+	// snippets are matched against Text.
+	HeadText []string
+	// ExternalScripts counts the page's <script src=…> tags, which together
+	// with the text floor tells an application shell from an empty document.
+	ExternalScripts int
 }
 
 type crawlSkip struct {
@@ -375,7 +383,7 @@ func newCrawlRun(c *siteCrawler, pacer crawlPacer, seedURL string, seedPage webr
 		pacer:   pacer,
 		seedURL: seedURL,
 		crawl: siteCrawl{
-			Pages:      []crawlPage{{URL: seedURL, Kind: crmcontracts.SiteReadPageKindHome, Text: seedPage.Text, Bytes: seedPage.Bytes, Fingerprint: seedPage.Fingerprint}},
+			Pages:      []crawlPage{pageFrom(seedURL, crmcontracts.SiteReadPageKindHome, seedPage)},
 			SeedAssets: declaredAssets{ogImage: seedPage.OGImage, icons: seedPage.Icons},
 			SeedURL:    seedURL,
 		},

--- a/backend/internal/compose/sitecrawl_test.go
+++ b/backend/internal/compose/sitecrawl_test.go
@@ -65,6 +65,11 @@ type fakeSitePage struct {
 	// refresh is the meta-refresh target this page declares, which the real
 	// parser only reports for a same-site target it could resolve.
 	refresh string
+	// headText is what this page's <head> declares it is about, and scripts
+	// how many bundles it loads. Together they are what tells a
+	// client-rendered application shell from an empty document.
+	headText []string
+	scripts  int
 }
 
 func (s *fakeSite) FetchPage(_ context.Context, rawURL string) (webread.Page, error) {
@@ -101,6 +106,7 @@ func (s *fakeSite) FetchPage(_ context.Context, rawURL string) (webread.Page, er
 	return webread.Page{
 		URL: rawURL, FinalURL: finalURL, Text: page.text, Links: page.links, Bytes: len(page.text),
 		OGImage: page.ogImage, Icons: page.icons, Refresh: page.refresh,
+		HeadText: page.headText, ExternalScripts: page.scripts,
 	}, nil
 }
 
@@ -436,6 +442,65 @@ func TestCrawlSkipsADuplicateTextPageSilently(t *testing.T) {
 			t.Fatalf("the duplicate-text page was reported as a skip (%s)", skip.Reason)
 		}
 	}
+}
+
+// The same catch-all, serving a SHORT document — which is what a
+// client-rendered site actually sends. The duplicate was recognised only after
+// the text floor had already reported it, so one loader shell became
+// thirty-one `unreadable` skips and the report read as a site that could not be
+// read rather than one page seen many times.
+func TestADuplicateShellIsSilentEvenThoughItIsShort(t *testing.T) {
+	shell := fakeSitePage{text: "Acme", scripts: 2}
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		seedURL: {text: readable("Welcome to Acme."), links: []string{
+			seedURL + "/about", seedURL + "/team", seedURL + "/kontakt",
+		}},
+	}}
+	// The catch-all: every path a probe guesses at answers 200 with the same
+	// loader, which is what a client-rendered site does and why the probes all
+	// come back looking like separate unreadable pages.
+	for _, probe := range wellKnownProbes {
+		site.pages[seedURL+probe.path] = shell
+	}
+	for _, path := range []string{"/about", "/team", "/kontakt"} {
+		site.pages[seedURL+path] = shell
+	}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unreadable := 0
+	for _, skip := range crawl.Skipped {
+		if skip.Reason == crmcontracts.SiteReadSkipReasonUnreadable {
+			unreadable++
+		}
+	}
+	// One document, said once. The first shell is honest degradation and
+	// belongs in the report; the repeats are the same fact again, and it was
+	// repeating them thirty-one times that made a readable site look unread.
+	if unreadable != 1 {
+		t.Fatalf("unreadable skips = %d, want 1 — one repeated document is one fact: %+v",
+			unreadable, crawl.Skipped)
+	}
+}
+
+// A short page nobody has seen before is still honest degradation, and still
+// belongs in the report.
+func TestAShortPageSeenOnceIsStillReportedUnreadable(t *testing.T) {
+	site := &fakeSite{pages: seedOnly("/about")}
+	site.pages[seedURL+"/about"] = fakeSitePage{text: "Thin", scripts: 1}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, skip := range crawl.Skipped {
+		if skip.URL == seedURL+"/about" && skip.Reason == crmcontracts.SiteReadSkipReasonUnreadable {
+			return
+		}
+	}
+	t.Fatalf("a unique unreadable page vanished from the report: %+v", crawl.Skipped)
 }
 
 func TestCrawlClassifiesPageKinds(t *testing.T) {

--- a/backend/internal/compose/sitecrawl_test.go
+++ b/backend/internal/compose/sitecrawl_test.go
@@ -70,6 +70,7 @@ type fakeSitePage struct {
 	// client-rendered application shell from an empty document.
 	headText []string
 	scripts  int
+	modules  int
 }
 
 func (s *fakeSite) FetchPage(_ context.Context, rawURL string) (webread.Page, error) {
@@ -106,7 +107,7 @@ func (s *fakeSite) FetchPage(_ context.Context, rawURL string) (webread.Page, er
 	return webread.Page{
 		URL: rawURL, FinalURL: finalURL, Text: page.text, Links: page.links, Bytes: len(page.text),
 		OGImage: page.ogImage, Icons: page.icons, Refresh: page.refresh,
-		HeadText: page.headText, ExternalScripts: page.scripts,
+		HeadText: page.headText, ExternalScripts: page.scripts, ModuleScripts: page.modules,
 	}, nil
 }
 
@@ -442,65 +443,6 @@ func TestCrawlSkipsADuplicateTextPageSilently(t *testing.T) {
 			t.Fatalf("the duplicate-text page was reported as a skip (%s)", skip.Reason)
 		}
 	}
-}
-
-// The same catch-all, serving a SHORT document — which is what a
-// client-rendered site actually sends. The duplicate was recognised only after
-// the text floor had already reported it, so one loader shell became
-// thirty-one `unreadable` skips and the report read as a site that could not be
-// read rather than one page seen many times.
-func TestADuplicateShellIsSilentEvenThoughItIsShort(t *testing.T) {
-	shell := fakeSitePage{text: "Acme", scripts: 2}
-	site := &fakeSite{pages: map[string]fakeSitePage{
-		seedURL: {text: readable("Welcome to Acme."), links: []string{
-			seedURL + "/about", seedURL + "/team", seedURL + "/kontakt",
-		}},
-	}}
-	// The catch-all: every path a probe guesses at answers 200 with the same
-	// loader, which is what a client-rendered site does and why the probes all
-	// come back looking like separate unreadable pages.
-	for _, probe := range wellKnownProbes {
-		site.pages[seedURL+probe.path] = shell
-	}
-	for _, path := range []string{"/about", "/team", "/kontakt"} {
-		site.pages[seedURL+path] = shell
-	}
-
-	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	unreadable := 0
-	for _, skip := range crawl.Skipped {
-		if skip.Reason == crmcontracts.SiteReadSkipReasonUnreadable {
-			unreadable++
-		}
-	}
-	// One document, said once. The first shell is honest degradation and
-	// belongs in the report; the repeats are the same fact again, and it was
-	// repeating them thirty-one times that made a readable site look unread.
-	if unreadable != 1 {
-		t.Fatalf("unreadable skips = %d, want 1 — one repeated document is one fact: %+v",
-			unreadable, crawl.Skipped)
-	}
-}
-
-// A short page nobody has seen before is still honest degradation, and still
-// belongs in the report.
-func TestAShortPageSeenOnceIsStillReportedUnreadable(t *testing.T) {
-	site := &fakeSite{pages: seedOnly("/about")}
-	site.pages[seedURL+"/about"] = fakeSitePage{text: "Thin", scripts: 1}
-
-	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, skip := range crawl.Skipped {
-		if skip.URL == seedURL+"/about" && skip.Reason == crmcontracts.SiteReadSkipReasonUnreadable {
-			return
-		}
-	}
-	t.Fatalf("a unique unreadable page vanished from the report: %+v", crawl.Skipped)
 }
 
 func TestCrawlClassifiesPageKinds(t *testing.T) {

--- a/backend/internal/compose/sitecrawlfetch.go
+++ b/backend/internal/compose/sitecrawlfetch.go
@@ -31,11 +31,9 @@ func (c *siteCrawler) ReadSeed(ctx context.Context, seedURL string) (crawlPage, 
 	if err != nil {
 		return crawlPage{}, err
 	}
-	return crawlPage{
-		URL: seed.URL, Kind: crmcontracts.SiteReadPageKindHome,
-		Text: seed.Page.Text, Bytes: seed.Page.Bytes, Fingerprint: seed.Page.Fingerprint,
-		UnresolvedForward: seed.UnresolvedForward,
-	}, nil
+	page := pageFrom(seed.URL, crmcontracts.SiteReadPageKindHome, seed.Page)
+	page.UnresolvedForward = seed.UnresolvedForward
+	return page, nil
 }
 
 // fetchPaced is one polite fetch: pacer slot in, fetch, slot out.

--- a/backend/internal/compose/sitecrawlwave.go
+++ b/backend/internal/compose/sitecrawlwave.go
@@ -152,14 +152,29 @@ func (r *crawlRun) commit(ctx context.Context, adm admission, res fetchResult) {
 		r.skip(adm.url, crmcontracts.SiteReadSkipReasonOffDomain)
 		return
 	}
-	if utf8.RuneCountInString(page.Text) < crawlMinRunes {
-		r.skip(adm.url, crmcontracts.SiteReadSkipReasonUnreadable)
-		return
-	}
 	if r.seenText[page.Text] {
 		// An SPA catch-all serves the same document on every path; the
 		// duplicate carries zero new evidence and reporting it as a skip
 		// would flood the report with noise, so it vanishes silently.
+		//
+		// Asked BEFORE the text floor, because on exactly that site the
+		// duplicate is also SHORT: a client-rendered shell is the same two
+		// kilobytes of loader on every path, so thirty-one probes each wrote
+		// an `unreadable` skip for one document the crawl had already read.
+		// A body already seen carries no new evidence whatever its length,
+		// and the report is meant to name what could not be read rather than
+		// list one page thirty-one times.
+		return
+	}
+	if utf8.RuneCountInString(page.Text) < crawlMinRunes {
+		// Remembered as seen, though it was never committed as a page. A
+		// client-rendered site answers every path with the same short loader,
+		// and without this the dedupe above can never fire for it: each probe
+		// finds a body no commit ever recorded, so one document was reported
+		// as thirty-one separate unreadable pages. The FIRST one is the honest
+		// report; the repeats are the same fact again.
+		r.seenText[page.Text] = true
+		r.skip(adm.url, crmcontracts.SiteReadSkipReasonUnreadable)
 		return
 	}
 
@@ -195,7 +210,8 @@ func (r *crawlRun) commit(ctx context.Context, adm admission, res fetchResult) {
 		// what it guessed at; its kind stays open for the next guess.
 		r.probeKindDone[adm.cand.kind] = true
 	}
-	committed := crawlPage{URL: servedURL, Kind: kind, Text: page.Text, Bytes: page.Bytes, FetchDur: res.dur, Fingerprint: page.Fingerprint}
+	committed := pageFrom(servedURL, kind, page)
+	committed.FetchDur = res.dur
 	r.crawl.Pages = append(r.crawl.Pages, committed)
 	if r.onPage != nil {
 		r.onPage(committed)

--- a/backend/internal/compose/sitecrawlwave.go
+++ b/backend/internal/compose/sitecrawlwave.go
@@ -152,7 +152,7 @@ func (r *crawlRun) commit(ctx context.Context, adm admission, res fetchResult) {
 		r.skip(adm.url, crmcontracts.SiteReadSkipReasonOffDomain)
 		return
 	}
-	if r.seenText[page.Text] {
+	if r.seenText[bodyIdentity(page.Text, page.HeadText)] {
 		// An SPA catch-all serves the same document on every path; the
 		// duplicate carries zero new evidence and reporting it as a skip
 		// would flood the report with noise, so it vanishes silently.
@@ -173,7 +173,7 @@ func (r *crawlRun) commit(ctx context.Context, adm admission, res fetchResult) {
 		// finds a body no commit ever recorded, so one document was reported
 		// as thirty-one separate unreadable pages. The FIRST one is the honest
 		// report; the repeats are the same fact again.
-		r.seenText[page.Text] = true
+		r.seenText[bodyIdentity(page.Text, page.HeadText)] = true
 		r.skip(adm.url, crmcontracts.SiteReadSkipReasonUnreadable)
 		return
 	}
@@ -199,7 +199,7 @@ func (r *crawlRun) commit(ctx context.Context, adm admission, res fetchResult) {
 		r.markVisited(servedURL)
 		kind = classifyKind(servedURL)
 	}
-	r.seenText[page.Text] = true
+	r.seenText[bodyIdentity(page.Text, page.HeadText)] = true
 	r.canonicalDone[localeCanonical(adm.url)] = true
 	if kind == crmcontracts.SiteReadPageKindImpressum {
 		r.impressumRead++

--- a/backend/internal/compose/sitejsshell_test.go
+++ b/backend/internal/compose/sitejsshell_test.go
@@ -19,7 +19,7 @@ import (
 // The worker is the zero value: it carries no brain, so a verdict that needed a
 // model call would panic rather than pass quietly.
 func TestAJavaScriptShellIsNotSettledAsParked(t *testing.T) {
-	shell := crawlPage{Text: "", ExternalScripts: 3}
+	shell := crawlPage{Text: "", ExternalScripts: 3, ModuleScripts: 1}
 	verdict, err := (&siteDeepReadWorker{}).classifySeed(context.Background(), shell)
 	if err != nil {
 		t.Fatalf("classifying: %v", err)
@@ -42,32 +42,63 @@ func TestAnEmptyPageWithNoScriptsIsStillParked(t *testing.T) {
 	}
 }
 
-// A shell that DID declare what it is about has prose to judge, so it goes to
-// the classifier like any other page rather than being settled deterministically.
-func TestAShellThatDeclaresItselfIsHandedToTheClassifier(t *testing.T) {
-	declared := crawlPage{Text: "", ExternalScripts: 2, HeadText: []string{"We build robots."}}
-	if !strings.Contains(declared.prose(), "We build robots.") {
-		t.Fatalf("prose() = %q, want the head declaration", declared.prose())
+// A parked domain carries analytics and a registrar's own script as readily as
+// a real site does. Counting ANY external script would let a squatter's
+// placeholder escape the parked verdict and become a pending, retried,
+// never-evidenced read — so the shell test asks for a MODULE, which is how
+// every current bundler emits an application entry point.
+func TestAParkedPageWithAnalyticsIsStillParked(t *testing.T) {
+	parked := crawlPage{Text: "", ExternalScripts: 2, ModuleScripts: 0}
+	verdict, err := (&siteDeepReadWorker{}).classifySeed(context.Background(), parked)
+	if err != nil {
+		t.Fatalf("classifying: %v", err)
 	}
-	if declared.isJSShell() != true {
-		t.Fatal("a scripted, textless page is a shell whatever its head declared")
+	if !verdict.Aborts() {
+		t.Errorf("verdict %+v leaves a parked domain open — a tag manager is not an application", verdict)
 	}
 }
 
-// What the model is shown: the page's own claim about itself, ahead of its
-// body text. On a shell it is the only prose the server ever sent.
-func TestTheModelIsShownWhatTheHeadDeclared(t *testing.T) {
+// A shell that DID declare what it is about has prose to judge, so it reaches
+// the classifier — with that declaration in the prompt, which is the whole
+// point of harvesting it.
+func TestAShellThatDeclaresItselfReachesTheClassifierWithIt(t *testing.T) {
+	declared := crawlPage{
+		URL: seedURL, Text: "", ExternalScripts: 2, ModuleScripts: 1,
+		HeadText: []string{"We build robots for warehouses."},
+	}
+	// It is NOT settled deterministically: the empty-text shortcut steps aside
+	// for a page that said something about itself.
+	if declared.prose() == "" {
+		t.Fatal("a declared shell has prose to judge")
+	}
+	req := triageRequest(declared, "en")
+	if len(req.Messages) == 0 {
+		t.Fatal("the triage request carries no message")
+	}
+	if !strings.Contains(req.Messages[0].Content, "We build robots for warehouses.") {
+		t.Fatalf("the declaration never reached the triage prompt:\n%s", req.Messages[0].Content)
+	}
+}
+
+// What the profile lane is shown: the page's own claim about itself, ahead of
+// its body text, inside the same budget every other passage is charged.
+func TestTheProfileCorpusCarriesWhatTheHeadDeclared(t *testing.T) {
 	page := crawlPage{
+		URL: seedURL, Kind: crmcontracts.SiteReadPageKindHome,
 		Text:     "Body words.",
-		HeadText: []string{"A description.", "A title."},
+		HeadText: []string{"A description."},
 	}
-	want := "A description.\nA title.\n\nBody words."
-	if got := page.prose(); got != want {
-		t.Fatalf("prose() = %q, want %q", got, want)
+	excerpts := profileExcerptPages([]crawlPage{page})
+	if len(excerpts) == 0 {
+		t.Fatal("the home page did not reach the profile corpus")
 	}
-	// Text itself is untouched: evidence snippets are matched against it.
+	if !strings.Contains(excerpts[0].Text, "A description.") {
+		t.Fatalf("excerpt = %q, want the head declaration in the corpus", excerpts[0].Text)
+	}
+	// The crawl's own record of the page is untouched: evidence snippets from
+	// other lanes are matched against StripTags' output.
 	if page.Text != "Body words." {
-		t.Fatalf("Text = %q — prose() must not rewrite it", page.Text)
+		t.Fatalf("Text = %q — building the corpus must not rewrite the page", page.Text)
 	}
 }
 
@@ -82,7 +113,7 @@ func TestAPageWithNoHeadDeclarationReadsAsItsTextAlone(t *testing.T) {
 // The dossier says what kind of read this was, so a thin result is not
 // mistaken for a thin company.
 func TestTheDossierSaysWhenOnlyAShellCouldBeRead(t *testing.T) {
-	shell := []crawlPage{{Kind: crmcontracts.SiteReadPageKindHome, Text: "", ExternalScripts: 4}}
+	shell := []crawlPage{{Kind: crmcontracts.SiteReadPageKindHome, Text: "", ExternalScripts: 4, ModuleScripts: 1}}
 	warnings := readWarnings("", nil, seedIsJSShell(shell))
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "browser") {
 		t.Fatalf("warnings = %v, want one naming that the site builds its pages in the browser", warnings)
@@ -91,4 +122,116 @@ func TestTheDossierSaysWhenOnlyAShellCouldBeRead(t *testing.T) {
 	if got := readWarnings("", nil, seedIsJSShell(ordinary)); len(got) != 0 {
 		t.Fatalf("warnings = %v, want none for a site that served its words", got)
 	}
+}
+
+// The same catch-all, serving a SHORT document — which is what a
+// client-rendered site actually sends. The duplicate was recognised only after
+// the text floor had already reported it, so one loader shell became
+// thirty-one `unreadable` skips and the report read as a site that could not be
+// read rather than one page seen many times.
+func TestADuplicateShellIsSilentEvenThoughItIsShort(t *testing.T) {
+	shell := fakeSitePage{text: "Acme", scripts: 2, modules: 1}
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		seedURL: {text: readable("Welcome to Acme."), links: []string{
+			seedURL + "/about", seedURL + "/team", seedURL + "/kontakt",
+		}},
+	}}
+	// The catch-all: every path a probe guesses at answers 200 with the same
+	// loader, which is what a client-rendered site does and why the probes all
+	// come back looking like separate unreadable pages.
+	for _, probe := range wellKnownProbes {
+		site.pages[seedURL+probe.path] = shell
+	}
+	for _, path := range []string{"/about", "/team", "/kontakt"} {
+		site.pages[seedURL+path] = shell
+	}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reported []string
+	for _, skip := range crawl.Skipped {
+		if skip.Reason == crmcontracts.SiteReadSkipReasonUnreadable {
+			reported = append(reported, skip.URL)
+		}
+	}
+	// One document, said once. The first shell is honest degradation and
+	// belongs in the report; the repeats are the same fact again, and it was
+	// repeating them thirty-one times that made a readable site look unread.
+	if len(reported) != 1 {
+		t.Fatalf("unreadable skips = %d, want 1 — one repeated document is one fact: %v",
+			len(reported), reported)
+	}
+	// And it is the FIRST one walked, not whichever happened to land last:
+	// probes run in wellKnownProbes order ahead of the seed's own links.
+	if want := seedURL + wellKnownProbes[0].path; reported[0] != want {
+		t.Fatalf("the reported shell was %q, want the first one walked %q", reported[0], want)
+	}
+}
+
+// The seed's own body is in the dedupe from the start, so a catch-all that
+// answers every path with the LANDING page reports nothing at all — the shape
+// TestCrawlSkipsADuplicateTextPageSilently covers for a long page, here for a
+// short one, which is the half that used to fall through the text floor.
+func TestACatchAllServingTheSeedItselfIsSilent(t *testing.T) {
+	shell := fakeSitePage{text: "Acme", scripts: 1, modules: 1}
+	site := &fakeSite{pages: map[string]fakeSitePage{seedURL: shell}}
+	for _, probe := range wellKnownProbes {
+		site.pages[seedURL+probe.path] = shell
+	}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, skip := range crawl.Skipped {
+		if skip.Reason == crmcontracts.SiteReadSkipReasonUnreadable {
+			t.Fatalf("the seed's own body was reported as an unreadable page at %s", skip.URL)
+		}
+	}
+}
+
+// Two routes can share a body and still say different things about themselves.
+// Once a page's own declaration became evidence the profile lane reads, keying
+// the dedupe on body text alone would drop the second silently — taking a
+// description no other page carries with it.
+func TestTwoRoutesWithDifferentDeclarationsAreTwoDocuments(t *testing.T) {
+	body := readable("Shared body.")
+	site := &fakeSite{pages: map[string]fakeSitePage{
+		seedURL: {
+			text: body, headText: []string{"The home page."},
+			links: []string{seedURL + "/services"},
+		},
+		seedURL + "/services": {text: body, headText: []string{"What we build for clients."}},
+	}}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, page := range crawl.Pages {
+		if page.URL == seedURL+"/services" {
+			return
+		}
+	}
+	t.Fatalf("the second declaration vanished as a duplicate: %+v", crawl.Pages)
+}
+
+// A short page nobody has seen before is still honest degradation, and still
+// belongs in the report.
+func TestAShortPageSeenOnceIsStillReportedUnreadable(t *testing.T) {
+	site := &fakeSite{pages: seedOnly("/about")}
+	site.pages[seedURL+"/about"] = fakeSitePage{text: "Thin", scripts: 1}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, skip := range crawl.Skipped {
+		if skip.URL == seedURL+"/about" && skip.Reason == crmcontracts.SiteReadSkipReasonUnreadable {
+			return
+		}
+	}
+	t.Fatalf("a unique unreadable page vanished from the report: %+v", crawl.Skipped)
 }

--- a/backend/internal/compose/sitejsshell_test.go
+++ b/backend/internal/compose/sitejsshell_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// A client-rendered site sends a loader, not its words. Judging that "no
+// readable text" puts a real company on file as an empty address, with no model
+// call made and nothing later to reopen it — the same failure the meta-refresh
+// follow exists to prevent, arriving by another route.
+//
+// The worker is the zero value: it carries no brain, so a verdict that needed a
+// model call would panic rather than pass quietly.
+func TestAJavaScriptShellIsNotSettledAsParked(t *testing.T) {
+	shell := crawlPage{Text: "", ExternalScripts: 3}
+	verdict, err := (&siteDeepReadWorker{}).classifySeed(context.Background(), shell)
+	if err != nil {
+		t.Fatalf("classifying: %v", err)
+	}
+	if verdict.Aborts() {
+		t.Errorf("verdict %+v settles the domain — a shell this reader cannot render is an unread page, not an empty one", verdict)
+	}
+}
+
+// The guard's other half. A page with nothing on it and nothing to build it
+// with is genuinely empty, and that answer still costs no model call.
+func TestAnEmptyPageWithNoScriptsIsStillParked(t *testing.T) {
+	empty := crawlPage{Text: "", ExternalScripts: 0}
+	verdict, err := (&siteDeepReadWorker{}).classifySeed(context.Background(), empty)
+	if err != nil {
+		t.Fatalf("classifying: %v", err)
+	}
+	if !verdict.Aborts() {
+		t.Errorf("verdict %+v does not settle a genuinely empty landing page", verdict)
+	}
+}
+
+// A shell that DID declare what it is about has prose to judge, so it goes to
+// the classifier like any other page rather than being settled deterministically.
+func TestAShellThatDeclaresItselfIsHandedToTheClassifier(t *testing.T) {
+	declared := crawlPage{Text: "", ExternalScripts: 2, HeadText: []string{"We build robots."}}
+	if !strings.Contains(declared.prose(), "We build robots.") {
+		t.Fatalf("prose() = %q, want the head declaration", declared.prose())
+	}
+	if declared.isJSShell() != true {
+		t.Fatal("a scripted, textless page is a shell whatever its head declared")
+	}
+}
+
+// What the model is shown: the page's own claim about itself, ahead of its
+// body text. On a shell it is the only prose the server ever sent.
+func TestTheModelIsShownWhatTheHeadDeclared(t *testing.T) {
+	page := crawlPage{
+		Text:     "Body words.",
+		HeadText: []string{"A description.", "A title."},
+	}
+	want := "A description.\nA title.\n\nBody words."
+	if got := page.prose(); got != want {
+		t.Fatalf("prose() = %q, want %q", got, want)
+	}
+	// Text itself is untouched: evidence snippets are matched against it.
+	if page.Text != "Body words." {
+		t.Fatalf("Text = %q — prose() must not rewrite it", page.Text)
+	}
+}
+
+// A page that declared nothing reads exactly as it did before.
+func TestAPageWithNoHeadDeclarationReadsAsItsTextAlone(t *testing.T) {
+	page := crawlPage{Text: "Body words."}
+	if got := page.prose(); got != "Body words." {
+		t.Fatalf("prose() = %q, want the text unchanged", got)
+	}
+}
+
+// The dossier says what kind of read this was, so a thin result is not
+// mistaken for a thin company.
+func TestTheDossierSaysWhenOnlyAShellCouldBeRead(t *testing.T) {
+	shell := []crawlPage{{Kind: crmcontracts.SiteReadPageKindHome, Text: "", ExternalScripts: 4}}
+	warnings := readWarnings("", nil, seedIsJSShell(shell))
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "browser") {
+		t.Fatalf("warnings = %v, want one naming that the site builds its pages in the browser", warnings)
+	}
+	ordinary := []crawlPage{{Kind: crmcontracts.SiteReadPageKindHome, Text: strings.Repeat("word ", 40)}}
+	if got := readWarnings("", nil, seedIsJSShell(ordinary)); len(got) != 0 {
+		t.Fatalf("warnings = %v, want none for a site that served its words", got)
+	}
+}

--- a/backend/internal/compose/sitepageprose.go
+++ b/backend/internal/compose/sitepageprose.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a crawled page says, and whether the reader actually got it.
+//
+// Its own file because it is one question the crawler proper does not ask: the
+// crawl decides what to FETCH, and these three decide what a fetched page
+// amounts to once a model or a triage has to judge the company behind it.
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/webread"
+)
+
+// pageFrom carries one fetched page into the crawl's own record of it.
+//
+// One spelling for all three places a crawlPage is built — the seed, a
+// committed wave page, and ReadSeed — because they were three hand-written
+// copies of the same mapping, and a field added to the struct reached whichever
+// of them the author happened to be looking at. Kind, and anything the crawl
+// decides rather than the fetch, stays with the caller.
+func pageFrom(url string, kind crmcontracts.SiteReadPageKind, page webread.Page) crawlPage {
+	return crawlPage{
+		URL:             url,
+		Kind:            kind,
+		Text:            page.Text,
+		Bytes:           page.Bytes,
+		Fingerprint:     page.Fingerprint,
+		HeadText:        page.HeadText,
+		ExternalScripts: page.ExternalScripts,
+	}
+}
+
+// prose is everything this page SAYS, for a reader that wants to understand it:
+// what the <head> declares the page is about, then the body text.
+//
+// It exists because Text alone is not what the page says on a client-rendered
+// site — there the server sends a loader and a description, and reading only
+// the first left a company judged on eight words of <title>. The head goes
+// FIRST: it is one or two sentences written to explain the site to a stranger,
+// which is exactly the question both model lanes ask.
+//
+// Text itself is never rewritten. Stored evidence snippets are matched against
+// StripTags' output (evidencematch.go), so a page whose Text grew a preamble
+// would silently invalidate every snippet already on file.
+func (p crawlPage) prose() string {
+	if len(p.HeadText) == 0 {
+		return p.Text
+	}
+	head := strings.Join(p.HeadText, "\n")
+	if strings.TrimSpace(p.Text) == "" {
+		return head
+	}
+	return head + "\n\n" + p.Text
+}
+
+// isJSShell reports whether this page is a client-rendered application shell:
+// too little prose to read, and the scripts that would have rendered it.
+//
+// Both halves are needed. Short AND scriptless is a genuinely empty document —
+// a parked domain, a placeholder — and must keep reading as one. Short and
+// SCRIPTED is a site whose words exist and are assembled by a browser this
+// reader does not run; judging that one "no readable text" says something
+// false about the company behind it.
+func (p crawlPage) isJSShell() bool {
+	return p.ExternalScripts > 0 &&
+		utf8.RuneCountInString(strings.TrimSpace(p.Text)) < crawlMinRunes
+}

--- a/backend/internal/compose/sitepageprose.go
+++ b/backend/internal/compose/sitepageprose.go
@@ -33,7 +33,26 @@ func pageFrom(url string, kind crmcontracts.SiteReadPageKind, page webread.Page)
 		Fingerprint:     page.Fingerprint,
 		HeadText:        page.HeadText,
 		ExternalScripts: page.ExternalScripts,
+		ModuleScripts:   page.ModuleScripts,
 	}
+}
+
+// bodyIdentity is what makes two fetched pages the SAME document for the
+// crawl's dedupe: their stripped text and what their heads declared.
+//
+// The head half is not decoration. Once a page's meta description became
+// evidence the profile lane reads, two routes sharing a body but declaring
+// different descriptions stopped being the same document — and keying on text
+// alone would have dropped the second silently, taking a description no other
+// page carries with it. That is the one failure a dedupe must not have.
+//
+// The separator cannot occur in either part: StripTags collapses whitespace
+// runs, and a harvested declaration is joined from strings.Fields.
+func bodyIdentity(text string, headText []string) string {
+	if len(headText) == 0 {
+		return text
+	}
+	return text + "\n\x00\n" + strings.Join(headText, "\n")
 }
 
 // prose is everything this page SAYS, for a reader that wants to understand it:
@@ -60,14 +79,21 @@ func (p crawlPage) prose() string {
 }
 
 // isJSShell reports whether this page is a client-rendered application shell:
-// too little prose to read, and the scripts that would have rendered it.
+// too little prose to read, and a MODULE bundle that would have rendered it.
 //
-// Both halves are needed. Short AND scriptless is a genuinely empty document —
-// a parked domain, a placeholder — and must keep reading as one. Short and
-// SCRIPTED is a site whose words exist and are assembled by a browser this
-// reader does not run; judging that one "no readable text" says something
+// Both halves are needed. Short and scriptless is a genuinely empty document —
+// a parked domain, a placeholder — and must keep reading as one. Short with an
+// application bundle is a site whose words exist and are assembled by a browser
+// this reader does not run; judging that one "no readable text" says something
 // false about the company behind it.
+//
+// A parked domain is the case that decides the second half's shape. Those pages
+// routinely carry an analytics tag or a registrar's own script, so counting ANY
+// external script would let a squatter's placeholder escape the parked verdict
+// and stay a pending, retried, never-evidenced read forever. `type="module"` is
+// what separates them: it is how every current bundler emits an application
+// entry point, and no analytics snippet is served that way.
 func (p crawlPage) isJSShell() bool {
-	return p.ExternalScripts > 0 &&
+	return p.ModuleScripts > 0 &&
 		utf8.RuneCountInString(strings.TrimSpace(p.Text)) < crawlMinRunes
 }

--- a/backend/internal/compose/siteprofile.go
+++ b/backend/internal/compose/siteprofile.go
@@ -166,11 +166,21 @@ func profileExcerptPages(pages []crawlPage) excerptPages {
 				}
 			}
 		}
-		pageRunes := []rune(page.Text)
+		// prose, not Text: on a client-rendered site the server sends a loader
+		// and a <head> description, so reading Text alone handed the model
+		// eight words of <title> — and it answered with the only two fields a
+		// title can ground. The declaration is charged against the same
+		// per-page cap and the same total budget as any other passage, and
+		// gateProfile stores the corpus passage itself as evidence, so a
+		// meta-grounded field quotes text the page really carries.
+		//
+		// `page` is this loop's own copy, so the narrowed Text travels into
+		// the excerpt and never back into the crawl's record of the page.
+		pageRunes := []rune(page.prose())
 		if len(pageRunes) > capRunes {
 			pageRunes = pageRunes[:capRunes]
-			page.Text = string(pageRunes)
 		}
+		page.Text = string(pageRunes)
 		if used+len(pageRunes) > profileExcerptBudgetRunes {
 			return false
 		}

--- a/backend/internal/compose/sitetriage.go
+++ b/backend/internal/compose/sitetriage.go
@@ -136,7 +136,7 @@ func triageSchema() json.RawMessage {
 //promptvoice:exempt decides what a website IS and answers a classification with a confidence; no sentence reaches a reader.
 func triageRequest(page crawlPage, lang string) model.Request {
 	fence := promptfence.New()
-	body := fmt.Sprintf("url: %s\n\n%s", page.URL, triageExcerpt(page.Text))
+	body := fmt.Sprintf("url: %s\n\n%s", page.URL, triageExcerpt(page.prose()))
 	return model.Request{
 		System:         triageSystemFor(fence, lang),
 		Messages:       []model.Message{{Role: chatRoleUser, Content: fence.Wrap(body)}},

--- a/backend/internal/platform/webread/headtext.go
+++ b/backend/internal/platform/webread/headtext.go
@@ -73,20 +73,25 @@ func truncateRunes(s string, n int) string {
 	return string([]rune(s)[:n])
 }
 
-// countExternalScripts counts the <script src=…> tags a page loads.
+// countScripts counts the <script src=…> tags a page loads, and how many of
+// those are ES MODULES.
 //
 // It reads the whole document, not just the head: a client-rendered site puts
 // its bundle wherever the build tool chose, and the question here is what the
 // page needs a BROWSER for, not what it declares about itself. Inline scripts
-// are not counted — an analytics snippet is on every page, including the ones
-// that also carry prose.
-func countExternalScripts(rawHTML string) int {
+// are not counted — they carry no application.
+//
+// The module count is kept apart because the plain one cannot answer the
+// question a caller actually asks. A parked domain carries analytics and a
+// registrar's script just as readily as a real site does, so "has a script"
+// says nothing; `type="module"` is how every current bundler emits an
+// application entry point, and no analytics snippet is served that way.
+func countScripts(rawHTML string) (external, modules int) {
 	tokenizer := html.NewTokenizer(strings.NewReader(rawHTML))
-	count := 0
 	for {
 		tokenType := tokenizer.Next()
 		if tokenType == html.ErrorToken {
-			return count
+			return external, modules
 		}
 		if tokenType != html.StartTagToken && tokenType != html.SelfClosingTagToken {
 			continue
@@ -95,8 +100,13 @@ func countExternalScripts(rawHTML string) int {
 		if string(name) != "script" || !hasAttr {
 			continue
 		}
-		if tagAttrs(tokenizer)["src"] != "" {
-			count++
+		attrs := tagAttrs(tokenizer)
+		if attrs["src"] == "" {
+			continue
+		}
+		external++
+		if strings.EqualFold(strings.TrimSpace(attrs["type"]), "module") {
+			modules++
 		}
 	}
 }

--- a/backend/internal/platform/webread/headtext.go
+++ b/backend/internal/platform/webread/headtext.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+// What a page SAYS about itself, and what it needs a browser for.
+//
+// Its own file because it is one concept the rest of page.go does not share:
+// every other harvest there reads an ASSET — an image, an icon, a forwarding
+// address — while these two read the page's prose and the shape of its markup.
+// Together they are what lets a caller tell a client-rendered application
+// shell from an empty document, which is a question about the site rather than
+// about any file it serves.
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/net/html"
+)
+
+// headTextRunes bounds one harvested head declaration. A description is a
+// sentence or two by convention; anything longer is a page stuffing the tag,
+// and it would be spent out of a prompt budget that belongs to the page's own
+// prose.
+const headTextRunes = 1000
+
+// headTextNames are the <head> declarations that say what a page is ABOUT,
+// in the order a reader would want them: the description first, because it is
+// written for a stranger, then the Open Graph pair a site keeps for sharing.
+var headTextNames = []string{"description", "og:title", "og:description"}
+
+// headTextFrom reads one <meta>'s attributes as a claim about what the page is
+// about. Open Graph names its fields in `property` and some CMSs emit them in
+// `name`, so both are accepted — the same rule ogImageFrom follows.
+//
+// seen carries the declarations already harvested, so a page repeating a tag
+// contributes it once: first declaration wins, as it does for og:image, and a
+// site that emits og:description twice must not spend the budget twice. A
+// declaration whose content duplicates one already taken is dropped too — a
+// title and an og:title are commonly identical, and reading the same sentence
+// twice tells a reader nothing the first did not.
+func headTextFrom(attrs map[string]string, seen map[string]bool) (string, bool) {
+	var field string
+	for _, candidate := range headTextNames {
+		if attrs["property"] == candidate || attrs["name"] == candidate {
+			field = candidate
+			break
+		}
+	}
+	if field == "" || seen[field] {
+		return "", false
+	}
+	seen[field] = true
+	content := strings.Join(strings.Fields(attrs["content"]), " ")
+	if content == "" {
+		return "", false
+	}
+	content = truncateRunes(content, headTextRunes)
+	if seen["v:"+content] {
+		return "", false
+	}
+	seen["v:"+content] = true
+	return content, true
+}
+
+// truncateRunes cuts a string to at most n runes, counting characters rather
+// than bytes so a multi-byte sentence is not split mid-rune.
+func truncateRunes(s string, n int) string {
+	if utf8.RuneCountInString(s) <= n {
+		return s
+	}
+	return string([]rune(s)[:n])
+}
+
+// countExternalScripts counts the <script src=…> tags a page loads.
+//
+// It reads the whole document, not just the head: a client-rendered site puts
+// its bundle wherever the build tool chose, and the question here is what the
+// page needs a BROWSER for, not what it declares about itself. Inline scripts
+// are not counted — an analytics snippet is on every page, including the ones
+// that also carry prose.
+func countExternalScripts(rawHTML string) int {
+	tokenizer := html.NewTokenizer(strings.NewReader(rawHTML))
+	count := 0
+	for {
+		tokenType := tokenizer.Next()
+		if tokenType == html.ErrorToken {
+			return count
+		}
+		if tokenType != html.StartTagToken && tokenType != html.SelfClosingTagToken {
+			continue
+		}
+		name, hasAttr := tokenizer.TagName()
+		if string(name) != "script" || !hasAttr {
+			continue
+		}
+		if tagAttrs(tokenizer)["src"] != "" {
+			count++
+		}
+	}
+}

--- a/backend/internal/platform/webread/headtext_test.go
+++ b/backend/internal/platform/webread/headtext_test.go
@@ -125,3 +125,38 @@ func TestOnlyLoadedScriptsAreCounted(t *testing.T) {
 		t.Fatalf("Page.ExternalScripts = %d, want 0 — an inline snippet loads nothing", page.ExternalScripts)
 	}
 }
+
+// A parked domain routinely carries a registrar's script or an analytics tag,
+// so "has a script" cannot separate one from a real site whose words a browser
+// assembles. The module count is what does, because that is how every current
+// bundler emits an application entry point.
+func TestOnlyAModuleBundleCountsAsAnApplication(t *testing.T) {
+	doc := `<html><head>
+<script src="https://plausible.io/js/script.js"></script>
+<script async src="https://www.googletagmanager.com/gtag/js"></script>
+</head><body><p>For sale.</p></body></html>`
+	page, err := testFetcher().FetchPage(context.Background(), serveHTML(t, doc).URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.ExternalScripts != 2 {
+		t.Fatalf("Page.ExternalScripts = %d, want 2 — both are loaded", page.ExternalScripts)
+	}
+	if page.ModuleScripts != 0 {
+		t.Fatalf("Page.ModuleScripts = %d, want 0 — analytics is not an application", page.ModuleScripts)
+	}
+}
+
+func TestAModuleBundleIsCountedAsOne(t *testing.T) {
+	doc := `<html><head>
+<script src="https://plausible.io/js/script.js"></script>
+<script type="module" crossorigin src="/assets/index-DyqdXLtN.js"></script>
+</head><body><div id="root"></div></body></html>`
+	page, err := testFetcher().FetchPage(context.Background(), serveHTML(t, doc).URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.ModuleScripts != 1 {
+		t.Fatalf("Page.ModuleScripts = %d, want 1 — the bundle is the application", page.ModuleScripts)
+	}
+}

--- a/backend/internal/platform/webread/headtext_test.go
+++ b/backend/internal/platform/webread/headtext_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// serveHTML answers every path with one document, the way a client-rendered
+// site's catch-all does.
+func serveHTML(t *testing.T, doc string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		//craft:ignore swallowed-errors httptest handler write; a failed write fails the test through the assertions below
+		_, _ = w.Write([]byte(doc))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// The shape that produced the bug: a Vite build's index.html, whose whole
+// server-sent prose is the <title> and the head declarations. What the company
+// does is stated in the description, and it was being thrown away.
+const shellHTML = `<!doctype html><html lang="en"><head>
+<title>Erler Ventures | The Operating System for Founders</title>
+<meta name="description" content="90% of startups fail. Yours doesn't have to. The systematic operating system for founders and scaling companies." />
+<meta property="og:title" content="Erler Ventures | The Operating System for Founders" />
+<meta property="og:description" content="Systematic execution from Day 1 to profitable scale." />
+<script type="module" crossorigin src="/assets/index-DyqdXLtN.js"></script>
+</head><body><div id="root"></div></body></html>`
+
+func TestAPageCarriesWhatItsHeadSaysItIsAbout(t *testing.T) {
+	srv := serveHTML(t, shellHTML)
+	page, err := testFetcher().FetchPage(context.Background(), srv.URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"90% of startups fail. Yours doesn't have to. The systematic operating system for founders and scaling companies.",
+		"Erler Ventures | The Operating System for Founders",
+		"Systematic execution from Day 1 to profitable scale.",
+	}
+	if !reflect.DeepEqual(page.HeadText, want) {
+		t.Fatalf("Page.HeadText = %q,\nwant %q", page.HeadText, want)
+	}
+	// The text contract is what stored evidence snippets are matched against,
+	// so the head prose must NOT have been folded into it.
+	if page.Text != StripTags(shellHTML) {
+		t.Fatalf("Page.Text = %q diverged from StripTags", page.Text)
+	}
+	if page.ExternalScripts != 1 {
+		t.Fatalf("Page.ExternalScripts = %d, want 1 — the module bundle", page.ExternalScripts)
+	}
+}
+
+// A page repeating a declaration offers no basis to rank the repeats, and a
+// title echoed as og:title is one sentence, not two.
+func TestAHeadDeclarationIsHarvestedOnce(t *testing.T) {
+	doc := `<html><head>
+<meta name="description" content="The first one." />
+<meta name="description" content="A second, later one." />
+<meta property="og:title" content="The first one." />
+</head><body>Words enough to read.</body></html>`
+	page, err := testFetcher().FetchPage(context.Background(), serveHTML(t, doc).URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"The first one."}; !reflect.DeepEqual(page.HeadText, want) {
+		t.Fatalf("Page.HeadText = %q, want %q — first declaration wins, duplicates drop", page.HeadText, want)
+	}
+}
+
+// The head is where a site declares its own identity. On a page carrying
+// somebody else's writing, whoever wrote the body also wrote the tags around
+// it, and a description down there is not the site's claim about itself.
+func TestADescriptionInTheBodyIsNotTheSitesOwnClaim(t *testing.T) {
+	doc := `<html><head><title>Real</title></head><body>
+<meta name="description" content="Injected by a commenter." />
+Words enough to read.</body></html>`
+	page, err := testFetcher().FetchPage(context.Background(), serveHTML(t, doc).URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.HeadText) != 0 {
+		t.Fatalf("Page.HeadText = %q, want none — the body is not the head", page.HeadText)
+	}
+}
+
+// A tag stuffed with a page of prose would spend a prompt budget that belongs
+// to the site's own words.
+func TestAnOverlongDeclarationIsCutToTheBudget(t *testing.T) {
+	doc := `<html><head><meta name="description" content="` +
+		strings.Repeat("ü", headTextRunes+500) + `" /></head><body>Words enough.</body></html>`
+	page, err := testFetcher().FetchPage(context.Background(), serveHTML(t, doc).URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.HeadText) != 1 {
+		t.Fatalf("HeadText = %q, want one declaration", page.HeadText)
+	}
+	if got := len([]rune(page.HeadText[0])); got != headTextRunes {
+		t.Fatalf("declaration = %d runes, want it cut to %d", got, headTextRunes)
+	}
+}
+
+// Inline scripts are on pages that carry prose too; only a loaded bundle says
+// the page expects a browser to build it.
+func TestOnlyLoadedScriptsAreCounted(t *testing.T) {
+	doc := `<html><head><script>window.x=1</script></head><body>Words enough to read.</body></html>`
+	page, err := testFetcher().FetchPage(context.Background(), serveHTML(t, doc).URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.ExternalScripts != 0 {
+		t.Fatalf("Page.ExternalScripts = %d, want 0 — an inline snippet loads nothing", page.ExternalScripts)
+	}
+}

--- a/backend/internal/platform/webread/page.go
+++ b/backend/internal/platform/webread/page.go
@@ -49,6 +49,21 @@ type Page struct {
 	// leaving the page's own registrable domain. A caller follows it only
 	// after finding nothing else to read — see MetaRefreshOnly.
 	Refresh string
+	// HeadText is what the <head> says this page is ABOUT, in document order:
+	// the meta description and the Open Graph title and description, each at
+	// most headTextRunes long.
+	//
+	// Kept apart from Text, and that separation is the point. Text is
+	// StripTags' output and evidence snippets are matched against it, so
+	// folding head prose in would silently invalidate every stored snippet.
+	// This is the same page's own claim about itself, offered to a caller that
+	// wants it — which for a client-rendered site is the only prose the server
+	// ever sends.
+	HeadText []string
+	// ExternalScripts counts the <script src=…> tags the page loads. It says
+	// nothing on its own; a caller pairs it with a text floor to tell a
+	// client-rendered application shell from an empty document.
+	ExternalScripts int
 }
 
 // MetaRefreshOnly reports whether this page is a redirect trampoline: it
@@ -127,24 +142,28 @@ func (f *Fetcher) FetchPage(ctx context.Context, rawURL string) (Page, error) {
 	body := string(got.body)
 	head := extractHeadAssets(body, base)
 	return Page{
-		URL:         rawURL,
-		FinalURL:    base.String(),
-		Text:        StripTags(body),
-		Links:       extractLinks(body, base),
-		Bytes:       len(body),
-		OGImage:     head.ogImage,
-		Icons:       head.icons,
-		Refresh:     head.refresh,
-		Fingerprint: fingerprintOf(got.header, body, base),
+		URL:             rawURL,
+		FinalURL:        base.String(),
+		Text:            StripTags(body),
+		Links:           extractLinks(body, base),
+		Bytes:           len(body),
+		OGImage:         head.ogImage,
+		Icons:           head.icons,
+		Refresh:         head.refresh,
+		HeadText:        head.text,
+		ExternalScripts: countExternalScripts(body),
+		Fingerprint:     fingerprintOf(got.header, body, base),
 	}, nil
 }
 
 // headAssets is what a page's <head> declared about itself: its visual
-// identity, and where it says the reader should go instead.
+// identity, what it says it is about, and where it says the reader should go
+// instead.
 type headAssets struct {
 	ogImage string
 	icons   []IconRef
 	refresh string
+	text    []string
 }
 
 // extractHeadAssets harvests what a page's <head> declares about itself: its
@@ -156,6 +175,7 @@ func extractHeadAssets(rawHTML string, base *url.URL) headAssets {
 	tokenizer := html.NewTokenizer(strings.NewReader(rawHTML))
 	var head headAssets
 	seen := map[string]bool{}
+	seenText := map[string]bool{}
 	for {
 		tokenType := tokenizer.Next()
 		if tokenType == html.ErrorToken {
@@ -185,6 +205,9 @@ func extractHeadAssets(rawHTML string, base *url.URL) headAssets {
 			}
 			if found, ok := refreshFrom(attrs, base); ok && head.refresh == "" {
 				head.refresh = found
+			}
+			if found, ok := headTextFrom(attrs, seenText); ok {
+				head.text = append(head.text, found)
 			}
 		case "link":
 			if icon, ok := iconFrom(tokenizer, base); ok && !seen[icon.URL] {

--- a/backend/internal/platform/webread/page.go
+++ b/backend/internal/platform/webread/page.go
@@ -5,10 +5,7 @@ package webread
 
 import (
 	"context"
-	"encoding/xml"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -60,10 +57,15 @@ type Page struct {
 	// wants it — which for a client-rendered site is the only prose the server
 	// ever sends.
 	HeadText []string
-	// ExternalScripts counts the <script src=…> tags the page loads. It says
-	// nothing on its own; a caller pairs it with a text floor to tell a
-	// client-rendered application shell from an empty document.
+	// ExternalScripts counts the <script src=…> tags the page loads, and
+	// ModuleScripts how many of those are ES modules.
+	//
+	// The module count is the one that answers "is this an application shell":
+	// a parked domain carries analytics and registrar scripts too, so the plain
+	// count cannot separate a squatter's placeholder from a real site whose
+	// words a browser assembles. A caller pairs ModuleScripts with a text floor.
 	ExternalScripts int
+	ModuleScripts   int
 }
 
 // MetaRefreshOnly reports whether this page is a redirect trampoline: it
@@ -141,6 +143,7 @@ func (f *Fetcher) FetchPage(ctx context.Context, rawURL string) (Page, error) {
 	}
 	body := string(got.body)
 	head := extractHeadAssets(body, base)
+	external, modules := countScripts(body)
 	return Page{
 		URL:             rawURL,
 		FinalURL:        base.String(),
@@ -151,7 +154,8 @@ func (f *Fetcher) FetchPage(ctx context.Context, rawURL string) (Page, error) {
 		Icons:           head.icons,
 		Refresh:         head.refresh,
 		HeadText:        head.text,
-		ExternalScripts: countExternalScripts(body),
+		ExternalScripts: external,
+		ModuleScripts:   modules,
 		Fingerprint:     fingerprintOf(got.header, body, base),
 	}, nil
 }
@@ -406,72 +410,6 @@ func resolveLink(base *url.URL, href string) (string, bool) {
 	}
 	abs.Fragment = ""
 	return abs.String(), true
-}
-
-// FetchSitemap retrieves <origin>/sitemap.xml (robots-checked like any path)
-// and returns its <loc> entries. Both shapes parse: a urlset yields page URLs;
-// a sitemapindex yields the CHILD SITEMAP URLs as-is — deliberately not
-// recursed, the crawl's discovery budget does not chase nested indexes, and
-// the caller is expected to ignore entries that are sitemaps rather than
-// pages. A missing sitemap (4xx) is an empty list with no error: most sites
-// have none, absence is normal.
-func (f *Fetcher) FetchSitemap(ctx context.Context, origin string) ([]string, error) {
-	sitemapURL := strings.TrimSuffix(origin, "/") + "/sitemap.xml"
-	parsed, err := url.Parse(sitemapURL)
-	if err != nil || parsed.Host == "" {
-		return nil, fmt.Errorf("webread: %q is not a fetchable origin", origin)
-	}
-	allowed, err := f.pathAllowed(ctx, parsed)
-	if err != nil {
-		return nil, err
-	}
-	if !allowed {
-		return nil, fmt.Errorf("%w: %s", ErrRobotsDisallowed, parsed.Path)
-	}
-
-	body, status, _, err := f.getRaw(ctx, sitemapURL, "")
-	if err != nil {
-		return nil, err
-	}
-	switch {
-	case status == http.StatusOK:
-		return parseSitemapLocs(body)
-	case status >= 400 && status < 500:
-		return nil, nil // no sitemap declared — absence is normal
-	default:
-		return nil, fmt.Errorf("webread: sitemap.xml answered %d", status)
-	}
-}
-
-// parseSitemapLocs collects every <loc>'s text. Walking the token stream
-// instead of unmarshalling a struct lets one pass read both the urlset and
-// sitemapindex shapes — the element carrying a <loc> differs, the <loc> does
-// not.
-func parseSitemapLocs(body string) ([]string, error) {
-	decoder := xml.NewDecoder(strings.NewReader(body))
-	var locs []string
-	inLoc := false
-	for {
-		token, err := decoder.Token()
-		if errors.Is(err, io.EOF) {
-			return locs, nil
-		}
-		if err != nil {
-			return nil, fmt.Errorf("webread: sitemap.xml is not XML: %w", err)
-		}
-		switch element := token.(type) {
-		case xml.StartElement:
-			inLoc = element.Name.Local == "loc"
-		case xml.EndElement:
-			inLoc = false
-		case xml.CharData:
-			if inLoc {
-				if loc := strings.TrimSpace(string(element)); loc != "" {
-					locs = append(locs, loc)
-				}
-			}
-		}
-	}
 }
 
 // SameRegistrableDomain reports whether two URLs' hostnames share an eTLD+1

--- a/backend/internal/platform/webread/sitemap.go
+++ b/backend/internal/platform/webread/sitemap.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+// sitemap.xml: the one discovery channel a site publishes for crawlers rather
+// than for readers. Its own file because it is the only fetch here that parses
+// XML rather than HTML, and the only one whose result is a list of addresses
+// rather than a page.
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// FetchSitemap retrieves <origin>/sitemap.xml (robots-checked like any path)
+// and returns its <loc> entries. Both shapes parse: a urlset yields page URLs;
+// a sitemapindex yields the CHILD SITEMAP URLs as-is — deliberately not
+// recursed, the crawl's discovery budget does not chase nested indexes, and
+// the caller is expected to ignore entries that are sitemaps rather than
+// pages. A missing sitemap (4xx) is an empty list with no error: most sites
+// have none, absence is normal.
+func (f *Fetcher) FetchSitemap(ctx context.Context, origin string) ([]string, error) {
+	sitemapURL := strings.TrimSuffix(origin, "/") + "/sitemap.xml"
+	parsed, err := url.Parse(sitemapURL)
+	if err != nil || parsed.Host == "" {
+		return nil, fmt.Errorf("webread: %q is not a fetchable origin", origin)
+	}
+	allowed, err := f.pathAllowed(ctx, parsed)
+	if err != nil {
+		return nil, err
+	}
+	if !allowed {
+		return nil, fmt.Errorf("%w: %s", ErrRobotsDisallowed, parsed.Path)
+	}
+
+	body, status, _, err := f.getRaw(ctx, sitemapURL, "")
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case status == http.StatusOK:
+		return parseSitemapLocs(body)
+	case status >= 400 && status < 500:
+		return nil, nil // no sitemap declared — absence is normal
+	default:
+		return nil, fmt.Errorf("webread: sitemap.xml answered %d", status)
+	}
+}
+
+// parseSitemapLocs collects every <loc>'s text. Walking the token stream
+// instead of unmarshalling a struct lets one pass read both the urlset and
+// sitemapindex shapes — the element carrying a <loc> differs, the <loc> does
+// not.
+func parseSitemapLocs(body string) ([]string, error) {
+	decoder := xml.NewDecoder(strings.NewReader(body))
+	var locs []string
+	inLoc := false
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return locs, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("webread: sitemap.xml is not XML: %w", err)
+		}
+		switch element := token.(type) {
+		case xml.StartElement:
+			inLoc = element.Name.Local == "loc"
+		case xml.EndElement:
+			inLoc = false
+		case xml.CharData:
+			if inLoc {
+				if loc := strings.TrimSpace(string(element)); loc != "" {
+					locs = append(locs, loc)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What was wrong

A client-rendered site sends a loader and a `<head>`; this reader took the loader for the whole site.

On a real company in the dev workspace the crawl read **8 words** — the `<title>` — filed **31 `unreadable` skips** for one document served on every path, and produced a dossier with the only two fields a title can ground. What the company actually does was in the page the whole time, in its `<meta name="description">`: *"90% of startups fail. Yours doesn't have to. The systematic operating system for founders and scaling companies."*

A titleless shell was worse: `classifySeed` settled it as **parked, confidence 1**, with no model call and nothing to reopen it.

## What changed

- **`webread` carries what a page's `<head>` says about itself** — description, `og:title`, `og:description` (first-declaration-wins, deduped by value, each capped at 1000 runes) — plus how many scripts it loads. `Page.Text` is untouched: stored evidence snippets are matched against `StripTags`' output, so head prose rides a sibling field and never rewrites that contract.
- **A skipped short page is now remembered as seen.** The dedupe already existed and could never fire for this shape, because a page skipped as unreadable recorded nothing — so one loader became 31 separate report lines. The first occurrence is still reported; the repeats are the same fact.
- **Both model lanes read `crawlPage.prose()`** — the head declaration, then the body. The profile lane charges it against the same per-page cap and the same total budget, and `gateProfile` stores the corpus passage itself as evidence, so a meta-grounded field quotes text the page really carries.
- **`classifySeed` no longer settles a scripted, textless page as parked.** The words exist and a browser would assemble them, so this reader having none is a gap in the read — the same judgement an unfollowable forward already gets. A shell that *did* declare a description goes to the classifier with that prose. The dossier says so out loud, because a thin read must not read as a thin company.

## Tests

Five in `webread` (harvest, first-declaration-wins, the head boundary, the rune cap, inline-vs-loaded scripts), six in `compose` (the parked guard both ways, `prose()` both ways, the warning), and two crawl tests for the skip flood.

Mutation-checked one clause at a time. Reverting the seen-text record reproduces the production symptom exactly: **31 unreadable skips for one document**. Reverting `ExternalScripts > 0` to `>= 0` fails the scriptless-parked test; removing the shell arm returns `parked, confidence 1`.

Two files crossed the 500-line cap and were split by concept rather than waived: `webread/headtext.go` and `compose/sitepageprose.go`.

## Deliberately not done

No headless browser. No `crm.yaml` or skip-reason enum change — the honest cause goes in the free-form dossier warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Client-rendered sites were previously judged from their loader text, which could mark a real company as parked and report the same short shell as many unreadable pages. The crawler now keeps the page's head declarations alongside body text and identifies scripted shells, so model inputs and reports reflect what the server can actually say without changing stored body-text evidence.

**Details**

- Uses the description, `og:title`, and `og:description` in triage and profile prompts, within the existing per-page and total budgets.
- Treats a textless page loading a `type="module"` bundle as an unclear read instead of a parked domain, so a parked page with only analytics scripts still settles as parked.
- Dedupes short pages by body text plus head declarations, so a catch-all shell is reported once while routes sharing a body but declaring different descriptions stay distinct.
- Adds a dossier warning when the site builds its content in the browser, and carries head declarations through seed and crawled-page records.

<sup>Written for commit 7ae8f5fc174febee292a24c2f335eefce0ab4204. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved analysis of JavaScript-rendered websites.
  * Added relevant page metadata to improve site classification and profile evidence.
  * Added warnings when content requires browser-based rendering.
  * Added sitemap discovery to support broader site analysis.

* **Bug Fixes**
  * Prevented repeated JavaScript shell responses from creating duplicate unreadable-page notices.
  * Avoided incorrectly classifying client-rendered sites as having no content.
  * Preserved meaningful reports for genuinely short, unreadable pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->