### PR TITLE
A message records why it was queued, in the transaction that queues it

### DIFF
--- a/backend/gates/stagingdecision_test.go
+++ b/backend/gates/stagingdecision_test.go
@@ -36,6 +36,13 @@ func TestEveryStagedDeliveryRecordsWhyItWasAllowed(t *testing.T) {
 			if !ok {
 				continue
 			}
+			// Receiver-qualified, because the method NAME is fixed by the
+			// interface: every type satisfying activities.DeliveryStager must
+			// call its method StageTx. Keyed on the bare name, a wrapper that
+			// staged without deciding would land in the same map entry as the
+			// one that decides, and the gate would absorb it and report PASS —
+			// which is the exact shape a second send door takes.
+			name := receiverQualified(fn)
 			ast.Inspect(fn, func(n ast.Node) bool {
 				sel, ok := n.(*ast.SelectorExpr)
 				if !ok {
@@ -47,9 +54,9 @@ func TestEveryStagedDeliveryRecordsWhyItWasAllowed(t *testing.T) {
 				// StageOrJoinPendingInTx on the site-read transport — which
 				// queues no message and owes no decision.
 				case "StageTx", "StageChannelTx":
-					staging[fn.Name.Name] = true
+					staging[name] = true
 				case "AuthorizeStagingTx":
-					authorizing[fn.Name.Name] = true
+					authorizing[name] = true
 				}
 				return true
 			})
@@ -67,4 +74,21 @@ func TestEveryStagedDeliveryRecordsWhyItWasAllowed(t *testing.T) {
 				"a message queued with nothing on record about why is one nobody can answer for", fn)
 		}
 	}
+}
+
+// receiverQualified names a function the way this gate must count it: the
+// receiver type and the method, so two types implementing one interface method
+// are two subjects rather than one.
+func receiverQualified(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return fn.Name.Name
+	}
+	expr := fn.Recv.List[0].Type
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	if id, ok := expr.(*ast.Ident); ok {
+		return id.Name + "." + fn.Name.Name
+	}
+	return fn.Name.Name
 }

--- a/backend/gates/stagingdecision_test.go
+++ b/backend/gates/stagingdecision_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+//gate:kind census H3
+
+package gates
+
+// Every path that stages a delivery records why it was allowed to.
+//
+// The transmit ticket catches a delivery that reaches a provider with nothing
+// on record, but it catches it in a worker — minutes or days later, against a
+// parked row, with the person who typed the message long gone. The staging
+// decision is what makes a refusal answerable, and this is what stops a new
+// send path from quietly not taking one.
+//
+// Derived rather than listed: the corpus is every caller of a Stage*Tx method
+// on the comms store, so a send path added tomorrow is judged the day it is
+// written. A hand-kept list would go stale exactly when a new door appeared,
+// which is the failure this gate exists to prevent.
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+)
+
+func TestEveryStagedDeliveryRecordsWhyItWasAllowed(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	staging := map[string]bool{}     // functions that stage a delivery
+	authorizing := map[string]bool{} // functions that record a decision
+
+	for _, file := range parsePackageDir(t, fset, composeTier) {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			ast.Inspect(fn, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				switch sel.Sel.Name {
+				// The comms store's two delivery-staging entry points, named
+				// exactly. A prefix match also catches unrelated staging —
+				// StageOrJoinPendingInTx on the site-read transport — which
+				// queues no message and owes no decision.
+				case "StageTx", "StageChannelTx":
+					staging[fn.Name.Name] = true
+				case "AuthorizeStagingTx":
+					authorizing[fn.Name.Name] = true
+				}
+				return true
+			})
+		}
+	}
+
+	// Under-recognition is the one way this gate must not break: a scan that
+	// found nothing would report PASS over an empty corpus.
+	if len(staging) == 0 {
+		t.Fatal("found no delivery staging in compose — the scan is looking in the wrong place")
+	}
+	for fn := range staging {
+		if !authorizing[fn] {
+			t.Errorf("%s stages a delivery and records no authorization decision — "+
+				"a message queued with nothing on record about why is one nobody can answer for", fn)
+		}
+	}
+}

--- a/backend/gates/stagingdecision_test.go
+++ b/backend/gates/stagingdecision_test.go
@@ -12,25 +12,37 @@ package gates
 // decision is what makes a refusal answerable, and this is what stops a new
 // send path from quietly not taking one.
 //
