### PR TITLE
A pending thread verdict always has something to read, and an always-held mailbox is never asked to publish

### DIFF
--- a/backend/internal/compose/capturepromote_integration_test.go
+++ b/backend/internal/compose/capturepromote_integration_test.go
@@ -383,21 +383,7 @@ func TestAReopenedThreadKeepsSomethingToAskAbout(t *testing.T) {
 	const first = "kunde@partner.example"
 	const stranger = "anwalt@kanzlei.example"
 
-	// A classified mailbox: the posture that holds its mail until a classifier
-	// judges the thread, and so the only one that opens a question at all.
-	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(context.Background(), `
-			INSERT INTO capture_connection
-			       (user_id, provider, status, credential_ref, mail_posture, account_label)
-			VALUES ($1, 'gmail', 'connected', 'vault:test', 'classified', 'a@authz.test')
-			ON CONFLICT (user_id, provider)
-			DO UPDATE SET mail_posture = 'classified', archived_at = NULL,
-			              account_label = 'a@authz.test'`, e.Rep1)
-		return err
-	}); err != nil {
-		t.Fatalf("seeding a classified gmail connection: %v", err)
-	}
-
+	seedClassifiedGmail(t, e, e.Rep1)
 	seedAttestedOutbound(t, e, "reopen-out-1", first, "reopen-t1")
 	captureInboundThroughRealSink(t, e, e.Rep1, "reopen-in-1", first, "reopen-t1")
 
@@ -444,5 +430,77 @@ func TestAReopenedThreadKeepsSomethingToAskAbout(t *testing.T) {
 		t.Fatalf("the re-opened question is about mail from %q, want %q: the classifier must read the "+
 			"message that caused the re-open, not the one a previous answer already covered",
 			pointedAt, stranger)
+	}
+}
+
+// TestAHeldMailboxIsNotAskedToPublishItsMail is the refusal the posture owes.
+//
+// A `held` mailbox keeps its mail whatever a classifier concludes, so it must
+// never have a confidentiality question opened for it: an `ordinary` answer on
+// that question maps to a workspace audience, which is exactly the publication
+// the posture exists to refuse.
+func TestAHeldMailboxIsNotAskedToPublishItsMail(t *testing.T) {
+	e := integration.Setup(t)
+	const first = "kunde@partner.example"
+	const stranger = "anwalt@kanzlei.example"
+
+	seedClassifiedGmail(t, e, e.Rep1)
+	seedAttestedOutbound(t, e, "held-out-1", first, "held-t1")
+	captureInboundThroughRealSink(t, e, e.Rep1, "held-in-1", first, "held-t1")
+
+	// The thread is settled, and THEN the seat asks for their mail to be kept.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			UPDATE capture_thread_verdict
+			   SET status = 'cleared', seen_addresses = ARRAY[$2::text],
+			       resolved_at = now(), next_attempt_at = NULL
+			 WHERE thread_key = $1`, "held-t1", first); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(),
+			`UPDATE capture_connection SET mail_posture = 'held' WHERE user_id = $1`, e.Rep1)
+		return err
+	}); err != nil {
+		t.Fatalf("holding the mailbox: %v", err)
+	}
+
+	// A sender the verdict never read replies, which re-opens the question.
+	captureInboundThroughRealSink(t, e, e.Rep1, "held-in-2", stranger, "held-t1")
+
+	// The question, if one stands, must not be answerable: a claim is what
+	// spends an attempt and reaches a model, and a `cleared` answer to this
+	// thread would publish mail the seat asked to keep.
+	store := capture.NewThreadVerdictStore(InstallationDB(e.Pool))
+	claimed, err := store.ClaimDue(e.Admin(), 10)
+	if err != nil {
+		t.Fatalf("claiming due threads: %v", err)
+	}
+	for _, c := range claimed {
+		if c.ThreadKey == "held-t1" {
+			t.Fatal("an `always held` mailbox's thread was claimed for classification, and an " +
+				"`ordinary` answer publishes mail the seat asked to keep whatever a classifier concludes")
+		}
+	}
+}
+
+// seedClassifiedGmail connects a mailbox under the posture that holds its mail
+// until a classifier judges the thread — the only one that opens a question.
+//
+// account_label is what puts the seat's own address in the identity set, which
+// is the evidence an import row is written on: without it the sink stores the
+// activity and records no per-seat contribution at all.
+func seedClassifiedGmail(t *testing.T, e *integration.Env, user ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_connection
+			       (user_id, provider, status, credential_ref, mail_posture, account_label)
+			VALUES ($1, 'gmail', 'connected', 'vault:test', 'classified', 'a@authz.test')
+			ON CONFLICT (user_id, provider)
+			DO UPDATE SET mail_posture = 'classified', archived_at = NULL,
+			              account_label = 'a@authz.test'`, user)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a classified gmail connection: %v", err)
 	}
 }

--- a/backend/internal/compose/capturepromote_integration_test.go
+++ b/backend/internal/compose/capturepromote_integration_test.go
@@ -86,6 +86,10 @@ func captureInboundThroughRealSink(
 			Kind: "email", Subject: "Angebot", Body: "Anbei.", Direction: connector.DirectionInbound,
 		},
 		ThreadKey: threadKey,
