### PR TITLE
Apply review findings from PR #3844's end-of-work round

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -38120,11 +38120,11 @@ components:
       description: |
         The deal behind an item, with the facts its card states. `expected_minor_base` is
         `amount_minor` converted to the installation's base currency — the only figure by
-        which two deals in different currencies may be compared. It does not yet weight by
-        `win_probability`: the pipeline this row comes from does not read a deal's stage
-        today, so the two fields are independent facts rather than one computed from the
-        other, and a reader must not multiply them together expecting the product to equal
-        a risk-adjusted figure the API does not compute.
+        which two deals in different currencies may be compared. It is not weighted by
+        `win_probability`: the pipeline this row comes from does not read a deal's stage,
+        so the two fields are independent facts rather than one computed from the other,
+        and a reader must not multiply them together expecting the product to equal a
+        risk-adjusted figure the API does not compute.
       properties:
         stage_id: { type: [string, 'null'], format: uuid }
         amount_minor: { type: [integer, 'null'], format: int64 }

--- a/backend/internal/compose/attention/basemoney_test.go
+++ b/backend/internal/compose/attention/basemoney_test.go
@@ -299,6 +299,24 @@ func TestTheDealFactsCarryTheConvertedExpectedRevenue(t *testing.T) {
 	}
 }
 
+// A converted figure with no base currency named states no base-currency
+// figure — the same guard dayMoney.value already holds for the reason
+// field, over a misbehaving FX seam that priced a deal without naming what
+// currency the price is in. A number is not a smaller error than none.
+func TestAConvertedDealWithNoNamedBaseCarriesNoExpectedMinorBase(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("yen", "deal_at_risk", withPricedDeal(fiveMillionYen))),
+	}
+	fx := stubFX{base: "", answers: map[CurrencyAmount]int64{fiveMillionYen: 3_000_000}}
+
+	out := pricedWorklist(t, fx, day)
+
+	if deal := out.Queue[0].Deal; deal != nil && deal.ExpectedMinorBase != nil {
+		t.Fatalf("expected_minor_base = %v with no base currency named", *deal.ExpectedMinorBase)
+	}
+}
+
 // A deal the estate cannot price states no base-currency figure: null means
 // "could not be priced", the same null a client already reads for an unpriced
 // deal's other money fields, not a second and different meaning of null.

--- a/backend/internal/compose/attention/basemoney_test.go
+++ b/backend/internal/compose/attention/basemoney_test.go
@@ -317,6 +317,26 @@ func TestAConvertedDealWithNoNamedBaseCarriesNoExpectedMinorBase(t *testing.T) {
 	}
 }
 
+// The same unnamed conversion must not drive a material verdict either: an
+// amount with no named currency is not a smaller error than none, whether it
+// reaches the reader as the row's ExpectedMinorBase or as the "material" /
+// "below_material" reason classifyRisk states over it.
+func TestAConvertedDealWithNoNamedBaseStatesNoMaterialVerdict(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:   rankInstant,
+		AtRisk: lane(item("yen", "deal_at_risk", withPricedDeal(fiveMillionYen))),
+	}
+	fx := stubFX{base: "", answers: map[CurrencyAmount]int64{fiveMillionYen: 3_000_000}}
+
+	out := pricedWorklist(t, fx, day)
+
+	for _, because := range out.Queue[0].Because {
+		if because.Kind == "material" || because.Kind == "below_material" {
+			t.Fatalf("stated %q over a figure converted with no base currency named", because.Kind)
+		}
+	}
+}
+
 // A deal the estate cannot price states no base-currency figure: null means
 // "could not be priced", the same null a client already reads for an unpriced
 // deal's other money fields, not a second and different meaning of null.

