### PR TITLE
A cited cell opens to the records behind it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16453,6 +16453,58 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
+  /analytics/runs/{run_id}/cells/explain:
+    post:
+      tags: [Reports]
+      operationId: explainReportRunCell
+      summary: The records behind one cell of a saved run.
+      description: |
+        The evidence a report block's drawer opens. A block cites a run and a cell; this
+        turns that citation into the records the number was computed from.
+
+        THE QUESTION COMES FROM THE SAVED RUN, not from the request. That is the whole
+        difference between this and `/analytics/explain`, which carries the question whole
+        because a caller-supplied handle they could edit would let an explanation describe a
+        DIFFERENT query than the number came from. A saved run is immutable, so its id names
+        one question and cannot be edited into another.
+
+        The records are read under the CALLER's authority and re-judged against the current
+        floor, exactly as the run's own answer is. A cell the floor withholds explains to
+        `withheld` with no rows: handing those records over one at a time is the same
+        disclosure at a slower pace.
+
+        The cell is named by its group key values, in the saved question's own `group_by`
+        order. A wrong-length group is refused rather than matched positionally against what
+        happens to line up.
+      x-agent-access: human-only
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ReportRunCell' }
+      responses:
+        '200':
+          description: The records behind the cell, as this caller may read them.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AnalyticsExplanation' }
+        '400':
+          description: >-
+            The cell names a different number of group keys than the saved question grouped
+            by. A typed refusal rather than a validation error: the request is well-formed
+            and the mismatch is only knowable against the stored question.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
   /analytics/explain:
     post:
       tags: [Reports]
@@ -31918,6 +31970,19 @@ components:
             The group floor that judged the ORIGINAL answer. Reported, never applied — this
             read is floored by the installation's current setting. Two runs served under
             different floors make different promises about what is missing.
+      additionalProperties: false
+    ReportRunCell:
+      type: object
+      description: One cell of a saved run, named by its group keys.
+      properties:
+        group:
+          type: array
+          items: {}
+          description: >-
+            The cell's group key values, one per grouping in the SAVED question and in that
+            question's own order. Omitted for an ungrouped run, which has one cell. A null
+            entry means the group whose value is unset, which resolves to the records that
+            have nothing there rather than to none.
       additionalProperties: false
     AnalyticsExplainRequest:
       type: object

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -389,6 +389,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/ai/feedback":                                               {Op: "recordAIFeedback", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/analytics/explain":                                         {Op: "explainAnalyticsCell", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/analytics/query":                                           {Op: "runAnalyticsQuery", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/analytics/runs/{run_id}/cells/explain":                     {Op: "explainReportRunCell", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/approval-bundles/{bundle_id}/approve":                      {Op: "approveApprovalBundle", Access: "tool", Tool: "decide_approval_bundle", RecordType: "", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/approval-bundles/{bundle_id}/reject":                       {Op: "rejectApprovalBundle", Access: "tool", Tool: "decide_approval_bundle", RecordType: "", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/approvals/{id}/approve":                                    {Op: "approveApproval", Access: "tool", Tool: "decide_approval", RecordType: "", Tier: "auto_execute", Scope: "write"},

--- a/backend/internal/compose/analyticsqueryhandlers.go
+++ b/backend/internal/compose/analyticsqueryhandlers.go
@@ -159,6 +159,35 @@ func queryFromWire(in crmcontracts.AnalyticsQuery) analyticsquery.Query {
 	return out
 }
 
+// ExplainReportRunCell implements POST /analytics/runs/{run_id}/cells/explain.
+func (h analyticsQueryHandlers) ExplainReportRunCell(
+	w http.ResponseWriter, r *http.Request, runID openapi_types.UUID,
+) {
+	var body crmcontracts.ReportRunCell
+	if !httperr.Decode(w, r, &body) {
+		return
+	}
+	var group []any
+	if body.Group != nil {
+		group = *body.Group
+	}
+
+	ctx := r.Context()
+	var out AnalyticsExplanation
+	if err := h.db.Tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		out, err = ExplainReportRunCell(ctx, tx, ids.UUID(runID), group, h.floor)
+		return err
+	}); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.AnalyticsExplanation{
+		Columns: out.Columns, Rows: out.Rows,
+		Withheld: out.Withheld, Truncated: out.Truncated,
+	})
+}
+
 // wireFromQuery converts a stored question back to the wire.
 //
 // The inverse of queryFromWire, and it exists because a saved run answers with

