### PR TITLE
The tree says who may draw an email, and both halves are held

### DIFF
--- a/backend/gates/emailpresentation_test.go
+++ b/backend/gates/emailpresentation_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// A retained email reads the same everywhere, or it does not read the same
+// anywhere.
+//
+// The tree once held five independent renderings of one message — the
+// timeline's, the account page's recent list, the person memory's fold, the
+// relationship spine's and search's — each deciding for itself which parts of
+// an email to show and whether it could be opened. They drifted, because
+// nothing failed when they did: a surface that grew a sixth reading looked
+// exactly like one reusing the canonical row.
+//
+// So the contract names which of its schemas ARE an email, in the schema
+// itself:
+//
+//	x-email-presentation: entry    — this is a message, and it is rendered by
+//	                                 the canonical components
+//	x-email-presentation: exempt   — with x-email-presentation-reason stating
+//	                                 why this one is not
+//
+// and this census holds the two halves against each other. It reads the
+// annotation from `api/crm.yaml` and the consumers from `frontend/src`, and
+// fails in BOTH directions: an `entry` schema reaching a file that is not a
+// canonical renderer, and a canonical renderer that has stopped consuming any
+// `entry` schema at all.
+//
+// The second direction is the one worth having. A gate that only checked
+// "nothing else renders an email" would report PASS over a tree where the
+// canonical row had been deleted and every surface had gone back to its own
+// spelling — the exact state this arc was built to end, reported as clean.
+//
+// A file satisfies this gate by ONE of three means:
+//
+//   - it is a canonical renderer, named in emailRenderers below;
+//   - it merely PASSES the type through to one — a host that declares a prop
+//     and hands it on renders nothing itself, and is admitted by name;
+//   - it is a test, a story or the generated schema, which describe the
+//     components rather than adding a rendering.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+const (
+	emailContractPath   = "api/crm.yaml"
+	emailFrontendSource = "../frontend/src"
+)
+
+// emailRenderers are the components allowed to draw a message FROM ITS
+// CONTRACT TYPE: EmailEntry shows a message as a row, EmailDetail is the drawer
+// the row opens into.
+//
+// EmailReference is deliberately NOT here. It cites a message rather than
+// showing one, and it takes a subject and a date as plain scalars — no contract
+// type at all, which is what stops a citation from ever growing a preview. A
+// gate expecting it to consume an `entry` schema would be asserting the
+// opposite of the design.
+//
+// Named rather than derived, because this is the decision the census exists to
+// hold: a third renderer is exactly the thing that must not appear quietly, so
+// adding one here is the deliberate act of widening the rule.
+var emailRenderers = map[string]bool{
+	"design-system/emailentry.tsx":  true,
+	"design-system/emaildetail.tsx": true,
+}
+
+// emailPassthroughs hold an `entry` type without rendering it: they declare a
+// prop and hand it to a canonical component. Each is a sentence somebody wrote
+// rather than an omission nobody noticed.
+var emailPassthroughs = gatekit.Waive(map[string]string{
+	"design-system/composed.tsx": "declares TimelineEntry.emailSummary and passes it to EmailEntry; the timeline row chooses WHICH component draws a kind, and drawing none itself is what keeps that choice in one place",
+})
+
+// entrySchemas reads the schemas the contract marks as an email.
+//
+// It matches the ANNOTATION and walks back to the schema name, rather than
+// matching a name pattern: a schema called EmailFoo that carries no annotation
+// is not this gate's business, and one called Correspondence that carries
+// `entry` is. Deriving the corpus from the marker is what stops the census
+// answering about a set the contract never declared.
+func entrySchemas(t *testing.T) []string {
+	t.Helper()
+	source, err := os.ReadFile(emailContractPath)
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	var names []string
+	var current string
+	schemaLine := regexp.MustCompile(`^    ([A-Za-z][A-Za-z0-9]*):\s*$`)
+	for _, line := range strings.Split(string(source), "\n") {
+		if match := schemaLine.FindStringSubmatch(line); match != nil {
+			current = match[1]
+			continue
+		}
+		if strings.TrimSpace(line) == "x-email-presentation: entry" && current != "" {
+			names = append(names, current)
+		}
+	}
+	return names
+}
+
+// consumersOf answers every frontend file naming this schema's generated type.
+//
+// The generated spelling is `components["schemas"]["Name"]`, which is how a
+// TypeScript file reaches a contract type — there is no other way in, so a
+// consumer this misses is a consumer that cannot exist.
+func consumersOf(t *testing.T, schema string) []string {
+	t.Helper()
+	needle := fmt.Sprintf(`components["schemas"]["%s"]`, schema)
+	var found []string
+	err := filepath.WalkDir(emailFrontendSource, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".ts") && !strings.HasSuffix(path, ".tsx") {
+			return nil
+		}
+		source, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(source), needle) {
+			rel, relErr := filepath.Rel(emailFrontendSource, path)
+			if relErr != nil {
+				return relErr
+			}
+			found = append(found, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the frontend sources: %v", err)
+	}
+	return found
+}
+
+// describesRatherThanRenders is a file that talks ABOUT the components: a test,
+// a story, or the generated schema itself. None of them is a second rendering.
+func describesRatherThanRenders(path string) bool {
+	return strings.HasPrefix(path, "api/") ||
+		strings.Contains(path, ".test.") ||
+		strings.Contains(path, ".stories.")
+}
+
+// An `entry` schema reaches the canonical components and nothing else.
+func TestAnEmailIsDrawnOnlyByTheCanonicalComponents(t *testing.T) {
+	t.Parallel()
+	defer emailPassthroughs.AssertAllMatched(t)
+	schemas := entrySchemas(t)
+	// A census that can fail short has already failed: an annotation whose
+	// spelling drifted would leave this walking an empty set and reporting
+	// PASS over every surface at once.
+	if len(schemas) == 0 {
+		t.Fatal("no schema in the contract carries `x-email-presentation: entry` — " +
+			"either the annotation was removed or its spelling drifted, and this census " +
+			"is now judging nothing")
+	}
+	for _, schema := range schemas {
+		for _, consumer := range consumersOf(t, schema) {
+			if emailRenderers[consumer] || describesRatherThanRenders(consumer) {
+				continue
+			}
+			if emailPassthroughs.Waived(t, consumer) {
+				continue
+			}
+			t.Errorf("%s consumes %s and is not a canonical renderer — render EmailEntry "+
+				"or EmailReference instead, or ratify the file in emailPassthroughs with "+
+				"what it does with the type", consumer, schema)
+		}
+	}
+}
+
+// And the other direction: each canonical renderer still consumes one.
+//
+// Without this the census passes over a tree where EmailEntry has been gutted
+// and every surface has gone back to its own rendering — nothing consumes an
+// `entry` schema, so nothing is unauthorized, so the gate reports clean about
+// the exact state it exists to prevent.
+func TestEachCanonicalRendererStillDrawsAnEmail(t *testing.T) {
+	t.Parallel()
+	schemas := entrySchemas(t)
+	drawing := map[string]bool{}
+	for _, schema := range schemas {
+		for _, consumer := range consumersOf(t, schema) {
+			drawing[consumer] = true
+		}
+	}
+	for renderer := range emailRenderers {
+		if !drawing[renderer] {
+			t.Errorf("%s is named as a canonical email renderer and consumes no schema marked "+
+				"`x-email-presentation: entry` — it has stopped drawing a message, and every "+
+				"surface that reused it has stopped too", renderer)
+		}
+	}
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -86,7 +86,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (86)
+## Census (87)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -116,6 +116,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `draftreplyreader_test.go` | H2 | A {subject, body} model reply has ONE reader. |
 | `edgeendpointcensus_test.go` | H2 | Every end a link can have is an end that link's history is read from. |
 | `edgereaders_test.go` | H2 | `relationship` is a first-class RBAC object, and it is the only join table in the schema that is one. |
+| `emailpresentation_test.go` | H2 | A retained email reads the same everywhere, or it does not read the same anywhere. |
 | `emptylistwire_test.go` | H2 | Every list envelope carries its rows in a field the writer can find. |
 | `envcontract_test.go` | H3 | Environment-variable contract fitness functions. |
 | `erasurecascadereach_test.go` | H2 | Every file the Art. 17 cascade executes SQL from is one the PII censuses read. |


### PR DESCRIPTION
Final slice of the email display unification arc — the contract-derived gate the plan put last, after every surface had migrated.

## What it holds

Five surfaces once drew a retained email their own way, and nothing failed when they drifted: a sixth reading looked exactly like one reusing the canonical row.

The contract names which schemas **are** an email, in the schema itself (`x-email-presentation: entry`, with `exempt` carrying a reason — annotations added in #3779). This census reads the annotation from `api/crm.yaml` and the consumers from `frontend/src`, and holds the two halves against each other.

## It fails in both directions

**A schema reaching a non-renderer** — a sixth rendering appears and the gate names it.

**A canonical renderer that stopped consuming one** — and this is the direction worth having. A gate that only asked "does anything else render an email" reports **PASS** over a tree where `EmailEntry` has been gutted and every surface has gone back to its own spelling: nothing consumes an `entry` schema, so nothing is unauthorized, so the census reports clean about the exact state this arc exists to end.

**And it refuses to judge nothing.** An annotation whose spelling drifts leaves the corpus empty — the one way a census must not break, because it reads a smaller tree, reports PASS, and leaves no failing assertion to notice. The empty corpus is a `t.Fatal`.

## Three mutations, each verified

| Mutation | Result |
|---|---|
| A new file consumes `EmailSummary` | named as not a canonical renderer |
| `emailentry.tsx` stops naming the contract type | "it has stopped drawing a message" |
| `entry` renamed to `row` in the contract | "this census is now judging nothing" |

## Writing it corrected a premise

The plan listed `EmailReference` among the canonical renderers, and the first version of the gate failed on it. **It is not one, for this gate's purposes:** it *cites* a message rather than showing one, and takes a subject and a date as plain scalars — no contract type at all, which is precisely what stops a citation from ever growing a preview.

A gate expecting it to consume an `entry` schema would have asserted the opposite of the design. The comment says so, so the next reader does not re-add it.

## One waiver

`design-system/composed.tsx` declares `TimelineEntry.emailSummary` and hands it to `EmailEntry`. The timeline row chooses *which* component draws a kind; drawing none itself is what keeps that choice in one place.

`docs/reference/gate-inventory.md` regenerated — census count 86 → 87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the final gate of the email presentation unification arc. It reads which schemas the contract marks as emails (`x-email-presentation: entry`) from `api/crm.yaml`, finds every frontend consumer of those generated types, and fails when the two halves disagree.

- Fails in both directions: a non-canonical renderer consuming an `entry` schema, and a canonical renderer that stopped consuming one — the second catches a gutted `EmailEntry`, which a one-directional check would report clean.
- Refuses to judge nothing: a drifted annotation leaves an empty corpus, and the gate hard-fails (`t.Fatal`) instead of passing silently.
- `EmailReference` is deliberately not a canonical renderer; it cites a message rather than showing one, so expecting it to consume an `entry` schema would assert the opposite of the design.
- `design-system/composed.tsx` is waived as a passthrough that hands the type to `EmailEntry` without drawing it.
- Regenerates `docs/reference/gate-inventory.md`, census count 86 → 87.

<sup>Written for commit 7bb426ae4455c4d7b567336f249f237c48692ebb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Added automated safeguards to ensure email information is rendered consistently through approved interface components.
  - Expanded validation coverage to detect unintended email presentation changes and confirm supported renderers remain active.
  - Updated internal quality tracking to reflect the additional validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->