### PR TITLE
A country states its messaging rules, and the engine applies them

### DIFF
--- a/backend/internal/compose/extensionpolicy.go
+++ b/backend/internal/compose/extensionpolicy.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The boot checks over a unit's PASSIVE POLICY: its jurisdiction packs, its
+// retention floors and its outbound-messaging rules.
+//
+// Their own file because they are one concept and extensions.go had reached
+// the size cap. What joins them is what they protect against: none of these
+// declarations is a governed operation an operator resolves, so none appears in
+// the manifest — and a malformed one would therefore compose silently, look
+// registered, and be read by an engine as the country's law. These checks are
+// the only place that reads the VALUES before the registries take them.
+
+import (
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+	"github.com/margince/margince/backend/pkg/extension"
+)
+
+// preflightJurisdictions checks one unit's declared packs for grammar,
+// duplicates within the composed set, collisions with core packs, and
+// retention classes outside the closed vocabularies — an unknown class
+// (or anchor, or a negative period) would be a statutory floor that
+// looks registered while the engine misreads or ignores it.
+func preflightJurisdictions(e extension.Extension, packCodes map[jurisdiction.Code]extension.Name) error {
+	for _, p := range e.Jurisdictions {
+		code := p.Code()
+		if err := code.Validate(); err != nil {
+			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
+		}
+		if owner, dup := packCodes[code]; dup {
+			return fmt.Errorf("compose: extensions %q and %q both declare jurisdiction %q", owner, e.Name, code)
+		}
+		if _, taken := jurisdiction.For(code); taken {
+			return fmt.Errorf("compose: extension %q declares jurisdiction %q, which a core pack already registers", e.Name, code)
+		}
+		if err := preflightRetentionClasses(e.Name, code, p.Retention()); err != nil {
+			return err
+		}
+		packCodes[code] = e.Name
+	}
+	return nil
+}
+
+// preflightMessagingRules checks one unit's declared messaging rules for
+// grammar and for a second rule set naming the same jurisdiction.
+//
+// A duplicate is refused rather than merged or last-one-wins, because two rule
+// sets for one country are two answers to "may we write to this person" — and
+// the failure would be silent: whichever set the engine happened to read would
+// look like the country's law.
+func preflightMessagingRules(e extension.Extension, messagingCodes map[jurisdiction.Code]extension.Name) error {
+	for _, r := range e.Messaging {
+		if err := r.Validate(); err != nil {
+			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
+		}
+		if owner, dup := messagingCodes[r.Jurisdiction]; dup {
+			return fmt.Errorf("compose: extensions %q and %q both declare messaging rules for jurisdiction %q",
+				owner, e.Name, r.Jurisdiction)
+		}
+		messagingCodes[r.Jurisdiction] = e.Name
+	}
+	return nil
+}
+
+// preflightRetentionClasses validates one pack's declared floors: class
+// name, period, and anchor each carry their own published grammar, and a
+// class may be declared once — two floors for the same class with
+// different Keep/Anchor would leave the engine picking one silently.
+func preflightRetentionClasses(unit extension.Name, code jurisdiction.Code, ret jurisdiction.Retention) error {
+	if ret == nil {
+		return nil
+	}
+	seen := make(map[jurisdiction.RetentionClassName]bool)
+	for _, class := range ret.Classes() {
+		if err := class.Name.Validate(); err != nil {
+			return fmt.Errorf("compose: extension %q, jurisdiction %q: %w", unit, code, err)
+		}
+		if seen[class.Name] {
+			return fmt.Errorf("compose: extension %q, jurisdiction %q declares retention class %q twice", unit, code, class.Name)
+		}
+		seen[class.Name] = true
+		if err := class.Keep.Validate(); err != nil {
+			return fmt.Errorf("compose: extension %q, jurisdiction %q, class %q: %w", unit, code, class.Name, err)
+		}
+		if err := class.Anchor.Validate(); err != nil {
+			return fmt.Errorf("compose: extension %q, jurisdiction %q, class %q: %w", unit, code, class.Name, err)
+		}
+	}
+	return nil
+}

--- a/backend/internal/compose/extensionpolicy.go
+++ b/backend/internal/compose/extensionpolicy.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+	"github.com/margince/margince/backend/internal/shared/ports/messagingrules"
 	"github.com/margince/margince/backend/pkg/extension"
 )
 
@@ -60,6 +61,15 @@ func preflightMessagingRules(e extension.Extension, messagingCodes map[jurisdict
 		if owner, dup := messagingCodes[r.Jurisdiction]; dup {
 			return fmt.Errorf("compose: extensions %q and %q both declare messaging rules for jurisdiction %q",
 				owner, e.Name, r.Jurisdiction)
+		}
+		// The core-collision check its jurisdiction sibling carries. No core
+		// caller registers a rule set today, and the day one does an extension
+		// naming the same code must meet this composed error rather than the
+		// registry's panic — a boot that dies in a registry tells an operator
+		// far less than one that names both declarers.
+		if _, taken := messagingrules.For(r.Jurisdiction); taken {
+			return fmt.Errorf("compose: extension %q declares messaging rules for jurisdiction %q, which the core already registers",
+				e.Name, r.Jurisdiction)
 		}
 		messagingCodes[r.Jurisdiction] = e.Name
 	}

--- a/backend/internal/compose/extensions.go
+++ b/backend/internal/compose/extensions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	kevents "github.com/margince/margince/backend/internal/shared/kernel/events"
 	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+	"github.com/margince/margince/backend/internal/shared/ports/messagingrules"
 	"github.com/margince/margince/backend/pkg/extension"
 )
 
