### PR TITLE
Three surfaces still drew their own email, and the gate could not see them

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -20755,15 +20755,19 @@ components:
         has_message:
           type: boolean
           description: |
-            The message this thread began with is still readable by you. False where it was erased
-            while the verdict stood — which the ledger deliberately survives, because losing the
-            verdict would re-open a thread a classifier already held — and false where its content
-            is withheld from you.
+            The message this thread began with still EXISTS. False only where it was erased while
+            the verdict stood — which the ledger deliberately survives, because losing the verdict
+            would re-open a thread a classifier already held.
 
-            Separate from `subject` because absence has two causes that read differently: no
-            message to name, versus a message somebody sent with a blank subject line. It also
-            decides whether releasing is offered at all: the release works on your own messages on
-            the thread, so with none left there is nothing to share.
+            Existence, not readability: it stays true for a message whose content is withheld from
+            you, and that is the point. Read through the content gate it reported a withheld
+            message as erased, which told a holder their evidence had been destroyed while it was
+            sitting in the thread they are holding.
+
+            So `subject` absent with this true is a message you may not read, or one sent with a
+            blank subject line; this false is no message at all. It also decides whether releasing
+            is offered: the release works on your own messages on the thread, so with none left
+            there is nothing to share.
         subject:
           type: string
           description: |

--- a/backend/gates/emailpresentation_test.go
+++ b/backend/gates/emailpresentation_test.go
@@ -29,6 +29,27 @@ package gates
 // canonical renderer, and a canonical renderer that has stopped consuming any
 // `entry` schema at all.
 //
+// A surface reaches an email by EITHER route, and the census must see both.
+// Naming the generated type is one. Reading the property that carries it off a
+// record already in hand — `row.email_summary.subject` on an Activity — is the
+// other, and it names no type at all. An earlier version of this gate looked
+// only for the type name and argued in a comment that there was no other way
+// in. Three surfaces were drawing their own email rows while it reported PASS:
+// the person page's memory card, the account page's recent list and the held
+// threads table. Under-recognition is the one way a census must not break,
+// because a smaller corpus fails silently and reads exactly like a clean tree.
+//
+// What this still cannot see, stated so the next reader does not assume
+// otherwise: a surface that draws an email from the ACTIVITY's own scalars —
+// `activity.subject`, `activity.body` — without ever touching the carrier
+// field. It reads a message and names nothing an email, so no derivation
+// reaches it. The account page's recent list and the held threads table were
+// both in that shape. They are fixed, and what holds them is a rendering test
+// each rather than this census; a fourth such surface would arrive unseen.
+// Widening to activity scalars would put `.subject` — which notes, calls and
+// tasks all carry — in front of a rule about email, and a census that flags
+// every kind teaches a reader to waive it.
+//
 // The second direction is the one worth having. A gate that only checked
 // "nothing else renders an email" would report PASS over a tree where the
 // canonical row had been deleted and every surface had gone back to its own
@@ -76,11 +97,20 @@ var emailRenderers = map[string]bool{
 	"design-system/emaildetail.tsx": true,
 }
 
-// emailPassthroughs hold an `entry` type without rendering it: they declare a
-// prop and hand it to a canonical component. Each is a sentence somebody wrote
-// rather than an omission nobody noticed.
+// emailPassthroughs hold an `entry` type without rendering it: they carry the
+// message toward a canonical component without drawing any part of it. Each is
+// a sentence somebody wrote rather than an omission nobody noticed.
+//
+// A file that MOUNTS a canonical component needs no entry here — it discharges
+// the obligation by doing the thing, and is admitted by rendersCanonically.
+// These are the ones that never mount anything: builders, mappers and the
+// surfaces whose only act is to suppress their own title in favour of the row.
 var emailPassthroughs = gatekit.Waive(map[string]string{
-	"design-system/composed.tsx": "declares TimelineEntry.emailSummary and passes it to EmailEntry; the timeline row chooses WHICH component draws a kind, and drawing none itself is what keeps that choice in one place",
+	"design-system/activitytimeline.tsx": "maps an Activity onto a TimelineEntry, email_summary included, for composed.tsx to draw; it builds the entry and renders nothing",
+	"screens/openemail.ts":               "the drawer controller: it reads emailSummary only to decide an entry HAS a message to open, and holds no part of one",
+	"screens/recordchronology.tsx":       "wires onOpenEmail onto the entries it hands to the timeline; the rendering is composed.tsx's",
+	"screens/worklist.focus.tsx":         "suppresses its own title when the item carries a summary, leaving the row to WaitingEmailLine; the branch is the whole of its involvement",
+	"screens/worklist.row.tsx":           "same branch as the focus card, for the list row",
 })
 
 // entrySchemas reads the schemas the contract marks as an email.
@@ -111,14 +141,83 @@ func entrySchemas(t *testing.T) []string {
 	return names
 }
 
-// consumersOf answers every frontend file naming this schema's generated type.
+// carrierFields answers the property names under which an `entry` schema hangs
+// off another object — `email_summary` today, and whatever a later property is
+// called, because the names are read from the contract rather than written here.
 //
