### PR TITLE
A commitment can be corrected without being thrown away

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16221,6 +16221,41 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '422': { $ref: '#/components/responses/ValidationError' }
+  /weekly-plans/commitments/{id}:
+    patch:
+      tags: [Brief]
+      operationId: editWeeklyPlanCommitment
+      summary: Correct what a commitment says, when it is due, or what it is about.
+      description: |
+        The CALLER's own commitment, on an open week. A rep types a commitment on Monday and
+        finds the typo on Tuesday; without this the only way out is to drop the row and write
+        a new one, which discards the manager's answer and any help already asked for — the
+        two fields on the row that were never the rep's to throw away.
+
+        Every field is optional and only what is PRESENT changes. `due_on: null` clears the
+        date, which is a real state: something to do this week rather than by a day. Sending
+        `linked_record: null` unlinks the record.
+
+        State is not settable here. `PUT .../state` owns the move between open, done and
+        dropped because it ties `completed_at` to the state the schema's CHECK binds them
+        with, and two writers of that pair would drift.
+      x-agent-access: human-only
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/WeeklyPlanCommitmentEdit' }
+      responses:
+        '204': { description: Corrected. }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
   /weekly-plans/commitments/{id}/state:
     put:
       tags: [Brief]
@@ -31136,6 +31171,26 @@ components:
           description: Both halves or neither — a type with no id names nothing.
           allOf: [{ $ref: '#/components/schemas/WeeklyPlanLink' }]
         due_on: { type: [string, 'null'], format: date }
