### PR TITLE
The closed week says what it did and what it left

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2422,6 +2422,16 @@ export const de = {
   "brief.sentence.manyWithCost":
     "Zuerst: {lead} — {consequence} Danach {rest} weitere.",
 
+  // Der Einstiegssatz des Wochen-Briefs, aus den eingefrorenen Zahlen gebaut.
+  "brief.week.won": "Sie haben {count} Abschlüsse gemacht.",
+  "brief.week.moved": "Sie haben {count} Deals vorangebracht.",
+  "brief.week.met": "Sie hatten {count} Termine.",
+  "brief.week.carryPromises": "{count} Zusagen sind offen geblieben.",
+  "brief.week.carryTasks": "{count} Aufgaben sind offen geblieben.",
+  "brief.week.andCarry": "{result} {carry}",
+  "brief.week.quiet":
+    "Eine ruhige Woche — nichts abgeschlossen, nichts bewegt.",
+
   "brief.donext.sub": "Eine Reihenfolge, aus deiner Arbeitsliste.",
   "brief.donext.loading": "Was auf dich wartet, wird gelesen",
   "brief.donext.clear": "Gerade wartet nichts auf dich.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2471,6 +2471,16 @@ export const en = {
   "brief.sentence.manyWithCost":
     "First: {lead} — {consequence} Then {rest} more.",
 
+  // The weekly Brief's opening sentence, composed from the counts the week was
+  // frozen with. Result first, then what carried — the outcome before the debt.
+  "brief.week.won": "You closed {count} deals.",
+  "brief.week.moved": "You moved {count} deals forward.",
+  "brief.week.met": "You held {count} meetings.",
+  "brief.week.carryPromises": "{count} promises carried over.",
+  "brief.week.carryTasks": "{count} tasks carried over.",
+  "brief.week.andCarry": "{result} {carry}",
+  "brief.week.quiet": "A quiet week — nothing closed and nothing moved.",
+
   "brief.donext.sub": "One order, from your worklist.",
   "brief.donext.loading": "Reading what waits on you",
   "brief.donext.clear": "Nothing is waiting on you right now.",

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -31,6 +31,11 @@ const KEPT_IN_ENGLISH = new Set<string>([
   // the dimension's own label and the sentence the server wrote — so there is
   // nothing here for a locale to translate.
   "co.strip.healthSummary.because",
+  // Two whole clauses and the space between them. The weekly's opening sentence
+  // is built from result keys and carry keys that ARE translated; this joins the
+  // two rendered clauses and contributes no word of its own, so a locale has
+  // nothing here to change.
+  "brief.week.andCarry",
   // The record's own name beside the numeral that names its reading. There is
   // no word in it to translate — a locale that changed it would be changing
   // the account's name.

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2398,6 +2398,16 @@ export const vi = {
   "brief.sentence.manyWithCost":
     "Trước tiên: {lead} — {consequence} Rồi {rest} mục nữa.",
 
+  // Câu mở đầu của Bản tin tuần, dựng từ các con số đã đóng băng.
+  "brief.week.won": "Bạn đã chốt {count} giao dịch.",
+  "brief.week.moved": "Bạn đã đẩy {count} giao dịch tiến lên.",
+  "brief.week.met": "Bạn đã có {count} cuộc họp.",
+  "brief.week.carryPromises": "{count} cam kết còn dang dở.",
+  "brief.week.carryTasks": "{count} công việc còn dang dở.",
+  "brief.week.andCarry": "{result} {carry}",
+  "brief.week.quiet":
+    "Một tuần yên ắng — không chốt được gì và không có gì chuyển động.",
+
   "brief.donext.sub": "Một thứ tự, từ danh sách công việc của bạn.",
   "brief.donext.loading": "Đang đọc những gì đang chờ bạn",
   "brief.donext.clear": "Hiện không có gì đang chờ bạn.",

--- a/frontend/src/screens/brief.weeksentence.test.ts
+++ b/frontend/src/screens/brief.weeksentence.test.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { describe, expect, it } from "vitest";
+import type { MessageKey } from "../i18n/en";
+import { en } from "../i18n/en";
+import { weekSentence } from "./brief.weeksentence";
+import type { WeeklyReview } from "./home.queries";
+
+// The catalog's own words, filled the way the app fills them. A second copy of
+// the templates here would let this suite pass over a sentence the product
+// never prints.
+function t(key: MessageKey, values?: Record<string, string>): string {
+  // Widened to a plain string: the catalog's values are a union of every
+  // literal it holds, and a reduce that substitutes into one cannot stay inside
+  // that union.
+  const template: string = en[key];
+  return Object.entries(values ?? {}).reduce(
+    (text, [name, value]) => text.replaceAll(`{${name}}`, value),
+    template,
+  );
+}
+
+function say(review: WeeklyReview | null | undefined): string | null {
+  const sentence = weekSentence(review, t);
+  return sentence === null ? null : t(sentence.key, sentence.values);
+}
+
+const ZERO_COUNTS = {
+  tasks_due: 0,
+  tasks_done: 0,
+  tasks_carried_over: 0,
+  deals_moved: 0,
+  deals_won: 0,
+  deals_lost: 0,
+  proposals_accepted: 0,
+  proposals_rejected: 0,
+  brief_items_acted: 0,
+  brief_items_dismissed: 0,
+  commitments_due: 0,
+  commitments_kept: 0,
+  leads_routed: 0,
+  leads_answered_in_target: 0,
+  leads_breached: 0,
+  meetings_held: 0,
+  meetings_with_next_step: 0,
+};
+
+function week(
+  counts: Partial<typeof ZERO_COUNTS>,
+  pipeline?: { won_minor: number; currency: string },
+): WeeklyReview {
+  return {
+    local_week_start: "2026-06-29",
+    counts: { ...ZERO_COUNTS, ...counts },
+    ...(pipeline === undefined ? {} : { pipeline }),
+  } as unknown as WeeklyReview;
+}
+
+describe("weekSentence — what the closed week says about itself", () => {
+  // The distinction the whole composer exists for. A read that never landed is
+  // not a quiet week, and saying so would send a rep away believing their week
+  // was calm on no evidence at all.
+  it("says nothing at all about a week it has not read", () => {
+    expect(say(undefined)).toBeNull();
+  });
+
+  // 404 from the weekly read: no week has been written yet. Same silence, same
+  // reason — there is no week to describe.
+  it("says nothing about a week nobody has written", () => {
+    expect(say(null)).toBeNull();
+  });
+
+  it("leads with what the week closed", () => {
+    expect(say(week({ deals_won: 2 }))).toContain("closed 2");
+  });
+
+  // What the wins were WORTH belongs to the Won card's detail line, which gave
+  // up its week-on-week delta to carry it (#3898). A week whose money the
+  // review DOES record must still not print it here, or one figure is on the
+  // page twice and a reader has two places to reconcile.
+  it("never prices the wins, even when the week recorded the money", () => {
+    const priced = say(
+      week({ deals_won: 2 }, { won_minor: 4200000, currency: "EUR" }),
+    );
+    expect(priced).toBe(say(week({ deals_won: 2 })));
+    expect(priced).not.toContain("42");
+  });
+
+  // Ranked by what a week is judged on, not by the bigger integer: twelve
+  // routed leads must not outrank the deal that paid for the quarter.
+  it("puts a single win ahead of a busier count of anything else", () => {
+    const said = say(week({ deals_won: 1, deals_moved: 9, meetings_held: 12 }));
+    expect(said).toContain("closed 1");
+    expect(said).not.toContain("9");
+  });
+
+  it("falls back to what moved, then to what was held", () => {
+    expect(say(week({ deals_moved: 3, meetings_held: 12 }))).toContain(
+      "moved 3",
+    );
+    expect(say(week({ meetings_held: 12 }))).toContain("held 12");
+  });
+
+  // A promise the rep made and did not keep is the first debt, because they
+  // said they would do it.
+  it("names the promises that did not survive the week", () => {
+    const said = say(
+      week({ deals_won: 1, commitments_due: 4, commitments_kept: 1 }),
+    );
+    expect(said).toContain("3 promises");
+  });
+
+  // A commitment DROPPED is in neither figure — the schema says deciding on
+  // Wednesday that a thing is not worth doing is not failing to do it. Kept
+  // equal to due therefore leaves no debt, whatever was dropped.
+  it("charges nothing to a week that kept every promise it made", () => {
+    const said = say(
+      week({ deals_won: 1, commitments_due: 4, commitments_kept: 4 }),
+    );
+    expect(said).not.toContain("promises");
+  });
+
+  it("falls back to postponed tasks when no promise was missed", () => {
+    expect(say(week({ deals_won: 1, tasks_carried_over: 2 }))).toContain(
+      "2 tasks",
+    );
+  });
+
+  // A week with no result of its own still has a true thing to say, and silence
+  // would read as a page that failed to load.
+  it("calls a week with nothing in it quiet, and still names its debt", () => {
+    expect(say(week({}))).toBe(en["brief.week.quiet"]);
+    expect(say(week({ tasks_carried_over: 2 }))).toContain("quiet");
+    expect(say(week({ tasks_carried_over: 2 }))).toContain("2 tasks");
+  });
+});

--- a/frontend/src/screens/brief.weeksentence.ts
+++ b/frontend/src/screens/brief.weeksentence.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { MessageKey } from "../i18n/en";
+import type { BriefSentence } from "./brief.sentence";
+import type { WeeklyReview } from "./home.queries";
+
+// The weekly Brief's opening sentence, composed from the counts the week was
+// frozen with.
+//
+// Same construction rule as the morning's `briefSentence`, and for the same
+// reason: it is built from the very figures the strip below draws, so the
+// sentence cannot say something those figures contradict, and no pass has to
+// have run before the page can speak. It carries no agent tag — indigo means
+// Margince decided, and a client-composed sentence marked that way would claim
+// an authorship that is not true.
+//
+// What it says is fixed by two questions a closed week answers: what moved, and
+// what did not finish. The result leads because a rep opening a closed week
+// wants the outcome before the debt; the carry follows because it is the part
+// that is still theirs on Monday.
+
+/**
+ * The week's largest movement, as the key naming it and the figure to fill.
+ *
+ * Ordered by what a week is judged on rather than by magnitude: a won deal
+ * outranks a leads figure however many leads there were, because the numbers
+ * are not comparable and picking the bigger integer would let twelve routed
+ * leads outrank the deal that paid for the quarter.
+ */
+function resultOf(
+  review: WeeklyReview,
+): { key: MessageKey; values: Record<string, string> } | null {
+  const c = review.counts;
+  if (c.deals_won > 0) {
+    // THE COUNT, NOT THE MONEY. What the wins were worth is already the Won
+    // card's detail line, which gave up its week-on-week delta to carry it
+    // (#3898) — and a figure printed twice on one page is two places a reader
+    // has to reconcile. The sentence says what the week did; the strip says
+    // what it was worth.
+    return { key: "brief.week.won", values: { count: String(c.deals_won) } };
+  }
+  if (c.deals_moved > 0) {
+    return {
+      key: "brief.week.moved",
+      values: { count: String(c.deals_moved) },
+    };
+  }
+  if (c.meetings_held > 0) {
+    return {
+      key: "brief.week.met",
+      values: { count: String(c.meetings_held) },
+    };
+  }
+  return null;
+}
+
+/**
+ * What the week left behind, or null when it left nothing.
+ *
+ * A commitment that was due and not kept is the first carry, because the rep
+ * said they would do it. Postponed tasks come second: they are older than the
+ * week and were already postponed at least once.
+ */
+function carryOf(
+  review: WeeklyReview,
+): { key: MessageKey; values: Record<string, string> } | null {
+  const c = review.counts;
+  const missed = c.commitments_due - c.commitments_kept;
+  if (missed > 0) {
+    return {
+      key: "brief.week.carryPromises",
+      values: { count: String(missed) },
+    };
+  }
+  if (c.tasks_carried_over > 0) {
+    return {
+      key: "brief.week.carryTasks",
+      values: { count: String(c.tasks_carried_over) },
+    };
+  }
+  return null;
+}
+
+/**
+ * The closed week in one sentence, or null when there is no week to describe.
+ *
+ * Null on an unread week, deliberately — the same distinction the panel below
+ * keeps between a week that was quiet and a read that never landed. A page that
+ * said "a quiet week" over a failed read would tell a rep their week was calm
+ * on no evidence at all.
+ */
+export function weekSentence(
+  review: WeeklyReview | null | undefined,
+  t: (key: MessageKey, values?: Record<string, string>) => string,
+): BriefSentence | null {
+  if (!review) {
+    return null;
+  }
+  const result = resultOf(review);
+  const carry = carryOf(review);
+  // A week with no result of its own still has a true thing to say. It says the
+  // week was quiet — never a manufactured outcome, and never silence, which a
+  // reader would take for a page that failed to load.
+  const said =
+    result === null
+      ? { key: "brief.week.quiet" as MessageKey, values: {} }
+      : result;
+  if (carry === null) {
+    return said;
+  }
+  // ONE SENTENCE, TWO CLAUSES, and the join is a whole key rather than a
+  // template that glues two rendered strings together. A translator gets the
+  // sentence with both holes in it, which is what lets German put the clauses
+  // where German puts them — the same reason the morning stores `.one` and
+  // `.oneWithCost` separately instead of appending the cost.
+  return {
+    key: "brief.week.andCarry",
+    values: {
+      result: t(said.key, said.values),
+      carry: t(carry.key, carry.values),
+    },
+  };
+}

--- a/frontend/src/screens/home.glance.tsx
+++ b/frontend/src/screens/home.glance.tsx
@@ -8,6 +8,8 @@ import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { briefSentence } from "./brief.sentence";
 import type { BriefView } from "./brief.view";
+import { weekSentence } from "./brief.weeksentence";
+import type { WeeklyReview } from "./home.queries";
 import type { Worklist } from "./worklist.queries";
 
 // The first thing a reader sees each morning: who they are, what hour it is for
@@ -70,9 +72,13 @@ export type GlanceFacts = Readonly<{
    *  while it is in flight or after it failed — the sentence is then absent
    *  rather than guessed at. */
   day: Worklist | undefined;
-  /** Which Brief this is. The eyebrow names it, and the sentence belongs to the
-   *  morning: it is composed from the ranked queue, which says nothing about a
-   *  week that has closed. */
+  /** The week that closed, for the weekly's opening sentence. Null when no week
+   *  has been written yet; undefined while the read is in flight or after it
+   *  failed — a quiet week and an unread one are different sentences. */
+  week: WeeklyReview | null | undefined;
+  /** Which Brief this is. The eyebrow names it, and each view composes its own
+   *  sentence: the morning's from the ranked queue, the weekly's from the
+   *  counts the week was frozen with. Neither can describe the other. */
   view: BriefView;
 }>;
 
@@ -102,7 +108,7 @@ function eyebrowText(
   });
 }
 
-export function HomeGlance({ firstName, now, day, view }: GlanceProps) {
+export function HomeGlance({ firstName, now, day, week, view }: GlanceProps) {
   const t = useT();
   const hour = hourInZone(now, viewerZone());
   // No name yet is not a reason to greet nobody: the hour is known either way,
@@ -115,10 +121,12 @@ export function HomeGlance({ firstName, now, day, view }: GlanceProps) {
   // THE DAY IN ONE SENTENCE, from the rows the page is already showing. The
   // lines below say the same facts as separate counts; this says what to do
   // about the first one, which a column of figures cannot.
-  // MORNING ONLY. It is composed from the ranked queue, which is what waits
-  // TODAY — over the weekly it would be describing this morning under a heading
-  // about the week that closed.
-  const sentence = view === "morning" ? briefSentence(day, t, locale) : null;
+  // EACH VIEW COMPOSES ITS OWN. The morning's comes from the ranked queue,
+  // which is what waits TODAY; over the weekly it would be describing this
+  // morning under a heading about the week that closed. The weekly's comes from
+  // the frozen counts, which is what the week is now a record of.
+  const sentence =
+    view === "morning" ? briefSentence(day, t, locale) : weekSentence(week, t);
 
   return (
     <header className="glance arrive" data-testid="home-glance">
@@ -133,9 +141,11 @@ export function HomeGlance({ firstName, now, day, view }: GlanceProps) {
           {t(sentence.key, sentence.values)}
         </p>
       ) : (
-        // The weekly has no composed sentence, so the fallback is the only line
-        // under its heading — and the morning's "this is your day" read as the
-        // wrong week entirely beneath "YOUR WEEK". Each view says its own.
+        // Neither view could compose a sentence: the queue or the week has not
+        // arrived, or the read failed. The fallback names the view rather than
+        // describing it, because there is nothing yet to describe — and the
+        // morning's "this is your day" read as the wrong week entirely beneath
+        // "YOUR WEEK". Each view says its own.
         <p className="glance-intro t-caption">
           {t(
             view === "weekly" ? "home.glance.introWeekly" : "home.glance.intro",

--- a/frontend/src/screens/home.parts.stories.tsx
+++ b/frontend/src/screens/home.parts.stories.tsx
@@ -123,6 +123,38 @@ const GLANCE_DAY = {
   summary: { total: 2, urgent: 1 },
 } as unknown as Parameters<typeof HomeGlance>[0]["day"];
 
+// A week that closed with a result and a debt — the two things the weekly's
+// opening sentence is built from.
+const GLANCE_WEEK = {
+  local_week_start: "2026-06-29",
+  generated_at: "2026-07-06T03:00:00Z",
+  counts: {
+    tasks_due: 6,
+    tasks_done: 4,
+    tasks_carried_over: 2,
+    deals_moved: 3,
+    deals_won: 2,
+    deals_lost: 0,
+    proposals_accepted: 1,
+    proposals_rejected: 0,
+    brief_items_acted: 5,
+    brief_items_dismissed: 1,
+    commitments_due: 4,
+    commitments_kept: 2,
+    leads_routed: 7,
+    leads_answered_in_target: 6,
+    leads_breached: 1,
+    meetings_held: 5,
+    meetings_with_next_step: 4,
+  },
+  pipeline: {
+    won_minor: 4200000,
+    created_minor: 0,
+    lost_minor: 0,
+    currency: "EUR",
+  },
+} as unknown as Parameters<typeof HomeGlance>[0]["week"];
+
 // The header the Brief opens with: eyebrow, greeting, and ONE composed sentence
 // about the day — not a column of counts. Each fact the old briefing lines
 // stated has a better home on the page now: the decisions deck draws its own
@@ -133,6 +165,7 @@ export const Glance: Story = {
     <HomeGlance
       view="morning"
       day={GLANCE_DAY}
+      week={null}
       firstName="Lena"
       now={NOW_DATE}
     />,
@@ -147,19 +180,37 @@ export const GlanceUnnamed: Story = {
     <HomeGlance
       view="morning"
       day={GLANCE_DAY}
+      week={null}
       firstName={null}
       now={NOW_DATE}
     />,
   ),
 };
 
-// The weekly says its own thing under its own heading: no composed sentence,
-// because that one is built from the ranked queue and describes THIS morning.
+// The weekly says its own thing under its own heading, composed from the counts
+// the week was frozen with rather than from the ranked queue — which describes
+// THIS morning and would read as the wrong week entirely.
 export const GlanceWeekly: Story = {
   render: part(
     <HomeGlance
       view="weekly"
       day={GLANCE_DAY}
+      week={GLANCE_WEEK}
+      firstName="Lena"
+      now={NOW_DATE}
+    />,
+  ),
+};
+
+// A week nobody has written yet. The heading names the view and says nothing
+// about it, because there is nothing yet to say — never a quiet-week claim,
+// which would tell a rep their week was calm on no evidence.
+export const GlanceWeeklyUnread: Story = {
+  render: part(
+    <HomeGlance
+      view="weekly"
+      day={GLANCE_DAY}
+      week={undefined}
       firstName="Lena"
       now={NOW_DATE}
     />,

--- a/frontend/src/screens/home.test.tsx
+++ b/frontend/src/screens/home.test.tsx
@@ -331,6 +331,7 @@ describe("HomeGlance — the greeting follows the reader's own hour", () => {
           // right value for them: the sentence is then absent, and the greeting
           // is what the assertion reads.
           day={undefined}
+          week={undefined}
         />
       </LocaleProvider>,
     );
@@ -366,6 +367,7 @@ describe("HomeGlance — the greeting follows the reader's own hour", () => {
           firstName="Ada"
           now={new Date(2026, 6, 5, 9, 0, 0)}
           day={undefined}
+          week={undefined}
         />
       </LocaleProvider>,
     );
@@ -376,6 +378,78 @@ describe("HomeGlance — the greeting follows the reader's own hour", () => {
     // panels — so an unread queue leaves the header saying only the greeting.
     expect(screen.queryByTestId("glance-sentence")).toBeNull();
     expect(screen.queryByText("Nothing is waiting on you.")).toBeNull();
+  });
+});
+
+// ── The weekly speaks about its own week ──
+
+describe("HomeGlance — the weekly's sentence comes from the closed week", () => {
+  // Only what the sentence reads. A fuller review would let this suite pass
+  // over a composer reaching for a figure the weekly does not actually carry.
+  const CLOSED_WEEK = {
+    local_week_start: "2026-06-29",
+    counts: {
+      tasks_due: 0,
+      tasks_done: 0,
+      tasks_carried_over: 0,
+      deals_moved: 0,
+      deals_won: 2,
+      deals_lost: 0,
+      proposals_accepted: 0,
+      proposals_rejected: 0,
+      brief_items_acted: 0,
+      brief_items_dismissed: 0,
+      commitments_due: 3,
+      commitments_kept: 1,
+      leads_routed: 0,
+      leads_answered_in_target: 0,
+      leads_breached: 0,
+      meetings_held: 0,
+      meetings_with_next_step: 0,
+    },
+  } as unknown as Parameters<typeof HomeGlance>[0]["week"];
+
+  function sentenceOf(
+    view: BriefView,
+    week: Parameters<typeof HomeGlance>[0]["week"],
+  ): string | null {
+    const rendered = rtlRender(
+      <LocaleProvider initial="en">
+        <HomeGlance
+          view={view}
+          firstName="Ada"
+          now={new Date(2026, 6, 5, 9, 0, 0)}
+          // A read day, so the MORNING case has a sentence of its own to draw.
+          // Without it both views would fall silent and the assertion that they
+          // say different things would pass over a component saying neither.
+          day={readingsDay({})}
+          week={week}
+        />
+      </LocaleProvider>,
+    );
+    const text = screen.queryByTestId("glance-sentence")?.textContent ?? null;
+    rendered.unmount();
+    return text;
+  }
+
+  it("states the week's result and what it left behind", () => {
+    const said = sentenceOf("weekly", CLOSED_WEEK);
+    expect(said).toContain("closed 2");
+    expect(said).toContain("2 promises");
+  });
+
+  // The two views compose from different reads. Over the weekly the morning's
+  // sentence would be describing today under a heading about a closed week.
+  it("does not put the morning's sentence under the weekly's heading", () => {
+    expect(sentenceOf("weekly", CLOSED_WEEK)).not.toBe(
+      sentenceOf("morning", CLOSED_WEEK),
+    );
+  });
+
+  // A week still in flight, or one that failed to read. The heading names the
+  // view and claims nothing about it.
+  it("draws no sentence at all over a week it has not read", () => {
+    expect(sentenceOf("weekly", undefined)).toBeNull();
   });
 });
 
@@ -390,6 +464,7 @@ describe("HomeGlance — the eyebrow says when the queue was read", () => {
           firstName="Ada"
           now={new Date(2026, 6, 5, 9, 0, 0)}
           day={day}
+          week={undefined}
         />
       </LocaleProvider>,
     );

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -24,6 +24,7 @@ import {
   quietDeals,
   useHomeDeals,
   useMorningBrief,
+  useWeeklyReview,
 } from "./home.queries";
 import { OvernightPanel, PositionPanel, WatchPanel } from "./home.rail";
 import { HomeReadingsStrip } from "./home.readings";
@@ -257,6 +258,11 @@ export function HomeScreen() {
   // Worklist's "dials stay state" choice deliberately excluded.
   const [params, setParams] = useUrlParams();
   const address = addressFrom(params, teamOffered);
+  // The closed week, for the weekly's opening sentence. The SAME query key
+  // WeeklySection uses for the latest week, so the header band and the panel
+  // below it read one answer rather than two that could differ — and the read
+  // is served from cache, not made twice.
+  const weeklyReview = useWeeklyReview();
 
   const approvals = approvalsQuery.data?.data ?? [];
   const items = useMemo(() => deckItems(approvals), [approvals]);
@@ -291,6 +297,7 @@ export function HomeScreen() {
       <HomeGlance
         view={address.view}
         day={worklistQuery.data}
+        week={weeklyReview.data}
         firstName={firstNameOf(me.data?.user?.display_name)}
         now={new Date(nowMs)}
       />


### PR DESCRIPTION
The weekly Brief opened with a greeting and a fixed line — "This is the week
you just closed" — over a strip of eleven figures. The morning has composed a
sentence from its own rows since the dials shipped; the weekly said nothing
about the week it was heading.

`weekSentence` composes it from the counts the week was frozen with, the same
way `briefSentence` composes the morning's from the ranked queue: deterministic,
no model, no agent tag. It names the result and then the debt — what closed or
moved, then the promises or tasks that did not survive the week.

Ranked by what a week is judged on rather than by the larger integer. A single
won deal outranks nine moved deals and twelve meetings, because those numbers
are not comparable and picking the bigger one would let a busy week outrank a
paid one.

WHAT IT DOES NOT SAY IS THE MONEY. `home.weekly.test.tsx` failed on the first
version with "found multiple elements": the won value was on the page twice,
once in the sentence and once in the Won card's detail line, which gave up its
week-on-week delta to carry it (#3898). The sentence says what the week did and
the strip says what it was worth.

An unread week draws no sentence at all. A quiet one says it was quiet — never
silence, which a reader takes for a page that failed to load, and never a
manufactured outcome.

The join key carries two clauses and the space between them, so it is the same
string in all three catalogs and earns a KEPT_IN_ENGLISH entry beside
co.strip.healthSummary.because, which is the same shape. Each clause it joins
is translated normally.

Six guards mutation-checked one at a time: the unread-week null, the no-money
rule, the result ranking, missed-versus-due commitments, the carry clause, and
the quiet-week sentence. Each fails its own test and nothing else.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The weekly Brief now opens with a sentence composed from the week's frozen counts instead of a fixed line, so it names what the week closed or moved and what carried over.

- Composes deterministically from the same counts the strip below draws, with no model or agent tag.
- Ranks results by what a week is judged on: a won deal outranks any number of moved deals or meetings.
- Never prints the won value — that stays on the Won card's detail line (#3898).
- Draws no sentence for an unread week; a quiet week says it was quiet rather than staying silent.
- Adds `brief.week.*` keys to en, de, and vi; the join key `brief.week.andCarry` is kept in English.
- `HomeGlance` takes a new `week` prop, fed from the same `useWeeklyReview` query the weekly section already uses.

<sup>Written for commit a4d1184e94bbf370626b0e3ecb2732564b3f883c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekly Brief summaries to the home screen.
  * Weekly summaries highlight wins, deal progress, meetings, carried-over commitments, or quiet weeks.
  * Added English, German, and Vietnamese translations for weekly Brief messages.
  * Weekly and morning views now display distinct, relevant messaging.

* **Bug Fixes**
  * Weekly summaries remain hidden when review data is unavailable.

* **Tests**
  * Added coverage for weekly result prioritization, carryovers, quiet weeks, and unavailable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->