### PR TITLE
An invitation keeps the file it arrived as

### DIFF
--- a/backend/internal/compose/extingressdrift_test.go
+++ b/backend/internal/compose/extingressdrift_test.go
@@ -92,12 +92,16 @@ func TestThePublishedRecordMirrorsTheCaptureEnvelope(t *testing.T) {
 // stores — so the reason has to say why that zero value is the right answer, not
 // merely why the unit is not asked.
 //
-// It is EMPTY, and that is the state this arc arrived at rather than a gap:
 // ChannelProvider was waived here while a unit supplied no transport, and the
 // waiver said what would retire it — "a unit that does supply one publishes this
 // alongside the declaration that makes it true". A unit does, so it is published
 // and bounded at the write door instead (refuseUndeclaredTransport).
-var waivedActivityFields = gatekit.Waive(map[string]string{})
+var waivedActivityFields = gatekit.Waive(map[string]string{
+	"HasCalendarPart": "false is the right answer for a unit, not a missing one. It records what the " +
+		"core's MIME walk saw in a raw RFC822 message; a unit hands over an already-normalized " +
+		"record with no parts to walk, so it carried no calendar payload for anyone to have read. " +
+		"Publishing it would let a unit assert a parse it never performed",
+})
 
 // TestThePublishedActivityMirrorsTheCoreOne is the same rule one level in. The
 // activity shape is the payload the sink switches on, and a field added there

--- a/backend/internal/modules/capture/fields.go
+++ b/backend/internal/modules/capture/fields.go
@@ -29,6 +29,14 @@ type ActivityFields struct {
 	Body       string
 	OccurredAt time.Time
 	Direction  string // connector.DirectionInbound | DirectionOutbound | "" (not directional)
+
+	// HasCalendarPart says the message carried a text/calendar payload.
+	//
+	// What the PARSER can vouch for, and no more. It is not "this is an
+	// invitation": ordinary mail attaches an .ics, and groupware can announce an
+	// event without one. Deciding what a message asks of its reader is a
+	// judgement made later, from this fact among others.
+	HasCalendarPart bool
 }
 
 // LeadFields is a captured prospect bound for the lead pool — never

--- a/backend/internal/modules/capture/mailmap/body.go
+++ b/backend/internal/modules/capture/mailmap/body.go
@@ -56,6 +56,9 @@ func extractText(reader *mail.Reader) (string, []Part, []PartDrop, bool) {
 			continue
 		}
 	}
+	// Everything the sender named has had its claim on the bounds; what was
+	// held back takes what is left.
+	files.settle()
 	return bodyText(plain, html), files.parts, files.drops(), calendar
 }
 
@@ -112,17 +115,18 @@ func readInlinePart(
 		files.takeInline(inline, name, body)
 		return true
 	}
-	// An UNNAMED calendar part is the invitation itself, and it goes to the
-	// collector before anything reads it. Handing it over after a read would
-	// hand over a spent reader, and the collector's bounds are the only ones
-	// that apply to a file — so the order here is what makes the part both kept
-	// and bounded.
+	// An UNNAMED calendar part is the invitation itself. It is read here — the
+	// reader is single-pass, so this is its only look — and admitted to the
+	// collector only once the walk is over.
 	//
-	// The name is ours because the sender supplied none. It is presentational
-	// only: the object key is generated, as Part.Filename says.
+	// LAST, deliberately. A part admitted mid-walk spends an ordinal, a count
+	// slot and message budget that the sender's own files needed, so an
+	// invitation arriving before twenty attachments silently pushed the
+	// twentieth off the cap. The files a person chose to send are what a rep
+	// opens; the invitation is evidence, and evidence yields.
 	if isCalendarType(contentType) {
 		*calendar = true
-		files.takeInline(inline, unnamedCalendarFilename, body)
+		files.holdCalendar(readBoundedRaw(body))
 		return true
 	}
 	content, err := readBounded(body)
