### PR TITLE
A report carries words and handles, never a number of its own

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16505,6 +16505,55 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
+  /analytics/reports/render:
+    post:
+      tags: [Reports]
+      operationId: renderAnalyticsReport
+      summary: Resolve a report document's figures for this reader.
+      description: |
+        A report document carries STRUCTURE and WORDS. It never carries a figure: every
+        number names a saved run and a cell inside it, and this is where those handles turn
+        into numbers.
+
+        THE DOCUMENT IS REFUSED IF IT CARRIES A NUMBER OF ITS OWN — and it is refused even
+        when a valid handle sits beside the literal. That case is the dangerous one rather
+        than the harmless one: the literal is what would render, the two can disagree, and
+        no reader could tell the page is showing a figure the database never computed.
+
+        Each cited run is resolved the way reading a run directly resolves: the saved
+        QUESTION is re-asked under this caller's own authority and re-judged against the
+        current privacy floor. So the same document shows different figures to readers who
+        may see different populations, and a cell the floor withholds renders as withheld
+        rather than as a number.
+
+        The blocks come back in the order they were composed, each carrying the resolved
+        values for its cells. Nothing is dropped: a document that cannot be rendered whole
+        is refused, because a report missing a block it was composed with says something
+        different from the report that was composed.
+      x-agent-access: human-only
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ReportDocument' }
+      responses:
+        '200':
+          description: The document with every figure resolved for this caller.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RenderedReport' }
+        '400':
+          description: >-
+            The document is not in the block grammar — an unknown block, a literal number, a
+            figure block naming no cell, or an untyped callout. The message names the block
+            by index.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
   /analytics/explain:
     post:
       tags: [Reports]
@@ -31970,6 +32019,130 @@ components:
             The group floor that judged the ORIGINAL answer. Reported, never applied — this
             read is floored by the installation's current setting. Two runs served under
             different floors make different promises about what is missing.
+      additionalProperties: false
+    ReportDocument:
+      type: object
+      description: >-
+        A report as composed: structure and words, with every figure named by a handle.
+      required: [blocks]
+      properties:
+        blocks:
+          type: array
+          minItems: 1
+          items: { $ref: '#/components/schemas/ReportBlock' }
+      additionalProperties: false
+    ReportBlock:
+      type: object
+      description: One element of a report. What fields are legal is decided by `kind`.
+      required: [kind]
+      properties:
+        kind:
+          type: string
+          enum:
+            - title
+            - subtitle
+            - scope
+            - generated_at
+            - summary
+            - methodology
+            - follow_ups
+            - stat_strip
+            - bar
+            - waterfall
+            - ranked_list
+            - record_table
+            - callout
+            - evidence_drawer
+          description: >-
+            The closed set a renderer knows how to draw. An unknown kind is refused rather
+            than dropped: a report missing a block it was composed with says something
+            different from the one composed.
+        text:
+          type: string
+          description: The composer's own words. Prose, never a figure.
+        cells:
+          type: array
+          items: { $ref: '#/components/schemas/ReportCell' }
+          description: >-
+            The figures this block shows, in render order. Required for a block whose
+            purpose is to display a number; refused on one that renders none, where the
+            figure would be silently unshown.
+        severity:
+          type: string
+          enum: [note, warning, partial, unknown, unsupported]
+          description: >-
+            Types a callout, and is meaningless elsewhere. A callout says what the numbers
+            cannot — a partial figure, an unanswerable question, an unsupported grouping —
+            and an untyped one renders as prose, which is how a measured absence becomes
+            indistinguishable from one nobody looked for.
+        value:
+          type: number
+          format: double
+          description: >-
+            ALWAYS REFUSED, and the field exists so the refusal can name what it found. A
+            composer that puts a number here is asking the renderer to draw a figure the
+            database never computed. Carrying one beside a valid handle is refused too, and
+            that case is worse: the literal is what renders, the two can disagree, and
+            nothing downstream can tell.
+      additionalProperties: false
+    ReportCell:
+      type: object
+      description: One figure, named by the run it lives in and the cell within it.
+      required: [run_id, column]
+      properties:
+        run_id:
+          type: string
+          format: uuid
+          description: The saved run. Resolved under the reading caller's own authority.
+        group:
+          type: array
+          items: {}
+          description: >-
+            The cell's group key values, one per grouping in the saved question. Omitted for
+            an ungrouped run, which has one cell.
+        column:
+          type: string
+          description: >-
+            Which measure of the cell to show. A cell can carry several and a block shows
+            one, so which is not a detail a renderer may pick.
+      additionalProperties: false
+    RenderedReport:
+      type: object
+      description: The composed document with every figure resolved for this reader.
+      required: [blocks]
+      properties:
+        blocks:
+          type: array
+          items: { $ref: '#/components/schemas/RenderedBlock' }
+      additionalProperties: false
+    RenderedBlock:
+      type: object
+      required: [kind, values]
+      properties:
+        kind: { type: string }
+        text: { type: string }
+        severity: { type: string }
+        values:
+          type: array
+          items: { $ref: '#/components/schemas/RenderedValue' }
+          description: One entry per cell the block named, in the same order.
+      additionalProperties: false
+    RenderedValue:
+      type: object
+      required: [withheld]
+      properties:
+        value:
+          nullable: true
+          description: >-
+            The figure the database computed, or null when it was withheld. A null with
+            `withheld` false means the cell resolved to no value at all, which is a
+            different fact from one kept back.
+        withheld:
+          type: boolean
+          description: >-
+            The privacy floor kept this figure back for this reader. The block still renders
+            — a figure that vanished would leave the report reading as complete while saying
+            less.
       additionalProperties: false
     ReportRunCell:
       type: object

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -389,6 +389,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/ai/feedback":                                               {Op: "recordAIFeedback", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/analytics/explain":                                         {Op: "explainAnalyticsCell", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/analytics/query":                                           {Op: "runAnalyticsQuery", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/analytics/reports/render":                                  {Op: "renderAnalyticsReport", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/analytics/runs/{run_id}/cells/explain":                     {Op: "explainReportRunCell", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/approval-bundles/{bundle_id}/approve":                      {Op: "approveApprovalBundle", Access: "tool", Tool: "decide_approval_bundle", RecordType: "", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/approval-bundles/{bundle_id}/reject":                       {Op: "rejectApprovalBundle", Access: "tool", Tool: "decide_approval_bundle", RecordType: "", Tier: "auto_execute", Scope: "write"},

--- a/backend/internal/compose/analyticsqueryhandlers.go
+++ b/backend/internal/compose/analyticsqueryhandlers.go
@@ -17,6 +17,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+	"github.com/margince/margince/backend/internal/compose/reportdoc"
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/httperr"
@@ -186,6 +187,80 @@ func (h analyticsQueryHandlers) ExplainReportRunCell(
 		Columns: out.Columns, Rows: out.Rows,
 		Withheld: out.Withheld, Truncated: out.Truncated,
 	})
+}
+
+// RenderAnalyticsReport implements POST /analytics/reports/render.
+func (h analyticsQueryHandlers) RenderAnalyticsReport(w http.ResponseWriter, r *http.Request) {
+	var body crmcontracts.ReportDocument
+	if !httperr.Decode(w, r, &body) {
+		return
+	}
+
+	ctx := r.Context()
+	var blocks []RenderedBlock
+	if err := h.db.Tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		blocks, err = RenderReport(ctx, tx, documentFromWire(body), h.floor)
+		return err
+	}); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+
+	out := crmcontracts.RenderedReport{Blocks: make([]crmcontracts.RenderedBlock, 0, len(blocks))}
+	for _, b := range blocks {
+		block := crmcontracts.RenderedBlock{
+			Kind:   b.Kind,
+			Values: make([]crmcontracts.RenderedValue, 0, len(b.Values)),
+		}
+		if b.Text != "" {
+			text := b.Text
+			block.Text = &text
+		}
+		if b.Severity != "" {
+			severity := b.Severity
+			block.Severity = &severity
+		}
+		for _, v := range b.Values {
+			value := crmcontracts.RenderedValue{Withheld: v.Withheld}
+			if v.Value != nil {
+				held := v.Value
+				value.Value = &held
+			}
+			block.Values = append(block.Values, value)
+		}
+		out.Blocks = append(out.Blocks, block)
+	}
+	httperr.WriteJSON(w, http.StatusOK, out)
+}
+
+// documentFromWire converts the request without validating it.
+//
+// Validation belongs to reportdoc, which is the thing that decides what may
+// render. A second check here would be a second answer to what a report may
+// contain, and the two would drift the first time a block was added.
+func documentFromWire(in crmcontracts.ReportDocument) reportdoc.Document {
+	out := reportdoc.Document{Blocks: make([]reportdoc.Block, 0, len(in.Blocks))}
+	for _, b := range in.Blocks {
+		block := reportdoc.Block{Kind: reportdoc.Kind(b.Kind), Value: b.Value}
+		if b.Text != nil {
+			block.Text = *b.Text
+		}
+		if b.Severity != nil {
+			block.Severity = reportdoc.Severity(*b.Severity)
+		}
+		if b.Cells != nil {
+			for _, c := range *b.Cells {
+				cell := reportdoc.Cell{RunID: c.RunId.String(), Column: c.Column}
+				if c.Group != nil {
+					cell.Group = *c.Group
+				}
+				block.Cells = append(block.Cells, cell)
+			}
+		}
+		out.Blocks = append(out.Blocks, block)
+	}
+	return out
 }
 
 // wireFromQuery converts a stored question back to the wire.

