### PR TITLE
A team's week is read by that team

### DIFF
--- a/backend/internal/compose/integration/teamweekly_integration_test.go
+++ b/backend/internal/compose/integration/teamweekly_integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose/integration"
 	"github.com/margince/margince/backend/internal/compose/weekly"
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -40,8 +41,12 @@ func setupTeamWeekly(t *testing.T) *teamEnv {
 	t.Helper()
 	e := integration.Setup(t)
 	return &teamEnv{
-		Env:     e,
-		engine:  weekly.NewEngine(e.Pool),
+		Env: e,
+		// Bound the way compose binds it. An engine WITHOUT the seam refuses
+		// every team read, so a suite built on one would prove nothing about
+		// which reader is admitted — and the real identity service, not a stub,
+		// because the question here is what team_membership says.
+		engine:  weekly.NewEngine(e.Pool).WithTeamMembers(identity.NewService(e.Pool)),
 		leadCtx: e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms),
 		repCtx:  ownScoped(e, e.Rep2),
 	}
@@ -71,6 +76,139 @@ func TestAnOwnScopedSeatIsRefusedTheTeamWeek(t *testing.T) {
 
 	if !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("an own-scoped seat got %v, wanted a refusal", err)
+	}
+}
+
+// teamScoped is a lead: they may read deals, and their row scope reaches a
+// team. Every other test here runs under AdminPerms, which is RowScopeAll and
+// short-circuits the membership question — which is exactly why the leak below
+// stayed invisible until someone asked for a team they are not on.
+func teamScoped(e *integration.Env, user ids.UUID, teams []ids.UUID) context.Context {
+	perms := integration.AdminPerms
+	perms.RowScope = principal.RowScopeTeam
+	return e.As(user, teams, perms)
+}
+
+// A LEAD OF ONE TEAM MUST NOT READ ANOTHER'S WEEK. The team id arrives from the
+// query string and nothing on the row narrows it to the reader, so without a
+// membership gate one changed parameter hands over every member of another
+// team: their name, their won deals, their breached leads, and the one thing
+// their own lead was told to raise with them.
+func TestALeadOfOneTeamCannotOpenAnothersWeek(t *testing.T) {
+	e := setupTeamWeekly(t)
+
+	// Team2 is Rep3's in the harness; Rep1 and Rep2 share Team1.
+	writeRepWeek(t, e, e.Rep3)
+	if _, _, err := e.engine.AssembleTeamFor(e.leadCtx, e.Team2, "Team Two",
+		[]weekly.TeamMember{{UserID: e.Rep3, DisplayName: "Rep Three"}}, teamClock); err != nil {
+		t.Fatal(err)
+	}
+
+	outsider := teamScoped(e.Env, e.Rep1, []ids.UUID{e.Team1})
+
+	_, err := e.engine.LatestTeamReview(outsider, e.Team2, nil)
+
+	// NOT FOUND, not permission denied. A refusal that distinguished "this team
+	// exists but is not yours" from "no such team" would let an outsider
+	// enumerate the chart one id at a time — the same reason a row-scope miss
+	// reads as 404 everywhere else in this tree.
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("a lead read another team's week: got %v, wanted ErrNotFound", err)
+	}
+}
+
+// AND THE SAME SEAT READS ITS OWN TEAM. Without this case the test above passes
+// over an engine that refuses everyone, which is how a refusal test proves
+// nothing at all.
+func TestATeamScopedLeadReadsTheirOwnTeamsWeek(t *testing.T) {
+	e := setupTeamWeekly(t)
+
+	writeRepWeek(t, e, e.Rep1)
+	if _, _, err := e.engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock); err != nil {
+		t.Fatal(err)
+	}
+
+	lead := teamScoped(e.Env, e.Rep1, []ids.UUID{e.Team1})
+
+	read, err := e.engine.LatestTeamReview(lead, e.Team1, nil)
+	if err != nil {
+		t.Fatalf("a lead reading their own team's week: %v", err)
+	}
+	if read.TeamName != "Team One" {
+		t.Errorf("got the week of %q, wanted Team One", read.TeamName)
+	}
+}
+
+// A MANAGEMENT SEAT OPENS A TEAM IT IS NOT ON. Row scope "all" reaches every
+// row by definition, so asking membership of it would refuse a reader the
+// row-scope predicate then admits.
+//
+// This case is why the gate short-circuits on auth.Unbounded rather than asking
+// membership of everyone: removing that short-circuit leaves every OTHER test
+// here green, because their readers happen to be members of the team they ask
+// about. Only a reader who is deliberately not can tell the difference.
+func TestAManagementSeatOpensATeamItIsNotOn(t *testing.T) {
+	e := setupTeamWeekly(t)
+
+	writeRepWeek(t, e, e.Rep3)
+	if _, _, err := e.engine.AssembleTeamFor(e.leadCtx, e.Team2, "Team Two",
+		[]weekly.TeamMember{{UserID: e.Rep3, DisplayName: "Rep Three"}}, teamClock); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rep1 is on Team1 and nowhere near Team2 — AdminPerms is RowScopeAll.
+	management := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+
+	read, err := e.engine.LatestTeamReview(management, e.Team2, nil)
+	if err != nil {
+		t.Fatalf("a management seat reading another team's week: %v", err)
+	}
+	if read.TeamName != "Team Two" {
+		t.Errorf("got the week of %q, wanted Team Two", read.TeamName)
+	}
+}
+
+// The NAMED week takes the same gate as the newest one. They are separate entry
+// points, and a gate written into one alone leaves "?week=2026-06-01" open.
+func TestNamingTheWeekDoesNotBypassTheTeamGate(t *testing.T) {
+	e := setupTeamWeekly(t)
+
+	writeRepWeek(t, e, e.Rep3)
+	written, _, err := e.engine.AssembleTeamFor(e.leadCtx, e.Team2, "Team Two",
+		[]weekly.TeamMember{{UserID: e.Rep3, DisplayName: "Rep Three"}}, teamClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outsider := teamScoped(e.Env, e.Rep1, []ids.UUID{e.Team1})
+
+	// The week that was actually written, so a refusal cannot be a miss on the
+	// date rather than the gate doing its job.
+	_, err = e.engine.TeamReview(outsider, e.Team2, written.LocalWeekStart)
+
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("naming another team's week: got %v, wanted ErrNotFound", err)
+	}
+}
+
+// An engine with NO membership seam refuses a team read rather than serving it
+// unchecked. An unbound seam is a wiring mistake, and the failure mode of
+// serving anyway is handing every lead every team's week.
+func TestAnUnboundMembershipSeamRefusesTheTeamWeek(t *testing.T) {
+	e := setupTeamWeekly(t)
+
+	writeRepWeek(t, e, e.Rep1)
+	if _, _, err := e.engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock); err != nil {
+		t.Fatal(err)
+	}
+
+	unwired := weekly.NewEngine(e.Pool)
+	lead := teamScoped(e.Env, e.Rep1, []ids.UUID{e.Team1})
+
+	if _, err := unwired.LatestTeamReview(lead, e.Team1, nil); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("an unbound seam served a team week: got %v, wanted ErrNotFound", err)
 	}
 }
 

