### PR TITLE
The team's week says what its wins were worth

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2469,6 +2469,7 @@ export const de = {
   "teamweekly.card.commitmentsBasis": "des Zugesagten",
   "teamweekly.card.won": "Gewonnen",
   "teamweekly.card.wonBasis": "{lost} verloren",
+  "teamweekly.card.wonBasisValue": "{value} gewonnen · {lost} verloren",
   "teamweekly.card.reps": "Gezählte Mitglieder",
   "teamweekly.card.repsBasis": "deren Woche vollständig gelesen wurde",
   "teamweekly.movement.title": "Was die Woche bewegt hat",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2518,6 +2518,7 @@ export const en = {
   "teamweekly.card.commitmentsBasis": "of what was owed",
   "teamweekly.card.won": "Won",
   "teamweekly.card.wonBasis": "{lost} lost",
+  "teamweekly.card.wonBasisValue": "{value} won · {lost} lost",
   "teamweekly.card.reps": "Members counted",
   "teamweekly.card.repsBasis": "whose week was read in full",
   "teamweekly.movement.title": "What the week did",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2445,6 +2445,7 @@ export const vi = {
   "teamweekly.card.commitmentsBasis": "trên số đã cam kết",
   "teamweekly.card.won": "Thắng",
   "teamweekly.card.wonBasis": "{lost} thua",
+  "teamweekly.card.wonBasisValue": "thắng {value} · thua {lost}",
   "teamweekly.card.reps": "Thành viên được tính",
   "teamweekly.card.repsBasis": "có tuần được đọc đầy đủ",
   "teamweekly.movement.title": "Tuần đã làm được gì",

--- a/frontend/src/screens/brief.teamweekly.test.tsx
+++ b/frontend/src/screens/brief.teamweekly.test.tsx
@@ -117,6 +117,52 @@ describe("the headline states the bar it measured against", () => {
   });
 });
 
+describe("the scorecard says what the wins were worth", () => {
+  // The count alone says a week of five small renewals and a week of one
+  // company-making deal are the same week. The money was computed, converted
+  // and stored when the snapshot was written — and read by nothing until now.
+  it("prices the wins beside the losses when the snapshot recorded the money", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () =>
+        jsonResponse(
+          review({}, {
+            pipeline: {
+              created_minor: 9000000,
+              won_minor: 2500000,
+              lost_minor: 0,
+              currency: "EUR",
+            },
+          } as Partial<TeamWeeklyReview>),
+        ),
+    });
+    render(<TeamWeeklySection teamId="t1" />);
+
+    // The review's OWN currency, not the installation's current setting: base
+    // currency is operator-mutable, and re-reading it would re-label a closed
+    // week with a currency its numbers were never in.
+    expect(await screen.findByText(/25.000,00\s*€|€25,000\.00/)).toBeTruthy();
+    // The lost count survives the money arriving: it is a different fact, not a
+    // delta the value replaces.
+    expect(screen.getByText(/1 lost|1 verloren/)).toBeTruthy();
+  });
+
+  // The block is ABSENT whenever any member's week could not be converted, and
+  // summing only the reps who did convert would be a confident number quietly
+  // missing one. A zero here would claim a team that won three deals won
+  // nothing.
+  it("draws no money at all over a week that could not be converted", async () => {
+    stubApi({ "GET /weekly-reviews/team": () => jsonResponse(review()) });
+    render(<TeamWeeklySection teamId="t1" />);
+
+    expect(
+      await screen.findByText(
+        en["teamweekly.card.wonBasis"].replace("{lost}", "1"),
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/€|EUR/)).toBeNull();
+  });
+});
+
 describe("the team's frozen week", () => {
   // A snapshot covering four of six reps reads exactly like a team of four, and
   // every figure on the page is short by the same two people.

--- a/frontend/src/screens/brief.teamweekly.tsx
+++ b/frontend/src/screens/brief.teamweekly.tsx
@@ -9,8 +9,8 @@ import { Meter } from "../design-system/readings";
 import { Select } from "../design-system/select";
 import { StatStrip } from "../design-system/statstrip";
 import { SurfaceState } from "../design-system/surfacestate";
-import { formatDate, formatNumber } from "../format/format";
-import { useLocale, useT } from "../i18n";
+import { formatDate, formatMoney, formatNumber } from "../format/format";
+import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { EntityRef } from "./entityref";
 import {
@@ -245,6 +245,30 @@ function Coverage({ review }: Readonly<{ review: TeamWeeklyReview }>) {
   );
 }
 
+/**
+ * What the team's wins were worth, or nothing.
+ *
+ * NOTHING, not a zero, when the snapshot carries no pipeline block. That block
+ * is absent whenever any member's week could not be converted — the schema says
+ * so — because summing only the reps who DID convert would be a confident
+ * number quietly missing one. "€0 won" over a team that won deals is the
+ * opposite of what happened.
+ *
+ * The currency is the SNAPSHOT's, never the installation's current setting:
+ * base currency is operator-mutable, and re-reading it would re-label a closed
+ * week with a currency its numbers were never in.
+ */
+function wonValue(
+  review: TeamWeeklyReview,
+  locale: Locale,
+): string | undefined {
+  const pipeline = review.pipeline;
+  if (pipeline === undefined) {
+    return undefined;
+  }
+  return formatMoney(pipeline.won_minor, pipeline.currency, locale);
+}
+
 function Scorecard({ review }: Readonly<{ review: TeamWeeklyReview }>) {
   const t = useT();
   const { locale } = useLocale();
@@ -252,6 +276,7 @@ function Scorecard({ review }: Readonly<{ review: TeamWeeklyReview }>) {
   const n = (value: number) => formatNumber(value, locale);
   const ofTotal = (part: number, whole: number) =>
     t("teamweekly.ofTotal", { part: n(part), whole: n(whole) });
+  const won = wonValue(review, locale);
 
   return (
     <StatStrip testId="teamweekly-strip">
@@ -275,7 +300,22 @@ function Scorecard({ review }: Readonly<{ review: TeamWeeklyReview }>) {
       <StatCard
         label={t("teamweekly.card.won")}
         value={n(counts.deals_won)}
-        detail={t("teamweekly.card.wonBasis", { lost: n(counts.deals_lost) })}
+        // What the wins were WORTH, beside how many were lost. The count alone
+        // says a week of five small renewals and a week of one company-making
+        // deal are the same week — and the money was computed, FX-converted and
+        // stored when the snapshot was written, then read by nothing.
+        //
+        // It rides the won slot rather than taking a sixth: five is what a
+        // strip can be read across as one comparison. The lost count stays,
+        // because it is a different fact rather than a delta the money replaces.
+        detail={
+          won === undefined
+            ? t("teamweekly.card.wonBasis", { lost: n(counts.deals_lost) })
+            : t("teamweekly.card.wonBasisValue", {
+                value: won,
+                lost: n(counts.deals_lost),
+              })
+        }
       />
       <StatCard
         label={t("teamweekly.card.reps")}


### PR DESCRIPTION
The team scorecard's Won slot read "3" over "1 lost". Whether that was three
small renewals or three company-making deals, the card said the same thing.

`team_weekly_review.pipeline_won_minor` has been computed, FX-converted, stored
at snapshot time and served as `TeamWeeklyReview.pipeline` since the table
shipped. Nothing read it. Same gap as the rep's weekly (#3898) and the third
instance of this pattern on these screens.

The value rides the Won slot's detail line rather than taking a sixth: five is
what a strip can be read across as one comparison, and a tenth slot folded the
row into two ranks at 1280 (#3709). The lost count stays beside it — unlike the
rep weekly's week-on-week delta, it is a different fact rather than one the
money replaces, so the line carries both.

ABSENT DRAWS NO MONEY. The pipeline block is missing whenever any member's week
could not be converted, because summing only the reps who did convert would be
a confident number quietly short one person. A zero there would tell a lead a
team that won three deals won nothing.

The currency is the SNAPSHOT's, never the installation's current setting. Base
currency is operator-mutable and re-reading it would re-label a closed week with
a currency its numbers were never in.

Three guards mutation-checked one at a time: the money reaching the card at all,
the absent-block rule, and the lost count surviving the money's arrival.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The team scorecard's Won slot now shows what the wins were worth alongside the lost count, using pipeline data already stored at snapshot time.

- The money only appears when the snapshot recorded a pipeline block; if any member's week could not be converted, the block is absent and no money is shown rather than a misleading zero.
- The currency comes from the snapshot, not the installation's current base currency setting.
- The lost count stays on the line next to the value.

<sup>Written for commit 9423c5ffb056342d46777c9e3941b3f5ce532051. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly team scorecards now display won deal values alongside won and lost deal counts.
  * Monetary values use the currency recorded in the snapshot and are formatted according to the selected locale.
  * When conversion data is unavailable, the scorecard continues showing the available deal-count information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->