### PR TITLE
The drawer opens the message instead of falling over

### DIFF
--- a/backend/internal/compose/integration/emailpresentation_integration_test.go
+++ b/backend/internal/compose/integration/emailpresentation_integration_test.go
@@ -7,7 +7,11 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"os"
+	"regexp"
+	"strings"
 	"testing"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
@@ -23,6 +27,10 @@ import (
 // each kind of reader, and then the state machines that are not audiences at
 // all — statutory retention, a non-email row, blind recipients — kept separate
 // because folding them into the matrix would multiply cases that share no rule.
+
+// The contract, from this package's directory: the wire-shape test below reads
+// which properties it declares required rather than keeping its own list.
+const contractPathForLists = "../../../api/crm.yaml"
 
 // logEmailActivity logs one email against a contact and answers its id.
 func logEmailActivity(author context.Context, t *testing.T, e *Env, contact ids.UUID, subject, body string) ids.ActivityID {
@@ -306,4 +314,115 @@ func TestEmailSummaryRidesEveryActivityRow(t *testing.T) {
 	if call.EmailSummary != nil {
 		t.Error("a call carries an email_summary; only an email has an email's shape")
 	}
+}
+
+// TestEveryRequiredListReachesTheWireAsAList holds the difference between an
+// empty list and a missing one, ON THE WIRE.
+//
+// The contract makes `from`, `to`, `cc`, `bcc`, `attachments` and `links`
+// required, so a viewer is entitled to treat each as a list and read its
+// length without asking whether it is there. A nil Go slice marshals to `null`,
+// which satisfies neither the contract nor that reader.
+//
+// It went wrong exactly where nothing was appended: a message with nobody in
+// copy left `cc` nil, and the drawer crashed on `parties.length` the moment
+// anybody opened one. Every unit test passed — they assert Go structs, where a
+// nil slice and an empty one both have length zero and read identically. Only
+// the encoded bytes tell them apart, so this test encodes.
+func TestEveryRequiredListReachesTheWireAsAList(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+
+	// A message with no CC, no BCC and no attachments — the ordinary shape,
+	// and the one whose empty lists are all built by appending nothing.
+	id := logEmailActivity(author, t, e, contact, "Q3 renewal terms",
+		"Können wir Dienstag sprechen?")
+	got, err := e.Activities.GetEmailPresentation(author, id, nil)
+	if err != nil {
+		t.Fatalf("presentation: %v", err)
+	}
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("encoding the presentation: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("decoding the presentation: %v", err)
+	}
+
+	// Derived from the contract's own `required` rather than typed out here:
+	// a seventh required list would otherwise be added with nothing checking
+	// it, which is how the sixth arrived.
+	for _, field := range requiredListFields(t, "EmailPresentation") {
+		raw, ok := wire[field]
+		if !ok {
+			t.Errorf("%s is required and was not sent at all", field)
+			continue
+		}
+		if string(raw) == "null" {
+			t.Errorf("%s reached the wire as null; the contract requires a list, "+
+				"and a viewer reading its length crashes on this", field)
+		}
+	}
+}
+
+// requiredListFields answers the ARRAY properties a schema marks required.
+//
+// Derived from the contract rather than listed here on purpose: a list typed
+// out in a test only holds the fields somebody remembered, and the field that
+// broke the drawer would have been exactly the one nobody added.
+func requiredListFields(t *testing.T, schema string) []string {
+	t.Helper()
+	source, err := os.ReadFile(contractPathForLists)
+	if err != nil {
+		t.Fatalf("reading the contract: %v", err)
+	}
+	schemaLine := regexp.MustCompile(`^    ([A-Za-z][A-Za-z0-9]*):\s*$`)
+	requiredLine := regexp.MustCompile(`^      required:\s*\[(.*)\]\s*$`)
+	propertyLine := regexp.MustCompile(`^        ([a-z][a-z0-9_]*):\s*$`)
+	var required []string
+	arrays := map[string]bool{}
+	inSchema := false
+	current := ""
+	for _, line := range strings.Split(string(source), "\n") {
+		if match := schemaLine.FindStringSubmatch(line); match != nil {
+			inSchema = match[1] == schema
+			current = ""
+			continue
+		}
+		if !inSchema {
+			continue
+		}
+		if match := requiredLine.FindStringSubmatch(line); match != nil {
+			for _, name := range strings.Split(match[1], ",") {
+				required = append(required, strings.TrimSpace(name))
+			}
+			continue
+		}
+		if match := propertyLine.FindStringSubmatch(line); match != nil {
+			current = match[1]
+			continue
+		}
+		if current != "" && strings.TrimSpace(line) == "type: array" {
+			arrays[current] = true
+		}
+	}
+	if len(required) == 0 {
+		t.Fatalf("%s declares no required properties — this test is judging nothing", schema)
+	}
+	var out []string
+	for _, name := range required {
+		if arrays[name] {
+			out = append(out, name)
+		}
+	}
+	// A census that can fail short has already failed: with the parse broken
+	// this would walk an empty set and report PASS over every field at once.
+	if len(out) == 0 {
+		t.Fatalf("%s declares no required ARRAY property — either the contract "+
+			"changed shape or this parse no longer reads it", schema)
+	}
+	return out
 }

--- a/backend/internal/modules/activities/emailpresentation.go
+++ b/backend/internal/modules/activities/emailpresentation.go
@@ -390,7 +390,16 @@ func readEmailParties(ctx context.Context, tx pgx.Tx, id ids.ActivityID) (emailP
 	}
 	defer rows.Close()
 
-	var out emailParties
+	// Empty, not nil. Every one of these four is `required` in the contract, and
+	// a nil slice marshals to `null` rather than `[]` — so a message with
+	// nobody in copy served a null the viewer is entitled to treat as a list.
+	// It read `.length` off it and the drawer died where the message should be.
+	out := emailParties{
+		from: emptyParties(),
+		to:   emptyParties(),
+		cc:   emptyParties(),
+		bcc:  emptyParties(),
+	}
 	for rows.Next() {
 		var role, address string
 		var personID, userID *ids.UUID

--- a/frontend/e2e/person-record.spec.ts
+++ b/frontend/e2e/person-record.spec.ts
@@ -1,0 +1,211 @@
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * The contact page against a LIVE stack, loaded in a real browser.
+ *
+ * This suite exists because the person page shipped a white "This view stopped
+ * working" card and every unit test was green. The unit tests render the memory
+ * card against fixtures the author wrote; nothing rendered the PAGE against the
+ * payload the server actually sends, so a field the fixtures always included
+ * and the server sometimes omits took the whole route down.
+ *
+ * So the rule this file holds is narrow and worth stating: the page LOADS, on
+ * real data, with no uncaught error. Not what it looks like — the design suites
+ * do that — but that a reader who clicks a contact sees the contact.
+ *
+ * It runs only with BASE_URL and a real contact id, and it fails loudly rather
+ * than skipping when one is set without the other: a half-configured run that
+ * quietly passes is the exact failure the suite was written to stop.
+ */
+
+const BASE_URL = process.env.BASE_URL;
+const PERSON = process.env.E2E_PERSON;
+
+if (BASE_URL && !PERSON) {
+  throw new Error(
+    "BASE_URL is set but E2E_PERSON is not — point it at a contact id on that stack",
+  );
+}
+
+const live = test.describe[BASE_URL ? "serial" : "skip"];
+
+async function signIn(page: Page) {
+  await page.goto("/#/login", { waitUntil: "networkidle" });
+  const email = page
+    .locator('input[type="email"], input[name="email"]')
+    .first();
+  if ((await email.count()) === 0) {
+    return;
+  }
+  await email.fill(process.env.E2E_EMAIL ?? "admin@demo.test");
+  await page
+    .locator('input[type="password"], input[name="password"]')
+    .first()
+    .fill(process.env.E2E_PASSWORD ?? "demo-password-123");
+  await page.locator('button[type="submit"]').first().click();
+  await expect(page.locator("nav.rail").first()).toBeVisible();
+}
+
+live("the contact page on live data", () => {
+  test("loads without falling over", async ({ page }) => {
+    // Every uncaught error, not only the one that happens to reach the DOM. A
+    // boundary that catches a render crash draws a tidy card, so asserting on
+    // what is visible alone can pass over a page that is entirely broken.
+    const crashes: string[] = [];
+    page.on("pageerror", (e) => crashes.push(e.stack ?? e.message));
+
+    await signIn(page);
+    await page.goto(`/#/contacts/${PERSON}`, { waitUntil: "networkidle" });
+
+    // The error boundary's own words, in the three catalogs it can render in.
+    // Asserting the boundary is ABSENT is the whole test: it is what the
+    // reader saw instead of the page.
+    await expect(
+      page.getByText(
+        /stopped working|nicht mehr|ngừng hoạt động/i,
+      ),
+    ).toHaveCount(0);
+    expect(crashes, `uncaught error on the contact page:\n${crashes[0]}`).toEqual([]);
+
+    // And something of the contact is actually drawn, so the assertion above
+    // cannot pass over a blank page that merely failed quietly.
+    await expect(page.locator("main")).not.toBeEmpty();
+  });
+
+  test("draws its retained email as the canonical row", async ({ page }) => {
+    await signIn(page);
+    await page.goto(`/#/contacts/${PERSON}`, { waitUntil: "networkidle" });
+
+    // The row the whole unification arc is about. One is enough: this asserts
+    // the canonical component is MOUNTED on real data, which is the half the
+    // unit tests cannot see.
+    await expect(page.locator(".emailentry").first()).toBeVisible();
+  });
+
+  // Opening the message, which is where it actually broke.
+  //
+  // The drawer crashed on every message with nobody in copy — the server sent
+  // `cc: null` for a field the contract makes required, and the viewer read
+  // `.length` off it. Every unit test passed: they assert Go structs and
+  // hand-written fixtures, where nil and empty are indistinguishable and the
+  // author always fills the field in.
+  //
+  // Asserting on `pageerror` alone does NOT catch this. React's error boundary
+  // catches a render crash and draws a tidy card, so the page reports no
+  // uncaught error while showing the reader nothing. The boundary's own words
+  // are what has to be absent.
+  test("opens the message in a drawer over the record", async ({ page }) => {
+    await signIn(page);
+    await page.goto(`/#/contacts/${PERSON}`, { waitUntil: "networkidle" });
+    const address = page.url();
+
+    // The OPENABLE row, which is a button; a row the reader may not open is a
+    // div of the same class. Clicking `.emailentry` first-of-any picks
+    // whichever came back first, and on a contact whose newest message is
+    // withheld that is a div — the click does nothing, no drawer opens, no
+    // crash happens, and the test passes having exercised none of this. It
+    // did exactly that against a live null-cc build before this locator was
+    // narrowed.
+    const openable = page.locator("button.emailentry--open").first();
+    await expect(openable).toBeVisible();
+    await openable.click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    // The MESSAGE, not merely the dialog around it. The crash was inside
+    // PartyLine, so the error boundary replaced the drawer's body while the
+    // modal shell — title, close button — kept rendering perfectly: a test
+    // that stopped at `dialog` is visible reported success over a reader
+    // staring at "This view stopped working".
+    //
+    // The recipient line is the assertion because it is what broke: it is
+    // drawn from the four party lists the server sends, and a null in any of
+    // them takes it down.
+    await expect(page.locator(".emaildetail__parties")).toBeVisible();
+    await expect(
+      page.getByText(/stopped working|funktioniert nicht mehr|ngừng hoạt động/i),
+    ).toHaveCount(0);
+
+    // A drawer OVER the record, not a page instead of it: the address does not
+    // change and the shell stays drawn behind it. A modal that navigated would
+    // lose the reader's place in the record they are working on.
+    expect(page.url()).toBe(address);
+    await expect(page.locator("nav.rail").first()).toBeVisible();
+  });
+
+  // EVERY tab, because the page is seven screens behind one address and a
+  // reader reaches the other six by clicking. Testing only the one the URL
+  // opens on is how a broken tab ships under a green suite.
+  for (const tab of [
+    "overview",
+    "timeline",
+    "network",
+    "deals",
+    "meetings",
+    "research",
+    "documents",
+  ]) {
+    test(`the ${tab} tab loads without falling over`, async ({ page }) => {
+      const crashes: string[] = [];
+      page.on("pageerror", (e) => crashes.push(e.stack ?? e.message));
+
+      await signIn(page);
+      await page.goto(`/#/contacts/${PERSON}/${tab}`, {
+        waitUntil: "networkidle",
+      });
+
+      await expect(
+        page.getByText(/stopped working|nicht mehr|ngừng hoạt động/i),
+      ).toHaveCount(0);
+      expect(
+        crashes,
+        `uncaught error on the ${tab} tab:\n${crashes[0]}`,
+      ).toEqual([]);
+    });
+  }
+});
+
+/**
+ * The other two surfaces the same arc changed, opened in a real browser for
+ * the same reason: the account page's recent-exchange list and the held
+ * threads table both draw a message, and the account's rows open the same
+ * drawer.
+ *
+ * They are here rather than in files of their own because the claim is one
+ * claim — a reader clicks a message and reads it — and the null that crashed
+ * the contact page would have taken all three down together.
+ */
+live("the other surfaces that draw a message", () => {
+  test("the account page loads and opens its messages", async ({ page }) => {
+    test.skip(!process.env.E2E_ORG, "set E2E_ORG to an account on this stack");
+    await signIn(page);
+    await page.goto(`/#/companies/${process.env.E2E_ORG}`, {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.getByText(/stopped working|nicht mehr|ngừng hoạt động/i),
+    ).toHaveCount(0);
+
+    const row = page.locator(".emailentry").first();
+    // An account with no retained mail says nothing about the drawer, and
+    // failing here would be reporting on the seed rather than on the code.
+    if ((await row.count()) === 0) {
+      return;
+    }
+    const address = page.url();
+    await row.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(
+      page.getByText(/stopped working|nicht mehr|ngừng hoạt động/i),
+    ).toHaveCount(0);
+    expect(page.url()).toBe(address);
+  });
+
+  test("the held threads screen loads", async ({ page }) => {
+    await signIn(page);
+    await page.goto("/#/settings/held-threads", { waitUntil: "networkidle" });
+    await expect(
+      page.getByText(/stopped working|nicht mehr|ngừng hoạt động/i),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Lars opened a contact, clicked a message, and got a white "This view stopped
working" card. Every unit test was green and always would have been.

## The defect

`readEmailParties` accumulates by appending, so a message with **nobody in CC**
left the slice nil — and a nil Go slice marshals to `null`. The contract makes
`from`, `to`, `cc` and `bcc` required, so the viewer is entitled to treat each
as a list. `PartyLine` read `parties.length` off the null and the drawer died.

Every email without a CC was affected, which on the demo data is most of them.

## Why nothing caught it

**The Go tests assert structs.** A nil slice and an empty one both have length
zero and compare identically; only the encoded bytes tell them apart.

**The frontend tests use fixtures the author wrote**, and those always filled
the field in.

**Nothing had ever opened the page in a browser.** That is the honest summary.

## The tests that would have caught it

`TestEveryRequiredListReachesTheWireAsAList` encodes the presentation and
asserts on the JSON. It reads *which* fields must be lists from the contract's
own `required` rather than keeping its own list — a hand-maintained one holds
the fields somebody remembered, and the field that broke this is exactly the
one nobody would have added. It fails on the old code naming both `cc` and
`bcc`.

`e2e/person-record.spec.ts` loads the contact page and **all seven tabs**
against a live stack, opens a message, and covers the account page and held
threads.

Three things about that suite are load-bearing, and I learned each by watching
an earlier version of it pass over the live bug:

- **Asserting on `pageerror` is not enough.** React's error boundary catches a
  render crash and draws a tidy card, so the page reports no uncaught error
  while showing the reader nothing.
- **`.emailentry` is on both an openable row (a `button`) and one the reader
  may not open (a `div`).** Clicking first-of-any picked the div on a contact
  whose newest message is withheld — no drawer, no crash, green.
- **The dialog opening proves nothing.** The crash was *inside* the drawer, so
  the modal shell rendered perfectly while the boundary replaced its body. The
  assertion has to be on the message itself.

With all three corrected, the suite fails against the null-cc build and passes
against this one.

## On the modal

The drawer already is a `Modal placement="right"` over the record — the URL
does not change and the shell stays behind it. What looked like a new page was
the modal opening and its body immediately crashing. The e2e test now asserts
the address is unchanged and the nav rail is still visible.

## Gates

`make check-backend`, `make check-fe`, the compose integration lane, craft
static (0 findings), rls-store-path and the jurisdiction gate. 12/12 e2e
against a live stack.

One unrelated flake seen once in `company-act.test.tsx` (onboarding, untouched
by this diff): fails under full-suite load, passes in isolation and on rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the email drawer crashing on messages with no CC or BCC recipients. Opening a message now shows the message instead of the white "This view stopped working" card.

**Bug Fixes**
- Nil Go slices for required party lists encoded as `null`, and the viewer read `.length` off them.
- All four party lists are now initialized empty so they reach the wire as `[]`.

**Tests**
- Adds a backend test that encodes the presentation and checks every list the contract requires, using the contract's own `required` list.
- Adds a live-stack e2e suite that opens the contact page, all tabs, and the message drawer, and covers the account page and held threads.

<sup>Written for commit bcdc8f99bd9664e7e5f4a3b935002f09819b5ea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty email recipient fields are now returned as empty lists instead of `null`, improving consistency for email integrations and API consumers.

- **Tests**
  - Added integration coverage to verify required list fields are always present and serialized correctly.
  - Added end-to-end coverage for contact records, message drawers, contact tabs, account messages, and held threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->