### PR TITLE
The overlay flip runs on one workspace handle

### DIFF
--- a/backend/gates/agentgrantscopes_test.go
+++ b/backend/gates/agentgrantscopes_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -197,10 +198,17 @@ func between(src, from, to string) string {
 	return rest
 }
 
+// sortedKeys is the set's keys in a stable order.
+//
+// It really does sort now. Both callers put the result in a FAILURE MESSAGE,
+// and map iteration order is randomised per run — so the same finding read
+// differently every time, which is how somebody comparing two runs concludes
+// the tree moved when only the map did.
 func sortedKeys(set map[string]bool) []string {
 	out := make([]string, 0, len(set))
 	for k := range set {
 		out = append(out, k)
 	}
+	sort.Strings(out)
 	return out
 }

--- a/backend/gates/fliponehandle_test.go
+++ b/backend/gates/fliponehandle_test.go
@@ -51,13 +51,21 @@ func TestTheOverlayFlipLaneResolvesOneWorkspaceHandle(t *testing.T) {
 	// silently matched no file at all, or if the lane stopped resolving a
 	// handle by any route.
 	//
-	// Counted PER FUNCTION, not per file. Two resolutions in flip.go is the
-	// correct shape and always was: the parity dry-run is its own operation —
-	// zero-write, no run id, no operator — and Execute is another. What must
-	// never happen is one operation resolving twice, because that is the
-	// divergence itself rather than a route to it. A file-wide count of one
-	// would fail today and say nothing about the invariant; a file-wide count
-	// of "any" would admit Execute asking twice.
+	// Counted against NAMED ENTRY POINTS, not per function and not per file.
+	// Each is finer than the last for a reason the coarser version misses:
+	//
+	//   - per FILE would demand one call and fail today. Two resolutions in
+	//     this file is the correct shape and always was — the parity dry-run is
+	//     its own operation (zero-write, no run id, no operator) and Execute is
+	//     another.
+	//   - per FUNCTION admits a helper. Execute resolves once, a helper it
+	//     calls resolves once, both counts are one, and the operation is back
+	//     to two handles — which is the defect, not a route to it.
+	//
+	// So resolution is a PRIVILEGE of the two operation entry points, and every
+	// other function in the lane must receive the handle. That is the rule that
+	// cannot be satisfied by moving the second call somewhere else.
+	resolvers := map[string]bool{"Execute": true, "parityPreview": true}
 	acting := map[string]int{}
 	installation := 0
 	for _, decl := range file.Decls {
@@ -70,12 +78,12 @@ func TestTheOverlayFlipLaneResolvesOneWorkspaceHandle(t *testing.T) {
 			if !ok {
 				return true
 			}
-			// calleeName (retentionscope_test.go) already answers this for
-			// the package, and it handles a QUALIFIED call as well as a bare
-			// one — which matters here even though dbhandle.go is the same
-			// package today: a helper that later moves would arrive as a
-			// selector and slip past a gate that only looked at identifiers,
-			// and a prohibition that stops matching is one that passes.
+			// calleeName (retentionscope_test.go) already answers this for the
+			// package, and it handles a QUALIFIED call as well as a bare one —
+			// which matters here even though dbhandle.go is the same package
+			// today: a helper that later moves would arrive as a selector and
+			// slip past a gate that only looked at identifiers, and a
+			// prohibition that stops matching is one that passes.
 			switch calleeName(call) {
 			case "actingWorkspaceDB":
 				acting[fn.Name.Name]++
@@ -86,12 +94,22 @@ func TestTheOverlayFlipLaneResolvesOneWorkspaceHandle(t *testing.T) {
 		})
 	}
 
-	if len(acting) == 0 {
-		t.Errorf("%s reaches actingWorkspaceDB nowhere — the lane stopped resolving the "+
-			"operator's workspace, and this gate was about to pass having checked nothing", lane)
+	for name := range resolvers {
+		if acting[name] == 0 {
+			t.Errorf("%s: %s resolves no workspace handle. It is one of the lane's operation "+
+				"entry points, so if it stopped resolving one this gate was about to pass "+
+				"having checked nothing — or the entry point was renamed and this list is "+
+				"now describing a function that does not exist", lane, name)
+		}
 	}
 	for fn, count := range acting {
-		if count > 1 {
+		switch {
+		case !resolvers[fn]:
+			t.Errorf("%s: %s resolves the acting workspace, and only the operation entry "+
+				"points (%s) may. A helper that resolves its own handle puts the operation "+
+				"back on two of them however few times each function asks (#2561) — take the "+
+				"handle as a parameter instead.", lane, fn, strings.Join(sortedKeys(resolvers), ", "))
+		case count > 1:
 			t.Errorf("%s: %s resolves the acting workspace %d times. One operation, one handle — "+
 				"a second resolution inside one function is the divergence #2561 closed, not a "+
 				"route to it. Resolve once and hand it down.", lane, fn, count)

--- a/backend/gates/fliponehandle_test.go
+++ b/backend/gates/fliponehandle_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The overlay flip runs on ONE workspace binding, and this is what keeps it so.
+//
+// It used to run on two. The import and the reconstruction took
+// actingWorkspaceDB — the workspace the operator is acting in, which for a
+// rebuild onto a clean instance is one the server never resolved — while the
+// mode flip took an overlay.Service built over InstallationDB, the
+// installation's singleton. Two handles for one operation, and if they had ever
+// named different workspaces the flip would import an estate into one workspace
+// and flip the other out of overlay mode. margince/margince#2561.
+//
+// WHY A GATE AND NOT JUST THE FIX. The divergence was not a bug anybody could
+// see: every caller is HTTP-driven and identity's middleware binds the request
+// context from the same resolver the installation handle uses, so the two
+// agreed on every live path and no test could have caught them differing. What
+// went wrong was compositional — three steps each asked for a handle
+// separately, and two of them asked a different question. Re-introducing it is
+// one line, and it would be as invisible as it was the first time.
+//
+// So the rule is shape, not behaviour: inside flip.go, nothing may reach
+// InstallationDB. The lane resolves its handle once, from the acting workspace,
+// and hands it down.
+func TestTheOverlayFlipLaneResolvesOneWorkspaceHandle(t *testing.T) {
+	t.Parallel()
+
+	const lane = "flip.go"
+	// TestMain chdirs to the backend root, so paths here are module-relative.
+	path := filepath.Join("internal", "compose", lane)
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+
+	// The POSITIVE side first, because this gate is a prohibition and "found
+	// nothing" is what success looks like — so it would read green if the walk
+	// silently matched no file at all, or if the lane stopped resolving a
+	// handle by any route.
+	acting := 0
+	installation := 0
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		name, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch name.Name {
+		case "actingWorkspaceDB":
+			acting++
+		case "InstallationDB":
+			installation++
+		}
+		return true
+	})
+
+	if acting == 0 {
+		t.Errorf("%s reaches actingWorkspaceDB nowhere — the lane stopped resolving the "+
+			"operator's workspace, and this gate was about to pass having checked nothing", lane)
+	}
+	if installation != 0 {
+		t.Errorf("%s reaches InstallationDB %d time(s). The flip resolves ONE handle, from the "+
+			"acting workspace, and hands it down: a second resolution here is how the import and "+
+			"the mode flip came to target different workspaces (#2561). Pass the handle the lane "+
+			"already resolved.", lane, installation)
+	}
+
+	// And the field that used to hold the second answer stays gone. A run store
+	// on the runner is reachable from every method without resolving anything,
+	// which is exactly how two of the three lanes ended up on the installation
+	// handle while the import was on the acting one.
+	if strings.Contains(runnerStruct(t, file), "RunStore") {
+		t.Errorf("%s puts a RunStore on flipRunner. Every lane builds one from the handle IT "+
+			"resolved — a field here is a second answer available to a caller that had already "+
+			"resolved a handle (#2561)", lane)
+	}
+}
+
+// runnerStruct renders the flipRunner declaration, or fails: a gate that
+// silently found no struct would report the field absent because it looked at
+// nothing.
+func runnerStruct(t *testing.T, file *ast.File) string {
+	t.Helper()
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != "flipRunner" {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				t.Fatal("flipRunner is no longer a struct")
+			}
+			var fields []string
+			for _, f := range st.Fields.List {
+				fields = append(fields, renderFieldType(f.Type))
+			}
+			return strings.Join(fields, " ")
+		}
+	}
+	t.Fatal("no flipRunner declaration in flip.go — this gate is about that type")
+	return ""
+}
+
+func renderFieldType(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.StarExpr:
+		return renderFieldType(t.X)
+	case *ast.SelectorExpr:
+		return renderFieldType(t.X) + "." + t.Sel.Name
+	case *ast.Ident:
+		return t.Name
+	default:
+		return ""
+	}
+}

--- a/backend/gates/fliponehandle_test.go
+++ b/backend/gates/fliponehandle_test.go
@@ -50,29 +50,52 @@ func TestTheOverlayFlipLaneResolvesOneWorkspaceHandle(t *testing.T) {
 	// nothing" is what success looks like — so it would read green if the walk
 	// silently matched no file at all, or if the lane stopped resolving a
 	// handle by any route.
-	acting := 0
+	//
+	// Counted PER FUNCTION, not per file. Two resolutions in flip.go is the
+	// correct shape and always was: the parity dry-run is its own operation —
+	// zero-write, no run id, no operator — and Execute is another. What must
+	// never happen is one operation resolving twice, because that is the
+	// divergence itself rather than a route to it. A file-wide count of one
+	// would fail today and say nothing about the invariant; a file-wide count
+	// of "any" would admit Execute asking twice.
+	acting := map[string]int{}
 	installation := 0
-	ast.Inspect(file, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
 		if !ok {
+			continue
+		}
+		ast.Inspect(fn, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			// calleeName (retentionscope_test.go) already answers this for
+			// the package, and it handles a QUALIFIED call as well as a bare
+			// one — which matters here even though dbhandle.go is the same
+			// package today: a helper that later moves would arrive as a
+			// selector and slip past a gate that only looked at identifiers,
+			// and a prohibition that stops matching is one that passes.
+			switch calleeName(call) {
+			case "actingWorkspaceDB":
+				acting[fn.Name.Name]++
+			case "InstallationDB":
+				installation++
+			}
 			return true
-		}
-		name, ok := call.Fun.(*ast.Ident)
-		if !ok {
-			return true
-		}
-		switch name.Name {
-		case "actingWorkspaceDB":
-			acting++
-		case "InstallationDB":
-			installation++
-		}
-		return true
-	})
+		})
+	}
 
