### PR TITLE
frontend: the rail head at its own size, and quieter outlined verbs

### DIFF
--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -457,16 +457,19 @@
   text-decoration: none;
   color: var(--textPrimary);
   border-radius: 9px;
-  padding: 2px 7px; /* ds:ignore 7 + the rail's 8px inset centres the 32px chip on the rows' own 18px glyph axis */
+  padding: 2px 7px 2px 3px; /* ds:ignore 3 + the rail's 8px inset centres the 40px chip on the rows' own 18px glyph axis */
   flex: 1;
   min-width: 0;
   overflow: hidden;
 }
 .rail .ws-chip {
-  width: 32px;
-  height: 32px;
+  /* The workspace's mark is the one picture in the chrome, and at 32px it read
+     as one more row glyph. 40px fills the strip's height less the head's own
+     inset, which is as large as the head can carry without moving the rows. */
+  width: 40px;
+  height: 40px;
   flex: none;
-  border-radius: 9px;
+  border-radius: 10px;
   /* Flat brand emerald, no gradient and no lift: the mark is the one filled
      thing in the chrome, and a lit, shadowed chip beside quiet rows was the
      loudest object on the screen. */
@@ -479,7 +482,7 @@
    stands here is a logo drawn for its own background, or the monogram Avatar
    tints from the record's identity, and either one on the brand emerald would
    be a second surface behind a finished mark. The avatar fills the slot so the
-   collapsed rail keeps centring the same 32px box on the rows' glyph axis. */
+   collapsed rail keeps centring the same 40px box on the rows' glyph axis. */
 .rail .ws-chip-company {
   background: none;
 }
@@ -518,7 +521,9 @@
   opacity: 0;
 }
 .rail .ws-name b {
-  font-size: 13px;
+  /* A step up from the rows: the workspace's name heads the column and reads
+     first, and at the rows' own size it was one more label among them. */
+  font-size: 15px;
   font-weight: var(--fw-semibold);
   color: var(--textPrimary);
   line-height: 1.25;

--- a/frontend/src/design-system/base.css
+++ b/frontend/src/design-system/base.css
@@ -163,10 +163,13 @@
    button reads as a label, and four of them as a sentence. */
 .btn-ghost {
   background: var(--pane);
-  color: var(--textPrimary);
-  /* The control boundary, not the hairline: on the near-white pane the
-     hairline sits under the 3:1 floor a control's edge owes (tokens.css). */
-  border-color: var(--borderControl);
+  color: var(--textContent);
+  /* The hairline, not the control boundary: an outlined verb is a pane with
+     a word on it, and the darker edge drew a row of them as a strip of
+     cartoon buttons. The word is what identifies the control (WCAG 1.4.11
+     asks the boundary to clear 3:1 only where it is the sole cue), so the
+     edge can be as quiet as every other pane's. */
+  border-color: var(--borderSubtle);
 }
 .btn-ghost:hover {
   background: var(--bgHover);


### PR DESCRIPTION
## What

Two follow-ups to the shell (#3889) that landed on its branch after it had merged, carried here as their own change:

- **The workspace mark and name lead the rail.** The mark goes from 32px to 40px and the name from 13px to 15px; the head's inset moves so the mark stays on the rows' glyph axis in both states.
- **Outlined verbs take the hairline, not the control boundary.** A row of ghost buttons on the darker edge read as cartoon buttons. The word identifies the control, so the edge is the pane's own hairline (`--borderSubtle`) and the ink one step quieter (`--textContent`).

## Why

Both from Jo's review of the shell in the app: the logo and name were small for the head of the column, and the secondary buttons too loud.

## How verified

- `rail.test.tsx`, `shell.test.tsx`, `conformance.test.ts`, `onecard.test.ts`, `atoms.test.tsx` pass; `check-ds-spacing.sh` and biome clean.
- Storybook `Shell/Navigation shell` (Default, Sidebar states) rendered in both rail states.

- [x] `make check` frontend gates relevant to the change are green; no Go touched
- [x] `make test-integration` — this change does not touch tenant data / RLS / the write shape
- [x] `make craft-static` — no Go touched
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Generated by an agent under Jo Ziethen's direction.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. Commits are signed
off (`git commit -s`, DCO). See [CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC

---
_Generated by [Claude Code](https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusts the rail header so the workspace mark and name read as the head of the column, and tones down outlined buttons to use the pane's hairline instead of the control boundary.

- The workspace mark grows from 32px to 40px and the name from 13px to 15px.
- Outlined verbs now use `--borderSubtle` and `--textContent` instead of `--borderControl` and `--textPrimary`.

<sup>Written for commit 7cc1113660ef03da67fbe3ff434e75cf9858dbf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the workspace chip size for improved visibility and adjusted its spacing and corner rounding.
  * Increased the workspace name text size.
  * Updated ghost button text and border styling for improved visual consistency across the interface.
  * Preserved company avatar sizing within the workspace chip area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->