--- a/backend/internal/compose/integration/teamweekly_integration_test.go
+++ b/backend/internal/compose/integration/teamweekly_integration_test.go
@@ -46,7 +46,7 @@ func setupTeamWeekly(t *testing.T) *teamEnv {
 		// every team read, so a suite built on one would prove nothing about
 		// which reader is admitted — and the real identity service, not a stub,
 		// because the question here is what team_membership says.
-		engine:  weekly.NewEngine(e.Pool).WithTeamMembers(identity.NewService(e.Pool)),
+		engine:  weekly.NewEngine(e.Pool, identity.NewService(e.Pool)),
 		leadCtx: e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms),
 		repCtx:  ownScoped(e, e.Rep2),
 	}
@@ -204,7 +204,7 @@ func TestAnUnboundMembershipSeamRefusesTheTeamWeek(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	unwired := weekly.NewEngine(e.Pool)
+	unwired := weekly.NewEngine(e.Pool, nil)
 	lead := teamScoped(e.Env, e.Rep1, []ids.UUID{e.Team1})
 
 	if _, err := unwired.LatestTeamReview(lead, e.Team1, nil); !errors.Is(err, apperrors.ErrNotFound) {

--- a/backend/internal/compose/jobs_weekly.go
+++ b/backend/internal/compose/jobs_weekly.go
@@ -27,7 +27,11 @@ import (
 func addWeeklyReviewJobs(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Logger, narrator completer, mail WeeklyMailConfig) {
 	addDeclaredWorker[WeeklyReviewGenerateArgs](reg, &weeklyGenerateWorker{pool: pool})
 	addDeclaredWorker[WeeklyReviewGenerateWorkspaceArgs](reg, &weeklyGenerateWorkspaceWorker{
-		engine:   weekly.NewEngine(pool),
+		// The job re-reads a snapshot it has just written when a later tick
+		// finds one already there, and that read takes the same team gate a
+		// lead's does — it runs under a MEMBER's own authority, not the system
+		// principal, so it must be able to answer the membership question.
+		engine:   weekly.NewEngine(pool, newTeammatesSeam(pool)),
 		pool:     pool,
 		users:    identity.NewService(pool),
 		now:      time.Now,

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -166,12 +166,11 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// The Morning Brief always serves on the deterministic §10.1 floor;
 		// the L2 re-order is opt-in via WithBrief (the api role's model path).
 		Handlers: briefs.NewHandlers(briefs.NewBriefEngine(pool, people.NewStore(InstallationDB(pool)))),
-		weeklyHandlers: weekly.NewHandlers(weekly.NewEngine(pool).
-			WithPlan(weeklyPlanOutcome{store: weeklyPlanStore(pool)}).
-			// Which team's week a lead may open. Unbound, every team read is
-			// refused — the team id arrives from the request, and nothing else
-			// on the row narrows it to the reader.
-			WithTeamMembers(newTeammatesSeam(pool))),
+		// The membership seam decides which team's week a lead may open: the
+		// team id arrives from the request, and nothing on the row narrows it
+		// to the reader.
+		weeklyHandlers: weekly.NewHandlers(weekly.NewEngine(pool, newTeammatesSeam(pool)).
+			WithPlan(weeklyPlanOutcome{store: weeklyPlanStore(pool)})),
 		// ONE spelling of "which Monday": the plan and the review beside it must
 		// be about the same seven days, and weekly owns that answer. A module
 		// may not import compose, so it takes the function.

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -167,7 +167,11 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// the L2 re-order is opt-in via WithBrief (the api role's model path).
 		Handlers: briefs.NewHandlers(briefs.NewBriefEngine(pool, people.NewStore(InstallationDB(pool)))),
 		weeklyHandlers: weekly.NewHandlers(weekly.NewEngine(pool).
-			WithPlan(weeklyPlanOutcome{store: weeklyPlanStore(pool)})),
+			WithPlan(weeklyPlanOutcome{store: weeklyPlanStore(pool)}).
+			// Which team's week a lead may open. Unbound, every team read is
+			// refused — the team id arrives from the request, and nothing else
+			// on the row narrows it to the reader.
+			WithTeamMembers(newTeammatesSeam(pool))),
 		// ONE spelling of "which Monday": the plan and the review beside it must
 		// be about the same seven days, and weekly owns that answer. A module
 		// may not import compose, so it takes the function.

--- a/backend/internal/compose/teammatesseam.go
+++ b/backend/internal/compose/teammatesseam.go
@@ -5,13 +5,14 @@ package compose
 
 // Who are my teammates?
 //
-// One question with three askers, in two shapes. The Worklist asks the yes/no
+// One question with four askers, in three shapes. The Worklist asks the yes/no
 // shape to decide whether a team-scoped reader may open a named person's queue;
 // coaching asks the same one to decide whether a lead may put a notice in
-// somebody's queue; the team board asks the enumerating shape to draw its rows.
-// All three read through this one seam rather than each deriving membership for
-// itself — two derivations would drift, and the pair that drifts here is "may I
-// see your day" against "may I speak into it".
+// somebody's queue; the team board asks the enumerating shape to draw its rows;
+// the team's frozen week asks the by-team-id shape, because a snapshot names a
+// team rather than a person. All four read through this one seam rather than
+// each deriving membership for itself — two derivations would drift, and the
+// pair that drifts here is "may I see your day" against "may I speak into it".
 //
 // The two shapes answer from the same predicate inside identity, which is the
 // property the board depends on: a name this seam lists is a queue the same seam
@@ -42,6 +43,13 @@ func newTeammatesSeam(pool *pgxpool.Pool) teammatesSeam {
 // caller is not an end of.
 func (t teammatesSeam) SharesLiveTeamWithCaller(ctx context.Context, other ids.UUID) (bool, error) {
 	return t.svc.SharesLiveTeamWithCaller(ctx, ids.From[ids.UserKind](other))
+}
+
+// CallerLeadsLiveTeam names a TEAM rather than a person, which is the shape the
+// frozen team week needs: its subject is a team id off the request, and the
+// question is whether the reader belongs to it.
+func (t teammatesSeam) CallerLeadsLiveTeam(ctx context.Context, team ids.UUID) (bool, error) {
+	return t.svc.CallerLeadsLiveTeam(ctx, team)
 }
 
 // LiveTeammatesOfCaller carries no caller argument for the same reason: identity

--- a/backend/internal/compose/weekly/teamreviewstore.go
+++ b/backend/internal/compose/weekly/teamreviewstore.go
@@ -150,22 +150,61 @@ func insertTeamReps(ctx context.Context, tx pgx.Tx, reviewID ids.UUID, reps []Te
 	return nil
 }
 
-// TeamReview answers one team's frozen week.
+// mayReadTeam decides whether this caller may open this team's week.
 //
-// Gated on a row scope of team or wider: a team snapshot is a team question,
-// and an own-scoped reader asking it would get a page about people whose rows
-// they cannot read. The membership itself is not re-checked here — the caller
-// resolved which teams they lead when they asked, and the snapshot names the
-// team it is about.
-func (e *Engine) TeamReview(
-	ctx context.Context, teamID ids.UUID, week time.Time,
-) (TeamReview, error) {
+// TWO QUESTIONS, and both have to be asked. The row scope says whether a team
+// snapshot is a question this reader may ask at all — an own-scoped reader
+// would get a page about people whose rows they cannot read. Membership says
+// WHICH team, and without it a lead of one team reads any other team's week by
+// changing one query parameter, because the team id arrives from the request
+// and nothing else narrows the row.
+//
+// A reader who sees every row passes without the membership question, matching
+// how attention/scope.go resolves an owner: a management seat reaches every row
+// by definition, and asking membership of it would refuse a reader the
+// row-scope predicate then admits. That set includes the system principal, so
+// the weekly job can re-read the snapshot it just wrote.
+//
+// An out-of-team lead gets ErrNotFound, not ErrPermissionDenied. A refusal that
+// distinguished "this team exists but is not yours" from "no such team" would
+// let an outsider enumerate the chart one id at a time — the same reason a
+// row-scope miss reads as 404 everywhere else in this tree.
+func (e *Engine) mayReadTeam(ctx context.Context, teamID ids.UUID) error {
 	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
-		return TeamReview{}, err
+		return err
 	}
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.Permissions.RowScope == principal.RowScopeOwn {
-		return TeamReview{}, apperrors.ErrPermissionDenied
+		return apperrors.ErrPermissionDenied
+	}
+	// auth.Unbounded rather than a RowScopeAll comparison of its own: it is the
+	// tree's one spelling of "sees every row", and it also admits the system
+	// principal — which the weekly job composes under when it re-reads a
+	// snapshot it has just written to answer idempotently.
+	if auth.Unbounded(actor) {
+		return nil
+	}
+	// Fails closed. An unbound seam is a wiring mistake, and serving the
+	// snapshot anyway would hand every lead every team's week.
+	if e.teams == nil {
+		return apperrors.ErrNotFound
+	}
+	member, err := e.teams.CallerLeadsLiveTeam(ctx, teamID)
+	if err != nil {
+		return err
+	}
+	if !member {
+		return apperrors.ErrNotFound
+	}
+	return nil
+}
+
+// TeamReview answers one team's frozen week.
+func (e *Engine) TeamReview(
+	ctx context.Context, teamID ids.UUID, week time.Time,
+) (TeamReview, error) {
+	if err := e.mayReadTeam(ctx, teamID); err != nil {
+		return TeamReview{}, err
 	}
 	var review TeamReview
 	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
@@ -193,12 +232,8 @@ func (e *Engine) LatestTeamReview(
 	if week != nil {
 		return e.TeamReview(ctx, teamID, *week)
 	}
-	if err := auth.Require(ctx, "deal", principal.ActionRead); err != nil {
+	if err := e.mayReadTeam(ctx, teamID); err != nil {
 		return TeamReview{}, err
-	}
-	actor, ok := principal.Actor(ctx)
-	if !ok || actor.Permissions.RowScope == principal.RowScopeOwn {
-		return TeamReview{}, apperrors.ErrPermissionDenied
 	}
 	var review TeamReview
 	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {

--- a/backend/internal/compose/weekly/teamreviewstore.go
+++ b/backend/internal/compose/weekly/teamreviewstore.go
@@ -162,8 +162,12 @@ func insertTeamReps(ctx context.Context, tx pgx.Tx, reviewID ids.UUID, reps []Te
 // A reader who sees every row passes without the membership question, matching
 // how attention/scope.go resolves an owner: a management seat reaches every row
 // by definition, and asking membership of it would refuse a reader the
-// row-scope predicate then admits. That set includes the system principal, so
-// the weekly job can re-read the snapshot it just wrote.
+// row-scope predicate then admits.
+//
+// It is NOT what lets the weekly job re-read the snapshot it just wrote: that
+// job composes under a MEMBER's own authority rather than the system principal,
+// deliberately, so its re-read passes the membership question like any other
+// team-scoped reader. Its engine therefore needs the seam bound.
 //
 // An out-of-team lead gets ErrNotFound, not ErrPermissionDenied. A refusal that
 // distinguished "this team exists but is not yours" from "no such team" would

--- a/backend/internal/compose/weekly/weekly_integration_test.go
+++ b/backend/internal/compose/weekly/weekly_integration_test.go
@@ -37,8 +37,12 @@ func setupWeekly(t *testing.T) *weekEnv {
 	t.Helper()
 	e := integration.Setup(t)
 	return &weekEnv{
-		Env:    e,
-		engine: NewEngine(e.Pool),
+		Env: e,
+		// No membership seam: this suite is about the PER-REP weekly, which is
+		// gated on being its own owner and never asks which team a reader is
+		// on. A seam bound here would be wiring the tests need and production
+		// does not exercise on this path.
+		engine: NewEngine(e.Pool, nil),
 		repCtx: e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms),
 	}
 }

--- a/backend/internal/compose/weekly/weeklystore.go
+++ b/backend/internal/compose/weekly/weeklystore.go
@@ -162,6 +162,24 @@ type Engine struct {
 	// no plan module is bound — the review then counts no commitments rather
 	// than failing, because a retrospective is still worth having without one.
 	plan WeekPlan
+	// teams answers whether the caller belongs to the team they are asking
+	// about. Nil FAILS CLOSED: a team read is refused rather than served
+	// unchecked, because an unbound seam is a wiring mistake and serving the
+	// snapshot anyway would hand every lead every team's week.
+	teams TeamMembers
+}
+
+// TeamMembers answers whether the caller belongs to a named team.
+//
+// The team-id half of the membership question identity already answers by user
+// id for the Worklist's owner reads. It lives behind an interface for the
+// reason WeekPlan does: this package cannot import the module that owns
+// team_membership, and what it needs is one boolean.
+type TeamMembers interface {
+	// CallerLeadsLiveTeam reports whether the acting human is a live member of
+	// this live team. False for a team that does not exist, so an outsider
+	// cannot learn which team ids are real.
+	CallerLeadsLiveTeam(ctx context.Context, team ids.UUID) (bool, error)
 }
 
 // WeekPlan settles the closing week's plan and says what it came to.
@@ -184,6 +202,13 @@ func NewEngine(pool *pgxpool.Pool) *Engine { return &Engine{pool: pool} }
 // to. Absent, the review's commitment counts stay zero.
 func (e *Engine) WithPlan(plan WeekPlan) *Engine {
 	e.plan = plan
+	return e
+}
+
+// WithTeamMembers binds the membership question the team snapshot is gated on.
+// Absent, every team read is refused.
+func (e *Engine) WithTeamMembers(teams TeamMembers) *Engine {
+	e.teams = teams
 	return e
 }
 

--- a/backend/internal/compose/weekly/weeklystore.go
+++ b/backend/internal/compose/weekly/weeklystore.go
@@ -195,20 +195,27 @@ type WeekPlan interface {
 	CloseWeek(ctx context.Context, now time.Time) (due, kept int, err error)
 }
 
-// NewEngine binds the engine to the installation pool.
-func NewEngine(pool *pgxpool.Pool) *Engine { return &Engine{pool: pool} }
+// NewEngine binds the engine to the installation pool and to the membership
+// question its team reads are gated on.
+//
+// TeamMembers is an ARGUMENT rather than a With… option, unlike WeekPlan beside
+// it, and the asymmetry is deliberate: an absent plan degrades honestly — the
+// review counts no commitments and says so — while an absent membership seam
+// refuses every team read. A caller that forgets an option gets a broken
+// snapshot job at the second tick of the week; a caller that forgets an
+// argument does not compile.
+//
+// Nil is still handled where the gate reads it, because a test may pass one to
+// assert the refusal, and a gate that trusted the constructor would be a gate
+// with a hole in it the day someone adds a second construction path.
+func NewEngine(pool *pgxpool.Pool, teams TeamMembers) *Engine {
+	return &Engine{pool: pool, teams: teams}
+}
 
 // WithPlan binds the week-ahead, so a closed review carries what the plan came
 // to. Absent, the review's commitment counts stay zero.
 func (e *Engine) WithPlan(plan WeekPlan) *Engine {
 	e.plan = plan
-	return e
-}
-
-// WithTeamMembers binds the membership question the team snapshot is gated on.
-// Absent, every team read is refused.
-func (e *Engine) WithTeamMembers(teams TeamMembers) *Engine {
-	e.teams = teams
 	return e
 }
 

--- a/backend/internal/compose/weeklymail_integration_test.go
+++ b/backend/internal/compose/weeklymail_integration_test.go
@@ -81,7 +81,7 @@ func setupWeeklyMail(t *testing.T) *mailEnv {
 		Env:   e,
 		relay: relay,
 		worker: &weeklyGenerateWorkspaceWorker{
-			engine: weekly.NewEngine(e.Pool),
+			engine: weekly.NewEngine(e.Pool, newTeammatesSeam(e.Pool)),
 			pool:   e.Pool,
 			users:  identity.NewService(e.Pool),
 			now:    func() time.Time { return weeklyMailClock },

--- a/backend/internal/compose/weeklyteamjobs.go
+++ b/backend/internal/compose/weeklyteamjobs.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose/weekly"
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -71,7 +72,7 @@ func (w *weeklyGenerateWorkspaceWorker) liveTeams(ctx context.Context) ([]liveTe
 			  FROM team t
 			  JOIN team_membership m ON m.team_id = t.id
 			  JOIN app_user u ON u.id = m.user_id
-			    AND u.deactivated_at IS NULL AND NOT u.is_agent
+			    AND `+identity.LiveMemberSQL("u")+` AND NOT u.is_agent
 			 WHERE t.archived_at IS NULL
 			 GROUP BY t.id, t.name
 			 ORDER BY t.id`)
@@ -152,7 +153,7 @@ func (w *weeklyGenerateWorkspaceWorker) teamMembers(
 		rows, err := tx.Query(ctx, `
 			SELECT u.id, u.display_name FROM team_membership m
 			  JOIN app_user u ON u.id = m.user_id
-			    AND u.deactivated_at IS NULL AND NOT u.is_agent
+			    AND `+identity.LiveMemberSQL("u")+` AND NOT u.is_agent
 			 WHERE m.team_id = $1
 			 ORDER BY u.display_name, u.id`, teamID)
 		if err != nil {

--- a/backend/internal/compose/weeklyteamjobs_integration_test.go
+++ b/backend/internal/compose/weeklyteamjobs_integration_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// Whether the team snapshot job runs at all.
+//
+// It drives snapshotTeams — the production entry point — rather than a copy of
+// its queries. That is the whole point: liveTeams filtered on an app_user
+// column that does not exist, so every run of this job errored on its first
+// statement and team_weekly_review was written by nothing. Nothing failed,
+// because nothing tested it: the table's own suite calls AssembleTeamFor
+// directly and never reaches the query that finds the teams to call it for.
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/compose/weekly"
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// teamJobClock is a Wednesday, so the week that closed is unambiguous.
+var teamJobClock = time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)
+
+// teamSnapshotWorker builds the worker the way addWeeklyReviewJobs does, so a
+// wiring mistake there is a wiring mistake here. The narrator and the mail
+// relay are omitted on purpose: both are absent by design in an installation
+// without them, and neither is what this test is about.
+func teamSnapshotWorker(e *integration.Env) *weeklyGenerateWorkspaceWorker {
+	return &weeklyGenerateWorkspaceWorker{
+		engine: weekly.NewEngine(e.Pool, newTeammatesSeam(e.Pool)),
+		pool:   e.Pool,
+		users:  identity.NewService(e.Pool),
+		now:    func() time.Time { return teamJobClock },
+		log:    slog.Default(),
+	}
+}
+
+// seedManagerRoles gives every harness seat the role a Team Lead has.
+//
+// The harness inserts app_user rows with no role assignment at all, and the job
+// resolves each acting seat's authority for real — so without this every team
+// is skipped as "a team whose members' roles do not grant reading deals", and
+// the job reports success having written nothing. That is a true refusal, and a
+// test that accepted it would be asserting the skip rather than the snapshot.
+func seedManagerRoles(t *testing.T, e *integration.Env, users ...ids.UUID) {
+	t.Helper()
+	// The harness seeds no RBAC catalog at all, so the role is created here
+	// with the shape migration 1788244324 gave the seeded manager: deal:read
+	// and a row scope that reaches a team. Both halves matter — the job needs
+	// the object grant to assemble and the team scope to re-read.
+	e.WsExec(t, `INSERT INTO role (key, name, permissions)
+	             VALUES ('team_lead_under_test', 'Team Lead', $1::jsonb)`,
+		`{"objects":{"deal":{"read":true},"person":{"read":true},`+
+			`"activity":{"read":true},"installation_settings":{"read":true}},`+
+			`"row_scope":"team"}`)
+	for _, user := range users {
+		e.WsExec(t, `INSERT INTO role_assignment (role_id, user_id)
+		             SELECT r.id, $1 FROM role r WHERE r.key = 'team_lead_under_test'`, user)
+	}
+}
+
+// THE JOB RUNS AND WRITES A ROW. Asserted through snapshotTeams rather than
+// AssembleTeamFor, because everything between the two is what was broken: the
+// query that lists the teams, the seat it acts as, and the members it counts.
+func TestTheTeamSnapshotJobWritesAWeek(t *testing.T) {
+	e := integration.Setup(t)
+	w := teamSnapshotWorker(e)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	seedManagerRoles(t, e, e.Rep1, e.Rep2, e.Rep3)
+
+	// Each member needs their own week first — a team week is a total over
+	// them, and a team whose members have no reviews counts every one unread.
+	for _, rep := range []ids.UUID{e.Rep1, e.Rep2} {
+		if _, _, err := w.engine.AssembleFor(
+			e.As(rep, []ids.UUID{e.Team1}, integration.AdminPerms), teamJobClock,
+		); err != nil {
+			t.Fatalf("writing %v's week: %v", rep, err)
+		}
+	}
+
+	if failures := w.snapshotTeams(ctx, e.WS, teamJobClock); len(failures) > 0 {
+		t.Fatalf("the team snapshot job failed: %v", failures)
+	}
+
+	if got := e.WsCount(t, `SELECT count(*) FROM team_weekly_review`); got == 0 {
+		t.Fatal("the job reported success and wrote no team week at all")
+	}
+}
+
+// AND A SECOND TICK DOES NOT FAIL. The dispatcher runs every few hours, so this
+// path re-reads a snapshot it has already written by design. That re-read takes
+// the team gate, under a MEMBER's authority rather than the system principal —
+// so a worker whose engine has no membership seam refuses its own snapshot from
+// the second tick onward, and the workspace job fails forever.
+func TestASecondTickOfTheTeamSnapshotJobSucceeds(t *testing.T) {
+	e := integration.Setup(t)
+	w := teamSnapshotWorker(e)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	seedManagerRoles(t, e, e.Rep1, e.Rep2, e.Rep3)
+
+	for _, rep := range []ids.UUID{e.Rep1, e.Rep2} {
+		if _, _, err := w.engine.AssembleFor(
+			e.As(rep, []ids.UUID{e.Team1}, integration.AdminPerms), teamJobClock,
+		); err != nil {
+			t.Fatalf("writing %v's week: %v", rep, err)
+		}
+	}
+	if failures := w.snapshotTeams(ctx, e.WS, teamJobClock); len(failures) > 0 {
+		t.Fatalf("the first tick failed: %v", failures)
+	}
+
+	if failures := w.snapshotTeams(ctx, e.WS, teamJobClock); len(failures) > 0 {
+		t.Fatalf("the second tick failed: %v", failures)
+	}
+
+	// One row per team, not one per tick.
+	if got := e.WsCount(t, `SELECT count(*) FROM team_weekly_review`); got != 2 {
+		t.Errorf("after two ticks there are %d team weeks, wanted one per team (2)", got)
+	}
+}

--- a/backend/internal/modules/identity/teams.go
+++ b/backend/internal/modules/identity/teams.go
@@ -274,6 +274,38 @@ func (s *Service) SharesLiveTeamWithCaller(ctx context.Context, other ids.UserID
 	return shares, err
 }
 
+// CallerLeadsLiveTeam reports whether the caller is a live member of a live
+// team, by the team's id.
+//
+// The team-id counterpart to SharesLiveTeamWithCaller, and it holds the same
+// posture for the same reasons: humans only, live team, live seat, and no walk
+// up parent_team_id. What differs is only which end of the membership edge the
+// caller names — a user there, a team here — so the two ask one question of one
+// table rather than disagreeing about who is on a team.
+//
+// A caller asking about a team that does not exist gets false, not an error:
+// the answer to "may I read this team" is no either way, and distinguishing the
+// two would tell an outsider which team ids are real.
+func (s *Service) CallerLeadsLiveTeam(ctx context.Context, team ids.UUID) (bool, error) {
+	if err := auth.RequireHuman(ctx); err != nil {
+		return false, err
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Type != principal.PrincipalHuman || actor.UserID.IsZero() {
+		return false, apperrors.ErrPermissionDenied
+	}
+	me := ids.From[ids.UserKind](actor.UserID)
+	var member bool
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT EXISTS (
+		         SELECT 1 FROM team_membership m
+		           JOIN team t ON t.id = m.team_id AND t.archived_at IS NULL
+		           JOIN app_user u ON u.id = m.user_id AND `+LiveMemberSQL("u")+`
+		          WHERE m.team_id = $1 AND m.user_id = $2)`, team, me).Scan(&member)
+	})
+	return member, err
+}
+
 // validTeamName trims and bounds a team name.
 func validTeamName(raw string) (string, error) {
 	name := strings.TrimSpace(raw)


### PR DESCRIPTION
A team's week is read by that team

A lead of one team could read any other team's frozen week by changing the
`team` query parameter. The response names every member of that team, their won
deals, their breached leads, and the one thing their own lead was told to raise
with them.

The row-scope check was there and correct — 403 for an own-scoped reader, as the
contract documents. What was missing is which team. `GetTeamWeeklyReview` passes
`params.Team` straight to the engine, and the snapshot row carries a `team_id`
that nothing narrowed to the reader.

TeamReview's comment said the caller had already resolved which teams they lead.
There is one caller and it does not: the id comes off the request. The comment
described an arrangement that was never built, which is why nothing looked
wrong.

`identity.CallerLeadsLiveTeam` asks the team-id half of the membership question
the tree already answers by user id, over the same table with the same posture —
humans only, live team, live seat, no walk up parent_team_id. It joins
`teammatesSeam` as its fourth asker rather than deriving membership again.

An out-of-team lead gets 404, not 403. Distinguishing "this team exists but is
not yours" from "no such team" would let an outsider enumerate the chart one id
at a time.

A reader who sees every row skips the membership question, through
`auth.Unbounded` rather than a RowScopeAll comparison of its own. That is the
tree's one spelling of it, and it also admits the system principal — which the
weekly job composes under when it re-reads the snapshot it just wrote to answer
idempotently.

An unbound seam refuses every team read. Serving anyway would hand every lead
every team's week, which is the defect being fixed.

Six integration tests, against the real identity service rather than a stub —
the question is what team_membership says, and a double would let the suite pass
over a gate that never queries it. The existing suite ran entirely under
AdminPerms, which is RowScopeAll and short-circuits membership; that is why the
leak was invisible to four tests that all looked like team tests.

MUTATION-CHECKED ONE CLAUSE AT A TIME. Removing the membership check fails both
cross-team reads while the legitimate read stays green. Removing the nil-seam
refusal fails the unbound case. Removing the unbounded short-circuit passed
everything at first — every reader in the suite happened to be a member of the
team they asked about — so the management-seat case was added, and it fails.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

---
The team snapshot job runs, and its engine can answer the gate

Two defects, found by redteaming the membership gate in the commit before this
one. One of them predates it.

THE JOB HAS NEVER RUN. `liveTeams` and `teamMembers` both filtered on
`u.deactivated_at IS NULL`. `app_user` has no such column — deactivation is a
`status` value. Every run of the team snapshot job errored on its first
statement, so `team_weekly_review` has been written by nothing in production.
Both queries now use `identity.LiveMemberSQL`, which is the tree's one spelling
of "may this person act" and what the new team gate already asks.

Nothing caught it because nothing tested the job. The table's suite calls
`AssembleTeamFor` directly and never reaches the query that finds the teams to
call it for.

THE GATE WOULD HAVE BROKEN THE JOB FROM THE SECOND TICK. The previous commit
bound the membership seam on the HTTP engine only. The dispatcher ticks every
few hours, so a later tick finds the snapshot already written and re-reads it to
answer idempotently — and that read now takes the team gate. The worker's engine
had no seam, so it would have refused its own snapshot and failed the workspace
job on every tick thereafter.

My commit message for that change said the job composes under the system
principal. It does not: `weeklyteamjobs.go` builds a HUMAN principal from a
member's own authority, and the code says why in as many words — a system
principal bypasses both the object grant and the row scope, which is exactly the
authority a snapshot must not be assembled with. The `auth.Unbounded`
short-circuit is right for a management seat and does not cover the job.

The seam is now a NewEngine argument rather than a With… option, unlike WeekPlan
beside it. The asymmetry is the point: an absent plan degrades honestly, while
an absent membership seam refuses every team read. A caller that forgets an
option gets a broken job at the second tick; a caller that forgets an argument
does not compile.

Two integration tests drive `snapshotTeams` itself rather than a copy of its
queries. Restoring the missing column fails both. Unbinding the worker's seam
passes the first tick and fails the second, which is the shape of the bug.

The test seeds a Team Lead role, because the harness seeds no RBAC catalog and
the job resolves each seat's authority for real — without it every team is
skipped as ungranted and the job reports success having written nothing, which
is a test asserting the skip rather than the snapshot.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

---
The gate's comment names the reader that actually skips the question

The system principal is not what lets the weekly job re-read its own snapshot —
that job composes under a member's authority on purpose, and the comment said
otherwise.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Team weekly reviews no longer let a lead read another team’s frozen week by changing the `team` parameter; reads now require live membership, while management seats retain access and out-of-team requests return 404. The snapshot job now uses the valid live-member predicate and the same membership gate, so it can write and re-read team snapshots reliably.

**Bug Fixes**

- Applies the gate to both latest and explicitly dated team review reads.
- Fails closed when the membership dependency is not wired.
- Adds integration coverage for cross-team access, management access, and first and subsequent snapshot-job runs.

<sup>Written for commit 7376f762f47741258b5f6adbce1a0eac86b6a521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Team-scoped leads can access weekly reviews only for teams they belong to.
  - Management users with broader access can review teams outside their membership.
  - Team names cannot be used to bypass team access restrictions.
  - Unauthorized or unavailable team access is safely reported as not found.

- **Reliability**
  - Automated team weekly snapshots now create reviews consistently and can run repeatedly without duplicate results.
  - Weekly processing uses active team members and excludes agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->