### PR TITLE
A country states how often it may be advertised to, and the engine counts what arrived

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,11 @@ coverage-extensions.out
 # an unrelated future /build asset is never silently hidden), and
 # extensions/ is the installation-owned enabled set. The vanilla tree
 # ships the placeholder, the approval lock, and the FIRST-PARTY units
-# enabled by default (extensions/de, the German jurisdiction pack;
-# extensions/openchannel, the reference connector — presence under
-# extensions/ IS the enablement, so a unit missing from the un-ignore
-# list below is a unit no clone of this repository has).
+# enabled by default (extensions/de and extensions/vn, the German and
+# Vietnamese jurisdiction packs; extensions/openchannel, the reference
+# connector — presence under extensions/ IS the enablement, so a unit
+# missing from the un-ignore list below is a unit no clone of this
+# repository has).
 /build/composition/
 # The SECOND composition root, and it exists for a reason that is not tidiness:
 # gen-composition's -verify requires build/composition/ to hold EXACTLY the files
@@ -40,6 +41,7 @@ coverage-extensions.out
 !/extensions/approvals.lock
 !/extensions/de
 !/extensions/openchannel
+!/extensions/vn
 # A unit's installed frontend dependencies. Its package.json and the workspace
 # lockfile are what ship; node_modules is what pnpm makes from them, and it is
 # per-member now that a unit's frontend layer is a workspace package.

--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -22,7 +22,6 @@ import (
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/comms"
-	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/jobs"
@@ -360,7 +359,7 @@ func newSendWorker(pool *pgxpool.Pool, registry *capture.Registry, pacing SendPa
 		commsResolver{registry: registry, channels: registry},
 		NewSendSeatAuthority(pool),
 		NewSendAttachmentAuthority(pool, blob),
-		consent.NewGate(consent.NewStore(InstallationDB(pool))),
+		consentGateFor(pool),
 		[]comms.SendPolicy{comms.NewMailboxRatePolicy(p.Limit, p.Window, time.Now)},
 		time.Now,
 		p.MaxAge,

--- a/backend/internal/compose/commsscheduled.go
+++ b/backend/internal/compose/commsscheduled.go
@@ -14,7 +14,6 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/margince/margince/backend/internal/modules/activities"
-	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/blobstore"
 	"github.com/margince/margince/backend/internal/platform/database"
@@ -118,7 +117,7 @@ func newScheduledSendWorker(pool *pgxpool.Pool, delivery DeliveryMachinery, blob
 		pool:      pool,
 		store:     sendStore(pool, SendPath{}).WithBlobstore(blob),
 		authority: identity.NewService(pool),
-		consent:   consent.NewGate(consent.NewStore(InstallationDB(pool))),
+		consent:   consentGateFor(pool),
 		// The SAME machinery every other send stages with, handed in rather
 		// than built here: firing enqueues a delivery job, and a second
 		// construction site would be a second way for the two to disagree.

--- a/backend/internal/compose/commsscheduled_integration.go
+++ b/backend/internal/compose/commsscheduled_integration.go
@@ -22,7 +22,6 @@ import (
 	"github.com/riverqueue/river/rivertype"
 
 	"github.com/margince/margince/backend/internal/modules/activities"
-	"github.com/margince/margince/backend/internal/modules/consent"
 	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/jobs"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -92,7 +91,7 @@ func ScheduleAsAgentForTest(
 		principal.WithActor(principal.WithWorkspaceID(ctx, workspace), actor), ids.NewV7())
 	return store.SendOrSchedule(agentCtx, activities.FromActivity(anchor), in,
 		&activities.SendSchedule{At: at, TZ: "Europe/Berlin"},
-		consent.NewGate(consent.NewStore(InstallationDB(pool))),
+		consentGateFor(pool),
 		NewDeliveryStager(pool, inserter), NewScheduleTimer(inserter))
 }
 

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -177,7 +177,14 @@ func (s *Server) applySendPath(pool *pgxpool.Pool) {
 // this is composition naming a dependency, every caller assigns it into the
 // seam itself, and widening here would only hide which gate was built.
 func consentGateFor(pool *pgxpool.Pool) *consent.Gate {
-	return consent.NewGate(consent.NewStore(InstallationDB(pool)))
+	return consent.NewGate(consent.NewStore(InstallationDB(pool))).
+		// Where the installation is established, which selects the messaging
+		// rules a decision is taken under. Injected rather than read directly
+		// because the setting belongs to identity and consent may not import a
+		// sibling — and injected HERE, in the one construction every send path
+		// goes through, so no surface can end up with a gate that resolves no
+		// jurisdiction and quietly skips a statutory ceiling.
+		WithInstallationCountry(consent.InstallationCountryFunc(identity.CountryOf))
 }
 
 // lateApprovalEffect is one kind's approve-side pair: the executor that runs

--- a/backend/internal/modules/consent/authorizecap.go
+++ b/backend/internal/modules/consent/authorizecap.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The jurisdiction frequency ceiling: how many advertising messages one address
+// may receive in a rolling window, and why the count is of messages that were
+// actually delivered.
+//
+// A cap is a fact about VOLUME rather than about a person. Nothing the
+// recipient did refuses the message, and the same message becomes lawful again
+// once the window rolls — which is why a cap refusal is not one of the absolute
+// denials and why its reason code says so.
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/messagingrules"
+)
+
+// capLockNamespace keys this module's advisory locks apart from every other
+// user of pg_advisory_xact_lock in the installation. It occupies the high half
+// of the single-argument bigint key, so a collision with another subsystem's
+// lock on the same number is impossible rather than unlikely.
+const capLockNamespace = int64(0x636d7361) << 32 // "cmsa"
+
+// applyFrequencyCap refuses an advertising message that would exceed the
+// applicable jurisdiction's ceiling for this address.
+//
+// It runs only for a decision the engine has ALREADY decided to allow, and only
+// for advertising. A cap cannot rescue a refused message and does not bind an
+// operational one, so asking about either would be counting for nothing.
+//
+// The lock comes before the count, and that ordering is the whole guarantee.
+// Two dispatches for the same address that both read "two below the cap" would
+// both send a third message, and the ceiling would be exceeded by exactly the
+// number of concurrent workers. Holding a transaction-scoped advisory lock on
+// the address makes the read-decide-send sequence serial per address, and the
+// lock is released by the commit that records the decision — so a crash cannot
+// strand it.
+func (g *Gate) applyFrequencyCap(ctx context.Context, tx pgx.Tx, d commsauthz.Decision, now time.Time) (commsauthz.Decision, error) {
+	if d.Verdict != commsauthz.VerdictAllow || d.Resolved != commsauthz.CategoryMarketing {
+		return d, nil
+	}
+	address := strings.TrimSpace(d.Recipient.Email)
+	if address == "" {
+		// A channel recipient has no address for a per-address ceiling to bind
+		// to. The cap the packs declare is on advertising EMAIL, so a channel
+		// message is out of its scope rather than exempt from an applicable
+		// rule — stated here because silence would read as an oversight.
+		return d, nil
+	}
+	rules, applicable, err := g.applicableRules(ctx, tx)
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	if !applicable || rules.FrequencyCap == nil {
+		return d, nil
+	}
+	if err := lockAddressForCap(ctx, tx, address); err != nil {
+		return commsauthz.Decision{}, err
+	}
+	received, err := advertisingMessagesReceived(ctx, tx, address, now.Add(-rules.FrequencyCap.Window))
+	if err != nil {
+		return commsauthz.Decision{}, err
+	}
+	if received < rules.FrequencyCap.Messages {
+		return d, nil
+	}
+	d.Verdict = commsauthz.VerdictDeny
+	d.ReasonCode = commsauthz.ReasonFrequencyCapReached
+	return d, nil
+}
+
+// lockAddressForCap serializes the count-and-decide for one address.
+//
+// The address is hashed rather than used directly because the lock key is an
+// integer. A hash collision costs two unrelated addresses a moment of
+// serialization and never costs correctness — the opposite trade from a lock
+// that could be MISSED, which would let the cap be exceeded.
+//
+// Transaction-scoped (pg_advisory_xact_lock, not the session form): the lock
+// ends with the transaction that records the decision, so nothing has to
+// remember to release it and a failed transaction cannot hold an address shut.
+func lockAddressForCap(ctx context.Context, tx pgx.Tx, address string) error {
+	h := fnv.New32a()
+	// Hash writes never fail; the interface returns an error for io.Writer
+	// compatibility. Lower-cased so two spellings of one mailbox take the same
+	// lock, matching how the count below compares addresses.
+	if _, err := h.Write([]byte(strings.ToLower(address))); err != nil {
+		return fmt.Errorf("consent: key the frequency-cap lock: %w", err)
+	}
+	// The single-argument bigint form, so the namespace and the hash occupy
+	// separate halves of one key with no conversion that could narrow either.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`,
+		capLockNamespace|int64(h.Sum32())); err != nil {
+		return fmt.Errorf("consent: hold the frequency-cap lock for this address: %w", err)
+	}
+	return nil
+}
+
+// advertisingMessagesReceived counts what the recipient ACTUALLY GOT.
+//
+// The join is the invariant. A count over communication_decision alone would
+// include a decision taken in observe mode (which records what the engine would
+// have said while the old gate ruled) and a delivery that was staged and then
+// parked — both of which describe a message nobody received. Counting either
+// would consume somebody's statutory allowance for mail that never arrived, and
+// the person would be silenced for a day by an accounting error.
+//
+// So the count starts from comms_outbound rows that reached 'sent' — the status
+// every reader in this tree takes to mean the provider accepted the message —
+// and joins each to its own transmit decision to establish that it was
+// ADVERTISING. Neither half is sufficient alone: the delivery says it went, the
+// decision says what it was.
+func advertisingMessagesReceived(ctx context.Context, tx pgx.Tx, address string, since time.Time) (int, error) {
+	var count int
+	err := tx.QueryRow(ctx, `
+		SELECT count(DISTINCT o.id)
+		  FROM comms_outbound o
+		  JOIN communication_decision d ON d.delivery_id = o.id
+		 WHERE o.status = 'sent'
+		   AND o.sent_at IS NOT NULL
+		   AND o.sent_at >= $2
+		   AND d.phase = 'transmit'
+		   AND d.verdict = 'allow'
+		   AND d.resolved_category = $3
+		   AND lower(d.recipient_address) = lower($1)`,
+		address, since, string(commsauthz.CategoryMarketing)).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("consent: count the advertising this address received: %w", err)
+	}
+	return count, nil
+}
+
+// applicableRules resolves which jurisdiction's messaging rules bind this
+// installation's outbound mail.
+//
+// Today that is the country the installation declares. The recipient's own
+// country is the other half and is not read yet: the product records no
+// reliable recipient country, and guessing one from an email domain would apply
+// a foreign ceiling on a guess. When that evidence exists the resolution folds
+// both codes through messagingrules.Strictest, which is why this returns the
+// FOLD of a code list rather than a single lookup.
+//
+// An unstated or unknown country resolves to no rules, and no rules means no
+// ceiling — not because an unknown country is permissive, but because a cap is
+// a jurisdiction's own number and there is no universal one to fall back to.
+// The consent requirement that DOES bind everywhere is enforced by the marketing
+// verdict itself, which runs before this and does not depend on a pack.
+func (g *Gate) applicableRules(ctx context.Context, tx pgx.Tx) (messagingrules.Rules, bool, error) {
+	code, err := g.installationCountry(ctx, tx)
+	if err != nil {
+		return messagingrules.Rules{}, false, err
+	}
+	if code == "" {
+		return messagingrules.Rules{}, false, nil
+	}
+	rules, _, found := messagingrules.Strictest(code)
+	return rules, found, nil
+}