+
+    WeeklyPlanCommitmentEdit:
+      type: object
+      additionalProperties: false
+      description: |
+        What a rep may correct about their own commitment. Only the fields PRESENT change —
+        an absent field is left alone, which is what lets a client send a new label without
+        also having to restate the due date it is not touching.
+      properties:
+        label: { type: string, minLength: 1, maxLength: 500 }
+        linked_record:
+          description: |
+            Both halves or neither, as on create. Null unlinks the record, which is how a
+            commitment stops being about one without being rewritten.
+          nullable: true
+          allOf: [{ $ref: '#/components/schemas/WeeklyPlanLink' }]
+        due_on:
+          description: Null clears the date — something to do this week, rather than by a day.
+          type: [string, 'null']
+          format: date
 
     RbacObject:
       type: string

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -368,6 +368,7 @@ var agentPolicies = map[string]agentPolicy{
 	"PATCH /v1/voice-profiles/{id}":                                      {Op: "updateVoiceProfile", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"PATCH /v1/voice-profiles/{id}/sources/{sourceId}":                   {Op: "updateVoiceCorpusSource", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"PATCH /v1/webhook-subscriptions/{id}":                               {Op: "updateWebhookSubscription", Access: "tool", Tool: "update_record", RecordType: "webhook_subscription", Tier: "confirmation_required", Scope: "write"},
+	"PATCH /v1/weekly-plans/commitments/{id}":                            {Op: "editWeeklyPlanCommitment", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/activities":                                                {Op: "logActivity", Access: "tool", Tool: "log_activity", RecordType: "activity", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/activities/relink-bulk":                                    {Op: "relinkActivities", Access: "tool", Tool: "relink_activities", RecordType: "activity", Tier: "dynamic", Scope: "write"},
 	"POST /v1/activities/relink-thread":                                  {Op: "relinkThread", Access: "tool", Tool: "relink_thread", RecordType: "activity", Tier: "dynamic", Scope: "write"},

--- a/backend/internal/compose/integration/weeklyplan_integration_test.go
+++ b/backend/internal/compose/integration/weeklyplan_integration_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // teammates is the membership seam, over the REAL identity service.
@@ -327,7 +328,7 @@ func countRows(t *testing.T, conn *pgx.Conn, ctx context.Context, query string, 
 // assertion is not only that the label moved: it is that the answer survived.
 func TestCorrectingACommitmentKeepsWhatItWasNotAbout(t *testing.T) {
 	e := setupPlan(t)
-	id := planCommitment(t, e, e.rep1Ctx, "Call the Aster buyer bakc")
+	id := planCommitment(t, e, e.rep1Ctx, "Call the Aster buyer on Monday")
 
 	if err := e.store.AskForHelp(e.rep1Ctx, id, "need the Q3 discount sheet"); err != nil {
 		t.Fatalf("asking for help: %v", err)
@@ -336,7 +337,7 @@ func TestCorrectingACommitmentKeepsWhatItWasNotAbout(t *testing.T) {
 		t.Fatalf("the lead answering: %v", err)
 	}
 
-	label := "Call the Aster buyer back"
+	label := "Call the Aster buyer on Tuesday"
 	if err := e.store.EditCommitment(e.rep1Ctx, id,
 		weeklyplan.CommitmentEdit{Label: &label}); err != nil {
 		t.Fatalf("correcting the label: %v", err)
@@ -474,4 +475,28 @@ func commitmentByID(t *testing.T, plan weeklyplan.Plan, id ids.UUID) weeklyplan.
 	}
 	t.Fatalf("commitment %s is not on the plan", id)
 	return weeklyplan.Commitment{}
+}
+
+// A closed week is frozen into a review that has already been counted, so its
+// commitments stop being editable — the same refusal the settle path makes.
+func TestCorrectingACommitmentOnAClosedWeekIsRefused(t *testing.T) {
+	e := setupPlan(t)
+	id := planCommitment(t, e, e.rep1Ctx, "written while the week was open")
+
+	// CloseWeek settles the week BEFORE the instant it is given — the same
+	// window the review covers — so closing the week this commitment lives in
+	// means standing a week later.
+	if _, err := e.store.CloseWeek(e.rep1Ctx, planClock.AddDate(0, 0, 7)); err != nil {
+		t.Fatalf("closing the week: %v", err)
+	}
+
+	label := "rewritten after the close"
+	err := e.store.EditCommitment(e.rep1Ctx, id, weeklyplan.CommitmentEdit{Label: &label})
+	if err == nil {
+		t.Fatal("a commitment on a closed week was edited — the review's counts no longer agree with the rows they were counted from")
+	}
+	var parse *values.ParseError
+	if !errors.As(err, &parse) || parse.Code != "week_closed" {
+		t.Errorf("editing a closed week gave %v, wanted a week_closed refusal", err)
+	}
 }

--- a/backend/internal/compose/integration/weeklyplan_integration_test.go
+++ b/backend/internal/compose/integration/weeklyplan_integration_test.go
@@ -317,3 +317,159 @@ func countRows(t *testing.T, conn *pgx.Conn, ctx context.Context, query string, 
 	}
 	return n
 }
+
+// A typo is correctable, and correcting it keeps what the correction was not
+// about.
+//
+// Before this existed the only way out was to drop the row and write a new one,
+// which discards the manager's answer and any help already asked for — the two
+// fields on a commitment that were never the rep's to throw away. So the
+// assertion is not only that the label moved: it is that the answer survived.
+func TestCorrectingACommitmentKeepsWhatItWasNotAbout(t *testing.T) {
+	e := setupPlan(t)
+	id := planCommitment(t, e, e.rep1Ctx, "Call the Aster buyer bakc")
+
+	if err := e.store.AskForHelp(e.rep1Ctx, id, "need the Q3 discount sheet"); err != nil {
+		t.Fatalf("asking for help: %v", err)
+	}
+	if err := e.store.Respond(e.rep2Ctx, id, "sent it over"); err != nil {
+		t.Fatalf("the lead answering: %v", err)
+	}
+
+	label := "Call the Aster buyer back"
+	if err := e.store.EditCommitment(e.rep1Ctx, id,
+		weeklyplan.CommitmentEdit{Label: &label}); err != nil {
+		t.Fatalf("correcting the label: %v", err)
+	}
+
+	plan, err := e.store.Current(e.rep1Ctx, planClock)
+	if err != nil {
+		t.Fatalf("reading the plan back: %v", err)
+	}
+	got := commitmentByID(t, plan, id)
+	if got.Label != label {
+		t.Errorf("the label reads %q, wanted %q", got.Label, label)
+	}
+	if got.HelpRequested != "need the Q3 discount sheet" {
+		t.Errorf("correcting a typo lost the help request: %q", got.HelpRequested)
+	}
+	if got.ManagerResponse != "sent it over" {
+		t.Errorf("correcting a typo lost the lead's answer: %q", got.ManagerResponse)
+	}
+}
+
+// Only what is PRESENT changes. A rep fixing a label must not lose the date
+// they never mentioned.
+func TestCorrectingOneFieldLeavesTheOthersAlone(t *testing.T) {
+	e := setupPlan(t)
+	due := planClock.AddDate(0, 0, 2)
+	written, err := e.store.AddCommitment(e.rep1Ctx, planClock,
+		weeklyplan.NewCommitment{Label: "Send the Weber quote", DueOn: &due})
+	if err != nil {
+		t.Fatalf("writing the commitment: %v", err)
+	}
+
+	label := "Send the Weber quote today"
+	if err := e.store.EditCommitment(e.rep1Ctx, written.ID,
+		weeklyplan.CommitmentEdit{Label: &label}); err != nil {
+		t.Fatalf("correcting the label: %v", err)
+	}
+
+	plan, err := e.store.Current(e.rep1Ctx, planClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := commitmentByID(t, plan, written.ID)
+	if got.DueOn == nil {
+		t.Fatal("editing the label cleared the due date the request never named")
+	}
+	if !got.DueOn.Equal(due.Truncate(24*time.Hour)) && got.DueOn.Format(time.DateOnly) != due.Format(time.DateOnly) {
+		t.Errorf("the due date moved to %v, wanted %v", got.DueOn, due)
+	}
+}
+
+// And a date can be CLEARED, which is a different request from not mentioning
+// it. Something to do this week, rather than by a day.
+func TestADueDateCanBeCleared(t *testing.T) {
+	e := setupPlan(t)
+	due := planClock.AddDate(0, 0, 2)
+	written, err := e.store.AddCommitment(e.rep1Ctx, planClock,
+		weeklyplan.NewCommitment{Label: "Draft the Q3 plan", DueOn: &due})
+	if err != nil {
+		t.Fatalf("writing the commitment: %v", err)
+	}
+
+	var cleared *time.Time
+	if err := e.store.EditCommitment(e.rep1Ctx, written.ID,
+		weeklyplan.CommitmentEdit{DueOn: &cleared}); err != nil {
+		t.Fatalf("clearing the date: %v", err)
+	}
+
+	plan, err := e.store.Current(e.rep1Ctx, planClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := commitmentByID(t, plan, written.ID); got.DueOn != nil {
+		t.Errorf("the due date is still %v after being cleared", got.DueOn)
+	}
+}
+
+// Somebody else's commitment is NOT FOUND, not refused: whether a colleague
+// wrote a particular thing on their week is itself something a stranger may not
+// learn.
+func TestCorrectingSomebodyElsesCommitmentIsNotFound(t *testing.T) {
+	e := setupPlan(t)
+	id := planCommitment(t, e, e.rep1Ctx, "rep1's own")
+
+	label := "rewritten by somebody else"
+	err := e.store.EditCommitment(e.rep2Ctx, id, weeklyplan.CommitmentEdit{Label: &label})
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("a teammate editing rep1's commitment got %v, wanted not found", err)
+	}
+}
+
+// One correction is one audit row and one event, like every other write here.
+//
+// A no-op correction is NEITHER. Filing an audit row saying a rep changed
+// something they did not is a false record, and bumping the version would move
+// a row a concurrent reader is holding.
+func TestACorrectionLandsOneAuditRowAndANoOpLandsNone(t *testing.T) {
+	e := setupPlan(t)
+	id := planCommitment(t, e, e.rep1Ctx, "the original")
+
+	const audits = `SELECT count(*) FROM audit_log
+	                 WHERE entity_type = 'weekly_plan_commitment' AND entity_id = $1
+	                   AND action = 'update'`
+	before := countRows(t, e.Conn, e.OwnerCtx, audits, id)
+
+	label := "the corrected"
+	if err := e.store.EditCommitment(e.rep1Ctx, id,
+		weeklyplan.CommitmentEdit{Label: &label}); err != nil {
+		t.Fatalf("correcting: %v", err)
+	}
+	if got := countRows(t, e.Conn, e.OwnerCtx, audits, id) - before; got != 1 {
+		t.Errorf("one correction filed %d audit rows, wanted 1", got)
+	}
+
+	// The same label again changes nothing.
+	after := countRows(t, e.Conn, e.OwnerCtx, audits, id)
+	if err := e.store.EditCommitment(e.rep1Ctx, id,
+		weeklyplan.CommitmentEdit{Label: &label}); err != nil {
+		t.Fatalf("re-sending the same label: %v", err)
+	}
+	if got := countRows(t, e.Conn, e.OwnerCtx, audits, id) - after; got != 0 {
+		t.Errorf("a correction that changed nothing filed %d audit rows", got)
+	}
+}
+
+// commitmentByID finds one commitment on a plan the test just read back.
+func commitmentByID(t *testing.T, plan weeklyplan.Plan, id ids.UUID) weeklyplan.Commitment {
+	t.Helper()
+	for _, c := range plan.Commitments {
+		if c.ID == id {
+			return c
+		}
+	}
+	t.Fatalf("commitment %s is not on the plan", id)
+	return weeklyplan.Commitment{}
+}

--- a/backend/internal/compose/integration/weeklyplan_integration_test.go
+++ b/backend/internal/compose/integration/weeklyplan_integration_test.go
@@ -435,29 +435,31 @@ func TestCorrectingSomebodyElsesCommitmentIsNotFound(t *testing.T) {
 // a row a concurrent reader is holding.
 func TestACorrectionLandsOneAuditRowAndANoOpLandsNone(t *testing.T) {
 	e := setupPlan(t)
+	owner := integration.OwnerConn(t)
+	ctx := context.Background()
 	id := planCommitment(t, e, e.rep1Ctx, "the original")
 
 	const audits = `SELECT count(*) FROM audit_log
 	                 WHERE entity_type = 'weekly_plan_commitment' AND entity_id = $1
 	                   AND action = 'update'`
-	before := countRows(t, e.Conn, e.OwnerCtx, audits, id)
+	before := countRows(t, owner, ctx, audits, id)
 
 	label := "the corrected"
 	if err := e.store.EditCommitment(e.rep1Ctx, id,
 		weeklyplan.CommitmentEdit{Label: &label}); err != nil {
 		t.Fatalf("correcting: %v", err)
 	}
-	if got := countRows(t, e.Conn, e.OwnerCtx, audits, id) - before; got != 1 {
+	if got := countRows(t, owner, ctx, audits, id) - before; got != 1 {
 		t.Errorf("one correction filed %d audit rows, wanted 1", got)
 	}
 
 	// The same label again changes nothing.
-	after := countRows(t, e.Conn, e.OwnerCtx, audits, id)
+	after := countRows(t, owner, ctx, audits, id)
 	if err := e.store.EditCommitment(e.rep1Ctx, id,
 		weeklyplan.CommitmentEdit{Label: &label}); err != nil {
 		t.Fatalf("re-sending the same label: %v", err)
 	}
-	if got := countRows(t, e.Conn, e.OwnerCtx, audits, id) - after; got != 0 {
+	if got := countRows(t, owner, ctx, audits, id) - after; got != 0 {
 		t.Errorf("a correction that changed nothing filed %d audit rows", got)
 	}
 }

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -2227,6 +2227,10 @@ func (stubs) AddWeeklyPlanCommitment(w nethttp.ResponseWriter, r *nethttp.Reques
 	httperr.NotImplemented(w, r, "AddWeeklyPlanCommitment")
 }
 
+func (stubs) EditWeeklyPlanCommitment(w nethttp.ResponseWriter, r *nethttp.Request, id openapi_types.UUID) {
+	httperr.NotImplemented(w, r, "EditWeeklyPlanCommitment")
+}
+
 func (stubs) AskForWeeklyPlanHelp(w nethttp.ResponseWriter, r *nethttp.Request, id openapi_types.UUID) {
 	httperr.NotImplemented(w, r, "AskForWeeklyPlanHelp")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -31012,6 +31012,19 @@ type WeeklyPlanCommitment struct {
 // deciding a thing is not worth doing is not failing to do it.
 type WeeklyPlanCommitmentState string
 
+// WeeklyPlanCommitmentEdit What a rep may correct about their own commitment. Only the fields PRESENT change —
+// an absent field is left alone, which is what lets a client send a new label without
+// also having to restate the due date it is not touching.
+type WeeklyPlanCommitmentEdit struct {
+	// DueOn Null clears the date — something to do this week, rather than by a day.
+	DueOn *openapi_types.Date `json:"due_on,omitempty"`
+	Label *string             `json:"label,omitempty"`
+
+	// LinkedRecord Both halves or neither, as on create. Null unlinks the record, which is how a
+	// commitment stops being about one without being rewritten.
+	LinkedRecord *WeeklyPlanLink `json:"linked_record,omitempty"`
+}
+
 // WeeklyPlanLink defines model for WeeklyPlanLink.
 type WeeklyPlanLink struct {
 	Id   openapi_types.UUID `json:"id"`
@@ -37292,6 +37305,9 @@ type UpdateWebhookSubscriptionJSONRequestBody = UpdateWebhookSubscriptionRequest
 
 // AddWeeklyPlanCommitmentJSONRequestBody defines body for AddWeeklyPlanCommitment for application/json ContentType.
 type AddWeeklyPlanCommitmentJSONRequestBody = NewWeeklyPlanCommitment
+
+// EditWeeklyPlanCommitmentJSONRequestBody defines body for EditWeeklyPlanCommitment for application/json ContentType.
+type EditWeeklyPlanCommitmentJSONRequestBody = WeeklyPlanCommitmentEdit
 
 // AskForWeeklyPlanHelpJSONRequestBody defines body for AskForWeeklyPlanHelp for application/json ContentType.
 type AskForWeeklyPlanHelpJSONRequestBody AskForWeeklyPlanHelpJSONBody
@@ -46670,6 +46686,9 @@ type ServerInterface interface {
 	// Write one thing onto this week's plan.
 	// (POST /weekly-plans/commitments)
 	AddWeeklyPlanCommitment(w http.ResponseWriter, r *http.Request)
+	// Correct what a commitment says, when it is due, or what it is about.
+	// (PATCH /weekly-plans/commitments/{id})
+	EditWeeklyPlanCommitment(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// Say what you need from your lead on one commitment.
 	// (PUT /weekly-plans/commitments/{id}/help)
 	AskForWeeklyPlanHelp(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
@@ -50018,6 +50037,12 @@ func (_ Unimplemented) RotateWebhookSecret(w http.ResponseWriter, r *http.Reques
 // Write one thing onto this week's plan.
 // (POST /weekly-plans/commitments)
 func (_ Unimplemented) AddWeeklyPlanCommitment(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Correct what a commitment says, when it is due, or what it is about.
+// (PATCH /weekly-plans/commitments/{id})
+func (_ Unimplemented) EditWeeklyPlanCommitment(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -74038,6 +74063,40 @@ func (siw *ServerInterfaceWrapper) AddWeeklyPlanCommitment(w http.ResponseWriter
 	handler.ServeHTTP(w, r)
 }
 
+// EditWeeklyPlanCommitment operation middleware
+func (siw *ServerInterfaceWrapper) EditWeeklyPlanCommitment(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.EditWeeklyPlanCommitment(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // AskForWeeklyPlanHelp operation middleware
 func (siw *ServerInterfaceWrapper) AskForWeeklyPlanHelp(w http.ResponseWriter, r *http.Request) {
 
@@ -76278,6 +76337,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/weekly-plans/commitments", wrapper.AddWeeklyPlanCommitment)
+	})
+	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/weekly-plans/commitments/{id}", wrapper.EditWeeklyPlanCommitment)
 	})
 	r.Group(func(r chi.Router) {
 		r.Put(options.BaseURL+"/weekly-plans/commitments/{id}/help", wrapper.AskForWeeklyPlanHelp)

--- a/backend/internal/modules/weeklyplan/edit.go
+++ b/backend/internal/modules/weeklyplan/edit.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package weeklyplan
+
+// Correcting a commitment: what it says, when it is due, and what it is about.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+// CommitmentEdit is what a rep may correct about their own commitment.
+//
+// Every field is a POINTER, and the distinction is the whole shape: nil means
+// "leave this alone" and a set pointer means "make it this". Without it, a
+// client sending only a new label would be indistinguishable from one clearing
+// the due date, and the two are different requests.
+//
+// State is absent on purpose. Moving a commitment between open, done and
+// dropped is SetState's, which ties completed_at to the state the schema's own
+// CHECK binds them with. Two writers of that pair would drift.
+type CommitmentEdit struct {
+	Label *string
+	// DueOn set to a pointer-to-nil clears the date. A commitment with no date
+	// is a real state — something to do this week, not by a day — so clearing
+	// has to be expressible rather than only replacing.
+	DueOn **time.Time
+	// The link moves as a PAIR or not at all, the same rule checkLink holds on
+	// create: a type with no id names nothing, and an id with no type cannot be
+	// routed to.
+	LinkedRecordType *string
+	LinkedRecordID   *ids.UUID
+}
+
+// EditCommitment corrects one of the caller's own commitments.
+//
+// A rep types a commitment on Monday and finds the typo on Tuesday. Until this
+// existed the only way out was to drop the row and write a new one, which loses
+// the manager's answer and any help already asked for — the two fields on the
+// row that were not the rep's to throw away.
+func (s *Store) EditCommitment(
+	ctx context.Context, commitmentID ids.UUID, edit CommitmentEdit,
+) error {
+	if err := auth.Require(ctx, "weekly_plan", principal.ActionUpdate); err != nil {
+		return err
+	}
+	if err := edit.check(); err != nil {
+		return err
+	}
+	owner, err := planUser(ctx)
+	if err != nil {
+		return err
+	}
+	return database.WithWorkspaceTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
+		planID, current, err := ownEditableCommitmentTx(ctx, tx, commitmentID, owner)
+		if err != nil {
+			return err
+		}
+		// Inside the transaction, like the create path: a grant revoked between
+		// the probe and the write must not leave the link written.
+		if edit.LinkedRecordType != nil {
+			if err := ensureLinkVisible(ctx, tx, *edit.LinkedRecordType, *edit.LinkedRecordID); err != nil {
+				return err
+			}
+		}
+		patch := edit.patch(current)
+		if patch.Empty() {
+			// Nothing asked for differs from what is stored. Writing anyway
+			// would file an audit row saying a rep changed something they did
+			// not, and bump the version a concurrent reader is holding.
+			return nil
+		}
+		lock, err := storekit.LockRow(ctx, tx, "weekly_plan_commitment",
+			commitmentID, storekit.NoArchiveColumn)
+		if err != nil {
+			return err
+		}
+		if err := patch.ApplyLocked(ctx, tx, lock); err != nil {
+			return err
+		}
+		auditID, err := storekit.Audit(ctx, tx, "update", "weekly_plan_commitment", commitmentID,
+			patch.Before(), patch.After())
+		if err != nil {
+			return err
+		}
+		return storekit.EmitEvent(ctx, tx, auditID, owner, crmcontracts.PublicEventWeeklyPlanUpdated{
+			PlanId: openapi_types.UUID(planID), OwnerUserId: openapi_types.UUID(owner),
+			ChangedFields: []string{"commitments"},
+		})
+	})
+}
+
+// check validates what was asked for, before any row is read.
+func (e CommitmentEdit) check() error {
+	if e.Label == nil && e.DueOn == nil && e.LinkedRecordType == nil {
+		return &values.ParseError{
+			Field: "label", Code: "required",
+			Message: "an edit has to change something",
+		}
+	}
+	if e.Label != nil {
+		label, err := bounded("label", *e.Label, labelBound)
+		if err != nil {
+			return err
+		}
+		if label == "" {
+			return &values.ParseError{
+				Field: "label", Code: "required", Message: "a commitment needs saying in words",
+			}
+		}
+	}
+	if e.LinkedRecordType != nil {
+		if e.LinkedRecordID == nil {
+			return &values.ParseError{
+				Field: "linked_record_id", Code: "required",
+				Message: "a linked record needs both a type and an id",
+			}
+		}
+		return checkLink(*e.LinkedRecordType, *e.LinkedRecordID)
+	}
+	if e.LinkedRecordID != nil {
+		return &values.ParseError{
+			Field: "linked_record_type", Code: "required",
+			Message: "a linked record needs both a type and an id",
+		}
+	}
+	return nil
+}
+
+// patch is the columns this edit actually moves.
+func (e CommitmentEdit) patch(current Commitment) *storekit.Patch {
+	patch := storekit.NewPatch()
+	if e.Label != nil {
+		label, _ := bounded("label", *e.Label, labelBound)
+		patch.Set("label", current.Label, label)
+	}
+	if e.DueOn != nil {
+		// SetDate, not Set: due_on is a `date` column, and storekit's own rule
+		// is that a date goes in as its own text so the audit image round-trips
+		// back into the column an undo would write it to.
+		patch.SetDate("due_on", current.DueOn, *e.DueOn)
+	}
+	if e.LinkedRecordType != nil {
+		// Both columns move together or neither does. An empty type clears the
+		// pair, which is how a commitment stops being about a record without
+		// being rewritten.
+		var nextType, nextID any
+		if *e.LinkedRecordType != "" {
+			nextType, nextID = *e.LinkedRecordType, *e.LinkedRecordID
+		}
+		patch.Set("linked_record_type", stringOrNil(current.LinkedRecordType), nextType)
+		patch.Set("linked_record_id", uuidOrNil(current.LinkedRecordID), nextID)
+	}
+	return patch
+}
+
+// The two nil-shapes a patch compares against. A column that is NULL in the row
+// has to be compared as nil rather than as a zero value, or clearing an already
+// empty link would report the empty string changing to the empty string and
+// file an audit row saying a rep changed something they did not.
+func stringOrNil(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func uuidOrNil(id ids.UUID) any {
+	if id == ids.Nil {
+		return nil
+	}
+	return id
+}
+
+// ownEditableCommitmentTx reads the row's editable fields under the caller's
+// ownership, refusing a closed week exactly as the settle path does.
+//
+// A second reader beside ownCommitmentTx rather than a wider one: that query
+// selects the settle path's columns, and adding four more to it would make
+// every state change read fields it does not use.
+func ownEditableCommitmentTx(
+	ctx context.Context, tx pgx.Tx, commitmentID, owner ids.UUID,
+) (ids.UUID, Commitment, error) {
+	var planID ids.UUID
+	var status string
+	var current Commitment
+	var linkType *string
+	var linkID *ids.UUID
+	err := tx.QueryRow(ctx, `
+		SELECT p.id, p.status, c.label, c.due_on, c.linked_record_type, c.linked_record_id
+		  FROM weekly_plan_commitment c
+		  JOIN weekly_plan p ON p.id = c.plan_id
+		 WHERE c.id = $1 AND p.owner_id = $2`, commitmentID, owner).
+		Scan(&planID, &status, &current.Label, &current.DueOn, &linkType, &linkID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ids.Nil, Commitment{}, apperrors.ErrNotFound
+	}
+	if err != nil {
+		return ids.Nil, Commitment{}, fmt.Errorf("weeklyplan: reading the commitment: %w", err)
+	}
+	// A closed week is frozen into a review that has already been counted.
+	if status != "open" {
+		return ids.Nil, Commitment{}, &values.ParseError{
+			Field: "week", Code: "week_closed",
+			Message: "that week is closed and its outcome is recorded",
+		}
+	}
+	if linkType != nil {
+		current.LinkedRecordType = *linkType
+	}
+	if linkID != nil {
+		current.LinkedRecordID = *linkID
+	}
+	return planID, current, nil
+}

--- a/backend/internal/modules/weeklyplan/edit.go
+++ b/backend/internal/modules/weeklyplan/edit.go
@@ -100,7 +100,7 @@ func (s *Store) EditCommitment(
 		}
 		return storekit.EmitEvent(ctx, tx, auditID, owner, crmcontracts.PublicEventWeeklyPlanUpdated{
 			PlanId: openapi_types.UUID(planID), OwnerUserId: openapi_types.UUID(owner),
-			ChangedFields: []string{"commitments"},
+			ChangedFields: []string{changedCommitments},
 		})
 	})
 }
@@ -109,25 +109,25 @@ func (s *Store) EditCommitment(
 func (e CommitmentEdit) check() error {
 	if e.Label == nil && e.DueOn == nil && e.LinkedRecordType == nil {
 		return &values.ParseError{
-			Field: "label", Code: "required",
+			Field: fieldLabel, Code: codeRequired,
 			Message: "an edit has to change something",
 		}
 	}
 	if e.Label != nil {
-		label, err := bounded("label", *e.Label, labelBound)
+		label, err := bounded(fieldLabel, *e.Label, labelBound)
 		if err != nil {
 			return err
 		}
 		if label == "" {
 			return &values.ParseError{
-				Field: "label", Code: "required", Message: "a commitment needs saying in words",
+				Field: fieldLabel, Code: codeRequired, Message: "a commitment needs saying in words",
 			}
 		}
 	}
 	if e.LinkedRecordType != nil {
 		if e.LinkedRecordID == nil {
 			return &values.ParseError{
-				Field: "linked_record_id", Code: "required",
+				Field: "linked_record_id", Code: codeRequired,
 				Message: "a linked record needs both a type and an id",
 			}
 		}
@@ -135,7 +135,7 @@ func (e CommitmentEdit) check() error {
 	}
 	if e.LinkedRecordID != nil {
 		return &values.ParseError{
-			Field: "linked_record_type", Code: "required",
+			Field: "linked_record_type", Code: codeRequired,
 			Message: "a linked record needs both a type and an id",
 		}
 	}
@@ -153,7 +153,7 @@ func (e CommitmentEdit) check() error {
 func (e CommitmentEdit) patch(current Commitment) *storekit.Patch {
 	patch := storekit.NewPatch()
 	if e.Label != nil {
-		label, _ := bounded("label", *e.Label, labelBound)
+		label, _ := bounded(fieldLabel, *e.Label, labelBound)
 		if label != current.Label {
 			patch.Set("label", current.Label, label)
 		}
@@ -237,9 +237,9 @@ func ownEditableCommitmentTx(
 		return ids.Nil, Commitment{}, fmt.Errorf("weeklyplan: reading the commitment: %w", err)
 	}
 	// A closed week is frozen into a review that has already been counted.
-	if status != "open" {
+	if status != StateOpen {
 		return ids.Nil, Commitment{}, &values.ParseError{
-			Field: "week", Code: "week_closed",
+			Field: fieldWeek, Code: codeWeekClosed,
 			Message: "that week is closed and its outcome is recorded",
 		}
 	}

--- a/backend/internal/modules/weeklyplan/edit.go
+++ b/backend/internal/modules/weeklyplan/edit.go
@@ -142,29 +142,42 @@ func (e CommitmentEdit) check() error {
 	return nil
 }
 
-// patch is the columns this edit actually moves.
+// patch is the columns this edit actually MOVES.
+//
+// Each field is compared before it is set, because storekit.Patch records an
+// assignment unconditionally — comparing is the caller's job, and every other
+// writer here changes a column it already knows differs. An edit does not: a
+// client may send back the label it read, and setting it anyway would file an
+// audit row saying a rep changed something they did not and bump the version a
+// concurrent reader is holding.
 func (e CommitmentEdit) patch(current Commitment) *storekit.Patch {
 	patch := storekit.NewPatch()
 	if e.Label != nil {
 		label, _ := bounded("label", *e.Label, labelBound)
-		patch.Set("label", current.Label, label)
+		if label != current.Label {
+			patch.Set("label", current.Label, label)
+		}
 	}
 	if e.DueOn != nil {
 		// SetDate, not Set: due_on is a `date` column, and storekit's own rule
 		// is that a date goes in as its own text so the audit image round-trips
 		// back into the column an undo would write it to.
-		patch.SetDate("due_on", current.DueOn, *e.DueOn)
+		if !sameDay(current.DueOn, *e.DueOn) {
+			patch.SetDate("due_on", current.DueOn, *e.DueOn)
+		}
 	}
 	if e.LinkedRecordType != nil {
 		// Both columns move together or neither does. An empty type clears the
 		// pair, which is how a commitment stops being about a record without
 		// being rewritten.
-		var nextType, nextID any
-		if *e.LinkedRecordType != "" {
-			nextType, nextID = *e.LinkedRecordType, *e.LinkedRecordID
+		nextType, nextID := *e.LinkedRecordType, *e.LinkedRecordID
+		if nextType == "" {
+			nextID = ids.Nil
 		}
-		patch.Set("linked_record_type", stringOrNil(current.LinkedRecordType), nextType)
-		patch.Set("linked_record_id", uuidOrNil(current.LinkedRecordID), nextID)
+		if nextType != current.LinkedRecordType || nextID != current.LinkedRecordID {
+			patch.Set("linked_record_type", stringOrNil(current.LinkedRecordType), stringOrNil(nextType))
+			patch.Set("linked_record_id", uuidOrNil(current.LinkedRecordID), uuidOrNil(nextID))
+		}
 	}
 	return patch
 }
@@ -173,6 +186,16 @@ func (e CommitmentEdit) patch(current Commitment) *storekit.Patch {
 // has to be compared as nil rather than as a zero value, or clearing an already
 // empty link would report the empty string changing to the empty string and
 // file an audit row saying a rep changed something they did not.
+// sameDay compares two optional calendar days as days, which is what the column
+// stores. Comparing the time.Time values would call a date read back from
+// Postgres different from the one written, on the instant alone.
+func sameDay(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Format(time.DateOnly) == b.Format(time.DateOnly)
+}
+
 func stringOrNil(value string) any {
 	if value == "" {
 		return nil

--- a/backend/internal/modules/weeklyplan/handlers.go
+++ b/backend/internal/modules/weeklyplan/handlers.go
@@ -4,6 +4,7 @@
 package weeklyplan
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // Handlers is the plan's HTTP surface.
@@ -83,6 +85,103 @@ func (h Handlers) AddWeeklyPlanCommitment(w http.ResponseWriter, r *http.Request
 		return
 	}
 	httperr.WriteJSON(w, http.StatusCreated, commitmentToWire(out))
+}
+
+// EditWeeklyPlanCommitment corrects one of the caller's own commitments.
+//
+// DECODED AS RAW KEYS, not into the generated struct, and that is forced by the
+// shape of the request. Both `due_on` absent and `due_on: null` render as a nil
+// pointer there, and the two mean opposite things: leave the date alone, and
+// clear it. A rep who fixes a typo would otherwise silently lose the date they
+// never mentioned.
+func (h Handlers) EditWeeklyPlanCommitment(
+	w http.ResponseWriter, r *http.Request, id openapi_types.UUID,
+) {
+	var body map[string]json.RawMessage
+	if !httperr.Decode(w, r, &body) {
+		return
+	}
+	edit, err := editFromBody(body)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	if err := h.store.EditCommitment(r.Context(), ids.UUID(id), edit); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// editFromBody reads the keys that are PRESENT into the store's edit.
+//
+// Each block is the same three steps — the key is there, it parses, it becomes
+// a pointer — and the ParseError names the field the client sent rather than
+// the Go one, so a malformed date reads as `due_on` and not as `DueOn`.
+func editFromBody(body map[string]json.RawMessage) (CommitmentEdit, error) {
+	var edit CommitmentEdit
+	if raw, ok := body["label"]; ok {
+		var label string
+		if err := json.Unmarshal(raw, &label); err != nil {
+			return edit, &values.ParseError{
+				Field: "label", Code: "invalid", Message: "a label is text",
+			}
+		}
+		edit.Label = &label
+	}
+	if raw, ok := body["due_on"]; ok {
+		due, err := parseEditDate(raw)
+		if err != nil {
+			return edit, err
+		}
+		edit.DueOn = &due
+	}
+	if raw, ok := body["linked_record"]; ok {
+		linkType, linkID, err := parseEditLink(raw)
+		if err != nil {
+			return edit, err
+		}
+		edit.LinkedRecordType, edit.LinkedRecordID = &linkType, &linkID
+	}
+	return edit, nil
+}
+
+// parseEditDate reads a date or an explicit null.
+func parseEditDate(raw json.RawMessage) (*time.Time, error) {
+	if string(raw) == "null" {
+		return nil, nil
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err != nil {
+		return nil, &values.ParseError{
+			Field: "due_on", Code: "invalid", Message: "a due date is a calendar day",
+		}
+	}
+	day, err := time.Parse(time.DateOnly, text)
+	if err != nil {
+		return nil, &values.ParseError{
+			Field: "due_on", Code: "invalid", Message: "a due date is a calendar day",
+		}
+	}
+	return &day, nil
+}
+
+// parseEditLink reads a record link or an explicit null.
+//
+// A null unlinks, which reaches the store as the empty pair — the same shape
+// the store already treats as "this commitment is about no record".
+func parseEditLink(raw json.RawMessage) (string, ids.UUID, error) {
+	if string(raw) == "null" {
+		return "", ids.Nil, nil
+	}
+	var link crmcontracts.WeeklyPlanLink
+	if err := json.Unmarshal(raw, &link); err != nil {
+		return "", ids.Nil, &values.ParseError{
+			Field: "linked_record", Code: "invalid",
+			Message: "a linked record is a type and an id",
+		}
+	}
+	return string(link.Type), ids.UUID(link.Id), nil
 }
 
 // SetWeeklyPlanCommitmentState settles one of the caller's commitments.

--- a/backend/internal/modules/weeklyplan/handlers.go
+++ b/backend/internal/modules/weeklyplan/handlers.go
@@ -87,6 +87,14 @@ func (h Handlers) AddWeeklyPlanCommitment(w http.ResponseWriter, r *http.Request
 	httperr.WriteJSON(w, http.StatusCreated, commitmentToWire(out))
 }
 
+// The two literals only this file needs: the wire's null, and the code every
+// malformed value here answers with. The field names and the refusal codes the
+// STORE shares with its callers live in store.go.
+const (
+	jsonNull    = "null"
+	codeInvalid = "invalid"
+)
+
 // EditWeeklyPlanCommitment corrects one of the caller's own commitments.
 //
 // DECODED AS RAW KEYS, not into the generated struct, and that is forced by the
@@ -124,13 +132,13 @@ func editFromBody(body map[string]json.RawMessage) (CommitmentEdit, error) {
 		var label string
 		if err := json.Unmarshal(raw, &label); err != nil {
 			return edit, &values.ParseError{
-				Field: "label", Code: "invalid", Message: "a label is text",
+				Field: fieldLabel, Code: codeInvalid, Message: "a label is text",
 			}
 		}
 		edit.Label = &label
 	}
 	if raw, ok := body["due_on"]; ok {
-		due, err := parseEditDate(raw)
+		due, _, err := parseEditDate(raw)
 		if err != nil {
 			return edit, err
 		}
@@ -146,24 +154,28 @@ func editFromBody(body map[string]json.RawMessage) (CommitmentEdit, error) {
 	return edit, nil
 }
 
-// parseEditDate reads a date or an explicit null.
-func parseEditDate(raw json.RawMessage) (*time.Time, error) {
-	if string(raw) == "null" {
-		return nil, nil
+// parseEditDate reads a date, or an explicit null meaning "clear it".
+//
+// A nil day with a nil error is the ANSWER here, not a missing one: JSON null
+// on this field is a request to clear the date. Reported as a separate `ok`
+// rather than as (nil, nil), which reads at a call site as a value nobody
+// checked.
+func parseEditDate(raw json.RawMessage) (*time.Time, bool, error) {
+	if string(raw) == jsonNull {
+		return nil, true, nil
+	}
+	badDate := &values.ParseError{
+		Field: "due_on", Code: codeInvalid, Message: "a due date is a calendar day",
 	}
 	var text string
 	if err := json.Unmarshal(raw, &text); err != nil {
-		return nil, &values.ParseError{
-			Field: "due_on", Code: "invalid", Message: "a due date is a calendar day",
-		}
+		return nil, false, badDate
 	}
 	day, err := time.Parse(time.DateOnly, text)
 	if err != nil {
-		return nil, &values.ParseError{
-			Field: "due_on", Code: "invalid", Message: "a due date is a calendar day",
-		}
+		return nil, false, badDate
 	}
-	return &day, nil
+	return &day, true, nil
 }
 
 // parseEditLink reads a record link or an explicit null.
@@ -171,13 +183,13 @@ func parseEditDate(raw json.RawMessage) (*time.Time, error) {
 // A null unlinks, which reaches the store as the empty pair — the same shape
 // the store already treats as "this commitment is about no record".
 func parseEditLink(raw json.RawMessage) (string, ids.UUID, error) {
-	if string(raw) == "null" {
+	if string(raw) == jsonNull {
 		return "", ids.Nil, nil
 	}
 	var link crmcontracts.WeeklyPlanLink
 	if err := json.Unmarshal(raw, &link); err != nil {
 		return "", ids.Nil, &values.ParseError{
-			Field: "linked_record", Code: "invalid",
+			Field: "linked_record", Code: codeInvalid,
 			Message: "a linked record is a type and an id",
 		}
 	}

--- a/backend/internal/modules/weeklyplan/settle.go
+++ b/backend/internal/modules/weeklyplan/settle.go
@@ -78,7 +78,7 @@ func (s *Store) SetState(ctx context.Context, commitmentID ids.UUID, state strin
 		}
 		return storekit.EmitEvent(ctx, tx, auditID, owner, crmcontracts.PublicEventWeeklyPlanUpdated{
 			PlanId: openapi_types.UUID(planID), OwnerUserId: openapi_types.UUID(owner),
-			ChangedFields: []string{"commitments"},
+			ChangedFields: []string{changedCommitments},
 		})
 	})
 }
@@ -155,7 +155,7 @@ func (s *Store) Respond(ctx context.Context, commitmentID ids.UUID, answer strin
 	}
 	if text == "" {
 		return &values.ParseError{
-			Field: "manager_response", Code: "required",
+			Field: "manager_response", Code: codeRequired,
 			Message: "an answer needs saying in words",
 		}
 	}
@@ -233,7 +233,7 @@ func ownCommitmentTx(
 	// A closed week is frozen into a review that has already been counted.
 	if status != "open" {
 		return ids.Nil, Commitment{}, &values.ParseError{
-			Field: "week", Code: "week_closed",
+			Field: fieldWeek, Code: codeWeekClosed,
 			Message: "that week is closed and its outcome is recorded",
 		}
 	}

--- a/backend/internal/modules/weeklyplan/store.go
+++ b/backend/internal/modules/weeklyplan/store.go
@@ -24,7 +24,26 @@ import (
 // a request for help is a paragraph, not a document.
 const (
 	labelBound = 500
-	proseBound = 2000
+)
+
+// The parse-error vocabulary this module answers with, and the field name its
+// update event carries.
+//
+// Named rather than typed at each site because a refusal code is what a client
+// BRANCHES on: two spellings of one code is a client that stops recognising
+// half of it. `week_closed` is the same refusal whether it comes from settling
+// a commitment or correcting one, and a reader of either path should land on
+// the same constant.
+const (
+	codeRequired   = "required"
+	codeWeekClosed = "week_closed"
+	fieldLabel     = "label"
+	fieldWeek      = "week"
+
+	// changedCommitments is the field name every write to a plan's commitments
+	// reports, so a consumer filtering on it sees all of them.
+	changedCommitments = "commitments"
+	proseBound         = 2000
 	// planCap bounds one week's list. A plan is what a person means to do in
 	// five days; past this it is a backlog, and a backlog belongs in tasks.
 	planCap = 50

--- a/backend/internal/modules/weeklyplan/write.go
+++ b/backend/internal/modules/weeklyplan/write.go
@@ -100,13 +100,13 @@ func (s *Store) AddCommitment(ctx context.Context, now time.Time, in NewCommitme
 	if err := auth.Require(ctx, "weekly_plan", principal.ActionUpdate); err != nil {
 		return Commitment{}, err
 	}
-	label, err := bounded("label", in.Label, labelBound)
+	label, err := bounded(fieldLabel, in.Label, labelBound)
 	if err != nil {
 		return Commitment{}, err
 	}
 	if label == "" {
 		return Commitment{}, &values.ParseError{
-			Field: "label", Code: "required", Message: "a commitment needs saying in words",
+			Field: fieldLabel, Code: codeRequired, Message: "a commitment needs saying in words",
 		}
 	}
 	if err := checkLink(in.LinkedRecordType, in.LinkedRecordID); err != nil {
@@ -163,7 +163,7 @@ func (s *Store) AddCommitment(ctx context.Context, now time.Time, in NewCommitme
 		}
 		return storekit.EmitEvent(ctx, tx, auditID, owner, crmcontracts.PublicEventWeeklyPlanUpdated{
 			PlanId: openapi_types.UUID(plan.ID), OwnerUserId: openapi_types.UUID(owner),
-			ChangedFields: []string{"commitments"},
+			ChangedFields: []string{changedCommitments},
 		})
 	})
 	if err != nil {
@@ -203,7 +203,7 @@ func (s *Store) openPlanTx(
 	// already frozen, so the two would disagree about a week that is over.
 	if plan.Status != "open" {
 		return Plan{}, &values.ParseError{
-			Field: "week", Code: "week_closed",
+			Field: fieldWeek, Code: codeWeekClosed,
 			Message: "that week is closed; plan the current one",
 		}
 	}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11007,6 +11007,37 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/weekly-plans/commitments/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Correct what a commitment says, when it is due, or what it is about.
+         * @description The CALLER's own commitment, on an open week. A rep types a commitment on Monday and
+         *     finds the typo on Tuesday; without this the only way out is to drop the row and write
+         *     a new one, which discards the manager's answer and any help already asked for — the
+         *     two fields on the row that were never the rep's to throw away.
+         *
+         *     Every field is optional and only what is PRESENT changes. `due_on: null` clears the
+         *     date, which is a real state: something to do this week rather than by a day. Sending
+         *     `linked_record: null` unlinks the record.
+         *
+         *     State is not settable here. `PUT .../state` owns the move between open, done and
+         *     dropped because it ties `completed_at` to the state the schema's CHECK binds them
+         *     with, and two writers of that pair would drift.
+         */
+        patch: operations["editWeeklyPlanCommitment"];
+        trace?: never;
+    };
     "/weekly-plans/commitments/{id}/state": {
         parameters: {
             query?: never;
@@ -22734,6 +22765,24 @@ export interface components {
             /** @description Both halves or neither — a type with no id names nothing. */
             linked_record?: components["schemas"]["WeeklyPlanLink"];
             /** Format: date */
+            due_on?: string | null;
+        };
+        /**
+         * @description What a rep may correct about their own commitment. Only the fields PRESENT change —
+         *     an absent field is left alone, which is what lets a client send a new label without
+         *     also having to restate the due date it is not touching.
+         */
+        WeeklyPlanCommitmentEdit: {
+            label?: string;
+            /**
+             * @description Both halves or neither, as on create. Null unlinks the record, which is how a
+             *     commitment stops being about one without being rewritten.
+             */
+            linked_record?: components["schemas"]["WeeklyPlanLink"] | null;
+            /**
+             * Format: date
+             * @description Null clears the date — something to do this week, rather than by a day.
+             */
             due_on?: string | null;
         };
         /**
@@ -46268,6 +46317,34 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    editWeeklyPlanCommitment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WeeklyPlanCommitmentEdit"];
+            };
+        };
+        responses: {
+            /** @description Corrected. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
             422: components["responses"]["ValidationError"];
         };
     };


### PR DESCRIPTION
A rep types a commitment on Monday and finds it wrong on Tuesday. The only way out was to **drop the row and write a new one** — which discards the manager's answer and any help already asked for, the two fields on the row that were never the rep's to throw away.

`PATCH /weekly-plans/commitments/{id}` corrects the label, the due date and the linked record. State stays with `PUT .../state`, which ties `completed_at` to the state the schema's CHECK binds them with; two writers of that pair would drift.

### Absent and null are different requests

The generated struct cannot tell them apart — both render as a nil pointer. So the handler decodes raw keys: only what is **present** changes, and `due_on: null` clears the date, which is a real state (something to do this week, rather than by a day). Without that, a rep fixing a typo would silently lose the date they never mentioned.

### Compare before setting

`storekit.Patch` records an assignment unconditionally — comparing is the caller's job, and every other writer here already knows its column differs. An edit does not: a client may send back the label it read, and writing anyway would file an audit row saying a rep changed something they did not, and bump the version a concurrent reader holds.

`due_on` goes through `SetDate`, not `Set`. It is a `date` column, and storekit's rule is that a date is stored as its own text so the audit image round-trips into the column an undo would write it to.

### Proof

Six integration tests against a real database and the real writers. Four guards mutation-checked one at a time — the ownership clause (**a teammate's edit succeeded without it**), the closed-week refusal, the no-op comparison, and the link's visibility probe.

### Fixed along the way

The linter found two things that were true: the module's refusal codes were spelled across four files and are now named once, and `parseEditDate` reported "cleared" as `(nil, nil)`, which reads at a call site as a value nobody checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `PATCH /weekly-plans/commitments/{id}` so a rep can correct a commitment's label, due date, or linked record. Previously the only fix was to drop the row and write a new one, which threw away the manager's answer and any help already asked for.

**Edit semantics**
- Only fields present in the request change; `due_on: null` clears the date and `linked_record: null` unlinks the record.
- State moves only via `PUT .../state`, which already ties `completed_at` to the state.
- No-op edits write no audit row and don't bump the row version.

**Tests and cleanup**
- Six integration tests cover the endpoint against a real database; the ownership, closed-week, no-op, and link-visibility guards were mutation-checked.
- The module's refusal codes are now named once instead of spelled across four files.
- `parseEditDate` no longer reports "cleared" as `(nil, nil)`.

<sup>Written for commit 1ade7dd83a4cc366859e0d735a2989576fc6272a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit weekly-plan commitment labels, due dates, and linked records.
  * Supports clearing due dates and unlinking records.
  * Changes are limited to the user’s own commitments in open weekly plans.
  * Invalid edits, unauthorized access, and edits to closed weeks return clear errors.
  * Successful edits return no content; unchanged edits produce no audit activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->