### PR TITLE
An agent says why it is writing, through the same validator a person does

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29306,8 +29306,7 @@ components:
           type: [string, 'null']
           enum: [reply_to_inbound, requested_followup, precontract_quote, active_deal_followup,
                  customer_service, account_notice, contract_notice, invoice_or_payment,
-                 security_notice, privacy_notice, record_confirmation, consent_confirmation,
-                 optout_confirmation, marketing, null]
+                 marketing, null]
           description: |
             What kind of communication this is. The caller CLAIMS a category; the engine
             resolves the one the evidence actually supports and records both, so a claim
@@ -29318,12 +29317,13 @@ components:
             therefore honest and is the ordinary case for a reply; naming one matters when
             there is no anchor to derive from.
 
-            Five categories exist to serve the recipient — `security_notice`,
+            Five categories are absent from this list on purpose — `security_notice`,
             `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-            `record_confirmation` — and are refused (422 `invalid`) from an
-            ordinary send. They are reserved for the installation's own controller mail,
-            which rides a registered template; a caller that could claim one could dress
-            marketing as a security warning and reach somebody who has objected.
+            `record_confirmation`. They serve the recipient, which is why a hard
+            suppression does not stop them, and they are reserved for the installation's
+            own controller mail behind a registered template. A caller that could claim
+            one could dress marketing as a security warning and reach somebody who has
+            objected, so naming one here is refused (422 `invalid`).
         marketing_purpose:
           type: [string, 'null']
           description: |
@@ -29538,8 +29538,7 @@ components:
           type: [string, 'null']
           enum: [reply_to_inbound, requested_followup, precontract_quote, active_deal_followup,
                  customer_service, account_notice, contract_notice, invoice_or_payment,
-                 security_notice, privacy_notice, record_confirmation, consent_confirmation,
-                 optout_confirmation, marketing, null]
+                 marketing, null]
           description: |
             What kind of communication this is. The caller CLAIMS a category; the engine
             resolves the one the evidence actually supports and records both, so a claim
@@ -29550,12 +29549,13 @@ components:
             therefore honest and is the ordinary case for a reply; naming one matters when
             there is no anchor to derive from.
 
-            Five categories exist to serve the recipient — `security_notice`,
+            Five categories are absent from this list on purpose — `security_notice`,
             `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-            `record_confirmation` — and are refused (422 `invalid`) from an
-            ordinary send. They are reserved for the installation's own controller mail,
-            which rides a registered template; a caller that could claim one could dress
-            marketing as a security warning and reach somebody who has objected.
+            `record_confirmation`. They serve the recipient, which is why a hard
+            suppression does not stop them, and they are reserved for the installation's
+            own controller mail behind a registered template. A caller that could claim
+            one could dress marketing as a security warning and reach somebody who has
+            objected, so naming one here is refused (422 `invalid`).
         marketing_purpose:
           type: [string, 'null']
           description: |
@@ -29638,8 +29638,7 @@ components:
           type: [string, 'null']
           enum: [reply_to_inbound, requested_followup, precontract_quote, active_deal_followup,
                  customer_service, account_notice, contract_notice, invoice_or_payment,
-                 security_notice, privacy_notice, record_confirmation, consent_confirmation,
-                 optout_confirmation, marketing, null]
+                 marketing, null]
           description: |
             What kind of communication this is. The caller CLAIMS a category; the engine
             resolves the one the evidence actually supports and records both, so a claim
@@ -29650,12 +29649,13 @@ components:
             therefore honest and is the ordinary case for a reply; naming one matters when
             there is no anchor to derive from.
 
