### PR TITLE
A message's header names everyone on it, and says when it was sent

### DIFF
--- a/backend/internal/compose/integration/emailpresentation_integration_test.go
+++ b/backend/internal/compose/integration/emailpresentation_integration_test.go
@@ -14,8 +14,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/activities"
+	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -425,4 +428,163 @@ func requiredListFields(t *testing.T, schema string) []string {
 			"changed shape or this parse no longer reads it", schema)
 	}
 	return out
+}
+
+// A party the reader is entitled to see must be NAMED, whichever record knows
+// the name.
+//
+// Three sources, and the query read only one. A colleague copied on a message
+// is recorded as a SEAT — capture writes their user_id and, having resolved
+// them rather than read them off a header, no address at all — so the party
+// came back with an empty address and no name. The viewer rendered it as a bare
+// comma in the middle of the To line, and the reader who saw that gap was
+// usually the very person it stood for: a rep could not tell why the message
+// had reached them.
+func TestAColleaguesSeatIsNamedOnTheHeader(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+	id := logEmailActivity(author, t, e, contact, "Outstanding invoices", "Hallo,\n\nanbei.")
+
+	// The row capture writes when it resolves our own side: a user_id, and no
+	// address, exactly as insertParticipant's NULLIF($4, '') leaves it.
+	seatParticipant(t, e, id.UUID, e.Rep2)
+
+	got, err := e.Activities.GetEmailPresentation(author, id, nil)
+	if err != nil {
+		t.Fatalf("presentation: %v", err)
+	}
+	seat := partyForUser(got.To, e.Rep2)
+	if seat == nil {
+		t.Fatal("the colleague's seat is not on the To line at all")
+	}
+	// A name, from app_user. Without it the viewer prints an empty string
+	// between two commas and the reader learns nothing.
+	if seat.DisplayName == nil || strings.TrimSpace(*seat.DisplayName) == "" {
+		t.Error("a colleague's seat reaches the header with no name; app_user knows it")
+	}
+	// And an address, so a reader can see WHICH mailbox of theirs it went to —
+	// which is the fact that answers "why did I get this?".
+	if strings.TrimSpace(seat.Address) == "" {
+		t.Error("a colleague's seat reaches the header with no address; app_user knows it")
+	}
+}
+
+// A colleague who has since LEFT was still on the message. Who it went to in
+// August is a fact about August, and dropping their name because they resigned
+// leaves exactly the gap this join was added to close.
+func TestADepartedColleagueStaysNamedOnAnOldMessage(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+	id := logEmailActivity(author, t, e, contact, "Outstanding invoices", "Hallo,\n\nanbei.")
+	seatParticipant(t, e, id.UUID, e.Rep2)
+
+	deactivateSeat(t, e, e.Rep2)
+
+	got, err := e.Activities.GetEmailPresentation(author, id, nil)
+	if err != nil {
+		t.Fatalf("presentation: %v", err)
+	}
+	seat := partyForUser(got.To, e.Rep2)
+	if seat == nil {
+		t.Fatal("a departed colleague fell off the To line entirely")
+	}
+	if seat.DisplayName == nil || strings.TrimSpace(*seat.DisplayName) == "" {
+		t.Error("a departed colleague lost their name on a message they were on")
+	}
+}
+
+// deactivateSeat is what happens when somebody leaves: status changes and
+// archived_at stays null, which is the pair livemember_test exists to keep
+// callers honest about.
+func deactivateSeat(t *testing.T, e *Env, user ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE app_user SET status = 'deactivated' WHERE id = $1`, user)
+		return err
+	}); err != nil {
+		t.Fatalf("deactivating a seat: %v", err)
+	}
+}
+
+// The weakest of the three sources, and the one nothing read: the name the
+// SENDER typed into the header. Capture keeps it in activity_participant.
+// display_name for a party that resolves to no record of ours, and printing a
+// bare address at a reader when we were told a name is a worse answer.
+func TestAnUnknownSenderIsNamedAsTheyWroteThemselves(t *testing.T) {
+	e := Setup(t)
+	author := e.As(e.Rep1, []ids.UUID{e.Team1}, activityLifecyclePerms)
+	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
+	id := logEmailActivity(author, t, e, contact, "Outstanding invoices", "Hallo,\n\nanbei.")
+
+	// Nobody we hold: no contact, no seat — only what the header said.
+	headerParticipant(t, e, id.UUID, "cc", "aussen@stehend.example", "Andreas Eschbach")
+
+	got, err := e.Activities.GetEmailPresentation(author, id, nil)
+	if err != nil {
+		t.Fatalf("presentation: %v", err)
+	}
+	var found *crmcontracts.EmailParty
+	for i, party := range got.Cc {
+		if party.Address == "aussen@stehend.example" {
+			found = &got.Cc[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("the copied address is not on the Cc line")
+	}
+	if found.DisplayName == nil || *found.DisplayName != "Andreas Eschbach" {
+		t.Errorf("display name = %v, want the name the sender wrote", found.DisplayName)
+	}
+}
+
+// partyForUser finds the party standing for one seat.
+func partyForUser(parties []crmcontracts.EmailParty, user ids.UUID) *crmcontracts.EmailParty {
+	for i, party := range parties {
+		if party.UserId != nil && ids.UUID(*party.UserId) == user {
+			return &parties[i]
+		}
+	}
+	return nil
+}
+
+// seatParticipant records our own side the way capture does when the provider
+// attests it: the seat's id, and NO address.
+//
+// The statement is capture.insertParticipant's, column for column, because the
+// defect under test IS that shape — a row identified only by user_id. That
+// writer is capture-internal and takes a connector message this test has no
+// business assembling, so the shape is reproduced rather than the call; a
+// fixture that wrote an address here would describe a row capture never
+// produces and prove nothing about the one it does.
+func seatParticipant(t *testing.T, e *Env, activityID ids.UUID, user ids.UUID) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO activity_participant (activity_id, user_id, person_id, address, role)
+			SELECT $1, $2, NULL, NULLIF('', ''), 'to'
+			 WHERE EXISTS (SELECT 1 FROM app_user u WHERE u.id = $2)
+			ON CONFLICT DO NOTHING`, activityID, user)
+		return err
+	}); err != nil {
+		t.Fatalf("stamping our own side: %v", err)
+	}
+}
+
+// headerParticipant records a party read off the header and resolved to nothing
+// we hold — an address and the name the sender typed, which is what
+// capture.StampFurtherParticipants leaves when no seat and no contact match.
+func headerParticipant(t *testing.T, e *Env, activityID ids.UUID, role, address, name string) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO activity_participant (activity_id, user_id, person_id, address, role, display_name)
+			VALUES ($1, NULL, NULL, $2, $3, $4)
+			ON CONFLICT DO NOTHING`, activityID, address, role, name)
+		return err
+	}); err != nil {
+		t.Fatalf("stamping a header participant: %v", err)
+	}
 }

--- a/backend/internal/modules/activities/emailpresentation.go
+++ b/backend/internal/modules/activities/emailpresentation.go
@@ -376,10 +376,39 @@ func readEmailParties(ctx context.Context, tx pgx.Tx, id ids.ActivityID) (emailP
 	if scope != "" {
 		personJoin += ` AND (` + scope + `)`
 	}
+	// Three sources for one name, in the order of how much this installation
+	// knows the person. The contact record first — it is ours and it is
+	// maintained. Then the SEAT, for a colleague. Then the name the sender typed
+	// into the header, which capture keeps and nothing here read: it is the
+	// weakest, because it is whatever the other side wrote, but it beats
+	// printing a bare address at a reader.
+	//
+	// A colleague's SEAT is named from app_user, not from person. A message to
+	// somebody in this workspace records their user_id and, for a seat capture
+	// resolved rather than read off a header, no address at all — so a party
+	// joined only against `person` came back with an empty address and no name,
+	// and the reader saw a bare comma where a colleague should be. That reader
+	// is usually the very person it stood for: this is how a rep could not tell
+	// why a message had reached them.
+	//
+	// A seat is not row-scoped the way a contact is. The workspace roster is
+	// readable to every member — it is who a reader shares an installation with
+	// — so naming one discloses nothing the roster does not already.
+	//
+	// And NO liveness filter on that join. Who a message went to in August is a
+	// fact about August: a colleague who has since left was still on it, and
+	// dropping their name would leave a gap in a header that is otherwise
+	// complete — the very defect this join fixes, reappearing for anybody who
+	// resigns. This is the case livemember_test names as outside its rule: a row
+	// resolved by id to render a name does not ask whether the person still
+	// works here.
 	rows, err := tx.Query(ctx, `