--- a/backend/internal/modules/consent/authorizecap.go
+++ b/backend/internal/modules/consent/authorizecap.go
@@ -16,12 +16,14 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
 	"github.com/margince/margince/backend/internal/shared/ports/messagingrules"
 )
 
@@ -45,6 +47,31 @@ const capLockNamespace = int64(0x636d7361) << 32 // "cmsa"
 // the address makes the read-decide-send sequence serial per address, and the
 // lock is released by the commit that records the decision — so a crash cannot
 // strand it.
+// lockCapAddresses takes every recipient's cap lock before any of them is
+// counted, when a ceiling is in force. It is separate from applyFrequencyCap
+// because the ORDER matters across the whole message: the locks must all be
+// held, sorted, before the first count, and a per-recipient lock taken inside
+// the decide loop would order them by the caller's To list.
+func (g *Gate) lockCapAddresses(ctx context.Context, tx pgx.Tx, recipients []connector.Recipient) error {
+	rules, applicable, err := g.applicableRules(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if !applicable || rules.FrequencyCap == nil {
+		return nil
+	}
+	addresses := make([]string, 0, len(recipients))
+	for _, r := range recipients {
+		if a := strings.TrimSpace(r.Email); a != "" {
+			addresses = append(addresses, a)
+		}
+	}
+	if len(addresses) == 0 {
+		return nil
+	}
+	return lockAddressesForCap(ctx, tx, addresses)
+}
+
 func (g *Gate) applyFrequencyCap(ctx context.Context, tx pgx.Tx, d commsauthz.Decision, now time.Time) (commsauthz.Decision, error) {
 	if d.Verdict != commsauthz.VerdictAllow || d.Resolved != commsauthz.CategoryMarketing {
 		return d, nil
@@ -64,9 +91,6 @@ func (g *Gate) applyFrequencyCap(ctx context.Context, tx pgx.Tx, d commsauthz.De
 	if !applicable || rules.FrequencyCap == nil {
 		return d, nil
 	}
-	if err := lockAddressForCap(ctx, tx, address); err != nil {
-		return commsauthz.Decision{}, err
-	}
 	received, err := advertisingMessagesReceived(ctx, tx, address, now.Add(-rules.FrequencyCap.Window))
 	if err != nil {
 		return commsauthz.Decision{}, err
@@ -79,61 +103,128 @@ func (g *Gate) applyFrequencyCap(ctx context.Context, tx pgx.Tx, d commsauthz.De
 	return d, nil
 }
 
-// lockAddressForCap serializes the count-and-decide for one address.
+// lockAddressesForCap serializes the count-and-decide for every address this
+// message will be judged against, ALL OF THEM UP FRONT and in sorted order.
 //
-// The address is hashed rather than used directly because the lock key is an
-// integer. A hash collision costs two unrelated addresses a moment of
-// serialization and never costs correctness — the opposite trade from a lock
-// that could be MISSED, which would let the cap be exceeded.
+// One lock per recipient taken as the decide loop reaches it would take them in
+// the order the caller supplied the recipients. Two messages naming the same
+// two addresses in opposite orders would then take the same pair of locks in
+// opposite orders, Postgres would resolve it by killing one transaction, and a
+// legitimate send would burn its retry ladder — a deadlock a caller can provoke
+// by choosing a To order. Sorting and deduplicating first makes that
+// impossible to express, which is the discipline storekit.LockSubjectKeys
+// already applies to subject locks for the same reason.
 //
-// Transaction-scoped (pg_advisory_xact_lock, not the session form): the lock
-// ends with the transaction that records the decision, so nothing has to
-// remember to release it and a failed transaction cannot hold an address shut.
-func lockAddressForCap(ctx context.Context, tx pgx.Tx, address string) error {
-	h := fnv.New32a()
-	// Hash writes never fail; the interface returns an error for io.Writer
-	// compatibility. Lower-cased so two spellings of one mailbox take the same
-	// lock, matching how the count below compares addresses.
-	if _, err := h.Write([]byte(strings.ToLower(address))); err != nil {
-		return fmt.Errorf("consent: key the frequency-cap lock: %w", err)
-	}
-	// The single-argument bigint form, so the namespace and the hash occupy
-	// separate halves of one key with no conversion that could narrow either.
-	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`,
-		capLockNamespace|int64(h.Sum32())); err != nil {
-		return fmt.Errorf("consent: hold the frequency-cap lock for this address: %w", err)
+// The address is hashed because the lock key is an integer. A hash collision
+// costs two unrelated addresses a moment of serialization and never costs
+// correctness — the opposite trade from a lock that could be MISSED, which
+// would let the ceiling be exceeded.
+//
+// Transaction-scoped (pg_advisory_xact_lock, not the session form): the locks
+// end with the transaction that records the decisions, so nothing has to
+// remember to release them and a failed transaction cannot hold an address
+// shut.
+func lockAddressesForCap(ctx context.Context, tx pgx.Tx, addresses []string) error {
+	for _, key := range capLockKeys(addresses) {
+		// The single-argument bigint form, so the namespace and the hash
+		// occupy separate halves of one key with no conversion that could
+		// narrow either.
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, key); err != nil {
+			return fmt.Errorf("consent: hold the frequency-cap lock for this address: %w", err)
+		}
 	}
 	return nil
 }
 
-// advertisingMessagesReceived counts what the recipient ACTUALLY GOT.
+// capLockKeys is the order the locks are taken in: sorted and deduplicated, so
+// two messages naming the same addresses take the same locks in the same order
+// whatever order their recipients arrived in. This is the ordering itself
+// rather than a step inside the locker, so a test can assert the property
+// without running two transactions and hoping they cross.
+func capLockKeys(addresses []string) []int64 {
+	keys := make([]int64, 0, len(addresses))
+	for _, address := range addresses {
+		keys = append(keys, capLockKey(address))
+	}
+	slices.Sort(keys)
+	return slices.Compact(keys)
+}
+
+// capLockKey is one address's lock key: the namespace in the high half, the
+// address hash in the low half. Lower-cased and trimmed so two spellings of one
+// mailbox take the same lock, matching how the count compares addresses.
+func capLockKey(address string) int64 {
+	h := fnv.New32a()
+	// hash.Hash documents Write as never returning an error; it carries one
+	// only to satisfy io.Writer. Discarded explicitly rather than silently, so
+	// a reader can see the claim and check it.
+	//craft:ignore T2 hash.Hash.Write is documented never to fail
+	_, _ = h.Write([]byte(normalizeCapAddress(address)))
+	return capLockNamespace | int64(h.Sum32())
+}
+
+// normalizeCapAddress answers "which mailbox is this" for both the lock key and
+// the count's comparison. Two answers would mean an address could be locked
+// under one form and counted under another, and the ceiling would bind to
+// neither.
 //
-// The join is the invariant. A count over communication_decision alone would
-// include a decision taken in observe mode (which records what the engine would
-// have said while the old gate ruled) and a delivery that was staged and then
-// parked — both of which describe a message nobody received. Counting either
-// would consume somebody's statutory allowance for mail that never arrived, and
-// the person would be silenced for a day by an accounting error.
+// Held by: TestTheLockAndTheCountNormalizeAlike (authorizecaplock_test.go)
+func normalizeCapAddress(address string) string {
+	return strings.ToLower(strings.TrimSpace(address))
+}
+
+// advertisingMessagesReceived counts what the recipient has GOT or is ABOUT TO
+// GET, and both halves are load-bearing.
 //
-// So the count starts from comms_outbound rows that reached 'sent' — the status
-// every reader in this tree takes to mean the provider accepted the message —
-// and joins each to its own transmit decision to establish that it was
-// ADVERTISING. Neither half is sufficient alone: the delivery says it went, the
-// decision says what it was.
+// The delivered half is the obvious one, and the join under it is the rule. A
+// count over communication_decision alone would include a decision taken in
+// observe mode (which records what the engine would have said while the old
+// gate ruled) and a delivery that was staged and then parked — both of which
+// describe a message nobody received. Counting either would consume somebody's
+// statutory allowance for mail that never arrived, and the person would be
+// silenced for a day by an accounting error. So a delivered message is a
+// comms_outbound row that reached 'sent' joined to its own transmit decision:
+// the delivery says it went, the decision says what it was.
+//
+// The IN-FLIGHT half is what makes the ceiling actually bind. An authorization
+// commits before the provider is called — it must, because provider I/O cannot
+// sit inside a transaction — and 'sent' is written afterwards by a different
+// transaction. So between deciding and sending there is a window in which a
+// message is going out and no 'sent' row says so. Counting only delivered mail
+// would let every worker in that window read the same number and each send,
+// and the ceiling would be exceeded by however many workers happened to be
+// running. An allowing transmit decision against a delivery that is still
+// pending IS that message: it was written under the address lock, it exists
+// exactly once per attempt, and it resolves within the ladder to either a
+// 'sent' row (which the first half then counts, and DISTINCT keeps from
+// counting twice) or a park (which stops matching, returning the allowance).
+//
+// Art. 17 erasure rewrites recipient_address to a placeholder, so a subject's
+// advertising history stops matching this count and a re-captured address
+// starts from zero. That is the right answer — the count is evidence about a
+// person, and erasure is meant to destroy it — but it is worth saying, because
+// nothing else in this file would tell a reader that another engine can empty
+// the record the ceiling rests on.
 func advertisingMessagesReceived(ctx context.Context, tx pgx.Tx, address string, since time.Time) (int, error) {
 	var count int
 	err := tx.QueryRow(ctx, `
 		SELECT count(DISTINCT o.id)
 		  FROM comms_outbound o
 		  JOIN communication_decision d ON d.delivery_id = o.id
-		 WHERE o.status = 'sent'
-		   AND o.sent_at IS NOT NULL
-		   AND o.sent_at >= $2
-		   AND d.phase = 'transmit'
+		 WHERE d.phase = 'transmit'
 		   AND d.verdict = 'allow'
 		   AND d.resolved_category = $3
-		   AND lower(d.recipient_address) = lower($1)`,
-		address, since, string(commsauthz.CategoryMarketing)).Scan(&count)
+		   -- Trimmed and lowered on BOTH sides, matching normalizeCapAddress.
+		   -- The stored key is the address as the caller supplied it (the
+		   -- dispatcher already normalizes, other callers of this public gate
+		   -- need not), so comparing raw would let a leading space or a
+		   -- capital reach a capped mailbox again.
+		   AND lower(btrim(d.recipient_address)) = $1
+		   AND (
+		         (o.status = 'sent' AND o.sent_at IS NOT NULL AND o.sent_at >= $2)
+		      OR (o.status = 'pending' AND d.decided_at >= $2)
+		       )`,
+		normalizeCapAddress(address), since, string(commsauthz.CategoryMarketing)).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("consent: count the advertising this address received: %w", err)
 	}

--- a/backend/internal/modules/consent/authorizecap_integration_test.go
+++ b/backend/internal/modules/consent/authorizecap_integration_test.go
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// What the frequency cap counts, which is the whole rule.
+//
+// The ceiling is on messages the recipient RECEIVED. Two shapes look like a
+// delivered advertising message and are not: a delivery that was staged and
+// then parked, and a decision taken in observe mode while the old gate still
+// ruled. Counting either would consume somebody's statutory allowance for mail
+// that never arrived, and they would be silenced for a day by an accounting
+// error nobody could see — the decision rows would all look correct.
+//
+// This is an integration test because the invariant IS the SQL: the join
+// between a sent delivery and its transmit decision is what separates the three
+// cases, and no unit test of a Go function can show that the query does it.
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/testdb"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+	"github.com/margince/margince/backend/internal/shared/ports/connector"
+	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+	"github.com/margince/margince/backend/internal/shared/ports/messagingrules"
+)
+
+// marketingPurposeKey names the purpose the cap test sends under. Advertising
+// is the only category a frequency cap binds, so a test that sent under any
+// other purpose would prove nothing about the ceiling.
+const marketingPurposeKey = "marketing_email"
+
+type capEnv struct {
+	store    *Store
+	ctx      context.Context
+	owner    *pgx.Conn
+	ws, user ids.UUID
+	activity ids.UUID
+	address  string
+	// decisionDelivery is the delivery the transmit decisions are recorded
+	// against. It is deliberately NOT one of the delivered rows the counter
+	// reads: a decision row must be able to exist for a delivery that has not
+	// been sent, which is the whole distinction under test.
+	decisionDelivery ids.UUID
+}
+
+// seedMarketingSubject gives the address a person with a live marketing grant,
+// so the engine reaches an allow and the cap is what refuses. Without the grant
+// every message would be denied for want of consent and the ceiling would never
+// be the reason.
+func (e *capEnv) seedMarketingSubject(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	personID := ids.New[ids.PersonKind]()
+	purposeID := ids.New[ids.PurposeKind]()
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO person (id, full_name, source, captured_by)
+		VALUES ($1, 'Cap Subject', 'manual', 'human:x')`, personID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO person_email (person_id, email, is_primary, source, captured_by)
+		VALUES ($1, $2, true, 'manual', 'human:x')`, personID, e.address); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO consent_purpose (id, key, label, class, requires_double_opt_in)
+		VALUES ($1, $2, 'Marketing email', 'marketing', false)`,
+		purposeID, marketingPurposeKey); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO person_consent (person_id, purpose_id, state, lawful_basis, captured_at, source)
+		VALUES ($1, $2, 'granted', 'consent', now(), 'test')`, personID, purposeID); err != nil {
+		t.Fatal(err)
+	}
+	// The delivery the transmit decisions attach to. Left 'pending' on purpose:
+	// it must never be counted as received.
+	e.decisionDelivery = ids.NewV7()
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO comms_outbound
+		  (id, activity_id, user_id, provider, message_id, recipients, cc, subject, body,
+		   consent_purpose, references_chain, status)
+		VALUES ($1, $2, $3, 'gmail', $4, $5, '[]'::jsonb, 'Offer', 'body', $6, '[]'::jsonb, 'pending')`,
+		e.decisionDelivery, e.activity, e.user, "msg-"+e.decisionDelivery.String(),
+		`["`+e.address+`"]`, marketingPurposeKey); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupCap(t *testing.T) *capEnv {
+	t.Helper()
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if ownerDSN == "" || appDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	ctx := context.Background()
+	owner, err := pgx.Connect(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+	if err := testdb.Reset(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &capEnv{
+		ws: ids.NewV7(), user: ids.NewV7(), activity: ids.NewV7(),
+		owner: owner, address: "buyer@cap.test",
+	}
+	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id) VALUES ($1)`, e.ws); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := owner.Exec(ctx,
+		`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Rep')`,
+		e.user, "rep-"+e.user.String()+"@cap.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO activity (id, kind, direction, source, occurred_at, captured_by)
+		VALUES ($1, 'email', 'outbound', 'manual', now(), 'human:x')`, e.activity); err != nil {
+		t.Fatal(err)
+	}
+
+	pool, err := testdb.Pool(ctx, appDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
+	e.store = NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](e.ws)))
+
+	opCtx := principal.WithWorkspaceID(context.Background(), e.ws)
+	opCtx = principal.WithCorrelationID(opCtx, ids.NewV7())
+	e.ctx = principal.WithActor(opCtx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.user.String(), UserID: e.user,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"admin"},
+			Objects: map[string]principal.ObjectGrant{
+				"person": {Create: true, Read: true, Update: true, Delete: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	return e
+}
+
+// deliveredAdvertising plants what the cap is supposed to count: a delivery
+// that reached 'sent' with an allowing transmit decision for advertising.
+func (e *capEnv) deliveredAdvertising(t *testing.T, sentAt time.Time) {
+	t.Helper()
+	e.plant(t, plantSpec{
+		status: "sent", sentAt: &sentAt, phase: "transmit",
+		verdict: "allow", category: string(commsauthz.CategoryMarketing), mode: "enforce",
+	})
+}
+
+type plantSpec struct {
+	status   string
+	sentAt   *time.Time
+	phase    string
+	verdict  string
+	category string
+	mode     string
+}
+
+// plant writes one delivery and one decision about it, exactly as the two
+// writers would. The point of the test is which COMBINATIONS count, so the
+// shapes are built from a spec rather than from four near-identical helpers.
+func (e *capEnv) plant(t *testing.T, spec plantSpec) {
+	t.Helper()
+	ctx := context.Background()
+	deliveryID := ids.NewV7()
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO comms_outbound
+		  (id, activity_id, user_id, provider, message_id, recipients, cc, subject, body,
+		   consent_purpose, references_chain, status, sent_at)
+		VALUES ($1, $2, $3, 'gmail', $4, $5, '[]'::jsonb, 'Offer', 'body',
+		        'marketing', '[]'::jsonb, $6, $7)`,
+		deliveryID, e.activity, e.user, "msg-"+deliveryID.String(),
+		`["`+e.address+`"]`, spec.status, spec.sentAt); err != nil {
+		t.Fatalf("planting the delivery: %v", err)
+	}
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO communication_decision
+		  (delivery_id, attempt, decision_set_id, recipient_address, phase,
+		   resolved_category, verdict, reason_code, mode, actor)
+		VALUES ($1, 1, $2, $3, $4, $5, $6, 'allowed', $7, 'test')`,
+		deliveryID, ids.NewV7(), e.address, spec.phase, spec.category,
+		spec.verdict, spec.mode); err != nil {
+		t.Fatalf("planting the decision: %v", err)
+	}
+}
+
+// received runs the counter the cap consults.
+func (e *capEnv) received(t *testing.T, window time.Duration) int {
+	t.Helper()
+	var count int
+	if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+		var err error
+		count, err = advertisingMessagesReceived(context.Background(), tx, e.address, time.Now().Add(-window))
+		return err
+	}); err != nil {
+		t.Fatalf("counting: %v", err)
+	}
+	return count
+}
+
+// A delivered advertising message counts. Without this the three refusals below
+// would all pass against a counter that counts nothing at all.
+func TestADeliveredAdvertisingMessageCountsTowardTheCap(t *testing.T) {
+	e := setupCap(t)
+	e.deliveredAdvertising(t, time.Now().Add(-time.Hour))
+	if got := e.received(t, 24*time.Hour); got != 1 {
+		t.Fatalf("counted %d delivered advertising messages, want 1", got)
+	}
+}
+
+// THE INVARIANT. A parked delivery and an observe-mode decision both describe a
+// message nobody received, and neither may consume the recipient's allowance.
+//
+// Mutation: count communication_decision rows instead of joining to a sent
+// comms_outbound row, and this fails — which is exactly the defect it exists to
+// catch, because the decision rows for both shapes look perfectly ordinary.
+func TestOnlyMailTheRecipientReceivedConsumesTheCap(t *testing.T) {
+	e := setupCap(t)
+	sent := time.Now().Add(-time.Hour)
+
+	// Staged, decided, and then parked: the decision exists, the mail does not.
+	e.plant(t, plantSpec{
+		status: "parked", phase: "transmit", verdict: "allow",
+		category: string(commsauthz.CategoryMarketing), mode: "enforce",
+	})
+	// Still queued: nothing has gone anywhere yet.
+	e.plant(t, plantSpec{
+		status: "pending", phase: "transmit", verdict: "allow",
+		category: string(commsauthz.CategoryMarketing), mode: "enforce",
+	})
+	// A refusal recorded against a delivery that never left.
+	e.plant(t, plantSpec{
+		status: "parked", phase: "transmit", verdict: "deny",
+		category: string(commsauthz.CategoryMarketing), mode: "enforce",
+	})
+
+	if got := e.received(t, 24*time.Hour); got != 0 {
+		t.Fatalf("counted %d messages the recipient never received, want 0", got)
+	}
+
+	// And one that really went, to prove the counter was awake for all of it.
+	e.deliveredAdvertising(t, sent)
+	if got := e.received(t, 24*time.Hour); got != 1 {
+		t.Fatalf("counted %d, want 1 — only the delivered message counts", got)
+	}
+}
+
+// A staging decision is not a transmit decision. Both phases write a row about
+// the same delivery, so counting without the phase filter would double every
+// sent message and halve the effective ceiling.
+func TestAStagingDecisionDoesNotCountBesideItsTransmitRow(t *testing.T) {
+	e := setupCap(t)
+	sent := time.Now().Add(-time.Hour)
+	e.deliveredAdvertising(t, sent)
+	// The staging row the same delivery would carry.
+	e.plant(t, plantSpec{
+		status: "sent", sentAt: &sent, phase: "staging", verdict: "allow",
+		category: string(commsauthz.CategoryMarketing), mode: "enforce",
+	})
+
+	if got := e.received(t, 24*time.Hour); got != 1 {
+		t.Fatalf("counted %d, want 1 — a staging row is not a second message", got)
+	}
+}
+
+// An operational message is not advertising. A ceiling that counted every mail
+// would silence a customer's invoices for a day because somebody sent them
+// three offers.
+func TestAnOperationalMessageDoesNotConsumeTheAdvertisingCap(t *testing.T) {
+	e := setupCap(t)
+	sent := time.Now().Add(-time.Hour)
+	e.plant(t, plantSpec{
+		status: "sent", sentAt: &sent, phase: "transmit", verdict: "allow",
+		category: string(commsauthz.CategoryInvoiceOrPayment), mode: "enforce",
+	})
+
+	if got := e.received(t, 24*time.Hour); got != 0 {
+		t.Fatalf("counted %d, want 0 — an invoice is not advertising", got)
+	}
+}
+
+// The window rolls. A message older than the window has stopped counting, or the
+// cap would be a permanent ban rather than a daily ceiling.
+func TestAMessageOlderThanTheWindowHasStoppedCounting(t *testing.T) {
+	e := setupCap(t)
+	e.deliveredAdvertising(t, time.Now().Add(-25*time.Hour))
+
+	if got := e.received(t, 24*time.Hour); got != 0 {
+		t.Fatalf("counted %d, want 0 — the message fell outside the 24h window", got)
+	}
+	if got := e.received(t, 48*time.Hour); got != 1 {
+		t.Fatalf("counted %d over 48h, want 1 — the message is still there", got)
+	}
+}
+
+// One mailbox, two spellings. Addresses are compared case-insensitively on both
+// sides, or a capped recipient could be reached again by capitalising their
+// address.
+func TestTheCapFollowsTheMailboxNotItsSpelling(t *testing.T) {
+	e := setupCap(t)
+	sent := time.Now().Add(-time.Hour)
+	deliveryID := ids.NewV7()
+	ctx := context.Background()
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO comms_outbound
+		  (id, activity_id, user_id, provider, message_id, recipients, cc, subject, body,
+		   consent_purpose, references_chain, status, sent_at)
+		VALUES ($1, $2, $3, 'gmail', $4, '[]'::jsonb, '[]'::jsonb, 'Offer', 'body',
+		        'marketing', '[]'::jsonb, 'sent', $5)`,
+		deliveryID, e.activity, e.user, "msg-"+deliveryID.String(), sent); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO communication_decision
+		  (delivery_id, attempt, decision_set_id, recipient_address, phase,
+		   resolved_category, verdict, reason_code, mode, actor)
+		VALUES ($1, 1, $2, $3, 'transmit', 'marketing', 'allow', 'allowed', 'enforce', 'test')`,
+		deliveryID, ids.NewV7(), "Buyer@Cap.Test"); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.received(t, 24*time.Hour); got != 1 {
+		t.Fatalf("counted %d, want 1 — Buyer@Cap.Test is the same mailbox as buyer@cap.test", got)
+	}
+}
+
+// The cap REFUSES, and only after the ceiling is reached — driven through
+// AuthorizeTransmit, which is the entry point the dispatcher actually calls.
+//
+// Going through the real door rather than calling applyFrequencyCap directly is
+// the point. A test of the helper alone stays green when the helper stops being
+// called, which is how a working guard becomes an unwired one that every gate
+// still passes.
+func TestTheCapRefusesTheMessageAfterTheCeiling(t *testing.T) {
+	e := setupCap(t)
+	e.seedMarketingSubject(t)
+	// A code no pack in the tree claims, so registering it here cannot collide
+	// with a real jurisdiction's rules and cannot be affected by one.
+	messagingrules.Register(messagingrules.Rules{
+		Jurisdiction: "zc", Version: 1,
+		FrequencyCap: &messagingrules.FrequencyCap{Messages: 3, Window: 24 * time.Hour},
+	})
+	gate := NewGate(e.store).WithInstallationCountry(
+		InstallationCountryFunc(func(context.Context, pgx.Tx) (jurisdiction.Code, error) {
+			return "zc", nil
+		}))
+
+	decide := func(t *testing.T, attempt int) commsauthz.Decision {
+		t.Helper()
+		ticket, err := gate.AuthorizeTransmit(e.ctx, commsauthz.TransmitRequest{
+			DeliveryID: e.decisionDelivery, Attempt: attempt,
+			Recipients: []connector.Recipient{{Email: e.address}},
+			PurposeKey: marketingPurposeKey, Subject: "Offer", Body: "body",
+		})
+		if err != nil {
+			t.Fatalf("authorizing the transmit: %v", err)
+		}
+		var out commsauthz.Decision
+		if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+			return tx.QueryRow(context.Background(), `
+				SELECT verdict, reason_code FROM communication_decision
+				 WHERE decision_set_id = $1 AND phase = 'transmit'`,
+				ticket.DecisionSetID).Scan(&out.Verdict, &out.ReasonCode)
+		}); err != nil {
+			t.Fatalf("reading back the decision: %v", err)
+		}
+		return out
+	}
+
+	for i := range 3 {
+		if got := decide(t, i+1); got.Verdict != commsauthz.VerdictAllow {
+			t.Fatalf("message %d refused with %q, want an allow below the ceiling", i+1, got.ReasonCode)
+		}
+		e.deliveredAdvertising(t, time.Now().Add(-time.Minute))
+	}
+	fourth := decide(t, 4)
+	if fourth.Verdict != commsauthz.VerdictDeny {
+		t.Fatalf("the fourth message in 24h was allowed, want a refusal at the ceiling")
+	}
+	if fourth.ReasonCode != commsauthz.ReasonFrequencyCapReached {
+		t.Errorf("refused with %q, want %q", fourth.ReasonCode, commsauthz.ReasonFrequencyCapReached)
+	}
+}
+
+// A jurisdiction that declares no ceiling caps nothing, and an installation
+// with no country stated resolves no jurisdiction at all. Both must leave mail
+// exactly as it was, or this change would silently throttle every installation
+// that never asked for a cap.
+func TestNoCountryAndNoCeilingBothLeaveTheMessageAlone(t *testing.T) {
+	e := setupCap(t)
+	for range 5 {
+		e.deliveredAdvertising(t, time.Now().Add(-time.Minute))
+	}
+	// Registered with no FrequencyCap: a real jurisdiction that imposes no
+	// ceiling, which must behave like no jurisdiction at all for this rule.
+	messagingrules.Register(messagingrules.Rules{Jurisdiction: "zu", Version: 1})
+	allowed := commsauthz.Decision{
+		Verdict:   commsauthz.VerdictAllow,
+		Resolved:  commsauthz.CategoryMarketing,
+		Recipient: connector.Recipient{Email: e.address},
+	}
+	for _, tc := range []struct {
+		name string
+		gate *Gate
+	}{
+		{"no country stated", NewGate(e.store)},
+		{"a jurisdiction that declares no ceiling", NewGate(e.store).WithInstallationCountry(
+			InstallationCountryFunc(func(context.Context, pgx.Tx) (jurisdiction.Code, error) {
+				return "zu", nil
+			}))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out commsauthz.Decision
+			if err := e.store.db.Tx(e.ctx, func(tx pgx.Tx) error {
+				var err error
+				out, err = tc.gate.applyFrequencyCap(context.Background(), tx, allowed, time.Now())
+				return err
+			}); err != nil {
+				t.Fatalf("applying the cap: %v", err)
+			}
+			if out.Verdict != commsauthz.VerdictAllow {
+				t.Fatalf("refused with %q, want the message left alone", out.ReasonCode)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/consent/authorizecap_integration_test.go
+++ b/backend/internal/modules/consent/authorizecap_integration_test.go
@@ -85,8 +85,10 @@ func (e *capEnv) seedMarketingSubject(t *testing.T) {
 		VALUES ($1, $2, 'granted', 'consent', now(), 'test')`, personID, purposeID); err != nil {
 		t.Fatal(err)
 	}
