### PR TITLE
frontend: a larger workspace mark, room under the rail head, a tighter orb

### DIFF
--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -138,9 +138,10 @@
      that has to be visible without being looked for. */
   /* One length, and never a percentage: a size that resolves against the card's
      width in one axis and the viewport in the other would give the ball two
-     different diameters. 232px is the width the card can give it, and 24vh is
-     what a short window can, whichever is smaller. */
-  --coreSize: min(196px, 20vh);
+     different diameters. 172px is a step under the width the card could give
+     it — the ball leads the rail without crowding the destinations above it —
+     and 18vh is what a short window can, whichever is smaller. */
+  --coreSize: min(172px, 18vh);
   --coreGlass: calc(var(--coreSize) - 6px);
   /* The viewport cap is for a hero standing in a content column; the rail's own
      width and height are the only caps this one needs. */

--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -175,13 +175,15 @@
      while the agent works, and a box that is one line tall for "Idle" and two for
      "Ingesting KoreaPartner Co., Ltd." moves the card, the badge and the figure
      under it every time a name is long. So the room for the second line is held
-     open whether or not it is used, and the text is centred in it. */
+     open whether or not it is used. The text sits at the TOP of that room, not
+     centred in it: centring put half a line of air between the ball and a
+     one-line reading, which read as distance from the thing it names. */
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   min-height: 2.6em;
   overflow: hidden;
-  align-content: center;
+  align-content: start;
 }
 /* What the TOOL is fetching, under the agent's line and plainly subordinate to
    it. The two are different subjects and both can be true at once, so the

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -457,19 +457,20 @@
   text-decoration: none;
   color: var(--textPrimary);
   border-radius: 9px;
-  padding: 2px 7px 2px 3px; /* ds:ignore 3 + the rail's 8px inset centres the 40px chip on the rows' own 18px glyph axis */
+  padding: 2px 7px 2px 1px; /* ds:ignore 1 + the rail's 8px inset centres the 44px chip on the rows' own 18px glyph axis */
   flex: 1;
   min-width: 0;
   overflow: hidden;
 }
 .rail .ws-chip {
   /* The workspace's mark is the one picture in the chrome, and at 32px it read
-     as one more row glyph. 40px fills the strip's height less the head's own
-     inset, which is as large as the head can carry without moving the rows. */
-  width: 40px;
-  height: 40px;
+     as one more row glyph. 44px is the head's height less a 2px inset on each
+     side: the head is the strip's height to the pixel, so this is as large as
+     the mark can be without touching the rail's edge or the rule under it. */
+  width: 44px;
+  height: 44px;
   flex: none;
-  border-radius: 10px;
+  border-radius: 11px;
   /* Flat brand emerald, no gradient and no lift: the mark is the one filled
      thing in the chrome, and a lit, shadowed chip beside quiet rows was the
      loudest object on the screen. */
@@ -482,7 +483,7 @@
    stands here is a logo drawn for its own background, or the monogram Avatar
    tints from the record's identity, and either one on the brand emerald would
    be a second surface behind a finished mark. The avatar fills the slot so the
-   collapsed rail keeps centring the same 40px box on the rows' glyph axis. */
+   collapsed rail keeps centring the same 44px box on the rows' glyph axis. */
 .rail .ws-chip-company {
   background: none;
 }

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -7,9 +7,9 @@
    the reading column. */
 :root {
   /* The session strip's height. The sidebar's own head measures against it, so
-     the first destination's row begins where the strip's rule ends and the two
-     halves of the chrome share one horizontal line rather than nearly sharing
-     one. */
+     the mark's axis is the strip's and the two halves of the chrome share one
+     horizontal line rather than nearly sharing one; the first destination's row
+     begins a breath under the strip's rule. */
   --topbarH: 50px;
   /* The page's own inset, spelled ONCE and used by every part of the frame that
      touches it: the strip, the heading, the screen's block, and the air under the
@@ -396,7 +396,9 @@
      destination's row on the line under that rule. */
   height: var(--topbarH);
   margin-top: calc(-1 * var(--space-3));
-  margin-bottom: 0;
+  /* A breath between the mark and the first destination: with the mark at the
+     head's full height the row under it read as one more item in its stack. */
+  margin-bottom: var(--space-3);
   /* The release marker below hangs off this box. */
   position: relative;
 }


### PR DESCRIPTION
## What

Three tweaks to the rail's chrome:

- The workspace mark in the head grows from 40px to 44px, with its radius and the head's left inset following so it still centres on the rows' glyph axis.
- The head keeps a `--space-3` margin below it, so the first destination no longer sits on the rule under the mark.
- The agent orb at the foot steps down from `min(196px, 20vh)` to `min(172px, 18vh)`, and its one-line reading sits at the top of its held two-line room rather than centred in it, which had put half a line of air between the ball and the words that name it.

## Why

Jo's read of the shell: the mark was still too small for the one picture in the chrome, the first row crowded it, and the orb was a touch large with its caption too far below. 44px is the most the head can carry: the head is the top bar's height to the pixel, and 44 leaves a 2px inset on each side before the mark touches the rail's edge or the rule under it. Going past that means raising the whole strip, which is a different change.

## How verified

- `rail.test.tsx`, `agentrail.test.tsx` and `conformance.test.ts` pass.
- `check-ds-spacing.sh` and `check-ds-purity.sh` pass on the diff.
- Storybook shell story rendered in both themes; the mark sits on the rows' glyph axis expanded and centred collapsed, and the caption keeps its two-line room while a one-line reading sits close under the ball.

- [x] `make check` frontend gates relevant to the change are green; no Go touched
- [x] `make test-integration` — this change does not touch tenant data / RLS / the write shape
- [x] `make craft-static` — no Go touched
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Generated by an agent under Jo Ziethen's direction, from Jo's requests for a larger mark, room under the head, and a smaller orb with its caption closer.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. Commits are signed
off (`git commit -s`, DCO). See [CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC

---
_Generated by [Claude Code](https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC)_