### PR TITLE
The queue is workable with a thumb

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1211,11 +1211,23 @@ test.describe("§3.8: 390px mobile", () => {
     });
     expect(narrow).toEqual([]);
 
-    // Every verb a rep can press is a real target. Named offenders rather than
-    // a count, so whoever breaks it learns which control shrank.
+    // Every verb in the QUEUE is a real target — the rows and the focus card
+    // above them, which is the work this screen exists for. The focus CTA is a
+    // full-size `.btn` and already clears the floor through `--control-h`; it
+    // is measured anyway, because a rule that holds only where somebody
+    // remembered to look is not a floor.
+    //
+    // The readings strip above is deliberately NOT measured. Its "open this
+    // lane" link is a 24px target on a phone and genuinely too small, but it
+    // belongs to the design system's StatCard rather than to this screen —
+    // fixing it here would size every reading card in the product from the
+    // worklist's stylesheet. Filed as #3961.
+    //
+    // Visible controls only: the page carries collapsed panels whose buttons
+    // lay out at zero height, and those are not targets a thumb can miss.
     const small = await page.evaluate(() => {
       const controls = document.querySelectorAll(
-        ".worklist-row-verbs .btn, .worklist-row-dispositions .btn, .worklist-row .link-button",
+        ".worklist-list button, .worklist-list a.btn, .worklist-list .link-button, .worklist-focus button, .worklist-focus a.btn",
       );
       return Array.from(controls)
         .filter((element) => element.getBoundingClientRect().height > 0)

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1171,13 +1171,62 @@ test.describe("§3.8: 390px mobile", () => {
     });
   }
 
-  test("S-E11.2: the day's queue is readable on mobile at 390px", async ({
+  // The queue is WORKABLE with a thumb, not merely present.
+  //
+  // What stood here asserted that one text node was visible at 390px, and it
+  // passed for as long as the screen was unusable: the row is a three-column
+  // line whose verbs never yield width, so the title column was squeezed to a
+  // few characters while three buttons held their full size beside it. A test
+  // that cannot tell that from a working screen is part of the defect.
+  //
+  // So this measures the row itself — every row, not the first — and the
+  // targets a rep presses.
+  test("S-E11.2: the day's queue is workable with a thumb at 390px", async ({
     page,
   }) => {
     await page.goto("/#/worklist");
+    await page.waitForLoadState("networkidle");
     await expect(
       page.getByText(/Send the follow-up to Anna Weber/).first(),
     ).toBeVisible();
+
+    // Nothing runs off the side. The row wraps instead of pushing the page
+    // wider, which is the difference between a stacked layout and a squeezed
+    // one.
+    expect(await pageOverflow(page)).toEqual([]);
+
+    // The text column is wide enough to read a sentence in. Half the viewport
+    // is a low bar deliberately: it is the one this layout FAILED, at roughly a
+    // quarter, and a ceiling tuned to today's rows would break on tomorrow's
+    // longer verb.
+    const narrow = await page.evaluate(() => {
+      const floor = 390 / 2;
+      return Array.from(document.querySelectorAll(".worklist-row-text"))
+        .map((element) => ({
+          width: element.getBoundingClientRect().width,
+          text: (element.textContent ?? "").slice(0, 40),
+        }))
+        .filter(({ width }) => width < floor)
+        .map(({ width, text }) => `${Math.round(width)}px: ${text}`);
+    });
+    expect(narrow).toEqual([]);
+
+    // Every verb a rep can press is a real target. Named offenders rather than
+    // a count, so whoever breaks it learns which control shrank.
+    const small = await page.evaluate(() => {
+      const controls = document.querySelectorAll(
+        ".worklist-row-verbs .btn, .worklist-row-dispositions .btn, .worklist-row .link-button",
+      );
+      return Array.from(controls)
+        .filter((element) => element.getBoundingClientRect().height > 0)
+        .map((element) => ({
+          height: element.getBoundingClientRect().height,
+          label: (element.textContent ?? "").trim(),
+        }))
+        .filter(({ height }) => height < 44)
+        .map(({ height, label }) => `${label}: ${Math.round(height)}px`);
+    });
+    expect(small).toEqual([]);
   });
 
   // The bar's centre cell and the panel it opens, neither of which exists above

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -1890,7 +1890,7 @@ export async function mockApi(
         as_of: "2026-07-05T06:00:00Z",
         scope: "mine",
         scope_options: ["mine"],
-        summary: { urgent: 0, due: 0, lower_priority: 1, total: 1 },
+        summary: { urgent: 0, due: 1, lower_priority: 1, total: 2 },
         sources_unavailable: [],
         // Both accountings, because the server sends both. A fixture that omits
         // them models a response the product never produces, and a spec driving
@@ -1902,6 +1902,7 @@ export async function mockApi(
             shown: 1,
             more_available: false,
           },
+          { source: "task", considered: 1, shown: 1, more_available: false },
         ],
         counts: [
           {
@@ -1910,6 +1911,7 @@ export async function mockApi(
             shown: 1,
             more_available: false,
           },
+          { category: "tasks", considered: 1, shown: 1, more_available: false },
         ],
         // The strip above the queue. This day is one routine decision and
         // nothing else, so three readings are honestly zero and the money is
@@ -1933,6 +1935,25 @@ export async function mockApi(
             title: approval.summary,
             because: [{ kind: "routine" }],
             actions: ["decide"],
+          },
+          // A task row, for the verbs the approval above does not draw.
+          //
+          // The mobile case measures every control a rep can press, and an
+          // approval offers one. Without this row the disposition verbs and the
+          // duration picker — the WIDEST thing the row puts on a line — are
+          // never on the page the sweep measures, so it would report a workable
+          // screen having looked at the narrowest row in the product.
+          {
+            id: "01a05500-0000-7000-8000-0000000000d1",
+            source: "task",
+            category: "tasks",
+            level: 3,
+            consequence: "task_slips",
+            title: "Send the retrofit quote to Turbinenbau",
+            due_at: "2026-07-06T13:00:00Z",
+            because: [{ kind: "due_today" }, { kind: "unassigned" }],
+            actions: [],
+            dispositions: ["snooze", "not_mine"],
           },
         ],
       });

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -281,3 +281,52 @@
   align-items: flex-start;
   gap: var(--space-1);
 }
+
+/* The queue on a phone.
+ *
+ * The row is a three-column line — rank, text, verbs — and the verbs are
+ * `flex: 0 0 auto`, so they never yield width. On a 390px screen that leaves
+ * the title column squeezed to a few characters per line while three buttons
+ * hold their full width beside it: the rep is reading a column of broken words
+ * next to controls they cannot comfortably hit.
+ *
+ * The fix is to stop competing for one line. The text takes the width, and the
+ * verbs move below it where they can wrap and take a real target height.
+ *
+ * 720px is the tree's own breakpoint, not a number chosen here — the modal, the
+ * record head and the page zones all turn at it.
+ */
+@media (max-width: 720px) {
+  .worklist-row {
+    flex-wrap: wrap;
+  }
+
+  /* The text takes what is left of the first line, beside the rank. Wrapping
+     rather than a column direction so the RANK stays on the title's line: a
+     rank stacked above its own row is a number belonging to nothing. */
+  .worklist-row-text {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+
+  /* Every group of verbs below the text, at full width and free to wrap. They
+     are separate elements — the row's own, the ways to put it down, the
+     hand-off — and each has to yield, or the one that does not squeezes the
+     others back onto a sliver. */
+  .worklist-row-verbs,
+  .worklist-row-dispositions {
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+  }
+
+  /* The touch floor. `--control-h-sm` rises only to 36px for a coarse pointer,
+     which is the size these verbs take — short of the 44px the sign-in door
+     and the list rows already keep. A queue worked with a thumb owes the same
+     target: a mis-hit here files somebody else's judgement on a customer's
+     message. */
+  .worklist-row-verbs .btn,
+  .worklist-row-dispositions .btn,
+  .worklist-row .link-button {
+    min-block-size: 44px;
+  }
+}

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -323,9 +323,14 @@
      which is the size these verbs take — short of the 44px the sign-in door
      and the list rows already keep. A queue worked with a thumb owes the same
      target: a mis-hit here files somebody else's judgement on a customer's
-     message. */
-  .worklist-row-verbs .btn,
-  .worklist-row-dispositions .btn,
+     message.
+     Every pressable thing INSIDE a row, not a list of the verb groups: a row
+     also carries the approval's own three decisions, and those were the
+     smallest targets on the page at 32px. A selector naming today's groups is
+     a claim about which controls exist, and it goes stale the day a row grows
+     another one. */
+  .worklist-row button,
+  .worklist-row a.btn,
   .worklist-row .link-button {
     min-block-size: 44px;
   }

--- a/frontend/src/screens/worklist.row.stories.tsx
+++ b/frontend/src/screens/worklist.row.stories.tsx
@@ -159,3 +159,19 @@ export const ATaskNobodyOwnsBeingPutDown: Story = {
     );
   },
 };
