### PR TITLE
The rollout posture is a setting, and the engine can answer about a lead

### DIFF
--- a/backend/internal/compose/settingswiring.go
+++ b/backend/internal/compose/settingswiring.go
@@ -18,6 +18,7 @@ import (
 	"github.com/margince/margince/backend/internal/compose/installseam"
 	"github.com/margince/margince/backend/internal/modules/ai"
 	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/modules/deals"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/modules/integrations"
@@ -48,6 +49,7 @@ var settingsDefinitions = sync.OnceValue(func() []settings.Definition {
 	var defs []settings.Definition
 	defs = append(defs, ai.Definitions()...)
 	defs = append(defs, capture.Definitions()...)
+	defs = append(defs, consent.Definitions()...)
 	defs = append(defs, identity.Definitions()...)
 	defs = append(defs, integrations.Definitions()...)
 	defs = append(defs, people.Definitions()...)

--- a/backend/internal/modules/consent/authorizelead.go
+++ b/backend/internal/modules/consent/authorizelead.go
@@ -25,6 +25,43 @@ import (
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
+// The two columns person_consent keys a subject on. Compile-time literals, and
+// the only values recordedStateFor's caller may pass — nothing off a request
+// reaches the format below.
+const (
+	subjectColumnPerson = "person_id"
+	subjectColumnLead   = "lead_id"
+)
+
+// recordedStateFor is the same read for either subject arm.
+//
+// One reader for both, because the STATE is what names the refusal a subject is
+// later shown: a withdrawal is Art. 7(3) and an absence is default-deny, and
+// they are different things that happened. A lead arm asking only "is it
+// granted" could not tell them apart and reported every refusal as an absence —
+// a false statement in a record the subject can obtain through Art. 15.
+func recordedStateFor(ctx context.Context, tx pgx.Tx, subjectColumn, subjectID, purposeID string, requiresDOI bool) (string, bool, error) {
+	var state string
+	var granted bool
+	err := tx.QueryRow(ctx, fmt.Sprintf(`
+		SELECT pc.state,
+		       pc.state = 'granted' AND (NOT $3::boolean OR EXISTS (
+		         SELECT 1 FROM consent_event ce
+		         WHERE ce.%[1]s = pc.%[1]s AND ce.purpose_id = pc.purpose_id
+		           AND ce.new_state = 'granted' AND ce.double_opt_in_confirmed_at IS NOT NULL
+		           AND ce.issuance_trigger IS NOT NULL))
+		FROM person_consent pc
+		WHERE pc.%[1]s = $1 AND pc.purpose_id = $2`, subjectColumn),
+		subjectID, purposeID, requiresDOI).Scan(&state, &granted)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return string(StateUnknown), false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("read the recorded consent state: %w", err)
+	}
+	return state, granted, nil
+}
+
 // entityLead is the subject kind a decision records for an unpromoted lead,
 // the sibling of entityPerson.
 const entityLead = "lead"
@@ -114,8 +151,40 @@ func (g *Gate) decideLead(ctx context.Context, tx pgx.Tx, r connector.Recipient,
 		return d, nil
 	}
 	d.Verdict = commsauthz.VerdictDeny
-	d.ReasonCode = commsauthz.ReasonNoMarketingConsent
+	d.ReasonCode, err = leadRefusalReason(ctx, tx, leadID, purpose)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
 	return d, nil
+}
+
+// leadRefusalReason names WHY a lead's send was refused, in the same vocabulary
+// the person arm uses.
+//
+// A withdrawal and an absence are different things that happened — Art. 7(3)
+// against default-deny — and the reason code is what a subject is shown when
+// they ask. The lead arm previously called every refusal an absence, because
+// grantedForLead answers a bare bool; a lead who had exercised their right to
+// withdraw would have been told the installation merely never had consent,
+// which is a false statement in a record Art. 15 discloses.
+//
+// A grant that exists but never completed its round trip is its own answer
+// again: the subject did agree, and the mailbox never confirmed it.
+func leadRefusalReason(ctx context.Context, tx pgx.Tx, leadID string, purpose PurposeRow) (string, error) {
+	state, _, err := recordedStateFor(ctx, tx, subjectColumnLead, leadID, purpose.ID, purpose.RequiresDOI)
+	if err != nil {
+		return "", err
+	}
+	switch ConsentState(state) {
+	case StateWithdrawn:
+		return commsauthz.ReasonConsentWithdrawn, nil
+	case StateGranted:
+		// Granted and still not authorized means the DOI round trip is what is
+		// missing — the only other condition grantedForLead imposes.
+		return commsauthz.ReasonUnconfirmedDOI, nil
+	default:
+		return commsauthz.ReasonNoMarketingConsent, nil
+	}
 }
 
 // resolveLead names the live lead behind an address, or reports that none does.

--- a/backend/internal/modules/consent/authorizelead.go
+++ b/backend/internal/modules/consent/authorizelead.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What the engine answers about a recipient who is a LEAD rather than a person.
+//
+// Its own file because authorizetransmit.go had reached the size cap, and
+// because this is one concept: a lead is a subject the engine can identify, and
+// everything here is about telling that case apart from the one where nobody
+// could be identified at all. The difference matters more than it looks — a
+// no-subject verdict is absolute and denies in every rollout mode, so recording
+// an identified lead as nobody would refuse the send whatever the installation
+// had configured.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+)
+
+// entityLead is the subject kind a decision records for an unpromoted lead,
+// the sibling of entityPerson.
+const entityLead = "lead"
+
+// purposeRowFor reads the live purpose a delivery was staged under, or nil when
+// nothing defines that key.
+//
+// One reader for both subject arms. A second copy in the lead arm would be a
+// second answer to "what is this purpose", and the one that stopped matching —
+// after an archived_at check moved, say — would look exactly like the one that
+// still did.
+func purposeRowFor(ctx context.Context, tx pgx.Tx, purposeKey string) (PurposeRow, bool, error) {
+	var purpose PurposeRow
+	err := tx.QueryRow(ctx,
+		`SELECT id, key, label, class, requires_double_opt_in
+		   FROM consent_purpose WHERE key = $1 AND archived_at IS NULL`,
+		normalizedPurposeKey(purposeKey)).Scan(
+		&purpose.ID, &purpose.Key, &purpose.Label, &purpose.Class, &purpose.RequiresDOI)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Not an error: an undefined purpose is an ANSWER about this send, and
+		// the caller records it as a denial rather than failing the dispatch.
+		return PurposeRow{}, false, nil
+	}
+	if err != nil {
+		return PurposeRow{}, false, err
+	}
+	return purpose, true, nil
+}
+
+// decideLead answers about a recipient who is a lead rather than a person.
+//
+// It asks the same question the legacy lead arm asks — grantedForLead — rather
+// than a second one of its own. Two implementations of "may we write to this
+// lead" would be two answers, and the one that stopped matching would look
+// exactly like the one that still did.
+//
+// A lead nothing resolves to stays `review` with no subject: that is the
+// honest answer, and it is the one shape here that must not become an allow,
+// because no suppression, objection or consent state can be read for a subject
+// nobody identified.
+func (g *Gate) decideLead(ctx context.Context, tx pgx.Tx, r connector.Recipient, purposeKey string, d commsauthz.Decision) (commsauthz.Decision, error) {
+	leadID, found, err := resolveLead(ctx, tx, r)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	if !found {
+		d.Verdict = commsauthz.VerdictReview
+		d.ReasonCode = commsauthz.ReasonNoSubject
+		return d, nil
+	}
+	parsed, err := ids.Parse(leadID)
+	if err != nil {
+		return commsauthz.Decision{}, fmt.Errorf("consent: the resolved lead is not an id: %w", err)
+	}
+	d.SubjectKind, d.SubjectID = entityLead, parsed
+
+	// A suppression binds a lead exactly as it binds a person: the row may
+	// name a lead_id or bare address, and liveSuppression already reads both.
+	suppressed, kind, err := liveSuppression(ctx, tx, leadID, r)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	if suppressed {
+		d.Verdict = commsauthz.VerdictDeny
+		d.ReasonCode = kind
+		d.Suppression = kind
+		return d, nil
+	}
+
+	purpose, defined, err := purposeRowFor(ctx, tx, purposeKey)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	if !defined {
+		d.Verdict = commsauthz.VerdictDeny
+		d.ReasonCode = commsauthz.ReasonUnknownPurpose
+		return d, nil
+	}
+	d.Resolved = categoryForClass(purpose.Class)
+	granted, err := grantedForLead(ctx, tx, r, purpose.ID, purpose.RequiresDOI)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	if granted {
+		d.Verdict = commsauthz.VerdictAllow
+		d.ReasonCode = commsauthz.ReasonAllowed
+		return d, nil
+	}
+	d.Verdict = commsauthz.VerdictDeny
+	d.ReasonCode = commsauthz.ReasonNoMarketingConsent
+	return d, nil
+}
+
+// resolveLead names the live lead behind an address, or reports that none does.
+// Ambiguity is not possible to resolve here and is not guessed at: two live
+// leads on one address answer `found=false`, which decideLead records as a
+// recipient with no single subject.
+func resolveLead(ctx context.Context, tx pgx.Tx, r connector.Recipient) (string, bool, error) {
+	if r.Channel != nil {
+		// A channel identity binds a Person and nothing else, so there is no
+		// lead behind one.
+		return "", false, nil
+	}
+	rows, err := tx.Query(ctx, `
+		SELECT id FROM lead
+		 WHERE lower(email) = lower($1) AND archived_at IS NULL
+		 LIMIT 2`, r.Email)
+	if err != nil {
+		return "", false, fmt.Errorf("consent: resolve the lead: %w", err)
+	}
+	defer rows.Close()
+	var matches []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return "", false, fmt.Errorf("consent: resolve the lead: %w", err)
+		}
+		matches = append(matches, id)
+	}
+	if err := rows.Err(); err != nil {
+		return "", false, fmt.Errorf("consent: resolve the lead: %w", err)
+	}
+	if len(matches) != 1 {
+		return "", false, nil
+	}
+	return matches[0], true, nil
+}