-		SELECT ap.role, coalesce(ap.address, ''), p.id, p.full_name, ap.user_id
+		SELECT ap.role, coalesce(ap.address, ''), p.id,
+		       coalesce(p.full_name, u.display_name, ap.display_name), ap.user_id,
+		       coalesce(u.email, '')
 		  FROM activity_participant ap
 		  `+personJoin+`
+		  LEFT JOIN app_user u ON u.id = ap.user_id
 		 WHERE ap.activity_id = $1
 		   AND ap.role IN ('from', 'to', 'cc', 'bcc')
 		 ORDER BY CASE ap.role
@@ -401,11 +430,18 @@ func readEmailParties(ctx context.Context, tx pgx.Tx, id ids.ActivityID) (emailP
 		bcc:  emptyParties(),
 	}
 	for rows.Next() {
-		var role, address string
+		var role, address, seatEmail string
 		var personID, userID *ids.UUID
 		var fullName *string
-		if err := rows.Scan(&role, &address, &personID, &fullName, &userID); err != nil {
+		if err := rows.Scan(&role, &address, &personID, &fullName, &userID, &seatEmail); err != nil {
 			return emailParties{}, err
+		}
+		// The seat's own address, when the participant row carries none. Capture
+		// writes an address for a party it read off a header and only a user_id
+		// for one it resolved to a seat, so this is the difference between a
+		// header line naming a colleague and one with a gap in it.
+		if address == "" {
+			address = seatEmail
 		}
 		party := crmcontracts.EmailParty{Address: address, DisplayName: fullName}
 		if personID != nil {

--- a/frontend/src/design-system/emaildetail.css
+++ b/frontend/src/design-system/emaildetail.css
@@ -26,9 +26,11 @@
   margin: 0;
 }
 
+/* Wide enough for the longest label in every catalog — "Gesendet" is the one
+   that sets it — so the values line up in a column instead of stepping. */
 .emaildetail__partyLabel {
   display: inline-block;
-  min-width: 3.5rem;
+  min-width: 5.5rem;
   color: var(--textSecondary);
 }
 
@@ -66,12 +68,6 @@
   color: var(--textSecondary);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-}
-
-.emaildetail__when {
-  margin: 0;
-  color: var(--textSecondary);
-  font-size: var(--fs-meta);
 }
 
 /* The heading and the way out, on one line. */

--- a/frontend/src/design-system/emaildetail.tsx
+++ b/frontend/src/design-system/emaildetail.tsx
@@ -169,7 +169,7 @@ function EmailBody({
   const parts = splitEmailBody(presentation.body ?? "");
   return (
     <div className="emaildetail__body">
-      <Parties presentation={presentation} />
+      <Parties presentation={presentation} formatWhen={formatWhen} />
       <p className="emaildetail__main">{parts.main}</p>
       {/* A SIGN-OFF is the sender still speaking, and it is two lines. It is
           shown, quietly, under the message it belongs to.
@@ -192,9 +192,6 @@ function EmailBody({
         </details>
       )}
       <Attachments files={presentation.attachments} />
-      <p className="emaildetail__when">
-        {formatWhen(presentation.occurred_at)}
-      </p>
     </div>
   );
 }
@@ -250,30 +247,63 @@ function Attachments({ files }: Readonly<{ files: EmailAttachmentSummary[] }>) {
   );
 }
 
+/**
+ * partyName is what one participant is called on a header line.
+ *
+ * The name, then the address, then nothing — and the LAST step is the one that
+ * matters. `display_name ?? address` renders an empty string as empty, because
+ * `??` only catches null: a party with neither produced a bare comma in the
+ * middle of the To line, which reads as a recipient whose name we lost rather
+ * than as a row the response never filled in.
+ */
+function partyName(party: EmailParty): string {
+  return party.display_name?.trim() || party.address.trim();
+}
+
 function PartyLine({
   label,
   parties,
 }: Readonly<{ label: string; parties: EmailParty[] }>) {
-  if (parties.length === 0) {
+  // Only the parties that can actually be named. A row carrying neither a name
+  // nor an address says nothing to a reader, and joining it in puts a gap in
+  // the list where a person should be — so it is dropped, and a line with
+  // nobody left to name does not draw at all.
+  const named = parties.map(partyName).filter(Boolean);
+  if (named.length === 0) {
     return null;
   }
   return (
     <p className="emaildetail__party">
       <span className="emaildetail__partyLabel">{label}</span>
-      {parties.map((p) => p.display_name ?? p.address).join(", ")}
+      {named.join(", ")}
     </p>
   );
 }
 
 function Parties({
   presentation,
-}: Readonly<{ presentation: EmailPresentation }>) {
+  formatWhen,
+}: Readonly<{
+  presentation: EmailPresentation;
+  formatWhen: (iso: string) => string;
+}>) {
   const t = useT();
   return (
     <div className="emaildetail__parties">
       <PartyLine label={t("email.detail.from")} parties={presentation.from} />
       <PartyLine label={t("email.detail.to")} parties={presentation.to} />
       <PartyLine label={t("email.detail.cc")} parties={presentation.cc} />
+      {/* WHEN it was sent, beside who it was sent to. It used to sit under the
+          message, below the attachments — so on anything longer than a screen
+          the reader had to scroll past the whole body to learn the date, which
+          is one of the first things they came for. It is an envelope fact and
+          it belongs with the others. */}
+      <p className="emaildetail__party">
+        <span className="emaildetail__partyLabel">
+          {t("email.detail.when")}
+        </span>
+        {formatWhen(presentation.occurred_at)}
+      </p>
       {/* Said rather than shown: an absent BCC list reads as "nobody was
           blind-copied", which is a different fact from "you may not see who
           was". Only the sending seat gets the names. */}

--- a/frontend/src/design-system/emailentry.test.tsx
+++ b/frontend/src/design-system/emailentry.test.tsx
@@ -213,6 +213,59 @@ describe("EmailDetail", () => {
     expect(screen.getByText(/Ana Sommer/)).toBeInTheDocument();
   });
 
+  // WHEN it was sent, in the header with the other envelope facts. It used to
+  // sit under the message, below the attachments, so on anything longer than a
+  // screen the reader scrolled past the whole body to learn the date.
+  it("says when the message was sent, beside who it was sent to", async () => {
+    vi.stubGlobal("fetch", jsonOnce(PRESENTATION));
+    wrap(
+      <EmailDetail
+        activityId={READABLE.activity_id}
+        onClose={() => {}}
+        formatWhen={() => "1 Sep 09:12"}
+      />,
+    );
+
+    const when = await screen.findByText("1 Sep 09:12");
+    // In the envelope block, not trailing the body: the assertion is WHERE, so
+    // finding the text anywhere on the page would pass over the bug.
+    expect(when.closest(".emaildetail__parties")).not.toBeNull();
+  });
+
+  // A party the response could not name is DROPPED, not joined in as an empty
+  // string. It used to render as a bare comma in the middle of the To line —
+  // `display_name ?? address` keeps an empty string, because ?? only catches
+  // null — which reads as a recipient whose name we lost.
+  it("leaves out a party it cannot name, rather than a gap in the line", async () => {
+    vi.stubGlobal(
+      "fetch",
+      jsonOnce({
+        ...PRESENTATION,
+        to: [
+          { address: "", display_name: "" },
+          { address: "andreas@buyer.test", display_name: null },
+        ],
+      }),
+    );
+    wrap(
+      <EmailDetail
+        activityId={READABLE.activity_id}
+        onClose={() => {}}
+        formatWhen={() => "1 Sep 09:12"}
+      />,
+    );
+
+    // The line is read WITHOUT its label, because the gap the bug leaves is
+    // between the label and the first name — an assertion over the whole
+    // element's text has the word "To" in front of the comma and never sees it.
+    const line = await screen.findByText(/andreas@buyer.test/);
+    const label = line.querySelector(".emaildetail__partyLabel");
+    const names = (line.textContent ?? "").slice(
+      (label?.textContent ?? "").length,
+    );
+    expect(names.trim()).toBe("andreas@buyer.test");
+  });
+
   it("folds an older message under this one, and says that is what it is", async () => {
     // The other side of the pair above. Without this case, deleting the fold
     // entirely would pass — a drawer that never folds anything satisfies "no

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1531,6 +1531,7 @@ export const de = {
   "email.detail.from": "Von",
   "email.detail.to": "An",
   "email.detail.cc": "Cc",
+  "email.detail.when": "Gesendet",
   "email.detail.bccWithheld":
     "Einige Empfänger stehen im Blindkopie-Feld und werden Ihnen nicht angezeigt",
   "compose.audienceWorkspace": "Alle in der Organisation",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1584,6 +1584,7 @@ export const en = {
   "email.detail.from": "From",
   "email.detail.to": "To",
   "email.detail.cc": "Cc",
+  "email.detail.when": "Sent",
   "email.detail.bccWithheld":
     "Some recipients were blind-copied and are not shown to you",
   "compose.audienceWorkspace": "Everyone in the organization",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1524,6 +1524,7 @@ export const vi = {
   "email.detail.from": "Từ",
   "email.detail.to": "Tới",
   "email.detail.cc": "Cc",
+  "email.detail.when": "Đã gửi",
   "email.detail.bccWithheld":
     "Một số người nhận ở dạng ẩn và không hiển thị với bạn",
   "compose.audienceWorkspace": "Mọi người trong tổ chức",


### PR DESCRIPTION
Two reports on the email drawer. The first turned out to be a hole in the server's read, not a display problem.

## You were on the message and the header did not say so

A colleague on a message is recorded as a **seat**: capture writes their `user_id` and — having resolved them rather than read them off a header — **no address at all** (`insertParticipant`'s `NULLIF($4, '')` leaves it null).

The presentation query joined only `person`, so that party came back with an empty address and no name. The viewer joined it into the line as an empty string, and the reader saw a bare comma sitting in `To` where a person should be. Your screenshot shows it: `To  , Andreas Eschbach`.

**The reader who sees that gap is usually the very person it stands for.** That is how you could look at a message you had received and not find yourself on it — so "why did I get this?" had no answer on the screen that owed one.

### Three sources for one name

In the order of how much this installation knows the person:

1. the **contact record** — ours, and maintained
2. the **seat** (`app_user`) — for a colleague
3. the name the **sender typed** into the header — which capture has been keeping in `activity_participant.display_name` and which nothing read

Each is held by its own test against a real database, mutation-checked one at a time: dropping any one source fails exactly the test that names it, and nothing else.

### No liveness filter on the seat join, deliberately

Who a message went to in August is a fact about August. A colleague who has since left was still on it, and filtering them out would reopen the same gap for anybody who resigns. `livemember_test` names this case as outside its rule — *"a row resolved by id to render a name does not ask whether the person still works here"* — and it caught the half-spelling (`archived_at IS NULL` alone) I first wrote, which would have kept naming a deactivated colleague while dropping an archived one.

### The viewer keeps its own promise too

`display_name ?? address` renders an empty string as empty, because `??` only catches null. A party that cannot be named is now dropped from the line, and a line with nobody left does not draw — so a response assembled by some future path that forgets cannot put a gap back on screen.

## The date was there, in the wrong place

It rendered at the very bottom, under the body and below the attachments. On any message longer than a screen the reader scrolls past the whole thing to learn when it arrived — which is one of the first things they came for.

It is an envelope fact and now sits with the others, labelled `Sent` / `Gesendet` / `Đã gửi`.

## One near-miss worth recording

The first version of the empty-party test **passed with the bug restored**. It read `textContent` off the element containing the address, which includes the `To` label — so the leading comma was never at the start of the string it matched. It now reads the line past its label and fails as it should.

## Verification

`make check-backend` green after the final rebase. Frontend: 6,256 of 6,258 pass; the two failures are in `onboarding-conversation`, pass in isolation, and sit in a directory this branch does not touch — the same load-dependent flake seen in #3972 and #3977.

Three new integration tests run against a real Postgres, each mutation-checked individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The email header now names everyone on a message and shows when it was sent. Previously, colleagues recorded as seats rendered as a bare comma in the To line, and the date sat below the body and attachments where readers had to scroll past the whole message to find it.

**Bug Fixes**
- Names resolve from three sources in order: contact record, seat (`app_user`), then the sender-typed display name.
- The seat join deliberately has no liveness filter, so a departed colleague stays named on old messages.
- Parties with no name or address are dropped from the line instead of rendering as an empty gap.
- The sent date now sits in the envelope block, labeled "Sent" / "Gesendet" / "Đã gửi" in the three catalogs.

<sup>Written for commit e7b5bbad75f8c63e4f65ee387cc98e95029733bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Email details now show clearer participant names and addresses, including historical messages and contacts without saved names.
  - The sent timestamp appears alongside recipient information for easier message context.
  - Unnamed recipients are omitted, preventing empty rows and formatting gaps.
  - Sender and recipient labels now align more consistently.

- **Localization**
  - Added translated “Sent” labels for English, German, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->