+		// One of the SEAT's own addresses on the message, which is the evidence
+		// the import row is written on: without it the sink stores the activity
+		// but records no per-seat contribution, and nothing opens a question.
+		Addresses: []string{counterparty, "a@authz.test"},
 		Source:    "gmail:" + sourceID, CapturedBy: "connector:gmail",
 	})
 	if err != nil {
@@ -363,4 +367,82 @@ func domainAdmission(t *testing.T, e *integration.Env, domain string) string {
 		t.Fatalf("reading the admission of %s: %v", domain, err)
 	}
 	return admission
+}
+
+// TestAReopenedThreadKeepsSomethingToAskAbout covers the message that reopens a
+// settled thread from a mailbox whose posture opens nothing.
+//
+// The reopen clears first_activity_id so the classifier is not shown the text a
+// previous answer was about. Filling it again used to depend on the NEXT
+// message arriving under a `classified` posture — and a shared mailbox never
+// takes that branch, so the row sat pending with nothing to read: unclaimable
+// once the claim requires a readable message, and before that, claimed and
+// judged on a blank prompt.
+func TestAReopenedThreadKeepsSomethingToAskAbout(t *testing.T) {
+	e := integration.Setup(t)
+	const first = "kunde@partner.example"
+	const stranger = "anwalt@kanzlei.example"
+
+	// A classified mailbox: the posture that holds its mail until a classifier
+	// judges the thread, and so the only one that opens a question at all.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_connection
+			       (user_id, provider, status, credential_ref, mail_posture, account_label)
+			VALUES ($1, 'gmail', 'connected', 'vault:test', 'classified', 'a@authz.test')
+			ON CONFLICT (user_id, provider)
+			DO UPDATE SET mail_posture = 'classified', archived_at = NULL,
+			              account_label = 'a@authz.test'`, e.Rep1)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding a classified gmail connection: %v", err)
+	}
+
+	seedAttestedOutbound(t, e, "reopen-out-1", first, "reopen-t1")
+	captureInboundThroughRealSink(t, e, e.Rep1, "reopen-in-1", first, "reopen-t1")
+
+	// The thread is settled as ordinary, recording the sender it read.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			UPDATE capture_thread_verdict
+			   SET status = 'cleared', seen_addresses = ARRAY[$2::text],
+			       resolved_at = now(), next_attempt_at = NULL
+			 WHERE thread_key = $1`, "reopen-t1", first)
+		return err
+	}); err != nil {
+		t.Fatalf("settling the thread: %v", err)
+	}
+
+	// A sender the verdict never read replies on the same thread. That reopens
+	// the question, and this message is what the question is now about.
+	captureInboundThroughRealSink(t, e, e.Rep1, "reopen-in-2", stranger, "reopen-t1")
+
+	var status string
+	var pointer *ids.UUID
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT status, first_activity_id FROM capture_thread_verdict WHERE thread_key = $1`,
+			"reopen-t1").Scan(&status, &pointer)
+	}); err != nil {
+		t.Fatalf("reading the reopened thread: %v", err)
+	}
+	if status != capture.VerdictPending {
+		t.Fatalf("thread status = %q, want pending: an unseen sender must re-open the question", status)
+	}
+	if pointer == nil {
+		t.Fatal("the re-opened thread points at no message, so the classifier would be asked to " +
+			"judge an empty prompt — or, once the claim requires a readable message, never asked at all")
+	}
+	var pointedAt string
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT coalesce(counterparty_email, '') FROM activity WHERE id = $1`, *pointer).Scan(&pointedAt)
+	}); err != nil {
+		t.Fatalf("reading the message the re-opened question is about: %v", err)
+	}
+	if pointedAt != stranger {
+		t.Fatalf("the re-opened question is about mail from %q, want %q: the classifier must read the "+
+			"message that caused the re-open, not the one a previous answer already covered",
+			pointedAt, stranger)
+	}
 }