--- a/backend/internal/compose/reportrun_integration_test.go
+++ b/backend/internal/compose/reportrun_integration_test.go
@@ -318,3 +318,117 @@ func TestSavingARunAuditsTheQuestionAndNotTheRows(t *testing.T) {
 		}
 	}
 }
+
+// A cited cell opens to the records behind it.
+//
+// The drawer's whole job: a report block names a run and a cell, and this turns
+// that citation into rows somebody can read.
+func TestACitedCellOpensToItsRecords(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	for i := 0; i < 6; i++ {
+		e.seedOpenDeal(t, "Deal", 20, &e.Rep1, &amount, nil)
+	}
+	ctx := e.askerCtx()
+	runID := e.saveRun(ctx, t, countAllDeals())
+
+	out, err := e.explainRunCell(ctx, t, runID, nil)
+	if err != nil {
+		t.Fatalf("opening a cited cell: %v", err)
+	}
+	if out.Withheld {
+		t.Fatal("six deals were withheld from a floor of five")
+	}
+	if len(out.Rows) != 6 {
+		t.Errorf("the cell opened to %d records and six deals were seeded", len(out.Rows))
+	}
+}
+
+// A cell naming the wrong number of groupings is refused.
+//
+// The refusal comes from CompileExplain rather than from this path, and the
+// test asserts the MESSAGE for that reason: it is the existing rule being
+// reached through a new door, not a second copy of it, and a change that
+// stopped the door reaching it would leave a citation explainable as a broader
+// cell than the one cited.
+func TestACitedCellIsRefusedWhenItNamesTheWrongNumberOfGroups(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	for i := 0; i < 6; i++ {
+		e.seedOpenDeal(t, "Deal", 20, &e.Rep1, &amount, nil)
+	}
+	ctx := e.askerCtx()
+	// Ungrouped: the saved question has zero groupings, so one group key is
+	// one too many. Matched positionally it would explain the whole population
+	// while claiming to explain a narrower cell.
+	runID := e.saveRun(ctx, t, countAllDeals())
+
+	_, err := e.explainRunCell(ctx, t, runID, []any{"anything"})
+	if err == nil {
+		t.Fatal("a cell naming a grouping the saved question does not have was explained " +
+			"anyway, so a citation can be widened into one covering more records")
+	}
+	var refusal *analyticsquery.RefusalError
+	if !errors.As(err, &refusal) {
+		t.Fatalf("the refusal is %v and should be a typed refusal naming the mismatch", err)
+	}
+	// Both counts, so a reader knows which end is wrong.
+	if !strings.Contains(refusal.Message, "1 group") || !strings.Contains(refusal.Message, "by 0") {
+		t.Errorf("the refusal does not name both counts: %s", refusal.Message)
+	}
+}
+
+// An unknown run explains to not-found, not to a server error.
+func TestAnUnknownRunHasNoCellToExplain(t *testing.T) {
+	e := setupForecast(t)
+	if _, err := e.explainRunCell(e.askerCtx(), t, ids.NewV7(), nil); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("explaining a cell of an unknown run answered %v", err)
+	}
+}
+
+// A reader who may not read the population is refused the records too.
+//
+// The drawer must not be a way around the gate the number itself passes: if the
+// answer refuses, the evidence behind it refuses identically.
+//
+// TWO independent guards hold this, and the test does not distinguish them:
+// ExplainAnalyticsCell asks auth.Require on the population, and the schema
+// derivation drops an entity this caller cannot read so the compile fails with
+// its own denial (deal.read: permission denied). Mutating either alone leaves
+// this green — defence in depth rather than a redundant check to delete.
+func TestACitedCellIsRefusedToAReaderWhoMayNotReadThePopulation(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	for i := 0; i < 6; i++ {
+		e.seedOpenDeal(t, "Deal", 20, &e.Rep1, &amount, nil)
+	}
+	runID := e.saveRun(e.askerCtx(), t, countAllDeals())
+
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:outsider", UserID: ids.NewV7(),
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{
+				"forecast": {Read: true}, "installation_settings": {Read: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	if _, err := e.explainRunCell(ctx, t, runID, nil); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("a seat with no grant on the population opened the evidence drawer: %v", err)
+	}
+}
+
+func (e *forecastEnv) explainRunCell(
+	ctx context.Context, t *testing.T, id ids.UUID, group []any,
+) (AnalyticsExplanation, error) {
+	t.Helper()
+	var out AnalyticsExplanation
+	err := forecasting.NewStore(InstallationDB(e.Pool)).InTx(ctx,
+		func(ctx context.Context, tx pgx.Tx) error {
+			var err error
+			out, err = ExplainReportRunCell(ctx, tx, id, group, analyticsquery.DefaultFloor)
+			return err
+		})
+	return out, err
+}

--- a/backend/internal/compose/reportrunstore.go
+++ b/backend/internal/compose/reportrunstore.go
@@ -178,3 +178,39 @@ func ReadReportRun(
 	out.Answer = answer
 	return out, nil
 }
+
+// ExplainReportRunCell resolves one cell of a saved run to its records.
+//
+// The question comes from the RUN, never from the request. That is what makes a
+// citable evidence handle safe at all: /analytics/explain carries the question
+// whole precisely because a handle a caller could edit would let an explanation
+// describe a different query than the number came from, and nothing downstream
+// could tell. A saved run is immutable, so its id names one question and cannot
+// be edited into another.
+//
+// Everything else is the drill-through's own rules, unchanged: the caller's
+// authority narrows the population, and the cell is re-judged against the
+// CURRENT floor before any record is returned.
+func ExplainReportRunCell(
+	ctx context.Context, tx pgx.Tx, id ids.UUID, group []any, floor analyticsquery.Floor,
+) (AnalyticsExplanation, error) {
+	var queryJSON []byte
+	if err := tx.QueryRow(ctx, `
+		SELECT query FROM report_run WHERE id = $1`, id,
+	).Scan(&queryJSON); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AnalyticsExplanation{}, apperrors.ErrNotFound
+		}
+		return AnalyticsExplanation{}, fmt.Errorf("compose: reading a report run to explain: %w", err)
+	}
+	var q analyticsquery.Query
+	if err := json.Unmarshal(queryJSON, &q); err != nil {
+		return AnalyticsExplanation{}, fmt.Errorf("compose: decoding a report run's question: %w", err)
+	}
+
+	// A group of the wrong length is refused by CompileExplain, which already
+	// counts the cell's keys against the question's groupings and names both
+	// numbers in its message. Re-checking it here would be a second answer to one
+	// question, and the two would drift the first time the rule moved.
+	return ExplainAnalyticsCell(ctx, tx, analyticsquery.Explain{Query: q, Group: group}, floor)
+}

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -199,6 +199,10 @@ func (stubs) GetReportRun(w nethttp.ResponseWriter, r *nethttp.Request, runId op
 	httperr.NotImplemented(w, r, "GetReportRun")
 }
 
