### PR TITLE
The week's money says whether it beat the week before

### DIFF
--- a/frontend/src/format/format.test.ts
+++ b/frontend/src/format/format.test.ts
@@ -10,6 +10,7 @@ import {
   formatMoney,
   formatMoneyOrAbsent,
   formatNumber,
+  formatSignedMoney,
   formatTimeOfDay,
   formatUsdPerMTok,
   identifierNumber,
@@ -38,6 +39,35 @@ describe("money formatting (B-EP09.17)", () => {
   it("respects the currency's minor-unit scale", () => {
     // JPY has zero minor digits — 1234 minor units is ¥1,234, not ¥12.34
     expect(formatMoney(1234, "JPY", "en")).toContain("1,234");
+  });
+
+  // The SIGNED money formatter takes the same minor-unit scale. It is a second
+  // function doing the conversion, so a regression here is invisible to every
+  // formatMoney case above — and a yen delta rendered with two decimals is
+  // wrong by a factor of a hundred.
+  it("respects the currency's minor-unit scale for a change too", () => {
+    // EXACT strings, not `toContain`. The amount is converted by
+    // `toMajorUnits`, which reads the currency itself, so a wrong digit count
+    // does not move the figure — it appends decimals a currency with no
+    // subunit does not have. "+¥1,234.00" contains "1,234" and is still wrong,
+    // which is how a looser assertion passed over exactly this defect.
+    expect(formatSignedMoney(1234, "JPY", "en")).toBe("+JP¥1,234");
+    expect(formatSignedMoney(1_284_000, "VND", "vi")).toBe("+1.284.000\u00a0₫");
+  });
+
+  // The sign always shows: a bare figure beside last week's leaves the reader
+  // to work out which way it moved, and half of them will guess.
+  it("always draws the direction a money change moved", () => {
+    expect(formatSignedMoney(250000, "EUR", "en")).toContain("+");
+    expect(formatSignedMoney(-250000, "EUR", "en")).toMatch(/[-−]/);
+  });
+
+  // A week that matched the one before is a real answer. "+0" dresses it as
+  // growth, which is a small lie repeated weekly.
+  it("marks an exactly level change with ± rather than +", () => {
+    const level = formatSignedMoney(0, "EUR", "en");
+    expect(level).toContain("±");
+    expect(level).not.toContain("+");
   });
 
   // VND is a zero-decimal currency: formatMoney divides by

--- a/frontend/src/format/format.ts
+++ b/frontend/src/format/format.ts
@@ -245,6 +245,37 @@ export function formatSignedNumber(value: number, locale: Locale): string {
 }
 
 /**
+ * A CHANGE in money: "+€3,000", "-€1,200", "±€0".
+ *
+ * The money counterpart to `formatSignedNumber`, and it keeps both of that
+ * function's rules — the sign always shows, because a bare figure beside last
+ * week's leaves the direction to be guessed; and an exactly level result prints
+ * "±" rather than "+", because a week that matched the one before is a real
+ * answer and dressing it as growth is a small lie repeated weekly.
+ *
+ * It goes through the same minor-unit conversion `formatMoney` uses rather than
+ * dividing by a hundred: the fraction digits differ by currency, and a yen
+ * delta rendered with two decimals is off by a factor of a hundred.
+ */
+export function formatSignedMoney(
+  amountMinor: number,
+  currency: string,
+  locale: Locale,
+): string {
+  const digits = minorUnitDigits(currency);
+  const formatted = new Intl.NumberFormat(INTL_LOCALE[locale], {
+    style: "currency",
+    currency,
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+    signDisplay: "always",
+  }).format(toMajorUnits(amountMinor, currency));
+  // Intl has no "±", so the zero case is spelled here — over the FORMATTED
+  // string, so the currency symbol keeps whatever position the locale gives it.
+  return amountMinor === 0 ? formatted.replace("+", "±") : formatted;
+}
+
+/**
  * A number that NAMES something rather than measuring it — a version, a
  * revision, an invoice number, a record's own number.
  *

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2552,6 +2552,7 @@ export const de = {
   "home.weekly.queueWorked": "Morgen-Liste",
   "home.weekly.actedDismissed": "{acted} bearbeitet · {dismissed} weggeklickt",
   "home.weekly.sincePrior": "{delta} ggü. Vorwoche",
+  "home.weekly.wonVsPrior": "{value} · {delta} zur Vorwoche",
   "home.weekly.leadsAnswered": "Leads rechtzeitig beantwortet",
   "home.weekly.ofRouted": "{answered} von {routed}",
   "home.weekly.planCommitmentsKept": "Planzusagen eingehalten",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2601,6 +2601,7 @@ export const en = {
   "home.weekly.queueWorked": "Morning queue",
   "home.weekly.actedDismissed": "{acted} acted · {dismissed} dismissed",
   "home.weekly.sincePrior": "{delta} vs last week",
+  "home.weekly.wonVsPrior": "{value} · {delta} vs prior week",
   "home.weekly.leadsAnswered": "Leads answered in time",
   "home.weekly.ofRouted": "{answered} of {routed}",
   "home.weekly.planCommitmentsKept": "Plan commitments kept",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2528,6 +2528,7 @@ export const vi = {
   "home.weekly.queueWorked": "Danh sách buổi sáng",
   "home.weekly.actedDismissed": "{acted} đã xử lý · {dismissed} đã bỏ qua",
   "home.weekly.sincePrior": "{delta} so với tuần trước",
+  "home.weekly.wonVsPrior": "{value} · {delta} so với tuần trước",
   "home.weekly.leadsAnswered": "Lead được trả lời đúng hạn",
   "home.weekly.ofRouted": "{answered} trên {routed}",
   "home.weekly.planCommitmentsKept": "Cam kết kế hoạch đã giữ",

--- a/frontend/src/screens/home.weekly.test.tsx
+++ b/frontend/src/screens/home.weekly.test.tsx
@@ -111,6 +111,127 @@ describe("HomeScreen — the weekly retrospective", () => {
     expect(await screen.findByText(/12.500,00\s*€|€12,500\.00/)).toBeTruthy();
   });
 
+  // THE PACE READING. What the wins were worth, and whether that beat the week
+  // before — the question a rep opens a closed week to ask.
+  it("says whether the week's money beat the week before", async () => {
+    stubApi({
+      "GET /weekly-reviews/latest": () =>
+        jsonResponse({
+          ...review,
+          pipeline: {
+            created_minor: 4500000,
+            won_minor: 1250000,
+            lost_minor: 0,
+            currency: "EUR",
+          },
+          prior: {
+            local_week_start: "2026-06-22",
+            counts: review.counts,
+            pipeline: {
+              created_minor: 3000000,
+              won_minor: 1000000,
+              lost_minor: 0,
+              currency: "EUR",
+            },
+          },
+        }),
+      "GET /weekly-reviews": () => jsonResponse({ weeks: ["2026-06-29"] }),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    render(<HomeScreen />);
+
+    // +2.500,00 € on 12.500 against 10.000, and the SIGN is always drawn: a
+    // bare figure beside last week's leaves the direction to be guessed.
+    expect(
+      await screen.findByText(/\+2\.500,00\s*€|\+€2,500\.00/),
+    ).toBeTruthy();
+  });
+
+  // A week that matched the one before says so, rather than reading as growth.
+  it("marks a level week level rather than dressing it as a gain", async () => {
+    const money = {
+      created_minor: 4500000,
+      won_minor: 1250000,
+      lost_minor: 0,
+      currency: "EUR",
+    };
+    stubApi({
+      "GET /weekly-reviews/latest": () =>
+        jsonResponse({
+          ...review,
+          pipeline: money,
+          prior: {
+            local_week_start: "2026-06-22",
+            counts: review.counts,
+            pipeline: money,
+          },
+        }),
+      "GET /weekly-reviews": () => jsonResponse({ weeks: ["2026-06-29"] }),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    render(<HomeScreen />);
+
+    expect(await screen.findByText(/±0,00\s*€|±€0\.00/)).toBeTruthy();
+  });
+
+  // A PRIOR WEEK NOBODY COULD PRICE yields no comparison — not a change
+  // measured against a zero that was never a figure. The value still draws.
+  it("compares nothing against a prior week that carries no money", async () => {
+    stubApi({
+      "GET /weekly-reviews/latest": () =>
+        jsonResponse({
+          ...review,
+          pipeline: {
+            created_minor: 4500000,
+            won_minor: 1250000,
+            lost_minor: 0,
+            currency: "EUR",
+          },
+          prior: { local_week_start: "2026-06-22", counts: review.counts },
+        }),
+      "GET /weekly-reviews": () => jsonResponse({ weeks: ["2026-06-29"] }),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    render(<HomeScreen />);
+
+    expect(await screen.findByText(/12.500,00\s*€|€12,500\.00/)).toBeTruthy();
+    expect(screen.queryByText(/vs prior|zur Vorwoche/)).toBeNull();
+  });
+
+  // TWO CURRENCIES ARE NOT COMPARABLE. Each week is stored in the currency it
+  // was measured in, so an operator who changed the base currency mid-quarter
+  // leaves two weeks whose subtraction would print a change nobody can act on.
+  it("refuses to subtract across a change of currency", async () => {
+    stubApi({
+      "GET /weekly-reviews/latest": () =>
+        jsonResponse({
+          ...review,
+          pipeline: {
+            created_minor: 4500000,
+            won_minor: 1250000,
+            lost_minor: 0,
+            currency: "EUR",
+          },
+          prior: {
+            local_week_start: "2026-06-22",
+            counts: review.counts,
+            pipeline: {
+              created_minor: 3000000,
+              won_minor: 1000000,
+              lost_minor: 0,
+              currency: "USD",
+            },
+          },
+        }),
+      "GET /weekly-reviews": () => jsonResponse({ weeks: ["2026-06-29"] }),
+      "GET /deals": () => jsonResponse({ data: [fleetDeal] }),
+    });
+    render(<HomeScreen />);
+
+    expect(await screen.findByText(/12.500,00\s*€|€12,500\.00/)).toBeTruthy();
+    expect(screen.queryByText(/vs prior|zur Vorwoche/)).toBeNull();
+  });
+
   // And a week with no pipeline block draws no money at all.
   //
   // The block is optional on the wire — a week assembled before the money

--- a/frontend/src/screens/home.weekly.tsx
+++ b/frontend/src/screens/home.weekly.tsx
@@ -15,9 +15,10 @@ import {
   formatDateTime,
   formatMoney,
   formatNumber,
+  formatSignedMoney,
   formatSignedNumber,
 } from "../format/format";
-import { type Locale, useLocale, useT } from "../i18n";
+import { type Locale, type Translator, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
   useWeeklyReview,
@@ -245,24 +246,50 @@ function readState(
 }
 
 /**
- * What the week's wins were worth, or nothing.
+ * What the week's wins were worth, and whether that beat the week before.
  *
- * NOTHING, not a zero, when the review carries no pipeline block. That block is
- * optional on the wire: a week assembled before the money columns existed, or
- * one where an FX rate was missing, has no honest figure — and "€0 won" is a
- * claim about a week nobody measured, which is the opposite of what happened.
+ * THE PACE NUMBER, and it lives here rather than on the morning for a reason
+ * the morning's own contract states: every figure in that strip describes the
+ * same set — today's queue, before filtering — which is what keeps those
+ * numbers stable as a rep works down the page. Money closed over a week is a
+ * different population, and standing it beside four same-set figures would put
+ * two measurements in one row with nothing saying they differ.
  *
- * The currency comes from the review, never from the installation's current
- * setting. Base currency is operator-mutable, so re-reading it later would
- * re-label an old week with a currency its numbers were never in. The contract
- * stores it beside the figures for exactly this reason.
+ * Here the whole panel is already about one closed week, so a week-on-week
+ * comparison is the question the surface exists to answer.
+ *
+ * BOTH WEEKS OR NEITHER for the delta. A prior week with no pipeline block is
+ * one nobody could price, not one that earned nothing — so it yields no
+ * comparison rather than a change measured against a zero that was never a
+ * figure. The value still draws; only the comparison is withheld.
+ *
+ * The currencies must MATCH. Each week is stored in the currency it was
+ * measured in, and an operator who changed the base currency mid-quarter leaves
+ * two weeks whose numbers are not comparable. Subtracting across them would
+ * print a change nobody can act on.
  */
-function wonValue(review: WeeklyReview, locale: Locale): string | undefined {
+function wonPace(
+  review: WeeklyReview,
+  locale: Locale,
+  t: Translator,
+): string | undefined {
   const pipeline = review.pipeline;
   if (pipeline === undefined) {
     return undefined;
   }
-  return formatMoney(pipeline.won_minor, pipeline.currency, locale);
+  const value = formatMoney(pipeline.won_minor, pipeline.currency, locale);
+  const before = review.prior?.pipeline;
+  if (before === undefined || before.currency !== pipeline.currency) {
+    return value;
+  }
+  return t("home.weekly.wonVsPrior", {
+    value,
+    delta: formatSignedMoney(
+      pipeline.won_minor - before.won_minor,
+      pipeline.currency,
+      locale,
+    ),
+  });
 }
 
 function WeeklyBody({
@@ -348,11 +375,12 @@ function WeeklyBody({
           //
           // It rides the won slot rather than taking a sixth: five is what a
           // strip can be read across as one comparison, and a tenth slot folded
-          // the row into two ranks at 1280 (#3709). The delta line gives way to
-          // it, because "what it was worth" is the fact a reader wants first
-          // and the strip has one detail line to give.
+          // the row into two ranks at 1280 (#3709). The one detail line carries
+          // the value AND its change against the week before, which is the
+          // pace reading — it belongs here rather than on the morning, whose
+          // strip is bound to one same-set population.
           detail={
-            wonValue(review, locale) ?? since(c.deals_won, prior?.deals_won)
+            wonPace(review, locale, t) ?? since(c.deals_won, prior?.deals_won)
           }
         />
         <StatCard


### PR DESCRIPTION
Quota was retired (#3625), and with it the pace reading — the number that told
a rep whether they were ahead or behind. This puts one back, built from money
the product already stores rather than from a target nobody sets.

The weekly's Won card showed "2 · €12,500". True, and silent about direction: a
rep could not tell a good week from a bad one without opening last week's.

The detail line now carries both, so the card reads "2 · €12,500 · +€2,500 vs
prior week". `prior.pipeline` has been on the wire since the money columns
shipped; nothing read it. No contract change, no new query.

IT LIVES HERE RATHER THAN ON THE MORNING, and that is the whole design
question. The morning strip's contract binds every figure to one population —
today's queue before filtering — which is what keeps those numbers stable as a
rep works down the page. Money closed over a week is a different population, and
standing it beside four same-set figures would put two kinds of measurement in
one row with nothing saying they differ. The weekly panel is already about one
closed week, so a week-on-week comparison is the question it exists to answer.
The morning's fifth slot keeps saying no target is set, which is true.

BOTH WEEKS OR NEITHER. A prior week carrying no pipeline block is one nobody
could price, not one that earned nothing, so it yields no comparison rather than
a change measured against a zero that was never a figure. The value still draws.

THE CURRENCIES MUST MATCH. Each week is stored in the currency it was measured
in, so an operator who changed the base currency mid-quarter leaves two weeks
whose subtraction would print a change nobody can act on.

`formatSignedMoney` joins `formatSignedNumber` and keeps its two rules: the sign
always shows, and an exactly level result prints "±" rather than "+", because a
week that matched the one before is a real answer and dressing it as growth is a
small lie repeated weekly.

A MUTATION THAT PASSED IS WHY THE FORMATTER TESTS ARE EXACT. Hardcoding the
minor-unit digits left every assertion green: the amount is converted by
`toMajorUnits`, which reads the currency itself, so a wrong digit count does not
move the figure — it appends decimals a currency with no subunit does not have.
"+JP¥1,234.00" contains "1,234" and is still wrong. The assertions are whole
strings now, and that mutation fails.

Six guards mutation-checked one at a time: the comparison drawing at all, the
absent-prior rule, the currency match, the ± zero, the always-shown sign, and
the minor-unit scale.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a week-on-week pace reading to the weekly Won card so the detail line shows "2 · €12,500 · +€2,500 vs prior week" instead of only "2 · €12,500". It reads `prior.pipeline`, which has been on the wire since the money columns shipped, so there's no contract change or new query.

**Behavior**
- The comparison draws only when the prior week has a pipeline block and the two weeks share a currency; otherwise the card shows the value alone.
- A level week prints "±" rather than "+", and the sign always shows, so direction is never left to guess.
- The comparison lives on the weekly panel, not the morning strip, whose figures are all bound to today's queue.

**Tests**
- Added exact-string assertions so a regression in the currency's minor-unit scale fails instead of passing via substring.

<sup>Written for commit d194da9c4b7fc8cefc7b2ebbd1001e4d65aa2df7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly home metrics now show the won value alongside its signed change versus the prior week.
  * Comparisons are displayed when prior data and currencies are compatible, with clear handling for unchanged or unavailable values.
  * Added localized English, German, and Vietnamese text for the weekly comparison.

* **Bug Fixes**
  * Improved currency formatting for positive, negative, and zero monetary changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->