--- a/backend/internal/compose/confidentialityverdict_integration_test.go
+++ b/backend/internal/compose/confidentialityverdict_integration_test.go
@@ -153,6 +153,20 @@ func activityAudience(t *testing.T, e *integration.Env, id ids.UUID) string {
 // the row production would have written.
 func seedThreadQuestion(t *testing.T, e *integration.Env, threadKey string, activityID ids.UUID) ids.UUID {
 	t.Helper()
+	// The classified mailbox the question belongs to. A question is claimed
+	// only for a seat still asking to be classified, so a fixture without the
+	// connection describes a mailbox that never had one.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_connection
+			       (user_id, provider, status, credential_ref, mail_posture)
+			VALUES ($1, 'gmail', 'connected', 'vault:test', 'classified')
+			ON CONFLICT (user_id, provider)
+			DO UPDATE SET mail_posture = 'classified', archived_at = NULL`, e.Rep1)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the classified mailbox the question belongs to: %v", err)
+	}
 	store := capture.NewThreadVerdictStore(InstallationDB(e.Pool))
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return store.EnsureTx(context.Background(), tx, threadKey, e.Rep1, activityID, time.Now().Add(-time.Minute))
@@ -469,7 +483,16 @@ func TestAThreadWhoseMessageWasErasedRetiresRatherThanBeingJudgedOnNothing(t *te
 
 	// The erasure the retention path performs, which SET NULLs the pointer.
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(context.Background(), `DELETE FROM activity WHERE id = $1`, activityID)
+		if _, err := tx.Exec(context.Background(),
+			`DELETE FROM activity WHERE id = $1`, activityID); err != nil {
+			return err
+		}
+		// Past the grace a live capture is given to supply its own pointer.
+		// The erasure is minutes old by the time a sweep sees it; a row this
+		// second old belongs to a transaction still in flight.
+		_, err := tx.Exec(context.Background(),
+			`UPDATE capture_thread_verdict SET updated_at = now() - interval '1 hour' WHERE id = $1`,
+			threadID)
 		return err
 	}); err != nil {
 		t.Fatalf("erasing the message the question was about: %v", err)

--- a/backend/internal/compose/confidentialityverdict_integration_test.go
+++ b/backend/internal/compose/confidentialityverdict_integration_test.go
@@ -452,3 +452,114 @@ func personIsArchived(t *testing.T, e *integration.Env, id ids.PersonID) bool {
 	}
 	return archived
 }
+
+// TestAThreadWhoseMessageWasErasedRetiresRatherThanBeingJudgedOnNothing pins the
+// end of a question nothing can answer.
+//
+// first_activity_id is nullable and its foreign key is ON DELETE SET NULL, so
+// erasing the message a question was raised about leaves the question standing
+// with nothing to ask about. The claim used to take that row anyway: its
+// subject and body lookups return empty for a missing activity, so the model
+// was asked to judge a blank prompt and its answer was recorded as if it had
+// read the conversation.
+func TestAThreadWhoseMessageWasErasedRetiresRatherThanBeingJudgedOnNothing(t *testing.T) {
+	e := integration.Setup(t)
+	activityID := seedHeldThreadMail(t, e, "thread-erased", "kunde@example.test", "Angebot")
+	threadID := seedThreadQuestion(t, e, "thread-erased", activityID)
+
+	// The erasure the retention path performs, which SET NULLs the pointer.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `DELETE FROM activity WHERE id = $1`, activityID)
+		return err
+	}); err != nil {
+		t.Fatalf("erasing the message the question was about: %v", err)
+	}
+
+	store := capture.NewThreadVerdictStore(InstallationDB(e.Pool))
+	claimed, err := store.ClaimDue(e.Admin(), 10)
+	if err != nil {
+		t.Fatalf("claiming due threads: %v", err)
+	}
+	for _, c := range claimed {
+		if c.ID == threadID {
+			t.Fatal("a thread whose message is gone was claimed, and would be judged on an empty prompt")
+		}
+	}
+
+	if _, err := store.RetireExhausted(e.Admin(), "unreadable"); err != nil {
+		t.Fatalf("retiring: %v", err)
+	}
+	if got := threadStatus(t, e, threadID); got != "unsure" {
+		t.Fatalf("thread status = %q, want unsure: a question nothing can answer must reach a terminal state", got)
+	}
+}
+
+// TestAThreadPointedAtRestrictedMailIsNotJudgedOnAnEmptyPrompt is the same
+// failure reached by the other route.
+//
+// The claim's own subject and body lookups exclude a restricted row, so a
+// message put under a statutory hold after its question opened leaves the
+// classifier reading nothing while the row still looks answerable.
+func TestAThreadPointedAtRestrictedMailIsNotJudgedOnAnEmptyPrompt(t *testing.T) {
+	e := integration.Setup(t)
+	activityID := seedHeldThreadMail(t, e, "thread-restricted", "kunde@example.test", "Angebot")
+	threadID := seedThreadQuestion(t, e, "thread-restricted", activityID)
+
+	// A hold needs the evidence that qualified it: the database refuses a
+	// restriction that records no basis, which is the point of the trigger.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			INSERT INTO activity_retention_evidence
+			       (activity_id, basis, qualified_at, decided_by_name, reason)
+			VALUES ($1, 'controller_pin', now(), 'Datenschutz', 'litigation hold')`,
+			activityID); err != nil {
+			return err
+		}
+		// The whole shape a restriction takes: archived, with a reason and an
+		// end date. The schema refuses any partial version of it.
+		_, err := tx.Exec(context.Background(), `
+			UPDATE activity
+			   SET restricted_at = now(), archived_at = now(),
+			       restricted_reason = 'litigation hold',
+			       restricted_until = now() + interval '1 year',
+			       retention_class = 'commercial_correspondence', retention_class_at = now()
+			 WHERE id = $1`, activityID)
+		return err
+	}); err != nil {
+		t.Fatalf("placing the message under a hold: %v", err)
+	}
+
+	store := capture.NewThreadVerdictStore(InstallationDB(e.Pool))
+	claimed, err := store.ClaimDue(e.Admin(), 10)
+	if err != nil {
+		t.Fatalf("claiming due threads: %v", err)
+	}
+	for _, c := range claimed {
+		if c.ID == threadID {
+			t.Fatal("a thread pointed at restricted mail was claimed, and its prompt would carry no text")
+		}
+	}
+}
+
+// TestAReadableThreadIsStillClaimed is the admit case for the two refusals
+// above: a filter that refused everything would pass both of them.
+func TestAReadableThreadIsStillClaimed(t *testing.T) {
+	e := integration.Setup(t)
+	activityID := seedHeldThreadMail(t, e, "thread-readable", "kunde@example.test", "Angebot")
+	threadID := seedThreadQuestion(t, e, "thread-readable", activityID)
+
+	store := capture.NewThreadVerdictStore(InstallationDB(e.Pool))
+	claimed, err := store.ClaimDue(e.Admin(), 10)
+	if err != nil {
+		t.Fatalf("claiming due threads: %v", err)
+	}
+	for _, c := range claimed {
+		if c.ID == threadID {
+			if c.Subject != "Angebot" {
+				t.Fatalf("claimed subject = %q, want the message's own", c.Subject)
+			}
+			return
+		}
+	}
+	t.Fatal("a thread whose message is readable was not claimed")
+}

