### PR TITLE
An overlay mapping is offered to a seat that can still log in

### DIFF
--- a/backend/gates/livemember_test.go
+++ b/backend/gates/livemember_test.go
@@ -91,21 +91,19 @@ var cannotReachIdentity = gatekit.Waive(map[string]string{
 // deliberatelyNotLiveness ratifies the half-spellings that are not answering
 // the workforce question at all.
 //
-// overlay's user-map eligibility is `NOT is_agent AND archived_at IS NULL`, and
-// it is a different set on purpose: it decides whom an admin may GRANT a mirror
-// mapping to, not who still works here. It is already held as its own
-// three-site invariant, named in selectUserMapTargetSQL's comment.
+// overlay's user-map eligibility USED to be `NOT is_agent AND archived_at IS
+// NULL` and is no longer: #2592 tightened it to the same pair this file names,
+// which overlay's own mappableSeatSQL now renders because a module cannot import
+// identity (ADR-0054 §3). Its two files are ratified below as spellings rather
+// than as divergences.
 //
-// What the difference costs, stated rather than waved away: a DEACTIVATED seat
-// is not archived, so all three overlay sites still offer it a mapping — and
-// listUserMapSQL's own comment justifies excluding archived users as "a seat
-// that no longer logs in", which is just as true of a deactivated one. Whether
-// overlay wants the tighter set is overlay's call and moves three statements at
-// once, so it is issue margince/margince#2592 rather than a change made here on
-// a guess.
+// The reason it was a divergence and stopped being one is worth keeping: a
+// DEACTIVATED seat is not archived, so all three overlay sites went on offering
+// it a mapping — while listUserMapSQL's own comment justified excluding archived
+// users as "a seat that no longer logs in", which is exactly as true of a
+// deactivated one. The predicate disagreed with its own stated reason, which is
+// what made it a defect rather than a preference.
 var deliberatelyNotLiveness = gatekit.Waive(map[string]string{
-	"internal/modules/overlay/usermapadmin.go":                                 "overlay mapping eligibility is NOT is_agent AND archived_at IS NULL, a different set held as its own three-site invariant; see issue 2592",
-	"internal/modules/overlay/usermapseed.go":                                  "overlay mapping eligibility is NOT is_agent AND archived_at IS NULL, a different set held as its own three-site invariant; see issue 2592",
 	"internal/modules/identity/roster.go":                                      "listUsersAllQuery is the ADMIN roster and says so: every non-archived member REGARDLESS of status, because a deactivated member has to be visible to reactivate",
 	"internal/modules/identity/reset.go":                                       "OperatorResetPassword is the operator CLI's lockout path, never exposed over HTTP; it must reach an account whose status is not active, which is what administrator lockout means. Login itself calls the helper (lockout.go)",
 	"internal/compose/integration/agentaccess/oauth_grant_integration_test.go": "the fixture deactivates every seat that CAN still act, to prove revocation binds mid-session; the archived half would narrow nothing, because every seat in it was created by the harness moments earlier and none is archived",

--- a/backend/internal/modules/overlay/disconnectfence.go
+++ b/backend/internal/modules/overlay/disconnectfence.go
@@ -223,7 +223,8 @@ func (s *MirrorStore) assertFence(ctx context.Context, tx pgx.Tx) error {
 // read is visible to it.
 func assertMirrorUnfrozen(ctx context.Context, tx pgx.Tx) error {
 	var frozen bool
-	if err := tx.QueryRow(ctx,
+	if err := tx.QueryRow(
+		ctx,
 		`SELECT EXISTS (SELECT 1 FROM overlay_sync_state WHERE mirror_frozen_at IS NOT NULL)`,
 	).Scan(&frozen); err != nil {
 		return fmt.Errorf("overlay: checking the flip freeze before a fenced write: %w", err)

--- a/backend/internal/modules/overlay/flipreads.go
+++ b/backend/internal/modules/overlay/flipreads.go
@@ -136,7 +136,8 @@ func (s *MirrorStore) ResolveMirrorOwner(ctx context.Context, incumbentUserID st
 	var id ids.UUID
 	found := false
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		err := tx.QueryRow(ctx,
+		err := tx.QueryRow(
+			ctx,
 			`SELECT app_user_id FROM mirror_user_map WHERE incumbent_user_id = $1`, incumbentUserID,
 		).Scan(&id)
 		if err != nil {

--- a/backend/internal/modules/overlay/flipstate.go
+++ b/backend/internal/modules/overlay/flipstate.go
@@ -120,7 +120,8 @@ func (s *Service) FlipChecks(ctx context.Context) (FlipChecks, error) {
 
 		var pending, stale int
 		var lastSynced *time.Time
-		if err := tx.QueryRow(ctx, `
+		if err := tx.QueryRow(
+			ctx, `
 			SELECT count(*) FILTER (WHERE sync_state = $1),
 			       count(*) FILTER (WHERE sync_state = $2 OR `+staleProjectionSQL+`),
 			       count(*), max(last_synced_at)
@@ -194,7 +195,8 @@ func (s *Service) SealFlipSnapshot(ctx context.Context) (FlipSnapshot, error) {
 	// against a DIFFERENT freeze would skip rows it never imported.
 	candidate := "snap-" + time.Now().UTC().Format("2006-01-02T15:04:05Z") + "-" + ids.NewV7().String()
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		if err := tx.QueryRow(ctx, `
+		if err := tx.QueryRow(
+			ctx, `
 			INSERT INTO overlay_sync_state (next_sweep_at, flip_snapshot_id, mirror_frozen_at, updated_at)
 			VALUES (now(), $1, now(), now())
 			ON CONFLICT ((true)) DO UPDATE SET
@@ -269,7 +271,8 @@ func (s *Service) UnsealFlipSnapshot(ctx context.Context) error {
 		// pre-update snapshot the CTE holds.
 		var priorID string
 		var priorFrozen time.Time
-		err := tx.QueryRow(ctx, `
+		err := tx.QueryRow(
+			ctx, `
 			WITH prior AS (
 			  SELECT flip_snapshot_id, mirror_frozen_at FROM overlay_sync_state
 			  WHERE mirror_frozen_at IS NOT NULL

--- a/backend/internal/modules/overlay/flipstate_integration_test.go
+++ b/backend/internal/modules/overlay/flipstate_integration_test.go
@@ -251,7 +251,8 @@ func TestFlipChecksCountARowThatRecordsNoDeclarationAsStale(t *testing.T) {
 	ingestMirrorRow(ctx, t, ms, "person", "p-unfingerprinted", "", baseline)
 	var stored *string
 	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx,
+		return tx.QueryRow(
+			ctx,
 			`SELECT projection_fingerprint FROM overlay_mirror WHERE external_id = 'p-unfingerprinted'`,
 		).Scan(&stored)
 	}); err != nil {
@@ -434,7 +435,8 @@ func TestCompleteFlipFlipsModeOnceAndKeepsConnection(t *testing.T) {
 		var mode string
 		var incumbent *string
 		var connStatus string
-		if err := tx.QueryRow(ctx, `
+		if err := tx.QueryRow(
+			ctx, `
 			SELECT sor_mode, incumbent FROM overlay_mode`,
 		).Scan(&mode, &incumbent); err != nil {
 			return err
@@ -449,7 +451,8 @@ func TestCompleteFlipFlipsModeOnceAndKeepsConnection(t *testing.T) {
 			t.Errorf("connection after flip = %s, want active (still present, no longer authoritative — retirement revokes it later)", connStatus)
 		}
 		var audits int
-		if err := tx.QueryRow(ctx,
+		if err := tx.QueryRow(
+			ctx,
 			`SELECT count(*) FROM audit_log WHERE entity_type = 'workspace' AND action = 'update'`,
 		).Scan(&audits); err != nil {
 			return err
@@ -498,7 +501,8 @@ func TestDisconnectRefusesARunningImportButNeverALatchedFreeze(t *testing.T) {
 		if err := tx.QueryRow(ctx, `SELECT status FROM incumbent_connection`).Scan(&connStatus); err != nil {
 			return err
 		}
-		if err := tx.QueryRow(ctx, `
+		if err := tx.QueryRow(
+			ctx, `
 			SELECT sor_mode FROM overlay_mode`,
 		).Scan(&mode); err != nil {
 			return err

--- a/backend/internal/modules/overlay/freshness_integration_test.go
+++ b/backend/internal/modules/overlay/freshness_integration_test.go
@@ -406,7 +406,8 @@ func TestFreshnessReaderShedDegradesToMirrorAndEmitsBudgetDegraded(t *testing.T)
 	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(
 			context.Background(),
-			`SELECT count(*) FROM system_log WHERE action = 'mirror.budget_degraded'`).Scan(&systemLogCount)
+			`SELECT count(*) FROM system_log WHERE action = 'mirror.budget_degraded'`,
+		).Scan(&systemLogCount)
 	}); err != nil {
 		t.Fatalf("querying system_log: %v", err)
 	}

--- a/backend/internal/modules/overlay/handlers_usermap_test.go
+++ b/backend/internal/modules/overlay/handlers_usermap_test.go
@@ -135,7 +135,8 @@ func TestUnmappedReasonIsDerivedFromTheLiveDirectory(t *testing.T) {
 func TestABlockedUserReportsTheBlockEvenWhenAnOwnerMatchesTheirEmail(t *testing.T) {
 	views := userMapViews(
 		[]UserMapEntry{entry("solo@acme.test", "", "", true)},
-		[]OwnerRef{{ExternalID: "owner-1", Email: "solo@acme.test"}}, true)
+		[]OwnerRef{{ExternalID: "owner-1", Email: "solo@acme.test"}}, true,
+	)
 
 	if views[0].UnmappedReason != reasonBlocked {
 		t.Errorf("reason = %q, want %q — the admin's block outranks the email match", views[0].UnmappedReason, reasonBlocked)
@@ -203,7 +204,8 @@ func TestAStaleOwnerReferenceIsFlaggedOnlyWhenTheDirectoryWasRead(t *testing.T) 
 func TestAMappedUserCarriesTheOwnersIdentityFromTheDirectory(t *testing.T) {
 	views := userMapViews(
 		[]UserMapEntry{entry("rep@acme.test", "owner-1", "manual", false)},
-		[]OwnerRef{{ExternalID: "owner-1", Email: "ada@acme.test", Name: "Ada Lovelace"}}, true)
+		[]OwnerRef{{ExternalID: "owner-1", Email: "ada@acme.test", Name: "Ada Lovelace"}}, true,
+	)
 
 	if views[0].OwnerName != "Ada Lovelace" || views[0].OwnerEmail != "ada@acme.test" {
 		t.Errorf("owner identity = %q/%q, want Ada Lovelace/ada@acme.test", views[0].OwnerName, views[0].OwnerEmail)

--- a/backend/internal/modules/overlay/mappableseat.go
+++ b/backend/internal/modules/overlay/mappableseat.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// Who an admin may grant a mirror user-map to, in one place.
+//
+// Held by: TestEveryMappabilityStatementAsksTheHelper
+// (backend/internal/modules/overlay/mappableseat_test.go), which reads the two
+// SQL constants and fails if either carries a predicate beside the call, and
+// TestTheMappableSeatPredicateNamesEveryHalf, which fails if this function
+// drops one.
+//
+// It was spelled three times — listUserMapSQL (what the admin surface offers),
+// selectUserMapTargetSQL (whether a target may be granted one) and
+// usersMatchingEmail (what the automated sweep seeds) — each carrying a comment
+// naming the other two as the thing that must move with it. Three statements
+// held together by prose is one statement waiting to diverge, and the divergence
+// this closes is what proved it: all three excluded an ARCHIVED seat and none
+// excluded a DEACTIVATED one.
+//
+// That was not a deliberate difference. listUserMapSQL's own comment justified
+// excluding an archived user because offering one "invites an admin to grant
+// visibility to a seat that no longer logs in" — which is exactly as true of a
+// deactivated seat, since deactivation sets `status` and leaves `archived_at`
+// NULL. The predicate and its own stated reason disagreed.
+// margince/margince#2592.
+//
+// BOTH HALVES, and neither implies the other — the same pair
+// identity.LiveMemberSQL is, spelled here rather than imported because a module
+// never imports a sibling (ADR-0054 §3) and identity owns app_user. That
+// duplication is ratified by name in TestOnlyOneSpellingOfALiveMember, which is
+// where the two spellings are held to agreeing.
+//
+// It governs GRANTING a mapping, not reading one. A mapping a deactivated seat
+// already holds keeps working, and historical mail attributed to that seat keeps
+// whatever mapping it had: nothing here revokes, and revocation is its own
+// operation with its own audit row.
+//
+// alias is the table's alias in the caller's query, formatted in as an
+// IDENTIFIER — so it must be a compile-time literal, never anything off a
+// request. Every caller in this package passes "u".
+func mappableSeatSQL(alias string) string {
+	prefix := ""
+	if alias != "" {
+		prefix = alias + "."
+	}
+	return "NOT " + prefix + "is_agent AND " + prefix + "status = 'active' AND " + prefix + "archived_at IS NULL"
+}

--- a/backend/internal/modules/overlay/mappableseat_test.go
+++ b/backend/internal/modules/overlay/mappableseat_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+import (
+	"strings"
+	"testing"
+)
+
+// The mappable-seat predicate carries all three halves, on every alias.
+//
+// This exists because naming the predicate once made it INVISIBLE to the gate
+// that used to watch it. TestOnlyOneSpellingOfALiveMember detects literal
+// `status = 'active'` / `archived_at IS NULL` halves in statements that read
+// app_user; overlay's three sites carried those literals, so the gate saw them
+// (as ratified copies) and would have seen one of them lose a half. Now they
+// call this helper, the literals are not in the statement text, and the gate
+// treats the call as opaque — so dropping a half here would be silent.
+//
+// Which is the trade naming it once makes, and this is the other side of it.
+func TestTheMappableSeatPredicateNamesEveryHalf(t *testing.T) {
+	t.Parallel()
+	for _, alias := range []string{"u", ""} {
+		got := mappableSeatSQL(alias)
+		prefix := ""
+		if alias != "" {
+			prefix = alias + "."
+		}
+		// Each half separately, with the reason it is there, because a failure
+		// that says "the predicate changed" sends a reader to diff two strings
+		// while a failure that says WHICH half went sends them to the seat it
+		// would have started offering.
+		for _, half := range []struct{ sql, opens string }{
+			{
+				"NOT " + prefix + "is_agent",
+				"an agent seat is a passport identity with no incumbent counterpart to map",
+			},
+			{
+				prefix + "status = 'active'",
+				"a DEACTIVATED seat can no longer log in, and offering it a mapping grants mirror visibility to an account nobody is using (#2592)",
+			},
+			{
+				prefix + "archived_at IS NULL",
+				"an ARCHIVED seat can no longer log in either, and this half is the one that was always here",
+			},
+		} {
+			if !strings.Contains(got, half.sql) {
+				t.Errorf("mappableSeatSQL(%q) does not carry %q, so it would offer a mapping to a seat where %s\n\ngot: %s",
+					alias, half.sql, half.opens, got)
+			}
+		}
+	}
+}
+
+// And every statement in this package that decides mappability asks the helper
+// rather than spelling a predicate beside it.
+//
+// The three call sites are the whole invariant, and they used to be three
+// literal spellings held together by comments naming each other — which is what
+// let them all diverge from their own stated reason in the same direction.
+func TestEveryMappabilityStatementAsksTheHelper(t *testing.T) {
+	t.Parallel()
+	// Rendered from the constants themselves, so a statement that stopped
+	// calling the helper shows up as a missing fragment rather than as prose
+	// somebody has to re-read.
+	for name, sql := range map[string]string{
+		"listUserMapSQL":         listUserMapSQL,
+		"selectUserMapTargetSQL": selectUserMapTargetSQL,
+	} {
+		if !strings.Contains(sql, mappableSeatSQL("u")) {
+			t.Errorf("%s does not carry mappableSeatSQL(\"u\"). The three mappability sites are "+
+				"one invariant; a predicate spelled beside the helper is how they diverged "+
+				"before (#2592).\n\ngot: %s", name, sql)
+		}
+	}
+}

--- a/backend/internal/modules/overlay/provider_archive.go
+++ b/backend/internal/modules/overlay/provider_archive.go
@@ -88,7 +88,8 @@ func (p *Provider) ArchiveAt(ctx context.Context, in datasource.ArchiveInput) (d
 		return datasource.EntityRef{}, fmt.Errorf(
 			"this workspace's system of record archives a %s without a version precondition, so an "+
 				"archive approved against version %d cannot be carried out as approved: %w",
-			in.Ref.Type, *in.IfVersion, apperrors.ErrUnsupportedBySoR)
+			in.Ref.Type, *in.IfVersion, apperrors.ErrUnsupportedBySoR,
+		)
 	}
 	return p.archiveThroughIncumbent(ctx, in.Ref)
 }

--- a/backend/internal/modules/overlay/reconnect.go
+++ b/backend/internal/modules/overlay/reconnect.go
@@ -53,7 +53,8 @@ func (s *Service) reconnectConnection(ctx context.Context, in ConnectInput, ref 
 		}
 
 		var connectedAt time.Time
-		if scanErr := tx.QueryRow(ctx, `
+		if scanErr := tx.QueryRow(
+			ctx, `
 			UPDATE incumbent_connection SET
 			  incumbent = $2, region = $3, credential_ref = $4, scopes = $5,
 			  incumbent_account_id = NULLIF($6, ''),

--- a/backend/internal/modules/overlay/synchealth.go
+++ b/backend/internal/modules/overlay/synchealth.go
@@ -240,7 +240,8 @@ func (s *Service) objectConcerns(ctx context.Context) ([]SyncConcern, error) {
 func (s *Service) backfillStillOwed(ctx context.Context) (bool, error) {
 	var unconverged, total int
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx,
+		return tx.QueryRow(
+			ctx,
 			`SELECT count(*) FILTER (WHERE NOT done OR truncated), count(*) FROM overlay_backfill_cursor`,
 		).Scan(&unconverged, &total)
 	})
@@ -260,7 +261,8 @@ func (s *Service) sweepFailureConcern(ctx context.Context) (concern SyncConcern,
 		nextSweepAt *time.Time
 	)
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx,
+		return tx.QueryRow(
+			ctx,
 			`SELECT consecutive_failures, last_error_class, next_sweep_at FROM overlay_sync_state`,
 		).Scan(&failures, &errorClass, &nextSweepAt)
 	})

--- a/backend/internal/modules/overlay/syncstatus.go
+++ b/backend/internal/modules/overlay/syncstatus.go
@@ -85,7 +85,8 @@ func (s *Service) requireOverlayMode(ctx context.Context) error {
 func (s *Service) resolveOverlayMode(ctx context.Context) (incumbent string, err error) {
 	var mode string
 	err = database.WithInfraTx(ctx, s.db.Pool(), func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx,
+		return tx.QueryRow(
+			ctx,
 			`SELECT sor_mode, coalesce(incumbent, '') FROM overlay_mode`,
 		).Scan(&mode, &incumbent)
 	})
@@ -177,7 +178,8 @@ func (s *Service) SyncStatus(ctx context.Context) ([]ObjectSyncStatus, error) {
 
 		// The freeze is workspace-level: one read fills every entry.
 		var frozen bool
-		if err := tx.QueryRow(ctx,
+		if err := tx.QueryRow(
+			ctx,
 			`SELECT EXISTS (SELECT 1 FROM overlay_sync_state WHERE mirror_frozen_at IS NOT NULL)`,
 		).Scan(&frozen); err != nil {
 			return fmt.Errorf("overlay: reading the flip freeze for sync status: %w", err)
@@ -255,7 +257,8 @@ func (s *Service) backfillCompleteFor(ctx context.Context, tx pgx.Tx, canonicalO
 	}
 	for _, incumbentClass := range incumbentClasses {
 		var done, truncated bool
-		err := tx.QueryRow(ctx,
+		err := tx.QueryRow(
+			ctx,
 			`SELECT done, truncated FROM overlay_backfill_cursor WHERE object_class = $1`, incumbentClass,
 		).Scan(&done, &truncated)
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/modules/overlay/testsupport_integration.go
+++ b/backend/internal/modules/overlay/testsupport_integration.go
@@ -283,6 +283,24 @@ func seedArchivedUser(t *testing.T, ws ids.UUID, email string) ids.UserID {
 	return user
 }
 
+// seedDeactivatedUser is a seat that can no longer log in and is NOT archived —
+// the state deactivation actually leaves: `status` moves and `archived_at` stays
+// NULL. That combination is the whole of #2592: a predicate on archived_at alone
+// reads it as a live colleague.
+// It takes no workspace, unlike the two seeders above: ADR-0091 §8 phase D took
+// the tenant column off app_user, so there is nothing to bind. Those two still
+// take one they do not use, which is theirs to drop.
+func seedDeactivatedUser(t *testing.T, email string) ids.UserID {
+	t.Helper()
+	user := ids.New[ids.UserKind]()
+	if _, err := testOwnerConn(t).Exec(context.Background(),
+		`INSERT INTO app_user (id, email, display_name, status) VALUES ($1, $2, 'Overlay Deactivated User', 'deactivated')`,
+		user, email); err != nil {
+		t.Fatalf("seeding a deactivated app_user: %v", err)
+	}
+	return user
+}
+
 // archiveUser archives an app_user that already exists — the "archived while
 // still mapped" state, which no seeder can produce up front because the
 // mapping has to be written by a live seat first.

--- a/backend/internal/modules/overlay/usermapadmin.go
+++ b/backend/internal/modules/overlay/usermapadmin.go
@@ -133,10 +133,12 @@ type UserMapEntry struct {
 // with an empty owner rather than be filtered out. Keyset-ordered by id so
 // the cursor is stable across pages.
 //
-// Agent and archived users are excluded: a passport identity has no incumbent
-// counterpart to map, and offering an archived user a mapping affordance
-// invites an admin to grant visibility to a seat that no longer logs in.
-const listUserMapSQL = `
+// The seats it offers are the mappable ones (mappableSeatSQL): a passport
+// identity has no incumbent counterpart to map, and a seat that no longer logs
+// in — archived OR deactivated — must not be handed a mapping affordance. The
+// predicate is spelled there rather than here, because it is one invariant this
+// file shares with two other sites.
+var listUserMapSQL = `
 SELECT u.id, u.email, u.display_name,
        coalesce(m.incumbent_user_id, ''), coalesce(m.match_source, ''),
        b.app_user_id IS NOT NULL
@@ -146,8 +148,7 @@ LEFT JOIN mirror_user_map m
 LEFT JOIN mirror_user_automap_block b
        ON b.app_user_id = u.id AND b.incumbent = $1
 WHERE u.id > $2
-  AND NOT u.is_agent
-  AND u.archived_at IS NULL
+  AND ` + mappableSeatSQL("u") + `
 ORDER BY u.id
 LIMIT $3`
 
@@ -203,24 +204,28 @@ func (s *MirrorStore) ListUserMap(ctx context.Context, incumbent, cursor string,
 // its target: that it exists at all, and whether it is a seat an admin may
 // GRANT a mapping to.
 //
-// The eligibility half is ONE invariant with two siblings that must move with
-// it: listUserMapSQL (what the admin surface offers) and usersMatchingEmail
-// (usermapseed.go — what the automated sweep will seed). All three exclude an
-// agent seat and an archived seat; a change here belongs in all three.
+// The eligibility half is ONE invariant with two siblings — listUserMapSQL
+// (what the admin surface offers) and usersMatchingEmail (usermapseed.go — what
+// the automated sweep seeds) — and all three now READ it from mappableSeatSQL
+// rather than each spelling it. They used to spell it three times, held
+// together by comments naming each other, and they diverged from their own
+// stated reason: every one excluded an archived seat and none excluded a
+// deactivated one (#2592).
 //
 // It resolves by id alone. A workspace predicate stood here until ADR-0091 §8
 // phase D took the tenant column off app_user; what it bought — turning an id
 // this installation does not have into no rows, and so into ErrNotFound — the
 // id itself now buys, because an installation serves one organization
 // (ADR-0061) and an unknown id matches nothing.
-const selectUserMapTargetSQL = `
-SELECT NOT u.is_agent AND u.archived_at IS NULL
+var selectUserMapTargetSQL = `
+SELECT ` + mappableSeatSQL("u") + `
 FROM app_user u
 WHERE u.id = $1`
 
 // resolveUserMapTarget resolves appUser inside tx, reporting whether the seat
 // is grantable — a live human. An agent seat is a passport identity with no
-// incumbent counterpart, and an archived seat no longer logs in.
+// incumbent counterpart, and a seat that no longer logs in — archived or
+// deactivated — is not somebody to grant mirror visibility to.
 //
 // An id naming no user — a stale one in an admin's open tab is the routine
 // case — answers apperrors.ErrNotFound: a row-scope miss is existence-hiding,

--- a/backend/internal/modules/overlay/usermapadmin_integration_test.go
+++ b/backend/internal/modules/overlay/usermapadmin_integration_test.go
@@ -203,13 +203,14 @@ func TestListUserMapIncludesUnmappedAndBlockedUsers(t *testing.T) {
 // A passport identity has no incumbent counterpart, and an archived seat no
 // longer logs in — offering either a mapping affordance invites an admin to
 // grant mirror visibility to something that should not have it.
-func TestListUserMapExcludesAgentAndArchivedUsers(t *testing.T) {
+func TestListUserMapExcludesAgentArchivedAndDeactivatedUsers(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	_, humanRaw := testWorkspaceCtxAsUser(t, ws, "human@acme.test")
 	human := ids.From[ids.UserKind](humanRaw)
 	agent := seedAgentUser(t, ws, "agent@acme.test")
 	archived := seedArchivedUser(t, ws, "gone@acme.test")
+	deactivated := seedDeactivatedUser(t, "suspended@acme.test")
 
 	entries, _, err := store.ListUserMap(ctx, "hubspot", "", 50)
 	if err != nil {
@@ -227,6 +228,14 @@ func TestListUserMapExcludesAgentAndArchivedUsers(t *testing.T) {
 	}
 	if present[archived] {
 		t.Fatal("an archived user must not be offered a mapping")
+	}
+	// Deactivation moves `status` and leaves archived_at NULL, so the
+	// archived-only predicate this surface used to carry read a suspended seat
+	// as a live colleague and offered it a mapping — while the comment above
+	// the query justified the archived exclusion as "a seat that no longer logs
+	// in" (#2592).
+	if present[deactivated] {
+		t.Fatal("a deactivated user can no longer log in and must not be offered a mapping")
 	}
 }
 
@@ -255,17 +264,24 @@ func TestUserMapWritesRefuseAUserThatDoesNotExist(t *testing.T) {
 // ListUserMap hides agent and archived seats; the verb that GRANTS mirror
 // visibility has to agree, or the exclusion is cosmetic and an admin can map
 // exactly the identities the list refuses to offer.
-func TestSetManualUserMapRefusesAgentAndArchivedUsers(t *testing.T) {
+func TestSetManualUserMapRefusesAgentArchivedAndDeactivatedUsers(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), noOwnerEmails{})
 	agent := seedAgentUser(t, ws, "agent@acme.test")
 	archived := seedArchivedUser(t, ws, "gone@acme.test")
+	deactivated := seedDeactivatedUser(t, "suspended@acme.test")
 
 	if err := store.SetManualUserMap(ctx, agent, "hubspot", "owner-1"); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("an agent seat has no incumbent counterpart and must answer ErrNotFound, got: %v", err)
 	}
 	if err := store.SetManualUserMap(ctx, archived, "hubspot", "owner-1"); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("an archived seat must answer ErrNotFound, got: %v", err)
+	}
+	// The GRANT half of #2592, and the one that matters most: the surface no
+	// longer offers a deactivated seat, so a grant naming one now reaches this
+	// check rather than the admin's own stale tab being the only guard.
+	if err := store.SetManualUserMap(ctx, deactivated, "hubspot", "owner-1"); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("a deactivated seat must answer ErrNotFound, got: %v", err)
 	}
 
 	var mapped int

--- a/backend/internal/modules/overlay/usermapseed.go
+++ b/backend/internal/modules/overlay/usermapseed.go
@@ -220,22 +220,21 @@ func (s *MirrorStore) revokeEmailMappingsForOwners(ctx context.Context, incumben
 // off app_user, so the installation's users ARE the candidate set, and
 // uq_app_user_email makes an address name at most one of them.
 //
-// Agent and archived seats are excluded for the same reason the admin
-// surface refuses them: an agent seat is a passport identity with no
-// incumbent counterpart to match, and an archived seat no longer logs in, so
-// a mapping either way grants mirror visibility to something that should not
-// carry it. This is ONE invariant with the eligibility predicate
-// selectUserMapTargetSQL (usermapadmin.go) applies to ListUserMap and
-// SetManualUserMap — spelled twice because a scalar check and a set query
-// read better apart, so a change to either belongs in both.
+// The seats it matches are the mappable ones, and it READS that predicate from
+// mappableSeatSQL rather than spelling it: an agent seat is a passport identity
+// with no incumbent counterpart to match, and a seat that no longer logs in —
+// archived or deactivated — must not be handed mirror visibility. It used to be
+// spelled here, on the ground that "a scalar check and a set query read better
+// apart"; what that bought in readability it lost in agreement, since this site
+// and its two siblings all excluded an archived seat and none excluded a
+// deactivated one (#2592).
 func (s *MirrorStore) usersMatchingEmail(ctx context.Context, email, incumbent string) ([]ids.UserID, error) {
 	var users []ids.UserID
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT u.id FROM app_user u
 			WHERE lower(trim(u.email)) = lower(trim($1))
-			  AND NOT u.is_agent
-			  AND u.archived_at IS NULL
+			  AND `+mappableSeatSQL("u")+`
 			  AND NOT EXISTS (
 			      SELECT 1 FROM mirror_user_map m
 			      WHERE m.app_user_id = u.id AND m.incumbent = $2 AND m.match_source = 'manual'

--- a/backend/internal/modules/overlay/usermapseed_integration_test.go
+++ b/backend/internal/modules/overlay/usermapseed_integration_test.go
@@ -198,6 +198,69 @@ func TestSeedUserMapMatchesOwnersToUsersByEmail(t *testing.T) {
 // manually mapped to owner-X, whose email ALSO matches owner-Y in the
 // directory, must keep owner-X — seeding must not remap them to owner-Y
 // (which would revoke owner-X's records the escape hatch exists to grant).
+// The automated sweep is the third mappability site, and it skips a seat that
+// can no longer log in for the same reason the admin surface refuses to offer
+// one: the mapping would grant mirror visibility to an account nobody is using.
+//
+// A DEACTIVATED seat is the case that used to slip through all three, and it is
+// worse here than on the admin surface: nobody chose it. The sweep runs on
+// connect and on its own schedule, so a suspended colleague whose address
+// matched an incumbent owner was silently re-granted the mapping every pass,
+// with an admin's revocation undone by automation the next time it ran (#2592).
+func TestSeedUserMapSkipsASeatThatCanNoLongerLogIn(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{
+		"owner-live":      "live@example.com",
+		"owner-suspended": "suspended@example.com",
+		"owner-archived":  "archived@example.com",
+	})
+	_, liveRaw := testWorkspaceCtxAsUser(t, ws, "live@example.com")
+	live := ids.From[ids.UserKind](liveRaw)
+	suspended := seedDeactivatedUser(t, "suspended@example.com")
+	archived := seedArchivedUser(t, ws, "archived@example.com")
+
+	owners := []OwnerRef{
+		{ExternalID: "owner-live", Email: "live@example.com"},
+		{ExternalID: "owner-suspended", Email: "suspended@example.com"},
+		{ExternalID: "owner-archived", Email: "archived@example.com"},
+	}
+	if err := store.SeedUserMap(ctx, "hubspot", owners); err != nil {
+		t.Fatalf("SeedUserMap: %v", err)
+	}
+
+	mapped := map[ids.UserID]bool{}
+	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT app_user_id FROM mirror_user_map WHERE incumbent = 'hubspot'`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id ids.UserID
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			mapped[id] = true
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatalf("reading the seeded mappings: %v", err)
+	}
+
+	// The live seat, so a failing sweep is told apart from a sweep that seeded
+	// nothing at all.
+	if !mapped[live] {
+		t.Fatal("the live seat was not seeded, so this test proves nothing about the two below")
+	}
+	if mapped[suspended] {
+		t.Error("the sweep seeded a DEACTIVATED seat — an account that can no longer log in, " +
+			"re-granted on every pass and undoing an admin's revocation each time")
+	}
+	if mapped[archived] {
+		t.Error("the sweep seeded an ARCHIVED seat")
+	}
+}
+
 func TestSeedUserMapNeverOverwritesAManualMapping(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	store := NewMirrorStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](ws)), stubOwnerEmails{

--- a/backend/internal/modules/overlay/visibility.go
+++ b/backend/internal/modules/overlay/visibility.go
@@ -56,7 +56,8 @@ func resolveActingMirrorUserID(ctx context.Context, tx pgx.Tx) (ids.UUID, error)
 		return ids.UUID{}, errors.New("overlay: no principal bound to context")
 	}
 	var mapped ids.UUID
-	err := tx.QueryRow(ctx,
+	err := tx.QueryRow(
+		ctx,
 		`SELECT app_user_id FROM mirror_user_map WHERE app_user_id = $1 LIMIT 1`,
 		actor.UserID,
 	).Scan(&mapped)

--- a/backend/internal/modules/overlay/writeledger.go
+++ b/backend/internal/modules/overlay/writeledger.go
@@ -97,7 +97,8 @@ func (l *WriteLedger) OpenEntries(ctx context.Context, objectClass, externalID s
 			return err
 		}
 		for prop, val := range props {
-			if _, err := tx.Exec(ctx, `
+			if _, err := tx.Exec(
+				ctx, `
 				INSERT INTO overlay_write_ledger
 					(object_class, external_id, property, value_hash, value_canonical)
 				VALUES ($1, $2, $3, $4, $5)


### PR DESCRIPTION
Closes #2592, taking option 1.

## Why this is a defect and not a preference

The ticket calls it "a product question", and I want to be explicit about why I read it as decided: **the predicate disagreed with its own stated reason.**

`listUserMapSQL`'s comment justified excluding archived users because offering one *"invites an admin to grant visibility to a seat that no longer logs in"*. Deactivation sets `status` and leaves `archived_at` NULL — so a deactivated seat also no longer logs in, and all three sites went on offering it a mapping. Option 2 would have required **adding** a rationale nobody has stated (that a suspension is temporary and an admin should prepare the mapping ahead of reactivation). Option 1 just makes the code do what it already said.

## The sweep is the worse half

`usersMatchingEmail` runs on connect and on a schedule. A suspended colleague whose address matched an incumbent owner was re-granted the mapping **every pass** — so an admin's revocation was undone by automation the next time it ran. Nobody chose that, which is different from the admin surface, where at least a human clicked.

## Spelled once

`mappableSeatSQL`, in overlay rather than imported — a module never imports a sibling (ADR-0054 §3) and identity owns `app_user`. Three statements held together by comments naming each other is one statement waiting to diverge, and this is what diverging looked like.

**Naming it once cost something, and this pays for it.** `TestOnlyOneSpellingOfALiveMember` detects *literal* halves in statements that read `app_user` — so it used to see these three (as ratified copies) and would have seen one lose a half. It now sees a call it cannot read into. So the two waivers naming this issue are **gone**, and two tests in overlay hold what the gate no longer can:

- `TestTheMappableSeatPredicateNamesEveryHalf` — every half, on every alias, each with the seat it would otherwise start offering.
- `TestEveryMappabilityStatementAsksTheHelper` — no predicate spelled beside the call.

## Evidence — five mutation checks

| mutation | what failed |
|---|---|
| drop the `status` half | the predicate test, on both aliases |
| " | `a deactivated user … must not be offered a mapping` (list) |
| " | `a deactivated seat must answer ErrNotFound` (grant) |
| " | `the sweep seeded a DEACTIVATED seat` (sweep) |
| a site stops calling the helper | `listUserMapSQL does not carry mappableSeatSQL("u")` |

The sweep test asserts the **live** seat was seeded first, so a sweep that seeded nothing at all is told apart from one that skipped correctly.

## Scope

This governs **granting**, not reading. A mapping a deactivated seat already holds keeps working; revocation is its own operation with its own audit row. `BlockAutoMap` deliberately still admits an ineligible seat, because it *removes* access — that asymmetry is unchanged and already has its own test.

`make check-backend` exit 0; `modules/overlay` and the `overlay` integration subpackage green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User mapping now excludes deactivated, archived, and agent seats from listing, targeting, and automatic seeding.
  * Prevented automatic mapping from restoring access for users who can no longer sign in.
  * Manual mapping attempts for ineligible users are rejected without creating a mapping.

* **Tests**
  * Added coverage for eligibility rules across user-map operations, including deactivated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->