-// Derived rather than listed: the corpus is every caller of a Stage*Tx method
-// on the comms store, so a send path added tomorrow is judged the day it is
-// written. A hand-kept list would go stale exactly when a new door appeared,
-// which is the failure this gate exists to prevent.
+// Derived rather than listed, on both axes. The method names come from the
+// comms store's own declarations, so a fourth staging method is judged the day
+// it is declared; and the corpus walks every package under the compose tier,
+// because a stager wired through WithDelivery may live in a subpackage. A
+// hand-kept list on either axis would go stale exactly when a new door
+// appeared, which is the failure this gate exists to prevent.
 
 import (
 	"go/ast"
+	"go/parser"
 	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// commsStoreDir holds the delivery store whose staging methods this gate
+// derives its subject from.
+const commsStoreDir = "internal/modules/comms"
 
 func TestEveryStagedDeliveryRecordsWhyItWasAllowed(t *testing.T) {
 	t.Parallel()
 
 	fset := token.NewFileSet()
+	stagers := stagingMethodNames(t, fset)
+
 	staging := map[string]bool{}     // functions that stage a delivery
 	authorizing := map[string]bool{} // functions that record a decision
 
-	for _, file := range parsePackageDir(t, fset, composeTier) {
+	for _, file := range parseTreeUnder(t, fset, composeTier) {
 		for _, decl := range file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
 			if !ok {
@@ -48,14 +60,10 @@ func TestEveryStagedDeliveryRecordsWhyItWasAllowed(t *testing.T) {
 				if !ok {
 					return true
 				}
-				switch sel.Sel.Name {
-				// The comms store's two delivery-staging entry points, named
-				// exactly. A prefix match also catches unrelated staging —
-				// StageOrJoinPendingInTx on the site-read transport — which
-				// queues no message and owes no decision.
-				case "StageTx", "StageChannelTx":
+				switch {
+				case stagers[sel.Sel.Name]:
 					staging[name] = true
-				case "AuthorizeStagingTx":
+				case sel.Sel.Name == "AuthorizeStagingTx":
 					authorizing[name] = true
 				}
 				return true
@@ -74,6 +82,62 @@ func TestEveryStagedDeliveryRecordsWhyItWasAllowed(t *testing.T) {
 				"a message queued with nothing on record about why is one nobody can answer for", fn)
 		}
 	}
+}
+
+// stagingMethodNames reads the comms store's own declarations for the methods
+// that queue a message. Deriving them is what makes a fourth door — a
+// StageBroadcastTx, say — a subject of this gate on the day it is written
+// rather than on the day somebody remembers to add it here.
+//
+// StageOrJoinPendingInTx on the site-read transport is deliberately not
+// matched: it declares no delivery and queues no message, so it owes no
+// decision. That is why this reads the comms store alone rather than every
+// Stage* method in the tree.
+func stagingMethodNames(t *testing.T, fset *token.FileSet) map[string]bool {
+	t.Helper()
+	names := map[string]bool{}
+	for _, file := range parsePackageDir(t, fset, commsStoreDir) {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || !fn.Name.IsExported() {
+				continue
+			}
+			if strings.HasPrefix(fn.Name.Name, "Stage") && strings.HasSuffix(fn.Name.Name, "Tx") {
+				names[fn.Name.Name] = true
+			}
+		}
+	}
+	if len(names) == 0 {
+		t.Fatalf("found no Stage…Tx methods in %s — the scan is looking in the wrong place", commsStoreDir)
+	}
+	return names
+}
+
+// parseTreeUnder parses every hand-written Go file under a directory, walking
+// into subpackages. A gate that names identifiers needs one package's scope,
+// but this one counts call sites, and a call site in a subpackage stages just
+// as real a message as one beside the wiring.
+func parseTreeUnder(t *testing.T, fset *token.FileSet, root string) []*ast.File {
+	t.Helper()
+	var files []*ast.File
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		files = append(files, file)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	return files
 }
 
 // receiverQualified names a function the way this gate must count it: the

--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
@@ -300,98 +299,6 @@ func (s commsSeats) ActiveSeat(ctx context.Context, userID ids.UserID) (bool, st
 		return false, "the sender holds a read-only seat; a read seat may not transmit staged messages", nil
 	}
 	return true, "", nil
-}
-
-// commsStager records an accepted send for transmission: the delivery row and
-// the job that will carry it, both on the caller's transaction. One commit, one
-// fact — a crash between them would either promise a send nothing queued or
-// queue one with no timeline entry behind it.
-type commsStager struct {
-	store  *comms.Store
-	runner *jobs.Runner
-}
-
-var (
-	_ activities.DeliveryStager        = commsStager{}
-	_ activities.ChannelDeliveryStager = commsStager{}
-)
-
-// DeliveryMachinery is the ONE delivery path in both the shapes a message can be
-// staged in. It is a single seam rather than two because there is a single
-// machinery behind it — one delivery table, one status machine, one retry ladder,
-// one dispatcher — and a role able to wire mail staging without channel staging
-// could serve a reply surface that accepts a message nothing will ever carry.
-type DeliveryMachinery interface {
-	activities.DeliveryStager
-	activities.ChannelDeliveryStager
-}
-
-// NewDeliveryStager builds the delivery machinery every send transport is
-// composed with (compose.WithDelivery). The runner is insert-only in the api
-// role; the worker role works what it inserts.
-//
-//nolint:ireturn // returns the DeliveryMachinery seam by design: the concrete type is unexported and every caller holds the interface
-func NewDeliveryStager(pool *pgxpool.Pool, runner *jobs.Runner) DeliveryMachinery {
-	return commsStager{store: comms.NewStore(InstallationDB(pool), time.Now, activities.NewStore(InstallationDB(pool))), runner: runner}
-}
-
-func (s commsStager) StageTx(ctx context.Context, tx pgx.Tx, in activities.DeliveryRequest) error {
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return errors.New("comms: staging a delivery outside workspace context")
-	}
-	id, err := s.store.StageTx(ctx, tx, comms.StageInput{
-		ActivityID:      in.ActivityID,
-		Provider:        in.Provider,
-		MessageID:       in.MessageID,
-		Recipients:      in.Recipients,
-		Cc:              in.Cc,
-		Bcc:             in.Bcc,
-		Subject:         in.Subject,
-		Body:            in.Body,
-		HTMLBody:        in.HTMLBody,
-		FromName:        in.FromName,
-		Attachments:     commsFiles(in.Attachments),
-		ConsentPurpose:  in.ConsentPurpose,
-		InReplyTo:       in.InReplyTo,
-		References:      in.References,
-		ThreadKey:       in.ThreadKey,
-		ListUnsubscribe: in.ListUnsubscribe,
-	})
-	if err != nil {
-		return err
-	}
-	return s.runner.EnqueueTx(ctx, tx, SendEmailArgs{
-		Workspace: ws, DeliveryID: id.String(),
-	}, sendInsertOpts())
-}
-
-// StageChannelTx is the same staging for a channel reply: the channel-shaped row
-// and the SAME transmit job, on the caller's transaction.
-//
-// One job kind carries both shapes deliberately. The worker loads the delivery
-// and dispatches it, and the dispatcher branches on the ROW's shape exactly once
-// (comms/sendseam.go) — a second job kind would be a second path to keep in step
-// with the first, and the channel is the one that would fall behind.
-func (s commsStager) StageChannelTx(ctx context.Context, tx pgx.Tx, in activities.ChannelDeliveryRequest) error {
-	ws, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return errors.New("comms: staging a channel delivery outside workspace context")
-	}
-	id, err := s.store.StageChannelTx(ctx, tx, comms.StageChannelInput{
-		ActivityID:     in.ActivityID,
-		Provider:       in.Provider,
-		Recipient:      in.Recipient,
-		Body:           in.Body,
-		Attachments:    commsFiles(in.Attachments),
-		ConsentPurpose: in.ConsentPurpose,
-	})
-	if err != nil {
-		return err
-	}
-	return s.runner.EnqueueTx(ctx, tx, SendEmailArgs{
-		Workspace: ws, DeliveryID: id.String(),
-	}, sendInsertOpts())
 }
 
 // SendPacing is the deployment's outbound pacing: how many messages one