--- a/backend/internal/modules/capture/threadownerdecision.go
+++ b/backend/internal/modules/capture/threadownerdecision.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// What the MAILBOX OWNER concluded about a thread, which outranks the
+// classifier: the seat whose correspondence it is decides, and their answer is
+// recorded as its own status so a later reader can tell a person's decision
+// from a model's.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// DecideAsOwner records what the mailbox owner themselves concluded about a
+// thread, overruling whatever a classifier said.
+//
+// A human decision is not a verdict with a different author: it is the end of
+// the question. The row resolves, its attempts stop mattering, and no later
+// pass re-asks — a classifier that could overturn an owner would make the
+// owner's click advisory, which is not what a person clicking "keep this
+// private" is told they are doing.
+//
+// Own thread only. The ledger is per seat, so the row this writes is the
+// caller's own contribution and no other seat's is touched: a thread reaching
+// two mailboxes ends at the strictest of what the two of them ask for, and one
+// owner sharing cannot publish what the other holds.
+func (s *ThreadVerdictStore) DecideAsOwner(
+	ctx context.Context, tx pgx.Tx, threadKey string, share bool,
+) error {
+	if err := auth.RequireHuman(ctx); err != nil {
+		return err
+	}
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.UserID == ids.Nil {
+		return apperrors.ErrPermissionDenied
+	}
+	status := VerdictHeldByOwner
+	if share {
+		status = VerdictSharedByOwner
+	}
+	// Upserted, because a thread the owner decides about may have no ledger row
+	// at all: a message born open under a `shared` mailbox never opened a
+	// question, and its owner may still want it held.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO capture_thread_verdict
+		  (thread_key, user_id, status, disposition_reason, resolved_at, next_attempt_at)
+		VALUES ($1, $2, $3, $4, now(), NULL)
+		ON CONFLICT (thread_key, user_id) DO UPDATE
+		   SET status = EXCLUDED.status,
+		       disposition_reason = EXCLUDED.disposition_reason,
+		       resolved_at = now(),
+		       next_attempt_at = NULL,
+		       claimed_by = NULL, claimed_until = NULL,
+		       updated_at = now()`,
+		threadKey, actor.UserID, status, ownerDecisionReason); err != nil {
+		return fmt.Errorf("capture: recording the owner's decision about a thread: %w", err)
+	}
+	// The seat's own import rows for the thread, which is what the audience
+	// derivation reads. Without this the ledger would carry a decision nothing
+	// acts on.
+	// restricted_at excluded: a message under a statutory hold or an open
+	// erasure is not one an owner's click may move. The hold is an obligation
+	// the installation owes somebody else, and it outranks both directions of
+	// this decision — sharing a held message would publish it, and re-holding
+	// one changes nothing a hold has not already done.
+	if _, err := tx.Exec(ctx, `
+		UPDATE capture_import i
+		   SET verdict_status = $3
+		  FROM activity a
+		 WHERE a.id = i.activity_id
+		   AND a.thread_key = $1
+		   AND a.restricted_at IS NULL
+		   AND a.archived_at IS NULL
+		   AND i.user_id = $2`, threadKey, actor.UserID, status); err != nil {
+		return fmt.Errorf("capture: applying the owner's decision to their import rows: %w", err)
+	}
+	return nil
+}
+
+// ownerDecisionReason marks a ledger row a person settled, so a reader can tell
+// it from one a classifier reached.
+const ownerDecisionReason = "owner_decision"
+
+// ThreadActivityIDsTx lists the messages of one thread this seat imported.
+//
+// Scoped to the caller's own imports rather than to the thread key alone: a
+// thread key is the sender-controlled References root in a workspace-wide
+// namespace, so a walk over it would reach messages this seat never received.
+func ThreadActivityIDsTx(ctx context.Context, tx pgx.Tx, threadKey string, user ids.UUID) ([]ids.UUID, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT a.id FROM activity a
+		  JOIN capture_import i ON i.activity_id = a.id AND i.user_id = $2
+		 WHERE a.thread_key = $1 AND a.archived_at IS NULL
+		   AND a.restricted_at IS NULL
+		 ORDER BY a.id`, threadKey, user)
+	if err != nil {
+		return nil, fmt.Errorf("capture: listing a thread's messages: %w", err)
+	}
+	defer rows.Close()
+	var out []ids.UUID
+	for rows.Next() {
+		var id ids.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("capture: listing a thread's messages: %w", err)
+		}
+		out = append(out, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("capture: listing a thread's messages: %w", err)
+	}
+	return out, nil
+}

