### PR TITLE
The rail belongs to the view it is beside

### DIFF
--- a/frontend/e2e/brief.spec.ts
+++ b/frontend/e2e/brief.spec.ts
@@ -344,6 +344,30 @@ test.describe("the Brief — page shape", () => {
     );
   });
 
+  // The weekly uses the FULL width, because it has no rail.
+  //
+  // Every rail panel answers a question about today, so none of them belongs
+  // beside a week that closed. A grid track does not collapse when its item is
+  // missing, so leaving the aside shape in place would draw the weekly at
+  // seventy per cent width against a third of nothing — a column that reads as
+  // a rail which failed to load. Measured rather than asserted on a class,
+  // because the defect is a width a reader sees.
+  test("gives the weekly the whole width", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await openWeekly(page);
+    await expectShellRendered(page);
+
+    await expect(page.locator(".home-rail")).toHaveCount(0);
+    const main = await page.locator(".home-main").boundingBox();
+    const zones = await page.locator(".page-zones-main").boundingBox();
+    if (!main || !zones) {
+      throw new Error("the weekly drew no work column to measure");
+    }
+    // The work column fills its own grid area rather than leaving a third of
+    // it empty beside itself.
+    expect(main.width).toBeGreaterThan(zones.width * 0.9);
+  });
+
   // And the morning shows the morning's work — the weekly is a dial away, not
   // a section further down the same page.
   test("keeps the week off the morning", async ({ page }) => {

--- a/frontend/src/screens/home.dials.test.tsx
+++ b/frontend/src/screens/home.dials.test.tsx
@@ -129,6 +129,47 @@ describe("the Brief's dials", () => {
     expect(globalThis.history.length).toBe(before);
   });
 
+  // The rail belongs to the view it is beside.
+  //
+  // Every panel in it answers a question about TODAY — what the day is booked
+  // with, what is owed now, what arrived overnight. Under the weekly they sit
+  // beside a week that closed, so the page shows a rep "Today's schedule" next
+  // to a retrospective and reads as two screens overlaid.
+  //
+  // The work column already switches on the view. The rail did not, because it
+  // is drawn once outside that branch and nothing asserted otherwise.
+  it("leaves the morning's rail off the weekly", async () => {
+    globalThis.location.hash = "#/home?view=weekly";
+    stubHome(["mine"]);
+    render(<HomeScreen />);
+
+    await screen.findByRole("group", { name: en["brief.view.label"] });
+    await waitFor(() =>
+      expect(document.querySelector("#home-weekly")).not.toBeNull(),
+    );
+    expect(document.querySelector("#home-schedule")).toBeNull();
+    expect(document.querySelector("#home-watch")).toBeNull();
+    // And the TRACK is gone with them. The <aside> element is gated on having
+    // content, but the grid template is on the wrapper and driven by `shape` —
+    // so dropping only the contents leaves the weekly at seventy per cent
+    // width beside a third of nothing, which reads as a rail that failed to
+    // load rather than one that was never there. `page-zones-aside` is the
+    // class that reserves the column.
+    expect(document.querySelector(".page-zones-aside")).toBeNull();
+  });
+
+  // And it is still there on the morning, or the assertion above passes over a
+  // rail that was deleted rather than placed.
+  it("keeps the rail on the morning", async () => {
+    stubHome(["mine"]);
+    render(<HomeScreen />);
+
+    await waitFor(() =>
+      expect(document.querySelector("#home-schedule")).not.toBeNull(),
+    );
+    expect(document.querySelector(".page-zones-aside")).not.toBeNull();
+  });
+
   // DECISION 5, ON THE PAGE. Every combination the dials offer must draw
   // something. An empty work column under a selectable dial is the defect the
   // rule exists to prevent, and it is invisible to a test that only checks the

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -309,7 +309,12 @@ export function HomeScreen() {
       {/* Screen-level so it survives the deck re-rendering under it. */}
       {decidedNote}
       <PageZones
-        shape="aside"
+        // The SHAPE moves with the aside, not just its contents. A grid track
+        // does not collapse when its item is missing (pagezones.tsx says so in
+        // as many words), so leaving this at "aside" would draw the weekly at
+        // seventy per cent width with an empty third beside it — a column that
+        // reads as a rail which failed to load.
+        shape={address.view === "weekly" ? "single" : "aside"}
         mainClassName="home-main"
         main={
           <HomeWork
@@ -332,30 +337,50 @@ export function HomeScreen() {
         }
         asideClassName="home-rail"
         asideLabel={t("home.rail")}
+        // THE RAIL BELONGS TO THE VIEW IT IS BESIDE.
+        //
+        // Every panel below answers a question about TODAY: what the day is
+        // booked with, what is owed now, what arrived overnight, which deals
+        // have gone quiet. Beside the weekly they sat next to a week that had
+        // closed, so a rep reading their retrospective was shown "Today's
+        // schedule" against it and the page read as two screens overlaid.
+        //
+        // The work column has switched on the view since the dials shipped.
+        // The rail did not, because it is drawn once outside that branch —
+        // and nothing asserted it, so the mismatch was invisible.
+        //
+        // The weekly draws NO rail rather than a substitute one. Its three
+        // planned panels each need something that is not there: the manager's
+        // answer already renders on the commitment row it belongs to, and
+        // "carried into this week" is a COUNT on the wire with no rows behind
+        // it. A rail invented from what is available would be a region that
+        // says less than the column beside it.
         aside={
-          <>
-            {/* The day's own shape leads the rail: what it is booked with, then
-                what is owed. Both are cuts of the SAME worklist answer the work
-                column is drawn from, so the rail cannot name a meeting the
-                queue has already dropped. */}
-            <SchedulePanel
-              day={worklistQuery.data}
-              state={readState(worklistQuery)}
-            />
-            <PromisesPanel
-              day={worklistQuery.data}
-              state={readState(worklistQuery)}
-            />
-            <OvernightPanel />
-            <PositionPanel />
-            <section id="home-watch">
-              <WatchPanel
-                deals={quiet}
-                more={beyondPage}
-                state={readState(dealsQuery)}
+          address.view === "weekly" ? undefined : (
+            <>
+              {/* The day's own shape leads the rail: what it is booked with,
+                  then what is owed. Both are cuts of the SAME worklist answer
+                  the work column is drawn from, so the rail cannot name a
+                  meeting the queue has already dropped. */}
+              <SchedulePanel
+                day={worklistQuery.data}
+                state={readState(worklistQuery)}
               />
-            </section>
-          </>
+              <PromisesPanel
+                day={worklistQuery.data}
+                state={readState(worklistQuery)}
+              />
+              <OvernightPanel />
+              <PositionPanel />
+              <section id="home-watch">
+                <WatchPanel
+                  deals={quiet}
+                  more={beyondPage}
+                  state={readState(dealsQuery)}
+                />
+              </section>
+            </>
+          )
         }
       />
     </div>


### PR DESCRIPTION
Every panel in Home's rail answers a question about **today**: what the day is booked with, what is owed now, what arrived overnight, which deals have gone quiet. All five drew on the **weekly** too — so a rep reading a week that closed was shown "Today's schedule" against it, and the page read as two screens overlaid.

The work column has switched on the view since the dials shipped. The rail did not, because it is drawn once outside that branch — and nothing asserted it, so the mismatch was invisible.

### The shape moves with it, not only the contents

A grid track does not collapse when its item is missing — `pagezones.tsx` says so in as many words. Dropping the panels alone would leave the weekly at seventy per cent width beside a third of nothing, which reads as a rail that failed to load.

**My first test caught only one of the two halves.** It asserted the `<aside>` element, which is gated on having content — so the shape mutation stayed green over an empty grid track. It asserts `page-zones-aside`, the class that reserves the column, now. Both halves fail their mutation.

### The weekly draws no rail rather than a substitute one

Its three planned panels each need something that is not there: the manager's answer already renders on the commitment row it belongs to, and "carried into this week" is a **count** on the wire with no rows behind it. A rail invented from what is available would be a region saying less than the column beside it.

### One thing I could not verify

The browser assertion for the weekly's width is written but **was not run**. A freshly seeded dev stack answers 404 on `/company`, so the shell redirects into onboarding and all 19 tests in `brief.spec.ts` fail at sign-in.

Confirmed environmental rather than a regression: stashing this branch and running the same spec against `origin/main` on the same stack fails identically. Filed as #3915 — `seed-dev` never describes the installation's own company, and `seed.ts:1285` already documents that a 404 there rightly forces onboarding.

The behaviour itself is proven by the two unit tests, which do run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the weekly view showing the today-focused rail beside it, so the weekly now uses the full width instead of a rail that doesn't apply.

- The rail's panels all answer questions about today, so they are hidden on the weekly view.
- The grid shape now switches to `single` on the weekly so the layout fills the space.
- Adds unit tests for the rail on both views and an e2e test for the weekly width; the e2e test is written but not run due to a local environment issue.

<sup>Written for commit 34d9ac32f741221dab465cff9508b9ccce374249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the weekly Brief view to use a streamlined single-column layout.
  * Removed the daily rail from weekly view, allowing the main work area to expand across nearly the full page.
  * Preserved the schedule, promises, overnight, position, and watch panels in the rail for non-weekly views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->