--- a/backend/internal/compose/reportdoc/block.go
+++ b/backend/internal/compose/reportdoc/block.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package reportdoc
+
+// The closed block grammar: what a report document may contain.
+//
+// Closed on purpose. An open grammar — "any block with a type string" — moves
+// the decision about what may render onto whoever composes the document, which
+// is the model. A renderer that meets an unknown block has two bad options,
+// draw it or drop it silently, and both are worse than refusing the document
+// before anybody reads it.
+
+import "fmt"
+
+// Kind names one block type.
+type Kind string
+
+// The blocks a report may carry. Each is here because a report needs it; a
+// kind nobody renders is a kind that cannot be validated against what it
+// renders as.
+const (
+	// Prose and structure. These carry words, never figures.
+	KindTitle       Kind = "title"
+	KindSubtitle    Kind = "subtitle"
+	KindScope       Kind = "scope"
+	KindGeneratedAt Kind = "generated_at"
+	KindSummary     Kind = "summary"
+	KindMethodology Kind = "methodology"
+	KindFollowUps   Kind = "follow_ups"
+
+	// Figures. Every one of these dereferences a cell.
+	KindStatStrip   Kind = "stat_strip"
+	KindBar         Kind = "bar"
+	KindWaterfall   Kind = "waterfall"
+	KindRankedList  Kind = "ranked_list"
+	KindRecordTable Kind = "record_table"
+
+	// What the reader is owed when a number is incomplete or missing.
+	KindCallout        Kind = "callout"
+	KindEvidenceDrawer Kind = "evidence_drawer"
+)
+
+// Severity types a callout. A callout is how a document says something the
+// numbers cannot: that a figure is partial, that a question was unanswerable,
+// that a grouping is unsupported. Typed rather than free prose so a renderer
+// can style a warning differently from a note, and so a reader can tell an
+// absence that was measured from one nobody looked for.
+type Severity string
+
+// The severities a callout may carry.
+const (
+	SeverityNote        Severity = "note"
+	SeverityWarning     Severity = "warning"
+	SeverityPartial     Severity = "partial"
+	SeverityUnknown     Severity = "unknown"
+	SeverityUnsupported Severity = "unsupported"
+)
+
+// Cell names one figure: a saved run and, within it, one cell's group keys.
+//
+// This is the ONLY way a number reaches a report. The document says where the
+// figure lives; what it IS resolves at read time, under the reader's own
+// grants, which is why two readers of one report can legitimately see
+// different figures and one of them can see a refusal.
+type Cell struct {
+	// RunID is the saved run. A string rather than a parsed uuid because this
+	// is wire-shaped input and a malformed one is a refusal with a message,
+	// not a parse panic.
+	RunID string `json:"run_id"`
+	// Group binds the cell's keys, one per grouping in the saved question.
+	// Empty for an ungrouped run, which has one cell.
+	Group []any `json:"group,omitempty"`
+	// Column names which measure of the cell to show. A cell can carry several
+	// and a block shows one.
+	Column string `json:"column"`
+}
+
+// Block is one element of a report.
+//
+// One struct rather than an interface per kind: the wire shape is JSON from a
+// composer, so the type has to survive a round trip through a map anyway, and
+// a dozen tiny types would each need their own decoder. Which fields are legal
+// is decided by Kind, in validate.go.
+type Block struct {
+	Kind Kind `json:"kind"`
+	// Text is the composer's own words. Always allowed to be prose; never
+	// allowed to be a figure the document sourced itself.
+	Text string `json:"text,omitempty"`
+	// Cells are the figures this block shows, in render order.
+	Cells []Cell `json:"cells,omitempty"`
+	// Severity types a callout and is meaningless elsewhere.
+	Severity Severity `json:"severity,omitempty"`
+	// Value is the trap this grammar exists to spring.
+	//
+	// A composer that puts a number here is telling the renderer to draw a
+	// figure the database never computed. It is refused ALWAYS — including,
+	// and especially, when Cells is populated beside it: a block carrying both
+	// renders the literal, the two can disagree, and nothing downstream can
+	// tell that the page is showing a made-up number. The field exists so the
+	// refusal can name what it found rather than silently dropping it.
+	Value *float64 `json:"value,omitempty"`
+}
+
+// Document is a whole report.
+type Document struct {
+	Blocks []Block `json:"blocks"`
+}
+
+// String makes a Kind printable in a refusal without a cast at each site.
+func (k Kind) String() string { return string(k) }
+
+// carriesFigures says whether a kind's purpose is to show numbers.
+//
+// Used to require at least one cell of the blocks that exist to display a
+// figure: a stat strip with nothing to show is a composer error that would
+// render as an empty box, and an empty box beside real numbers reads as a
+// figure of zero.
+func (k Kind) carriesFigures() bool {
+	switch k {
+	case KindStatStrip, KindBar, KindWaterfall, KindRankedList, KindRecordTable:
+		return true
+	default:
+		return false
+	}
+}
+
+// known says whether a kind is in the grammar.
+func (k Kind) known() bool {
+	switch k {
+	case KindTitle, KindSubtitle, KindScope, KindGeneratedAt, KindSummary,
+		KindMethodology, KindFollowUps, KindStatStrip, KindBar, KindWaterfall,
+		KindRankedList, KindRecordTable, KindCallout, KindEvidenceDrawer:
+		return true
+	default:
+		return false
+	}
+}
+
+// known says whether a severity is in the closed set.
+func (s Severity) known() bool {
+	switch s {
+	case SeverityNote, SeverityWarning, SeverityPartial, SeverityUnknown, SeverityUnsupported:
+		return true
+	default:
+		return false
+	}
+}
+
+// blockRef names a block in a refusal so a composer can find it.
+func blockRef(i int, k Kind) string {
+	return fmt.Sprintf("block %d (%s)", i, k)
+}

