### PR TITLE
A number you can open

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16331,6 +16331,40 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '422': { $ref: '#/components/responses/ValidationError' }
+  /analytics/explain:
+    post:
+      tags: [Reports]
+      operationId: explainAnalyticsCell
+      summary: The records one cell of an analytics answer was computed from.
+      description: |
+        A number is worth having only if somebody can open it, and opening it means the
+        ROWS rather than a restatement of the formula.
+
+        The request carries the QUESTION unchanged plus the cell's own group keys. The
+        question rather than a handle, because an explanation of a different query than the
+        one that produced the number is not an explanation and nothing downstream could
+        tell.
+
+        The explanation reads the identical row set the answer read: same population, same
+        filters, same authority narrowings. It never out-sees the number it explains.
+
+        A cell the privacy floor withheld answers `withheld` with no rows. Handing over
+        those records one at a time is the same disclosure at a slower pace.
+      x-agent-access: human-only
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AnalyticsExplainRequest' }
+      responses:
+        '200':
+          description: The records behind the cell, as this caller may read them.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AnalyticsExplanation' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '422': { $ref: '#/components/responses/ValidationError' }
   /weekly-plans/current:
     get:
       tags: [Brief]
@@ -31533,6 +31567,47 @@ components:
         schema_version:
           type: string
           description: The vocabulary this was asked in.
