### PR TITLE
main is red: every outbound send job dies on an undeclared setting

### DIFF
--- a/backend/gates/machineryapplied_test.go
+++ b/backend/gates/machineryapplied_test.go
@@ -43,11 +43,23 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 	// rather than only the entry.
 	read := map[string]string{}
 
+	// The call sites whose entry expression this walk could not name at all.
+	// Kept rather than skipped: an entry the walk drops is one it agrees with,
+	// while ApplyTx refuses it at runtime — which is the defect this gate is
+	// for, one level up.
+	var unreadable []string
+
 	for _, file := range files {
 		pkg := ""
 		if file.Name != nil {
 			pkg = file.Name.Name
 		}
+		// The file's own import aliases, so a qualified entry resolves to the
+		// package that DECLARED it rather than to whatever this file happens to
+		// call that package. An alias is not exotic — the tree carries several —
+		// and an unresolved qualifier would land in the "declaration not found"
+		// arm below, which is precisely where a false negative could hide.
+		aliases := importAliases(file)
 		ast.Inspect(file, func(n ast.Node) bool {
 			switch node := n.(type) {
 			case *ast.ValueSpec:
@@ -60,9 +72,12 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 				if calleeName(node) != "ApplyTx" || len(node.Args) != 3 {
 					return true
 				}
-				if entry := entryName(node.Args[2], pkg); entry != "" {
-					read[entry] = fset.Position(node.Pos()).String()
+				entry := entryName(node.Args[2], pkg, aliases)
+				if entry == "" {
+					unreadable = append(unreadable, fset.Position(node.Pos()).String())
+					return true
 				}
+				read[entry] = fset.Position(node.Pos()).String()
 			}
 			return true
 		})
@@ -81,14 +96,27 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 		t.Fatal("found no settings.Define declarations at all, so nothing below could have been judged")
 	}
 
+	for _, where := range unreadable {
+		t.Errorf("%s: this gate cannot name the entry passed to settings.ApplyTx here, so it cannot "+
+			"check that entry's declaration — and an entry it cannot check is one it agrees with, "+
+			"while ApplyTx refuses an undeclared one at runtime. Pass the entry as a plain "+
+			"identifier or a qualified one.", where)
+	}
+
 	for entry, where := range read {
 		isDeclared, found := declared[entry]
 		switch {
 		case !found:
-			// Not a failure: the call names an entry this walk did not resolve
-			// — a different package's, most often. Reported so the gate's reach
-			// is visible rather than silently narrower than it looks.
-			t.Logf("%s: %s is read through ApplyTx and its declaration was not found in this walk", where, entry)
+			// A FAILURE, not a note. This walk covers all of internal/, which is
+			// where every settings.Define lives, so an entry whose declaration
+			// it cannot find is one it did not resolve rather than one declared
+			// out of reach — and an unresolved entry is exactly the shape a
+			// false negative takes here: reported as "not found" while its
+			// machineryApplied is false and the send lane dies.
+			t.Errorf("%s reads %s through settings.ApplyTx and this walk found no settings.Define "+
+				"for it. Either the entry is declared outside internal/ — in which case this gate's "+
+				"reach is wrong and should say so — or the name was not resolved, and an entry this "+
+				"gate cannot resolve is one it silently passes.", where, entry)
 		case !isDeclared:
 			t.Errorf("%s reads %s through settings.ApplyTx, which refuses an entry not declared "+
 				"MachineryApplied — at runtime, inside the machinery. Declare it where it is defined, "+
@@ -143,14 +171,41 @@ func hasMachineryApplied(expr ast.Expr) bool {
 
 // entryName renders the entry argument as package.Name, resolving a bare
 // identifier against the file's own package.
-func entryName(expr ast.Expr, pkg string) string {
+func entryName(expr ast.Expr, pkg string, aliases map[string]string) string {
 	switch e := expr.(type) {
 	case *ast.Ident:
 		return pkg + "." + e.Name
 	case *ast.SelectorExpr:
 		if qualifier, ok := e.X.(*ast.Ident); ok {
+			// Through the file's aliases, so `idp "…/identity"` names identity
+			// and not idp. An unaliased import maps to itself, so the ordinary
+			// case is unchanged.
+			if declaring, aliased := aliases[qualifier.Name]; aliased {
+				return declaring + "." + e.Sel.Name
+			}
 			return qualifier.Name + "." + e.Sel.Name
 		}
 	}
 	return ""
+}
+
+// importAliases maps the names a file refers to its imports BY onto the package
+// names those imports actually declare.
+//
+// The last path segment is the package name in this tree — the module layout
+// keeps the two the same, and a package whose name differed from its directory
+// would be caught by the "declaration not found" arm rather than passed.
+func importAliases(file *ast.File) map[string]string {
+	out := map[string]string{}
+	for _, spec := range file.Imports {
+		if spec.Name == nil || spec.Name.Name == "_" || spec.Name.Name == "." {
+			continue
+		}
+		path := strings.Trim(spec.Path.Value, `"`)
+		if at := strings.LastIndex(path, "/"); at >= 0 {
+			path = path[at+1:]
+		}
+		out[spec.Name.Name] = path
+	}
+	return out
 }

--- a/backend/gates/machineryapplied_test.go
+++ b/backend/gates/machineryapplied_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+)
+
+// Every setting read through settings.ApplyTx is declared MachineryApplied.
+//
+// The store enforces this already — ApplyTx refuses an undeclared entry — but it
+// refuses at RUNTIME, inside whatever machinery was applying the posture. That
+// is the worst place to find out. installation.country landed read through
+// ApplyTx and not declared (#3976), and the failure surfaced as every outbound
+// send job dying with "installation.country is not declared MachineryApplied"
+// — a dead send lane on main, discovered by a channel round-trip test timing
+// out sixty seconds at a time rather than by anything naming the cause.
+//
+// A declaration and its reader are two lines in two files, and nothing but this
+// held them together. Here they fail at build.
+//
+// WHAT IT DOES NOT CHECK, and cannot from the AST alone: whether the entry
+// SHOULD be machinery-applied. That is a disclosure judgement — the flag lets
+// machinery read a value ungated, so declaring one to silence this gate would
+// be exactly the "never to skip a read gate for convenience" its own doc warns
+// against. This asks only that the two agree; whether they agree on the right
+// answer is the reviewer's.
+func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
+	t.Parallel()
+
+	fset, files := parseGoFilesUnder(t, "internal")
+
+	// entry name -> declared MachineryApplied. Keyed by the VAR name because
+	// that is what a call site names; the key string lives on the entry and is
+	// not resolvable from the call.
+	declared := map[string]bool{}
+	// The reads, as entry name -> where, so a failure names the call site
+	// rather than only the entry.
+	read := map[string]string{}
+
+	for _, file := range files {
+		pkg := ""
+		if file.Name != nil {
+			pkg = file.Name.Name
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.ValueSpec:
+				for i, name := range node.Names {
+					if i < len(node.Values) && definesASetting(node.Values[i]) {
+						declared[pkg+"."+name.Name] = hasMachineryApplied(node.Values[i])
+					}
+				}
+			case *ast.CallExpr:
+				if calleeName(node) != "ApplyTx" || len(node.Args) != 3 {
+					return true
+				}
+				if entry := entryName(node.Args[2], pkg); entry != "" {
+					read[entry] = fset.Position(node.Pos()).String()
+				}
+			}
+			return true
+		})
+	}
+
+	// The floor. This is a prohibition, so an empty walk reads exactly like a
+	// clean tree — and the walk is the part most likely to break silently, since
+	// it depends on Define staying a call and ApplyTx staying a three-argument
+	// one.
+	const readFloor = 4
+	if len(read) < readFloor {
+		t.Fatalf("found %d settings.ApplyTx call site(s), fewer than the %d this gate assumes — "+
+			"the walk stopped matching rather than the tree stopping doing it", len(read), readFloor)
+	}
+	if len(declared) == 0 {
+		t.Fatal("found no settings.Define declarations at all, so nothing below could have been judged")
+	}
+
+	for entry, where := range read {
+		isDeclared, found := declared[entry]
+		switch {
+		case !found:
+			// Not a failure: the call names an entry this walk did not resolve
+			// — a different package's, most often. Reported so the gate's reach
+			// is visible rather than silently narrower than it looks.
+			t.Logf("%s: %s is read through ApplyTx and its declaration was not found in this walk", where, entry)
+		case !isDeclared:
+			t.Errorf("%s reads %s through settings.ApplyTx, which refuses an entry not declared "+
+				"MachineryApplied — at runtime, inside the machinery. Declare it where it is defined, "+
+				"or read it through Get/GetTx and its gate.", where, entry)
+		}
+	}
+}
+
+// definesASetting reports whether the expression is a settings.Define call,
+// possibly wrapped in the builder methods an entry chains.
+func definesASetting(expr ast.Expr) bool {
+	for {
+		call, ok := expr.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+			if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "settings" && strings.HasPrefix(sel.Sel.Name, "Define") {
+				return true
+			}
+			// A builder method — unwrap and keep looking for the Define under it.
+			expr = sel.X
+			continue
+		}
+		// Define[T] renders its type argument as an IndexExpr around the
+		// selector, so the generic form arrives here rather than above.
+		if idx, ok := call.Fun.(*ast.IndexExpr); ok {
+			expr = &ast.CallExpr{Fun: idx.X}
+			continue
+		}
+		return false
+	}
+}
+
+// hasMachineryApplied reports whether the chain carries the declaration.
+func hasMachineryApplied(expr ast.Expr) bool {
+	for {
+		call, ok := expr.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		if sel.Sel.Name == "MachineryApplied" {
+			return true
+		}
+		expr = sel.X
+	}
+}
+
+// entryName renders the entry argument as package.Name, resolving a bare
+// identifier against the file's own package.
+func entryName(expr ast.Expr, pkg string) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return pkg + "." + e.Name
+	case *ast.SelectorExpr:
+		if qualifier, ok := e.X.(*ast.Ident); ok {
+			return qualifier.Name + "." + e.Sel.Name
+		}
+	}
+	return ""
+}

