### PR TITLE
A send says what kind of communication it is

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29300,7 +29300,7 @@ components:
 
             Five categories exist to serve the recipient — `security_notice`,
             `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-            `record_confirmation` — and are refused (422 `context_not_available`) from an
+            `record_confirmation` — and are refused (422 `invalid`) from an
             ordinary send. They are reserved for the installation's own controller mail,
             which rides a registered template; a caller that could claim one could dress
             marketing as a security warning and reach somebody who has objected.
@@ -29532,7 +29532,7 @@ components:
 
             Five categories exist to serve the recipient — `security_notice`,
             `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-            `record_confirmation` — and are refused (422 `context_not_available`) from an
+            `record_confirmation` — and are refused (422 `invalid`) from an
             ordinary send. They are reserved for the installation's own controller mail,
             which rides a registered template; a caller that could claim one could dress
             marketing as a security warning and reach somebody who has objected.
@@ -29632,7 +29632,7 @@ components:
 
             Five categories exist to serve the recipient — `security_notice`,
             `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-            `record_confirmation` — and are refused (422 `context_not_available`) from an
+            `record_confirmation` — and are refused (422 `invalid`) from an
             ordinary send. They are reserved for the installation's own controller mail,
             which rides a registered template; a caller that could claim one could dress
             marketing as a security warning and reach somebody who has objected.

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29189,6 +29189,42 @@ components:
         evidence_ref:
           $ref: '#/components/schemas/OrganizationBriefEvidence'
 
+    CommunicationEvidence:
+      type: object
+      description: |
+        Records the caller can name in support of a send, each by id. Evidence is
+        CHECKED, never trusted: the engine reads the named record and asks whether it
+        actually supports the category claimed — a deal id that is closed, an invoice
+        belonging to another organization, or a record the caller cannot see supports
+        nothing. Naming a record therefore never widens what a caller may do.
+
+        Every field is optional. A caller that can name nothing says nothing, and the
+        engine resolves the send from its origin instead.
+      properties:
+        activity_id:
+          type: [string, 'null']
+          format: uuid
+          description: The inbound message this send answers.
+        deal_id:
+          type: [string, 'null']
+          format: uuid
+          description: The live opportunity this send moves along.
+        invoice_id:
+          type: [string, 'null']
+          format: uuid
+          description: The invoice or payment event this send is about.
+        contract_id:
+          type: [string, 'null']
+          format: uuid
+          description: The live contract whose notice this send carries.
+        consent_event_id:
+          type: [string, 'null']
+          format: uuid
+          description: The recorded consent this send relies on.
+        basis_id:
+          type: [string, 'null']
+          format: uuid
+          description: A recorded communication basis this send relies on.
     SendEmailRequest:
       type: object
       required: [subject, body, to, consent_purpose]
@@ -29246,6 +29282,46 @@ components:
             edited-and-sent metadata. Only a guarded, human-authored final edit may become a
             `draft_signal` corpus source. Omit for independently composed mail; no voice-learning
             outcome is inferred without a valid reference.
+        communication_context:
+          type: [string, 'null']
+          enum: [reply_to_inbound, requested_followup, precontract_quote, active_deal_followup,
+                 customer_service, account_notice, contract_notice, invoice_or_payment,
+                 security_notice, privacy_notice, record_confirmation, consent_confirmation,
+                 optout_confirmation, marketing, null]
+          description: |
+            What kind of communication this is. The caller CLAIMS a category; the engine
+            resolves the one the evidence actually supports and records both, so a claim
+            that the evidence does not carry is visible rather than silently honoured.
+
+            Omit it and the engine resolves the category from the send's origin — a reply
+            to an inbound message is a reply whether or not anybody said so. Omitting is
+            therefore honest and is the ordinary case for a reply; naming one matters when
+            there is no anchor to derive from.
+
+            Five categories exist to serve the recipient — `security_notice`,
+            `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+            `record_confirmation` — and are refused (422 `context_not_available`) from an
+            ordinary send. They are reserved for the installation's own controller mail,
+            which rides a registered template; a caller that could claim one could dress
+            marketing as a security warning and reach somebody who has objected.
+        marketing_purpose:
+          type: [string, 'null']
+          description: |
+            For a marketing send, the consent purpose key naming the topic it is for.
+            Marketing consent is purpose-specific: a grant for one topic authorizes that
+            topic and no other.
+        operator_reason:
+          type: [string, 'null']
+          maxLength: 500
+          description: |
+            What a human typed when a first message was genuinely ambiguous. It is
+            RECORDED on the decision and grants nothing — a sentence a sender wrote about
+            their own send is not evidence about the recipient. It exists so a later
+            reader can see what the sender believed, not so the engine can be talked into
+            an allow.
+        evidence:
+          allOf: [{ $ref: '#/components/schemas/CommunicationEvidence' }]
+          description: Records the caller names in support of this send. Checked, never trusted.
         consent_purpose:
           type: string
           description: |
@@ -29438,6 +29514,46 @@ components:
           description: |
             Opaque reference returned by the drafting operation, exactly as on `send_email`.
             Omit for independently composed mail.
