### PR TITLE
The credential relocation says when it happened

### DIFF
--- a/backend/internal/compose/integration/capture/keyvault_capture_integration_test.go
+++ b/backend/internal/compose/integration/capture/keyvault_capture_integration_test.go
@@ -18,11 +18,14 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	capturemod "github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/keyvault"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -187,6 +190,89 @@ func TestLocalVaultIsolationAndWrongKeyOnRealPostgres(t *testing.T) {
 	}
 }
 
+// systemLogDetails reads the detail payloads this pass filed under one action.
+//
+// Straight from the table rather than through a reader, because there is no
+// reader: system_log is an operator's ledger with no API surface, which is
+// exactly why nothing would have noticed the rows being absent.
+func systemLogDetails(t *testing.T, e *integration.SearchEnv, action string) []map[string]any {
+	t.Helper()
+	rows, err := e.Owner.Query(context.Background(),
+		`SELECT detail FROM system_log WHERE action = $1 ORDER BY id`, action)
+	if err != nil {
+		t.Fatalf("reading the %s ledger: %v", action, err)
+	}
+	defer rows.Close()
+	var out []map[string]any
+	for rows.Next() {
+		var detail map[string]any
+		if err := rows.Scan(&detail); err != nil {
+			t.Fatalf("decoding a %s detail: %v", action, err)
+		}
+		out = append(out, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the %s ledger: %v", action, err)
+	}
+	return out
+}
+
+// Two workers booting at once relocate one credential once, and record it once.
+//
+// The pass reads its work list in one transaction and claims each row in
+// another, so between the two a second boot can take the row — its UPDATE
+// carries `AND credential_ref IS NULL` and simply matches nothing. That loser
+// must file no ledger row: the relocation is the fact, and a row per boot that
+// tried would make an operator scanning for when a credential moved read one
+// entry per worker.
+//
+// The assertion does not depend on WHICH boot wins, which is what keeps this
+// from being a coin flip: exactly one relocation is possible, so exactly one
+// ledger row is the answer either way.
+func TestTwoBootsRelocateOneCredentialOnce(t *testing.T) {
+	e := integration.SetupSearch(t)
+	vault := newTestKeyvault(t, e)
+	first := newTestCaptureRegistry(e, vault)
+	first.Register(&authAssertingFake{})
+	second := newTestCaptureRegistry(e, vault)
+	second.Register(&authAssertingFake{})
+
+	connID := ids.NewV7()
+	if _, err := e.Owner.Exec(context.Background(), `
+		INSERT INTO capture_connection (id, provider, user_id, scopes, status, auth)
+		VALUES ($1, 'graph', $2, $3, 'connected', $4)`,
+		connID, e.Rep1, []string{string(principal.ScopeRead)}, []byte("granted-token")); err != nil {
+		t.Fatalf("seeding the legacy connection: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	counts := make([]int, 2)
+	errs := make([]error, 2)
+	for i, registry := range []*capturemod.Registry{first, second} {
+		wg.Add(1)
+		go func(slot int, r *capturemod.Registry) {
+			defer wg.Done()
+			counts[slot], errs[slot] = r.BackfillCredentials(context.Background())
+		}(i, registry)
+	}
+	wg.Wait()
+
+	for slot, err := range errs {
+		if err != nil {
+			t.Fatalf("boot %d: %v", slot, err)
+		}
+	}
+	// One row, one relocation, however the two interleaved.
+	if total := counts[0] + counts[1]; total != 1 {
+		t.Errorf("the two boots between them migrated %d rows, want 1 — the claim is "+
+			"conditional on credential_ref still being null", total)
+	}
+	if rows := systemLogDetails(t, e, "capture_credential_relocated"); len(rows) != 1 {
+		t.Errorf("the two boots filed %d ledger row(s), want 1 — the boot that lost the "+
+			"row moved nothing and has nothing to record", len(rows))
+	}
+}
+
 func TestBackfillMigratesLegacyAuthRowOntoTheVault(t *testing.T) {
 	e := integration.SetupSearch(t)
 	vault := newTestKeyvault(t, e)
@@ -236,6 +322,32 @@ func TestBackfillMigratesLegacyAuthRowOntoTheVault(t *testing.T) {
 		t.Fatalf("vault does not hold the migrated credential: got %q err %v", got, err)
 	}
 
+	// The relocation is in the ledger, and it is the only ledger that can hold
+	// it: the row is not pending so no decision lane sees it, and the pass files
+	// no audit row on purpose — the credential VALUE did not change, so "who set
+	// this credential" is still the connect row's answer. What was missing was
+	// WHEN the bytes moved, which is what an operator debugging a connection
+	// that broke across a deploy needs (#2552).
+	relocations := systemLogDetails(t, e, "capture_credential_relocated")
+	if len(relocations) != 1 {
+		t.Fatalf("the relocation filed %d system_log row(s), want 1 — the one writer that "+
+			"repoints a live connection at new ciphertext left no trace of when", len(relocations))
+	}
+	if got := relocations[0]["connection_id"]; got != connID.String() {
+		t.Errorf("the ledger names connection %v, want %s", got, connID)
+	}
+	if got := relocations[0]["credential_ref"]; got != *credentialRef {
+		t.Errorf("the ledger names ref %v, want the one on the row (%s) — an operator "+
+			"correlates the two", got, *credentialRef)
+	}
+	// And never the material. The bytes are the whole reason this moved into a
+	// vault, so a ledger anybody can read must not carry them.
+	for key, value := range relocations[0] {
+		if text, ok := value.(string); ok && strings.Contains(text, "granted-token") {
+			t.Errorf("the ledger's %s carries the credential itself: %q", key, text)
+		}
+	}
+
 	// A second backfill is a no-op: the row already carries a ref.
 	migrated, err = registry.BackfillCredentials(context.Background())
 	if err != nil {
@@ -243,6 +355,14 @@ func TestBackfillMigratesLegacyAuthRowOntoTheVault(t *testing.T) {
 	}
 	if migrated != 0 {
 		t.Fatalf("idempotent backfill migrated %d rows on the second run, want 0", migrated)
+	}
+	// And it files nothing either. The pass runs on EVERY boot, so a ledger
+	// that recorded each run would count restarts rather than relocations —
+	// and an operator scanning for when a credential moved would find one
+	// entry per deploy since.
+	if again := systemLogDetails(t, e, "capture_credential_relocated"); len(again) != 1 {
+		t.Errorf("after a second boot the ledger holds %d row(s), want the one relocation — "+
+			"the pass runs every boot and only the move is a fact", len(again))
 	}
 
 	// Sync now resolves the migrated credential through the vault.

--- a/backend/internal/modules/capture/credentialbackfill.go
+++ b/backend/internal/modules/capture/credentialbackfill.go
@@ -5,9 +5,24 @@ package capture
 
 // The one-time relocation of connector credentials off the legacy
 // capture_connection.auth bytea column and into the keyvault, run on every
-// boot until the column can be dropped. It is a raw relocation of bytes
-// already in the tenant's own store, not a domain mutation: no record changes
-// meaning, so it carries no audit or event.
+// boot until the column can be dropped.
+//
+// It is a raw relocation of bytes already in the tenant's own store, not a
+// domain mutation: no record changes meaning, so it files no audit row and no
+// event. That posture stays, and it is why "who set this credential" is still
+// answered by the connect row that set it.
+//
+// What it DOES file is a system_log entry, because the posture was being read
+// as "and therefore nothing is recorded" — and it left the one path that
+// repoints a live connection at new ciphertext as the only writer of
+// credential_ref with no trace of when it happened. Every sibling records
+// something: connect and reconnect, channelconn, integrations, overlay and the
+// two settings seals all write audit rows, and extsecrets writes system_log for
+// exactly this shape. An operator debugging a connection that broke across a
+// deploy had no ledger to read. margince/margince#2552.
+//
+// system_log rather than audit_log, matching extsecrets: a timestamped record
+// that bytes moved, without filing a domain act nobody performed.
 
 import (
 	"context"
@@ -16,9 +31,27 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 )
+
+// CredentialBackfillActor names this pass on its ledger rows. A system id
+// rather than a person, for the reason the rows exist: an operator reading the
+// trail has to be able to tell bytes the BOOT relocated from a credential a
+// colleague connected, and those are the two things that write this column.
+const CredentialBackfillActor = "system:capture-credential-backfill"
+
+// detailConnectionID is the ledger key naming which connection moved. A
+// constant because three writers in this package spell it — the rotation
+// ledger, the sync-state log and this one — and an operator correlating them
+// matches on it.
+const detailConnectionID = "connection_id"
+
+// actionCredentialRelocated is the system_log action this pass files. Named as
+// a constant because the ledger is read by matching on it, and a literal at the
+// one call site is a string a reader has to find twice to trust.
+const actionCredentialRelocated = "capture_credential_relocated"
 
 // BackfillCredentials migrates every legacy capture_connection row whose
 // credential still lives in the auth bytea column onto the vault: it seals the
@@ -46,10 +79,22 @@ func (r *Registry) BackfillCredentials(ctx context.Context) (int, error) {
 	total := 0
 	var errs error
 	for _, wsID := range workspaces {
-		// The backfill's UPDATE runs under the workspace GUC only (a raw
-		// relocation, not an audited domain write), so no actor/correlation
-		// context is set — nothing here reads it.
+		// The pass names ITSELF as the actor. Nobody asked for this — it is
+		// the boot noticing a legacy row — so binding a human would put
+		// somebody's name on a move they did not make, and the ledger's whole
+		// value is telling a relocation apart from a connect.
+		//
+		// A bound actor is also storekit.LogSystem's precondition: it refuses
+		// rather than guessing, which is what made this the one credential_ref
+		// writer with no ledger row until the actor arrived with it.
+		//
+		// The correlation id groups one boot's relocations as the single pass
+		// they are, exactly as the expiry sweep's does for one tick.
 		wsCtx := principal.WithWorkspaceID(ctx, wsID)
+		wsCtx = principal.WithCorrelationID(wsCtx, ids.NewV7())
+		wsCtx = principal.WithActor(wsCtx, principal.Principal{
+			Type: principal.PrincipalSystem, ID: CredentialBackfillActor,
+		})
 		migrated, err := r.backfillWorkspace(wsCtx, ids.From[ids.WorkspaceKind](wsID))
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("capture: backfilling workspace %s: %w", wsID, err))
@@ -107,7 +152,36 @@ func (r *Registry) backfillWorkspace(ctx context.Context, ws ids.WorkspaceID) (i
 				return err
 			}
 			claimed = ct.RowsAffected() == 1
-			return nil
+			if !claimed {
+				// Another boot won the row: the UPDATE carries `AND
+				// credential_ref IS NULL` and matched nothing. Nothing moved
+				// here, so nothing is recorded — a line per losing racer would
+				// make the ledger count boots rather than relocations.
+				//
+				// NOT PROVEN BY A TEST, and worth saying so rather than
+				// implying otherwise. TestTwoBootsRelocateOneCredentialOnce
+				// runs two passes concurrently and holds the pair to one
+				// relocation and one row, which is the claim that matters — but
+				// it cannot force the interleaving that reaches THIS branch,
+				// because the window is between the work-list read and the
+				// claim, and forcing it would mean a hook in this function
+				// whose only caller is a test. So the branch is reasoned from
+				// the UPDATE's own predicate rather than demonstrated.
+				return nil
+			}
+			// INSIDE the same transaction as the UPDATE, so a recorded
+			// relocation is one that actually committed — the reason
+			// extsecrets logs inside its caller's transaction too. The detail
+			// names the connection and the workspace and never the material:
+			// the ciphertext ref is the thing an operator needs to correlate
+			// with the vault, and the bytes are what must not appear in a
+			// ledger anybody can read.
+			_, err = storekit.LogSystem(ctx, tx, actionCredentialRelocated, map[string]any{
+				detailConnectionID: l.id.String(),
+				"workspace_id":     ws.String(),
+				"credential_ref":   string(ref),
+			})
+			return err
 		})
 		if err != nil {
 			return migrated, err

--- a/backend/internal/modules/capture/registry_rotation.go
+++ b/backend/internal/modules/capture/registry_rotation.go
@@ -150,9 +150,9 @@ func (s rotationSink) record(ctx context.Context, ref keyvault.Ref) (superseded 
 		// The secret is never a detail field. The refs are opaque addresses,
 		// and they are what a reader needs to follow the chain.
 		_, logErr := storekit.LogSystem(ctx, tx, "capture.credential_rotated", map[string]any{
-			"connection_id":  s.connectionID.String(),
-			"credential_ref": string(ref),
-			"replaced_ref":   previous,
+			detailConnectionID: s.connectionID.String(),
+			"credential_ref":   string(ref),
+			"replaced_ref":     previous,
 		})
 		return logErr
 	})

--- a/backend/internal/modules/capture/syncstate.go
+++ b/backend/internal/modules/capture/syncstate.go
@@ -179,10 +179,10 @@ func (r *Registry) recordSyncFailure(ctx context.Context, connectionID ids.UUID,
 		// The class is on the row; the detail belongs to the operational
 		// ledger (0078's rationale, kept).
 		if _, err := storekit.LogSystem(ctx, tx, "capture_sync_error", map[string]any{
-			"connection_id": connectionID.String(),
-			"class":         string(class),
-			"failures":      failures,
-			"detail":        syncErr.Error(),
+			detailConnectionID: connectionID.String(),
+			"class":            string(class),
+			"failures":         failures,
+			"detail":           syncErr.Error(),
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes #2552, taking the ticket's recommended resolution.

## What was wrong

`BackfillCredentials` repoints a live connection at new ciphertext on **every worker boot** and recorded nothing — no audit row, no `system_log`, no event. It was the only writer of `capture_connection.credential_ref` that left no trace, against the six-plus siblings the ticket tabulates.

## What lands

`storekit.LogSystem`, not `Audit` — the ticket's recommendation, matching `platform/extsecrets/store.go`, which already documents this exact shape (bytes relocated, no domain fact moved). That keeps the tree's answer to *"what does a non-domain secret move record?"* as one answer instead of two.

**The file's posture stays and is right.** A raw relocation of bytes already in the tenant's own store is not a domain mutation, so *"who set this credential"* is still the connect row's answer. What the posture was being *read* as is "and therefore nothing is recorded" — which left an operator debugging a connection that broke across a deploy with no ledger at all.

Filed **inside the UPDATE's own transaction**, so a recorded relocation is one that committed — the reason `extsecrets` logs inside its caller's transaction too.

**The pass names itself as the actor** (`system:capture-credential-backfill`). Nobody asked for this; it is the boot noticing a legacy row, so a human actor would put somebody's name on a move they did not make — and telling a relocation apart from a connect is the ledger's whole value. A bound actor is also `LogSystem`'s precondition: it refuses rather than guessing, which is part of why this writer had no row until the actor arrived with it.

The detail names the connection, the workspace and the ref, **never the material**.

## Evidence — three mutations, each caught

| mutation | result |
|---|---|
| file no ledger row | `the relocation filed 0 system_log row(s), want 1` |
| put the credential in the detail | `the ledger's leaked carries the credential itself: "granted-token"` |
| file a row on every boot | `after a second boot the ledger holds 2 row(s), want the one relocation` |

That last one matters because the pass runs on every boot: a ledger recording each run would count restarts rather than relocations, and an operator scanning for when a credential moved would find one entry per deploy since.

## One branch I could not prove, stated rather than implied

The losing side of a two-boot race files nothing. `TestTwoBootsRelocateOneCredentialOnce` runs two passes concurrently and holds the pair to one relocation and one ledger row — which is the claim that matters, and its assertion does not depend on who wins. But it **cannot force the interleaving that reaches that branch**: the window is between the work-list read and the claim, and forcing it would need a hook in production code whose only caller is a test. The doc comment says exactly this, and reasons the branch from the UPDATE's own `AND credential_ref IS NULL` predicate instead of claiming a test covers it.

Also folded in: `goconst` wanted `"connection_id"` named, so the ledger key three writers in this package spell is now one constant.

`make check-backend` exit 0; `modules/capture` and the `capture` integration subpackage green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - System activity logs now record successful capture credential relocations, including the related connection, workspace, and credential reference.
  - Concurrent credential relocations are handled safely, producing only one relocation log entry.

- **Bug Fixes**
  - Repeated credential backfills no longer create duplicate activity entries.
  - Credential material is excluded from relocation logging.
  - Capture rotation and synchronization logs now use consistent connection identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->