### PR TITLE
main is red: rowCount without the waiver its signature needs

### DIFF
--- a/backend/internal/compose/analyticsqueryrun.go
+++ b/backend/internal/compose/analyticsqueryrun.go
@@ -250,6 +250,8 @@ const withheldColumn = "_withheld"
 // A count that failed to parse answers ZERO, which the floor reads as below it
 // and withholds. Failing open here would serve a group whose size nothing
 // established.
+//
+//craft:ignore naked-any a driver returns a count as whichever integer width it chose, and reading it is the whole job of this function — naming one width here would be this code deciding what pgx returns
 func rowCount(v any) int {
 	switch n := v.(type) {
 	case int64:


### PR DESCRIPTION
`make craft-static` blocks on clean `origin/main` (`de1352be9`), so every open PR is red on `craftsmanship` for a reason unrelated to its diff. **No open PR was fixing it** — #3985 and #3978 are different reds.

```
../../backend/internal/compose/analyticsqueryrun.go
  253: [MAJOR] naked-any — bare any/interface{} in a signature
BLOCK — 0 blocker, 1 major, 0 minor
```

`rowCount` reads the plan's count out of whatever a driver handed back, and its own body is a type switch over `int64`, `int32` and the rest. The `any` is the right type: naming one width would be this code deciding what pgx returns, and getting it wrong is not a compile error — the switch would fall through to the default and answer **zero**, which the privacy floor reads as below it and withholds. A group would silently stop being served.

So it takes the waiver with that reason, in the same shape the tree already uses for the value-or-null contract in `storekit` (`Patch.Set`, `dateOnly`).

Arrived with #3906/#3927 (*"A question nobody wrote a report for"*), which is why the file is new to the checker.

**Verification.** `make craft-static` green on all four roots. `make check-backend` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an inline clarification explaining compatibility with database drivers that return count values using different integer widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->