--- a/backend/internal/compose/attention/classifybrief.go
+++ b/backend/internal/compose/attention/classifybrief.go
@@ -25,16 +25,11 @@ import (
 // due date: closing_soon whenever a date is set, never due_today, because a
 // close date three months out is a forecast and not work owed for today.
 //
-// Overdue is never recomputed here. It arrives on item.Overdue from the SAME
+// Overdue is never recomputed here — it arrives on item.Overdue from the SAME
 // deal-figures read that supplied DueAt (applyDealFigures, dealfacts.go),
-// which states deals.CloseIsOverdue's verdict — a CALENDAR-DATE comparison in
-// the workspace zone, the same rule the sibling "deals_at_risk" row for the
-// identical deal is judged by. A close date round-trips as UTC midnight, so
-// an INSTANT comparison here would call a deal overdue from 00:00 UTC onward
-// on the due day itself — up to a whole local day before the calendar-date
-// verdict agrees, and the two rows for one deal would disagree over exactly
-// that window. base() already carries item.Overdue onto row.Overdue; there
-// is nothing left to set here.
+// stating deals.CloseIsOverdue's own verdict, the identical rule the sibling
+// "deals_at_risk" row for the same deal is judged by. base() already carries
+// item.Overdue onto row.Overdue; there is nothing left to set here.
 func classifyBriefItem(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	row := base(item, levelAgreed, "deals_at_risk", "deal_drifts")
 	if item.DueAt != nil {

--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -39,9 +39,11 @@ func classifyRisk(item crmcontracts.AttentionItem, asOf time.Time, bar materialB
 	row := base(item, level, "deals_at_risk", consequence)
 	// The contract's own per-row figure, sent rather than left for a client to
 	// re-derive from `because`/`above_next` — set only once conversion actually
-	// ran and priced this item, so a raw amount (no FX seam bound) or an
-	// unpriced deal never claims to be a base-currency figure it is not.
-	if row.Deal != nil && money.converted() && money.base != "" && known {
+	// ran and priced this item. expectedRevenue already answers known=false
+	// for a raw amount (no FX seam bound), an unpriced deal, or a converted
+	// figure with no base currency named, so this is the one place that
+	// answer is spent rather than a second copy of any of its three reasons.
+	if row.Deal != nil && money.converted() && known {
 		row.Deal.ExpectedMinorBase = &expected
 	}
 	// The reason carries the figure the verdict actually weighed, in the units

--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -41,7 +41,7 @@ func classifyRisk(item crmcontracts.AttentionItem, asOf time.Time, bar materialB
 	// re-derive from `because`/`above_next` — set only once conversion actually
 	// ran and priced this item, so a raw amount (no FX seam bound) or an
 	// unpriced deal never claims to be a base-currency figure it is not.
-	if row.Deal != nil && money.converted() && known {
+	if row.Deal != nil && money.converted() && money.base != "" && known {
 		row.Deal.ExpectedMinorBase = &expected
 	}
 	// The reason carries the figure the verdict actually weighed, in the units

--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -39,10 +39,11 @@ func classifyRisk(item crmcontracts.AttentionItem, asOf time.Time, bar materialB
 	row := base(item, level, "deals_at_risk", consequence)
 	// The contract's own per-row figure, sent rather than left for a client to
 	// re-derive from `because`/`above_next` — set only once conversion actually
-	// ran and priced this item. expectedRevenue already answers known=false
-	// for a raw amount (no FX seam bound), an unpriced deal, or a converted
-	// figure with no base currency named, so this is the one place that
-	// answer is spent rather than a second copy of any of its three reasons.
+	// ran and priced this item (money.converted() below is the raw-amount
+	// guard). expectedRevenue already answers known=false for a deal with no
+	// amount, an unpriced converted item, or a converted figure with no base
+	// currency named, so this is the one place that answer is spent rather
+	// than a second copy of any of its three reasons.
 	if row.Deal != nil && money.converted() && known {
 		row.Deal.ExpectedMinorBase = &expected
 	}

--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -121,6 +121,12 @@ func expectedRevenue(item crmcontracts.AttentionItem, money dayMoney) (int64, bo
 	if !money.converted() {
 		return *item.Deal.AmountMinor, true
 	}
+	// The same guard dayMoney.value already holds for the reason field: a
+	// converted figure with no base currency named is not a smaller answer,
+	// it is no answer, and must not drive a material verdict either.
+	if money.base == "" {
+		return 0, false
+	}
 	converted, priced := money.byItem[item.Id]
 	return converted, priced
 }

--- a/backend/internal/compose/attention/dealfacts.go
+++ b/backend/internal/compose/attention/dealfacts.go
@@ -29,12 +29,15 @@ import (
 )
 
 // nameTheMoney puts a deal's figures on every lane item that names one and
-// carries none — and drops the item where Figures cannot answer for it at
-// all, since a row that can name nothing is not a suggestion.
+// carries none.
 //
 // Items that already have facts are left alone: the lane that produced them
 // read the deal under this same reader, and asking again could only produce a
-// second answer to a settled question.
+// second answer to a settled question. Whether a row belongs on the day at
+// all when its deal cannot be resolved is the briefing lane's own question,
+// asked at its source (attentionBriefing.Queue, over the SAME DealFacts
+// reader) — this pass runs after that filter has already applied, so it is
+// never the one deciding whether a row survives.
 func (s *Service) nameTheMoney(ctx context.Context, day *crmcontracts.Attention) error {
 	if s.dealFacts == nil {
 		return nil
@@ -60,28 +63,20 @@ func (s *Service) nameTheMoney(ctx context.Context, day *crmcontracts.Attention)
 		return err
 	}
 	for _, lane := range lanes {
-		kept := make([]crmcontracts.AttentionItem, 0, len(*lane))
 		for i := range *lane {
-			item := (*lane)[i]
-			id, needsFigures := needsDealFigures(item)
-			if !needsFigures {
-				kept = append(kept, item)
+			id, ok := needsDealFigures((*lane)[i])
+			if !ok {
 				continue
 			}
 			found, ok := figures[id]
 			if !ok {
-				// The deal is gone (archived, deleted) or the reader can no
-				// longer see it — Figures answers the same absence either
-				// way, and a row that can name nothing is not a suggestion:
-				// dropped here rather than left on the page with no amount,
-				// no close date and no reason, still offering act/set_aside/
-				// dismiss over a deal that no longer resolves.
+				// The reader may not see this deal, or it is gone. The row
+				// keeps its name and says no more, which is the shape an
+				// unnamed subject already has.
 				continue
 			}
-			applyDealFigures(&item, found)
-			kept = append(kept, item)
+			applyDealFigures(&(*lane)[i], found)
 		}
-		*lane = kept
 	}
 	return nil
 }

--- a/backend/internal/compose/attention/dealfacts_test.go
+++ b/backend/internal/compose/attention/dealfacts_test.go
@@ -72,14 +72,13 @@ func TestABriefRowGainsItsDealsFigures(t *testing.T) {
 	}
 }
 
-// A deal Figures cannot answer for — gone (archived, deleted) or no longer
-// visible to this reader — drops the row entirely, rather than
-// leaving an unidentifiable one on the page: no amount, no close date, no
-// reason, yet still offering act/set_aside/dismiss over a deal that no longer
-// resolves. A row that can name nothing is not a suggestion, and the refusal
-// is an absent answer rather than an error, so one unresolved deal cannot take
-// the whole read down.
-func TestABriefRowWhoseDealCannotBeResolvedIsDropped(t *testing.T) {
+// A deal Figures cannot answer for — withheld from this reader, or gone
+// entirely — leaves the row as it was: named, and saying no more. Whether
+// such a row belongs on the day at all is attentionBriefing.Queue's own
+// question, asked at its source over the SAME DealFacts reader; a second
+// answer here would be a second place the same invariant could drift from
+// the first.
+func TestAnUnresolvedDealLeavesTheRowUnchanged(t *testing.T) {
 	dealID := ids.NewV7()
 	svc := (&Service{}).WithDealFacts(&stubDealFacts{figures: map[ids.UUID]DealFigures{}})
 	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{briefRow(dealID)}}
@@ -88,32 +87,11 @@ func TestABriefRowWhoseDealCannotBeResolvedIsDropped(t *testing.T) {
 		t.Fatalf("an unresolved deal failed the whole read: %v", err)
 	}
 
-	if len(day.ThisMorning) != 0 {
-		t.Fatalf("ThisMorning still carries %d row(s); an unresolved deal's row should have been dropped", len(day.ThisMorning))
-	}
-}
-
-// A row beside an unresolved one is untouched: dropping one deal's row is not
-// a reason to drop, reorder or otherwise disturb its neighbours.
-func TestABriefRowBesideAnUnresolvedOneIsUntouched(t *testing.T) {
-	resolved, unresolved := ids.NewV7(), ids.NewV7()
-	amount := int64(50_00)
-	svc := (&Service{}).WithDealFacts(&stubDealFacts{figures: map[ids.UUID]DealFigures{
-		resolved: {AmountMinor: &amount, Currency: "EUR"},
-	}})
-	day := crmcontracts.Attention{AsOf: rankInstant, ThisMorning: []crmcontracts.AttentionItem{
-		briefRow(unresolved), briefRow(resolved),
-	}}
-
-	if err := svc.nameTheMoney(context.Background(), &day); err != nil {
-		t.Fatalf("naming the money: %v", err)
-	}
-
 	if len(day.ThisMorning) != 1 {
-		t.Fatalf("ThisMorning carries %d row(s), wanted exactly the resolved one", len(day.ThisMorning))
+		t.Fatalf("ThisMorning carries %d row(s), wanted the row left in place", len(day.ThisMorning))
 	}
-	if day.ThisMorning[0].Id != resolved.String() {
-		t.Fatalf("the surviving row is %q, wanted the resolved deal %q", day.ThisMorning[0].Id, resolved.String())
+	if day.ThisMorning[0].Deal != nil {
+		t.Fatal("an unresolved deal put figures on the row anyway")
 	}
 }
 

--- a/backend/internal/compose/integration/dealfigures_integration_test.go
+++ b/backend/internal/compose/integration/dealfigures_integration_test.go
@@ -196,15 +196,7 @@ func TestDealFiguresFlagsAPastCloseDateAsOverdue(t *testing.T) {
 // comparison, and a deal due today is due today, not late.
 func TestDealFiguresDoesNotFlagATodayOrFutureCloseDateAsOverdue(t *testing.T) {
 	e := Setup(t)
-	// The DB's own "today", not Go's: Figures compares against Postgres's
-	// now() in the installation's zone, and seeding from the wall clock this
-	// process reads would race a UTC-midnight rollover between the seed and
-	// the query.
-	var today time.Time
-	if err := OwnerConn(t).QueryRow(context.Background(),
-		`SELECT (timezone('UTC', now()))::date`).Scan(&today); err != nil {
-		t.Fatalf("reading the database's own today: %v", err)
-	}
+	today := time.Now().UTC()
 	dealID := seedFiguresDealClosing(t, e.Rep1, 50_000_00, today)
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
 

--- a/backend/internal/compose/integration/dealfigures_integration_test.go
+++ b/backend/internal/compose/integration/dealfigures_integration_test.go
@@ -194,10 +194,17 @@ func TestDealFiguresFlagsAPastCloseDateAsOverdue(t *testing.T) {
 // A close date that has not yet arrived — today's or later — is not overdue.
 // Today itself is the boundary this asserts: CloseIsOverdue is a calendar-date
 // comparison, and a deal due today is due today, not late.
+//
+// The seed and Figures' own read of "now" must agree on what day it is: a
+// wall-clock instant seeded here and re-read by Figures moments later could
+// straddle UTC midnight between the two calls, which would make the seeded
+// date read as YESTERDAY and fail this test on a defect it does not have. One
+// pinned instant closes that gap.
 func TestDealFiguresDoesNotFlagATodayOrFutureCloseDateAsOverdue(t *testing.T) {
 	e := Setup(t)
-	today := time.Now().UTC()
-	dealID := seedFiguresDealClosing(t, e.Rep1, 50_000_00, today)
+	now := time.Now().UTC()
+	e.Deals.WithClock(func() time.Time { return now })
+	dealID := seedFiguresDealClosing(t, e.Rep1, 50_000_00, now)
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
 
 	figures, err := e.Deals.Figures(rep, []ids.UUID{dealID})

--- a/backend/internal/compose/integration/dealfigures_integration_test.go
+++ b/backend/internal/compose/integration/dealfigures_integration_test.go
@@ -31,6 +31,11 @@ func seedFiguresDeal(t *testing.T, owner ids.UUID, amount int64) ids.UUID {
 // seedFiguresDealClosing writes one deal with the given expected close date —
 // the workspace's own timezone setting is what Figures reads it against
 // (UTC, the fresh-installation default this harness never overrides).
+//
+// closes is bound as a plain calendar-date string, not the time.Time itself:
+// a date literal parses to the exact day named, with no session TimeZone GUC
+// in between, so a caller stating "today" in UTC gets that same day in the
+// column whatever the connection's zone happens to be.
 func seedFiguresDealClosing(t *testing.T, owner ids.UUID, amount int64, closes time.Time) ids.UUID {
 	t.Helper()
 	conn := OwnerConn(t)
@@ -41,8 +46,8 @@ func seedFiguresDealClosing(t *testing.T, owner ids.UUID, amount int64, closes t
 	return SeedIDRow(t, conn, `INSERT INTO deal
 		(id, owner_id, name, pipeline_id, stage_id, amount_minor, currency, expected_close_date,
 		 source, captured_by)
-		VALUES ($1, $2, 'Northstar renewal', $3, $4, $5, 'EUR', $6, 'manual', 'human:x')`,
-		owner, pipeline, stage, amount, closes)
+		VALUES ($1, $2, 'Northstar renewal', $3, $4, $5, 'EUR', $6::date, 'manual', 'human:x')`,
+		owner, pipeline, stage, amount, closes.Format(time.DateOnly))
 }
 
 // A deal the reader may see comes back with the figures a card states.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -32229,11 +32229,11 @@ type WorklistCountCategory string
 
 // WorklistDealFacts The deal behind an item, with the facts its card states. `expected_minor_base` is
 // `amount_minor` converted to the installation's base currency — the only figure by
-// which two deals in different currencies may be compared. It does not yet weight by
-// `win_probability`: the pipeline this row comes from does not read a deal's stage
-// today, so the two fields are independent facts rather than one computed from the
-// other, and a reader must not multiply them together expecting the product to equal
-// a risk-adjusted figure the API does not compute.
+// which two deals in different currencies may be compared. It is not weighted by
+// `win_probability`: the pipeline this row comes from does not read a deal's stage,
+// so the two fields are independent facts rather than one computed from the other,
+// and a reader must not multiply them together expecting the product to equal a
+// risk-adjusted figure the API does not compute.
 type WorklistDealFacts struct {
 	AmountMinor       *int64              `json:"amount_minor,omitempty"`
 	Currency          *string             `json:"currency,omitempty"`
@@ -32312,11 +32312,11 @@ type WorklistItem struct {
 
 	// Deal The deal behind an item, with the facts its card states. `expected_minor_base` is
 	// `amount_minor` converted to the installation's base currency — the only figure by
-	// which two deals in different currencies may be compared. It does not yet weight by
-	// `win_probability`: the pipeline this row comes from does not read a deal's stage
-	// today, so the two fields are independent facts rather than one computed from the
-	// other, and a reader must not multiply them together expecting the product to equal
-	// a risk-adjusted figure the API does not compute.
+	// which two deals in different currencies may be compared. It is not weighted by
+	// `win_probability`: the pipeline this row comes from does not read a deal's stage,
+	// so the two fields are independent facts rather than one computed from the other,
+	// and a reader must not multiply them together expecting the product to equal a
+	// risk-adjusted figure the API does not compute.
 	Deal *WorklistDealFacts `json:"deal,omitempty"`
 
 	// Detail One supporting line, in PROSE — a bounce reason, a park reason, the mailbox that

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -76,15 +77,22 @@ const systemCapturedByPattern = systemCapturedBy + ":%"
 // recompute.
 func FollowUpWorkflows(store *Store) []workflow.Handler {
 	return []workflow.Handler{
-		followUpAutoResolve{store: store, name: "follow_up_auto_resolve", trigger: "activity.captured", leadsFromLinks: true},
+		followUpAutoResolve{store: store, name: "follow_up_auto_resolve", trigger: activityCapturedTrigger, leadsFromLinks: true},
 		followUpAutoResolve{store: store, name: "follow_up_auto_resolve_on_promoted", trigger: leadPromotedTrigger},
-		followUpAutoResolve{store: store, name: "follow_up_auto_resolve_on_disqualified", trigger: "lead.disqualified"},
+		followUpAutoResolve{store: store, name: "follow_up_auto_resolve_on_disqualified", trigger: leadDisqualifiedTrigger},
 	}
 }
 
-// leadPromotedTrigger names the one trigger whose Apply also has to resolve
-// by PERSON rather than by lead — see the comment on Apply for why.
-const leadPromotedTrigger = "lead.promoted"
+// The three triggers this file's Apply arms watch. Named together because
+// they are read together (FollowUpWorkflows, Apply's leadPromotedTrigger
+// check), and a third literal beside two names is the spelling that drifts.
+const (
+	activityCapturedTrigger = "activity.captured"
+	// leadPromotedTrigger is the one trigger whose Apply also has to resolve
+	// by PERSON rather than by lead — see the comment on Apply for why.
+	leadPromotedTrigger     = "lead.promoted"
+	leadDisqualifiedTrigger = "lead.disqualified"
+)
 
 // followUpAutoResolve is one trigger's arm of the auto-resolve invariant.
 // leadsFromLinks says the fired entity is an ACTIVITY whose linked leads
@@ -177,7 +185,7 @@ func (w followUpAutoResolve) Apply(ctx context.Context, ev workflow.Event, eff w
 			return workflow.RunResult{}, fmt.Errorf("decoding the promoted person: %w", err)
 		}
 		if promoted.DedupeOutcome == dedupeOutcomeCreated {
-			done, err := w.store.CompleteOpenSystemTasksForPerson(ctx, promoted.PersonID)
+			done, err := w.store.CompleteOpenSystemTasksForPerson(ctx, promoted.PersonID, ev.OccurredAt)
 			if err != nil {
 				return workflow.RunResult{}, fmt.Errorf("resolving follow-ups on person %s: %w", promoted.PersonID, err)
 			}
@@ -247,19 +255,45 @@ func (w followUpAutoResolve) linkedLeads(ctx context.Context, activityID ids.Act
 }
 
 // CompleteOpenSystemTasksForLead completes every open system-minted task
-// linked to the lead, each through UpdateActivity — the module's own
-// write path — so every completion carries the write shape (audit row,
-// activity.updated event) exactly like a human ticking the box. A bulk
-// UPDATE would be invisible history. Replays are harmless: a completed
-// task no longer matches the open filter.
+// linked to the lead — see completeOpenSystemTasksLinkedBy for the write
+// shape, the version-skew handling and what "system-minted" means.
+func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.LeadID) (int, error) {
+	return s.completeOpenSystemTasksLinkedBy(ctx, "lead_id", leadID.UUID, nil)
+}
+
+// CompleteOpenSystemTasksForPerson is CompleteOpenSystemTasksForLead's
+// sibling for a lead that PROMOTED: carryLeadActivities (people/promote.go)
+// re-points a follow-up task's link from the lead onto the person it became,
+// in the same transaction that emits lead.promoted, so a lead id can no
+// longer find it — only the person id it was carried to can.
+//
+// before bounds completion to tasks that existed by that instant. This
+// arm's caller runs asynchronously off the outbox, so "the person is fresh
+// and cannot yet carry anything else" is only true up to the moment the
+// promotion committed — a sibling automation (no_activity_reminder,
+// check_in_cadence) can anchor its own system task on the same person before
+// this handler runs, and completing every open system task on the person
+// would claim that task too. The caller passes the triggering event's own
+// OccurredAt.
+func (s *Store) CompleteOpenSystemTasksForPerson(ctx context.Context, personID ids.PersonID, before time.Time) (int, error) {
+	return s.completeOpenSystemTasksLinkedBy(ctx, "person_id", personID.UUID, &before)
+}
+
+// completeOpenSystemTasksLinkedBy completes every open system-minted task the
+// given column and value select, each through UpdateActivity — the module's
+// own write path — so every completion carries the write shape (audit row,
+// activity.updated event) exactly like a human ticking the box. A bulk UPDATE
+// would be invisible history. Replays are harmless: a completed task no
+// longer matches the open filter.
 //
 // The selection and the completions are separate transactions, so two
-// firings for one lead — an activity.captured racing a lead.promoted — can
-// both select the same open task. Each completion therefore carries the
-// version the selection read, and a task somebody else finished first
-// answers version skew and is SKIPPED. Without it the loser writes
-// is_done = true over a row that already says so, and the task's history
-// shows two identical completions of the same thing.
+// firings — an activity.captured racing a lead.promoted, or two firings that
+// both resolve through this same helper — can both select the same open
+// task. Each completion therefore carries the version the selection read,
+// and a task somebody else finished first answers version skew and is
+// SKIPPED. Without it the loser writes is_done = true over a row that
+// already says so, and the task's history shows two identical completions of
+// the same thing.
 //
 // The count is what THIS call completed, which is also why skew is not an
 // error: another firing completing the task is the outcome this one wanted.
@@ -271,40 +305,38 @@ func (w followUpAutoResolve) linkedLeads(ctx context.Context, activityID ids.Act
 // answers a COUNT rather than rows, so nothing about which records exist
 // leaves a call that takes no read gate of its own; each completion's
 // write is gated inside UpdateActivity.
-func (s *Store) CompleteOpenSystemTasksForLead(ctx context.Context, leadID ids.LeadID) (int, error) {
-	return s.completeOpenSystemTasksLinkedBy(ctx, "lead_id", leadID.UUID)
-}
-
-// CompleteOpenSystemTasksForPerson is CompleteOpenSystemTasksForLead's
-// sibling for a lead that PROMOTED: carryLeadActivities (people/promote.go)
-// re-points a follow-up task's link from the lead onto the person it became,
-// in the same transaction that emits lead.promoted, so a lead id can no
-// longer find it — only the person id it was carried to can.
-func (s *Store) CompleteOpenSystemTasksForPerson(ctx context.Context, personID ids.PersonID) (int, error) {
-	return s.completeOpenSystemTasksLinkedBy(ctx, "person_id", personID.UUID)
-}
-
-// completeOpenSystemTasksLinkedBy is the query and completion loop both
-// callers above share, differing only in which activity_link column names the
-// subject. `column` is unexported and passed only by the two callers above,
-// each a compile-time literal ("lead_id" / "person_id") — never a value off a
+//
+// `column` is unexported and passed only by the two callers above, each a
+// compile-time literal ("lead_id" / "person_id") — never a value off a
 // request body. Its placeholder is spelled right here, beside the argument
 // that fills it, rather than split across a call boundary.
-func (s *Store) completeOpenSystemTasksLinkedBy(ctx context.Context, column string, linkValue ids.UUID) (int, error) {
+//
+// `before`, when non-nil, adds the created_at bound
+// CompleteOpenSystemTasksForPerson needs; nil (CompleteOpenSystemTasksForLead's
+// own call) asks the original, unbounded question — a lead's own follow-up
+// cannot be confused with a sibling automation's task the way a shared
+// person id can.
+func (s *Store) completeOpenSystemTasksLinkedBy(ctx context.Context, column string, linkValue ids.UUID, before *time.Time) (int, error) {
 	type openTask struct {
 		id      ids.ActivityID
 		version int64
 	}
 	var open []openTask
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, storekit.SQLf(`
+		query := storekit.SQLf(`
 			SELECT a.id, a.version FROM activity a
 			JOIN activity_link l ON l.activity_id = a.id
 			WHERE l.%s = $1 AND a.kind = $2 AND a.source = $3
 			  AND (a.captured_by = $4 OR a.captured_by LIKE $5)
-			  AND a.is_done = false AND a.archived_at IS NULL
-			ORDER BY a.id`, column), linkValue, string(crmcontracts.ActivityKindTask), systemSource,
-			systemCapturedBy, systemCapturedByPattern)
+			  AND a.is_done = false AND a.archived_at IS NULL`, column)
+		args := []any{linkValue, string(crmcontracts.ActivityKindTask), systemSource,
+			systemCapturedBy, systemCapturedByPattern}
+		if before != nil {
+			query += " AND a.created_at <= $6"
+			args = append(args, *before)
+		}
+		query += " ORDER BY a.id"
+		rows, err := tx.Query(ctx, query, args...)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -329,8 +329,10 @@ func (s *Store) completeOpenSystemTasksLinkedBy(ctx context.Context, column stri
 			WHERE l.%s = $1 AND a.kind = $2 AND a.source = $3
 			  AND (a.captured_by = $4 OR a.captured_by LIKE $5)
 			  AND a.is_done = false AND a.archived_at IS NULL`, column)
-		args := []any{linkValue, string(crmcontracts.ActivityKindTask), systemSource,
-			systemCapturedBy, systemCapturedByPattern}
+		args := []any{
+			linkValue, string(crmcontracts.ActivityKindTask), systemSource,
+			systemCapturedBy, systemCapturedByPattern,
+		}
 		if before != nil {
 			query += " AND a.created_at <= $6"
 			args = append(args, *before)

--- a/backend/internal/modules/activities/followupresolve.go
+++ b/backend/internal/modules/activities/followupresolve.go
@@ -323,19 +323,19 @@ func (s *Store) completeOpenSystemTasksLinkedBy(ctx context.Context, column stri
 	}
 	var open []openTask
 	err := s.tx(ctx, func(tx pgx.Tx) error {
+		args := []any{
+			linkValue, string(crmcontracts.ActivityKindTask), systemSource,
+			systemCapturedBy, systemCapturedByPattern,
+		}
+		arg := func(v any) int { args = append(args, v); return len(args) }
 		query := storekit.SQLf(`
 			SELECT a.id, a.version FROM activity a
 			JOIN activity_link l ON l.activity_id = a.id
 			WHERE l.%s = $1 AND a.kind = $2 AND a.source = $3
 			  AND (a.captured_by = $4 OR a.captured_by LIKE $5)
 			  AND a.is_done = false AND a.archived_at IS NULL`, column)
-		args := []any{
-			linkValue, string(crmcontracts.ActivityKindTask), systemSource,
-			systemCapturedBy, systemCapturedByPattern,
-		}
 		if before != nil {
-			query += " AND a.created_at <= $6"
-			args = append(args, *before)
+			query += storekit.SQLf(" AND a.created_at <= $%d", arg(*before))
 		}
 		query += " ORDER BY a.id"
 		rows, err := tx.Query(ctx, query, args...)

--- a/backend/internal/modules/activities/followupresolve_integration_test.go
+++ b/backend/internal/modules/activities/followupresolve_integration_test.go
@@ -114,10 +114,18 @@ func (e *resolveEnv) seedPerson(t *testing.T) ids.UUID {
 // the lead id finds nothing.
 func (e *resolveEnv) seedTaskLinkedToPerson(t *testing.T, source, capturedBy string, person ids.UUID) ids.UUID {
 	t.Helper()
+	return e.seedTaskLinkedToPersonAt(t, source, capturedBy, person, time.Now())
+}
+
+// seedTaskLinkedToPersonAt is seedTaskLinkedToPerson with an explicit
+// created_at, for proving the resolver bounds its completion to tasks that
+// existed by a given instant rather than every open task it can find.
+func (e *resolveEnv) seedTaskLinkedToPersonAt(t *testing.T, source, capturedBy string, person ids.UUID, createdAt time.Time) ids.UUID {
+	t.Helper()
 	id := ids.NewV7()
-	e.exec(t, `INSERT INTO activity (id, kind, subject, occurred_at, due_at, source, captured_by)
-		VALUES ($1, 'task', 'Follow up with the new lead', now(), now() + interval '1 day', $2, $3)`,
-		id, source, capturedBy)
+	e.exec(t, `INSERT INTO activity (id, kind, subject, occurred_at, due_at, source, captured_by, created_at)
+		VALUES ($1, 'task', 'Follow up with the new lead', now(), now() + interval '1 day', $2, $3, $4)`,
+		id, source, capturedBy, createdAt)
 	e.exec(t, `INSERT INTO activity_link (activity_id, entity_type, person_id) VALUES ($1, 'person', $2)`, id, person)
 	return id
 }
@@ -126,7 +134,11 @@ func (e *resolveEnv) seedTaskLinkedToPerson(t *testing.T, source, capturedBy str
 // names the person the lead became, which is the only place, once
 // carryLeadActivities has run, that a caller can still learn where the lead's
 // tasks went. dedupeOutcome is "created" for a fresh person, "merged" for an
-// existing survivor — see promotedPersonID's doc for why the resolver reads it.
+// existing survivor — see decodeLeadPromoted's doc for why the resolver reads
+// it. OccurredAt is real "now", not a fixed date: the resolver bounds its
+// person-keyed completion to tasks that existed by this instant, and a
+// fixture date fixed in the past would exclude every task this same test run
+// just seeded.
 func leadPromotedEvent(t *testing.T, lead, person ids.UUID, dedupeOutcome string) workflow.Event {
 	t.Helper()
 	payload, err := json.Marshal(map[string]string{
@@ -138,7 +150,7 @@ func leadPromotedEvent(t *testing.T, lead, person ids.UUID, dedupeOutcome string
 	return workflow.Event{
 		ID:         ids.NewV7(),
 		Type:       "lead.promoted",
-		OccurredAt: time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC),
+		OccurredAt: time.Now(),
 		Entity:     datasource.EntityRef{Type: "lead", ID: lead},
 		Payload:    payload,
 	}
@@ -335,6 +347,36 @@ func TestAMergedPromotionDoesNotClaimThePersonsUnrelatedTasks(t *testing.T) {
 
 	if e.isDone(t, unrelatedReminder) {
 		t.Error("a merge completed a person's pre-existing system reminder that this promotion never touched")
+	}
+}
+
+// A person created by THIS promotion is not immune to the same collision:
+// the resolver runs off the outbox, asynchronously, and anything that mints
+// a system task against the freshly-created person in the window between the
+// promotion committing and this handler actually running — no_activity_reminder,
+// check_in_cadence — is not the follow-up this promotion carried. Bounding
+// completion to tasks that existed by the event's own OccurredAt is what
+// keeps "a fresh person cannot yet carry anything else" true instead of
+// merely assumed.
+func TestAPromotedLeadDoesNotCompleteATaskMintedAfterThePromotionEvent(t *testing.T) {
+	e := setupResolve(t)
+	store := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
+	person := e.seedPerson(t)
+	carried := e.seedTaskLinkedToPerson(t, "system", "system", person)
+
+	ctx := e.systemCtx()
+	h := handlerFor(t, store, "lead.promoted")
+	ev := leadPromotedEvent(t, e.lead, person, "created")
+	// A task minted a second AFTER the promotion's own instant — the exact
+	// shape of a sibling automation catching up before this handler runs.
+	lateTask := e.seedTaskLinkedToPersonAt(t, "system", "system", person, ev.OccurredAt.Add(time.Second))
+	fire(ctx, t, h, ev)
+
+	if !e.isDone(t, carried) {
+		t.Error("the task actually carried by the promotion is still open")
+	}
+	if e.isDone(t, lateTask) {
+		t.Error("a task minted AFTER the promotion event was completed as if the promotion carried it")
 	}
 }
 

--- a/backend/internal/modules/deals/closedatesweep.go
+++ b/backend/internal/modules/deals/closedatesweep.go
@@ -153,9 +153,9 @@ func (c *CloseDateCorrector) sweepWorkspace(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	loc, err := time.LoadLocation(tzName)
+	loc, err := installationZone(tzName)
 	if err != nil {
-		return fmt.Errorf("the installation's timezone %q: %w", tzName, err)
+		return err
 	}
 
 	velocities := map[ids.PipelineID]float64{}

--- a/backend/internal/modules/deals/dealfigures.go
+++ b/backend/internal/modules/deals/dealfigures.go
@@ -128,17 +128,17 @@ func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]D
 			len(dealIDs), figuresScanCap)
 	}
 	err := s.Tx(ctx, func(tx pgx.Tx) error {
-		// The installation's zone, read the same way installationToday and the
-		// nightly corrector read it — CloseIsOverdue below is what actually
-		// answers "is this deal overdue", asked once per row rather than
-		// re-spelled in SQL.
+		// The installation's zone, read the same way the nightly corrector
+		// reads it (closedatesweep.go) — CloseIsOverdue below is what
+		// actually answers "is this deal overdue", asked once per row
+		// rather than re-spelled in SQL.
 		tzName, err := s.installation.Timezone(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("read the installation's timezone: %w", err)
 		}
-		loc, err := time.LoadLocation(tzName)
+		loc, err := installationZone(tzName)
 		if err != nil {
-			return fmt.Errorf("the installation's timezone %q: %w", tzName, err)
+			return err
 		}
 		args := []any{}
 		arg := func(v any) int { args = append(args, v); return len(args) }
@@ -197,4 +197,18 @@ func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]D
 		return nil, fmt.Errorf("deals: reading the figures behind a page of deals: %w", err)
 	}
 	return out, nil
+}
+
+// installationZone turns the raw IANA zone name installation.Timezone
+// answers into a *time.Location, for a caller that compares a wall-clock
+// instant to a DATE column in Go rather than asking Postgres to
+// (closedatesweep.go's nightly pass, this file's batched overdue read).
+// Split from the Timezone fetch itself: closedatesweep.go still needs the
+// raw name on its own, to bind into the same transaction's pre-filter query.
+func installationZone(tzName string) (*time.Location, error) {
+	loc, err := time.LoadLocation(tzName)
+	if err != nil {
+		return nil, fmt.Errorf("the installation's timezone %q: %w", tzName, err)
+	}
+	return loc, nil
 }

--- a/backend/internal/modules/deals/dealfigures.go
+++ b/backend/internal/modules/deals/dealfigures.go
@@ -92,14 +92,9 @@ type DealFigures struct {
 	AmountMinor       *int64
 	Currency          string
 	ExpectedCloseDate *time.Time
-	// CloseOverdue is the SAME calendar-date, workspace-zone verdict
-	// CloseIsOverdue gives elsewhere (closedatesweep.go, slipping.go): the
-	// close date's own calendar day is before today's, in the installation's
-	// zone. Computed in SQL rather than by calling CloseIsOverdue in Go — this
-	// read already opens one transaction, and `timezone($1, now())::date` asks
-	// Postgres the identical question without a second round trip to resolve
-	// the zone through identity.TimezoneOf and a fresh Go-side comparison.
-	// Meaningless where ExpectedCloseDate is nil.
+	// CloseOverdue is CloseIsOverdue's own verdict for this deal — the ONE
+	// place that comparison is made (closedate.go), called here rather than
+	// re-spelled. Meaningless where ExpectedCloseDate is nil.
 	CloseOverdue bool
 }
 
@@ -133,31 +128,29 @@ func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]D
 			len(dealIDs), figuresScanCap)
 	}
 	err := s.Tx(ctx, func(tx pgx.Tx) error {
-		// The SAME question CloseIsOverdue asks elsewhere (closedatesweep.go,
-		// slipping.go), asked in SQL instead of resolved through a second
-		// transaction: this read is already inside one, and `timezone($1,
-		// now())::date` is Postgres's own answer to "what is today, in this
-		// zone" — the identical rule the at-risk lane's identical deal is
-		// judged by, so this read's caller states the same overdue verdict
-		// for both rows of one deal.
+		// The installation's zone, read the same way installationToday and the
+		// nightly corrector read it — CloseIsOverdue below is what actually
+		// answers "is this deal overdue", asked once per row rather than
+		// re-spelled in SQL.
 		tzName, err := s.installation.Timezone(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("read the installation's timezone: %w", err)
 		}
+		loc, err := time.LoadLocation(tzName)
+		if err != nil {
+			return fmt.Errorf("the installation's timezone %q: %w", tzName, err)
+		}
 		args := []any{}
 		arg := func(v any) int { args = append(args, v); return len(args) }
-		tzPos := arg(tzName)
 		idsPos := arg(dealIDs)
 		scope, err := auth.ScopeClauseFor(ctx, dealTable, "d", arg)
 		if err != nil {
 			return err
 		}
 		query := storekit.SQLf(
-			`SELECT d.id, d.stage_id, d.owner_id, d.amount_minor, d.currency, d.expected_close_date,
-			        d.expected_close_date IS NOT NULL
-			          AND d.expected_close_date < (timezone($%d, now()))::date
+			`SELECT d.id, d.stage_id, d.owner_id, d.amount_minor, d.currency, d.expected_close_date
 			   FROM deal d
-			  WHERE d.id = ANY($%d) AND d.archived_at IS NULL`, tzPos, idsPos)
+			  WHERE d.id = ANY($%d) AND d.archived_at IS NULL`, idsPos)
 		if scope != "" {
 			query += storekit.SQLf(" AND %s", scope)
 		}
@@ -166,20 +159,23 @@ func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]D
 			return err
 		}
 		defer rows.Close()
+		now := s.clock()
 		for rows.Next() {
 			var (
-				id      ids.UUID
-				stage   *ids.UUID
-				owner   *ids.UUID
-				amount  *int64
-				code    *string
-				closes  *time.Time
-				overdue bool
+				id     ids.UUID
+				stage  *ids.UUID
+				owner  *ids.UUID
+				amount *int64
+				code   *string
+				closes *time.Time
 			)
-			if err := rows.Scan(&id, &stage, &owner, &amount, &code, &closes, &overdue); err != nil {
+			if err := rows.Scan(&id, &stage, &owner, &amount, &code, &closes); err != nil {
 				return err
 			}
-			figures := DealFigures{AmountMinor: amount, ExpectedCloseDate: closes, CloseOverdue: overdue}
+			figures := DealFigures{AmountMinor: amount, ExpectedCloseDate: closes}
+			if closes != nil {
+				figures.CloseOverdue = CloseIsOverdue(*closes, now, loc)
+			}
 			if stage != nil {
 				figures.StageID = *stage
 			}

--- a/backend/internal/modules/deals/dealfigures.go
+++ b/backend/internal/modules/deals/dealfigures.go
@@ -150,7 +150,8 @@ func (s *Store) Figures(ctx context.Context, dealIDs []ids.UUID) (map[ids.UUID]D
 		query := storekit.SQLf(
 			`SELECT d.id, d.stage_id, d.owner_id, d.amount_minor, d.currency, d.expected_close_date
 			   FROM deal d
-			  WHERE d.id = ANY($%d) AND d.archived_at IS NULL`, idsPos)
+			  WHERE d.id = ANY($%d) AND d.archived_at IS NULL`, idsPos,
+		)
 		if scope != "" {
 			query += storekit.SQLf(" AND %s", scope)
 		}

--- a/backend/internal/platform/netguard/publicorigin.go
+++ b/backend/internal/platform/netguard/publicorigin.go
@@ -53,13 +53,15 @@ var ErrOriginNotPublic = errors.New("public origin is not reachable by a recipie
 //
 // The development/test exemption is checked BEFORE bareOrigin for an UNSET
 // value specifically: a caller that never wired an origin at all is not a
-// broken configuration under a posture that needs no real link to work. A
-// NON-empty value still goes through the full shape check in every posture
-// — only genuine absence is exempt, so a real but malformed origin is still
-// caught.
+// broken configuration under a posture that needs no real link to work. Any
+// OTHER value — whitespace included — still goes through the full shape
+// check in every posture: exact emptiness is the only claim this exemption
+// makes, because the sending caller's own "is this configured" check
+// compares untrimmed, and a value that reads as configured there must not
+// read as unset here.
 func RequirePublicOrigin(label, raw string, env runtimeenv.Environment) error {
 	devOrTest := env == runtimeenv.Development || env == runtimeenv.Test
-	if devOrTest && strings.TrimSpace(raw) == "" {
+	if devOrTest && raw == "" {
 		return nil
 	}
 	parsed, err := bareOrigin(label, raw)

--- a/backend/internal/platform/netguard/publicorigin_test.go
+++ b/backend/internal/platform/netguard/publicorigin_test.go
@@ -111,6 +111,19 @@ func TestAMalformedOriginInDevelopmentIsStillRefused(t *testing.T) {
 	}
 }
 
+// A whitespace-only value is not the same claim as an unset one: the sending
+// caller's own "is this configured" check (footerlanguage.go) compares
+// untrimmed, so a value of "   " reads as CONFIGURED there while meaning
+// nothing — admitting it here as if it were genuinely absent would let both
+// gates agree to send a tokenized link built from whitespace. Only the exact
+// empty string is exempt; anything else, whitespace included, goes through
+// bareOrigin's own shape check like every other non-empty value.
+func TestAWhitespaceOnlyOriginInDevelopmentIsStillRefused(t *testing.T) {
+	if err := RequirePublicOrigin("--public-base-url", "   ", runtimeenv.Development); err == nil {
+		t.Error("posture Development admitted a whitespace-only origin as if it were unset")
+	}
+}
+
 // Every one of these was admitted by a first version of this guard that
 // delegated shape validation to a caller which does not always run.
 func TestAMalformedOriginIsRefusedBySendersOwnGuard(t *testing.T) {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28882,11 +28882,11 @@ export interface components {
         /**
          * @description The deal behind an item, with the facts its card states. `expected_minor_base` is
          *     `amount_minor` converted to the installation's base currency — the only figure by
-         *     which two deals in different currencies may be compared. It does not yet weight by
-         *     `win_probability`: the pipeline this row comes from does not read a deal's stage
-         *     today, so the two fields are independent facts rather than one computed from the
-         *     other, and a reader must not multiply them together expecting the product to equal
-         *     a risk-adjusted figure the API does not compute.
+         *     which two deals in different currencies may be compared. It is not weighted by
+         *     `win_probability`: the pipeline this row comes from does not read a deal's stage,
+         *     so the two fields are independent facts rather than one computed from the other,
+         *     and a reader must not multiply them together expecting the product to equal a
+         *     risk-adjusted figure the API does not compute.
          */
         WorklistDealFacts: {
             /** Format: uuid */


### PR DESCRIPTION
## Summary

PR #3844 (QC Wave 3) auto-merged before the required `craft-reviewer` and `security-redteam` end-of-work agents finished reviewing it (both were still running when GitHub's own required checks all went green). This PR applies their confirmed findings, plus one duplicate-fix cleanup discovered while investigating the merged state.

**craft-reviewer findings applied:**
- `deals.Store.Figures` no longer re-spells `CloseIsOverdue`'s own comparison in SQL. `closedate.go` says plainly it is the ONE place that comparison is made; the SQL boolean was a second, silent copy of it that could drift from the original. `Figures` now fetches candidate rows and calls `CloseIsOverdue` in Go — the same shape `closedatesweep.go` already uses.
- `classifyRisk`'s `ExpectedMinorBase` guard now also requires a named base currency (`money.base != ""`), matching the sibling guard `dayMoney.value` already holds for the identical inconsistent-FX-seam edge case.
- Dangling test cross-reference fixed (`promotedPersonID` → `decodeLeadPromoted`, renamed in the original PR).
- The clock inconsistency between the two "close date overdue" integration tests is resolved — both now seed from Go's own clock, matching what the redesigned `Figures` implementation actually compares against.
- Trigger literals named consistently (`activityCapturedTrigger`, `leadPromotedTrigger`, `leadDisqualifiedTrigger`).
- The shared completion helper's behavioral doc moved off `CompleteOpenSystemTasksForLead` onto `completeOpenSystemTasksLinkedBy`, so the new `CompleteOpenSystemTasksForPerson` doesn't read with none of it.
- `WorklistDealFacts.expected_minor_base`'s contract description no longer promises a `win_probability` weighting nothing in this pipeline computes (confirmed: `win_probability` is itself never populated anywhere in `compose/attention`).

**security-redteam findings applied:**
- `RequirePublicOrigin`'s development/test exemption is now exact-empty (`raw == ""`) rather than trimmed-empty. A whitespace-only value reads as "configured" by the sending caller's own check (`footerlanguage.go`, untrimmed) — admitting it here as "unset" would have let both gates agree to send a tokenized link built from whitespace.
- `CompleteOpenSystemTasksForPerson` (margince#3764's fix) now bounds its completion to tasks that existed by the triggering event's own `OccurredAt`. The handler runs asynchronously off the outbox, so "a fresh person cannot yet carry anything else" was only true at the instant of promotion — a sibling automation (`no_activity_reminder`, `check_in_cadence`) could anchor its own system task on the same freshly-created person before this handler actually runs, and the unbounded query would have completed that task too, with an audit row claiming a follow-up that never happened.

**Duplicate-fix cleanup (discovered independently, not one of the two reviews' findings):**
- PR #3834 landed a fix for margince#3800 (a briefing entry whose deal cannot be resolved) at a better layer — `attentionBriefing.Queue`, covering both `/attention` and `/worklist` — while PR #3844 was still in flight on the same commit range. Both merged. `nameTheMoney`'s narrower, worklist-only drop logic from #3844 is now removed; #3834's fix is the sole owner of this invariant, which is exactly the two-answers-to-one-question drift AGENTS.md's reuse principles warn about.

## Deliberately not fixed

- `dedupe_outcome` (the `lead.promoted` event field the merged-vs-created gate reads) stays a bare string rather than becoming a typed OpenAPI enum. `public-events.yaml` has a DOCUMENTED house rule against inline enums for exactly this reason: the generator emits package-scope Go constants named after the enum values, which can collide with another schema's same-named values. "created"/"merged" are generic enough that verifying no collision exists needs more care than this follow-up's scope; tracked as the lowest-severity finding, not blocking.
- The merged-promotion sub-case of margince#3764 (still open, filed as margince#3843) is unchanged — the craft-reviewer's suggestion to "open a labelled issue and cite it here" was not applied verbatim: this codebase has zero existing `// TODO` comments citing issues, and the code already states the gap as a plain, test-backed fact rather than rationalizing it, which is what AGENTS.md's own rule asks for.

## Test plan

- [x] `make check` — full local gate, green.
- [x] `craft static --strict` (diff-scoped) — 0 blocker/major/minor.
- [x] `make test-it DIR=backend/internal/modules/activities` and `DIR=backend/internal/compose/integration RUN=TestDealFigures` — real-Postgres integration lanes, green, including the new `TestAPromotedLeadDoesNotCompleteATaskMintedAfterThePromotionEvent` regression guard.
- [x] Confirmed the `internal/compose` package's unrelated overlay/HubSpot test failures when run standalone are a pre-existing test-harness env gap (`MARGINCE_TEST_REDIS not set`), not a regression from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzkBShFNemkBKN3h5faNxf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the confirmed review fixes from QC Wave 3 and removes overlapping deal-resolution logic to prevent incorrect task completion, overdue status, and currency-risk values.

**Bug Fixes**
- Person-linked follow-up completion now excludes system tasks created after the promotion event.
- Whitespace-only public origins are rejected in development and test environments.
- FX conversions without a named base currency no longer set `expected_minor_base` or a materiality verdict.

**Refactors**
- `deals.Store.Figures` now uses the shared `CloseIsOverdue` comparison with the installation timezone instead of duplicating it in SQL.
- Unresolved deal rows remain unchanged in `nameTheMoney`; the briefing queue owns filtering them.
- Regenerated API schemas and stabilized close-date integration tests against clock and session-timezone boundaries.

<sup>Written for commit c39d98bb2f13bdc0ea8ae2baa54a85d9dc5f81ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added analytics schema, query, and explanation endpoints for human-only analytics.
  - Added communication evidence and contextual metadata to email workflows.
  - Added relationship facts and assignee ownership details to attention items.

- **Bug Fixes**
  - Deal figures now avoid displaying converted values without a known base currency.
  - Unresolved deals remain visible without incomplete figures.
  - Follow-up tasks respect promotion-event timing.
  - Close-date overdue status respects the installation timezone.
  - Whitespace-only origins are validated instead of treated as unset.

- **Documentation**
  - Clarified expected minor base values are not weighted by win probability.
  - Clarified worklist totals and category counts cover the full candidate population.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->