+      additionalProperties: false
+    AnalyticsExplainRequest:
+      type: object
+      description: One cell of an answer, named by the question and its group keys.
+      required: [query]
+      properties:
+        query: { $ref: '#/components/schemas/AnalyticsQuery' }
+        group:
+          type: array
+          items: {}
+          description: >-
+            The cell's group key values, one per grouping in the question and in the same
+            order. Omitted for an ungrouped answer, which has one cell. A null entry means
+            the group whose value is unset, which resolves to the records that have nothing
+            there rather than to none.
+      additionalProperties: false
+    AnalyticsExplanation:
+      type: object
+      required: [columns, rows, withheld, truncated]
+      properties:
+        columns:
+          type: array
+          items: { type: string }
+        rows:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: >-
+            The records, each carrying its id, the dimensions that put it in this group,
+            and the fields the measures were computed over.
+        withheld:
+          type: boolean
+          description: >-
+            The cell itself was withheld, so there is nothing to open. Different from an
+            empty list, which would mean the group had no records at all.
+        truncated:
+          type: boolean
+          description: >-
+            The cell covers more records than were returned. A reader who adds up the rows
+            and finds less than the cell needs to know why.
       additionalProperties: false
     WeeklyPlan:
       type: object

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -386,6 +386,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/ai-model-rates":                                            {Op: "setAiModelRate", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/ai-model-rates/propose-refresh":                            {Op: "proposeAiModelRateRefresh", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/ai/feedback":                                               {Op: "recordAIFeedback", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/analytics/explain":                                         {Op: "explainAnalyticsCell", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/analytics/query":                                           {Op: "runAnalyticsQuery", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/approval-bundles/{bundle_id}/approve":                      {Op: "approveApprovalBundle", Access: "tool", Tool: "decide_approval_bundle", RecordType: "", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/approval-bundles/{bundle_id}/reject":                       {Op: "rejectApprovalBundle", Access: "tool", Tool: "decide_approval_bundle", RecordType: "", Tier: "auto_execute", Scope: "write"},

--- a/backend/internal/compose/analyticsexplain.go
+++ b/backend/internal/compose/analyticsexplain.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Opening one cell of a generic analytics answer.
+//
+// The rule that decides everything here: the explanation reads the SAME rows
+// the number was computed from, under the same authority. It runs the same
+// narrowings through specNarrowings, and it re-judges the cell against the
+// floor before returning anything — because a withheld cell explained record by
+// record is the same disclosure at a slower pace.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// AnalyticsExplanation is one cell's records.
+type AnalyticsExplanation struct {
+	Columns []string
+	Rows    []map[string]any
+	// Withheld says the cell itself was withheld, so there is nothing to open.
+	// The rows are empty in that case and the two are different facts: an
+	// empty explanation of a served cell means the group had no records, which
+	// cannot happen, and reading one as the other would hide the refusal.
+	Withheld bool
+	// Truncated says the cell covers more records than were returned. A reader
+	// who sums the rows and finds less than the cell needs to know why.
+	Truncated bool
+}
+
+// ExplainAnalyticsCell resolves one cell to its records.
+func ExplainAnalyticsCell(
+	ctx context.Context, tx pgx.Tx, in analyticsquery.Explain, floor analyticsquery.Floor,
+) (AnalyticsExplanation, error) {
+	spec, ok := prebuiltReports[in.Query.Entity]
+	if !ok {
+		return AnalyticsExplanation{}, &analyticsquery.RefusalError{
+			Kind:    analyticsquery.RefusalUnsupported,
+			Message: "no population by that name",
+			Suggest: "explain a cell of an answer this seat can ask for",
+		}
+	}
+	if err := auth.Require(ctx, string(spec.entity), principal.ActionRead); err != nil {
+		return AnalyticsExplanation{}, err
+	}
+
+	// The cell's own size, judged before anything is opened. Asked by RUNNING
+	// the question again rather than trusting a size the caller sent: a caller
+	// who could assert their cell was large would have turned the floor off.
+	withheld, err := cellIsWithheld(ctx, tx, in, floor)
+	if err != nil {
+		return AnalyticsExplanation{}, err
+	}
+	if withheld {
+		return AnalyticsExplanation{Withheld: true}, nil
+	}
+
+	schema := AnalyticsSchemaFor(ctx)
+	plan, err := analyticsquery.CompileExplain(in, schema, analyticsScope(ctx, spec))
+	if err != nil {
+		return AnalyticsExplanation{}, err
+	}
+	frame, err := readReportFrame(ctx, tx)
+	if err != nil {
+		return AnalyticsExplanation{}, err
+	}
+	sql, args, err := bindReportTokens(ctx, frame, plan.SQL, plan.Args)
+	if err != nil {
+		return AnalyticsExplanation{}, err
+	}
+
+	pgRows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		return AnalyticsExplanation{}, fmt.Errorf("compose: explaining an analytics cell: %w", err)
+	}
+	defer pgRows.Close()
+	rows, err := scanReportRows(pgRows, plan.Columns)
+	if err != nil {
+		return AnalyticsExplanation{}, fmt.Errorf("compose: reading an explanation: %w", err)
+	}
+	return AnalyticsExplanation{
+		Columns: plan.Columns, Rows: rows,
+		Truncated: len(rows) == analyticsquery.ExplainRowLimit,
+	}, nil
+}
+
+// cellIsWithheld re-runs the question and asks the floor about THIS cell.
+//
+// The whole answer rather than one group, because the floor's decision about a
+// group depends on the others: a group is withheld for being small, and its
+// complements go with it so it cannot be recovered by subtraction. Asking about
+// one group in isolation would serve a complement the answer withheld.
+func cellIsWithheld(
+	ctx context.Context, tx pgx.Tx, in analyticsquery.Explain, floor analyticsquery.Floor,
+) (bool, error) {
+	answer, err := RunAnalyticsQuery(ctx, tx, in.Query, floor)
+	if err != nil {
+		return false, err
+	}
+	if !answer.Withheld {
+		return false, nil
+	}
+	// Nothing left to match against: every group of the answer was withheld,
+	// including whichever one this is.
+	if len(in.Query.GroupBy) == 0 {
+		return true, nil
+	}
+	for _, row := range answer.Rows {
+		if !cellMatchesRow(in, row) {
+			continue
+		}
+		return row[withheldColumn] == true, nil
+	}
+	// The cell is in no row of the answer. A group that does not appear is one
+	// the caller did not get, so there is nothing to explain and saying so
+	// beats an empty list that reads as "no records".
+	return true, nil
+}
+
+// cellMatchesRow answers whether a row is the cell being explained.
+//
+// A withheld row carries nil for every key, so it matches nothing here — which
+// is correct and is why the fallthrough above answers withheld: a cell the
+// caller can name but cannot find in the answer is one that was withheld from
+// them, key and all.
+func cellMatchesRow(in analyticsquery.Explain, row map[string]any) bool {
+	for i, name := range in.Query.GroupBy {
+		if fmt.Sprint(row[name]) != fmt.Sprint(in.Group[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/compose/analyticsquery/explain.go
+++ b/backend/internal/compose/analyticsquery/explain.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package analyticsquery
+
+// Resolving one cell of an answer back to the records it was computed from.
+//
+// A number on a revenue screen is only worth having if somebody can open it,
+// and "open it" means the ROWS — not a restatement of the formula. So an
+// explanation is the same population, the same authority narrowings and the
+// same filters as the answer, plus the group this cell belongs to.
+//
+// THE EXPLANATION MUST NOT OUT-SEE THE NUMBER. It reads the identical row set,
+// which is why it is built from the same Query rather than from a description
+// of it: a second assembly would drift, and the direction it drifts is a
+// drill-through showing rows that were excluded from the total above it.
+//
+// A WITHHELD CELL EXPLAINS TO NOTHING. The floor withheld the group because it
+// covers too few records; handing over those records one at a time is the same
+// disclosure at a slower pace.
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Explain is a request to resolve one cell.
+type Explain struct {
+	// Query is the question the cell came from, unchanged. Carried whole
+	// rather than as a handle the caller could edit: an explanation of a
+	// DIFFERENT query than the one that produced the number is not an
+	// explanation, and nothing downstream could tell.
+	Query Query
+	// Group binds the cell's group keys — one entry per GroupBy dimension, in
+	// the same order. Empty for an ungrouped answer, which has one cell.
+	Group []any
+}
+
+// ExplainPlan is the compiled drill-through.
+type ExplainPlan struct {
+	SQL     string
+	Args    []any
+	Columns []string
+}
+
+// ExplainRowLimit bounds how many records a cell resolves to.
+//
+// A cell over ten thousand deals cannot be read row by row, and returning them
+// would be a dump wearing an explanation's name. Exported so the caller can
+// tell a full page from a truncated one without spelling the number twice, and
+// the answer says which so a reader knows they are seeing part.
+const ExplainRowLimit = 200
+
+// CompileExplain renders the drill-through for one cell.
+//
+// The same scope source as the answer, because the two must read one row set.
+// Passing a different one here would be the whole defect this function exists
+// to avoid, so it takes the same type the compiler does.
+func CompileExplain(in Explain, schema Schema, scope ScopeClauses) (ExplainPlan, error) {
+	if scope == nil {
+		return ExplainPlan{}, &RefusalError{
+			Kind:    RefusalInvalid,
+			Message: "an explanation was compiled with no scope source",
+			Suggest: "this is a wiring fault rather than a question anybody asked",
+		}
+	}
+	if err := in.Query.Validate(schema); err != nil {
+		return ExplainPlan{}, err
+	}
+	if len(in.Group) != len(in.Query.GroupBy) {
+		return ExplainPlan{}, &RefusalError{
+			Kind: RefusalInvalid,
+			Message: fmt.Sprintf(
+				"the cell names %d group value(s) and the question grouped by %d",
+				len(in.Group), len(in.Query.GroupBy)),
+			Suggest: "pass the cell's own group keys, in the order the answer listed them",
+		}
+	}
+	entity := schema.Entities[in.Query.Entity]
+
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	bind := func(v any) string { return fmt.Sprintf("$%d", arg(v)) }
+
+	where, err := whereClauses(entity, in.Query.Filters, bind)
+	if err != nil {
+		return ExplainPlan{}, err
+	}
+	scoped, err := scope(arg)
+	if err != nil {
+		return ExplainPlan{}, err
+	}
+	where = append(where, scoped...)
+
+	// The cell's own group. A NULL key is bound as IS NULL rather than `= NULL`
+	// — which is never true — so a cell whose group is "unset" resolves to the
+	// rows that have nothing there rather than to none at all.
+	for i, name := range in.Query.GroupBy {
+		expr := entity.Fields[name].Expr
+		if in.Group[i] == nil {
+			where = append(where, expr+" IS NULL")
+			continue
+		}
+		where = append(where, expr+" = "+bind(in.Group[i]))
+	}
+
+	// The identifying column plus every dimension the question named, so a
+	// reader can see WHY each record is in this group. The measures are not
+	// re-listed: the cell above already carries them, and computing them again
+	// here is a second answer to one question.
+	selects := []string{"t.id"}
+	columns := []string{"id"}
+	for _, name := range in.Query.GroupBy {
+		selects = append(selects, entity.Fields[name].Expr)
+		columns = append(columns, name)
+	}
+	for _, m := range in.Query.Measures {
+		if m.Field == "" {
+			continue
+		}
+		selects = append(selects, entity.Fields[m.Field].Expr)
+		columns = append(columns, m.Field)
+	}
+
+	// Ordered by id and bounded. Deterministic because a reader who pages
+	// through an explanation twice must see the same records in the same
+	// order, and an order over a measure re-sorts the moment a record changes.
+	sql := fmt.Sprintf("SELECT %s FROM %s WHERE %s ORDER BY t.id LIMIT %s",
+		strings.Join(selects, ", "), entity.From,
+		strings.Join(where, " AND "), bind(ExplainRowLimit))
+	return ExplainPlan{SQL: sql, Args: args, Columns: columns}, nil
+}

--- a/backend/internal/compose/analyticsquery_integration_test.go
+++ b/backend/internal/compose/analyticsquery_integration_test.go
@@ -297,3 +297,125 @@ func TestAWithheldGroupKeepsNoKeysEither(t *testing.T) {
 		}
 	}
 }
+
+// explainCell opens one cell of an answer.
+func (e *forecastEnv) explainCell(
+	ctx context.Context, t *testing.T, in analyticsquery.Explain,
+) (AnalyticsExplanation, error) {
+	t.Helper()
+	var out AnalyticsExplanation
+	err := forecasting.NewStore(InstallationDB(e.Pool)).InTx(ctx,
+		func(ctx context.Context, tx pgx.Tx) error {
+			var err error
+			out, err = ExplainAnalyticsCell(ctx, tx, in, analyticsquery.DefaultFloor)
+			return err
+		})
+	return out, err
+}
+
+func TestACellOpensToTheRecordsItWasComputedFrom(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	for i := 0; i < 6; i++ {
+		e.seedOpenDeal(t, "Deal", 20, &e.Rep1, &amount, nil)
+	}
+	ctx := e.reportReaderCtx()
+	q := analyticsquery.Query{
+		Entity:   "open-deals-per-company",
+		GroupBy:  []string{"owner_id"},
+		Measures: []analyticsquery.Measure{{Fn: analyticsquery.CountAll, As: "n"}},
+	}
+
+	answer, err := e.askAnalytics(ctx, t, q)
+	if err != nil {
+		t.Fatalf("the question was refused: %v", err)
+	}
+	if answer.Withheld {
+		t.Fatal("six deals in one group were withheld from a floor of five")
+	}
+
+	explanation, err := e.explainCell(ctx, t, analyticsquery.Explain{
+		Query: q, Group: []any{e.Rep1.String()},
+	})
+	if err != nil {
+		t.Fatalf("opening the cell was refused: %v", err)
+	}
+	if explanation.Withheld {
+		t.Fatal("a served cell explained to nothing")
+	}
+	// The explanation reads the SAME rows the number counted. A drill-through
+	// that showed more would be showing rows excluded from the total above it.
+	if len(explanation.Rows) != 6 {
+		t.Errorf("the cell counted six deals and opened to %d records", len(explanation.Rows))
+	}
+	if explanation.Truncated {
+		t.Error("six records were reported as a truncated page")
+	}
+}
+
+func TestAWithheldCellExplainsToWithheldRatherThanToNothing(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	// Two deals for one rep. Under the floor, so the answer withholds the
+	// group — and opening it record by record would be that same disclosure at
+	// a slower pace.
+	for i := 0; i < 2; i++ {
+		e.seedOpenDeal(t, "Small", 20, &e.Rep3, &amount, nil)
+	}
+	for i := 0; i < 6; i++ {
+		e.seedOpenDeal(t, "Big", 20, &e.Rep1, &amount, nil)
+	}
+	ctx := e.reportReaderCtx()
+	q := analyticsquery.Query{
+		Entity:   "open-deals-per-company",
+		GroupBy:  []string{"owner_id"},
+		Measures: []analyticsquery.Measure{{Fn: analyticsquery.CountAll, As: "n"}},
+	}
+	if _, err := e.askAnalytics(ctx, t, q); err != nil {
+		t.Fatalf("the question was refused: %v", err)
+	}
+
+	explanation, err := e.explainCell(ctx, t, analyticsquery.Explain{
+		Query: q, Group: []any{e.Rep3.String()},
+	})
+	if err != nil {
+		t.Fatalf("opening a withheld cell errored rather than answering withheld: %v", err)
+	}
+	if !explanation.Withheld {
+		t.Fatal("a withheld cell opened to its records")
+	}
+	if len(explanation.Rows) != 0 {
+		t.Errorf("a withheld cell returned %d records", len(explanation.Rows))
+	}
+}
+
+func TestAnExplanationCannotOutSeeTheNumberItExplains(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	for i := 0; i < 6; i++ {
+		e.seedOpenDeal(t, "Mine", 20, &e.Rep1, &amount, nil)
+		e.seedOpenDeal(t, "Theirs", 20, &e.Rep3, &amount, nil)
+	}
+	q := analyticsquery.Query{
+		Entity:   "open-deals-per-company",
+		Measures: []analyticsquery.Measure{{Fn: analyticsquery.CountAll, As: "n"}},
+	}
+
+	// A fully masked reader counts nothing, because every row leaves the money
+	// through the mask exclusion. Their explanation must be empty too — an
+	// explanation showing rows the aggregate excluded is the drill-through
+	// disclosing what the total was narrowed to hide.
+	masked := e.forecastReader(e.maskedDealReader(principal.MaskAlways))
+	answer, err := e.askAnalytics(masked, t, q)
+	if err != nil {
+		t.Fatalf("the masked reader's question was refused: %v", err)
+	}
+	explanation, err := e.explainCell(masked, t, analyticsquery.Explain{Query: q})
+	if err != nil {
+		t.Fatalf("the masked reader's explanation was refused: %v", err)
+	}
+	if len(explanation.Rows) != 0 {
+		t.Errorf("a masked reader whose answer counted %v opened it to %d records",
+			answer.Rows, len(explanation.Rows))
+	}
+}

--- a/backend/internal/compose/analyticsqueryhandlers.go
+++ b/backend/internal/compose/analyticsqueryhandlers.go
@@ -105,3 +105,30 @@ func queryFromWire(in crmcontracts.AnalyticsQuery) analyticsquery.Query {
 	}
 	return out
 }
+
+// ExplainAnalyticsCell implements POST /analytics/explain.
+func (h analyticsQueryHandlers) ExplainAnalyticsCell(w http.ResponseWriter, r *http.Request) {
+	var body crmcontracts.AnalyticsExplainRequest
+	if !httperr.Decode(w, r, &body) {
+		return
+	}
+	in := analyticsquery.Explain{Query: queryFromWire(body.Query)}
+	if body.Group != nil {
+		in.Group = *body.Group
+	}
+
+	ctx := r.Context()
+	var out AnalyticsExplanation
+	if err := h.db.Tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		out, err = ExplainAnalyticsCell(ctx, tx, in, h.floor)
+		return err
+	}); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.AnalyticsExplanation{
+		Columns: out.Columns, Rows: out.Rows,
+		Withheld: out.Withheld, Truncated: out.Truncated,
+	})
+}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -187,6 +187,10 @@ func (stubs) GetDataCoverage(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetDataCoverage")
 }
 