--- a/backend/gates/machineryapplied_test.go
+++ b/backend/gates/machineryapplied_test.go
@@ -71,6 +71,20 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 			pkg = file.Name.Name
 		}
 		aliases := aliasesOf(file, packageOfDir)
+		// The identifiers each function declares for itself. A local, a
+		// parameter or a receiver may share a name with an imported package and
+		// SHADOWS it inside that function — Go says so, and the gate would
+		// otherwise map the qualifier to the package's declarations and match
+		// one, while ApplyTx receives something else entirely and refuses it at
+		// runtime. That is the one direction this gate must not fail in.
+		//
+		// Resolved from the syntax rather than through go/types: a gate that
+		// loaded and type-checked the tree to answer one qualifier would cost
+		// the whole build for a question this answers. It over-refuses instead —
+		// a function holding an unrelated local named like an import makes its
+		// ApplyTx call unreadable — which is a loud, fixable failure rather than
+		// a silent pass, and no call site in the tree hits it today.
+		shadowed := shadowedNamesByFunc(file)
 		ast.Inspect(file, func(n ast.Node) bool {
 			switch node := n.(type) {
 			case *ast.ValueSpec:
@@ -83,7 +97,7 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 				if calleeName(node) != "ApplyTx" || len(node.Args) != 3 {
 					return true
 				}
-				entry := entryName(node.Args[2], pkg, aliases)
+				entry := entryName(node.Args[2], pkg, aliases, shadowed[enclosingFunc(file, node.Pos())])
 				if entry == "" {
 					// The other half of the same rule. An entry whose EXPRESSION
 					// this walk cannot name — one handed through a call, an
@@ -189,7 +203,7 @@ func hasMachineryApplied(expr ast.Expr) bool {
 // resolves the QUALIFIER through the file's imports, so an alias names the
 // package that actually declares the entry rather than whatever the importer
 // chose to call it.
-func entryName(expr ast.Expr, pkg string, aliases map[string]string) string {
+func entryName(expr ast.Expr, pkg string, aliases map[string]string, shadowed map[string]bool) string {
 	switch e := expr.(type) {
 	case *ast.Ident:
 		return pkg + "." + e.Name
@@ -199,12 +213,99 @@ func entryName(expr ast.Expr, pkg string, aliases map[string]string) string {
 			return ""
 		}
 		name := qualifier.Name
+		// A qualifier the enclosing function declares for itself is NOT the
+		// package it looks like. Answering "" makes the call site unreadable
+		// and fails, which is the only safe answer: mapping it through the
+		// aliases would name a package's entry the call never passed.
+		if shadowed[name] {
+			return ""
+		}
 		if declared, found := aliases[name]; found {
 			name = declared
 		}
 		return name + "." + e.Sel.Name
 	}
 	return ""
+}
+
+// enclosingFunc names the function declaration a position falls inside, or ""
+// for a call at file scope. The NAME rather than the node, because it is only
+// ever used to look one set up.
+func enclosingFunc(file *ast.File, pos token.Pos) string {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		if pos >= fn.Pos() && pos <= fn.End() {
+			return fn.Name.Name
+		}
+	}
+	return ""
+}
+
+// shadowedNamesByFunc collects, per function, every identifier that function
+// binds — receiver, parameters, named results, short declarations, var specs
+// and range bindings.
+//
+// Deliberately coarse: it does not model block scope, so a name bound anywhere
+// in a function counts as shadowed throughout it. That over-refuses and cannot
+// under-refuse, which is the direction a gate is allowed to be wrong in.
+func shadowedNamesByFunc(file *ast.File) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		bound := map[string]bool{}
+		for _, field := range fieldsOf(fn) {
+			for _, name := range field.Names {
+				bound[name.Name] = true
+			}
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.AssignStmt:
+				if node.Tok != token.DEFINE {
+					return true
+				}
+				for _, lhs := range node.Lhs {
+					if ident, ok := lhs.(*ast.Ident); ok {
+						bound[ident.Name] = true
+					}
+				}
+			case *ast.ValueSpec:
+				for _, name := range node.Names {
+					bound[name.Name] = true
+				}
+			case *ast.RangeStmt:
+				for _, expr := range []ast.Expr{node.Key, node.Value} {
+					if ident, ok := expr.(*ast.Ident); ok {
+						bound[ident.Name] = true
+					}
+				}
+			}
+			return true
+		})
+		out[fn.Name.Name] = bound
+	}
+	return out
+}
+
+// fieldsOf is a function's receiver, parameters and named results together.
+func fieldsOf(fn *ast.FuncDecl) []*ast.Field {
+	var out []*ast.Field
+	if fn.Recv != nil {
+		out = append(out, fn.Recv.List...)
+	}
+	if fn.Type.Params != nil {
+		out = append(out, fn.Type.Params.List...)
+	}
+	if fn.Type.Results != nil {
+		out = append(out, fn.Type.Results.List...)
+	}
+	return out
 }
 
 // aliasesOf maps each import qualifier in this file to the package name that

--- a/backend/gates/machineryapplied_test.go
+++ b/backend/gates/machineryapplied_test.go
@@ -62,6 +62,8 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 	// The reads, as entry name -> where, so a failure names the call site
 	// rather than only the entry.
 	read := map[string]string{}
+	// The call sites whose entry expression this walk could not name at all.
+	var unreadable []string
 
 	for _, file := range files {
 		pkg := ""
@@ -81,9 +83,18 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 				if calleeName(node) != "ApplyTx" || len(node.Args) != 3 {
 					return true
 				}
-				if entry := entryName(node.Args[2], pkg, aliases); entry != "" {
-					read[entry] = fset.Position(node.Pos()).String()
+				entry := entryName(node.Args[2], pkg, aliases)
+				if entry == "" {
+					// The other half of the same rule. An entry whose EXPRESSION
+					// this walk cannot name — one handed through a call, an
+					// index, a conversion — was dropped here, and a dropped
+					// entry is one the gate agrees with while ApplyTx refuses it
+					// at runtime. Aliases are resolved above; this is what is
+					// left when the shape itself is unreadable.
+					unreadable = append(unreadable, fset.Position(node.Pos()).String())
+					return true
 				}
+				read[entry] = fset.Position(node.Pos()).String()
 			}
 			return true
 		})
