### PR TITLE
main is red: two nil-shapes without the waiver their siblings carry

### DIFF
--- a/backend/internal/modules/weeklyplan/edit.go
+++ b/backend/internal/modules/weeklyplan/edit.go
@@ -196,6 +196,12 @@ func sameDay(a, b *time.Time) bool {
 	return a.Format(time.DateOnly) == b.Format(time.DateOnly)
 }
 
+// Both are storekit.dateOnly's siblings: the column-value contract Patch.Set
+// takes is "the value, or a JSON null", and it has to be an untyped nil rather
+// than a typed nil pointer — the audit image is compared as JSON and a *string
+// holding nil is not `== nil` once it is an any.
+//
+//craft:ignore naked-any a nullable column is either its value or a JSON null, and the audit image and the bind value both have to carry that pair — the same column-value contract as Patch.Set
 func stringOrNil(value string) any {
 	if value == "" {
 		return nil
@@ -203,6 +209,7 @@ func stringOrNil(value string) any {
 	return value
 }
 
+//craft:ignore naked-any the same column-value contract as stringOrNil above
 func uuidOrNil(id ids.UUID) any {
 	if id == ids.Nil {
 		return nil


### PR DESCRIPTION
`make craft-static` blocks on clean `origin/main` (`2cf698486`), so every open PR is red on the `craftsmanship` check for a reason that has nothing to do with its diff. **No open PR was fixing it** — #3908 is a different red.

```
../../backend/internal/modules/weeklyplan/edit.go
  199: [MAJOR] naked-any — bare any/interface{} in a signature
  206: [MAJOR] naked-any — bare any/interface{} in a signature
BLOCK — 0 blocker, 2 major, 0 minor
```

`stringOrNil` and `uuidOrNil` feed `storekit.Patch.Set`, and the contract that function takes is *"the value, or a JSON null"*. Both of the shapes already in `storekit` that produce that pair ratify it in source with the same waiver — `Patch.Set` itself (*"column values span every SQL type a module owns; they flow to bind parameters and the schemaless audit diff"*) and `dateOnly` (*"a date is either its own text or a JSON null, and the audit image and the bind value both have to carry that pair"*). These two are their siblings and now say so.

**A typed pointer is not the fix, and the waiver says why.** `*string` and `*ids.UUID` would satisfy the checker and change behaviour: a nil `*string` is not `== nil` once it is an `any`, and the audit image is compared as JSON on both sides — which is the exact hazard `dateOnly`'s own comment records for the undo path, where a wrongly-shaped image left a whole kind of record permanently un-undoable. The reason the file gives for these two functions existing at all is that *"a column that is NULL in the row has to be compared as nil rather than as a zero value, or clearing an already empty link would report the empty string changing to the empty string and file an audit row saying a rep changed something they did not."* A typed nil would reintroduce that from the other side.

**Verification.** `make craft-static` green on all four roots. `make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification for handling nullable values and JSON `null` conversions.
  * Documented the intentional use of a flexible return type in this internal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->