--- a/backend/internal/modules/consent/authorizestaging.go
+++ b/backend/internal/modules/consent/authorizestaging.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/platform/settings"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
@@ -49,6 +50,14 @@ func (g *Gate) AuthorizeStagingTx(ctx context.Context, tx pgx.Tx, deliveryID ids
 			"consent: a staging decision needs at least one recipient: %w", apperrors.ErrInvalidArgument)
 	}
 
+	// The posture, read on the caller's transaction — the same one the
+	// decision rows commit on, so a row's stamped mode is the one that was
+	// live when it was taken.
+	modes, err := settings.ApplyTx(ctx, tx, AuthorizationModes)
+	if err != nil {
+		return commsauthz.DecisionSet{}, err
+	}
+
 	setID := ids.NewV7()
 	set := commsauthz.DecisionSet{}
 	for _, r := range req.Recipients {
@@ -57,7 +66,9 @@ func (g *Gate) AuthorizeStagingTx(ctx context.Context, tx pgx.Tx, deliveryID ids
 			return commsauthz.DecisionSet{}, err
 		}
 		d.Phase = commsauthz.PhaseStaging
-		d.Mode = commsauthz.ModeObserve
+		// From the RESOLVED category, so the authority stamped on the row is
+		// the one belonging to what the engine decided the message is.
+		d.Mode = ModeFor(modes, d.Resolved)
 		d.Requested = req.Context
 		set.Decisions = append(set.Decisions, d)
 	}

