### PR TITLE
A meeting filed under a record stops being held to its attendees

### DIFF
--- a/backend/internal/compose/captureensurer.go
+++ b/backend/internal/compose/captureensurer.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -37,8 +38,14 @@ func newCounterpartyStore(pool *pgxpool.Pool) *people.Store {
 	// that holds a job runner. A site read's accepted fields land through the
 	// approval effect's store, so without it the lane's main trigger queued
 	// nothing — see BindVatChecking.
+	// The audience derivation rides here for a reason of the same shape: the
+	// cohort repair FILES a captured meeting under the person it has just
+	// resolved, and a meeting the capture limiter held for having no record is
+	// no longer that record-less thing once it does. activities owns the
+	// derivation, people may not import it, so compose hands it over.
 	return people.NewStore(InstallationDB(pool)).
 		WithConsumerMail(capture.MatcherTx).
+		WithAudienceRecompute(activities.RecomputeAudienceTx).
 		WithVatCheckEnqueue(boundVatCheckEnqueue())
 }
 

--- a/backend/internal/compose/cohortpromotegen.go
+++ b/backend/internal/compose/cohortpromotegen.go
@@ -44,6 +44,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/shared/kernel/events"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -60,7 +61,16 @@ type CohortPromoteGen struct {
 
 // NewCohortPromoteGen builds the repair consumer over the people store.
 func NewCohortPromoteGen(pool *pgxpool.Pool, store *people.Store, log *slog.Logger) *CohortPromoteGen {
-	return &CohortPromoteGen{pool: pool, store: store, log: log}
+	// The audience derivation is applied HERE rather than asked of the caller.
+	// This consumer's whole job is the cohort repair, and that repair files
+	// captured meetings under the people it resolves; a caller handing over a
+	// bare store would leave every meeting it filed held to its participants
+	// forever, and nothing about the call would look wrong.
+	return &CohortPromoteGen{
+		pool:  pool,
+		store: store.WithAudienceRecompute(activities.RecomputeAudienceTx),
+		log:   log,
+	}
 }
 
 // HandleEvent routes one envelope to a repair pass. An event this consumer does

--- a/backend/internal/compose/integration/capture/gcal_meetinglink_integration_test.go
+++ b/backend/internal/compose/integration/capture/gcal_meetinglink_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/capture/gcal"
 	"github.com/margince/margince/backend/internal/modules/capture/gmail"
 	"github.com/margince/margince/backend/internal/modules/people"
@@ -187,5 +188,55 @@ func TestACapturedMeetingWithNoKnownAttendeeStaysHeld(t *testing.T) {
 	}
 	if persons != 0 {
 		t.Errorf("the capture created %d records for an unknown attendee, want 0 — an invitation is not correspondence", persons)
+	}
+}
+
+// systemRepairCtx is the context a scheduled repair runs under: the workspace,
+// a correlation id (storekit refuses to publish without one), and the system
+// principal that has no human behind it.
+func systemRepairCtx(e *integration.SearchEnv) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:test-repair",
+		Permissions: principal.Permissions{RowScope: principal.RowScopeAll},
+	})
+}
+
+// The other half of the hold: once the meeting IS filed, the reason it was held
+// has stopped being true.
+//
+// This is the ordering Chris's meeting was in — captured while nobody had a
+// record for the attendee, filed under them by the cohort repair a day later,
+// and held to its participants ever since. The invitation EMAILS beside it on
+// the same page were workspace-readable the whole time, so the meeting was the
+// one row a colleague could not see.
+func TestAMeetingFiledLaterStopsBeingHeld(t *testing.T) {
+	e := integration.SetupSearch(t)
+
+	activity := syncOneGcalMeeting(t, e)
+	if _, _, audience, reason := meetingFiling(t, e, activity); audience != "participants" ||
+		reason == nil || *reason != "no_record" {
+		t.Fatalf("the meeting was not born held: audience=%q reason=%v", audience, reason)
+	}
+
+	// The contact arrives, and the repair files the meeting under them. Through
+	// the real store, so the seam compose wires is the one under test.
+	store := people.NewStore(e.DB()).WithAudienceRecompute(activities.RecomputeAudienceTx)
+	buyer, err := store.EnsurePersonByEmail(personCreator(e), "Buyer Example", "buyer@acme.com", "manual")
+	if err != nil {
+		t.Fatalf("seeding the attendee: %v", err)
+	}
+	if _, err := store.RepairPersonCohort(systemRepairCtx(e), ids.From[ids.PersonKind](buyer)); err != nil {
+		t.Fatalf("repairing the cohort: %v", err)
+	}
+
+	linked, _, audience, reason := meetingFiling(t, e, activity)
+	if len(linked) != 1 || linked[0] != buyer {
+		t.Fatalf("the repair filed the meeting under %v, want the attendee %s", linked, buyer)
+	}
+	if audience != "workspace" || reason != nil {
+		t.Errorf("meeting audience=%q reason=%v, want workspace/nil — it is filed under a record now, "+
+			"so the hold that said it was filed under none is no longer true", audience, reason)
 	}
 }