--- a/backend/internal/compose/commsstager.go
+++ b/backend/internal/compose/commsstager.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Staging one outbound message: the delivery row, the decision recording why it
+// was allowed to be queued, and the job that will send it — all on the caller's
+// transaction.
+//
+// Its own file because it is the seam where three modules meet and none may
+// import another: activities hands down the message, comms owns the delivery
+// row, consent owns the decision. Compose is the only place that may see all
+// three, which is exactly why the wiring belongs here rather than in any of
+// them.
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/modules/comms"
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// commsStager records an accepted send for transmission: the delivery row and
+// the job that will carry it, both on the caller's transaction. One commit, one
+// fact — a crash between them would either promise a send nothing queued or
+// queue one with no timeline entry behind it.
+type commsStager struct {
+	store  *comms.Store
+	runner *jobs.Runner
+	// authority records why this message was allowed to be queued, on the same
+	// transaction that queues it. Held here because compose is the only place
+	// that may see both modules: comms owns the delivery row, consent owns the
+	// decision, and neither may import the other.
+	authority *consent.Gate
+}
+
+var (
+	_ activities.DeliveryStager        = commsStager{}
+	_ activities.ChannelDeliveryStager = commsStager{}
+)
+
+// DeliveryMachinery is the ONE delivery path in both the shapes a message can be
+// staged in. It is a single seam rather than two because there is a single
+// machinery behind it — one delivery table, one status machine, one retry ladder,
+// one dispatcher — and a role able to wire mail staging without channel staging
+// could serve a reply surface that accepts a message nothing will ever carry.
+type DeliveryMachinery interface {
+	activities.DeliveryStager
+	activities.ChannelDeliveryStager
+}
+
+// NewDeliveryStager builds the delivery machinery every send transport is
+// composed with (compose.WithDelivery). The runner is insert-only in the api
+// role; the worker role works what it inserts.
+//
+//nolint:ireturn // returns the DeliveryMachinery seam by design: the concrete type is unexported and every caller holds the interface
+func NewDeliveryStager(pool *pgxpool.Pool, runner *jobs.Runner) DeliveryMachinery {
+	return commsStager{
+		store:     comms.NewStore(InstallationDB(pool), time.Now, activities.NewStore(InstallationDB(pool))),
+		runner:    runner,
+		authority: consentGateFor(pool),
+	}
+}
+
+func (s commsStager) StageTx(ctx context.Context, tx pgx.Tx, in activities.DeliveryRequest) error {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return errors.New("comms: staging a delivery outside workspace context")
+	}
+	id, err := s.store.StageTx(ctx, tx, comms.StageInput{
+		ActivityID:      in.ActivityID,
+		Provider:        in.Provider,
+		MessageID:       in.MessageID,
+		Recipients:      in.Recipients,
+		Cc:              in.Cc,
+		Bcc:             in.Bcc,
+		Subject:         in.Subject,
+		Body:            in.Body,
+		HTMLBody:        in.HTMLBody,
+		FromName:        in.FromName,
+		Attachments:     commsFiles(in.Attachments),
+		ConsentPurpose:  in.ConsentPurpose,
+		InReplyTo:       in.InReplyTo,
+		References:      in.References,
+		ThreadKey:       in.ThreadKey,
+		ListUnsubscribe: in.ListUnsubscribe,
+	})
+	if err != nil {
+		return err
+	}
+	// Why this was allowed to be queued, written before the job that will send
+	// it. In the same transaction as the activity, the delivery row, the audit
+	// entry and the outbox event: all of them or none, so a decision can never
+	// describe a message that rolled back, and a delivery can never reach the
+	// worker with nothing on record about why it exists.
+	if s.authority != nil {
+		if _, err := s.authority.AuthorizeStagingTx(ctx, tx, id, in.Authorization); err != nil {
+			return err
+		}
+	}
+	return s.runner.EnqueueTx(ctx, tx, SendEmailArgs{
+		Workspace: ws, DeliveryID: id.String(),
+	}, sendInsertOpts())
+}
+
+// StageChannelTx is the same staging for a channel reply: the channel-shaped row
+// and the SAME transmit job, on the caller's transaction.
+//
+// One job kind carries both shapes deliberately. The worker loads the delivery
+// and dispatches it, and the dispatcher branches on the ROW's shape exactly once
+// (comms/sendseam.go) — a second job kind would be a second path to keep in step
+// with the first, and the channel is the one that would fall behind.
+func (s commsStager) StageChannelTx(ctx context.Context, tx pgx.Tx, in activities.ChannelDeliveryRequest) error {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return errors.New("comms: staging a channel delivery outside workspace context")
+	}
+	id, err := s.store.StageChannelTx(ctx, tx, comms.StageChannelInput{
+		ActivityID:     in.ActivityID,
+		Provider:       in.Provider,
+		Recipient:      in.Recipient,
+		Body:           in.Body,
+		Attachments:    commsFiles(in.Attachments),
+		ConsentPurpose: in.ConsentPurpose,
+	})
+	if err != nil {
+		return err
+	}
+	// The channel path is a second implementation of staging, and this is the
+	// half a fix to the mail path does not reach. It records the same decision
+	// for the same reason.
+	if s.authority != nil {
+		if _, err := s.authority.AuthorizeStagingTx(ctx, tx, id, in.Authorization); err != nil {
+			return err
+		}
+	}
+	return s.runner.EnqueueTx(ctx, tx, SendEmailArgs{
+		Workspace: ws, DeliveryID: id.String(),
+	}, sendInsertOpts())
+}

