### PR TITLE
The team board's contract describes the access model this product has

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -10032,11 +10032,15 @@ paths:
         who to talk to, then opens that person's own day with `GET /worklist?owner=`,
         which is the drill-down this board exists to route to.
 
-        Every count is read under the CALLER's visibility, never the teammate's. A number
-        summing rows the reader may not open would publish a colleague's volume to
-        somebody with no access to any of it, so what this reports is "how much of their
-        load you can see" — the only honest answer available without giving one person a
-        licence to read another's records.
+        Every count is read under the CALLER's visibility, which in this product is nearly
+        everything: work is shared across the workspace, so a teammate's deals, companies
+        and tasks all count. What does NOT count is correspondence narrowed to an audience
+        the reader is not on, and mail captured into a colleague's mailbox that nobody has
+        promoted — the one boundary the access model keeps.
+
+        So a figure here is the teammate's real load minus any private mail the reader is
+        not party to. It is not a partial view of their work, and a reader may open every
+        record behind a count they can see.
 
         Requires a row scope of `team` or `all`; an own-scoped reader is refused with 403
         rather than shown a board of one. The teammates listed are the live human seats

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -6701,11 +6701,15 @@ export interface paths {
          *     who to talk to, then opens that person's own day with `GET /worklist?owner=`,
          *     which is the drill-down this board exists to route to.
          *
-         *     Every count is read under the CALLER's visibility, never the teammate's. A number
-         *     summing rows the reader may not open would publish a colleague's volume to
-         *     somebody with no access to any of it, so what this reports is "how much of their
-         *     load you can see" — the only honest answer available without giving one person a
-         *     licence to read another's records.
+         *     Every count is read under the CALLER's visibility, which in this product is nearly
+         *     everything: work is shared across the workspace, so a teammate's deals, companies
+         *     and tasks all count. What does NOT count is correspondence narrowed to an audience
+         *     the reader is not on, and mail captured into a colleague's mailbox that nobody has
+         *     promoted — the one boundary the access model keeps.
+         *
+         *     So a figure here is the teammate's real load minus any private mail the reader is
+         *     not party to. It is not a partial view of their work, and a reader may open every
+         *     record behind a count they can see.
          *
          *     Requires a row scope of `team` or `all`; an own-scoped reader is refused with 403
          *     rather than shown a board of one. The teammates listed are the live human seats


### PR DESCRIPTION
The route's description said every count is "how much of their load you can
see", and justified it as the only honest answer "without giving one person a
licence to read another's records". That describes an ownership-scoped product.
This one is not.

The rule here is that everyone sees everything: work is shared across the
workspace, and the single boundary is correspondence — a message narrowed to an
audience the reader is not on, or mail captured into a colleague's mailbox that
nobody promoted. `activityAudienceArm` renders exactly that, and its first
clause is `audience = 'workspace'`, which every shared row carries.

So the count is a teammate's real load, not a partial view of it, and a reader
may open every record behind a figure they can see. The prose now says so.

No behaviour changes. The comment misled a reader today, twice in one sitting,
which is the cost of prose that outlives the design it describes.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the team board contract's access-model description so it matches the product. The old text claimed counts showed only how much of a teammate's load the reader can see; the new text states work is shared across the workspace and counts are real load, minus private correspondence the reader isn't party to. No behavior changes.

<sup>Written for commit f46d3329f307621420d32a1ccdc0b1f88e80bc7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that CRM board counts include shared workspace work visible to the current reader, including teammates’ deals, companies, and tasks.
  - Documented that counts exclude correspondence restricted to inaccessible audiences and unpromoted mail in colleagues’ mailboxes.
  - Clarified that counts reflect each teammate’s full visible workload, while records included in the count remain openable by the reader.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->