### PR TITLE
A lapsed relationship says what it was worth

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -36893,6 +36893,16 @@ components:
           $ref: '#/components/schemas/AttentionPair'
         deal:
           $ref: '#/components/schemas/AttentionDealFacts'
+        assignee_id:
+          type: [string, 'null']
+          format: uuid
+          description: |
+            Who holds this task, null when nobody has taken it. Sent by `task`.
+
+            The lane serves three scopes and only one is the reader's own queue: an
+            unassigned sweep and a named colleague's queue both put work on the page that
+            is not the reader's. Without this those rows read identically to their own,
+            and the row nobody owns — the whole point of that scope — cannot say so.
         due_at: { type: string, format: date-time, description: "When this is due (tasks), or when it lapses (approvals)." }
         overdue: { type: boolean, description: "Past due at the read instant, resolved server-side so every surface agrees." }
         occurred_at: { type: string, format: date-time, description: "When a done_for_you receipt actually happened." }

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -36846,6 +36846,8 @@ components:
             deal card's own figure, and the age each row carries into the ordering. A number
             parsed back out of a sentence reads as zero the day somebody rewords the
             sentence, and every one of those uses would go quietly wrong together.
+        relationship:
+          $ref: '#/components/schemas/AttentionRelationshipFacts'
         cause_ref:
           type: string
           description: |
@@ -36966,6 +36968,35 @@ components:
         amount_minor: { type: [integer, 'null'], format: int64 }
         currency: { type: [string, 'null'], pattern: '^[A-Z]{3}$' }
         owner_id: { type: [string, 'null'], format: uuid }
+
+    AttentionRelationshipFacts:
+      type: object
+      description: |
+        What the lapsed relationship behind a `relationship_decay` item was WORTH before
+        it went quiet. Sent only for `source: relationship_decay`.
+
+        Without it every lapsed contact reads alike, and the rep's strongest relationship
+        going quiet is the row that most deserves to be told apart from a cc who has
+        drifted. Both facts were already in the lane's hand and discarded: the band is
+        scored from the edge the lane loads, and the deal is one batched read over the
+        candidates it already narrowed to.
+
+        The band travels rather than the raw score, because a number between 0 and 100
+        invites a client to draw a precision the §4 arithmetic does not claim.
+      properties:
+        strength:
+          type: string
+          enum: [none, weak, moderate, strong]
+          description: |
+            The relationship's band at the read instant, from the same §4 scoring the
+            contact's own page shows — computed on read rather than stored, so the two
+            surfaces cannot come to disagree about who this person is.
+        has_open_deal:
+          type: boolean
+          description: |
+            Whether money this reader can see still rests on this contact. Absent is not
+            "no": a contact with an open deal the reader may not see reads the same as one
+            with none, which is the answer every row-scoped read gives.
 
     AttentionPairEvidence:
       type: object

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -382,6 +382,12 @@ func classifyTask(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	} else if item.DueAt != nil {
 		row.Because = append(row.Because, reason("due_today", nil))
 	}
