### PR TITLE
The team's week counts what advanced

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -36341,13 +36341,26 @@ components:
     TeamWeeklyCounts:
       type: object
       additionalProperties: false
-      required: [reps_counted, deals_won, deals_lost, leads_routed, leads_answered_in_target,
+      required: [reps_counted, deals_won, deals_lost, deals_moved, leads_routed,
+                 leads_answered_in_target,
                  leads_breached, meetings_held, meetings_with_next_step,
                  commitments_due, commitments_kept]
       properties:
         reps_counted: { type: integer, minimum: 0, description: 'Members whose week was read and totalled.' }
         deals_won: { type: integer, minimum: 0 }
         deals_lost: { type: integer, minimum: 0 }
+        deals_moved:
+          type: integer
+          minimum: 0
+          description: |
+            Deals that changed stage in the week without closing — what the team ADVANCED.
+
+            A count and never an amount. Advancing is a stage fact: a deal moving from
+            Proposal to Negotiation did not change price, so a "value advanced" figure would
+            count the deal's whole worth a second time beside the pipeline it already sits in.
+
+            Snapshots written before this figure existed carry zero. A count of zero is a
+            count, unlike a money sum of zero over deals nobody could price.
         leads_routed: { type: integer, minimum: 0 }
         leads_answered_in_target: { type: integer, minimum: 0 }
         leads_breached: { type: integer, minimum: 0 }

--- a/backend/internal/compose/integration/teamweekly_integration_test.go
+++ b/backend/internal/compose/integration/teamweekly_integration_test.go
@@ -89,6 +89,47 @@ func teamScoped(e *integration.Env, user ids.UUID, teams []ids.UUID) context.Con
 	return e.As(user, teams, perms)
 }
 