-// The generated spelling is `components["schemas"]["Name"]`, which is how a
-// TypeScript file reaches a contract type — there is no other way in, so a
-// consumer this misses is a consumer that cannot exist.
-func consumersOf(t *testing.T, schema string) []string {
+// This is the half a name-only census cannot see. A surface reaches an email
+// through the record it is already holding — `row.email_summary.subject` off an
+// Activity — and never writes the generated type at all, so it consumes a
+// message while naming nothing this gate was looking for.
+func carrierFields(t *testing.T, schemas []string) []string {
+	t.Helper()
+	source, err := os.ReadFile(emailContractPath)
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	marked := map[string]bool{}
+	for _, schema := range schemas {
+		marked[schema] = true
+	}
+	// A carrier is a property at the schema's OWN property depth holding a ref
+	// to a marked schema, on a schema the contract says nothing about.
+	//
+	// Each half of that excludes a different thing. A response body's
+	// `content:` is not a property, and admitting it would put `.content` — a
+	// word half the tree writes — before the census as an email. A schema that
+	// carries an annotation of its own is already judged: `EmailPresentation`
+	// holding its `summary`, and the `exempt` EmailThreadPage holding its
+	// `members`, are the drawer reading its own parts rather than a foreign
+	// record carrying a message.
+	schemaLine := regexp.MustCompile(`^    ([A-Za-z][A-Za-z0-9]*):\s*$`)
+	propertyLine := regexp.MustCompile(`^        ([a-z][a-z0-9_]*):\s*$`)
+	refLine := regexp.MustCompile(`#/components/schemas/([A-Za-z][A-Za-z0-9]*)`)
+	seen := map[string]bool{}
+	var fields []string
+	var current string
+	judged := false
+	for _, line := range strings.Split(string(source), "\n") {
+		if schemaLine.MatchString(line) {
+			current, judged = "", false
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(line), "x-email-presentation:") {
+			judged = true
+			continue
+		}
+		if match := propertyLine.FindStringSubmatch(line); match != nil {
+			current = match[1]
+			continue
+		}
+		match := refLine.FindStringSubmatch(line)
+		if match == nil || current == "" || judged || !marked[match[1]] || seen[current] {
+			continue
+		}
+		seen[current] = true
+		fields = append(fields, current)
+	}
+	return fields
+}
+
+// consumersOf answers every frontend file that reaches this schema, by either
+// route: naming its generated type, or reading a property that carries one.
+//
+// The camelCase spelling is searched alongside the contract's snake_case,
+// because a file that maps the wire shape onto its own props keeps rendering
+// the same message under the other spelling.
+func consumersOf(t *testing.T, schema string, fields []string) []string {
 	t.Helper()
 	needle := fmt.Sprintf(`components["schemas"]["%s"]`, schema)
+	// The field as a WHOLE word, in both spellings. Anchoring on the boundary
+	// is what separates reading `entry.emailSummary` from calling
+	// `emailSummaryText`, the shared preview splitter, whose name merely starts
+	// with the field's — a census matching the bare prefix would report on a
+	// function's spelling rather than on what the file does with a message.
+	alternatives := make([]string, 0, len(fields)*2)
+	for _, field := range fields {
+		alternatives = append(alternatives, regexp.QuoteMeta(field), regexp.QuoteMeta(camelCase(field)))
+	}
+	access := regexp.MustCompile(`\b(` + strings.Join(alternatives, "|") + `)\b`)
 	var found []string
 	err := filepath.WalkDir(emailFrontendSource, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
@@ -131,19 +230,33 @@ func consumersOf(t *testing.T, schema string) []string {
 		if readErr != nil {
 			return readErr
 		}
-		if strings.Contains(string(source), needle) {
-			rel, relErr := filepath.Rel(emailFrontendSource, path)
-			if relErr != nil {
-				return relErr
-			}
-			found = append(found, filepath.ToSlash(rel))
+		text := string(source)
+		if !strings.Contains(text, needle) && !access.MatchString(text) {
+			return nil
 		}
+		rel, relErr := filepath.Rel(emailFrontendSource, path)
+		if relErr != nil {
+			return relErr
+		}
+		found = append(found, filepath.ToSlash(rel))
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walking the frontend sources: %v", err)
 	}
 	return found
+}
+
+// camelCase is the contract's snake_case as a TypeScript property.
+func camelCase(field string) string {
+	parts := strings.Split(field, "_")
+	for i := 1; i < len(parts); i++ {
+		if parts[i] == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+	}
+	return strings.Join(parts, "")
 }
 
 // describesRatherThanRenders is a file that talks ABOUT the components: a test,
@@ -167,19 +280,61 @@ func TestAnEmailIsDrawnOnlyByTheCanonicalComponents(t *testing.T) {
 			"either the annotation was removed or its spelling drifted, and this census " +
 			"is now judging nothing")
 	}
+	fields := carrierFields(t, schemas)
+	// The same floor for the other half of the corpus. With no carrier field
+	// the census sees only the files that name a generated type, which is the
+	// shape of the miss this gate was widened to catch.
+	if len(fields) == 0 {
+		t.Fatal("no property in the contract carries a schema marked " +
+			"`x-email-presentation: entry` — this census can no longer see a surface " +
+			"that reads an email off the record holding it")
+	}
+	// Reported once per file rather than once per schema it reaches: the two
+	// entry schemas travel together on the same records, so a surface drawing
+	// its own row is one defect with one fix, and naming it twice makes a
+	// reader look for a second.
+	reported := map[string]bool{}
 	for _, schema := range schemas {
-		for _, consumer := range consumersOf(t, schema) {
-			if emailRenderers[consumer] || describesRatherThanRenders(consumer) {
+		for _, consumer := range consumersOf(t, schema, fields) {
+			if emailRenderers[consumer] || describesRatherThanRenders(consumer) || reported[consumer] {
+				continue
+			}
+			// Holding the data is not the offence; drawing it yourself is. A
+			// surface that hands what it read to EmailEntry or EmailReference
+			// has done the thing this gate asks for, and most of them must
+			// touch the field to decide an email is what they have.
+			if rendersCanonically(t, consumer) {
 				continue
 			}
 			if emailPassthroughs.Waived(t, consumer) {
 				continue
 			}
-			t.Errorf("%s consumes %s and is not a canonical renderer — render EmailEntry "+
+			reported[consumer] = true
+			t.Errorf("%s reads %s and draws it with its own markup — render EmailEntry "+
 				"or EmailReference instead, or ratify the file in emailPassthroughs with "+
 				"what it does with the type", consumer, schema)
 		}
 	}
+}
+
+// rendersCanonically is a file that mounts one of the canonical components.
+//
+// Matched as a JSX opening tag rather than as the bare word, so that naming a
+// component in a comment or importing it and never mounting it does not
+// discharge the obligation.
+func rendersCanonically(t *testing.T, consumer string) bool {
+	t.Helper()
+	source, err := os.ReadFile(filepath.Join(emailFrontendSource, consumer))
+	if err != nil {
+		t.Fatalf("reading %s: %v", consumer, err)
+	}
+	text := string(source)
+	for _, component := range []string{"EmailEntry", "EmailReference", "EmailDetail"} {
+		if strings.Contains(text, "<"+component) {
+			return true
+		}
+	}
+	return false
 }
 
 // And the other direction: each canonical renderer still consumes one.
@@ -191,9 +346,10 @@ func TestAnEmailIsDrawnOnlyByTheCanonicalComponents(t *testing.T) {
 func TestEachCanonicalRendererStillDrawsAnEmail(t *testing.T) {
 	t.Parallel()
 	schemas := entrySchemas(t)
+	fields := carrierFields(t, schemas)
 	drawing := map[string]bool{}
 	for _, schema := range schemas {
-		for _, consumer := range consumersOf(t, schema) {
+		for _, consumer := range consumersOf(t, schema, fields) {
 			drawing[consumer] = true
 		}
 	}

--- a/backend/internal/compose/heldthreads_integration_test.go
+++ b/backend/internal/compose/heldthreads_integration_test.go
@@ -183,6 +183,15 @@ func TestAHeldThreadWithholdsAMessageTheReaderIsNotOn(t *testing.T) {
 			"the id is read from the ledger rather than the gated join",
 			*got[0].ActivityID)
 	}
+	// Refusing the content is right; reporting the message GONE is not. The
+	// screen draws a row with no activity as "no message at all", which tells a
+	// holder their evidence was destroyed while it sits in the thread. That is
+	// the confusion HasActivity exists to prevent, arriving from the other
+	// side: not evidence destroyed read as unnamed, but evidence withheld read
+	// as destroyed.
+	if !got[0].HasActivity {
+		t.Error("a message that exists and is merely withheld reports itself erased")
+	}
 }
 
 // The id a client opens is present for a message the reader may read, and the

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -22009,15 +22009,19 @@ type HeldThread struct {
 	// whose attempts stop climbing is a model that stopped answering.
 	Attempts int `json:"attempts"`
 
-	// HasMessage The message this thread began with is still readable by you. False where it was erased
-	// while the verdict stood — which the ledger deliberately survives, because losing the
-	// verdict would re-open a thread a classifier already held — and false where its content
-	// is withheld from you.
+	// HasMessage The message this thread began with still EXISTS. False only where it was erased while
+	// the verdict stood — which the ledger deliberately survives, because losing the verdict
+	// would re-open a thread a classifier already held.
 	//
-	// Separate from `subject` because absence has two causes that read differently: no
-	// message to name, versus a message somebody sent with a blank subject line. It also
-	// decides whether releasing is offered at all: the release works on your own messages on
-	// the thread, so with none left there is nothing to share.
+	// Existence, not readability: it stays true for a message whose content is withheld from
+	// you, and that is the point. Read through the content gate it reported a withheld
+	// message as erased, which told a holder their evidence had been destroyed while it was
+	// sitting in the thread they are holding.
+	//
+	// So `subject` absent with this true is a message you may not read, or one sent with a
+	// blank subject line; this false is no message at all. It also decides whether releasing
+	// is offered: the release works on your own messages on the thread, so with none left
+	// there is nothing to share.
 	HasMessage bool `json:"has_message"`
 
 	// Kind What the classifier concluded the thread is ABOUT — legal, personnel,

--- a/backend/internal/modules/capture/heldthreadslist.go
+++ b/backend/internal/modules/capture/heldthreadslist.go
@@ -43,11 +43,16 @@ type HeldThread struct {
 	// a reader can tell one held thread from another.
 	Subject    string
 	OccurredAt *time.Time
-	// HasActivity separates "no message to read a subject from" — erased while
-	// the verdict stood, which the ledger deliberately survives — from a
-	// message somebody sent with a blank subject line. Collapsing the two would
-	// tell a reader their evidence was destroyed when it is sitting there
-	// unnamed.
+	// HasActivity is whether the message this hold was raised about still
+	// exists — read WITHOUT the content clause, because existence and
+	// readability are different questions.
+	//
+	// It separates three states the screen draws differently: a message with a
+	// subject, a message whose subject this reader may not have (withheld, or
+	// sent blank), and no message at all — erased while the verdict stood,
+	// which the ledger deliberately survives. Deriving it from the gated
+	// subject collapsed the middle into the last and told a holder their
+	// evidence was destroyed while it sat in the thread.
 	HasActivity bool
 	// ActivityID is the message that opened the thread, for a reader who wants
 	// to read it rather than only be told it is held.
@@ -116,6 +121,17 @@ func HeldThreadsFor(ctx context.Context, db *database.DB) ([]HeldThread, error) 
 		// The content clause rides the JOIN rather than the WHERE for the same
 		// reason: in the WHERE it would turn the outer join into an inner one
 		// and drop every row whose activity is absent or withheld.
+		//
+		// `present` is a SECOND join carrying no content clause, and that is
+		// deliberate. Whether the message still exists and whether this reader
+		// may read it are different questions; the gated join answers only the
+		// second, and its columns go null for an erased message and a withheld
+		// one alike. Deriving existence from them told a holder their evidence
+		// had been destroyed while it sat in the thread.
+		//
+		// It discloses nothing new: the reader is looking at their own verdict
+		// row, which names first_activity_id. Only the boolean crosses over —
+		// no subject, no id, no occurred_at.
 		rows, err := tx.Query(ctx, `
 			SELECT v.thread_key,
 			       v.status,
@@ -123,12 +139,16 @@ func HeldThreadsFor(ctx context.Context, db *database.DB) ([]HeldThread, error) 
 			       a.id                    AS activity_id,
 			       a.subject,
 			       a.occurred_at,
-			       v.attempts
+			       v.attempts,
+			       present.id IS NOT NULL  AS has_activity
 			  FROM capture_thread_verdict v
 			  LEFT JOIN activity a
 			    ON a.id = v.first_activity_id
 			   AND a.archived_at IS NULL
 			   AND `+content+`
+			  LEFT JOIN activity present
+			    ON present.id = v.first_activity_id
+			   AND present.archived_at IS NULL
 			 WHERE v.user_id = $1
 			   AND v.status NOT IN ('cleared', 'shared_by_owner')
 			 ORDER BY (v.status = 'pending') DESC,
@@ -142,13 +162,13 @@ func HeldThreadsFor(ctx context.Context, db *database.DB) ([]HeldThread, error) 
 			var t HeldThread
 			var subject *string
 			if err := rows.Scan(&t.ThreadKey, &t.Status, &t.Kind, &t.ActivityID,
-				&subject, &t.OccurredAt, &t.Attempts); err != nil {
+				&subject, &t.OccurredAt, &t.Attempts, &t.HasActivity); err != nil {
 				return fmt.Errorf("capture: listing a seat's held threads: %w", err)
 			}
-			// NULL is "no message to read one from"; an empty string is a
-			// message somebody sent with a blank subject line. The two read
-			// differently on screen, so they stay different here.
-			t.HasActivity = subject != nil
+			// The subject stays gated, and its own NULL still means only "no
+			// subject reached this reader" — erased or withheld, the row does
+			// not say which and does not need to. Which of the two it is comes
+			// from HasActivity, off the ungated join.
 			if subject != nil {
 				t.Subject = *subject
 			}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -14027,15 +14027,19 @@ export interface components {
              */
             readonly activity_id?: string | null;
             /**
-             * @description The message this thread began with is still readable by you. False where it was erased
-             *     while the verdict stood — which the ledger deliberately survives, because losing the
-             *     verdict would re-open a thread a classifier already held — and false where its content
-             *     is withheld from you.
+             * @description The message this thread began with still EXISTS. False only where it was erased while
+             *     the verdict stood — which the ledger deliberately survives, because losing the verdict
+             *     would re-open a thread a classifier already held.
              *
-             *     Separate from `subject` because absence has two causes that read differently: no
-             *     message to name, versus a message somebody sent with a blank subject line. It also
-             *     decides whether releasing is offered at all: the release works on your own messages on
-             *     the thread, so with none left there is nothing to share.
+             *     Existence, not readability: it stays true for a message whose content is withheld from
+             *     you, and that is the point. Read through the content gate it reported a withheld
+             *     message as erased, which told a holder their evidence had been destroyed while it was
+             *     sitting in the thread they are holding.
+             *
+             *     So `subject` absent with this true is a message you may not read, or one sent with a
+             *     blank subject line; this false is no message at all. It also decides whether releasing
+             *     is offered: the release works on your own messages on the thread, so with none left
+             *     there is nothing to share.
              */
             has_message: boolean;
             /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -4192,7 +4192,6 @@ export const de = {
   "heldThreads.release": "Mit dem Team teilen",
   "heldThreads.released": "Mit dem Team geteilt",
   "heldThreads.noSubject": "die ursprüngliche Nachricht ist gelöscht",
-  "heldThreads.blankSubject": "kein Betreff",
   "heldThreads.nothingToShare":
     "Es ist keine Nachricht mehr da, die geteilt werden könnte — die erste Nachricht dieser Konversation wurde gelöscht. Die Zurückhaltung bleibt, damit eine spätere Antwort nicht offen eintrifft.",
   "heldThreads.pending": "Wartet auf Beurteilung",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -4237,7 +4237,6 @@ export const en = {
   "heldThreads.release": "Share with the team",
   "heldThreads.released": "Shared with the team",
   "heldThreads.noSubject": "the message this began with is gone",
-  "heldThreads.blankSubject": "no subject",
   "heldThreads.nothingToShare":
     "There is no message left to share — this thread\u2019s first message was erased, and the hold stays so a later reply does not arrive open.",
   "heldThreads.pending": "Waiting on a verdict",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -4146,7 +4146,6 @@ export const vi = {
   "heldThreads.release": "Chia sẻ với nhóm",
   "heldThreads.released": "Đã chia sẻ với nhóm",
   "heldThreads.noSubject": "thư mở đầu đã bị xóa",
-  "heldThreads.blankSubject": "không có tiêu đề",
   "heldThreads.nothingToShare":
     "Không còn thư nào để chia sẻ — thư đầu tiên của chuỗi này đã bị xóa. Việc giữ lại vẫn tiếp tục để một thư trả lời sau không đến ở trạng thái mở.",
   "heldThreads.pending": "Đang chờ phán quyết",

--- a/frontend/src/screens/companyrecent.stories.tsx
+++ b/frontend/src/screens/companyrecent.stories.tsx
@@ -24,6 +24,21 @@ const base: Activity = {
   captured_by: "human:u1",
   created_at: "2026-08-20T09:00:00Z",
   updated_at: "2026-08-20T09:00:00Z",
+  // A retained email carries the server's own row model, and drawing it is
+  // what makes these stories show the canonical row rather than the fallback
+  // every other kind takes.
+  email_summary: {
+    activity_id: "a-1",
+    occurred_at: "2026-08-20T09:00:00Z",
+    version: 1,
+    subject: "Renewal terms",
+    preview: "Sending the revised terms across for Thursday.",
+    counterparty: "Dana Buyer",
+    direction: "inbound",
+    display_status: "team",
+    move: "needs_reply",
+    attachment_count: 1,
+  },
 };
 
 function List({ activities }: Readonly<{ activities: Activity[] }>) {
@@ -37,6 +52,7 @@ function List({ activities }: Readonly<{ activities: Activity[] }>) {
               ? "Acme Expansion"
               : undefined
           }
+          onOpenRecord={() => {}}
         />
       </div>
     </StoryProviders>
@@ -96,7 +112,20 @@ export const MixedKinds: Story = {
           subject: "Re: Renewal terms",
           direction: "inbound",
           occurred_at: "2026-08-20T09:00:00Z",
+          email_summary: {
+            ...base.email_summary,
+            activity_id: "a-3",
+            occurred_at: "2026-08-20T09:00:00Z",
+            version: 1,
+            subject: "Re: Renewal terms",
+            display_status: "team",
+            move: "needs_reply",
+            attachment_count: 1,
+          },
         },
+        // Every kind below drops the summary `base` carries. Only an email has
+        // one, so a call spreading it would draw as a message and this story
+        // would be describing a record the server never sends.
         {
           ...base,
           id: "a-4",
@@ -105,6 +134,7 @@ export const MixedKinds: Story = {
           direction: "outbound",
           duration_seconds: 900,
           occurred_at: "2026-08-19T14:00:00Z",
+          email_summary: undefined,
         },
         {
           ...base,
@@ -113,6 +143,7 @@ export const MixedKinds: Story = {
           subject: "Send updated MSA",
           direction: undefined,
           occurred_at: "2026-08-18T11:00:00Z",
+          email_summary: undefined,
         },
         {
           ...base,
@@ -121,6 +152,7 @@ export const MixedKinds: Story = {
           subject: "Prefers async updates",
           direction: undefined,
           occurred_at: "2026-08-17T16:00:00Z",
+          email_summary: undefined,
         },
       ]}
     />
@@ -133,4 +165,35 @@ export const MixedKinds: Story = {
 export const MixedKindsDark: Story = {
   ...MixedKinds,
   globals: { theme: "dark" },
+};
+
+// A message this reader may not open, beside one they may.
+//
+// The withheld row keeps its shape and loses its words — no subject, no
+// counterparty, no preview. Drawing it as absent would report a quieter
+// account than the one on file; drawing it as empty would say there was
+// nothing to read, which is a claim about the message rather than about them.
+export const WithheldBesideReadable: Story = {
+  render: () => (
+    <List
+      activities={[
+        base,
+        {
+          ...base,
+          id: "a-7",
+          subject: undefined,
+          occurred_at: "2026-08-19T08:30:00Z",
+          content_state: "withheld",
+          email_summary: {
+            activity_id: "a-7",
+            occurred_at: "2026-08-19T08:30:00Z",
+            version: 1,
+            display_status: "withheld",
+            move: "none",
+            attachment_count: 0,
+          },
+        },
+      ]}
+    />
+  ),
 };

--- a/frontend/src/screens/companyrecent.test.tsx
+++ b/frontend/src/screens/companyrecent.test.tsx
@@ -91,10 +91,7 @@ function renderList(
 ) {
   return render(
     <LocaleProvider initial="en">
-      <CompanyRecentList
-        activities={activities}
-        onOpenRecord={onOpenRecord}
-      />
+      <CompanyRecentList activities={activities} onOpenRecord={onOpenRecord} />
     </LocaleProvider>,
   );
 }

--- a/frontend/src/screens/companyrecent.test.tsx
+++ b/frontend/src/screens/companyrecent.test.tsx
@@ -1,0 +1,167 @@
+/** @vitest-environment jsdom */
+
+// What the account page's recent-exchange list draws for each kind it holds.
+//
+// The list shipped drawing `activity.subject` for every kind, email included,
+// so a message here had no access badge, no counterparty, no preview and no
+// way to open it — while the same message on the History tab had all four.
+// Nothing failed, because this file did not exist.
+//
+// The claims are separable on purpose: an email is the canonical row, a
+// withheld one discloses nothing, and every other kind keeps the kind chip and
+// direction line that are the only things telling a call from a note.
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { CompanyRecentList } from "./companyrecent";
+
+type Activity = components["schemas"]["Activity"];
+type EmailSummary = components["schemas"]["EmailSummary"];
+
+afterEach(cleanup);
+
+const EMAIL_ID = "01a05500-0000-7000-8000-00000000cc01";
+const CALL_ID = "01a05500-0000-7000-8000-00000000cc02";
+
+// The subject and the preview differ from the body on purpose: a row drawing
+// the body where the preview belongs is the defect, and a fixture whose three
+// text fields agreed could not tell them apart.
+const WHOLE_BODY =
+  "Can you hold the price until Friday? Procurement meets on Thursday.";
+
+function emailSummary(over: Partial<EmailSummary> = {}): EmailSummary {
+  return {
+    activity_id: EMAIL_ID,
+    occurred_at: "2026-08-29T09:15:00Z",
+    version: 4,
+    subject: "Re: the renewal quote",
+    preview: "Can you hold the price until Friday?",
+    counterparty: "Dana Buyer",
+    direction: "inbound",
+    display_status: "team",
+    move: "needs_reply",
+    attachment_count: 0,
+    ...over,
+  };
+}
+
+function emailRow(over: Partial<Activity> = {}): Activity {
+  return {
+    id: EMAIL_ID,
+    kind: "email",
+    occurred_at: "2026-08-29T09:15:00Z",
+    subject: "Re: the renewal quote",
+    body: WHOLE_BODY,
+    direction: "inbound",
+    content_state: "available",
+    source: "manual",
+    captured_by: "human:u-1",
+    created_at: "2026-08-29T09:15:00Z",
+    updated_at: "2026-08-29T09:15:00Z",
+    version: 4,
+    is_done: false,
+    email_summary: emailSummary(),
+    ...over,
+  };
+}
+
+// A call in the same list. It carries no summary and never will, so it is the
+// control for "only the email branch moved".
+const callRow: Activity = {
+  id: CALL_ID,
+  kind: "call",
+  occurred_at: "2026-08-28T14:00:00Z",
+  subject: "Depot walkthrough",
+  direction: "outbound",
+  content_state: "available",
+  source: "manual",
+  captured_by: "human:u-1",
+  created_at: "2026-08-28T14:00:00Z",
+  updated_at: "2026-08-28T14:00:00Z",
+  version: 1,
+  is_done: false,
+};
+
+function renderList(
+  activities: Activity[],
+  onOpenRecord?: (entityType: string, entityId: string) => void,
+) {
+  return render(
+    <LocaleProvider initial="en">
+      <CompanyRecentList
+        activities={activities}
+        onOpenRecord={onOpenRecord}
+      />
+    </LocaleProvider>,
+  );
+}
+
+describe("the account's recent exchanges", () => {
+  it("draws a retained email as the canonical row, with its preview and not its body", () => {
+    renderList([emailRow()]);
+
+    expect(screen.getByText("Re: the renewal quote")).toBeTruthy();
+    expect(
+      screen.getByText("Can you hold the price until Friday?"),
+    ).toBeTruthy();
+    expect(screen.queryByText(WHOLE_BODY)).toBeNull();
+    // Who may read it, which this list could not say at all before.
+    expect(screen.getByText("Team")).toBeTruthy();
+  });
+
+  it("opens the message through the page's own router", async () => {
+    const user = userEvent.setup();
+    const onOpenRecord = vi.fn();
+    renderList([emailRow()], onOpenRecord);
+
+    await user.click(
+      screen.getByRole("button", { name: /Re: the renewal quote/ }),
+    );
+
+    // "activity", not "email": the page's citation router already sends an
+    // activity to the drawer, and a second vocabulary would be a second router.
+    expect(onOpenRecord).toHaveBeenCalledWith("activity", EMAIL_ID);
+  });
+
+  it("discloses nothing from a withheld message", () => {
+    renderList(
+      [
+        emailRow({
+          content_state: "withheld",
+          subject: null,
+          body: null,
+          email_summary: emailSummary({
+            display_status: "withheld",
+            subject: null,
+            preview: null,
+            counterparty: null,
+          }),
+        }),
+      ],
+      vi.fn(),
+    );
+
+    expect(screen.queryByText("Re: the renewal quote")).toBeNull();
+    expect(screen.queryByText("Dana Buyer")).toBeNull();
+    expect(screen.queryByText(WHOLE_BODY)).toBeNull();
+    // The row still draws. A section that silently dropped what this reader
+    // may not see would report a quieter account than the one on file.
+    expect(screen.getByText("Withheld")).toBeTruthy();
+  });
+
+  it("leaves every other kind with its chip and its direction", () => {
+    renderList([callRow], vi.fn());
+
+    expect(screen.getByText("Depot walkthrough")).toBeTruthy();
+    // The chip and the direction phrase are what tell a call from a note here,
+    // and an email's own row states both in its own words instead.
+    expect(screen.getByText("Call")).toBeTruthy();
+    expect(screen.getByText("we called")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Depot walkthrough/ }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/screens/companyrecent.tsx
+++ b/frontend/src/screens/companyrecent.tsx
@@ -12,10 +12,18 @@
 // Its own renderer rather than a mode of the timeline: the two disagree about
 // what a row IS, not about how one looks, and a `compact` flag threaded
 // through the timeline would be that disagreement spelled as a boolean.
+//
+// A retained EMAIL is the exception, and it is not one of layout. The message
+// is the same message the timeline shows, so it draws the same EmailEntry —
+// this list keeps the avatar, the deal link and the date column that place the
+// exchange in the account's reading, and hands the message itself to the one
+// component that draws one. The disagreement above is about a row's SHAPE and
+// still stands for every other kind.
 
 import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { Avatar, Badge } from "../design-system/atoms";
+import { EmailEntry } from "../design-system/emailentry";
 import { PanelBody } from "../design-system/panel";
 import { formatDateAbbrev, formatNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -140,6 +148,7 @@ function RecentRow({
   // call logged with no subject is still an event, and a blank line where the
   // headline goes reads as a row that failed to load.
   const title = activity.subject?.trim() || kind;
+  const email = activity.email_summary;
   const deal = activity.links?.find((link) => link.entity_type === "deal");
   const dealName = deal && nameOf?.("deal", deal.entity_id);
   const dealLabel = dealName
@@ -149,15 +158,40 @@ function RecentRow({
     <li className="co-recent-row">
       <Avatar name={title} identity={activity.id} size="xs" />
       <span className="co-recent-body">
-        <span className="co-recent-head">
-          {/* No tone: the chip says what KIND of exchange this was, and every
-              row here is the account's own correspondence. The AI indigo is a
-              provenance claim — "an agent did this" — and painting it on a
-              human's email tells the reader something false. */}
-          <Badge>{kind}</Badge>
-          {direction && <span className="co-recent-dir">{t(direction)}</span>}
-        </span>
-        <span className="co-recent-title">{title}</span>
+        {/* A retained email is the canonical row here as everywhere: it already
+            says which way it went, who was at the other end and who may read
+            it, so the kind chip and direction line above would print the same
+            facts a second time in this row's own words.
+
+            Every other kind keeps them. A call, a note or a task has no
+            summary and no access state, and the chip is the only thing telling
+            one from another. */}
+        {email ? (
+          <EmailEntry
+            summary={email}
+            timestamp={when}
+            onOpen={
+              onOpenRecord
+                ? () => onOpenRecord("activity", activity.id)
+                : undefined
+            }
+          />
+        ) : (
+          <>
+            <span className="co-recent-head">
+              {/* No tone: the chip says what KIND of exchange this was, and
+                  every row here is the account's own correspondence. The AI
+                  indigo is a provenance claim — "an agent did this" — and
+                  painting it on a human's email tells the reader something
+                  false. */}
+              <Badge>{kind}</Badge>
+              {direction && (
+                <span className="co-recent-dir">{t(direction)}</span>
+              )}
+            </span>
+            <span className="co-recent-title">{title}</span>
+          </>
+        )}
         <span className="co-recent-meta">
           {duration && <span>{duration}</span>}
           {deal &&

--- a/frontend/src/screens/held-threads.stories.tsx
+++ b/frontend/src/screens/held-threads.stories.tsx
@@ -21,6 +21,9 @@ type HeldThread = components["schemas"]["HeldThread"];
 const MIXED: HeldThread[] = [
   // Pending leads, which is the ordering the endpoint guarantees and the whole
   // reason this page is worth opening during an outage.
+  // Each readable row carries its activity_id beside its subject. The two come
+  // through the same content clause on the server, so a fixture with one and
+  // not the other draws the withheld reading over a subject it was given.
   {
     thread_key: "t-1",
     status: "pending",
@@ -28,6 +31,7 @@ const MIXED: HeldThread[] = [
     attempts: 4,
     has_message: true,
     subject: "Angebot Q4 — Rückfragen",
+    activity_id: "01a05500-0000-7000-8000-0000000000a1",
     occurred_at: "2026-08-30T09:12:00Z",
   },
   {
@@ -38,6 +42,7 @@ const MIXED: HeldThread[] = [
     has_message: true,
     kind: "legal",
     subject: "Entwurf Aufhebungsvertrag",
+    activity_id: "01a05500-0000-7000-8000-0000000000a2",
     occurred_at: "2026-08-29T15:40:00Z",
   },
   {
@@ -47,7 +52,21 @@ const MIXED: HeldThread[] = [
     attempts: 2,
     has_message: true,
     subject: "Re: Termin",
+    activity_id: "01a05500-0000-7000-8000-0000000000a3",
     occurred_at: "2026-08-28T11:02:00Z",
+  },
+  // A message held by this seat that this seat may not READ: somebody else's
+  // personnel mail, on a thread they are holding. It exists — so it is not the
+  // erased row below — and neither its subject nor its id crossed the content
+  // clause, so it names itself and offers nothing.
+  {
+    thread_key: "t-5",
+    status: "held",
+    pending: false,
+    attempts: 1,
+    has_message: true,
+    kind: "personnel",
+    occurred_at: "2026-08-28T08:15:00Z",
   },
   // The verdict outlives its evidence: an erasure inside the window nulls the
   // activity and the hold stands. The row says the message is gone rather than

--- a/frontend/src/screens/held-threads.test.tsx
+++ b/frontend/src/screens/held-threads.test.tsx
@@ -31,6 +31,11 @@ const PENDING: HeldThread = {
   occurred_at: "2026-08-30T09:12:00Z",
 };
 
+// A message this reader may read. The subject and the id come through the SAME
+// content clause on the server, so a row carrying one carries the other — a
+// fixture with a subject and no id would describe a record the server cannot
+// send, and every component judged against it would be judged against a shape
+// that does not exist.
 const JUDGED: HeldThread = {
   thread_key: "t-legal",
   status: "held",
@@ -39,7 +44,18 @@ const JUDGED: HeldThread = {
   has_message: true,
   kind: "legal",
   subject: "Entwurf Aufhebungsvertrag",
+  activity_id: "01a05500-0000-7000-8000-0000000000b1",
   occurred_at: "2026-08-29T15:40:00Z",
+};
+
+// And the refusal, as the server actually answers it: the message EXISTS —
+// `has_message` is read without the content gate — and neither its subject nor
+// its id crossed the clause.
+const WITHHELD: HeldThread = {
+  ...JUDGED,
+  thread_key: "t-withheld",
+  subject: undefined,
+  activity_id: undefined,
 };
 
 function renderCard(rows: HeldThread[], share?: Record<string, unknown>) {
@@ -175,9 +191,26 @@ describe("held threads", () => {
 
   it("tells a message with no subject from no message at all", async () => {
     // Both draw an unnamed row, and collapsing them would tell a reader their
-    // evidence was destroyed when it is sitting there unnamed.
+    // evidence was destroyed when it is sitting there unnamed. This one keeps
+    // its id: the content clause admitted the message, and the sender simply
+    // left the subject line empty.
     renderCard([{ ...JUDGED, subject: undefined }]);
     expect(await screen.findByText(/^no subject$/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/the message this began with is gone/i),
+    ).not.toBeInTheDocument();
+    // And not the withheld reading either: a blank subject is a fact about the
+    // sender, "not shared with you" a fact about the reader.
+    expect(screen.queryByText(/not shared with you/i)).not.toBeInTheDocument();
+  });
+
+  it("does not report a withheld message as one that was erased", async () => {
+    // The three states are separate all the way down. A message this reader
+    // may not open still EXISTS, so telling them the evidence they are holding
+    // is gone would be false — and it is the release they would stop asking
+    // for.
+    renderCard([WITHHELD]);
+    expect(await screen.findByText(/not shared with you/i)).toBeInTheDocument();
     expect(
       screen.queryByText(/the message this began with is gone/i),
     ).not.toBeInTheDocument();
@@ -247,15 +280,18 @@ it("opens the message a held thread is about", async () => {
   });
 });
 
-// And a thread whose message it may NOT read names itself and offers nothing.
-// The server withholds the id for a message outside the caller's audience, so
-// this row must not become a control — a button that opened nothing would be
-// worse than the plain text it replaced.
-it("names a thread it cannot open without offering to", async () => {
-  renderCard([JUDGED]);
+// And a thread whose message it may NOT read says so and offers nothing.
+//
+// The server withholds the subject and the id together for a message outside
+// the caller's audience, so the row names itself as withheld rather than
+// printing words it was refused, and does not become a control — a button that
+// opened nothing would be worse than the plain text it replaced.
+it("says a thread is not the reader's without offering to open it", async () => {
+  renderCard([WITHHELD]);
 
-  expect(await screen.findByText("Entwurf Aufhebungsvertrag")).toBeTruthy();
-  expect(
-    screen.queryByRole("button", { name: "Entwurf Aufhebungsvertrag" }),
-  ).toBeNull();
+  expect(await screen.findByText(/not shared with you/i)).toBeTruthy();
+  // The row is still LISTED: they are holding it and must be able to release
+  // it. Only the message's words are refused.
+  expect(screen.getByText("Legal")).toBeTruthy();
+  expect(screen.queryByRole("button", { name: /not shared/i })).toBeNull();
 });

--- a/frontend/src/screens/held-threads.tsx
+++ b/frontend/src/screens/held-threads.tsx
@@ -4,6 +4,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { Badge, Button, DataTable, EmptyState } from "../design-system/atoms";
 import { Callout } from "../design-system/callout";
+import { EmailReference } from "../design-system/emailreference";
 import { OpenEmailDrawer } from "../design-system/openemaildrawer";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useToast } from "../design-system/toast";
@@ -281,38 +282,38 @@ function WhyCell({ row }: Readonly<{ row: HeldThread }>) {
 }
 
 /**
- * A held thread's subject, openable where the reader may read the message.
+ * A held thread's subject, as a citation of the message it was raised about.
  *
- * Three states, unchanged from before plus one: a subject, a message carrying
- * none, and — new — whether either is a control. `activity_id` is present only
- * when the server's own content gate admitted the message, so a thread held
- * because it is somebody else's personnel mail names itself and does not offer
- * to open. A button that opened nothing would be worse than the plain text it
- * replaced.
+ * EmailReference rather than this file's own button: naming a message and
+ * offering to open it is exactly what a citation is, and the hand-rolled
+ * version here had grown its own copies of the blank-subject fallback, the
+ * withheld reading and the not-openable branch — three rules that must agree
+ * with every other citation in the product and had no way of doing so.
+ *
+ * No date, because the table has a When column of its own. A reference that
+ * printed one would put the same timestamp twice in one row.
+ *
+ * Two flags, because there are three states and the caller must not collapse
+ * them. `has_message` is whether the message still EXISTS, read without the
+ * content gate; `activity_id` is read from the gated join, so the presence of
+ * that field IS the permission. A message that exists and carries no id is one
+ * this reader may not read — withheld — and one that carries an id but no
+ * subject was simply sent with a blank subject line, which reads as "No
+ * subject" and still opens.
+ *
+ * Only a thread whose message still exists reaches here; the caller draws the
+ * erased case, which is a statement about the ledger rather than a citation.
  */
 function ThreadSubject({
   row,
   onOpen,
 }: Readonly<{ row: HeldThread; onOpen: (activityId: string) => void }>) {
-  const t = useT();
-  const label = row.subject ?? t("heldThreads.blankSubject");
-  const plain = row.subject ? (
-    <>{label}</>
-  ) : (
-    <span className="t-meta">{label}</span>
-  );
-  if (!row.activity_id) {
-    return plain;
-  }
   const activityId = row.activity_id;
   return (
-    <button
-      type="button"
-      className="entity-link"
-      aria-haspopup="dialog"
-      onClick={() => onOpen(activityId)}
-    >
-      {label}
-    </button>
+    <EmailReference
+      subject={row.subject}
+      withheld={!activityId}
+      onOpen={activityId ? () => onOpen(activityId) : undefined}
+    />
   );
 }

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -2376,7 +2376,15 @@ function CommercialSection({
 function RecentActivitySection360({
   view,
   loading,
-}: Readonly<{ view?: Organization360View; loading: boolean }>) {
+  onOpenRecord,
+}: Readonly<{
+  view?: Organization360View;
+  loading: boolean;
+  // The page's own citation router. An email row opens through it exactly as a
+  // cited activity does, so the account has one drawer and not a second one
+  // this section owns.
+  onOpenRecord: (entityType: string, entityId: string) => void;
+}>) {
   const t = useT();
   const logged = view?.activities?.data ?? [];
   const state = sectionState(
@@ -2403,6 +2411,7 @@ function RecentActivitySection360({
     <CompanyRecentList
       activities={logged.slice(0, RECENT_360_LIMIT)}
       nameOf={recordNamesIn(view)}
+      onOpenRecord={onOpenRecord}
     />
   );
 }
@@ -2417,10 +2426,12 @@ function RecentActivitySection({
   view,
   loading,
   onOpenHistory,
+  onOpenRecord,
 }: Readonly<{
   view?: Organization360View;
   loading: boolean;
   onOpenHistory: () => void;
+  onOpenRecord: (entityType: string, entityId: string) => void;
 }>) {
   const t = useT();
   return (
@@ -2436,7 +2447,11 @@ function RecentActivitySection({
           chronicle; inside the account's reading this section answers whether
           anything moved and which way, and the chronicle answered it in five
           screens. */}
-      <RecentActivitySection360 view={view} loading={loading} />
+      <RecentActivitySection360
+        view={view}
+        loading={loading}
+        onOpenRecord={onOpenRecord}
+      />
     </Section>
   );
 }
@@ -2656,6 +2671,7 @@ function CompanyOverviewStack({
                 view={view}
                 loading={loading}
                 onOpenHistory={onOpenHistory}
+                onOpenRecord={onOpenRecord}
               />
             </Panel>
           </RecordReadingPair>

--- a/frontend/src/screens/personmemory.test.tsx
+++ b/frontend/src/screens/personmemory.test.tsx
@@ -212,8 +212,6 @@ describe("the person page's memory card", () => {
     expect(
       screen.getByText("Wants the fleet numbers before we talk pricing."),
     ).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: /Call prep/ }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: /Call prep/ })).toBeNull();
   });
 });

--- a/frontend/src/screens/personmemory.test.tsx
+++ b/frontend/src/screens/personmemory.test.tsx
@@ -1,0 +1,219 @@
+/** @vitest-environment jsdom */
+
+// What the person page's memory card draws for each kind it holds.
+//
+// The card shipped reading `email_summary` for its title and preview while
+// painting its own two lines with them, so a message read one way here and
+// another way on the timeline six inches above it: no access badge, no mail
+// icon, the whole body instead of a preview, and no way to open the message.
+// Nothing failed, because this file did not exist.
+//
+// Three claims, and each fails on its own. An email is the canonical row; a
+// withheld one says so and discloses nothing; every other kind keeps the two
+// lines the card has always drawn for it.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { PersonMemory } from "./personmemory";
+
+type Person360 = components["schemas"]["Person360"];
+type Activity = components["schemas"]["Activity"];
+type EmailSummary = components["schemas"]["EmailSummary"];
+
+afterEach(cleanup);
+
+const EMAIL_ID = "01a05500-0000-7000-8000-00000000ee01";
+const NOTE_ID = "01a05500-0000-7000-8000-00000000ee02";
+
+const person: components["schemas"]["Person"] = {
+  id: "p-1",
+  full_name: "Dana Buyer",
+  first_name: "Dana",
+  source: "manual",
+  captured_by: "human:u-1",
+  created_at: "2026-06-01T08:00:00Z",
+  updated_at: "2026-08-01T08:00:00Z",
+  emails: [],
+};
+
+// A retained email, as the server sends one: the summary carries the subject
+// and the preview, and the activity's own body carries the whole message. The
+// two differ on purpose — a card drawing the body where the preview belongs is
+// exactly the defect, and a fixture whose body equalled its preview could not
+// tell the two apart.
+const WHOLE_BODY =
+  "Can you hold the price until Friday? " +
+  "I have to take it past procurement first and they meet on Thursday.";
+
+function emailSummary(over: Partial<EmailSummary> = {}): EmailSummary {
+  return {
+    activity_id: EMAIL_ID,
+    occurred_at: "2026-08-29T09:15:00Z",
+    version: 4,
+    subject: "Re: the renewal quote",
+    preview: "Can you hold the price until Friday?",
+    counterparty: "Dana Buyer",
+    direction: "inbound",
+    display_status: "team",
+    move: "needs_reply",
+    attachment_count: 0,
+    ...over,
+  };
+}
+
+function emailRow(over: Partial<Activity> = {}): Activity {
+  return {
+    id: EMAIL_ID,
+    kind: "email",
+    occurred_at: "2026-08-29T09:15:00Z",
+    subject: "Re: the renewal quote",
+    body: WHOLE_BODY,
+    direction: "inbound",
+    content_state: "available",
+    source: "manual",
+    captured_by: "human:u-1",
+    created_at: "2026-08-29T09:15:00Z",
+    updated_at: "2026-08-29T09:15:00Z",
+    version: 4,
+    is_done: false,
+    email_summary: emailSummary(),
+    ...over,
+  };
+}
+
+// A note on the same card. It has no email_summary and never had one, so it is
+// the control for "only the email branch moved".
+const noteRow: Activity = {
+  id: NOTE_ID,
+  kind: "note",
+  occurred_at: "2026-08-28T11:00:00Z",
+  subject: "Call prep",
+  body: "Wants the fleet numbers before we talk pricing.",
+  content_state: "available",
+  source: "manual",
+  captured_by: "human:u-1",
+  created_at: "2026-08-28T11:00:00Z",
+  updated_at: "2026-08-28T11:00:00Z",
+  version: 1,
+  is_done: false,
+};
+
+const onePage = { has_more: false, next_cursor: null };
+
+// The activity rows above are typed, so a fixture that drifts from the wire
+// shape fails to compile. The view around them is asserted rather than built:
+// Person360 carries twenty-odd sections this card never reads, and spelling
+// them all would describe the page instead of the card.
+function viewWith(activities: Activity[]): Person360 {
+  return {
+    as_of: "2026-08-30T09:00:00Z",
+    person,
+    sections_omitted: [],
+    activities: { data: activities, page: onePage },
+  } as Person360;
+}
+
+// The card reads the transport directory for its channel labels, so it needs a
+// client. Nothing here depends on that read resolving: every claim below is
+// about an email, whose label comes from the kind.
+function renderCard(
+  view: Person360,
+  onOpenEmail?: (activityId: string) => void,
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">
+        <PersonMemory view={view} onOpenEmail={onOpenEmail} />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("the person page's memory card", () => {
+  it("draws a retained email as the canonical row, with its preview and not its body", () => {
+    renderCard(viewWith([emailRow()]));
+
+    expect(screen.getByText("Re: the renewal quote")).toBeTruthy();
+    expect(
+      screen.getByText("Can you hold the price until Friday?"),
+    ).toBeTruthy();
+    // The whole message belongs to the drawer. Printing it here is what the
+    // card did before, and it is what a reader saw instead of a row.
+    expect(screen.queryByText(WHOLE_BODY)).toBeNull();
+    // The access state travels with the message. Its absence was how a reader
+    // could not tell a team-wide thread from a private one.
+    expect(screen.getByText("Team")).toBeTruthy();
+  });
+
+  it("opens the page's drawer on the message the row is about", async () => {
+    const user = userEvent.setup();
+    const onOpenEmail = vi.fn();
+    renderCard(viewWith([emailRow()]), onOpenEmail);
+
+    await user.click(
+      screen.getByRole("button", { name: /Re: the renewal quote/ }),
+    );
+
+    expect(onOpenEmail).toHaveBeenCalledWith(EMAIL_ID);
+  });
+
+  it("offers no opener when the page mounts no drawer", () => {
+    renderCard(viewWith([emailRow()]));
+
+    // Readable, and not pressable: a row that looks openable and answers
+    // nothing teaches a reader the product is broken.
+    expect(
+      screen.queryByRole("button", { name: /Re: the renewal quote/ }),
+    ).toBeNull();
+    expect(screen.getByText("Re: the renewal quote")).toBeTruthy();
+  });
+
+  it("discloses nothing from a withheld message", () => {
+    renderCard(
+      viewWith([
+        emailRow({
+          content_state: "withheld",
+          subject: null,
+          body: null,
+          email_summary: emailSummary({
+            display_status: "withheld",
+            subject: null,
+            preview: null,
+            counterparty: null,
+          }),
+        }),
+      ]),
+      vi.fn(),
+    );
+
+    expect(screen.queryByText("Re: the renewal quote")).toBeNull();
+    expect(
+      screen.queryByText("Can you hold the price until Friday?"),
+    ).toBeNull();
+    expect(screen.queryByText(WHOLE_BODY)).toBeNull();
+    // The row stays, saying it is limited. Drawing it as absent would leave a
+    // reader unable to tell a private conversation from one that never was.
+    expect(screen.getByText("Withheld")).toBeTruthy();
+  });
+
+  it("leaves every other kind reading as it did", () => {
+    renderCard(viewWith([noteRow]), vi.fn());
+
+    expect(screen.getByText("Call prep")).toBeTruthy();
+    // A note's own words, in full: the card's two lines are still the reading
+    // for everything that is not an email.
+    expect(
+      screen.getByText("Wants the fleet numbers before we talk pricing."),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Call prep/ }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/screens/personmemory.tsx
+++ b/frontend/src/screens/personmemory.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { Badge, SegmentedControl } from "../design-system/atoms";
+import { EmailEntry } from "../design-system/emailentry";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import { formatDayMonth, formatTimeOfDay } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -28,11 +29,23 @@ import { interactionIcon, useInteractionLabel } from "./interactionchrome";
 
 type Person360 = components["schemas"]["Person360"];
 type Activity = components["schemas"]["Activity"];
+type EmailSummary = components["schemas"]["EmailSummary"];
 
 const FILTERS = ["all", "email", "meetings", "calls", "notes"] as const;
 type Filter = (typeof FILTERS)[number];
 
-export function PersonMemory({ view }: Readonly<{ view: Person360 }>) {
+export function PersonMemory({
+  view,
+  onOpenEmail,
+}: Readonly<{
+  view: Person360;
+  /**
+   * Opens the page's email drawer. Optional because the page owns the drawer,
+   * not this card: a host that mounts none passes none, and the rows stay
+   * readable rather than offering a control that answers nothing.
+   */
+  onOpenEmail?: (activityId: string) => void;
+}>) {
   const t = useT();
   const { locale } = useLocale();
   const recordZone = useRecordZone();
@@ -86,10 +99,22 @@ export function PersonMemory({ view }: Readonly<{ view: Person360 }>) {
             {interactionIcon(row.kind)}
             {row.channelLabel}
           </span>
-          <span>
-            <span className="pe-memory-title">{row.title}</span>
-            <span className="pe-memory-summary">{row.summary}</span>
-          </span>
+          {/* A retained email is the canonical row, whatever surface it is on.
+              The card keeps its own date, channel, badge and time columns —
+              those place the message in this card's reading — and hands the
+              message itself to the one component that draws one. */}
+          {row.emailSummary ? (
+            <EmailEntry
+              summary={row.emailSummary}
+              timestamp={row.time}
+              onOpen={openerFor(row, onOpenEmail)}
+            />
+          ) : (
+            <span>
+              <span className="pe-memory-title">{row.title}</span>
+              <span className="pe-memory-summary">{row.summary}</span>
+            </span>
+          )}
           {row.status ? (
             <Badge tone={row.tone}>{row.statusLabel}</Badge>
           ) : (
@@ -135,6 +160,14 @@ type Row = {
   channelLabel: string;
   title: string;
   summary: string;
+  // The server's own row model for a retained email, when this row is one.
+  // Present it and the card draws EmailEntry instead of its own two lines, so
+  // a message reads here exactly as it does on the timeline beside it.
+  //
+  // Null on every other kind, and null for a thread-projection entry too: a
+  // conversation summary is a fold of several messages and has no single
+  // message's access state to show.
+  emailSummary: EmailSummary | null;
   // `status` stays the STORED key and `statusLabel` is what the reader sees.
   // Folding them into one field would make the badge's tone depend on the
   // active locale, since tone is chosen by the same word.
@@ -142,6 +175,24 @@ type Row = {
   statusLabel: string;
   tone: "success" | "warn" | "accent" | undefined;
 };
+
+// The row's opener, or nothing.
+//
+// Both halves are required and neither is assumed: a page that mounts no
+// drawer passes no opener, and a row the projection gave no activity id has
+// nothing to open. EmailEntry draws an un-openable row as plain text, which is
+// the honest reading — a row that looks openable and is not teaches a reader
+// the product does not work.
+function openerFor(
+  row: Row,
+  onOpenEmail: ((activityId: string) => void) | undefined,
+): (() => void) | undefined {
+  const { activityId } = row;
+  if (!onOpenEmail || !activityId) {
+    return undefined;
+  }
+  return () => onOpenEmail(activityId);
+}
 
 // The filter key for the channel column. Since ADR-0107/A158 a message names
 // its transport separately, so the kind alone renders every channel row as the
@@ -192,6 +243,9 @@ function fromEntry(
     channelLabel: interactionLabel(entry.channel, entry.channel_provider),
     title: entry.title,
     summary: entry.summary,
+    // A conversation entry folds a whole thread, so no single message's access
+    // state describes it. It keeps the card's own two lines.
+    emailSummary: null,
     status,
     statusLabel: statusLabel(status, t),
     tone: toneFor(status),
@@ -242,6 +296,10 @@ function foldActivities(
           : row.email_summary
             ? (row.email_summary.preview ?? "")
             : (row.body ?? ""),
+        // A retained email draws the canonical row. The title and summary
+        // above stay filled for it: they are what the segmented filter reads,
+        // and what the row falls back to if a server has not caught up.
+        emailSummary: row.email_summary ?? null,
         status,
         statusLabel: statusLabel(status, t),
         tone: toneFor(status),

--- a/frontend/src/screens/personpage.stories.tsx
+++ b/frontend/src/screens/personpage.stories.tsx
@@ -1465,6 +1465,86 @@ const emptyMemory: View = {
   activities: { data: [], page },
 };
 
+// The OTHER path through the card, and the one the thread fixtures above
+// cannot reach. With no conversation_memory the card folds the captured
+// activities instead, and a retained email there draws the canonical row —
+// mail icon, access badge, the server's preview, openable.
+//
+// Both access states, because one component draws them and a story showing
+// only the readable one would not say what a limited message looks like: the
+// second row keeps its shape and loses its words. The note is the control —
+// every other kind still reads as the card's own two lines.
+const foldedActivities: View = {
+  ...populated,
+  conversation_memory: [],
+  activities: {
+    data: [
+      {
+        id: "a-40",
+        kind: "email",
+        occurred_at: "2026-08-29T09:15:00Z",
+        subject: "Re: the renewal quote",
+        body: "Can you hold the price until Friday? I have to take it past procurement first.",
+        direction: "inbound",
+        content_state: "available",
+        source: "manual",
+        captured_by: "human:u-1",
+        created_at: "2026-08-29T09:15:00Z",
+        updated_at: "2026-08-29T09:15:00Z",
+        version: 4,
+        is_done: false,
+        email_summary: {
+          activity_id: "a-40",
+          occurred_at: "2026-08-29T09:15:00Z",
+          version: 4,
+          subject: "Re: the renewal quote",
+          preview: "Can you hold the price until Friday?",
+          counterparty: "Dana Buyer",
+          direction: "inbound",
+          display_status: "team",
+          move: "needs_reply",
+          attachment_count: 2,
+        },
+      },
+      {
+        id: "a-41",
+        kind: "email",
+        occurred_at: "2026-08-27T16:40:00Z",
+        content_state: "withheld",
+        source: "manual",
+        captured_by: "human:u-2",
+        created_at: "2026-08-27T16:40:00Z",
+        updated_at: "2026-08-27T16:40:00Z",
+        version: 2,
+        is_done: false,
+        email_summary: {
+          activity_id: "a-41",
+          occurred_at: "2026-08-27T16:40:00Z",
+          version: 2,
+          display_status: "withheld",
+          move: "none",
+          attachment_count: 0,
+        },
+      },
+      {
+        id: "a-42",
+        kind: "note",
+        occurred_at: "2026-08-26T11:00:00Z",
+        subject: "Call prep",
+        body: "Wants the fleet numbers before we talk pricing.",
+        content_state: "available",
+        source: "manual",
+        captured_by: "human:u-1",
+        created_at: "2026-08-26T11:00:00Z",
+        updated_at: "2026-08-26T11:00:00Z",
+        version: 1,
+        is_done: false,
+      },
+    ],
+    page,
+  },
+};
+
 // The gaps `OverviewPanels` above leaves: the withheld commercial card, the
 // populated one with a deal and a committee, every commitments loop kind
 // including a done row, the brief's loading and undefined-brief readings,
@@ -1485,6 +1565,7 @@ export const OverviewGaps: Story = {
           <PersonCommercialCard view={dealWithCommittee} />
           <PersonCommitmentsCard view={richLoops} firstName="Dana" />
           <PersonMemory view={richMemory} />
+          <PersonMemory view={foldedActivities} onOpenEmail={() => {}} />
           <PersonMemory view={emptyMemory} />
         </div>
       </StoryProviders>

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -469,7 +469,7 @@ export function PersonPageV2({
                 onOpenTasks={() => navigate({ screen: "worklist" })}
               />
               <RecordReadingPair>
-                <PersonMemory view={view.data} />
+                <PersonMemory view={view.data} onOpenEmail={setOpenEmail} />
                 <PersonCommitmentsCard view={view.data} firstName={firstName} />
               </RecordReadingPair>
             </RecordReading>


### PR DESCRIPTION
Lars found the person page still drawing its own email row, weeks after the
unification arc reported itself complete. He was right, and two more surfaces
were in the same state.

## What was wrong

**The person page's memory card** read `email_summary` for its title and
preview and then painted its own two lines with them. A message read one way
there and another way on the timeline six inches above it: no mail icon, no
access badge, the whole body where the preview belongs, no way to open it.

**The account page's recent list** drew `activity.subject` for every kind,
email included — no counterparty, no access state, no opener.

**The held threads table** hand-rolled a blank-subject fallback, a withheld
reading and a not-openable branch: three rules that must agree with every other
citation in the product and had no way of doing so.

## Why the gate passed over all three

`emailpresentation_test.go` found consumers by grepping for the generated type
name, and argued in a comment that there was no other way in. There is: a
surface reaches an email through the record it is already holding —
`row.email_summary.subject` on an Activity — naming no type at all.

The census now derives the carrier PROPERTY from the contract as well, and a
file discharges the obligation by mounting a canonical component rather than by
appearing on a list. Pass-throughs are ratified by name with what each does.

Under-recognition is the one way a census must not break, and this one broke
that way: it read a smaller tree, reported PASS, and there was no failing
assertion to notice. What it still cannot see is written down beside it — a
surface drawing an email from `activity.subject` alone touches no carrier field
and no derivation reaches it. Widening to activity scalars would put `.subject`
in front of a rule about email, and a census that flags every kind teaches a
reader to waive it.

## A server defect found on the way

`has_message` on a held thread was derived from whether the subject came back,
and the subject is read through the content clause — so a refusal and a
deletion arrived as the same nil. **A message this reader may not open reported
itself as erased**, and the screen said "the message this began with is gone"
over a message sitting in the thread they are holding.

Existence now comes from a second, ungated join on the same
`first_activity_id`. It discloses nothing the row does not already carry, and
only the boolean crosses over. The contract's own description said the old
thing and now says this one.

The gap was in the tests as much as the code: erased and readable each had a
case, present-and-refused had none, so it was free to report itself as either.

## Tests

Two of the three surfaces had **no test file at all**, which is why migrating
them was never proven and skipping them was never caught. Both now have one.

Mutation-checked one clause at a time throughout:

- disabling the memory card's branch fails three of its five; dropping only the
  opener fails exactly the opener test
- same shape for the recent list: three of four, then one
- putting the gated join back fails the withheld case while the erased case
  still passes
- dropping `withheld` on the held-threads citation fails exactly the two tests
  about withholding

Fixtures were corrected where they described records the server cannot send:
`JUDGED` carried a subject and no `activity_id`, though both cross the same
content clause, so every component judged against it was judged against a shape
that does not exist. The `MixedKinds` stories now clear `email_summary` on the
call, task and note, which spread an email base and would have drawn a call as
a message.

## Gates

`make check-backend`, `make check-fe` and the compose integration lane all green
on the rebased tree, plus `craft static` (0 findings), the RLS store-path gate
and the jurisdiction gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emails now render through the canonical `EmailEntry`/`EmailReference` rows on the person page's memory card, the account's recent list, and the held threads table instead of each surface drawing its own version. Also fixes the held-threads endpoint so a message that exists but is withheld is no longer reported as erased.

**Bug Fixes**
- `has_message` now comes from an ungated join on `first_activity_id`, so it means existence rather than readability.
- A withheld row now reads as "not shared with you" and stays listed, instead of claiming the message is gone.
- The email-presentation gate now finds consumers that reach an email through `email_summary` on a record they already hold, not only files that name the generated type.

**Refactors**
- The memory card and recent list mount `EmailEntry` for retained emails; held threads use `EmailReference` instead of a hand-rolled button.
- Emails in the recent list open through the page's existing citation router.
- Adds the first tests for the memory card and recent list and corrects story fixtures that described records the server cannot send.
- Removes `heldThreads.blankSubject` from all locale catalogs.

<sup>Written for commit 1ba37eb4e386c42a61996000efa185b7b026817b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recent activity and person memory now display retained emails with subjects, previews, status, and links to open the email.
  * Email references across activity views use consistent display and opening behavior.
  * Non-email activities retain their existing titles, badges, and direction indicators.

* **Bug Fixes**
  * Withheld messages are clearly labeled and no longer appear erased or openable.
  * Held threads remain listed when activity exists but its content is withheld or has no subject.
  * Message existence is now distinguished from whether its contents can be viewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->