-	// The delivery the transmit decisions attach to. Left 'pending' on purpose:
-	// it must never be counted as received.
+	// The delivery each authorization under test attaches its decision to. It
+	// stays 'pending' throughout, and the test moves it to 'parked' between
+	// authorizations so the previous decision stops counting as in-flight —
+	// which is what really happens when a delivery does not go out.
 	e.decisionDelivery = ids.NewV7()
 	if _, err := e.owner.Exec(ctx, `
 		INSERT INTO comms_outbound
@@ -210,6 +212,20 @@ func (e *capEnv) plant(t *testing.T, spec plantSpec) {
 	}
 }
 
+// settleDecisionDelivery parks the delivery the previous authorization decided
+// against, so its decision stops counting as a message in flight. A real
+// dispatch settles the row the same way — either sent or parked — and leaving
+// it pending would make each authorization under test count its own
+// predecessor twice.
+func (e *capEnv) settleDecisionDelivery(t *testing.T) {
+	t.Helper()
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE comms_outbound SET status = 'parked', reason = 'test' WHERE id = $1`,
+		e.decisionDelivery); err != nil {
+		t.Fatalf("settling the decision delivery: %v", err)
+	}
+}
+
 // received runs the counter the cap consults.
 func (e *capEnv) received(t *testing.T, window time.Duration) int {
 	t.Helper()
@@ -234,13 +250,13 @@ func TestADeliveredAdvertisingMessageCountsTowardTheCap(t *testing.T) {
 	}
 }
 