-            Five categories exist to serve the recipient — `security_notice`,
+            Five categories are absent from this list on purpose — `security_notice`,
             `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-            `record_confirmation` — and are refused (422 `invalid`) from an
-            ordinary send. They are reserved for the installation's own controller mail,
-            which rides a registered template; a caller that could claim one could dress
-            marketing as a security warning and reach somebody who has objected.
+            `record_confirmation`. They serve the recipient, which is why a hard
+            suppression does not stop them, and they are reserved for the installation's
+            own controller mail behind a registered template. A caller that could claim
+            one could dress marketing as a security warning and reach somebody who has
+            objected, so naming one here is refused (422 `invalid`).
         marketing_purpose:
           type: [string, 'null']
           description: |

--- a/backend/gates/sendcontextvalidation_test.go
+++ b/backend/gates/sendcontextvalidation_test.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+//gate:kind census H3
+
+package gates
+
+// Every door that builds a send input runs the claim through the shared
+// validator.
+//
+// The categories that serve the recipient are the ones a hard suppression does
+// not stop, and they belong to the installation's own controller mail behind a
+// registered template. A door able to claim one could dress marketing as a
+// security warning and reach somebody who has objected. The HTTP doors are
+// refused by sendContextFrom and the tool doors by ApplyContext /
+// ApplyChannelContext — one validator, and this is what stops a third door from
+// deciding for itself.
+//
+// Derived from the input types rather than from a list of doors: a function
+// that constructs an activities.SendEmailInput or SendMessageInput IS a send
+// door, whatever it is called and wherever it lives, so one added tomorrow is
+// judged the day it is written.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sendInputTypes are the two structs a send door fills in. Named by their bare
+// type name because a composite literal writes them either qualified
+// (activities.SendEmailInput, from compose) or bare (from inside the module).
+var sendInputTypes = map[string]bool{
+	"SendEmailInput":   true,
+	"SendMessageInput": true,
+}
+
+// validators are the entry points that apply the shared refusals. A door
+// reaching any of them has asked the one validator; sendContextFrom is the
+// HTTP spelling, the two Apply… functions the typed one.
+var validators = map[string]bool{
+	"sendContextFrom":     true,
+	"ApplyContext":        true,
+	"ApplyChannelContext": true,
+	// The two HTTP decoders wrap sendContextFrom and are what the handlers
+	// actually call, so a handler reaching one has reached the validator.
+	"replySendInput":   true,
+	"accountSendInput": true,
+}
+
+// revalidationExempt is the one shape that restores a claim rather than
+// accepting one. thaw reads back what freezePayload wrote, and what it wrote
+// was validated at schedule time by the door that took it — so re-running the
+// refusals here would judge the same claim twice and, worse, would make a
+// scheduled send fail at FIRE time for a claim the rep was told was accepted
+// hours earlier, with nobody at the keyboard to correct it.
+//
+// Keyed on the exact function, so moving the restore somewhere else re-arms
+// the gate rather than inheriting the exemption.
+var revalidationExempt = map[string]bool{
+	"internal/modules/activities/scheduledpayload.go:scheduledPayload.thaw": true,
+}
+
+func TestEverySendDoorValidatesTheClaimedContext(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	building := map[string]string{}    // doors that set a context field themselves
+	buildsInput := map[string]string{} // every function that builds a send input
+	readsClaim := map[string]bool{}    // functions that read the caller's claim
+	validating := map[string]bool{}    // functions that reach a validator
+
+	for _, root := range []string{"internal/compose", "internal/modules/activities"} {
+		for path, file := range parseTreeFiles(t, fset, root) {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok {
+					continue
+				}
+				name := path + ":" + receiverQualified(fn)
+				ast.Inspect(fn, func(n ast.Node) bool {
+					switch node := n.(type) {
+					case *ast.CompositeLit:
+						// A door is a function that puts a claim ON a send
+						// input: it either fills a context field itself, or it
+						// builds an input in a function that also reads the
+						// caller's claim. The three that rebuild an
+						// already-validated input — the held-draft release, the
+						// scheduled thaw and its replay — do neither, and a gate
+						// that failed them would ask them to judge a claim
+						// nobody made twice.
+						if sendInputTypes[bareTypeName(literalTypeName(node))] {
+							buildsInput[name] = path
+						}
+						if sendInputTypes[bareTypeName(literalTypeName(node))] && setsAContextField(node) {
+							building[name] = path
+						}
+					case *ast.SelectorExpr:
+						if validators[node.Sel.Name] {
+							validating[name] = true
+						}
+						// Reading the caller's own claim is what makes a
+						// function a door. A door that then hands the input
+						// straight to the validator sets no field itself, so
+						// the composite-literal test alone cannot see it.
+						if node.Sel.Name == claimArgsField {
+							readsClaim[name] = true
+						}
+					case *ast.Ident:
+						if validators[node.Name] {
+							validating[name] = true
+						}
+					}
+					return true
+				})
+			}
+		}
+	}
+
+	// Under-recognition is the one way this gate must not break: a scan that
+	// found nothing would report PASS over an empty corpus.
+	if len(building) == 0 {
+		t.Fatal("found no send input construction — the scan is looking in the wrong place")
+	}
+	// Both shapes of door, judged the same way.
+	for door, path := range buildsInput {
+		if readsClaim[door] {
+			building[door] = path
+		}
+	}
+	for door := range building {
+		if revalidationExempt[door] {
+			continue
+		}
+		if !validating[door] {
+			t.Errorf("%s builds a send input and never validates the claimed context — "+
+				"a door that judges its own claims can name a category reserved for controller mail", door)
+		}
+	}
+}
+
+// claimArgsField is the embedded struct a transport reads a caller's claim out
+// of. A function naming it is accepting a claim, whatever it does next.
+const claimArgsField = "SendContextArgs"
+
+// contextFields are the four a caller's claim lands in. A literal setting any
+// of them is accepting a claim and owes it the validator.
+var contextFields = map[string]bool{
+	"Context": true, "MarketingPurpose": true, "OperatorReason": true, "Evidence": true,
+}
+
+// setsAContextField reports whether this literal fills in a claim.
+func setsAContextField(lit *ast.CompositeLit) bool {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if key, ok := kv.Key.(*ast.Ident); ok && contextFields[key.Name] {
+			return true
+		}
+	}
+	return false
+}
+
+// bareTypeName drops a package qualifier, because a send input is written
+// activities.SendEmailInput from compose and SendEmailInput inside the module,
+// and both are the same door.
+func bareTypeName(name string) string {
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		return name[i+1:]
+	}
+	return name
+}
+
+// parseTreeFiles parses every hand-written Go file under a directory, keyed by
+// path so a finding can say where the door lives.
+func parseTreeFiles(t *testing.T, fset *token.FileSet, root string) map[string]*ast.File {
+	t.Helper()
+	out := map[string]*ast.File{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		out[path] = file
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	return out
+}
+
+// The tool surface declares the four context arguments in exactly one place.
+//
+// A second copy is how one send tool starts advertising a category, a bound or
+// a description the others do not — the two transports then disagree about one
+// behaviour, which is exactly what TestEveryToolEnumMatchesTheContractItMirrors
+// catches at the contract level and cannot catch between two tool schemas.
+//
+// Held by this test for the claim on sendContextProperties.
+func TestTheToolSurfaceSpellsTheSendContextOnce(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	var declarations []string
+	for path, file := range parseTreeFiles(t, fset, "internal/modules/agents") {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, name := range value.Names {
+					if strings.Contains(literalOf(value), `"communication_context"`) {
+						declarations = append(declarations, path+":"+name.Name)
+					}
+				}
+			}
+		}
+	}
+	if len(declarations) == 0 {
+		t.Fatal("found no send-context schema in the tool surface — the scan is looking in the wrong place")
+	}
+	if len(declarations) > 1 {
+		t.Errorf("the send context is declared %d times (%s) — a second copy is how two send tools "+
+			"start advertising different categories", len(declarations), strings.Join(declarations, ", "))
+	}
+}
+
+// literalOf concatenates a const spec's string parts, so a schema built by
+// joining several literals is read as the one string it becomes.
+func literalOf(spec *ast.ValueSpec) string {
+	var out strings.Builder
+	for _, v := range spec.Values {
+		ast.Inspect(v, func(n ast.Node) bool {
+			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+				out.WriteString(lit.Value)
+			}
+			return true
+		})
+	}
+	return out.String()
+}

--- a/backend/gates/sendcontextvalidation_test.go
+++ b/backend/gates/sendcontextvalidation_test.go
@@ -30,50 +30,102 @@ import (
 	"testing"
 )
 
-// sendInputTypes are the two structs a send door fills in. Named by their bare
-// type name because a composite literal writes them either qualified
-// (activities.SendEmailInput, from compose) or bare (from inside the module).
-var sendInputTypes = map[string]bool{
-	"SendEmailInput":   true,
-	"SendMessageInput": true,
+// sendChokepoints are the two store methods every outbound message passes
+// through. The corpus is derived from THEM rather than from a syntactic tell,
+// because they are the owner this gate protects: a function calling one is
+// sending a message, whatever shape it used to build the input and wherever it
+// lives.
+//
+// An earlier version of this gate looked for a composite literal with a Context
+// key inside two named directories. Three probes walked straight past it — a
+// door in cmd/, an assignment after the literal, and a method that sets the
+// field — so it defended the shape of the code that existed rather than the
+// obligation.
+var sendChokepoints = map[string]bool{
+	"SendOrSchedule": true,
+	"SendMessage":    true,
 }
 
-// validators are the entry points that apply the shared refusals. A door
-// reaching any of them has asked the one validator; sendContextFrom is the
-// HTTP spelling, the two Apply… functions the typed one.
+// sendStoreReceivers are the expressions the chokepoint is called ON. Bound
+// because "SendMessage" is a common method name — the Telegram connector, the
+// fenced channel sender, the dispatcher's own seam and the generated HTTP
+// wrapper all have one, and none of them decodes a caller's claim. What this
+// gate is about is the ACTIVITIES store, the one object that turns a request
+// into an outbound message.
+//
+// Matched on the selector's base expression rather than by resolving types,
+// because a gate that needed type information would need the whole program
+// loaded. The names below are what the store is called at its call sites.
+var sendStoreReceivers = map[string]bool{
+	"store": true, "s": true, "h.store": true, "c.store": true, "t.comms": true,
+}
+
+// callsTheSendStore reports whether this selector is the chokepoint called on
+// something that looks like the activities store.
+func callsTheSendStore(sel *ast.SelectorExpr) bool {
+	if !sendChokepoints[sel.Sel.Name] {
+		return false
+	}
+	return sendStoreReceivers[receiverText(sel.X)]
+}
+
+// receiverText renders the expression a method was called on, for the two shapes a
+// store reaches a call site in: a bare identifier and one field selection.
+func receiverText(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		if base, ok := v.X.(*ast.Ident); ok {
+			return base.Name + "." + v.Sel.Name
+		}
+	}
+	return ""
+}
+
+// validators are the entry points that apply the shared refusals. A caller
+// reaching any of them has asked the one validator; sendContextFrom is the HTTP
+// spelling, the two Apply… functions the typed one, and the two decoders wrap
+// sendContextFrom for the handlers.
 var validators = map[string]bool{
 	"sendContextFrom":     true,
 	"ApplyContext":        true,
 	"ApplyChannelContext": true,
-	// The two HTTP decoders wrap sendContextFrom and are what the handlers
-	// actually call, so a handler reaching one has reached the validator.
-	"replySendInput":   true,
-	"accountSendInput": true,
+	"replySendInput":      true,
+	"accountSendInput":    true,
 }
 
-// revalidationExempt is the one shape that restores a claim rather than
-// accepting one. thaw reads back what freezePayload wrote, and what it wrote
-// was validated at schedule time by the door that took it — so re-running the
-// refusals here would judge the same claim twice and, worse, would make a
-// scheduled send fail at FIRE time for a claim the rep was told was accepted
-// hours earlier, with nobody at the keyboard to correct it.
+// forwardsAnAlreadyValidatedInput are the callers that take a send input as a
+// PARAMETER rather than building one from a caller's claim. They cannot
+// validate what they did not decode, and requiring them to would ask the same
+// claim to be judged twice.
 //
-// Keyed on the exact function, so moving the restore somewhere else re-arms
-// the gate rather than inheriting the exemption.
-var revalidationExempt = map[string]bool{
-	"internal/modules/activities/scheduledpayload.go:scheduledPayload.thaw": true,
+// Keyed on the exact function, so moving the call re-arms the gate rather than
+// inheriting the exemption. Each entry names why it is safe.
+var forwardsAnAlreadyValidatedInput = map[string]bool{
+	// Test-only drivers: they take the send input their caller already built,
+	// so there is no claim here to decode.
+	"internal/compose/commsscheduled_integration.go:DriveScheduledSendForTest": true,
+	"internal/compose/commsscheduled_integration.go:ScheduleAsAgentForTest":    true,
+	// The tool hands its raw arguments to commsAdapter.SendMessage, which is
+	// what runs ApplyChannelContext. Validating here too would decode the same
+	// claim twice, and the adapter is the seam every channel caller shares.
+	"internal/modules/agents/tools_comms.go:sendMessageTool.Handle": true,
+	// The store's own methods are the chokepoint, not callers of it.
+	"internal/modules/activities/sendcore.go:Store.SendOrSchedule": true,
+	"internal/modules/activities/channelsend.go:Store.SendMessage": true,
 }
 
 func TestEverySendDoorValidatesTheClaimedContext(t *testing.T) {
 	t.Parallel()
 
 	fset := token.NewFileSet()
-	building := map[string]string{}    // doors that set a context field themselves
-	buildsInput := map[string]string{} // every function that builds a send input
-	readsClaim := map[string]bool{}    // functions that read the caller's claim
-	validating := map[string]bool{}    // functions that reach a validator
+	sending := map[string]bool{}    // functions that send a message
+	validating := map[string]bool{} // functions that reach a validator
 
-	for _, root := range []string{"internal/compose", "internal/modules/activities"} {
+	// The whole backend tree, because a send door is wherever somebody calls
+	// the chokepoint — cmd/ included, which already owns an outbound mail lane.
+	for _, root := range []string{"internal", "cmd"} {
 		for path, file := range parseTreeFiles(t, fset, root) {
 			for _, decl := range file.Decls {
 				fn, ok := decl.(*ast.FuncDecl)
@@ -82,37 +134,18 @@ func TestEverySendDoorValidatesTheClaimedContext(t *testing.T) {
 				}
 				name := path + ":" + receiverQualified(fn)
 				ast.Inspect(fn, func(n ast.Node) bool {
-					switch node := n.(type) {
-					case *ast.CompositeLit:
-						// A door is a function that puts a claim ON a send
-						// input: it either fills a context field itself, or it
-						// builds an input in a function that also reads the
-						// caller's claim. The three that rebuild an
-						// already-validated input — the held-draft release, the
-						// scheduled thaw and its replay — do neither, and a gate
-						// that failed them would ask them to judge a claim
-						// nobody made twice.
-						if sendInputTypes[bareTypeName(literalTypeName(node))] {
-							buildsInput[name] = path
-						}
-						if sendInputTypes[bareTypeName(literalTypeName(node))] && setsAContextField(node) {
-							building[name] = path
-						}
-					case *ast.SelectorExpr:
-						if validators[node.Sel.Name] {
+					sel, ok := n.(*ast.SelectorExpr)
+					if !ok {
+						if id, ok := n.(*ast.Ident); ok && validators[id.Name] {
 							validating[name] = true
 						}
-						// Reading the caller's own claim is what makes a
-						// function a door. A door that then hands the input
-						// straight to the validator sets no field itself, so
-						// the composite-literal test alone cannot see it.
-						if node.Sel.Name == claimArgsField {
-							readsClaim[name] = true
-						}
-					case *ast.Ident:
-						if validators[node.Name] {
-							validating[name] = true
-						}
+						return true
+					}
+					if callsTheSendStore(sel) {
+						sending[name] = true
+					}
+					if validators[sel.Sel.Name] {
+						validating[name] = true
 					}
 					return true
 				})
@@ -122,83 +155,18 @@ func TestEverySendDoorValidatesTheClaimedContext(t *testing.T) {
 
 	// Under-recognition is the one way this gate must not break: a scan that
 	// found nothing would report PASS over an empty corpus.
-	if len(building) == 0 {
-		t.Fatal("found no send input construction — the scan is looking in the wrong place")
+	if len(sending) == 0 {
+		t.Fatal("found no send call — the scan is looking in the wrong place")
 	}
-	// Both shapes of door, judged the same way.
-	for door, path := range buildsInput {
-		if readsClaim[door] {
-			building[door] = path
-		}
-	}
-	for door := range building {
-		if revalidationExempt[door] {
+	for door := range sending {
+		if forwardsAnAlreadyValidatedInput[door] {
 			continue
 		}
 		if !validating[door] {
-			t.Errorf("%s builds a send input and never validates the claimed context — "+
+			t.Errorf("%s sends a message and never validates the claimed context — "+
 				"a door that judges its own claims can name a category reserved for controller mail", door)
 		}
 	}
-}
-
-// claimArgsField is the embedded struct a transport reads a caller's claim out
-// of. A function naming it is accepting a claim, whatever it does next.
-const claimArgsField = "SendContextArgs"
-
-// contextFields are the four a caller's claim lands in. A literal setting any
-// of them is accepting a claim and owes it the validator.
-var contextFields = map[string]bool{
-	"Context": true, "MarketingPurpose": true, "OperatorReason": true, "Evidence": true,
-}
-
-// setsAContextField reports whether this literal fills in a claim.
-func setsAContextField(lit *ast.CompositeLit) bool {
-	for _, elt := range lit.Elts {
-		kv, ok := elt.(*ast.KeyValueExpr)
-		if !ok {
-			continue
-		}
-		if key, ok := kv.Key.(*ast.Ident); ok && contextFields[key.Name] {
-			return true
-		}
-	}
-	return false
-}
-
-// bareTypeName drops a package qualifier, because a send input is written
-// activities.SendEmailInput from compose and SendEmailInput inside the module,
-// and both are the same door.
-func bareTypeName(name string) string {
-	if i := strings.LastIndex(name, "."); i >= 0 {
-		return name[i+1:]
-	}
-	return name
-}
-
-// parseTreeFiles parses every hand-written Go file under a directory, keyed by
-// path so a finding can say where the door lives.
-func parseTreeFiles(t *testing.T, fset *token.FileSet, root string) map[string]*ast.File {
-	t.Helper()
-	out := map[string]*ast.File{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		file, parseErr := parser.ParseFile(fset, path, nil, 0)
-		if parseErr != nil {
-			return parseErr
-		}
-		out[path] = file
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walking %s: %v", root, err)
-	}
-	return out
 }
 
 // The tool surface declares the four context arguments in exactly one place.
@@ -255,4 +223,29 @@ func literalOf(spec *ast.ValueSpec) string {
 		})
 	}
 	return out.String()
+}
+
+// parseTreeFiles parses every hand-written Go file under a directory, keyed by
+// path so a finding can say where the door lives.
+func parseTreeFiles(t *testing.T, fset *token.FileSet, root string) map[string]*ast.File {
+	t.Helper()
+	out := map[string]*ast.File{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		out[path] = file
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	return out
 }

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -22,7 +22,6 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
-	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // sendAccepted is what a send answers with: the delivery path took it. It is
@@ -275,29 +274,6 @@ func sendContextOf(in agents.SendContextArgs) activities.SendContextInput {
 		Context:          in.CommunicationContext,
 		MarketingPurpose: in.MarketingPurpose,
 		OperatorReason:   in.OperatorReason,
-		Evidence:         evidenceOf(in.Evidence),
-	}
-}
-
-// evidenceOf flattens the optional evidence block. An unnamed record stays
-// zero, which is what the engine reads as "the caller named none".
-func evidenceOf(in *agents.SendEvidence) commsauthz.Evidence {
-	if in == nil {
-		return commsauthz.Evidence{}
-	}
-	id := func(p *ids.UUID) ids.UUID {
-		if p == nil {
-			return ids.UUID{}
-		}
-		return *p
-	}
-	return commsauthz.Evidence{
-		ActivityID:     id(in.ActivityID),
-		DealID:         id(in.DealID),
-		InvoiceID:      id(in.InvoiceID),
-		ContractID:     id(in.ContractID),
-		ConsentEventID: id(in.ConsentEventID),
-		BasisID:        id(in.BasisID),
 	}
 }
 

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -22,6 +22,7 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
 )
 
 // sendAccepted is what a send answers with: the delivery path took it. It is
@@ -197,13 +198,22 @@ func (c commsAdapter) send(
 	if err != nil {
 		return agents.SendEmailResult{}, err
 	}
-	out, err := c.store.SendOrSchedule(ctx, origin, activities.SendEmailInput{
+	// Through the SAME validator the HTTP door runs. An agent may propose a
+	// category and name evidence; the categories reserved for the
+	// installation's own notices are refused here exactly as they are there,
+	// because a claim one transport may not make must not become makeable by
+	// choosing the other.
+	input, err := activities.ApplyContext(activities.SendEmailInput{
 		Recipients:     append(append([]string{}, in.To...), in.Cc...),
 		Cc:             append([]string{}, in.Cc...),
 		Subject:        in.Subject,
 		Body:           in.Body,
 		ConsentPurpose: in.ConsentPurpose,
-	}, sched, c.gate, c.stager, c.timer)
+	}, sendContextOf(in.SendContextArgs))
+	if err != nil {
+		return agents.SendEmailResult{}, err
+	}
+	out, err := c.store.SendOrSchedule(ctx, origin, input, sched, c.gate, c.stager, c.timer)
 	if err != nil {
 		return agents.SendEmailResult{}, err
 	}
@@ -244,14 +254,51 @@ func agentSchedule(in agents.SendEmailArgs) (*activities.SendSchedule, error) {
 // resolution and the RBAC check cannot differ by transport. The recipient is
 // absent from the arguments by design: the store resolves it from the anchor.
 func (c commsAdapter) SendMessage(ctx context.Context, anchor ids.UUID, in agents.SendMessageArgs) (agents.SendMessageResult, error) {
-	sent, err := c.store.SendMessage(ctx, ids.From[ids.ActivityKind](anchor), activities.SendMessageInput{
+	input, err := activities.ApplyChannelContext(activities.SendMessageInput{
 		Body:           in.Body,
 		ConsentPurpose: in.ConsentPurpose,
-	}, c.gate, c.channelStager)
+	}, sendContextOf(in.SendContextArgs))
+	if err != nil {
+		return agents.SendMessageResult{}, err
+	}
+	sent, err := c.store.SendMessage(ctx, ids.From[ids.ActivityKind](anchor), input, c.gate, c.channelStager)
 	if err != nil {
 		return agents.SendMessageResult{}, err
 	}
 	return agents.SendMessageResult{ActivityID: ids.UUID(sent.Id), Status: sendAccepted}, nil
+}
+
+// sendContextOf turns the tool surface's wire shape into the module's, so the
+// two send doors hand the validator one type between them.
+func sendContextOf(in agents.SendContextArgs) activities.SendContextInput {
+	return activities.SendContextInput{
+		Context:          in.CommunicationContext,
+		MarketingPurpose: in.MarketingPurpose,
+		OperatorReason:   in.OperatorReason,
+		Evidence:         evidenceOf(in.Evidence),
+	}
+}
+
+// evidenceOf flattens the optional evidence block. An unnamed record stays
+// zero, which is what the engine reads as "the caller named none".
+func evidenceOf(in *agents.SendEvidence) commsauthz.Evidence {
+	if in == nil {
+		return commsauthz.Evidence{}
+	}
+	id := func(p *ids.UUID) ids.UUID {
+		if p == nil {
+			return ids.UUID{}
+		}
+		return *p
+	}
+	return commsauthz.Evidence{
+		ActivityID:     id(in.ActivityID),
+		DealID:         id(in.DealID),
+		InvoiceID:      id(in.InvoiceID),
+		ContractID:     id(in.ContractID),
+		ConsentEventID: id(in.ConsentEventID),
+		BasisID:        id(in.BasisID),
+	}
 }
 
 // IsChannelKind delegates to activities.IsChannelKind — the same test the

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -10518,20 +10518,15 @@ func (e SearchResultType) Valid() bool {
 
 // Defines values for SendAccountEmailRequestCommunicationContext.
 const (
-	SendAccountEmailRequestCommunicationContextAccountNotice       SendAccountEmailRequestCommunicationContext = "account_notice"
-	SendAccountEmailRequestCommunicationContextActiveDealFollowup  SendAccountEmailRequestCommunicationContext = "active_deal_followup"
-	SendAccountEmailRequestCommunicationContextConsentConfirmation SendAccountEmailRequestCommunicationContext = "consent_confirmation"
-	SendAccountEmailRequestCommunicationContextContractNotice      SendAccountEmailRequestCommunicationContext = "contract_notice"
-	SendAccountEmailRequestCommunicationContextCustomerService     SendAccountEmailRequestCommunicationContext = "customer_service"
-	SendAccountEmailRequestCommunicationContextInvoiceOrPayment    SendAccountEmailRequestCommunicationContext = "invoice_or_payment"
-	SendAccountEmailRequestCommunicationContextMarketing           SendAccountEmailRequestCommunicationContext = "marketing"
-	SendAccountEmailRequestCommunicationContextOptoutConfirmation  SendAccountEmailRequestCommunicationContext = "optout_confirmation"
-	SendAccountEmailRequestCommunicationContextPrecontractQuote    SendAccountEmailRequestCommunicationContext = "precontract_quote"
-	SendAccountEmailRequestCommunicationContextPrivacyNotice       SendAccountEmailRequestCommunicationContext = "privacy_notice"
-	SendAccountEmailRequestCommunicationContextRecordConfirmation  SendAccountEmailRequestCommunicationContext = "record_confirmation"
-	SendAccountEmailRequestCommunicationContextReplyToInbound      SendAccountEmailRequestCommunicationContext = "reply_to_inbound"
-	SendAccountEmailRequestCommunicationContextRequestedFollowup   SendAccountEmailRequestCommunicationContext = "requested_followup"
-	SendAccountEmailRequestCommunicationContextSecurityNotice      SendAccountEmailRequestCommunicationContext = "security_notice"
+	SendAccountEmailRequestCommunicationContextAccountNotice      SendAccountEmailRequestCommunicationContext = "account_notice"
+	SendAccountEmailRequestCommunicationContextActiveDealFollowup SendAccountEmailRequestCommunicationContext = "active_deal_followup"
+	SendAccountEmailRequestCommunicationContextContractNotice     SendAccountEmailRequestCommunicationContext = "contract_notice"
+	SendAccountEmailRequestCommunicationContextCustomerService    SendAccountEmailRequestCommunicationContext = "customer_service"
+	SendAccountEmailRequestCommunicationContextInvoiceOrPayment   SendAccountEmailRequestCommunicationContext = "invoice_or_payment"
+	SendAccountEmailRequestCommunicationContextMarketing          SendAccountEmailRequestCommunicationContext = "marketing"
+	SendAccountEmailRequestCommunicationContextPrecontractQuote   SendAccountEmailRequestCommunicationContext = "precontract_quote"
+	SendAccountEmailRequestCommunicationContextReplyToInbound     SendAccountEmailRequestCommunicationContext = "reply_to_inbound"
+	SendAccountEmailRequestCommunicationContextRequestedFollowup  SendAccountEmailRequestCommunicationContext = "requested_followup"
 )
 
 // Valid indicates whether the value is a known member of the SendAccountEmailRequestCommunicationContext enum.
@@ -10541,8 +10536,6 @@ func (e SendAccountEmailRequestCommunicationContext) Valid() bool {
 		return true
 	case SendAccountEmailRequestCommunicationContextActiveDealFollowup:
 		return true
-	case SendAccountEmailRequestCommunicationContextConsentConfirmation:
-		return true
 	case SendAccountEmailRequestCommunicationContextContractNotice:
 		return true
 	case SendAccountEmailRequestCommunicationContextCustomerService:
@@ -10551,19 +10544,11 @@ func (e SendAccountEmailRequestCommunicationContext) Valid() bool {
 		return true
 	case SendAccountEmailRequestCommunicationContextMarketing:
 		return true
-	case SendAccountEmailRequestCommunicationContextOptoutConfirmation:
-		return true
 	case SendAccountEmailRequestCommunicationContextPrecontractQuote:
-		return true
-	case SendAccountEmailRequestCommunicationContextPrivacyNotice:
-		return true
-	case SendAccountEmailRequestCommunicationContextRecordConfirmation:
 		return true
 	case SendAccountEmailRequestCommunicationContextReplyToInbound:
 		return true
 	case SendAccountEmailRequestCommunicationContextRequestedFollowup:
-		return true
-	case SendAccountEmailRequestCommunicationContextSecurityNotice:
 		return true
 	default:
 		return false
@@ -10572,20 +10557,15 @@ func (e SendAccountEmailRequestCommunicationContext) Valid() bool {
 
 // Defines values for SendEmailRequestCommunicationContext.
 const (
-	SendEmailRequestCommunicationContextAccountNotice       SendEmailRequestCommunicationContext = "account_notice"
-	SendEmailRequestCommunicationContextActiveDealFollowup  SendEmailRequestCommunicationContext = "active_deal_followup"
-	SendEmailRequestCommunicationContextConsentConfirmation SendEmailRequestCommunicationContext = "consent_confirmation"
-	SendEmailRequestCommunicationContextContractNotice      SendEmailRequestCommunicationContext = "contract_notice"
-	SendEmailRequestCommunicationContextCustomerService     SendEmailRequestCommunicationContext = "customer_service"
-	SendEmailRequestCommunicationContextInvoiceOrPayment    SendEmailRequestCommunicationContext = "invoice_or_payment"
-	SendEmailRequestCommunicationContextMarketing           SendEmailRequestCommunicationContext = "marketing"
-	SendEmailRequestCommunicationContextOptoutConfirmation  SendEmailRequestCommunicationContext = "optout_confirmation"
-	SendEmailRequestCommunicationContextPrecontractQuote    SendEmailRequestCommunicationContext = "precontract_quote"
-	SendEmailRequestCommunicationContextPrivacyNotice       SendEmailRequestCommunicationContext = "privacy_notice"
-	SendEmailRequestCommunicationContextRecordConfirmation  SendEmailRequestCommunicationContext = "record_confirmation"
-	SendEmailRequestCommunicationContextReplyToInbound      SendEmailRequestCommunicationContext = "reply_to_inbound"
-	SendEmailRequestCommunicationContextRequestedFollowup   SendEmailRequestCommunicationContext = "requested_followup"
-	SendEmailRequestCommunicationContextSecurityNotice      SendEmailRequestCommunicationContext = "security_notice"
+	SendEmailRequestCommunicationContextAccountNotice      SendEmailRequestCommunicationContext = "account_notice"
+	SendEmailRequestCommunicationContextActiveDealFollowup SendEmailRequestCommunicationContext = "active_deal_followup"
+	SendEmailRequestCommunicationContextContractNotice     SendEmailRequestCommunicationContext = "contract_notice"
+	SendEmailRequestCommunicationContextCustomerService    SendEmailRequestCommunicationContext = "customer_service"
+	SendEmailRequestCommunicationContextInvoiceOrPayment   SendEmailRequestCommunicationContext = "invoice_or_payment"
+	SendEmailRequestCommunicationContextMarketing          SendEmailRequestCommunicationContext = "marketing"
+	SendEmailRequestCommunicationContextPrecontractQuote   SendEmailRequestCommunicationContext = "precontract_quote"
+	SendEmailRequestCommunicationContextReplyToInbound     SendEmailRequestCommunicationContext = "reply_to_inbound"
+	SendEmailRequestCommunicationContextRequestedFollowup  SendEmailRequestCommunicationContext = "requested_followup"
 )
 
 // Valid indicates whether the value is a known member of the SendEmailRequestCommunicationContext enum.
@@ -10595,8 +10575,6 @@ func (e SendEmailRequestCommunicationContext) Valid() bool {
 		return true
 	case SendEmailRequestCommunicationContextActiveDealFollowup:
 		return true
-	case SendEmailRequestCommunicationContextConsentConfirmation:
-		return true
 	case SendEmailRequestCommunicationContextContractNotice:
 		return true
 	case SendEmailRequestCommunicationContextCustomerService:
@@ -10605,19 +10583,11 @@ func (e SendEmailRequestCommunicationContext) Valid() bool {
 		return true
 	case SendEmailRequestCommunicationContextMarketing:
 		return true
-	case SendEmailRequestCommunicationContextOptoutConfirmation:
-		return true
 	case SendEmailRequestCommunicationContextPrecontractQuote:
-		return true
-	case SendEmailRequestCommunicationContextPrivacyNotice:
-		return true
-	case SendEmailRequestCommunicationContextRecordConfirmation:
 		return true
 	case SendEmailRequestCommunicationContextReplyToInbound:
 		return true
 	case SendEmailRequestCommunicationContextRequestedFollowup:
-		return true
-	case SendEmailRequestCommunicationContextSecurityNotice:
 		return true
 	default:
 		return false
@@ -10626,20 +10596,15 @@ func (e SendEmailRequestCommunicationContext) Valid() bool {
 
 // Defines values for SendMessageRequestCommunicationContext.
 const (
-	SendMessageRequestCommunicationContextAccountNotice       SendMessageRequestCommunicationContext = "account_notice"
-	SendMessageRequestCommunicationContextActiveDealFollowup  SendMessageRequestCommunicationContext = "active_deal_followup"
-	SendMessageRequestCommunicationContextConsentConfirmation SendMessageRequestCommunicationContext = "consent_confirmation"
-	SendMessageRequestCommunicationContextContractNotice      SendMessageRequestCommunicationContext = "contract_notice"
-	SendMessageRequestCommunicationContextCustomerService     SendMessageRequestCommunicationContext = "customer_service"
-	SendMessageRequestCommunicationContextInvoiceOrPayment    SendMessageRequestCommunicationContext = "invoice_or_payment"
-	SendMessageRequestCommunicationContextMarketing           SendMessageRequestCommunicationContext = "marketing"
-	SendMessageRequestCommunicationContextOptoutConfirmation  SendMessageRequestCommunicationContext = "optout_confirmation"
-	SendMessageRequestCommunicationContextPrecontractQuote    SendMessageRequestCommunicationContext = "precontract_quote"
-	SendMessageRequestCommunicationContextPrivacyNotice       SendMessageRequestCommunicationContext = "privacy_notice"
-	SendMessageRequestCommunicationContextRecordConfirmation  SendMessageRequestCommunicationContext = "record_confirmation"
-	SendMessageRequestCommunicationContextReplyToInbound      SendMessageRequestCommunicationContext = "reply_to_inbound"
-	SendMessageRequestCommunicationContextRequestedFollowup   SendMessageRequestCommunicationContext = "requested_followup"
-	SendMessageRequestCommunicationContextSecurityNotice      SendMessageRequestCommunicationContext = "security_notice"
+	SendMessageRequestCommunicationContextAccountNotice      SendMessageRequestCommunicationContext = "account_notice"
+	SendMessageRequestCommunicationContextActiveDealFollowup SendMessageRequestCommunicationContext = "active_deal_followup"
+	SendMessageRequestCommunicationContextContractNotice     SendMessageRequestCommunicationContext = "contract_notice"
+	SendMessageRequestCommunicationContextCustomerService    SendMessageRequestCommunicationContext = "customer_service"
+	SendMessageRequestCommunicationContextInvoiceOrPayment   SendMessageRequestCommunicationContext = "invoice_or_payment"
+	SendMessageRequestCommunicationContextMarketing          SendMessageRequestCommunicationContext = "marketing"
+	SendMessageRequestCommunicationContextPrecontractQuote   SendMessageRequestCommunicationContext = "precontract_quote"
+	SendMessageRequestCommunicationContextReplyToInbound     SendMessageRequestCommunicationContext = "reply_to_inbound"
+	SendMessageRequestCommunicationContextRequestedFollowup  SendMessageRequestCommunicationContext = "requested_followup"
 )
 
 // Valid indicates whether the value is a known member of the SendMessageRequestCommunicationContext enum.
@@ -10649,8 +10614,6 @@ func (e SendMessageRequestCommunicationContext) Valid() bool {
 		return true
 	case SendMessageRequestCommunicationContextActiveDealFollowup:
 		return true
-	case SendMessageRequestCommunicationContextConsentConfirmation:
-		return true
 	case SendMessageRequestCommunicationContextContractNotice:
 		return true
 	case SendMessageRequestCommunicationContextCustomerService:
@@ -10659,19 +10622,11 @@ func (e SendMessageRequestCommunicationContext) Valid() bool {
 		return true
 	case SendMessageRequestCommunicationContextMarketing:
 		return true
-	case SendMessageRequestCommunicationContextOptoutConfirmation:
-		return true
 	case SendMessageRequestCommunicationContextPrecontractQuote:
-		return true
-	case SendMessageRequestCommunicationContextPrivacyNotice:
-		return true
-	case SendMessageRequestCommunicationContextRecordConfirmation:
 		return true
 	case SendMessageRequestCommunicationContextReplyToInbound:
 		return true
 	case SendMessageRequestCommunicationContextRequestedFollowup:
-		return true
-	case SendMessageRequestCommunicationContextSecurityNotice:
 		return true
 	default:
 		return false
@@ -29551,12 +29506,13 @@ type SendAccountEmailRequest struct {
 	// therefore honest and is the ordinary case for a reply; naming one matters when
 	// there is no anchor to derive from.
 	//
-	// Five categories exist to serve the recipient — `security_notice`,
+	// Five categories are absent from this list on purpose — `security_notice`,
 	// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-	// `record_confirmation` — and are refused (422 `invalid`) from an
-	// ordinary send. They are reserved for the installation's own controller mail,
-	// which rides a registered template; a caller that could claim one could dress
-	// marketing as a security warning and reach somebody who has objected.
+	// `record_confirmation`. They serve the recipient, which is why a hard
+	// suppression does not stop them, and they are reserved for the installation's
+	// own controller mail behind a registered template. A caller that could claim
+	// one could dress marketing as a security warning and reach somebody who has
+	// objected, so naming one here is refused (422 `invalid`).
 	CommunicationContext *SendAccountEmailRequestCommunicationContext `json:"communication_context,omitempty"`
 
 	// ConsentPurpose The consent purpose this send falls under. Default-deny per purpose (A22/ADR-0011):
@@ -29635,12 +29591,13 @@ type SendAccountEmailRequest struct {
 // therefore honest and is the ordinary case for a reply; naming one matters when
 // there is no anchor to derive from.
 //
-// Five categories exist to serve the recipient — `security_notice`,
+// Five categories are absent from this list on purpose — `security_notice`,
 // `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-// `record_confirmation` — and are refused (422 `invalid`) from an
