### PR TITLE
fix(compose): waive rowCount's naked-any with the reason it holds

### DIFF
--- a/backend/internal/compose/analyticsqueryrun.go
+++ b/backend/internal/compose/analyticsqueryrun.go
@@ -249,7 +249,11 @@ const withheldColumn = "_withheld"
 //
 // A count that failed to parse answers ZERO, which the floor reads as below it
 // and withholds. Failing open here would serve a group whose size nothing
-// established.
+// established. v is one scanAnalyticsRows value off a caller-composed plan;
+// its Go type follows the plan's own count expression, which this function
+// exists to not have to know ahead of time.
+//
+//craft:ignore naked-any v's type follows the caller's own analytics plan, which is what this switch exists to not have to know ahead of time
 func rowCount(v any) int {
 	switch n := v.(type) {
 	case int64:


### PR DESCRIPTION
## Summary
The whole-tree \`craft-static\` gate (\`make craft-static\`, which CI runs identically per AGENTS.md) blocks every PR merged against current \`main\`: #3927 added \`rowCount(v any) int\` in \`backend/internal/compose/analyticsqueryrun.go\`, a genuine MAJOR naked-any finding under the ADR-0045 rubric.

## Why a waiver rather than a concrete type
\`v\` is one value \`scanAnalyticsRows\` read off a caller-composed analytics plan (\`pgx.Rows.Values()\`); its Go type follows whatever Postgres type the plan's own count expression resolves to at runtime, which is exactly what the function's type switch exists to handle rather than assume ahead of time. Traced the one call site (\`withheldAnswer\`) to confirm there is exactly one shape of caller and it genuinely is this dynamic — no concrete or constrained parameter type is available here, matching the existing \`//craft:ignore naked-any\` precedent this tree already uses for the same driver-decoded-dynamic-value shape (\`storekit.go\`, \`gen-configschema/schema.go\`, \`seed-demo/apiclient.go\`).

## Test plan
- [x] \`go run -C cli/craft . static --strict --root ../../backend\` — 0 blocker, 0 major, 0 minor (was 1 major)
- [x] \`go build ./...\`, \`gofumpt -l\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzkBShFNemkBKN3h5faNxf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waives the naked-any lint on `rowCount` in `backend/internal/compose/analyticsqueryrun.go` to unblock the `craft-static` CI gate. Adds a `//craft:ignore` comment explaining that `v`'s type comes from a Postgres query result, so a concrete type isn't possible.

<sup>Written for commit 53b42776c56f090953a86f86b60dcec70c76a98c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that analytics row-count values come from caller-composed plans and may use different data types.
  * No runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->