--- a/backend/internal/compose/integration/capture/gcal_meetinglink_integration_test.go
+++ b/backend/internal/compose/integration/capture/gcal_meetinglink_integration_test.go
@@ -175,9 +175,9 @@ func TestACapturedMeetingWithNoKnownAttendeeStaysHeld(t *testing.T) {
 	if len(linked) != 0 {
 		t.Fatalf("meeting filed under %v, want nothing — no attendee has a record, and an invite does not create one", linked)
 	}
-	if audience != "participants" || reason == nil || *reason != "no_record" {
-		t.Errorf("meeting born audience=%q reason=%v, want participants/no_record — a meeting filed under nothing is still held to the people on it",
-			audience, reason)
+	if audience != "participants" || reason == nil || *reason != activities.ReasonNoCounterparty {
+		t.Errorf("meeting born audience=%q reason=%v, want participants/%s — a meeting filed under nothing is still held to the people on it",
+			audience, reason, activities.ReasonNoCounterparty)
 	}
 	var persons int
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -216,7 +216,7 @@ func TestAMeetingFiledLaterStopsBeingHeld(t *testing.T) {
 
 	activity := syncOneGcalMeeting(t, e)
 	if _, _, audience, reason := meetingFiling(t, e, activity); audience != "participants" ||
-		reason == nil || *reason != "no_record" {
+		reason == nil || *reason != activities.ReasonNoCounterparty {
 		t.Fatalf("the meeting was not born held: audience=%q reason=%v", audience, reason)
 	}
 

--- a/backend/internal/compose/integration/capture/norecordlift_integration_test.go
+++ b/backend/internal/compose/integration/capture/norecordlift_integration_test.go
@@ -71,3 +71,45 @@ func TestASuppressedSendersHoldSurvivesBeingFiled(t *testing.T) {
 			"the hold is about who sent it, and a link says nothing about that", got, reason)
 	}
 }
+
+// The reason the two holds are separate words rather than one word read two
+// ways: a MEETING can carry a judged hold too.
+//
+// The sink admits a record by its counterparty SHAPE, never by its kind
+// (capture.Sink.Upsert), so a meeting-shaped record arriving with a mail
+// counterparty reaches the same ladder mail does — the private-thread branch
+// and the suppression registry included. Such a meeting is held for a real
+// reason about a real person, and telling it apart from a structurally
+// counterparty-less one by KIND would open exactly that message the moment
+// anything filed it.
+//
+// This drives the recompute against a row stamped the way that ladder stamps
+// one, which is the state the two paths differ on.
+func TestAJudgedHoldSurvivesBeingFiledWhateverTheKind(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+
+	sync(t, email("dse@eu.docusign.net", "DocuSign EU", captureOwner, "judged-meeting@docusign.net", ""))
+	activityID := oneActivityID(t, e)
+
+	// The same row, wearing the kind a calendar connector writes. The hold on
+	// it was placed by a judgement about its sender, and that is what the
+	// reason records.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE activity SET kind = 'meeting' WHERE id = $1`, activityID)
+		return err
+	}); err != nil {
+		t.Fatalf("restating the activity as a meeting: %v", err)
+	}
+	filedUnder := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by)
+		VALUES ($1, 'Someone', 'manual', 'human:x')`)
+	fileUnder(t, e, activityID, filedUnder)
+
+	recompute(t, e, activityID)
+	got, reason := audienceOf(t, e, activityID)
+	if got != "participants" || reason != activities.ReasonNoRecord {
+		t.Fatalf("a judged hold on a meeting-kind row opened when it was filed: audience %q reason %q — "+
+			"the kind says nothing about whether somebody was judged", got, reason)
+	}
+}

--- a/backend/internal/compose/integration/capture/norecordlift_integration_test.go
+++ b/backend/internal/compose/integration/capture/norecordlift_integration_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package capture
+
+// When a `no_record` hold stops being true, and when it never does.
+//
+// The reason reads like "this row has no link", and that is not what it
+// records. The capture ladder writes it only on a TERMINAL no-record outcome:
+// a suppressed newsletter, a role mailbox, a sender a prior verdict settled, a
+// thread judged the mailbox owner's private life. Each of those is a decision
+// about the SENDER, and a link can arrive on such a row long afterwards — a
+// project attribution, a hand relink, a cohort promotion. Lifting on the mere
+// presence of a link would republish a mailbox owner's private correspondence
+// to the whole workspace.
+//
+// A MEETING reached the same ladder for no such reason. Attendance is a list,
+// so the calendar mapper leaves the counterparty unset, the gate concludes
+// "captured, named nobody", and the limiter holds a record whose only defect is
+// that nothing had filed it yet.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// fileUnder plants an activity_link the way a repair pass does, so a test can
+// ask what the recompute makes of a row that has since been filed.
+func fileUnder(t *testing.T, e *integration.SearchEnv, activity ids.UUID, person ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO activity_link (activity_id, entity_type, person_id)
+			VALUES ($1, 'person', $2) ON CONFLICT DO NOTHING`, activity, person)
+		return err
+	}); err != nil {
+		t.Fatalf("filing the activity under a person: %v", err)
+	}
+}
+
+// A suppressed sender's message is held because of WHO SENT IT. Filing it under
+// a record later says nothing about that, and must not open it.
+func TestASuppressedSendersHoldSurvivesBeingFiled(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+
+	sync(t, email("dse@eu.docusign.net", "DocuSign EU", captureOwner, "held-then-filed@docusign.net", ""))
+	activityID := oneActivityID(t, e)
+	if _, reason := audienceOf(t, e, activityID); reason != activities.ReasonNoRecord {
+		t.Fatalf("the ladder did not hold the link-less message: reason %q", reason)
+	}
+
+	// Somebody files it — a project attribution, a hand relink, a cohort pass.
+	filedUnder := e.SeedID(t, `INSERT INTO person (id, full_name, source, captured_by)
+		VALUES ($1, 'Someone', 'manual', 'human:x')`)
+	fileUnder(t, e, activityID, filedUnder)
+
+	recompute(t, e, activityID)
+	got, reason := audienceOf(t, e, activityID)
+	if got != "participants" || reason != activities.ReasonNoRecord {
+		t.Fatalf("filing a suppressed sender's mail opened it: audience %q reason %q — "+
+			"the hold is about who sent it, and a link says nothing about that", got, reason)
+	}
+}