+	// Nobody has taken it. The same fact the lead lane states, and this lane
+	// has a whole scope devoted to surfacing it — a sweep of unowned work whose
+	// rows could not say that was what they were.
+	if item.AssigneeId == nil {
+		row.Because = append(row.Because, reason("unassigned", nil))
+	}
 	return ranked{
 		item:       row,
 		deadlineAt: deadlineOf(item.DueAt),
@@ -416,12 +422,13 @@ func classifyUndelivered(item crmcontracts.AttentionItem, asOf time.Time) ranked
 // classifyDecay: a relationship going quiet. Nobody is waiting on the reader
 // for it, which is exactly why it goes unnoticed — and why it sits low rather
 // than not at all.
-// A lapsed relationship that still carries money, or that was a real
-// relationship before it went quiet, is agreed work rather than routine. The
-// same shape classifyWaiting uses for a stale wait, and for the same reason: a
-// lane where every row ranks alike is one a rep reads once. This is the row that
-// most needs telling apart — the rep's strongest contact going silent and a cc
-// drifting are not the same morning's work.
+//
+// How low depends on what the relationship was WORTH. One that still carries
+// money, or that was real before it went silent, is agreed work; a weak one
+// with nothing on it is routine. The same shape classifyWaiting uses for a
+// stale wait, and for the same reason: a lane where every row ranks alike is
+// one a rep reads once, and the rep's strongest contact going silent is not
+// the same morning's work as a cc drifting.
 func classifyDecay(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	level := levelRoutine
 	if decayMatters(item.Relationship) {

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -419,64 +419,6 @@ func classifyUndelivered(item crmcontracts.AttentionItem, asOf time.Time) ranked
 	return ranked{item: row, occurredAt: occurredOf(item, asOf)}
 }
 
-// classifyDecay: a relationship going quiet. Nobody is waiting on the reader
-// for it, which is exactly why it goes unnoticed — and why it sits low rather
-// than not at all.
-//
-// How low depends on what the relationship was WORTH. One that still carries
-// money, or that was real before it went silent, is agreed work; a weak one
-// with nothing on it is routine. The same shape classifyWaiting uses for a
-// stale wait, and for the same reason: a lane where every row ranks alike is
-// one a rep reads once, and the rep's strongest contact going silent is not
-// the same morning's work as a cc drifting.
-func classifyDecay(item crmcontracts.AttentionItem, asOf time.Time) ranked {
-	level := levelRoutine
-	if decayMatters(item.Relationship) {
-		level = levelAgreed
-	}
-	row := base(item, level, "system", "data_drifts")
-	quiet := quietDaysOf(item)
-	if quiet > 0 {
-		row.Because = append(row.Because, reason("quiet_days", daysValue(quiet)))
-	}
-	// Why this silence outranks the others, in the vocabulary the contract
-	// already declares. Only the deal says so out loud: `expected_revenue`
-	// reads as "money rests on this" with no figure, which is exactly the claim.
-	//
-	// The BAND deliberately states nothing. It moves the level, and the reason
-	// vocabulary has no word for it — `no_champion` is the nearest and means
-	// the opposite here, an account with nobody carrying it rather than a
-	// person who WAS carrying it. A reason that reads backwards is worse than
-	// a rank the row does not explain, so the band waits for a word of its own.
-	if facts := item.Relationship; facts != nil && facts.HasOpenDeal != nil && *facts.HasOpenDeal {
-		row.Because = append(row.Because, reason("expected_revenue", nil))
-	}
-	return ranked{item: row, waitingDays: quiet, occurredAt: occurredOf(item, asOf)}
-}
-
-// decayMatters says whether a lapsed relationship is worth more than routine
-// attention: money still resting on it, or a real relationship behind it.
-//
-// A lane that sent no facts answers false rather than true. Absent is not a
-// claim, and promoting every silence on a field nobody filled would empty the
-// routine band for a reason no reader could see.
-func decayMatters(facts *crmcontracts.AttentionRelationshipFacts) bool {
-	if facts == nil {
-		return false
-	}
-	if facts.HasOpenDeal != nil && *facts.HasOpenDeal {
-		return true
-	}
-	if facts.Strength == nil {
-		return false
-	}
-	// Moderate counts. The §4 threshold for it already means a real two-way
-	// history, and a rep losing those quietly is who this lane is for —
-	// admitting only `strong` would leave it ranking almost nothing.
-	return *facts.Strength == crmcontracts.AttentionRelationshipFactsStrengthModerate ||
-		*facts.Strength == crmcontracts.AttentionRelationshipFactsStrengthStrong
-}
-
 // classifySystem: the pipes. A mailbox that stopped capturing makes every quiet
 // claim on this page suspect, which is why it is here at all rather than only in
 // an admin screen.

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -416,13 +416,58 @@ func classifyUndelivered(item crmcontracts.AttentionItem, asOf time.Time) ranked
 // classifyDecay: a relationship going quiet. Nobody is waiting on the reader
 // for it, which is exactly why it goes unnoticed — and why it sits low rather
 // than not at all.
+// A lapsed relationship that still carries money, or that was a real
+// relationship before it went quiet, is agreed work rather than routine. The
+// same shape classifyWaiting uses for a stale wait, and for the same reason: a
+// lane where every row ranks alike is one a rep reads once. This is the row that
+// most needs telling apart — the rep's strongest contact going silent and a cc
+// drifting are not the same morning's work.
 func classifyDecay(item crmcontracts.AttentionItem, asOf time.Time) ranked {
-	row := base(item, levelRoutine, "system", "data_drifts")
+	level := levelRoutine
+	if decayMatters(item.Relationship) {
+		level = levelAgreed
+	}
+	row := base(item, level, "system", "data_drifts")
 	quiet := quietDaysOf(item)
 	if quiet > 0 {
 		row.Because = append(row.Because, reason("quiet_days", daysValue(quiet)))
 	}
+	// Why this silence outranks the others, in the vocabulary the contract
+	// already declares. Only the deal says so out loud: `expected_revenue`
+	// reads as "money rests on this" with no figure, which is exactly the claim.
+	//
+	// The BAND deliberately states nothing. It moves the level, and the reason
+	// vocabulary has no word for it — `no_champion` is the nearest and means
+	// the opposite here, an account with nobody carrying it rather than a
+	// person who WAS carrying it. A reason that reads backwards is worse than
+	// a rank the row does not explain, so the band waits for a word of its own.
+	if facts := item.Relationship; facts != nil && facts.HasOpenDeal != nil && *facts.HasOpenDeal {
+		row.Because = append(row.Because, reason("expected_revenue", nil))
+	}
 	return ranked{item: row, waitingDays: quiet, occurredAt: occurredOf(item, asOf)}
+}
+
+// decayMatters says whether a lapsed relationship is worth more than routine
+// attention: money still resting on it, or a real relationship behind it.
+//
+// A lane that sent no facts answers false rather than true. Absent is not a
+// claim, and promoting every silence on a field nobody filled would empty the
+// routine band for a reason no reader could see.
+func decayMatters(facts *crmcontracts.AttentionRelationshipFacts) bool {
+	if facts == nil {
+		return false
+	}
+	if facts.HasOpenDeal != nil && *facts.HasOpenDeal {
+		return true
+	}
+	if facts.Strength == nil {
+		return false
+	}
+	// Moderate counts. The §4 threshold for it already means a real two-way
+	// history, and a rep losing those quietly is who this lane is for —
+	// admitting only `strong` would leave it ranking almost nothing.
+	return *facts.Strength == crmcontracts.AttentionRelationshipFactsStrengthModerate ||
+		*facts.Strength == crmcontracts.AttentionRelationshipFactsStrengthStrong
 }
 
 // classifySystem: the pipes. A mailbox that stopped capturing makes every quiet

--- a/backend/internal/compose/attention/classifydecay.go
+++ b/backend/internal/compose/attention/classifydecay.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// What a lapsed relationship is WORTH, and therefore how high it sits.
+//
+// Apart from the other classifiers for the reason classifyrisk.go is: those
+// rank a clock, and this one weighs the relationship the clock ran out on.
+// Nobody is waiting on the reader for a silence, which is exactly why it goes
+// unnoticed — so the lane exists at all, and the question it has to answer is
+// which of these silences the rep should have noticed first.
+
+import (
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// classifyDecay: a relationship going quiet. Nobody is waiting on the reader
+// for it, which is exactly why it goes unnoticed — and why it sits low rather
+// than not at all.
+//
+// How low depends on what the relationship was WORTH. One that still carries
+// money, or that was real before it went silent, is agreed work; a weak one
+// with nothing on it is routine. The same shape classifyWaiting uses for a
+// stale wait, and for the same reason: a lane where every row ranks alike is
+// one a rep reads once, and the rep's strongest contact going silent is not
+// the same morning's work as a cc drifting.
+func classifyDecay(item crmcontracts.AttentionItem, asOf time.Time) ranked {
+	level := levelRoutine
+	if decayMatters(item.Relationship) {
+		level = levelAgreed
+	}
+	row := base(item, level, "system", "data_drifts")
+	quiet := quietDaysOf(item)
+	if quiet > 0 {
+		row.Because = append(row.Because, reason("quiet_days", daysValue(quiet)))
+	}
+	// Why this silence outranks the others, in the vocabulary the contract
+	// already declares. Only the deal says so out loud: `expected_revenue`
+	// reads as "money rests on this" with no figure, which is exactly the claim.
+	//
+	// The BAND deliberately states nothing. It moves the level, and the reason
+	// vocabulary has no word for it — `no_champion` is the nearest and means
+	// the opposite here, an account with nobody carrying it rather than a
+	// person who WAS carrying it. A reason that reads backwards is worse than
+	// a rank the row does not explain, so the band waits for a word of its own.
+	if facts := item.Relationship; facts != nil && facts.HasOpenDeal != nil && *facts.HasOpenDeal {
+		row.Because = append(row.Because, reason("expected_revenue", nil))
+	}
+	return ranked{item: row, waitingDays: quiet, occurredAt: occurredOf(item, asOf)}
+}
+
+// decayMatters says whether a lapsed relationship is worth more than routine
+// attention: money still resting on it, or a real relationship behind it.
+//
+// A lane that sent no facts answers false rather than true. Absent is not a
+// claim, and promoting every silence on a field nobody filled would empty the
+// routine band for a reason no reader could see.
+func decayMatters(facts *crmcontracts.AttentionRelationshipFacts) bool {
+	if facts == nil {
+		return false
+	}
+	if facts.HasOpenDeal != nil && *facts.HasOpenDeal {
+		return true
+	}
+	if facts.Strength == nil {
+		return false
+	}
+	// Moderate counts. The §4 threshold for it already means a real two-way
+	// history, and a rep losing those quietly is who this lane is for —
+	// admitting only `strong` would leave it ranking almost nothing.
+	return *facts.Strength == crmcontracts.AttentionRelationshipFactsStrengthModerate ||
+		*facts.Strength == crmcontracts.AttentionRelationshipFactsStrengthStrong
+}

--- a/backend/internal/compose/attention/decayworth_test.go
+++ b/backend/internal/compose/attention/decayworth_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// What a lapsed relationship was WORTH, and what the queue does with it.
+//
+// The lane could say only how long a silence had run, so the rep's strongest
+// contact going quiet and a cc drifting arrived as the same row at the same
+// rank. Both facts that tell them apart were already in the lane's hand and
+// discarded: the band is scored from the edge the projection loads, and the
+// open deal is one batched read over candidates it already narrowed to.
+//
+// These run the classifier directly. The question is what the facts BECOME —
+// the rank the row takes and the reason it states — not how they were measured.
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func decayItem(facts *crmcontracts.AttentionRelationshipFacts) crmcontracts.AttentionItem {
+	personID := ids.NewV7()
+	name := "Dana Weiss"
+	days := 63
+	return crmcontracts.AttentionItem{
+		Id:           personID.String(),
+		Source:       "relationship_decay",
+		Title:        &name,
+		QuietDays:    &days,
+		Relationship: facts,
+		Subject:      subjectOf("person", personID),
+		Actions:      []crmcontracts.AttentionItemActions{},
+	}
+}
+
+func band(b crmcontracts.AttentionRelationshipFactsStrength) *crmcontracts.AttentionRelationshipFactsStrength {
+	return &b
+}
+
+func openDeal(has bool) *bool { return &has }
+
+func hasReason(row crmcontracts.WorklistItem, kind crmcontracts.WorklistReasonKind) bool {
+	for _, because := range row.Because {
+		if because.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// The rank, across the whole band vocabulary plus the deal. This is the table
+// that decides which silences a rep sees above the routine tidying, so it is
+// written as one rather than as four tests that could each drift.
+func TestWhatALapsedRelationshipWasWorthDecidesItsRank(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		facts *crmcontracts.AttentionRelationshipFacts
+		want  int
+	}{
+		{
+			name:  "a strong relationship going quiet",
+			facts: &crmcontracts.AttentionRelationshipFacts{Strength: band("strong")},
+			want:  levelAgreed,
+		},
+		{
+			// Moderate counts, and that is the deliberate edge of this rule:
+			// §4's moderate threshold already means a real two-way history,
+			// and admitting only `strong` would leave the lane ranking almost
+			// nothing.
+			name:  "a moderate one, the edge of the rule",
+			facts: &crmcontracts.AttentionRelationshipFacts{Strength: band("moderate")},
+			want:  levelAgreed,
+		},
+		{
+			name:  "a weak one with nothing resting on it",
+			facts: &crmcontracts.AttentionRelationshipFacts{Strength: band("weak"), HasOpenDeal: openDeal(false)},
+			want:  levelRoutine,
+		},
+		{
+			// The case the band alone would get wrong. A contact barely spoken
+			// to who still sits on an open deal is money going quiet, and it is
+			// exactly the silence nobody notices.
+			name:  "a weak one an open deal still rests on",
+			facts: &crmcontracts.AttentionRelationshipFacts{Strength: band("weak"), HasOpenDeal: openDeal(true)},
+			want:  levelAgreed,
+		},
+		{
+			name:  "a relationship §4 scored at nothing",
+			facts: &crmcontracts.AttentionRelationshipFacts{Strength: band("none")},
+			want:  levelRoutine,
+		},
+		{
+			// A lane that sent no facts at all. Absent is not a claim: an
+			// installation whose seam predates these fields keeps the routine
+			// rank it has rather than having every silence promoted on a field
+			// nobody filled.
+			name:  "a lane that measured nothing",
+			facts: nil,
+			want:  levelRoutine,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			row := classifyDecay(decayItem(c.facts), rankInstant)
+			if row.item.Level != c.want {
+				t.Fatalf("level = %d, want %d", row.item.Level, c.want)
+			}
+		})
+	}
+}
+
+// The row says why it outranks the routine ones. A rank a reader cannot account
+// for is the complaint this whole campaign started from.
+func TestALapsedRelationshipWithMoneyOnItSaysSo(t *testing.T) {
+	row := classifyDecay(decayItem(&crmcontracts.AttentionRelationshipFacts{
+		Strength: band("weak"), HasOpenDeal: openDeal(true),
+	}), rankInstant)
+
+	if !hasReason(row.item, "expected_revenue") {
+		t.Fatalf("a lapsed contact with an open deal states %v, want it to say money rests on this",
+			row.item.Because)
+	}
+}
+
+// And a silence with nothing on it does NOT say money rests on it. The reason
+// renders as "expected revenue" with no figure, so claiming it for a contact
+// carrying no deal is the row inventing a fact.
+func TestALapsedRelationshipWithNoDealClaimsNoRevenue(t *testing.T) {
+	row := classifyDecay(decayItem(&crmcontracts.AttentionRelationshipFacts{
+		Strength: band("strong"), HasOpenDeal: openDeal(false),
+	}), rankInstant)
+
+	if hasReason(row.item, "expected_revenue") {
+		t.Fatalf("a contact with no open deal claims revenue: %v", row.item.Because)
+	}
+}
+
+// The band moves the rank and states NOTHING. `no_champion` is the nearest word
+// the reason vocabulary has and it means the opposite here — an account with
+// nobody carrying it, rather than the person who WAS carrying it going quiet.
+//
+// This is a test for a deliberate silence, so it is written to fail if somebody
+// reaches for that word: a reason that reads backwards is worse than a rank the
+// row does not explain.
+func TestAStrongLapsedRelationshipNeverClaimsTheAccountHasNoChampion(t *testing.T) {
+	row := classifyDecay(decayItem(&crmcontracts.AttentionRelationshipFacts{
+		Strength: band("strong"),
+	}), rankInstant)
+
+	if hasReason(row.item, "no_champion") {
+		t.Fatalf("a decayed champion is reported as the account having none: %v", row.item.Because)
+	}
+}
+
+// The wire mapping refuses a band this contract does not declare, rather than
+// casting it through. The two vocabularies are declared in different places, so
+// a cast would widen the wire silently the day either grows a term and reach a
+// reader as a word their client cannot translate.
+func TestABandThisContractDoesNotDeclareReachesNoReader(t *testing.T) {
+	if got := relationshipBand("legendary"); got != nil {
+		t.Fatalf("an undeclared band reached the wire as %q", *got)
+	}
+	for _, bucket := range []string{"none", "weak", "moderate", "strong"} {
+		if got := relationshipBand(bucket); got == nil || string(*got) != bucket {
+			t.Fatalf("the §4 bucket %q did not reach the wire", bucket)
+		}
+	}
+}

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -9,6 +9,7 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
 // What each lane READS, and the shape it reads it into.
@@ -354,6 +355,19 @@ type QuietRelationship struct {
 	// LastAt is when they last spoke, so the card can date the silence rather
 	// than only measure it.
 	LastAt time.Time
+	// Strength is what the relationship was WORTH before it went quiet, scored
+	// at the read instant through §4 — the same arithmetic the contact's own
+	// page shows, so the two cannot disagree about who this person is.
+	//
+	// The lane already holds the edge this is computed from and used to discard
+	// it. Without the band every lapsed contact reads alike, and the rep's
+	// strongest relationship going quiet is the row that most deserves to be
+	// told apart from a cc who has drifted.
+	Strength relstrength.Score
+	// HasOpenDeal reports whether money this reader can see still rests on this
+	// contact. Same fact the waiting lane carries and for the same reason: a
+	// silence with a deal behind it is not the same work as one without.
+	HasOpenDeal bool
 }
 
 // DealFacts answers the figures behind deals a row names but does not carry.

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -154,6 +154,13 @@ type Task struct {
 	// route to, which is a real state and not an error.
 	LinkType string
 	LinkID   ids.UUID
+	// AssigneeID is who the task belongs to, nil when nobody has taken it.
+	//
+	// The lane serves three scopes and only one of them is the reader's own
+	// queue: an unassigned sweep and a named colleague's queue both put tasks
+	// on the page that are not theirs. Without this the rows read identically,
+	// and the one nobody owns — the whole point of that scope — cannot say so.
+	AssigneeID *ids.UUID
 }
 
 // Receipts is what the system did on its own, most recent first.

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -363,8 +363,10 @@ type QuietRelationship struct {
 	// than only measure it.
 	LastAt time.Time
 	// Strength is what the relationship was WORTH before it went quiet, scored
-	// at the read instant through §4 — the same arithmetic the contact's own
-	// page shows, so the two cannot disagree about who this person is.
+	// at the read instant through §4 — relstrength.Compute, which is what the
+	// contact's own page reads too. The band comes back off that call rather
+	// than being derived here: bucketFor is unexported, so there is no second
+	// way to turn a score into the word a rep reads.
 	//
 	// The lane already holds the edge this is computed from and used to discard
 	// it. Without the band every lapsed contact reads alike, and the rep's

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -9,7 +9,6 @@ import (
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
-	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
 // What each lane READS, and the shape it reads it into.
@@ -284,99 +283,6 @@ type Commitment struct {
 	SourceLabel string
 	OccurredAt  time.Time
 	DueAt       time.Time
-}
-
-// AtRisk is the open deals going quiet, or already past their expected close.
-//
-// The seam behind it reads the SAME candidate engine the whats_slipping tool
-// reads, at a shorter idle window. A second at-risk rule living here would be
-// two answers to one question, and the two would disagree in front of a rep.
-//
-// Optional exactly as Commitments is: nil means this feed does not do deal risk,
-// which is a different fact from a pipeline with nothing wrong in it.
-type AtRisk interface {
-	// The bool reports that the read was CUT — the lane scanned to its own bound
-	// and deals may sit past it.
-	//
-	// It travels beside the rows rather than being inferred from their number,
-	// because this lane FILTERS after it scans: it returns only what is quiet or
-	// overdue out of a bounded sweep, so ten rows can be the survivors of a full
-	// fifty. A caller counting rows against the bound would read a truncated
-	// scan with few survivors as a complete one — under-reporting, which is the
-	// one direction a work figure must never fail in.
-	Quiet(ctx context.Context) ([]RiskyDeal, bool, error)
-}
-
-// RiskyDeal is one deal the pipeline should worry about, and the ground it is
-// worried on.
-//
-// Both flags travel because they are different warnings: a deal nobody has
-// touched is neglected, and a deal past its close date is late whether or not
-// anyone touched it. A card that collapsed them would say "at risk" and leave
-// the rep to guess which.
-type RiskyDeal struct {
-	DealID ids.UUID
-	Name   string
-	// The card's facts, carried so the client draws value, stage and
-	// ownership without a second read per row. All optional: a deal can be
-	// ownerless, unpriced, or an overlay mirror with no native stage.
-	StageID     *ids.UUID
-	OwnerID     *ids.UUID
-	AmountMinor *int64
-	Currency    *string
-	// QuietDays is how long the deal has been idle, which is the number the
-	// card says out loud. Zero for a deal admitted only by its close date.
-	QuietDays int
-	// CloseOverdue is set when the expected close date has already passed.
-	CloseOverdue      bool
-	ExpectedCloseDate *time.Time
-}
-
-// Decay is the reader's own relationships that have gone silent.
-//
-// A separate lane from AtRisk rather than more rows in it, because the two rest
-// on different records and warn about different things: AtRisk is a DEAL nobody
-// is moving, and this is a PERSON nobody is talking to. A contact carrying no
-// open deal never reaches that lane at all, and those are exactly the
-// relationships that lapse without anyone noticing.
-//
-// The seam behind it derives the silence through the same §4 change engine the
-// contact's own page reads, so there is one quiet rule in the product rather
-// than a second threshold spelled here.
-//
-// Optional exactly as the others are: nil means this feed does not derive
-// relationship changes, which is a different fact from a rep whose
-// relationships are all current.
-type Decay interface {
-	Lapsed(ctx context.Context) ([]QuietRelationship, error)
-}
-
-// QuietRelationship is one contact this reader has stopped talking to.
-type QuietRelationship struct {
-	PersonID ids.UUID
-	Name     string
-	// QuietDays is how long the silence has run, which is the number the card
-	// says out loud. It comes from the derivation rather than from the
-	// projection's own last_at, so the card and the contact's page agree.
-	QuietDays int
-	// LastAt is when they last spoke, so the card can date the silence rather
-	// than only measure it.
-	LastAt time.Time
-	// Strength is what the relationship was WORTH before it went quiet, scored
-	// at the read instant through §4 — relstrength.Compute, which is what the
-	// contact's own page reads too. The band comes back off that call rather
-	// than being derived here: bucketFor is unexported, so there is no second
-	// way to turn a score into the word a rep reads.
-	//
-	// The lane already holds the edge this is computed from and used to discard
-	// it. Without the band every lapsed contact reads alike, and the rep's
-	// strongest relationship going quiet is the row that most deserves to be
-	// told apart from a cc who has drifted.
-	Strength relstrength.Score
-	// HasOpenDeal reports whether money this reader can see still rests on this
-	// contact. Same fact the waiting lane carries and for the same reason: a
-	// silence with a deal behind it is not the same work as one without.
-	HasOpenDeal bool
 }
 
 // DealFacts answers the figures behind deals a row names but does not carry.

--- a/backend/internal/compose/attention/lanessilence.go
+++ b/backend/internal/compose/attention/lanessilence.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The two lanes that report a SILENCE, and what each reads it into.
+//
+// A deal nobody is moving and a person nobody is talking to. They rest on
+// different records and warn about different things, which is why they are two
+// lanes rather than more rows in one — a contact carrying no open deal never
+// reaches the risk lane at all, and those are exactly the relationships that
+// lapse without anyone noticing.
+//
+// What makes them one concept is the question they both have to answer beyond
+// the clock: how long is not enough. A silence has to say what it COSTS, or
+// every row reads alike and the rep stops reading the lane.
+//
+// Optional exactly as the other lanes are: nil means this feed derives no such
+// answer, which is a different fact from a rep whose deals are all moving.
+
+import (
+	"context"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
+)
+
+// AtRisk is the open deals going quiet, or already past their expected close.
+//
+// The seam behind it reads the SAME candidate engine the whats_slipping tool
+// reads, at a shorter idle window. A second at-risk rule living here would be
+// two answers to one question, and the two would disagree in front of a rep.
+//
+// Optional exactly as Commitments is: nil means this feed does not do deal risk,
+// which is a different fact from a pipeline with nothing wrong in it.
+type AtRisk interface {
+	// The bool reports that the read was CUT — the lane scanned to its own bound
+	// and deals may sit past it.
+	//
+	// It travels beside the rows rather than being inferred from their number,
+	// because this lane FILTERS after it scans: it returns only what is quiet or
+	// overdue out of a bounded sweep, so ten rows can be the survivors of a full
+	// fifty. A caller counting rows against the bound would read a truncated
+	// scan with few survivors as a complete one — under-reporting, which is the
+	// one direction a work figure must never fail in.
+	Quiet(ctx context.Context) ([]RiskyDeal, bool, error)
+}
+
+// RiskyDeal is one deal the pipeline should worry about, and the ground it is
+// worried on.
+//
+// Both flags travel because they are different warnings: a deal nobody has
+// touched is neglected, and a deal past its close date is late whether or not
+// anyone touched it. A card that collapsed them would say "at risk" and leave
+// the rep to guess which.
+type RiskyDeal struct {
+	DealID ids.UUID
+	Name   string
+	// The card's facts, carried so the client draws value, stage and
+	// ownership without a second read per row. All optional: a deal can be
+	// ownerless, unpriced, or an overlay mirror with no native stage.
+	StageID     *ids.UUID
+	OwnerID     *ids.UUID
+	AmountMinor *int64
+	Currency    *string
+	// QuietDays is how long the deal has been idle, which is the number the
+	// card says out loud. Zero for a deal admitted only by its close date.
+	QuietDays int
+	// CloseOverdue is set when the expected close date has already passed.
+	CloseOverdue      bool
+	ExpectedCloseDate *time.Time
+}
+
+// Decay is the reader's own relationships that have gone silent.
+//
+// A separate lane from AtRisk rather than more rows in it, because the two rest
+// on different records and warn about different things: AtRisk is a DEAL nobody
+// is moving, and this is a PERSON nobody is talking to. A contact carrying no
+// open deal never reaches that lane at all, and those are exactly the
+// relationships that lapse without anyone noticing.
+//
+// The seam behind it derives the silence through the same §4 change engine the
+// contact's own page reads, so there is one quiet rule in the product rather
+// than a second threshold spelled here.
+//
+// Optional exactly as the others are: nil means this feed does not derive
+// relationship changes, which is a different fact from a rep whose
+// relationships are all current.
+type Decay interface {
+	Lapsed(ctx context.Context) ([]QuietRelationship, error)
+}
+
+// QuietRelationship is one contact this reader has stopped talking to.
+type QuietRelationship struct {
+	PersonID ids.UUID
+	Name     string
+	// QuietDays is how long the silence has run, which is the number the card
+	// says out loud. It comes from the derivation rather than from the
+	// projection's own last_at, so the card and the contact's page agree.
+	QuietDays int
+	// LastAt is when they last spoke, so the card can date the silence rather
+	// than only measure it.
+	LastAt time.Time
+	// Strength is what the relationship was WORTH before it went quiet, scored
+	// at the read instant through §4 — relstrength.Compute, which is what the
+	// contact's own page reads too. The band comes back off that call rather
+	// than being derived here: bucketFor is unexported, so there is no second
+	// way to turn a score into the word a rep reads.
+	//
+	// The lane already holds the edge this is computed from and used to discard
+	// it. Without the band every lapsed contact reads alike, and the rep's
+	// strongest relationship going quiet is the row that most deserves to be
+	// told apart from a cc who has drifted.
+	Strength relstrength.Score
+	// HasOpenDeal reports whether money this reader can see still rests on this
+	// contact. Same fact the waiting lane carries and for the same reason: a
+	// silence with a deal behind it is not the same work as one without.
+	HasOpenDeal bool
+}

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -243,6 +243,12 @@ func taskItem(task Task, asOf time.Time) crmcontracts.AttentionItem {
 		past := deadline.Passed(task.DueAt, asOf)
 		item.Overdue = &past
 	}
+	// Who holds it. Absent means nobody has taken it, which the unassigned
+	// scope exists to surface and which the row could not say before.
+	if task.AssigneeID != nil {
+		assignee := openapi_types.UUID(*task.AssigneeID)
+		item.AssigneeId = &assignee
+	}
 	return item
 }
 

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -14,7 +14,6 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
-	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
 // One item's shape, per producer.
@@ -312,124 +311,6 @@ func commitmentItem(promise Commitment, asOf time.Time) crmcontracts.AttentionIt
 	return item
 }
 
-// riskItem renders one deal the pipeline should worry about.
-//
-// The title is the deal's own name, which the reader recognises. The card's
-// SENTENCE is the client's to write, because the two grounds read differently
-// in every language and the server has none — so what travels is the deal, the
-// idle days, and whether the close date has passed, and the client says it.
-//
-// `kind` carries the ground rather than a label: `quiet` when only the idle
-// clock admitted it, `close_overdue` when the date has passed. A deal that is
-// both is reported as overdue, because a date the customer agreed to outranks
-// a silence nobody agreed to.
-//
-// It offers no verb that DECIDES. What to do about a quiet deal is a judgement,
-// and a queue that answered it here would be deciding rather than warning. It
-// does offer `open`, which decides nothing: naming a deal as drifting and then
-// leaving the reader to go and find it by hand is a warning they cannot act on.
-// The `deal` facts ride along so the card states value, stage and ownership
-// without a second read per row.
-func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
-	name := deal.Name
-	ground := "quiet"
-	if deal.CloseOverdue {
-		ground = "close_overdue"
-	}
-	item := crmcontracts.AttentionItem{
-		Id:      deal.DealID.String(),
-		Source:  crmcontracts.AttentionItemSource("deal_at_risk"),
-		Kind:    &ground,
-		Title:   &name,
-		Subject: subjectOf("deal", deal.DealID),
-		Overdue: &deal.CloseOverdue,
-		Deal:    dealFacts(deal),
-		Actions: []crmcontracts.AttentionItemActions{actionOpen},
-	}
-	// The idle count travels TYPED, so the card can say the window the server
-	// actually applied instead of implying one — and so `detail` stays the
-	// supporting sentence it is everywhere else. It used to ride as the detail's
-	// own decimal, which made one field mean a sentence on ten sources and an
-	// integer on two, and any client rendering it faithfully printed a naked
-	// "90" under the title.
-	if deal.QuietDays > 0 {
-		days := deal.QuietDays
-		item.QuietDays = &days
-	}
-	if deal.ExpectedCloseDate != nil {
-		due := *deal.ExpectedCloseDate
-		item.DueAt = &due
-	}
-	return item
-}
-
-// lapsedItem renders one relationship this reader has stopped talking to.
-//
-// The contact's NAME travels as the title because a person's name is a
-// sentence in every language, and the silence rides as a typed count, the way
-// the risk card carries its idle days — so the client writes "quiet 63 days"
-// and the server implies no window it did not apply.
-//
-// `occurred_at` is the last time they spoke. It is the fact the card dates
-// itself from, and it lets the lane be read as a chronology rather than only
-// as a list of numbers.
-//
-// It offers NO verb, exactly as the risk card does not. What to do about a
-// lapsed relationship is a judgement about that person, and a queue that
-// answered it here would be deciding rather than warning.
-func lapsedItem(quiet QuietRelationship) crmcontracts.AttentionItem {
-	name := quiet.Name
-	days := quiet.QuietDays
-	lastAt := quiet.LastAt
-	funded := quiet.HasOpenDeal
-	return crmcontracts.AttentionItem{
-		Id:     quiet.PersonID.String(),
-		Source: crmcontracts.AttentionItemSource("relationship_decay"),
-		Title:  &name,
-		// Typed, for the reason riskItem's is: `detail` is a sentence on every
-		// other source, and the client writes "quiet N days" in the reader's
-		// own language rather than rendering a decimal the server chose.
-		QuietDays: &days,
-		// What the relationship was worth before it lapsed. Typed for the same
-		// reason: the client writes the phrase, and the queue READS the band —
-		// a weak, unfunded silence is routine work and a strong or funded one
-		// is not.
-		Relationship: &crmcontracts.AttentionRelationshipFacts{
-			Strength:    relationshipBand(quiet.Strength.Bucket),
-			HasOpenDeal: &funded,
-		},
-		Subject:    subjectOf("person", quiet.PersonID),
-		OccurredAt: &lastAt,
-		Actions:    []crmcontracts.AttentionItemActions{},
-	}
-}
-
-// relationshipBand carries the §4 bucket onto the wire, answering nothing for a
-// word this contract does not declare.
-//
-// A mapping rather than a cast, because the two vocabularies are declared in
-// different places: §4 owns the bands and the contract owns what a client is
-// promised. A cast would widen the wire silently the day either grows a term,
-// and the reader would get a band their client cannot translate. An unmapped
-// bucket is ABSENT, which the client already draws the way it draws a lane that
-// scored none.
-func relationshipBand(bucket string) *crmcontracts.AttentionRelationshipFactsStrength {
-	var band crmcontracts.AttentionRelationshipFactsStrength
-	switch bucket {
-	case relstrength.BucketNone:
-		band = crmcontracts.AttentionRelationshipFactsStrengthNone
-	case relstrength.BucketWeak:
-		band = crmcontracts.AttentionRelationshipFactsStrengthWeak
-	case relstrength.BucketModerate:
-		band = crmcontracts.AttentionRelationshipFactsStrengthModerate
-	case relstrength.BucketStrong:
-		band = crmcontracts.AttentionRelationshipFactsStrengthStrong
-	default:
-		return nil
-	}
-	return &band
-}
-
 // receiptItem renders one thing the system did on its own.
 //
 // It offers no decision: a receipt reports a finished act, and asking the reader
@@ -456,27 +337,6 @@ func receiptItem(receipt Receipt) crmcontracts.AttentionItem {
 		OccurredAt: &occurred,
 		Actions:    actions,
 	}
-}
-
-// dealFacts carries the at-risk deal's card facts onto the wire, or nothing:
-// a facts object with every field empty says less than its absence.
-func dealFacts(deal RiskyDeal) *crmcontracts.AttentionDealFacts {
-	if deal.StageID == nil && deal.OwnerID == nil && deal.AmountMinor == nil && deal.Currency == nil {
-		return nil
-	}
-	facts := &crmcontracts.AttentionDealFacts{
-		AmountMinor: deal.AmountMinor,
-		Currency:    deal.Currency,
-	}
-	if deal.StageID != nil {
-		stage := openapi_types.UUID(*deal.StageID)
-		facts.StageId = &stage
-	}
-	if deal.OwnerID != nil {
-		owner := openapi_types.UUID(*deal.OwnerID)
-		facts.OwnerId = &owner
-	}
-	return facts
 }
 
 // subjectOf names the record an item concerns, when the producer named one.

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -14,6 +14,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/deadline"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
 )
 
 // One item's shape, per producer.
