### PR TITLE
A share the issuer can close, and a contract that says what the server returns

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16168,6 +16168,15 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/IssuedForecastShare' }
+        '400':
+          description: >-
+            The request is unanswerable as written: an expiry past the ceiling, a field
+            this caller cannot name, a measure that means nothing over that column, or a
+            filter separating out too few records to answer about. The body names what
+            would have worked.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '422': { $ref: '#/components/responses/ValidationError' }
@@ -16191,6 +16200,7 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
   /forecast/shared/{token}:
     parameters:
       - name: token
@@ -16332,6 +16342,15 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/AnalyticsAnswer' }
+        '400':
+          description: >-
+            The request is unanswerable as written: an expiry past the ceiling, a field
+            this caller cannot name, a measure that means nothing over that column, or a
+            filter separating out too few records to answer about. The body names what
+            would have worked.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '422': { $ref: '#/components/responses/ValidationError' }
@@ -16366,6 +16385,15 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/AnalyticsExplanation' }
+        '400':
+          description: >-
+            The request is unanswerable as written: an expiry past the ceiling, a field
+            this caller cannot name, a measure that means nothing over that column, or a
+            filter separating out too few records to answer about. The body names what
+            would have worked.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '422': { $ref: '#/components/responses/ValidationError' }

--- a/backend/internal/compose/analyticsshare_integration_test.go
+++ b/backend/internal/compose/analyticsshare_integration_test.go
@@ -503,3 +503,52 @@ func TestAnUnpricedDealExportsAnEmptyCellRatherThanAZero(t *testing.T) {
 		t.Errorf("an unpriced deal exported a zero amount:\n%s", body)
 	}
 }
+
+func TestASeatThatCanIssueAShareCanCloseIt(t *testing.T) {
+	e := setupForecast(t)
+	// The role a real installation seeds, read from the policy defaults rather
+	// than invented here. The first version of this file built a principal with
+	// Delete: true and passed — against an authority no seat in the product
+	// holds, because the forecast object is seeded create+read and nothing
+	// grants delete. Revoke was gated on that verb, so every share was
+	// permanent and no test noticed.
+	seat := ids.NewV7()
+	e.seedSeatHolding(t, seat, "issuer-real@forecast.test", "share_issuer_real")
+	ctx := principal.WithCorrelationID(
+		principal.WithWorkspaceID(context.Background(), e.WS), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + seat.String(), UserID: seat,
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{
+				// EXACTLY the seeded forecast posture: create and read, no
+				// delete. Spelled out so a reader can see that the absence is
+				// the point of the test.
+				"forecast":              {Create: true, Read: true},
+				"deal":                  {Read: true},
+				"installation_settings": {Read: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+
+	share, token := e.issue(ctx, t, NewShare{
+		Kind: shareKindLive, Target: "forecast",
+		Scope: forecasting.Scope{Kind: forecasting.ScopeWorkspace},
+	})
+
+	store := forecasting.NewStore(InstallationDB(e.Pool))
+	if err := store.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		return e.shareStore(time.Now).Revoke(ctx, tx, share.ID)
+	}); err != nil {
+		t.Fatalf("the seat that issued this share cannot close it: %v — a link nobody can revoke is permanent", err)
+	}
+
+	// And it actually stopped serving, rather than the call merely succeeding.
+	err := store.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		_, err := e.shareStore(time.Now).Resolve(ctx, tx, token)
+		return err
+	})
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("a revoked share answered %v; it must stop serving", err)
+	}
+}

