### PR TITLE
A work-calendar meeting is workspace business

### DIFF
--- a/backend/internal/compose/integration/capture/gcal_meetinglink_integration_test.go
+++ b/backend/internal/compose/integration/capture/gcal_meetinglink_integration_test.go
@@ -164,9 +164,10 @@ func TestACapturedMeetingIsFiledUnderTheAttendeeWhoIsAContact(t *testing.T) {
 }
 
 // Nobody has a record for the attendee, so there is nothing to file the meeting
-// under, and the limiter's hold still applies. An invite is not correspondence:
-// this path must not create a person to have something to link.
-func TestACapturedMeetingWithNoKnownAttendeeStaysHeld(t *testing.T) {
+// under — and it is STILL workspace business, because a connected calendar is a
+// work calendar. An invite is not correspondence, though: this path must not
+// create a person to have something to link.
+func TestACapturedMeetingWithNoKnownAttendeeIsStillWorkspaceBusiness(t *testing.T) {
 	e := integration.SetupSearch(t)
 
 	activity := syncOneGcalMeeting(t, e)
@@ -175,9 +176,10 @@ func TestACapturedMeetingWithNoKnownAttendeeStaysHeld(t *testing.T) {
 	if len(linked) != 0 {
 		t.Fatalf("meeting filed under %v, want nothing — no attendee has a record, and an invite does not create one", linked)
 	}
-	if audience != "participants" || reason == nil || *reason != activities.ReasonNoCounterparty {
-		t.Errorf("meeting born audience=%q reason=%v, want participants/%s — a meeting filed under nothing is still held to the people on it",
-			audience, reason, activities.ReasonNoCounterparty)
+	if audience != "workspace" || reason != nil {
+		t.Errorf("meeting born audience=%q reason=%v, want workspace/nil — every event on a connected work calendar is workspace business, "+
+			"and holding one to its attendees hid it from colleagues while the invitation MAIL beside it stayed readable",
+			audience, reason)
 	}
 	var persons int
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -203,40 +205,76 @@ func systemRepairCtx(e *integration.SearchEnv) context.Context {
 	})
 }
 
-// The other half of the hold: once the meeting IS filed, the reason it was held
-// has stopped being true.
+// A meeting captured BEFORE the limiter stopped holding calendar records still
+// wears the hold, and the release is what opens it.
 //
-// This is the ordering Chris's meeting was in — captured while nobody had a
-// record for the attendee, filed under them by the cohort repair a day later,
-// and held to its participants ever since. The invitation EMAILS beside it on
-// the same page were workspace-readable the whole time, so the meeting was the
-// one row a colleague could not see.
-func TestAMeetingFiledLaterStopsBeingHeld(t *testing.T) {
+// This is the state Chris's meeting was found in: every meeting already in the
+// database carried the hold, so shipping the rule for new captures alone left
+// the whole existing calendar invisible to everyone but the invitees, while the
+// invitation EMAILS beside them stayed workspace-readable.
+//
+// The hold is stamped by hand here because production can no longer produce one
+// — which is the point. The row is the shape the old writer left behind, and
+// what is under test is that the release recognises it.
+func TestAMeetingHeldByTheOldRuleIsReleased(t *testing.T) {
 	e := integration.SetupSearch(t)
 
 	activity := syncOneGcalMeeting(t, e)
-	if _, _, audience, reason := meetingFiling(t, e, activity); audience != "participants" ||
-		reason == nil || *reason != activities.ReasonNoCounterparty {
-		t.Fatalf("the meeting was not born held: audience=%q reason=%v", audience, reason)
+	for _, held := range []string{activities.ReasonNoRecord, activities.ReasonNoCounterparty} {
+		if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+			_, err := tx.Exec(context.Background(),
+				`UPDATE activity SET audience = 'participants', audience_reason = $2 WHERE id = $1`,
+				activity, held)
+			return err
+		}); err != nil {
+			t.Fatalf("stamping the old hold %s: %v", held, err)
+		}
+
+		repair := systemRepairCtx(e)
+		if err := database.WithWorkspaceTx(repair, e.Pool, func(tx pgx.Tx) error {
+			return activities.ReleaseCalendarMeetingHoldTx(repair, tx, activity)
+		}); err != nil {
+			t.Fatalf("releasing the hold %s: %v", held, err)
+		}
+
+		_, _, audience, reason := meetingFiling(t, e, activity)
+		if audience != "workspace" || reason != nil {
+			t.Errorf("after releasing %s: meeting audience=%q reason=%v, want workspace/nil — "+
+				"the rule that held it no longer exists, and nothing else asks for it to be held",
+				held, audience, reason)
+		}
+	}
+}
+
+// The release removes ONE contributor and asks the rest. A human who narrowed
+// the meeting by hand is not a contributor it may overrule: opening the row
+// would publish what a person deliberately closed.
+func TestTheReleaseLeavesAHumansOwnNarrowingAlone(t *testing.T) {
+	e := integration.SetupSearch(t)
+
+	activity := syncOneGcalMeeting(t, e)
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE activity SET audience = 'participants', audience_reason = $2 WHERE id = $1`,
+			activity, activities.ReasonManual)
+		return err
+	}); err != nil {
+		t.Fatalf("recording the human's narrowing: %v", err)
 	}
 
-	// The contact arrives, and the repair files the meeting under them. Through
-	// the real store, so the seam compose wires is the one under test.
-	store := people.NewStore(e.DB()).WithAudienceRecompute(activities.RecomputeAudienceTx)
-	buyer, err := store.EnsurePersonByEmail(personCreator(e), "Buyer Example", "buyer@acme.com", "manual")
-	if err != nil {
-		t.Fatalf("seeding the attendee: %v", err)
-	}
-	if _, err := store.RepairPersonCohort(systemRepairCtx(e), ids.From[ids.PersonKind](buyer)); err != nil {
-		t.Fatalf("repairing the cohort: %v", err)
+	// A context that COULD write, so the refusal under test is the guard's and
+	// not a missing actor's: with the manual check removed this opens the row.
+	repair := systemRepairCtx(e)
+	if err := database.WithWorkspaceTx(repair, e.Pool, func(tx pgx.Tx) error {
+		return activities.ReleaseCalendarMeetingHoldTx(repair, tx, activity)
+	}); err != nil {
+		t.Fatalf("releasing: %v", err)
 	}
 
-	linked, _, audience, reason := meetingFiling(t, e, activity)
-	if len(linked) != 1 || linked[0] != buyer {
-		t.Fatalf("the repair filed the meeting under %v, want the attendee %s", linked, buyer)
-	}
-	if audience != "workspace" || reason != nil {
-		t.Errorf("meeting audience=%q reason=%v, want workspace/nil — it is filed under a record now, "+
-			"so the hold that said it was filed under none is no longer true", audience, reason)
+	_, _, audience, reason := meetingFiling(t, e, activity)
+	if audience != "participants" || reason == nil || *reason != activities.ReasonManual {
+		t.Errorf("meeting audience=%q reason=%v, want participants/%s — a person closed this row by hand, "+
+			"and a repair that opens it publishes what they closed",
+			audience, reason, activities.ReasonManual)
 	}
 }

--- a/backend/internal/compose/integration/capture/norecordlift_integration_test.go
+++ b/backend/internal/compose/integration/capture/norecordlift_integration_test.go
@@ -33,6 +33,44 @@ import (
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
+// A record can reach capture wearing the meeting kind and NAMING a sender.
+//
+// The kind is reported per message: a connector supplies it alongside the raw
+// bytes, and the extension ingress copies Activity.Kind straight off a
+// third-party unit's record with no vocabulary check in front of it
+// (compose/extingress.go). activity has no CHECK constraint on the column
+// either. So "meeting" is a word a caller chooses, not a fact a calendar mapper
+// establishes.
+//
+// Capture no longer holds a work-calendar meeting. That rule is about a record
+// that named NOBODY — attendance is a list — and reaching it by spelling one
+// word over a suppressed sender's message would publish that message to the
+// whole workspace. The counterparty shape is what tells the two apart, because
+// nothing a caller writes can make a named sender unnamed.
+func TestTheLimiterStillHoldsAMeetingThatNamesAJudgedSender(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, syncAsKind := env.e, env.syncAsKind
+
+	// A sender the transactional gate judges, landed as a "meeting".
+	syncAsKind(t, map[string]string{"forged-kind@docusign.net": "meeting"},
+		email("dse@eu.docusign.net", "DocuSign EU", captureOwner, "forged-kind@docusign.net", ""))
+
+	var activityID ids.UUID
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT id FROM activity WHERE kind = 'meeting'`).Scan(&activityID)
+	}); err != nil {
+		t.Fatalf("reading the captured row: %v", err)
+	}
+
+	audience, reason := audienceOf(t, e, activityID)
+	if audience != "participants" || reason != activities.ReasonNoRecord {
+		t.Fatalf("a meeting-kind record naming a judged sender was born audience=%q reason=%q, "+
+			"want participants/%s — the kind is a word the caller chose, and the ladder judged "+
+			"the person who sent it", audience, reason, activities.ReasonNoRecord)
+	}
+}
+
 // fileUnder plants an activity_link the way a repair pass does, so a test can
 // ask what the recompute makes of a row that has since been filed.
 func fileUnder(t *testing.T, e *integration.SearchEnv, activity ids.UUID, person ids.UUID) {
@@ -111,5 +149,53 @@ func TestAJudgedHoldSurvivesBeingFiledWhateverTheKind(t *testing.T) {
 	if got != "participants" || reason != activities.ReasonNoRecord {
 		t.Fatalf("a judged hold on a meeting-kind row opened when it was filed: audience %q reason %q — "+
 			"the kind says nothing about whether somebody was judged", got, reason)
+	}
+}
+
+// The calendar release is a SECOND door into the same row, and it reads the
+// judged reason by name.
+//
+// It is allowed to, because a calendar record is the only thing that reaches
+// that reason wearing this kind AND naming no counterparty. This drives the
+// release against a row that has the kind but names a sender — the state a
+// judgement leaves — and proves the second condition is what refuses it. With
+// the counterparty_email clause removed, this test opens a suppressed sender's
+// mail to the whole workspace.
+func TestTheCalendarReleaseRefusesARowThatNamesASender(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+
+	sync(t, email("dse@eu.docusign.net", "DocuSign EU", captureOwner, "release-refuses@docusign.net", ""))
+	activityID := oneActivityID(t, e)
+	if _, reason := audienceOf(t, e, activityID); reason != activities.ReasonNoRecord {
+		t.Fatalf("the ladder did not hold the link-less message: reason %q", reason)
+	}
+	// The kind a calendar connector writes, on a row a judgement holds. The
+	// counterparty the mail carries is untouched, and it is what tells the two
+	// apart.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE activity SET kind = 'meeting' WHERE id = $1`, activityID)
+		return err
+	}); err != nil {
+		t.Fatalf("restating the activity as a meeting: %v", err)
+	}
+
+	// The context a repair pass runs under, so the row is refused by the guard
+	// rather than by a caller that could not have written anyway. Removing the
+	// counterparty_email clause opens this row.
+	repair := systemRepairCtx(e)
+	if err := database.WithWorkspaceTx(repair, e.Pool, func(tx pgx.Tx) error {
+		return activities.ReleaseCalendarMeetingHoldTx(repair, tx,
+			ids.From[ids.ActivityKind](activityID))
+	}); err != nil {
+		t.Fatalf("releasing: %v", err)
+	}
+
+	got, reason := audienceOf(t, e, activityID)
+	if got != "participants" || reason != activities.ReasonNoRecord {
+		t.Fatalf("the calendar release opened a judged sender's mail: audience %q reason %q — "+
+			"the row names a counterparty, so a judgement placed the hold and no calendar rule lifts it",
+			got, reason)
 	}
 }