--- a/backend/internal/compose/jobs_graph.go
+++ b/backend/internal/compose/jobs_graph.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/people"
 )
@@ -36,7 +37,12 @@ func addGraphJobs(reg *jobRegistry, pool *pgxpool.Pool, cfg JobRunnerConfig, log
 	graphEdges := newGraphEdgeReconcileWorker(pool, log)
 	addDeclaredWorker[GraphEdgeReconcileArgs](reg, graphEdges)
 	addDeclaredWorker[GraphEdgeWorkspaceArgs](reg, &graphEdgeWorkspaceWorker{graphEdgeReconcileWorker: graphEdges})
-	links := newLinkReconcileWorker(pool, people.NewStore(InstallationDB(pool)), log)
+	// The link-reconcile sweep runs the same cohort repair the capture paths
+	// do, so it carries the same audience derivation: a meeting it files is a
+	// meeting whose no-record hold has stopped being true.
+	links := newLinkReconcileWorker(pool,
+		people.NewStore(InstallationDB(pool)).
+			WithAudienceRecompute(activities.RecomputeAudienceTx), log)
 	addDeclaredWorker[LinkReconcileArgs](reg, links)
 	addDeclaredWorker[LinkReconcileWorkspaceArgs](reg, &linkReconcileWorkspaceWorker{linkReconcileWorker: links})
 	rematch := newLinkedInRematchWorker(pool, people.NewStore(InstallationDB(pool)), identity.NewService(pool), log)

--- a/backend/internal/compose/linkreconcile.go
+++ b/backend/internal/compose/linkreconcile.go
@@ -148,8 +148,8 @@ func (w *linkReconcileWorkspaceWorker) Work(ctx context.Context, job *river.Job[
 // empty and never delays the repair above it.
 const liftFiledMeetingHoldsPerTick = 200
 
-// liftFiledMeetingHolds re-derives the audience of meetings that are filed under
-// a record and still carry the capture limiter's no-record hold.
+// liftFiledMeetingHolds re-derives the audience of records that are filed under
+// something and still carry the limiter's "named nobody" hold.
 //
 // These are the rows this change would otherwise leave behind. A meeting
 // captured before its attendee was a contact was held to its participants, the
@@ -157,6 +157,9 @@ const liftFiledMeetingHoldsPerTick = 200
 // question — so the meeting on a colleague's page stayed invisible to everyone
 // but the people on the invitation, while the invitation EMAILS beside it were
 // workspace-readable.
+//
+// ReasonNoCounterparty only. A judged sender's hold (ReasonNoRecord) is not
+// this pass's to touch however the row is filed.
 //
 // It drains permanently: the recompute rewrites the reason on every row it
 // selects, so a row worked once cannot match again, and afterwards the same
@@ -167,14 +170,18 @@ func (w *linkReconcileWorker) liftFiledMeetingHolds(ctx context.Context) (int, e
 		rows, err := tx.Query(ctx, `
 			SELECT a.id
 			  FROM activity a
-			 WHERE a.kind = 'meeting'
-			   AND a.audience = 'participants'
+			 WHERE a.audience = 'participants'
 			   AND a.audience_reason = $1
 			   AND a.restricted_at IS NULL
 			   AND a.archived_at IS NULL
 			   AND EXISTS (SELECT 1 FROM activity_link l WHERE l.activity_id = a.id)
+			   -- A row with no import rows is not a captured row, and the
+			   -- recompute leaves it alone. Selecting one would return it every
+			   -- tick, and a full page of them would starve the rows this can
+			   -- actually repair.
+			   AND EXISTS (SELECT 1 FROM capture_import ci WHERE ci.activity_id = a.id)
 			 ORDER BY a.occurred_at DESC, a.id
-			 LIMIT $2`, activities.ReasonNoRecord, liftFiledMeetingHoldsPerTick)
+			 LIMIT $2`, activities.ReasonNoCounterparty, liftFiledMeetingHoldsPerTick)
 		if err != nil {
 			return fmt.Errorf("selecting the filed meetings still held: %w", err)
 		}

--- a/backend/internal/compose/linkreconcile.go
+++ b/backend/internal/compose/linkreconcile.go
@@ -27,10 +27,13 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
+	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -129,7 +132,76 @@ func (w *linkReconcileWorkspaceWorker) Work(ctx context.Context, job *river.Job[
 			"workspace", job.Args.Workspace.String(),
 			"people", len(owed), "linked", linked, "promoted", promoted)
 	}
+	lifted, err := w.liftFiledMeetingHolds(sweepCtx)
+	if err != nil {
+		failed = errors.Join(failed, err)
+	}
+	if lifted > 0 {
+		w.log.InfoContext(ctx, "link reconcile: filed meetings are no longer held to their attendees",
+			"workspace", job.Args.Workspace.String(), "meetings", lifted)
+	}
 	return jobs.FaultContext(ctx, errors.Join(failed, w.attachDomainBacklogs(sweepCtx, job.Args.Workspace)))
+}
+
+// liftFiledMeetingHoldsPerTick bounds the drain. The population is finite and
+// shrinks as it is worked, so a small bound costs one probe a tick once it is
+// empty and never delays the repair above it.
+const liftFiledMeetingHoldsPerTick = 200
+
+// liftFiledMeetingHolds re-derives the audience of meetings that are filed under
+// a record and still carry the capture limiter's no-record hold.
+//
+// These are the rows this change would otherwise leave behind. A meeting
+// captured before its attendee was a contact was held to its participants, the
+// cohort repair filed it under them a day later, and nothing re-asked the
+// question — so the meeting on a colleague's page stayed invisible to everyone
+// but the people on the invitation, while the invitation EMAILS beside it were
+// workspace-readable.
+//
+// It drains permanently: the recompute rewrites the reason on every row it
+// selects, so a row worked once cannot match again, and afterwards the same
+// predicate guards the invariant for the price of one probe.
+func (w *linkReconcileWorker) liftFiledMeetingHolds(ctx context.Context) (int, error) {
+	var held []ids.ActivityID
+	if err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT a.id
+			  FROM activity a
+			 WHERE a.kind = 'meeting'
+			   AND a.audience = 'participants'
+			   AND a.audience_reason = $1
+			   AND a.restricted_at IS NULL
+			   AND a.archived_at IS NULL
+			   AND EXISTS (SELECT 1 FROM activity_link l WHERE l.activity_id = a.id)
+			 ORDER BY a.occurred_at DESC, a.id
+			 LIMIT $2`, activities.ReasonNoRecord, liftFiledMeetingHoldsPerTick)
+		if err != nil {
+			return fmt.Errorf("selecting the filed meetings still held: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id ids.ActivityID
+			if err := rows.Scan(&id); err != nil {
+				return fmt.Errorf("reading a filed meeting still held: %w", err)
+			}
+			held = append(held, id)
+		}
+		return rows.Err()
+	}); err != nil {
+		return 0, err
+	}
+	lifted := 0
+	for _, id := range held {
+		// One transaction per meeting, like the repair above: a row another
+		// writer holds a lock on costs that row and not the whole drain.
+		if err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+			return activities.RecomputeAudienceTx(ctx, tx, id)
+		}); err != nil {
+			return lifted, fmt.Errorf("re-deriving the audience of %s: %w", id, err)
+		}
+		lifted++
+	}
+	return lifted, nil
 }
 
 // attachDomainBacklogs gives the people on a company's domain their employer.