--- a/backend/internal/modules/consent/authorizetransmit.go
+++ b/backend/internal/modules/consent/authorizetransmit.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/platform/settings"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
@@ -75,14 +76,24 @@ func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitReq
 	legacyAllowed := legacyErr == nil
 
 	err := g.store.db.Tx(ctx, func(tx pgx.Tx) error {
-		set, err := g.decideRecipients(ctx, tx, req, legacyAllowed)
+		// Read inside the transaction that binds the decision, so the posture
+		// a row records is the one that was live when it was taken. Reading it
+		// before the transaction would let a rollout change between the read
+		// and the write, leaving a row stamped with a mode that never decided
+		// it.
+		modes, err := settings.ApplyTx(ctx, tx, AuthorizationModes)
+		if err != nil {
+			return err
+		}
+		modeFor := func(c commsauthz.Category) commsauthz.Mode { return ModeFor(modes, c) }
+		set, err := g.decideRecipients(ctx, tx, req, legacyAllowed, modeFor)
 		if err != nil {
 			return err
 		}
 		if err := g.recordDecisions(ctx, tx, req, setID, set); err != nil {
 			return err
 		}
-		ticket.Allowed = set.Effective(commsauthz.ModeObserve, legacyAllowed)
+		ticket.Allowed = set.Effective(modeFor, legacyAllowed)
 		ticket.Reason = refusalReason(set, legacyAllowed)
 		return nil
 	})