--- a/backend/internal/modules/capture/threadverdict.go
+++ b/backend/internal/modules/capture/threadverdict.go
@@ -139,6 +139,9 @@ func (s *ThreadVerdictStore) ClaimDue(ctx context.Context, limit int) ([]Pending
 			      AND next_attempt_at IS NOT NULL AND next_attempt_at <= now()
 			      AND (claimed_until IS NULL OR claimed_until <= now())
 			      AND attempts < $3
+			      AND EXISTS (SELECT 1 FROM activity a
+			                   WHERE a.id = first_activity_id
+			                     AND a.restricted_at IS NULL)
 			    ORDER BY next_attempt_at
 			    LIMIT $1
 			    FOR UPDATE SKIP LOCKED)
@@ -237,6 +240,15 @@ func (s *ThreadVerdictStore) Defer(
 // moving them to `unsure` — which HOLDS, because a thread nothing could judge
 // is exactly the one not to publish on a guess.
 //
+// It also ends the threads that CANNOT be judged: a row whose first_activity_id
+// names nothing readable. The column is nullable and the foreign key is
+// ON DELETE SET NULL, so erasing the message a question was raised about leaves
+// the question standing with nothing to ask about; a message later put under a
+// statutory hold reads the same way, because the claim's own subject and body
+// lookups exclude a restricted row. Both used to be claimed anyway and judged
+// on an empty prompt. Retiring them costs the model call and holds the mail,
+// which is the safe direction for a thread nothing can read.
+//
 // A terminal state, reached by spending the attempts rather than by a second
 // spelling of "give up".
 func (s *ThreadVerdictStore) RetireExhausted(ctx context.Context, reason string) (int64, error) {
@@ -247,8 +259,12 @@ func (s *ThreadVerdictStore) RetireExhausted(ctx context.Context, reason string)
 			   SET status = 'unsure', disposition_reason = NULLIF($1, ''),
 			       resolved_at = now(), next_attempt_at = NULL,
 			       claimed_until = NULL, claimed_by = NULL, updated_at = now()
-			 WHERE status = 'pending' AND attempts >= $2
-			   AND (claimed_until IS NULL OR claimed_until <= now())`,
+			 WHERE status = 'pending'
+			   AND (claimed_until IS NULL OR claimed_until <= now())
+			   AND (attempts >= $2 OR NOT EXISTS (
+			         SELECT 1 FROM activity a
+			          WHERE a.id = capture_thread_verdict.first_activity_id
+			            AND a.restricted_at IS NULL))`,
 			reason, ThreadVerdictMaxAttempts)
 		if err != nil {
 			return err
@@ -330,6 +346,17 @@ func openConfidentialityQuestionTx(
 		// A meeting or a channel message is not correspondence a
 		// confidentiality classifier was ever asked about.
 		return nil
+	}
+	// A message that INHERITED a pending verdict is the one the reopen is
+	// waiting for, whatever this mailbox's posture asks of it.
+	//
+	// The reopen clears first_activity_id so the classifier is not shown the
+	// text a previous answer was about. Something must then supply the message
+	// it IS about, and only this path has one in hand. Leaving it to the
+	// posture check below strands the row: a shared mailbox never reaches
+	// EnsureTx, the column stays NULL, and the claim has nothing to read.
+	if birth.verdictStatus == VerdictPending {
+		return (&ThreadVerdictStore{}).EnsureTx(ctx, tx, rec.ThreadKey, owner, id.UUID, time.Now())
 	}
 	// Checked on the posture rather than the derived audience, because `held`
 	// and `classified` collapse to the same audience and only the posture can

--- a/backend/internal/modules/capture/threadverdict.go
+++ b/backend/internal/modules/capture/threadverdict.go
@@ -22,11 +22,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/platform/database"
-	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
-	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
 )
 
@@ -35,6 +32,11 @@ import (
 // answer", and two different ceilings would be two different stories about the
 // same kind of giving up.
 const ThreadVerdictMaxAttempts = PendingMaxAttempts
+
+// ReasonThreadUnreadable retires a question whose message nothing can read —
+// erased while the question stood, or placed under a statutory hold since. It
+// is not an exhaustion: such a row can have spent no attempts at all.
+const ReasonThreadUnreadable = "the message the question was about is no longer readable"
 
 // threadVerdictLease is how long a claimed thread stays off other workers'
 // scans, matching the sender ledger's for the same reason.
@@ -117,7 +119,21 @@ func (s *ThreadVerdictStore) EnsureTx(
 	return nil
 }
 
-// ClaimDue takes up to limit threads whose next attempt has come round.
+// ClaimDue takes up to limit threads whose next attempt has come round, and
+// only for a mailbox that asked to be classified.
+//
+// The posture is re-read HERE, not trusted from whatever opened the question,
+// because a question outlives the moment it was raised. A seat whose thread was
+// cleared last week can switch their mailbox to `always held` today; the ledger
+// row is re-opened by the next unseen sender either way, and a `cleared` answer
+// to that re-opened question maps straight to a workspace audience. The claim is
+// the one chokepoint every question passes through, whoever opened it, so the
+// promise the posture makes — held to the people on it, whatever any classifier
+// concludes — is kept here rather than at each of the places a row is written.
+//
+// A row belonging to a mailbox that is no longer classified is left pending
+// rather than retired: the seat may switch back, and the question is still the
+// right one to ask if they do.
 //
 // The attempt is charged AT CLAIM, not at answer, which is what makes a worker
 // that dies mid-call cost one attempt rather than nothing: the bound is a
@@ -142,6 +158,10 @@ func (s *ThreadVerdictStore) ClaimDue(ctx context.Context, limit int) ([]Pending
 			      AND EXISTS (SELECT 1 FROM activity a
 			                   WHERE a.id = first_activity_id
 			                     AND a.restricted_at IS NULL)
+			      AND EXISTS (SELECT 1 FROM capture_connection c
+			                   WHERE c.user_id = capture_thread_verdict.user_id
+			                     AND c.archived_at IS NULL
+			                     AND c.mail_posture = 'classified')
 			    ORDER BY next_attempt_at
 			    LIMIT $1
 			    FOR UPDATE SKIP LOCKED)
@@ -249,6 +269,10 @@ func (s *ThreadVerdictStore) Defer(
 // on an empty prompt. Retiring them costs the model call and holds the mail,
 // which is the safe direction for a thread nothing can read.
 //
+// The two arms record two reasons. A row retired for an unreadable message can
+// have spent no attempts at all, and writing the caller's exhaustion reason on
+// it would put a false explanation in the ledger: nobody ran out of anything.
+//
 // A terminal state, reached by spending the attempts rather than by a second
 // spelling of "give up".
 func (s *ThreadVerdictStore) RetireExhausted(ctx context.Context, reason string) (int64, error) {
@@ -256,16 +280,26 @@ func (s *ThreadVerdictStore) RetireExhausted(ctx context.Context, reason string)
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE capture_thread_verdict
-			   SET status = 'unsure', disposition_reason = NULLIF($1, ''),
+			   SET status = 'unsure',
+			       disposition_reason = CASE
+			         WHEN attempts >= $2 THEN NULLIF($1, '')
+			         ELSE $3
+			       END,
 			       resolved_at = now(), next_attempt_at = NULL,
 			       claimed_until = NULL, claimed_by = NULL, updated_at = now()
 			 WHERE status = 'pending'
 			   AND (claimed_until IS NULL OR claimed_until <= now())
+			   -- A row a capture is filling in RIGHT NOW is not this pass's to
+			   -- end: the arriving message supplies the pointer in its own
+			   -- transaction, and retiring on a read taken before that commits
+			   -- would answer a question the mailbox had just re-asked. The
+			   -- grace is on updated_at, which every write to this row touches.
+			   AND updated_at < now() - interval '1 minute'
 			   AND (attempts >= $2 OR NOT EXISTS (
 			         SELECT 1 FROM activity a
 			          WHERE a.id = capture_thread_verdict.first_activity_id
 			            AND a.restricted_at IS NULL))`,
-			reason, ThreadVerdictMaxAttempts)
+			reason, ThreadVerdictMaxAttempts, ReasonThreadUnreadable)
 		if err != nil {
 			return err
 		}
@@ -347,22 +381,36 @@ func openConfidentialityQuestionTx(
 		// confidentiality classifier was ever asked about.
 		return nil
 	}
-	// A message that INHERITED a pending verdict is the one the reopen is
-	// waiting for, whatever this mailbox's posture asks of it.
+	// The posture decides whether this mailbox has a question at all, and it is
+	// read here rather than taken from the birth decision.
 	//
-	// The reopen clears first_activity_id so the classifier is not shown the
-	// text a previous answer was about. Something must then supply the message
-	// it IS about, and only this path has one in hand. Leaving it to the
-	// posture check below strands the row: a shared mailbox never reaches
-	// EnsureTx, the column stays NULL, and the claim has nothing to read.
-	if birth.verdictStatus == VerdictPending {
-		return (&ThreadVerdictStore{}).EnsureTx(ctx, tx, rec.ThreadKey, owner, id.UUID, time.Now())
+	// A message that INHERITED a verdict returns from the birth ladder before
+	// the posture is ever consulted, so birth.posture is empty for exactly the
+	// message a re-open is waiting for. Testing that empty field would open a
+	// question for an `always held` mailbox, whose mail stays with the people
+	// on it whatever a classifier concludes — and a `cleared` answer publishes
+	// to the workspace, which is the one thing that posture promises will not
+	// happen.
+	posture := birth.posture
+	if posture == "" {
+		read, err := mailboxPostureTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		posture = read
 	}
 	// Checked on the posture rather than the derived audience, because `held`
 	// and `classified` collapse to the same audience and only the posture can
 	// tell them apart.
-	if birth.posture != PostureClassified {
+	if posture != PostureClassified {
 		return nil
+	}
+	// A message that inherited a PENDING verdict is the one the re-open is
+	// waiting for. The re-open cleared first_activity_id so the classifier is
+	// not shown the text a previous answer was about; this message is what the
+	// question is now about, and only this path has it in hand.
+	if birth.verdictStatus == VerdictPending {
+		return (&ThreadVerdictStore{}).EnsureTx(ctx, tx, rec.ThreadKey, owner, id.UUID, time.Now())
 	}
 	if audience, _ := birth.bornAudience(); audience != audienceParticipants {
 		return nil
@@ -371,104 +419,4 @@ func openConfidentialityQuestionTx(
 	// touches no pool, which is what lets the capture path and the engine share
 	// one spelling of what opening a question means.
 	return (&ThreadVerdictStore{}).EnsureTx(ctx, tx, rec.ThreadKey, owner, id.UUID, time.Now())
-}
-
-// DecideAsOwner records what the mailbox owner themselves concluded about a
-// thread, overruling whatever a classifier said.
-//
-// A human decision is not a verdict with a different author: it is the end of
-// the question. The row resolves, its attempts stop mattering, and no later
-// pass re-asks — a classifier that could overturn an owner would make the
-// owner's click advisory, which is not what a person clicking "keep this
-// private" is told they are doing.
-//
-// Own thread only. The ledger is per seat, so the row this writes is the
-// caller's own contribution and no other seat's is touched: a thread reaching
-// two mailboxes ends at the strictest of what the two of them ask for, and one
-// owner sharing cannot publish what the other holds.
-func (s *ThreadVerdictStore) DecideAsOwner(
-	ctx context.Context, tx pgx.Tx, threadKey string, share bool,
-) error {
-	if err := auth.RequireHuman(ctx); err != nil {
-		return err
-	}
-	actor, ok := principal.Actor(ctx)
-	if !ok || actor.UserID == ids.Nil {
-		return apperrors.ErrPermissionDenied
-	}
-	status := VerdictHeldByOwner
-	if share {
-		status = VerdictSharedByOwner
-	}
-	// Upserted, because a thread the owner decides about may have no ledger row
-	// at all: a message born open under a `shared` mailbox never opened a
-	// question, and its owner may still want it held.
-	if _, err := tx.Exec(ctx, `
-		INSERT INTO capture_thread_verdict
-		  (thread_key, user_id, status, disposition_reason, resolved_at, next_attempt_at)
-		VALUES ($1, $2, $3, $4, now(), NULL)
-		ON CONFLICT (thread_key, user_id) DO UPDATE
-		   SET status = EXCLUDED.status,
-		       disposition_reason = EXCLUDED.disposition_reason,
-		       resolved_at = now(),
-		       next_attempt_at = NULL,
-		       claimed_by = NULL, claimed_until = NULL,
-		       updated_at = now()`,
-		threadKey, actor.UserID, status, ownerDecisionReason); err != nil {
-		return fmt.Errorf("capture: recording the owner's decision about a thread: %w", err)
-	}
-	// The seat's own import rows for the thread, which is what the audience
-	// derivation reads. Without this the ledger would carry a decision nothing
-	// acts on.
-	// restricted_at excluded: a message under a statutory hold or an open
-	// erasure is not one an owner's click may move. The hold is an obligation
-	// the installation owes somebody else, and it outranks both directions of
-	// this decision — sharing a held message would publish it, and re-holding
-	// one changes nothing a hold has not already done.
-	if _, err := tx.Exec(ctx, `
-		UPDATE capture_import i
-		   SET verdict_status = $3
-		  FROM activity a
-		 WHERE a.id = i.activity_id
-		   AND a.thread_key = $1
-		   AND a.restricted_at IS NULL
-		   AND a.archived_at IS NULL
-		   AND i.user_id = $2`, threadKey, actor.UserID, status); err != nil {
-		return fmt.Errorf("capture: applying the owner's decision to their import rows: %w", err)
-	}
-	return nil
-}
-
-// ownerDecisionReason marks a ledger row a person settled, so a reader can tell
-// it from one a classifier reached.
-const ownerDecisionReason = "owner_decision"
-
-// ThreadActivityIDsTx lists the messages of one thread this seat imported.
-//
-// Scoped to the caller's own imports rather than to the thread key alone: a
-// thread key is the sender-controlled References root in a workspace-wide
-// namespace, so a walk over it would reach messages this seat never received.
-func ThreadActivityIDsTx(ctx context.Context, tx pgx.Tx, threadKey string, user ids.UUID) ([]ids.UUID, error) {
-	rows, err := tx.Query(ctx, `
-		SELECT a.id FROM activity a
-		  JOIN capture_import i ON i.activity_id = a.id AND i.user_id = $2
-		 WHERE a.thread_key = $1 AND a.archived_at IS NULL
-		   AND a.restricted_at IS NULL
-		 ORDER BY a.id`, threadKey, user)
-	if err != nil {
-		return nil, fmt.Errorf("capture: listing a thread's messages: %w", err)
-	}
-	defer rows.Close()
-	var out []ids.UUID
-	for rows.Next() {
-		var id ids.UUID
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("capture: listing a thread's messages: %w", err)
-		}
-		out = append(out, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("capture: listing a thread's messages: %w", err)
-	}
-	return out, nil
 }

--- a/backend/internal/modules/capture/verdictinherit.go
+++ b/backend/internal/modules/capture/verdictinherit.go
@@ -135,9 +135,11 @@ func reopenClearedThreadTx(ctx context.Context, tx pgx.Tx, threadKey string) err
 	// triggered the re-ask. The unseen sender that caused the reopen would be
 	// judged by correspondence they were never part of.
 	//
-	// The next message on this thread supplies a new one: EnsureTx fills the
-	// column on the row it finds empty, and a claim skips a row that still has
-	// none rather than judging an empty prompt.
+	// The message that triggered this reopen supplies a new one: it inherits
+	// VerdictPending, and openConfidentialityQuestionTx fills the column with
+	// that message in this same transaction. A claim requires a readable
+	// activity, so a row that somehow reaches one without a pointer retires
+	// rather than being judged on an empty prompt.
 	if _, err := tx.Exec(ctx, `
 		UPDATE capture_thread_verdict
 		   SET status = 'pending', kind = NULL, confidence = NULL,


### PR DESCRIPTION
Two defects in the confidentiality-verdict path, both found while implementing the access-rights plan. The second is a privacy leak and was already on `main`.

## An always-held mailbox could have its mail published

The `Always held` posture promises, in the product's own words, that a message is "held to the people on it, whatever any classifier concludes". It was not.

A thread cleared while the mailbox was still `classified` is re-opened by a later message from a sender the verdict never read. The re-open does not consult the posture, so a seat who has since switched to `Always held` still has an open question — and a `cleared` answer maps straight to a workspace audience.

The posture is now re-read at the **claim**, the one chokepoint every question passes through whoever opened it. A row whose mailbox is no longer classified stays pending rather than retiring, because the seat may switch back.

## A question with nothing to read was still asked

Three ways a thread reached the classifier with an empty prompt, its answer recorded as though the model had read the conversation:

- An unseen sender re-opens a settled thread, which clears the pointer to the message. Refilling it depended on the *next* message arriving under a classified posture — but the message that caused the re-open is the one the question is now about, and a shared mailbox never took that branch.
- `first_activity_id` is nullable with an `ON DELETE SET NULL` foreign key, so erasing the message leaves the question standing.
- A message later placed under a statutory hold reads the same way, because the claim's own subject and body lookups exclude a restricted row.

Now the message that inherits a pending verdict fills the pointer, a claim requires a message it can actually read, and a row whose message is gone or held retires to `unsure` — which holds the mail, the safe direction.

## Also

- The two retirement arms record two reasons. A row retired for an unreadable message can have spent no attempts, and "the attempts ran out" was a false entry in the ledger.
- Retirement leaves a one-minute grace so a sweep cannot end a row a capture is filling in right now.
- `threadverdict.go` crossed the 500-line cap; the owner-decision half moves to `threadownerdecision.go`.

## Tests

Seven integration tests, each mutation-checked (revert the guard, watch the named assertion fail). `TestAReadableThreadIsStillClaimed` is the admit case, so a filter that refused everything cannot pass. Full `make check-backend` green, plus the whole `internal/compose` and `internal/modules/capture` integration lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two confidentiality-verdict defects: an `always held` mailbox could have its mail published to the workspace, and verdict questions with nothing to read were still claimed and judged on blank prompts.

**Bug Fixes**
- The mailbox posture is now re-read when a pending question is claimed, so a thread cleared under `classified` cannot be re-opened and published after the seat switches to `always held`.
- The message that reopens a settled thread now fills the question's message pointer in the same transaction.
- A question whose message was erased or placed under a statutory hold retires to `unsure`, which holds the mail, instead of being claimed without readable text.
- Retirement records `unreadable` as its reason rather than a false "attempts exhausted", and waits one minute so a capture filling in a row is not cut off.
- The owner-decision code moved from `threadverdict.go` to `threadownerdecision.go` to stay under the line cap.

<sup>Written for commit a5f33ff006c47c272cf1b1eed15bbee1172c4012. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread questions so reopened conversations reference newly received activity.
  * Prevented restricted, deleted, archived, or otherwise unreadable messages from being evaluated with empty prompts.
  * Unreadable pending questions are now retired with an appropriate “unsure” outcome.
  * Only currently classified mailboxes can contribute to thread classification questions.
  * Preserved access to readable threads for claiming and evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->