--- a/backend/internal/modules/activities/audiencerecompute.go
+++ b/backend/internal/modules/activities/audiencerecompute.go
@@ -62,7 +62,10 @@ const (
 	ReasonConfidentialMarker = "explicitly_confidential"
 	// ReasonNoRecord: the message is filed under no record, so nobody outside
 	// the people on it has a reason to read it. Written by the capture ladder
-	// rather than derived here, and carried through every recompute.
+	// rather than derived here, and carried through every recompute — with one
+	// exception, which is a MEETING that has since been filed under a record.
+	// noRecordHoldStands says why that one is not a judgement about a sender
+	// the way every other no-record outcome is.
 	ReasonNoRecord = "no_record"
 )
 
@@ -190,7 +193,15 @@ func RecomputeAudienceTx(ctx context.Context, tx pgx.Tx, activityID ids.Activity
 	// nowhere but this column. Letting the posture take the tie overwrites the
 	// only record of the durable hold, and the message opens the moment that
 	// mailbox's verdict clears.
-	if held, why := rowCarriedHold(stored, storedReason); held && audienceRank[audienceParticipants] >= audienceRank[derived] {
+	held, why := rowCarriedHold(stored, storedReason)
+	if held && why == ReasonNoRecord {
+		stands, err := noRecordHoldStands(ctx, tx, activityID)
+		if err != nil {
+			return err
+		}
+		held = stands
+	}
+	if held && audienceRank[audienceParticipants] >= audienceRank[derived] {
 		derived, reason = audienceParticipants, why
 	}
 	if derived == stored && sameReason(storedReason, reason) {
@@ -283,6 +294,48 @@ func rowCarriedHold(stored string, storedReason *string) (bool, string) {
 	}
 	return false, ""
 }
+
+// noRecordHoldStands answers whether a `no_record` hold is still the truth.
+//
+// It is one question about ONE kind, and the narrowness is the whole design.
+// `no_record` reads like "this row has no link", and it is not: the capture
+// ladder writes it only on a TERMINAL no-record outcome (capture's
+// limitLinkLessAudience), which covers a suppressed newsletter, a role mailbox,
+// a sender a prior `noise` verdict settled, and a thread judged the mailbox
+// owner's private life. Every one of those is a decision about the SENDER, and
+// a link can arrive on such a row long afterwards — a project attribution, a
+// hand relink, a cohort promotion. Lifting on the presence of a link would
+// republish a mailbox owner's private correspondence to the whole workspace,
+// which is the exact disclosure the hold exists to prevent.
+//
+// A MEETING reached that ladder for a different reason, and not a judgement at
+// all: attendance is a list, so the calendar mapper leaves the counterparty
+// unset, the tiered gate concludes "captured, named nobody", and the limiter
+// holds a record whose only defect is that nothing had filed it yet. When the
+// cohort repair later files it under the person who attended, the premise is
+// simply gone — and until this probe existed the row stayed held forever, so
+// the meeting on a colleague's page was invisible to everyone but its
+// attendees while the invitation EMAILS beside it were workspace-readable.
+//
+// Answering false only removes the row-carried hold; the derivation over the
+// import rows still decides, and a seat's own posture or verdict still holds
+// the row if one asks for it.
+func noRecordHoldStands(ctx context.Context, tx pgx.Tx, activityID ids.ActivityID) (bool, error) {
+	var filedMeeting bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		    SELECT 1 FROM activity a
+		     WHERE a.id = $1 AND a.kind = $2
+		       AND EXISTS (SELECT 1 FROM activity_link l WHERE l.activity_id = a.id))`,
+		activityID, kindMeeting).Scan(&filedMeeting); err != nil {
+		return false, fmt.Errorf("activities: asking whether %s is a filed meeting: %w", activityID, err)
+	}
+	return !filedMeeting, nil
+}
+
+// kindMeeting is the activity kind a calendar connector writes, and the one
+// kind whose no-record hold is liftable — see noRecordHoldStands.
+const kindMeeting = "meeting"
 
 // contributionOf answers what ONE importing seat's row asks of the audience.
 //

--- a/backend/internal/modules/activities/audiencerecompute.go
+++ b/backend/internal/modules/activities/audiencerecompute.go
@@ -60,13 +60,19 @@ const (
 	// verdict for the same reason a counterparty hold does — a person marked
 	// this message, and a classifier disagreeing does not unmark it.
 	ReasonConfidentialMarker = "explicitly_confidential"
-	// ReasonNoRecord: the message is filed under no record, so nobody outside
-	// the people on it has a reason to read it. Written by the capture ladder
-	// rather than derived here, and carried through every recompute — with one
-	// exception, which is a MEETING that has since been filed under a record.
-	// noRecordHoldStands says why that one is not a judgement about a sender
-	// the way every other no-record outcome is.
+	// ReasonNoRecord: the message is filed under no record because something
+	// JUDGED its sender — a suppression rule, a settled verdict, a thread the
+	// owner's own. Written by the capture ladder rather than derived here, and
+	// carried through every recompute: a link arriving later says nothing about
+	// a judgement that was never about the filing.
 	ReasonNoRecord = "no_record"
+	// ReasonNoCounterparty: the message named nobody a record could be created
+	// FOR. The calendar case — attendance is a list, so the mapper leaves the
+	// counterparty unset and the ladder concludes it named nobody. No judgement
+	// was made about anyone, so this hold means only "nothing has filed it
+	// yet", and it stops being true the moment something does. That is the one
+	// row-carried hold a link lifts, and noRecordHoldStands is where it does.
+	ReasonNoCounterparty = "no_counterparty"
 )
 
 // audienceRank orders the audiences from most open to most closed. The
@@ -194,7 +200,7 @@ func RecomputeAudienceTx(ctx context.Context, tx pgx.Tx, activityID ids.Activity
 	// only record of the durable hold, and the message opens the moment that
 	// mailbox's verdict clears.
 	held, why := rowCarriedHold(stored, storedReason)
-	if held && why == ReasonNoRecord {
+	if held && why == ReasonNoCounterparty {
 		stands, err := noRecordHoldStands(ctx, tx, activityID)
 		if err != nil {
 			return err
@@ -289,53 +295,42 @@ func rowCarriedHold(stored string, storedReason *string) (bool, string) {
 		return false, ""
 	}
 	switch why := deref(storedReason); why {
-	case ReasonNoRecord, ReasonWorkspaceFloor, ReasonCounterparty, ReasonConfidentialMarker:
+	case ReasonNoRecord, ReasonNoCounterparty, ReasonWorkspaceFloor, ReasonCounterparty, ReasonConfidentialMarker:
 		return true, why
 	}
 	return false, ""
 }
 
-// noRecordHoldStands answers whether a `no_record` hold is still the truth.
+// noRecordHoldStands answers whether a "named nobody" hold is still the truth.
 //
-// It is one question about ONE kind, and the narrowness is the whole design.
-// `no_record` reads like "this row has no link", and it is not: the capture
-// ladder writes it only on a TERMINAL no-record outcome (capture's
-// limitLinkLessAudience), which covers a suppressed newsletter, a role mailbox,
-// a sender a prior `noise` verdict settled, and a thread judged the mailbox
-// owner's private life. Every one of those is a decision about the SENDER, and
-// a link can arrive on such a row long afterwards — a project attribution, a
-// hand relink, a cohort promotion. Lifting on the presence of a link would
-// republish a mailbox owner's private correspondence to the whole workspace,
-// which is the exact disclosure the hold exists to prevent.
+// It asks ONE question — has anything filed this row yet — and it is asked only
+// of ReasonNoCounterparty, which is the hold capture writes when a record named
+// nobody a contact could be created FOR. A calendar meeting is that case:
+// attendance is a list, the mapper leaves the counterparty unset, and the
+// limiter holds a row whose only defect is that nothing had filed it.
 //
-// A MEETING reached that ladder for a different reason, and not a judgement at
-// all: attendance is a list, so the calendar mapper leaves the counterparty
-// unset, the tiered gate concludes "captured, named nobody", and the limiter
-// holds a record whose only defect is that nothing had filed it yet. When the
-// cohort repair later files it under the person who attended, the premise is
-// simply gone — and until this probe existed the row stayed held forever, so
-// the meeting on a colleague's page was invisible to everyone but its
-// attendees while the invitation EMAILS beside it were workspace-readable.
+// It is deliberately NOT asked of ReasonNoRecord. That reason records a
+// judgement about a SENDER — a suppression rule, a settled verdict, a thread
+// the mailbox owner's own — and a link arriving afterwards says nothing about
+// it. The two were one reason until this probe needed to tell them apart, and
+// telling them apart by KIND was the mistake worth naming: a meeting-shaped
+// record can carry a mail counterparty (the sink admits by counterparty shape,
+// never by kind), reach the private-thread or suppression branch, and be held
+// for a real reason. Inferring "structural" from kind would have opened exactly
+// that message.
 //
 // Answering false only removes the row-carried hold; the derivation over the
 // import rows still decides, and a seat's own posture or verdict still holds
 // the row if one asks for it.
 func noRecordHoldStands(ctx context.Context, tx pgx.Tx, activityID ids.ActivityID) (bool, error) {
-	var filedMeeting bool
+	var filed bool
 	if err := tx.QueryRow(ctx, `
-		SELECT EXISTS (
-		    SELECT 1 FROM activity a
-		     WHERE a.id = $1 AND a.kind = $2
-		       AND EXISTS (SELECT 1 FROM activity_link l WHERE l.activity_id = a.id))`,
-		activityID, kindMeeting).Scan(&filedMeeting); err != nil {
-		return false, fmt.Errorf("activities: asking whether %s is a filed meeting: %w", activityID, err)
+		SELECT EXISTS (SELECT 1 FROM activity_link l WHERE l.activity_id = $1)`,
+		activityID).Scan(&filed); err != nil {
+		return false, fmt.Errorf("activities: asking whether %s is filed anywhere: %w", activityID, err)
 	}
-	return !filedMeeting, nil
+	return !filed, nil
 }