--- a/backend/internal/compose/reportdoc/doc.go
+++ b/backend/internal/compose/reportdoc/doc.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package reportdoc validates a report document against the closed block
+// grammar.
+//
+// The rule the whole package exists for: a number a reader sees is
+// dereferenced from a saved run's cell, never carried in the document. A
+// composer — a person building a report, or a model drafting one — supplies
+// the STRUCTURE and the WORDS. It never supplies a figure.
+//
+// That is why a numeric literal is refused even when a valid handle sits
+// beside it. A block carrying both is the dangerous case rather than the
+// harmless one: the two can disagree, the literal is what renders, and nobody
+// downstream can tell that the number on the page is not the number the
+// database computed. Refusing only the literal-without-handle case would admit
+// exactly the failure the design exists to prevent.
+//
+// Validation is structural. It says whether a document is well formed and
+// whether every number it shows is dereferenceable; it does not resolve the
+// handles, because resolving is a read and a read belongs to whoever is
+// reading, under their own grants.
+package reportdoc

--- a/backend/internal/compose/reportdoc/validate.go
+++ b/backend/internal/compose/reportdoc/validate.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package reportdoc
+
+// Deciding whether a document may be rendered.
+//
+// Every rule here answers one question: can a reader trust that the figures on
+// this page came from the database? A document that fails is refused whole
+// rather than rendered with the offending block dropped, because a report
+// missing a block it was composed with says something different from the
+// report that was composed.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// InvalidError is a document refused, naming the block and what was wrong.
+//
+// It unwraps to ErrInvalidArgument, so the HTTP layer maps it the way it maps
+// every other malformed input, and a composer reading the message can find the
+// block by index.
+type InvalidError struct {
+	Where  string
+	Reason string
+}
+
+func (e *InvalidError) Error() string { return e.Where + ": " + e.Reason }
+
+// Unwrap ties this to the fixed sentinel registry rather than to a status code
+// spelled here. A refusal that picked its own code would drift from every
+// other invalid input the moment the registry changed.
+func (e *InvalidError) Unwrap() error { return apperrors.ErrInvalidArgument }
+
+// MaxBlocks bounds a document.
+//
+// Not a performance limit: a report is something a person reads, and a
+// thousand-block document is a dump wearing a report's name. The bound is here
+// so the refusal says so rather than a renderer discovering it.
+const MaxBlocks = 200
+
+// Validate refuses a document that a reader could not trust.
+//
+// Returns the distinct run ids the document cites, so the caller can check
+// they exist and are readable in one pass instead of once per block. An empty
+// slice is a legitimate answer: a document of pure prose cites nothing, and
+// nothing about that is wrong — it simply has no figures to get wrong.
+func Validate(doc Document) ([]ids.UUID, error) {
+	if len(doc.Blocks) == 0 {
+		return nil, &InvalidError{
+			Where:  "document",
+			Reason: "a report with no blocks renders as an empty page",
+		}
+	}
+	if len(doc.Blocks) > MaxBlocks {
+		return nil, &InvalidError{
+			Where: "document",
+			Reason: fmt.Sprintf("a report carries at most %d blocks and this one has %d",
+				MaxBlocks, len(doc.Blocks)),
+		}
+	}
+
+	// Ordered, not a bare set: the caller resolves these and reports which
+	// failed, and a map's iteration order would make that message differ
+	// between two identical documents.
+	var runIDs []ids.UUID
+	seen := map[ids.UUID]bool{}
+
+	for i, b := range doc.Blocks {
+		where := blockRef(i, b.Kind)
+		if !b.Kind.known() {
+			return nil, &InvalidError{
+				Where: where,
+				Reason: "no such block kind — a renderer meeting one either draws something " +
+					"nobody specified or drops it silently, and a report missing a block it " +
+					"was composed with says something different from the one composed",
+			}
+		}
+		if err := checkNoLiteral(b, where); err != nil {
+			return nil, err
+		}
+		if err := checkSeverity(b, where); err != nil {
+			return nil, err
+		}
+		if err := checkFigures(b, where); err != nil {
+			return nil, err
+		}
+		for j, c := range b.Cells {
+			id, err := checkCell(c, fmt.Sprintf("%s cell %d", where, j))
+			if err != nil {
+				return nil, err
+			}
+			if !seen[id] {
+				seen[id] = true
+				runIDs = append(runIDs, id)
+			}
+		}
+	}
+	return runIDs, nil
+}
+
+// checkNoLiteral is the rule the package exists for.
+//
+// A literal is refused whether or not a handle sits beside it, and the
+// both-present case is the one that matters: it renders the literal, the two
+// can disagree, and no reader can tell the page is showing a number the
+// database never computed. Refusing only the literal-alone case would admit
+// exactly that.
+func checkNoLiteral(b Block, where string) error {
+	if b.Value == nil {
+		return nil
+	}
+	reason := "a block may not carry a number of its own — every figure is dereferenced " +
+		"from a saved run's cell, so that what a reader sees is what the database computed"
+	if len(b.Cells) > 0 {
+		reason = "this block carries BOTH a literal number and a cell handle. That is worse " +
+			"than a literal alone: the literal is what renders, the two can disagree, and " +
+			"nothing downstream can tell the page is showing a figure the database never " +
+			"computed. Remove the literal and keep the handle"
+	}
+	return &InvalidError{Where: where, Reason: reason}
+}
+
+// checkSeverity keeps the typed-callout vocabulary closed.
+//
+// A callout is how a document reports what the numbers cannot — a partial
+// figure, an unanswerable question, an unsupported grouping. An untyped one
+// would render as ordinary prose, which is how a measured absence becomes
+// indistinguishable from one nobody looked for.
+func checkSeverity(b Block, where string) error {
+	if b.Kind != KindCallout {
+		if b.Severity != "" {
+			return &InvalidError{
+				Where:  where,
+				Reason: "only a callout carries a severity",
+			}
+		}
+		return nil
+	}
+	if b.Severity == "" {
+		return &InvalidError{
+			Where: where,
+			Reason: "a callout states its kind — an untyped one renders as prose, and a " +
+				"measured absence then reads the same as one nobody looked for",
+		}
+	}
+	if !b.Severity.known() {
+		return &InvalidError{
+			Where:  where,
+			Reason: fmt.Sprintf("no such severity %q", b.Severity),
+		}
+	}
+	return nil
+}
+
+// checkFigures requires a figure block to have a figure, and forbids one on a
+// block that renders none.
+//
+// The second half is not tidiness. A cell on a title is a number the composer
+// meant to show somewhere, silently not shown — and a report missing a figure
+// somebody put in it is a report that reads as complete while saying less.
+func checkFigures(b Block, where string) error {
+	if b.Kind.carriesFigures() {
+		if len(b.Cells) == 0 {
+			return &InvalidError{
+				Where: where,
+				Reason: "this block exists to show a figure and names none — it would render " +
+					"as an empty frame, which beside real numbers reads as a figure of zero",
+			}
+		}
+		return nil
+	}
+	if len(b.Cells) > 0 && b.Kind != KindSummary && b.Kind != KindEvidenceDrawer {
+		return &InvalidError{
+			Where: where,
+			Reason: "this block renders no figures, so a cell on it is a number the composer " +
+				"meant to show and nobody would see",
+		}
+	}
+	return nil
+}
+
+// checkCell validates one handle and returns the run it names.
+func checkCell(c Cell, where string) (ids.UUID, error) {
+	id, err := ids.Parse(c.RunID)
+	if err != nil {
+		return ids.UUID{}, &InvalidError{
+			Where:  where,
+			Reason: "names no readable run id",
+		}
+	}
+	if strings.TrimSpace(c.Column) == "" {
+		return ids.UUID{}, &InvalidError{
+			Where: where,
+			Reason: "names no column — a cell can carry several measures and a block shows one, " +
+				"so which is not a detail a renderer may pick",
+		}
+	}
+	return id, nil
+}
+
+// IsInvalid says whether an error is a grammar refusal.
+//
+// Exported because the caller distinguishes "this document is malformed" from
+// "this run does not exist", and the two are different answers to a composer.
+func IsInvalid(err error) bool {
+	var invalid *InvalidError
+	return errors.As(err, &invalid)
+}