+
+// The same row on a phone.
+//
+// The state the old mobile test could not see: above this breakpoint the row is
+// rank, text and verbs on one line, and the verbs never yield width — so at
+// 390px the title column was squeezed to a few characters while three buttons
+// held their full size beside it. Here the text takes the line and the verbs
+// drop below it at a real target height.
+//
+// Worth a story of its own rather than a note on the desktop one: this is a
+// different layout, and the two are checked by looking at both.
+export const ATaskOnAPhone: Story = {
+  ...ATaskNobodyOwnsBeingPutDown,
+  globals: { viewport: { value: "phone" } },
+  play: undefined,
+};


### PR DESCRIPTION
`worklist.css` had **zero `@media` rules** in 265 lines. The row is a three-column flex line — rank, text, verbs — and `.worklist-row-verbs` is `flex: 0 0 auto`, so the verbs never yield width. At 390px that left the title column at **92px and 147px** while three buttons held their full size beside it: a rep reading a column of broken words next to controls they could not comfortably hit.

Those two numbers are not an estimate. They are what the new test prints when the fix is removed.

## What changes

One `@media (max-width: 720px)` block — the tree's own breakpoint, the one `atoms.css`, `composed.css` and `pagezones.css` already turn at. The row wraps, the text takes the line, and the verbs move below it where they can wrap. The rank stays on the title's line, because a rank stacked above its own row names nothing.