-	if acting == 0 {
+	if len(acting) == 0 {
 		t.Errorf("%s reaches actingWorkspaceDB nowhere — the lane stopped resolving the "+
 			"operator's workspace, and this gate was about to pass having checked nothing", lane)
+	}
+	for fn, count := range acting {
+		if count > 1 {
+			t.Errorf("%s: %s resolves the acting workspace %d times. One operation, one handle — "+
+				"a second resolution inside one function is the divergence #2561 closed, not a "+
+				"route to it. Resolve once and hand it down.", lane, fn, count)
+		}
 	}
 	if installation != 0 {
 		t.Errorf("%s reaches InstallationDB %d time(s). The flip resolves ONE handle, from the "+

--- a/backend/internal/compose/flip.go
+++ b/backend/internal/compose/flip.go
@@ -42,6 +42,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/migration"
 	"github.com/margince/margince/backend/internal/modules/overlay"
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -61,14 +62,18 @@ type flipRunner struct {
 	pool *pgxpool.Pool
 	svc  *overlay.Service
 	ms   *overlay.MirrorStore
-	runs *migration.RunStore
 	log  *slog.Logger
 }
 
 var _ overlay.FlipRunner = (*flipRunner)(nil)
 
 func newFlipRunner(pool *pgxpool.Pool, svc *overlay.Service, ms *overlay.MirrorStore, log *slog.Logger) *flipRunner {
-	return &flipRunner{pool: pool, svc: svc, ms: ms, runs: migration.NewRunStore(InstallationDB(pool)), log: log}
+	// No run store on the runner, deliberately. Every lane that needs one
+	// builds it from the handle IT resolved, which is the whole of #2561's fix:
+	// a field here is a second answer available to a caller that had already
+	// resolved a handle, and two of the three lanes took the field while the
+	// import took the acting binding.
+	return &flipRunner{pool: pool, svc: svc, ms: ms, log: log}
 }
 
 // Preflight is OVA-WIRE-7: {ready, blocking[], unresolved_conflicts[]}
@@ -174,7 +179,10 @@ func (f *flipRunner) parityPreview(ctx context.Context, incumbent string) ([]crm
 		return nil, err
 	}
 	writers := newFlipWriters(db, f.ms, incumbent)
-	rep, err := migration.NewEngine(f.runs, writers).DryRun(ctx, mirrorFlipSource{ms: f.ms})
+	// The dry-run's run store rides the handle it already resolved, for the
+	// reason Execute resolves one: a lane that asks twice is a lane that can
+	// get two answers.
+	rep, err := migration.NewEngine(migration.NewRunStore(db), writers).DryRun(ctx, mirrorFlipSource{ms: f.ms})
 	if err != nil {
 		return nil, fmt.Errorf("flip preflight: parity dry-run: %w", err)
 	}
@@ -236,23 +244,51 @@ func (f *flipRunner) Execute(ctx context.Context, req crmcontracts.OverlayFlipRe
 		return crmcontracts.OverlayFlipAccepted{}, err
 	}
 
+	// ONE handle for the whole flip, resolved once here.
+	//
+	// The import and the reconstruction have always run on the ACTING
+	// workspace's binding — a rebuild writes an exported estate into the
+	// workspace whose operator ordered it, which on a clean instance is a
+	// workspace the server never resolved (dbhandle.go says why). The mode
+	// flip ran on f.svc, built over the installation's singleton. Two handles
+	// for one operation: if they ever named different workspaces, the flip
+	// imported an estate into one and flipped the other out of overlay mode
+	// (margince/margince#2561).
+	//
+	// Not reachable today — every caller is HTTP-driven and identity's
+	// middleware binds the request context from the same resolver the
+	// installation handle uses — so this closes the possibility rather than a
+	// symptom. Resolving it HERE rather than per step is the point: three
+	// callers each asking separately is what let two of them differ.
+	db, err := actingWorkspaceDB(ctx, f.pool)
+	if err != nil {
+		return crmcontracts.OverlayFlipAccepted{}, err
+	}
+	// The run store rides the same handle, and it is the third one the lane
+	// held. The run store used to be built over the installation's singleton at
+	// construction time, so the run RECORDS of a flip could be written into a
+	// different workspace from the estate the flip imported — the same
+	// divergence one level down, and the record is what a resumed attempt reads
+	// to know where it got to.
+	svc, runs := f.svc.On(db), migration.NewRunStore(db)
+
 	// Freeze (idempotent — a green preflight already sealed).
-	snap, err := f.svc.SealFlipSnapshot(ctx)
+	snap, err := svc.SealFlipSnapshot(ctx)
 	if err != nil {
 		return crmcontracts.OverlayFlipAccepted{}, err
 	}
 
-	run, err := f.resumeOrCreateRun(ctx, snap, string(mode))
+	run, err := f.resumeOrCreateRun(ctx, runs, snap, string(mode))
 	if err != nil {
 		return crmcontracts.OverlayFlipAccepted{}, err
 	}
 
-	rep, err := f.importMirrorEstate(ctx, run, mode, v.checks.Incumbent)
+	rep, err := f.importMirrorEstate(ctx, db, runs, run, mode, v.checks.Incumbent)
 	if err != nil {
 		return crmcontracts.OverlayFlipAccepted{}, err
 	}
 
-	if err := f.svc.CompleteFlip(ctx, run.ID, string(mode)); err != nil {
+	if err := svc.CompleteFlip(ctx, run.ID, string(mode)); err != nil {
 		return crmcontracts.OverlayFlipAccepted{}, err
 	}
 	f.log.Info("overlay flip completed", "run_id", run.ID.String(), "mode", string(mode), "imported", rep.Imported)
@@ -273,12 +309,10 @@ func (f *flipRunner) Execute(ctx context.Context, req crmcontracts.OverlayFlipRe
 // this run: the writers attribute every imported record to the run and to the
 // human who ordered the cutover, and the association map is loaded before the
 // first object so a record's links land with it rather than a pass later.
-func (f *flipRunner) importMirrorEstate(ctx context.Context, run migration.Run, mode crmcontracts.OverlayFlipRequestMode, incumbent string) (migration.Report, error) {
+// The handle is PASSED IN rather than resolved here, so the import cannot
+// differ from the mode flip that follows it — see Execute.
+func (f *flipRunner) importMirrorEstate(ctx context.Context, db *database.DB, runs *migration.RunStore, run migration.Run, mode crmcontracts.OverlayFlipRequestMode, incumbent string) (migration.Report, error) {
 	operator, err := flipOperator(ctx)
-	if err != nil {
-		return migration.Report{}, err
-	}
-	db, err := actingWorkspaceDB(ctx, f.pool)
 	if err != nil {
 		return migration.Report{}, err
 	}
@@ -290,7 +324,7 @@ func (f *flipRunner) importMirrorEstate(ctx context.Context, run migration.Run, 
 	}
 	writers.SetAssociations(assocs)
 
-	rep, err := migration.NewEngine(f.runs, writers).Run(ctx, run.ID, source)
+	rep, err := migration.NewEngine(runs, writers).Run(ctx, run.ID, source)
 	if err != nil {
 		// The run record holds the failure + checkpoint: executing again
 		// resumes it. The mirror stays frozen — the estate must not
@@ -361,21 +395,21 @@ func (f *flipRunner) admitMode(ctx context.Context, mode crmcontracts.OverlayFli
 // resumeOrCreateRun continues an interrupted flip run for the SAME
 // sealed snapshot (checkpoint intact — never from zero, never past it),
 // or records a fresh one.
-func (f *flipRunner) resumeOrCreateRun(ctx context.Context, snap overlay.FlipSnapshot, mode string) (migration.Run, error) {
-	latest, err := f.runs.Latest(ctx, migration.ConnectorMirror)
+func (f *flipRunner) resumeOrCreateRun(ctx context.Context, runs *migration.RunStore, snap overlay.FlipSnapshot, mode string) (migration.Run, error) {
+	latest, err := runs.Latest(ctx, migration.ConnectorMirror)
 	switch {
 	case err == nil && latest.SourceRef == snap.ID && latest.Status == migration.StatusFailed:
-		if err := f.runs.Resume(ctx, latest.ID); err != nil {
+		if err := runs.Resume(ctx, latest.ID); err != nil {
 			return migration.Run{}, err
 		}
-		return f.runs.Get(ctx, latest.ID)
+		return runs.Get(ctx, latest.ID)
 	case err == nil && latest.SourceRef == snap.ID && latest.Status == migration.StatusRunning:
 		// A crashed request left the run marked running; re-enter it.
 		return latest, nil
 	case err != nil && !errors.Is(err, apperrors.ErrNotFound):
 		return migration.Run{}, err
 	}
-	return f.runs.Create(ctx, migration.CreateRunInput{
+	return runs.Create(ctx, migration.CreateRunInput{
 		Connector: migration.ConnectorMirror,
 		SourceRef: snap.ID,
 		Source:    "overlay:flip:" + mode,

--- a/backend/internal/modules/overlay/flipstate.go
+++ b/backend/internal/modules/overlay/flipstate.go
@@ -32,6 +32,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -369,4 +370,29 @@ func (s *Service) CompleteFlip(ctx context.Context, runID ids.UUID, mode string)
 	}
 	s.notifyModeFlip(ws)
 	return nil
+}
+
+// On is this Service over a DIFFERENT workspace binding, every option kept.
+//
+// It exists for the flip lane and says so, because the alternative is what the
+// lane was doing: the import and the reconstruction ran on the handle bound to
+// the workspace the operator is acting in, while the mode flip ran on a Service
+// built over the installation's singleton. Two handles for one operation, and
+// if they ever named different workspaces the flip would import an estate into
+// one and flip the other out of overlay mode (margince/margince#2561).
+//
+// No live path reaches that divergence today — every caller is HTTP-driven and
+// identity's middleware binds the request context from the same resolver the
+// installation handle uses — which is why this is a composition fix rather than
+// an incident. What it removes is the possibility, not a symptom.
+//
+// A SHALLOW copy is correct here and would not be if this struct cached
+// anything per handle: it holds injected collaborators and option functions,
+// and the one piece of state that IS per-workspace — the mirror store — is
+// itself handle-bound and shared deliberately, because the mirror the flip
+// imports is the mirror the preflight sealed.
+func (s *Service) On(db *database.DB) *Service {
+	rebound := *s
+	rebound.db = db
+	return &rebound
 }

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -87,7 +87,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (90)
+## Census (91)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -126,6 +126,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `eventtypeownership_test.go` | H3 | One module owns an event type. |
 | `extensioncapabilitycensus_test.go` | H2 | Every capability the extension tier publishes must have a live unit declaring it. |
 | `extensionsignored_test.go` | H3 | The enabled set must be a set git actually has. |
+| `fliponehandle_test.go` | H2 | The overlay flip runs on ONE workspace binding, and this is what keeps it so. |
 | `gatecensus_test.go` | H2 | The census over this repo's own gate machinery: a gate's exceptions are held to the standard the gate holds its subjects to. |
 | `gateinventory_test.go` | H3 | The gate inventory: every gate in this package declares its own shape, and the reference page listing them is rendered from those declarations. |
 | `jobbinding_test.go` | H2 | workspaceBindFloor guards against a vacuous pass. |


### PR DESCRIPTION
Closes #2561.

## It was three handles, not two

The ticket names two; there was a third.

| step | handle |
|---|---|
| import + reconstruction | `actingWorkspaceDB` — the workspace the operator is acting in |
| mode flip | `f.svc`, an `overlay.Service` over `InstallationDB` |
| **run records** | `f.runs`, a field built over `InstallationDB` at construction |

That last one matters on its own: a flip's run records could land in a different workspace from the estate it imported, and the record is what a **resumed** attempt reads to know where it got to.

## The fix

`Execute` resolves **one** handle and hands it down. Resolving it there rather than per step is the whole point — three callers each asking separately is what let two of them ask a different question.

- `overlay.Service.On(db)` rebinds a service with **every option kept**. That matters because `CompleteFlip` calls the mode-flip observer: a second service built fresh for the flip would have dropped it silently. The shallow copy is correct only because this struct caches nothing per handle, and its doc says so rather than leaving the next reader to verify it.
- The runner's run-store **field is gone**, not rebound. A field is a second answer available to a method that had already resolved a handle — exactly how two of the three lanes ended up on the installation binding.

## Option 1, deliberately, and option 2 is not foreclosed

Option 2 deletes `actingWorkspaceDB` and accepts that a flip only ever targets the installation's workspace. That turns on whether a rebuild must write into a workspace the server cannot resolve — and `dbhandle.go` currently asserts it must ("on a clean instance is a workspace the server never resolved"). That is the ticket's *"question to settle first"*, and it is a **capability ruling, not a composition one**.

Option 1 closes the divergence either way, so the bug does not wait on that ruling. If option 2 is later chosen, this change is what makes it a deletion rather than a rewrite.

## The gate is the point

The divergence was invisible and not reachable: every caller is HTTP-driven, and identity's middleware binds the request context from the same resolver the installation handle uses, so the two agreed on every live path. **No behavioural test could have caught them differing** — which is also why re-introducing it is one line and would be as invisible as it was the first time.

So the rule is shape, not behaviour: nothing in `flip.go` may reach `InstallationDB`; the lane must still reach `actingWorkspaceDB` somewhere (the positive floor, so a prohibition cannot pass by checking nothing); and no `RunStore` may sit on the runner.

**All three arms mutation-checked**, each failing with its own message:

```
M1 reintroduce InstallationDB → flip.go reaches InstallationDB 1 time(s). …
M2 put the RunStore back      → flip.go puts a RunStore on flipRunner. …
M3 stop resolving the acting  → flip.go reaches actingWorkspaceDB nowhere — this
   handle                        gate was about to pass having checked nothing
```

`make check-backend` exit 0; `modules/overlay`, the `overlay` integration subpackage, and `compose` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace consistency during overlay migrations by ensuring related operations use the same workspace database.
  * Preserved the ability to resume migrations after failures using saved checkpoints.
  * Improved reliability for migration preflight, execution, previews, and run creation or resumption by keeping operations aligned to the active workspace.
  * Improved validation of workspace handling and consistency of diagnostic output.

* **Documentation**
  * Updated the gate inventory to include the new workspace-binding validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->