-// ordinary send. They are reserved for the installation's own controller mail,
-// which rides a registered template; a caller that could claim one could dress
-// marketing as a security warning and reach somebody who has objected.
+// `record_confirmation`. They serve the recipient, which is why a hard
+// suppression does not stop them, and they are reserved for the installation's
+// own controller mail behind a registered template. A caller that could claim
+// one could dress marketing as a security warning and reach somebody who has
+// objected, so naming one here is refused (422 `invalid`).
 type SendAccountEmailRequestCommunicationContext string
 
 // SendEmailRequest defines model for SendEmailRequest.
@@ -29714,12 +29671,13 @@ type SendEmailRequest struct {
 	// therefore honest and is the ordinary case for a reply; naming one matters when
 	// there is no anchor to derive from.
 	//
-	// Five categories exist to serve the recipient — `security_notice`,
+	// Five categories are absent from this list on purpose — `security_notice`,
 	// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-	// `record_confirmation` — and are refused (422 `invalid`) from an
-	// ordinary send. They are reserved for the installation's own controller mail,
-	// which rides a registered template; a caller that could claim one could dress
-	// marketing as a security warning and reach somebody who has objected.
+	// `record_confirmation`. They serve the recipient, which is why a hard
+	// suppression does not stop them, and they are reserved for the installation's
+	// own controller mail behind a registered template. A caller that could claim
+	// one could dress marketing as a security warning and reach somebody who has
+	// objected, so naming one here is refused (422 `invalid`).
 	CommunicationContext *SendEmailRequestCommunicationContext `json:"communication_context,omitempty"`
 
 	// ConsentPurpose The consent purpose this send falls under (e.g. `transactional`, `marketing_email`).
@@ -29790,12 +29748,13 @@ type SendEmailRequest struct {
 // therefore honest and is the ordinary case for a reply; naming one matters when
 // there is no anchor to derive from.
 //
-// Five categories exist to serve the recipient — `security_notice`,
+// Five categories are absent from this list on purpose — `security_notice`,
 // `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-// `record_confirmation` — and are refused (422 `invalid`) from an
-// ordinary send. They are reserved for the installation's own controller mail,
-// which rides a registered template; a caller that could claim one could dress
-// marketing as a security warning and reach somebody who has objected.
+// `record_confirmation`. They serve the recipient, which is why a hard
+// suppression does not stop them, and they are reserved for the installation's
+// own controller mail behind a registered template. A caller that could claim
+// one could dress marketing as a security warning and reach somebody who has
+// objected, so naming one here is refused (422 `invalid`).
 type SendEmailRequestCommunicationContext string
 
 // SendMessageRequest One channel reply. It carries no subject and no addressee list, and that absence is the
@@ -29838,12 +29797,13 @@ type SendMessageRequest struct {
 	// therefore honest and is the ordinary case for a reply; naming one matters when
 	// there is no anchor to derive from.
 	//
-	// Five categories exist to serve the recipient — `security_notice`,
+	// Five categories are absent from this list on purpose — `security_notice`,
 	// `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-	// `record_confirmation` — and are refused (422 `invalid`) from an
-	// ordinary send. They are reserved for the installation's own controller mail,
-	// which rides a registered template; a caller that could claim one could dress
-	// marketing as a security warning and reach somebody who has objected.
+	// `record_confirmation`. They serve the recipient, which is why a hard
+	// suppression does not stop them, and they are reserved for the installation's
+	// own controller mail behind a registered template. A caller that could claim
+	// one could dress marketing as a security warning and reach somebody who has
+	// objected, so naming one here is refused (422 `invalid`).
 	CommunicationContext *SendMessageRequestCommunicationContext `json:"communication_context,omitempty"`
 
 	// ConsentPurpose The consent purpose this send falls under (e.g. `transactional`). The send is
@@ -29876,12 +29836,13 @@ type SendMessageRequest struct {
 // therefore honest and is the ordinary case for a reply; naming one matters when
 // there is no anchor to derive from.
 //
-// Five categories exist to serve the recipient — `security_notice`,
+// Five categories are absent from this list on purpose — `security_notice`,
 // `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-// `record_confirmation` — and are refused (422 `invalid`) from an
-// ordinary send. They are reserved for the installation's own controller mail,
-// which rides a registered template; a caller that could claim one could dress
-// marketing as a security warning and reach somebody who has objected.
+// `record_confirmation`. They serve the recipient, which is why a hard
+// suppression does not stop them, and they are reserved for the installation's
+// own controller mail behind a registered template. A caller that could claim
+// one could dress marketing as a security warning and reach somebody who has
+// objected, so naming one here is refused (422 `invalid`).
 type SendMessageRequestCommunicationContext string
 
 // SetActivityAudienceRequest defines model for SetActivityAudienceRequest.

--- a/backend/internal/modules/activities/scheduledpayload.go
+++ b/backend/internal/modules/activities/scheduledpayload.go
@@ -137,6 +137,16 @@ func (p scheduledPayload) thaw() (SendEmailInput, error) {
 	if err != nil {
 		return SendEmailInput{}, err
 	}
+	// A category reserved for the installation's own notices can never
+	// legitimately be in a scheduled payload: the door that wrote it refuses
+	// one, and freezePayload has a single caller behind that door. Refusing it
+	// again here costs a live send nothing and removes the assumption — a
+	// second payload writer added later cannot smuggle one past the fire.
+	if commsauthz.Category(p.Context).ServesTheSubject() {
+		return SendEmailInput{}, &CommunicationContextError{
+			Reason: "that category is reserved for the installation's own notices and cannot be claimed by a send",
+		}
+	}
 	return SendEmailInput{
 		Recipients:     p.Recipients,
 		Cc:             p.Cc,

--- a/backend/internal/modules/activities/scheduledpayload_test.go
+++ b/backend/internal/modules/activities/scheduledpayload_test.go
@@ -103,3 +103,38 @@ func TestAnUnnamedRecordDoesNotBecomeAZeroID(t *testing.T) {
 		t.Errorf("evidence = %+v, want zero after a round trip that named nothing", out.Evidence)
 	}
 }
+
+// A reserved category cannot be restored from a scheduled payload.
+//
+// It can never legitimately be in one: the door that writes the payload refuses
+// it, and freezePayload has a single caller behind that door. Refusing it again
+// at the restore costs a live send nothing and removes the assumption — the
+// exemption this shape holds in the send-door gate rests on there being exactly
+// one payload writer, and nothing fails today if somebody adds a second.
+func TestAReservedCategoryCannotBeRestoredFromAScheduledPayload(t *testing.T) {
+	for _, c := range commsauthz.Categories() {
+		if !c.ServesTheSubject() {
+			continue
+		}
+		payload := freezePayload(SendEmailInput{Subject: "Anything"})
+		payload.Context = string(c)
+		if _, err := payload.thaw(); err == nil {
+			t.Errorf("a scheduled payload restored %q, which no send may claim", c)
+		}
+	}
+}
+
+// And an ordinary category still restores, or the refusal above would be
+// indistinguishable from a thaw that rejects every category.
+func TestAnOrdinaryCategoryStillRestores(t *testing.T) {
+	payload := freezePayload(SendEmailInput{
+		Subject: "Anything", Context: commsauthz.CategoryReplyToInbound,
+	})
+	out, err := payload.thaw()
+	if err != nil {
+		t.Fatalf("an ordinary category was refused at restore: %v", err)
+	}
+	if out.Context != commsauthz.CategoryReplyToInbound {
+		t.Errorf("context = %q, want reply_to_inbound", out.Context)
+	}
+}

--- a/backend/internal/modules/activities/sendcontext.go
+++ b/backend/internal/modules/activities/sendcontext.go
@@ -174,3 +174,61 @@ func accountSendInput(req crmcontracts.SendAccountEmailRequest) (SendEmailInput,
 		req.ConsentPurpose, req.DraftRef,
 	)), nil
 }
+
+// SendContextInput is what a NON-HTTP transport says about why it is writing.
+//
+// The MCP tool surface cannot reach the generated request types, and must not
+// grow a second validator — a door validating its own claims differently is
+// how one surface ends up able to say what another cannot. So the wire shape
+// is decoded here and the same refusals apply, whichever transport asked.
+type SendContextInput struct {
+	Context          string
+	MarketingPurpose string
+	OperatorReason   string
+	Evidence         commsauthz.Evidence
+}
+
+// ApplyContext validates a non-HTTP caller's claim and puts it on the send
+// input. The refusals are the ones sendContextFrom applies: an unknown
+// category, a category reserved for the installation's own notices, and an
+// operator reason longer than the contract allows.
+func ApplyContext(in SendEmailInput, claim SendContextInput) (SendEmailInput, error) {
+	decoded, err := decodeSendContext(claim)
+	if err != nil {
+		return SendEmailInput{}, err
+	}
+	return decoded.applyTo(in), nil
+}
+
+// ApplyChannelContext is the channel twin. The two inputs are different structs
+// and share this one validation for the reason the mail and channel doors share
+// everything else they can: a claim an agent may not make on one transport must
+// not become makeable by choosing the other.
+func ApplyChannelContext(in SendMessageInput, claim SendContextInput) (SendMessageInput, error) {
+	decoded, err := decodeSendContext(claim)
+	if err != nil {
+		return SendMessageInput{}, err
+	}
+	in.Context = decoded.category
+	in.MarketingPurpose = decoded.marketing
+	in.OperatorReason = decoded.reason
+	in.Evidence = decoded.evidence
+	return in, nil
+}
+
+// decodeSendContext runs the shared refusals over an already-typed claim.
+func decodeSendContext(claim SendContextInput) (sendContext, error) {
+	var category *string
+	if claim.Context != "" {
+		category = &claim.Context
+	}
+	decoded, err := sendContextFrom(category, &claim.MarketingPurpose, &claim.OperatorReason, nil)
+	if err != nil {
+		return sendContext{}, err
+	}
+	// Evidence arrives already typed on this path, so it is carried rather than
+	// re-flattened. Nothing about it is trusted here either: the engine reads
+	// each named record and asks whether it supports the category.
+	decoded.evidence = claim.Evidence
+	return decoded, nil
+}

--- a/backend/internal/modules/activities/sendcontext_test.go
+++ b/backend/internal/modules/activities/sendcontext_test.go
@@ -198,3 +198,87 @@ func TestAReasonAtTheBoundIsAccepted(t *testing.T) {
 		t.Errorf("a reason of exactly %d characters was refused: %v", maxOperatorReasonRunes, err)
 	}
 }
+
+// The non-HTTP transports run the SAME refusals.
+//
+// The MCP surface cannot reach the generated request types, so it needs its own
+// entry point — and an entry point is where a second, laxer validator grows. A
+// claim an agent may not make over HTTP must not become makeable by choosing
+// the tool surface, so both doors are asserted against the same vocabulary
+// rather than against a list written twice.
+func TestANonHTTPCallerCannotClaimAControllerCategory(t *testing.T) {
+	for _, c := range commsauthz.Categories() {
+		if !c.ServesTheSubject() {
+			continue
+		}
+		claim := SendContextInput{Context: string(c)}
+		if _, err := ApplyContext(SendEmailInput{}, claim); err == nil {
+			t.Errorf("the mail tool accepted %q, which is reserved for controller mail", c)
+		}
+		if _, err := ApplyChannelContext(SendMessageInput{}, claim); err == nil {
+			t.Errorf("the channel tool accepted %q, which is reserved for controller mail", c)
+		}
+	}
+}
+
+// And an unknown category, for the same reason it is refused over HTTP: a claim
+// nothing reads is worse than a refusal.
+func TestANonHTTPCallerCannotClaimAnUnknownCategory(t *testing.T) {
+	claim := SendContextInput{Context: "transactional"}
+	if _, err := ApplyContext(SendEmailInput{}, claim); err == nil {
+		t.Error("the mail tool accepted a category that does not exist")
+	}
+	if _, err := ApplyChannelContext(SendMessageInput{}, claim); err == nil {
+		t.Error("the channel tool accepted a category that does not exist")
+	}
+}
+
+// An ordinary claim reaches the input on both doors, or the refusals above
+// would be indistinguishable from a surface that drops everything.
+func TestANonHTTPClaimReachesBothInputs(t *testing.T) {
+	claim := SendContextInput{
+		Context:          string(commsauthz.CategoryActiveDealFollowup),
+		MarketingPurpose: "newsletter",
+		OperatorReason:   "they asked at the fair",
+		Evidence:         commsauthz.Evidence{DealID: ids.NewV7()},
+	}
+	mail, err := ApplyContext(SendEmailInput{Subject: "Hello"}, claim)
+	if err != nil {
+		t.Fatalf("mail: %v", err)
+	}
+	if mail.Context != commsauthz.CategoryActiveDealFollowup || mail.MarketingPurpose != "newsletter" {
+		t.Errorf("the claim did not reach the mail input: %+v", mail)
+	}
+	if mail.Evidence.DealID != claim.Evidence.DealID {
+		t.Error("named evidence did not reach the mail input")
+	}
+	if mail.Subject != "Hello" {
+		t.Error("ApplyContext overwrote a field it does not own")
+	}
+
+	channel, err := ApplyChannelContext(SendMessageInput{Body: "Hi"}, claim)
+	if err != nil {
+		t.Fatalf("channel: %v", err)
+	}
+	if channel.Context != commsauthz.CategoryActiveDealFollowup {
+		t.Errorf("the claim did not reach the channel input: %+v", channel)
+	}
+	if channel.Evidence.DealID != claim.Evidence.DealID {
+		t.Error("named evidence did not reach the channel input")
+	}
+	if channel.Body != "Hi" {
+		t.Error("ApplyChannelContext overwrote a field it does not own")
+	}
+}
+
+// An overlong operator reason is refused on these doors too. The bound lives in
+// one decoder, and this is what proves both entry points reach it.
+func TestANonHTTPOperatorReasonIsBounded(t *testing.T) {
+	claim := SendContextInput{OperatorReason: strings.Repeat("x", maxOperatorReasonRunes+1)}
+	if _, err := ApplyContext(SendEmailInput{}, claim); err == nil {
+		t.Error("the mail tool accepted an unbounded operator reason")
+	}
+	if _, err := ApplyChannelContext(SendMessageInput{}, claim); err == nil {
+		t.Error("the channel tool accepted an unbounded operator reason")
+	}
+}

--- a/backend/internal/modules/agents/tools_account_send.go
+++ b/backend/internal/modules/agents/tools_account_send.go
@@ -55,7 +55,7 @@ func (t sendAccountEmailTool) Spec() mcp.ToolSpec {
 				"entity_type":{"type":"string","enum":` + activityLinkEntityTypeEnum + `},
 				"entity_id":{"type":"string","format":"uuid"}},"additionalProperties":false},"maxItems":25,
 				"description":"The records this conversation is filed under; at least one. The send is refused without it."},
