### PR TITLE
docs(gates): bump the census count to match the added staging-decision gate

### DIFF
--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -86,7 +86,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (87)
+## Census (88)
 
 | Gate | Hardness | What it holds |
 |---|---|---|


### PR DESCRIPTION
## Summary
`docs/reference/gate-inventory.md`'s "Census (87)" header was left stale by #3913, which added a new row (`stagingdecision_test.go`) but did not bump the section count to 88. `TestTheGateInventoryPageIsCurrent` (backend/gates) fails on any PR merged against current `main` as a result — confirmed this is blocking the `extension-reference` and `deterministic-gates` checks on an unrelated PR (#3921) of mine.

## Fix
Ran `go test ./gates -run GateInventory -update-gate-inventory` and committed the resulting one-line diff.

## Test plan
- [x] `go test ./gates -run TestTheGateInventoryPageIsCurrent` passes locally against this branch merged onto `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzkBShFNemkBKN3h5faNxf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the gate inventory census count from 87 to 88 so `docs/reference/gate-inventory.md` matches the staging-decision gate that was added without updating the count. This fixes `TestTheGateInventoryPageIsCurrent`, which was failing on `main` and blocking unrelated PRs.

<sup>Written for commit c1346e930a56274b1430f2c43cb64877672fdcad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Census reference to reflect the correct number of sections: 88 instead of 87.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->