@@ -374,6 +375,7 @@ func lapsedItem(quiet QuietRelationship) crmcontracts.AttentionItem {
 	name := quiet.Name
 	days := quiet.QuietDays
 	lastAt := quiet.LastAt
+	funded := quiet.HasOpenDeal
 	return crmcontracts.AttentionItem{
 		Id:     quiet.PersonID.String(),
 		Source: crmcontracts.AttentionItemSource("relationship_decay"),
@@ -381,11 +383,45 @@ func lapsedItem(quiet QuietRelationship) crmcontracts.AttentionItem {
 		// Typed, for the reason riskItem's is: `detail` is a sentence on every
 		// other source, and the client writes "quiet N days" in the reader's
 		// own language rather than rendering a decimal the server chose.
-		QuietDays:  &days,
+		QuietDays: &days,
+		// What the relationship was worth before it lapsed. Typed for the same
+		// reason: the client writes the phrase, and the queue READS the band —
+		// a weak, unfunded silence is routine work and a strong or funded one
+		// is not.
+		Relationship: &crmcontracts.AttentionRelationshipFacts{
+			Strength:    relationshipBand(quiet.Strength.Bucket),
+			HasOpenDeal: &funded,
+		},
 		Subject:    subjectOf("person", quiet.PersonID),
 		OccurredAt: &lastAt,
 		Actions:    []crmcontracts.AttentionItemActions{},
 	}
+}
+
+// relationshipBand carries the §4 bucket onto the wire, answering nothing for a
+// word this contract does not declare.
+//
+// A mapping rather than a cast, because the two vocabularies are declared in
+// different places: §4 owns the bands and the contract owns what a client is
+// promised. A cast would widen the wire silently the day either grows a term,
+// and the reader would get a band their client cannot translate. An unmapped
+// bucket is ABSENT, which the client already draws the way it draws a lane that
+// scored none.
+func relationshipBand(bucket string) *crmcontracts.AttentionRelationshipFactsStrength {
+	var band crmcontracts.AttentionRelationshipFactsStrength
+	switch bucket {
+	case relstrength.BucketNone:
+		band = crmcontracts.AttentionRelationshipFactsStrengthNone
+	case relstrength.BucketWeak:
+		band = crmcontracts.AttentionRelationshipFactsStrengthWeak
+	case relstrength.BucketModerate:
+		band = crmcontracts.AttentionRelationshipFactsStrengthModerate
+	case relstrength.BucketStrong:
+		band = crmcontracts.AttentionRelationshipFactsStrengthStrong
+	default:
+		return nil
+	}
+	return &band
 }
 
 // receiptItem renders one thing the system did on its own.

--- a/backend/internal/compose/attention/rendersilence.go
+++ b/backend/internal/compose/attention/rendersilence.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The two lanes that report a SILENCE, and what each one says it is worth.
+//
+// A deal nobody is moving and a person nobody is talking to. They rest on
+// different records and warn about different things, but they render as one
+// concept: neither is a deadline anybody agreed to, so neither carries a verb
+// that decides, and both have to say how long the silence has run AND why that
+// silence costs something. A card that could only say "quiet 63 days" left the
+// reader to guess which of those it was.
+
+import (
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/relstrength"
+)
+
+// riskItem renders one deal the pipeline should worry about.
+//
+// The title is the deal's own name, which the reader recognises. The card's
+// SENTENCE is the client's to write, because the two grounds read differently
+// in every language and the server has none — so what travels is the deal, the
+// idle days, and whether the close date has passed, and the client says it.
+//
+// `kind` carries the ground rather than a label: `quiet` when only the idle
+// clock admitted it, `close_overdue` when the date has passed. A deal that is
+// both is reported as overdue, because a date the customer agreed to outranks
+// a silence nobody agreed to.
+//
+// It offers no verb that DECIDES. What to do about a quiet deal is a judgement,
+// and a queue that answered it here would be deciding rather than warning. It
+// does offer `open`, which decides nothing: naming a deal as drifting and then
+// leaving the reader to go and find it by hand is a warning they cannot act on.
+// The `deal` facts ride along so the card states value, stage and ownership
+// without a second read per row.
+func riskItem(deal RiskyDeal) crmcontracts.AttentionItem {
+	name := deal.Name
+	ground := "quiet"
+	if deal.CloseOverdue {
+		ground = "close_overdue"
+	}
+	item := crmcontracts.AttentionItem{
+		Id:      deal.DealID.String(),
+		Source:  crmcontracts.AttentionItemSource("deal_at_risk"),
+		Kind:    &ground,
+		Title:   &name,
+		Subject: subjectOf("deal", deal.DealID),
+		Overdue: &deal.CloseOverdue,
+		Deal:    dealFacts(deal),
+		Actions: []crmcontracts.AttentionItemActions{actionOpen},
+	}
+	// The idle count travels TYPED, so the card can say the window the server
+	// actually applied instead of implying one — and so `detail` stays the
+	// supporting sentence it is everywhere else. It used to ride as the detail's
+	// own decimal, which made one field mean a sentence on ten sources and an
+	// integer on two, and any client rendering it faithfully printed a naked
+	// "90" under the title.
+	if deal.QuietDays > 0 {
+		days := deal.QuietDays
+		item.QuietDays = &days
+	}
+	if deal.ExpectedCloseDate != nil {
+		due := *deal.ExpectedCloseDate
+		item.DueAt = &due
+	}
+	return item
+}
+
+// lapsedItem renders one relationship this reader has stopped talking to.
+//
+// The contact's NAME travels as the title because a person's name is a
+// sentence in every language, and the silence rides as a typed count, the way
+// the risk card carries its idle days — so the client writes "quiet 63 days"
+// and the server implies no window it did not apply.
+//
+// `occurred_at` is the last time they spoke. It is the fact the card dates
+// itself from, and it lets the lane be read as a chronology rather than only
+// as a list of numbers.
+//
+// It offers NO verb, exactly as the risk card does not. What to do about a
+// lapsed relationship is a judgement about that person, and a queue that
+// answered it here would be deciding rather than warning.
+func lapsedItem(quiet QuietRelationship) crmcontracts.AttentionItem {
+	name := quiet.Name
+	days := quiet.QuietDays
+	lastAt := quiet.LastAt
+	funded := quiet.HasOpenDeal
+	return crmcontracts.AttentionItem{
+		Id:     quiet.PersonID.String(),
+		Source: crmcontracts.AttentionItemSource("relationship_decay"),
+		Title:  &name,
+		// Typed, for the reason riskItem's is: `detail` is a sentence on every
+		// other source, and the client writes "quiet N days" in the reader's
+		// own language rather than rendering a decimal the server chose.
+		QuietDays: &days,
+		// What the relationship was worth before it lapsed. Typed for the same
+		// reason: the client writes the phrase, and the queue READS the band —
+		// a weak, unfunded silence is routine work and a strong or funded one
+		// is not.
+		Relationship: &crmcontracts.AttentionRelationshipFacts{
+			Strength:    relationshipBand(quiet.Strength.Bucket),
+			HasOpenDeal: &funded,
+		},
+		Subject:    subjectOf("person", quiet.PersonID),
+		OccurredAt: &lastAt,
+		Actions:    []crmcontracts.AttentionItemActions{},
+	}
+}
+
+// relationshipBand carries the §4 bucket onto the wire, answering nothing for a
+// word this contract does not declare.
+//
+// A mapping rather than a cast, because the two vocabularies are declared in
+// different places: §4 owns the bands and the contract owns what a client is
+// promised. A cast would widen the wire silently the day either grows a term,
+// and the reader would get a band their client cannot translate. An unmapped
+// bucket is ABSENT, which the client already draws the way it draws a lane that
+// scored none.
+func relationshipBand(bucket string) *crmcontracts.AttentionRelationshipFactsStrength {
+	var band crmcontracts.AttentionRelationshipFactsStrength
+	switch bucket {
+	case relstrength.BucketNone:
+		band = crmcontracts.AttentionRelationshipFactsStrengthNone
+	case relstrength.BucketWeak:
+		band = crmcontracts.AttentionRelationshipFactsStrengthWeak
+	case relstrength.BucketModerate:
+		band = crmcontracts.AttentionRelationshipFactsStrengthModerate
+	case relstrength.BucketStrong:
+		band = crmcontracts.AttentionRelationshipFactsStrengthStrong
+	default:
+		return nil
+	}
+	return &band
+}
+
+// dealFacts carries the at-risk deal's card facts onto the wire, or nothing:
+// a facts object with every field empty says less than its absence.
+func dealFacts(deal RiskyDeal) *crmcontracts.AttentionDealFacts {
+	if deal.StageID == nil && deal.OwnerID == nil && deal.AmountMinor == nil && deal.Currency == nil {
+		return nil
+	}
+	facts := &crmcontracts.AttentionDealFacts{
+		AmountMinor: deal.AmountMinor,
+		Currency:    deal.Currency,
+	}
+	if deal.StageID != nil {
+		stage := openapi_types.UUID(*deal.StageID)
+		facts.StageId = &stage
+	}
+	if deal.OwnerID != nil {
+		owner := openapi_types.UUID(*deal.OwnerID)
+		facts.OwnerId = &owner
+	}
+	return facts
+}

--- a/backend/internal/compose/attention/taskowner_test.go
+++ b/backend/internal/compose/attention/taskowner_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// Who holds a task, and the row that has to say so.
+//
+// The lane serves three scopes and only one of them is the reader's own queue.
+// An unassigned sweep and a named colleague's queue both put work on the page
+// that is not the reader's — and the scope built to surface work NOBODY has
+// taken produced rows that could not say that was what they were. The fact was
+// on the activity the store returned and the seam dropped it.
+
+import (
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func taskRow(assignee *ids.UUID) crmcontracts.AttentionItem {
+	taskID := ids.NewV7()
+	subject := "Send the retrofit quote"
+	due := rankInstant.AddDate(0, 0, 2)
+	item := crmcontracts.AttentionItem{
+		Id:      taskID.String(),
+		Source:  "task",
+		Title:   &subject,
+		DueAt:   &due,
+		Subject: subjectOf("deal", ids.NewV7()),
+		Actions: []crmcontracts.AttentionItemActions{"complete", "snooze"},
+	}
+	if assignee != nil {
+		held := openapi_types.UUID(*assignee)
+		item.AssigneeId = &held
+	}
+	return item
+}
+
+// The row nobody owns says so. This is the entire reason the unassigned scope
+// exists, and its rows arrived indistinguishable from the reader's own.
+func TestATaskNobodyHasTakenSaysNobodyOwnsIt(t *testing.T) {
+	row := classifyTask(taskRow(nil), rankInstant)
+
+	if !hasReason(row.item, "unassigned") {
+		t.Fatalf("an unheld task states %v, want it to say nobody owns it", row.item.Because)
+	}
+}
+
+// And a held one does NOT. A task with an owner claiming to be unowned would
+// send a rep to take work a colleague is already doing, which is worse than the
+// silence it replaces.
+func TestAHeldTaskNeverClaimsNobodyOwnsIt(t *testing.T) {
+	holder := ids.NewV7()
+	row := classifyTask(taskRow(&holder), rankInstant)
+
+	if hasReason(row.item, "unassigned") {
+		t.Fatalf("a task held by somebody claims nobody owns it: %v", row.item.Because)
+	}
+}
+
+// The holder reaches the wire, so a reader looking at a colleague's queue can
+// be shown whose work it is rather than having to infer it from the scope they
+// picked.
+func TestTheHolderOfATaskReachesTheRow(t *testing.T) {
+	holder := ids.NewV7()
+	item := taskItem(Task{
+		ID:         ids.NewV7(),
+		Subject:    "Send the retrofit quote",
+		DueAt:      &rankInstant,
+		AssigneeID: &holder,
+	}, rankInstant)
+
+	if item.AssigneeId == nil {
+		t.Fatal("the task's holder never reached the row")
+	}
+	if ids.UUID(*item.AssigneeId) != holder {
+		t.Fatalf("the row names %v as the holder, want %v", *item.AssigneeId, holder)
+	}
+}
+
+// An unheld task carries no holder rather than a zero uuid. A zero id is a
+// value a client would try to resolve to a person, and it names nobody.
+func TestAnUnheldTaskCarriesNoHolderRatherThanAZeroOne(t *testing.T) {
+	item := taskItem(Task{
+		ID:      ids.NewV7(),
+		Subject: "Send the retrofit quote",
+		DueAt:   &rankInstant,
+	}, rankInstant)
+
+	if item.AssigneeId != nil {
+		t.Fatalf("an unheld task names %v as its holder", *item.AssigneeId)
+	}
+}

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -17,6 +17,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -181,8 +182,14 @@ func (d attentionDecay) Lapsed(ctx context.Context) ([]attention.QuietRelationsh
 		// set. In the SAME transaction as the derivation above, so a deal
 		// closing mid-read cannot make the lane say a contact is worth chasing
 		// for a reason that stopped being true between two statements.
+		//
+		// A reader without the edge grant NARROWS rather than fails. This lane
+		// answers "who have you stopped talking to", and the deal behind a
+		// silence is one fact on that answer, not the answer: failing here
+		// would take a rep's whole decay lane away over a grant that governs
+		// something else. They lose the ranking bump and keep the row.
 		funded, err := deals.OpenDealPeople(ctx, tx, candidates)
-		if err != nil {
+		if err != nil && !errors.Is(err, apperrors.ErrPermissionDenied) {
 			return err
 		}
 		lapsed = quietRelationships(quiet, changed, funded, now)

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -177,7 +177,15 @@ func (d attentionDecay) Lapsed(ctx context.Context) ([]attention.QuietRelationsh
 		if err != nil {
 			return err
 		}
-		lapsed = quietRelationships(quiet, changed)
+		// Which of them still carries money, read once for the whole candidate
+		// set. In the SAME transaction as the derivation above, so a deal
+		// closing mid-read cannot make the lane say a contact is worth chasing
+		// for a reason that stopped being true between two statements.
+		funded, err := deals.OpenDealPeople(ctx, tx, candidates)
+		if err != nil {
+			return err
+		}
+		lapsed = quietRelationships(quiet, changed, funded, now)
 		return nil
 	})
 	if err != nil {
@@ -201,6 +209,8 @@ func (d attentionDecay) Lapsed(ctx context.Context) ([]attention.QuietRelationsh
 func quietRelationships(
 	quiet []search.InteractionEdge,
 	changed []people.PersonChanges,
+	funded map[ids.UUID]bool,
+	now time.Time,
 ) []attention.QuietRelationship {
 	byPerson := make(map[ids.UUID]people.PersonChanges, len(changed))
 	for _, row := range changed {
@@ -225,11 +235,18 @@ func quietRelationships(
 			// <120 days ago>": a card disagreeing with itself, and with the
 			// contact's own page. `change.At` is the touch `change.Days`
 			// counts from, so the two agree by construction.
+			// The strength comes off the EDGE, scored at the read instant, and
+			// the edge is the one the projection already loaded. Scoring it
+			// here rather than storing a band means the lane and the contact's
+			// own page answer from the same arithmetic at the same moment,
+			// which is the property §4 is pure for.
 			lapsed = append(lapsed, attention.QuietRelationship{
-				PersonID:  row.PersonID.UUID,
-				Name:      row.DisplayName,
-				QuietDays: change.Days,
-				LastAt:    change.At,
+				PersonID:    row.PersonID.UUID,
+				Name:        row.DisplayName,
+				QuietDays:   change.Days,
+				LastAt:      change.At,
+				Strength:    edge.StrengthOf(now),
+				HasOpenDeal: funded[edge.PersonID],
 			})
 			break
 		}

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -357,13 +357,22 @@ func (t attentionTasks) OpenForViewer(
 		}
 		due := *row.DueAt
 		linkType, linkID := primaryLink(row)
-		open = append(open, attention.Task{
+		task := attention.Task{
 			ID:       ids.UUID(row.Id),
 			Subject:  subjectOfActivity(row),
 			DueAt:    &due,
 			LinkType: linkType,
 			LinkID:   linkID,
-		})
+		}
+		// Who holds it, already on the row the store returned and dropped
+		// here. Two of this lane's three scopes put somebody else's task in
+		// front of the reader, and one of them exists precisely to surface the
+		// tasks nobody has taken.
+		if row.AssigneeId != nil {
+			assignee := ids.UUID(*row.AssigneeId)
+			task.AssigneeID = &assignee
+		}
+		open = append(open, task)
 	}
 	return open, nil
 }

--- a/backend/internal/compose/attentionlanesseam.go
+++ b/backend/internal/compose/attentionlanesseam.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/compose/attention"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/modules/deals"
@@ -362,26 +363,36 @@ func (t attentionTasks) OpenForViewer(
 		if row.DueAt == nil {
 			continue
 		}
-		due := *row.DueAt
-		linkType, linkID := primaryLink(row)
-		task := attention.Task{
-			ID:       ids.UUID(row.Id),
-			Subject:  subjectOfActivity(row),
-			DueAt:    &due,
-			LinkType: linkType,
-			LinkID:   linkID,
-		}
-		// Who holds it, already on the row the store returned and dropped
-		// here. Two of this lane's three scopes put somebody else's task in
-		// front of the reader, and one of them exists precisely to surface the
-		// tasks nobody has taken.
-		if row.AssigneeId != nil {
-			assignee := ids.UUID(*row.AssigneeId)
-			task.AssigneeID = &assignee
-		}
-		open = append(open, task)
+		open = append(open, taskFromActivity(row))
 	}
 	return open, nil
+}
+
+// taskFromActivity carries one stored activity across the seam as a task.
+//
+// A function rather than a loop body so the crossing can be tested without a
+// store: every field here is one the activity already held and this seam once
+// dropped, and a copy that stops happening is invisible — the lane still
+// returns the right NUMBER of rows, each one just quietly missing a fact.
+func taskFromActivity(row crmcontracts.Activity) attention.Task {
+	due := *row.DueAt
+	linkType, linkID := primaryLink(row)
+	task := attention.Task{
+		ID:       ids.UUID(row.Id),
+		Subject:  subjectOfActivity(row),
+		DueAt:    &due,
+		LinkType: linkType,
+		LinkID:   linkID,
+	}
+	// Who holds it, already on the row the store returned and dropped here.
+	// Two of this lane's three scopes put somebody else's task in front of the
+	// reader, and one of them exists precisely to surface the tasks nobody has
+	// taken.
+	if row.AssigneeId != nil {
+		assignee := ids.UUID(*row.AssigneeId)
+		task.AssigneeID = &assignee
+	}
+	return task
 }
 
 // attentionOverdue counts overdue tasks per assignee for the team board.

--- a/backend/internal/compose/attentionseam_test.go
+++ b/backend/internal/compose/attentionseam_test.go
@@ -159,6 +159,8 @@ func TestOnlyADerivedSilenceReachesTheDecayLane(t *testing.T) {
 				},
 			},
 		},
+		map[ids.UUID]bool{oldest: true},
+		readInstantForDecay,
 	)
 
 	if len(quiet) != 2 {
@@ -178,14 +180,38 @@ func TestOnlyADerivedSilenceReachesTheDecayLane(t *testing.T) {
 	if !quiet[0].LastAt.Equal(oldestDerived) {
 		t.Errorf("the card dates the silence at %s, want the derived %s", quiet[0].LastAt, oldestDerived)
 	}
+	// What the relationship was worth, carried from the two sources that hold
+	// it: the band scored off the EDGE the projection loaded, and the deal from
+	// the batched read. Both were already in the lane's hand and discarded, so
+	// every lapsed contact ranked alike.
+	if quiet[0].Strength.Bucket == "" {
+		t.Errorf("the lane scored no band for %q — the edge it loaded was discarded", quiet[0].Name)
+	}
+	if !quiet[0].HasOpenDeal {
+		t.Errorf("the funded contact %q is not reported as carrying a deal", quiet[0].Name)
+	}
+	// And the contact the funded set does NOT name carries none. Without this
+	// the assertion above would pass on a lane that marked everybody funded.
+	if quiet[1].HasOpenDeal {
+		t.Errorf("%q carries no open deal and the lane says it does", quiet[1].Name)
+	}
 }
+
+// readInstantForDecay is the moment the lane's derivations are scored at. Fixed
+// rather than time.Now(), because a band is a function of how long ago the last
+// exchange was and a wall clock would make the same fixture answer differently
+// on two runs.
+var readInstantForDecay = time.Date(2026, 6, 15, 9, 0, 0, 0, time.UTC)
 
 // A contact the caller may not read never reaches the derivation, so the lane
 // simply has nothing to say about them — no row, and no empty-handed entry that
 // would disclose the pair exists.
 func TestTheDecayLaneReportsNothingItCannotDerive(t *testing.T) {
 	edge := search.InteractionEdge{PersonID: ids.NewV7(), LastAt: time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)}
-	if quiet := quietRelationships([]search.InteractionEdge{edge}, nil); len(quiet) != 0 {
+	quiet := quietRelationships(
+		[]search.InteractionEdge{edge}, nil, map[ids.UUID]bool{}, readInstantForDecay,
+	)
+	if len(quiet) != 0 {
 		t.Errorf("the lane invented %d relationships from an empty derivation", len(quiet))
 	}
 }

--- a/backend/internal/compose/attentionseam_test.go
+++ b/backend/internal/compose/attentionseam_test.go
@@ -184,8 +184,25 @@ func TestOnlyADerivedSilenceReachesTheDecayLane(t *testing.T) {
 	// it: the band scored off the EDGE the projection loaded, and the deal from
 	// the batched read. Both were already in the lane's hand and discarded, so
 	// every lapsed contact ranked alike.
-	if quiet[0].Strength.Bucket == "" {
-		t.Errorf("the lane scored no band for %q — the edge it loaded was discarded", quiet[0].Name)
+	//
+	// The band is asserted against the kernel's own answer for THIS edge, not
+	// against a nonempty string: a bucket that is merely set passes for every
+	// band including the wrong one, and the failure worth guarding is the lane
+	// scoring the wrong edge — which yields a perfectly well-formed band about
+	// somebody else's relationship.
+	wantBand := search.InteractionEdge{PersonID: oldest, LastAt: oldestSpoke}.
+		StrengthOf(readInstantForDecay)
+	if quiet[0].Strength != wantBand {
+		t.Errorf("the lane scored %+v for %q, want §4's own answer for that edge %+v",
+			quiet[0].Strength, quiet[0].Name, wantBand)
+	}
+	// And the SECOND row is scored from its OWN edge. One score copied across
+	// every row would satisfy the line above on its own.
+	wantSecond := search.InteractionEdge{PersonID: newer, LastAt: newerSpoke}.
+		StrengthOf(readInstantForDecay)
+	if quiet[1].Strength != wantSecond {
+		t.Errorf("the lane scored %+v for %q, want that contact's own edge %+v",
+			quiet[1].Strength, quiet[1].Name, wantSecond)
 	}
 	if !quiet[0].HasOpenDeal {
 		t.Errorf("the funded contact %q is not reported as carrying a deal", quiet[0].Name)

--- a/backend/internal/compose/attentiontaskseam_test.go
+++ b/backend/internal/compose/attentiontaskseam_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What survives the crossing from a stored activity to a queue task.
+//
+// The seam's failure mode is silent by construction: a field it stops copying
+// costs no rows and raises no error, so the lane still returns the right NUMBER
+// of tasks and each one is quietly missing a fact. The assignee is the case
+// that made this worth a test — dropped, every held task reaches the reader
+// labelled as one nobody has taken, which is the opposite of true and reads as
+// an invitation to pick up a colleague's work.
+
+import (
+	"testing"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+func storedTask(assignee *ids.UUID, links *[]crmcontracts.ActivityLink) crmcontracts.Activity {
+	subject := "Send the retrofit quote"
+	due := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	row := crmcontracts.Activity{
+		Id:      openapi_types.UUID(ids.NewV7()),
+		Subject: &subject,
+		DueAt:   &due,
+		Links:   links,
+	}
+	if assignee != nil {
+		held := openapi_types.UUID(*assignee)
+		row.AssigneeId = &held
+	}
+	return row
+}
+
+// The holder crosses. Two of the lane's three scopes put somebody else's task
+// in front of the reader, so who owns it is not decoration.
+func TestTheHolderOfATaskCrossesTheSeam(t *testing.T) {
+	holder := ids.NewV7()
+	task := taskFromActivity(storedTask(&holder, nil))
+
+	if task.AssigneeID == nil {
+		t.Fatal("the stored assignee did not reach the queue task — every held task then " +
+			"reaches the reader labelled as one nobody has taken")
+	}
+	if *task.AssigneeID != holder {
+		t.Fatalf("the task names %v as its holder, want %v", *task.AssigneeID, holder)
+	}
+}
+
+// An unheld task crosses as unheld rather than as a zero id, which is a value a
+// client would try to resolve to a person who does not exist.
+func TestAnUnheldTaskCrossesTheSeamCarryingNoHolder(t *testing.T) {
+	if task := taskFromActivity(storedTask(nil, nil)); task.AssigneeID != nil {
+		t.Fatalf("an unheld task crossed naming %v as its holder", *task.AssigneeID)
+	}
+}
+
+// The rest of the crossing, asserted beside the assignee so a future edit that
+// drops one of these is caught by the same test rather than by nothing.
+func TestATaskCrossesTheSeamWithTheFactsTheRowNeeds(t *testing.T) {
+	deal := ids.NewV7()
+	row := storedTask(nil, &[]crmcontracts.ActivityLink{
+		{EntityType: flipObjectDeal, EntityId: openapi_types.UUID(deal)},
+	})
+
+	task := taskFromActivity(row)
+
+	if task.ID != ids.UUID(row.Id) {
+		t.Errorf("the task's id is %v, want the activity's %v", task.ID, row.Id)
+	}
+	if task.Subject != "Send the retrofit quote" {
+		t.Errorf("the task's subject is %q, want the activity's", task.Subject)
+	}
+	if task.DueAt == nil || !task.DueAt.Equal(*row.DueAt) {
+		t.Errorf("the task is due %v, want the activity's %v", task.DueAt, row.DueAt)
+	}
+	// The record the task is FOR. Without it the row is a sentence the reader
+	// cannot act on, and the lane knew which deal it meant all along.
+	if task.LinkType != string(flipObjectDeal) || task.LinkID != deal {
+		t.Errorf("the task is filed under %s/%v, want the deal %v", task.LinkType, task.LinkID, deal)
+	}
+}

--- a/backend/internal/compose/integration/opendealpeople_integration_test.go
+++ b/backend/internal/compose/integration/opendealpeople_integration_test.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Which lapsed contacts still have money resting on them, and who is allowed to
+// learn that.
+//
+// The decay lane ranks a silence higher when a deal sits behind it, so this read
+// decides what a rep is shown first. It carries TWO admissions that answer
+// different questions — the edge grant asks whether this caller may read
+// stakeholder pairs at all, the deal row scope asks which deals count — and
+// neither implies the other. A unit test cannot tell them apart: both are SQL,
+// and both fail open in the same direction, by naming a contact whose deal the
+// caller was never entitled to know about.
+//
+// Seeded through the module stores the HTTP writers use, so the seat and the
+// deal are rows production writes.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/modules/people"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// fundedReaderPerms is everything the read asks for except the edge, which
+// withEdge adds — so two callers can differ in exactly one grant.
+func fundedReaderPerms(withEdge bool, scope principal.RowScope) principal.Permissions {
+	objects := map[string]principal.ObjectGrant{
+		"deal":         {Read: true},
+		"person":       {Read: true},
+		"organization": {Read: true},
+	}
+	if withEdge {
+		objects["relationship"] = principal.ObjectGrant{Read: true}
+	}
+	return principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects:  objects,
+		RowScope: scope,
+	}
+}
+
+func openDealPeople(
+	t *testing.T, e *Env, perms principal.Permissions, candidates []ids.PersonID,
+) (map[ids.UUID]bool, error) {
+	t.Helper()
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
+	var out map[ids.UUID]bool
+	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		funded, readErr := deals.OpenDealPeople(ctx, tx, candidates)
+		out = funded
+		return readErr
+	})
+	return out, err
+}
+
+// fundedOrFail is the ordinary path, where a refusal is a test failure rather
+// than a case under test.
+func fundedOrFail(
+	t *testing.T, e *Env, perms principal.Permissions, candidates []ids.PersonID,
+) map[ids.UUID]bool {
+	t.Helper()
+	funded, err := openDealPeople(t, e, perms, candidates)
+	if err != nil {
+		t.Fatalf("reading which contacts carry an open deal: %v", err)
+	}
+	return funded
+}
+
+func TestOnlyContactsOnAnOpenDealTheReaderMaySeeAreReportedAsFunded(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Kessler Systems", nil)
+	orgID := ids.From[ids.OrganizationKind](org)
+
+	seated := ids.From[ids.PersonKind](e.SeedPerson(t, "Seated Contact", nil))
+	// A contact on NO deal, so the answer has something to be wrong about. A
+	// read that reported every candidate would pass a fixture holding only the
+	// funded one.
+	unseated := ids.From[ids.PersonKind](e.SeedPerson(t, "Unseated Contact", nil))
+
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
+	// OWNED by somebody other than the reader. An ownerless deal is shared for
+	// reads by design — a row nobody owns is the workspace's to see — so a
+	// fixture that left the owner unset would put every caller inside the row
+	// scope and the narrowing case below would pass without the clause.
+	owner := ids.From[ids.UserKind](e.Rep2)
+	deal, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "Retrofit", PipelineID: pipeline, StageID: open,
+		OrganizationID: &orgID, OwnerID: &owner, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("creating the deal: %v", err)
+	}
+	dealID := ids.From[ids.DealKind](ids.UUID(deal.Id))
+	champion := "champion"
+	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
+		Kind: "deal_stakeholder", PersonID: &seated, DealID: &dealID,
+		Role: &champion, Source: "manual",
+	}); err != nil {
+		t.Fatalf("seating the champion: %v", err)
+	}
+
+	candidates := []ids.PersonID{seated, unseated}
+
+	granted := fundedOrFail(t, e, fundedReaderPerms(true, principal.RowScopeAll), candidates)
+	if !granted[seated.UUID] {
+		t.Fatalf("the seated contact is not reported as carrying an open deal — the fixture "+
+			"then proves nothing about the refusals below: %v", granted)
+	}
+	if granted[unseated.UUID] {
+		t.Errorf("a contact on no deal at all is reported as carrying one")
+	}
+
+	// The edge grant, removed alone. A seat is a PAIR, and knowing a deal does
+	// not license learning who sits on it — so a caller who may read both the
+	// person and the deal still learns nothing about the seat joining them.
+	//
+	// It REFUSES rather than answering an empty set, which is what lets the
+	// decay lane above it choose: that lane narrows, because a deal behind a
+	// silence is one fact on its answer rather than the answer. A read that
+	// returned "nobody is funded" would have made that choice here, silently,
+	// for every future caller.
+	withheld, err := openDealPeople(t, e, fundedReaderPerms(false, principal.RowScopeAll), candidates)
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a caller with no edge grant got %v, want the edge refusal", err)
+	}
+	if withheld[seated.UUID] {
+		t.Errorf("a caller with no edge grant is told which contact carries the deal")
+	}
+
+	// The DEAL row scope, narrowed alone while the edge grant stays — and the
+	// answer does NOT change, because `deal` is an identity table: customer
+	// identity is workspace-readable, so the own/team arm is TRUE for every
+	// seated actor and only capture privacy or a grant narrows it
+	// (platform/auth/tableclass.go).
+	//
+	// Asserted rather than left out. The read composes the deal's own scope
+	// clause, so what that clause does here is part of what this read means,
+	// and writing the expectation down is what stops the next reader assuming
+	// the narrowing they would get on an owner-scoped table. The deal above is
+	// owned by somebody other than this reader, so the case is real: if deal
+	// ever leaves the identity set, this line fails and says so.
+	bounded := fundedOrFail(t, e, fundedReaderPerms(true, principal.RowScopeOwn), candidates)
+	if !bounded[seated.UUID] {
+		t.Errorf("a reader bounded to their own rows lost a deal that customer identity is " +
+			"workspace-readable for — the row-scope clause narrowed an identity table")
+	}
+}
+
+// The deal's own status. A contact whose only deal has closed carries no money
+// any more, and ranking their silence as if they did would send a rep chasing
+// business that is already decided.
+func TestAContactWhoseOnlyDealHasClosedCarriesNoOpenDeal(t *testing.T) {
+	e := Setup(t)
+	org := e.SeedOrg(t, "Kessler Systems", nil)
+	orgID := ids.From[ids.OrganizationKind](org)
+	seated := ids.From[ids.PersonKind](e.SeedPerson(t, "Seated Contact", nil))
+
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e.Deals)
+	deal, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "Retrofit", PipelineID: pipeline, StageID: open,
+		OrganizationID: &orgID, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("creating the deal: %v", err)
+	}
+	dealID := ids.From[ids.DealKind](ids.UUID(deal.Id))
+	champion := "champion"
+	if _, err := e.People.CreateRelationship(e.Admin(), people.CreateRelationshipInput{
+		Kind: "deal_stakeholder", PersonID: &seated, DealID: &dealID,
+		Role: &champion, Source: "manual",
+	}); err != nil {
+		t.Fatalf("seating the champion: %v", err)
+	}
+
+	perms := fundedReaderPerms(true, principal.RowScopeAll)
+	// Open first, so the closure below is what changes the answer rather than
+	// the fixture never having produced one.
+	if !fundedOrFail(t, e, perms, []ids.PersonID{seated})[seated.UUID] {
+		t.Fatal("the seat carries no open deal before the deal was closed")
+	}
+
+	// Closed through the store's OWN advance path, not by writing the status
+	// column: the read filters on a value the transition derives, and a
+	// hand-set column would prove this test agrees with itself rather than
+	// that a closed deal really stops counting.
+	closeDealForTest(t, e, pipeline, dealID)
+
+	if fundedOrFail(t, e, perms, []ids.PersonID{seated})[seated.UUID] {
+		t.Errorf("a contact whose only deal has closed is still reported as carrying one")
+	}
+}
+
+// closeDealForTest advances the deal onto a terminal stage, which is how the
+// product closes one. `lost` rather than `won` because a win must account for
+// the agreement behind it, and this fixture is about the status alone.
+func closeDealForTest(t *testing.T, e *Env, pipeline ids.PipelineID, dealID ids.DealID) {
+	t.Helper()
+	ctx := e.Admin()
+	stages, err := e.Deals.ListStages(ctx, &pipeline, storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("listing the pipeline's stages: %v", err)
+	}
+	var lost ids.StageID
+	for _, st := range stages {
+		if st.Semantic == "lost" {
+			lost = ids.From[ids.StageKind](ids.UUID(st.Id))
+			break
+		}
+	}
+	if lost.IsZero() {
+		t.Fatal("the seeded pipeline has no lost stage to close onto")
+	}
+	reason := "the fixture closes it"
+	if _, err := e.Deals.AdvanceDeal(ctx, dealID, deals.AdvanceDealInput{
+		ToStageID: lost, LostReason: &reason,
+	}); err != nil {
+		t.Fatalf("closing the deal: %v", err)
+	}
+}