--- a/backend/internal/compose/commsstager.go
+++ b/backend/internal/compose/commsstager.go
@@ -16,6 +16,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -25,7 +26,9 @@ import (
 	"github.com/margince/margince/backend/internal/modules/comms"
 	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // commsStager records an accepted send for transmission: the delivery row and
@@ -101,10 +104,22 @@ func (s commsStager) StageTx(ctx context.Context, tx pgx.Tx, in activities.Deliv
 	// entry and the outbox event: all of them or none, so a decision can never
 	// describe a message that rolled back, and a delivery can never reach the
 	// worker with nothing on record about why it exists.
-	if s.authority != nil {
-		if _, err := s.authority.AuthorizeStagingTx(ctx, tx, id, in.Authorization); err != nil {
-			return err
-		}
+	//
+	// Not guarded on the authority being wired. A nil check here would read as
+	// caution and behave as a bypass: a refactor that dropped the field would
+	// compile, stage every message with no decision, and satisfy the census
+	// gate — which sees the CALL and cannot see that it was skipped. The
+	// transmit gate refuses a missing consent authority outright
+	// (comms/gates.go), and this fails the same way.
+	if s.authority == nil {
+		return errors.New("compose: no authorization authority is wired on this send path")
+	}
+	set, err := s.authority.AuthorizeStagingTx(ctx, tx, id, in.Authorization)
+	if err != nil {
+		return err
+	}
+	if err := refuseAbsoluteDenial(set); err != nil {
+		return err
 	}
 	return s.runner.EnqueueTx(ctx, tx, SendEmailArgs{
 		Workspace: ws, DeliveryID: id.String(),
@@ -136,13 +151,41 @@ func (s commsStager) StageChannelTx(ctx context.Context, tx pgx.Tx, in activitie
 	}
 	// The channel path is a second implementation of staging, and this is the
 	// half a fix to the mail path does not reach. It records the same decision
-	// for the same reason.
-	if s.authority != nil {
-		if _, err := s.authority.AuthorizeStagingTx(ctx, tx, id, in.Authorization); err != nil {
-			return err
-		}
+	// and fails closed the same way.
+	if s.authority == nil {
+		return errors.New("compose: no authorization authority is wired on this send path")
+	}
+	set, err := s.authority.AuthorizeStagingTx(ctx, tx, id, in.Authorization)
+	if err != nil {
+		return err
+	}
+	if err := refuseAbsoluteDenial(set); err != nil {
+		return err
 	}
 	return s.runner.EnqueueTx(ctx, tx, SendEmailArgs{
 		Workspace: ws, DeliveryID: id.String(),
 	}, sendInsertOpts())
+}
+
+// refuseAbsoluteDenial stops a send at STAGING for the four refusals no
+// rollout mode may soften: an Art. 21 objection, a processing restriction, a
+// hard bounce, and marketing consent whose round trip never completed.
+//
+// Observe mode is why every other disagreement is recorded and let through: the
+// engine is being measured against the old gate, and blocking on a difference
+// nobody has reviewed would refuse legitimate mail. An absolute denial is not a
+// difference of opinion — the transmit phase already refuses it, so letting it
+// stage buys nothing and costs two things. The rep learns minutes or days
+// later, from a parked row in an operator lane rather than at the moment they
+// pressed send. And the activity commits first, carrying the outbound
+// attestation that makes an address correspondence-positive — so a message to
+// somebody who objected would mint evidence of correspondence with them that
+// never happened.
+func refuseAbsoluteDenial(set commsauthz.DecisionSet) error {
+	if !set.HasAbsoluteDenial() {
+		return nil
+	}
+	denied := set.Denied()
+	return fmt.Errorf("consent: %d of %d recipients may not be written to (%s): %w",
+		len(denied), len(set.Decisions), denied[0].ReasonCode, apperrors.ErrConsentNotGranted)
 }

--- a/backend/internal/compose/commsstager_test.go
+++ b/backend/internal/compose/commsstager_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What staging refuses before a message is queued.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// The four refusals no rollout mode may soften stop the send HERE, not two
+// phases later in a worker.
+//
+// Observe mode lets every other disagreement through on purpose: the engine is
+// being measured, and blocking on a difference nobody has reviewed would refuse
+// legitimate mail. These four are not differences of opinion — transmit already
+// refuses them, so staging them buys nothing and costs the rep the chance to
+// learn now.
+func TestStagingRefusesTheDenialsNoModeMaySoften(t *testing.T) {
+	for _, reason := range []string{
+		commsauthz.ReasonObjection,
+		commsauthz.ReasonRestricted,
+		commsauthz.ReasonHardBounce,
+		commsauthz.ReasonUnconfirmedDOI,
+		commsauthz.ReasonNoSubject,
+		commsauthz.ReasonConsentWithdrawn,
+	} {
+		set := commsauthz.DecisionSet{Decisions: []commsauthz.Decision{
+			{Verdict: commsauthz.VerdictDeny, ReasonCode: reason},
+		}}
+		err := refuseAbsoluteDenial(set)
+		if !errors.Is(err, apperrors.ErrConsentNotGranted) {
+			t.Errorf("%s staged anyway: err = %v", reason, err)
+		}
+	}
+}
+
+// And the converse, or the test above would pass with every send refused: an
+// ordinary disagreement is recorded and let through, which is what observe mode
+// is for.
+func TestStagingLetsAnObservedDisagreementThrough(t *testing.T) {
+	set := commsauthz.DecisionSet{Decisions: []commsauthz.Decision{
+		{Verdict: commsauthz.VerdictReview, ReasonCode: commsauthz.ReasonNoEvidence},
+	}}
+	if err := refuseAbsoluteDenial(set); err != nil {
+		t.Errorf("refuseAbsoluteDenial = %v, want nil while the engine is only being observed", err)
+	}
+}
+
+// A message every recipient may receive is not refused for any reason.
+func TestStagingAllowsAnOrdinarySend(t *testing.T) {
+	set := commsauthz.DecisionSet{Decisions: []commsauthz.Decision{
+		{Verdict: commsauthz.VerdictAllow, ReasonCode: commsauthz.ReasonAllowed},
+	}}
+	if err := refuseAbsoluteDenial(set); err != nil {
+		t.Errorf("refuseAbsoluteDenial = %v, want nil for an allowed send", err)
+	}
+}
+
+// The refusal names a count and a bounded reason code, never a recipient: it
+// becomes the detail of a client error, and a caller is owed what they can act
+// on rather than somebody's consent history.
+func TestTheStagingRefusalNamesNobody(t *testing.T) {
+	set := commsauthz.DecisionSet{Decisions: []commsauthz.Decision{
+		{
+			Verdict:    commsauthz.VerdictDeny,
+			ReasonCode: commsauthz.ReasonObjection,
+			Recipient:  connector.Recipient{Email: "objector@example.test"},
+		},
+	}}
+	err := refuseAbsoluteDenial(set)
+	if err == nil {
+		t.Fatal("want a refusal")
+	}
+	if got := err.Error(); strings.Contains(got, "objector@example.test") {
+		t.Errorf("the refusal names the recipient: %q", got)
+	}
+}

--- a/backend/internal/compose/integration/stagingrefusal_integration_test.go
+++ b/backend/internal/compose/integration/stagingrefusal_integration_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A recipient who said stop is refused at the door, on BOTH doors.
+//
+// The staging decision is written for every queued message, and the census gate
+// beside it proves the call happens. A call is not an enforcement: the gate
+// sees that AuthorizeStagingTx was invoked and cannot see whether anybody read
+// its answer. Deleting the refusal from both doors left the whole unit lane
+// green, which is what these two tests are here to stop.
+//
+// What a missing refusal costs is not abstract. The send stages, the activity
+// commits attesting that this installation corresponded with the person, and a
+// message goes to somebody carrying an Art. 21 objection. The rep learns
+// nothing until the transmit gate parks the row in an operator lane days
+// later, by which time the outbound activity is on the timeline as evidence of
+// a conversation that should never have happened.
+//
+// One test per door, and deliberately not one table-driven test over both: the
+// mail path and the channel path are two implementations of staging, and a
+// mutation check has to be able to revert one without the other going quiet.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration/apptest"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// suppressPerson records an Art. 21 marketing objection against a person.
+//
+// Written directly rather than through a store method because there is no
+// production writer for communication_suppression yet — the unsubscribe path
+// that will own it lands with the preference centre. The row shape is the one
+// liveSuppression reads, and when that writer arrives this helper is what
+// should be repointed at it.
+func suppressPerson(t *testing.T, e *apptest.AppEnv, personID string) {
+	t.Helper()
+	if err := apptest.InWorkspace(e, t, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO communication_suppression (person_id, kind, source, captured_by)
+			VALUES ($1, 'marketing_objection', 'test', $2)`, personID, "test")
+		return err
+	}); err != nil {
+		t.Fatalf("recording the objection: %v", err)
+	}
+}
+
+// The mail door. A staged send to an objecting recipient is refused with the
+// whole transaction, so no delivery row survives it.
+func TestAMailSendToAnObjectingRecipientStagesNothing(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+	suppressPerson(t, p.AppEnv, p.personID)
+
+	status, code, _ := p.send(t)
+
+	if status != http.StatusConflict || code != "consent_not_granted" {
+		t.Fatalf("mail to an objecting recipient → %d %q, want 409 consent_not_granted", status, code)
+	}
+	if n := p.stagedDeliveries(t); n != 0 {
+		t.Fatalf("%d deliveries staged behind a refused send, want 0 — "+
+			"a refusal that leaves a row behind still queued the message", n)
+	}
+}
+
+// The channel door, which is a second implementation of staging rather than a
+// variant of the mail one. A fix to the mail path does not reach it, so it is
+// asserted separately.
+func TestAChannelSendToAnObjectingRecipientStagesNothing(t *testing.T) {
+	c := setupChannelSend(t)
+	c.grantConsent(t, "transactional")
+	suppressPerson(t, c.AppEnv, c.personID)
+
+	status, code, _ := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
+
+	if status != http.StatusConflict || code != "consent_not_granted" {
+		t.Fatalf("channel reply to an objecting recipient → %d %q, want 409 consent_not_granted", status, code)
+	}
+	c.assertNoOutboundEffect(t, "a send to an objecting recipient")
+}
+
+// stagingDecisions reads back what the engine wrote for one delivery at the
+// staging phase: the recipient it decided about, its verdict and its actor.
+func (p *preflightEnv) stagingDecisions(t *testing.T, deliveryID ids.UUID) []stagedDecision {
+	t.Helper()
+	var rows []stagedDecision
+	if err := apptest.InWorkspace(p.AppEnv, t, func(tx pgx.Tx) error {
+		found, err := tx.Query(context.Background(), `
+			SELECT recipient_address, verdict, reason_code, attempt, actor
+			  FROM communication_decision
+			 WHERE delivery_id = $1 AND phase = 'staging'
+			 ORDER BY recipient_address`, deliveryID)
+		if err != nil {
+			return err
+		}
+		defer found.Close()
+		for found.Next() {
+			var d stagedDecision
+			if err := found.Scan(&d.address, &d.verdict, &d.reason, &d.attempt, &d.actor); err != nil {
+				return err
+			}
+			rows = append(rows, d)
+		}
+		return found.Err()
+	}); err != nil {
+		t.Fatalf("reading the staging decisions: %v", err)
+	}
+	return rows
+}
+
+type stagedDecision struct {
+	address, verdict, reason, actor string
+	attempt                         int
+}
+
+// The allow path writes the row, and the row says who decided.
+//
+// The refusal tests above prove the engine's answer is acted on; this proves
+// the answer is recorded. Without it the whole table could stay empty and every
+// other test in this file would still pass — a refusal that leaves no trail is
+// exactly as unanswerable later as no refusal at all.
+func TestAnAllowedSendRecordsItsStagingDecision(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	sent := p.sendExpectingAcceptance(t, "transactional", "Re: Inbound question", "As discussed.")
+	deliveryID, _ := p.deliveryFor(t, sent)
+
+	rows := p.stagingDecisions(t, deliveryID)
+	if len(rows) != 1 {
+		t.Fatalf("%d staging decisions for a one-recipient send, want 1", len(rows))
+	}
+	d := rows[0]
+	if d.address != "buyer@preflight.test" {
+		t.Errorf("decision recorded for %q, want the recipient the message went to", d.address)
+	}
+	if d.verdict != "allow" {
+		t.Errorf("verdict = %q, want allow for a consented recipient", d.verdict)
+	}
+	// Zero means "before any attempt": every transmit row that follows carries
+	// the attempt it belonged to, so a staging row sharing that numbering would
+	// be indistinguishable from the first transmit.
+	if d.attempt != 0 {
+		t.Errorf("attempt = %d, want 0 — a staging decision precedes every attempt", d.attempt)
+	}
+	// From the authenticated principal, never the request body: the row is
+	// evidence of who authorized the message.
+	if d.actor == "" {
+		t.Error("the decision names no actor — a proof row nobody can be held to is not proof")
+	}
+}

--- a/backend/internal/modules/activities/channelsend.go
+++ b/backend/internal/modules/activities/channelsend.go
@@ -37,6 +37,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -72,10 +73,15 @@ type ChannelDeliveryStager interface {
 // workspace's bot transmits, but the human is still the sender the seat gate
 // re-reads at transmission.
 type ChannelDeliveryRequest struct {
-	ActivityID ids.ActivityID
-	Provider   string
-	Recipient  connector.ChannelIdentity
-	Body       string
+	// Authorization is the same question the mail path asks, about a channel
+	// recipient. Carried rather than rebuilt: a channel reply resolves its
+	// recipient server-side from the conversation, so this is the only place
+	// that knows who it is.
+	Authorization commsauthz.Request
+	ActivityID    ids.ActivityID
+	Provider      string
+	Recipient     connector.ChannelIdentity
+	Body          string
 	// Attachments is what this message carries, snapshotted at staging — the
 	// same type and the same meaning as DeliveryRequest.Attachments, because a
 	// second spelling of the snapshot is a second set of fields that can
@@ -446,5 +452,12 @@ func (m outboundChannelMessage) delivery(activityID ids.ActivityID) ChannelDeliv
 		Body:           m.in.Body,
 		Attachments:    m.files,
 		ConsentPurpose: m.in.ConsentPurpose,
+		// The recipient the conversation resolved to, which a caller never
+		// named and cannot substitute.
+		Authorization: commsauthz.Request{
+			Recipients:       []connector.Recipient{{Channel: &m.conversation.recipient}},
+			LegacyPurposeKey: m.in.ConsentPurpose,
+			Body:             m.in.Body,
+		},
 	}
 }

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -22,6 +22,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -129,7 +130,13 @@ type DeliveryRequest struct {
 	// same From header the first attempt did.
 	FromName string
 	// Attachments is what this message carries, snapshotted at staging.
-	Attachments    []OutboundFile
+	Attachments []OutboundFile
+	// Authorization is the question the engine answers about this message, put
+	// once and answered in the same transaction that stages it. Carried on the
+	// request rather than rebuilt by the stager: the recipients, the anchor and
+	// the content are all known HERE, and a stager that re-derived them would
+	// be a second reading of the same message.
+	Authorization  commsauthz.Request
 	ConsentPurpose string
 	InReplyTo      string   // unbracketed; empty starts a conversation
 	References     []string // unbracketed ancestry, oldest first

--- a/backend/internal/modules/activities/outboundmessage.go
+++ b/backend/internal/modules/activities/outboundmessage.go
@@ -12,7 +12,11 @@ package activities
 // unsubscribe token and the recorded one carries a redacted copy, and having
 // both projections in one place is what keeps that difference deliberate.
 
-import "github.com/margince/margince/backend/internal/shared/kernel/ids"
+import (
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
 
 // outboundMessage is one send's derived facts, computed before the
 // transaction opens so the transaction holds writes only. The timeline row and
@@ -109,9 +113,28 @@ func (m outboundMessage) delivery(activityID ids.UUID, chain threading) Delivery
 		FromName:        m.fromName,
 		Attachments:     m.files,
 		ConsentPurpose:  m.in.ConsentPurpose,
+		Authorization:   m.authorization(),
 		InReplyTo:       chain.inReplyTo,
 		References:      chain.references,
 		ThreadKey:       chain.threadKey,
 		ListUnsubscribe: m.listUnsubscribe,
+	}
+}
+
+// authorization is the question the engine is asked about this message.
+//
+// Built here because this is where the whole message is known — the merged
+// recipient list including blind copies, the content that will actually go out,
+// and the purpose the caller named. A stager that rebuilt it would be reading
+// the same message a second time, and the two readings would drift.
+//
+// Recipients is the MERGED list, not the To: line. A blind copy is blind to the
+// other recipients and never to the engine.
+func (m outboundMessage) authorization() commsauthz.Request {
+	return commsauthz.Request{
+		Recipients:       connector.EmailRecipients(m.in.Recipients),
+		LegacyPurposeKey: m.in.ConsentPurpose,
+		Subject:          m.in.Subject,
+		Body:             m.body,
 	}
 }

--- a/backend/internal/modules/consent/authorizestaging.go
+++ b/backend/internal/modules/consent/authorizestaging.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The decision taken as a message is written down, in the same transaction that
+// writes it.
+//
+// The transmit decision beside this one answers "may this go out now" and is
+// the last word. It cannot be the only word: it runs in a worker, minutes or
+// days later, and its refusal reaches a parked row and an operator's lane
+// rather than the person who typed the message. A staging decision is what
+// makes a refusal answerable — the rep is still there, and the message has not
+// yet been promised to anybody.
+//
+// It commits with the activity, the delivery row, the audit entry, the outbox
+// event and the job. All of them or none: a decision recorded for a delivery
+// that rolled back would describe a message nobody sent, and a delivery staged
+// with no decision is the gap the transmit ticket exists to catch.
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// AuthorizeStagingTx records why this message was allowed to be queued, one row
+// per recipient, on the caller's transaction.
+//
+// It does NOT open its own: the whole point is to commit with the delivery it
+// describes. That also means it must not acquire a connection of its own, which
+// is why every read below runs on the passed tx.
+func (g *Gate) AuthorizeStagingTx(ctx context.Context, tx pgx.Tx, deliveryID ids.UUID, req commsauthz.Request) (commsauthz.DecisionSet, error) {
+	for _, r := range req.Recipients {
+		if err := r.Validate(); err != nil {
+			return commsauthz.DecisionSet{}, fmt.Errorf(
+				"consent: this recipient cannot be put to the engine: %w", err)
+		}
+	}
+	if len(req.Recipients) == 0 {
+		return commsauthz.DecisionSet{}, fmt.Errorf(
+			"consent: a staging decision needs at least one recipient: %w", apperrors.ErrInvalidArgument)
+	}
+
+	setID := ids.NewV7()
+	set := commsauthz.DecisionSet{}
+	for _, r := range req.Recipients {
+		d, err := g.decideOne(ctx, tx, r, req.LegacyPurposeKey)
+		if err != nil {
+			return commsauthz.DecisionSet{}, err
+		}
+		d.Phase = commsauthz.PhaseStaging
+		d.Mode = commsauthz.ModeObserve
+		d.Requested = req.Context
+		set.Decisions = append(set.Decisions, d)
+	}
+	if err := g.recordStagingDecisions(ctx, tx, deliveryID, setID, req, set); err != nil {
+		return commsauthz.DecisionSet{}, err
+	}
+	return set, nil
+}
+
+// recordStagingDecisions writes the rows.
+//
+// attempt is 0 and means "before any attempt": the delivery has not been picked
+// up yet, and every transmit row that follows carries the attempt it belonged
+// to. The fingerprint is of the message as staged, so a later reader can tell
+// whether what went out is what was authorized.
+func (g *Gate) recordStagingDecisions(ctx context.Context, tx pgx.Tx, deliveryID, setID ids.UUID, req commsauthz.Request, set commsauthz.DecisionSet) error {
+	sum := sha256.Sum256([]byte(req.Subject + "\x00" + req.Body))
+	by, err := storekit.CapturedBy(ctx)
+	if err != nil {
+		return err
+	}
+	for _, d := range set.Decisions {
+		subjectKind := nullableText(d.SubjectKind)
+		var subjectID *ids.UUID
+		if d.SubjectKind != "" {
+			id := d.SubjectID
+			subjectID = &id
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO communication_decision
+			  (delivery_id, attempt, decision_set_id, recipient_address, subject_kind, subject_id,
+			   phase, requested_category, resolved_category, verdict, reason_code, basis, suppression,
+			   content_fingerprint, mode, actor)
+			VALUES ($1,0,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+			ON CONFLICT (decision_set_id, recipient_address, phase) DO NOTHING`,
+			deliveryID, setID, decisionRecipientKey(d.Recipient),
+			subjectKind, subjectID, string(d.Phase), nullableCategory(d.Requested),
+			string(d.Resolved), string(d.Verdict), d.ReasonCode,
+			nullableBasis(d.Basis), nullableText(d.Suppression),
+			sum[:], string(d.Mode), by); err != nil {
+			return fmt.Errorf("consent: record the staging decision: %w", err)
+		}
+	}
+	return nil
+}
+
+// nullableCategory keeps the requested category NULL when the caller claimed
+// none, which is the honest record: a door that said nothing is different from
+// one that named a category the engine then disagreed with.
+func nullableCategory(c commsauthz.Category) *string {
+	if c == "" {
+		return nil
+	}
+	v := string(c)
+	return &v
+}

--- a/backend/internal/modules/consent/authorizestaging_test.go
+++ b/backend/internal/modules/consent/authorizestaging_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The staging decision's shape, and the refusals it makes before touching a
+// database.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// A message with no recipients has not been authorized; it has failed to ask.
+// Reported as the caller defect it is rather than as a suppression, because
+// dressing it up would park the send with a reason an operator reads as "this
+// person opted out" for a bug that named nobody.
+func TestStagingRefusesAMessageWithNoRecipients(t *testing.T) {
+	_, err := (&Gate{}).AuthorizeStagingTx(context.Background(), nil, ids.NewV7(), commsauthz.Request{})
+	if !errors.Is(err, apperrors.ErrInvalidArgument) {
+		t.Errorf("err = %v, want an invalid-argument fault for a message addressed to nobody", err)
+	}
+}
+
+// A recipient carrying both an address and a channel identity would be answered
+// about on the channel arm alone, and the address — which may be the one that
+// objected — would never be looked at. The legacy gate refuses the same shape
+// for the same reason.
+func TestStagingRefusesAMalformedRecipient(t *testing.T) {
+	both := connector.Recipient{
+		Email:   "someone@example.test",
+		Channel: &connector.ChannelIdentity{Provider: "telegram", ChannelUserID: "42"},
+	}
+	_, err := (&Gate{}).AuthorizeStagingTx(context.Background(), nil, ids.NewV7(),
+		commsauthz.Request{Recipients: []connector.Recipient{both}})
+	if err == nil {
+		t.Fatal("a recipient naming two subjects must be refused")
+	}
+	if errors.Is(err, apperrors.ErrConsentNotGranted) {
+		t.Error("a malformed recipient is a caller defect, not an answer about anybody's consent")
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -85,7 +85,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (86)
+## Census (87)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -170,6 +170,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `seatfanout_test.go` | H2 | A nightly agent acts FOR A PERSON, and the identity of one night's work has to say which person. |
 | `sendinghumanreaders_test.go` | H2 | principal.SendingHuman has ONE reader, and it answers one question. |
 | `settingscatalog_test.go` | H3 | The settings-catalog fitness gates (ADR-0090/A135 §7). |
+| `stagingdecision_test.go` | H3 | Every path that stages a delivery records why it was allowed to. |
 | `statutoryfloorsingle_test.go` | H2 | The statutory retention floor is spelled once, and every destructive activity path applies that one spelling. |
 | `tableownershipdiscovery_test.go` | H2 | WHICH packages the ownership gate walks, derived rather than remembered. |
 | `undoreasoncensus_test.go` | H2 | One refusal set, three spellings. |


### PR DESCRIPTION
Every staged delivery now writes a per-recipient authorization decision in the
same transaction that queues it, on both send doors.

## What changed

`consent.Gate.AuthorizeStagingTx` runs on the caller's transaction and writes
one `communication_decision` row per recipient at `phase=staging, attempt=0`.
It validates recipient shape and refuses an empty recipient list with
`ErrInvalidArgument` rather than staging a send it decided nothing about.

`compose.commsStager` calls it from `StageTx` and from `StageChannelTx`. The
channel door is a second implementation of sending, not a variant of the mail
door, so wiring only the mail path would have left channel sends unrecorded —
which is what the first draft of this branch did.

A send whose path has no authority wired is refused, not staged. `nil` was
previously a silent skip.

`refuseAbsoluteDenial` turns a decision set carrying an absolute denial into
`ErrConsentNotGranted`. Absolute denials are the ones no rollout mode may
soften: an Art. 21 marketing objection, a processing restriction, a hard
bounce, an unconfirmed double opt-in, no subject, and a withdrawn consent.

`commsstager.go` is a new file because `commsjobs.go` had reached the 500-line
cap.

## The gate

`backend/gates/stagingdecision_test.go` asserts that every function calling
`StageTx` or `StageChannelTx` also calls `AuthorizeStagingTx`.

It counts a function by its receiver type and method name, not by the bare
method name. Keyed on the bare name, every type satisfying
`activities.DeliveryStager` collapses into one map entry, so a wrapper that
staged without deciding would share an entry with the one that decides and the
gate would report PASS. A bypass-wrapper probe confirmed the receiver-qualified
version catches what fooled the first one.

## Verification

`make check-backend`, `make craft-static`, `make rls-store-path` and
`make no-jurisdiction` all pass, re-run after rebasing onto the current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Every staged delivery now records a per-recipient authorization decision in the same transaction that queues it, on both the mail and channel send paths. Absolute denials are refused at staging; other disagreements are recorded and allowed through while the engine is being observed. A send with no authority wired is refused instead of silently staged.

**New Features**
- `consent.Gate.AuthorizeStagingTx` writes one `communication_decision` row per recipient on the caller's transaction and refuses an empty recipient list with `ErrInvalidArgument`.
- The authorization request is built once where the whole message is known — merged recipients including blind copies, content, and purpose — and carried on the delivery request.
- The staging gate derives staging method names from the comms store, walks the whole compose tree, and counts stagers by receiver type, so a wrapper that stages without deciding cannot hide behind the one that does.
- Mutation-checked tests hold the refusal on both doors and read an allowed send's decision back, so removing either guard or the writer fails.

<sup>Written for commit 3e5551b8101d8a9aa84ba9f171b065915bce2cd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Outbound email and channel deliveries now include consent authorization details during staging.
  - Consent decisions are evaluated and recorded transactionally before delivery jobs are queued.
  - Deliveries with absolute consent denials are refused without creating outbound delivery effects.
  - Observable consent disagreements are handled safely.
  - Invalid delivery requests, including missing or conflicting recipient information, are rejected with clear validation errors.

- **Documentation**
  - Updated the gate inventory to reflect expanded staging authorization coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->