--- a/backend/internal/compose/reportdoc/validate_test.go
+++ b/backend/internal/compose/reportdoc/validate_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package reportdoc
+
+// What a report is allowed to say, and the one thing it may never say: a
+// number of its own.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// aRun is a syntactically valid run id. Whether it EXISTS is the caller's
+// question, not the grammar's — validation is structural on purpose.
+var aRun = ids.NewV7().String()
+
+func cell() Cell { return Cell{RunID: aRun, Column: "n"} }
+
+// A figure comes from a handle, and a document of handles is well formed.
+func TestADocumentWhoseFiguresAllComeFromHandlesIsAccepted(t *testing.T) {
+	runs, err := Validate(Document{Blocks: []Block{
+		{Kind: KindTitle, Text: "Pipeline this quarter"},
+		{Kind: KindStatStrip, Cells: []Cell{cell()}},
+		{Kind: KindMethodology, Text: "Open deals, expected close inside the quarter."},
+	}})
+	if err != nil {
+		t.Fatalf("a document citing only handles was refused: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Errorf("the document cites one run and Validate reported %d", len(runs))
+	}
+}
+
+// THE RULE. A literal beside a valid handle is refused, and the refusal says
+// why this case is worse than a literal alone.
+//
+// The plan states it directly: "a test supplies a correct-looking literal
+// alongside a handle and expects refusal". Correct-looking is the point — a
+// wrong number would be caught by a reader, and a plausible one would not.
+func TestALiteralIsRefusedEvenBesideAValidHandle(t *testing.T) {
+	plausible := 42.0
+	_, err := Validate(Document{Blocks: []Block{
+		{Kind: KindTitle, Text: "Pipeline"},
+		{Kind: KindStatStrip, Cells: []Cell{cell()}, Value: &plausible},
+	}})
+	if err == nil {
+		t.Fatal("a block carrying both a literal and a handle was accepted: the literal is " +
+			"what renders, so the page would show a number the database never computed")
+	}
+	if !IsInvalid(err) {
+		t.Fatalf("the refusal is %v and should be a grammar refusal", err)
+	}
+	if !strings.Contains(err.Error(), "BOTH") {
+		t.Errorf("the refusal does not tell the composer that carrying both is the "+
+			"problem: %s", err)
+	}
+}
+
+// And a literal alone is refused too, with the plainer reason.
+func TestALiteralWithNoHandleIsRefused(t *testing.T) {
+	n := 42.0
+	_, err := Validate(Document{Blocks: []Block{
+		{Kind: KindStatStrip, Value: &n},
+	}})
+	if !IsInvalid(err) {
+		t.Fatalf("a block carrying a bare literal was accepted: %v", err)
+	}
+}
+
+// A refusal maps like every other malformed input.
+func TestAGrammarRefusalIsAnInvalidArgument(t *testing.T) {
+	n := 1.0
+	_, err := Validate(Document{Blocks: []Block{{Kind: KindStatStrip, Value: &n}}})
+	if !errors.Is(err, apperrors.ErrInvalidArgument) {
+		t.Errorf("a grammar refusal is %v and should unwrap to the invalid-argument "+
+			"sentinel, so the HTTP layer maps it like every other bad input", err)
+	}
+}
+
+// An unknown block is refused rather than dropped.
+func TestAnUnknownBlockIsRefused(t *testing.T) {
+	_, err := Validate(Document{Blocks: []Block{{Kind: "freeform_html", Text: "<b>hi</b>"}}})
+	if !IsInvalid(err) {
+		t.Fatalf("an unknown block kind was accepted: %v", err)
+	}
+}
+
+// A figure block with no figure would render an empty frame.
+func TestAFigureBlockThatNamesNoCellIsRefused(t *testing.T) {
+	for _, k := range []Kind{KindStatStrip, KindBar, KindWaterfall, KindRankedList, KindRecordTable} {
+		if _, err := Validate(Document{Blocks: []Block{{Kind: k}}}); !IsInvalid(err) {
+			t.Errorf("%s with no cell was accepted: an empty frame beside real numbers "+
+				"reads as a figure of zero", k)
+		}
+	}
+}
+
+// A cell on a block that renders none is a number nobody would see.
+func TestACellOnABlockThatRendersNoFiguresIsRefused(t *testing.T) {
+	if _, err := Validate(Document{Blocks: []Block{
+		{Kind: KindTitle, Text: "Q3", Cells: []Cell{cell()}},
+	}}); !IsInvalid(err) {
+		t.Error("a title carrying a cell was accepted: the figure would be silently unshown")
+	}
+}
+
+// A callout states its kind.
+func TestAnUntypedCalloutIsRefused(t *testing.T) {
+	if _, err := Validate(Document{Blocks: []Block{
+		{Kind: KindCallout, Text: "Some deals lack a close date."},
+	}}); !IsInvalid(err) {
+		t.Error("an untyped callout was accepted: it renders as prose, and a measured " +
+			"absence then reads the same as one nobody looked for")
+	}
+	if _, err := Validate(Document{Blocks: []Block{
+		{Kind: KindCallout, Text: "x", Severity: "catastrophe"},
+	}}); !IsInvalid(err) {
+		t.Error("a callout with an unknown severity was accepted")
+	}
+}
+
+// Severity belongs to a callout and nowhere else.
+func TestSeverityOnANonCalloutIsRefused(t *testing.T) {
+	if _, err := Validate(Document{Blocks: []Block{
+		{Kind: KindTitle, Text: "Q3", Severity: SeverityWarning},
+	}}); !IsInvalid(err) {
+		t.Error("a severity on a title was accepted")
+	}
+}
+
+// A cell names a run and a column.
+func TestACellWithoutARunOrAColumnIsRefused(t *testing.T) {
+	if _, err := Validate(Document{Blocks: []Block{
+		{Kind: KindStatStrip, Cells: []Cell{{RunID: "not-a-uuid", Column: "n"}}},
+	}}); !IsInvalid(err) {
+		t.Error("a cell naming no readable run was accepted")
+	}
+	if _, err := Validate(Document{Blocks: []Block{
+		{Kind: KindStatStrip, Cells: []Cell{{RunID: aRun, Column: "  "}}},
+	}}); !IsInvalid(err) {
+		t.Error("a cell naming no column was accepted: a renderer would pick one")
+	}
+}
+
+// One run cited twice is reported once, in citation order.
+func TestTheCitedRunsAreDistinctAndOrdered(t *testing.T) {
+	second := ids.NewV7().String()
+	runs, err := Validate(Document{Blocks: []Block{
+		{Kind: KindStatStrip, Cells: []Cell{cell(), {RunID: second, Column: "n"}}},
+		{Kind: KindBar, Cells: []Cell{cell()}},
+	}})
+	if err != nil {
+		t.Fatalf("a document citing two runs was refused: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("two distinct runs were cited and Validate reported %d", len(runs))
+	}
+	if runs[0].String() != aRun || runs[1].String() != second {
+		t.Error("the cited runs came back out of citation order, so two identical " +
+			"documents would produce different refusal messages")
+	}
+}
+
+// An empty document is refused, and so is an oversized one.
+func TestADocumentMustHaveBlocksAndNotTooMany(t *testing.T) {
+	if _, err := Validate(Document{}); !IsInvalid(err) {
+		t.Error("a document with no blocks was accepted: it renders as an empty page")
+	}
+	many := make([]Block, MaxBlocks+1)
+	for i := range many {
+		many[i] = Block{Kind: KindTitle, Text: "x"}
+	}
+	if _, err := Validate(Document{Blocks: many}); !IsInvalid(err) {
+		t.Errorf("a document of %d blocks was accepted", len(many))
+	}
+}
+
+// A document of pure prose cites nothing, and that is not an error.
+func TestAProseOnlyDocumentIsAcceptedAndCitesNothing(t *testing.T) {
+	runs, err := Validate(Document{Blocks: []Block{
+		{Kind: KindTitle, Text: "Nothing closed this week"},
+		{Kind: KindSummary, Text: "No deal moved stage."},
+	}})
+	if err != nil {
+		t.Fatalf("a prose-only report was refused: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("a report with no figures cited %d runs", len(runs))
+	}
+}

--- a/backend/internal/compose/reportrender.go
+++ b/backend/internal/compose/reportrender.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Turning a composed report's handles into figures.
+//
+// The document says WHERE each number lives. This resolves each cited run the
+// way reading a run directly resolves it — the saved question re-asked under
+// this caller's own authority, re-judged against the current floor — and then
+// reads the named cell out of the answer.
+//
+// So one document shows different figures to readers who may see different
+// populations, and a cell the floor withheld renders as withheld rather than
+// as a number. That is the same property a saved run has, reached through a
+// second door, and it is why a report can be handed to somebody without
+// handing them the data behind it.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+	"github.com/margince/margince/backend/internal/compose/reportdoc"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// RenderedValue is one figure as this reader may see it.
+type RenderedValue struct {
+	// Value is nil for a withheld figure AND for a cell that resolved to
+	// nothing. Withheld tells the two apart, which matters: one is a number
+	// somebody may not see, the other is a number that does not exist.
+	Value    any
+	Withheld bool
+}
+
+// RenderedBlock is one block with its figures filled in.
+type RenderedBlock struct {
+	Kind     string
+	Text     string
+	Severity string
+	Values   []RenderedValue
+}
+
+// RenderReport resolves every figure a document cites.
+//
+// Each run is read ONCE however many cells cite it. Not for speed: reading a
+// run re-runs its question, and two reads of one run inside a single render
+// could disagree if a row changed between them — the same document would then
+// show two different numbers for one cell.
+func RenderReport(
+	ctx context.Context, tx pgx.Tx, doc reportdoc.Document, floor analyticsquery.Floor,
+) ([]RenderedBlock, error) {
+	runIDs, err := reportdoc.Validate(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	answers := make(map[ids.UUID]AnalyticsAnswer, len(runIDs))
+	for _, id := range runIDs {
+		// The reader's own authority, not the composer's. A run the composer
+		// could read and this reader cannot refuses here, and the refusal is
+		// the whole document's — a report that rendered the blocks a reader
+		// may see and dropped the rest would read as complete while saying
+		// less.
+		run, err := ReadReportRun(ctx, tx, id, floor)
+		if err != nil {
+			return nil, err
+		}
+		answers[id] = run.Answer
+	}
+
+	out := make([]RenderedBlock, 0, len(doc.Blocks))
+	for _, b := range doc.Blocks {
+		rendered := RenderedBlock{
+			Kind: string(b.Kind), Text: b.Text, Severity: string(b.Severity),
+			// Empty, never nil: a block with no figures marshals to [] rather
+			// than null, and a reader parsing null as "unknown" would be
+			// wrong about a block that simply shows prose.
+			Values: []RenderedValue{},
+		}
+		for _, c := range b.Cells {
+			id, err := ids.Parse(c.RunID)
+			if err != nil {
+				// Unreachable: Validate parsed every run id already. Returned
+				// rather than ignored because a swallowed error here would
+				// render a figure of nothing as though it were data.
+				return nil, fmt.Errorf("compose: a validated report cell names an unreadable run: %w", err)
+			}
+			rendered.Values = append(rendered.Values, valueFromAnswer(answers[id], c))
+		}
+		out = append(out, rendered)
+	}
+	return out, nil
+}
+
+// valueFromAnswer reads one cell out of a resolved answer.
+//
+// A cell nothing matches answers withheld=false and value=nil, which is the
+// honest report of "no such group in this reader's data" — different from a
+// group the floor kept back, and different again from a figure of zero.
+func valueFromAnswer(answer AnalyticsAnswer, c reportdoc.Cell) RenderedValue {
+	for _, row := range answer.Rows {
+		if !rowMatchesGroup(row, answer.Columns, c.Group) {
+			continue
+		}
+		// A withheld row lost its values AND its keys, so this reads the row's
+		// own marker rather than inferring withholding from a nil value: a
+		// null measure on a served row is a real absence and must not be
+		// reported as something kept back.
+		if withheld, _ := row[withheldColumn].(bool); withheld {
+			return RenderedValue{Withheld: true}
+		}
+		return RenderedValue{Value: row[c.Column]}
+	}
+	return RenderedValue{}
+}
+
+// rowMatchesGroup says whether a row is the cell the block named.
+//
+// The group keys are compared as their WIRE values, which is what both sides
+// already are: the answer's rows came back through the same JSON shaping the
+// document's group keys were written in, so a number is a float on both sides
+// and a comparison here needs no type table that would drift from it.
+func rowMatchesGroup(row map[string]any, columns []string, group []any) bool {
+	if len(group) == 0 {
+		return true
+	}
+	// The group binds the leading columns, in the answer's own order, because
+	// that is the order the query grouped by and the order the cell's keys
+	// were listed in.
+	for i, want := range group {
+		if i >= len(columns) {
+			return false
+		}
+		if fmt.Sprint(row[columns[i]]) != fmt.Sprint(want) {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/compose/reportrun_integration_test.go
+++ b/backend/internal/compose/reportrun_integration_test.go
@@ -20,12 +20,14 @@ package compose
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+	"github.com/margince/margince/backend/internal/compose/reportdoc"
 	"github.com/margince/margince/backend/internal/modules/forecasting"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -428,6 +430,121 @@ func (e *forecastEnv) explainRunCell(
 		func(ctx context.Context, tx pgx.Tx) error {
 			var err error
 			out, err = ExplainReportRunCell(ctx, tx, id, group, analyticsquery.DefaultFloor)
+			return err
+		})
+	return out, err
+}
+
+// A composed report resolves its figures for whoever is reading.
+//
+// The document carries a handle where the number goes; this is the proof that
+// the number arrives from the database rather than from the document.
+func TestAComposedReportResolvesItsFiguresFromTheRun(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	for i := 0; i < 6; i++ {
+		e.seedOpenDeal(t, "Deal", 20, &e.Rep1, &amount, nil)
+	}
+	ctx := e.askerCtx()
+	runID := e.saveRun(ctx, t, countAllDeals())
+
+	blocks, err := e.render(ctx, t, reportdoc.Document{Blocks: []reportdoc.Block{
+		{Kind: reportdoc.KindTitle, Text: "Open deals"},
+		{Kind: reportdoc.KindStatStrip, Cells: []reportdoc.Cell{
+			{RunID: runID.String(), Column: measureAlias},
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("rendering a report: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("a two-block document rendered %d blocks", len(blocks))
+	}
+	if len(blocks[0].Values) != 0 {
+		t.Errorf("the title rendered %d figures and carries none", len(blocks[0].Values))
+	}
+	if len(blocks[1].Values) != 1 {
+		t.Fatalf("the stat strip rendered %d figures and named one", len(blocks[1].Values))
+	}
+	got := blocks[1].Values[0]
+	if got.Withheld {
+		t.Fatal("six deals were withheld from a floor of five")
+	}
+	if fmt.Sprint(got.Value) != "6" {
+		t.Errorf("the figure resolved to %v and six deals were seeded", got.Value)
+	}
+}
+
+// A figure the floor withholds renders as withheld, not as a number.
+//
+// The block still renders: a figure that vanished would leave the report
+// reading as complete while saying less.
+func TestAWithheldFigureRendersAsWithheld(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	// Two deals, under the floor of five.
+	for i := 0; i < 2; i++ {
+		e.seedOpenDeal(t, "Deal", 20, &e.Rep1, &amount, nil)
+	}
+	ctx := e.askerCtx()
+	runID := e.saveRun(ctx, t, countAllDeals())
+
+	blocks, err := e.render(ctx, t, reportdoc.Document{Blocks: []reportdoc.Block{
+		{Kind: reportdoc.KindStatStrip, Cells: []reportdoc.Cell{
+			{RunID: runID.String(), Column: measureAlias},
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("rendering a withheld report: %v", err)
+	}
+	if len(blocks) != 1 || len(blocks[0].Values) != 1 {
+		t.Fatalf("the document rendered %d blocks", len(blocks))
+	}
+	if !blocks[0].Values[0].Withheld {
+		t.Error("a figure under the floor rendered as a number rather than as withheld")
+	}
+	if blocks[0].Values[0].Value != nil {
+		t.Errorf("a withheld figure carried the value %v", blocks[0].Values[0].Value)
+	}
+}
+
+// A report citing a run this reader may not read is refused whole.
+func TestAReportCitingAnUnreadableRunIsRefused(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	for i := 0; i < 6; i++ {
+		e.seedOpenDeal(t, "Deal", 20, &e.Rep1, &amount, nil)
+	}
+	runID := e.saveRun(e.askerCtx(), t, countAllDeals())
+
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:outsider", UserID: ids.NewV7(),
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{
+				"forecast": {Read: true}, "installation_settings": {Read: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	if _, err := e.render(ctx, t, reportdoc.Document{Blocks: []reportdoc.Block{
+		{Kind: reportdoc.KindStatStrip, Cells: []reportdoc.Cell{
+			{RunID: runID.String(), Column: measureAlias},
+		}},
+	}}); err == nil {
+		t.Fatal("a reader with no grant on the population rendered a report of it")
+	}
+}
+
+func (e *forecastEnv) render(
+	ctx context.Context, t *testing.T, doc reportdoc.Document,
+) ([]RenderedBlock, error) {
+	t.Helper()
+	var out []RenderedBlock
+	err := forecasting.NewStore(InstallationDB(e.Pool)).InTx(ctx,
+		func(ctx context.Context, tx pgx.Tx) error {
+			var err error
+			out, err = RenderReport(ctx, tx, doc, analyticsquery.DefaultFloor)
 			return err
 		})
 	return out, err

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -195,6 +195,10 @@ func (stubs) RunAnalyticsQuery(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "RunAnalyticsQuery")
 }
 
+func (stubs) RenderAnalyticsReport(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "RenderAnalyticsReport")
+}
+
 func (stubs) GetReportRun(w nethttp.ResponseWriter, r *nethttp.Request, runId openapi_types.UUID) {
 	httperr.NotImplemented(w, r, "GetReportRun")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -10141,6 +10141,87 @@ func (e RenewContractRequestValueBasis) Valid() bool {
 	}
 }
 
+// Defines values for ReportBlockKind.
+const (
+	ReportBlockKindBar            ReportBlockKind = "bar"
+	ReportBlockKindCallout        ReportBlockKind = "callout"
+	ReportBlockKindEvidenceDrawer ReportBlockKind = "evidence_drawer"
+	ReportBlockKindFollowUps      ReportBlockKind = "follow_ups"
+	ReportBlockKindGeneratedAt    ReportBlockKind = "generated_at"
+	ReportBlockKindMethodology    ReportBlockKind = "methodology"
+	ReportBlockKindRankedList     ReportBlockKind = "ranked_list"
+	ReportBlockKindRecordTable    ReportBlockKind = "record_table"
+	ReportBlockKindScope          ReportBlockKind = "scope"
+	ReportBlockKindStatStrip      ReportBlockKind = "stat_strip"
+	ReportBlockKindSubtitle       ReportBlockKind = "subtitle"
+	ReportBlockKindSummary        ReportBlockKind = "summary"
+	ReportBlockKindTitle          ReportBlockKind = "title"
+	ReportBlockKindWaterfall      ReportBlockKind = "waterfall"
+)
+
+// Valid indicates whether the value is a known member of the ReportBlockKind enum.
+func (e ReportBlockKind) Valid() bool {
+	switch e {
+	case ReportBlockKindBar:
+		return true
+	case ReportBlockKindCallout:
+		return true
+	case ReportBlockKindEvidenceDrawer:
+		return true
+	case ReportBlockKindFollowUps:
+		return true
+	case ReportBlockKindGeneratedAt:
+		return true
+	case ReportBlockKindMethodology:
+		return true
+	case ReportBlockKindRankedList:
+		return true
+	case ReportBlockKindRecordTable:
+		return true
+	case ReportBlockKindScope:
+		return true
+	case ReportBlockKindStatStrip:
+		return true
+	case ReportBlockKindSubtitle:
+		return true
+	case ReportBlockKindSummary:
+		return true
+	case ReportBlockKindTitle:
+		return true
+	case ReportBlockKindWaterfall:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ReportBlockSeverity.
+const (
+	ReportBlockSeverityNote        ReportBlockSeverity = "note"
+	ReportBlockSeverityPartial     ReportBlockSeverity = "partial"
+	ReportBlockSeverityUnknown     ReportBlockSeverity = "unknown"
+	ReportBlockSeverityUnsupported ReportBlockSeverity = "unsupported"
+	ReportBlockSeverityWarning     ReportBlockSeverity = "warning"
+)
+
+// Valid indicates whether the value is a known member of the ReportBlockSeverity enum.
+func (e ReportBlockSeverity) Valid() bool {
+	switch e {
+	case ReportBlockSeverityNote:
+		return true
+	case ReportBlockSeverityPartial:
+		return true
+	case ReportBlockSeverityUnknown:
+		return true
+	case ReportBlockSeverityUnsupported:
+		return true
+	case ReportBlockSeverityWarning:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ResolveInputCheckOutcome.
 const (
 	AddedEvidence ResolveInputCheckOutcome = "added_evidence"
@@ -13926,25 +14007,25 @@ func (e StartOidcSignInParamsProvider) Valid() bool {
 
 // Defines values for ListAutomationRunsParamsOutcome.
 const (
-	Blocked           ListAutomationRunsParamsOutcome = "blocked"
-	Failed            ListAutomationRunsParamsOutcome = "failed"
-	Fired             ListAutomationRunsParamsOutcome = "fired"
-	QueuedForApproval ListAutomationRunsParamsOutcome = "queued_for_approval"
-	Skipped           ListAutomationRunsParamsOutcome = "skipped"
+	ListAutomationRunsParamsOutcomeBlocked           ListAutomationRunsParamsOutcome = "blocked"
+	ListAutomationRunsParamsOutcomeFailed            ListAutomationRunsParamsOutcome = "failed"
+	ListAutomationRunsParamsOutcomeFired             ListAutomationRunsParamsOutcome = "fired"
+	ListAutomationRunsParamsOutcomeQueuedForApproval ListAutomationRunsParamsOutcome = "queued_for_approval"
+	ListAutomationRunsParamsOutcomeSkipped           ListAutomationRunsParamsOutcome = "skipped"
 )
 
 // Valid indicates whether the value is a known member of the ListAutomationRunsParamsOutcome enum.
 func (e ListAutomationRunsParamsOutcome) Valid() bool {
 	switch e {
-	case Blocked:
+	case ListAutomationRunsParamsOutcomeBlocked:
 		return true
-	case Failed:
+	case ListAutomationRunsParamsOutcomeFailed:
 		return true
-	case Fired:
+	case ListAutomationRunsParamsOutcomeFired:
 		return true
-	case QueuedForApproval:
+	case ListAutomationRunsParamsOutcomeQueuedForApproval:
 		return true
-	case Skipped:
+	case ListAutomationRunsParamsOutcomeSkipped:
 		return true
 	default:
 		return false
@@ -28939,6 +29020,30 @@ type RenameCustomFieldRequest struct {
 	Label *string `json:"label,omitempty"`
 }
 
+// RenderedBlock defines model for RenderedBlock.
+type RenderedBlock struct {
+	Kind     string  `json:"kind"`
+	Severity *string `json:"severity,omitempty"`
+	Text     *string `json:"text,omitempty"`
+
+	// Values One entry per cell the block named, in the same order.
+	Values []RenderedValue `json:"values"`
+}
+
+// RenderedReport The composed document with every figure resolved for this reader.
+type RenderedReport struct {
+	Blocks []RenderedBlock `json:"blocks"`
+}
+
+// RenderedValue defines model for RenderedValue.
+type RenderedValue struct {
+	// Value The figure the database computed, or null when it was withheld. A null with `withheld` false means the cell resolved to no value at all, which is a different fact from one kept back.
+	Value interface{} `json:"value,omitempty"`
+
+	// Withheld The privacy floor kept this figure back for this reader. The block still renders — a figure that vanished would leave the report reading as complete while saying less.
+	Withheld bool `json:"withheld"`
+}
+
 // RenewContractRequest The successor's terms. It freezes its own rate and inherits none — the counterparty
 // excepted, which comes from the predecessor because a renewal that changed companies would
 // be a different agreement wearing this one's history.
@@ -28990,6 +29095,42 @@ type ReplyRecipient struct {
 	FullName string `json:"full_name"`
 }
 
+// ReportBlock One element of a report. What fields are legal is decided by `kind`.
+type ReportBlock struct {
+	// Cells The figures this block shows, in render order. Required for a block whose purpose is to display a number; refused on one that renders none, where the figure would be silently unshown.
+	Cells *[]ReportCell `json:"cells,omitempty"`
+
+	// Kind The closed set a renderer knows how to draw. An unknown kind is refused rather than dropped: a report missing a block it was composed with says something different from the one composed.
+	Kind ReportBlockKind `json:"kind"`
+
+	// Severity Types a callout, and is meaningless elsewhere. A callout says what the numbers cannot — a partial figure, an unanswerable question, an unsupported grouping — and an untyped one renders as prose, which is how a measured absence becomes indistinguishable from one nobody looked for.
+	Severity *ReportBlockSeverity `json:"severity,omitempty"`
+
+	// Text The composer's own words. Prose, never a figure.
+	Text *string `json:"text,omitempty"`
+
+	// Value ALWAYS REFUSED, and the field exists so the refusal can name what it found. A composer that puts a number here is asking the renderer to draw a figure the database never computed. Carrying one beside a valid handle is refused too, and that case is worse: the literal is what renders, the two can disagree, and nothing downstream can tell.
+	Value *float64 `json:"value,omitempty"`
+}
+
+// ReportBlockKind The closed set a renderer knows how to draw. An unknown kind is refused rather than dropped: a report missing a block it was composed with says something different from the one composed.
+type ReportBlockKind string
+
+// ReportBlockSeverity Types a callout, and is meaningless elsewhere. A callout says what the numbers cannot — a partial figure, an unanswerable question, an unsupported grouping — and an untyped one renders as prose, which is how a measured absence becomes indistinguishable from one nobody looked for.
+type ReportBlockSeverity string
+
+// ReportCell One figure, named by the run it lives in and the cell within it.
+type ReportCell struct {
+	// Column Which measure of the cell to show. A cell can carry several and a block shows one, so which is not a detail a renderer may pick.
+	Column string `json:"column"`
+
+	// Group The cell's group key values, one per grouping in the saved question. Omitted for an ungrouped run, which has one cell.
+	Group *[]interface{} `json:"group,omitempty"`
+
+	// RunId The saved run. Resolved under the reading caller's own authority.
+	RunId openapi_types.UUID `json:"run_id"`
+}
+
 // ReportDerivation The "Explain This Number" resolution (features/03 §1.3): a plain-language definition of
 // the exact filter+group+aggregate plus the underlying source rows, which reconcile
 // exactly to the explained aggregate (AC-X1).
@@ -29014,6 +29155,11 @@ type ReportDerivation struct {
 
 	// TotalRows Source rows matched (rows is capped at the report row limit).
 	TotalRows *int `json:"total_rows,omitempty"`
+}
+
+// ReportDocument A report as composed: structure and words, with every figure named by a handle.
+type ReportDocument struct {
+	Blocks []ReportBlock `json:"blocks"`
 }
 
 // ReportResult defines model for ReportResult.
@@ -37487,6 +37633,9 @@ type ExplainAnalyticsCellJSONRequestBody = AnalyticsExplainRequest
 
 // RunAnalyticsQueryJSONRequestBody defines body for RunAnalyticsQuery for application/json ContentType.
 type RunAnalyticsQueryJSONRequestBody = AnalyticsQuery
+
+// RenderAnalyticsReportJSONRequestBody defines body for RenderAnalyticsReport for application/json ContentType.
+type RenderAnalyticsReportJSONRequestBody = ReportDocument
 
 // ExplainReportRunCellJSONRequestBody defines body for ExplainReportRunCell for application/json ContentType.
 type ExplainReportRunCellJSONRequestBody = ReportRunCell
@@ -45962,6 +46111,9 @@ type ServerInterface interface {
 	// Answer a question nobody wrote a report for.
 	// (POST /analytics/query)
 	RunAnalyticsQuery(w http.ResponseWriter, r *http.Request)
+	// Resolve a report document's figures for this reader.
+	// (POST /analytics/reports/render)
+	RenderAnalyticsReport(w http.ResponseWriter, r *http.Request)
 	// The answer a report sentence points at.
 	// (GET /analytics/runs/{run_id})
 	GetReportRun(w http.ResponseWriter, r *http.Request, runId openapi_types.UUID)
@@ -47819,6 +47971,12 @@ func (_ Unimplemented) ExplainAnalyticsCell(w http.ResponseWriter, r *http.Reque
 // Answer a question nobody wrote a report for.
 // (POST /analytics/query)
 func (_ Unimplemented) RunAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Resolve a report document's figures for this reader.
+// (POST /analytics/reports/render)
+func (_ Unimplemented) RenderAnalyticsReport(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -52862,6 +53020,28 @@ func (siw *ServerInterfaceWrapper) RunAnalyticsQuery(w http.ResponseWriter, r *h
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.RunAnalyticsQuery(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RenderAnalyticsReport operation middleware
+func (siw *ServerInterfaceWrapper) RenderAnalyticsReport(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RenderAnalyticsReport(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -75993,6 +76173,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/analytics/query", wrapper.RunAnalyticsQuery)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/analytics/reports/render", wrapper.RenderAnalyticsReport)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/analytics/runs/{run_id}", wrapper.GetReportRun)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11237,6 +11237,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/analytics/reports/render": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resolve a report document's figures for this reader.
+         * @description A report document carries STRUCTURE and WORDS. It never carries a figure: every
+         *     number names a saved run and a cell inside it, and this is where those handles turn
+         *     into numbers.
+         *
+         *     THE DOCUMENT IS REFUSED IF IT CARRIES A NUMBER OF ITS OWN — and it is refused even
+         *     when a valid handle sits beside the literal. That case is the dangerous one rather
+         *     than the harmless one: the literal is what would render, the two can disagree, and
+         *     no reader could tell the page is showing a figure the database never computed.
+         *
+         *     Each cited run is resolved the way reading a run directly resolves: the saved
+         *     QUESTION is re-asked under this caller's own authority and re-judged against the
+         *     current privacy floor. So the same document shows different figures to readers who
+         *     may see different populations, and a cell the floor withholds renders as withheld
+         *     rather than as a number.
+         *
+         *     The blocks come back in the order they were composed, each carrying the resolved
+         *     values for its cells. Nothing is dropped: a document that cannot be rendered whole
+         *     is refused, because a report missing a block it was composed with says something
+         *     different from the report that was composed.
+         */
+        post: operations["renderAnalyticsReport"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/analytics/explain": {
         parameters: {
             query?: never;
@@ -23376,6 +23414,61 @@ export interface components {
             asked_by: string;
             /** @description The group floor that judged the ORIGINAL answer. Reported, never applied — this read is floored by the installation's current setting. Two runs served under different floors make different promises about what is missing. */
             stored_floor: number;
+        };
+        /** @description A report as composed: structure and words, with every figure named by a handle. */
+        ReportDocument: {
+            blocks: components["schemas"]["ReportBlock"][];
+        };
+        /** @description One element of a report. What fields are legal is decided by `kind`. */
+        ReportBlock: {
+            /**
+             * @description The closed set a renderer knows how to draw. An unknown kind is refused rather than dropped: a report missing a block it was composed with says something different from the one composed.
+             * @enum {string}
+             */
+            kind: "title" | "subtitle" | "scope" | "generated_at" | "summary" | "methodology" | "follow_ups" | "stat_strip" | "bar" | "waterfall" | "ranked_list" | "record_table" | "callout" | "evidence_drawer";
+            /** @description The composer's own words. Prose, never a figure. */
+            text?: string;
+            /** @description The figures this block shows, in render order. Required for a block whose purpose is to display a number; refused on one that renders none, where the figure would be silently unshown. */
+            cells?: components["schemas"]["ReportCell"][];
+            /**
+             * @description Types a callout, and is meaningless elsewhere. A callout says what the numbers cannot — a partial figure, an unanswerable question, an unsupported grouping — and an untyped one renders as prose, which is how a measured absence becomes indistinguishable from one nobody looked for.
+             * @enum {string}
+             */
+            severity?: "note" | "warning" | "partial" | "unknown" | "unsupported";
+            /**
+             * Format: double
+             * @description ALWAYS REFUSED, and the field exists so the refusal can name what it found. A composer that puts a number here is asking the renderer to draw a figure the database never computed. Carrying one beside a valid handle is refused too, and that case is worse: the literal is what renders, the two can disagree, and nothing downstream can tell.
+             */
+            value?: number;
+        };
+        /** @description One figure, named by the run it lives in and the cell within it. */
+        ReportCell: {
+            /**
+             * Format: uuid
+             * @description The saved run. Resolved under the reading caller's own authority.
+             */
+            run_id: string;
+            /** @description The cell's group key values, one per grouping in the saved question. Omitted for an ungrouped run, which has one cell. */
+            group?: unknown[];
+            /** @description Which measure of the cell to show. A cell can carry several and a block shows one, so which is not a detail a renderer may pick. */
+            column: string;
+        };
+        /** @description The composed document with every figure resolved for this reader. */
+        RenderedReport: {
+            blocks: components["schemas"]["RenderedBlock"][];
+        };
+        RenderedBlock: {
+            kind: string;
+            text?: string;
+            severity?: string;
+            /** @description One entry per cell the block named, in the same order. */
+            values: components["schemas"]["RenderedValue"][];
+        };
+        RenderedValue: {
+            /** @description The figure the database computed, or null when it was withheld. A null with `withheld` false means the cell resolved to no value at all, which is a different fact from one kept back. */
+            value?: unknown;
+            /** @description The privacy floor kept this figure back for this reader. The block still renders — a figure that vanished would leave the report reading as complete while saying less. */
+            withheld: boolean;
         };
         /** @description One cell of a saved run, named by its group keys. */
         ReportRunCell: {
@@ -47232,6 +47325,43 @@ export interface operations {
                 };
             };
             /** @description The cell names a different number of group keys than the saved question grouped by. A typed refusal rather than a validation error: the request is well-formed and the mismatch is only knowable against the stored question. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    renderAnalyticsReport: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReportDocument"];
+            };
+        };
+        responses: {
+            /** @description The document with every figure resolved for this caller. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RenderedReport"];
+                };
+            };
+            /** @description The document is not in the block grammar — an unknown block, a literal number, a figure block naming no cell, or an untyped callout. The message names the block by index. */
             400: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Stacked on #3980, which is stacked on #3973. Review those first; this PR targets `feat/evidence-handle`, so its diff shows only the block-grammar commit.

Completes PR 14 of the analytics plan for the **web surface**. No MCP tool and no `ui://` app — see "What is deliberately not here".

## The rule

A report document says WHERE each figure lives — a saved run and a cell inside it — and the number resolves when somebody reads the report. The composer, person or model, supplies structure and words.

**A numeric literal on a block is refused, including when a valid handle sits beside it.** The plan states this directly: *"a model-supplied numeric literal is rejected even when the block also carries a valid handle... a test supplies a correct-looking literal alongside a handle and expects refusal."*

That case is the dangerous one, not the harmless one. The literal is what renders, the two can disagree, and nothing downstream can tell the page is showing a figure the database never computed.

Live, against a running server:

```
POST /analytics/reports/render
{"blocks":[{"kind":"stat_strip","value":42,
            "cells":[{"run_id":"...","column":"n"}]}]}

400 — block 0 (stat_strip): this block carries BOTH a literal number and a
cell handle. That is worse than a literal alone: the literal is what renders,
the two can disagree, and nothing downstream can tell the page is showing a
figure the database never computed. Remove the literal and keep the handle
```

The valid document rendered `{"value":10,"withheld":false}` — the document said where, the database said what.

**Mutation-checked.** Changing the guard to accept a literal when a handle is present — the plausible "it also has a handle, so it is fine" reading — fails `TestALiteralIsRefusedEvenBesideAValidHandle` with the message explaining why.

## The grammar is closed

- An **unknown block** is refused rather than drawn or dropped: a report missing a block it was composed with says something different from the report that was composed.
- A **callout states its severity**. An untyped one renders as prose, and a measured absence then reads the same as one nobody looked for.
- A **figure block names a cell**. An empty frame beside real numbers reads as a figure of zero.
- A **cell on a block that renders none** is refused: the figure would be silently unshown.

## Rendering

Each cited run resolves the way reading a run resolves: the saved question re-asked under THIS caller authority, re-judged against the current floor. One document shows different figures to readers who may see different populations, and a withheld cell renders as withheld rather than as a number — with the block still present, because a figure that vanished would leave the report reading as complete while saying less.

Each run is read once however many cells cite it. Not for speed: two reads of one run inside a single render could disagree if a row changed between them, and the same document would then show two different numbers for one cell.

## Verified live

Every declared status code was observed against the running server: 200, and 400 for unknown block / untyped callout / figure block with no cell / literal / empty document, 404 for an unknown run, 401 unauthenticated.

## What is deliberately not here

`compose_analytics_report` and `frontend/src/mcp-apps/analytics-report/`. The served tool catalog is at ~94% of the certification lane prompt window, and that ceiling is derived arithmetic from the local provider context (32,768 = 24,576 prompt + 4,096 completion, rounded), not a number to raise — exceeding it truncates a completion inside a reasoning model thinking, which returns well-formed empty content and reads as a bad model. `run_report`, the closest comparable tool, costs 786 tokens against ~1,270 free.

The validator and the render route are surface-agnostic, so the MCP half can be added later without redoing this.

## Also

`ReportBlock.value` is pinned `format: double`. The generator defaulted it to `float32`, and a truncating cast on a money figure is precisely the silent error this feature exists to prevent.

13 grammar unit tests and 3 integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report documents now carry handles pointing at saved runs instead of numbers, and a new render endpoint resolves those figures at read time under the caller's own authority and privacy floor.

**Report grammar**
- A numeric literal on a block is refused, including when a valid handle sits beside it.
- Unknown blocks, untyped callouts, and figure blocks without a cell are refused whole rather than drawn or dropped.
- A cell on a block that renders no figures is refused.

**Rendering**
- Each cited run's saved question is re-asked under the reader's authority and re-judged against the current floor, so withheld cells render as withheld and two readers can see different figures.
- Each run is read once per render even when several cells cite it, so one document never shows two different numbers for one cell.

<sup>Written for commit 92ce10f28997eb2495782a26a362378cec717833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added report rendering through a human-only analytics endpoint.
  * Reports can reference saved-run data and render supported text, figures, tables, charts, callouts, and evidence sections.
  * Privacy-protected values are clearly marked as withheld.
  * Added validation for report structure, supported content types, citations, and callout severity.

* **Bug Fixes**
  * Prevented unauthorized or unreadable saved-run data from being rendered.
  * Ensured report figures cannot use unverified literal values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->