-			"approval_id":{"type":"string","format":"uuid","description":"Set on approved retry"}},
+			"approval_id":{"type":"string","format":"uuid","description":"Set on approved retry"}` + sendContextProperties + `},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[SendEmailResult](),
 	}

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -84,26 +84,15 @@ type SendEmailArgs struct {
 // SendContextArgs is what a caller says about WHY it is writing, shared by the
 // three send tools so the surface asks one question one way.
 //
-// An agent may PROPOSE a category and name evidence; it cannot set a basis, an
-// exception, or one of the five categories reserved for the installation's own
-// notices — the send door refuses those from any caller, agent or human.
-// Nothing here authorizes: the engine reads the named records and resolves the
-// category the evidence supports.
+// An agent may PROPOSE a category; it cannot set a basis, an exception, or one
+// of the five categories reserved for the installation's own notices — the send
+// door refuses those from any caller, agent or human. Nothing here authorizes:
+// the claim is recorded beside the category the engine resolved, so a claim the
+// engine disagrees with is visible rather than honoured.
 type SendContextArgs struct {
-	CommunicationContext string        `json:"communication_context,omitempty"`
-	MarketingPurpose     string        `json:"marketing_purpose,omitempty"`
-	OperatorReason       string        `json:"operator_reason,omitempty"`
-	Evidence             *SendEvidence `json:"evidence,omitempty"`
-}
-
-// SendEvidence names records in support of a send, by id and never by content.
-type SendEvidence struct {
-	ActivityID     *ids.UUID `json:"activity_id,omitempty"`
-	DealID         *ids.UUID `json:"deal_id,omitempty"`
-	InvoiceID      *ids.UUID `json:"invoice_id,omitempty"`
-	ContractID     *ids.UUID `json:"contract_id,omitempty"`
-	ConsentEventID *ids.UUID `json:"consent_event_id,omitempty"`
-	BasisID        *ids.UUID `json:"basis_id,omitempty"`
+	CommunicationContext string `json:"communication_context,omitempty"`
+	MarketingPurpose     string `json:"marketing_purpose,omitempty"`
+	OperatorReason       string `json:"operator_reason,omitempty"`
 }
 
 // SendMessageArgs is one channel reply. It carries no subject and no
@@ -259,8 +248,17 @@ type sendEmailTool struct {
 	p     datasource.SystemOfRecordProvider
 }
 
-// sendContextProperties is the four context arguments, spelled once for the
-// three send tools. One question asked one way, and one place to change it.
+// sendContextProperties is the context arguments, spelled once for the three
+// send tools. One question asked one way, and one place to change it.
+//
+// There is deliberately no `evidence` here. The HTTP contract has one, and
+// nothing in the engine reads it yet — the validators that will resolve a
+// category FROM the named records land with the jurisdiction packs. A tool
+// description is text a model reads and reasons about, so advertising a check
+// the system does not perform teaches it something false, and the next author
+// to wire evidence up would read it and skip writing the validation. It also
+// costs the catalog budget on every step of every run that carries one of
+// these tools.
 //
 // Held by: TestTheToolSurfaceSpellsTheSendContextOnce
 // (backend/gates/sendcontextvalidation_test.go)
@@ -274,16 +272,9 @@ const sendContextProperties = `,
 	"communication_context":{"type":"string","enum":["reply_to_inbound","requested_followup",` +
 	`"precontract_quote","active_deal_followup","customer_service","account_notice",` +
 	`"contract_notice","invoice_or_payment","marketing"],` +
-	`"description":"What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured."},
+	`"description":"What kind of message this is. Omit to let the server resolve it from the thread; the claim is recorded and grants nothing."},
 	"marketing_purpose":{"type":"string","description":"For marketing, the purpose key naming the topic"},