--- a/backend/internal/compose/linkreconcile.go
+++ b/backend/internal/compose/linkreconcile.go
@@ -140,6 +140,14 @@ func (w *linkReconcileWorkspaceWorker) Work(ctx context.Context, job *river.Job[
 		w.log.InfoContext(ctx, "link reconcile: filed meetings are no longer held to their attendees",
 			"workspace", job.Args.Workspace.String(), "meetings", lifted)
 	}
+	released, err := w.releaseCalendarMeetingHolds(sweepCtx)
+	if err != nil {
+		failed = errors.Join(failed, err)
+	}
+	if released > 0 {
+		w.log.InfoContext(ctx, "link reconcile: work-calendar meetings are workspace business again",
+			"workspace", job.Args.Workspace.String(), "meetings", released)
+	}
 	return jobs.FaultContext(ctx, errors.Join(failed, w.attachDomainBacklogs(sweepCtx, job.Args.Workspace)))
 }
 
@@ -147,6 +155,86 @@ func (w *linkReconcileWorkspaceWorker) Work(ctx context.Context, job *river.Job[
 // shrinks as it is worked, so a small bound costs one probe a tick once it is
 // empty and never delays the repair above it.
 const liftFiledMeetingHoldsPerTick = 200
+
+// releaseCalendarMeetingHolds opens the meetings captured before the limiter
+// stopped holding them.
+//
+// A connected calendar is a WORK calendar, so an event on it is workspace
+// business and capture no longer holds one at all. Rows captured before that
+// still carry the hold, and no later event re-asks the question: the ones with
+// no link are not even offered to the drain above, so a recurring internal
+// meeting would stay invisible to the workspace for the rest of its life.
+//
+// Both spellings, because the reason was split at the writer AFTER these rows
+// were written: a meeting held before the split carries ReasonNoRecord and one
+// held after it carries ReasonNoCounterparty.
+//
+// ReasonNoRecord is otherwise the JUDGED hold — a suppressed sender, a thread
+// judged the owner's private life — and opening one of those would publish a
+// mailbox owner's private correspondence to the workspace. Two conditions make
+// reading it safe here, and both are required:
+//
+//   - kind = 'meeting'. A necessary condition, never a sufficient one: the
+//     extension ingress copies Kind straight off a third-party unit's record
+//     with no vocabulary check in front of it, so the word is not the calendar's
+//     to claim.
+//   - counterparty_email IS NULL, which is WHY a meeting reached the limiter at
+//     all. Attendance is a list, so the mapper names no counterparty, and the
+//     ladder concluded "captured, named nobody" without judging anyone. Every
+//     judged hold is about a sender, so its row names one, and this is the
+//     condition no writer can forge by choosing a string.
+//
+// The null counterparty alone would admit the address-less mail that reaches the
+// same branch. Together they are the shape only a record that named nobody has.
+//
+// It drains permanently: the release rewrites audience and reason on every row
+// it selects, so a row worked once cannot match again.
+func (w *linkReconcileWorker) releaseCalendarMeetingHolds(ctx context.Context) (int, error) {
+	var held []ids.ActivityID
+	if err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT a.id
+			  FROM activity a
+			 WHERE a.kind = 'meeting'
+			   AND a.counterparty_email IS NULL
+			   AND a.audience = 'participants'
+			   AND a.audience_reason IN ($1, $2)
+			   AND a.restricted_at IS NULL
+			   AND a.archived_at IS NULL
+			   -- Captured, not booked in the app: the in-app meeting writes its
+			   -- own audience and leaves no import row, and the recompute
+			   -- declines it. Selecting one would return it every tick.
+			   AND EXISTS (SELECT 1 FROM capture_import ci WHERE ci.activity_id = a.id)
+			 ORDER BY a.occurred_at DESC, a.id
+			 LIMIT $3`,
+			activities.ReasonNoRecord, activities.ReasonNoCounterparty,
+			liftFiledMeetingHoldsPerTick)
+		if err != nil {
+			return fmt.Errorf("selecting the calendar meetings still held: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id ids.ActivityID
+			if err := rows.Scan(&id); err != nil {
+				return fmt.Errorf("reading a calendar meeting still held: %w", err)
+			}
+			held = append(held, id)
+		}
+		return rows.Err()
+	}); err != nil {
+		return 0, err
+	}
+	released := 0
+	for _, id := range held {
+		if err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+			return activities.ReleaseCalendarMeetingHoldTx(ctx, tx, id)
+		}); err != nil {
+			return released, fmt.Errorf("releasing the hold on %s: %w", id, err)
+		}
+		released++
+	}
+	return released, nil
+}
 
 // liftFiledMeetingHolds re-derives the audience of records that are filed under
 // something and still carry the limiter's "named nobody" hold.

--- a/backend/internal/modules/activities/calendarmeetingrelease.go
+++ b/backend/internal/modules/activities/calendarmeetingrelease.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// Opening the work-calendar meetings that were captured while the limiter still
+// held them.
+//
+// Capture no longer holds a calendar meeting at all: a connected calendar is a
+// work calendar, so an event on it is workspace business. That rule binds every
+// meeting captured from now on, and nothing re-asks the question for the ones
+// captured before it — the ordinary recompute would read the hold off the row
+// and honour it forever.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// ReleaseCalendarMeetingHoldTx drops the limiter's hold from one captured
+// calendar meeting and re-derives its audience without it.
+//
+// It removes one contributor — the hold the limiter would no longer place — and
+// then asks the ordinary derivation what the remaining contributors say. A human
+// who narrowed the row by hand outranks it, and so does a human's explicit
+// member list.
+//
+// A mailbox posture is NOT among those contributors, and that is settled rather
+// than overlooked: decideBirthTx returns before reading the mail-sharing posture
+// for any kind but "email" (capture/birthdecision.go), because a meeting is not
+// correspondence a mailbox posture was ever asked about, and holding one on the
+// strength of a mail setting would empty the shared calendar for a reason nobody
+// stated. TestACalendarEventFollowsTheWorkspaceDefaultNotTheMailPosture holds
+// that. So a meeting's import row records no posture, deriveAudienceTx answers
+// "workspace" for every meeting no person narrowed, and in practice this opens
+// the row. Said plainly because the mechanism reads like a safety net it is not.
+//
+// ReasonNoRecord is otherwise the JUDGED hold — a suppressed sender, a thread
+// judged the mailbox owner's private life — and opening one of those publishes
+// private correspondence to the workspace. The read below refuses any row that
+// is not shaped like a calendar record, so a caller that passes the wrong id
+// gets no write rather than a disclosure. The two conditions, both required:
+//
+//   - kind = 'meeting'. Not a claim about who writes that kind: the extension
+//     ingress copies it off a third-party unit's record unvalidated, so it is a
+//     necessary condition and never a sufficient one.
+//   - counterparty_email IS NULL, which is WHY a meeting reached the limiter at
+//     all. This is the one no caller can forge by choosing a string: a judged
+//     hold is always about a sender, so its row names one.
+//
+// Stated in the WHERE clause rather than trusted to the caller, because this is
+// the function that does the opening.
+func ReleaseCalendarMeetingHoldTx(ctx context.Context, tx pgx.Tx, activityID ids.ActivityID) error {
+	// The same locked read RecomputeAudienceTx takes, and for the same reasons:
+	// the lock orders this against every other writer of a derived row, and
+	// restricted_at excludes a row under a statutory hold, which this must never
+	// make more readable.
+	var stored string
+	var storedReason *string
+	err := tx.QueryRow(ctx, `
+		SELECT audience, audience_reason FROM activity
+		 WHERE id = $1 AND kind = 'meeting' AND counterparty_email IS NULL
+		   AND restricted_at IS NULL AND archived_at IS NULL FOR UPDATE`,
+		activityID).Scan(&stored, &storedReason)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			// Erased, deleted, under a statutory hold, archived by the noise
+			// sweep, not a meeting, or a row naming a counterparty — which is a
+			// judged hold, not this function's. Releasing nothing is the right
+			// answer to all of them.
+			return nil
+		}
+		return fmt.Errorf("activities: reading the meeting being released: %w", err)
+	}
+	// A human's explicit member list is not a repair's to move, exactly as it is
+	// not the recompute's.
+	if stored == audienceSelected {
+		return nil
+	}
+	// Everything else is refused by naming what this release IS about.
+	//
+	// RecomputeAudienceTx derives an audience from scratch, so it has to ask
+	// separately whether a human's narrowing outranks what it derived. This
+	// removes ONE named contributor instead, and a reason that is not that
+	// contributor is a hold this function has nothing to say about — a person's
+	// ReasonManual among them. One check rather than two: a second that refuses
+	// the same rows only looks like defence in depth, because a mutation of
+	// either one still passes and neither is then proven to hold anything.
+	if !releasableHold(deref(storedReason)) {
+		// A workspace floor, a counterparty hold, a confidentiality marker, a
+		// person's own narrowing. Every one of them is still true.
+		return nil
+	}
+	derived, reason, ok, err := deriveAudienceTx(ctx, tx, activityID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		// No import rows: not a captured row, and not this function's to decide.
+		return nil
+	}
+	if derived == stored && sameReason(storedReason, reason) {
+		return nil
+	}
+	return writeDerivedAudienceTx(ctx, tx, activityID, stored, storedReason, derived, reason)
+}
+
+// releasableHold names the two spellings of the limiter's "named nobody" hold.
+//
+// Two, because the reason was split at the writer partway through this tree's
+// life: a meeting held before the split carries ReasonNoRecord and one held
+// after it carries ReasonNoCounterparty. Both meant the same thing on a calendar
+// meeting — the mapper leaves the counterparty unset because attendance is a
+// list — and neither was ever a judgement about a person.
+func releasableHold(reason string) bool {
+	return reason == ReasonNoRecord || reason == ReasonNoCounterparty
+}

--- a/backend/internal/modules/capture/sinkactivity.go
+++ b/backend/internal/modules/capture/sinkactivity.go
@@ -177,7 +177,7 @@ func (s *Sink) finishNewActivity(
 			return counterpartyDecision{}, err
 		}
 	}
-	if err := limitLinkLessAudience(ctx, tx, id, rec, decision, derivedLinks); err != nil {
+	if err := limitLinkLessAudience(ctx, tx, id, rec, fields.Kind, decision, derivedLinks); err != nil {
 		return counterpartyDecision{}, err
 	}
 	// This mailbox's own record of having imported the message, and the

--- a/backend/internal/modules/capture/sinkaudience.go
+++ b/backend/internal/modules/capture/sinkaudience.go
@@ -26,7 +26,31 @@ import (
 // links written rather than attempted, because this write is deterministic: a
 // row claimed to be linked and left unlinked would be workspace-readable with
 // nothing filing it anywhere.
-func limitLinkLessAudience(ctx context.Context, tx pgx.Tx, id ids.ActivityID, rec connector.NormalizedRecord, decision counterpartyDecision, derivedLinks int) error {
+//
+// A connected calendar is a WORK calendar, so every event on it is workspace
+// business and none of them is this function's to hold. kind says what the
+// record is; the counterparty shape says whether anybody was judged.
+func limitLinkLessAudience(ctx context.Context, tx pgx.Tx, id ids.ActivityID, rec connector.NormalizedRecord, kind string, decision counterpartyDecision, derivedLinks int) error {
+	if kind == meetingKind && counterpartyShapeOf(rec.Counterparty) == shapeNone {
+		// A meeting reached the no-record arm only because the calendar mapper
+		// leaves the counterparty unset — attendance is a list, so there is no
+		// single party to create a record for. That is a modelling fact about
+		// calendars, never a judgement about anybody, and holding a work meeting
+		// to its attendees while the invitation MAIL beside it stayed
+		// workspace-readable told the workspace two different things about one
+		// appointment.
+		//
+		// BOTH conditions, because the kind alone is not the calendar's to claim.
+		// A connector reports the kind per message (the batch connectors take a
+		// kind map) and the extension ingress copies it straight off a
+		// third-party unit's record with no vocabulary check in front of it
+		// (compose/extingress.go), so "meeting" is a word a caller chooses. The
+		// counterparty shape is the fact no caller forges by choosing a string:
+		// shapeNone means the record named nobody, which is the only reason this
+		// arm is reachable with no judgement behind it. A meeting-shaped record
+		// that DOES name somebody keeps the hold their judgement earned.
+		return nil
+	}
 	if decision.create || len(rec.Links) > 0 || derivedLinks > 0 {
 		return nil
 	}


### PR DESCRIPTION
## What was wrong

A connected calendar is a work calendar, so every event on it is the workspace's business. Capture held one anyway.

A meeting names no counterparty — attendance is a list, so `meetingmap` leaves it unset — and the ladder concluded "captured, named nobody". The audience limiter read that as grounds to hold the record to its participants.

The result was one appointment described two ways on one page: the meeting invisible to every colleague who was not on the invitation, while the invitation **emails** beside it stayed workspace-readable. In the dev workspace that was all 468 captured meetings, including the one a workspace admin reported he could not read.

## What changed

- **The limiter places no hold on a meeting that named nobody**, so there is nothing to lift afterwards.
- **`ReleaseCalendarMeetingHoldTx`** opens the meetings captured before the rule changed. A human's manual narrowing and a human's explicit member list both still outrank it.
- **A bounded drain on the existing link-reconcile sweep** feeds it, and drains permanently: the release rewrites the reason on every row it selects.

## The privacy boundary

`audience_reason = 'no_record'` is otherwise the **judged** hold — a suppressed sender, a role mailbox, a thread judged the mailbox owner's private life. Opening one of those publishes private correspondence to the whole workspace. The release reads it by name, because rows written before the reason was split at the writer all carry the older spelling.

**The kind alone does not identify a calendar record.** A connector reports the kind per message, and the extension ingress copies `Activity.Kind` straight off a third-party unit's record with no vocabulary check in front of it — so `"meeting"` is a word a caller chooses, not a fact a calendar mapper establishes. Both the limiter and the release pair it with the fact no caller can forge by choosing a string: the record named nobody (`shapeNone` at capture, `counterparty_email IS NULL` on the stored row). A judged hold is always about a sender, so its row names one.

That guard is not theoretical. `TestTheLimiterStillHoldsAMeetingThatNamesAJudgedSender` lands a suppressed sender's message through the real connector with the kind reported as `"meeting"`; with the counterparty condition removed it is born workspace-readable. `TestTheCalendarReleaseRefusesARowThatNamesASender` is the same attack against the release.

## One thing worth knowing

A meeting does not follow the mailbox mail-sharing posture. `decideBirthTx` never reads it for a non-mail kind, which `TestACalendarEventFollowsTheWorkspaceDefaultNotTheMailPosture` has held since before this change — holding a meeting on the strength of a mail setting would empty the shared calendar for a reason nobody stated.

So the release opens the row in practice rather than re-deriving a hold from other contributors. The doc comment now says that plainly instead of implying a safety net that is not there.

## Testing

Every guard was mutation-checked alone, one clause at a time. That found a redundant pair — a `ReasonManual` check that refused nothing `releasableHold` did not already refuse — and it is gone rather than kept as defence in depth, because a mutation of either one passed.

`make check-backend`, `craft-static`, `rls-store-path`, `no-jurisdiction` green; the capture integration package passes in full. The selector was dry-run against the reporting workspace's data: it picks all 468 meetings and excludes the two null-counterparty mail rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Captured calendar meetings are now workspace business, so the audience limiter no longer holds one that named nobody. Previously such a meeting was invisible to every colleague not on the invitation, while the invitation emails beside it stayed workspace-readable.

**Release of previously held meetings**
- A bounded drain on the link-reconcile sweep opens meetings captured before the rule changed, rewriting the reason so each row releases once.
- A human's manual narrowing or explicit member list still outranks the release.
- The limiter and release both require kind `meeting` plus a null counterparty, so judged holds (like suppressed senders) stay closed; tests cover the forged-kind case.

<sup>Written for commit 1443dea6420692e3f7e27db0bbbee6aa2a8c2f24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connected-calendar meetings without a known attendee are now treated as workspace business without creating a person record.
  * Previously held calendar meetings can be released when they no longer meet hold criteria.
  * Manually narrowed audience settings are preserved when a calendar hold is released.
  * Meetings naming a judged sender remain held, preventing incorrect release.
* **Tests**
  * Added coverage for legacy hold release, audience preservation, and sender-related hold protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->