-
-// kindMeeting is the activity kind a calendar connector writes, and the one
-// kind whose no-record hold is liftable — see noRecordHoldStands.
-const kindMeeting = "meeting"
 
 // contributionOf answers what ONE importing seat's row asks of the audience.
 //

--- a/backend/internal/modules/capture/sinkaudience.go
+++ b/backend/internal/modules/capture/sinkaudience.go
@@ -43,9 +43,20 @@ func limitLinkLessAudience(ctx context.Context, tx pgx.Tx, id ids.ActivityID, re
 	// and would otherwise see a participants-only row that no import row asks
 	// for, and widen it back — the reason is how a hold placed for something
 	// other than a mailbox's posture survives being recomputed.
+	// WHICH no-record case this is, recorded rather than inferred later. Both
+	// hold the message identically today; they differ in what a later link
+	// means. A judged sender's message stays held however it is filed — the
+	// judgement was about them, not about the filing — while a record that
+	// merely named nobody is held only until something files it. A reader that
+	// tried to tell the two apart afterwards, by kind or by any other proxy,
+	// would be guessing at a distinction only this decision knows.
+	reason := audienceReasonNoRecord
+	if decision.traceReason == traceReasonNoCounterparty {
+		reason = audienceReasonNoCounterparty
+	}
 	tag, err := tx.Exec(ctx,
 		`UPDATE activity SET audience = $2, audience_reason = $3 WHERE id = $1`,
-		id, audienceParticipants, audienceReasonNoRecord)
+		id, audienceParticipants, reason)
 	if err != nil {
 		return fmt.Errorf("capture: limiting a link-less message to its participants: %w", err)
 	}
