### PR TITLE
main is red: the 360 flat-cost budget is one short of the attachment read

### DIFF
--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -207,7 +207,12 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 	// cost the budget had been blind to rather than a cost just added. One
 	// statement for the account's own chips, flat in the size of the
 	// account like every section above.
-	const budget = 44
+	// 45 since an email shows the files that came with it (#3897): one read of
+	// the attachment count per activity on the page, asked over the whole page's
+	// activity ids at once. Flat in the size of the account like the timeline it
+	// decorates — a per-activity count would have shown up in the flatness
+	// assertion above rather than here.
+	const budget = 45
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}


### PR DESCRIPTION
`TestOrganization360CostDoesNotGrowWithTheAccount` fails on the tip of `main`, and on every PR whose shard draws it:

```
org360_querycount_integration_test.go:212: one 360 issued 45 queries, budget is 44
```

Reproduced on `7bba710be` in a clean worktree with no other changes.

## The 45th statement

Traced with the counting tracer the test already installs. It is the attachment read that came with #3897 (*An email shows the files that came with it*):

```sql
SELECT at.entity_id, count(*) FROM attachment at
 WHERE at.entity_type = 'activity' AND at.entity_id = ANY($1) …
```

One statement over the whole page's activity ids — the shape this budget exists to admit. Flat in the size of the account, like the timeline it decorates: a per-activity count would have moved the flatness assertion higher up in the file rather than this number.

So the number moves, with its reason recorded beside its neighbours (42 for the work-in-flight card, 43 for the account-owes card, 44 for the tag chips the harness's admin grant revealed).

## Verification

`make test-it DIR=backend/internal/compose/integration/org360` — the whole package passes, 55s.

Nothing else in this PR. The other two red things on the tip are #3899 (two files one line over their craft cap) and the tool-schema census (#3886).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the Organization 360 flat-cost query budget from 44 to 45 to account for the batched attachment-count read for activities on the page. The integration test now documents why this query remains flat as the account grows.

<sup>Written for commit 91f8a2c1064d63ef8fe290cd65f4a061470ade25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the integration test query budget to account for an additional attachment-count lookup across the account timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->