+        communication_context:
+          type: [string, 'null']
+          enum: [reply_to_inbound, requested_followup, precontract_quote, active_deal_followup,
+                 customer_service, account_notice, contract_notice, invoice_or_payment,
+                 security_notice, privacy_notice, record_confirmation, consent_confirmation,
+                 optout_confirmation, marketing, null]
+          description: |
+            What kind of communication this is. The caller CLAIMS a category; the engine
+            resolves the one the evidence actually supports and records both, so a claim
+            that the evidence does not carry is visible rather than silently honoured.
+
+            Omit it and the engine resolves the category from the send's origin — a reply
+            to an inbound message is a reply whether or not anybody said so. Omitting is
+            therefore honest and is the ordinary case for a reply; naming one matters when
+            there is no anchor to derive from.
+
+            Five categories exist to serve the recipient — `security_notice`,
+            `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+            `record_confirmation` — and are refused (422 `context_not_available`) from an
+            ordinary send. They are reserved for the installation's own controller mail,
+            which rides a registered template; a caller that could claim one could dress
+            marketing as a security warning and reach somebody who has objected.
+        marketing_purpose:
+          type: [string, 'null']
+          description: |
+            For a marketing send, the consent purpose key naming the topic it is for.
+            Marketing consent is purpose-specific: a grant for one topic authorizes that
+            topic and no other.
+        operator_reason:
+          type: [string, 'null']
+          maxLength: 500
+          description: |
+            What a human typed when a first message was genuinely ambiguous. It is
+            RECORDED on the decision and grants nothing — a sentence a sender wrote about
+            their own send is not evidence about the recipient. It exists so a later
+            reader can see what the sender believed, not so the engine can be talked into
+            an allow.
+        evidence:
+          allOf: [{ $ref: '#/components/schemas/CommunicationEvidence' }]
+          description: Records the caller names in support of this send. Checked, never trusted.
         consent_purpose:
           type: string
           description: |
@@ -29498,6 +29614,46 @@ components:
             The (possibly edited) final message text that is sent. A messaging provider rejects a
             text-less message, so an empty or whitespace-only body is refused at request time
             (422 `empty_message_body`) rather than staged for a delivery that could only park.
+        communication_context:
+          type: [string, 'null']
+          enum: [reply_to_inbound, requested_followup, precontract_quote, active_deal_followup,
+                 customer_service, account_notice, contract_notice, invoice_or_payment,
+                 security_notice, privacy_notice, record_confirmation, consent_confirmation,
+                 optout_confirmation, marketing, null]
+          description: |
+            What kind of communication this is. The caller CLAIMS a category; the engine
+            resolves the one the evidence actually supports and records both, so a claim
+            that the evidence does not carry is visible rather than silently honoured.
+
+            Omit it and the engine resolves the category from the send's origin — a reply
+            to an inbound message is a reply whether or not anybody said so. Omitting is
+            therefore honest and is the ordinary case for a reply; naming one matters when
+            there is no anchor to derive from.
+
+            Five categories exist to serve the recipient — `security_notice`,
+            `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+            `record_confirmation` — and are refused (422 `context_not_available`) from an
+            ordinary send. They are reserved for the installation's own controller mail,
+            which rides a registered template; a caller that could claim one could dress
+            marketing as a security warning and reach somebody who has objected.
+        marketing_purpose:
+          type: [string, 'null']
+          description: |
+            For a marketing send, the consent purpose key naming the topic it is for.
+            Marketing consent is purpose-specific: a grant for one topic authorizes that
+            topic and no other.
+        operator_reason:
+          type: [string, 'null']
+          maxLength: 500
+          description: |
+            What a human typed when a first message was genuinely ambiguous. It is
+            RECORDED on the decision and grants nothing — a sentence a sender wrote about
+            their own send is not evidence about the recipient. It exists so a later
+            reader can see what the sender believed, not so the engine can be talked into
+            an allow.
+        evidence:
+          allOf: [{ $ref: '#/components/schemas/CommunicationEvidence' }]
+          description: Records the caller names in support of this send. Checked, never trusted.
         consent_purpose:
           type: string
           description: |

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -187,6 +187,15 @@ func (c *channelSendEnv) connectBot(t *testing.T) {
 // where the "what do I do about it" has to live.
 func (c *channelSendEnv) sendReply(t *testing.T, purpose, body string, headers map[string]string) (status int, code, message string) {
 	t.Helper()
+	return c.sendReplyClaiming(t, purpose, body, "", headers)
+}
+
+// sendReplyClaiming is sendReply plus a claimed communication category, which
+// is the only way to reach the channel door's own copy of the category
+// refusal. Empty context omits the field entirely, so the ordinary caller
+// above sends exactly the body it used to.
+func (c *channelSendEnv) sendReplyClaiming(t *testing.T, purpose, body, context string, headers map[string]string) (status int, code, message string) {
+	t.Helper()
 	var answer struct {
 		Code    string `json:"code"`
 		Detail  string `json:"detail"`
@@ -197,9 +206,11 @@ func (c *channelSendEnv) sendReply(t *testing.T, purpose, body string, headers m
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	status = c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", AnyMap{
-		"body": body, "consent_purpose": purpose,
-	}, headers, &answer)
+	payload := AnyMap{"body": body, "consent_purpose": purpose}
+	if context != "" {
+		payload["communication_context"] = context
+	}
+	status = c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", payload, headers, &answer)
 	if errs := answer.Details.Errors; len(errs) > 0 {
 		return status, errs[0].Code, errs[0].Message
 	}

--- a/backend/internal/compose/integration/stagingrefusal_integration_test.go
+++ b/backend/internal/compose/integration/stagingrefusal_integration_test.go
@@ -158,3 +158,92 @@ func TestAnAllowedSendRecordsItsStagingDecision(t *testing.T) {
 		t.Error("the decision names no actor — a proof row nobody can be held to is not proof")
 	}
 }
+
+// sendExpectingAcceptanceClaiming sends while naming a category, and expects
+// the send to be accepted. It is the accepting twin of sendClaiming below.
+func (p *preflightEnv) sendExpectingAcceptanceClaiming(t *testing.T, context string) ids.UUID {
+	t.Helper()
+	var sent struct {
+		ID string `json:"id"`
+	}
+	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
+		"subject": "Re: Inbound question", "body": "As discussed.",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"communication_context": context,
+	}, nil, &sent)
+	if status != http.StatusAccepted {
+		t.Fatalf("send-email claiming %q → %d, want 202", context, status)
+	}
+	id, err := ids.Parse(sent.ID)
+	if err != nil {
+		t.Fatalf("accepted send returned no activity id: %v", err)
+	}
+	return id
+}
+
+// sendClaiming posts a send naming a communication context, and returns the
+// status plus the problem code.
+func (p *preflightEnv) sendClaiming(t *testing.T, context string) (status int, code string) {
+	t.Helper()
+	var problem struct {
+		Code    string `json:"code"`
+		Details struct {
+			Errors []struct {
+				Field string `json:"field"`
+				Code  string `json:"code"`
+			} `json:"errors"`
+		} `json:"details"`
+	}
+	status = p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", AnyMap{
+		"subject": "Re: Inbound question", "body": "answer",
+		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
+		"communication_context": context,
+	}, nil, &problem)
+	if errs := problem.Details.Errors; len(errs) > 0 {
+		return status, errs[0].Code
+	}
+	return status, problem.Code
+}
+
+// A rep may say what their own message is about, and the claim is recorded
+// beside the category the engine resolved — so a claim the evidence does not
+// support is visible later rather than silently honoured or silently dropped.
+func TestAClaimedContextReachesTheDecision(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	sent := p.sendExpectingAcceptanceClaiming(t, "reply_to_inbound")
+	deliveryID, _ := p.deliveryFor(t, sent)
+
+	var requested *string
+	if err := apptest.InWorkspace(p.AppEnv, t, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT requested_category FROM communication_decision
+			  WHERE delivery_id = $1 AND phase = 'staging'`, deliveryID).Scan(&requested)
+	}); err != nil {
+		t.Fatalf("reading the decision: %v", err)
+	}
+	if requested == nil || *requested != "reply_to_inbound" {
+		t.Fatalf("requested_category = %v, want the category the caller claimed", requested)
+	}
+}
+
+// The five categories reserved for controller mail are refused at the send
+// door. A send able to claim one could dress marketing as a security warning
+// and pass a suppression that exists to stop exactly that.
+func TestASendCannotClaimAControllerCategory(t *testing.T) {
+	p := setupPreflight(t)
+	p.connect(t, gmailReadonlyScope, gmailSendScope)
+
+	status, code := p.sendClaiming(t, "security_notice")
+
+	if status != http.StatusUnprocessableEntity {
+		t.Fatalf("a send claiming security_notice → %d, want 422", status)
+	}
+	if code != "invalid" {
+		t.Errorf("refusal code = %q, want invalid", code)
+	}
+	if n := p.stagedDeliveries(t); n != 0 {
+		t.Errorf("%d deliveries staged behind a refused claim, want 0", n)
+	}
+}

--- a/backend/internal/compose/integration/stagingrefusal_integration_test.go
+++ b/backend/internal/compose/integration/stagingrefusal_integration_test.go
@@ -247,3 +247,39 @@ func TestASendCannotClaimAControllerCategory(t *testing.T) {
 		t.Errorf("%d deliveries staged behind a refused claim, want 0", n)
 	}
 }
+
+// The channel door's own copy of the category refusal.
+//
+// Its twin above covers the mail door. Both exist for the reason the two
+// suppression tests do: the channel reply is a second implementation of
+// sending, and a refusal proven on one door says nothing about the other. This
+// one was written after a mutation showed the channel handler's refusal could
+// be removed with the whole unit lane and the whole integration lane green —
+// no test anywhere posted a communication_context to this route.
+func TestAChannelSendCannotClaimAControllerCategory(t *testing.T) {
+	c := setupChannelSend(t)
+	c.grantConsent(t, "transactional")
+
+	status, code, _ := c.sendReplyClaiming(t, "transactional", "Yes — shipping Monday.", "security_notice", nil)
+
+	if status != http.StatusUnprocessableEntity {
+		t.Fatalf("a channel reply claiming security_notice → %d, want 422", status)
+	}
+	if code != "invalid" {
+		t.Errorf("refusal code = %q, want invalid", code)
+	}
+	c.assertNoOutboundEffect(t, "a refused category claim")
+}
+
+// And the ordinary claim still goes through on this door, so the refusal above
+// is a category check rather than the channel door rejecting the field itself.
+func TestAChannelSendMayClaimAnOrdinaryCategory(t *testing.T) {
+	c := setupChannelSend(t)
+	c.grantConsent(t, "transactional")
+
+	status, _, detail := c.sendReplyClaiming(t, "transactional", "Yes — shipping Monday.", "reply_to_inbound", nil)
+
+	if status != http.StatusAccepted {
+		t.Fatalf("a channel reply claiming reply_to_inbound → %d (%s), want 202", status, detail)
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -29542,7 +29542,7 @@ type SendAccountEmailRequest struct {
 	//
 	// Five categories exist to serve the recipient — `security_notice`,
 	// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-	// `record_confirmation` — and are refused (422 `context_not_available`) from an
+	// `record_confirmation` — and are refused (422 `invalid`) from an
 	// ordinary send. They are reserved for the installation's own controller mail,
 	// which rides a registered template; a caller that could claim one could dress
 	// marketing as a security warning and reach somebody who has objected.
@@ -29626,7 +29626,7 @@ type SendAccountEmailRequest struct {
 //
 // Five categories exist to serve the recipient — `security_notice`,
 // `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-// `record_confirmation` — and are refused (422 `context_not_available`) from an
+// `record_confirmation` — and are refused (422 `invalid`) from an
 // ordinary send. They are reserved for the installation's own controller mail,
 // which rides a registered template; a caller that could claim one could dress
 // marketing as a security warning and reach somebody who has objected.
@@ -29705,7 +29705,7 @@ type SendEmailRequest struct {
 	//
 	// Five categories exist to serve the recipient — `security_notice`,
 	// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-	// `record_confirmation` — and are refused (422 `context_not_available`) from an
+	// `record_confirmation` — and are refused (422 `invalid`) from an
 	// ordinary send. They are reserved for the installation's own controller mail,
 	// which rides a registered template; a caller that could claim one could dress
 	// marketing as a security warning and reach somebody who has objected.
@@ -29781,7 +29781,7 @@ type SendEmailRequest struct {
 //
 // Five categories exist to serve the recipient — `security_notice`,
 // `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-// `record_confirmation` — and are refused (422 `context_not_available`) from an
+// `record_confirmation` — and are refused (422 `invalid`) from an
 // ordinary send. They are reserved for the installation's own controller mail,
 // which rides a registered template; a caller that could claim one could dress
 // marketing as a security warning and reach somebody who has objected.
@@ -29829,7 +29829,7 @@ type SendMessageRequest struct {
 	//
 	// Five categories exist to serve the recipient — `security_notice`,
 	// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-	// `record_confirmation` — and are refused (422 `context_not_available`) from an
+	// `record_confirmation` — and are refused (422 `invalid`) from an
 	// ordinary send. They are reserved for the installation's own controller mail,
 	// which rides a registered template; a caller that could claim one could dress
 	// marketing as a security warning and reach somebody who has objected.
@@ -29867,7 +29867,7 @@ type SendMessageRequest struct {
 //
 // Five categories exist to serve the recipient — `security_notice`,
 // `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-// `record_confirmation` — and are refused (422 `context_not_available`) from an
+// `record_confirmation` — and are refused (422 `invalid`) from an
 // ordinary send. They are reserved for the installation's own controller mail,
 // which rides a registered template; a caller that could claim one could dress
 // marketing as a security warning and reach somebody who has objected.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -8610,22 +8610,22 @@ func (e PersonConsentGuardEntryChannel) Valid() bool {
 
 // Defines values for PersonConsentGuardEntryPurposeClass.
 const (
-	BusinessCorrespondence PersonConsentGuardEntryPurposeClass = "business_correspondence"
-	Marketing              PersonConsentGuardEntryPurposeClass = "marketing"
-	PhoneOutreach          PersonConsentGuardEntryPurposeClass = "phone_outreach"
-	Transactional          PersonConsentGuardEntryPurposeClass = "transactional"
+	PersonConsentGuardEntryPurposeClassBusinessCorrespondence PersonConsentGuardEntryPurposeClass = "business_correspondence"
+	PersonConsentGuardEntryPurposeClassMarketing              PersonConsentGuardEntryPurposeClass = "marketing"
+	PersonConsentGuardEntryPurposeClassPhoneOutreach          PersonConsentGuardEntryPurposeClass = "phone_outreach"
+	PersonConsentGuardEntryPurposeClassTransactional          PersonConsentGuardEntryPurposeClass = "transactional"
 )
 
 // Valid indicates whether the value is a known member of the PersonConsentGuardEntryPurposeClass enum.
 func (e PersonConsentGuardEntryPurposeClass) Valid() bool {
 	switch e {
-	case BusinessCorrespondence:
+	case PersonConsentGuardEntryPurposeClassBusinessCorrespondence:
 		return true
-	case Marketing:
+	case PersonConsentGuardEntryPurposeClassMarketing:
 		return true
-	case PhoneOutreach:
+	case PersonConsentGuardEntryPurposeClassPhoneOutreach:
 		return true
-	case Transactional:
+	case PersonConsentGuardEntryPurposeClassTransactional:
 		return true
 	default:
 		return false
@@ -10510,6 +10510,168 @@ func (e SearchResultType) Valid() bool {
 	case SearchResultTypeProject:
 		return true
 	case SearchResultTypeTag:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SendAccountEmailRequestCommunicationContext.
+const (
+	SendAccountEmailRequestCommunicationContextAccountNotice       SendAccountEmailRequestCommunicationContext = "account_notice"
+	SendAccountEmailRequestCommunicationContextActiveDealFollowup  SendAccountEmailRequestCommunicationContext = "active_deal_followup"
+	SendAccountEmailRequestCommunicationContextConsentConfirmation SendAccountEmailRequestCommunicationContext = "consent_confirmation"
+	SendAccountEmailRequestCommunicationContextContractNotice      SendAccountEmailRequestCommunicationContext = "contract_notice"
+	SendAccountEmailRequestCommunicationContextCustomerService     SendAccountEmailRequestCommunicationContext = "customer_service"
+	SendAccountEmailRequestCommunicationContextInvoiceOrPayment    SendAccountEmailRequestCommunicationContext = "invoice_or_payment"
+	SendAccountEmailRequestCommunicationContextMarketing           SendAccountEmailRequestCommunicationContext = "marketing"
+	SendAccountEmailRequestCommunicationContextOptoutConfirmation  SendAccountEmailRequestCommunicationContext = "optout_confirmation"
+	SendAccountEmailRequestCommunicationContextPrecontractQuote    SendAccountEmailRequestCommunicationContext = "precontract_quote"
+	SendAccountEmailRequestCommunicationContextPrivacyNotice       SendAccountEmailRequestCommunicationContext = "privacy_notice"
+	SendAccountEmailRequestCommunicationContextRecordConfirmation  SendAccountEmailRequestCommunicationContext = "record_confirmation"
+	SendAccountEmailRequestCommunicationContextReplyToInbound      SendAccountEmailRequestCommunicationContext = "reply_to_inbound"
+	SendAccountEmailRequestCommunicationContextRequestedFollowup   SendAccountEmailRequestCommunicationContext = "requested_followup"
+	SendAccountEmailRequestCommunicationContextSecurityNotice      SendAccountEmailRequestCommunicationContext = "security_notice"
+)
+
+// Valid indicates whether the value is a known member of the SendAccountEmailRequestCommunicationContext enum.
+func (e SendAccountEmailRequestCommunicationContext) Valid() bool {
+	switch e {
+	case SendAccountEmailRequestCommunicationContextAccountNotice:
+		return true
+	case SendAccountEmailRequestCommunicationContextActiveDealFollowup:
+		return true
+	case SendAccountEmailRequestCommunicationContextConsentConfirmation:
+		return true
+	case SendAccountEmailRequestCommunicationContextContractNotice:
+		return true
+	case SendAccountEmailRequestCommunicationContextCustomerService:
+		return true
+	case SendAccountEmailRequestCommunicationContextInvoiceOrPayment:
+		return true
+	case SendAccountEmailRequestCommunicationContextMarketing:
+		return true
+	case SendAccountEmailRequestCommunicationContextOptoutConfirmation:
+		return true
+	case SendAccountEmailRequestCommunicationContextPrecontractQuote:
+		return true
+	case SendAccountEmailRequestCommunicationContextPrivacyNotice:
+		return true
+	case SendAccountEmailRequestCommunicationContextRecordConfirmation:
+		return true
+	case SendAccountEmailRequestCommunicationContextReplyToInbound:
+		return true
+	case SendAccountEmailRequestCommunicationContextRequestedFollowup:
+		return true
+	case SendAccountEmailRequestCommunicationContextSecurityNotice:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SendEmailRequestCommunicationContext.
+const (
+	SendEmailRequestCommunicationContextAccountNotice       SendEmailRequestCommunicationContext = "account_notice"
+	SendEmailRequestCommunicationContextActiveDealFollowup  SendEmailRequestCommunicationContext = "active_deal_followup"
+	SendEmailRequestCommunicationContextConsentConfirmation SendEmailRequestCommunicationContext = "consent_confirmation"
+	SendEmailRequestCommunicationContextContractNotice      SendEmailRequestCommunicationContext = "contract_notice"
+	SendEmailRequestCommunicationContextCustomerService     SendEmailRequestCommunicationContext = "customer_service"
+	SendEmailRequestCommunicationContextInvoiceOrPayment    SendEmailRequestCommunicationContext = "invoice_or_payment"
+	SendEmailRequestCommunicationContextMarketing           SendEmailRequestCommunicationContext = "marketing"
+	SendEmailRequestCommunicationContextOptoutConfirmation  SendEmailRequestCommunicationContext = "optout_confirmation"
+	SendEmailRequestCommunicationContextPrecontractQuote    SendEmailRequestCommunicationContext = "precontract_quote"
+	SendEmailRequestCommunicationContextPrivacyNotice       SendEmailRequestCommunicationContext = "privacy_notice"
+	SendEmailRequestCommunicationContextRecordConfirmation  SendEmailRequestCommunicationContext = "record_confirmation"
+	SendEmailRequestCommunicationContextReplyToInbound      SendEmailRequestCommunicationContext = "reply_to_inbound"
+	SendEmailRequestCommunicationContextRequestedFollowup   SendEmailRequestCommunicationContext = "requested_followup"
+	SendEmailRequestCommunicationContextSecurityNotice      SendEmailRequestCommunicationContext = "security_notice"
+)
+
+// Valid indicates whether the value is a known member of the SendEmailRequestCommunicationContext enum.
+func (e SendEmailRequestCommunicationContext) Valid() bool {
+	switch e {
+	case SendEmailRequestCommunicationContextAccountNotice:
+		return true
+	case SendEmailRequestCommunicationContextActiveDealFollowup:
+		return true
+	case SendEmailRequestCommunicationContextConsentConfirmation:
+		return true
+	case SendEmailRequestCommunicationContextContractNotice:
+		return true
+	case SendEmailRequestCommunicationContextCustomerService:
+		return true
+	case SendEmailRequestCommunicationContextInvoiceOrPayment:
+		return true
+	case SendEmailRequestCommunicationContextMarketing:
+		return true
+	case SendEmailRequestCommunicationContextOptoutConfirmation:
+		return true
+	case SendEmailRequestCommunicationContextPrecontractQuote:
+		return true
+	case SendEmailRequestCommunicationContextPrivacyNotice:
+		return true
+	case SendEmailRequestCommunicationContextRecordConfirmation:
+		return true
+	case SendEmailRequestCommunicationContextReplyToInbound:
+		return true
+	case SendEmailRequestCommunicationContextRequestedFollowup:
+		return true
+	case SendEmailRequestCommunicationContextSecurityNotice:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SendMessageRequestCommunicationContext.
+const (
+	SendMessageRequestCommunicationContextAccountNotice       SendMessageRequestCommunicationContext = "account_notice"
+	SendMessageRequestCommunicationContextActiveDealFollowup  SendMessageRequestCommunicationContext = "active_deal_followup"
+	SendMessageRequestCommunicationContextConsentConfirmation SendMessageRequestCommunicationContext = "consent_confirmation"
+	SendMessageRequestCommunicationContextContractNotice      SendMessageRequestCommunicationContext = "contract_notice"
+	SendMessageRequestCommunicationContextCustomerService     SendMessageRequestCommunicationContext = "customer_service"
+	SendMessageRequestCommunicationContextInvoiceOrPayment    SendMessageRequestCommunicationContext = "invoice_or_payment"
+	SendMessageRequestCommunicationContextMarketing           SendMessageRequestCommunicationContext = "marketing"
+	SendMessageRequestCommunicationContextOptoutConfirmation  SendMessageRequestCommunicationContext = "optout_confirmation"
+	SendMessageRequestCommunicationContextPrecontractQuote    SendMessageRequestCommunicationContext = "precontract_quote"
+	SendMessageRequestCommunicationContextPrivacyNotice       SendMessageRequestCommunicationContext = "privacy_notice"
+	SendMessageRequestCommunicationContextRecordConfirmation  SendMessageRequestCommunicationContext = "record_confirmation"
+	SendMessageRequestCommunicationContextReplyToInbound      SendMessageRequestCommunicationContext = "reply_to_inbound"
+	SendMessageRequestCommunicationContextRequestedFollowup   SendMessageRequestCommunicationContext = "requested_followup"
+	SendMessageRequestCommunicationContextSecurityNotice      SendMessageRequestCommunicationContext = "security_notice"
+)
+
+// Valid indicates whether the value is a known member of the SendMessageRequestCommunicationContext enum.
+func (e SendMessageRequestCommunicationContext) Valid() bool {
+	switch e {
+	case SendMessageRequestCommunicationContextAccountNotice:
+		return true
+	case SendMessageRequestCommunicationContextActiveDealFollowup:
+		return true
+	case SendMessageRequestCommunicationContextConsentConfirmation:
+		return true
+	case SendMessageRequestCommunicationContextContractNotice:
+		return true
+	case SendMessageRequestCommunicationContextCustomerService:
+		return true
+	case SendMessageRequestCommunicationContextInvoiceOrPayment:
+		return true
+	case SendMessageRequestCommunicationContextMarketing:
+		return true
+	case SendMessageRequestCommunicationContextOptoutConfirmation:
+		return true
+	case SendMessageRequestCommunicationContextPrecontractQuote:
+		return true
+	case SendMessageRequestCommunicationContextPrivacyNotice:
+		return true
+	case SendMessageRequestCommunicationContextRecordConfirmation:
+		return true
+	case SendMessageRequestCommunicationContextReplyToInbound:
+		return true
+	case SendMessageRequestCommunicationContextRequestedFollowup:
+		return true
+	case SendMessageRequestCommunicationContextSecurityNotice:
 		return true
 	default:
 		return false
@@ -18430,6 +18592,34 @@ type CommissionSummaryRow struct {
 
 	// Status accrued → approved → paid, with void as the exit at any point.
 	Status CommissionStatus `json:"status"`
+}
+
+// CommunicationEvidence Records the caller can name in support of a send, each by id. Evidence is
+// CHECKED, never trusted: the engine reads the named record and asks whether it
+// actually supports the category claimed — a deal id that is closed, an invoice
+// belonging to another organization, or a record the caller cannot see supports
+// nothing. Naming a record therefore never widens what a caller may do.
+//
+// Every field is optional. A caller that can name nothing says nothing, and the
+// engine resolves the send from its origin instead.
+type CommunicationEvidence struct {
+	// ActivityId The inbound message this send answers.
+	ActivityId *openapi_types.UUID `json:"activity_id,omitempty"`
+
+	// BasisId A recorded communication basis this send relies on.
+	BasisId *openapi_types.UUID `json:"basis_id,omitempty"`
+
+	// ConsentEventId The recorded consent this send relies on.
+	ConsentEventId *openapi_types.UUID `json:"consent_event_id,omitempty"`
+
+	// ContractId The live contract whose notice this send carries.
+	ContractId *openapi_types.UUID `json:"contract_id,omitempty"`
+
+	// DealId The live opportunity this send moves along.
+	DealId *openapi_types.UUID `json:"deal_id,omitempty"`
+
+	// InvoiceId The invoice or payment event this send is about.
+	InvoiceId *openapi_types.UUID `json:"invoice_id,omitempty"`
 }
 
 // CompanyContext defines model for CompanyContext.
@@ -29341,6 +29531,23 @@ type SendAccountEmailRequest struct {
 	Body string                 `json:"body"`
 	Cc   *[]openapi_types.Email `json:"cc,omitempty"`
 
+	// CommunicationContext What kind of communication this is. The caller CLAIMS a category; the engine
+	// resolves the one the evidence actually supports and records both, so a claim
+	// that the evidence does not carry is visible rather than silently honoured.
+	//
+	// Omit it and the engine resolves the category from the send's origin — a reply
+	// to an inbound message is a reply whether or not anybody said so. Omitting is
+	// therefore honest and is the ordinary case for a reply; naming one matters when
+	// there is no anchor to derive from.
+	//
+	// Five categories exist to serve the recipient — `security_notice`,
+	// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+	// `record_confirmation` — and are refused (422 `context_not_available`) from an
+	// ordinary send. They are reserved for the installation's own controller mail,
+	// which rides a registered template; a caller that could claim one could dress
+	// marketing as a security warning and reach somebody who has objected.
+	CommunicationContext *SendAccountEmailRequestCommunicationContext `json:"communication_context,omitempty"`
+
 	// ConsentPurpose The consent purpose this send falls under. Default-deny per purpose (A22/ADR-0011):
 	// suppressed 409 `consent_not_granted` unless every recipient has an active `granted`
 	// `person_consent` for THIS purpose.
@@ -29349,6 +29556,9 @@ type SendAccountEmailRequest struct {
 	// DraftRef Opaque reference returned by the drafting operation, exactly as on `send_email`.
 	// Omit for independently composed mail.
 	DraftRef *string `json:"draft_ref,omitempty"`
+
+	// Evidence Records the caller names in support of this send. Checked, never trusted.
+	Evidence *CommunicationEvidence `json:"evidence,omitempty"`
 
 	// HtmlBody The same message as markup, or omitted for a plain-text send. It never
 	// REPLACES `body`: a message carrying both goes out as multipart/alternative
@@ -29364,6 +29574,18 @@ type SendAccountEmailRequest struct {
 	// cannot see is refused 404 — and each probe is its own query, so the list is bounded
 	// at 25 (a message about more records than that is about none of them).
 	Links []ActivityLinkInput `json:"links"`
+
+	// MarketingPurpose For a marketing send, the consent purpose key naming the topic it is for.
+	// Marketing consent is purpose-specific: a grant for one topic authorizes that
+	// topic and no other.
+	MarketingPurpose *string `json:"marketing_purpose,omitempty"`
+
+	// OperatorReason What a human typed when a first message was genuinely ambiguous. It is
+	// RECORDED on the decision and grants nothing — a sentence a sender wrote about
+	// their own send is not evidence about the recipient. It exists so a later
+	// reader can see what the sender believed, not so the engine can be talked into
+	// an allow.
+	OperatorReason *string `json:"operator_reason,omitempty"`
 
 	// ScheduledAt Send this message at this instant instead of now (ADR-0104/A155). Absolute
 	// and unambiguous; `scheduled_tz` records the zone the human picked it in.
@@ -29392,6 +29614,23 @@ type SendAccountEmailRequest struct {
 	// anything is staged — `cc` alone does not make a message addressed to anyone.
 	To []openapi_types.Email `json:"to"`
 }
+
+// SendAccountEmailRequestCommunicationContext What kind of communication this is. The caller CLAIMS a category; the engine
+// resolves the one the evidence actually supports and records both, so a claim
+// that the evidence does not carry is visible rather than silently honoured.
+//
+// Omit it and the engine resolves the category from the send's origin — a reply
+// to an inbound message is a reply whether or not anybody said so. Omitting is
+// therefore honest and is the ordinary case for a reply; naming one matters when
+// there is no anchor to derive from.
+//
+// Five categories exist to serve the recipient — `security_notice`,
+// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+// `record_confirmation` — and are refused (422 `context_not_available`) from an
+// ordinary send. They are reserved for the installation's own controller mail,
+// which rides a registered template; a caller that could claim one could dress
+// marketing as a security warning and reach somebody who has objected.
+type SendAccountEmailRequestCommunicationContext string
 
 // SendEmailRequest defines model for SendEmailRequest.
 type SendEmailRequest struct {
@@ -29455,6 +29694,23 @@ type SendEmailRequest struct {
 	Body string                 `json:"body"`
 	Cc   *[]openapi_types.Email `json:"cc,omitempty"`
 
+	// CommunicationContext What kind of communication this is. The caller CLAIMS a category; the engine
+	// resolves the one the evidence actually supports and records both, so a claim
+	// that the evidence does not carry is visible rather than silently honoured.
+	//
+	// Omit it and the engine resolves the category from the send's origin — a reply
+	// to an inbound message is a reply whether or not anybody said so. Omitting is
+	// therefore honest and is the ordinary case for a reply; naming one matters when
+	// there is no anchor to derive from.
+	//
+	// Five categories exist to serve the recipient — `security_notice`,
+	// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+	// `record_confirmation` — and are refused (422 `context_not_available`) from an
+	// ordinary send. They are reserved for the installation's own controller mail,
+	// which rides a registered template; a caller that could claim one could dress
+	// marketing as a security warning and reach somebody who has objected.
+	CommunicationContext *SendEmailRequestCommunicationContext `json:"communication_context,omitempty"`
+
 	// ConsentPurpose The consent purpose this send falls under (e.g. `transactional`, `marketing_email`).
 	// The send is suppressed (409 `consent_not_granted`) unless every recipient has an active
 	// `granted` `person_consent` for THIS purpose (default-deny per purpose, A22/ADR-0011).
@@ -29467,12 +29723,27 @@ type SendEmailRequest struct {
 	// outcome is inferred without a valid reference.
 	DraftRef *string `json:"draft_ref,omitempty"`
 
+	// Evidence Records the caller names in support of this send. Checked, never trusted.
+	Evidence *CommunicationEvidence `json:"evidence,omitempty"`
+
 	// HtmlBody The same message as markup, or omitted for a plain-text send. It never
 	// REPLACES `body`: a message carrying both goes out as multipart/alternative
 	// with the plain part first, so a client that cannot render HTML still
 	// receives the words. The sender's signature and the unsubscribe footer are
 	// appended to BOTH parts by the server, in each part's own syntax.
 	HtmlBody *string `json:"html_body,omitempty"`
+
+	// MarketingPurpose For a marketing send, the consent purpose key naming the topic it is for.
+	// Marketing consent is purpose-specific: a grant for one topic authorizes that
+	// topic and no other.
+	MarketingPurpose *string `json:"marketing_purpose,omitempty"`
+
+	// OperatorReason What a human typed when a first message was genuinely ambiguous. It is
+	// RECORDED on the decision and grants nothing — a sentence a sender wrote about
+	// their own send is not evidence about the recipient. It exists so a later
+	// reader can see what the sender believed, not so the engine can be talked into
+	// an allow.
+	OperatorReason *string `json:"operator_reason,omitempty"`
 
 	// ScheduledAt Send this message at this instant instead of now (ADR-0104/A155). Absolute
 	// and unambiguous; `scheduled_tz` records the zone the human picked it in.
@@ -29498,6 +29769,23 @@ type SendEmailRequest struct {
 	Subject     string                `json:"subject"`
 	To          []openapi_types.Email `json:"to"`
 }
+
+// SendEmailRequestCommunicationContext What kind of communication this is. The caller CLAIMS a category; the engine
+// resolves the one the evidence actually supports and records both, so a claim
+// that the evidence does not carry is visible rather than silently honoured.
+//
+// Omit it and the engine resolves the category from the send's origin — a reply
+// to an inbound message is a reply whether or not anybody said so. Omitting is
+// therefore honest and is the ordinary case for a reply; naming one matters when
+// there is no anchor to derive from.
+//
+// Five categories exist to serve the recipient — `security_notice`,
+// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+// `record_confirmation` — and are refused (422 `context_not_available`) from an
+// ordinary send. They are reserved for the installation's own controller mail,
+// which rides a registered template; a caller that could claim one could dress
+// marketing as a security warning and reach somebody who has objected.
+type SendEmailRequestCommunicationContext string
 
 // SendMessageRequest One channel reply. It carries no subject and no addressee list, and that absence is the
 // shape of the transport rather than an omission: a messaging channel has no subject line
@@ -29530,11 +29818,60 @@ type SendMessageRequest struct {
 	// (422 `empty_message_body`) rather than staged for a delivery that could only park.
 	Body string `json:"body"`
 
+	// CommunicationContext What kind of communication this is. The caller CLAIMS a category; the engine
+	// resolves the one the evidence actually supports and records both, so a claim
+	// that the evidence does not carry is visible rather than silently honoured.
+	//
+	// Omit it and the engine resolves the category from the send's origin — a reply
+	// to an inbound message is a reply whether or not anybody said so. Omitting is
+	// therefore honest and is the ordinary case for a reply; naming one matters when
+	// there is no anchor to derive from.
+	//
+	// Five categories exist to serve the recipient — `security_notice`,
+	// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+	// `record_confirmation` — and are refused (422 `context_not_available`) from an
+	// ordinary send. They are reserved for the installation's own controller mail,
+	// which rides a registered template; a caller that could claim one could dress
+	// marketing as a security warning and reach somebody who has objected.
+	CommunicationContext *SendMessageRequestCommunicationContext `json:"communication_context,omitempty"`
+
 	// ConsentPurpose The consent purpose this send falls under (e.g. `transactional`). The send is
 	// suppressed (409 `consent_not_granted`) unless the recipient has an active `granted`
 	// `person_consent` for THIS purpose (default-deny per purpose, A22/ADR-0011).
 	ConsentPurpose string `json:"consent_purpose"`
+
+	// Evidence Records the caller names in support of this send. Checked, never trusted.
+	Evidence *CommunicationEvidence `json:"evidence,omitempty"`
+
+	// MarketingPurpose For a marketing send, the consent purpose key naming the topic it is for.
+	// Marketing consent is purpose-specific: a grant for one topic authorizes that
+	// topic and no other.
+	MarketingPurpose *string `json:"marketing_purpose,omitempty"`
+
+	// OperatorReason What a human typed when a first message was genuinely ambiguous. It is
+	// RECORDED on the decision and grants nothing — a sentence a sender wrote about
+	// their own send is not evidence about the recipient. It exists so a later
+	// reader can see what the sender believed, not so the engine can be talked into
+	// an allow.
+	OperatorReason *string `json:"operator_reason,omitempty"`
 }
+
+// SendMessageRequestCommunicationContext What kind of communication this is. The caller CLAIMS a category; the engine
+// resolves the one the evidence actually supports and records both, so a claim
+// that the evidence does not carry is visible rather than silently honoured.
+//
+// Omit it and the engine resolves the category from the send's origin — a reply
+// to an inbound message is a reply whether or not anybody said so. Omitting is
+// therefore honest and is the ordinary case for a reply; naming one matters when
+// there is no anchor to derive from.
+//
+// Five categories exist to serve the recipient — `security_notice`,
+// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+// `record_confirmation` — and are refused (422 `context_not_available`) from an
+// ordinary send. They are reserved for the installation's own controller mail,
+// which rides a registered template; a caller that could claim one could dress
+// marketing as a security warning and reach somebody who has objected.
+type SendMessageRequestCommunicationContext string
 
 // SetActivityAudienceRequest defines model for SetActivityAudienceRequest.
 type SetActivityAudienceRequest struct {

--- a/backend/internal/modules/activities/channelsend.go
+++ b/backend/internal/modules/activities/channelsend.go
@@ -51,6 +51,15 @@ type SendMessageInput struct {
 	// rewrite what the timeline says this message carried (ADR-0086/A131 §4).
 	AttachmentIDs  []ids.UUID
 	ConsentPurpose string
+	// Context, MarketingPurpose, OperatorReason and Evidence are the mail
+	// path's four context fields, carried here for the reason every engine
+	// change lands twice: the channel reply is a second implementation of
+	// sending, not a variant of the mail one, so a field that reached only
+	// SendEmailInput would leave this door answering the old question.
+	Context          commsauthz.Category
+	MarketingPurpose string
+	OperatorReason   string
+	Evidence         commsauthz.Evidence
 }
 
 // ChannelDeliveryStager records an outbound CHANNEL message for transmission —
@@ -275,7 +284,7 @@ func (s *Store) SendMessage(ctx context.Context, anchorID ids.ActivityID, in Sen
 
 	message := outboundChannelMessage{
 		in: in, provider: provider, conversation: conversation,
-		links: inheritedLinks(anchor), files: files,
+		links: inheritedLinks(anchor), files: files, anchorID: anchorID,
 	}
 	var sent crmcontracts.Activity
 	err = s.tx(ctx, func(tx pgx.Tx) error {
@@ -402,6 +411,11 @@ type outboundChannelMessage struct {
 	conversation channelConversation
 	links        []ActivityLinkInput
 	files        []OutboundFile
+	// anchorID is the captured conversation this reply answers. The delivery
+	// deliberately anchors on nothing (see delivery below), but the ENGINE
+	// needs it: a reply to a message the subject sent is a reply, and the
+	// anchor is what says so without the caller having to.
+	anchorID ids.ActivityID
 }
 
 // activity is the timeline row the reply commits — the row that makes the sent
@@ -444,6 +458,17 @@ func (m outboundChannelMessage) activity() LogActivityInput {
 // that belongs to the capture provider, and which this module would be guessing
 // at. A wrong anchor is refused by the provider outright, so guessing costs the
 // rep their message to buy some visual nesting.
+// evidence is what the caller offered, with the answered conversation filled in
+// when they named no activity themselves — the channel twin of the mail path's
+// own derivation.
+func (m outboundChannelMessage) evidence() commsauthz.Evidence {
+	e := m.in.Evidence
+	if e.ActivityID == (ids.UUID{}) {
+		e.ActivityID = m.anchorID.UUID
+	}
+	return e
+}
+
 func (m outboundChannelMessage) delivery(activityID ids.ActivityID) ChannelDeliveryRequest {
 	return ChannelDeliveryRequest{
 		ActivityID:     activityID,
@@ -456,7 +481,13 @@ func (m outboundChannelMessage) delivery(activityID ids.ActivityID) ChannelDeliv
 		// named and cannot substitute.
 		Authorization: commsauthz.Request{
 			Recipients:       []connector.Recipient{{Channel: &m.conversation.recipient}},
+			Context:          m.in.Context,
 			LegacyPurposeKey: m.in.ConsentPurpose,
+			MarketingPurpose: m.in.MarketingPurpose,
+			OperatorReason:   m.in.OperatorReason,
+			Evidence:         m.evidence(),
+			AnchorActivityID: m.anchorID.UUID,
+			Links:            linkedRecordIDs(m.links),
 			Body:             m.in.Body,
 		},
 	}

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -89,6 +89,22 @@ type SendEmailInput struct {
 	// message carried (ADR-0086/A131 §4).
 	AttachmentIDs  []ids.UUID
 	ConsentPurpose string
+	// Context is the communication category the CALLER claims, empty when they
+	// claim none. It is a claim and never an authorization: the engine resolves
+	// the category the evidence supports and records both, so a claim the
+	// evidence does not carry shows up as a disagreement rather than passing.
+	Context commsauthz.Category
+	// MarketingPurpose names the topic a marketing send is for. Marketing
+	// consent is purpose-specific, so a grant for one topic authorizes that
+	// topic alone.
+	MarketingPurpose string
+	// OperatorReason is what a human typed about a genuinely ambiguous first
+	// message. Recorded, never weighed: a sentence the sender wrote about their
+	// own send says nothing about the recipient.
+	OperatorReason string
+	// Evidence names records the caller offers in support. Each is read and
+	// checked against the category; naming one widens nothing.
+	Evidence commsauthz.Evidence
 	// DraftRef names the voice draft this message came from, so the send can
 	// close the learning signal that draft opened. Empty is the ordinary case:
 	// mail the human composed independently resolves no draft.

--- a/backend/internal/modules/activities/email_test.go
+++ b/backend/internal/modules/activities/email_test.go
@@ -265,7 +265,7 @@ func TestASendGoesOutThroughTheMailboxItResolved(t *testing.T) {
 			// transmits, and the activity's source_system is the natural key the
 			// provider's own echo carries. Two answers here would file a
 			// duplicate timeline row for every message anybody sends.
-			if got := m.delivery(ids.NewV7(), threading{}).Provider; got != provider {
+			if got := m.delivery(ids.NewV7(), threading{}, SendOrigin{}).Provider; got != provider {
 				t.Errorf("delivery provider = %q, want %q — handed to a connector this sender has no grant on", got, provider)
 			}
 			act := m.activity(threading{})

--- a/backend/internal/modules/activities/handlers_channelsend.go
+++ b/backend/internal/modules/activities/handlers_channelsend.go
@@ -41,10 +41,20 @@ func (h Handlers) SendMessage(w http.ResponseWriter, r *http.Request, id crmcont
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
+	claimed, err := sendContextFrom((*string)(req.CommunicationContext),
+		req.MarketingPurpose, req.OperatorReason, req.Evidence)
+	if err != nil {
+		writeChannelSendErr(w, r, err)
+		return
+	}
 	sent, err := h.store.SendMessage(r.Context(), pathID[ids.ActivityKind](id), SendMessageInput{
-		Body:           req.Body,
-		AttachmentIDs:  attachmentIDsFrom(req.AttachmentIds),
-		ConsentPurpose: req.ConsentPurpose,
+		Body:             req.Body,
+		AttachmentIDs:    attachmentIDsFrom(req.AttachmentIds),
+		ConsentPurpose:   req.ConsentPurpose,
+		Context:          claimed.category,
+		MarketingPurpose: claimed.marketing,
+		OperatorReason:   claimed.reason,
+		Evidence:         claimed.evidence,
 	}, h.consent, h.channelDelivery)
 	if err != nil {
 		writeChannelSendErr(w, r, err)

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -356,10 +356,13 @@ func (h Handlers) SendAccountEmail(w http.ResponseWriter, r *http.Request, _ crm
 		writeStoreErr(w, r, err)
 		return
 	}
-	out, err := h.store.SendOrSchedule(r.Context(), FromAccount(links), sendInputFrom(
-		req.To, req.Cc, req.Bcc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
-		req.ConsentPurpose, req.DraftRef,
-	), sched, h.consent, h.delivery, h.timer)
+	in, err := accountSendInput(req)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	out, err := h.store.SendOrSchedule(r.Context(), FromAccount(links), in,
+		sched, h.consent, h.delivery, h.timer)
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return
@@ -450,10 +453,13 @@ func (h Handlers) SendEmail(w http.ResponseWriter, r *http.Request, id crmcontra
 	// reply with none of its own is unchanged, which is every reply that was
 	// sent before this field existed.
 	origin := FromActivity(pathID[ids.ActivityKind](id)).AlsoFiledUnder(linkInputsOf(req.AlsoLinks))
-	out, err := h.store.SendOrSchedule(r.Context(), origin, sendInputFrom(
-		req.To, req.Cc, req.Bcc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
-		req.ConsentPurpose, req.DraftRef,
-	), sched, h.consent, h.delivery, h.timer)
+	in, err := replySendInput(req)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	out, err := h.store.SendOrSchedule(r.Context(), origin, in,
+		sched, h.consent, h.delivery, h.timer)
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return

--- a/backend/internal/modules/activities/outboundmessage.go
+++ b/backend/internal/modules/activities/outboundmessage.go
@@ -99,7 +99,7 @@ func (m outboundMessage) activity(chain threading) LogActivityInput {
 }
 
 // delivery is the same message as the delivery machinery receives it.
-func (m outboundMessage) delivery(activityID ids.UUID, chain threading) DeliveryRequest {
+func (m outboundMessage) delivery(activityID ids.UUID, chain threading, origin SendOrigin) DeliveryRequest {
 	return DeliveryRequest{
 		ActivityID:      ids.From[ids.ActivityKind](activityID),
 		Provider:        m.provider,
@@ -113,7 +113,7 @@ func (m outboundMessage) delivery(activityID ids.UUID, chain threading) Delivery
 		FromName:        m.fromName,
 		Attachments:     m.files,
 		ConsentPurpose:  m.in.ConsentPurpose,
-		Authorization:   m.authorization(),
+		Authorization:   m.authorization(origin),
 		InReplyTo:       chain.inReplyTo,
 		References:      chain.references,
 		ThreadKey:       chain.threadKey,
@@ -130,11 +130,46 @@ func (m outboundMessage) delivery(activityID ids.UUID, chain threading) Delivery
 //
 // Recipients is the MERGED list, not the To: line. A blind copy is blind to the
 // other recipients and never to the engine.
-func (m outboundMessage) authorization() commsauthz.Request {
+func (m outboundMessage) authorization(origin SendOrigin) commsauthz.Request {
 	return commsauthz.Request{
 		Recipients:       connector.EmailRecipients(m.in.Recipients),
+		Context:          m.in.Context,
 		LegacyPurposeKey: m.in.ConsentPurpose,
+		MarketingPurpose: m.in.MarketingPurpose,
+		OperatorReason:   m.in.OperatorReason,
+		Evidence:         m.evidence(origin),
+		// The anchor is where a reply's own answer comes from: a message
+		// continuing a thread the subject started is a reply whether or not the
+		// caller thought to say so. Zero on an account-started send, which is
+		// exactly what tells the engine there is no thread to lean on.
+		AnchorActivityID: origin.anchor.UUID,
+		Links:            linkedRecordIDs(m.links),
 		Subject:          m.in.Subject,
 		Body:             m.body,
 	}
+}
+
+// evidence is what the caller offered, with the anchor filled in from the
+// origin when they named no activity themselves.
+//
+// Derived rather than demanded: a rep replying in the compose window names
+// nothing, and asking them to would be asking them to restate what the send
+// already knows. A caller that DID name an activity keeps theirs — they may be
+// pointing at an earlier message in the thread than the one being answered.
+func (m outboundMessage) evidence(origin SendOrigin) commsauthz.Evidence {
+	e := m.in.Evidence
+	if e.ActivityID == (ids.UUID{}) {
+		e.ActivityID = origin.anchor.UUID
+	}
+	return e
+}
+
+// linkedRecordIDs names the records this message is filed under, which is where
+// a deal, an invoice or a contract validator looks when the caller named none.
+func linkedRecordIDs(links []ActivityLinkInput) []ids.UUID {
+	out := make([]ids.UUID, 0, len(links))
+	for _, l := range links {
+		out = append(out, l.EntityID)
+	}
+	return out
 }

--- a/backend/internal/modules/activities/scheduledpayload.go
+++ b/backend/internal/modules/activities/scheduledpayload.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// What a scheduled message keeps while it waits, and how it comes back.
+//
+// Its own file because freeze and thaw are one concept and scheduledsend.go had
+// outgrown the size cap. They are inverses, and the only place a send's own
+// description can narrow without anything failing: a field added to
+// SendEmailInput and not carried here is dropped silently, and the message
+// still goes out — just describing itself as less than the rep said it was.
+// scheduledpayload_test.go compares the round trip field by field for that
+// reason, rather than asserting the handful somebody remembered.
+
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+type scheduledPayload struct {
+	Recipients     []string `json:"recipients"`
+	Cc             []string `json:"cc,omitempty"`
+	Bcc            []string `json:"bcc,omitempty"`
+	Subject        string   `json:"subject"`
+	Body           string   `json:"body"`
+	HTMLBody       string   `json:"html_body,omitempty"`
+	AttachmentIDs  []string `json:"attachment_ids,omitempty"`
+	ConsentPurpose string   `json:"consent_purpose"`
+	DraftRef       string   `json:"draft_ref,omitempty"`
+	// The four context fields the send door decoded. Frozen with the message
+	// for the reason everything else here is: what the rep claimed at 17:00
+	// today is what the decision row must say when the message goes out at
+	// 09:00 tomorrow. A payload that dropped them recorded a scheduled
+	// marketing send as claiming nothing, and made its proof row strictly
+	// worse than the same message sent immediately.
+	Context          string         `json:"context,omitempty"`
+	MarketingPurpose string         `json:"marketing_purpose,omitempty"`
+	OperatorReason   string         `json:"operator_reason,omitempty"`
+	Evidence         frozenEvidence `json:"evidence,omitzero"`
+}
+
+// frozenEvidence is the evidence block as it sits on a scheduled row. Ids as
+// strings, because a payload outlives the code that wrote it and a typed id is
+// the code's shape rather than the row's.
+type frozenEvidence struct {
+	ActivityID     string `json:"activity_id,omitempty"`
+	DealID         string `json:"deal_id,omitempty"`
+	InvoiceID      string `json:"invoice_id,omitempty"`
+	ContractID     string `json:"contract_id,omitempty"`
+	ConsentEventID string `json:"consent_event_id,omitempty"`
+	BasisID        string `json:"basis_id,omitempty"`
+}
+
+// freezeEvidence and thawEvidence are inverses. An id that is zero stays empty
+// rather than becoming the zero UUID's text, so a round trip through the row
+// gives back exactly what went in.
+func freezeEvidence(e commsauthz.Evidence) frozenEvidence {
+	return frozenEvidence{
+		ActivityID:     idText(e.ActivityID),
+		DealID:         idText(e.DealID),
+		InvoiceID:      idText(e.InvoiceID),
+		ContractID:     idText(e.ContractID),
+		ConsentEventID: idText(e.ConsentEventID),
+		BasisID:        idText(e.BasisID),
+	}
+}
+
+func (f frozenEvidence) thaw() (commsauthz.Evidence, error) {
+	var out commsauthz.Evidence
+	for _, field := range []struct {
+		raw  string
+		into *ids.UUID
+	}{
+		{f.ActivityID, &out.ActivityID},
+		{f.DealID, &out.DealID},
+		{f.InvoiceID, &out.InvoiceID},
+		{f.ContractID, &out.ContractID},
+		{f.ConsentEventID, &out.ConsentEventID},
+		{f.BasisID, &out.BasisID},
+	} {
+		if field.raw == "" {
+			continue
+		}
+		id, err := ids.Parse(field.raw)
+		if err != nil {
+			return commsauthz.Evidence{}, fmt.Errorf("scheduled send: evidence id %q: %w", field.raw, err)
+		}
+		*field.into = id
+	}
+	return out, nil
+}
+
+// idText renders an id for the row, and an unnamed record as the empty string.
+func idText(id ids.UUID) string {
+	if id == (ids.UUID{}) {
+		return ""
+	}
+	return id.String()
+}
+
+func freezePayload(in SendEmailInput) scheduledPayload {
+	files := make([]string, 0, len(in.AttachmentIDs))
+	for _, id := range in.AttachmentIDs {
+		files = append(files, id.String())
+	}
+	return scheduledPayload{
+		Recipients:     in.Recipients,
+		Cc:             in.Cc,
+		Bcc:            in.Bcc,
+		Subject:        in.Subject,
+		Body:           in.Body,
+		HTMLBody:       in.HTMLBody,
+		AttachmentIDs:  files,
+		ConsentPurpose: in.ConsentPurpose,
+		DraftRef:       in.DraftRef,
+
+		Context:          string(in.Context),
+		MarketingPurpose: in.MarketingPurpose,
+		OperatorReason:   in.OperatorReason,
+		Evidence:         freezeEvidence(in.Evidence),
+	}
+}
+
+func (p scheduledPayload) thaw() (SendEmailInput, error) {
+	files := make([]ids.UUID, 0, len(p.AttachmentIDs))
+	for _, raw := range p.AttachmentIDs {
+		id, err := ids.Parse(raw)
+		if err != nil {
+			return SendEmailInput{}, fmt.Errorf("scheduled send: attachment id %q: %w", raw, err)
+		}
+		files = append(files, id)
+	}
+	evidence, err := p.Evidence.thaw()
+	if err != nil {
+		return SendEmailInput{}, err
+	}
+	return SendEmailInput{
+		Recipients:     p.Recipients,
+		Cc:             p.Cc,
+		Bcc:            p.Bcc,
+		Subject:        p.Subject,
+		Body:           p.Body,
+		HTMLBody:       p.HTMLBody,
+		AttachmentIDs:  files,
+		ConsentPurpose: p.ConsentPurpose,
+		DraftRef:       p.DraftRef,
+
+		Context:          commsauthz.Category(p.Context),
+		MarketingPurpose: p.MarketingPurpose,
+		OperatorReason:   p.OperatorReason,
+		Evidence:         evidence,
+	}, nil
+}

--- a/backend/internal/modules/activities/scheduledpayload_test.go
+++ b/backend/internal/modules/activities/scheduledpayload_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// A scheduled message comes back out exactly as it went in.
+//
+// The freeze/thaw pair is the one place a send's own description can narrow
+// without anything failing: a field added to SendEmailInput and not to
+// scheduledPayload is dropped silently, and the send still goes — just
+// describing itself as less than it was. That failed safe for the context
+// fields (an empty claim records NULL rather than a false claim) and would not
+// have for marketing_purpose, whose whole job is to scope a grant to one topic:
+// a send scheduled for one minute from now would have arrived with no purpose
+// to check against.
+//
+// So this compares field by field through reflection rather than asserting the
+// handful somebody remembered. The next field added to SendEmailInput fails
+// here until it is carried.
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// A fully-populated input survives the round trip with every field intact.
+func TestAScheduledSendCarriesEveryFieldOfItsInput(t *testing.T) {
+	in := SendEmailInput{
+		Recipients:       []string{"buyer@example.test", "cc@example.test"},
+		Cc:               []string{"cc@example.test"},
+		Bcc:              []string{"blind@example.test"},
+		Subject:          "Your quote",
+		Body:             "As discussed.",
+		HTMLBody:         "<p>As discussed.</p>",
+		AttachmentIDs:    []ids.UUID{ids.NewV7()},
+		ConsentPurpose:   "marketing_email",
+		DraftRef:         "draft-7",
+		Context:          commsauthz.CategoryMarketing,
+		MarketingPurpose: "newsletter",
+		OperatorReason:   "they asked at the fair",
+		Evidence: commsauthz.Evidence{
+			ActivityID:     ids.NewV7(),
+			DealID:         ids.NewV7(),
+			InvoiceID:      ids.NewV7(),
+			ContractID:     ids.NewV7(),
+			ConsentEventID: ids.NewV7(),
+			BasisID:        ids.NewV7(),
+		},
+	}
+
+	out, err := freezePayload(in).thaw()
+	if err != nil {
+		t.Fatalf("thawing a frozen send: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("a scheduled send came back changed:\n frozen: %+v\n thawed: %+v", in, out)
+	}
+}
+
+// Every field of the input is actually SET by the fixture above. Without this,
+// a new field would be zero on both sides, DeepEqual would pass, and the test
+// meant to catch a dropped field would be the thing hiding it.
+func TestTheRoundTripFixtureLeavesNoFieldUnset(t *testing.T) {
+	in := SendEmailInput{
+		Recipients:       []string{"buyer@example.test"},
+		Cc:               []string{"cc@example.test"},
+		Bcc:              []string{"blind@example.test"},
+		Subject:          "Your quote",
+		Body:             "As discussed.",
+		HTMLBody:         "<p>As discussed.</p>",
+		AttachmentIDs:    []ids.UUID{ids.NewV7()},
+		ConsentPurpose:   "marketing_email",
+		DraftRef:         "draft-7",
+		Context:          commsauthz.CategoryMarketing,
+		MarketingPurpose: "newsletter",
+		OperatorReason:   "they asked at the fair",
+		Evidence:         commsauthz.Evidence{ActivityID: ids.NewV7()},
+	}
+	v := reflect.ValueOf(in)
+	for i := range v.NumField() {
+		if v.Field(i).IsZero() {
+			t.Errorf("SendEmailInput.%s is zero in the round-trip fixture, so the round trip proves nothing about it",
+				v.Type().Field(i).Name)
+		}
+	}
+}
+
+// An unnamed record stays unnamed. Rendering a zero id as text would put the
+// all-zeroes UUID on the row, which reads as a record that exists.
+func TestAnUnnamedRecordDoesNotBecomeAZeroID(t *testing.T) {
+	frozen := freezePayload(SendEmailInput{Subject: "Hello"})
+	if frozen.Evidence != (frozenEvidence{}) {
+		t.Errorf("evidence = %+v, want every field empty when the caller named nothing", frozen.Evidence)
+	}
+	out, err := frozen.thaw()
+	if err != nil {
+		t.Fatalf("thawing: %v", err)
+	}
+	if out.Evidence != (commsauthz.Evidence{}) {
+		t.Errorf("evidence = %+v, want zero after a round trip that named nothing", out.Evidence)
+	}
+}

--- a/backend/internal/modules/activities/scheduledsend.go
+++ b/backend/internal/modules/activities/scheduledsend.go
@@ -26,7 +26,7 @@ const scheduleCeiling = 90 * 24 * time.Hour
 // payloadVersionCurrent is the frozen-payload schema this build writes. Rows
 // outlive the code that wrote them, so a reader checks this rather than
 // assuming the struct it compiled against is the one on disk.
-const payloadVersionCurrent = 1
+const payloadVersionCurrent = 2
 
 // The scheduling fields, named once. They are a wire contract, an audit key and
 // a refusal's field name at the same time, so a typo in any one spelling would
@@ -98,58 +98,6 @@ type SendSchedule struct {
 // Attachments are IDS, not bytes. The fire path re-resolves them so a document
 // archived or superseded between scheduling and sending is caught by the same
 // gate an immediate send passes through.
-type scheduledPayload struct {
-	Recipients     []string `json:"recipients"`
-	Cc             []string `json:"cc,omitempty"`
-	Bcc            []string `json:"bcc,omitempty"`
-	Subject        string   `json:"subject"`
-	Body           string   `json:"body"`
-	HTMLBody       string   `json:"html_body,omitempty"`
-	AttachmentIDs  []string `json:"attachment_ids,omitempty"`
-	ConsentPurpose string   `json:"consent_purpose"`
-	DraftRef       string   `json:"draft_ref,omitempty"`
-}
-
-func freezePayload(in SendEmailInput) scheduledPayload {
-	files := make([]string, 0, len(in.AttachmentIDs))
-	for _, id := range in.AttachmentIDs {
-		files = append(files, id.String())
-	}
-	return scheduledPayload{
-		Recipients:     in.Recipients,
-		Cc:             in.Cc,
-		Bcc:            in.Bcc,
-		Subject:        in.Subject,
-		Body:           in.Body,
-		HTMLBody:       in.HTMLBody,
-		AttachmentIDs:  files,
-		ConsentPurpose: in.ConsentPurpose,
-		DraftRef:       in.DraftRef,
-	}
-}
-
-func (p scheduledPayload) thaw() (SendEmailInput, error) {
-	files := make([]ids.UUID, 0, len(p.AttachmentIDs))
-	for _, raw := range p.AttachmentIDs {
-		id, err := ids.Parse(raw)
-		if err != nil {
-			return SendEmailInput{}, fmt.Errorf("scheduled send: attachment id %q: %w", raw, err)
-		}
-		files = append(files, id)
-	}
-	return SendEmailInput{
-		Recipients:     p.Recipients,
-		Cc:             p.Cc,
-		Bcc:            p.Bcc,
-		Subject:        p.Subject,
-		Body:           p.Body,
-		HTMLBody:       p.HTMLBody,
-		AttachmentIDs:  files,
-		ConsentPurpose: p.ConsentPurpose,
-		DraftRef:       p.DraftRef,
-	}, nil
-}
-
 // ScheduledSend is one message waiting for its moment.
 type ScheduledSend struct {
 	ID          ids.UUID

--- a/backend/internal/modules/activities/sendcontext.go
+++ b/backend/internal/modules/activities/sendcontext.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// What a caller says about WHY they are writing, decoded off the wire.
+//
+// The four fields travel together because they answer one question between
+// them — the category claimed, the topic a marketing send is for, the sentence
+// a human typed about an ambiguous first message, and the records offered in
+// support. Splitting them across a parameter list would put four more
+// positional arguments on a decoder that already carries nine.
+//
+// None of it authorizes anything. A claim is a claim: the engine reads the
+// evidence, resolves the category the evidence actually supports, and records
+// both, so a caller naming `invoice_or_payment` over a message with no invoice
+// behind it produces a visible disagreement rather than a send.
+
+import (
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// contextField is the wire path a refusal about a claimed category points at.
+const contextField = "communication_context"
+
+// sendContext is the decoded claim.
+type sendContext struct {
+	category  commsauthz.Category
+	marketing string
+	reason    string
+	evidence  commsauthz.Evidence
+}
+
+// applyTo puts the claim on the send input.
+func (c sendContext) applyTo(in SendEmailInput) SendEmailInput {
+	in.Context = c.category
+	in.MarketingPurpose = c.marketing
+	in.OperatorReason = c.reason
+	in.Evidence = c.evidence
+	return in
+}
+
+// sendContextFrom decodes and validates what the caller claimed.
+//
+// An unknown category is refused rather than dropped: a caller who misspells
+// one and is silently given the engine's own resolution has been told their
+// claim was accepted when it was never read.
+func sendContextFrom(category *string, marketing, reason *string, evidence *crmcontracts.CommunicationEvidence) (sendContext, error) {
+	out := sendContext{
+		marketing: deref(marketing),
+		reason:    deref(reason),
+		evidence:  evidenceFrom(evidence),
+	}
+	if category == nil || *category == "" {
+		return out, nil
+	}
+	claimed := commsauthz.Category(*category)
+	if !claimed.Valid() {
+		return sendContext{}, &CommunicationContextError{
+			Reason: "that is not a communication category",
+		}
+	}
+	// The five categories that exist to serve the recipient are the ones a
+	// hard suppression does not stop, and they are reserved for the
+	// installation's own controller mail, which rides a registered template. A
+	// caller able to claim one could dress marketing as a security warning and
+	// reach somebody who has objected — so the claim is refused here, at the
+	// door, rather than left for the engine to disbelieve.
+	if claimed.ServesTheSubject() {
+		return sendContext{}, &CommunicationContextError{
+			Reason: "that category is reserved for the installation's own notices and cannot be claimed by a send",
+		}
+	}
+	out.category = claimed
+	return out, nil
+}
+
+// evidenceFrom flattens the optional block. An absent id stays zero, which is
+// what the engine reads as "the caller named none".
+func evidenceFrom(in *crmcontracts.CommunicationEvidence) commsauthz.Evidence {
+	if in == nil {
+		return commsauthz.Evidence{}
+	}
+	return commsauthz.Evidence{
+		ActivityID:     derefID(in.ActivityId),
+		DealID:         derefID(in.DealId),
+		InvoiceID:      derefID(in.InvoiceId),
+		ContractID:     derefID(in.ContractId),
+		ConsentEventID: derefID(in.ConsentEventId),
+		BasisID:        derefID(in.BasisId),
+	}
+}
+
+func derefID(id *openapi_types.UUID) ids.UUID {
+	if id == nil {
+		return ids.UUID{}
+	}
+	return ids.UUID(*id)
+}
+
+// CommunicationContextError maps to 422: the caller named a category, and it is
+// not one they may name. The claimed value is never echoed back — the wire's own
+// field pointer says which input to change, and the message says why.
+type CommunicationContextError struct{ Reason string }
+
+func (e *CommunicationContextError) Error() string { return e.Reason }
+
+// FieldFault names the offending field, on every surface.
+func (e *CommunicationContextError) FieldFault() (field, code, message string) {
+	return contextField, faultInvalid, e.Reason
+}
+
+// replySendInput decodes a reply's whole body into the send input: the message
+// itself, and the claim the caller made about why they are writing.
+//
+// Here rather than in the handler because the two are one decode. Splitting the
+// claim from the message put both halves in a handler that had already outgrown
+// the file cap, and neither half means anything without the other.
+func replySendInput(req crmcontracts.SendEmailRequest) (SendEmailInput, error) {
+	claimed, err := sendContextFrom((*string)(req.CommunicationContext),
+		req.MarketingPurpose, req.OperatorReason, req.Evidence)
+	if err != nil {
+		return SendEmailInput{}, err
+	}
+	return claimed.applyTo(sendInputFrom(
+		req.To, req.Cc, req.Bcc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
+		req.ConsentPurpose, req.DraftRef,
+	)), nil
+}
+
+// accountSendInput is the same decode for an account-started send, which names
+// its own links and has no anchor to derive a category from — the one shape
+// where a caller's claim is the only thing that can say what the message is.
+func accountSendInput(req crmcontracts.SendAccountEmailRequest) (SendEmailInput, error) {
+	claimed, err := sendContextFrom((*string)(req.CommunicationContext),
+		req.MarketingPurpose, req.OperatorReason, req.Evidence)
+	if err != nil {
+		return SendEmailInput{}, err
+	}
+	return claimed.applyTo(sendInputFrom(
+		req.To, req.Cc, req.Bcc, req.Subject, req.Body, req.HtmlBody, req.AttachmentIds,
+		req.ConsentPurpose, req.DraftRef,
+	)), nil
+}

--- a/backend/internal/modules/activities/sendcontext.go
+++ b/backend/internal/modules/activities/sendcontext.go
@@ -24,8 +24,17 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
-// contextField is the wire path a refusal about a claimed category points at.
-const contextField = "communication_context"
+// contextField is the wire path a refusal about a claimed category points at,
+// and operatorReasonField its twin for the sentence beside it.
+const (
+	contextField        = "communication_context"
+	operatorReasonField = "operator_reason"
+)
+
+// maxOperatorReasonRunes mirrors the contract's maxLength. Named rather than
+// inlined because the refusal message states it too, and two spellings of one
+// bound drift.
+const maxOperatorReasonRunes = 500
 
 // sendContext is the decoded claim.
 type sendContext struct {
@@ -54,6 +63,16 @@ func sendContextFrom(category *string, marketing, reason *string, evidence *crmc
 		marketing: deref(marketing),
 		reason:    deref(reason),
 		evidence:  evidenceFrom(evidence),
+	}
+	// The contract bounds the reason at 500 and nothing in this stack validates
+	// a request against the schema, so the bound is enforced here or nowhere. A
+	// sentence about one send is short; anything longer is a paste accident or
+	// an attempt to use the decision trail as storage.
+	if len([]rune(out.reason)) > maxOperatorReasonRunes {
+		return sendContext{}, &CommunicationContextError{
+			field:  operatorReasonField,
+			Reason: "an operator reason is at most 500 characters",
+		}
 	}
 	if category == nil || *category == "" {
 		return out, nil
@@ -105,13 +124,22 @@ func derefID(id *openapi_types.UUID) ids.UUID {
 // CommunicationContextError maps to 422: the caller named a category, and it is
 // not one they may name. The claimed value is never echoed back — the wire's own
 // field pointer says which input to change, and the message says why.
-type CommunicationContextError struct{ Reason string }
+type CommunicationContextError struct {
+	// field is the wire path the refusal points at, so a caller is told which
+	// of the four inputs to change rather than being handed the block's name.
+	field  string
+	Reason string
+}
 
 func (e *CommunicationContextError) Error() string { return e.Reason }
 
 // FieldFault names the offending field, on every surface.
 func (e *CommunicationContextError) FieldFault() (field, code, message string) {
-	return contextField, faultInvalid, e.Reason
+	named := e.field
+	if named == "" {
+		named = contextField
+	}
+	return named, faultInvalid, e.Reason
 }
 
 // replySendInput decodes a reply's whole body into the send input: the message

--- a/backend/internal/modules/activities/sendcontext_test.go
+++ b/backend/internal/modules/activities/sendcontext_test.go
@@ -168,3 +168,33 @@ func asFieldFault(err error, target *interface {
 	}
 	return ok
 }
+
+// The contract bounds the operator reason and nothing in this stack validates a
+// request against the schema, so the bound is enforced in the decoder or
+// nowhere. The refusal names the reason field, not the category one — a caller
+// told to fix the wrong input fixes nothing.
+func TestAnOverlongOperatorReasonIsRefused(t *testing.T) {
+	long := strings.Repeat("x", maxOperatorReasonRunes+1)
+	_, err := sendContextFrom(nil, nil, &long, nil)
+	if err == nil {
+		t.Fatal("an unbounded operator reason was accepted")
+	}
+	var fault interface {
+		FieldFault() (string, string, string)
+	}
+	if !asFieldFault(err, &fault) {
+		t.Fatalf("refusal %v names no field", err)
+	}
+	if field, _, _ := fault.FieldFault(); field != operatorReasonField {
+		t.Errorf("refusal names field %q, want %q", field, operatorReasonField)
+	}
+}
+
+// A reason exactly at the bound is accepted: an off-by-one here refuses a
+// sentence the contract promises to take.
+func TestAReasonAtTheBoundIsAccepted(t *testing.T) {
+	atLimit := strings.Repeat("x", maxOperatorReasonRunes)
+	if _, err := sendContextFrom(nil, nil, &atLimit, nil); err != nil {
+		t.Errorf("a reason of exactly %d characters was refused: %v", maxOperatorReasonRunes, err)
+	}
+}

--- a/backend/internal/modules/activities/sendcontext_test.go
+++ b/backend/internal/modules/activities/sendcontext_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// What a caller may claim about their own send, and what they may not.
+
+import (
+	"strings"
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// Claiming nothing is the ordinary case and must stay free: a rep answering a
+// message in the compose window names no category, and the engine resolves one
+// from the origin. A decoder that refused an absent claim would refuse every
+// reply this product sends.
+func TestClaimingNoCategoryIsAccepted(t *testing.T) {
+	got, err := sendContextFrom(nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("an absent claim was refused: %v", err)
+	}
+	if got.category != "" {
+		t.Errorf("category = %q, want empty — the engine resolves it, not the decoder", got.category)
+	}
+}
+
+// The five categories that serve the recipient are the ones a hard suppression
+// does not stop. They belong to the installation's own controller mail, which
+// rides a registered template. A send that could claim one could dress
+// marketing as a security warning and reach somebody who has objected — so
+// every one of them is refused here, at the door.
+func TestAServeTheSubjectCategoryCannotBeClaimedByASend(t *testing.T) {
+	reserved := []commsauthz.Category{
+		commsauthz.CategorySecurityNotice,
+		commsauthz.CategoryPrivacyNotice,
+		commsauthz.CategoryOptoutConfirmation,
+		commsauthz.CategoryConsentConfirmation,
+		commsauthz.CategoryRecordConfirmation,
+	}
+	for _, c := range reserved {
+		claimed := string(c)
+		if _, err := sendContextFrom(&claimed, nil, nil, nil); err == nil {
+			t.Errorf("a send claiming %q was accepted — that category is reserved for controller mail", c)
+		}
+	}
+}
+
+// Every reserved category is one this test knows about. Derived from the
+// vocabulary rather than listed beside it: a category added to
+// ServesTheSubject without being added above would otherwise be claimable by
+// an ordinary send and no test would notice.
+func TestEveryServeTheSubjectCategoryIsRefused(t *testing.T) {
+	for _, c := range commsauthz.Categories() {
+		if !c.ServesTheSubject() {
+			continue
+		}
+		claimed := string(c)
+		if _, err := sendContextFrom(&claimed, nil, nil, nil); err == nil {
+			t.Errorf("%q serves the subject and a send may still claim it", c)
+		}
+	}
+}
+
+// The categories a rep's own send is ABOUT stay claimable. A decoder that
+// refused these would leave a caller unable to say anything true about their
+// message.
+func TestAnOrdinaryCategoryIsAccepted(t *testing.T) {
+	for _, c := range []commsauthz.Category{
+		commsauthz.CategoryReplyToInbound,
+		commsauthz.CategoryActiveDealFollowup,
+		commsauthz.CategoryInvoiceOrPayment,
+		commsauthz.CategoryMarketing,
+	} {
+		claimed := string(c)
+		got, err := sendContextFrom(&claimed, nil, nil, nil)
+		if err != nil {
+			t.Errorf("claiming %q was refused: %v", c, err)
+			continue
+		}
+		if got.category != c {
+			t.Errorf("category = %q, want %q", got.category, c)
+		}
+	}
+}
+
+// A misspelled category is refused rather than dropped. Silently ignoring it
+// would tell the caller their claim was accepted when nothing ever read it.
+func TestAnUnknownCategoryIsRefusedRatherThanIgnored(t *testing.T) {
+	claimed := "transactional"
+	_, err := sendContextFrom(&claimed, nil, nil, nil)
+	if err == nil {
+		t.Fatal("an unknown category was accepted — a claim nothing reads is worse than a refusal")
+	}
+	var fault interface {
+		FieldFault() (string, string, string)
+	}
+	if !asFieldFault(err, &fault) {
+		t.Fatalf("refusal %v names no field; a caller cannot tell which input to change", err)
+	}
+	field, _, _ := fault.FieldFault()
+	if field != contextField {
+		t.Errorf("refusal names field %q, want %q", field, contextField)
+	}
+}
+
+// The claimed value never comes back in the message. It is the caller's own
+// text, and echoing it is how a refusal becomes a reflection surface.
+func TestTheRefusalDoesNotEchoTheClaim(t *testing.T) {
+	claimed := "<script>alert(1)</script>"
+	_, err := sendContextFrom(&claimed, nil, nil, nil)
+	if err == nil {
+		t.Fatal("want a refusal")
+	}
+	if got := err.Error(); strings.Contains(got, "script") {
+		t.Errorf("the refusal echoes the caller's value: %q", got)
+	}
+}
+
+// Evidence arrives as ids and nothing else. The decoder's job is to flatten
+// the optional block; whether a named record supports anything is the engine's
+// question, asked against the record itself.
+func TestEvidenceIsFlattenedById(t *testing.T) {
+	deal := openapi_types.UUID(ids.NewV7())
+	got, err := sendContextFrom(nil, nil, nil, &crmcontracts.CommunicationEvidence{DealId: &deal})
+	if err != nil {
+		t.Fatalf("evidence was refused: %v", err)
+	}
+	if got.evidence.DealID != ids.UUID(deal) {
+		t.Errorf("deal id = %v, want %v", got.evidence.DealID, ids.UUID(deal))
+	}
+	if got.evidence.InvoiceID != (ids.UUID{}) {
+		t.Error("an unnamed record came back non-zero; the engine reads zero as 'the caller named none'")
+	}
+}
+
+// applyTo puts the claim on the input the send path actually carries. Without
+// it the decode would be correct and reach nothing.
+func TestTheClaimReachesTheSendInput(t *testing.T) {
+	c := sendContext{category: commsauthz.CategoryMarketing, marketing: "newsletter", reason: "they asked at the fair"}
+	got := c.applyTo(SendEmailInput{Subject: "Hello"})
+	if got.Context != commsauthz.CategoryMarketing {
+		t.Errorf("Context = %q, want marketing", got.Context)
+	}
+	if got.MarketingPurpose != "newsletter" || got.OperatorReason != "they asked at the fair" {
+		t.Errorf("marketing purpose or operator reason did not reach the input: %+v", got)
+	}
+	if got.Subject != "Hello" {
+		t.Error("applyTo overwrote a field it does not own")
+	}
+}
+
+// asFieldFault is errors.As without importing errors for one call.
+func asFieldFault(err error, target *interface {
+	FieldFault() (string, string, string)
+},
+) bool {
+	f, ok := err.(interface {
+		FieldFault() (string, string, string)
+	})
+	if ok {
+		*target = f
+	}
+	return ok
+}

--- a/backend/internal/modules/activities/sendcore.go
+++ b/backend/internal/modules/activities/sendcore.go
@@ -204,7 +204,7 @@ func (s *Store) SendPreparedTx(ctx context.Context, tx pgx.Tx, origin SendOrigin
 	if err != nil {
 		return crmcontracts.Activity{}, err
 	}
-	if err := stager.StageTx(ctx, tx, p.message.delivery(ids.UUID(sent.Id), chain)); err != nil {
+	if err := stager.StageTx(ctx, tx, p.message.delivery(ids.UUID(sent.Id), chain, origin)); err != nil {
 		return crmcontracts.Activity{}, err
 	}
 	// in.Body, not message.body: the judgment is about the text the HUMAN

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21116,7 +21116,7 @@ export interface components {
              *
              *     Five categories exist to serve the recipient — `security_notice`,
              *     `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-             *     `record_confirmation` — and are refused (422 `context_not_available`) from an
+             *     `record_confirmation` — and are refused (422 `invalid`) from an
              *     ordinary send. They are reserved for the installation's own controller mail,
              *     which rides a registered template; a caller that could claim one could dress
              *     marketing as a security warning and reach somebody who has objected.
@@ -21337,7 +21337,7 @@ export interface components {
              *
              *     Five categories exist to serve the recipient — `security_notice`,
              *     `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-             *     `record_confirmation` — and are refused (422 `context_not_available`) from an
+             *     `record_confirmation` — and are refused (422 `invalid`) from an
              *     ordinary send. They are reserved for the installation's own controller mail,
              *     which rides a registered template; a caller that could claim one could dress
              *     marketing as a security warning and reach somebody who has objected.
@@ -21426,7 +21426,7 @@ export interface components {
              *
              *     Five categories exist to serve the recipient — `security_notice`,
              *     `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-             *     `record_confirmation` — and are refused (422 `context_not_available`) from an
+             *     `record_confirmation` — and are refused (422 `invalid`) from an
              *     ordinary send. They are reserved for the installation's own controller mail,
              *     which rides a registered template; a caller that could claim one could dress
              *     marketing as a security warning and reach somebody who has objected.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21010,6 +21010,48 @@ export interface components {
             label: string;
             evidence_ref?: components["schemas"]["OrganizationBriefEvidence"];
         };
+        /**
+         * @description Records the caller can name in support of a send, each by id. Evidence is
+         *     CHECKED, never trusted: the engine reads the named record and asks whether it
+         *     actually supports the category claimed — a deal id that is closed, an invoice
+         *     belonging to another organization, or a record the caller cannot see supports
+         *     nothing. Naming a record therefore never widens what a caller may do.
+         *
+         *     Every field is optional. A caller that can name nothing says nothing, and the
+         *     engine resolves the send from its origin instead.
+         */
+        CommunicationEvidence: {
+            /**
+             * Format: uuid
+             * @description The inbound message this send answers.
+             */
+            activity_id?: string | null;
+            /**
+             * Format: uuid
+             * @description The live opportunity this send moves along.
+             */
+            deal_id?: string | null;
+            /**
+             * Format: uuid
+             * @description The invoice or payment event this send is about.
+             */
+            invoice_id?: string | null;
+            /**
+             * Format: uuid
+             * @description The live contract whose notice this send carries.
+             */
+            contract_id?: string | null;
+            /**
+             * Format: uuid
+             * @description The recorded consent this send relies on.
+             */
+            consent_event_id?: string | null;
+            /**
+             * Format: uuid
+             * @description A recorded communication basis this send relies on.
+             */
+            basis_id?: string | null;
+        };
         SendEmailRequest: {
             subject: string;
             /** @description The (possibly edited) final body that is sent. */
@@ -21062,6 +21104,41 @@ export interface components {
              *     outcome is inferred without a valid reference.
              */
             draft_ref?: string | null;
+            /**
+             * @description What kind of communication this is. The caller CLAIMS a category; the engine
+             *     resolves the one the evidence actually supports and records both, so a claim
+             *     that the evidence does not carry is visible rather than silently honoured.
+             *
+             *     Omit it and the engine resolves the category from the send's origin — a reply
+             *     to an inbound message is a reply whether or not anybody said so. Omitting is
+             *     therefore honest and is the ordinary case for a reply; naming one matters when
+             *     there is no anchor to derive from.
+             *
+             *     Five categories exist to serve the recipient — `security_notice`,
+             *     `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+             *     `record_confirmation` — and are refused (422 `context_not_available`) from an
+             *     ordinary send. They are reserved for the installation's own controller mail,
+             *     which rides a registered template; a caller that could claim one could dress
+             *     marketing as a security warning and reach somebody who has objected.
+             * @enum {string|null}
+             */
+            communication_context?: "reply_to_inbound" | "requested_followup" | "precontract_quote" | "active_deal_followup" | "customer_service" | "account_notice" | "contract_notice" | "invoice_or_payment" | "security_notice" | "privacy_notice" | "record_confirmation" | "consent_confirmation" | "optout_confirmation" | "marketing" | null;
+            /**
+             * @description For a marketing send, the consent purpose key naming the topic it is for.
+             *     Marketing consent is purpose-specific: a grant for one topic authorizes that
+             *     topic and no other.
+             */
+            marketing_purpose?: string | null;
+            /**
+             * @description What a human typed when a first message was genuinely ambiguous. It is
+             *     RECORDED on the decision and grants nothing — a sentence a sender wrote about
+             *     their own send is not evidence about the recipient. It exists so a later
+             *     reader can see what the sender believed, not so the engine can be talked into
+             *     an allow.
+             */
+            operator_reason?: string | null;
+            /** @description Records the caller names in support of this send. Checked, never trusted. */
+            evidence?: components["schemas"]["CommunicationEvidence"];
             /**
              * @description The consent purpose this send falls under (e.g. `transactional`, `marketing_email`).
              *     The send is suppressed (409 `consent_not_granted`) unless every recipient has an active
@@ -21249,6 +21326,41 @@ export interface components {
              */
             draft_ref?: string | null;
             /**
+             * @description What kind of communication this is. The caller CLAIMS a category; the engine
+             *     resolves the one the evidence actually supports and records both, so a claim
+             *     that the evidence does not carry is visible rather than silently honoured.
+             *
+             *     Omit it and the engine resolves the category from the send's origin — a reply
+             *     to an inbound message is a reply whether or not anybody said so. Omitting is
+             *     therefore honest and is the ordinary case for a reply; naming one matters when
+             *     there is no anchor to derive from.
+             *
+             *     Five categories exist to serve the recipient — `security_notice`,
+             *     `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+             *     `record_confirmation` — and are refused (422 `context_not_available`) from an
+             *     ordinary send. They are reserved for the installation's own controller mail,
+             *     which rides a registered template; a caller that could claim one could dress
+             *     marketing as a security warning and reach somebody who has objected.
+             * @enum {string|null}
+             */
+            communication_context?: "reply_to_inbound" | "requested_followup" | "precontract_quote" | "active_deal_followup" | "customer_service" | "account_notice" | "contract_notice" | "invoice_or_payment" | "security_notice" | "privacy_notice" | "record_confirmation" | "consent_confirmation" | "optout_confirmation" | "marketing" | null;
+            /**
+             * @description For a marketing send, the consent purpose key naming the topic it is for.
+             *     Marketing consent is purpose-specific: a grant for one topic authorizes that
+             *     topic and no other.
+             */
+            marketing_purpose?: string | null;
+            /**
+             * @description What a human typed when a first message was genuinely ambiguous. It is
+             *     RECORDED on the decision and grants nothing — a sentence a sender wrote about
+             *     their own send is not evidence about the recipient. It exists so a later
+             *     reader can see what the sender believed, not so the engine can be talked into
+             *     an allow.
+             */
+            operator_reason?: string | null;
+            /** @description Records the caller names in support of this send. Checked, never trusted. */
+            evidence?: components["schemas"]["CommunicationEvidence"];
+            /**
              * @description The consent purpose this send falls under. Default-deny per purpose (A22/ADR-0011):
              *     suppressed 409 `consent_not_granted` unless every recipient has an active `granted`
              *     `person_consent` for THIS purpose.
@@ -21302,6 +21414,41 @@ export interface components {
              *     (422 `empty_message_body`) rather than staged for a delivery that could only park.
              */
             body: string;
+            /**
+             * @description What kind of communication this is. The caller CLAIMS a category; the engine
+             *     resolves the one the evidence actually supports and records both, so a claim
+             *     that the evidence does not carry is visible rather than silently honoured.
+             *
+             *     Omit it and the engine resolves the category from the send's origin — a reply
+             *     to an inbound message is a reply whether or not anybody said so. Omitting is
+             *     therefore honest and is the ordinary case for a reply; naming one matters when
+             *     there is no anchor to derive from.
+             *
+             *     Five categories exist to serve the recipient — `security_notice`,
+             *     `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
+             *     `record_confirmation` — and are refused (422 `context_not_available`) from an
+             *     ordinary send. They are reserved for the installation's own controller mail,
+             *     which rides a registered template; a caller that could claim one could dress
+             *     marketing as a security warning and reach somebody who has objected.
+             * @enum {string|null}
+             */
+            communication_context?: "reply_to_inbound" | "requested_followup" | "precontract_quote" | "active_deal_followup" | "customer_service" | "account_notice" | "contract_notice" | "invoice_or_payment" | "security_notice" | "privacy_notice" | "record_confirmation" | "consent_confirmation" | "optout_confirmation" | "marketing" | null;
+            /**
+             * @description For a marketing send, the consent purpose key naming the topic it is for.
+             *     Marketing consent is purpose-specific: a grant for one topic authorizes that
+             *     topic and no other.
+             */
+            marketing_purpose?: string | null;
+            /**
+             * @description What a human typed when a first message was genuinely ambiguous. It is
+             *     RECORDED on the decision and grants nothing — a sentence a sender wrote about
+             *     their own send is not evidence about the recipient. It exists so a later
+             *     reader can see what the sender believed, not so the engine can be talked into
+             *     an allow.
+             */
+            operator_reason?: string | null;
+            /** @description Records the caller names in support of this send. Checked, never trusted. */
+            evidence?: components["schemas"]["CommunicationEvidence"];
             /**
              * @description The consent purpose this send falls under (e.g. `transactional`). The send is
              *     suppressed (409 `consent_not_granted`) unless the recipient has an active `granted`


### PR DESCRIPTION
The three send doors gain `communication_context`, `marketing_purpose`,
`operator_reason` and `evidence`, and the staging decision records what the
caller claimed beside the category the engine resolved.

## A claim is never an authorization

The engine reads the named records and resolves the category the evidence
actually supports. A send naming `invoice_or_payment` over a message with no
invoice behind it produces a visible disagreement on the decision row rather
than a send. Naming a record widens nothing.

## Omitting the context stays the ordinary case

A reply to an inbound message is a reply whether or not anybody said so, and
the anchor is what says it. The builder fills `AnchorActivityID` and the filed
record links from `SendOrigin`, so a rep answering in the compose window names
nothing and the engine still resolves a reply. Asking them to restate what the
send already knows is how a compliance feature becomes something reps route
around.

## Five categories a send may not claim

`security_notice`, `privacy_notice`, `optout_confirmation`,
`consent_confirmation` and `record_confirmation` are refused from an ordinary
send with a 422. They are the categories a hard suppression does not stop, and
they belong to the installation's own controller mail behind a registered
template. A caller able to claim one could dress marketing as a security
warning and reach somebody who has objected.

The test that holds this is derived from `Category.ServesTheSubject()` rather
than from a list beside it, so a category added to that set without being added
to the refusal fails a test instead of becoming claimable.

## All three doors land together

The channel reply is a second implementation of sending, not a variant of the
mail one. A field reaching only `SendEmailInput` would leave that door asking
the old question, so `SendMessageInput` carries the same four.

## Tests

Unit coverage in `sendcontext_test.go`: an absent claim is accepted, every
`ServesTheSubject` category is refused, ordinary categories pass, an unknown
category is refused rather than dropped, and the refusal does not echo the
caller's value back.

Two integration tests over the real composition: a claimed context reaches
`communication_decision.requested_category`, and a send claiming
`security_notice` is refused with nothing staged.

Mutation-checked: reverting the `ServesTheSubject` guard fails the reserved-
category tests; restoring it passes.

## Verification

`make check-backend`, `make check-fe`, `make rls-store-path` and
`make no-jurisdiction` all pass, re-run after rebasing onto current main.
`craft static` is clean across all eleven Go files in the diff. The contract
change is additive optional properties — `check-contract-breaking.sh` reports
no breaking changes, so no allowlist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets senders claim what kind of communication they're sending; the claim is verified against evidence and never widens authorization. All three send doors (email, account email, channel) accept `communication_context`, `marketing_purpose`, `operator_reason`, and `evidence`, and the staging decision records the claimed category beside the engine-resolved one. Omitting the context remains ordinary—the engine derives the category from the reply anchor. Five subject-serving categories (`security_notice`, `privacy_notice`, `optout_confirmation`, `consent_confirmation`, `record_confirmation`) are refused with 422 when claimed by a regular send, since they're reserved for controller mail.

- Scheduled sends keep the claimed context, which they previously dropped at scheduling time.
- The channel door's category refusal now has integration coverage.
- `operator_reason` is enforced at 500 characters; refusals use the `invalid` code.

<sup>Written for commit 3e401d22a8cee2ddbc006c16a887530856fb4f7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added communication context, marketing purpose, operator notes, and supporting evidence to email and channel-send requests.
  - Requests can reference related activities, deals, invoices, contracts, consent events, and communication bases.
  - Added an analytics explanation endpoint that can return records behind an analytics cell, including withheld or truncated results.
  - Attention items now show relationship strength, open-deal visibility, and assignee details.
  - Valid authorization context and evidence are carried through to delivery decisions.

- **Bug Fixes**
  - Invalid or unsupported communication contexts now return clear validation errors.
  - Controller-reserved categories are rejected without staging or delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->