@@ -100,6 +111,12 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 	}
 	if len(declared) == 0 {
 		t.Fatal("found no settings.Define declarations at all, so nothing below could have been judged")
+	}
+
+	for _, where := range unreadable {
+		t.Errorf("%s: this gate cannot name the entry passed to settings.ApplyTx here, so it cannot "+
+			"check that entry's declaration — and one it cannot check is one it agrees with. Pass "+
+			"the entry as a plain identifier or a qualified one.", where)
 	}
 
 	for entry, where := range read {

--- a/backend/gates/machineryapplied_test.go
+++ b/backend/gates/machineryapplied_test.go
@@ -7,6 +7,9 @@ package gates
 
 import (
 	"go/ast"
+	"go/token"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -35,6 +38,23 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 
 	fset, files := parseGoFilesUnder(t, "internal")
 
+	// Which package each import path actually declares, so an ALIAS cannot
+	// hide an entry. `identitymod "…/identity"` makes a call read
+	// identitymod.Country while the declaration is identity.Country, and a gate
+	// comparing the two strings finds no match — which used to mean the entry
+	// was logged and accepted, i.e. exactly the case this exists to catch
+	// slipping through under a rename.
+	//
+	// Read from the parsed files rather than assumed from the path's last
+	// segment, because those differ in this tree (contracts declares
+	// crmcontracts).
+	packageOfDir := map[string]string{}
+	for _, path := range goFilePaths(t, "internal") {
+		if file, ok := parsedByPath(files, fset, path); ok && file.Name != nil {
+			packageOfDir[filepath.ToSlash(filepath.Dir(path))] = file.Name.Name
+		}
+	}
+
 	// entry name -> declared MachineryApplied. Keyed by the VAR name because
 	// that is what a call site names; the key string lives on the entry and is
 	// not resolvable from the call.
@@ -48,6 +68,7 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 		if file.Name != nil {
 			pkg = file.Name.Name
 		}
+		aliases := aliasesOf(file, packageOfDir)
 		ast.Inspect(file, func(n ast.Node) bool {
 			switch node := n.(type) {
 			case *ast.ValueSpec:
@@ -60,7 +81,7 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 				if calleeName(node) != "ApplyTx" || len(node.Args) != 3 {
 					return true
 				}
-				if entry := entryName(node.Args[2], pkg); entry != "" {
+				if entry := entryName(node.Args[2], pkg, aliases); entry != "" {
 					read[entry] = fset.Position(node.Pos()).String()
 				}
 			}
@@ -85,10 +106,14 @@ func TestEverySettingReadThroughApplyIsDeclaredMachineryApplied(t *testing.T) {
 		isDeclared, found := declared[entry]
 		switch {
 		case !found:
-			// Not a failure: the call names an entry this walk did not resolve
-			// — a different package's, most often. Reported so the gate's reach
-			// is visible rather than silently narrower than it looks.
-			t.Logf("%s: %s is read through ApplyTx and its declaration was not found in this walk", where, entry)
+			// A FAILURE, not a note. Aliases are resolved above, so an entry
+			// this walk cannot place is one the gate genuinely cannot see —
+			// and accepting it would mean the one shape that hides a missing
+			// declaration is the one shape that passes.
+			t.Errorf("%s reads %s through settings.ApplyTx and this gate cannot find its "+
+				"declaration. Either the entry is declared outside internal/, or the walk "+
+				"stopped recognising a declaration shape — both leave a MachineryApplied "+
+				"omission unable to fail here, which is what this gate is for.", where, entry)
 		case !isDeclared:
 			t.Errorf("%s reads %s through settings.ApplyTx, which refuses an entry not declared "+
 				"MachineryApplied — at runtime, inside the machinery. Declare it where it is defined, "+
@@ -141,16 +166,72 @@ func hasMachineryApplied(expr ast.Expr) bool {
 	}
 }
 
-// entryName renders the entry argument as package.Name, resolving a bare
-// identifier against the file's own package.
-func entryName(expr ast.Expr, pkg string) string {
+// entryName renders the entry argument as declaringPackage.Name.
+//
+// A bare identifier resolves against the file's own package; a qualified one
+// resolves the QUALIFIER through the file's imports, so an alias names the
+// package that actually declares the entry rather than whatever the importer
+// chose to call it.
+func entryName(expr ast.Expr, pkg string, aliases map[string]string) string {
 	switch e := expr.(type) {
 	case *ast.Ident:
 		return pkg + "." + e.Name
 	case *ast.SelectorExpr:
-		if qualifier, ok := e.X.(*ast.Ident); ok {
-			return qualifier.Name + "." + e.Sel.Name
+		qualifier, ok := e.X.(*ast.Ident)
+		if !ok {
+			return ""
 		}
+		name := qualifier.Name
+		if declared, found := aliases[name]; found {
+			name = declared
+		}
+		return name + "." + e.Sel.Name
 	}
 	return ""
+}
+
+// aliasesOf maps each import qualifier in this file to the package name that
+// import path actually declares.
+func aliasesOf(file *ast.File, packageOfDir map[string]string) map[string]string {
+	out := map[string]string{}
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+		// The tree's own packages only. A third-party import can never be the
+		// qualifier on a settings entry, and guessing its package name from a
+		// module path is how a resolver starts inventing answers.
+		declared, known := packageOfDir[strings.TrimPrefix(path, modulePath+"/")]
+		if !known {
+			continue
+		}
+		qualifier := declared
+		if spec.Name != nil {
+			qualifier = spec.Name.Name
+		}
+		out[qualifier] = declared
+	}
+	return out
+}
+
+// goFilePaths is goFilesUnder with the walk error turned into a test failure.
+func goFilePaths(t *testing.T, dir string) []string {
+	t.Helper()
+	paths, err := goFilesUnder(dir)
+	if err != nil {
+		t.Fatalf("walking %s: %v", dir, err)
+	}
+	return paths
+}
+
+// parsedByPath finds the already-parsed file for one path, so the walk is not
+// repeated just to learn package names.
+func parsedByPath(files []*ast.File, fset *token.FileSet, path string) (*ast.File, bool) {
+	for _, file := range files {
+		if fset.Position(file.Pos()).Filename == path {
+			return file, true
+		}
+	}
+	return nil, false
 }

--- a/backend/gates/machineryapplied_test.go
+++ b/backend/gates/machineryapplied_test.go
@@ -206,6 +206,14 @@ func hasMachineryApplied(expr ast.Expr) bool {
 func entryName(expr ast.Expr, pkg string, aliases map[string]string, shadowed map[string]bool) string {
 	switch e := expr.(type) {
 	case *ast.Ident:
+		// The SAME rule the selector arm applies below, and it is needed on
+		// this arm too: a local named for the package-level entry it shadows —
+		// `Country := somethingElse` — would otherwise resolve to the
+		// declaration while ApplyTx receives the local. Unreadable is the only
+		// safe answer here for the reason given there.
+		if shadowed[e.Name] {
+			return ""
+		}
 		return pkg + "." + e.Name
 	case *ast.SelectorExpr:
 		qualifier, ok := e.X.(*ast.Ident)

--- a/backend/internal/compose/integration/capture/gcal_attendeename_integration_test.go
+++ b/backend/internal/compose/integration/capture/gcal_attendeename_integration_test.go
@@ -50,10 +50,19 @@ func personName(t *testing.T, e *integration.SearchEnv, id ids.UUID) (first, las
 func TestACalendarInvitationNamesAContactItsAddressCouldNot(t *testing.T) {
 	e := integration.SetupSearch(t)
 
-	// Through the real people store, and with only the local part for a name —
-	// exactly what capture writes for a person minted from a bare address.
+	// Through the real people store, with only the local part for a name AND
+	// under a CONNECTOR principal — which together are what capture writes for
+	// a person minted from a bare address.
+	//
+	// The principal is not incidental. captured_by records who minted the row,
+	// and completePersonName reads it: a person a human created is one whose
+	// name a human is taken to have set, so the invitation must not overwrite
+	// it (#3974). Seeding this under a human context said "a colleague typed
+	// Buyer" while the comment claimed the capture shape, and the fill then
+	// correctly refused — the test asserted the opposite of what its own setup
+	// described.
 	store := people.NewStore(e.DB())
-	buyer, err := store.EnsurePersonByEmail(personCreator(e), "Buyer", "buyer@acme.com", "manual")
+	buyer, err := store.EnsurePersonByEmail(connectorCreator(e), "Buyer", "buyer@acme.com", "manual")
 	if err != nil {
 		t.Fatalf("seeding the attendee: %v", err)
 	}

--- a/backend/internal/compose/integration/capture/gcal_meetinglink_integration_test.go
+++ b/backend/internal/compose/integration/capture/gcal_meetinglink_integration_test.go
@@ -39,6 +39,29 @@ import (
 // personCreator is a principal that may CREATE a contact. The shared capture
 // helper grants person:read only — deliberately, because a capture connector
 // does not create people through that path — so seeding a contact needs its own.
+// connectorCreator mints a person the way the capture sink does: under a
+// CONNECTOR principal, so captured_by records a connector rather than a
+// colleague.
+//
+// The difference is load-bearing rather than cosmetic. completePersonName takes
+// `captured_by LIKE 'human:%'` as evidence that a human set the display name,
+// and refuses to move it — so a fixture that seeds a capture-shaped person
+// under personCreator is asserting a human typed the name it then expects to be
+// replaced.
+func connectorCreator(e *integration.SearchEnv) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalConnector, ID: "connector:gcal",
+		SeatType: principal.SeatFull,
+		Scopes:   principal.NewScopeSet(),
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"person": {Create: true, Read: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
 func personCreator(e *integration.SearchEnv) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())

--- a/backend/internal/modules/identity/settingsentry.go
+++ b/backend/internal/modules/identity/settingsentry.go
@@ -170,7 +170,22 @@ var Country = settings.Define[string](
 		}
 		return jurisdiction.Code(v).Validate()
 	},
-).AsInstallationIdentity()
+	// MachineryApplied because the outbound authorization engine reads it while
+	// applying the posture to its OWN write — the case that declaration exists
+	// for, and its doc's own words: "the posture must bind whoever the acting
+	// principal happens to be". A send runs under whatever credential asked for
+	// it, and which jurisdiction's rules bind that message is not a fact the
+	// asker's read grants may vary.
+	//
+	// Without it CountryOf's settings.ApplyTx refuses, and every send job fails
+	// with "installation.country is not declared MachineryApplied" — which is
+	// what it did: the entry landed with #3976 reading it through ApplyTx and
+	// not declaring it, so the send lane was dead on main.
+	//
+	// It discloses a jurisdiction code through behaviour, which is the weakest
+	// thing this flag can leak and is already public: an installation's country
+	// is inferable from the rules its own outbound mail obeys.
+).AsInstallationIdentity().MachineryApplied()
 
 // FiscalYearStartMonth is the month the installation's business year begins,
 // 1..12. January is the default, which is what every installation reported by

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -89,7 +89,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (92)
+## Census (93)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -138,6 +138,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `leadpersonlockorder_test.go` | H2 | ONE lock order over the lead and the person it was promoted into. |
 | `license_test.go` | H3 | License-notice fitness function (business/12-license.md §5 "honest labeling", §8 "don't strip notices"): every hand-written Go file must carry the BUSL-1.1 SPDX header, and the obligation is derived from the tree rather than a checklist — a new file is enrolled the moment it exists. |
 | `lintbuildtagreach_test.go` | H2 | Every Go file in this repository is compiled by a pass the merge gate runs, analysed by one that lints, and read by both lint configs or neither. |
+| `machineryapplied_test.go` | H2 | Every setting read through settings.ApplyTx is declared MachineryApplied. |
 | `mailboxproofwriters_test.go` | H2 | A MailboxProof is set in exactly one place, and that place spends the token that earns it. |
 | `makefilepaths_test.go` | H1 | Every config file the Makefiles name is a config file that exists. |
 | `mcpfaultcoverage_test.go` | H2 | A module's typed refusal must be legible on EVERY surface that can reach it, not just the one it was written for. |


### PR DESCRIPTION
`main`'s send lane is dead. Bisected to `a8b0ab8aa` (#3976).

## What happens

`installation.country` landed read through `settings.ApplyTx` and **not declared `MachineryApplied`**, so the store refuses it — at runtime, inside the machinery:

```
ERROR jobs: a worker failed with an unclassified cause
  error.message="settings: installation.country is not declared MachineryApplied
                 — read it through Get/GetTx and its gate"
```

Every `comms_send_email` job fails. It surfaces as `TestInboundThenReplyRoundTrip` timing out **sixty seconds at a time** waiting for a job that will never complete — which names nothing about the cause. The reason was only ever in a worker log line.

## The fix

Declare it. This is the case `MachineryApplied` exists for, in its own doc's words: *"machinery applying the posture to its own write may read it ungated, because the posture must bind whoever the acting principal happens to be."*

A send runs under whatever credential asked for it, and **which jurisdiction's rules bind that message is not a fact the asker's read grants may vary**. What it discloses through behaviour is a jurisdiction code — already inferable from the rules the installation's own outbound mail obeys, which is the weakest thing this flag can leak.

## The gate is the point

The store already enforced this, and enforced it in the worst possible place. A declaration and its reader are two lines in two files; nothing held them together, and the cost of them disagreeing was a dead lane found by a timeout.

`TestEverySettingReadThroughApplyIsDeclaredMachineryApplied` fails at build:

```
internal/modules/identity/settingsentry.go:456:15 reads identity.Country through
settings.ApplyTx, which refuses an entry not declared MachineryApplied — at runtime,
inside the machinery. Declare it where it is defined, or read it through Get/GetTx
and its gate.
```

Verified by undeclaring `Country` again, which reproduces exactly the defect that shipped. It carries a floor on the number of `ApplyTx` call sites, because a prohibition whose walk stopped matching reads exactly like a clean tree — and this walk depends on `Define` staying a call and `ApplyTx` staying three-argument.

**What it deliberately does not check, and says so in the doc comment:** whether an entry *should* be machinery-applied. That is a disclosure judgement, and declaring one to silence a gate is precisely what `MachineryApplied`'s own doc warns against. It asks only that the declaration and the read agree; whether they agree on the right answer is the reviewer's.

## Evidence

`make check-backend` exit 0. `compose/integration/channels`, `modules/consent`, `modules/identity` green. `TestInboundThenReplyRoundTrip` 60.5s timeout → 1.3s pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization processing now accepts the Country setting when applied through settings transactions.
  * Added validation for settings used during transaction processing without the required declarations.
  * Updated capture integration coverage to accurately represent connector-created attendees and contacts.

* **Documentation**
  * Updated the gate inventory to include the new validation and revise the Census total.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->