**Every control inside a row gets a 44px floor.** `--control-h` rises to 44 for a coarse pointer but **`--control-h-sm` only reaches 36** (`tokens.css:751-753`), and the row's verbs are `small` buttons. The selector is `.worklist-row button, .worklist-row a.btn, .worklist-row .link-button` rather than a list of the verb groups — a list is a claim about which controls exist, and the approval row's three decisions were nested inside at 32px, which is exactly the control a list would have missed.

## The test was part of the defect

S-E11.2 asserted that one text node was visible at 390px. It passed for as long as the screen was unusable, which is the only thing worth saying about it.

It now measures the page: no horizontal overflow, every `.worklist-row-text` at least half the viewport, and every pressable control in the queue at least 44px tall — named offenders rather than a count, so whoever breaks it learns which control shrank.

The e2e worklist fixture held **one approval row** with a single verb, so the disposition verbs and the duration picker — the widest things a row puts on a line — were never on the page being measured. A task row with dispositions is now seeded beside it, with `reach` and `counts` kept honest.

**Mutation-checked**: deleting the `@media` block fails the test with the two collapsed widths above.

## One finding filed rather than fixed

Scoped to the whole screen, the same assertion named the readings strip's "open this lane" link at **24px**. That control belongs to the design system's `StatCard`, not to this screen, and sizing it from `worklist.css` would either miss every other surface that draws a reading card or reach across the tier boundary the catalog exists to hold. Filed as #3961, which also asks the wider question: `--control-h-sm` being 36px on a coarse pointer means every small button in the product is short of the floor, and this PR's rule is a local patch over that.

The assertion is scoped to the queue and the focus card, with a comment naming the issue so the next reader knows the omission was decided rather than overlooked.

## Verification

- `make check-fe` (6212 tests) and `make check-backend` green on the rebased tree
- `make frontend-e2e`: S-E11.2 passes; the one failure (`AC-overlay-7`) fails identically on clean `origin/main` and is not from this branch
- A phone story added to `worklist.row.stories.tsx`, per `frontend/AGENTS.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the worklist queue workable with a thumb: the row's verbs never yielded width, squeezing the title column to under 100px at 390px while three buttons held full size beside it. Below 720px — the tree's existing breakpoint — the row now wraps, the text takes the line, the verbs move underneath, and every control inside a row gets a 44px touch floor.

**Bug Fixes**
- The old mobile test only asserted one text node was visible, so it passed while the screen was unusable; it now checks for no horizontal overflow, a text column at least half the viewport, and ≥44px-tall controls, naming offenders instead of counting them.
- The e2e fixture only had one approval row with a single verb, so the disposition verbs and duration picker were never measured; a task row with dispositions is now seeded beside it.
- The readings strip's "open this lane" link is a 24px target on a phone, but it belongs to the design system's `StatCard`; it's filed as #3961 (along with `--control-h-sm` staying at 36px on a coarse pointer), and the test scopes around it with a comment naming the issue.
- Added a phone story for the task row.

<sup>Written for commit 88dd36d0c27691e1a9507e6c26b8ea6b1480f2cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worklist usability on mobile screens.
  * Worklist rows now wrap correctly, use available screen width, and prevent horizontal overflow.
  * Queue and focus controls now provide touch targets of at least 44px.
  * Added coverage for displaying due tasks alongside approvals in the worklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->