### PR TITLE
A first message is addressed on the person and deal pages too

### DIFF
--- a/backend/gates/frontendprimaryemail_test.go
+++ b/backend/gates/frontendprimaryemail_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H3
+
+package gates
+
+// The browser and the server pick the SAME address to write to, or the address
+// a composer prefills and the address a draft is written to differ on a record
+// where the reader can see both.
+//
+// A person carries a LIST of addresses — several, each with a type, a position
+// and a primary flag, some retired — so "the contact's email" is a decision
+// rather than a field. `persondraft.primaryEmail` makes it for the drafter and
+// `frontend/src/format/primaryemail.ts` makes it for every screen, and what
+// makes them a mirror is that both are held to ONE table of cases.
+//
+// The rule they implement has one answer that is actively wrong rather than
+// merely different: an ARCHIVED address. Somebody retired it, so mail sent
+// there either bounces or reaches a person who asked us to stop. The frontend
+// had no shared rule at all before this gate — `people.tsx` picked
+// `find(is_primary) ?? [0]`, which offers a retired address whenever it sits
+// first — so this is the case the two sides must agree on most.
+//
+// Compared in BOTH directions, because either alone passes over the drift it is
+// meant to catch: a Go case with no TypeScript twin means the browser was never
+// held to a rule the server follows, and the reverse for the other side.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	goPrimaryEmailTable = "internal/compose/persondraft/primaryemail_test.go"
+	tsPrimaryEmailTable = "../frontend/src/format/primaryemail.test.ts"
+)
+
+// The NAME of each case, which is what both tables spell identically. The
+// bodies cannot be compared the way the splitter's are — one side builds a
+// Person and the other an array of PersonEmail — so the case name is the shared
+// text, and each side's own test asserts the answer.
+var (
+	goCaseName = regexp.MustCompile(`(?m)^\s*name:\s*"([^"\\]*)"`)
+	tsCaseName = regexp.MustCompile(`(?m)^\s*it\("([^"\\]*)"`)
+)
+
+func TestBothSidesPickTheSameAddress(t *testing.T) {
+	t.Parallel()
+	goCases := caseNamesIn(t, goPrimaryEmailTable, goCaseName)
+	tsCases := caseNamesIn(t, tsPrimaryEmailTable, tsCaseName)
+
+	// A census that can fail short has already failed: a table this cannot
+	// parse reads as an empty set, and an empty set agrees with everything.
+	if len(goCases) == 0 {
+		t.Fatal("no case parsed out of the Go table — either it moved or this gate's " +
+			"pattern no longer reads it, and an unread table is one this gate agrees with")
+	}
+	if len(tsCases) == 0 {
+		t.Fatal("no case parsed out of the TypeScript table — same failure, other side")
+	}
+
+	for name := range goCases {
+		if !tsCases[name] {
+			t.Errorf("the server's address picker is held to a case the browser is not:\n  %q\n"+
+				"add it to %s, or the two are free to disagree about it", name, tsPrimaryEmailTable)
+		}
+	}
+	for name := range tsCases {
+		if !goCases[name] {
+			t.Errorf("the browser's address picker is held to a case the server is not:\n  %q\n"+
+				"add it to %s, or the two are free to disagree about it", name, goPrimaryEmailTable)
+		}
+	}
+}
+
+// caseNamesIn reads the case names out of one table.
+//
+// Comments are stripped first: a name quoted inside prose would otherwise count
+// as a case that exists, and this gate would report parity the tables do not
+// have. It reuses commentPattern from the splitter's gate beside it — one
+// spelling of "what a comment looks like" for both.
+func caseNamesIn(t *testing.T, path string, pattern *regexp.Regexp) map[string]bool {
+	t.Helper()
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	text := commentPattern.ReplaceAllString(string(source), "")
+	out := map[string]bool{}
+	for _, match := range pattern.FindAllStringSubmatch(text, -1) {
+		if name := strings.TrimSpace(match[1]); name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}

--- a/backend/internal/compose/persondraft/primaryemail_test.go
+++ b/backend/internal/compose/persondraft/primaryemail_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package persondraft
+
+// Which address a message goes to.
+//
+// The cases here are the shared table the BROWSER's picker is held to as well:
+// a case added on one side and not the other is the drift
+// gates/frontendprimaryemail_test.go exists to catch. Written to be read from
+// both languages — one list in, one address out.
+
+import (
+	"testing"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+func address(email string, primary bool, archived bool) crmcontracts.PersonEmail {
+	out := crmcontracts.PersonEmail{
+		Email:     openapi_types.Email(email),
+		IsPrimary: primary,
+	}
+	if archived {
+		when := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		out.ArchivedAt = &when
+	}
+	return out
+}
+
+func personWith(emails ...crmcontracts.PersonEmail) crmcontracts.Person {
+	if emails == nil {
+		return crmcontracts.Person{}
+	}
+	return crmcontracts.Person{Emails: &emails}
+}
+
+func TestTheAddressAContactIsWrittenTo(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		person crmcontracts.Person
+		want   string
+	}{
+		{
+			name: "takes the one marked primary",
+			person: personWith(
+				address("old@buyer.test", false, false),
+				address("anna@buyer.test", true, false),
+			),
+			want: "anna@buyer.test",
+		},
+		{
+			// An unmarked address is still reachable. A contact with exactly one
+			// address and no flag set is the ordinary case, and refusing to write
+			// to them would read the flag as permission when it only ranks.
+			name: "takes the first live one when nothing is marked",
+			person: personWith(
+				address("anna@buyer.test", false, false),
+				address("anna.weber@buyer.test", false, false),
+			),
+			want: "anna@buyer.test",
+		},
+		{
+			// The one wrong answer here. Somebody retired that address: mail to
+			// it either bounces or reaches a person who asked us to stop.
+			name: "skips an archived address even when it is first",
+			person: personWith(
+				address("left@buyer.test", false, true),
+				address("anna@buyer.test", false, false),
+			),
+			want: "anna@buyer.test",
+		},
+		{
+			// Archived outranks primary: retirement is a decision about the
+			// address itself, and the flag only ranks among live ones.
+			name: "skips an archived address even when it is marked primary",
+			person: personWith(
+				address("left@buyer.test", true, true),
+				address("anna@buyer.test", false, false),
+			),
+			want: "anna@buyer.test",
+		},
+		{
+			name:   "answers nothing when every address is archived",
+			person: personWith(address("left@buyer.test", false, true)),
+			want:   "",
+		},
+		{
+			name:   "answers nothing for a contact with no address at all",
+			person: personWith(),
+			want:   "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := primaryEmail(tc.person); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/persondraft/primaryemail_test.go
+++ b/backend/internal/compose/persondraft/primaryemail_test.go
@@ -19,12 +19,24 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
 
-func address(email string, primary bool, archived bool) crmcontracts.PersonEmail {
+// The four shapes an address on a record can have. Named rather than passed as
+// two booleans: `address("x", false, true)` at a call site says nothing about
+// which flag is which, and the whole table turns on telling them apart.
+type addressShape int
+
+const (
+	plain addressShape = iota
+	marked
+	retired
+	markedAndRetired
+)
+
+func address(email string, shape addressShape) crmcontracts.PersonEmail {
 	out := crmcontracts.PersonEmail{
 		Email:     openapi_types.Email(email),
-		IsPrimary: primary,
+		IsPrimary: shape == marked || shape == markedAndRetired,
 	}
-	if archived {
+	if shape == retired || shape == markedAndRetired {
 		when := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 		out.ArchivedAt = &when
 	}
@@ -48,8 +60,8 @@ func TestTheAddressAContactIsWrittenTo(t *testing.T) {
 		{
 			name: "takes the one marked primary",
 			person: personWith(
-				address("old@buyer.test", false, false),
-				address("anna@buyer.test", true, false),
+				address("old@buyer.test", plain),
+				address("anna@buyer.test", marked),
 			),
 			want: "anna@buyer.test",
 		},
@@ -59,8 +71,8 @@ func TestTheAddressAContactIsWrittenTo(t *testing.T) {
 			// to them would read the flag as permission when it only ranks.
 			name: "takes the first live one when nothing is marked",
 			person: personWith(
-				address("anna@buyer.test", false, false),
-				address("anna.weber@buyer.test", false, false),
+				address("anna@buyer.test", plain),
+				address("anna.weber@buyer.test", plain),
 			),
 			want: "anna@buyer.test",
 		},
@@ -69,8 +81,8 @@ func TestTheAddressAContactIsWrittenTo(t *testing.T) {
 			// it either bounces or reaches a person who asked us to stop.
 			name: "skips an archived address even when it is first",
 			person: personWith(
-				address("left@buyer.test", false, true),
-				address("anna@buyer.test", false, false),
+				address("left@buyer.test", retired),
+				address("anna@buyer.test", plain),
 			),
 			want: "anna@buyer.test",
 		},
@@ -79,14 +91,14 @@ func TestTheAddressAContactIsWrittenTo(t *testing.T) {
 			// address itself, and the flag only ranks among live ones.
 			name: "skips an archived address even when it is marked primary",
 			person: personWith(
-				address("left@buyer.test", true, true),
-				address("anna@buyer.test", false, false),
+				address("left@buyer.test", markedAndRetired),
+				address("anna@buyer.test", plain),
 			),
 			want: "anna@buyer.test",
 		},
 		{
 			name:   "answers nothing when every address is archived",
-			person: personWith(address("left@buyer.test", false, true)),
+			person: personWith(address("left@buyer.test", retired)),
 			want:   "",
 		},
 		{

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (68)
+## Parity (69)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -53,6 +53,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `frontendlaneparity_test.go` | H3 | The frontend gate is spelled once as `make check-fe` and run by CI as three parallel jobs. |
 | `frontendminorunits_test.go` | H3 | The browser and the server must scale money by the SAME table, or the integer they exchange means two different amounts. |
 | `frontendoauthoutcomes_test.go` | H3 | The OAuth landing outcome is one vocabulary spelled on both sides of a redirect: the api puts it in the URL the provider sends a human back to, and the SPA turns it into the sentence that human reads. |
+| `frontendprimaryemail_test.go` | H3 | The browser and the server pick the SAME address to write to, or the address a composer prefills and the address a draft is written to differ on a record where the reader can see both. |
 | `frontendprofilevocabulary_test.go` | H3 | The browser spells the company-profile vocabulary five more times, and every one of them fails SILENTLY when it falls short. |
 | `frontendrowtagcap_test.go` | H3 | The browser and the server must agree on how many tags one LIST ROW carries, or the chip strip's "+N" counts a number nobody has. |
 | `frontendsetupproviders_test.go` | H3 | Onboarding offers a first-time admin a provider and a model, and the server has to be able to price and serve exactly what it offered. |

--- a/frontend/src/format/primaryemail.test.ts
+++ b/frontend/src/format/primaryemail.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { components } from "../api/schema";
+import { primaryEmail } from "./primaryemail";
+
+// Which address a message goes to.
+//
+// The cases here are the shared table the SERVER's picker is held to as well: a
+// case added on one side and not the other is the drift
+// backend/gates/frontendprimaryemail_test.go exists to catch. Written to be
+// read from both languages — one list in, one address out.
+
+type PersonEmail = components["schemas"]["PersonEmail"];
+
+function address(over: Partial<PersonEmail> & { email: string }): PersonEmail {
+  return {
+    id: `e-${over.email}`,
+    email_type: "work",
+    is_primary: false,
+    position: 0,
+    source: "manual",
+    captured_by: "human:u-1",
+    ...over,
+  };
+}
+
+describe("the address a contact is written to", () => {
+  it("takes the one marked primary", () => {
+    const emails = [
+      address({ email: "old@buyer.test" }),
+      address({ email: "anna@buyer.test", is_primary: true }),
+    ];
+    expect(primaryEmail(emails)).toBe("anna@buyer.test");
+  });
+
+  // An unmarked address is still reachable. A contact with exactly one address
+  // and no flag set is the ordinary case, and refusing to write to them would
+  // read the flag as permission when it only ranks.
+  it("takes the first live one when nothing is marked", () => {
+    const emails = [
+      address({ email: "anna@buyer.test" }),
+      address({ email: "anna.weber@buyer.test" }),
+    ];
+    expect(primaryEmail(emails)).toBe("anna@buyer.test");
+  });
+
+  // The one wrong answer here. Somebody retired that address: mail to it either
+  // bounces or reaches a person who asked us to stop using it.
+  it("skips an archived address even when it is first", () => {
+    const emails = [
+      address({
+        email: "left@buyer.test",
+        archived_at: "2026-01-01T00:00:00Z",
+      }),
+      address({ email: "anna@buyer.test" }),
+    ];
+    expect(primaryEmail(emails)).toBe("anna@buyer.test");
+  });
+
+  // Archived outranks primary, because retirement is a decision about the
+  // address itself and the flag is only a ranking among live ones.
+  it("skips an archived address even when it is marked primary", () => {
+    const emails = [
+      address({
+        email: "left@buyer.test",
+        is_primary: true,
+        archived_at: "2026-01-01T00:00:00Z",
+      }),
+      address({ email: "anna@buyer.test" }),
+    ];
+    expect(primaryEmail(emails)).toBe("anna@buyer.test");
+  });
+
+  it("answers nothing when every address is archived", () => {
+    const emails = [
+      address({
+        email: "left@buyer.test",
+        archived_at: "2026-01-01T00:00:00Z",
+      }),
+    ];
+    expect(primaryEmail(emails)).toBeUndefined();
+  });
+
+  it("answers nothing for a contact with no address at all", () => {
+    expect(primaryEmail([])).toBeUndefined();
+    expect(primaryEmail(undefined)).toBeUndefined();
+  });
+});

--- a/frontend/src/format/primaryemail.ts
+++ b/frontend/src/format/primaryemail.ts
@@ -1,0 +1,50 @@
+import type { components } from "../api/schema";
+
+// Which of a contact's addresses we write to.
+//
+// A person carries a LIST — several addresses, each with a type, a position and
+// a primary flag, some of them retired. "The contact's email" is therefore a
+// decision rather than a field, and it is one the server already made: this
+// mirrors persondraft.primaryEmail, which is what the drafter addresses a
+// message to. Two rules would mean the address a composer prefills and the
+// address a draft is written to could differ, on a record where the reader can
+// see both.
+//
+// Held by TestBothSidesPickTheSameAddress
+// (backend/gates/frontendprimaryemail_test.go).
+
+type PersonEmail = components["schemas"]["PersonEmail"];
+
+/**
+ * primaryEmail is the address to write to: the one marked primary, and
+ * otherwise the first live one on the record.
+ *
+ * An unmarked address is still reachable — a contact with exactly one address
+ * and no flag set is the ordinary case, and refusing to write to them would
+ * read the flag as permission when it only RANKS.
+ *
+ * An archived address is skipped either way. Somebody retired it, and offering
+ * it back is the one wrong answer here: mail to a retired address either
+ * bounces or reaches a person who asked us to stop using it.
+ *
+ * Undefined when the record carries no live address at all, which a caller
+ * shows as an empty field rather than as a guess.
+ */
+export function primaryEmail(
+  emails: readonly PersonEmail[] | undefined,
+): string | undefined {
+  if (!emails) {
+    return undefined;
+  }
+  let first: string | undefined;
+  for (const email of emails) {
+    if (email.archived_at) {
+      continue;
+    }
+    if (email.is_primary) {
+      return email.email;
+    }
+    first ??= email.email;
+  }
+  return first;
+}

--- a/frontend/src/screens/compose-recipient.test.tsx
+++ b/frontend/src/screens/compose-recipient.test.tsx
@@ -9,6 +9,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { primaryEmail } from "../format/primaryemail";
 import { LocaleProvider } from "../i18n";
 import { ComposeModal } from "./compose";
 
@@ -158,6 +159,50 @@ describe("ComposeModal recipient", () => {
 
     expect(await screen.findByText("dietmar@buyer.test")).toBeTruthy();
     expect(screen.queryByText("dung.ly@example.test")).toBeNull();
+  });
+
+  // A CONTACT's address, picked by the shared rule rather than by this test.
+  // A person carries a list, so the page decides which one; what must not
+  // happen is a retired address being offered, and the rule that prevents it
+  // is format/primaryEmail — mirrored by the drafter and held by
+  // backend/gates/frontendprimaryemail_test.go.
+  it("addresses a first message to the contact's live primary address", async () => {
+    stubRoutes();
+    render(
+      <ComposeModal
+        entityType="person"
+        entityId="p-1"
+        personId="p-1"
+        recordAddress={primaryEmail([
+          {
+            id: "e-1",
+            email: "left@buyer.test",
+            email_type: "work",
+            is_primary: true,
+            position: 0,
+            source: "manual",
+            captured_by: "human:u-1",
+            archived_at: "2026-01-01T00:00:00Z",
+          },
+          {
+            id: "e-2",
+            email: "anna@buyer.test",
+            email_type: "work",
+            is_primary: false,
+            position: 1,
+            source: "manual",
+            captured_by: "human:u-1",
+          },
+        ])}
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("anna@buyer.test")).toBeTruthy();
+    // The retired one is never offered: mail sent there either bounces or
+    // reaches somebody who asked us to stop using it.
+    expect(screen.queryByText("left@buyer.test")).toBeNull();
   });
 
   // A record with no address on file offers nothing, rather than an empty chip

--- a/frontend/src/screens/deal360/dealrecipient.test.ts
+++ b/frontend/src/screens/deal360/dealrecipient.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { components } from "../../api/schema";
+import { dealRecipientSeat } from "./dealrecipient";
+
+// Who a first message from a deal page is offered to.
+//
+// A deal has several stakeholders, so this is a CHOICE in a way a lead's
+// address is not. The rule is the one a rep makes by hand — champion, else
+// somebody the deal is actually talking to, else the first seat — and each
+// preference is asserted against a list where the others would win.
+
+type DealCoverageSeat = components["schemas"]["DealCoverageSeat"];
+
+function seat(over: Partial<DealCoverageSeat> & { person_id: string }) {
+  return {
+    person_name: `Person ${over.person_id}`,
+    role: "user",
+    engaged: false,
+    ...over,
+  } satisfies DealCoverageSeat;
+}
+
+describe("who a deal's first message is offered to", () => {
+  it("takes the champion over an engaged seat and over the first one", () => {
+    const seats = [
+      seat({ person_id: "p-first", engaged: true }),
+      seat({ person_id: "p-champ", role: "champion" }),
+    ];
+    expect(dealRecipientSeat(seats)?.person_id).toBe("p-champ");
+  });
+
+  // A seat somebody has actually spoken with beats one recorded and never
+  // contacted: `engaged` means a two-way exchange happened in the window.
+  it("takes an engaged seat when no champion is recorded", () => {
+    const seats = [
+      seat({ person_id: "p-first" }),
+      seat({ person_id: "p-talking", engaged: true }),
+    ];
+    expect(dealRecipientSeat(seats)?.person_id).toBe("p-talking");
+  });
+
+  it("falls back to the first seat when nobody is champion or engaged", () => {
+    const seats = [seat({ person_id: "p-first" }), seat({ person_id: "p-2" })];
+    expect(dealRecipientSeat(seats)?.person_id).toBe("p-first");
+  });
+
+  // A null person_name means the caller may not read that person. The seat
+  // still counts toward coverage — how many people carry a deal is not being
+  // withheld — but addressing a message to them would put a name in the To
+  // field that the rest of the product refuses to show this reader.
+  it("skips a seat whose person the reader may not see, champion included", () => {
+    const seats = [
+      seat({ person_id: "p-hidden", role: "champion", person_name: null }),
+      seat({ person_id: "p-visible" }),
+    ];
+    expect(dealRecipientSeat(seats)?.person_id).toBe("p-visible");
+  });
+
+  it("offers nobody when every seat is unreadable", () => {
+    const seats = [seat({ person_id: "p-hidden", person_name: null })];
+    expect(dealRecipientSeat(seats)).toBeUndefined();
+  });
+
+  it("offers nobody on a deal with no stakeholders", () => {
+    expect(dealRecipientSeat([])).toBeUndefined();
+    expect(dealRecipientSeat(undefined)).toBeUndefined();
+  });
+});

--- a/frontend/src/screens/deal360/dealrecipient.ts
+++ b/frontend/src/screens/deal360/dealrecipient.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Who a first message from a deal page is addressed to.
+//
+// A deal has SEVERAL stakeholders, each with a buying role, so unlike a lead —
+// whose address is on the record — this is a choice. The rule is the one a rep
+// makes by hand: write to the champion; failing that, to somebody the deal is
+// actually in conversation with; failing that, to the first seat on it.
+//
+// It only ever OFFERS. The composer fills an empty To field once and never over
+// what the reader typed, so a wrong guess here costs one deletion rather than a
+// misdirected message — which is what makes offering better than an empty field
+// on a deal whose champion is sitting in the rail.
+
+import type { components } from "../../api/schema";
+
+type DealCoverageSeat = components["schemas"]["DealCoverageSeat"];
+
+// The seat a rep writes to when the deal has one. Recorded, never inferred from
+// a job title — the contract says so where the role is declared.
+const CHAMPION = "champion";
+
+/**
+ * dealRecipientSeat picks the stakeholder a first message goes to, or undefined
+ * when the deal has nobody to offer.
+ *
+ * A seat whose `person_name` is null is skipped at every step. That null means
+ * the caller may not read that person: the seat still counts toward coverage —
+ * how many people carry a deal is not a fact being withheld — but addressing a
+ * message to somebody this reader cannot open would put a name in their To
+ * field that the rest of the product refuses to show them.
+ *
+ * `engaged` is the second preference because it means a two-way exchange
+ * happened in the window. A seat somebody has actually spoken with is a better
+ * guess than one recorded and never contacted.
+ */
+export function dealRecipientSeat(
+  seats: readonly DealCoverageSeat[] | undefined,
+): DealCoverageSeat | undefined {
+  if (!seats) {
+    return undefined;
+  }
+  const readable = seats.filter((seat) => seat.person_name);
+  return (
+    readable.find((seat) => seat.role === CHAMPION) ??
+    readable.find((seat) => seat.engaged) ??
+    readable[0]
+  );
+}

--- a/frontend/src/screens/deal360/usedealrecipient.tsx
+++ b/frontend/src/screens/deal360/usedealrecipient.tsx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The address a first message from the deal page is offered.
+//
+// Two steps, because a deal reaches an address through a person: pick the seat
+// (dealRecipientSeat), then read that person for the address the rest of the
+// product writes to (format/primaryEmail). Neither half decides anything on its
+// own — the seat rule is the deal's, the address rule is shared with the
+// drafter and every screen.
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../api/client";
+import { primaryEmail } from "../../format/primaryemail";
+import { throwProblem } from "../common";
+import { dealRecipientSeat } from "./dealrecipient";
+import type { useDealCoverage } from "./usedealcoverage";
+
+/**
+ * useDealRecipientAddress answers who a fresh mail on this deal is addressed
+ * to, or undefined when there is nobody to offer.
+ *
+ * It rides the `["person", id]` cache the person page and the composer already
+ * fetch under, so a reader who has opened that contact pays nothing here and
+ * one who has not pays a single read — and only once the coverage answered with
+ * a seat worth reading.
+ *
+ * Undefined while the reads are in flight, when coverage is WITHHELD, and for a
+ * deal whose stakeholders carry no live address. The composer fills an empty
+ * field only, so undefined leaves the reader typing the address exactly as they
+ * do today rather than waiting on anything.
+ */
+export function useDealRecipientAddress(
+  coverage: ReturnType<typeof useDealCoverage>,
+): string | undefined {
+  // Withheld is not empty: a caller without the relationship grant is served no
+  // seats at all, and picking "the first of none" would quietly become "this
+  // deal has nobody on it" for exactly the readers who cannot check.
+  const seat = coverage.withheld
+    ? undefined
+    : dealRecipientSeat(coverage.coverage?.stakeholders);
+  const person = useQuery({
+    queryKey: ["person", seat?.person_id],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/people/{id}", {
+        params: { path: { id: seat?.person_id as string } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+    enabled: seat?.person_id != null,
+  });
+  return primaryEmail(person.data?.emails);
+}

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -103,6 +103,7 @@ import { DealPulse } from "./deal360/dealpulse";
 import { DealSeats } from "./deal360/dealseats";
 import { DealStrip } from "./deal360/dealstrip";
 import { useDealCoverage } from "./deal360/usedealcoverage";
+import { useDealRecipientAddress } from "./deal360/usedealrecipient";
 import { DealBulkBar } from "./dealbulk";
 import { DealEmailAside } from "./dealemail";
 import { DealFiles } from "./dealfiles";
@@ -3162,6 +3163,12 @@ function DealEmailVerb({
   overlay,
   disabledReasonId,
 }: Readonly<{ deal: Deal; overlay: boolean; disabledReasonId?: string }>) {
+  // The same coverage read the readings band and the coverage card already
+  // make, served from one cache entry — so asking here costs no request. Off
+  // in overlay for the reason the hook documents: a mirrored deal's coverage
+  // cannot be assembled, and a doomed fetch reads as "nobody is on this deal".
+  const coverage = useDealCoverage(deal.id, !overlay);
+  const recordAddress = useDealRecipientAddress(coverage);
   if (overlay) {
     return null;
   }
@@ -3169,6 +3176,11 @@ function DealEmailVerb({
     <RecordEmailVerb
       entityType="deal"
       entityId={deal.id}
+      // Who a FIRST message on this deal goes to: the champion, else somebody
+      // the deal is actually in conversation with, else the first seat. Only
+      // ever an offer — the composer fills an empty To field once and never
+      // over what the reader typed.
+      recordAddress={recordAddress}
       disabledReasonId={disabledReasonId}
     />
   );

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -18,6 +18,7 @@ import { TimelineFilterBar } from "../design-system/timelinefilterbar";
 import { useToast } from "../design-system/toast";
 import { ProvenanceTag } from "../design-system/trust";
 import { formatDateTime } from "../format/format";
+import { primaryEmail } from "../format/primaryemail";
 import { normalizeProfileUrl } from "../format/profileurl";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -478,10 +479,12 @@ export function ContactsScreen() {
             key: "email",
             header: t("people.email"),
             cell: (person: Person) => (
+              // The shared rule, not a second spelling of it. This column
+              // used to take find(is_primary) ?? [0], which shows a RETIRED
+              // address whenever one sits first — the reader then writes to an
+              // address somebody deliberately took out of service.
               <span className="t-mono">
-                {person.emails?.find((email) => email.is_primary)?.email ??
-                  person.emails?.[0]?.email ??
-                  ""}
+                {primaryEmail(person.emails) ?? ""}
               </span>
             ),
           },

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -26,6 +26,7 @@ import { OffsiteLink } from "../design-system/offsitelink";
 import { OpenEmailDrawer } from "../design-system/openemaildrawer";
 import { liveProjects } from "../design-system/projectpicker";
 import { RecordTabs } from "../design-system/recordtabs";
+import { primaryEmail } from "../format/primaryemail";
 import { linkedinUrl } from "../format/weburl";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -390,6 +391,7 @@ export function PersonPageV2({
               />
               <PersonEmailPanel
                 personId={id}
+                recordAddress={primaryEmail(person.emails)}
                 overlay={overlay}
                 archived={Boolean(person.archived_at)}
               />
@@ -532,6 +534,7 @@ export function PersonPageV2({
         />
         <PersonMailDrawer
           personId={id}
+          recordAddress={primaryEmail(person.emails)}
           open={drawer === "mail"}
           onClose={() => setDrawer(null)}
         />
@@ -807,9 +810,15 @@ function writeRefusal(
 // page offers no writes.
 function PersonEmailPanel({
   personId,
+  recordAddress,
   overlay,
   archived,
-}: Readonly<{ personId: string; overlay: boolean; archived: boolean }>) {
+}: Readonly<{
+  personId: string;
+  recordAddress?: string;
+  overlay: boolean;
+  archived: boolean;
+}>) {
   if (overlay || archived) {
     return null;
   }
@@ -818,6 +827,7 @@ function PersonEmailPanel({
       entityType="person"
       entityId={personId}
       personId={personId}
+      recordAddress={recordAddress}
       detectWaitingReply
     />
   );
@@ -832,9 +842,18 @@ function PersonEmailPanel({
 // another.
 function PersonMailDrawer({
   personId,
+  recordAddress,
   open,
   onClose,
-}: Readonly<{ personId: string; open: boolean; onClose: () => void }>) {
+}: Readonly<{
+  personId: string;
+  // Which of the contact's addresses a FIRST message goes to. A person carries
+  // a list, so this is the shared decision rather than a field — see
+  // format/primaryemail.ts, mirrored by the drafter.
+  recordAddress?: string;
+  open: boolean;
+  onClose: () => void;
+}>) {
   if (!open) {
     return null;
   }
@@ -844,6 +863,7 @@ function PersonMailDrawer({
       entityType="person"
       entityId={personId}
       personId={personId}
+      recordAddress={recordAddress}
       open
       onClose={onClose}
     />


### PR DESCRIPTION
Follow-up to #3972, which prefilled the composer's To field on a lead but left the person and deal pages opening empty. Both now prefill — and doing it properly turned up a shipped bug.

## The bug it found

`people.tsx` picked a contact's address as `find(is_primary) ?? emails[0]`. That shows an **archived** address whenever one sits first in the list, so the contacts list could display an address somebody deliberately retired — and a reader who copies it writes to a mailbox that either bounces or reaches a person who asked us to stop.

The server has always had the correct rule (`persondraft.primaryEmail`: primary wins, else first live, archived always skipped). The frontend had no shared rule at all.

## One rule, mirrored and held

`format/primaryemail.ts` mirrors the server's picker, and `gates/frontendprimaryemail_test.go` holds the two to one table of six cases in both directions.

**Neither side had a test before this.** The rule was implemented once, in Go, and asserted nowhere — including the archived case, which is the one where being wrong is actively harmful rather than merely different.

## The deal needed a rule of its own

A person has one address to choose. A deal has **several stakeholders**, each with a buying role, so there is a real choice to make. `dealRecipientSeat` makes the one a rep makes by hand:

1. the **champion**
2. else somebody the deal is actually in conversation with (`engaged` means a two-way exchange in the window, not just our sends)
3. else the first seat

A seat whose person the reader may not open is skipped at every step. That seat still counts toward coverage — how many people carry a deal is not being withheld — but addressing a message to them would put a name in the To field that the rest of the product refuses to show them. Withheld coverage offers nobody rather than picking the first of none.

It reads the coverage the readings band and the coverage card already read, served from one cache entry, so it costs no extra request; the address rides the `["person", id]` cache the composer already uses.

## It only ever offers

The composer fills an empty To field once and never over what the reader typed, so a wrong guess costs one deletion. That is what makes offering better than an empty field on a deal whose champion is sitting in the rail.

## Verification

`make check-backend` and `make check-fe` both green after the final rebase; 6,254 frontend tests pass.

Every clause mutation-checked one at a time — dropping the champion preference, the engaged preference, the readable filter, the archived skip or the primary flag each fails exactly the case that names it, and nothing else.

The Go test table's `address(email, false, true)` was a boolean trap the craft gate caught; it now takes a named shape (`plain` / `marked` / `retired` / `markedAndRetired`), which is what the table turns on being able to tell apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefills the composer's To field on person and deal pages, and fixes a bug where the contacts list could show an archived email address.

- Adds `frontend/src/format/primaryemail.ts`, a shared address picker that mirrors the server's rule, and a parity gate that holds both to the same test table.
- Fixes `people.tsx` to use the shared rule instead of `find(is_primary) ?? [0]`, which could offer a retired address.
- Adds `dealRecipientSeat` to pick a deal stakeholder by champion, engaged, then first readable seat, skipping unreadable persons.
- Adds tests for both rules, including the archived-address case, and wires the prefilled address into the person and deal pages.

<sup>Written for commit 4fc069ffaed964e08f262f1548e7f8fb50e9599f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent primary-email selection across people, person profiles, and email composition.
  - Archived addresses are excluded; the first available active address is used when no primary is set.
  - Deal email actions now select an appropriate readable stakeholder and use their preferred email address.
  - Email actions remain unavailable when no eligible recipient or live address exists.

- **Documentation**
  - Updated the parity gate inventory to include the new primary-email consistency check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->