### PR TITLE
The fiscal-year field says what it does not carry, and names the issue

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -19774,6 +19774,13 @@ components:
             The label spells both calendar years a non-January year spans — `FY2026/27` — so
             a reader can tell which twelve months a bucket covers without knowing the
             convention. A January year is not a span and keeps the plain `2026`.
+
+            One thing it does NOT carry, and a client storing report filters should know it:
+            a SAVED report view holds the bucket's text, so a view saved under one fiscal
+            start names a different span after the start moves — or no span at all, since a
+            calendar year maps onto parts of two fiscal years. The report still runs and
+            still looks right. Whether such a view is re-pointed, invalidated or merely
+            warned about is undecided: margince/margince#2569.
         sign_in_providers:
           type: array
           description: |
@@ -19836,6 +19843,11 @@ components:
             The month the installation's business year begins, 1..12. Never frozen: it cuts
             reports on read and stores nothing, so moving it re-labels every period report at
             once and re-means no stored row.
+
+            It does not re-point a SAVED report view, which holds the bucket's TEXT and so
+            names a different span afterwards. Sending this field is enough to leave those
+            views filtering on a span nobody asked for; nothing here reports how many.
+            margince/margince#2569.
         enabled_oidc_providers:
           type: array
           maxItems: 32

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -22620,6 +22620,13 @@ type InstallationSettings struct {
 	// The label spells both calendar years a non-January year spans — `FY2026/27` — so
 	// a reader can tell which twelve months a bucket covers without knowing the
 	// convention. A January year is not a span and keeps the plain `2026`.
+	//
+	// One thing it does NOT carry, and a client storing report filters should know it:
+	// a SAVED report view holds the bucket's text, so a view saved under one fiscal
+	// start names a different span after the start moves — or no span at all, since a
+	// calendar year maps onto parts of two fiscal years. The report still runs and
+	// still looks right. Whether such a view is re-pointed, invalidated or merely
+	// warned about is undecided: margince/margince#2569.
 	FiscalYearStartMonth int `json:"fiscal_year_start_month"`
 
 	// MaxUploadBytes The largest upload request this installation accepts, in bytes — set by whoever
@@ -30959,6 +30966,11 @@ type UpdateInstallationSettingsRequest struct {
 	// FiscalYearStartMonth The month the installation's business year begins, 1..12. Never frozen: it cuts
 	// reports on read and stores nothing, so moving it re-labels every period report at
 	// once and re-means no stored row.
+	//
+	// It does not re-point a SAVED report view, which holds the bucket's TEXT and so
+	// names a different span afterwards. Sending this field is enough to leave those
+	// views filtering on a span nobody asked for; nothing here reports how many.
+	// margince/margince#2569.
 	FiscalYearStartMonth *int `json:"fiscal_year_start_month,omitempty"`
 
 	// Name Rename the organization.

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -158,7 +158,9 @@ var BaseLanguage = settings.Define[string](
 // saved under one fiscal start names a different span after it moves. Tracked
 // as its own decision — re-point, invalidate, or warn — rather than settled
 // here, because none of the three is obviously right and the label cannot fix
-// it either way.
+// it either way: margince/margince#2569. Named rather than described, so a
+// reader can see whether it is still open instead of trusting a comment's
+// account of a gap.
 //
 // What the label DOES fix is the reader's half: spelling both years means the
 // answer they get is unambiguous about which twelve months it covers, even when

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -13296,6 +13296,13 @@ export interface components {
              *     The label spells both calendar years a non-January year spans — `FY2026/27` — so
              *     a reader can tell which twelve months a bucket covers without knowing the
              *     convention. A January year is not a span and keeps the plain `2026`.
+             *
+             *     One thing it does NOT carry, and a client storing report filters should know it:
+             *     a SAVED report view holds the bucket's text, so a view saved under one fiscal
+             *     start names a different span after the start moves — or no span at all, since a
+             *     calendar year maps onto parts of two fiscal years. The report still runs and
+             *     still looks right. Whether such a view is re-pointed, invalidated or merely
+             *     warned about is undecided: margince/margince#2569.
              */
             fiscal_year_start_month: number;
             /**
@@ -13354,6 +13361,11 @@ export interface components {
              * @description The month the installation's business year begins, 1..12. Never frozen: it cuts
              *     reports on read and stores nothing, so moving it re-labels every period report at
              *     once and re-means no stored row.
+             *
+             *     It does not re-point a SAVED report view, which holds the bucket's TEXT and so
+             *     names a different span afterwards. Sending this field is enough to leave those
+             *     views filtering on a span nobody asked for; nothing here reports how many.
+             *     margince/margince#2569.
              */
             fiscal_year_start_month?: number;
             /**


### PR DESCRIPTION
The prose half of #2569, which that ticket hands to whoever picks it up. **The gap itself is not fixed** and the ticket stays open, labelled `status: needs-decision`.

## Why this part is separable

Re-point, invalidate and warn are three different products, and re-pointing is only defensible where an equivalent bucket exists — under a non-January start there often is not one, because a calendar year maps onto parts of two fiscal years. That is a ruling.

Citing the issue is correct under **all three**, which is what makes it doable now.

## What changed

The gap was described in three places and cited nowhere, so a reader had to trust each comment's account of it rather than being able to see whether it was still open.

- **Both contract descriptions** now carry the caveat, because a client that stores report filters is the party it happens to: a saved view holds the bucket's **text**, so a view saved under one fiscal start names a different span after the start moves. The report still runs and still looks right.
- **The request-side description** says the sharper thing: sending this field is enough to leave those views filtering on a span nobody asked for, and nothing here reports how many.
- **`settingsentry.go`** keeps its account and gains the number. It already said the gap was *"tracked as its own decision"*; naming it is the difference between a reader checking and a reader believing.

No behaviour, no schema shape — descriptions only. `contract-breaking-check`: no breaking changes. The regenerated `api_gen.go` and `schema.d.ts` are committed, since `check-contract-frontend-drift` diffs them.

`make check-backend` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining that changing the fiscal-year start may cause saved report views to reference a different or unavailable period.
  * Clarified that affected reports continue to run and display results.
  * Documented that handling for impacted saved views remains under review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->