### PR TITLE
A hung SonarCloud scan fails in eight minutes, not thirty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -850,6 +850,21 @@ jobs:
       # "became main".
       - name: SonarCloud scan
         if: ${{ env.SONAR_TOKEN != '' }}
+        # A CAP ON THE HANG, not on the scan. The scan itself runs in 72-125
+        # seconds; eight minutes is a hang, not a slow day.
+        #
+        # What it bounds is the action's signature verification of the scanner
+        # download, which fetches SonarSource's key from a public keyserver. On
+        # run 32687876395 keyserver.ubuntu.com simply stopped answering, and the
+        # step sat silent for 30 minutes until the JOB timeout killed it — a
+        # runner slot spent for nothing inside a 20-concurrent org ceiling every
+        # pull-request lane also queues in. A rerun of the same commit finished
+        # in 95 seconds. margince/margince#2543.
+        #
+        # NOT skipSignatureVerification. That would make the hang impossible by
+        # not verifying the scanner binary at all, trading an occasional lost
+        # scan for permanently trusting an unverified download.
+        timeout-minutes: 8
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         with:
           args: ${{ github.event_name == 'merge_group' && '-Dsonar.branch.name=main' || '' }}

--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -266,6 +266,21 @@ jobs:
           path: frontend/coverage
       - name: SonarCloud scan
         if: ${{ env.SONAR_TOKEN != '' }}
+        # A CAP ON THE HANG, not on the scan. The scan itself runs in 72-125
+        # seconds; eight minutes is a hang, not a slow day.
+        #
+        # What it bounds is the action's signature verification of the scanner
+        # download, which fetches SonarSource's key from a public keyserver. On
+        # run 32687876395 keyserver.ubuntu.com simply stopped answering, and the
+        # step sat silent for 30 minutes until the JOB timeout killed it — a
+        # runner slot spent for nothing inside a 20-concurrent org ceiling every
+        # pull-request lane also queues in. A rerun of the same commit finished
+        # in 95 seconds. margince/margince#2543.
+        #
+        # NOT skipSignatureVerification. That would make the hang impossible by
+        # not verifying the scanner binary at all, trading an occasional lost
+        # scan for permanently trusting an unverified download.
+        timeout-minutes: 8
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         with:
           args: -Dsonar.branch.name=main

--- a/scripts/scheduled-report.sh
+++ b/scripts/scheduled-report.sh
@@ -376,6 +376,16 @@ decline to answer, it publishes zeros. So the likely cause is an artifact a gree
 producer did not upload rather than anything about the scan itself, and the
 failing step names which download it was.
 
+READ THE RANGE BELOW MORE WEAKLY THAN THE OTHER ARMS' — this is the one lane
+that fails for reasons no commit caused. The scanner download's signature check
+fetches a public keyserver, and when that stopped answering the step sat silent
+until a timeout killed it (margince/margince#2543; the step now caps at eight
+minutes, so a hang is fast and legible rather than a 30-minute silent burn — but
+it still arrives here as a failure). A network outage attributed to somebody's
+commit is a false accusation generated automatically, which is worse than no
+report at all. Check whether the failing step is the scan itself or one of the
+three artifact downloads BEFORE reading these commits as suspects.
+
 ${MAIN_SUSPECTS:-_no suspect range was computed for this run._}
 
 Until it is fixed, treat the quality gate's reading for \`main\` as stale rather


### PR DESCRIPTION
Closes #2543.

## The cap

The scan runs in **72–125 seconds**. On run 32687876395 it sat silent for **30 minutes** and was killed by the *job* timeout having never started — the action's signature verification of the scanner download fetches SonarSource's key from a public keyserver, and `keyserver.ubuntu.com` stopped answering. A rerun of the same commit finished in 95s.

Neither scan step carried a step-level cap, so both inherited the job's. **Eight minutes at both sites** — `ci.yml` and `main-health.yml`, the pair the ticket names as the one that must not drift.

**Not `skipSignatureVerification`.** The ticket rules it out and is right to: it would make the hang impossible by not verifying the scanner binary at all, trading an occasional lost scan for permanently trusting an unverified download.

## The third cost, which the timeout does not fix

On `main-health` a hang reads as *"main's sonar lane is red"*, and that workflow files an issue naming the commits since the last green run. A keyserver outage gets attributed to somebody's commit — **a false accusation generated automatically**, which the ticket rightly calls worse than no report.

An eight-minute cap makes that arrive faster; it still arrives. So the arm now says to read its suspect range **more weakly than the other arms'**, because this is the one lane that fails for reasons no commit caused, and tells the reader to check whether the failing step was the scan itself or one of the three artifact downloads before treating those commits as suspects.

## Left open, deliberately

The ticket's own "worth deciding alongside" pair:

- **whether a hung scan retries once** — a policy call about spending a second runner slot on a lane that is already advisory.
- **whether the report distinguishes "the lane failed" from "the lane never ran"** — this needs the *step's* outcome rather than the job's, which is a change to what `main-health` passes into the reporter. The caveat above bounds the harm; it does not claim to remove it, and the commit message says so rather than implying the ticket is fully answered.

`make check-backend` exit 0; `test-scheduled-report` green; both workflows parse (15 and 7 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an eight-minute timeout to SonarCloud scans to prevent indefinite hangs during scanner downloads or signature verification.
  * Retained scanner signature verification while improving handling of stalled scans across automated workflows.

* **Documentation**
  * Updated scheduled scan failure guidance to distinguish infrastructure or artifact-download issues from failures caused by code changes.
  * Clarified how to interpret scan failures before attributing them to a specific commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->