-	"operator_reason":{"type":"string","maxLength":500,"description":"Why this first message is being sent. Recorded; grants nothing."},
-	"evidence":{"type":"object","additionalProperties":false,"description":"Records supporting this send, by id. Checked, never trusted.","properties":{
-		"activity_id":{"type":"string","format":"uuid"},
-		"deal_id":{"type":"string","format":"uuid"},
-		"invoice_id":{"type":"string","format":"uuid"},
-		"contract_id":{"type":"string","format":"uuid"},
-		"consent_event_id":{"type":"string","format":"uuid"},
-		"basis_id":{"type":"string","format":"uuid"}}}`
+	"operator_reason":{"type":"string","maxLength":500,"description":"Why this first message is being sent. Recorded; grants nothing."}`
 
 func (t sendEmailTool) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -78,6 +78,32 @@ type SendEmailArgs struct {
 	ScheduledAt string `json:"scheduled_at,omitempty"`
 	// ScheduledTZ is the IANA zone the moment was chosen in, required with it.
 	ScheduledTZ string `json:"scheduled_tz,omitempty"`
+	SendContextArgs
+}
+
+// SendContextArgs is what a caller says about WHY it is writing, shared by the
+// three send tools so the surface asks one question one way.
+//
+// An agent may PROPOSE a category and name evidence; it cannot set a basis, an
+// exception, or one of the five categories reserved for the installation's own
+// notices — the send door refuses those from any caller, agent or human.
+// Nothing here authorizes: the engine reads the named records and resolves the
+// category the evidence supports.
+type SendContextArgs struct {
+	CommunicationContext string        `json:"communication_context,omitempty"`
+	MarketingPurpose     string        `json:"marketing_purpose,omitempty"`
+	OperatorReason       string        `json:"operator_reason,omitempty"`
+	Evidence             *SendEvidence `json:"evidence,omitempty"`
+}
+
+// SendEvidence names records in support of a send, by id and never by content.
+type SendEvidence struct {
+	ActivityID     *ids.UUID `json:"activity_id,omitempty"`
+	DealID         *ids.UUID `json:"deal_id,omitempty"`
+	InvoiceID      *ids.UUID `json:"invoice_id,omitempty"`
+	ContractID     *ids.UUID `json:"contract_id,omitempty"`
+	ConsentEventID *ids.UUID `json:"consent_event_id,omitempty"`
+	BasisID        *ids.UUID `json:"basis_id,omitempty"`
 }
 
 // SendMessageArgs is one channel reply. It carries no subject and no