-// THE INVARIANT. A parked delivery and an observe-mode decision both describe a
-// message nobody received, and neither may consume the recipient's allowance.
+// THE INVARIANT. A parked delivery is a message nobody received, and it must
+// not consume the recipient's allowance.
 //
-// Mutation: count communication_decision rows instead of joining to a sent
-// comms_outbound row, and this fails — which is exactly the defect it exists to
-// catch, because the decision rows for both shapes look perfectly ordinary.
-func TestOnlyMailTheRecipientReceivedConsumesTheCap(t *testing.T) {
+// Mutation: count communication_decision rows instead of joining to the
+// delivery's own status, and this fails — which is exactly the defect it exists
+// to catch, because a parked row's decision looks perfectly ordinary.
+func TestAParkedDeliveryDoesNotConsumeTheCap(t *testing.T) {
 	e := setupCap(t)
 	sent := time.Now().Add(-time.Hour)
 
@@ -249,15 +265,16 @@ func TestOnlyMailTheRecipientReceivedConsumesTheCap(t *testing.T) {
 		status: "parked", phase: "transmit", verdict: "allow",
 		category: string(commsauthz.CategoryMarketing), mode: "enforce",
 	})
-	// Still queued: nothing has gone anywhere yet.
-	e.plant(t, plantSpec{
-		status: "pending", phase: "transmit", verdict: "allow",
-		category: string(commsauthz.CategoryMarketing), mode: "enforce",
-	})
 	// A refusal recorded against a delivery that never left.
 	e.plant(t, plantSpec{
 		status: "parked", phase: "transmit", verdict: "deny",
 		category: string(commsauthz.CategoryMarketing), mode: "enforce",
+	})
+	// An observe-mode row on a parked delivery: the engine recorded what it
+	// would have said while the old gate ruled, and nothing went out.
+	e.plant(t, plantSpec{
+		status: "parked", phase: "transmit", verdict: "allow",
+		category: string(commsauthz.CategoryMarketing), mode: "observe",
 	})
 
 	if got := e.received(t, 24*time.Hour); got != 0 {
@@ -268,6 +285,42 @@ func TestOnlyMailTheRecipientReceivedConsumesTheCap(t *testing.T) {
 	e.deliveredAdvertising(t, sent)
 	if got := e.received(t, 24*time.Hour); got != 1 {
 		t.Fatalf("counted %d, want 1 — only the delivered message counts", got)
+	}
+}
+
+// A message BETWEEN its authorization and its delivery counts, and it has to.
+//
+// The authorization commits before the provider is called, and 'sent' is
+// written afterwards by a different transaction. A counter that saw only
+// delivered mail would read the same number for every worker inside that
+// window, and each would send: the ceiling would be exceeded by however many
+// workers happened to be running. An allowing transmit decision on a still
+// pending delivery is that in-flight message.
+//
+// Mutation: drop the pending arm from the count and this fails, which is the
+// bug that made the whole cap unenforceable under any concurrency.
+func TestAMessageInFlightAlreadyConsumesTheCap(t *testing.T) {
+	e := setupCap(t)
+	e.plant(t, plantSpec{
+		status: "pending", phase: "transmit", verdict: "allow",
+		category: string(commsauthz.CategoryMarketing), mode: "enforce",
+	})
+	if got := e.received(t, 24*time.Hour); got != 1 {
+		t.Fatalf("counted %d, want 1 — an authorized message on its way out is one the recipient is getting", got)
+	}
+}
+
+// A queued delivery nothing has authorized yet does NOT count. Only the
+// transmit decision makes a pending row an in-flight message; the row alone is
+// a message that may still be refused.
+func TestAQueuedDeliveryWithNoTransmitDecisionDoesNotCount(t *testing.T) {
+	e := setupCap(t)
+	e.plant(t, plantSpec{
+		status: "pending", phase: "staging", verdict: "allow",
+		category: string(commsauthz.CategoryMarketing), mode: "enforce",
+	})
+	if got := e.received(t, 24*time.Hour); got != 0 {
+		t.Fatalf("counted %d, want 0 — nothing has authorized this delivery to go out", got)
 	}
 }
 
@@ -370,7 +423,11 @@ func TestTheCapRefusesTheMessageAfterTheCeiling(t *testing.T) {
 			return "zc", nil
 		}))
 