+func (stubs) ExplainAnalyticsCell(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "ExplainAnalyticsCell")
+}
+
 func (stubs) RunAnalyticsQuery(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "RunAnalyticsQuery")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -16076,6 +16076,29 @@ type AnalyticsEntity struct {
 	Name string `json:"name"`
 }
 
+// AnalyticsExplainRequest One cell of an answer, named by the question and its group keys.
+type AnalyticsExplainRequest struct {
+	// Group The cell's group key values, one per grouping in the question and in the same order. Omitted for an ungrouped answer, which has one cell. A null entry means the group whose value is unset, which resolves to the records that have nothing there rather than to none.
+	Group *[]interface{} `json:"group,omitempty"`
+
+	// Query One question, in the vocabulary the schema returned.
+	Query AnalyticsQuery `json:"query"`
+}
+
+// AnalyticsExplanation defines model for AnalyticsExplanation.
+type AnalyticsExplanation struct {
+	Columns []string `json:"columns"`
+
+	// Rows The records, each carrying its id, the dimensions that put it in this group, and the fields the measures were computed over.
+	Rows []map[string]interface{} `json:"rows"`
+
+	// Truncated The cell covers more records than were returned. A reader who adds up the rows and finds less than the cell needs to know why.
+	Truncated bool `json:"truncated"`
+
+	// Withheld The cell itself was withheld, so there is nothing to open. Different from an empty list, which would mean the group had no records at all.
+	Withheld bool `json:"withheld"`
+}
+
 // AnalyticsFilter defines model for AnalyticsFilter.
 type AnalyticsFilter struct {
 	Field string            `json:"field"`
@@ -37097,6 +37120,9 @@ type SetAiProviderKeyJSONRequestBody = AiProviderKeyInput
 // ReplaceAiRoutingJSONRequestBody defines body for ReplaceAiRouting for application/json ContentType.
 type ReplaceAiRoutingJSONRequestBody = AiRouting
 
+// ExplainAnalyticsCellJSONRequestBody defines body for ExplainAnalyticsCell for application/json ContentType.
+type ExplainAnalyticsCellJSONRequestBody = AnalyticsExplainRequest
+
 // RunAnalyticsQueryJSONRequestBody defines body for RunAnalyticsQuery for application/json ContentType.
 type RunAnalyticsQueryJSONRequestBody = AnalyticsQuery
 
@@ -45562,6 +45588,9 @@ type ServerInterface interface {
 	// How current the sources behind the numbers are.
 	// (GET /analytics/coverage)
 	GetDataCoverage(w http.ResponseWriter, r *http.Request)
+	// The records one cell of an analytics answer was computed from.
+	// (POST /analytics/explain)
+	ExplainAnalyticsCell(w http.ResponseWriter, r *http.Request)
 	// Answer a question nobody wrote a report for.
 	// (POST /analytics/query)
 	RunAnalyticsQuery(w http.ResponseWriter, r *http.Request)
@@ -47401,6 +47430,12 @@ func (_ Unimplemented) GetAiUsage(w http.ResponseWriter, r *http.Request, params
 // How current the sources behind the numbers are.
 // (GET /analytics/coverage)
 func (_ Unimplemented) GetDataCoverage(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// The records one cell of an analytics answer was computed from.
+// (POST /analytics/explain)
+func (_ Unimplemented) ExplainAnalyticsCell(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -52388,6 +52423,28 @@ func (siw *ServerInterfaceWrapper) GetDataCoverage(w http.ResponseWriter, r *htt
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetDataCoverage(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ExplainAnalyticsCell operation middleware
+func (siw *ServerInterfaceWrapper) ExplainAnalyticsCell(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ExplainAnalyticsCell(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -75435,6 +75492,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/analytics/coverage", wrapper.GetDataCoverage)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/analytics/explain", wrapper.ExplainAnalyticsCell)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/analytics/query", wrapper.RunAnalyticsQuery)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11114,6 +11114,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/analytics/explain": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * The records one cell of an analytics answer was computed from.
+         * @description A number is worth having only if somebody can open it, and opening it means the
+         *     ROWS rather than a restatement of the formula.
+         *
+         *     The request carries the QUESTION unchanged plus the cell's own group keys. The
+         *     question rather than a handle, because an explanation of a different query than the
+         *     one that produced the number is not an explanation and nothing downstream could
+         *     tell.
+         *
+         *     The explanation reads the identical row set the answer read: same population, same
+         *     filters, same authority narrowings. It never out-sees the number it explains.
+         *
+         *     A cell the privacy floor withheld answers `withheld` with no rows. Handing over
+         *     those records one at a time is the same disclosure at a slower pace.
+         */
+        post: operations["explainAnalyticsCell"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/weekly-plans/current": {
         parameters: {
             query?: never;
@@ -23028,6 +23060,23 @@ export interface components {
             total_safe: boolean;
             /** @description The vocabulary this was asked in. */
             schema_version: string;
+        };
+        /** @description One cell of an answer, named by the question and its group keys. */
+        AnalyticsExplainRequest: {
+            query: components["schemas"]["AnalyticsQuery"];
+            /** @description The cell's group key values, one per grouping in the question and in the same order. Omitted for an ungrouped answer, which has one cell. A null entry means the group whose value is unset, which resolves to the records that have nothing there rather than to none. */
+            group?: unknown[];
+        };
+        AnalyticsExplanation: {
+            columns: string[];
+            /** @description The records, each carrying its id, the dimensions that put it in this group, and the fields the measures were computed over. */
+            rows: {
+                [key: string]: unknown;
+            }[];
+            /** @description The cell itself was withheld, so there is nothing to open. Different from an empty list, which would mean the group had no records at all. */
+            withheld: boolean;
+            /** @description The cell covers more records than were returned. A reader who adds up the rows and finds less than the cell needs to know why. */
+            truncated: boolean;
         };
         /**
          * @description One rep's week as they meant it to go — the forward counterpart to the frozen
@@ -46738,6 +46787,33 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnalyticsAnswer"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    explainAnalyticsCell: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AnalyticsExplainRequest"];
+            };
+        };
+        responses: {
+            /** @description The records behind the cell, as this caller may read them. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnalyticsExplanation"];
                 };
             };
             401: components["responses"]["Unauthorized"];


### PR DESCRIPTION
A number you can open (#3928)

A cell of a generic analytics answer now resolves to the records it was computed
from. POST /analytics/explain takes the question unchanged plus the cell's own
group keys and returns those rows, each carrying its id, the dimensions that put
it in the group, and the fields the measures were computed over.

The question rather than a handle, deliberately. An explanation of a DIFFERENT
query than the one that produced the number is not an explanation, and nothing
downstream could tell the two apart.

Two rules make it safe, and both are tested.

The explanation cannot out-see the number. It runs the same population, the same
filters and the same authority narrowings — specNarrowings, the composer both
paths already share — so a drill-through can never show rows the aggregate above
it excluded. A fully masked reader whose answer counts nothing opens it to
nothing.

A withheld cell explains to `withheld`, not to its records. The floor withheld
the group for covering too few records; handing those records over one at a time
is the same disclosure at a slower pace. The cell's size is established by
RUNNING the question again rather than by trusting a size the caller sent — a
caller who could assert their cell was large would have turned the floor off.

Scope, stated plainly. The plan's PR 13 has two halves and only one was
buildable. `search_report_evidence` takes a COHORT HANDLE from PR 12, and no
cohort handle exists — that part of PR 12 was deferred, so the tool has no
subject to bound a search to. Building it against something else would be
building a different feature. `explain_report_element` is this PR, narrowed to
the generic analytics surface: the prebuilt reports already have their own
drill-through, which this deliberately does not duplicate.

Deferred with it: the narrative-statement half of explain (there are no
narrative statements to resolve until PR 14), and the prevalence/coverage
refusals, which belong with the evidence search they bound.

Also human-only, for the reason PR 12's routes are: the served tool catalog is
at ~87% of the certification lane's prompt window and a third analytics tool
does not fit.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `POST /analytics/explain` so a cell of a generic analytics answer can be opened to the records it was computed from. Each record carries its id, the dimensions that put it in the group, and the fields the measures were computed over.

**Safety**
- The explanation runs the same question with the same authority narrowings, so it can never show rows the aggregate above it excluded.
- A cell the privacy floor withheld answers `withheld` with no rows rather than handing over its records.
- Cell size is re-checked by re-running the question instead of trusting a caller-sent size.

**Scope**
- Only the generic analytics surface is covered; prebuilt reports keep their existing drill-through.
- Narrative statement resolution and prevalence/coverage refusals are deferred to later work.
- The route is human-only, consistent with the other analytics routes.

<sup>Written for commit 1d7d48d4c7b7406a78d218cc3aeed14880c30907. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a human-only analytics explanation endpoint for viewing the source records behind an analytics result cell.
  * Results indicate when data is privacy-withheld or truncated.
  * Explanations respect existing permissions, filters, grouping, and privacy controls.
  * Returned records are limited to 200 rows for predictable performance.

* **Bug Fixes**
  * Prevented access to records excluded from a viewer’s aggregate analytics results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->