@@ -86,6 +112,7 @@ type SendEmailArgs struct {
 type SendMessageArgs struct {
 	Body           string `json:"body"`
 	ConsentPurpose string `json:"consent_purpose"`
+	SendContextArgs
 }
 
 type BookMeetingArgs struct {
@@ -232,6 +259,32 @@ type sendEmailTool struct {
 	p     datasource.SystemOfRecordProvider
 }
 
+// sendContextProperties is the four context arguments, spelled once for the
+// three send tools. One question asked one way, and one place to change it.
+//
+// Held by: TestTheToolSurfaceSpellsTheSendContextOnce
+// (backend/gates/sendcontextvalidation_test.go)
+//
+// Deliberately terse: every byte here is written into the system prompt of
+// every step of every run that carries one of these tools, so the catalog
+// budget (docs/reference/agent-tool-budget.md) is spent on it whether or not a
+// caller ever sets the field. The refusals it names are enforced by the send
+// door, not by this text.
+const sendContextProperties = `,
+	"communication_context":{"type":"string","enum":["reply_to_inbound","requested_followup",` +
+	`"precontract_quote","active_deal_followup","customer_service","account_notice",` +
+	`"contract_notice","invoice_or_payment","marketing"],` +
+	`"description":"What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured."},
+	"marketing_purpose":{"type":"string","description":"For marketing, the purpose key naming the topic"},
+	"operator_reason":{"type":"string","maxLength":500,"description":"Why this first message is being sent. Recorded; grants nothing."},
+	"evidence":{"type":"object","additionalProperties":false,"description":"Records supporting this send, by id. Checked, never trusted.","properties":{
+		"activity_id":{"type":"string","format":"uuid"},
+		"deal_id":{"type":"string","format":"uuid"},
+		"invoice_id":{"type":"string","format":"uuid"},
+		"contract_id":{"type":"string","format":"uuid"},
+		"consent_event_id":{"type":"string","format":"uuid"},
+		"basis_id":{"type":"string","format":"uuid"}}}`
+
 func (t sendEmailTool) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "send_email", Title: "Send an email", Version: toolVersionV1,
@@ -247,7 +300,7 @@ func (t sendEmailTool) Spec() mcp.ToolSpec {
 			"consent_purpose":{"type":"string","description":"Purpose key the recipients must have granted"},
 			"scheduled_at":{"type":"string","format":"date-time"` + timestampNote + `},
 			"scheduled_tz":{"type":"string","description":"IANA zone name the moment was chosen in (e.g. Europe/Berlin), required with scheduled_at. The send is deferred to that instant: no activity exists until it fires, and every gate re-runs then."},
-			"approval_id":{"type":"string","format":"uuid","description":"Set on approved retry"}},
+			"approval_id":{"type":"string","format":"uuid","description":"Set on approved retry"}` + sendContextProperties + `},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[SendEmailResult](),
 	}
@@ -324,7 +377,7 @@ func (t sendMessageTool) Spec() mcp.ToolSpec {
 			"activity_id":{"type":"string","format":"uuid","description":"The captured conversation being replied to"},
 			"body":{"type":"string","minLength":1},
 			"consent_purpose":{"type":"string","description":"Purpose key the recipient must have granted"},
-			"approval_id":{"type":"string","format":"uuid","description":"Set on approved retry"}},
+			"approval_id":{"type":"string","format":"uuid","description":"Set on approved retry"}` + sendContextProperties + `},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[SendMessageResult](),
 	}

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,9 +6,9 @@
   "catalog": {
     "tools": 70,
     "system_frame_tokens": 353,
-    "tokens": 20552,
+    "tokens": 20230,
     "median_tool_tokens": 262,
-    "mean_tool_tokens": 293
+    "mean_tool_tokens": 288
   },
   "agents": [
     {
@@ -75,28 +75,24 @@
       "tokens": 786
     },
     {
-      "name": "send_account_email",
-      "tokens": 762
-    },
-    {
-      "name": "send_email",
-      "tokens": 695
-    },
-    {
       "name": "preview_import",
       "tokens": 677
+    },
+    {
+      "name": "send_account_email",
+      "tokens": 655
     },
     {
       "name": "log_activity",
       "tokens": 635
     },
     {
-      "name": "update_record",
-      "tokens": 572
+      "name": "send_email",
+      "tokens": 588
     },
     {
-      "name": "send_message",
-      "tokens": 538
+      "name": "update_record",
+      "tokens": 572
     },
     {
       "name": "resolve_entities",
@@ -113,6 +109,10 @@
     {
       "name": "advance_deal",
       "tokens": 443
+    },
+    {
+      "name": "send_message",
+      "tokens": 431
     },
     {
       "name": "annotate_brief",

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,9 +6,9 @@
   "catalog": {
     "tools": 70,
     "system_frame_tokens": 353,
-    "tokens": 19785,
+    "tokens": 20552,
     "median_tool_tokens": 262,
-    "mean_tool_tokens": 282
+    "mean_tool_tokens": 293
   },
   "agents": [
     {
@@ -75,6 +75,14 @@
       "tokens": 786
     },
     {
+      "name": "send_account_email",
+      "tokens": 762
+    },
+    {
+      "name": "send_email",
+      "tokens": 695
+    },
+    {
       "name": "preview_import",
       "tokens": 677
     },
@@ -87,8 +95,8 @@
       "tokens": 572
     },
     {
-      "name": "send_account_email",
-      "tokens": 507
+      "name": "send_message",
+      "tokens": 538
     },
     {
       "name": "resolve_entities",
@@ -105,10 +113,6 @@
     {
       "name": "advance_deal",
       "tokens": 443
-    },
-    {
-      "name": "send_email",
-      "tokens": 440
     },
     {
       "name": "annotate_brief",
@@ -161,10 +165,6 @@
     {
       "name": "merge_records",
       "tokens": 292
-    },
-    {
-      "name": "send_message",
-      "tokens": 283
     },
     {
       "name": "catch_me_up_on",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1621 | 6% | 15787 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2453 | 9% | 14955 | 15 | 8 |
-| _whole served catalog, for scale_ | 70 | 19785 | 80% | — | — | — |
+| _whole served catalog, for scale_ | 70 | 20552 | 83% | — | — | — |
 
 ### `morning_brief`
 
@@ -129,7 +129,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 262 tokens, mean 282, across 70 served tools.
+Median 262 tokens, mean 293, across 70 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -139,15 +139,16 @@ a term in an addition.
 | Tool | Tokens | Named as the wrong reach in |
 |---|---:|---:|
 | `run_report` | 786 | 3 scenarios |
+| `send_account_email` | 762 | — |
+| `send_email` | 695 | 1 scenario |
 | `preview_import` | 677 | — |
 | `log_activity` | 635 | 1 scenario |
 | `update_record` | 572 | 4 scenarios |
-| `send_account_email` | 507 | — |
+| `send_message` | 538 | — |
 | `resolve_entities` | 498 | — |
 | `list_records` | 494 | — |
 | `query_workspace` | 484 | 3 scenarios |
 | `advance_deal` | 443 | 1 scenario |
-| `send_email` | 440 | 1 scenario |
 | `annotate_brief` | 418 | — |
 | `progress_deal` | 404 | 3 scenarios |
 | `review_commitments` | 401 | — |
@@ -161,7 +162,6 @@ a term in an addition.
 | `forecast_readings` | 327 | — |
 | `prep_for_meeting` | 326 | — |
 | `merge_records` | 292 | — |
-| `send_message` | 283 | — |
 | `catch_me_up_on` | 280 | 3 scenarios |
 | `advance_project_phase` | 279 | — |
 | `draft_email` | 279 | — |

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1621 | 6% | 15787 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2453 | 9% | 14955 | 15 | 8 |
-| _whole served catalog, for scale_ | 70 | 20552 | 83% | — | — | — |
+| _whole served catalog, for scale_ | 70 | 20230 | 82% | — | — | — |
 
 ### `morning_brief`
 
@@ -129,7 +129,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 262 tokens, mean 293, across 70 served tools.
+Median 262 tokens, mean 288, across 70 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -139,16 +139,16 @@ a term in an addition.
 | Tool | Tokens | Named as the wrong reach in |
 |---|---:|---:|
 | `run_report` | 786 | 3 scenarios |
-| `send_account_email` | 762 | — |
-| `send_email` | 695 | 1 scenario |
 | `preview_import` | 677 | — |
+| `send_account_email` | 655 | — |
 | `log_activity` | 635 | 1 scenario |
+| `send_email` | 588 | 1 scenario |
 | `update_record` | 572 | 4 scenarios |
-| `send_message` | 538 | — |
 | `resolve_entities` | 498 | — |
 | `list_records` | 494 | — |
 | `query_workspace` | 484 | 3 scenarios |
 | `advance_deal` | 443 | 1 scenario |
+| `send_message` | 431 | — |
 | `annotate_brief` | 418 | — |
 | `progress_deal` | 404 | 3 scenarios |
 | `review_commitments` | 401 | — |

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -87,7 +87,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (91)
+## Census (92)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -173,6 +173,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `satellite_lifecycle_test.go` | H2 | Person-satellite lifecycle reach as a fitness function. |
 | `scrubverbs_test.go` | H2 | Every verb the privacy module writes is judged a scrub or ratified as not one. |
 | `seatfanout_test.go` | H2 | A nightly agent acts FOR A PERSON, and the identity of one night's work has to say which person. |
+| `sendcontextvalidation_test.go` | H3 | Every door that builds a send input runs the claim through the shared validator. |
 | `sendinghumanreaders_test.go` | H2 | principal.SendingHuman has ONE reader, and it answers one question. |
 | `settingscatalog_test.go` | H3 | The settings-catalog fitness gates (ADR-0090/A135 §7). |
 | `stagingdecision_test.go` | H3 | Every path that stages a delivery records why it was allowed to. |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 70,
     "resources": 10,
-    "tool_catalog_bytes": 197668,
+    "tool_catalog_bytes": 200824,
     "resource_catalog_bytes": 3915,
-    "approx_wire_tokens_total": 50395,
+    "approx_wire_tokens_total": 51184,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 47770,
-      "input_schema_bytes": 38885,
+      "input_schema_bytes": 42041,
       "output_schema_bytes": 95916,
-      "description_plus_input_schema_bytes": 86655
+      "description_plus_input_schema_bytes": 89811
     }
   },
   "tools": {
@@ -11739,9 +11739,55 @@
               },
               "type": "array"
             },
+            "communication_context": {
+              "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+              "enum": [
+                "reply_to_inbound",
+                "requested_followup",
+                "precontract_quote",
+                "active_deal_followup",
+                "customer_service",
+                "account_notice",
+                "contract_notice",
+                "invoice_or_payment",
+                "marketing"
+              ],
+              "type": "string"
+            },
             "consent_purpose": {
               "description": "Purpose key the recipients must have granted",
               "type": "string"
+            },
+            "evidence": {
+              "additionalProperties": false,
+              "description": "Records supporting this send, by id. Checked, never trusted.",
+              "properties": {
+                "activity_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "basis_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "consent_event_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "contract_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "deal_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "invoice_id": {
+                  "format": "uuid",
+                  "type": "string"
+                }
+              },
+              "type": "object"
             },
             "idempotency_key": {
               "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
@@ -11777,6 +11823,15 @@
               "maxItems": 25,
               "minItems": 1,
               "type": "array"
+            },
+            "marketing_purpose": {
+              "description": "For marketing, the purpose key naming the topic",
+              "type": "string"
+            },
+            "operator_reason": {
+              "description": "Why this first message is being sent. Recorded; grants nothing.",
+              "maxLength": 500,
+              "type": "string"
             },
             "scheduled_at": {
               "description": "RFC 3339 WITH a zone offset (…T16:35:00+07:00 or …Z); a bare local time is refused.",
@@ -11942,13 +11997,68 @@
               },
               "type": "array"
             },
+            "communication_context": {
+              "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+              "enum": [
+                "reply_to_inbound",
+                "requested_followup",
+                "precontract_quote",
+                "active_deal_followup",
+                "customer_service",
+                "account_notice",
+                "contract_notice",
+                "invoice_or_payment",
+                "marketing"
+              ],
+              "type": "string"
+            },
             "consent_purpose": {
               "description": "Purpose key the recipients must have granted",
               "type": "string"
             },