@@ -97,7 +108,7 @@ func (g *Gate) AuthorizeTransmit(ctx context.Context, req commsauthz.TransmitReq
 // Every recipient is asked even once one has refused, because the record is
 // per recipient: an operator answering "why did this not go" is owed the whole
 // answer, not the first line of it.
-func (g *Gate) decideRecipients(ctx context.Context, tx pgx.Tx, req commsauthz.TransmitRequest, legacyAllowed bool) (commsauthz.DecisionSet, error) {
+func (g *Gate) decideRecipients(ctx context.Context, tx pgx.Tx, req commsauthz.TransmitRequest, legacyAllowed bool, modeFor func(commsauthz.Category) commsauthz.Mode) (commsauthz.DecisionSet, error) {
 	legacy := commsauthz.VerdictDeny
 	if legacyAllowed {
 		legacy = commsauthz.VerdictAllow
@@ -109,7 +120,10 @@ func (g *Gate) decideRecipients(ctx context.Context, tx pgx.Tx, req commsauthz.T
 			return commsauthz.DecisionSet{}, err
 		}
 		d.Phase = commsauthz.PhaseTransmit
-		d.Mode = commsauthz.ModeObserve
+		// Stamped from the category the engine RESOLVED, not the one the
+		// caller claimed: the mode that decided this row is the one belonging
+		// to what the message actually is.
+		d.Mode = modeFor(d.Resolved)
 		d.LegacyVerdict = string(legacy)
 		set.Decisions = append(set.Decisions, d)
 	}
@@ -132,9 +146,13 @@ func (g *Gate) decideOne(ctx context.Context, tx pgx.Tx, r connector.Recipient, 
 		return commsauthz.Decision{}, err
 	}
 	if !found {
-		d.Verdict = commsauthz.VerdictReview
-		d.ReasonCode = commsauthz.ReasonNoSubject
-		return d, nil
+		// No person: this may still be a LEAD, which is a subject the engine
+		// can answer about. Without this arm every lead-only recipient came
+		// back `review`, so a category moved to enforce would refuse exactly
+		// the sends the legacy gate allows — an inversion rather than a
+		// tightening, and it would have arrived the day somebody flipped a
+		// mode rather than the day this code was written.
+		return g.decideLead(ctx, tx, r, purposeKey, d)
 	}
 	parsed, err := ids.Parse(personID)
 	if err != nil {
@@ -164,19 +182,14 @@ func (g *Gate) decideOne(ctx context.Context, tx pgx.Tx, r connector.Recipient, 
 // here would be a second answer, and the one that stopped matching would look
 // exactly like the one that still did.
 func classVerdict(ctx context.Context, tx pgx.Tx, personID, purposeKey string, d commsauthz.Decision) (commsauthz.Decision, error) {
-	var purpose PurposeRow
-	err := tx.QueryRow(ctx,
-		`SELECT id, key, label, class, requires_double_opt_in
-		   FROM consent_purpose WHERE key = $1 AND archived_at IS NULL`,
-		normalizedPurposeKey(purposeKey)).Scan(
-		&purpose.ID, &purpose.Key, &purpose.Label, &purpose.Class, &purpose.RequiresDOI)
-	if errors.Is(err, pgx.ErrNoRows) {
+	purpose, defined, err := purposeRowFor(ctx, tx, purposeKey)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	if !defined {
 		d.Verdict = commsauthz.VerdictDeny
 		d.ReasonCode = commsauthz.ReasonUnknownPurpose
 		return d, nil
-	}
-	if err != nil {
-		return commsauthz.Decision{}, err
 	}
 	d.Resolved = categoryForClass(purpose.Class)
 

--- a/backend/internal/modules/consent/leadconsent_integration_test.go
+++ b/backend/internal/modules/consent/leadconsent_integration_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
 type leadConsentEnv struct {
@@ -213,5 +215,108 @@ func TestOutboundGateAcceptsTheLeadArm(t *testing.T) {
 	}
 	if err := gate.RequireGrantedForEmails(e.ctx, []string{e.leadEmail}, "doi_newsletter"); !errors.Is(err, apperrors.ErrConsentNotGranted) {
 		t.Fatalf("a grant for one purpose authorized another: %v", err)
+	}
+}
+
+// The ENGINE's own answer about a lead, which is a different question from the
+// legacy gate's and had no answer at all until now.
+//
+// Without a lead arm the engine returned `review`/no-subject for every
+// lead-only recipient. That was harmless while the engine only observed and
+// would have become an inversion the day a category moved to enforce: the
+// conjunction would refuse exactly the sends the legacy gate allows, so a
+// rollout step meant to tighten marketing would have silently stopped ordinary
+// correspondence with every unpromoted lead.
+func TestTheEngineAnswersAboutALeadRatherThanShrugging(t *testing.T) {
+	e := setupLeadConsent(t)
+	gate := NewGate(e.store)
+	recipient := connector.Recipient{Email: e.leadEmail}
+
+	tx, err := e.store.db.Pool().Begin(e.ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := tx.Rollback(context.Background()); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("rolling back: %v", err)
+		}
+	}()
+
+	// Before the grant the engine denies, and names WHY: no consent, not "we
+	// could not find anybody". The distinction is the whole point — a
+	// no-subject verdict is absolute and would deny in every mode.
+	before, err := gate.decideOne(e.ctx, tx, recipient, "newsletter")
+	if err != nil {
+		t.Fatalf("deciding about an ungranted lead: %v", err)
+	}
+	if before.SubjectKind != entityLead {
+		t.Errorf("subject kind = %q, want lead — the engine did not recognise the subject", before.SubjectKind)
+	}
+	if before.Verdict != commsauthz.VerdictDeny {
+		t.Errorf("verdict = %q, want deny for a lead with no grant", before.Verdict)
+	}
+	if before.ReasonCode == commsauthz.ReasonNoSubject {
+		t.Error("an identified lead was recorded as nobody, which denies in every mode")
+	}
+
+	if _, err := e.store.Record(e.ctx, RecordInput{
+		LeadID: e.lead, PurposeID: e.newsletter, NewState: "granted",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := gate.decideOne(e.ctx, tx, recipient, "newsletter")
+	if err != nil {
+		t.Fatalf("deciding about a granted lead: %v", err)
+	}
+	if after.Verdict != commsauthz.VerdictAllow {
+		t.Errorf("verdict = %q (%s), want allow — the engine refused what the legacy gate allows",
+			after.Verdict, after.ReasonCode)
+	}
+	if after.SubjectID != e.lead.UUID {
+		t.Errorf("subject id = %v, want the lead's own id %v", after.SubjectID, e.lead.UUID)
+	}
+}
+
+// The engine and the legacy gate agree about a lead, which is what makes it
+// safe to enforce. Two implementations of "may we write to this lead" would be
+// two answers, and the one that stopped matching would look exactly like the
+// one that still did.
+func TestTheEngineAndTheLegacyGateAgreeAboutALead(t *testing.T) {
+	e := setupLeadConsent(t)
+	gate := NewGate(e.store)
+	recipient := connector.Recipient{Email: e.leadEmail}
+
+	for _, step := range []struct {
+		name  string
+		grant bool
+	}{{"before the grant", false}, {"after the grant", true}} {
+		if step.grant {
+			if _, err := e.store.Record(e.ctx, RecordInput{
+				LeadID: e.lead, PurposeID: e.newsletter, NewState: "granted",
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		legacyErr := gate.RequireGrantedForEmails(e.ctx, []string{e.leadEmail}, "newsletter")
+		legacyAllows := legacyErr == nil
+
+		tx, err := e.store.db.Pool().Begin(e.ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		d, err := gate.decideOne(e.ctx, tx, recipient, "newsletter")
+		if err != nil {
+			t.Fatalf("%s: deciding: %v", step.name, err)
+		}
+		if err := tx.Rollback(e.ctx); err != nil {
+			t.Fatalf("%s: rolling back: %v", step.name, err)
+		}
+		engineAllows := d.Verdict == commsauthz.VerdictAllow
+
+		if legacyAllows != engineAllows {
+			t.Errorf("%s: legacy allows=%v, engine allows=%v (%s) — enforcing this category would change who can be written to",
+				step.name, legacyAllows, engineAllows, d.ReasonCode)
+		}
 	}
 }

--- a/backend/internal/modules/consent/leadconsent_integration_test.go
+++ b/backend/internal/modules/consent/leadconsent_integration_test.go
@@ -320,3 +320,74 @@ func TestTheEngineAndTheLegacyGateAgreeAboutALead(t *testing.T) {
 		}
 	}
 }
+
+// A lead who withdrew is told they withdrew.
+//
+// A withdrawal and an absence are different things that happened — Art. 7(3)
+// against default-deny — and the reason code is what the subject reads when
+// they ask. The lead arm first reported every refusal as an absence, so a lead
+// who had exercised their right to withdraw would have been told the
+// installation merely never held consent: a false statement in a record Art. 15
+// discloses. It is also the difference between a refusal a rollout mode may
+// soften and one it may not.
+func TestAWithdrawnLeadIsNotReportedAsNeverGranted(t *testing.T) {
+	e := setupLeadConsent(t)
+	gate := NewGate(e.store)
+	recipient := connector.Recipient{Email: e.leadEmail}
+
+	for _, state := range []string{"granted", "withdrawn"} {
+		if _, err := e.store.Record(e.ctx, RecordInput{
+			LeadID: e.lead, PurposeID: e.newsletter, NewState: state,
+		}); err != nil {
+			t.Fatalf("recording %s: %v", state, err)
+		}
+	}
+
+	tx, err := e.store.db.Pool().Begin(e.ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := tx.Rollback(context.Background()); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("rolling back: %v", err)
+		}
+	}()
+
+	d, err := gate.decideOne(e.ctx, tx, recipient, "newsletter")
+	if err != nil {
+		t.Fatalf("deciding about a withdrawn lead: %v", err)
+	}
+	if d.Verdict != commsauthz.VerdictDeny {
+		t.Fatalf("verdict = %q, want deny after a withdrawal", d.Verdict)
+	}
+	if d.ReasonCode != commsauthz.ReasonConsentWithdrawn {
+		t.Errorf("reason = %q, want %q — the subject is shown this, and they did withdraw",
+			d.ReasonCode, commsauthz.ReasonConsentWithdrawn)
+	}
+}
+
+// And the converse, or the test above would pass with every refusal renamed: a
+// lead who never granted anything is still an absence.
+func TestALeadWhoNeverGrantedIsReportedAsAnAbsence(t *testing.T) {
+	e := setupLeadConsent(t)
+	gate := NewGate(e.store)
+
+	tx, err := e.store.db.Pool().Begin(e.ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := tx.Rollback(context.Background()); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("rolling back: %v", err)
+		}
+	}()
+
+	d, err := gate.decideOne(e.ctx, tx, connector.Recipient{Email: e.leadEmail}, "newsletter")
+	if err != nil {
+		t.Fatalf("deciding: %v", err)
+	}
+	if d.ReasonCode != commsauthz.ReasonNoMarketingConsent {
+		t.Errorf("reason = %q, want %q for a lead who granted nothing",
+			d.ReasonCode, commsauthz.ReasonNoMarketingConsent)
+	}
+}

--- a/backend/internal/modules/consent/settingsentry.go
+++ b/backend/internal/modules/consent/settingsentry.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// How much authority the authorization engine's answer carries, per category.
+//
+// The engine and the old purpose gate both answer every outbound send, and
+// this is what decides which one rules while the two are compared. It is per
+// category because the categories become trustworthy at different times: a
+// reply's evidence is a thread the subject started and is settled today, while
+// marketing waits for the jurisdiction packs — enforcing it before the German
+// existing-customer exception exists would refuse sends that are lawful under
+// §7(3), and the engine would be stricter than the law.
+//
+// It is NOT a way to switch the engine off. Four refusals bind in every mode —
+// an Art. 21 objection, a processing restriction, a hard bounce and an
+// unconfirmed double opt-in, plus a recipient nobody could resolve and a
+// withdrawn consent. Those are decided by law or by the subject, not by how
+// far along a rollout is (commsauthz/absolute.go holds the list). Rolling a
+// category back to observe re-admits the old gate's answer; it never
+// resurrects a consent, clears a suppression or reaches past those six.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/platform/settings"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// authorizationModesObject gates the rollout posture. installation_settings
+// rather than a new object: this is one installation-wide answer about how the
+// product behaves, the same shape as every other posture living there, and a
+// new RBAC object would need a presence-guarded backfill for every workspace
+// created before it existed.
+const authorizationModesObject = "installation_settings"
+
+// AuthorizationModes maps a communication category to the authority the
+// engine's answer carries for it.
+//
+// A category absent from the map is `observe`, so the default below can name
+// nothing and still be complete — and so a category added to the vocabulary
+// tomorrow arrives in the safest position rather than in whatever the map
+// happened to say.
+var AuthorizationModes = settings.Define[map[string]string](
+	"consent.authorization_modes",
+	authorizationModesObject,
+	"update",
+	// Every category observes. The engine records what it would have done and
+	// the old gate decides, which is what makes the disagreement measurable
+	// before it is binding.
+	map[string]string{},
+	validateAuthorizationModes,
+	// MachineryApplied: the transmit gate reads this inside the transaction
+	// that binds its own decision, and the posture must apply whoever the
+	// acting principal is — a worker dispatching a delivery holds the system
+	// principal and has no settings read gate to pass.
+).MachineryApplied()
+
+// validateAuthorizationModes refuses a map that names something that is not a
+// category, or a mode that is not a mode.
+//
+// Both halves are checked against the vocabularies rather than against a list
+// here: a typo in a category key would otherwise be accepted and then silently
+// mean nothing, which reads exactly like a rollout that was configured and did
+// not take.
+func validateAuthorizationModes(in map[string]string) error {
+	var unknownCategories, unknownModes []string
+	for category, mode := range in {
+		if !commsauthz.Category(category).Valid() {
+			unknownCategories = append(unknownCategories, category)
+		}
+		switch commsauthz.Mode(mode) {
+		case commsauthz.ModeObserve, commsauthz.ModeWarn, commsauthz.ModeEnforce:
+		default:
+			unknownModes = append(unknownModes, mode)
+		}
+	}
+	sort.Strings(unknownCategories)
+	sort.Strings(unknownModes)
+	if len(unknownCategories) > 0 {
+		return fmt.Errorf("not a communication category: %s", strings.Join(unknownCategories, ", "))
+	}
+	if len(unknownModes) > 0 {
+		return fmt.Errorf("a mode is observe, warn or enforce, not: %s", strings.Join(unknownModes, ", "))
+	}
+	return nil
+}
+
+// ModeFor answers the authority the engine carries for one category.
+//
+// Absent means observe, which is what makes the stored map a set of
+// EXCEPTIONS to the safe default rather than a table that must list every
+// category to be correct. A map that had to be complete would put a new
+// category into whatever position the last author typed.
+func ModeFor(modes map[string]string, category commsauthz.Category) commsauthz.Mode {
+	switch commsauthz.Mode(modes[string(category)]) {
+	case commsauthz.ModeEnforce:
+		return commsauthz.ModeEnforce
+	case commsauthz.ModeWarn:
+		return commsauthz.ModeWarn
+	default:
+		return commsauthz.ModeObserve
+	}
+}
+
+// Definitions is consent's contribution to the settings registry; compose
+// concatenates each module's list.
+func Definitions() []settings.Definition {
+	return []settings.Definition{AuthorizationModes}
+}

--- a/backend/internal/modules/consent/settingsentry_test.go
+++ b/backend/internal/modules/consent/settingsentry_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What the rollout posture accepts, and what it means when it says nothing.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// Absent means observe, which is what lets the stored map be a set of
+// EXCEPTIONS rather than a table that must list every category to be correct.
+// A map that had to be complete would put a category added tomorrow into
+// whatever position the last author happened to type.
+func TestACategoryTheMapDoesNotNameObserves(t *testing.T) {
+	modes := map[string]string{string(commsauthz.CategoryReplyToInbound): "enforce"}
+	if got := ModeFor(modes, commsauthz.CategoryMarketing); got != commsauthz.ModeObserve {
+		t.Errorf("an unnamed category resolved to %q, want observe", got)
+	}
+	if got := ModeFor(modes, commsauthz.CategoryReplyToInbound); got != commsauthz.ModeEnforce {
+		t.Errorf("a named category resolved to %q, want enforce", got)
+	}
+}
+
+// Every category in the vocabulary observes under the shipped default. This is
+// derived from the vocabulary rather than listed, so a category added without a
+// thought about its rollout position still arrives in the safest one.
+func TestTheDefaultObservesEveryCategory(t *testing.T) {
+	def := map[string]string{}
+	for _, c := range commsauthz.Categories() {
+		if got := ModeFor(def, c); got != commsauthz.ModeObserve {
+			t.Errorf("%s defaults to %q, want observe", c, got)
+		}
+	}
+}
+
+// A value that is not a mode resolves to observe rather than to itself. A
+// stored map can predate a validator, and a garbled value must fail safe.
+func TestAnUnreadableModeObserves(t *testing.T) {
+	modes := map[string]string{string(commsauthz.CategoryMarketing): "enforced"}
+	if got := ModeFor(modes, commsauthz.CategoryMarketing); got != commsauthz.ModeObserve {
+		t.Errorf("a garbled mode resolved to %q, want observe", got)
+	}
+}
+
+// A misspelled category is refused rather than stored. Accepting one would let
+// it silently mean nothing, which reads exactly like a rollout that was
+// configured and did not take.
+func TestAnUnknownCategoryIsRefused(t *testing.T) {
+	err := validateAuthorizationModes(map[string]string{"transactional": "enforce"})
+	if err == nil {
+		t.Fatal("a category that does not exist was accepted")
+	}
+	if !strings.Contains(err.Error(), "transactional") {
+		t.Errorf("the refusal does not name what was wrong: %v", err)
+	}
+}
+
+// And a mode that is not a mode.
+func TestAnUnknownModeIsRefused(t *testing.T) {
+	err := validateAuthorizationModes(map[string]string{
+		string(commsauthz.CategoryMarketing): "block",
+	})
+	if err == nil {
+		t.Fatal("a mode that does not exist was accepted")
+	}
+	if !strings.Contains(err.Error(), "block") {
+		t.Errorf("the refusal does not name what was wrong: %v", err)
+	}
+}
+
+// Every real category paired with every real mode is accepted, so the
+// validator above refuses the wrong thing and not the right one.
+func TestEveryCategoryAndModeIsAccepted(t *testing.T) {
+	for _, mode := range []commsauthz.Mode{
+		commsauthz.ModeObserve, commsauthz.ModeWarn, commsauthz.ModeEnforce,
+	} {
+		in := map[string]string{}
+		for _, c := range commsauthz.Categories() {
+			in[string(c)] = string(mode)
+		}
+		if err := validateAuthorizationModes(in); err != nil {
+			t.Errorf("every category in %s was refused: %v", mode, err)
+		}
+	}
+}
+
+// An empty map is the shipped default and must validate, or no installation
+// could save any other setting on the same surface.
+func TestTheEmptyMapValidates(t *testing.T) {
+	if err := validateAuthorizationModes(map[string]string{}); err != nil {
+		t.Errorf("the default posture was refused: %v", err)
+	}
+}

--- a/backend/internal/modules/consent/verdict.go
+++ b/backend/internal/modules/consent/verdict.go
@@ -426,25 +426,7 @@ func inboundQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (Qu
 // person could mint and redeem a confirmation the subject never saw. Those rows
 // stay on the proof log as the history they are, and authorize no send.
 func recordedState(ctx context.Context, tx pgx.Tx, personID, purposeID string, requiresDOI bool) (string, bool, error) {
-	var state string
-	var granted bool
-	err := tx.QueryRow(ctx, `
-		SELECT pc.state,
-		       pc.state = 'granted' AND (NOT $3::boolean OR EXISTS (
-		         SELECT 1 FROM consent_event ce
-		         WHERE ce.person_id = pc.person_id AND ce.purpose_id = pc.purpose_id
-		           AND ce.new_state = 'granted' AND ce.double_opt_in_confirmed_at IS NOT NULL
-		           AND ce.issuance_trigger IS NOT NULL))
-		FROM person_consent pc
-		WHERE pc.person_id = $1 AND pc.purpose_id = $2`,
-		personID, purposeID, requiresDOI).Scan(&state, &granted)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return string(StateUnknown), false, nil
-	}
-	if err != nil {
-		return "", false, fmt.Errorf("read the recorded consent state: %w", err)
-	}
-	return state, granted, nil
+	return recordedStateFor(ctx, tx, subjectColumnPerson, personID, purposeID, requiresDOI)
 }
 
 // existingCustomerFlag reads the UWG §7(3) flag. The DDL already refuses a row

--- a/backend/internal/shared/ports/commsauthz/absolute.go
+++ b/backend/internal/shared/ports/commsauthz/absolute.go
@@ -79,16 +79,37 @@ func (s DecisionSet) HasAbsoluteDenial() bool {
 	return false
 }
 
-// Effective folds the mode in: what this set actually permits right now.
+// Effective folds the modes in: what this set actually permits right now.
 //
-// In enforce the engine rules. In observe and warn the old gate rules, EXCEPT
-// for an absolute denial, which rules in every mode.
-func (s DecisionSet) Effective(mode Mode, legacyAllowed bool) bool {
+// The mode is read per DECISION rather than once for the set, because the
+// recipients of one message need not resolve to one category — a reply to a
+// thread that copies somebody the engine calls marketing is two categories in
+// one send, and a single mode would have to pick one of them. Each recipient
+// is judged under the authority its own category carries.
+//
+// In enforce the engine rules that recipient. In observe and warn the old gate
+// does. An absolute denial rules in every mode, whatever any category's mode
+// says — that is what "absolute" means here.
+//
+// Whole-message refusal is preserved: one recipient the engine refuses under
+// enforce refuses the send, exactly as one recipient the old gate refuses does.
+func (s DecisionSet) Effective(modeFor func(Category) Mode, legacyAllowed bool) bool {
 	if s.HasAbsoluteDenial() {
 		return false
 	}
-	if mode == ModeEnforce {
-		return legacyAllowed && s.Allowed()
+	if len(s.Decisions) == 0 {
+		// No decision is not an allow. An empty set reaching here means the
+		// engine was asked about nobody, and a message with no authorized
+		// recipient is not a message that may go out.
+		return false
+	}
+	for _, d := range s.Decisions {
+		if modeFor(d.Resolved) != ModeEnforce {
+			continue
+		}
+		if d.Verdict != VerdictAllow {
+			return false
+		}
 	}
 	return legacyAllowed
 }

--- a/backend/internal/shared/ports/commsauthz/commsauthz_test.go
+++ b/backend/internal/shared/ports/commsauthz/commsauthz_test.go
@@ -29,6 +29,13 @@ func TestAnEmptySetIsNotAllowed(t *testing.T) {
 	}
 }
 
+// everywhere lifts one mode into the per-category resolver Effective takes, for
+// a test whose subject is the mode itself rather than which category carries
+// it. A test about two categories at once builds its own resolver instead.
+func everywhere(m Mode) func(Category) Mode {
+	return func(Category) Mode { return m }
+}
+
 // The whole point of observe mode is that it does not block. The whole point of
 // this table is the four things that block anyway.
 func TestAbsoluteDenialsSurviveEveryMode(t *testing.T) {
@@ -39,7 +46,7 @@ func TestAbsoluteDenialsSurviveEveryMode(t *testing.T) {
 		set := DecisionSet{Decisions: []Decision{{Verdict: VerdictDeny, ReasonCode: reason}}}
 		for _, mode := range []Mode{ModeObserve, ModeWarn, ModeEnforce} {
 			// legacyAllowed true is the hard case: the OLD gate would send.
-			if set.Effective(mode, true) {
+			if set.Effective(everywhere(mode), true) {
 				t.Errorf("%s in %s mode: sent anyway — a rollout mode must not reach past this", reason, mode)
 			}
 		}
@@ -49,10 +56,10 @@ func TestAbsoluteDenialsSurviveEveryMode(t *testing.T) {
 // And the converse, or the test above would pass with everything denied.
 func TestAnOrdinaryDenialDefersToTheModeWhileObserving(t *testing.T) {
 	set := DecisionSet{Decisions: []Decision{{Verdict: VerdictDeny, ReasonCode: ReasonNoEvidence}}}
-	if !set.Effective(ModeObserve, true) {
+	if !set.Effective(everywhere(ModeObserve), true) {
 		t.Error("observe mode must let the old gate rule on a non-absolute disagreement")
 	}
-	if set.Effective(ModeEnforce, true) {
+	if set.Effective(everywhere(ModeEnforce), true) {
 		t.Error("enforce mode must apply the engine's own refusal")
 	}
 }
@@ -61,7 +68,7 @@ func TestAnOrdinaryDenialDefersToTheModeWhileObserving(t *testing.T) {
 // gate refused while both still run.
 func TestEnforceNeverOutranksTheOldGate(t *testing.T) {
 	set := DecisionSet{Decisions: []Decision{{Verdict: VerdictAllow, ReasonCode: ReasonAllowed}}}
-	if set.Effective(ModeEnforce, false) {
+	if set.Effective(everywhere(ModeEnforce), false) {
 		t.Error("an engine allow must not send what the legacy gate refused")
 	}
 }
@@ -91,5 +98,41 @@ func TestNoGenericTransactionalCategoryExists(t *testing.T) {
 	}
 	if len(Categories()) != 14 {
 		t.Errorf("Categories() has %d members, want the 14 the vocabulary declares", len(Categories()))
+	}
+}
+
+// The mode is read per recipient, not once for the message. One send can carry
+// two categories — a reply to a thread that copies somebody the engine calls
+// marketing — and a single mode for the set would have to pick one of them,
+// which means either enforcing a category the installation has not enforced or
+// observing one it has.
+func TestEachRecipientIsJudgedUnderItsOwnCategorysMode(t *testing.T) {
+	set := DecisionSet{Decisions: []Decision{
+		{Verdict: VerdictAllow, ReasonCode: ReasonAllowed, Resolved: CategoryReplyToInbound},
+		{Verdict: VerdictDeny, ReasonCode: ReasonNoEvidence, Resolved: CategoryMarketing},
+	}}
+	// Replies enforce; marketing still observes, which is the state this
+	// product ships in until the jurisdiction packs land.
+	repliesOnly := func(c Category) Mode {
+		if c == CategoryReplyToInbound {
+			return ModeEnforce
+		}
+		return ModeObserve
+	}
+	if !set.Effective(repliesOnly, true) {
+		t.Error("a marketing refusal blocked the send while marketing was still observing")
+	}
+	// And the converse: enforce marketing and the same set refuses.
+	marketingToo := func(Category) Mode { return ModeEnforce }
+	if set.Effective(marketingToo, true) {
+		t.Error("marketing was enforced and its refusal did not bind")
+	}
+}
+
+// An empty set is not an allow. It means the engine was asked about nobody,
+// and a message with no authorized recipient is not one that may go out.
+func TestAnEmptySetPermitsNothing(t *testing.T) {
+	if (DecisionSet{}).Effective(everywhere(ModeObserve), true) {
+		t.Error("a set with no decisions permitted a send")
 	}
 }


### PR DESCRIPTION
Two prerequisites for enforcing any category. Both were recorded as shipped in
the plan and neither was built.

## The posture was never a setting

`commsauthz.Mode` was a compile-time `ModeObserve` at all three sites, so the
enforce branch in `Effective` was dead code and there was nothing to flip.

`consent.authorization_modes` now maps a category to the authority the engine's
answer carries for it, read on the caller's transaction at staging and at
transmit — so the mode a decision row records is the one that was live when it
was taken, not one a concurrent rollout change swapped in between the read and
the write.

Per category, because categories become trustworthy at different times. A
reply's evidence is a thread the subject started and is settled today. Marketing
waits for the jurisdiction packs: enforcing it before the German
existing-customer exception exists would refuse sends that are lawful under
§7(3), and reps would route around an engine stricter than the law.

Absent means observe. That makes the stored map a set of exceptions rather than
a table that must list every category to be correct, and it means a category
added to the vocabulary tomorrow arrives in the safest position rather than in
whatever the last author typed. A garbled stored value also reads as observe.

`Effective` now takes a per-category resolver rather than a single mode. One
send can carry two categories — a reply to a thread that copies somebody the
engine calls marketing — and one mode for the set would have to pick, either
enforcing a category the installation has not enforced or observing one it has.
Whole-message refusal is unchanged, and the six absolute denials still bind in
every mode.

## The engine could not answer about a lead

`decideOne` had no lead arm: every lead-only recipient came back
`review`/`no_subject`. Harmless while the engine only observed, and an inversion
the day a category moved to enforce — `no_subject` is an absolute denial, so the
conjunction would have refused exactly the sends the legacy gate allows. A step
meant to tighten marketing would have silently stopped ordinary correspondence
with every unpromoted lead.

The arm asks `grantedForLead`, the same question the legacy arm asks, rather
than a second one of its own. An integration test asserts the two agree both
before and after a grant, so a future divergence fails rather than waiting to be
noticed. A lead nothing resolves to stays `review`/`no_subject` — the one shape
here that must not become an allow, because no suppression or consent state can
be read for a subject nobody identified.

## Tests

`settingsentry_test.go`: an unnamed category observes, the default observes
every category in the vocabulary (derived, not listed), a garbled mode observes,
an unknown category or mode is refused and named, and every real pairing is
accepted.

`commsauthz_test.go`: two recipients in two categories are each judged under
their own category's mode, and an empty decision set permits nothing.

`leadconsent_integration_test.go`: the engine identifies a lead as a subject and
denies for lack of consent rather than for lack of a subject, allows once
granted, and agrees with the legacy gate at both steps.

Mutation-checked: removing the lead arm makes a granted lead read
`review`/`no_subject` and fails both tests.

## Verification

`make check-backend`, `make rls-store-path` and `make no-jurisdiction` pass,
re-run after rebasing onto current main. `craft static` is clean across the
diff. `purposeRowFor` is extracted so both subject arms read the purpose once;
`authorizelead.go` is a new file because `authorizetransmit.go` had reached the
500-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes consent authorization configurable per communication category instead of hard-coding observe, so categories can move to enforce independently. Lead-only recipients previously returned `review`/`no_subject`; the engine now evaluates them with the same consent check as the legacy gate.

**Rollout posture**
- Adds `consent.authorization_modes`, with omitted or unreadable values resolving to observe.
- Reads the setting in the transaction that records each decision and evaluates mixed-category messages per recipient.
- Enforce applies the engine verdict, while observe and warn defer to the legacy gate; absolute denials and empty decision sets still block sends.

**Lead decisions**
- Resolves a unique email-matched lead, records it as the subject, and distinguishes missing consent, withdrawal, and unconfirmed double opt-in.
- Keeps `review`/`no_subject` when no unique person or lead can be identified.
- Tests that engine and legacy decisions agree before and after a lead grant.

<sup>Written for commit 1c89b6a025ac2826b203594833f0c9c38f314238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consent authorization settings with configurable **observe**, **warn**, or **enforce** modes by category.
  * Added lead-specific consent evaluation for transmission decisions, including lead identification and consent status checks.
  * Consent settings are now available through the application’s settings catalog.

* **Bug Fixes**
  * Staging and transmission decisions now consistently honor each category’s configured authorization mode.
  * Lead recipients are no longer automatically sent for review when valid consent can be evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->