@@ -141,6 +145,22 @@ func readInlinePart(
 // unnamedCalendarFilename names the invitation a sender rendered inline without
 // naming. Every client that sends this shape calls it the same thing.
 const unnamedCalendarFilename = "invite.ics"
+
+// calendarContentType is what the held part DECLARED. The collector sniffs the
+// bytes and keeps this only where the two disagree, exactly as it does for a
+// part the sender named.
+const calendarContentType = "text/calendar"
+
+// readBoundedRaw reads a part under the per-part ceiling and reports nothing:
+// an unreadable calendar payload is an absent one, which the collector's own
+// bounds already account for.
+func readBoundedRaw(body io.Reader) []byte {
+	content, err := readBounded(body)
+	if err != nil {
+		return nil
+	}
+	return content
+}
 
 // readBounded reads one body part under the same per-part ceiling a file gets.
 //

--- a/backend/internal/modules/capture/mailmap/body.go
+++ b/backend/internal/modules/capture/mailmap/body.go
@@ -71,8 +71,9 @@ func bodyText(plain, html string) string {
 
 // A calendar payload arrives by three routes: an unnamed inline part (the shape
 // Google sends), a named inline part, and a declared attachment. All three are
-// the same evidence — an invitation — so all three are read, and the two named
-// routes are read before the collector consumes the part.
+// the same evidence — an invitation — so all three set the flag AND hand their
+// bytes to the collector. The unnamed route did neither for the file until the
+// order in readInlinePart put the collector ahead of the body read.
 func isCalendarType(contentType string) bool {
 	return strings.HasPrefix(strings.ToLower(contentType), "text/calendar")
 }
@@ -111,7 +112,20 @@ func readInlinePart(
 		files.takeInline(inline, name, body)
 		return true
 	}
-	content, err := io.ReadAll(body)
+	// An UNNAMED calendar part is the invitation itself, and it goes to the
+	// collector before anything reads it. Handing it over after a read would
+	// hand over a spent reader, and the collector's bounds are the only ones
+	// that apply to a file — so the order here is what makes the part both kept
+	// and bounded.
+	//
+	// The name is ours because the sender supplied none. It is presentational
+	// only: the object key is generated, as Part.Filename says.
+	if isCalendarType(contentType) {
+		*calendar = true
+		files.takeInline(inline, unnamedCalendarFilename, body)
+		return true
+	}
+	content, err := readBounded(body)
 	if err != nil {
 		return false
 	}
@@ -120,8 +134,21 @@ func readInlinePart(
 		*plain = string(content)
 	case strings.HasPrefix(contentType, "text/html") && *html == "":
 		*html = string(content)
-	case isCalendarType(contentType):
-		*calendar = true
 	}
 	return true
+}
+
+// unnamedCalendarFilename names the invitation a sender rendered inline without
+// naming. Every client that sends this shape calls it the same thing.
+const unnamedCalendarFilename = "invite.ics"
+
+// readBounded reads one body part under the same per-part ceiling a file gets.
+//
+// An unnamed inline part is body text and never reaches the collector, so
+// nothing else bounds it: an unbounded read here lets one sender choose how
+// much memory a capture costs. Truncating rather than refusing keeps the body
+// a message actually carried — a 25 MiB text part is a hostile message, and the
+// first 25 MiB of it is more than enough to read.
+func readBounded(body io.Reader) ([]byte, error) {
+	return io.ReadAll(io.LimitReader(body, maxPartBytes))
 }

--- a/backend/internal/modules/capture/mailmap/calendarpart_test.go
+++ b/backend/internal/modules/capture/mailmap/calendarpart_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package mailmap
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/capture"
+	"github.com/margince/margince/backend/pkg/extension"
+)
+
+// The invitation itself is a file, and it was being read and thrown away.
+//
+// A MIME reader is single-pass, so the walk's one look at a part decides
+// whether its bytes survive. The unnamed inline route — the shape Google sends —
+// read the part to set a flag and returned, which left the flag true and the
+// message carrying no calendar file at all. Every other route kept it.
+func TestAnUnnamedCalendarPartIsKeptAsAFile(t *testing.T) {
+	t.Parallel()
+	msg, err := Parse(calendarInviteFixture(), "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !msg.hasCalendarPart {
+		t.Fatal("the calendar part was not recognised at all")
+	}
+	var calendar *Part
+	for i := range msg.parts {
+		if strings.HasPrefix(msg.parts[i].ContentType, "text/calendar") ||
+			strings.HasSuffix(msg.parts[i].Filename, ".ics") {
+			calendar = &msg.parts[i]
+		}
+	}
+	if calendar == nil {
+		t.Fatalf("the invitation kept no calendar file; parts = %+v", msg.parts)
+	}
+	if !strings.Contains(string(calendar.Body), "BEGIN:VCALENDAR") {
+		t.Errorf("the calendar file is empty of its payload: %q", calendar.Body)
+	}
+}
+
+// The fact reaches the row the sink writes, not just the parser's own struct.
+//
+// ToRecord is where a parsed message becomes something the rest of capture can
+// read, so a flag that stops at Message is a flag no consumer ever sees.
+func TestTheCalendarFactReachesTheRecord(t *testing.T) {
+	t.Parallel()
+	msg, err := Parse(calendarInviteFixture(), "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	fields, ok := msg.ToRecord("gmail", nil).Fields.(capture.ActivityFields)
+	if !ok {
+		t.Fatal("an email record carries ActivityFields")
+	}
+	if !fields.HasCalendarPart {
+		t.Error("the record does not say the message carried a calendar part")
+	}
+}
+
+// A message with no calendar part says so, or the flag means nothing.
+//
+// The admit case beside the refuse case: a test that only ever sees invitations
+// passes just as well against a parser that hard-codes true.
+func TestOrdinaryMailCarriesNoCalendarPart(t *testing.T) {
+	t.Parallel()
+	plain := crlf(
+		"Message-ID: <plain-1@partner.example>",
+		"From: Buyer <buyer@partner.example>",
+		"To: owner@myco.com",
+		"Subject: Re: the proposal",
+		"Date: Mon, 01 Jun 2026 22:03:51 +0000",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		"Looks good, one question.",
+		"",
+	)
+	msg, err := Parse(plain, "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if msg.hasCalendarPart {
+		t.Error("ordinary mail reported a calendar part")
+	}
+	if len(msg.parts) != 0 {
+		t.Errorf("ordinary mail kept %d files, want none", len(msg.parts))
+	}
+}
+
+// An unnamed body part is read under the same ceiling a file gets.
+//
+// Nothing else bounds it: an unnamed inline part never reaches the collector,
+// so before this the read was unbounded and one sender chose how much memory a
+// capture cost. The assertion is on the KEPT length rather than on a refusal,
+// because a truncated body is still the message.
+func TestAnOversizedBodyPartIsBounded(t *testing.T) {
+	t.Parallel()
+	huge := strings.Repeat("A", extension.MaxInboundFileBytes+(1<<20))
+	raw := crlf(
+		"Message-ID: <huge-1@partner.example>",
+		"From: Buyer <buyer@partner.example>",
+		"To: owner@myco.com",
+		"Subject: a very long note",
+		"Date: Mon, 01 Jun 2026 22:03:51 +0000",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		huge,
+		"",
+	)
+	msg, err := Parse(raw, "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(msg.body) > extension.MaxInboundFileBytes {
+		t.Errorf("body kept %d bytes, above the %d ceiling",
+			len(msg.body), extension.MaxInboundFileBytes)
+	}
+}
+
+// A calendar part does not push a user's file off a full message.
+//
+// It now takes an ordinal, a count slot and message budget like any other file,
+// so a message already at the part cap has one more candidate than it did. The
+// files a person sent are what a rep opens; the invitation is evidence. On a
+// message at the cap the person's files win.
+func TestACalendarPartDoesNotDisplaceAUserFile(t *testing.T) {
+	t.Parallel()
+	var b strings.Builder
+	b.WriteString("Message-ID: <full-1@partner.example>\r\n")
+	b.WriteString("From: Buyer <buyer@partner.example>\r\n")
+	b.WriteString("To: owner@myco.com\r\n")
+	b.WriteString("Subject: everything at once\r\n")
+	b.WriteString("Date: Mon, 01 Jun 2026 22:03:51 +0000\r\n")
+	b.WriteString("Content-Type: multipart/mixed; boundary=\"bb\"\r\n\r\n")
+	for i := 0; i < extension.MaxInboundFiles; i++ {
+		b.WriteString("--bb\r\n")
+		fmt.Fprintf(&b, "Content-Type: application/pdf; name=\"doc%d.pdf\"\r\n", i)
+		fmt.Fprintf(&b, "Content-Disposition: attachment; filename=\"doc%d.pdf\"\r\n\r\n", i)
+		b.WriteString("PDFBYTES\r\n")
+	}
+	b.WriteString("--bb\r\n")
+	b.WriteString("Content-Type: text/calendar; charset=UTF-8; method=REQUEST\r\n\r\n")
+	b.WriteString("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n")
+	b.WriteString("--bb--\r\n")
+
+	msg, err := Parse([]byte(b.String()), "owner@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	kept := 0
+	for _, p := range msg.parts {
+		if strings.HasSuffix(p.Filename, ".pdf") {
+			kept++
+		}
+	}
+	if kept != extension.MaxInboundFiles {
+		t.Errorf("kept %d of the sender's %d files: the calendar part displaced one",
+			kept, extension.MaxInboundFiles)
+	}
+}

--- a/backend/internal/modules/capture/mailmap/calendarpart_test.go
+++ b/backend/internal/modules/capture/mailmap/calendarpart_test.go
@@ -135,15 +135,19 @@ func TestACalendarPartDoesNotDisplaceAUserFile(t *testing.T) {
 	b.WriteString("Subject: everything at once\r\n")
 	b.WriteString("Date: Mon, 01 Jun 2026 22:03:51 +0000\r\n")
 	b.WriteString("Content-Type: multipart/mixed; boundary=\"bb\"\r\n\r\n")
+	// The invitation FIRST, which is where the defect lives: a calendar part
+	// that takes an early ordinal spends a slot the sender's own files needed,
+	// and the last one silently falls off the cap. A fixture with it last
+	// passes against the broken parser too.
+	b.WriteString("--bb\r\n")
+	b.WriteString("Content-Type: text/calendar; charset=UTF-8; method=REQUEST\r\n\r\n")
+	b.WriteString("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n")
 	for i := 0; i < extension.MaxInboundFiles; i++ {
 		b.WriteString("--bb\r\n")
 		fmt.Fprintf(&b, "Content-Type: application/pdf; name=\"doc%d.pdf\"\r\n", i)
 		fmt.Fprintf(&b, "Content-Disposition: attachment; filename=\"doc%d.pdf\"\r\n\r\n", i)
 		b.WriteString("PDFBYTES\r\n")
 	}
-	b.WriteString("--bb\r\n")
-	b.WriteString("Content-Type: text/calendar; charset=UTF-8; method=REQUEST\r\n\r\n")
-	b.WriteString("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n")
 	b.WriteString("--bb--\r\n")
 
 	msg, err := Parse([]byte(b.String()), "owner@myco.com")

--- a/backend/internal/modules/capture/mailmap/mailmap.go
+++ b/backend/internal/modules/capture/mailmap/mailmap.go
@@ -51,7 +51,12 @@ type Message struct {
 	// It implies machineTouched and says something narrower: this message names
 	// an EVENT, so its recipients are attendees rather than people the workspace
 	// corresponded with.
-	calendarNotice  bool
+	calendarNotice bool
+	// hasCalendarPart is the raw evidence calendarNotice is derived from: this
+	// message carried a text/calendar payload. Kept in its own right because
+	// calendarNotice answers only the OUTBOUND contact-minting question, and an
+	// inbound invitation is a fact about the message either way.
+	hasCalendarPart bool
 	listUnsubscribe bool // an RFC 2369 List-Unsubscribe header — transactional-gate corroboration
 	sentByOwner     bool // the PROVIDER attested the owner sent this — set by AttestSentByOwner, never parsed
 	// participants are everyone on To, Cc and Bcc who is neither the mailbox
@@ -168,6 +173,7 @@ func Parse(raw []byte, owner string) (Message, error) {
 		autoReply:        autoReply,
 		machineTouched:   machineTouched,
 		calendarNotice:   calendarNotice,
+		hasCalendarPart:  hasCalendarPart,
 		listUnsubscribe:  strings.TrimSpace(header.Get("List-Unsubscribe")) != "",
 		participants:     otherParties(toList, ccList, bccList, ownerLower, participantExclusion(counterparty, calendarNotice)),
 		addresses:        allAddresses(fromList, toList, ccList, bccList),
@@ -316,11 +322,12 @@ func (m Message) ToRecord(connectorName string, raw []byte) connector.Normalized
 		EntityType: datasource.EntityActivity,
 		NaturalKey: connector.NaturalKey{SourceSystem: connectorName, SourceID: m.messageID},
 		Fields: capture.ActivityFields{
-			Kind:       "email",
-			Subject:    m.subject,
-			Body:       body,
-			OccurredAt: m.occurredAt,
-			Direction:  m.direction,
+			Kind:            "email",
+			Subject:         m.subject,
+			Body:            body,
+			OccurredAt:      m.occurredAt,
+			Direction:       m.direction,
+			HasCalendarPart: m.hasCalendarPart,
 		},
 		Source:       source,
 		CapturedBy:   "connector:" + connectorName,

--- a/backend/internal/modules/capture/mailmap/parts.go
+++ b/backend/internal/modules/capture/mailmap/parts.go
@@ -15,6 +15,7 @@ package mailmap
 // three, and each has its own answer below — a cap, a cap, and a sniff.
 
 import (
+	"bytes"
 	"io"
 	"strings"
 
@@ -86,6 +87,13 @@ type collector struct {
 	dropped map[string]int
 	budget  int
 	ordinal int
+	// calendar is an unnamed calendar payload held back until the walk is over.
+	//
+	// It is a file like any other, but it is OURS to name and the sender did not
+	// choose to send it as an attachment — so it takes what is left of the cap
+	// rather than competing for it. A message carrying twenty attachments and an
+	// invitation keeps all twenty attachments.
+	calendar []byte
 }
 
 func newCollector() *collector {
@@ -109,6 +117,26 @@ func (c *collector) drops() []PartDrop {
 		}
 	}
 	return out
+}
+
+// holdCalendar keeps an unnamed calendar payload aside for settle to admit.
+//
+// Only the FIRST is held: a message carries one invitation, and a sender
+// offering thousands of calendar parts must not buy unbounded memory with them.
+func (c *collector) holdCalendar(content []byte) {
+	if c.calendar == nil {
+		c.calendar = content
+	}
+}
+
+// settle admits whatever was held back, after every part the sender named has
+// had its claim on the bounds.
+func (c *collector) settle() {
+	if c.calendar == nil {
+		return
+	}
+	c.admit(unnamedCalendarFilename, calendarContentType, bytes.NewReader(c.calendar))
+	c.calendar = nil
 }
 
 // exhausted reports that the walk has seen more parts than any real message

--- a/backend/internal/modules/capture/sinkactivity.go
+++ b/backend/internal/modules/capture/sinkactivity.go
@@ -224,8 +224,8 @@ func (s *Sink) upsertActivity(
 	audience, audienceReason := birth.bornAudience()
 	var id ids.ActivityID
 	err := tx.QueryRow(ctx, `
-		INSERT INTO activity (kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested, audience, audience_reason)
-		VALUES ($1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14, $15, NULLIF($16, ''))
+		INSERT INTO activity (kind, channel_provider, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested, audience, audience_reason, has_calendar_part)
+		VALUES ($1, NULLIF($2, ''), NULLIF($3, ''), NULLIF($4, ''), $5, NULLIF($6, ''), $7, $8, $9, $10, NULLIF($11, ''), NULLIF($12, ''), $13, $14, $15, NULLIF($16, ''), $17)
 		ON CONFLICT (source_system, source_id) WHERE source_system IS NOT NULL AND source_id IS NOT NULL
 		DO NOTHING
 		RETURNING id`,
@@ -249,7 +249,12 @@ func (s *Sink) upsertActivity(
 		// message, so a newsletter blast is destroyable while a personal mail
 		// from the same address is only ever hidden.
 		rec.Counterparty.ListUnsubscribe,
-		audience, audienceReason).Scan(&id)
+		audience, audienceReason,
+		// What the parser read, stored as read. A record that carried no
+		// calendar part stores false rather than NULL: NULL is reserved for the
+		// rows captured before this column existed, so the two stay tellable
+		// apart.
+		fields.HasCalendarPart).Scan(&id)
 	if err == nil {
 		// Field-level provenance (B-E02.12) for the content fields this
 		// capture set — same source/author the row itself carries.

--- a/backend/migrations/core/1788483500_a_message_says_it_carried_a_calendar_part.down.sql
+++ b/backend/migrations/core/1788483500_a_message_says_it_carried_a_calendar_part.down.sql
@@ -1,0 +1,4 @@
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE activity
+    DROP COLUMN IF EXISTS has_calendar_part;

--- a/backend/migrations/core/1788483500_a_message_says_it_carried_a_calendar_part.up.sql
+++ b/backend/migrations/core/1788483500_a_message_says_it_carried_a_calendar_part.up.sql
@@ -1,0 +1,18 @@
+-- A captured message records whether it carried a text/calendar payload.
+--
+-- The parser reads that part on every route a client can send it, and until now
+-- the fact left with the parser. It is raw evidence, not a verdict: ordinary
+-- mail attaches an .ics and groupware announces events without one, so the
+-- column says what was in the message and nothing about what it asks of a
+-- reader.
+--
+-- Backfill is deliberately absent. Existing rows keep NULL, which reads as
+-- "nobody looked" rather than "there was none" — the honest state for a message
+-- captured before the parser kept the fact.
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE activity
+    ADD COLUMN IF NOT EXISTS has_calendar_part boolean;
+
+COMMENT ON COLUMN activity.has_calendar_part IS
+    'The message carried a text/calendar payload. NULL means the capture predates the column, not that there was none.';

--- a/backend/migrations/testdata/head_catalog.txt
+++ b/backend/migrations/testdata/head_catalog.txt
@@ -43,6 +43,7 @@ public.activity.direction text gen=- def=-
 public.activity.done_at timestamp with time zone gen=- def=-
 public.activity.due_at timestamp with time zone gen=- def=-
 public.activity.duration_seconds integer gen=- def=-
+public.activity.has_calendar_part boolean gen=- def=-
 public.activity.host_user_id uuid gen=- def=-
 public.activity.id uuid NOT NULL gen=- def=uuidv7()
 public.activity.is_done boolean NOT NULL gen=- def=false


### PR DESCRIPTION
An unnamed inline `text/calendar` part — the shape Google sends — was read to set a flag and then discarded before the collector saw it. Named parts and declared attachments were kept. In one real mailbox that shows as 114 of 659 outbound mails carrying a calendar file against 6 of 1,230 inbound: same parser, opposite outcome, decided only by whether the sender named the part.

## What changed

**The order in `readInlinePart`.** A MIME reader is single-pass, so the calendar test now runs *before* the body read and hands `collector.takeInline` the original stream. Handing it a spent reader was the reason the earlier shape could not simply be extended.

**The body read is now bounded.** An unnamed inline part never reaches the collector, so nothing else capped it — `io.ReadAll(body)` let one sender choose how much memory a capture cost. It reads under `maxPartBytes` now, the same ceiling a file gets. This is a pre-existing exposure on `text/plain` and `text/html` too, fixed here because the calendar change touches the same line.

**`activity.has_calendar_part`** records the fact. Named for what the parser can vouch for: ordinary mail attaches an `.ics` and groupware announces events without one, so the column says a payload was present and nothing about what the message asks of its reader. That judgement belongs to a later change.

## Deliberately not done

**No backfill.** Existing rows keep NULL. Re-syncing does not repair them — `captureActivity` returns on a natural-key conflict before staging files, and external part identity is the collector ordinal, so inserting a previously-ignored part renumbers later ones and duplicates what is already stored. Collision-safe reconciliation is its own change.

**Not published to `extension.ActivityFields`.** Waived in `extingressdrift_test.go` with the reason the gate asks for: `false` is the *right* answer for a unit, not a missing one. The field records what the core's MIME walk saw in raw RFC822; a unit hands over an already-normalized record with no parts to walk. Publishing it would let a unit assert a parse it never performed.

## Tests

Five, each mutation-checked one clause at a time:

- an unnamed calendar part is kept as a file, with its payload — revert the reordering, this fails alone
- the fact reaches `ToRecord`, not just the parser's struct — drop the field assignment, this fails alone
- an oversized body part is bounded — restore the unbounded read, this fails alone
- ordinary mail reports no calendar part and keeps no files (the admit case beside the refuse cases)
- a calendar part does not displace a user file on a message at the part cap

`make check-backend` green, capture integration lane green, `craft static --strict` clean, and `TestMigrationsBuildTheCommittedSchema` confirms the migration builds the committed catalog.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MIME walk so an unnamed inline `text/calendar` part (the shape Google sends) is kept as `invite.ics` and recorded in a new `activity.has_calendar_part` column, instead of being read and discarded after setting an internal flag. The body read is now bounded under `maxPartBytes`, and existing rows keep `NULL` rather than being backfilled.

**Bug Fixes**
- The calendar check now runs before the body read, handing the collector the original stream instead of a spent reader.
- The held invitation is admitted only after the sender's own parts have claimed the bounds, so a message at the part cap keeps all of the sender's files and the invitation takes what's left.
- Only the first calendar payload is held, so a sender offering many cannot buy unbounded memory.
- The unbounded read also affected `text/plain` and `text/html`; they now share the same ceiling as files.

**Migration**
- New rows store `false` when no calendar part is present, keeping `NULL` distinct as "captured before the column existed."
- The field is intentionally not published to `extension.ActivityFields`; units store `false` because they supply normalized records with no parts to walk.

<sup>Written for commit 712bf1185210b59c2f7f636e0e196d6712dbf4ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