@@ -57,6 +58,16 @@ func RegisterExtensions(exts []extension.Extension, verbs []extension.Verb, jobD
 	for _, e := range exts {
 		for _, p := range e.Jurisdictions {
 			jurisdiction.Register(p)
+		}
+		// Beside the packs and for the same reason: the authorization engine
+		// asks the registry what the applicable jurisdiction requires, and a
+		// declared rule set that never reached it would leave the engine
+		// applying its own defaults while the manifest says the country pack
+		// is composed in. The preflight above already refused an invalid or
+		// duplicate set, so Register's own panics are unreachable here and
+		// stay as the wiring-defect backstop they are for a core caller.
+		for _, r := range e.Messaging {
+			messagingrules.Register(r)
 		}
 	}
 	// After the jurisdiction packs, and still in the apply phase: the RBAC
@@ -177,6 +188,7 @@ func validateExtensionSet(exts []extension.Extension) error {
 	seen := make(map[extension.Name]bool, len(exts))
 	namespaces := make(map[string]extension.Name, len(exts))
 	packCodes := make(map[jurisdiction.Code]extension.Name, len(exts))
+	messagingCodes := make(map[jurisdiction.Code]extension.Name, len(exts))
 	// Which provider each unit has claimed — a fact about the composed SET, so
 	// it is accumulated across the loop rather than asked of one declaration.
 	//
@@ -207,6 +219,9 @@ func validateExtensionSet(exts []extension.Extension) error {
 			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
 		}
 		if err := preflightJurisdictions(e, packCodes); err != nil {
+			return err
+		}
+		if err := preflightMessagingRules(e, messagingCodes); err != nil {
 			return err
 		}
 		if err := preflightTools(e); err != nil {
@@ -441,58 +456,6 @@ func preflightTools(e extension.Extension) error {
 			return fmt.Errorf("compose: extension %q declares tool %q twice", e.Name, tool.Name)
 		}
 		seen[tool.Name] = true
-	}
-	return nil
-}
-
-// preflightJurisdictions checks one unit's declared packs for grammar,
-// duplicates within the composed set, collisions with core packs, and
-// retention classes outside the closed vocabularies — an unknown class
-// (or anchor, or a negative period) would be a statutory floor that
-// looks registered while the engine misreads or ignores it.
-func preflightJurisdictions(e extension.Extension, packCodes map[jurisdiction.Code]extension.Name) error {
-	for _, p := range e.Jurisdictions {
-		code := p.Code()
-		if err := code.Validate(); err != nil {
-			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
-		}
-		if owner, dup := packCodes[code]; dup {
-			return fmt.Errorf("compose: extensions %q and %q both declare jurisdiction %q", owner, e.Name, code)
-		}
-		if _, taken := jurisdiction.For(code); taken {
-			return fmt.Errorf("compose: extension %q declares jurisdiction %q, which a core pack already registers", e.Name, code)
-		}
-		if err := preflightRetentionClasses(e.Name, code, p.Retention()); err != nil {
-			return err
-		}
-		packCodes[code] = e.Name
-	}
-	return nil
-}
-
-// preflightRetentionClasses validates one pack's declared floors: class
-// name, period, and anchor each carry their own published grammar, and a
-// class may be declared once — two floors for the same class with
-// different Keep/Anchor would leave the engine picking one silently.
-func preflightRetentionClasses(unit extension.Name, code jurisdiction.Code, ret jurisdiction.Retention) error {
-	if ret == nil {
-		return nil
-	}
-	seen := make(map[jurisdiction.RetentionClassName]bool)
-	for _, class := range ret.Classes() {
-		if err := class.Name.Validate(); err != nil {
-			return fmt.Errorf("compose: extension %q, jurisdiction %q: %w", unit, code, err)
-		}
-		if seen[class.Name] {
-			return fmt.Errorf("compose: extension %q, jurisdiction %q declares retention class %q twice", unit, code, class.Name)
-		}
-		seen[class.Name] = true
-		if err := class.Keep.Validate(); err != nil {
-			return fmt.Errorf("compose: extension %q, jurisdiction %q, class %q: %w", unit, code, class.Name, err)
-		}
-		if err := class.Anchor.Validate(); err != nil {
-			return fmt.Errorf("compose: extension %q, jurisdiction %q, class %q: %w", unit, code, class.Name, err)
-		}
 	}
 	return nil
 }

--- a/backend/internal/shared/ports/messagingrules/messagingrules.go
+++ b/backend/internal/shared/ports/messagingrules/messagingrules.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package messagingrules is the core-internal seam behind country messaging
+// rules: the rule CONTRACT lives on the published surface
+// backend/pkg/extension/messaging so extensions can declare it, and this
+// package keeps the registry and re-exports the types as aliases so core call
+// sites stay put.
+//
+// Core code never imports a pack and never contains a jurisdiction string
+// (scripts/check-no-jurisdiction.sh). What the authorization engine asks this
+// package is "what does the applicable jurisdiction require", and it gets data
+// back — never a pack it calls into.
+package messagingrules
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+	pub "github.com/margince/margince/backend/pkg/extension/messaging"
+)
+
+// The published types, aliased so a rule set declared by an extension and one
+// registered by a core module are the same type.
+type (
+	// Rules is one jurisdiction's outbound-messaging rule set.
+	Rules = pub.Rules
+	// MarketingException is one route to advertising without consent.
+	MarketingException = pub.MarketingException
+	// Disclosure is one obligation a first message carries.
+	Disclosure = pub.Disclosure
+	// FrequencyCap bounds advertising to one address in a window.
+	FrequencyCap = pub.FrequencyCap
+	// ExceptionKind names a route to lawful advertising without consent.
+	ExceptionKind = pub.ExceptionKind
+	// DisclosureKind names something a first message must carry.
+	DisclosureKind = pub.DisclosureKind
+)
+
+// The published constants, re-exported.
+const (
+	// ExistingCustomer is the sale-derived advertising exception.
+	ExistingCustomer = pub.ExistingCustomer
+	// ControllerIdentity is who is writing.
+	ControllerIdentity = pub.ControllerIdentity
+	// PrivacyContact is who answers about the data.
+	PrivacyContact = pub.PrivacyContact
+	// ObjectionRoute is how to say stop.
+	ObjectionRoute = pub.ObjectionRoute
+	// AdvertiserContact is the advertiser's own reachability.
+	AdvertiserContact = pub.AdvertiserContact
+)
+
+var (
+	mu    sync.RWMutex
+	rules = map[jurisdiction.Code]Rules{}
+)
+
+// Register records one jurisdiction's rules. A duplicate or invalid set is a
+// wiring defect and fails fast at boot, for the reason the jurisdiction
+// registry does the same: two rule sets for one country are two answers to
+// whether a message may go out, and whichever the engine happened to read
+// would look like that country's law.
+func Register(r Rules) {
+	mu.Lock()
+	defer mu.Unlock()
+	if err := r.Validate(); err != nil {
+		panic(fmt.Sprintf("messagingrules: %v", err))
+	}
+	if _, dup := rules[r.Jurisdiction]; dup {
+		panic(fmt.Sprintf("messagingrules: rules for %q registered twice", r.Jurisdiction))
+	}
+	rules[r.Jurisdiction] = r
+}
+
+// For returns the rules for a code; ok is false when the running binary was
+// not compiled with them.
+func For(code jurisdiction.Code) (Rules, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	r, ok := rules[code]
+	return r, ok
+}
+
+// Strictest folds the applicable jurisdictions into the one rule set the
+// engine applies, taking the STRICTEST answer for each obligation.
+//
+// Several jurisdictions can apply at once — the installation's own country and
+// the recipient's — and the answer is not "pick one". A message lawful where
+// the sender sits and unlawful where the recipient does is unlawful, so each
+// obligation resolves independently to whichever position permits less:
+// the shortest non-zero window, every declared disclosure, the tightest cap,
+// and an exception only where EVERY applicable jurisdiction grants it.
+//
+// An unknown jurisdiction contributes nothing to fold, which is why the caller
+// must treat "no rules at all" as the consent-only floor rather than as
+// permission — Strictest cannot invent an obligation for a country it was
+// never told about.
+func Strictest(codes ...jurisdiction.Code) (Rules, bool) {
+	var out Rules
+	found := false
+	for _, code := range codes {
+		r, ok := For(code)
+		if !ok {
+			continue
+		}
+		if !found {
+			out, found = r, true
+			continue
+		}
+		out = stricter(out, r)
+	}
+	return out, found
+}
+
+// stricter folds one rule set into another, obligation by obligation.
+func stricter(a, b Rules) Rules {
+	out := a
+	// The fold is no longer any one jurisdiction's, and stamping it with one
+	// country's code would misname the rules a decision was taken under.
+	out.Jurisdiction = ""
+	// A version is only meaningful for a single jurisdiction's set; a folded
+	// one carries none, and the decision records the codes it folded instead.
+	out.Version = 0
+	out.ReplyWindow = shorterWindow(a.ReplyWindow, b.ReplyWindow)
+	out.DealFollowUpWindow = shorterWindow(a.DealFollowUpWindow, b.DealFollowUpWindow)
+	// Every disclosure either side requires. An obligation one country imposes
+	// is not lifted by another that does not.
+	out.Disclosures = append(append([]Disclosure{}, a.Disclosures...), b.Disclosures...)
+	// A prefix either side requires. Two different prefixes cannot both be
+	// satisfied by one subject line, so the first declared wins and the caller
+	// is expected not to compose two prefixing jurisdictions — a case no
+	// shipped pack creates today.
+	if out.SubjectPrefix == "" {
+		out.SubjectPrefix = b.SubjectPrefix
+	}
+	out.FrequencyCap = tighterCap(a.FrequencyCap, b.FrequencyCap)
+	out.OptOutAcknowledgement = a.OptOutAcknowledgement || b.OptOutAcknowledgement
+	// An exception only where BOTH grant it: a route to advertising without
+	// consent that one jurisdiction does not recognise is not available in a
+	// send both govern.
+	out.MarketingExceptions = commonExceptions(a.MarketingExceptions, b.MarketingExceptions)
+	return out
+}
+
+// shorterWindow picks the tighter of two windows, treating zero as "this
+// jurisdiction says nothing" rather than as an instant expiry.
+func shorterWindow(a, b time.Duration) time.Duration {
+	switch {
+	case a == 0:
+		return b
+	case b == 0:
+		return a
+	case b < a:
+		return b
+	}
+	return a
+}
+
+// tighterCap picks the cap that permits fewer messages per unit of time. Nil
+// means uncapped, so a nil on either side yields the other's cap.
+func tighterCap(a, b *FrequencyCap) *FrequencyCap {
+	switch {
+	case a == nil:
+		return b
+	case b == nil:
+		return a
+	}
+	// Compare rates rather than raw counts: three per 24h is tighter than ten
+	// per 24h, and also tighter than four per hour.
+	if float64(b.Messages)/b.Window.Seconds() < float64(a.Messages)/a.Window.Seconds() {
+		return b
+	}
+	return a
+}
+
+// commonExceptions keeps only the exceptions BOTH sides grant, and a kept one
+// carries the union of the conditions either side attaches.
+func commonExceptions(a, b []MarketingException) []MarketingException {
+	byKind := map[ExceptionKind]MarketingException{}
+	for _, e := range a {
+		byKind[e.Kind] = e
+	}
+	var out []MarketingException
+	for _, e := range b {
+		mine, both := byKind[e.Kind]
+		if !both {
+			continue
+		}
+		out = append(out, MarketingException{
+			Kind: e.Kind,
+			// A condition either jurisdiction attaches is checked. Dropping one
+			// because the other does not require it would apply an exception on
+			// looser terms than one of the two countries allows.
+			RequiresSaleEvidence:         mine.RequiresSaleEvidence || e.RequiresSaleEvidence,
+			RequiresCollectionTimeOptOut: mine.RequiresCollectionTimeOptOut || e.RequiresCollectionTimeOptOut,
+			RequiresSimilarity:           mine.RequiresSimilarity || e.RequiresSimilarity,
+			RequiresNoObjection:          mine.RequiresNoObjection || e.RequiresNoObjection,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Kind < out[j].Kind })
+	return out
+}

--- a/backend/internal/shared/ports/messagingrules/messagingrules.go
+++ b/backend/internal/shared/ports/messagingrules/messagingrules.go
@@ -15,6 +15,7 @@ package messagingrules
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -73,7 +74,27 @@ func Register(r Rules) {
 	if _, dup := rules[r.Jurisdiction]; dup {
 		panic(fmt.Sprintf("messagingrules: rules for %q registered twice", r.Jurisdiction))
 	}
-	rules[r.Jurisdiction] = r
+	rules[r.Jurisdiction] = clone(r)
+}
+
+// clone deep-copies a rule set, so the registry and its callers never share
+// backing arrays.
+//
+// Rules is a struct of slices and a pointer, so a plain copy aliases them. A
+// caller that sorted, filtered or normalised the slice it got back — an
+// ordinary thing to write — would rewrite the registered rules for every later
+// send in the process, with no boot error and nothing failing. The sibling
+// jurisdiction registry is safe from this by accident: it hands out an
+// interface, so there is no reachable mutable state. This one has to say so.
+func clone(r Rules) Rules {
+	out := r
+	out.MarketingExceptions = slices.Clone(r.MarketingExceptions)
+	out.Disclosures = slices.Clone(r.Disclosures)
+	if r.FrequencyCap != nil {
+		copied := *r.FrequencyCap
+		out.FrequencyCap = &copied
+	}
+	return out
 }
 
 // For returns the rules for a code; ok is false when the running binary was
@@ -82,7 +103,10 @@ func For(code jurisdiction.Code) (Rules, bool) {
 	mu.RLock()
 	defer mu.RUnlock()
 	r, ok := rules[code]
-	return r, ok
+	if !ok {
+		return Rules{}, false
+	}
+	return clone(r), true
 }
 
 // Strictest folds the applicable jurisdictions into the one rule set the
@@ -99,12 +123,14 @@ func For(code jurisdiction.Code) (Rules, bool) {
 // must treat "no rules at all" as the consent-only floor rather than as
 // permission — Strictest cannot invent an obligation for a country it was
 // never told about.
-func Strictest(codes ...jurisdiction.Code) (Rules, bool) {
+func Strictest(codes ...jurisdiction.Code) (Rules, []jurisdiction.Code, bool) {
 	var out Rules
+	var unknown []jurisdiction.Code
 	found := false
 	for _, code := range codes {
 		r, ok := For(code)
 		if !ok {
+			unknown = append(unknown, code)
 			continue
 		}
 		if !found {
@@ -113,7 +139,7 @@ func Strictest(codes ...jurisdiction.Code) (Rules, bool) {
 		}
 		out = stricter(out, r)
 	}
-	return out, found
+	return out, unknown, found
 }
 
 // stricter folds one rule set into another, obligation by obligation.
@@ -169,20 +195,54 @@ func tighterCap(a, b *FrequencyCap) *FrequencyCap {
 	case b == nil:
 		return a
 	}
-	// Compare rates rather than raw counts: three per 24h is tighter than ten
-	// per 24h, and also tighter than four per hour.
-	if float64(b.Messages)/b.Window.Seconds() < float64(a.Messages)/a.Window.Seconds() {
+	// A degenerate cap is the strictest thing there is, and it is handled
+	// FIRST rather than left to the comparison. Validate refuses one on the
+	// extension path, but Register is exported and a core-built value never
+	// sees Validate — and a zero window divided by a zero count is NaN, which
+	// loses every comparison and would hand back whichever cap happened to sit
+	// on the left. That made the fold's answer depend on the order the caller
+	// listed the countries in.
+	if degenerate(a) {
+		return a
+	}
+	if degenerate(b) {
+		return b
+	}
+	// Cross-multiplied rather than divided: exact, and it cannot produce NaN.
+	// Three per 24h is tighter than ten per 24h, and also tighter than four per
+	// hour. int64 nanoseconds against a message count stays far from overflow
+	// for any cap a statute could state.
+	left := int64(b.Messages) * int64(a.Window)
+	right := int64(a.Messages) * int64(b.Window)
+	if left != right {
+		if left < right {
+			return b
+		}
+		return a
+	}
+	// Equal rates are not equal burst: {1, 1h} and {24, 24h} permit the same
+	// average and a 24-message burst is not the same restriction as one an
+	// hour. The smaller allowance wins.
+	if b.Messages < a.Messages {
 		return b
 	}
 	return a
 }
 
+// degenerate reports a cap that cannot bind as written.
+func degenerate(c *FrequencyCap) bool { return c.Messages <= 0 || c.Window <= 0 }
+
 // commonExceptions keeps only the exceptions BOTH sides grant, and a kept one
 // carries the union of the conditions either side attaches.
 func commonExceptions(a, b []MarketingException) []MarketingException {
+	// OR-folded rather than last-write-wins. A set declaring one kind twice is
+	// refused by Validate, but Register is exported and the fold must be total
+	// over its own type: overwriting let a weak duplicate erase a strong
+	// entry's conditions, and the fold then permitted MORE than the input it
+	// was folding — the one thing a strictest-wins fold may never do.
 	byKind := map[ExceptionKind]MarketingException{}
 	for _, e := range a {
-		byKind[e.Kind] = e
+		byKind[e.Kind] = unionConditions(byKind[e.Kind], e)
 	}
 	var out []MarketingException
 	for _, e := range b {
@@ -190,17 +250,22 @@ func commonExceptions(a, b []MarketingException) []MarketingException {
 		if !both {
 			continue
 		}
-		out = append(out, MarketingException{
-			Kind: e.Kind,
-			// A condition either jurisdiction attaches is checked. Dropping one
-			// because the other does not require it would apply an exception on
-			// looser terms than one of the two countries allows.
-			RequiresSaleEvidence:         mine.RequiresSaleEvidence || e.RequiresSaleEvidence,
-			RequiresCollectionTimeOptOut: mine.RequiresCollectionTimeOptOut || e.RequiresCollectionTimeOptOut,
-			RequiresSimilarity:           mine.RequiresSimilarity || e.RequiresSimilarity,
-			RequiresNoObjection:          mine.RequiresNoObjection || e.RequiresNoObjection,
-		})
+		// A condition either jurisdiction attaches is checked. Dropping one
+		// because the other does not require it would apply an exception on
+		// looser terms than one of the two countries allows.
+		out = append(out, unionConditions(mine, e))
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Kind < out[j].Kind })
 	return out
+}
+
+// unionConditions keeps every condition either side attaches to one kind.
+func unionConditions(a, b MarketingException) MarketingException {
+	return MarketingException{
+		Kind:                         b.Kind,
+		RequiresSaleEvidence:         a.RequiresSaleEvidence || b.RequiresSaleEvidence,
+		RequiresCollectionTimeOptOut: a.RequiresCollectionTimeOptOut || b.RequiresCollectionTimeOptOut,
+		RequiresSimilarity:           a.RequiresSimilarity || b.RequiresSimilarity,
+		RequiresNoObjection:          a.RequiresNoObjection || b.RequiresNoObjection,
+	}
 }

--- a/backend/internal/shared/ports/messagingrules/messagingrules_test.go
+++ b/backend/internal/shared/ports/messagingrules/messagingrules_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package messagingrules
+
+import (
+	"testing"
+	"time"
+)
+
+// Two jurisdictions apply to one message when the sender and the recipient sit
+// in different countries, and the answer is never "pick one". A message lawful
+// where the sender sits and unlawful where the recipient does is unlawful, so
+// each obligation resolves to whichever position permits less.
+
+// The shorter window wins, and a jurisdiction that declares none does not
+// shorten anything to zero.
+func TestTheShorterWindowWins(t *testing.T) {
+	strict := Rules{Jurisdiction: "aa", Version: 1, ReplyWindow: 30 * 24 * time.Hour}
+	loose := Rules{Jurisdiction: "bb", Version: 1, ReplyWindow: 365 * 24 * time.Hour}
+
+	if got := stricter(loose, strict).ReplyWindow; got != strict.ReplyWindow {
+		t.Errorf("reply window = %s, want the shorter %s", got, strict.ReplyWindow)
+	}
+	// Zero means "this jurisdiction says nothing", not "expires instantly".
+	silent := Rules{Jurisdiction: "cc", Version: 1}
+	if got := stricter(strict, silent).ReplyWindow; got != strict.ReplyWindow {
+		t.Errorf("reply window = %s; a silent jurisdiction collapsed a real window to nothing", got)
+	}
+}
+
+// An exception is available only where EVERY applicable jurisdiction grants
+// it. A route to advertising without consent that one country does not
+// recognise is not available in a send both govern — this is the fold's most
+// important direction, because getting it backwards makes the laxest country
+// the one that decides.
+func TestAnExceptionSurvivesOnlyWhereBothGrantIt(t *testing.T) {
+	grants := Rules{Jurisdiction: "aa", Version: 1, MarketingExceptions: []MarketingException{{
+		Kind: ExistingCustomer, RequiresSaleEvidence: true,
+	}}}
+	withholds := Rules{Jurisdiction: "bb", Version: 1}
+
+	if got := stricter(grants, withholds).MarketingExceptions; len(got) != 0 {
+		t.Errorf("an exception survived a jurisdiction that does not grant it: %+v", got)
+	}
+	if got := stricter(withholds, grants).MarketingExceptions; len(got) != 0 {
+		t.Error("the fold is order-dependent — an exception survived in one direction only")
+	}
+}
+
+// A kept exception carries the union of the conditions either side attaches.
+// Dropping a condition because the other country does not require it would
+// apply the exception on looser terms than one of the two allows.
+func TestAKeptExceptionCarriesEveryConditionEitherSideAttaches(t *testing.T) {
+	sale := Rules{Jurisdiction: "aa", Version: 1, MarketingExceptions: []MarketingException{{
+		Kind: ExistingCustomer, RequiresSaleEvidence: true,
+	}}}
+	similar := Rules{Jurisdiction: "bb", Version: 1, MarketingExceptions: []MarketingException{{
+		Kind: ExistingCustomer, RequiresSimilarity: true, RequiresNoObjection: true,
+	}}}
+
+	got := stricter(sale, similar).MarketingExceptions
+	if len(got) != 1 {
+		t.Fatalf("%d exceptions survived, want 1", len(got))
+	}
+	e := got[0]
+	if !e.RequiresSaleEvidence || !e.RequiresSimilarity || !e.RequiresNoObjection {
+		t.Errorf("a condition was dropped in the fold: %+v", e)
+	}
+}
+
+// Every disclosure either side requires. An obligation one country imposes is
+// not lifted by another that does not.
+func TestDisclosuresAccumulate(t *testing.T) {
+	a := Rules{Jurisdiction: "aa", Version: 1, Disclosures: []Disclosure{{Kind: ControllerIdentity}}}
+	b := Rules{Jurisdiction: "bb", Version: 1, Disclosures: []Disclosure{{Kind: AdvertiserContact}}}
+
+	got := stricter(a, b).Disclosures
+	if len(got) != 2 {
+		t.Fatalf("%d disclosures survived, want both", len(got))
+	}
+}
+
+// The tighter cap wins, compared as a RATE. Three per 24h is tighter than ten
+// per 24h and also tighter than four per hour — comparing raw counts would let
+// a high-count short-window cap look looser than it is.
+func TestTheTighterCapWinsByRate(t *testing.T) {
+	threePerDay := &FrequencyCap{Messages: 3, Window: 24 * time.Hour}
+	tenPerDay := &FrequencyCap{Messages: 10, Window: 24 * time.Hour}
+	fourPerHour := &FrequencyCap{Messages: 4, Window: time.Hour}
+
+	if got := tighterCap(tenPerDay, threePerDay); got != threePerDay {
+		t.Error("the looser of two same-window caps won")
+	}
+	if got := tighterCap(fourPerHour, threePerDay); got != threePerDay {
+		t.Error("a high-rate short-window cap beat a genuinely tighter one")
+	}
+	// Nil is uncapped, so the other side's cap survives.
+	if got := tighterCap(nil, threePerDay); got != threePerDay {
+		t.Error("an uncapped jurisdiction erased another's cap")
+	}
+}
+
+// An acknowledgement owed anywhere is owed. It is a message TO the subject, so
+// a country that does not require it is not harmed by one being sent.
+func TestAnAcknowledgementOwedAnywhereIsOwed(t *testing.T) {
+	owes := Rules{Jurisdiction: "aa", Version: 1, OptOutAcknowledgement: true}
+	silent := Rules{Jurisdiction: "bb", Version: 1}
+	if !stricter(silent, owes).OptOutAcknowledgement {
+		t.Error("an acknowledgement obligation was dropped in the fold")
+	}
+}
+
+// The fold is not any one jurisdiction's, and must not be stamped as one. A
+// decision recording a folded set under a single country's code and version
+// would misname the rules it was taken under.
+func TestAFoldedSetClaimsNoSingleJurisdiction(t *testing.T) {
+	a := Rules{Jurisdiction: "aa", Version: 3}
+	b := Rules{Jurisdiction: "bb", Version: 7}
+	got := stricter(a, b)
+	if got.Jurisdiction != "" {
+		t.Errorf("the fold claims jurisdiction %q", got.Jurisdiction)
+	}
+	if got.Version != 0 {
+		t.Errorf("the fold claims version %d, which belongs to one country's set", got.Version)
+	}
+}
+
+// A jurisdiction the binary was not compiled with contributes nothing, and
+// Strictest reports that it found nothing rather than returning an empty set
+// that reads as "no obligations".
+func TestAnUnknownJurisdictionIsNotAnAnswer(t *testing.T) {
+	if _, ok := Strictest("zz"); ok {
+		t.Error("an unknown jurisdiction reported rules — the caller would read the zero set as 'nothing required'")
+	}
+}

--- a/backend/internal/shared/ports/messagingrules/messagingrules_test.go
+++ b/backend/internal/shared/ports/messagingrules/messagingrules_test.go
@@ -130,7 +130,144 @@ func TestAFoldedSetClaimsNoSingleJurisdiction(t *testing.T) {
 // Strictest reports that it found nothing rather than returning an empty set
 // that reads as "no obligations".
 func TestAnUnknownJurisdictionIsNotAnAnswer(t *testing.T) {
-	if _, ok := Strictest("zz"); ok {
+	_, unknown, ok := Strictest("zz")
+	if ok {
 		t.Error("an unknown jurisdiction reported rules — the caller would read the zero set as 'nothing required'")
+	}
+	if len(unknown) != 1 {
+		t.Errorf("unknown codes = %v, want the one that could not be resolved", unknown)
+	}
+}
+
+// The registry hands out copies, not its own slices.
+//
+// Rules is a struct of slices and a pointer, so a plain return aliases the
+// stored value. A caller that sorted or filtered what it got — an ordinary
+// thing to write — would rewrite the registered rules for every later send in
+// the process, silently dropping a statutory condition with nothing failing.
+func TestTheRegistryHandsOutCopies(t *testing.T) {
+	Register(Rules{
+		Jurisdiction: "qa", Version: 1,
+		MarketingExceptions: []MarketingException{{Kind: ExistingCustomer, RequiresSimilarity: true}},
+		FrequencyCap:        &FrequencyCap{Messages: 3, Window: 24 * time.Hour},
+	})
+
+	got, ok := For("qa")
+	if !ok {
+		t.Fatal("the rules did not register")
+	}
+	got.MarketingExceptions[0].RequiresSimilarity = false
+	got.FrequencyCap.Messages = 1000
+
+	again, _ := For("qa")
+	if !again.MarketingExceptions[0].RequiresSimilarity {
+		t.Error("a caller erased a condition from the registry's own copy")
+	}
+	if again.FrequencyCap.Messages != 3 {
+		t.Errorf("a caller rewrote the registered cap to %d", again.FrequencyCap.Messages)
+	}
+}
+
+// Registering is a copy too, so a caller that keeps its literal and mutates it
+// afterwards does not reach in.
+func TestRegisteringTakesACopy(t *testing.T) {
+	exceptions := []MarketingException{{Kind: ExistingCustomer, RequiresSaleEvidence: true}}
+	Register(Rules{Jurisdiction: "qb", Version: 1, MarketingExceptions: exceptions})
+
+	exceptions[0].RequiresSaleEvidence = false
+
+	got, _ := For("qb")
+	if !got.MarketingExceptions[0].RequiresSaleEvidence {
+		t.Error("mutating the caller's own slice reached into the registry")
+	}
+}
+
+// The fold may never permit more than an input permits.
+//
+// This is the counterexample that proved it could: a set naming one kind twice,
+// where the weak duplicate overwrote the strong entry. The fold then required
+// none of the three conditions the first entry demanded — more permissive than
+// either side, which is the one thing a strictest-wins fold may not be.
+func TestADuplicateKindCannotErodeAnExceptionsConditions(t *testing.T) {
+	strong := MarketingException{
+		Kind: ExistingCustomer, RequiresSaleEvidence: true,
+		RequiresCollectionTimeOptOut: true, RequiresSimilarity: true, RequiresNoObjection: true,
+	}
+	weak := MarketingException{Kind: ExistingCustomer, RequiresNoObjection: true}
+
+	a := Rules{Jurisdiction: "aa", Version: 1, MarketingExceptions: []MarketingException{strong, weak}}
+	b := Rules{Jurisdiction: "bb", Version: 1, MarketingExceptions: []MarketingException{weak}}
+
+	got := stricter(a, b).MarketingExceptions
+	if len(got) != 1 {
+		t.Fatalf("%d exceptions survived, want 1 — a duplicate kind produced an order-dependent answer", len(got))
+	}
+	e := got[0]
+	if !e.RequiresSaleEvidence || !e.RequiresCollectionTimeOptOut || !e.RequiresSimilarity {
+		t.Errorf("the fold permits more than its input did: %+v", e)
+	}
+}
+
+// And the set that made it possible is refused outright.
+func TestARuleSetCannotNameOneExceptionKindTwice(t *testing.T) {
+	err := Rules{Jurisdiction: "aa", Version: 1, MarketingExceptions: []MarketingException{
+		{Kind: ExistingCustomer, RequiresSaleEvidence: true},
+		{Kind: ExistingCustomer, RequiresNoObjection: true},
+	}}.Validate()
+	if err == nil {
+		t.Error("a rule set naming one exception kind twice was accepted")
+	}
+}
+
+// A cap that cannot bind as written is the strictest thing there is, and it
+// does not depend on which side it sits on.
+//
+// A zero window over a zero count is NaN, which loses every comparison — so the
+// genuinely tighter cap lost whenever the degenerate one sat on the left, and
+// the fold's answer depended on the order the caller listed the countries in.
+func TestADegenerateCapDoesNotWinByArgumentOrder(t *testing.T) {
+	broken := &FrequencyCap{}
+	binding := &FrequencyCap{Messages: 1, Window: 24 * time.Hour}
+
+	if tighterCap(broken, binding) != broken || tighterCap(binding, broken) != broken {
+		t.Error("a cap that cannot bind lost to a real one, or won only from one side")
+	}
+}
+
+// Equal rates are not equal burst: {1, 1h} and {24, 24h} permit the same
+// average, and a 24-message burst is not the same restriction as one an hour.
+func TestEqualRatesBreakTowardTheSmallerBurst(t *testing.T) {
+	hourly := &FrequencyCap{Messages: 1, Window: time.Hour}
+	daily := &FrequencyCap{Messages: 24, Window: 24 * time.Hour}
+
+	if tighterCap(daily, hourly) != hourly || tighterCap(hourly, daily) != hourly {
+		t.Error("a 24-message burst beat a one-per-hour throttle at the same rate")
+	}
+}
+
+// Strictest must not report a complete answer over a partial fold.
+//
+// The intended call is Strictest(sender, recipient). With the German pack
+// compiled in and a recipient whose country has none, a silent skip returned
+// ok=true carrying Germany's existing-customer exception — applied to somebody
+// whose law the process knows nothing about, which is exactly the
+// laxest-country-decides failure the fold exists to prevent.
+func TestStrictestReportsTheJurisdictionsItCouldNotResolve(t *testing.T) {
+	Register(Rules{
+		Jurisdiction: "qc", Version: 1,
+		MarketingExceptions: []MarketingException{{Kind: ExistingCustomer, RequiresSaleEvidence: true}},
+	})
+
+	got, unknown, ok := Strictest("qc", "zz")
+	if !ok {
+		t.Fatal("a known jurisdiction reported nothing")
+	}
+	if len(unknown) != 1 || unknown[0] != "zz" {
+		t.Fatalf("unknown = %v, want the code that could not be resolved", unknown)
+	}
+	// The rules still come back — the caller decides what to do about a partial
+	// answer — but it can no longer mistake one for a complete fold.
+	if len(got.MarketingExceptions) != 1 {
+		t.Error("the resolvable jurisdiction's rules were lost")
 	}
 }

--- a/backend/pkg/extension/extension.go
+++ b/backend/pkg/extension/extension.go
@@ -80,6 +80,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/margince/margince/backend/pkg/extension/jurisdiction"
+	"github.com/margince/margince/backend/pkg/extension/messaging"
 )
 
 // nameGrammar is the one spelling of the unit-name rule; the grammar in
@@ -229,6 +230,17 @@ type Extension struct {
 	// jurisdiction code across the composed set is a wiring defect and
 	// fails the boot.
 	Jurisdictions []jurisdiction.Pack
+
+	// Messaging are the unit's outbound-messaging rule sets — the country
+	// rules the core authorization engine consults before a message goes out.
+	// Policy suppliers like a jurisdiction pack, and never actors: a pack
+	// states what its jurisdiction requires and the engine decides, so there
+	// is one answer to "may we write to this person" rather than one per
+	// country.
+	//
+	// At most one rule set per jurisdiction code across the composed set; two
+	// would be two answers, and the boot refuses them.
+	Messaging []messaging.Rules
 
 	// Tools are the governed agent tools the unit contributes: named
 	// operations running at a requested risk tier. Their tiers

--- a/backend/pkg/extension/messaging/messaging.go
+++ b/backend/pkg/extension/messaging/messaging.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package messaging carries the outbound-messaging contract of the published
+// extension surface: a pack supplies country-specific RULES the core
+// authorization engine consults — it is never an actor and never decides a
+// send.
+//
+// The split is the same one the jurisdiction packs draw. A rule here is DATA:
+// how long a reply stays a reply, whether the jurisdiction has an
+// existing-customer exception and what that exception requires, what a first
+// message must disclose, whether advertising carries a subject prefix, and how
+// many advertising messages one address may receive in a window. The engine
+// reads the data and answers; nothing in a pack is called back into.
+//
+// That matters more here than for retention. A pack that could decide a send
+// would be country-specific code on the path of every outbound message, and the
+// one thing this product cannot afford is two answers to "may we write to this
+// person". So a pack states its jurisdiction's rules and the engine applies
+// them, in one place, the same way for every country.
+//
+// These types are frozen published API from their first external consumer; they
+// evolve additively or through versioned successors, never in place (EXT-P3).
+//
+//margince:extension-surface
+package messaging
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/margince/margince/backend/pkg/extension/jurisdiction"
+)
+
+// Rules is one jurisdiction's outbound-messaging rule set.
+//
+// Every field is optional in the sense that the zero value is a legal, STRICT
+// answer: no exception, no disclosure obligation, no prefix, no cap, and the
+// core's own default windows. A pack that declares nothing therefore permits
+// nothing extra, which is the direction a missing declaration must fail in.
+type Rules struct {
+	// Jurisdiction is whose rules these are, lower-case ISO 3166-1 alpha-2.
+	Jurisdiction jurisdiction.Code
+
+	// Version is the rule set's own version, stamped onto every decision taken
+	// under it. A decision a subject later asks about must be readable against
+	// the rules that were live when it was taken, and those rules change — so
+	// the number is recorded rather than re-derived from whatever the code says
+	// today.
+	Version int
+
+	// ReplyWindow is how long an inbound message keeps making a reply a reply
+	// when there is no thread to continue. Zero means the core default.
+	//
+	// It bounds an UNPROMPTED follow-up, never a same-thread reply: the subject
+	// wrote to us and did not withdraw, and a rep answering a three-month-old
+	// thread is doing the ordinary thing. A pack that shortened replies would
+	// be refusing correspondence rather than restricting advertising.
+	ReplyWindow time.Duration
+
+	// DealFollowUpWindow is how long a live opportunity keeps supporting an
+	// unprompted follow-up. Zero means the core default.
+	DealFollowUpWindow time.Duration
+
+	// MarketingExceptions are the routes to lawful advertising WITHOUT a
+	// recorded consent. Empty means there are none, which is the strict
+	// position and the right default: a jurisdiction whose pack forgets to
+	// declare one requires consent rather than silently permitting a send.
+	MarketingExceptions []MarketingException
+
+	// Disclosures are what a first message to somebody must carry.
+	Disclosures []Disclosure
+
+	// SubjectPrefix is prepended to an advertising message's subject, exactly
+	// once. Empty means none.
+	SubjectPrefix string
+
+	// FrequencyCap bounds advertising to one address in a window. Nil means
+	// uncapped by this jurisdiction.
+	FrequencyCap *FrequencyCap
+
+	// OptOutAcknowledgement records whether an opt-out is owed a confirming
+	// message. False means none is sent, which is the default.
+	OptOutAcknowledgement bool
+}
+
+// ExceptionKind names a route to lawful advertising without consent. Closed:
+// the engine implements each kind, so a pack naming one nothing implements
+// would be an exception that looks declared and never applies.
+type ExceptionKind string
+
+// ExistingCustomer is the sale-derived exception several jurisdictions grant
+// for advertising similar goods to an existing customer (UWG §7(3) in Germany).
+// Its four conditions are declared on the exception rather than assumed,
+// because they differ by country and the engine checks each one it is told to.
+const ExistingCustomer ExceptionKind = "existing_customer"
+
+// Validate enforces membership in the closed set.
+func (k ExceptionKind) Validate() error {
+	if k == ExistingCustomer {
+		return nil
+	}
+	return fmt.Errorf("marketing exception %q is not one the engine implements", string(k))
+}
+
+// MarketingException is one route to advertising without a recorded consent,
+// and the conditions that route requires.
+//
+// The conditions are stated positively and each defaults to FALSE, so a pack
+// that declares an exception without naming its conditions gets an exception
+// the engine checks nothing for — which is why the core refuses one at boot
+// (Validate below). An exception with no conditions is not a lighter rule, it
+// is an unguarded one.
+type MarketingException struct {
+	Kind ExceptionKind
+
+	// RequiresSaleEvidence: there must be a recorded sale to this person.
+	RequiresSaleEvidence bool
+
+	// RequiresCollectionTimeOptOut: the address must have been collected with
+	// a notice offering a free, easy objection at the time it was taken.
+	RequiresCollectionTimeOptOut bool
+
+	// RequiresSimilarity: the advertised goods must be similar to what was
+	// bought. Checked per message, not once per person: a customer who bought
+	// one product has not opened the door to every catalogue the seller has.
+	RequiresSimilarity bool
+
+	// RequiresNoObjection: no standing objection. Always true in practice —
+	// an Art. 21 objection is absolute — and stated here so a pack cannot
+	// declare an exception that reads as though it outranks one.
+	RequiresNoObjection bool
+}
+
+// Validate refuses an exception the engine could apply without checking
+// anything.
+func (e MarketingException) Validate() error {
+	if err := e.Kind.Validate(); err != nil {
+		return err
+	}
+	if !e.RequiresSaleEvidence && !e.RequiresCollectionTimeOptOut &&
+		!e.RequiresSimilarity && !e.RequiresNoObjection {
+		return fmt.Errorf("marketing exception %q names no condition — an exception the engine checks nothing for is not a lighter rule, it is an unguarded one", string(e.Kind))
+	}
+	return nil
+}
+
+// DisclosureKind names something a first message must carry. Closed for the
+// reason ExceptionKind is: the engine renders each kind it knows, and one it
+// does not know would be an obligation nothing discharges.
+type DisclosureKind string
+
+const (
+	// ControllerIdentity is who is writing: the legal name and postal address
+	// of the controller.
+	ControllerIdentity DisclosureKind = "controller_identity"
+	// PrivacyContact is how to reach whoever answers about the data.
+	PrivacyContact DisclosureKind = "privacy_contact"
+	// ObjectionRoute is how to say stop, free and without a barrier.
+	ObjectionRoute DisclosureKind = "objection_route"
+	// AdvertiserContact is the advertiser's own reachability — phone, email,
+	// address, website — which some jurisdictions require on advertising
+	// beyond the controller's identity.
+	AdvertiserContact DisclosureKind = "advertiser_contact"
+)
+
+// Validate enforces membership in the closed set.
+func (k DisclosureKind) Validate() error {
+	switch k {
+	case ControllerIdentity, PrivacyContact, ObjectionRoute, AdvertiserContact:
+		return nil
+	}
+	return fmt.Errorf("disclosure %q is not one the engine renders", string(k))
+}
+
+// Disclosure is one obligation a message carries, and where it binds.
+type Disclosure struct {
+	Kind DisclosureKind
+
+	// MarketingOnly limits the obligation to advertising. False means every
+	// first message carries it.
+	MarketingOnly bool
+}
+
+// Validate checks the kind.
+func (d Disclosure) Validate() error { return d.Kind.Validate() }
+
+// FrequencyCap bounds how many advertising messages one address may receive in
+// a rolling window.
+//
+// It counts messages the recipient actually RECEIVED. A staged message that
+// parked and a decision taken in observe mode both describe a message nobody
+// got, and counting either would silently consume somebody's allowance — the
+// engine holds that invariant, and this type only says what the bound is.
+type FrequencyCap struct {
+	// Messages is the most that may be received in Window.
+	Messages int
+	// Window is the rolling period the count covers.
+	Window time.Duration
+}
+
+// Validate refuses a cap that cannot bind.
+func (c FrequencyCap) Validate() error {
+	if c.Messages <= 0 {
+		return fmt.Errorf("frequency cap allows %d messages — a cap of zero or less would refuse every advertising message, which is a ban stated as a cap", c.Messages)
+	}
+	if c.Window <= 0 {
+		return fmt.Errorf("frequency cap has a window of %s — a cap without a window never expires and would silence an address permanently", c.Window)
+	}
+	return nil
+}
+
+// Validate checks a whole rule set. The boot preflight refuses a pack whose
+// rules it cannot apply, rather than composing an installation that believes it
+// is following a country's law and is not.
+func (r Rules) Validate() error {
+	if err := r.Jurisdiction.Validate(); err != nil {
+		return err
+	}
+	if r.Version <= 0 {
+		return fmt.Errorf("messaging rules for %q carry version %d — a decision records the version it was taken under, and zero names nothing", string(r.Jurisdiction), r.Version)
+	}
+	if r.ReplyWindow < 0 || r.DealFollowUpWindow < 0 {
+		return fmt.Errorf("messaging rules for %q carry a negative window — a window reaches back, never forward", string(r.Jurisdiction))
+	}
+	for _, e := range r.MarketingExceptions {
+		if err := e.Validate(); err != nil {
+			return fmt.Errorf("messaging rules for %q: %w", string(r.Jurisdiction), err)
+		}
+	}
+	for _, d := range r.Disclosures {
+		if err := d.Validate(); err != nil {
+			return fmt.Errorf("messaging rules for %q: %w", string(r.Jurisdiction), err)
+		}
+	}
+	if r.FrequencyCap != nil {
+		if err := r.FrequencyCap.Validate(); err != nil {
+			return fmt.Errorf("messaging rules for %q: %w", string(r.Jurisdiction), err)
+		}
+	}
+	return nil
+}

--- a/backend/pkg/extension/messaging/messaging.go
+++ b/backend/pkg/extension/messaging/messaging.go
@@ -223,10 +223,21 @@ func (r Rules) Validate() error {
 	if r.ReplyWindow < 0 || r.DealFollowUpWindow < 0 {
 		return fmt.Errorf("messaging rules for %q carry a negative window — a window reaches back, never forward", string(r.Jurisdiction))
 	}
+	// One rule set may name a kind once. A second entry for the same kind is
+	// refused rather than merged, for the reason a duplicate retention class
+	// is: the fold would have to pick, and a weaker duplicate silently
+	// replacing a stronger one is an exception applied on terms the pack never
+	// declared.
+	seen := map[ExceptionKind]bool{}
 	for _, e := range r.MarketingExceptions {
 		if err := e.Validate(); err != nil {
 			return fmt.Errorf("messaging rules for %q: %w", string(r.Jurisdiction), err)
 		}
+		if seen[e.Kind] {
+			return fmt.Errorf("messaging rules for %q declare exception %q twice — two sets of conditions for one route is two answers",
+				string(r.Jurisdiction), string(e.Kind))
+		}
+		seen[e.Kind] = true
 	}
 	for _, d := range r.Disclosures {
 		if err := d.Validate(); err != nil {

--- a/backend/pkg/extension/messaging/messaging_test.go
+++ b/backend/pkg/extension/messaging/messaging_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package messaging
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The zero value permits nothing extra.
+//
+// This is the direction a missing declaration must fail in: a pack that forgets
+// to declare an exception requires consent, and one that forgets a cap is
+// uncapped by ITS OWN rules rather than by the engine's. A zero value that
+// silently granted an exception would make an incomplete pack more permissive
+// than a complete one.
+func TestTheZeroRuleSetGrantsNothing(t *testing.T) {
+	var r Rules
+	if len(r.MarketingExceptions) != 0 {
+		t.Error("the zero rule set grants a marketing exception")
+	}
+	if r.FrequencyCap != nil {
+		t.Error("the zero rule set carries a cap, which would bound advertising nobody declared a bound for")
+	}
+	if r.OptOutAcknowledgement {
+		t.Error("the zero rule set promises an acknowledgement nothing was asked to send")
+	}
+}
+
+// An exception the engine would apply while checking nothing is refused.
+//
+// An unguarded exception is worse than no exception: it looks lawful, it
+// appears in the manifest as a declared rule, and every advertising message it
+// touches goes out having satisfied a condition set that is empty.
+func TestAnExceptionMustNameAtLeastOneCondition(t *testing.T) {
+	err := MarketingException{Kind: ExistingCustomer}.Validate()
+	if err == nil {
+		t.Fatal("an exception with no conditions was accepted")
+	}
+	if !strings.Contains(err.Error(), "unguarded") {
+		t.Errorf("the refusal does not say what is wrong: %v", err)
+	}
+}
+
+// And one that names a condition is accepted, or the refusal above would be
+// indistinguishable from a validator that rejects every exception.
+func TestAnExceptionWithAConditionIsAccepted(t *testing.T) {
+	if err := (MarketingException{Kind: ExistingCustomer, RequiresSaleEvidence: true}).Validate(); err != nil {
+		t.Errorf("a guarded exception was refused: %v", err)
+	}
+}
+
+// A kind the engine does not implement is refused rather than stored. A pack
+// naming one would declare a rule that looks registered and never applies.
+func TestAnUnimplementedExceptionKindIsRefused(t *testing.T) {
+	if err := (MarketingException{Kind: "soft_opt_in", RequiresSaleEvidence: true}).Validate(); err == nil {
+		t.Error("an exception kind nothing implements was accepted")
+	}
+	if err := DisclosureKind("bank_details").Validate(); err == nil {
+		t.Error("a disclosure kind nothing renders was accepted")
+	}
+}
+
+// A cap of zero is a ban stated as a cap, and a window of zero silences an
+// address forever. Both are refused, because both are a pack meaning one thing
+// and the engine reading another.
+func TestACapMustBeAbleToPermitSomething(t *testing.T) {
+	if err := (FrequencyCap{Messages: 0, Window: time.Hour}).Validate(); err == nil {
+		t.Error("a cap permitting zero messages was accepted")
+	}
+	if err := (FrequencyCap{Messages: 3, Window: 0}).Validate(); err == nil {
+		t.Error("a cap with no window was accepted")
+	}
+	if err := (FrequencyCap{Messages: 3, Window: 24 * time.Hour}).Validate(); err != nil {
+		t.Errorf("an ordinary cap was refused: %v", err)
+	}
+}
+
+// A rule set records the version it was taken under, so zero names nothing.
+func TestRulesCarryAVersion(t *testing.T) {
+	r := Rules{Jurisdiction: "de"}
+	if err := r.Validate(); err == nil {
+		t.Fatal("a rule set with no version was accepted")
+	}
+	r.Version = 1
+	if err := r.Validate(); err != nil {
+		t.Errorf("an ordinary rule set was refused: %v", err)
+	}
+}
+
+// A negative window would reach forward, which is a window that has already
+// expired for every record — the same failure class the retention period
+// guards against.
+func TestANegativeWindowIsRefused(t *testing.T) {
+	r := Rules{Jurisdiction: "de", Version: 1, ReplyWindow: -time.Hour}
+	if err := r.Validate(); err == nil {
+		t.Error("a negative reply window was accepted")
+	}
+}
+
+// A malformed jurisdiction code is refused: the registry keys on it, so a code
+// nothing can resolve is a rule set that looks registered and never applies.
+func TestAMalformedJurisdictionIsRefused(t *testing.T) {
+	if err := (Rules{Jurisdiction: "DE", Version: 1}).Validate(); err == nil {
+		t.Error("an upper-case jurisdiction code was accepted")
+	}
+}

--- a/backend/tools/gen-composition/astreader.go
+++ b/backend/tools/gen-composition/astreader.go
@@ -342,10 +342,18 @@ func (r *unitReader) readExtensionField(elt ast.Expr, file *ast.File, m *unitMan
 		if err == nil {
 			err = r.joinJobsToContract(served(declared), r.jobs)
 		}
-	case "Jurisdictions":
-		// Recognized and deliberately skipped: a jurisdiction pack is
-		// passive policy the core consults, never a governed operation an
-		// operator resolves, so it contributes no manifest entry.
+	case "Jurisdictions", "Messaging":
+		// Recognized and deliberately skipped: both are passive policy the
+		// core consults — a jurisdiction pack's retention floors and a rule
+		// set's messaging obligations — never a governed operation an operator
+		// resolves, so neither contributes a manifest entry.
+		//
+		// SKIPPED HERE IS NOT UNCHECKED. Messaging rules decide whether a
+		// message may go out, so what holds them is nearer the use and sees
+		// the VALUES a static reader cannot: messaging.Rules.Validate refuses
+		// a malformed set, compose's preflightMessagingRules refuses a
+		// duplicate jurisdiction before any is registered, and the registry's
+		// own Register panics on either as the wiring-defect backstop.
 	case "FailureClasses":
 		// Recognized and deliberately skipped, for the reason a jurisdiction
 		// pack is: a failure vocabulary is inert operator-facing text — the

--- a/backend/uniquenessclaims.txt
+++ b/backend/uniquenessclaims.txt
@@ -119,7 +119,7 @@ internal/compose/documentextract.go#func documentFieldOrder
 internal/compose/documentextract.go#func toModelField
 internal/compose/draftcheck/draftcheck.go#func allDirectedRelationshipPhrases
 internal/compose/export.go#func exportableColumns
-internal/compose/extensions.go#func preflightRetentionClasses
+internal/compose/extensionpolicy.go#func preflightRetentionClasses
 internal/compose/extensions.go#var composedExtensions
 internal/compose/extensions.go#var composedSubscriptions
 internal/compose/extensions.go#var composedVerbs

--- a/extensions/de/README.md
+++ b/extensions/de/README.md
@@ -1,0 +1,81 @@
+# The German pack
+
+What German law requires of this product, stated as data the core engines apply.
+The pack decides nothing: it declares, and the engine reads.
+
+Two obligations live here.
+
+## Retention floors (GoBD, §147 AO)
+
+| Class | Keep | Anchored at |
+|---|---|---|
+| `commercial_correspondence` | 6 years | end of the calendar year |
+| `accounting_records` | 8 years | end of the calendar year |
+
+The core retention engine treats these as **floors**: a workspace policy may
+keep longer, never destroy earlier. Anchoring at calendar-year end is §147(4)
+AO, and it matters — a January Handelsbrief keeps almost seven calendar years,
+so a floor that counted from the record's own date would erase it early.
+
+Bücher and Abschlüsse (10 years) are deliberately absent. A CRM holds no books
+or annual accounts, and a floor no record can carry would be documentation
+posing as enforcement.
+
+## Outbound messaging (UWG §7, GDPR Art. 13)
+
+### Advertising without consent — the §7(3) existing-customer exception
+
+This is the only route, and it carries **all four** of its statutory conditions:
+
+| Condition | What §7(3) requires |
+|---|---|
+| Sale evidence | the address was obtained *in connection with a sale* |
+| Collection-time opt-out | the customer was told at collection they may object at any time, free beyond transmission cost |
+| Similarity | the advertising is for the seller's *own similar* goods |
+| No objection | no objection stands |
+
+Declaring three of four would be an exception the engine applies while checking
+less than the statute asks. That is worse than declaring none, because it looks
+lawful.
+
+**Similarity is checked per message, not once per person.** A customer who
+bought one product has not opened the door to everything the seller sells, and
+an exception evaluated once per person is the shape that turns one purchase into
+a permanent mailing list.
+
+### What a first message discloses (Art. 13)
+
+| Disclosure | Scope |
+|---|---|
+| Controller identity — legal name and postal address | every first message |
+| Privacy contact | every first message |
+| Objection route — free and without a barrier | advertising |
+
+The objection route is marketing-scoped because §7(3) requires it at *every*
+use, not only the first contact.
+
+### Windows
+
+A reply stays a reply for **12 months**; a live deal supports an unprompted
+follow-up for **6 months**.
+
+Neither bounds a same-thread reply. The subject wrote to us and did not
+withdraw, so a rep answering a months-old thread is doing the ordinary thing —
+these windows reach only an *unprompted* follow-up. A pack that shortened them
+would be refusing correspondence rather than restricting advertising.
+
+### What Germany does not require
+
+No subject-line prefix on commercial email, no statutory frequency ceiling, and
+no acknowledgement owed for an opt-out.
+
+The zero values say so, and the silence is deliberate: a reader comparing this
+pack against one that *does* impose them needs to tell a considered absence from
+a forgotten field. `TestGermanyImposesNoPrefixNoCapAndNoAcknowledgement` is what
+makes that difference hold.
+
+## Changing any of this
+
+Every claim above is asserted in `de_test.go`. A changed span, condition,
+disclosure or window is a legal-content change: edit the test in the same commit
+and say in the PR body which statute moved.

--- a/extensions/de/de.go
+++ b/extensions/de/de.go
@@ -14,8 +14,11 @@
 package de
 
 import (
+	"time"
+
 	"github.com/margince/margince/backend/pkg/extension"
 	"github.com/margince/margince/backend/pkg/extension/jurisdiction"
+	"github.com/margince/margince/backend/pkg/extension/messaging"
 )
 
 // New returns the unit's declaration (the ADR-0069 §4 constructor
@@ -24,8 +27,9 @@ func New() extension.Extension {
 	return extension.Extension{
 		Name:          "de",
 		Version:       "1.0.0",
-		Description:   "German jurisdiction pack: the statutory retention floors (GoBD, §147 AO) the core retention engine applies. Registers no records, routes or jobs.",
+		Description:   "German jurisdiction pack: the statutory retention floors (§147 AO) and the outbound-messaging rules (UWG §7, Art. 13) the core engines apply. Registers no records, routes or jobs.",
 		Jurisdictions: []jurisdiction.Pack{pack{}},
+		Messaging:     []messaging.Rules{messagingRules()},
 	}
 }
 
@@ -52,5 +56,65 @@ func (retention) Classes() []jurisdiction.RetentionClass {
 	return []jurisdiction.RetentionClass{
 		{Name: jurisdiction.CommercialCorrespondence, Keep: jurisdiction.Period{Years: 6}, Anchor: jurisdiction.AnchorCalendarYearEnd},
 		{Name: jurisdiction.AccountingRecords, Keep: jurisdiction.Period{Years: 8}, Anchor: jurisdiction.AnchorCalendarYearEnd},
+	}
+}
+
+// messagingRules is what German law requires of an outbound message, stated as
+// data the core engine applies. Nothing here decides a send.
+//
+// THE EXISTING-CUSTOMER EXCEPTION (UWG §7(3)) is the only route to advertising
+// without a recorded consent, and it carries all four of its statutory
+// conditions rather than a subset. §7(3) permits email advertising to an
+// existing customer only where the address was obtained IN CONNECTION WITH A
+// SALE, the customer was told at collection that they may object at any time
+// free of charge beyond transmission cost, the advertising is for the seller's
+// OWN SIMILAR goods, and no objection stands. Declaring the exception without
+// one of these would be an exception the engine applies while checking less
+// than the statute asks — which is worse than having none, because it looks
+// lawful.
+//
+// Similarity is checked PER MESSAGE. A customer who bought one product has not
+// opened the door to everything the seller sells, and an exception evaluated
+// once per person rather than once per message is the shape that turns one
+// purchase into a permanent mailing list.
+//
+// THE WINDOWS are the core defaults, restated here so this pack says what it
+// applies rather than inheriting silently. Twelve months is how long an inbound
+// message keeps making an unprompted follow-up a follow-up; six months is how
+// long a live deal does. Neither bounds a same-thread reply — the subject wrote
+// to us and did not withdraw.
+//
+// NO PREFIX, NO CAP, NO ACKNOWLEDGEMENT. German law requires none of the three:
+// no marking on the subject line of a commercial email beyond the general ban on
+// disguising the commercial nature, no statutory frequency ceiling, and no
+// confirmation owed for an opt-out. The zero values say so, and saying so is the
+// point — a reader comparing this pack with another can see which obligations
+// Germany does not impose rather than wondering whether somebody forgot.
+func messagingRules() messaging.Rules {
+	return messaging.Rules{
+		Jurisdiction: "de",
+		Version:      1,
+		// Twelve and six months as calendar-ish durations. Hours because the
+		// type is a time.Duration and a month is not one; the engine compares
+		// against a recorded timestamp, so the small drift against calendar
+		// months is on the permissive side of a window that bounds an
+		// unprompted follow-up rather than a refusal.
+		ReplyWindow:        365 * 24 * time.Hour,
+		DealFollowUpWindow: 182 * 24 * time.Hour,
+		MarketingExceptions: []messaging.MarketingException{{
+			Kind:                         messaging.ExistingCustomer,
+			RequiresSaleEvidence:         true,
+			RequiresCollectionTimeOptOut: true,
+			RequiresSimilarity:           true,
+			RequiresNoObjection:          true,
+		}},
+		// Art. 13 GDPR at first contact: who is writing, who answers about the
+		// data, and how to say stop. The objection route binds advertising
+		// specifically — §7(3) requires it at every use, not only the first.
+		Disclosures: []messaging.Disclosure{
+			{Kind: messaging.ControllerIdentity},
+			{Kind: messaging.PrivacyContact},
+			{Kind: messaging.ObjectionRoute, MarketingOnly: true},
+		},
 	}
 }

--- a/extensions/de/de_test.go
+++ b/extensions/de/de_test.go
@@ -5,8 +5,10 @@ package de
 
 import (
 	"testing"
+	"time"
 
 	"github.com/margince/margince/backend/pkg/extension/jurisdiction"
+	"github.com/margince/margince/backend/pkg/extension/messaging"
 )
 
 // TestNewDeclaresTheGoBDFloors pins the statutory content: the §147
@@ -41,5 +43,123 @@ func TestNewDeclaresTheGoBDFloors(t *testing.T) {
 		if c.Keep != keep {
 			t.Errorf("class %s keeps %s, want %s (statutory floor, calendar years)", c.Name, c.Keep, keep)
 		}
+	}
+}
+
+// The German messaging matrix, asserted rather than described.
+//
+// This is the rule set a reviewer ratifies, so each claim it makes is a test:
+// what §7(3) requires before advertising without consent, what Art. 13 puts on
+// a first message, and — as load-bearing as either — the three obligations
+// German law does NOT impose, which a reader comparing packs must be able to
+// tell apart from an omission.
+
+// UWG §7(3) permits email advertising to an existing customer only where all
+// four conditions hold. The pack declares all four; declaring three would be an
+// exception the engine applies while checking less than the statute asks, which
+// is worse than none because it looks lawful.
+func TestTheExistingCustomerExceptionCarriesAllFourConditions(t *testing.T) {
+	rules := messagingRules()
+	if len(rules.MarketingExceptions) != 1 {
+		t.Fatalf("%d marketing exceptions declared, want exactly the §7(3) one", len(rules.MarketingExceptions))
+	}
+	e := rules.MarketingExceptions[0]
+	if e.Kind != messaging.ExistingCustomer {
+		t.Fatalf("exception kind = %q, want existing_customer", e.Kind)
+	}
+	for _, c := range []struct {
+		name string
+		set  bool
+	}{
+		{"sale evidence (address obtained in connection with a sale)", e.RequiresSaleEvidence},
+		{"collection-time opt-out notice", e.RequiresCollectionTimeOptOut},
+		{"similarity to what was bought", e.RequiresSimilarity},
+		{"no standing objection", e.RequiresNoObjection},
+	} {
+		if !c.set {
+			t.Errorf("§7(3) requires %s and the pack does not ask the engine to check it", c.name)
+		}
+	}
+}
+
+// Art. 13 at first contact: who is writing, who answers about the data, and how
+// to say stop. The objection route is marketing-scoped because §7(3) requires it
+// at every use rather than only the first.
+func TestAFirstMessageDisclosesTheController(t *testing.T) {
+	want := map[messaging.DisclosureKind]bool{
+		messaging.ControllerIdentity: false,
+		messaging.PrivacyContact:     false,
+		messaging.ObjectionRoute:     true,
+	}
+	got := map[messaging.DisclosureKind]bool{}
+	for _, d := range messagingRules().Disclosures {
+		got[d.Kind] = d.MarketingOnly
+	}
+	for kind, marketingOnly := range want {
+		scope, declared := got[kind]
+		if !declared {
+			t.Errorf("a first message does not disclose %q", kind)
+			continue
+		}
+		if scope != marketingOnly {
+			t.Errorf("%q is marketing-only=%v, want %v", kind, scope, marketingOnly)
+		}
+	}
+}
+
+// German law imposes no subject prefix on commercial email, no statutory
+// frequency ceiling, and owes no acknowledgement for an opt-out. The zero
+// values say so, and this test is what makes the silence deliberate: a reader
+// comparing this pack against one that DOES impose them can tell a considered
+// absence from a forgotten field.
+func TestGermanyImposesNoPrefixNoCapAndNoAcknowledgement(t *testing.T) {
+	rules := messagingRules()
+	if rules.SubjectPrefix != "" {
+		t.Errorf("the pack prefixes advertising subjects with %q; German law requires no marking", rules.SubjectPrefix)
+	}
+	if rules.FrequencyCap != nil {
+		t.Errorf("the pack caps advertising at %+v; German law sets no statutory ceiling", rules.FrequencyCap)
+	}
+	if rules.OptOutAcknowledgement {
+		t.Error("the pack promises an opt-out acknowledgement; German law owes none")
+	}
+}
+
+// A reply stays a reply for a year and a deal follow-up for six months. Neither
+// bounds a same-thread reply — the subject wrote to us and did not withdraw —
+// so these windows only reach an UNPROMPTED follow-up. A pack that shortened
+// them would be refusing correspondence rather than restricting advertising.
+func TestTheWindowsBoundAnUnpromptedFollowUp(t *testing.T) {
+	rules := messagingRules()
+	if rules.ReplyWindow != 365*24*time.Hour {
+		t.Errorf("reply window = %s, want twelve months", rules.ReplyWindow)
+	}
+	if rules.DealFollowUpWindow != 182*24*time.Hour {
+		t.Errorf("deal follow-up window = %s, want six months", rules.DealFollowUpWindow)
+	}
+	if rules.DealFollowUpWindow >= rules.ReplyWindow {
+		t.Error("a deal follow-up outlasts a reply, which inverts which evidence is stronger")
+	}
+}
+
+// The declared rules pass the published validator, which is what the boot
+// preflight runs. A pack that composed and then failed at boot would be found
+// by an operator rather than by this suite.
+func TestTheDeclaredRulesPassThePublishedValidator(t *testing.T) {
+	if err := messagingRules().Validate(); err != nil {
+		t.Errorf("the German rules would be refused at boot: %v", err)
+	}
+}
+
+// The unit declares its rules under its own jurisdiction, so the registry keys
+// them where the engine looks.
+func TestTheUnitDeclaresItsMessagingRules(t *testing.T) {
+	declared := New().Messaging
+	if len(declared) != 1 {
+		t.Fatalf("%d messaging rule sets declared, want 1", len(declared))
+	}
+	if declared[0].Jurisdiction != New().Jurisdictions[0].Code() {
+		t.Errorf("messaging rules name jurisdiction %q while the pack is %q",
+			declared[0].Jurisdiction, New().Jurisdictions[0].Code())
 	}
 }


### PR DESCRIPTION
The extension tier gains a `Messaging` capability. `pkg/extension/messaging`
carries the contract, `extensions/de` declares the German rule set, and
`internal/shared/ports/messagingrules` is the core-internal registry the
authorization engine reads.

**Lars: the German matrix is the thing to ratify here.** It is written out in
[`extensions/de/README.md`](extensions/de/README.md) and every claim it makes is
asserted in `de_test.go`.

## Rules are data

A pack states what its jurisdiction requires — how long a reply stays a reply,
whether there is an existing-customer exception and what it demands, what a
first message discloses, whether advertising carries a subject prefix, how many
advertising messages one address may receive in a window. The engine reads it
and answers.

A pack that could *decide* a send would be country-specific code on the path of
every outbound message, and the one thing this product cannot afford is two
answers to "may we write to this person".

## The zero value permits nothing extra

No exception, no disclosure obligation, no prefix, no cap. That is the direction
a missing declaration has to fail in: a pack that forgets to declare an
exception requires consent rather than silently granting one.

## An exception must name a condition

UWG §7(3) carries all four of its statutory conditions — sale evidence,
collection-time opt-out notice, similarity, no standing objection — and the
validator refuses an exception naming none.

An unguarded exception is worse than no exception: it looks lawful, it appears
as a declared rule, and every advertising message it touches goes out having
satisfied an empty condition set.

**Similarity is checked per message, not once per person.** A customer who
bought one product has not opened the door to everything the seller sells.

## Strictest wins across jurisdictions

Sender and recipient can sit in different countries and the answer is never
"pick one" — a message lawful where the sender sits and unlawful where the
recipient does is unlawful. Each obligation folds independently to whichever
position permits less:

- the shorter window, with zero read as "this country says nothing" rather than
  as instant expiry
- every disclosure either side requires
- the tighter cap, compared as a **rate** — three per 24h beats ten per 24h and
  also beats four per hour
- an exception only where **every** applicable jurisdiction grants it, carrying
  the **union** of the conditions either attaches

A folded set claims no single jurisdiction or version. Stamping one would
misname the rules a decision was taken under.

## What Germany does not require

No subject-line prefix, no statutory frequency ceiling, no opt-out
acknowledgement. `TestGermanyImposesNoPrefixNoCapAndNoAcknowledgement` holds the
silence, because a reader comparing this pack against one that *does* impose
them needs to tell a considered absence from a forgotten field.

## The manifest generator

`Messaging` is skipped alongside `Jurisdictions` — passive policy, no governed
operation for an operator to resolve. Skipped is not unchecked: `Rules.Validate`,
compose's `preflightMessagingRules` and the registry's `Register` each see the
values a static reader cannot, and a duplicate jurisdiction is refused before any
is registered.

## Verification

`make check-backend`, `make check-composition` (composition reproducible),
`make pkg-freeze` (published surface additive), `make test-extensions`,
`make no-jurisdiction` (no country string leaked into core), `make rls-store-path`
and `craft static` all pass, re-run after rebasing onto current main.

`extensionpolicy.go` is a new file because `extensions.go` had reached the
500-line cap; the uniqueness-register entry for `preflightRetentionClasses` is
repointed to it.

Nothing consumes these rules yet — the engine reads them when the validators
land with the VN pack and the enforce flips. This PR is the capability and the
German declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `Messaging` capability to the extension tier so a country pack can declare outbound-messaging rules the authorization engine will apply, and ships the German rule set as the first declaration. Nothing consumes these rules yet; this PR establishes the capability, the German matrix, and the registry the engine will read, with engine validators landing separately.

**Behavior**

- Rules are data: a pack states reply windows, marketing exceptions, disclosures, subject prefix, and frequency caps; the engine reads them and decides.
- The zero value permits nothing extra — a pack that forgets a declaration requires consent rather than silently granting one.
- A marketing exception must name at least one condition; the validator refuses an unguarded exception, and similarity is checked per message.
- Across jurisdictions, each obligation folds independently to the strictest position: shorter window, every disclosure, tighter cap by rate, and exceptions only where every applicable jurisdiction grants it, carrying the union of conditions.
- Two rule sets for one jurisdiction are refused at boot, and `Messaging` is skipped by the manifest generator like `Jurisdictions` — passive policy, not a governed operation.
- `extensionpolicy.go` is a new file because `extensions.go` reached the 500-line cap; the uniqueness-register entry for `preflightRetentionClasses` is repointed to it.

**Security review hardening**

- The registry deep-copies rule sets on register and read, so a caller mutating what it got cannot rewrite the registered rules.
- A set naming one exception kind twice is refused, and a duplicate kind OR-folds its conditions so the fold cannot widen past either input.
- A degenerate cap is the strictest position and is handled first, so the fold's answer no longer depends on argument order.
- `Strictest` reports jurisdictions it could not resolve rather than presenting a partial fold as a complete answer.
- `preflightMessagingRules` refuses an extension set colliding with a core-registered one.

<sup>Written for commit d83e4c3229bd7edb478e596a12a147559fddfec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added jurisdiction-specific outbound messaging rules for extensions.
  * Added validation for disclosures, marketing exceptions, frequency caps, reply windows, and opt-out requirements.
  * Added strictest-rule selection when multiple jurisdictions apply.
  * Added German messaging requirements, including existing-customer exceptions and required disclosures.

* **Bug Fixes**
  * Invalid, duplicate, conflicting, or unsupported policy declarations are now rejected before registration.

* **Documentation**
  * Added documentation describing German retention and outbound-messaging requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->