--- a/backend/internal/compose/integration/opendealpeople_integration_test.go
+++ b/backend/internal/compose/integration/opendealpeople_integration_test.go
@@ -37,14 +37,25 @@ import (
 // fundedReaderPerms is everything the read asks for except the edge, which
 // withEdge adds — so two callers can differ in exactly one grant.
 func fundedReaderPerms(withEdge bool, scope principal.RowScope) principal.Permissions {
+	perms := fundedReaderPermsWithout("", scope)
+	if withEdge {
+		perms.Objects["relationship"] = principal.ObjectGrant{Read: true}
+	}
+	return perms
+}
+
+// fundedReaderPermsWithout builds the same reader MINUS one named object grant,
+// so a test can remove exactly one admission and attribute what changes to it.
+//
+// Passing "" removes nothing and yields the reader without the edge, which is
+// what fundedReaderPerms then adds back.
+func fundedReaderPermsWithout(dropped string, scope principal.RowScope) principal.Permissions {
 	objects := map[string]principal.ObjectGrant{
 		"deal":         {Read: true},
 		"person":       {Read: true},
 		"organization": {Read: true},
 	}
-	if withEdge {
-		objects["relationship"] = principal.ObjectGrant{Read: true}
-	}
+	delete(objects, dropped)
 	return principal.Permissions{
 		RoleKeys: []string{"rep"},
 		Objects:  objects,
@@ -156,6 +167,27 @@ func TestOnlyContactsOnAnOpenDealTheReaderMaySeeAreReportedAsFunded(t *testing.T
 	if !bounded[seated.UUID] {
 		t.Errorf("a reader bounded to their own rows lost a deal that customer identity is " +
 			"workspace-readable for — the row-scope clause narrowed an identity table")
+	}
+
+	// The DEAL OBJECT grant, removed alone while the edge grant stays. The
+	// third admission, and the one this read originally omitted: a caller who
+	// may read stakeholder pairs but not deals was told which contacts carry an
+	// open one, so the deal's existence leaked through a person they were
+	// entitled to read.
+	//
+	// Row scope does not cover this and cannot: `deal` is an identity table, so
+	// the own/team arm is TRUE for every seated actor. That is exactly why the
+	// case above passes and this one has to be asserted separately — a suite
+	// that granted deal.read to every principal would have called the leak
+	// green.
+	noDeals := fundedReaderPermsWithout("deal", principal.RowScopeAll)
+	noDeals.Objects["relationship"] = principal.ObjectGrant{Read: true}
+	blind, err := openDealPeople(t, e, noDeals, candidates)
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("a caller with no deal grant got %v, want the deal refusal", err)
+	}
+	if blind[seated.UUID] {
+		t.Errorf("a caller who may not read deals is told one rests on this contact")
 	}
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -16841,6 +16841,14 @@ type AttentionItem struct {
 	// handles `snooze` generically write the wrong endpoint.
 	Actions []AttentionItemActions `json:"actions"`
 
+	// AssigneeId Who holds this task, null when nobody has taken it. Sent by `task`.
+	//
+	// The lane serves three scopes and only one is the reader's own queue: an
+	// unassigned sweep and a named colleague's queue both put work on the page that
+	// is not the reader's. Without this those rows read identically to their own,
+	// and the row nobody owns — the whole point of that scope — cannot say so.
+	AssigneeId *openapi_types.UUID `json:"assignee_id,omitempty"`
+
 	// CauseLabel What `cause_ref` identifies, in words — the automation's name, the mailbox that
 	// stopped.
 	//

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1543,6 +1543,30 @@ func (e AttentionPairEvidenceSignal) Valid() bool {
 	}
 }
 
+// Defines values for AttentionRelationshipFactsStrength.
+const (
+	AttentionRelationshipFactsStrengthModerate AttentionRelationshipFactsStrength = "moderate"
+	AttentionRelationshipFactsStrengthNone     AttentionRelationshipFactsStrength = "none"
+	AttentionRelationshipFactsStrengthStrong   AttentionRelationshipFactsStrength = "strong"
+	AttentionRelationshipFactsStrengthWeak     AttentionRelationshipFactsStrength = "weak"
+)
+
+// Valid indicates whether the value is a known member of the AttentionRelationshipFactsStrength enum.
+func (e AttentionRelationshipFactsStrength) Valid() bool {
+	switch e {
+	case AttentionRelationshipFactsStrengthModerate:
+		return true
+	case AttentionRelationshipFactsStrengthNone:
+		return true
+	case AttentionRelationshipFactsStrengthStrong:
+		return true
+	case AttentionRelationshipFactsStrengthWeak:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AttentionSubjectType.
 const (
 	AttentionSubjectTypeActivity     AttentionSubjectType = "activity"
@@ -11181,22 +11205,22 @@ func (e TagColor) Valid() bool {
 
 // Defines values for TagDetailColor.
 const (
-	Amber TagDetailColor = "amber"
-	Rose  TagDetailColor = "rose"
-	Slate TagDetailColor = "slate"
-	Teal  TagDetailColor = "teal"
+	TagDetailColorAmber TagDetailColor = "amber"
+	TagDetailColorRose  TagDetailColor = "rose"
+	TagDetailColorSlate TagDetailColor = "slate"
+	TagDetailColorTeal  TagDetailColor = "teal"
 )
 
 // Valid indicates whether the value is a known member of the TagDetailColor enum.
 func (e TagDetailColor) Valid() bool {
 	switch e {
-	case Amber:
+	case TagDetailColorAmber:
 		return true
-	case Rose:
+	case TagDetailColorRose:
 		return true
-	case Slate:
+	case TagDetailColorSlate:
 		return true
-	case Teal:
+	case TagDetailColorTeal:
 		return true
 	default:
 		return false
@@ -16916,6 +16940,19 @@ type AttentionItem struct {
 	// Rank Position in its producer's own ordering, where the producer ranks (the briefing queue). 1 is first.
 	Rank *int `json:"rank,omitempty"`
 
+	// Relationship What the lapsed relationship behind a `relationship_decay` item was WORTH before
+	// it went quiet. Sent only for `source: relationship_decay`.
+	//
+	// Without it every lapsed contact reads alike, and the rep's strongest relationship
+	// going quiet is the row that most deserves to be told apart from a cc who has
+	// drifted. Both facts were already in the lane's hand and discarded: the band is
+	// scored from the edge the lane loads, and the deal is one batched read over the
+	// candidates it already narrowed to.
+	//
+	// The band travels rather than the raw score, because a number between 0 and 100
+	// invites a client to draw a precision the §4 arithmetic does not claim.
+	Relationship *AttentionRelationshipFacts `json:"relationship,omitempty"`
+
 	// Source Which producer raised it, and therefore which endpoint its verbs go to.
 	Source AttentionItemSource `json:"source"`
 
@@ -17009,6 +17046,34 @@ type AttentionPairSide struct {
 	// different fact from not having asked.
 	RelatedCount *int `json:"related_count,omitempty"`
 }
+
+// AttentionRelationshipFacts What the lapsed relationship behind a `relationship_decay` item was WORTH before
+// it went quiet. Sent only for `source: relationship_decay`.
+//
+// Without it every lapsed contact reads alike, and the rep's strongest relationship
+// going quiet is the row that most deserves to be told apart from a cc who has
+// drifted. Both facts were already in the lane's hand and discarded: the band is
+// scored from the edge the lane loads, and the deal is one batched read over the
+// candidates it already narrowed to.
+//
+// The band travels rather than the raw score, because a number between 0 and 100
+// invites a client to draw a precision the §4 arithmetic does not claim.
+type AttentionRelationshipFacts struct {
+	// HasOpenDeal Whether money this reader can see still rests on this contact. Absent is not
+	// "no": a contact with an open deal the reader may not see reads the same as one
+	// with none, which is the answer every row-scoped read gives.
+	HasOpenDeal *bool `json:"has_open_deal,omitempty"`
+
+	// Strength The relationship's band at the read instant, from the same §4 scoring the
+	// contact's own page shows — computed on read rather than stored, so the two
+	// surfaces cannot come to disagree about who this person is.
+	Strength *AttentionRelationshipFactsStrength `json:"strength,omitempty"`
+}
+
+// AttentionRelationshipFactsStrength The relationship's band at the read instant, from the same §4 scoring the
+// contact's own page shows — computed on read rather than stored, so the two
+// surfaces cannot come to disagree about who this person is.
+type AttentionRelationshipFactsStrength string
 
 // AttentionStagedFacts What the verdict engine already worked out about a staged contact decision, so a
 // surface can group alike questions without reading the proposal a second time.

--- a/backend/internal/modules/deals/openforpeople.go
+++ b/backend/internal/modules/deals/openforpeople.go
@@ -23,23 +23,35 @@ import (
 
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
 
 // OpenDealPeople answers which of the given contacts sit on an open deal the
 // caller can see.
 //
-// It carries BOTH admissions, because they answer different questions and
-// neither implies the other. The edge grant asks whether this caller may read
-// stakeholder pairs at all — a seat is an edge, and knowing a deal does not
-// license learning who is on it. The deal row scope asks WHICH deals count:
-// without it the answer would leak the existence of a deal through a contact
-// the caller can read, which is the side door the edge gate alone leaves open.
+// It carries THREE admissions, because they answer three different questions
+// and none of them implies another.
+//
+// The deal OBJECT gate asks whether this caller may read deals at all. It is
+// first, and it is the one this read originally omitted: a caller holding the
+// edge grant and no deal grant was told which contacts carry an open deal, so
+// the existence of the deal leaked through a person they were entitled to read.
+// Row scope does not cover it — `deal` is an identity table, so the own/team arm
+// is TRUE for every seated actor and the clause narrows nothing on its own.
+//
+// The edge grant asks whether this caller may read stakeholder pairs. A seat is
+// an edge, and knowing a deal does not license learning who is on it.
+//
+// The deal row scope asks WHICH deals count, for the tables where it bites.
 //
 // A contact absent from the answer is one with no open deal OR one whose deal
 // this caller cannot see, and the caller cannot tell those apart. That is the
 // same answer every other row-scoped read gives, and it is the right one here:
 // the alternative discloses the deal by the shape of the refusal.
 func OpenDealPeople(ctx context.Context, tx pgx.Tx, people []ids.PersonID) (map[ids.UUID]bool, error) {
+	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
+		return nil, err
+	}
 	if len(people) == 0 {
 		return map[ids.UUID]bool{}, nil
 	}

--- a/backend/internal/modules/deals/openforpeople.go
+++ b/backend/internal/modules/deals/openforpeople.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// Which of these contacts still has money resting on them.
+//
+// The question the other direction from Stakeholders: that one asks who sits on
+// a deal, this asks whose silence costs something. The attention feed's decay
+// lane needs it to tell a lapsed champion from a lapsed cc — the two read
+// identically today, and a rep who cannot tell them apart stops reading the
+// lane.
+//
+// Batched over the caller's whole candidate set rather than asked per person.
+// The lane derives at most decayCandidateCap contacts, and a per-person read
+// would be the N+1 the feed's own rules forbid.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// OpenDealPeople answers which of the given contacts sit on an open deal the
+// caller can see.
+//
+// It carries BOTH admissions, because they answer different questions and
+// neither implies the other. The edge grant asks whether this caller may read
+// stakeholder pairs at all — a seat is an edge, and knowing a deal does not
+// license learning who is on it. The deal row scope asks WHICH deals count:
+// without it the answer would leak the existence of a deal through a contact
+// the caller can read, which is the side door the edge gate alone leaves open.
+//
+// A contact absent from the answer is one with no open deal OR one whose deal
+// this caller cannot see, and the caller cannot tell those apart. That is the
+// same answer every other row-scoped read gives, and it is the right one here:
+// the alternative discloses the deal by the shape of the refusal.
+func OpenDealPeople(ctx context.Context, tx pgx.Tx, people []ids.PersonID) (map[ids.UUID]bool, error) {
+	if len(people) == 0 {
+		return map[ids.UUID]bool{}, nil
+	}
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	peoplePos := arg(people)
+	bound, err := edgeBound(ctx, "r", arg)
+	if err != nil {
+		return nil, err
+	}
+	scope, err := auth.ScopeClauseFor(ctx, "deal", "d", arg)
+	if err != nil {
+		return nil, err
+	}
+	visible := predicateAlways
+	if scope != "" {
+		visible = scope
+	}
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT DISTINCT r.person_id
+		  FROM relationship r
+		  JOIN deal d ON d.id = r.deal_id AND d.archived_at IS NULL
+		 WHERE r.kind = 'deal_stakeholder'
+		   AND r.person_id = ANY($%d)
+		   AND r.archived_at IS NULL
+		   AND d.status = 'open'
+		   AND (%s)
+		   AND (%s)`, peoplePos, bound, visible), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[ids.UUID]bool, len(people))
+	for rows.Next() {
+		var person ids.UUID
+		if err := rows.Scan(&person); err != nil {
+			return nil, err
+		}
+		out[person] = true
+	}
+	return out, rows.Err()
+}

--- a/backend/internal/modules/deals/openforpeople.go
+++ b/backend/internal/modules/deals/openforpeople.go
@@ -50,7 +50,7 @@ func OpenDealPeople(ctx context.Context, tx pgx.Tx, people []ids.PersonID) (map[
 	if err != nil {
 		return nil, err
 	}
-	scope, err := auth.ScopeClauseFor(ctx, "deal", "d", arg)
+	scope, err := auth.ScopeClauseFor(ctx, dealTable, "d", arg)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -27684,6 +27684,7 @@ export interface components {
              *     sentence, and every one of those uses would go quietly wrong together.
              */
             quiet_days?: number | null;
+            relationship?: components["schemas"]["AttentionRelationshipFacts"];
             /**
              * @description Which underlying CONDITION this row reports, for a surface that groups repeated
              *     failures of one thing into one row. Two failures of one broken automation carry
@@ -27724,6 +27725,16 @@ export interface components {
             subject?: components["schemas"]["AttentionSubject"];
             pair?: components["schemas"]["AttentionPair"];
             deal?: components["schemas"]["AttentionDealFacts"];
+            /**
+             * Format: uuid
+             * @description Who holds this task, null when nobody has taken it. Sent by `task`.
+             *
+             *     The lane serves three scopes and only one is the reader's own queue: an
+             *     unassigned sweep and a named colleague's queue both put work on the page that
+             *     is not the reader's. Without this those rows read identically to their own,
+             *     and the row nobody owns — the whole point of that scope — cannot say so.
+             */
+            assignee_id?: string | null;
             /**
              * Format: date-time
              * @description When this is due (tasks), or when it lapses (approvals).
@@ -27807,6 +27818,34 @@ export interface components {
             currency?: string | null;
             /** Format: uuid */
             owner_id?: string | null;
+        };
+        /**
+         * @description What the lapsed relationship behind a `relationship_decay` item was WORTH before
+         *     it went quiet. Sent only for `source: relationship_decay`.
+         *
+         *     Without it every lapsed contact reads alike, and the rep's strongest relationship
+         *     going quiet is the row that most deserves to be told apart from a cc who has
+         *     drifted. Both facts were already in the lane's hand and discarded: the band is
+         *     scored from the edge the lane loads, and the deal is one batched read over the
+         *     candidates it already narrowed to.
+         *
+         *     The band travels rather than the raw score, because a number between 0 and 100
+         *     invites a client to draw a precision the §4 arithmetic does not claim.
+         */
+        AttentionRelationshipFacts: {
+            /**
+             * @description The relationship's band at the read instant, from the same §4 scoring the
+             *     contact's own page shows — computed on read rather than stored, so the two
+             *     surfaces cannot come to disagree about who this person is.
+             * @enum {string}
+             */
+            strength?: "none" | "weak" | "moderate" | "strong";
+            /**
+             * @description Whether money this reader can see still rests on this contact. Absent is not
+             *     "no": a contact with an open deal the reader may not see reads the same as one
+             *     with none, which is the answer every row-scoped read gives.
+             */
+            has_open_deal?: boolean;
         };
         /** @description One field the detector compared across the two records. */
         AttentionPairEvidence: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7916,7 +7916,7 @@ export const de = {
   "worklist.because.overdue": "überfällig",
   "worklist.because.due_today": "heute fällig",
   "worklist.because.closing_soon": "hat ein Abschlussdatum",
-  "worklist.because.expected_revenue": "erwarteter Umsatz",
+  "worklist.because.expected_revenue": "ein offener Deal hängt daran",
   "worklist.because.expected_revenue.value": "Wert {value}",
   "worklist.because.material": "über dem üblichen offenen Deal",
   "worklist.because.material.value":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7994,7 +7994,7 @@ export const en = {
   "worklist.because.overdue": "overdue",
   "worklist.because.due_today": "due today",
   "worklist.because.closing_soon": "has a close date",
-  "worklist.because.expected_revenue": "expected revenue",
+  "worklist.because.expected_revenue": "an open deal rests on this",
   "worklist.because.expected_revenue.value": "worth {value}",
   "worklist.because.material": "above the typical open deal",
   "worklist.because.material.value":

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7825,7 +7825,7 @@ export const vi = {
   "worklist.because.overdue": "quá hạn",
   "worklist.because.due_today": "đến hạn hôm nay",
   "worklist.because.closing_soon": "có ngày chốt",
-  "worklist.because.expected_revenue": "doanh thu dự kiến",
+  "worklist.because.expected_revenue": "một giao dịch đang mở phụ thuộc vào người này",
   "worklist.because.expected_revenue.value": "trị giá {value}",
   "worklist.because.material": "trên mức giao dịch mở thông thường",
   "worklist.because.material.value": "trị giá {value}, trên mức thông thường",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7825,7 +7825,8 @@ export const vi = {
   "worklist.because.overdue": "quá hạn",
   "worklist.because.due_today": "đến hạn hôm nay",
   "worklist.because.closing_soon": "có ngày chốt",
-  "worklist.because.expected_revenue": "một giao dịch đang mở phụ thuộc vào người này",
+  "worklist.because.expected_revenue":
+    "một giao dịch đang mở phụ thuộc vào người này",
   "worklist.because.expected_revenue.value": "trị giá {value}",
   "worklist.because.material": "trên mức giao dịch mở thông thường",
   "worklist.because.material.value": "trị giá {value}, trên mức thông thường",

--- a/frontend/src/screens/worklist.reasons.test.tsx
+++ b/frontend/src/screens/worklist.reasons.test.tsx
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { ToastProvider, ToastRegion } from "../design-system/toast";
+import { LocaleProvider } from "../i18n";
+import { WorklistScreen } from "./worklist";
+
+// Why a row is worth the reader's morning, drawn.
+//
+// Two lanes could state only how LONG something had been true. A lapsed
+// relationship said "quiet for 63 days" whether it was the rep's strongest
+// contact with an open deal behind them or a cc who had drifted, and a task
+// nobody had taken read exactly like the reader's own. Both facts were already
+// in the server's hand and dropped on the way out.
+//
+// These assert the drawn phrase rather than the wire field: a reason that
+// reaches the client and has no sentence for it is silently omitted, so a test
+// on the payload would pass over a row that says nothing.
+
+type Worklist = components["schemas"]["Worklist"];
+type WorklistItem = components["schemas"]["WorklistItem"];
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function day(queue: WorklistItem[]): Worklist {
+  return {
+    as_of: "2026-08-31T09:00:00Z",
+    scope: "mine",
+    scope_options: ["mine"],
+    queue,
+    summary: {
+      urgent: 0,
+      due: queue.length,
+      lower_priority: 0,
+      total: queue.length,
+    },
+    sources_unavailable: [],
+    readings: {
+      revenue_at_risk_minor: null,
+      buyer_replies: 0,
+      prospecting: 0,
+      review: 0,
+      more_available: false,
+    },
+    reach: [],
+    counts: [],
+  };
+}
+
+function draw(queue: WorklistItem[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => jsonResponse(day(queue))),
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <ToastProvider>
+          <WorklistScreen />
+          <ToastRegion />
+        </ToastProvider>
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function decayRow(because: WorklistItem["because"]): WorklistItem {
+  return {
+    id: "d1",
+    source: "relationship_decay",
+    category: "system",
+    level: 3,
+    consequence: "data_drifts",
+    title: "Dana Weiss",
+    because,
+    actions: [],
+  };
+}
+
+describe("a lapsed relationship says what it was worth", () => {
+  it("says an open deal rests on the contact", async () => {
+    draw([
+      decayRow([
+        { kind: "quiet_days", value: { kind: "days", days: 63 } },
+        { kind: "expected_revenue" },
+      ]),
+    ]);
+
+    expect(await screen.findByText(/an open deal rests on this/)).toBeTruthy();
+    // Beside the span, not instead of it: the rep reads both — how long, and
+    // why it matters that long.
+    expect(await screen.findByText(/quiet for 63 days/)).toBeTruthy();
+  });
+
+  // The row that carries nothing says only how long. This is what makes the
+  // line above mean something: if every decay row claimed a deal, the claim
+  // would be decoration rather than a fact.
+  it("claims no deal when none rests on the contact", async () => {
+    draw([decayRow([{ kind: "quiet_days", value: { kind: "days", days: 63 } }])]);
+
+    expect(await screen.findByText(/quiet for 63 days/)).toBeTruthy();
+    expect(screen.queryByText(/an open deal rests on this/)).toBeNull();
+  });
+});
+
+describe("a task says who holds it", () => {
+  it("says nobody owns the one nobody has taken", async () => {
+    draw([
+      {
+        id: "t1",
+        source: "task",
+        category: "tasks",
+        level: 3,
+        consequence: "task_slips",
+        title: "Send the retrofit quote",
+        because: [{ kind: "due_today" }, { kind: "unassigned" }],
+        actions: [],
+      },
+    ]);
+
+    expect(await screen.findByText(/nobody owns it/)).toBeTruthy();
+  });
+
+  it("says nothing about ownership on a task somebody holds", async () => {
+    draw([
+      {
+        id: "t2",
+        source: "task",
+        category: "tasks",
+        level: 3,
+        consequence: "task_slips",
+        title: "Send the retrofit quote",
+        because: [{ kind: "due_today" }],
+        actions: [],
+      },
+    ]);
+
+    expect(await screen.findByText("Send the retrofit quote")).toBeTruthy();
+    expect(screen.queryByText(/nobody owns it/)).toBeNull();
+  });
+});

--- a/frontend/src/screens/worklist.reasons.test.tsx
+++ b/frontend/src/screens/worklist.reasons.test.tsx
@@ -114,7 +114,9 @@ describe("a lapsed relationship says what it was worth", () => {
   // line above mean something: if every decay row claimed a deal, the claim
   // would be decoration rather than a fact.
   it("claims no deal when none rests on the contact", async () => {
-    draw([decayRow([{ kind: "quiet_days", value: { kind: "days", days: 63 } }])]);
+    draw([
+      decayRow([{ kind: "quiet_days", value: { kind: "days", days: 63 } }]),
+    ]);
 
     expect(await screen.findByText(/quiet for 63 days/)).toBeTruthy();
     expect(screen.queryByText(/an open deal rests on this/)).toBeNull();


### PR DESCRIPTION
Two Worklist lanes could say only how LONG something had been true, never why it mattered. A lapsed relationship read "quiet for 63 days" whether it was the rep's strongest contact with an open deal behind them or a cc who had drifted, and every one of them ranked as routine tidying. A task nobody had taken read exactly like the reader's own.

Both facts were already in the server's hand and dropped on the way out.

## What changes

**A decayed relationship carries what it was worth.** The lane already loads the `InteractionEdge` and discarded it; it now scores it through `relstrength.Compute` — the same call the contact's own page makes — and carries the band. It also reads, once for the whole capped candidate set, which of those contacts still sit on an open deal (`deals.OpenDealPeople`). A silence with money behind it, or a moderate-or-better relationship behind it, is agreed work rather than routine, and the row says "an open deal rests on this" when a deal is why.

**A task says who holds it.** `assignee_id` was on the activity the store returned and the seam threw it away. It now travels, and a task nobody has taken states the `unassigned` reason the lead lane already uses — which is the entire point of the unassigned scope, whose rows previously could not say what they were.

## What it deliberately does not say

The band moves the rank and states nothing. `no_champion` is the nearest word the reason vocabulary has and it means the opposite here — an account with nobody carrying it, rather than the person who *was* carrying it going quiet. A reason that reads backwards is worse than a rank the row does not explain, so the band waits for a word of its own. There is a test that fails if someone reaches for it.

## Security

`OpenDealPeople` is a new read joining `relationship` to `deal`, and it carries three admissions: the deal object gate, the edge grant, and the deal row scope. The first was missing in my first draft and Codex caught it — a caller holding `relationship:read` and no `deal:read` was told which contacts carry an open deal, so the deal's existence leaked through a person they were entitled to read. Row scope does not cover that and cannot: `deal` is an identity table, so the own/team arm is TRUE for every seated actor.

The integration tests remove each grant alone and assert what changes. A reader without the edge grant NARROWS rather than failing — the decay lane's answer is the silences, and losing a whole lane over a grant governing something else would be the wrong trade.

## Verification

- `make check-backend`, `make check-fe` green on the rebased tree
- `make test-it DIR=backend/internal/compose/integration` for the new SQL
- `craft static --strict` clean over every changed file
- 16 clauses mutation-checked one at a time, each failing its own test
- `assignee_id` confirmed on the wire against a running API

Two files crossed the 500-line cap and were split by concept: the silence lanes now have their own `lanessilence.go`, `rendersilence.go` and `classifydecay.go`.

## Not in scope

`no_champion` and `win_probability` remain declared-and-unfilled: both need new reads (a batched `CoverageForMany`, and a stage read this feed does not make) rather than wiring. The plan's "stall evidence" item turned out to rest on a wrong premise — `SlippingEvidence` is derived inside the agents tool from flags the attention lane already carries and already renders as `quiet_days` and `closing_soon`, so there is no dropped field to forward.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ranks the decay lane by what a lapsed relationship was worth, and makes the task lane say who owns each row. Previously a rep's strongest contact going quiet and a drifted cc ranked alike as routine tidying, and a task nobody had taken read exactly like the reader's own.

- Decay rows now carry the relationship's strength band and whether an open deal rests on the contact; a moderate-or-better relationship or a deal raises the row to agreed work, and a deal-backed silence says "an open deal rests on this."
- The shared `expected_revenue` reason phrase changed from "expected revenue" to "an open deal rests on this" for every row carrying it.
- Tasks now carry `assignee_id`, and unheld ones state the `unassigned` reason the lead lane already uses.

**Security**
- The new `OpenDealPeople` read requires both the `deal` read grant and the `relationship` edge grant; without the deal grant the read refuses rather than leaking a deal's existence through a person.
- A caller without the edge grant narrows — the decay lane keeps the rows and loses only the ranking bump.

<sup>Written for commit e0d05c4a346ee898bbcd5d4cecf1dc14ab5b7244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worklist items now show relationship strength, time since last contact, and whether an open deal is associated.
  * Lapsed relationships and at-risk deals include more relevant context, such as quiet duration, overdue status, and deal details.
  * Tasks now identify their assignee and clearly flag unassigned tasks.
  * Open-deal information is shown only when permitted.

* **Localization**
  * Updated English, German, and Vietnamese wording to explain when an open deal depends on a relationship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->