+// THE TEAM'S WEEK COUNTS WHAT ADVANCED. Every member's weekly_review has
+// carried deals_moved since the review shipped, and the team total dropped it —
+// so a team that moved deals and closed none read as a team where nothing
+// happened, which is the week most teams have.
+//
+// Seeded through the REAL writer: a deal advanced with deals.Store, then the
+// member week assembled, then the team week summed. A hand-inserted count would
+// prove the column round-trips and nothing about whether anything fills it.
+func TestTheTeamWeekCountsWhatAdvanced(t *testing.T) {
+	e := setupTeamWeekly(t)
+
+	// Two reps, one advancing deal each, so the team figure is a SUM rather
+	// than one member's number passed through — which a single rep cannot tell
+	// apart.
+	for _, rep := range []ids.UUID{e.Rep1, e.Rep2} {
+		advanceOneDeal(t, e, rep)
+		writeRepWeek(t, e, rep)
+	}
+
+	written, _, err := e.engine.AssembleTeamFor(
+		e.leadCtx, e.Team1, "Team One", members(e), teamClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if written.Counts.DealsMoved != 2 {
+		t.Fatalf("the team advanced %d deals, wanted 2 — one per rep, summed",
+			written.Counts.DealsMoved)
+	}
+
+	// And it SURVIVES the round trip: the figure a lead reads comes off the
+	// stored row, not the struct the writer happened to return.
+	read, err := e.engine.LatestTeamReview(e.leadCtx, e.Team1, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Counts.DealsMoved != 2 {
+		t.Errorf("the stored week reads %d advanced, wanted 2", read.Counts.DealsMoved)
+	}
+}
+
 // A LEAD OF ONE TEAM MUST NOT READ ANOTHER'S WEEK. The team id arrives from the
 // query string and nothing on the row narrows it to the reader, so without a
 // membership gate one changed parameter hands over every member of another
@@ -332,6 +373,53 @@ func TestAMemberWithNoWeekIsCountedAsUnread(t *testing.T) {
 }
 
 // writeRepWeek gives one rep a review for the week that closed.
+// advanceOneDeal gives one rep a deal that changed stage inside the week under
+// review, without closing — which is exactly what deals_moved counts.
+//
+// The DEAL comes from the real writer. Only the stage change's timestamp is set
+// by hand, and it has to be: no writer lets a caller name a past instant, and
+// the figure is defined by a change falling inside a week that has closed. That
+// is the same seam weekly_integration_test.go takes for the same reason.
+func advanceOneDeal(t *testing.T, e *teamEnv, rep ids.UUID) {
+	t.Helper()
+	// The default pipeline through the store's own seeder, not a fixture of
+	// this suite's: the stage semantics are what decide whether a move counts,
+	// and a hand-built pipeline could disagree with the one production seeds.
+	//
+	// Seeded once for the whole test even when two reps each get a deal — a
+	// second SeedDefaults over the same workspace conflicts, which is the
+	// store saying the pipeline is already there.
+	if err := e.Deals.SeedDefaults(e.Admin()); err != nil &&
+		!errors.Is(err, apperrors.ErrConflict) {
+		t.Fatal(err)
+	}
+	p, err := e.Deals.DefaultPipeline(e.Admin())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var open ids.StageID
+	for _, st := range *p.Stages {
+		if st.Semantic == "open" {
+			open = ids.From[ids.StageKind](ids.UUID(st.Id))
+			break
+		}
+	}
+	pipeline := ids.From[ids.PipelineKind](ids.UUID(p.Id))
+	deal := e.SeedDeal(t, "Advanced for "+rep.String(), pipeline, open, &rep)
+
+	// The stage moved TO is chosen in the statement: a second stage of the same
+	// pipeline. Reusing `open` would write a row whose from and to are one
+	// stage, which is not a move and would count all the same.
+	inWeek := teamClock.AddDate(0, 0, -4)
+	e.WsExec(t, `INSERT INTO deal_stage_history
+	                 (deal_id, from_stage_id, to_stage_id, changed_by, changed_at)
+	             SELECT $1, $2, s.id, 'human:x', $4
+	               FROM stage s
+	              WHERE s.pipeline_id = $3 AND s.id <> $2
+	              ORDER BY s.position LIMIT 1`,
+		deal, open, pipeline, inWeek)
+}
+
 func writeRepWeek(t *testing.T, e *teamEnv, user ids.UUID) {
 	t.Helper()
 	repCtx := e.As(user, []ids.UUID{e.Team1}, integration.AdminPerms)

--- a/backend/internal/compose/weekly/teamreview.go
+++ b/backend/internal/compose/weekly/teamreview.go
@@ -76,9 +76,14 @@ type TeamReview struct {
 
 // TeamCounts are the team's totals over its member weeks.
 type TeamCounts struct {
-	RepsCounted           int
-	DealsWon              int
-	DealsLost             int
+	RepsCounted int
+	DealsWon    int
+	DealsLost   int
+	// DealsMoved counts deals that changed stage without closing — the week's
+	// advancement. Every member's review has carried it since the review
+	// shipped; the team total dropped it, so a team that moved eleven deals and
+	// closed none read as a team that did nothing.
+	DealsMoved            int
 	LeadsRouted           int
 	LeadsAnsweredInTarget int
 	LeadsBreached         int
@@ -194,6 +199,7 @@ func gatherTeamWeek(
 func addTeamCounts(team *TeamCounts, member Counts) {
 	team.DealsWon += member.DealsWon
 	team.DealsLost += member.DealsLost
+	team.DealsMoved += member.DealsMoved
 	team.LeadsRouted += member.LeadsRouted
 	team.LeadsAnsweredInTarget += member.LeadsAnsweredInTarget
 	team.LeadsBreached += member.LeadsBreached

--- a/backend/internal/compose/weekly/teamreviewhandlers.go
+++ b/backend/internal/compose/weekly/teamreviewhandlers.go
@@ -63,7 +63,7 @@ func teamReviewToWire(review TeamReview) crmcontracts.TeamWeeklyReview {
 		RepsUnread:     &review.RepsUnread,
 		Counts: crmcontracts.TeamWeeklyCounts{
 			RepsCounted: c.RepsCounted,
-			DealsWon:    c.DealsWon, DealsLost: c.DealsLost,
+			DealsWon:    c.DealsWon, DealsLost: c.DealsLost, DealsMoved: c.DealsMoved,
 			LeadsRouted: c.LeadsRouted, LeadsAnsweredInTarget: c.LeadsAnsweredInTarget,
 			LeadsBreached: c.LeadsBreached,
 			MeetingsHeld:  c.MeetingsHeld, MeetingsWithNextStep: c.MeetingsWithNextStep,

--- a/backend/internal/compose/weekly/teamreviewstore.go
+++ b/backend/internal/compose/weekly/teamreviewstore.go
@@ -25,7 +25,7 @@ import (
 // same week comes to render two different ways.
 const teamReviewSelect = `
 	SELECT id, team_id, team_name, local_week_start, generated_at, as_of,
-	       reps_counted, deals_won, deals_lost,
+	       reps_counted, deals_won, deals_lost, deals_moved,
 	       leads_routed, leads_answered_in_target, leads_breached,
 	       meetings_held, meetings_with_next_step,
 	       commitments_due, commitments_kept,
@@ -45,13 +45,13 @@ func memberWeek(
 	var created, won, lost *int64
 	var currency *string
 	err := tx.QueryRow(ctx, `
-		SELECT deals_won, deals_lost,
+		SELECT deals_won, deals_lost, deals_moved,
 		       leads_routed, leads_answered_in_target, leads_breached,
 		       meetings_held, meetings_with_next_step,
 		       commitments_due, commitments_kept,
 		       pipeline_created_minor, pipeline_won_minor, pipeline_lost_minor, base_currency
 		  FROM weekly_review WHERE user_id = $1 AND local_week_start = $2`, userID, week).
-		Scan(&c.DealsWon, &c.DealsLost,
+		Scan(&c.DealsWon, &c.DealsLost, &c.DealsMoved,
 			&c.LeadsRouted, &c.LeadsAnsweredInTarget, &c.LeadsBreached,
 			&c.MeetingsHeld, &c.MeetingsWithNextStep,
 			&c.CommitmentsDue, &c.CommitmentsKept,
@@ -100,6 +100,7 @@ func insertTeamReview(ctx context.Context, tx pgx.Tx, review TeamReview) (ids.UU
 	add("reps_unread", review.RepsUnread)
 	add("deals_won", c.DealsWon)
 	add("deals_lost", c.DealsLost)
+	add("deals_moved", c.DealsMoved)
 	add("leads_routed", c.LeadsRouted)
 	add("leads_answered_in_target", c.LeadsAnsweredInTarget)
 	add("leads_breached", c.LeadsBreached)
@@ -261,7 +262,7 @@ func scanTeamReview(ctx context.Context, tx pgx.Tx, row pgx.Row) (TeamReview, er
 	var currency *string
 	switch err := row.Scan(&review.ID, &review.TeamID, &review.TeamName,
 		&review.LocalWeekStart, &review.GeneratedAt, &review.AsOf,
-		&c.RepsCounted, &c.DealsWon, &c.DealsLost,
+		&c.RepsCounted, &c.DealsWon, &c.DealsLost, &c.DealsMoved,
 		&c.LeadsRouted, &c.LeadsAnsweredInTarget, &c.LeadsBreached,
 		&c.MeetingsHeld, &c.MeetingsWithNextStep,
 		&c.CommitmentsDue, &c.CommitmentsKept,

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -30492,9 +30492,19 @@ type TeamListResponse struct {
 
 // TeamWeeklyCounts defines model for TeamWeeklyCounts.
 type TeamWeeklyCounts struct {
-	CommitmentsDue        int `json:"commitments_due"`
-	CommitmentsKept       int `json:"commitments_kept"`
-	DealsLost             int `json:"deals_lost"`
+	CommitmentsDue  int `json:"commitments_due"`
+	CommitmentsKept int `json:"commitments_kept"`
+	DealsLost       int `json:"deals_lost"`
+
+	// DealsMoved Deals that changed stage in the week without closing — what the team ADVANCED.
+	//
+	// A count and never an amount. Advancing is a stage fact: a deal moving from
+	// Proposal to Negotiation did not change price, so a "value advanced" figure would
+	// count the deal's whole worth a second time beside the pipeline it already sits in.
+	//
+	// Snapshots written before this figure existed carry zero. A count of zero is a
+	// count, unlike a money sum of zero over deals nobody could price.
+	DealsMoved            int `json:"deals_moved"`
 	DealsWon              int `json:"deals_won"`
 	LeadsAnsweredInTarget int `json:"leads_answered_in_target"`
 	LeadsBreached         int `json:"leads_breached"`

--- a/backend/migrations/core/1788472537_the_team_week_counts_what_advanced.down.sql
+++ b/backend/migrations/core/1788472537_the_team_week_counts_what_advanced.down.sql
@@ -1,0 +1,20 @@
+-- Bounded so a migration never queues behind an open transaction forever:
+-- without it, one long-running reader stalls every write to team_weekly_review
+-- for as long as this is willing to wait.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE team_weekly_review
+    DROP CONSTRAINT team_weekly_review_counts_are_tallies;
+
+ALTER TABLE team_weekly_review
+    ADD CONSTRAINT team_weekly_review_counts_are_tallies CHECK (
+        reps_counted >= 0 AND reps_unread >= 0
+        AND deals_won >= 0 AND deals_lost >= 0
+        AND leads_routed >= 0 AND leads_answered_in_target >= 0 AND leads_breached >= 0
+        AND meetings_held >= 0 AND meetings_with_next_step >= 0
+        AND commitments_due >= 0 AND commitments_kept >= 0
+        AND (pipeline_created_minor IS NULL OR pipeline_created_minor >= 0)
+        AND (pipeline_won_minor IS NULL OR pipeline_won_minor >= 0)
+        AND (pipeline_lost_minor IS NULL OR pipeline_lost_minor >= 0));
+
+ALTER TABLE team_weekly_review DROP COLUMN deals_moved;

--- a/backend/migrations/core/1788472537_the_team_week_counts_what_advanced.up.sql
+++ b/backend/migrations/core/1788472537_the_team_week_counts_what_advanced.up.sql
@@ -1,0 +1,40 @@
+-- The team's week counts the deals that MOVED, not only the ones that closed.
+--
+-- Every member's weekly_review has carried deals_moved since the review shipped
+-- — deals that changed stage without closing. The team snapshot summed won and
+-- lost and dropped it, so a team that advanced eleven deals and closed none
+-- read as a team that did nothing at all. That is the week most teams have.
+--
+-- A COUNT, not money. Advancing is a stage fact and slipping is a date fact;
+-- neither has an amount that means anything. A deal moving from Proposal to
+-- Negotiation did not change price, so a "value advanced" figure would be the
+-- deal's whole worth counted again in a second column beside the pipeline it
+-- is already in.
+--
+-- Additive and nullable-free: the column defaults to zero, so snapshots written
+-- before this migration read as zero rather than unknown. That is honest here
+-- in a way it would not be for money — a count of zero is a count, while a sum
+-- of zero over deals nobody could price is a claim about a week nobody
+-- measured. The existing rows are weeks whose figure was never computed, and
+-- the next assembly overwrites nothing: a snapshot is written once.
+-- Bounded so a migration never queues behind an open transaction forever:
+-- without it, one long-running reader stalls every write to team_weekly_review
+-- for as long as this is willing to wait.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE team_weekly_review
+    ADD COLUMN deals_moved int DEFAULT 0 NOT NULL;
+
+ALTER TABLE team_weekly_review
+    DROP CONSTRAINT team_weekly_review_counts_are_tallies;
+
+ALTER TABLE team_weekly_review
+    ADD CONSTRAINT team_weekly_review_counts_are_tallies CHECK (
+        reps_counted >= 0 AND reps_unread >= 0
+        AND deals_won >= 0 AND deals_lost >= 0 AND deals_moved >= 0
+        AND leads_routed >= 0 AND leads_answered_in_target >= 0 AND leads_breached >= 0
+        AND meetings_held >= 0 AND meetings_with_next_step >= 0
+        AND commitments_due >= 0 AND commitments_kept >= 0
+        AND (pipeline_created_minor IS NULL OR pipeline_created_minor >= 0)
+        AND (pipeline_won_minor IS NULL OR pipeline_won_minor >= 0)
+        AND (pipeline_lost_minor IS NULL OR pipeline_lost_minor >= 0));

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -4826,6 +4826,7 @@ public.team_weekly_review.base_currency text gen=- def=-
 public.team_weekly_review.commitments_due integer NOT NULL gen=- def=0
 public.team_weekly_review.commitments_kept integer NOT NULL gen=- def=0
 public.team_weekly_review.deals_lost integer NOT NULL gen=- def=0
+public.team_weekly_review.deals_moved integer NOT NULL gen=- def=0
 public.team_weekly_review.deals_won integer NOT NULL gen=- def=0
 public.team_weekly_review.generated_at timestamp with time zone NOT NULL gen=- def=now()
 public.team_weekly_review.id uuid NOT NULL gen=- def=uuidv7()
@@ -4842,7 +4843,7 @@ public.team_weekly_review.reps_counted integer NOT NULL gen=- def=0
 public.team_weekly_review.reps_unread integer NOT NULL gen=- def=0
 public.team_weekly_review.team_id uuid NOT NULL gen=- def=-
 public.team_weekly_review.team_name text NOT NULL gen=- def=-
-public.team_weekly_review.team_weekly_review_counts_are_tallies CHECK (((reps_counted >= 0) AND (reps_unread >= 0) AND (deals_won >= 0) AND (deals_lost >= 0) AND (leads_routed >= 0) AND (leads_answered_in_target >= 0) AND (leads_breached >= 0) AND (meetings_held >= 0) AND (meetings_with_next_step >= 0) AND (commitments_due >= 0) AND (commitments_kept >= 0) AND ((pipeline_created_minor IS NULL) OR (pipeline_created_minor >= 0)) AND ((pipeline_won_minor IS NULL) OR (pipeline_won_minor >= 0)) AND ((pipeline_lost_minor IS NULL) OR (pipeline_lost_minor >= 0))))
+public.team_weekly_review.team_weekly_review_counts_are_tallies CHECK (((reps_counted >= 0) AND (reps_unread >= 0) AND (deals_won >= 0) AND (deals_lost >= 0) AND (deals_moved >= 0) AND (leads_routed >= 0) AND (leads_answered_in_target >= 0) AND (leads_breached >= 0) AND (meetings_held >= 0) AND (meetings_with_next_step >= 0) AND (commitments_due >= 0) AND (commitments_kept >= 0) AND ((pipeline_created_minor IS NULL) OR (pipeline_created_minor >= 0)) AND ((pipeline_won_minor IS NULL) OR (pipeline_won_minor >= 0)) AND ((pipeline_lost_minor IS NULL) OR (pipeline_lost_minor >= 0))))
 public.team_weekly_review.team_weekly_review_currency_check CHECK (((base_currency IS NULL) OR (base_currency ~ '^[A-Z]{3}$'::text)))
 public.team_weekly_review.team_weekly_review_money_names_its_currency CHECK (((base_currency IS NULL) = ((pipeline_created_minor IS NULL) AND (pipeline_won_minor IS NULL) AND (pipeline_lost_minor IS NULL))))
 public.team_weekly_review.team_weekly_review_name_present CHECK ((btrim(team_name) <> ''::text))

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -27256,6 +27256,17 @@ export interface components {
             reps_counted: number;
             deals_won: number;
             deals_lost: number;
+            /**
+             * @description Deals that changed stage in the week without closing — what the team ADVANCED.
+             *
+             *     A count and never an amount. Advancing is a stage fact: a deal moving from
+             *     Proposal to Negotiation did not change price, so a "value advanced" figure would
+             *     count the deal's whole worth a second time beside the pipeline it already sits in.
+             *
+             *     Snapshots written before this figure existed carry zero. A count of zero is a
+             *     count, unlike a money sum of zero over deals nobody could price.
+             */
+            deals_moved: number;
             leads_routed: number;
             leads_answered_in_target: number;
             leads_breached: number;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2490,6 +2490,7 @@ export const de = {
   "teamweekly.movement.title": "Was die Woche bewegt hat",
   "teamweekly.movement.won": "Gewonnen",
   "teamweekly.movement.lost": "Verloren",
+  "teamweekly.movement.moved": "Vorangebracht",
   "teamweekly.movement.meetings": "Gehaltene Termine",
   "teamweekly.movement.leads": "Zugewiesene Leads",
   "teamweekly.coach.title": "Diese Woche begleiten",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2539,6 +2539,7 @@ export const en = {
   "teamweekly.movement.title": "What the week did",
   "teamweekly.movement.won": "Won",
   "teamweekly.movement.lost": "Lost",
+  "teamweekly.movement.moved": "Advanced",
   "teamweekly.movement.meetings": "Meetings held",
   "teamweekly.movement.leads": "Leads routed",
   "teamweekly.coach.title": "Coach this week",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2466,6 +2466,7 @@ export const vi = {
   "teamweekly.movement.title": "Tuần đã làm được gì",
   "teamweekly.movement.won": "Thắng",
   "teamweekly.movement.lost": "Thua",
+  "teamweekly.movement.moved": "Đã tiến triển",
   "teamweekly.movement.meetings": "Cuộc họp đã diễn ra",
   "teamweekly.movement.leads": "Lead được phân",
   "teamweekly.coach.title": "Đồng hành tuần này",

--- a/frontend/src/screens/brief.teamweekly.test.tsx
+++ b/frontend/src/screens/brief.teamweekly.test.tsx
@@ -50,6 +50,7 @@ function review(
       reps_counted: 2,
       deals_won: 3,
       deals_lost: 1,
+      deals_moved: 5,
       leads_routed: 10,
       leads_answered_in_target: 10,
       leads_breached: 0,
@@ -114,6 +115,71 @@ describe("the headline states the bar it measured against", () => {
     expect(
       await screen.findByText(en["teamweekly.headline.plain"]),
     ).toBeTruthy();
+  });
+});
+
+describe("the week's movement counts what advanced", () => {
+  // A team that moved eleven deals and closed none read as a team where nothing
+  // happened. Every member's weekly has counted deals_moved since the review
+  // shipped; the team total dropped it on the way up, so the panel could not
+  // draw the row at all.
+  //
+  // Asserted through the METER ROLE rather than by text: the bar carries its
+  // label as `aria-label`, which is how a screen reader gets it and the only
+  // place it exists. A getByText here finds nothing however right the code is.
+  it("draws the advanced row beside won and lost", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () =>
+        jsonResponse(review({ deals_won: 0, deals_lost: 0, deals_moved: 11 })),
+    });
+    render(<TeamWeeklySection teamId="t1" />);
+
+    await screen.findByText(en["teamweekly.movement.title"]);
+    const advanced = screen.getByRole("meter", {
+      name: en["teamweekly.movement.moved"],
+    });
+    expect(advanced.getAttribute("aria-valuenow")).toBe("11");
+  });
+
+  // ONE BASELINE for every bar, and the advanced count must be part of what
+  // sets it. A week whose largest fact is what moved would otherwise draw that
+  // row against a scale taken from the closed deals alone — the biggest number
+  // on the panel rendering as the shortest bar.
+  it("lets the advanced count set the scale when it is the week's largest", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () =>
+        jsonResponse(review({ deals_won: 2, deals_lost: 1, deals_moved: 20 })),
+    });
+    render(<TeamWeeklySection teamId="t1" />);
+    await screen.findByText(en["teamweekly.movement.title"]);
+
+    const advanced = screen.getByRole("meter", {
+      name: en["teamweekly.movement.moved"],
+    });
+    const won = screen.getByRole("meter", {
+      name: en["teamweekly.movement.won"],
+    });
+    // Every bar shares the maximum, and it is the advanced figure.
+    expect(advanced.getAttribute("aria-valuemax")).toBe("20");
+    expect(won.getAttribute("aria-valuemax")).toBe("20");
+  });
+
+  // A snapshot written before the column existed carries zero, and zero is a
+  // COUNT rather than an absence — the row still draws, saying the team
+  // advanced nothing that week.
+  it("draws the row at zero rather than dropping it", async () => {
+    stubApi({
+      "GET /weekly-reviews/team": () =>
+        jsonResponse(review({ deals_moved: 0 })),
+    });
+    render(<TeamWeeklySection teamId="t1" />);
+    await screen.findByText(en["teamweekly.movement.title"]);
+
+    expect(
+      screen
+        .getByRole("meter", { name: en["teamweekly.movement.moved"] })
+        .getAttribute("aria-valuenow"),
+    ).toBe("0");
   });
 });
 

--- a/frontend/src/screens/brief.teamweekly.tsx
+++ b/frontend/src/screens/brief.teamweekly.tsx
@@ -339,6 +339,12 @@ function Movement({ review }: Readonly<{ review: TeamWeeklyReview }>) {
   const rows = [
     { key: "teamweekly.movement.won" as const, value: counts.deals_won },
     { key: "teamweekly.movement.lost" as const, value: counts.deals_lost },
+    // ADVANCED sits with the two outcomes above it rather than with the
+    // activity rows below, because it is the same kind of fact: what happened
+    // to the team's deals. Without it a week that moved eleven deals and closed
+    // none read as a week where nothing happened, which is the week most teams
+    // have and the one a lead most needs to see.
+    { key: "teamweekly.movement.moved" as const, value: counts.deals_moved },
     {
       key: "teamweekly.movement.meetings" as const,
       value: counts.meetings_held,


### PR DESCRIPTION
A team that moved eleven deals and closed none read as a team where nothing
happened. That is the week most teams have, and the one a lead most needs to
see.

Every member's weekly_review has carried deals_moved since the review shipped —
deals that changed stage without closing. The team snapshot summed won and lost
and dropped it on the way up, so the movement panel could draw four rows and
none of them was advancement.

A COUNT, NOT MONEY, and that is the decision behind the whole change. The plan
asked for advanced_minor and slipped_minor. Advancing is a stage fact and
slipping is a date fact; neither has an amount that means anything. A deal
moving from Proposal to Negotiation did not change price, so a "value advanced"
figure would count the deal's whole worth a second time beside the pipeline it
already sits in. Two money columns became one integer.

Snapshots written before the column carry zero, and zero is a count. That is
honest here in a way it would not be for money — a money sum of zero over deals
nobody could price is a claim about a week nobody measured, which is why the
pipeline columns are nullable and this one is not.

The Advanced row sits with won and lost rather than with the activity rows: it
is the same kind of fact, what happened to the team's deals. It joins the shared
baseline, so a week whose largest figure is what moved scales the panel by it
rather than rendering the biggest number as the shortest bar.

THE TEST ASSERTS THROUGH THE METER ROLE, not by text. The bar carries its label
as `aria-label`, which is where a screen reader gets it and the only place it
exists — a getByText finds nothing however right the code is, which is how my
first version failed against working code.

The deal comes from the real writer; only the stage change's timestamp is set by
hand, because no writer lets a caller name a past instant and the figure is
defined by a change inside a week that has closed. Same seam
weekly_integration_test.go takes for the same reason.

Two reps each advance one deal, so the team figure is a SUM rather than one
member's number passed through — which a single-rep fixture cannot tell apart.

Four guards mutation-checked one at a time: the sum itself (fails on the total),
the column write (fails on the round trip), the panel row, and its place in the
shared baseline.

Signed-off-by: Lars Jankowfsky <lars@gradion.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deals-moved count to the team weekly snapshot so a team that moved deals without closing any no longer reads as a week where nothing happened. The team total previously summed only won and lost, dropping the `deals_moved` each member review already carried; the movement panel now draws an Advanced row alongside Won and Lost.

- The figure is a count, not money: advancing is a stage fact, and a value-based figure would double-count a deal's worth beside the pipeline it already sits in.
- The migration adds `deals_moved` with DEFAULT 0, so existing snapshots read as zero — honest for a count where a zero money sum would not be.
- The Advanced row joins the shared bar baseline, so a week whose largest fact is movement scales the panel by it.
- API, generated types, and en/de/vi translations carry the new field.

<sup>Written for commit 1a96f5093b9daa0361db862e3385daa025ad1981. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Advanced” metric to team weekly reviews, showing deals that moved stages without closing.
  * Advanced deals are included alongside won and lost deals in the shared progress meter.
  * Weekly snapshots now preserve advanced-deal counts, including zero when no moves occurred.
  * Added labels for the new metric in English, German, and Vietnamese.

* **Tests**
  * Added coverage for calculating, storing, restoring, and displaying advanced-deal totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->