-	decide := func(t *testing.T, attempt int) commsauthz.Decision {
+	// Both halves of the answer: what the row records, and whether the
+	// dispatcher is actually allowed to send. Asserting only the row would pass
+	// with the ceiling recorded and the message going out anyway, which is
+	// exactly the shape a rollout mode could otherwise produce.
+	decide := func(t *testing.T, attempt int) (commsauthz.Decision, bool) {
 		t.Helper()
 		ticket, err := gate.AuthorizeTransmit(e.ctx, commsauthz.TransmitRequest{
 			DeliveryID: e.decisionDelivery, Attempt: attempt,
@@ -389,21 +446,37 @@ func TestTheCapRefusesTheMessageAfterTheCeiling(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("reading back the decision: %v", err)
 		}
-		return out
+		return out, ticket.Allowed
 	}
 
 	for i := range 3 {
-		if got := decide(t, i+1); got.Verdict != commsauthz.VerdictAllow {
+		got, allowed := decide(t, i+1)
+		if got.Verdict != commsauthz.VerdictAllow {
 			t.Fatalf("message %d refused with %q, want an allow below the ceiling", i+1, got.ReasonCode)
 		}
+		if !allowed {
+			t.Fatalf("message %d was not ticketed, want it to go out below the ceiling", i+1)
+		}
+		// That message goes out, and the delivery it was decided against
+		// settles — so the next authorization sees three DELIVERED messages
+		// rather than its own predecessor still counted as in flight.
 		e.deliveredAdvertising(t, time.Now().Add(-time.Minute))
+		e.settleDecisionDelivery(t)
 	}
-	fourth := decide(t, 4)
+	fourth, allowed := decide(t, 4)
 	if fourth.Verdict != commsauthz.VerdictDeny {
-		t.Fatalf("the fourth message in 24h was allowed, want a refusal at the ceiling")
+		t.Fatalf("the fourth message in 24h was recorded as allowed, want a refusal at the ceiling")
 	}
 	if fourth.ReasonCode != commsauthz.ReasonFrequencyCapReached {
 		t.Errorf("refused with %q, want %q", fourth.ReasonCode, commsauthz.ReasonFrequencyCapReached)
+	}
+	// THE half that matters. Every category defaults to observe, so a ceiling
+	// that only wrote a deny row would let the fourth message go out on every
+	// installation that has not set a mode — the pack would claim an enforced
+	// limit and enforce nothing. The cap denies regardless of mode because it
+	// is in the absolute set.
+	if allowed {
+		t.Fatal("the fourth message was ticketed for sending despite the ceiling — the cap recorded a refusal and permitted the send")
 	}
 }
 

--- a/backend/internal/modules/consent/authorizecaplock_test.go
+++ b/backend/internal/modules/consent/authorizecaplock_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// The order the cap takes its address locks in, which is what stops two
+// messages from deadlocking each other.
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// Two messages naming the same addresses in opposite orders must take the same
+// locks in the SAME order, or Postgres resolves the crossing by killing one
+// transaction and a legitimate send burns its retry ladder — a deadlock a
+// caller can provoke just by choosing a To order.
+//
+// Asserted on the keys rather than against a live database because the property
+// is the ordering itself: sorting the keys is what makes the crossing
+// impossible to express, and a test that only ran two transactions would pass
+// whenever the timing happened not to cross.
+func TestTwoMessagesTakeTheSameAddressLocksInTheSameOrder(t *testing.T) {
+	forward := capLockKeys([]string{"a@x.test", "b@x.test", "c@x.test"})
+	reversed := capLockKeys([]string{"c@x.test", "b@x.test", "a@x.test"})
+	if !slices.Equal(forward, reversed) {
+		t.Fatalf("the same addresses lock in different orders: %v vs %v", forward, reversed)
+	}
+	if !slices.IsSorted(forward) {
+		t.Errorf("lock keys are not sorted: %v", forward)
+	}
+}
+
+// One mailbox is one lock however it is spelled, or a message naming both
+// spellings would take two locks for one address and a concurrent message
+// naming one spelling could slip between them.
+func TestOneMailboxIsOneLock(t *testing.T) {
+	keys := capLockKeys([]string{" Buyer@X.test ", "buyer@x.test"})
+	if len(keys) != 1 {
+		t.Fatalf("two spellings of one mailbox produced %d locks, want 1", len(keys))
+	}
+}
+
+// The namespace occupies the high half and the hash the low half, so a cap lock
+// can never collide with another subsystem's advisory lock on a small integer,
+// and the key is always positive — a negative key is legal in Postgres but
+// makes a lock impossible to recognise in pg_locks.
+func TestTheLockKeyIsNamespacedAndPositive(t *testing.T) {
+	for _, address := range []string{"a@x.test", "zzzzzzzz@example.test", ""} {
+		key := capLockKey(address)
+		if key <= 0 {
+			t.Errorf("capLockKey(%q) = %d, want a positive key", address, key)
+		}
+		if key&^0xFFFFFFFF != capLockNamespace {
+			t.Errorf("capLockKey(%q) high half = %#x, want the namespace %#x",
+				address, key&^0xFFFFFFFF, capLockNamespace)
+		}
+	}
+}
+
+// The lock key and the count must agree on what a mailbox is, or an address
+// could be locked under one spelling and counted under another — and the
+// ceiling would bind to neither.
+func TestTheLockAndTheCountNormalizeAlike(t *testing.T) {
+	const address = "  Buyer@X.Test  "
+	if got := normalizeCapAddress(address); got != strings.ToLower(strings.TrimSpace(address)) {
+		t.Fatalf("normalizeCapAddress(%q) = %q", address, got)
+	}
+	if capLockKey(address) != capLockKey("buyer@x.test") {
+		t.Error("the lock key differs between two spellings of one mailbox")
+	}
+}

--- a/backend/internal/modules/consent/authorizetransmit.go
+++ b/backend/internal/modules/consent/authorizetransmit.go
@@ -115,6 +115,12 @@ func (g *Gate) decideRecipients(ctx context.Context, tx pgx.Tx, req commsauthz.T
 	}
 	set := commsauthz.DecisionSet{}
 	now := g.store.now().UTC()
+	// Every address's cap lock, sorted, before the first recipient is counted.
+	// Taking them inside the loop would order them by the caller's To list, and
+	// two messages naming the same pair in opposite orders would deadlock.
+	if err := g.lockCapAddresses(ctx, tx, req.Recipients); err != nil {
+		return commsauthz.DecisionSet{}, err
+	}
 	for _, r := range req.Recipients {
 		d, err := g.decideOne(ctx, tx, r, req.PurposeKey)
 		if err != nil {

--- a/backend/internal/modules/consent/authorizetransmit.go
+++ b/backend/internal/modules/consent/authorizetransmit.go
@@ -114,8 +114,17 @@ func (g *Gate) decideRecipients(ctx context.Context, tx pgx.Tx, req commsauthz.T
 		legacy = commsauthz.VerdictAllow
 	}
 	set := commsauthz.DecisionSet{}
+	now := g.store.now().UTC()
 	for _, r := range req.Recipients {
 		d, err := g.decideOne(ctx, tx, r, req.PurposeKey)
+		if err != nil {
+			return commsauthz.DecisionSet{}, err
+		}
+		// The ceiling is applied HERE and not at staging, because it counts
+		// what has already been delivered and that number moves while a message
+		// waits in the queue. A cap checked at staging would be answering about
+		// a moment that has passed by the time the message goes.
+		d, err = g.applyFrequencyCap(ctx, tx, d, now)
 		if err != nil {
 			return commsauthz.DecisionSet{}, err
 		}

--- a/backend/internal/modules/consent/gate.go
+++ b/backend/internal/modules/consent/gate.go
@@ -20,6 +20,10 @@ import (
 // different purpose authorizes nothing.
 type Gate struct {
 	store *Store
+	// country selects which jurisdiction's messaging rules a decision is taken
+	// under. Injected by compose because the setting lives in identity
+	// (installationcountry.go).
+	country InstallationCountryReader
 }
 
 func NewGate(store *Store) *Gate {

--- a/backend/internal/modules/consent/installationcountry.go
+++ b/backend/internal/modules/consent/installationcountry.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// Where this installation is established, which is what selects the messaging
+// rules an outbound decision is taken under.
+//
+// The setting lives in identity, and a module never imports a sibling — so the
+// reader is injected and this file holds only the seam.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
+)
+
+// InstallationCountryReader answers where the installation is established, as a
+// lower-case ISO 3166-1 alpha-2 code, or empty when it is unstated.
+//
+// It takes the CALLER'S transaction rather than opening its own, which is not
+// incidental. The answer is stamped onto an immutable decision row: reading it
+// outside the transaction that writes the row would let the setting change in
+// between, and the row would record a decision taken under rules that were not
+// the ones live when it was taken.
+type InstallationCountryReader interface {
+	InstallationCountryTx(ctx context.Context, tx pgx.Tx) (jurisdiction.Code, error)
+}
+
+// InstallationCountryFunc adapts a plain function, so compose can inject
+// identity's reader without either module knowing the other.
+type InstallationCountryFunc func(ctx context.Context, tx pgx.Tx) (jurisdiction.Code, error)
+
+// InstallationCountryTx satisfies InstallationCountryReader.
+func (f InstallationCountryFunc) InstallationCountryTx(ctx context.Context, tx pgx.Tx) (jurisdiction.Code, error) {
+	return f(ctx, tx)
+}
+
+// WithInstallationCountry injects the reader behind jurisdiction resolution.
+func (g *Gate) WithInstallationCountry(r InstallationCountryReader) *Gate {
+	g.country = r
+	return g
+}
+
+// installationCountry resolves the code, or empty when nothing is wired or
+// nothing is set.
+//
+// An unwired reader answers empty rather than failing, and empty selects NO
+// jurisdiction rules. That direction is the safe one for what currently reads
+// this: the frequency cap is a ceiling a pack adds, so its absence leaves the
+// consent requirement — which binds everywhere and is enforced before any pack
+// is consulted — doing exactly what it did before. A reader added later that
+// RELAXES a rule on the strength of a country must not use this, because it
+// would then relax on an unstated one.
+func (g *Gate) installationCountry(ctx context.Context, tx pgx.Tx) (jurisdiction.Code, error) {
+	if g.country == nil {
+		return "", nil
+	}
+	return g.country.InstallationCountryTx(ctx, tx)
+}

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -26,6 +26,7 @@ import (
 	"github.com/margince/margince/backend/internal/platform/settings"
 	"github.com/margince/margince/backend/internal/shared/kernel/textlang"
 	"github.com/margince/margince/backend/internal/shared/kernel/values"
+	"github.com/margince/margince/backend/internal/shared/ports/jurisdiction"
 )
 
 // installationSettingsObject is the RBAC object gating the installation
@@ -142,6 +143,35 @@ var BaseLanguage = settings.Define[string](
 	},
 ).AsInstallationIdentity()
 
+// Country is where this installation is established, as a lower-case ISO
+// 3166-1 alpha-2 code. Empty means unstated, and unstated is the strict answer
+// rather than a permissive one: with no country to resolve, the outbound
+// authorization engine falls back to the floor every jurisdiction shares —
+// consent, with no exception — instead of picking a lenient default nobody
+// chose.
+//
+// It is the input to jurisdiction resolution, not a display field. Which
+// messaging rules bind an outbound message follows from where the CONTROLLER
+// is established as well as where the recipient is, and this names the first
+// half. A wrong value here is a compliance fact, not a cosmetic one, which is
+// why it validates as a code rather than accepting free text.
+//
+// Lower-case because that is the spelling jurisdiction.Code carries and a pack
+// declares; accepting either case here would make "DE" and "de" two
+// installations as far as rule lookup is concerned.
+var Country = settings.Define[string](
+	"installation.country",
+	installationSettingsObject,
+	"update",
+	"",
+	func(v string) error {
+		if v == "" {
+			return nil
+		}
+		return jurisdiction.Code(v).Validate()
+	},
+).AsInstallationIdentity()
+
 // FiscalYearStartMonth is the month the installation's business year begins,
 // 1..12. January is the default, which is what every installation reported by
 // before this existed — so an installation that never touches it sees no
@@ -252,6 +282,7 @@ func Definitions() []settings.Definition {
 		Timezone,
 		BaseCurrency,
 		BaseLanguage,
+		Country,
 		FiscalYearStartMonth,
 		EnabledOidcProviders,
 		SMTPPasswordRef,
@@ -392,4 +423,24 @@ func InstallationNameForPublicPage(ctx context.Context, pool *pgxpool.Pool) (str
 		return err
 	})
 	return name, err
+}
+
+// CountryOf resolves where the installation is established inside a
+// transaction the caller already holds — the code that selects which
+// jurisdiction's messaging rules an outbound decision is taken under.
+//
+// ApplyTx rather than RequireTx, unlike its three siblings above. Those three
+// are seeded at bootstrap and an unset row means a broken installation; this
+// one is not, because it arrived after installations already existed. An
+// upgraded installation has no row until somebody sets one, and refusing there
+// would stop every outbound message on a tree that sent mail perfectly well the
+// day before. So an absent row reads as the registered default — the empty
+// string — which resolves to no jurisdiction and therefore adds no
+// jurisdiction-specific permission to anybody's mail.
+func CountryOf(ctx context.Context, tx pgx.Tx) (jurisdiction.Code, error) {
+	code, err := settings.ApplyTx(ctx, tx, Country)
+	if err != nil {
+		return "", err
+	}
+	return jurisdiction.Code(code), nil
 }

--- a/backend/internal/shared/ports/commsauthz/absolute.go
+++ b/backend/internal/shared/ports/commsauthz/absolute.go
@@ -67,6 +67,15 @@ var absoluteDenials = map[string]bool{
 	// objection and gets its own code, but it binds exactly as hard: no
 	// rollout mode may send to somebody who took their consent back.
 	ReasonConsentWithdrawn: true,
+	// A jurisdiction's ceiling on advertising is decided by that jurisdiction,
+	// not by how far along a rollout is. It is here for the same reason as the
+	// rest and one of its own: an installation that declares a country is
+	// asserting which law it sends under, so a mode setting that let it exceed
+	// that country's statutory limit would make the declaration false. It is
+	// also the one denial a sender can clear by waiting — the window rolls and
+	// the same message becomes lawful — so refusing costs a delay rather than
+	// the message.
+	ReasonFrequencyCapReached: true,
 }
 
 // Absolute reports whether this reason denies regardless of Mode.

--- a/backend/internal/shared/ports/commsauthz/absolute.go
+++ b/backend/internal/shared/ports/commsauthz/absolute.go
@@ -30,6 +30,11 @@ const (
 	// Distinct from an objection because they are different legal facts, and a
 	// proof row that called one the other would misstate what somebody did.
 	ReasonConsentWithdrawn = "consent_withdrawn"
+	// ReasonFrequencyCapReached is a jurisdiction's ceiling on how many
+	// advertising messages one address may receive in a window. A fact about
+	// VOLUME rather than about the person: nothing they did refuses this
+	// message, and the same message is lawful again once the window rolls.
+	ReasonFrequencyCapReached = "frequency_cap_reached"
 	// ReasonAllowed is the allow path's own code, so every row has one.
 	ReasonAllowed = "allowed"
 )

--- a/extensions/vn/README.md
+++ b/extensions/vn/README.md
@@ -1,0 +1,94 @@
+# The Vietnamese pack
+
+What Vietnamese law requires of this product's outbound messaging, stated as
+data the core engines apply. The pack decides nothing: it declares, and the
+engine reads.
+
+Everything here comes from **Decree 91/2020/ND-CP** on anti-spam messages,
+email and calls.
+
+## Advertising email needs prior consent — and there is no exception
+
+Art. 10 permits an advertising email only where the recipient has given prior
+consent. The decree grants **no** sale-derived route: nothing here corresponds
+to the German existing-customer exception (UWG §7(3)).
+
+So this pack declares an empty exception list, and the emptiness is the rule.
+`TestAdvertisingNeedsPriorConsent` holds it, because the consequence reaches
+across jurisdictions: the core engine folds the applicable rule sets
+strictest-wins, and an exception declared here would let evidence of a **German**
+sale authorize a Vietnamese advertising message.
+
+The consent itself must be demonstrable in three dimensions — what was consented
+to, how it was given, and how often the recipient agreed to hear from us. The
+core consent engine records all three on the proof row; this pack does not
+restate them.
+
+## The `[QC]` subject label (Art. 12)
+
+An advertising email is labelled as advertising in its subject line, with the
+label the decree fixes: `[QC]`.
+
+The engine applies it **exactly once** — a subject that already carries it is
+not labelled twice — and applies it to advertising **only**. An operational
+message wearing an advertising label misdescribes itself to the recipient in the
+other direction, which is the same wrong.
+
+## Who is advertising (Art. 13)
+
+An advertising message names the advertiser and gives a way to reach them:
+name, phone, email, address and website.
+
+This sits **alongside** the GDPR-shaped controller disclosures rather than
+replacing them. Who is processing someone's data and who is advertising to them
+are the same organisation here and need not be, and the two obligations come
+from different instruments.
+
+| Disclosure | Scope |
+|---|---|
+| Controller identity | every first message |
+| Privacy contact | every first message |
+| Objection route | advertising |
+| Advertiser contact — name, phone, email, address, website | advertising |
+
+## Three per address per day (Art. 22(2))
+
+At most **3** advertising emails reach one address in any rolling **24 hours**,
+unless that recipient has agreed to a different frequency.
+
+**The count is of messages the recipient actually received.** A staged message
+that parked and a decision taken in observe mode both describe a message nobody
+got, and counting either would silently consume somebody's allowance — so the
+engine counts sent deliveries joined to their advertising decision, never
+decision rows on their own. That invariant lives in core and is held by a test
+whose mutation is exactly "count decisions instead"; the pack only states the
+bound.
+
+## An opt-out is acknowledged (Art. 16)
+
+A recipient who refuses further advertising is owed a confirmation that the
+refusal was received, within 24 hours, carrying no advertising of its own.
+
+The acknowledgement goes out through the controller lane — the one lane that may
+write to somebody who has just suppressed themselves, because the message serves
+the subject rather than the sender.
+
+## Windows
+
+A reply stays a reply for **12 months**; a live deal supports an unprompted
+follow-up for **6 months**. These are the core defaults, restated so the pack
+says what it applies rather than inheriting silently. Neither bounds a
+same-thread reply.
+
+## Retention
+
+**None.** The core retention engine reads a pack's classes as statutory floors
+on records the product holds, and Vietnam's record-keeping duties fall on
+accounting books and invoices, which a CRM does not hold. A floor no record can
+carry would be documentation posing as enforcement.
+
+## Changing any of this
+
+Every claim above is asserted in `vn_test.go`. A changed label, ceiling,
+disclosure or window is a legal-content change: edit the test in the same commit
+and say in the PR body which article moved.

--- a/extensions/vn/README.md
+++ b/extensions/vn/README.md
@@ -56,13 +56,28 @@ from different instruments.
 At most **3** advertising emails reach one address in any rolling **24 hours**,
 unless that recipient has agreed to a different frequency.
 
-**The count is of messages the recipient actually received.** A staged message
-that parked and a decision taken in observe mode both describe a message nobody
-got, and counting either would silently consume somebody's allowance — so the
-engine counts sent deliveries joined to their advertising decision, never
-decision rows on their own. That invariant lives in core and is held by a test
-whose mutation is exactly "count decisions instead"; the pack only states the
+**The count is of messages the recipient got or is about to get.** A staged
+message that parked and a decision taken in observe mode both describe a message
+nobody received, and counting either would silently consume somebody's
+allowance — so the engine counts sent deliveries joined to their advertising
+decision, never decision rows on their own.
+
+It also counts messages in flight. An authorization commits before the provider
+is called, and a delivery is marked sent afterwards, so between the two there is
+a message going out that no sent row reports yet. Counting only delivered mail
+would let every worker in that window read the same number and each send, and
+the ceiling would be exceeded by however many workers were running.
+
+Both halves live in core and are held by tests whose mutations are exactly
+"count decisions instead" and "drop the in-flight arm"; the pack only states the
 bound.
+
+**The ceiling refuses regardless of rollout mode.** The engine's other rules can
+be run in observe while they are measured against the old consent gate; this one
+cannot, because an installation that declares a country is asserting which law
+it sends under, and a setting that let it exceed that country's statutory limit
+would make the declaration false. Waiting clears it — the window rolls and the
+same message becomes lawful — so refusing costs a delay rather than the message.
 
 ## An opt-out is acknowledged (Art. 16)
 
@@ -72,6 +87,12 @@ refusal was received, within 24 hours, carrying no advertising of its own.
 The acknowledgement goes out through the controller lane — the one lane that may
 write to somebody who has just suppressed themselves, because the message serves
 the subject rather than the sender.
+
+**Not yet built.** The flag is declared and nothing reads it: the controller
+template catalog it needs has not landed. Same for the `[QC]` label and the
+advertiser disclosure above — both are declared here and applied by nothing
+today. What this pack enforces right now is the ceiling and the absence of a
+marketing exception.
 
 ## Windows
 

--- a/extensions/vn/go.mod
+++ b/extensions/vn/go.mod
@@ -1,0 +1,3 @@
+module github.com/margince/margince/extensions/vn
+
+go 1.26.6

--- a/extensions/vn/manifest.generated.json
+++ b/extensions/vn/manifest.generated.json
@@ -1,0 +1,6 @@
+{
+  "schema": 1,
+  "name": "vn",
+  "version": "1.0.0",
+  "risk_tiers": []
+}

--- a/extensions/vn/vn.go
+++ b/extensions/vn/vn.go
@@ -78,24 +78,31 @@ const advertisingLabel = "[QC]"
 // authorizes nothing here.
 //
 // THE [QC] PREFIX is Art. 12: an advertising message must be labelled as
-// advertising in its subject, and the decree fixes the label. The engine applies
-// it exactly once — a message that already carries it is not labelled twice —
-// and applies it to advertising only. An operational message wearing an
-// advertising label would misdescribe itself to the recipient in the other
-// direction.
+// advertising in its subject, and the decree fixes the label. It is DECLARED
+// here and applied by nothing yet — the renderer that would apply it, once, to
+// advertising only, needs the controller template catalog that has not landed.
+// Declaring it now is deliberate: the rule is what the decree says, and a pack
+// that waited would leave the obligation unrecorded until the machinery caught
+// up.
 //
 // ADVERTISER IDENTIFICATION is Art. 13: an advertising message names the
 // advertiser and gives a way to reach them. It is declared as an
 // AdvertiserContact disclosure alongside the Art. 13 GDPR-shaped controller
 // disclosures, because a Vietnamese recipient is owed BOTH — who is processing
 // their data and who is advertising to them are the same organisation here and
-// need not be, and the two obligations come from different instruments.
+// need not be, and the two obligations come from different instruments. Also
+// declared and not yet rendered, for the same reason as the prefix.
 //
 // THE ACKNOWLEDGED OPT-OUT is Art. 16: a recipient who refuses further
 // advertising is owed a confirmation that their refusal was received, sent
 // within twenty-four hours and carrying no advertising of its own. The flag says
-// one is owed; the engine's controller lane is what sends it, which is the only
-// lane that may write to somebody who has just suppressed themselves.
+// one is owed; the engine's controller lane is what will send it, which is the
+// only lane that may write to somebody who has just suppressed themselves. Also
+// declared and not yet wired.
+//
+// THE DAILY CEILING is the one rule here the engine applies today. It refuses
+// regardless of rollout mode, because an installation declaring a country is
+// asserting which law it sends under.
 //
 // THE WINDOWS are the core defaults, restated so this pack says what it applies
 // rather than inheriting silently. Neither bounds a same-thread reply.

--- a/extensions/vn/vn.go
+++ b/extensions/vn/vn.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package vn is the Vietnamese jurisdiction pack as a stable-tier extension:
+// its directory under extensions/ IS the enablement. Core code never contains a
+// jurisdiction string — this unit is where Vietnam lives.
+//
+// V1 declares the outbound-messaging rules Decree 91/2020/ND-CP places on
+// advertising email. It declares NO retention class: the decree and the
+// Vietnamese accounting law bind records this CRM does not hold, and a floor no
+// record can carry would be documentation posing as enforcement.
+package vn
+
+import (
+	"time"
+
+	"github.com/margince/margince/backend/pkg/extension"
+	"github.com/margince/margince/backend/pkg/extension/jurisdiction"
+	"github.com/margince/margince/backend/pkg/extension/messaging"
+)
+
+// New returns the unit's declaration (the ADR-0069 §4 constructor contract the
+// generated composition calls).
+func New() extension.Extension {
+	return extension.Extension{
+		Name:          "vn",
+		Version:       "1.0.0",
+		Description:   "Vietnamese jurisdiction pack: the Decree 91/2020/ND-CP advertising-email rules — prior consent, the subject label, advertiser identity, the daily ceiling and the acknowledged opt-out.",
+		Jurisdictions: []jurisdiction.Pack{pack{}},
+		Messaging:     []messaging.Rules{messagingRules()},
+	}
+}
+
+type pack struct{}
+
+func (pack) Code() jurisdiction.Code { return "vn" }
+
+// Retention: none. The core engine reads a pack's classes as statutory FLOORS
+// on records the product holds, and Vietnam's record-keeping duties fall on
+// accounting books and invoices — neither of which lives in a CRM. Declaring a
+// class the product cannot carry would put a floor in the composition that
+// nothing is ever measured against, which reads as coverage and is not.
+func (pack) Retention() jurisdiction.Retention { return retention{} }
+
+type retention struct{}
+
+func (retention) Classes() []jurisdiction.RetentionClass { return nil }
+
+// vnAdvertisingCap is the ceiling Decree 91/2020/ND-CP Art. 22(2) places on
+// advertising email: at most three messages to one address in twenty-four
+// hours, unless the recipient has agreed otherwise.
+//
+// The engine counts messages the recipient actually RECEIVED. That is stated on
+// the FrequencyCap type and held by the engine, not by this pack — a pack says
+// what the bound is, never how it is counted.
+const (
+	vnAdvertisingMessagesPerDay = 3
+	vnAdvertisingWindow         = 24 * time.Hour
+)
+
+// advertisingLabel is the subject marking Decree 91/2020/ND-CP Art. 12 fixes
+// for an advertising message. The literal lives HERE rather than on the
+// published messaging surface for the reason every country string does: core
+// applies a prefix a pack supplies and knows nothing about which one, so a
+// second jurisdiction with a different label needs no core change.
+const advertisingLabel = "[QC]"
+
+// messagingRules is what Vietnamese law requires of an outbound message, stated
+// as data the core engine applies. Nothing here decides a send.
+//
+// NO MARKETING EXCEPTION. Decree 91/2020/ND-CP Art. 10 permits advertising email
+// only with the recipient's prior consent, and it grants no sale-derived route:
+// there is no Vietnamese analogue of the German existing-customer exception. The
+// empty MarketingExceptions slice is the whole rule, and it is empty
+// deliberately — a reader comparing this pack against extensions/de can see that
+// Vietnam has no such route rather than wondering whether one was forgotten.
+// The cross-jurisdiction consequence is that evidence of a German sale
+// authorizes nothing here.
+//
+// THE [QC] PREFIX is Art. 12: an advertising message must be labelled as
+// advertising in its subject, and the decree fixes the label. The engine applies
+// it exactly once — a message that already carries it is not labelled twice —
+// and applies it to advertising only. An operational message wearing an
+// advertising label would misdescribe itself to the recipient in the other
+// direction.
+//
+// ADVERTISER IDENTIFICATION is Art. 13: an advertising message names the
+// advertiser and gives a way to reach them. It is declared as an
+// AdvertiserContact disclosure alongside the Art. 13 GDPR-shaped controller
+// disclosures, because a Vietnamese recipient is owed BOTH — who is processing
+// their data and who is advertising to them are the same organisation here and
+// need not be, and the two obligations come from different instruments.
+//
+// THE ACKNOWLEDGED OPT-OUT is Art. 16: a recipient who refuses further
+// advertising is owed a confirmation that their refusal was received, sent
+// within twenty-four hours and carrying no advertising of its own. The flag says
+// one is owed; the engine's controller lane is what sends it, which is the only
+// lane that may write to somebody who has just suppressed themselves.
+//
+// THE WINDOWS are the core defaults, restated so this pack says what it applies
+// rather than inheriting silently. Neither bounds a same-thread reply.
+func messagingRules() messaging.Rules {
+	return messaging.Rules{
+		Jurisdiction:       "vn",
+		Version:            1,
+		ReplyWindow:        365 * 24 * time.Hour,
+		DealFollowUpWindow: 182 * 24 * time.Hour,
+		// Empty on purpose: prior consent is the only route. See above.
+		MarketingExceptions: nil,
+		Disclosures: []messaging.Disclosure{
+			{Kind: messaging.ControllerIdentity},
+			{Kind: messaging.PrivacyContact},
+			{Kind: messaging.ObjectionRoute, MarketingOnly: true},
+			{Kind: messaging.AdvertiserContact, MarketingOnly: true},
+		},
+		SubjectPrefix: advertisingLabel,
+		FrequencyCap: &messaging.FrequencyCap{
+			Messages: vnAdvertisingMessagesPerDay,
+			Window:   vnAdvertisingWindow,
+		},
+		OptOutAcknowledgement: true,
+	}
+}

--- a/extensions/vn/vn_test.go
+++ b/extensions/vn/vn_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package vn
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/pkg/extension/messaging"
+)
+
+// TestNewDeclaresTheJurisdictionAndNoRetentionClass pins the two structural
+// facts: this pack is Vietnam, and it declares no retention floor. The absent
+// class is deliberate content, so an added one must be an argued change rather
+// than a copy of extensions/de.
+func TestNewDeclaresTheJurisdictionAndNoRetentionClass(t *testing.T) {
+	e := New()
+	if e.Name != "vn" {
+		t.Fatalf("Name = %q, want the unit's directory name vn", e.Name)
+	}
+	if len(e.Jurisdictions) != 1 {
+		t.Fatalf("declaration carries %d jurisdiction packs, want 1", len(e.Jurisdictions))
+	}
+	if got := e.Jurisdictions[0].Code(); got != "vn" {
+		t.Fatalf("pack code = %q, want vn", got)
+	}
+	if classes := e.Jurisdictions[0].Retention().Classes(); len(classes) != 0 {
+		t.Fatalf("pack declares %d retention classes, want none — a CRM holds no record the Vietnamese floors bind", len(classes))
+	}
+}
+
+// TestTheRulesAreValid runs the same check the boot preflight runs, so a rule
+// set this pack could not be composed with fails here rather than at startup.
+func TestTheRulesAreValid(t *testing.T) {
+	if err := messagingRules().Validate(); err != nil {
+		t.Fatalf("the declared rules do not validate: %v", err)
+	}
+}
+
+// TestAdvertisingNeedsPriorConsent is the legal heart of the pack: Decree
+// 91/2020/ND-CP Art. 10 grants NO route to advertising email without the
+// recipient's prior consent. An added exception here would let a sale — or
+// German existing-customer evidence, which the core fold could otherwise carry
+// across — authorize a Vietnamese advertising message.
+func TestAdvertisingNeedsPriorConsent(t *testing.T) {
+	if got := messagingRules().MarketingExceptions; len(got) != 0 {
+		t.Fatalf("the pack declares %d marketing exceptions, want none — prior consent is the only route", len(got))
+	}
+}
+
+// TestTheAdvertisingLabelIsTheDecreesOwn pins the subject marking. The literal
+// is legal content: a changed label stops the message being labelled as the
+// decree requires, and nothing else in the tree would notice.
+func TestTheAdvertisingLabelIsTheDecreesOwn(t *testing.T) {
+	if got := messagingRules().SubjectPrefix; got != "[QC]" {
+		t.Fatalf("SubjectPrefix = %q, want the Art. 12 advertising label [QC]", got)
+	}
+}
+
+// TestTheDailyCeilingIsThreePerAddress pins Art. 22(2).
+func TestTheDailyCeilingIsThreePerAddress(t *testing.T) {
+	ceiling := messagingRules().FrequencyCap
+	if ceiling == nil {
+		t.Fatal("the pack declares no frequency cap, want three advertising messages per 24 hours")
+	}
+	if ceiling.Messages != 3 {
+		t.Errorf("cap allows %d messages, want 3", ceiling.Messages)
+	}
+	if ceiling.Window != 24*time.Hour {
+		t.Errorf("cap window = %s, want 24h", ceiling.Window)
+	}
+}
+
+// TestAnOptOutIsAcknowledged pins Art. 16.
+func TestAnOptOutIsAcknowledged(t *testing.T) {
+	if !messagingRules().OptOutAcknowledgement {
+		t.Fatal("the pack owes no opt-out acknowledgement, want one — Art. 16 requires a confirmation within 24 hours")
+	}
+}
+
+// TestAnAdvertisingMessageNamesItsAdvertiser holds Art. 13 alongside the
+// controller disclosures. Advertiser contact binds ADVERTISING only: an
+// operational message carries who is processing the data, not who is selling.
+func TestAnAdvertisingMessageNamesItsAdvertiser(t *testing.T) {
+	want := map[messaging.DisclosureKind]bool{
+		messaging.ControllerIdentity: false,
+		messaging.PrivacyContact:     false,
+		messaging.ObjectionRoute:     true,
+		messaging.AdvertiserContact:  true,
+	}
+	got := map[messaging.DisclosureKind]bool{}
+	for _, d := range messagingRules().Disclosures {
+		if _, seen := got[d.Kind]; seen {
+			t.Fatalf("disclosure %q declared twice", string(d.Kind))
+		}
+		got[d.Kind] = d.MarketingOnly
+	}
+	if len(got) != len(want) {
+		t.Fatalf("the pack declares %d disclosures, want %d", len(got), len(want))
+	}
+	for kind, marketingOnly := range want {
+		bound, declared := got[kind]
+		if !declared {
+			t.Errorf("disclosure %q is not declared", string(kind))
+			continue
+		}
+		if bound != marketingOnly {
+			t.Errorf("disclosure %q binds marketing-only = %v, want %v", string(kind), bound, marketingOnly)
+		}
+	}
+}


### PR DESCRIPTION
Vietnam gets its own jurisdiction pack, and the outbound engine gains the first rule that reads one: the advertising frequency ceiling.

## The pack

`extensions/vn` declares what Decree 91/2020/ND-CP requires, as data:

- **No marketing exception at all.** Prior consent is the only route to advertising email — there is no Vietnamese analogue of UWG §7(3). The empty list is the rule, and it matters across jurisdictions: the core fold is strictest-wins, so an exception declared here would let evidence of a *German* sale authorize a Vietnamese advertising message.
- **The `[QC]` subject label** (Art. 12), **advertiser identification** (Art. 13) alongside the controller disclosures, **3 messages per address per 24h** (Art. 22(2)), and an **acknowledged opt-out** (Art. 16).
- **No retention class.** Vietnam's record-keeping duties fall on accounting books and invoices, which a CRM does not hold. A floor no record can carry would be documentation posing as enforcement.

Every claim is asserted in `vn_test.go` and written out in `extensions/vn/README.md` for ratification. `.gitignore`'s un-ignore list is the enablement declaration, so `vn` joins it there.

## What the engine now enforces

**The ceiling, and only the ceiling.** The label, the disclosure and the acknowledgement are declared and applied by nothing yet — all three need the controller template catalog that PR 3 deferred. Both the code and the README say so rather than describing machinery that has not landed.

The count is of messages the recipient **got or is about to get**:

- **Delivered**: `comms_outbound` rows that reached `'sent'`, joined to their own transmit decision to establish the message was advertising. A count over decision rows alone would include an observe-mode decision and a staged-then-parked delivery — both describe mail nobody received, and counting either would silence somebody for a day by an accounting error no reader could see.
- **In flight**: an allowing transmit decision on a still-pending delivery. The authorization commits *before* the provider is called and `'sent'` is written afterwards, so counting only delivered mail would let every worker in that window read the same number and each send.

Evaluated at transmit, inside the decision's own transaction, with every recipient's `pg_advisory_xact_lock` taken up front in sorted order — so two messages naming the same addresses in opposite orders cannot deadlock, which is the discipline `storekit.LockSubjectKeys` already applies to subject locks.

`installation.country` is the new input to jurisdiction resolution. It reads as empty on any installation that never set one, and empty resolves to no rules and therefore no ceiling: **this change throttles nobody who did not ask for it.**

The ceiling refuses **regardless of rollout mode**. Every category defaults to `observe`, so a cap outside the absolute-denial set would write a refusal and let the message go. A statutory ceiling is decided by the jurisdiction, not by how far along a rollout is — and waiting clears it, so refusing costs a delay rather than the message.

## Along the way

Three compose sites constructed `consent.NewGate` directly while `consentGateFor`'s own comment claimed to be "the ONE spelling". They now go through it. One was the dispatcher — the single path that calls `AuthorizeTransmit` — so without this the cap would have been wired everywhere except where it runs.

## Review findings, all fixed

A `security-redteam` pass found three defects that each left the cap recording a refusal while the message went out: the lock serialized the region *before* the send rather than across it, the lock order was the caller's To list (a client-provokable deadlock), and the refusal did not refuse under the default observe mode. The second commit fixes all three. It also found that the test asserted the stored decision row rather than `ticket.Allowed`, which is what let the third hide — the assertion is now on both.

## Gates

`make check-backend` green, `make craft-static` green, `check-rls-store-path` and `check-no-jurisdiction` green, and the integration lane green for all four modules touched (`consent`, `comms`, `compose`, `compose/integration`, `identity`). No migration.

Every guard is mutation-checked one clause at a time: count decisions instead of joining the delivery status → `TestAParkedDeliveryDoesNotConsumeTheCap` fails; drop the in-flight arm → `TestAMessageInFlightAlreadyConsumesTheCap` fails; drop the phase filter, drop the category filter, unwire the cap from `AuthorizeTransmit`, remove it from the absolute set → each fails its own named test.

## Deferred

`[QC]` prefix application, advertiser disclosure rendering, the opt-out acknowledgement, `consent_scope`, and the marketing enforcement flip — all blocked on prerequisites absent from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Vietnamese jurisdiction pack `extensions/vn` and the consent engine's first enforcement of a pack rule: an advertising frequency ceiling of 3 messages per address per 24 hours (Decree 91/2020/ND-CP Art. 22(2)). The ceiling binds only installations that have set `installation.country`; an unset country resolves to no rules, so nobody is throttled who did not ask for it.

**New Features**
- The pack declares the decree's rules as data: no marketing exception (prior consent only), the `[QC]` subject label, advertiser contact, an acknowledged opt-out, and the ceiling; it declares no retention class.
- The count is of messages the recipient got or is about to get: `sent` deliveries joined to their own advertising transmit decision, plus an allowing transmit decision on a delivery still pending. Parked deliveries and observe-mode decisions don't consume the cap.
- All recipient cap locks are taken up front, in sorted order, inside the decision's own transaction, so concurrent sends to one address serialize and reversed recipient lists cannot deadlock.
- The cap sits in the absolute-denial set and refuses regardless of rollout mode.
- The `[QC]` label, advertiser disclosure, and opt-out acknowledgement are declared but not yet applied — all three await the controller template catalog.

**Refactors**
- The three direct `consent.NewGate` construction sites now go through `consentGateFor`, which wires in the installation-country reader; this includes the dispatcher, the one path that calls `AuthorizeTransmit`.

<sup>Written for commit 26f0e2c2590316e6d83c6bd28e27d79900368574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Vietnam compliance support, including consent requirements, advertising labels, disclosures, opt-out acknowledgements, and retention rules.
  - Added installation-country configuration to apply jurisdiction-specific messaging rules.
  - Added advertising frequency-cap enforcement, including a three-message-per-24-hour limit for Vietnam.
  - Added clear denial handling when statutory advertising limits are reached.

- **Documentation**
  - Added Vietnamese compliance documentation covering applicable requirements and enforcement status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->