### PR TITLE
A message can be limited to the people you name

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1526,6 +1526,11 @@ export const de = {
   "compose.audienceParticipants": "Nur Beteiligte",
   "compose.audienceParticipantsHint":
     "Nur die Personen auf dieser Nachricht lesen Betreff und Inhalt. Andere sehen nur, dass an diesem Tag eine Nachricht gewechselt wurde.",
+  "compose.audienceSelected": "Benannte Personen",
+  "compose.audienceSelectedHint":
+    "nur die Personen und Teams, die Sie benennen, sowie alle, die bereits auf der Nachricht stehen.",
+  "compose.audienceMembersLegend": "Wer sie lesen darf",
+  "compose.audienceMembersLoading": "Personenliste wird gelesen…",
   "compose.audienceConfirm": "Sichtbarkeit speichern",
   "compose.audienceNote":
     "Gilt nur f\u00fcr diese Nachricht \u2014 nicht f\u00fcr den Thread und nicht f\u00fcr den Kontakt.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1579,6 +1579,11 @@ export const en = {
   "compose.audienceParticipants": "Participants only",
   "compose.audienceParticipantsHint":
     "Only the people on this message read its subject and body. Others see that a message was exchanged that day, nothing more.",
+  "compose.audienceSelected": "Named people",
+  "compose.audienceSelectedHint":
+    "only the people and teams you name, plus anyone already on the message.",
+  "compose.audienceMembersLegend": "Who may read it",
+  "compose.audienceMembersLoading": "Reading the list of people…",
   "compose.audienceConfirm": "Save visibility",
   "compose.audienceNote":
     "Applies to this message only \u2014 not to the thread and not to the contact.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1519,6 +1519,11 @@ export const vi = {
   "compose.audienceParticipants": "Chỉ người tham gia",
   "compose.audienceParticipantsHint":
     "Chỉ những người có trên tin nhắn này đọc được tiêu đề và nội dung. Người khác chỉ thấy rằng có một tin nhắn được trao đổi vào ngày đó.",
+  "compose.audienceSelected": "Những người được nêu tên",
+  "compose.audienceSelectedHint":
+    "chỉ những người và nhóm bạn nêu tên, cùng những ai đã có trong thư.",
+  "compose.audienceMembersLegend": "Ai được đọc",
+  "compose.audienceMembersLoading": "Đang đọc danh sách người…",
   "compose.audienceConfirm": "Lưu hiển thị",
   "compose.audienceNote":
     "Chỉ áp dụng cho tin nhắn này — không cho chuỗi hội thoại và không cho liên hệ.",

--- a/frontend/src/screens/audiencemembers.css
+++ b/frontend/src/screens/audiencemembers.css
@@ -1,0 +1,32 @@
+/* The member checklist inside the audience dialog.
+ *
+ * Scrolls rather than growing: a workspace with sixty seats would otherwise
+ * push the dialog's confirm button off the bottom of the screen, which is the
+ * one control the reader came for. */
+
+.compose-audience-members {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-height: 40vh;
+  overflow-y: auto;
+  padding: var(--space-2);
+  border: 1px solid var(--borderSubtle);
+  border-radius: var(--r-sm);
+}
+
+.compose-audience-member {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* The note is the seat's address, which is how two people with one name are
+   told apart. It truncates; the name does not. */
+.compose-audience-member > .t-caption {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/src/screens/audiencemembers.tsx
+++ b/frontend/src/screens/audiencemembers.tsx
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Who is named on a `selected` audience.
+//
+// The third audience the API has always taken and the dialog never offered:
+// `AUDIENCE_CHOICES` listed workspace and participants because offering
+// `selected` without a way to name anybody would be a choice the reader cannot
+// complete. This is that way.
+//
+// The roster comes from `useRoster`, the same hook the share picker and the
+// filter reference already read — one fetch and one cache entry, whether the
+// names are being picked here or resolved for a chip somewhere else.
+
+import type { components } from "../api/schema";
+import { useT } from "../i18n";
+import { type RosterKind, useRoster } from "./entityref";
+import "./audiencemembers.css";
+
+type AudienceMember = components["schemas"]["AudienceMember"];
+type User = components["schemas"]["User"];
+type Team = components["schemas"]["Team"];
+
+/** One pickable seat or team, flattened out of the two rosters. */
+type Candidate = {
+  kind: RosterKind;
+  id: string;
+  name: string;
+  note?: string;
+};
+
+export function memberKey(member: AudienceMember): string {
+  return `${member.subject_type}:${member.subject_id}`;
+}
+
+/**
+ * The people and teams a message can be limited to.
+ *
+ * Agent seats are excluded for the reason the share picker excludes them: a
+ * message is limited to people and teams, never to an agent. The rule is spelled
+ * here rather than borrowed, because share.tsx's copy answers a different
+ * question — who a RECORD is shared with — and one changing is no reason for
+ * the other to.
+ */
+export function useAudienceCandidates(enabled: boolean): Candidate[] {
+  const users = useRoster("user", enabled);
+  const teams = useRoster("team", enabled);
+  const seats = ((users.data ?? []) as User[])
+    .filter((seat) => !seat.is_agent)
+    .map(
+      (seat): Candidate => ({
+        kind: "user",
+        id: seat.id,
+        name: seat.display_name,
+        note: seat.email,
+      }),
+    );
+  const groups = ((teams.data ?? []) as Team[]).map(
+    (team): Candidate => ({ kind: "team", id: team.id, name: team.name }),
+  );
+  return [...seats, ...groups];
+}
+
+/**
+ * The member picker, as a checklist.
+ *
+ * A checklist rather than a search-and-add: an audience is small and a reader
+ * changing one is usually removing somebody, which a list they can see makes
+ * one press and a search box makes a guessing game.
+ *
+ * The set it submits is the FULL replacement set, which is what the write
+ * takes — so what the reader sees ticked is exactly what the message will be
+ * limited to, with no merge happening behind them.
+ */
+export function AudienceMembers({
+  candidates,
+  chosen,
+  onChange,
+}: Readonly<{
+  candidates: Candidate[];
+  chosen: readonly AudienceMember[];
+  onChange: (next: AudienceMember[]) => void;
+}>) {
+  const t = useT();
+  const picked = new Set(chosen.map(memberKey));
+  const toggle = (candidate: Candidate) => {
+    const member: AudienceMember = {
+      subject_type: candidate.kind,
+      subject_id: candidate.id,
+    };
+    onChange(
+      picked.has(memberKey(member))
+        ? chosen.filter((each) => memberKey(each) !== memberKey(member))
+        : [...chosen, member],
+    );
+  };
+  if (candidates.length === 0) {
+    // The list has not answered yet, or answered with nobody. Either way the
+    // reader is told rather than shown an empty box that reads as an
+    // organization with no people in it.
+    return <p className="t-caption">{t("compose.audienceMembersLoading")}</p>;
+  }
+  return (
+    <fieldset className="compose-audience-members">
+      <legend className="t-label">{t("compose.audienceMembersLegend")}</legend>
+      {candidates.map((candidate) => {
+        const key = `${candidate.kind}:${candidate.id}`;
+        return (
+          <label key={key} className="compose-audience-member">
+            <input
+              type="checkbox"
+              checked={picked.has(key)}
+              onChange={() => toggle(candidate)}
+            />
+            <span>{candidate.name}</span>
+            {candidate.note && (
+              <span className="t-caption">{candidate.note}</span>
+            )}
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1795,6 +1795,129 @@ describe("TimelineActions", () => {
     expect(screen.queryByRole("button", { name: "Visibility" })).toBeNull();
   });
 
+  // `selected` is the API's third audience and the dialog offered two, because
+  // choosing it without a way to name anybody is a choice the reader cannot
+  // complete. These are the claims that closed that.
+  it("names the people a message is limited to and submits them as one set", async () => {
+    const roster = {
+      "GET /users": () =>
+        jsonResponse({
+          data: [
+            {
+              id: "u-2",
+              display_name: "Lena Fischer",
+              email: "lena@demo.test",
+            },
+            // An agent seat, which the picker must not offer: a message is
+            // limited to people and teams, never to an agent.
+            {
+              id: "u-9",
+              display_name: "Margince",
+              email: "agent@demo.test",
+              is_agent: true,
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+      "GET /teams": () =>
+        jsonResponse({
+          data: [{ id: "t-1", name: "Vertrieb" }],
+          page: { next_cursor: null, has_more: false },
+        }),
+    };
+    const sent = stubRoutes(roster);
+    render(
+      <TimelineActions
+        activity={{
+          ...activity202,
+          id: "a6",
+          captured_by: "human:u1",
+          version: 3,
+        }}
+        entityType="deal"
+        entityId="d1"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Visibility" }));
+    await userEvent.click(screen.getByLabelText(/Named people/));
+
+    // An agent seat is not on offer.
+    expect(await screen.findByLabelText(/Lena Fischer/)).toBeTruthy();
+    expect(screen.queryByLabelText(/Margince/)).toBeNull();
+
+    await userEvent.click(screen.getByLabelText(/Lena Fischer/));
+    await userEvent.click(screen.getByLabelText(/Vertrieb/));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Save visibility" }),
+    );
+
+    const write = sent.find(
+      (each) => each.key === "PATCH /activities/a6/audience",
+    );
+    // Fails loudly rather than passing vacuously: `find` answering undefined
+    // makes `write?.body` undefined, and a toEqual against undefined would
+    // report the write as absent instead of wrong.
+    if (!write) {
+      throw new Error(
+        `no audience write was sent; saw ${sent.map((e) => e.key).join(", ")}`,
+      );
+    }
+    expect(write.body).toEqual({
+      audience: "selected",
+      members: [
+        { subject_type: "user", subject_id: "u-2" },
+        { subject_type: "team", subject_id: "t-1" },
+      ],
+    });
+  });
+
+  // Limiting a message to NOBODY is not a limit anybody meant, and it would
+  // lock the author out of their own correspondence. The confirm refuses it
+  // rather than the server having to.
+  it("refuses to save a named audience with nobody named", async () => {
+    stubRoutes({
+      "GET /users": () =>
+        jsonResponse({
+          data: [
+            {
+              id: "u-2",
+              display_name: "Lena Fischer",
+              email: "lena@demo.test",
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+      "GET /teams": () =>
+        jsonResponse({
+          data: [],
+          page: { next_cursor: null, has_more: false },
+        }),
+    });
+    render(
+      <TimelineActions
+        activity={{
+          ...activity202,
+          id: "a7",
+          captured_by: "human:u1",
+          version: 3,
+        }}
+        entityType="deal"
+        entityId="d1"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Visibility" }));
+    await userEvent.click(screen.getByLabelText(/Named people/));
+    await screen.findByLabelText(/Lena Fischer/);
+
+    expect(
+      screen
+        .getByRole("button", { name: "Save visibility" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
   it("keeps the per-message control on hand-typed mail once narrowed", () => {
     const narrowedHandTyped: Activity = {
       ...activity202,

--- a/frontend/src/screens/timelineactions.tsx
+++ b/frontend/src/screens/timelineactions.tsx
@@ -16,6 +16,7 @@ import { ConfirmModal } from "../design-system/confirmmodal";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { entityTimelineKeys } from "./activitykeys";
+import { AudienceMembers, useAudienceCandidates } from "./audiencemembers";
 import { useMessageAudience, useThreadAudience } from "./audienceservice";
 import { problemMessageOf } from "./common";
 // Reply and Relink stay in compose.tsx for now: they are the composer's own
@@ -26,6 +27,7 @@ import { ChannelReplyAction, type RelinkKind, RelinkModal } from "./compose";
 
 type Activity = components["schemas"]["Activity"];
 type ActivityAudience = components["schemas"]["ActivityAudience"];
+type AudienceMember = components["schemas"]["AudienceMember"];
 
 // The per-row action cluster the 360 timelines mount in each entry's action
 // slot.
@@ -126,13 +128,28 @@ export function TimelineActions({
   );
 }
 
-// The audiences the dialog offers. `selected` (named users and teams) is the
-// API's third value and waits for a member picker; offering it without one
-// would be a choice the reader cannot complete.
+// The audiences the dialog offers — all three the API takes. `selected` waited
+// for a member picker, because offering it without one would be a choice the
+// reader cannot complete; AudienceMembers is that picker.
 const AUDIENCE_CHOICES: readonly ActivityAudience[] = [
   "workspace",
   "participants",
+  "selected",
 ];
+
+// What each audience is called and what it means, in one place: the label and
+// the hint were a pair of ternaries that a third value would have made a pair
+// of nested ones.
+const AUDIENCE_LABEL: Record<ActivityAudience, MessageKey> = {
+  workspace: "compose.audienceWorkspace",
+  participants: "compose.audienceParticipants",
+  selected: "compose.audienceSelected",
+};
+const AUDIENCE_HINT: Record<ActivityAudience, MessageKey> = {
+  workspace: "compose.audienceWorkspaceHint",
+  participants: "compose.audienceParticipantsHint",
+  selected: "compose.audienceSelectedHint",
+};
 
 // Why a captured message is held, in the reader's words. A reason the server
 // learned to give and this map has not falls back to nothing rather than to the
@@ -226,6 +243,21 @@ export function AudienceAction({
   const [open, setOpen] = useState(false);
   const current: ActivityAudience = activity.audience ?? "workspace";
   const [choice, setChoice] = useState<ActivityAudience>(current);
+  // The set the reader is building. Read only when `selected` is the choice,
+  // and submitted as the FULL replacement set, which is what the write takes.
+  //
+  // It starts EMPTY even on a message that is already limited, and that is a
+  // boundary rather than an oversight: `selected_members` rides EmailAccess,
+  // gated on `can_change`, and a timeline row carries no access block — reading
+  // one per row would be a detail fetch per visible line. So this dialog names
+  // a new set rather than editing the standing one, and the confirm below
+  // refuses an empty set so nobody narrows a message to nobody by pressing it
+  // twice. Editing an existing set in place belongs in the drawer, which
+  // already holds the access block it would start from.
+  const [members, setMembers] = useState<AudienceMember[]>([]);
+  // Fetched only while the dialog is open: the roster is two reads, and a
+  // timeline of twenty rows would otherwise fire them per row on mount.
+  const candidates = useAudienceCandidates(open && choice === "selected");
   const mutation = useMessageAudience({
     invalidate: () => entityTimelineKeys(entityType, entityId),
     onSettled: () => setOpen(false),
@@ -250,12 +282,16 @@ export function AudienceAction({
           onClose={() => setOpen(false)}
           title={t("compose.audienceTitle")}
           confirmLabel={t("compose.audienceConfirm")}
-          confirmDisabled={choice === current}
+          confirmDisabled={
+            choice === current ||
+            (choice === "selected" && members.length === 0)
+          }
           onConfirm={() =>
             mutation.mutate({
               activityId: activity.id,
               version: activity.version,
               audience: choice,
+              members: choice === "selected" ? members : undefined,
             })
           }
           pending={mutation.isPending}
@@ -268,16 +304,20 @@ export function AudienceAction({
               onChange={setChoice}
               choices={AUDIENCE_CHOICES.map((value) => ({
                 value,
-                label:
-                  value === "workspace"
-                    ? t("compose.audienceWorkspace")
-                    : t("compose.audienceParticipants"),
-                description:
-                  value === "workspace"
-                    ? t("compose.audienceWorkspaceHint")
-                    : t("compose.audienceParticipantsHint"),
+                label: t(AUDIENCE_LABEL[value]),
+                description: t(AUDIENCE_HINT[value]),
               }))}
             />
+            {/* The picker only where the choice needs one. A limited-to-nobody
+                audience is not a limit anybody meant, so the confirm below
+                refuses an empty set rather than writing it. */}
+            {choice === "selected" && (
+              <AudienceMembers
+                candidates={candidates}
+                chosen={members}
+                onChange={setMembers}
+              />
+            )}
             <p className="t-caption">{t("compose.audienceNote")}</p>
           </div>
         </ConfirmModal>


### PR DESCRIPTION
Twelfth slice of the email display unification arc.

## What changed

`selected` is the third audience the API has always taken, and the dialog offered two. The code said why: *"offering it without one would be a choice the reader cannot complete."* This is the member picker that closes it.

- `audiencemembers.tsx` — a checklist of the people and teams a message can be limited to, submitted as the **full replacement set** the write already takes, so what the reader sees ticked is exactly what the message becomes.
- `AUDIENCE_CHOICES` gains `selected`; the label/hint ternary pair became two maps, since a third value would have made them nested ternaries.
- Three i18n catalogs.

The roster is `useRoster` — the hook the share picker and the filter reference already read — so this is one more reader of one cache entry, not a second fetch. Agent seats are excluded: a message is limited to people and teams, never to an agent.

## Two refusals

**An empty set does not save.** Limiting a message to nobody is not a limit anybody meant, and it would lock the author out of their own correspondence. The confirm refuses rather than the server having to.

**The roster is fetched only while the dialog is open on `selected`.** It is two reads, and a timeline of twenty rows would otherwise fire them per row on mount.

## A boundary, stated rather than hidden

The set starts **empty** even on a message that is already limited. `selected_members` rides `EmailAccess`, gated on `can_change`, and a timeline row carries no access block — reading one per row would be a detail fetch per visible line.

So this dialog **names a new set** rather than editing the standing one. Editing in place belongs in the drawer, which already holds the access block it would start from. The empty-set refusal is what stops that boundary becoming a footgun.

## Tests

`compose.test.tsx` — the picker offers people and teams but not agent seats, and the write carries `{audience: "selected", members: [...]}` as one set; an empty set leaves the confirm disabled. Mutation-checked: dropping `members` from the write fails the first test.

**A test-fixture lesson:** the first version passed vacuously because `activity202` carries no `version`, and `useMessageAudience` requires one for `If-Match` — so no request was ever sent and `find` returned undefined. The assertion now throws with the list of requests actually made rather than comparing against `undefined`.

## Also fixed

`i18n.test.ts`'s tenant-vocabulary gate caught "Reading the workspace roster…" — the product says organization, not workspace. Reworded in all three catalogs.

## Still open

The `x-email-presentation` contract gate is **not** in this PR. The annotations exist in `crm.yaml` from PR1 (`EmailSummary` and `EmailPresentation` as `entry`, five schemas `exempt` with reasons); what remains is the two-sided derived comparison. It is its own change and I would rather ship the editor than half-build a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the "Named people" audience to the email visibility dialog, so a message can be limited to the people and teams you pick. The dialog previously offered only workspace and participants even though the API always accepted `selected`.

**Behavior**
- The picker is a checklist that submits the full replacement set; an empty set can't be saved, so the author can't lock themselves out.
- The roster is fetched only while the dialog is open on `selected`, and agent seats are excluded.
- The set starts empty even on an already-limited message; editing an existing set in place belongs in the drawer.
- Fixed the roster loading label to say "organization" instead of "workspace" in all three catalogs.
- The `x-email-presentation` contract gate is not included; the annotations exist in `crm.yaml`, and the derived comparison will follow separately.

<sup>Written for commit 8b2675c391724ea147f0c7b6f38accf7855b088f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a selected-audience option for targeting specific people and teams.
  * Added a member checklist with names, optional email addresses, loading states, and empty states.
  * Prevented agent accounts from appearing as selectable recipients.
  * Disabled confirmation until at least one audience member is selected.
  * Added German, English, and Vietnamese localization for the new audience controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->