### PR TITLE
A held thread opens the message it is holding

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -20467,6 +20467,18 @@ components:
             What the classifier concluded the thread is ABOUT — legal, personnel,
             financial_corporate, personal, security_incident, explicitly_confidential. Absent while
             pending, because nothing has concluded anything yet.
+        activity_id:
+          type: [string, 'null']
+          format: uuid
+          readOnly: true
+          description: |
+            The message that opened this thread, where this caller may read it — what a
+            client opens to show the correspondence rather than only naming it.
+
+            Null when the message was erased while the hold stood (the ledger deliberately
+            outlives it) AND null when the content is not this caller's: it is read from the
+            joined activity row, which carries the content gate, rather than from the
+            ledger's own column. `has_message` says which of the two it is.
         has_message:
           type: boolean
           description: |

--- a/backend/internal/compose/handlers_capturesenders.go
+++ b/backend/internal/compose/handlers_capturesenders.go
@@ -9,6 +9,8 @@ package compose
 import (
 	"net/http"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/platform/database"
@@ -76,6 +78,10 @@ func toContractHeldThread(t capture.HeldThread) crmcontracts.HeldThread {
 	}
 	if t.Subject != "" {
 		out.Subject = &t.Subject
+	}
+	if t.ActivityID != nil {
+		id := openapi_types.UUID(*t.ActivityID)
+		out.ActivityId = &id
 	}
 	out.OccurredAt = t.OccurredAt
 	return out

--- a/backend/internal/compose/heldthreads_integration_test.go
+++ b/backend/internal/compose/heldthreads_integration_test.go
@@ -173,6 +173,55 @@ func TestAHeldThreadWithholdsAMessageTheReaderIsNotOn(t *testing.T) {
 		t.Error("a message the caller is not on handed them its subject — " +
 			"the content clause is not composed")
 	}
+	// And no id either. The id is what a client OPENS, so handing one out for
+	// a message whose subject is withheld would route the reader straight to
+	// the words the line above just refused them. It is read from the joined
+	// activity row for exactly this reason — the ledger's own
+	// first_activity_id carries no content gate.
+	if got[0].ActivityID != nil {
+		t.Errorf("a message the caller is not on handed them its id (%v) — "+
+			"the id is read from the ledger rather than the gated join",
+			*got[0].ActivityID)
+	}
+}
+
+// The id a client opens is present for a message the reader may read, and the
+// admission case is asserted as hard as the refusal: a list that handed out no
+// id at all would pass every refusal above while opening nothing.
+func TestAHeldThreadCarriesTheMessageItsReaderMayOpen(t *testing.T) {
+	e := integration.Setup(t)
+	activityID := ids.NewV7()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO activity (id, kind, subject, occurred_at, source, captured_by, audience)
+			VALUES ($1, 'email', 'Rechnung Q3', now(), 'gmail', $2, 'workspace')`,
+			activityID, "human:"+e.Rep1.String())
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the message: %v", err)
+	}
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_thread_verdict (thread_key, user_id, status, kind, attempts, first_activity_id)
+			VALUES ('thread-openable', $1, 'held', 'financial_corporate', 1, $2)`,
+			e.Rep1, activityID)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the verdict: %v", err)
+	}
+
+	got := heldThreads(t, e, e.Rep1)
+	if len(got) != 1 {
+		t.Fatalf("%d threads, want 1", len(got))
+	}
+	if got[0].ActivityID == nil {
+		t.Fatal("a held thread whose message the reader may read carried no id; " +
+			"there is nothing for the drawer to open")
+	}
+	if *got[0].ActivityID != activityID {
+		t.Errorf("the row names activity %v, want the message that opened the thread %v",
+			*got[0].ActivityID, activityID)
+	}
 }
 
 func heldThreads(t *testing.T, e *integration.Env, user ids.UUID) []capture.HeldThread {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -21467,6 +21467,15 @@ type HealthDimensionRating string
 
 // HeldThread One thread your mailbox is withholding, and what is known about why.
 type HeldThread struct {
+	// ActivityId The message that opened this thread, where this caller may read it — what a
+	// client opens to show the correspondence rather than only naming it.
+	//
+	// Null when the message was erased while the hold stood (the ledger deliberately
+	// outlives it) AND null when the content is not this caller's: it is read from the
+	// joined activity row, which carries the content gate, rather than from the
+	// ledger's own column. `has_message` says which of the two it is.
+	ActivityId *openapi_types.UUID `json:"activity_id,omitempty"`
+
 	// Attempts How many times a verdict has been asked for. This is the outage signal: a pending row
 	// whose attempts stop climbing is a model that stopped answering.
 	Attempts int `json:"attempts"`

--- a/backend/internal/modules/capture/heldthreadslist.go
+++ b/backend/internal/modules/capture/heldthreadslist.go
@@ -49,6 +49,15 @@ type HeldThread struct {
 	// tell a reader their evidence was destroyed when it is sitting there
 	// unnamed.
 	HasActivity bool
+	// ActivityID is the message that opened the thread, for a reader who wants
+	// to read it rather than only be told it is held.
+	//
+	// Taken from the JOINED row rather than from the ledger's own
+	// first_activity_id, and that is the whole point: the join carries the
+	// content clause, so this is nil exactly when the message is gone OR when
+	// its content is not this caller's. Reading the ledger column instead would
+	// hand out an id for a message the caller may not open.
+	ActivityID *ids.UUID
 	// Attempts is how many times a verdict has been asked for. It is the
 	// outage signal: a pending row whose attempts stop climbing is a model
 	// that stopped answering, not a thread that is merely slow.
@@ -111,6 +120,7 @@ func HeldThreadsFor(ctx context.Context, db *database.DB) ([]HeldThread, error) 
 			SELECT v.thread_key,
 			       v.status,
 			       coalesce(v.kind, '')    AS kind,
+			       a.id                    AS activity_id,
 			       a.subject,
 			       a.occurred_at,
 			       v.attempts
@@ -131,7 +141,7 @@ func HeldThreadsFor(ctx context.Context, db *database.DB) ([]HeldThread, error) 
 		for rows.Next() {
 			var t HeldThread
 			var subject *string
-			if err := rows.Scan(&t.ThreadKey, &t.Status, &t.Kind,
+			if err := rows.Scan(&t.ThreadKey, &t.Status, &t.Kind, &t.ActivityID,
 				&subject, &t.OccurredAt, &t.Attempts); err != nil {
 				return fmt.Errorf("capture: listing a seat's held threads: %w", err)
 			}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -13765,6 +13765,17 @@ export interface components {
              */
             kind?: string;
             /**
+             * Format: uuid
+             * @description The message that opened this thread, where this caller may read it — what a
+             *     client opens to show the correspondence rather than only naming it.
+             *
+             *     Null when the message was erased while the hold stood (the ledger deliberately
+             *     outlives it) AND null when the content is not this caller's: it is read from the
+             *     joined activity row, which carries the content gate, rather than from the
+             *     ledger's own column. `has_message` says which of the two it is.
+             */
+            readonly activity_id?: string | null;
+            /**
              * @description The message this thread began with is still readable by you. False where it was erased
              *     while the verdict stood — which the ledger deliberately survives, because losing the
              *     verdict would re-open a thread a classifier already held — and false where its content

--- a/frontend/src/screens/held-threads.test.tsx
+++ b/frontend/src/screens/held-threads.test.tsx
@@ -5,7 +5,7 @@
 import "@testing-library/jest-dom/vitest";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -64,6 +64,49 @@ function renderCard(rows: HeldThread[], share?: Record<string, unknown>) {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
+      }
+      // The drawer's own read. Served here so opening a thread does not throw
+      // on a body with no access block; what the drawer draws from it is
+      // emaildetail's contract, tested there.
+      if (key.endsWith("/email-presentation")) {
+        return new Response(
+          JSON.stringify({
+            id: "01a05500-0000-7000-8000-0000000000b1",
+            lifecycle: "delivered",
+            occurred_at: "2026-08-29T15:40:00Z",
+            summary: {
+              activity_id: "01a05500-0000-7000-8000-0000000000b1",
+              occurred_at: "2026-08-29T15:40:00Z",
+              version: 1,
+              subject: "Entwurf Aufhebungsvertrag",
+              display_status: "participants",
+              move: "none",
+              attachment_count: 0,
+            },
+            body: "…",
+            from: [],
+            to: [],
+            cc: [],
+            bcc: [],
+            bcc_withheld: false,
+            attachments: [],
+            links: [],
+            thread: { members: [], next_cursor: null },
+            access: {
+              content_state: "available",
+              audience: "participants",
+              selected_members: [],
+              display_status: "participants",
+              can_change: false,
+              change_mode: "message",
+              held_by_others: false,
+            },
+            can_reply: false,
+            can_relink: false,
+            version: 1,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
       }
       if (key.startsWith("POST /activities/threads/")) {
         return new Response(JSON.stringify(share ?? { shared: true }), {
@@ -170,4 +213,49 @@ describe("held threads", () => {
       await screen.findByText(/withholding nothing right now/i),
     ).toBeInTheDocument();
   });
+});
+
+// A held thread whose message this reader may read opens it. The server sends
+// `activity_id` only for those — it reads the id off the gated join — so the
+// presence of the field IS the permission.
+it("opens the message a held thread is about", async () => {
+  const openable: HeldThread = {
+    ...JUDGED,
+    thread_key: "t-openable",
+    activity_id: "01a05500-0000-7000-8000-0000000000b1",
+  };
+  renderCard([openable]);
+
+  const button = await screen.findByRole("button", {
+    name: "Entwurf Aufhebungsvertrag",
+  });
+  expect(button.getAttribute("aria-haspopup")).toBe("dialog");
+  // Pressing it asks for THIS message's presentation — the screen's half of
+  // the job. What the drawer then draws is emaildetail's own contract.
+  await userEvent.click(button);
+  await waitFor(() => {
+    const asked = (
+      globalThis.fetch as ReturnType<typeof vi.fn>
+    ).mock.calls.some((call) => {
+      const [input] = call;
+      const url = input instanceof Request ? input.url : String(input);
+      return url.includes(
+        "/activities/01a05500-0000-7000-8000-0000000000b1/email-presentation",
+      );
+    });
+    expect(asked).toBe(true);
+  });
+});
+
+// And a thread whose message it may NOT read names itself and offers nothing.
+// The server withholds the id for a message outside the caller's audience, so
+// this row must not become a control — a button that opened nothing would be
+// worse than the plain text it replaced.
+it("names a thread it cannot open without offering to", async () => {
+  renderCard([JUDGED]);
+
+  expect(await screen.findByText("Entwurf Aufhebungsvertrag")).toBeTruthy();
+  expect(
+    screen.queryByRole("button", { name: "Entwurf Aufhebungsvertrag" }),
+  ).toBeNull();
 });

--- a/frontend/src/screens/held-threads.tsx
+++ b/frontend/src/screens/held-threads.tsx
@@ -4,6 +4,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { Badge, Button, DataTable, EmptyState } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
+import { OpenEmailDrawer } from "../design-system/openemaildrawer";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useToast } from "../design-system/toast";
 import { formatDateTime, formatNumber } from "../format/format";
@@ -12,6 +13,7 @@ import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { useThreadAudience } from "./audienceservice";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
+import { useOpenEmail } from "./openemail";
 
 // What this mailbox is holding back from the team, and the one press that
 // releases a thread.
@@ -114,6 +116,9 @@ function HeldThreadTable({ rows }: Readonly<{ rows: HeldThread[] }>) {
   });
 
   const stillHeld = Object.entries(heldByOthers);
+  // The message a held row opens. This table is the one place a reader meets
+  // these threads, so the drawer belongs to it.
+  const [openEmail, setOpenEmail] = useOpenEmail();
   return (
     <>
       <DataTable<HeldThread>
@@ -133,11 +138,7 @@ function HeldThreadTable({ rows }: Readonly<{ rows: HeldThread[] }>) {
               // a reader their evidence was destroyed when it is sitting there
               // unnamed.
               row.has_message ? (
-                (row.subject ?? (
-                  <span className="t-meta">
-                    {t("heldThreads.blankSubject")}
-                  </span>
-                ))
+                <ThreadSubject row={row} onOpen={setOpenEmail} />
               ) : (
                 <span className="t-meta">{t("heldThreads.noSubject")}</span>
               ),
@@ -198,6 +199,13 @@ function HeldThreadTable({ rows }: Readonly<{ rows: HeldThread[] }>) {
           })}
         </Callout>
       ))}
+      {/* One drawer over the table, at its level rather than inside a row:
+          two mounted dialogs would be two `aria-modal` elements. */}
+      <OpenEmailDrawer
+        activityId={openEmail}
+        zone={viewerZone()}
+        onClose={() => setOpenEmail(null)}
+      />
     </>
   );
 }
@@ -269,5 +277,42 @@ function WhyCell({ row }: Readonly<{ row: HeldThread }>) {
     <span className="cell-stack">
       <Badge>{kindKey ? t(kindKey) : (row.kind ?? row.status)}</Badge>
     </span>
+  );
+}
+
+/**
+ * A held thread's subject, openable where the reader may read the message.
+ *
+ * Three states, unchanged from before plus one: a subject, a message carrying
+ * none, and — new — whether either is a control. `activity_id` is present only
+ * when the server's own content gate admitted the message, so a thread held
+ * because it is somebody else's personnel mail names itself and does not offer
+ * to open. A button that opened nothing would be worse than the plain text it
+ * replaced.
+ */
+function ThreadSubject({
+  row,
+  onOpen,
+}: Readonly<{ row: HeldThread; onOpen: (activityId: string) => void }>) {
+  const t = useT();
+  const label = row.subject ?? t("heldThreads.blankSubject");
+  const plain = row.subject ? (
+    <>{label}</>
+  ) : (
+    <span className="t-meta">{label}</span>
+  );
+  if (!row.activity_id) {
+    return plain;
+  }
+  const activityId = row.activity_id;
+  return (
+    <button
+      type="button"
+      className="entity-link"
+      aria-haspopup="dialog"
+      onClick={() => onOpen(activityId)}
+    >
+      {label}
+    </button>
   );
 }


### PR DESCRIPTION
Eleventh slice of the email display unification arc.

## What changed

The held-threads table named a thread and stopped there — a reader could see their mailbox was withholding something about a contract, and had no way to read it. The subject opens the message now.

`HeldThread` gains `activity_id`; the held-threads query already joined `first_activity_id` without selecting it.

## The privacy argument is the whole change

The id comes from the **joined activity row** (`a.id`), not from the ledger's own `first_activity_id`. The join carries `auth.ActivityContentClause`, so the id is absent in both cases that matter:

- the message was erased while the hold stood (the ledger deliberately outlives it), and
- the content is not this caller's.

`has_message` already told those two apart and still does.

Reading the ledger column instead would hand out an id for a personnel message the reader may not open. **The mutation test does exactly that**, and `TestAHeldThreadWithholdsAMessageTheReaderIsNotOn` catches it — it now asserts the id is withheld alongside the subject it already checked.

A row with no id names itself and offers nothing. A button that opened nothing would be worse than the plain text it replaced.

## Tests

Backend: the refusal case gains the id assertion; `TestAHeldThreadCarriesTheMessageItsReaderMayOpen` is the admission case, asserted as hard — a list handing out no id at all would pass every refusal test while opening nothing.

Frontend: a readable thread's subject is a button with `aria-haspopup="dialog"` that asks for that message's presentation; an unreadable one renders text with no control. Mutation-checked in both directions.

## Two plan items deliberately not done

**The restricted-records wording already says the right thing** — *"the correspondence itself is not shown: it is restricted precisely so it is not read."* The plan asked to change it to "Restricted by retention". That would be less clear, so I left it.

**The capture trace rows cannot become email references yet.** `TraceEntry` carries no activity id, and many entries never became an activity — capture records what it *did*, including messages it declined. Giving those rows a reference needs a new contract field and a decision about what an entry with no message shows. That is its own change, not a wording pass, and I would rather say so than half-do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a held thread's subject open the message it holds, so a reader can read the correspondence instead of only seeing its name. The held-thread row now carries `activity_id` — but only when this caller may read the message.

- The id comes from the joined activity row, which carries the content gate, so it is absent when the message was erased or is outside the caller's audience; `has_message` still tells the two apart.
- The subject renders as a dialog-opening button when `activity_id` is present, and as plain text when it is not.
- Backend and frontend tests cover both the admission and refusal cases, including a mutation test that reads the ledger's own column.

**Deliberately left out**
- The restricted-records wording stays as-is; "Restricted by retention" would be less clear.
- Capture trace rows still carry no activity reference; they need a new contract field and a decision about entries with no message.

<sup>Written for commit 6792981eaace55a04c1b5e947f0a85c3c7f9a9ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Held-thread subjects can now be selected to open the associated message when it’s available.
  - The CRM API now provides the opening activity ID when the caller has access.
  - Subjects remain non-interactive when the associated message is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->