### PR TITLE
The week says it is settled, and when it was written

### DIFF
--- a/frontend/src/format/zone-by-purpose.test.ts
+++ b/frontend/src/format/zone-by-purpose.test.ts
@@ -148,6 +148,10 @@ function code(path: string, source: string): string {
 // output moved with the machine it ran on would assert nothing.
 const pinnedZones: { file: string; why: string }[] = [
   {
+    file: "screens/home.weekly.test.tsx",
+    why: "The case asserts that the weekly's 'written at' renders in the INSTALLATION's zone, so it provides one through RecordZoneProvider and formats its expectation against the same name. The alternative is naming FALLBACK_RECORD_ZONE, which the arm below forbids and rightly: the component reads that same constant, so the assertion would hold however wrong the zone decision was.",
+  },
+  {
     file: "screens/analytics.forecast.test.tsx",
     why: "The stubbed readings carry the installation zone the SERVER sends — the frame is the server's answer, not the reader's setting. A zone read off the runner would make the fixture describe whichever machine ran it.",
   },

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2507,6 +2507,8 @@ export const de = {
   "plan.new.save": "Hinzufügen",
   "plan.new.cancel": "Abbrechen",
 
+  "home.weekly.frozen": "Eingefroren",
+  "home.weekly.written": "geschrieben {at}",
   "home.weekly.pickWeek": "Andere Woche öffnen",
   "home.weekly.none":
     "Noch kein Wochenrückblick — der erste wird am Montag nach deiner ersten vollen Woche geschrieben.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2556,6 +2556,8 @@ export const en = {
   "plan.new.save": "Add",
   "plan.new.cancel": "Cancel",
 
+  "home.weekly.frozen": "Frozen",
+  "home.weekly.written": "written {at}",
   "home.weekly.pickWeek": "Open another week",
   "home.weekly.none":
     "No weekly review yet — the first one is written on the Monday after your first full week.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2483,6 +2483,8 @@ export const vi = {
   "plan.new.save": "Thêm",
   "plan.new.cancel": "Huỷ",
 
+  "home.weekly.frozen": "Đã chốt",
+  "home.weekly.written": "ghi lúc {at}",
   "home.weekly.pickWeek": "Mở tuần khác",
   "home.weekly.none":
     "Chưa có bản đánh giá tuần — bản đầu tiên được viết vào thứ Hai sau tuần đầy đủ đầu tiên của bạn.",

--- a/frontend/src/screens/home.weekly.css
+++ b/frontend/src/screens/home.weekly.css
@@ -89,3 +89,22 @@
   margin: 0;
   font-variant-numeric: tabular-nums;
 }
+
+/* The panel head's far end: the frozen mark, when it was written, and the way
+   to another week — on ONE line, because they are one statement about which
+   week this is and how settled it is. Without the row they stack under each
+   other and push the header to three times its height, which is the shape the
+   band's measured height was never drawn for. */
+.home-weekly-mark {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+/* Quieter than the badge beside it: the badge is the claim, this is its
+   footnote, and a reader who wants the moment goes looking for it. */
+.home-weekly-written {
+  color: var(--textMeta);
+}

--- a/frontend/src/screens/home.weekly.test.tsx
+++ b/frontend/src/screens/home.weekly.test.tsx
@@ -1,6 +1,8 @@
 /** @vitest-environment jsdom */
 import { cleanup, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RecordZoneProvider } from "../app/recordzone";
+import { formatDateTime } from "../format/format";
 import { en } from "../i18n/en";
 import { HomeScreen } from "./home";
 import { fleetDeal, jsonResponse, render, run, stubApi } from "./home.testkit";
@@ -126,6 +128,57 @@ describe("HomeScreen — the weekly retrospective", () => {
     const strip = document.querySelector('[data-testid="weekly-strip"]');
     expect(strip).not.toBeNull();
     expect(strip?.textContent ?? "").not.toMatch(/€|EUR/);
+  });
+
+  // The panel says its numbers can no longer move.
+  //
+  // That claim is what separates the weekly from every other panel on Home. A
+  // rep who reads it on Tuesday, acts, and re-reads on Thursday is looking at a
+  // record rather than a stale figure — and without the mark they have no way
+  // to tell those apart. The TEAM weekly has said so since it shipped; the
+  // rep's, which is the one a rep actually opens, did not.
+  it("marks the week frozen, and says when it was written", async () => {
+    stubApi({
+      "GET /weekly-reviews/latest": () => jsonResponse(review),
+      "GET /weekly-reviews": () => jsonResponse({ weeks: ["2026-06-29"] }),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    // A zone the TEST chooses, and not the product's fallback.
+    //
+    // The fallback is importable by its own reader alone (held by
+    // format/zone-by-purpose.test.ts), and rightly: a test asserting against it
+    // would be checking the component against the same constant the component
+    // reads, which passes however wrong the zone decision is. Naming one here
+    // means the assertion fails if the panel ever renders in the viewer's zone
+    // instead of the installation's.
+    const installationZone = "Asia/Ho_Chi_Minh";
+    render(
+      <RecordZoneProvider zone={installationZone}>
+        <HomeScreen />
+      </RecordZoneProvider>,
+    );
+
+    expect(await screen.findByText(en["home.weekly.frozen"])).toBeTruthy();
+    const written = en["home.weekly.written"].replace(
+      "{at}",
+      formatDateTime(review.generated_at, "en", installationZone),
+    );
+    expect(screen.getByText(written)).toBeTruthy();
+  });
+
+  // And nothing is certified when there is no review to certify. A badge over
+  // an absent week claims a record nobody wrote.
+  it("marks nothing frozen when there is no review", async () => {
+    stubApi({
+      "GET /weekly-reviews/latest": () =>
+        jsonResponse({ title: "Not Found" }, 404),
+      "GET /weekly-reviews": () => jsonResponse({ weeks: [] }),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    render(<HomeScreen />);
+
+    await screen.findByText(en["home.weekly.none"]);
+    expect(screen.queryByText(en["home.weekly.frozen"])).toBeNull();
   });
 
   it("says there is no review yet rather than drawing a week of zeroes", async () => {

--- a/frontend/src/screens/home.weekly.tsx
+++ b/frontend/src/screens/home.weekly.tsx
@@ -3,7 +3,7 @@
 
 import { useState } from "react";
 import { useRecordZone } from "../app/recordzone";
-import { StatCard } from "../design-system/atoms";
+import { Badge, StatCard } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { Select } from "../design-system/select";
 import { StatStrip } from "../design-system/statstrip";
@@ -11,6 +11,7 @@ import { type SectionState, SurfaceState } from "../design-system/surfacestate";
 import { ProvenanceTag } from "../design-system/trust";
 import {
   formatDate,
+  formatDateTime,
   formatMoney,
   formatNumber,
   formatSignedNumber,
@@ -66,18 +67,48 @@ export function WeeklySection() {
               })
             : undefined
         }
+        // The mark and the way out of the week, in that order.
+        //
+        // FROZEN is the claim that separates this panel from every other on
+        // Home: the numbers under it were written when the week closed and can
+        // no longer move, so a rep who acts on Tuesday and re-reads on Thursday
+        // is not looking at a stale figure — they are looking at a record. The
+        // team weekly has said so since it shipped; the rep's, which is the one
+        // a rep actually opens, did not.
+        //
+        // Drawn only over a review that exists, so an empty or failed read does
+        // not certify a week nobody wrote.
         titleAction={
-          index.data && index.data.length > 1 ? (
-            <Select
-              aria-label={t("home.weekly.pickWeek")}
-              value={week ?? index.data[0]}
-              onChange={(next) => setWeek(next)}
-              options={index.data.map((start) => ({
-                value: start,
-                label: formatDate(start, locale, recordZone),
-              }))}
-            />
-          ) : undefined
+          <span className="home-weekly-mark">
+            {review.data && (
+              <>
+                <Badge quiet>{t("home.weekly.frozen")}</Badge>
+                {/* When it was written, which is what makes the badge a fact
+                    rather than a decoration — a reader can tell a week closed
+                    an hour ago from one closed on Monday. */}
+                <span className="t-caption home-weekly-written">
+                  {t("home.weekly.written", {
+                    at: formatDateTime(
+                      review.data.generated_at,
+                      locale,
+                      recordZone,
+                    ),
+                  })}
+                </span>
+              </>
+            )}
+            {index.data && index.data.length > 1 && (
+              <Select
+                aria-label={t("home.weekly.pickWeek")}
+                value={week ?? index.data[0]}
+                onChange={(next) => setWeek(next)}
+                options={index.data.map((start) => ({
+                  value: start,
+                  label: formatDate(start, locale, recordZone),
+                }))}
+              />
+            )}
+          </span>
         }
       >
         <PanelBody>


### PR DESCRIPTION
The weekly panel drew its numbers with nothing to say they can no longer move. That claim is what separates it from every other panel on Home: a rep who reads it on Tuesday, acts, and re-reads on Thursday is looking at a **record** rather than a stale figure — and without the mark they cannot tell those apart.

The **team** weekly has said so since it shipped. The rep's — the one a rep actually opens — did not.

`WeeklyReview.generated_at` is served, typed, and was read by no screen. It sits beside the badge, because "written 06-07 08:00" is what makes *Frozen* a fact rather than a decoration: a reader can tell a week closed an hour ago from one closed on Monday.

Nothing is marked when there is no review — a badge over an absent week certifies a record nobody wrote. Both directions mutation-checked.

### Two gates shaped the test, and both were right

**`FALLBACK_RECORD_ZONE` is importable by its own reader alone.** My first version imported it to build the expected string. That checks the component against the same constant the component reads, so it passes however wrong the zone decision is. The case provides a zone through `RecordZoneProvider` instead — so it now fails if the panel ever renders in the **viewer's** zone rather than the installation's, which the first version could not have caught.

**Naming a zone in a screen test is itself a finding** unless the file earns an entry in `zone-by-purpose`'s `pinnedZones` with a reason. It has one, and the reason says why the alternative is worse.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Frozen" badge and "written at" timestamp to the weekly review panel so reps can tell the numbers are settled and when they were recorded. The mark only appears when a review exists, so an empty state doesn't certify a week that wasn't written.

<sup>Written for commit 0da3dcad87e6c6c516a081162dd617e88c69f184. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly reviews now show a **FROZEN** status and the time they were generated.
  * Deal cards display the stored pipeline value and currency when available, with a prior-week comparison as fallback.
  * Added German, English, and Vietnamese translations for weekly review status and timestamps.
  * Improved weekly panel header layout and timestamp styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->