--- a/backend/internal/compose/analyticssharestore.go
+++ b/backend/internal/compose/analyticssharestore.go
@@ -256,7 +256,16 @@ func (s *AnalyticsShareStore) Resolve(
 // Revoke closes a share before its expiry. Idempotent: revoking a revoked
 // share is the outcome the caller asked for.
 func (s *AnalyticsShareStore) Revoke(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
-	if err := auth.Require(ctx, objectForecast, principal.ActionDelete); err != nil {
+	// CREATE, not delete. No role holds forecast:delete — a forecast reading is
+	// derived and a call supersedes rather than being rewritten, so the object
+	// is seeded create+read and nothing grants the verb (policy/defaults.go).
+	// Gating revocation on it made every share permanent: the issuer could mint
+	// a link and no seat in the installation could close it.
+	//
+	// Create is the right verb rather than a workaround. Revoking is not
+	// deleting a forecast; it is withdrawing a link the same seat was allowed
+	// to issue, and whoever may issue one may close one.
+	if err := auth.Require(ctx, objectForecast, principal.ActionCreate); err != nil {
 		return err
 	}
 	// The row is locked before it is read-modified-written. Idempotence here

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -46835,6 +46835,15 @@ export interface operations {
                     "application/json": components["schemas"]["IssuedForecastShare"];
                 };
             };
+            /** @description The request is unanswerable as written: an expiry past the ceiling, a field this caller cannot name, a measure that means nothing over that column, or a filter separating out too few records to answer about. The body names what would have worked. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             422: components["responses"]["ValidationError"];
@@ -46861,6 +46870,7 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
         };
     };
     openForecastShare: {
@@ -46959,6 +46969,15 @@ export interface operations {
                     "application/json": components["schemas"]["AnalyticsAnswer"];
                 };
             };
+            /** @description The request is unanswerable as written: an expiry past the ceiling, a field this caller cannot name, a measure that means nothing over that column, or a filter separating out too few records to answer about. The body names what would have worked. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             422: components["responses"]["ValidationError"];
@@ -46984,6 +47003,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnalyticsExplanation"];
+                };
+            };
+            /** @description The request is unanswerable as written: an expiry past the ceiling, a field this caller cannot name, a measure that means nothing over that column, or a filter separating out too few records to answer about. The body names what would have worked. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
                 };
             };
             401: components["responses"]["Unauthorized"];


### PR DESCRIPTION
Revoking a share was gated on `forecast:delete`, and no role in this installation holds that verb: `policy/defaults.go` seeds `forecast` as create+read, because a forecast reading is derived and a call supersedes rather than being rewritten. So every link ever issued was permanent — the issuer could mint one and no seat in the installation could close it.

Create is the right verb rather than a workaround. Revoking is not deleting a forecast; it is withdrawing a link the same seat was allowed to issue, and whoever may issue one may close one.

## How it was missed

The test that covered revocation supplied its own principal with `Delete: true` — a posture production never seeds. It passed against an authority no role has. The new test uses the seeded forecast grants exactly as a role carries them, and was mutation-checked: moving the gate back fails it with "the seat that issued this share cannot close it".

Found by clicking through a running stack, not by a gate. Every gate was green while the bug shipped.

## Also in this change

Four operations declared status codes the server cannot return. Probed against a running API rather than reasoned about:

| Operation | Declared | Actually returns |
|---|---|---|
| `getAnalyticsSchema` | 400 | never — takes no input |
| `revokeForecastShare` | 400 | 422 on a malformed path UUID |
| `openForecastShare` | 400 | 404 |
| `exportForecastShare` | 400 | 404 |

The fixed sentinel registry maps `ErrInvalidArgument` to 400, which is why the blanket 400s were wrong. A declared code a route never returns is a branch a client writes and never exercises.

## Verification

`make check-backend` and `make check-fe` both green against current main after a rebase across 19 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes forecast share revocation so the seat that issued a share can now close it; previously every share was permanent because the gate required `forecast:delete`, a verb no role holds. Also corrects the API contract to declare the status codes the server actually returns.

**Bug Fixes**
- Revocation now requires `forecast:create`, the same permission used to issue a share.
- The old test granted `Delete: true`, a posture production never seeds; the new test uses the seeded role grants and confirms a revoked share stops serving.
- `getAnalyticsSchema` declares a 400 it can never return (takes no input); `revokeForecastShare` returns 422 and `openForecastShare`/`exportForecastShare` return 404 where they declared 400.

<sup>Written for commit 8353c4e7e0ad3a618f4c121fbfb304aa79ae5d6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Share issuers can now revoke links they created when they have permission to create and view forecasts, without requiring delete permission.
  * Revoked share links no longer resolve and are reported as not found.

* **Documentation**
  * Added API documentation for invalid requests and validation errors on forecast and analytics endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->