@@ -73,8 +84,17 @@ const (
 	audienceReasonPosture = "posture"
 	// Nothing has judged the thread yet.
 	audienceReasonPendingVerdict = "pending_verdict"
-	// The message is filed under no record at all.
+	// The message is filed under no record at all, because something JUDGED
+	// its sender: a suppression rule, a settled verdict, a thread the owner's
+	// own. Nothing about a later link says anything about that judgement, so
+	// the hold survives one.
 	audienceReasonNoRecord = "no_record"
+	// The message named nobody a record COULD be created for — the calendar
+	// case, where attendance is a list and the mapper leaves the counterparty
+	// unset. No judgement was made about anybody, so this hold is exactly as
+	// true as "nothing has filed it yet", and it stops being true when
+	// something does.
+	audienceReasonNoCounterparty = "no_counterparty"
 	// The workspace turned mail sharing off. No verdict clears this one.
 	audienceReasonWorkspaceFloor = "workspace_floor"
 	// This seat holds mail with one of the parties, whatever it is about.

--- a/backend/internal/modules/people/cohortpromote.go
+++ b/backend/internal/modules/people/cohortpromote.go
@@ -103,6 +103,17 @@ func (s *Store) PromotePersonCohortTx(
 	if err := fillPersonNameFromAttendance(ctx, tx, canonical); err != nil {
 		return CohortPromotion{}, err
 	}
+	// A meeting this pass has just FILED is no longer the link-less record the
+	// capture limiter held. Re-deriving says so: until this ran, a meeting
+	// captured before its attendee was a contact stayed participants-only
+	// forever, so the meeting on a colleague's page was invisible to everyone
+	// but the people on the invitation while the invitation emails beside it
+	// were workspace-readable. Only the meetings, and only the ones this call
+	// linked — the derivation itself decides whether the hold is still true
+	// (activities.noRecordHoldStands).
+	if err := s.rederiveAudiences(ctx, tx, meetings); err != nil {
+		return CohortPromotion{}, err
+	}
 	linked = append(linked, meetings...)
 	if len(linked) == 0 && len(promoted) == 0 {
 		// Nothing moved. A repair that found nothing is not an event in this

--- a/backend/internal/modules/people/participantname.go
+++ b/backend/internal/modules/people/participantname.go
@@ -20,9 +20,11 @@ package people
 // human typed.
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/jackc/pgx/v5"
 
@@ -159,11 +161,18 @@ func fillPersonNameFromAttendance(ctx context.Context, tx pgx.Tx, personID ids.P
 // cohorts, and every fixture is nil until it says otherwise. The ids are the
 // ones the caller actually linked — never a scan — so a pass that filed nothing
 // costs nothing.
+// Ordered by id, and that is a LOCK order rather than tidiness. The link insert
+// above took a key-share lock on each activity through the foreign key, and the
+// recompute upgrades the same rows to FOR UPDATE — so two promotions running for
+// two attendees of the same meetings would deadlock if they upgraded in
+// different orders. Sorting makes that order the same for every caller.
 func (s *Store) rederiveAudiences(ctx context.Context, tx pgx.Tx, activityIDs []ids.UUID) error {
 	if s.recomputeAudience == nil {
 		return nil
 	}
-	for _, id := range activityIDs {
+	ordered := slices.Clone(activityIDs)
+	slices.SortFunc(ordered, func(a, b ids.UUID) int { return bytes.Compare(a[:], b[:]) })
+	for _, id := range ordered {
 		if err := s.recomputeAudience(ctx, tx, ids.From[ids.ActivityKind](id)); err != nil {
 			return fmt.Errorf("people: re-deriving the audience of %s after filing it: %w", id, err)
 		}

--- a/backend/internal/modules/people/participantname.go
+++ b/backend/internal/modules/people/participantname.go
@@ -150,3 +150,23 @@ func fillPersonNameFromAttendance(ctx context.Context, tx pgx.Tx, personID ids.P
 	_, err = completePersonName(ctx, tx, personID, ParsePersonName(displayName, address))
 	return err
 }
+
+// rederiveAudiences re-runs the audience derivation over the activities this
+// store has just filed under a record.
+//
+// Nil recompute writes nothing, which is a real composition and not a broken
+// one: a deployment assembling people without the timeline still repairs its
+// cohorts, and every fixture is nil until it says otherwise. The ids are the
+// ones the caller actually linked — never a scan — so a pass that filed nothing
+// costs nothing.
+func (s *Store) rederiveAudiences(ctx context.Context, tx pgx.Tx, activityIDs []ids.UUID) error {
+	if s.recomputeAudience == nil {
+		return nil
+	}
+	for _, id := range activityIDs {
+		if err := s.recomputeAudience(ctx, tx, ids.From[ids.ActivityKind](id)); err != nil {
+			return fmt.Errorf("people: re-deriving the audience of %s after filing it: %w", id, err)
+		}
+	}
+	return nil
+}

--- a/backend/internal/modules/people/store.go
+++ b/backend/internal/modules/people/store.go
@@ -36,6 +36,12 @@ type Store struct {
 	// address and queues nothing; the coordinates are what an installation can
 	// offer, the address is what the caller asked for.
 	geocodeEnqueue GeocodeEnqueue
+	// recomputeAudience re-derives a captured activity's audience after this
+	// store has filed it under a record. The activities module owns the
+	// activity table and so owns that derivation; compose injects it, because
+	// people never imports a sibling. Nil files links and derives nothing —
+	// which is what every fixture is until it says otherwise.
+	recomputeAudience AudienceRecompute
 	// vatCheckEnqueue queues a VIES consultation when a VAT number is written.
 	// Nil is a real composition, for geocodeEnqueue's reason: the number is
 	// what the page stated, the verification is what an installation can offer.
@@ -101,6 +107,17 @@ func (s *Store) WithFieldCatalog(catalog fieldcatalog.Reader) *Store {
 // every writer gets it without any of them having to remember.
 func (s *Store) WithGeocodeEnqueue(enqueue GeocodeEnqueue) *Store {
 	s.geocodeEnqueue = enqueue
+	return s
+}
+
+// AudienceRecompute re-derives one captured activity's audience. See the
+// field above for why it is injected rather than called directly.
+type AudienceRecompute func(ctx context.Context, tx pgx.Tx, activityID ids.ActivityID) error
+
+// WithAudienceRecompute wires the derivation the cohort repair runs over the
+// activities it has just filed under a person.
+func (s *Store) WithAudienceRecompute(recompute AudienceRecompute) *Store {
+	s.recomputeAudience = recompute
 	return s
 }
 


### PR DESCRIPTION
## What was wrong

A calendar meeting captured before anyone had a record for its attendee was held to the people on it, because nothing had filed it anywhere. The cohort repair filed it under that contact a day later — and nothing re-asked the question.

So the meeting stayed invisible to every colleague, while the invitation **emails** beside it on the same contact page were workspace-readable the whole time. That is exactly what the reported page looked like: the meeting missing, its notifications present.

## The narrow fix, and why it is narrow

`no_record` reads like "this row has no link". It records something quite different: the capture ladder writes it only on a **terminal no-record outcome** — a suppressed newsletter, a role mailbox, a sender a prior `noise` verdict settled, or a thread judged the mailbox owner's **private life**.

Those are decisions about the *sender*, and a link can land on such a row long afterwards through a project attribution or a hand relink. Lifting on link presence alone would republish a mailbox owner's private correspondence to the whole workspace.

A meeting reached that same ladder for no judgement at all: attendance is a list, so the mapper leaves the counterparty unset and the gate concludes "captured, named nobody". Once it is filed, that premise is simply gone.

So the probe asks the narrow question — **is this a meeting, and is it filed now** — and everything else carries its hold exactly as before. Lifting only removes the row-carried reason; the derivation over the import rows still decides, so a seat's own posture or verdict still holds the row if one asks for it.

## Reach

The cohort repair re-derives what it files, through a compose-injected seam at all three sites that run it — including inside `NewCohortPromoteGen`, so the worker binary's bare store cannot miss it. Meetings already filed and still held are drained by an arm on the link-reconcile sweep, which cannot re-select a row it has worked.

## Tests

Two, mutation-checked in **both** directions:

- Dropping the meeting-kind restriction opens a suppressed sender's mail the moment anyone files it — the leak this design exists to prevent.
- Removing the lift leaves the filed meeting held, reproducing the reported symptom.

Integration lanes run: capture (whole package), activities, people.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a meeting captured before its attendee was a contact staying held to its participants forever, invisible to colleagues while the invitation emails beside it were readable. It now becomes workspace-readable once the cohort repair files it under that contact.

- The capture ladder now records which no-record case it meant: `no_counterparty` when the record named nobody a contact could be created for, `no_record` when a sender was judged. Only `no_counterparty` lifts once filed; a judged hold survives any later link.
- The cohort repair re-derives what it files at all three sites that run it, via an injected seam.
- A bounded drain on the link-reconcile sweep lifts meetings already filed and still held, can't re-select a row it has worked, and skips rows the recompute leaves alone.
- Tests verify the meeting lift, a suppressed sender's hold surviving a filing, and a judged hold on a meeting-kind row surviving a filing.

<sup>Written for commit c6b103785b3eda2384f4c59a254811719a99c17b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filed meetings can now have outdated “no counterparty” audience holds lifted after they’re linked to a person.
  * Audience assignments are recomputed when meeting links are repaired or created during cohort updates.
  * Existing “no record” holds remain intact when sender suppression or other applicable conditions still apply.
  * Link reconciliation now processes affected meetings automatically and reports recomputation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->