+            "evidence": {
+              "additionalProperties": false,
+              "description": "Records supporting this send, by id. Checked, never trusted.",
+              "properties": {
+                "activity_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "basis_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "consent_event_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "contract_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "deal_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "invoice_id": {
+                  "format": "uuid",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
             "idempotency_key": {
               "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
               "maxLength": 255,
+              "type": "string"
+            },
+            "marketing_purpose": {
+              "description": "For marketing, the purpose key naming the topic",
+              "type": "string"
+            },
+            "operator_reason": {
+              "description": "Why this first message is being sent. Recorded; grants nothing.",
+              "maxLength": 500,
               "type": "string"
             },
             "scheduled_at": {
@@ -12110,13 +12220,68 @@
               "minLength": 1,
               "type": "string"
             },
+            "communication_context": {
+              "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+              "enum": [
+                "reply_to_inbound",
+                "requested_followup",
+                "precontract_quote",
+                "active_deal_followup",
+                "customer_service",
+                "account_notice",
+                "contract_notice",
+                "invoice_or_payment",
+                "marketing"
+              ],
+              "type": "string"
+            },
             "consent_purpose": {
               "description": "Purpose key the recipient must have granted",
               "type": "string"
             },
+            "evidence": {
+              "additionalProperties": false,
+              "description": "Records supporting this send, by id. Checked, never trusted.",
+              "properties": {
+                "activity_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "basis_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "consent_event_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "contract_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "deal_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "invoice_id": {
+                  "format": "uuid",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
             "idempotency_key": {
               "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
               "maxLength": 255,
+              "type": "string"
+            },
+            "marketing_purpose": {
+              "description": "For marketing, the purpose key naming the topic",
+              "type": "string"
+            },
+            "operator_reason": {
+              "description": "Why this first message is being sent. Recorded; grants nothing.",
+              "maxLength": 500,
               "type": "string"
             }
           },

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 70,
     "resources": 10,
-    "tool_catalog_bytes": 200824,
+    "tool_catalog_bytes": 199450,
     "resource_catalog_bytes": 3915,
-    "approx_wire_tokens_total": 51184,
+    "approx_wire_tokens_total": 50841,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 47770,
-      "input_schema_bytes": 42041,
+      "input_schema_bytes": 40667,
       "output_schema_bytes": 95916,
-      "description_plus_input_schema_bytes": 89811
+      "description_plus_input_schema_bytes": 88437
     }
   },
   "tools": {
@@ -11740,7 +11740,7 @@
               "type": "array"
             },
             "communication_context": {
-              "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+              "description": "What kind of message this is. Omit to let the server resolve it from the thread; the claim is recorded and grants nothing.",
               "enum": [
                 "reply_to_inbound",
                 "requested_followup",
@@ -11757,37 +11757,6 @@
             "consent_purpose": {
               "description": "Purpose key the recipients must have granted",
               "type": "string"
-            },
-            "evidence": {
-              "additionalProperties": false,
-              "description": "Records supporting this send, by id. Checked, never trusted.",
-              "properties": {
-                "activity_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "basis_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "consent_event_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "contract_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "deal_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "invoice_id": {
-                  "format": "uuid",
-                  "type": "string"
-                }
-              },
-              "type": "object"
             },
             "idempotency_key": {
               "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
@@ -11998,7 +11967,7 @@
               "type": "array"
             },
             "communication_context": {
-              "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+              "description": "What kind of message this is. Omit to let the server resolve it from the thread; the claim is recorded and grants nothing.",
               "enum": [
                 "reply_to_inbound",
                 "requested_followup",
@@ -12015,37 +11984,6 @@
             "consent_purpose": {
               "description": "Purpose key the recipients must have granted",
               "type": "string"
-            },
-            "evidence": {
-              "additionalProperties": false,
-              "description": "Records supporting this send, by id. Checked, never trusted.",
-              "properties": {
-                "activity_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "basis_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "consent_event_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "contract_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "deal_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "invoice_id": {
-                  "format": "uuid",
-                  "type": "string"
-                }
-              },
-              "type": "object"
             },
             "idempotency_key": {
               "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
@@ -12221,7 +12159,7 @@
               "type": "string"
             },
             "communication_context": {
-              "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+              "description": "What kind of message this is. Omit to let the server resolve it from the thread; the claim is recorded and grants nothing.",
               "enum": [
                 "reply_to_inbound",
                 "requested_followup",
@@ -12238,37 +12176,6 @@
             "consent_purpose": {
               "description": "Purpose key the recipient must have granted",
               "type": "string"
-            },
-            "evidence": {
-              "additionalProperties": false,
-              "description": "Records supporting this send, by id. Checked, never trusted.",
-              "properties": {
-                "activity_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "basis_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "consent_event_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "contract_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "deal_id": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "invoice_id": {
-                  "format": "uuid",
-                  "type": "string"
-                }
-              },
-              "type": "object"
             },
             "idempotency_key": {
               "description": "Optional. Same key, same result; a key reused with other arguments is refused.",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 70 |
 | Resources | 10 |
-| Tool catalog | 196.1 KB |
+| Tool catalog | 194.8 KB |
 | Resource catalog | 3.8 KB |
-| Approx. wire tokens | 51184 |
+| Approx. wire tokens | 50841 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 93.7 KB | 47% | **No** — a result's shape, never listed to a model |
+| Output schemas | 93.7 KB | 48% | **No** — a result's shape, never listed to a model |
 | Descriptions (incl. governance clause) | 46.7 KB | 23% | Yes, every step |
-| Input schemas | 41.1 KB | 20% | Yes, every step |
+| Input schemas | 39.7 KB | 20% | Yes, every step |
 | _Names, annotations, punctuation_ | 14.7 KB | 7% | Partly |
-| **Description + input schema** | **87.7 KB** | **44%** | **the recurring cost** |
+| **Description + input schema** | **86.4 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -124,9 +124,9 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`run_report`](#run_report) | Run a report | yes |  | 4.4 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.1 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.8 KB |
-| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 4.3 KB |
-| [`send_email`](#send_email) | Send an email |  |  | 4.0 KB |
-| [`send_message`](#send_message) | Reply on a channel conversation |  |  | 3.3 KB |
+| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.9 KB |
+| [`send_email`](#send_email) | Send an email |  |  | 3.6 KB |
+| [`send_message`](#send_message) | Reply on a channel conversation |  |  | 2.9 KB |
 | [`update_record`](#update_record) | Update a record |  |  | 3.8 KB |
 | [`update_tag`](#update_tag) | Rename or recolour a tag |  |  | 2.0 KB |
 | [`whats_slipping_this_week`](#whats_slipping_this_week) | What's slipping this week | yes | [`ui://margince/pipeline-review.html`](#pipeline_review_view) | 2.3 KB |
@@ -12634,7 +12634,7 @@ Put a mail on the wire to a real recipient, from this workspace, starting a new 
       "type": "array"
     },
     "communication_context": {
-      "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+      "description": "What kind of message this is. Omit to let the server resolve it from the thread; the claim is recorded and grants nothing.",
       "enum": [
         "reply_to_inbound",
         "requested_followup",
@@ -12651,37 +12651,6 @@ Put a mail on the wire to a real recipient, from this workspace, starting a new 
     "consent_purpose": {
       "description": "Purpose key the recipients must have granted",
       "type": "string"
-    },
-    "evidence": {
-      "additionalProperties": false,
-      "description": "Records supporting this send, by id. Checked, never trusted.",
-      "properties": {
-        "activity_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "basis_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "consent_event_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "contract_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "deal_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "invoice_id": {
-          "format": "uuid",
-          "type": "string"
-        }
-      },
-      "type": "object"
     },
     "idempotency_key": {
       "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
@@ -12902,7 +12871,7 @@ Put a mail on the wire to a real recipient, from this workspace, and record it o
       "type": "array"
     },
     "communication_context": {
-      "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+      "description": "What kind of message this is. Omit to let the server resolve it from the thread; the claim is recorded and grants nothing.",
       "enum": [
         "reply_to_inbound",
         "requested_followup",
@@ -12919,37 +12888,6 @@ Put a mail on the wire to a real recipient, from this workspace, and record it o
     "consent_purpose": {
       "description": "Purpose key the recipients must have granted",
       "type": "string"
-    },
-    "evidence": {
-      "additionalProperties": false,
-      "description": "Records supporting this send, by id. Checked, never trusted.",
-      "properties": {
-        "activity_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "basis_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "consent_event_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "contract_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "deal_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "invoice_id": {
-          "format": "uuid",
-          "type": "string"
-        }
-      },
-      "type": "object"
     },
     "idempotency_key": {
       "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
@@ -13135,7 +13073,7 @@ Reply on a captured chat conversation — the channels this workspace has connec
       "type": "string"
     },
     "communication_context": {
-      "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+      "description": "What kind of message this is. Omit to let the server resolve it from the thread; the claim is recorded and grants nothing.",
       "enum": [
         "reply_to_inbound",
         "requested_followup",
@@ -13152,37 +13090,6 @@ Reply on a captured chat conversation — the channels this workspace has connec
     "consent_purpose": {
       "description": "Purpose key the recipient must have granted",
       "type": "string"
-    },
-    "evidence": {
-      "additionalProperties": false,
-      "description": "Records supporting this send, by id. Checked, never trusted.",
-      "properties": {
-        "activity_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "basis_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "consent_event_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "contract_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "deal_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "invoice_id": {
-          "format": "uuid",
-          "type": "string"
-        }
-      },
-      "type": "object"
     },
     "idempotency_key": {
       "description": "Optional. Same key, same result; a key reused with other arguments is refused.",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 70 |
 | Resources | 10 |
-| Tool catalog | 193.0 KB |
+| Tool catalog | 196.1 KB |
 | Resource catalog | 3.8 KB |
-| Approx. wire tokens | 50395 |
+| Approx. wire tokens | 51184 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 93.7 KB | 48% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 46.7 KB | 24% | Yes, every step |
-| Input schemas | 38.0 KB | 19% | Yes, every step |
+| Output schemas | 93.7 KB | 47% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 46.7 KB | 23% | Yes, every step |
+| Input schemas | 41.1 KB | 20% | Yes, every step |
 | _Names, annotations, punctuation_ | 14.7 KB | 7% | Partly |
-| **Description + input schema** | **84.6 KB** | **43%** | **the recurring cost** |
+| **Description + input schema** | **87.7 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -124,9 +124,9 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`run_report`](#run_report) | Run a report | yes |  | 4.4 KB |
 | [`search_context`](#search_context) | Search for relevant material | yes |  | 3.1 KB |
 | [`search_records`](#search_records) | Search records | yes |  | 2.8 KB |
-| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 3.3 KB |
-| [`send_email`](#send_email) | Send an email |  |  | 3.0 KB |
-| [`send_message`](#send_message) | Reply on a channel conversation |  |  | 2.3 KB |
+| [`send_account_email`](#send_account_email) | Start an email conversation from a record |  |  | 4.3 KB |
+| [`send_email`](#send_email) | Send an email |  |  | 4.0 KB |
+| [`send_message`](#send_message) | Reply on a channel conversation |  |  | 3.3 KB |
 | [`update_record`](#update_record) | Update a record |  |  | 3.8 KB |
 | [`update_tag`](#update_tag) | Rename or recolour a tag |  |  | 2.0 KB |
 | [`whats_slipping_this_week`](#whats_slipping_this_week) | What's slipping this week | yes | [`ui://margince/pipeline-review.html`](#pipeline_review_view) | 2.3 KB |
@@ -12633,9 +12633,55 @@ Put a mail on the wire to a real recipient, from this workspace, starting a new 
       },
       "type": "array"
     },
+    "communication_context": {
+      "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+      "enum": [
+        "reply_to_inbound",
+        "requested_followup",
+        "precontract_quote",
+        "active_deal_followup",
+        "customer_service",
+        "account_notice",
+        "contract_notice",
+        "invoice_or_payment",
+        "marketing"
+      ],
+      "type": "string"
+    },
     "consent_purpose": {
       "description": "Purpose key the recipients must have granted",
       "type": "string"
+    },
+    "evidence": {
+      "additionalProperties": false,
+      "description": "Records supporting this send, by id. Checked, never trusted.",
+      "properties": {
+        "activity_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "basis_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "consent_event_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "contract_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "deal_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "invoice_id": {
+          "format": "uuid",
+          "type": "string"
+        }
+      },
+      "type": "object"
     },
     "idempotency_key": {
       "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
@@ -12671,6 +12717,15 @@ Put a mail on the wire to a real recipient, from this workspace, starting a new 
       "maxItems": 25,
       "minItems": 1,
       "type": "array"
+    },
+    "marketing_purpose": {
+      "description": "For marketing, the purpose key naming the topic",
+      "type": "string"
+    },
+    "operator_reason": {
+      "description": "Why this first message is being sent. Recorded; grants nothing.",
+      "maxLength": 500,
+      "type": "string"
     },
     "scheduled_at": {
       "description": "RFC 3339 WITH a zone offset (…T16:35:00+07:00 or …Z); a bare local time is refused.",
@@ -12846,13 +12901,68 @@ Put a mail on the wire to a real recipient, from this workspace, and record it o
       },
       "type": "array"
     },
+    "communication_context": {
+      "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+      "enum": [
+        "reply_to_inbound",
+        "requested_followup",
+        "precontract_quote",
+        "active_deal_followup",
+        "customer_service",
+        "account_notice",
+        "contract_notice",
+        "invoice_or_payment",
+        "marketing"
+      ],
+      "type": "string"
+    },
     "consent_purpose": {
       "description": "Purpose key the recipients must have granted",
       "type": "string"
     },
+    "evidence": {
+      "additionalProperties": false,
+      "description": "Records supporting this send, by id. Checked, never trusted.",
+      "properties": {
+        "activity_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "basis_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "consent_event_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "contract_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "deal_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "invoice_id": {
+          "format": "uuid",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "idempotency_key": {
       "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
       "maxLength": 255,
+      "type": "string"
+    },
+    "marketing_purpose": {
+      "description": "For marketing, the purpose key naming the topic",
+      "type": "string"
+    },
+    "operator_reason": {
+      "description": "Why this first message is being sent. Recorded; grants nothing.",
+      "maxLength": 500,
       "type": "string"
     },
     "scheduled_at": {
@@ -13024,13 +13134,68 @@ Reply on a captured chat conversation — the channels this workspace has connec
       "minLength": 1,
       "type": "string"
     },
+    "communication_context": {
+      "description": "What kind of message this is. Omit to let the server resolve it from the thread; a claim the evidence does not support is recorded, not honoured.",
+      "enum": [
+        "reply_to_inbound",
+        "requested_followup",
+        "precontract_quote",
+        "active_deal_followup",
+        "customer_service",
+        "account_notice",
+        "contract_notice",
+        "invoice_or_payment",
+        "marketing"
+      ],
+      "type": "string"
+    },
     "consent_purpose": {
       "description": "Purpose key the recipient must have granted",
       "type": "string"
     },
+    "evidence": {
+      "additionalProperties": false,
+      "description": "Records supporting this send, by id. Checked, never trusted.",
+      "properties": {
+        "activity_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "basis_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "consent_event_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "contract_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "deal_id": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "invoice_id": {
+          "format": "uuid",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "idempotency_key": {
       "description": "Optional. Same key, same result; a key reused with other arguments is refused.",
       "maxLength": 255,
+      "type": "string"
+    },
+    "marketing_purpose": {
+      "description": "For marketing, the purpose key naming the topic",
+      "type": "string"
+    },
+    "operator_reason": {
+      "description": "Why this first message is being sent. Recorded; grants nothing.",
+      "maxLength": 500,
       "type": "string"
     }
   },

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21134,15 +21134,16 @@ export interface components {
              *     therefore honest and is the ordinary case for a reply; naming one matters when
              *     there is no anchor to derive from.
              *
-             *     Five categories exist to serve the recipient — `security_notice`,
+             *     Five categories are absent from this list on purpose — `security_notice`,
              *     `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-             *     `record_confirmation` — and are refused (422 `invalid`) from an
-             *     ordinary send. They are reserved for the installation's own controller mail,
-             *     which rides a registered template; a caller that could claim one could dress
-             *     marketing as a security warning and reach somebody who has objected.
+             *     `record_confirmation`. They serve the recipient, which is why a hard
+             *     suppression does not stop them, and they are reserved for the installation's
+             *     own controller mail behind a registered template. A caller that could claim
+             *     one could dress marketing as a security warning and reach somebody who has
+             *     objected, so naming one here is refused (422 `invalid`).
              * @enum {string|null}
              */
-            communication_context?: "reply_to_inbound" | "requested_followup" | "precontract_quote" | "active_deal_followup" | "customer_service" | "account_notice" | "contract_notice" | "invoice_or_payment" | "security_notice" | "privacy_notice" | "record_confirmation" | "consent_confirmation" | "optout_confirmation" | "marketing" | null;
+            communication_context?: "reply_to_inbound" | "requested_followup" | "precontract_quote" | "active_deal_followup" | "customer_service" | "account_notice" | "contract_notice" | "invoice_or_payment" | "marketing" | null;
             /**
              * @description For a marketing send, the consent purpose key naming the topic it is for.
              *     Marketing consent is purpose-specific: a grant for one topic authorizes that
@@ -21355,15 +21356,16 @@ export interface components {
              *     therefore honest and is the ordinary case for a reply; naming one matters when
              *     there is no anchor to derive from.
              *
-             *     Five categories exist to serve the recipient — `security_notice`,
+             *     Five categories are absent from this list on purpose — `security_notice`,
              *     `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-             *     `record_confirmation` — and are refused (422 `invalid`) from an
-             *     ordinary send. They are reserved for the installation's own controller mail,
-             *     which rides a registered template; a caller that could claim one could dress
-             *     marketing as a security warning and reach somebody who has objected.
+             *     `record_confirmation`. They serve the recipient, which is why a hard
+             *     suppression does not stop them, and they are reserved for the installation's
+             *     own controller mail behind a registered template. A caller that could claim
+             *     one could dress marketing as a security warning and reach somebody who has
+             *     objected, so naming one here is refused (422 `invalid`).
              * @enum {string|null}
              */
-            communication_context?: "reply_to_inbound" | "requested_followup" | "precontract_quote" | "active_deal_followup" | "customer_service" | "account_notice" | "contract_notice" | "invoice_or_payment" | "security_notice" | "privacy_notice" | "record_confirmation" | "consent_confirmation" | "optout_confirmation" | "marketing" | null;
+            communication_context?: "reply_to_inbound" | "requested_followup" | "precontract_quote" | "active_deal_followup" | "customer_service" | "account_notice" | "contract_notice" | "invoice_or_payment" | "marketing" | null;
             /**
              * @description For a marketing send, the consent purpose key naming the topic it is for.
              *     Marketing consent is purpose-specific: a grant for one topic authorizes that
@@ -21444,15 +21446,16 @@ export interface components {
              *     therefore honest and is the ordinary case for a reply; naming one matters when
              *     there is no anchor to derive from.
              *
-             *     Five categories exist to serve the recipient — `security_notice`,
+             *     Five categories are absent from this list on purpose — `security_notice`,
              *     `privacy_notice`, `optout_confirmation`, `consent_confirmation` and
-             *     `record_confirmation` — and are refused (422 `invalid`) from an
-             *     ordinary send. They are reserved for the installation's own controller mail,
-             *     which rides a registered template; a caller that could claim one could dress
-             *     marketing as a security warning and reach somebody who has objected.
+             *     `record_confirmation`. They serve the recipient, which is why a hard
+             *     suppression does not stop them, and they are reserved for the installation's
+             *     own controller mail behind a registered template. A caller that could claim
+             *     one could dress marketing as a security warning and reach somebody who has
+             *     objected, so naming one here is refused (422 `invalid`).
              * @enum {string|null}
              */
-            communication_context?: "reply_to_inbound" | "requested_followup" | "precontract_quote" | "active_deal_followup" | "customer_service" | "account_notice" | "contract_notice" | "invoice_or_payment" | "security_notice" | "privacy_notice" | "record_confirmation" | "consent_confirmation" | "optout_confirmation" | "marketing" | null;
+            communication_context?: "reply_to_inbound" | "requested_followup" | "precontract_quote" | "active_deal_followup" | "customer_service" | "account_notice" | "contract_notice" | "invoice_or_payment" | "marketing" | null;
             /**
              * @description For a marketing send, the consent purpose key naming the topic it is for.
              *     Marketing consent is purpose-specific: a grant for one topic authorizes that

--- a/scripts/contract-breaking-allowlist.txt
+++ b/scripts/contract-breaking-allowlist.txt
@@ -31,4 +31,4 @@ e0c11716048a939f1f1187d6992754335300ac41 ce200199d82e76fca7c07e5781a7af1a963b496
 0110dee350c9277dc41e5147dbba9c0a127c3f8a f26fe6c3b9c6e8dc75128b7bea48799033ecdab3 ratified-v1-tag-colour-is-a-closed-palette-and-a-name-is-bounded
 44085e526e3c71af58230ac3359eb9679dbd6a59 08ef392fc995b0b79872e2544d5f3d210d5923a1 ratified-a-double-opt-in-link-is-mailed-never-shown-to-the-operator
 98f26a4484760912e7cede9f57715a7be587b6c5 49728224fbaa221da787bacd7a391776d6fc85a4 ratified-worklist-move-carries-the-deal-cards-verbs
-a064127f258abdc3d0a0941dabe0ef94eb9d1a12 d308d4cc55c99a7d5bf982f73045da34c813b7a7 ratified-the-five-controller-only-categories-leave-the-send-enum-the-door-always-refused-them
+6a7b29a268183069393c39b1931648a5894b6abe 91cc59b5c3855fed8bf8ba020d95894ed60822e4 ratified-the-five-controller-only-categories-leave-the-send-enum-the-door-always-refused-them

--- a/scripts/contract-breaking-allowlist.txt
+++ b/scripts/contract-breaking-allowlist.txt
@@ -31,3 +31,4 @@ e0c11716048a939f1f1187d6992754335300ac41 ce200199d82e76fca7c07e5781a7af1a963b496
 0110dee350c9277dc41e5147dbba9c0a127c3f8a f26fe6c3b9c6e8dc75128b7bea48799033ecdab3 ratified-v1-tag-colour-is-a-closed-palette-and-a-name-is-bounded
 44085e526e3c71af58230ac3359eb9679dbd6a59 08ef392fc995b0b79872e2544d5f3d210d5923a1 ratified-a-double-opt-in-link-is-mailed-never-shown-to-the-operator
 98f26a4484760912e7cede9f57715a7be587b6c5 49728224fbaa221da787bacd7a391776d6fc85a4 ratified-worklist-move-carries-the-deal-cards-verbs
+a064127f258abdc3d0a0941dabe0ef94eb9d1a12 d308d4cc55c99a7d5bf982f73045da34c813b7a7 ratified-the-five-controller-only-categories-leave-the-send-enum-the-door-always-refused-them


### PR DESCRIPTION
The MCP send tools were the one door staging every message with no context at
all: the three schemas rejected the field outright (`additionalProperties:false`)
and `commsAdapter` built its send input without it. An agent's send recorded a
NULL `requested_category` while the identical send over HTTP recorded what the
caller claimed.

## The tools carry the four fields

`communication_context`, `marketing_purpose`, `operator_reason` and `evidence`,
spelled once in `sendContextProperties` for all three tools.

Terse on purpose. The schema is written into the system prompt of every step of
every run carrying one of these tools, and it costs 767 tokens of the catalog
budget whether or not a caller ever sets a field — the catalog now sits at 20,552
of its 21,504 floor.

## One validator, both transports

The adapter runs `activities.ApplyContext` / `ApplyChannelContext`, which apply
the same refusals `sendContextFrom` applies over HTTP. The tool surface cannot
reach the generated request types, so it needs its own entry point — and an entry
point is exactly where a second, laxer validator grows. A claim an agent may not
make over HTTP must not become makeable by choosing the tool surface.

## A gate that derives its corpus

`TestEverySendDoorValidatesTheClaimedContext` treats a door as a function that
builds a send input **and** reads the caller's claim, derived from the input
types rather than from a list of doors, so a fourth door is judged the day it is
written.

The scheduled `thaw` is exempted by name with its reason: it restores a claim
validated at schedule time, and re-running the refusals there would fail a send
at *fire* time for a claim the rep was told was accepted hours earlier, with
nobody at the keyboard to correct it.

## The REST enum loses five values

`TestEveryToolEnumMatchesTheContractItMirrors` caught a real disagreement: the
contract advertised `security_notice`, `privacy_notice`, `optout_confirmation`,
`consent_confirmation` and `record_confirmation`, which the door has always
refused with a 422. A value one transport accepts and the other refuses is the
two disagreeing about one behaviour.

Ratified in the allowlist rather than deprecated: they shipped hours ago in #3930
and were never acceptable at runtime, so no client can be relying on them.

## Verification

`make check-backend`, `make check-fe`, `craft static`, `rls-store-path` and
`no-jurisdiction` all pass, re-run after rebasing onto current main.

Mutation-checked: building the send input directly from the claim instead of
through `ApplyContext` fails the new gate.

One flake seen and re-confirmed green: `leads.test.tsx > a lead row navigates to
the LEAD detail` failed once under the parallel suite and passes both in
isolation and on a full re-run. This diff touches no frontend source, only the
generated `schema.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the MCP send tools state why they're writing, through the same validator an HTTP send uses. Previously the three send tools rejected context fields outright and an agent's send recorded a NULL `requested_category`; now they accept `communication_context`, `marketing_purpose`, and `operator_reason`, and the adapter runs them through `ApplyContext` / `ApplyChannelContext`, so a claim the HTTP door refuses is refused on the tool surface too.

**Breaking change**
- The REST `communication_context` enum drops five controller-only categories (`security_notice`, `privacy_notice`, `optout_confirmation`, `consent_confirmation`, `record_confirmation`) that were advertised but always refused with 422.
- Ratified in the allowlist: the values shipped only hours ago and were never acceptable at runtime, so no client can rely on them.

**Guard rails**
- A census gate fails any function that calls the activities store's `SendOrSchedule` or `SendMessage` without reaching a validator, derived from those chokepoints across `internal/` and `cmd/` rather than from the current door shapes.
- The scheduled `thaw` now refuses reserved categories outright, dropping the gate's exemption for it.
- `evidence` stays off the tool schema — nothing reads it yet, and the validators that resolve a category from it land later.
- The context schema is spelled once for all three tools, held by a second gate; the catalog grows 445 tokens to 20,230 of the 21,504 budget.

<sup>Written for commit 17388f6bc51c2f427a1ae370bc46d5dcb61bfae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional communication context, marketing purpose, and operator reason fields to email and message-sending tools.
  - Valid context details are applied when sending emails and messages.

- **Bug Fixes**
  - Invalid and controller-reserved communication categories are rejected with validation errors.
  - Reserved categories can no longer be restored from scheduled sends.

- **Documentation**
  - Updated tool schemas, reference documentation, and catalog metrics to reflect the expanded send-tool inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->