+func (stubs) ExplainReportRunCell(w nethttp.ResponseWriter, r *nethttp.Request, runId openapi_types.UUID) {
+	httperr.NotImplemented(w, r, "ExplainReportRunCell")
+}
+
 func (stubs) GetAnalyticsSchema(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetAnalyticsSchema")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -29063,6 +29063,12 @@ type ReportRun struct {
 	StoredFloor int `json:"stored_floor"`
 }
 
+// ReportRunCell One cell of a saved run, named by its group keys.
+type ReportRunCell struct {
+	// Group The cell's group key values, one per grouping in the SAVED question and in that question's own order. Omitted for an ungrouped run, which has one cell. A null entry means the group whose value is unset, which resolves to the records that have nothing there rather than to none.
+	Group *[]interface{} `json:"group,omitempty"`
+}
+
 // RequestAccessResponse defines model for RequestAccessResponse.
 type RequestAccessResponse struct {
 	Requested bool `json:"requested"`
@@ -37481,6 +37487,9 @@ type ExplainAnalyticsCellJSONRequestBody = AnalyticsExplainRequest
 
 // RunAnalyticsQueryJSONRequestBody defines body for RunAnalyticsQuery for application/json ContentType.
 type RunAnalyticsQueryJSONRequestBody = AnalyticsQuery
+
+// ExplainReportRunCellJSONRequestBody defines body for ExplainReportRunCell for application/json ContentType.
+type ExplainReportRunCellJSONRequestBody = ReportRunCell
 
 // ApproveApprovalBundleJSONRequestBody defines body for ApproveApprovalBundle for application/json ContentType.
 type ApproveApprovalBundleJSONRequestBody = ApprovalBundleDecisionRequest
@@ -45956,6 +45965,9 @@ type ServerInterface interface {
 	// The answer a report sentence points at.
 	// (GET /analytics/runs/{run_id})
 	GetReportRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
+	// The records behind one cell of a saved run.
+	// (POST /analytics/runs/{run_id}/cells/explain)
+	ExplainReportRunCell(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
 	// What questions this caller may ask, and in what words.
 	// (GET /analytics/schema)
 	GetAnalyticsSchema(w http.ResponseWriter, r *http.Request)
@@ -47813,6 +47825,12 @@ func (_ Unimplemented) RunAnalyticsQuery(w http.ResponseWriter, r *http.Request)
 // The answer a report sentence points at.
 // (GET /analytics/runs/{run_id})
 func (_ Unimplemented) GetReportRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// The records behind one cell of a saved run.
+// (POST /analytics/runs/{run_id}/cells/explain)
+func (_ Unimplemented) ExplainReportRunCell(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -52878,6 +52896,40 @@ func (siw *ServerInterfaceWrapper) GetReportRun(w http.ResponseWriter, r *http.R
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetReportRun(w, r, runId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ExplainReportRunCell operation middleware
+func (siw *ServerInterfaceWrapper) ExplainReportRunCell(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "run_id" -------------
+	var runId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "run_id", chi.URLParam(r, "run_id"), &runId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "run_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ExplainReportRunCell(w, r, runId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -75944,6 +75996,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/analytics/runs/{run_id}", wrapper.GetReportRun)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/analytics/runs/{run_id}/cells/explain", wrapper.ExplainReportRunCell)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/analytics/schema", wrapper.GetAnalyticsSchema)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11201,6 +11201,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/analytics/runs/{run_id}/cells/explain": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * The records behind one cell of a saved run.
+         * @description The evidence a report block's drawer opens. A block cites a run and a cell; this
+         *     turns that citation into the records the number was computed from.
+         *
+         *     THE QUESTION COMES FROM THE SAVED RUN, not from the request. That is the whole
+         *     difference between this and `/analytics/explain`, which carries the question whole
+         *     because a caller-supplied handle they could edit would let an explanation describe a
+         *     DIFFERENT query than the number came from. A saved run is immutable, so its id names
+         *     one question and cannot be edited into another.
+         *
+         *     The records are read under the CALLER's authority and re-judged against the current
+         *     floor, exactly as the run's own answer is. A cell the floor withholds explains to
+         *     `withheld` with no rows: handing those records over one at a time is the same
+         *     disclosure at a slower pace.
+         *
+         *     The cell is named by its group key values, in the saved question's own `group_by`
+         *     order. A wrong-length group is refused rather than matched positionally against what
+         *     happens to line up.
+         */
+        post: operations["explainReportRunCell"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/analytics/explain": {
         parameters: {
             query?: never;
@@ -23340,6 +23376,11 @@ export interface components {
             asked_by: string;
             /** @description The group floor that judged the ORIGINAL answer. Reported, never applied — this read is floored by the installation's current setting. Two runs served under different floors make different promises about what is missing. */
             stored_floor: number;
+        };
+        /** @description One cell of a saved run, named by its group keys. */
+        ReportRunCell: {
+            /** @description The cell's group key values, one per grouping in the SAVED question and in that question's own order. Omitted for an ungrouped run, which has one cell. A null entry means the group whose value is unset, which resolves to the records that have nothing there rather than to none. */
+            group?: unknown[];
         };
         /** @description One cell of an answer, named by the question and its group keys. */
         AnalyticsExplainRequest: {
@@ -47158,6 +47199,45 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ReportRun"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    explainReportRunCell: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReportRunCell"];
+            };
+        };
+        responses: {
+            /** @description The records behind the cell, as this caller may read them. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnalyticsExplanation"];
+                };
+            };
+            /** @description The cell names a different number of group keys than the saved question grouped by. A typed refusal rather than a validation error: the request is well-formed and the mismatch is only knowable against the stored question. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
                 };
             };
             401: components["responses"]["Unauthorized"];


### PR DESCRIPTION
Stacked on #3973 — review that first; this PR targets `feat/report-run`, not main, so its diff shows only the evidence-handle commit.

A report block cites a run and a cell. This turns that citation into the records the number was computed from, which is what the evidence drawer opens.

## The question comes from the saved run, not the request

That is the whole difference between this and `/analytics/explain`, which deliberately carries the question whole. Its own comment says why: *"Carried whole rather than as a handle the caller could edit: an explanation of a DIFFERENT query than the one that produced the number is not an explanation, and nothing downstream could tell."*

A saved run is immutable, so its id names one question and cannot be edited into another. That is what makes a citable handle safe here where a free-floating one would not be. The request body names only the cell.

Everything else is the drill-through unchanged: records read under the caller authority, cell re-judged against the current floor.

## Verified against a running stack

| Case | Result |
|---|---|
| Cell of a served run | the number said 10, the drawer returned exactly 10 records |
| **Cell the floor withheld** | `withheld: true`, zero rows |
| Unknown run | 404 |
| Malformed uuid | 422 |
| Wrong group count | 400 |
| Unauthenticated | 401 |

The withheld case is the one that matters: handing those records over one at a time is the same disclosure at a slower pace, and it is refused.

Probing also caught a contract error before it shipped. The wrong-group-count case returns **400**, not the 422 first declared — `RefusalError` unwraps to `ErrInvalidArgument`, which the fixed sentinel registry maps to 400. Every declared code is now one observed from the running server.

## Two mutation checks changed the code

**A group-length guard written here was a second implementation.** `CompileExplain` already counts the cell keys against the question groupings and names both numbers in its refusal. Removing my guard left the test green, which is what surfaced the duplication. The guard is gone; the test asserts the real refusal message.

**The permission test stays green when either guard is mutated alone**, because two independent defences hold it: `auth.Require` on the population, and the schema derivation dropping an entity the caller cannot read. Recorded beside the test so the next reader does not delete one as dead.

Four new integration tests; ten in the file total, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns a cited report cell into a link to the records it was computed from, so the evidence drawer can open the actual numbers behind a figure. The question is read from the saved run rather than the request, because a saved run is immutable and names exactly one query; the request only supplies the cell coordinates. The records are still read under the caller's authority and the cell is re-judged against the current floor, so a withheld cell explains with no rows.

**Refactors**
- Removes a group-length guard that duplicated `CompileExplain`'s existing check.
- Documents why the permission test passes when either defense is mutated alone.

<sup>Written for commit c580bee3c1037d2dbc9436e4de1fc1381ec58471. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for authorized users to expand a cell in a saved analytics report into its underlying records.
  * Supports grouped and ungrouped report cells, including unset group values.
  * Applies current access permissions and indicates when records are withheld or results are truncated.
  * Added validation for invalid group selections and standard responses for unauthorized or unavailable report runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->