### PR TITLE
The waiting queue asks who wrote, and whether we ever answered

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -38100,7 +38100,14 @@ components:
         How much waiting work each hiding rule is keeping off one reader's queue, at one
         instant. Every count is of THREADS, matching what the queue counts: a customer who
         wrote three times is waiting once.
-      required: [as_of, shown, set_aside, not_sales, past_horizon, unlinked, truncated, clear]
+
+        THE FIGURES DO NOT ADD UP, and that is deliberate. Each is the difference made by
+        relaxing ONE rule with the others still in force, because a reader needs to know
+        which rule to look at rather than a total they cannot act on. A thread held back
+        by two rules therefore appears in NEITHER figure: relaxing either one alone still
+        leaves the other hiding it. Summing these to estimate the hidden total
+        under-reports it.
+      required: [as_of, shown, set_aside, not_sales, past_horizon, unlinked, colleagues, truncated, clear]
       properties:
         as_of: { type: string, format: date-time, description: 'The instant every figure below was read at.' }
         shown:
@@ -38147,6 +38154,18 @@ components:
             is right — a rep's dentist is not a customer — and it is also where a real
             customer lands when capture failed to link their thread. Its own figure for
             that reason rather than folded into a total.
+        colleagues:
+          type: integer
+          minimum: 0
+          description: |
+            Mail from one of the workspace's own email domains. ALSO NOBODY'S CHOICE, and
+            watched because the rule is only as good as the domain list behind it: a
+            domain entered by mistake suppresses a real customer's correspondence for
+            everybody, and this is the figure that would show it.
+
+            The domains are the vouched-for ones — those the company claims and those an
+            administrator confirmed — never every domain a connected mailbox happened to
+            see. A contractor's genuine account at a customer must not read as internal.
         truncated:
           type: boolean
           description: |
@@ -38386,7 +38405,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [pinned, buyer_wrote_last, waiting_days, overdue, due_today, closing_soon, expected_revenue, material, below_material, quiet_days, no_champion, promised, approved_and_failed, blocks_customer_work, routine, repeated_failure, legal_deadline, meeting_soon, meeting_unprepared, response_overdue, response_due_soon, unassigned, stale]
+          enum: [pinned, buyer_wrote_last, waiting_days, overdue, due_today, closing_soon, expected_revenue, material, below_material, quiet_days, no_champion, promised, approved_and_failed, blocks_customer_work, routine, repeated_failure, legal_deadline, meeting_soon, meeting_unprepared, response_overdue, response_due_soon, unassigned, stale, no_reply_history]
           description: 'Which fact this is. The client writes the phrase.'
         value: { $ref: '#/components/schemas/WorklistValue' }
 

--- a/backend/gates/owndomainpredicate_test.go
+++ b/backend/gates/owndomainpredicate_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind prohibition H2
+
+package gates
+
+// One spelling of "this message came from one of our own domains".
+//
+// Two readers judge the same messages by it — the waiting queue and the
+// response reading — and they must agree: a message the queue hides as internal
+// must not count against the answer rate, or /worklist/response reports a
+// workspace answering work it never showed anybody.
+//
+// The predicate is also easy to get subtly wrong in a way that suppresses a
+// real customer silently, which is why a second copy is worse here than
+// elsewhere. Both known ways were live in the first version of it: reading the
+// domain after the FIRST at-sign (a quoted local part may contain one), and
+// comparing the suffix with LIKE (an operator's underscore is a wildcard). A
+// second copy is a second place for either to come back.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTheOwnDomainSenderPredicateHasOneSpelling fails when a second query
+// derives a sender's domain for itself instead of calling ownDomainSenderSQL.
+func TestTheOwnDomainSenderPredicateHasOneSpelling(t *testing.T) {
+	t.Parallel()
+	// The shape of deriving a domain from an address in SQL. Any query doing
+	// this is answering the question ownDomainSenderSQL already answers.
+	const derivesADomain = "split_part(ours.address, '@'"
+
+	var found []string
+	root := "internal"
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(string(body), derivesADomain) {
+			return nil
+		}
+		// The one spelling itself is where it is allowed to appear.
+		if strings.HasSuffix(path, filepath.Join("modules", "activities", "waiting.go")) {
+			return nil
+		}
+		found = append(found, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the tree: %v", err)
+	}
+	if len(found) > 0 {
+		t.Errorf("these files derive a sender's mail domain in SQL rather than "+
+			"calling activities.ownDomainSenderSQL: %v\n\n"+
+			"Two spellings of this rule drift, and the drift is invisible: each "+
+			"way it goes wrong — splitting at the first at-sign, comparing the "+
+			"suffix with LIKE — hides a real customer's mail with nothing on any "+
+			"page to say why. Call the shared fragment, or say here why this one "+
+			"cannot.", found)
+	}
+	// The subject must exist, or this walk passes over an empty tree — the
+	// under-recognition failure a census must not have.
+	subject, err := os.ReadFile(filepath.Join(root, "modules", "activities", "waiting.go"))
+	if err != nil {
+		t.Fatalf("reading the predicate's own file: %v", err)
+	}
+	if !strings.Contains(string(subject), derivesADomain) {
+		t.Fatal("ownDomainSenderSQL no longer derives a domain the way this gate " +
+			"looks for, so the walk above can no longer find a second copy either")
+	}
+}

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -261,12 +261,30 @@ func classifyWaiting(waiting WaitingCustomer, asOf time.Time) ranked {
 	if stale {
 		level = levelRoutine
 	}
+	// Nobody here has written on this thread, and no money is on it either.
+	//
+	// DEMOTED, never dropped. The evidence is thread identity, which comes from
+	// the sender's reply headers: a client that strips them gives every message
+	// its own thread, and this reads as "we never spoke" about a conversation
+	// three replies deep. Hiding on that would lose a live customer with nothing
+	// on the page to say so — the one failure this queue must not have — so the
+	// cost of being wrong is a scroll instead.
+	//
+	// Money outranks it, exactly as it does for staleness: an open deal on the
+	// thread is a stronger claim than any header the sender chose to send.
+	unproven := !waiting.Engaged && !waiting.HasOpenDeal
+	if unproven {
+		level = levelRoutine
+	}
 	because := []crmcontracts.WorklistReason{
 		reason("buyer_wrote_last", nil),
 		reason("waiting_days", daysValue(days)),
 	}
 	if stale {
 		because = append(because, reason("stale", nil))
+	}
+	if unproven {
+		because = append(because, reason("no_reply_history", nil))
 	}
 	row := crmcontracts.WorklistItem{
 		Id:          waiting.ActivityID.String(),
@@ -443,55 +461,4 @@ func classifySystem(item crmcontracts.AttentionItem, asOf time.Time) ranked {
 	}
 	row := base(item, levelBlocking, "system", consequence)
 	return ranked{item: row, occurredAt: occurredOf(item, asOf)}
-}
-
-// stampDeadline marks an item whose date the READER owes.
-//
-// The flag is what tells a real deadline from a staged proposal's expiry: the
-// producers whose date is a deadline resolve it here, and the ones whose date
-// is a lapse moment leave it unset, so the header can count work due without
-// counting proposals that merely go stale.
-func stampDeadline(row *crmcontracts.WorklistItem, due *time.Time, asOf time.Time) {
-	if due == nil {
-		return
-	}
-	past := overdueAt(due, asOf)
-	row.Overdue = &past
-}
-
-func reason(kind crmcontracts.WorklistReasonKind, value *crmcontracts.WorklistValue) crmcontracts.WorklistReason {
-	return crmcontracts.WorklistReason{Kind: kind, Value: value}
-}
-
-func deadlineOf(due *time.Time) time.Time {
-	if due == nil {
-		return time.Time{}
-	}
-	return *due
-}
-
-// occurredOf answers when the reported thing happened, falling back to the read
-// instant so a row with no timestamp sorts as "now" rather than as 1 January
-// year one — which would put every undated row at the head of its level.
-func occurredOf(item crmcontracts.AttentionItem, asOf time.Time) time.Time {
-	if item.OccurredAt != nil {
-		return *item.OccurredAt
-	}
-	return asOf
-}
-
-// quietDaysOf reads the idle count the risk and decay lanes measure.
-//
-// From the TYPED field, not parsed out of the supporting sentence. It used to
-// read `detail` a digit at a time and answer zero for anything else, which made
-// the ordering depend on a display string: a lane that made its sentence
-// friendlier — "quiet for 90 days" instead of "90" — would have dropped every
-// such row to the bottom of the queue, and nothing would have failed.
-//
-// A lane that measures no idle time sends none, and zero is what that means.
-func quietDaysOf(item crmcontracts.AttentionItem) int {
-	if item.QuietDays == nil {
-		return 0
-	}
-	return *item.QuietDays
 }

--- a/backend/internal/compose/attention/itemreadings.go
+++ b/backend/internal/compose/attention/itemreadings.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package attention
+
+// The small readings every classifier shares: what a row's deadline is, when it
+// happened, and how long it has been quiet.
+//
+// Beside classify.go rather than inside it because they answer questions about
+// ONE item that every lane asks, while that file decides what each KIND of item
+// means. Splitting them keeps each file to one concept, which is also what the
+// 500-line cap is asking for.
+
+import (
+	"time"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// stampDeadline marks an item whose date the READER owes.
+//
+// The flag is what tells a real deadline from a staged proposal's expiry: the
+// producers whose date is a deadline resolve it here, and the ones whose date
+// is a lapse moment leave it unset, so the header can count work due without
+// counting proposals that merely go stale.
+func stampDeadline(row *crmcontracts.WorklistItem, due *time.Time, asOf time.Time) {
+	if due == nil {
+		return
+	}
+	past := overdueAt(due, asOf)
+	row.Overdue = &past
+}
+
+func reason(kind crmcontracts.WorklistReasonKind, value *crmcontracts.WorklistValue) crmcontracts.WorklistReason {
+	return crmcontracts.WorklistReason{Kind: kind, Value: value}
+}
+
+func deadlineOf(due *time.Time) time.Time {
+	if due == nil {
+		return time.Time{}
+	}
+	return *due
+}
+
+// occurredOf answers when the reported thing happened, falling back to the read
+// instant so a row with no timestamp sorts as "now" rather than as 1 January
+// year one — which would put every undated row at the head of its level.
+func occurredOf(item crmcontracts.AttentionItem, asOf time.Time) time.Time {
+	if item.OccurredAt != nil {
+		return *item.OccurredAt
+	}
+	return asOf
+}
+
+// quietDaysOf reads the idle count the risk and decay lanes measure.
+//
+// From the TYPED field, not parsed out of the supporting sentence. It used to
+// read `detail` a digit at a time and answer zero for anything else, which made
+// the ordering depend on a display string: a lane that made its sentence
+// friendlier — "quiet for 90 days" instead of "90" — would have dropped every
+// such row to the bottom of the queue, and nothing would have failed.
+//
+// A lane that measures no idle time sends none, and zero is what that means.
+func quietDaysOf(item crmcontracts.AttentionItem) int {
+	if item.QuietDays == nil {
+		return 0
+	}
+	return *item.QuietDays
+}

--- a/backend/internal/compose/attention/waitingfreshness_test.go
+++ b/backend/internal/compose/attention/waitingfreshness_test.go
@@ -70,6 +70,11 @@ func TestTheStaleBoundaryIsWhereItSaysItIs(t *testing.T) {
 		return classifyWaiting(WaitingCustomer{
 			ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000c3"),
 			Since:      rankInstant.Add(-time.Duration(days) * 24 * time.Hour),
+			// Engaged, so the ONE thing varying across this boundary is age.
+			// The unproven-engagement rule demotes to the same level, and a
+			// fixture leaving it false would measure both rules at once and
+			// report the boundary as wherever the other one fired.
+			Engaged: true,
 		}, rankInstant)
 	}
 
@@ -221,5 +226,65 @@ func TestADayWithNoPricedDealsStatesNoBar(t *testing.T) {
 
 	if out.Summary.MaterialThresholdMinor != nil {
 		t.Fatalf("a pipeline with no prices stated a bar of %d", *out.Summary.MaterialThresholdMinor)
+	}
+}
+
+// A wait nobody here ever answered on is demoted, not dropped.
+//
+// The evidence behind Engaged is thread identity, and thread identity comes
+// from headers the SENDER chose to send. A client that strips References gives
+// every message its own thread, so a live conversation can arrive looking like
+// a stranger's first mail. Hiding on that would lose a customer with nothing on
+// the page to say so; demoting costs a scroll.
+func TestAWaitWithNoReplyHistoryIsDemotedRatherThanDropped(t *testing.T) {
+	cold := classifyWaiting(WaitingCustomer{
+		ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000d1"),
+		Subject:    "Cold approach",
+		Since:      rankInstant.Add(-2 * 24 * time.Hour),
+	}, rankInstant)
+
+	if cold.item.Level == levelWaiting {
+		t.Error("a thread with no reply history led the day")
+	}
+	if cold.item.Id == "" {
+		t.Fatal("the row was dropped — this rule may only demote")
+	}
+	if !hasReason(cold.item, "no_reply_history") {
+		t.Error("the row does not say why it was demoted")
+	}
+}
+
+// Money outranks the missing history, exactly as it does staleness.
+//
+// An open deal on the thread is a stronger claim than any header a sender chose
+// to send, so a funded wait keeps the top band even with nothing written back.
+func TestAnOpenDealKeepsAnUnengagedWaitInTheTopBand(t *testing.T) {
+	funded := classifyWaiting(WaitingCustomer{
+		ActivityID:  ids.MustParse("01a05500-0000-7000-8000-0000000000d2"),
+		Subject:     "Re: the contract",
+		Since:       rankInstant.Add(-2 * 24 * time.Hour),
+		HasOpenDeal: true,
+	}, rankInstant)
+
+	if funded.item.Level != levelWaiting {
+		t.Errorf("a funded wait was demoted to level %d for want of reply history",
+			funded.item.Level)
+	}
+}
+
+// The admit case: an engaged wait keeps the band and says nothing about history.
+func TestAnEngagedWaitLeadsAndClaimsNoMissingHistory(t *testing.T) {
+	engaged := classifyWaiting(WaitingCustomer{
+		ActivityID: ids.MustParse("01a05500-0000-7000-8000-0000000000d3"),
+		Subject:    "Re: pricing",
+		Since:      rankInstant.Add(-2 * 24 * time.Hour),
+		Engaged:    true,
+	}, rankInstant)
+
+	if engaged.item.Level != levelWaiting {
+		t.Errorf("an engaged wait was demoted to level %d", engaged.item.Level)
+	}
+	if hasReason(engaged.item, "no_reply_history") {
+		t.Error("an engaged wait claimed it had no reply history")
 	}
 }

--- a/backend/internal/compose/attention/waitinglane.go
+++ b/backend/internal/compose/attention/waitinglane.go
@@ -76,6 +76,7 @@ type HiddenWork struct {
 	NotSales    int
 	PastHorizon int
 	Unlinked    int
+	Colleagues  int
 	// Truncated says a read stopped at its own scan bound, which makes every
 	// figure a floor. The module states why it is fatal to Clear rather than
 	// merely noted beside it.
@@ -85,7 +86,8 @@ type HiddenWork struct {
 // Clear reports that nothing is being held back — the guardrail's target.
 func (h HiddenWork) Clear() bool {
 	return !h.Truncated &&
-		h.SetAside == 0 && h.NotSales == 0 && h.PastHorizon == 0 && h.Unlinked == 0
+		h.SetAside == 0 && h.NotSales == 0 && h.PastHorizon == 0 && h.Unlinked == 0 &&
+		h.Colleagues == 0
 }
 
 // WaitingCustomer is one message nobody has answered.
@@ -111,6 +113,11 @@ type WaitingCustomer struct {
 	// thread. It is what keeps a long wait in execution instead of sending it
 	// to review.
 	HasOpenDeal bool
+	// Engaged says the workspace wrote on this thread before the message
+	// arrived. False means unproven, not absent: a client that strips reply
+	// headers gives each message its own thread, so this demotes rather than
+	// hides.
+	Engaged bool
 	// OwnerID is who owes this reply, resolved by the module from the record
 	// the thread is filed under. Zero when nothing on it names an owner, which
 	// is an unowned customer rather than a missing answer.
@@ -189,6 +196,7 @@ func (s *Service) HiddenBacklog(ctx context.Context) (crmcontracts.HiddenBacklog
 		NotSales:    work.NotSales,
 		PastHorizon: work.PastHorizon,
 		Unlinked:    work.Unlinked,
+		Colleagues:  work.Colleagues,
 		Truncated:   work.Truncated,
 		// Derived from the same struct the figures came from, so the flag and
 		// the numbers cannot disagree — a client reading `clear` over four

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -508,6 +508,10 @@ func TestAWaitingCustomerLeadsTheDay(t *testing.T) {
 		ActivityID: ids.MustParse("01a05500-0000-7000-8000-00000000aaaa"),
 		Subject:    "Re: pricing",
 		Since:      rankInstant.Add(-2 * 24 * time.Hour),
+		// A conversation we are already in. Only such a wait leads the day —
+		// one where nothing proves we ever wrote is demoted, and a fixture
+		// leaving this false would be asserting the opposite claim.
+		Engaged: true,
 	}}
 
 	out := (&Service{}).worklistFrom(context.Background(), day, scopeAll, "", 25, waitingRead{rows: waiting, read: true}, leadRead{}, worklistCursor{}, nil)
@@ -767,14 +771,17 @@ func TestABatchNamesSomeOfWhatItHolds(t *testing.T) {
 // longest-waiting few lead; the rest are demoted, never dropped.
 func TestOneKindOfWorkCannotTakeTheWholePage(t *testing.T) {
 	waiting := []WaitingCustomer{}
-	// Every wait is LIVE — hours apart, none old enough to go stale. Crowding
-	// and staleness both move a row down the page, and a fixture that aged past
-	// the stale line would pass this test while proving the other rule.
+	// Every wait is LIVE and ENGAGED — hours apart, none old enough to go
+	// stale, each on a thread we already wrote on. Three rules move a row down
+	// this page: crowding, staleness and unproven engagement. A fixture that
+	// left any of the other two firing would pass this test while proving one
+	// of them instead.
 	for i := 0; i < 30; i++ {
 		waiting = append(waiting, WaitingCustomer{
 			ActivityID: ids.NewV7(),
 			Subject:    "Thread " + string(rune('a'+i%26)) + string(rune('0'+i/26)),
 			Since:      rankInstant.Add(-time.Duration(30-i) * time.Hour),
+			Engaged:    true,
 		})
 	}
 	day := crmcontracts.Attention{

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -378,7 +378,11 @@ func newAttentionService(pool *pgxpool.Pool, svc *approvals.Service, meter *over
 		// due-dated lanes. Unbound it would be UTC's, which is nobody's day
 		// outside one timezone.
 		attention.WithZone(attentionZone(pool)),
-	).WithWaiting(attentionWaiting{store: activities.NewStore(db), now: now}).
+	).WithWaiting(attentionWaiting{
+		store: activities.NewStore(db).WithOwnDomains(
+			ownDomainReader{store: capture.NewOwnDomainStore(db)}),
+		now: now,
+	}).
 		// The asks waiting on this colleague to answer. Until this lane existed
 		// a colleague learned they had been asked only by opening that
 		// contact's Network tab, so an ask nobody went looking for expired

--- a/backend/internal/compose/attentionwaitingseam.go
+++ b/backend/internal/compose/attentionwaitingseam.go
@@ -68,6 +68,7 @@ func (w attentionWaiting) Hidden(
 		NotSales:    got.NotSales,
 		PastHorizon: got.PastHorizon,
 		Unlinked:    got.Unlinked,
+		Colleagues:  got.Colleagues,
 		Truncated:   got.Truncated,
 	}, nil
 }
@@ -110,6 +111,7 @@ func (w attentionWaiting) Unanswered(
 			OrganizationID: row.OrganizationID,
 			DealID:         row.DealID,
 			HasOpenDeal:    row.HasOpenDeal,
+			Engaged:        row.Engaged,
 			OwnerID:        row.OwnerID,
 		})
 	}

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -12,9 +12,11 @@ package compose
 // layers on top of these defaults.
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/margince/margince/backend/internal/compose/accountdraft"
@@ -80,7 +82,20 @@ func newActivitiesHandlers(pool *pgxpool.Pool) activitiesHandlers {
 		// including the human an agent acts on behalf of — and that resolution
 		// must be the same one the audit log records, so it is injected rather
 		// than re-derived here.
-		WithSenderName(identity.NewServiceFor(InstallationDB(pool)))
+		WithSenderName(identity.NewServiceFor(InstallationDB(pool))).
+		// Which domains are our own, for the waiting queue's colleague rule.
+		// capture owns workspace_email_domain and the rule for which entries
+		// count as vouched-for, so the edge is injected rather than restated.
+		WithOwnDomains(ownDomainReader{store: capture.NewOwnDomainStore(InstallationDB(pool))})
+}
+
+// ownDomainReader adapts capture's own-domain store to the seam the waiting
+// queue takes. It borrows the caller's transaction so one read's strict and
+// relaxed counts see a single snapshot of the domains.
+type ownDomainReader struct{ store *capture.OwnDomainStore }
+
+func (o ownDomainReader) Domains(ctx context.Context, tx pgx.Tx) ([]string, error) {
+	return o.store.ColleagueDomainsTx(ctx, tx)
 }
 
 // NewCollectionsStore is the ONE spelling of "the collections store with

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -13485,6 +13485,7 @@ const (
 	WorklistReasonKindMeetingSoon        WorklistReasonKind = "meeting_soon"
 	WorklistReasonKindMeetingUnprepared  WorklistReasonKind = "meeting_unprepared"
 	WorklistReasonKindNoChampion         WorklistReasonKind = "no_champion"
+	WorklistReasonKindNoReplyHistory     WorklistReasonKind = "no_reply_history"
 	WorklistReasonKindOverdue            WorklistReasonKind = "overdue"
 	WorklistReasonKindPinned             WorklistReasonKind = "pinned"
 	WorklistReasonKindPromised           WorklistReasonKind = "promised"
@@ -13524,6 +13525,8 @@ func (e WorklistReasonKind) Valid() bool {
 	case WorklistReasonKindMeetingUnprepared:
 		return true
 	case WorklistReasonKindNoChampion:
+		return true
+	case WorklistReasonKindNoReplyHistory:
 		return true
 	case WorklistReasonKindOverdue:
 		return true
@@ -22104,6 +22107,13 @@ type HeldThreadListResponse struct {
 // HiddenBacklog How much waiting work each hiding rule is keeping off one reader's queue, at one
 // instant. Every count is of THREADS, matching what the queue counts: a customer who
 // wrote three times is waiting once.
+//
+// THE FIGURES DO NOT ADD UP, and that is deliberate. Each is the difference made by
+// relaxing ONE rule with the others still in force, because a reader needs to know
+// which rule to look at rather than a total they cannot act on. A thread held back
+// by two rules therefore appears in NEITHER figure: relaxing either one alone still
+// leaves the other hiding it. Summing these to estimate the hidden total
+// under-reports it.
 type HiddenBacklog struct {
 	// AsOf The instant every figure below was read at.
 	AsOf time.Time `json:"as_of"`
@@ -22112,6 +22122,16 @@ type HiddenBacklog struct {
 	// guardrail's target, sent as its own field because a number only ever read beside
 	// other numbers becomes decoration — this is what a check asserts on.
 	Clear bool `json:"clear"`
+
+	// Colleagues Mail from one of the workspace's own email domains. ALSO NOBODY'S CHOICE, and
+	// watched because the rule is only as good as the domain list behind it: a
+	// domain entered by mistake suppresses a real customer's correspondence for
+	// everybody, and this is the figure that would show it.
+	//
+	// The domains are the vouched-for ones — those the company claims and those an
+	// administrator confirmed — never every domain a connected mailbox happened to
+	// see. A contractor's genuine account at a customer must not read as internal.
+	Colleagues int `json:"colleagues"`
 
 	// NotSales Work somebody judged to be no business of the queue's. SOMEBODY'S CHOICE, and
 	// the judgement worth watching: it hides the thread from the WHOLE workspace and

--- a/backend/internal/modules/activities/activityread.go
+++ b/backend/internal/modules/activities/activityread.go
@@ -111,6 +111,11 @@ type ListActivitiesInput struct {
 	// this filter and the rest of the page judging against two different
 	// clock reads.
 	WaitingReplyAsOf *time.Time
+	// ownDomains is the colleague-domain snapshot the waiting walk tests senders
+	// against. Unexported and set by the store beside the transaction it reads
+	// in, never by a caller: it is one read's snapshot, not a request parameter,
+	// and a caller supplying it could widen or narrow who counts as a colleague.
+	ownDomains []string
 	// OpenAndDueBy narrows to tasks still open and already due at an instant:
 	// the day's work, asked as one question.
 	//
@@ -161,6 +166,14 @@ func (s *Store) ListActivities(ctx context.Context, in ListActivitiesInput) ([]c
 	var activities []crmcontracts.Activity
 	var page storekit.Page
 	err := s.tx(ctx, func(tx pgx.Tx) (err error) {
+		// The colleague-domain snapshot for THIS read, taken beside the rows it
+		// judges. ListActivitiesTx cannot take it itself: it is a free function
+		// for a caller that already holds a transaction, so it has no seam to
+		// ask — and a composite record read that carries none simply excludes
+		// no sender, which is the same open default WithOwnDomains documents.
+		if in.ownDomains, err = s.ownDomainList(ctx, tx); err != nil {
+			return err
+		}
 		activities, page, err = ListActivitiesTx(ctx, tx, in)
 		return err
 	})
@@ -406,6 +419,10 @@ func (s *Store) CountActivities(ctx context.Context, in ListActivitiesInput) (in
 			return err
 		}
 		if err := ensureNarrowingTargetVisible(ctx, tx, in.EntityType, in.EntityID); err != nil {
+			return err
+		}
+		var err error
+		if in.ownDomains, err = s.ownDomainList(ctx, tx); err != nil {
 			return err
 		}
 		if in.WithinProjectID != nil {

--- a/backend/internal/modules/activities/hiddenbacklog.go
+++ b/backend/internal/modules/activities/hiddenbacklog.go
@@ -88,6 +88,11 @@ type HiddenBacklog struct {
 	// customer lands when capture failed to link their thread. That ambiguity is
 	// why it is its own figure rather than folded into a total.
 	Unlinked int
+	// Colleagues is mail from our own email domains. Nobody's choice either,
+	// and the figure matters because the rule is only as good as the domain
+	// list behind it: a domain entered by mistake suppresses a real customer's
+	// correspondence workspace-wide, and this is the number that would show it.
+	Colleagues int
 }
 
 // Clear reports whether nothing is being held back.
@@ -100,7 +105,8 @@ type HiddenBacklog struct {
 // when the scan stopped before the question was settled.
 func (h HiddenBacklog) Clear() bool {
 	return !h.Truncated &&
-		h.SetAside == 0 && h.NotSales == 0 && h.PastHorizon == 0 && h.Unlinked == 0
+		h.SetAside == 0 && h.NotSales == 0 && h.PastHorizon == 0 && h.Unlinked == 0 &&
+		h.Colleagues == 0
 }
 
 // HiddenWaiting counts what each hiding rule is keeping off this reader's queue.
@@ -147,6 +153,7 @@ func (s *Store) HiddenWaiting(ctx context.Context, asOf time.Time) (HiddenBacklo
 			{&out.NotSales, waitingRelaxation{reader: reader, keepNotSales: true}},
 			{&out.PastHorizon, waitingRelaxation{reader: reader, wholeHorizon: true}},
 			{&out.Unlinked, waitingRelaxation{reader: reader, keepUnlinked: true}},
+			{&out.Colleagues, waitingRelaxation{reader: reader, keepColleagues: true}},
 		} {
 			widened, err := s.countWaiting(ctx, tx, asOf, relaxed.with)
 			if err != nil {
@@ -191,6 +198,8 @@ type waitingRelaxation struct {
 	wholeHorizon bool
 	// keepUnlinked admits inbound mail attached to no sales record.
 	keepUnlinked bool
+	// keepColleagues admits mail from our own email domains.
+	keepColleagues bool
 }
 
 // countWaiting runs the waiting query under one relaxation and counts its rows.
@@ -222,12 +231,19 @@ func (s *Store) countWaiting(
 	// it is the right one here: a relaxation admits every row the clause would
 	// have removed, which is the same "no bound applies" this constant already
 	// spells everywhere a scope is absent.
-	notSales, unlinked := neverRelaxed, neverRelaxed
+	notSales, unlinked, colleague := neverRelaxed, neverRelaxed, neverRelaxed
 	if relax.keepNotSales {
 		notSales = scopeUnbounded
 	}
 	if relax.keepUnlinked {
 		unlinked = scopeUnbounded
+	}
+	if relax.keepColleagues {
+		colleague = scopeUnbounded
+	}
+	ownDomains, err := s.ownDomainList(ctx, tx)
+	if err != nil {
+		return 0, err
 	}
 	inner := fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, WaitingScanCap,
 		horizon,
@@ -237,7 +253,8 @@ func (s *Store) countWaiting(
 		liveRecord(openDealPredicate, "fd"),
 		arg(relax.reader),
 		scopeUnbounded,
-		notSales, unlinked)
+		notSales, unlinked,
+		colleague, arg(ownDomains))
 	var count int
 	// Counted around the whole statement rather than by replacing its SELECT
 	// list: the query GROUPs and LIMITs, so the row count IS the answer and a

--- a/backend/internal/modules/activities/hiddenbacklog.go
+++ b/backend/internal/modules/activities/hiddenbacklog.go
@@ -254,7 +254,7 @@ func (s *Store) countWaiting(
 		arg(relax.reader),
 		scopeUnbounded,
 		notSales, unlinked,
-		colleague, arg(ownDomains))
+		colleague, ownDomainSenderSQL("a", arg(ownDomains)))
 	var count int
 	// Counted around the whole statement rather than by replacing its SELECT
 	// list: the query GROUPs and LIMITs, so the row count IS the answer and a

--- a/backend/internal/modules/activities/hiddenbacklog_integration_test.go
+++ b/backend/internal/modules/activities/hiddenbacklog_integration_test.go
@@ -53,6 +53,7 @@ func moved(before, after HiddenBacklog) HiddenBacklog {
 		NotSales:    after.NotSales - before.NotSales,
 		PastHorizon: after.PastHorizon - before.PastHorizon,
 		Unlinked:    after.Unlinked - before.Unlinked,
+		Colleagues:  after.Colleagues - before.Colleagues,
 	}
 }
 
@@ -220,6 +221,45 @@ func TestUnlinkedInboundIsCountedSeparately(t *testing.T) {
 	if got.PastHorizon != 0 {
 		t.Fatalf("unlinked mail was also counted against the horizon: %+v", got)
 	}
+}
+
+// The colleague rule gets a figure, because the rule is only as good as the
+// domain list behind it.
+//
+// A domain entered by mistake suppresses a real customer's correspondence for
+// the whole workspace, silently — the queue simply gets shorter. This figure is
+// the only thing that would show it, so it has to move when the rule fires and
+// stay still when another rule does the hiding.
+func TestMailFromOurOwnDomainIsCountedSeparately(t *testing.T) {
+	e := setupLoad(t)
+	person := e.buyer(t)
+	before := hiddenKnowing(t, e, "ourco.test")
+	e.waitingFrom(t, "A real customer", "buyer@customer.test", person)
+	e.waitingFrom(t, "Outstanding invoices", "eric@ourco.test", person)
+
+	got := moved(before, hiddenKnowing(t, e, "ourco.test"))
+
+	if got.Shown != 1 {
+		t.Fatalf("the queue gained %d waits, wanted only the customer's", got.Shown)
+	}
+	if got.Colleagues != 1 {
+		t.Fatalf("counted %d colleague waits, wanted the one (%+v)", got.Colleagues, got)
+	}
+	// The figures are marginal, so a colleague's message must not also show up
+	// as unlinked or past the horizon — it qualifies on both.
+	if got.Unlinked != 0 || got.PastHorizon != 0 {
+		t.Fatalf("the colleague's message was counted against another rule too: %+v", got)
+	}
+}
+
+// hiddenKnowing reads the guardrail with a colleague-domain answer bound.
+func hiddenKnowing(t *testing.T, e *loadEnv, domains ...string) HiddenBacklog {
+	t.Helper()
+	got, err := storeKnowing(e, domains...).HiddenWaiting(e.as(), time.Now())
+	if err != nil {
+		t.Fatalf("reading the hidden backlog: %v", err)
+	}
+	return got
 }
 
 // The property every figure rests on: a relaxed read is a SUPERSET of the

--- a/backend/internal/modules/activities/responsemetrics.go
+++ b/backend/internal/modules/activities/responsemetrics.go
@@ -113,15 +113,7 @@ const firstResponseSQL = `
 	   -- answers "how fast do we answer customers". Without the same exclusion
 	   -- the queue applies, an internal thread nobody replies to would drag the
 	   -- rate down over work the queue never showed anybody.
-	   AND NOT EXISTS (
-	         SELECT 1 FROM activity_participant ours
-	          WHERE ours.activity_id = inbound.id
-	            AND ours.role = 'from'
-	            AND EXISTS (
-	                  SELECT 1 FROM unnest($%[4]d::text[]) AS own(domain)
-	                   WHERE lower(split_part(ours.address, '@', 2)) = own.domain
-	                      OR lower(split_part(ours.address, '@', 2))
-	                         LIKE '%%.' || own.domain))
+	   AND NOT %[4]s
 	   -- A SALES thread, by the same four arms waitingRepliesSQL qualifies on.
 	   -- Restated rather than shared because this query has no wl join to hang
 	   -- them off; what must not drift is the DEFINITION, and a test feeding
@@ -199,7 +191,7 @@ func (s *Store) ResponseWindow(ctx context.Context, from, to time.Time) (Respons
 			content,
 			liveRecord(openDealPredicate, "d"),
 			liveRecord(workingLeadPredicate, "ld"),
-			arg(ownDomains)),
+			ownDomainSenderSQL("inbound", arg(ownDomains))),
 			args...).Scan(&out.Answered, &out.MedianMinutes); err != nil {
 			return fmt.Errorf("activities: reading first-response times: %w", err)
 		}

--- a/backend/internal/modules/activities/responsemetrics.go
+++ b/backend/internal/modules/activities/responsemetrics.go
@@ -109,7 +109,20 @@ const firstResponseSQL = `
 	   AND inbound.occurred_at >= $1
 	   AND inbound.occurred_at < $2
 	   AND %[1]s
-	   -- A SALES thread, by the same three arms waitingRepliesSQL qualifies on.
+	   -- A COLLEAGUE's message is not a customer waiting, and this reading
+	   -- answers "how fast do we answer customers". Without the same exclusion
+	   -- the queue applies, an internal thread nobody replies to would drag the
+	   -- rate down over work the queue never showed anybody.
+	   AND NOT EXISTS (
+	         SELECT 1 FROM activity_participant ours
+	          WHERE ours.activity_id = inbound.id
+	            AND ours.role = 'from'
+	            AND EXISTS (
+	                  SELECT 1 FROM unnest($%[4]d::text[]) AS own(domain)
+	                   WHERE lower(split_part(ours.address, '@', 2)) = own.domain
+	                      OR lower(split_part(ours.address, '@', 2))
+	                         LIKE '%%.' || own.domain))
+	   -- A SALES thread, by the same four arms waitingRepliesSQL qualifies on.
 	   -- Restated rather than shared because this query has no wl join to hang
 	   -- them off; what must not drift is the DEFINITION, and a test feeding
 	   -- both readers one timeline holds that better than a shared fragment
@@ -175,10 +188,18 @@ func (s *Store) ResponseWindow(ctx context.Context, from, to time.Time) (Respons
 		if err != nil {
 			return err
 		}
+		// The SAME colleague-domain snapshot the queue judges by, read in this
+		// transaction. Two readings of one rule taken from two snapshots would
+		// disagree the moment an administrator added a domain between them.
+		ownDomains, err := s.ownDomainList(ctx, tx)
+		if err != nil {
+			return err
+		}
 		if err := tx.QueryRow(ctx, fmt.Sprintf(firstResponseSQL,
 			content,
 			liveRecord(openDealPredicate, "d"),
-			liveRecord(workingLeadPredicate, "ld")),
+			liveRecord(workingLeadPredicate, "ld"),
+			arg(ownDomains)),
 			args...).Scan(&out.Answered, &out.MedianMinutes); err != nil {
 			return fmt.Errorf("activities: reading first-response times: %w", err)
 		}

--- a/backend/internal/modules/activities/store.go
+++ b/backend/internal/modules/activities/store.go
@@ -23,6 +23,10 @@ import (
 type Store struct {
 	// db binds the workspace this store runs for (ADR-0091 §9 step 3).
 	db *database.DB
+	// ownDomains tells a colleague's message from a customer's for the waiting
+	// queue. Nil in a deployment that has not wired it, and then no sender is
+	// excluded for being one of ours (WithOwnDomains).
+	ownDomains OwnDomains
 	// transcriptEnqueue starts the reading of a transcript the moment it
 	// lands, in the same transaction that stores it. Nil in a deployment with
 	// no transcript brain wired, and then a transcript is simply stored —

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -60,6 +60,16 @@ type WaitingReply struct {
 	// exists". The looser reading would let somebody learn a deal is there by
 	// watching a row they can see decline to go stale.
 	HasOpenDeal bool
+	// Engaged reports that this workspace wrote on this thread BEFORE the
+	// message arrived — the evidence that a conversation is one we are already
+	// in, rather than one that merely reached a mailbox.
+	//
+	// Reported, never used to hide. Thread identity comes from the reply
+	// headers, and a client that strips them gives every message its own
+	// thread: an exclusion keyed on this would drop a live customer silently,
+	// which is the one failure this queue must not have. A caller demotes an
+	// unengaged wait instead, so being wrong costs a scroll.
+	Engaged bool
 	// OwnerID is who owes this reply, resolved from the record the thread is
 	// filed under. Zero when no record on it names an owner.
 	//
@@ -222,6 +232,12 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 		// has nothing hidden from it, which is the honest answer: a background
 		// job has set nothing aside.
 		reader := arg(readerOrNobody(ctx))
+		// One snapshot for this read. Passed as a list rather than tested in Go
+		// so the clause runs before the scan cap — see OwnDomains.
+		ownDomains, err := s.ownDomainList(ctx, tx)
+		if err != nil {
+			return err
+		}
 		rows, err := tx.Query(ctx,
 			fmt.Sprintf(waitingRepliesSQL, instant, content, linkVisible, WaitingScanCap,
 				waitingHorizonDays,
@@ -231,7 +247,8 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 				liveRecord(openDealPredicate, "fd"),
 				reader,
 				scopeUnbounded,
-				neverRelaxed, neverRelaxed), args...)
+				neverRelaxed, neverRelaxed,
+				neverRelaxed, arg(ownDomains)), args...)
 		if err != nil {
 			return err
 		}
@@ -241,7 +258,7 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 			var row WaitingReply
 			if err := rows.Scan(&row.ActivityID, &row.Kind, &row.Subject, &row.Sender, &row.OccurredAt,
 				&row.PersonID, &row.OrganizationID, &row.DealID,
-				&row.HasOpenDeal, &row.OwnerID); err != nil {
+				&row.HasOpenDeal, &row.Engaged, &row.OwnerID); err != nil {
 				return err
 			}
 			waiting = append(waiting, row)
@@ -252,4 +269,57 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 		return nil, fmt.Errorf("activities: reading who is waiting for a reply: %w", err)
 	}
 	return waiting, nil
+}
+
+// OwnDomains reports the email domains this installation's own people write
+// from — the set a message's sender is tested against to tell a colleague from
+// a customer.
+//
+// A seam rather than a query here because the domains are capture's to define:
+// it owns workspace_email_domain and the rule for which entries count as
+// vouched-for, and a module may not read a sibling's tables. What this returns
+// is DATA the queue tests against in SQL, not a Go predicate, because the test
+// has to run before the scan cap — a predicate applied to the rows that came
+// back would let two hundred colleague threads fill the scan and push a real
+// customer past it, which is the failure every other rule in waitingsql.go is
+// ordered to avoid.
+//
+// The domains are read inside the CALLER's transaction, so the strict read and
+// every relaxed read beside it see one snapshot. A seam that opened its own
+// would let the set change between two counts that are meant to differ by
+// exactly one rule.
+type OwnDomains interface {
+	Domains(ctx context.Context, tx pgx.Tx) ([]string, error)
+}
+
+// WithOwnDomains wires the colleague-domain reader the waiting queue needs.
+//
+// Unbound, the queue admits every sender: a deployment that cannot say which
+// domains are its own must not guess, and the honest failure is a queue with
+// colleagues in it rather than one that silently drops a customer whose domain
+// resembles ours.
+func (s *Store) WithOwnDomains(own OwnDomains) *Store {
+	s.ownDomains = own
+	return s
+}
+
+// WithOwnDomains on Handlers wires the same reader the store needs, so the
+// timeline's `waiting_reply=true` filter answers with the queue's rule rather
+// than a looser one.
+func (h Handlers) WithOwnDomains(own OwnDomains) Handlers {
+	h.store = h.store.WithOwnDomains(own)
+	return h
+}
+
+// ownDomainList reads the colleague domains for one query, or none when no
+// reader is wired.
+func (s *Store) ownDomainList(ctx context.Context, tx pgx.Tx) ([]string, error) {
+	if s.ownDomains == nil {
+		return nil, nil
+	}
+	domains, err := s.ownDomains.Domains(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("activities: reading which domains are our own: %w", err)
+	}
+	return domains, nil
 }

--- a/backend/internal/modules/activities/waiting.go
+++ b/backend/internal/modules/activities/waiting.go
@@ -248,7 +248,7 @@ func (s *Store) WaitingReplies(ctx context.Context, asOf time.Time) ([]WaitingRe
 				reader,
 				scopeUnbounded,
 				neverRelaxed, neverRelaxed,
-				neverRelaxed, arg(ownDomains)), args...)
+				neverRelaxed, ownDomainSenderSQL("a", arg(ownDomains))), args...)
 		if err != nil {
 			return err
 		}
@@ -322,4 +322,47 @@ func (s *Store) ownDomainList(ctx context.Context, tx pgx.Tx) ([]string, error) 
 		return nil, fmt.Errorf("activities: reading which domains are our own: %w", err)
 	}
 	return domains, nil
+}
+
+// ownDomainSenderSQL is the ONE spelling of "this message came from one of our
+// own domains", rendered under a caller's activity alias with the placeholder
+// holding the domain list.
+//
+// Held by: TestTheOwnDomainSenderPredicateHasOneSpelling
+// (backend/gates/owndomainpredicate_test.go)
+//
+// A shared fragment rather than the same predicate typed twice, because the
+// waiting queue and the response reading judge the same messages: a rule that
+// drifted between them would make /worklist/response disagree with the queue
+// about who is waiting, and nothing would fail.
+//
+// Two things it does NOT do, each learned from a way it can suppress a real
+// customer silently:
+//
+//   - It reads the domain after the LAST at-sign, not the first. A quoted local
+//     part may legally contain one, so a sender can put one of our domains
+//     inside their own local part; splitting at the first would read that as
+//     the domain and hide their message.
+//   - It compares a suffix with right(), never LIKE. A domain is text an
+//     operator typed, and underscore is a LIKE wildcard, so an entry such as
+//     "our_.test" would match "ourx.test" and hide that customer's mail.
+//
+// A blank entry matches nothing on its own: equality fails against any real
+// domain, and the suffix comparison then asks whether a domain ends in a bare
+// dot, which none does. Stated here rather than guarded, because a guard no
+// test can fail is a claim nobody is holding.
+func ownDomainSenderSQL(alias string, domainArg int) string {
+	return fmt.Sprintf(`EXISTS (
+	         SELECT 1 FROM activity_participant ours
+	          CROSS JOIN LATERAL (SELECT lower(split_part(ours.address, '@',
+	                  length(ours.address) - length(replace(ours.address, '@', '')) + 1))
+	              ) AS sender(domain)
+	          WHERE ours.activity_id = %[1]s.id
+	            AND ours.role = 'from'
+	            AND sender.domain <> ''
+	            AND EXISTS (
+	                  SELECT 1 FROM unnest($%[2]d::text[]) AS own(domain)
+	                   WHERE (sender.domain = own.domain
+	                       OR right(sender.domain, length(own.domain) + 1)
+	                          = '.' || own.domain)))`, alias, domainArg)
 }

--- a/backend/internal/modules/activities/waitingengagement_integration_test.go
+++ b/backend/internal/modules/activities/waitingengagement_integration_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package activities
+
+// The two rules that decide whether a waiting message is a CUSTOMER waiting:
+// who wrote it, and whether this workspace was ever in the conversation.
+//
+// They differ in what they are allowed to do, and the difference is the point.
+// A colleague's domain is a fact about us — an administrator vouched for it — so
+// it EXCLUDES. Prior engagement is read from thread identity, which comes from
+// headers the sender chose to send, so it only DEMOTES: a client that strips
+// References gives every message its own thread, and excluding on that would
+// drop a live customer with nothing on the page to say so.
+//
+// Both need an admit case beside every refuse case. Three security tests in this
+// tree once passed against an authority that refused everyone, and a rule that
+// hides everything hides the real work too.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// fixedDomains is the own-domain seam under test, answering from a literal.
+//
+// A double here rather than capture's real store because what is under test is
+// the QUERY's use of the list, not how the list is assembled — capture's own
+// tests hold that. The seam takes the caller's transaction, and this honours it
+// by ignoring it: there is nothing to read.
+type fixedDomains []string
+
+func (f fixedDomains) Domains(context.Context, pgx.Tx) ([]string, error) {
+	return []string(f), nil
+}
+
+// storeKnowing builds the queue store with a colleague-domain answer bound.
+func storeKnowing(e *loadEnv, domains ...string) *Store {
+	return NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws))).
+		WithOwnDomains(fixedDomains(domains))
+}
+
+// waitingFrom seeds one otherwise-qualifying wait from a named address.
+func (e *loadEnv) waitingFrom(t *testing.T, subject, address string, person ids.UUID) ids.UUID {
+	t.Helper()
+	activity := ids.NewV7()
+	e.exec(t, `INSERT INTO activity (id, kind, direction, subject, occurred_at, thread_key, source, captured_by)
+		VALUES ($1, 'email', 'inbound', $2, now() - interval '2 days', $3, 'seed', 'system')`,
+		activity, subject, "thread-"+activity.String())
+	e.exec(t, `INSERT INTO activity_participant (id, activity_id, role, address)
+		VALUES ($1, $2, 'from', $3)`, ids.NewV7(), activity, address)
+	e.exec(t, `INSERT INTO activity_link (id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`, ids.NewV7(), activity, person)
+	return activity
+}
+
+// buyer writes one person record for a wait to hang off.
+func (e *loadEnv) buyer(t *testing.T) ids.UUID {
+	t.Helper()
+	person := ids.NewV7()
+	e.exec(t, `INSERT INTO person (id, full_name, owner_id, source, captured_by)
+		VALUES ($1, 'Buyer Person', $2, 'seed', 'system')`, person, e.rep)
+	return person
+}
+
+// present reports whether the given message came back from the queue.
+func present(t *testing.T, s *Store, e *loadEnv, activity ids.UUID) (WaitingReply, bool) {
+	t.Helper()
+	rows, err := s.WaitingReplies(e.as(), time.Now())
+	if err != nil {
+		t.Fatalf("reading who is waiting: %v", err)
+	}
+	for _, row := range rows {
+		if row.ActivityID == activity {
+			return row, true
+		}
+	}
+	return WaitingReply{}, false
+}
+
+// A colleague writing is not a customer waiting.
+func TestAMessageFromOurOwnDomainIsNotAWaitingCustomer(t *testing.T) {
+	e := setupLoad(t)
+	person := e.buyer(t)
+	colleague := e.waitingFrom(t, "Outstanding invoices", "eric@ourco.test", person)
+	customer := e.waitingFrom(t, "Question about pricing", "buyer@customer.test", person)
+
+	s := storeKnowing(e, "ourco.test")
+	if _, ok := present(t, s, e, colleague); ok {
+		t.Error("a colleague's message is in the queue as a waiting customer")
+	}
+	// The admit case, and it is not decoration: a rule that refused every
+	// sender would pass the assertion above and empty the queue.
+	if _, ok := present(t, s, e, customer); !ok {
+		t.Error("the customer's message was excluded too — the rule refuses everyone")
+	}
+}
+
+// A departmental host is still our own house.
+func TestASubdomainOfOursIsAlsoOurs(t *testing.T) {
+	e := setupLoad(t)
+	person := e.buyer(t)
+	sub := e.waitingFrom(t, "From the Berlin office", "ops@mail.ourco.test", person)
+	// A domain that merely ENDS with ours is somebody else's company.
+	lookalike := e.waitingFrom(t, "Not us at all", "sales@notourco.test", person)
+
+	s := storeKnowing(e, "ourco.test")
+	if _, ok := present(t, s, e, sub); ok {
+		t.Error("mail from a subdomain of ours was treated as a customer")
+	}
+	if _, ok := present(t, s, e, lookalike); !ok {
+		t.Error("a different company whose domain ends with ours was excluded")
+	}
+}
+
+// No domains wired, nobody excluded.
+//
+// The open default is deliberate: a deployment that cannot say which domains are
+// its own must not guess. A queue with colleagues in it is visible; a queue that
+// dropped a customer whose domain resembles ours is not.
+func TestWithNoOwnDomainsNobodyIsExcluded(t *testing.T) {
+	e := setupLoad(t)
+	person := e.buyer(t)
+	colleague := e.waitingFrom(t, "Outstanding invoices", "eric@ourco.test", person)
+
+	unbound := NewStore(database.BindTo(e.pool, ids.From[ids.WorkspaceKind](e.ws)))
+	if _, ok := present(t, unbound, e, colleague); !ok {
+		t.Error("an unwired store excluded a sender it has no domain list to judge")
+	}
+}
+
+// Prior engagement is REPORTED, and a message without it still comes back.
+//
+// This is the whole shape of the rule. If it ever becomes an exclusion, this
+// test fails — which is what it is for.
+func TestAnUnengagedThreadIsReportedNotHidden(t *testing.T) {
+	e := setupLoad(t)
+	person := e.buyer(t)
+	cold := e.waitingFrom(t, "Cold approach", "stranger@customer.test", person)
+
+	s := storeKnowing(e, "ourco.test")
+	row, ok := present(t, s, e, cold)
+	if !ok {
+		t.Fatal("a thread we never wrote on was HIDDEN — it must only be demoted")
+	}
+	if row.Engaged {
+		t.Error("a thread with no earlier outbound reported itself as engaged")
+	}
+}
+
+// An earlier outbound on the same thread is what engagement means.
+func TestAnEarlierOutboundOnTheThreadIsEngagement(t *testing.T) {
+	e := setupLoad(t)
+	person := e.buyer(t)
+	activity := e.waitingFrom(t, "Re: the proposal", "buyer@customer.test", person)
+	var thread string
+	e.exec(t, `SELECT 1`)
+	if err := e.pool.QueryRow(e.as(), `SELECT thread_key FROM activity WHERE id = $1`,
+		activity).Scan(&thread); err != nil {
+		t.Fatalf("reading the seeded thread key: %v", err)
+	}
+	// Ours, on the same thread, BEFORE the inbound arrived.
+	e.exec(t, `INSERT INTO activity (id, kind, direction, subject, occurred_at, thread_key, source, captured_by)
+		VALUES ($1, 'email', 'outbound', 'the proposal', now() - interval '5 days', $2, 'seed', 'system')`,
+		ids.NewV7(), thread)
+
+	s := storeKnowing(e, "ourco.test")
+	row, ok := present(t, s, e, activity)
+	if !ok {
+		t.Fatal("an engaged thread left the queue entirely")
+	}
+	if !row.Engaged {
+		t.Error("an earlier outbound on the same thread did not count as engagement")
+	}
+}
+
+// Engagement is what we wrote BEFORE, not after.
+//
+// Reading engagement without the ordering would call a thread engaged on the
+// strength of a reply that has not been sent yet — which is the one thing that
+// must not happen, because a scheduled send would then take the customer out of
+// the band before anybody answered them.
+func TestALaterOutboundIsNotEngagement(t *testing.T) {
+	e := setupLoad(t)
+	person := e.buyer(t)
+	activity := e.waitingFrom(t, "Still waiting", "buyer@customer.test", person)
+	var thread string
+	if err := e.pool.QueryRow(e.as(), `SELECT thread_key FROM activity WHERE id = $1`,
+		activity).Scan(&thread); err != nil {
+		t.Fatalf("reading the seeded thread key: %v", err)
+	}
+	// Ours, on the same thread, dated in the FUTURE. That is what isolates the
+	// ordering guard: the reply anti-join beside it is bounded by the read
+	// instant, so this row does not remove the wait — and if engagement ignored
+	// the ordering, this row alone would make the thread read as engaged.
+	//
+	// A scheduled send is exactly this shape, so the case is real rather than
+	// contrived: a queued reply must not make a customer look answered.
+	e.exec(t, `INSERT INTO activity (id, kind, direction, subject, occurred_at, thread_key, source, captured_by)
+		VALUES ($1, 'email', 'outbound', 'queued for tomorrow', now() + interval '1 day', $2, 'seed', 'system')`,
+		ids.NewV7(), thread)
+
+	s := storeKnowing(e, "ourco.test")
+	row, ok := present(t, s, e, activity)
+	if !ok {
+		t.Fatal("the wait left the queue")
+	}
+	if row.Engaged {
+		t.Error("a not-yet-sent outbound counted as engagement")
+	}
+}

--- a/backend/internal/modules/activities/waitingengagement_integration_test.go
+++ b/backend/internal/modules/activities/waitingengagement_integration_test.go
@@ -121,6 +121,68 @@ func TestASubdomainOfOursIsAlsoOurs(t *testing.T) {
 	}
 }
 
+// A sender cannot get their own message suppressed by naming us inside it.
+//
+// A quoted local part may legally contain an at-sign, so `"x@ourco.test"@evil.test`
+// is one address whose domain is evil.test. Reading the domain after the FIRST
+// at-sign returns `ourco.test"` — one trailing quote from a match — and a sender
+// who trimmed it right would have their message silently dropped from every
+// rep's queue. The domain is read after the LAST at-sign for that reason.
+func TestASenderCannotHideBehindOurDomainInTheirLocalPart(t *testing.T) {
+	e := setupLoad(t)
+	person := e.buyer(t)
+	quoted := e.waitingFrom(t, "Suppress me", `"x@ourco.test"@evil.test`, person)
+	doubled := e.waitingFrom(t, "And me", "a@ourco.test@evil.test", person)
+
+	s := storeKnowing(e, "ourco.test")
+	if _, ok := present(t, s, e, quoted); !ok {
+		t.Error("a quoted local part naming our domain suppressed the sender's message")
+	}
+	if _, ok := present(t, s, e, doubled); !ok {
+		t.Error("an address with two at-signs was read as internal")
+	}
+}
+
+// An own-domain entry is operator-typed text, never a pattern.
+//
+// Underscore and percent are LIKE wildcards. An entry of `our_.test` matched
+// `ourx.test` while this rule used LIKE, which hides a real customer's mail
+// across the whole workspace with nothing on any page to say why. The suffix is
+// compared with right() so an entry can only ever match itself.
+func TestAnOwnDomainIsNeverReadAsAPattern(t *testing.T) {
+	e := setupLoad(t)
+	person := e.buyer(t)
+	// A SUBDOMAIN, because that is the branch a pattern can reach: the equality
+	// branch compares whole strings and can never treat one as a pattern, so a
+	// fixture using a bare domain passes whether or not the suffix is safe.
+	customer := e.waitingFrom(t, "A real customer", "buyer@mail.ourx.test", person)
+
+	// The operator typed a wildcard character, deliberately or by accident.
+	s := storeKnowing(e, "our_.test")
+	if _, ok := present(t, s, e, customer); !ok {
+		t.Error("an underscore in an own-domain entry matched a customer's subdomain")
+	}
+}
+
+// An empty entry matches nothing, not everything.
+//
+// The suffix comparison would otherwise be against a bare dot, and an empty
+// string equals no domain — but a blank row in the list must not be able to
+// empty the queue, so it is refused explicitly.
+func TestABlankOwnDomainMatchesNothing(t *testing.T) {
+	e := setupLoad(t)
+	person := e.buyer(t)
+	// A subdomain again: a blank entry makes the suffix comparison ask whether
+	// the domain ends in a bare dot, which only a dotted address could satisfy.
+	// Against "customer.test" the test would pass with the guard removed.
+	customer := e.waitingFrom(t, "A real customer", "buyer@mail.customer.test", person)
+
+	s := storeKnowing(e, "")
+	if _, ok := present(t, s, e, customer); !ok {
+		t.Error("a blank own-domain entry excluded a customer")
+	}
+}
+
 // No domains wired, nobody excluded.
 //
 // The open default is deliberate: a deployment that cannot say which domains are

--- a/backend/internal/modules/activities/waitingrecordscope.go
+++ b/backend/internal/modules/activities/waitingrecordscope.go
@@ -87,7 +87,7 @@ func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.
 			reader,
 			entityClause,
 			neverRelaxed, neverRelaxed,
-			neverRelaxed, arg(ownDomains)) +
+			neverRelaxed, ownDomainSenderSQL("a", arg(ownDomains))) +
 		") waiting_thread)", nil
 }
 

--- a/backend/internal/modules/activities/waitingrecordscope.go
+++ b/backend/internal/modules/activities/waitingrecordscope.go
@@ -52,7 +52,7 @@ func waitingReplyEntityClause(entityType string, entityID ids.UUID, arg func(any
 // The subquery is uncorrelated — it computes its own candidate set rather
 // than reading the outer FROM — so its own `a` alias shadowing the outer
 // query's is harmless.
-func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.Time, entityType *string, entityID *ids.UUID) (string, error) {
+func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.Time, entityType *string, entityID *ids.UUID, ownDomains []string) (string, error) {
 	instant := arg(asOf)
 	content, err := auth.ActivityContentClause(ctx, "a", arg)
 	if err != nil {
@@ -86,7 +86,8 @@ func waitingReplyExistsClause(ctx context.Context, arg func(any) int, asOf time.
 			liveRecord(openDealPredicate, "fd"),
 			reader,
 			entityClause,
-			neverRelaxed, neverRelaxed) +
+			neverRelaxed, neverRelaxed,
+			neverRelaxed, arg(ownDomains)) +
 		") waiting_thread)", nil
 }
 
@@ -97,7 +98,7 @@ func appendWaitingReplyClause(ctx context.Context, in ListActivitiesInput, arg f
 	if in.WaitingReplyAsOf == nil {
 		return where, nil
 	}
-	clause, err := waitingReplyExistsClause(ctx, arg, *in.WaitingReplyAsOf, in.EntityType, in.EntityID)
+	clause, err := waitingReplyExistsClause(ctx, arg, *in.WaitingReplyAsOf, in.EntityType, in.EntityID, in.ownDomains)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/modules/activities/waitingsql.go
+++ b/backend/internal/modules/activities/waitingsql.go
@@ -214,15 +214,7 @@ const waitingRepliesSQL = `
 	   -- Matched on the address's domain, and on a subdomain of one of ours, the
 	   -- way the seam's own set does — mail from a departmental host is still
 	   -- from a colleague.
-	   AND (%[14]s OR NOT EXISTS (
-	         SELECT 1 FROM activity_participant ours
-	          WHERE ours.activity_id = a.id
-	            AND ours.role = 'from'
-	            AND EXISTS (
-	                  SELECT 1 FROM unnest($%[15]d::text[]) AS own(domain)
-	                   WHERE lower(split_part(ours.address, '@', 2)) = own.domain
-	                      OR lower(split_part(ours.address, '@', 2))
-	                         LIKE '%%.' || own.domain)))
+	   AND (%[14]s OR NOT %[15]s)
 	   -- The obvious machines, excluded BEFORE the cap. Filtering them after
 	   -- LIMIT lets two hundred notification threads fill the scan and push a
 	   -- real customer past it, and the page then says nobody is waiting —

--- a/backend/internal/modules/activities/waitingsql.go
+++ b/backend/internal/modules/activities/waitingsql.go
@@ -109,6 +109,24 @@ const waitingRepliesSQL = `
 	       -- Every arm reads through wl, the VISIBILITY-GATED link join. An
 	       -- owner off an ungated join would name who owns a record this reader
 	       -- may not open.
+	       -- Whether this workspace has ever written on this thread before the
+	       -- message arrived. It is REPORTED, never used to exclude: a client
+	       -- that strips References gives each message its own thread key, and
+	       -- an exclusion would then hard-drop a live customer with nothing on
+	       -- screen to say so. The caller demotes what it cannot prove instead,
+	       -- so the cost of being wrong is a scroll rather than a lost sale.
+	       --
+	       -- Ungated on purpose, like the sales-link arm it sits beside:
+	       -- eligibility that depended on the reader would make the same message
+	       -- engaged for one colleague and cold for another.
+	       EXISTS (
+	         SELECT 1 FROM activity ours
+	          WHERE ours.thread_key = a.thread_key
+	            AND ours.kind = a.kind
+	            AND ours.channel_provider IS NOT DISTINCT FROM a.channel_provider
+	            AND ours.direction = 'outbound'
+	            AND ours.archived_at IS NULL
+	            AND (ours.occurred_at, ours.id) < (a.occurred_at, a.id)),
 	       COALESCE(
 	         (array_agg(ownerDeal.owner_id ORDER BY ownerDeal.id::text)
 	          FILTER (WHERE ownerDeal.owner_id IS NOT NULL))[1],
@@ -180,6 +198,31 @@ const waitingRepliesSQL = `
 	                          WHERE d.id = sales.deal_id AND %[6]s)
 	              OR EXISTS (SELECT 1 FROM lead ld
 	                          WHERE ld.id = sales.lead_id AND %[7]s))))
+	   -- A COLLEAGUE is not a customer waiting.
+	   --
+	   -- Our own domains are read through the seam that owns them and passed in
+	   -- as a list, so the test runs here rather than over the rows that came
+	   -- back: after the cap, two hundred internal threads fill the scan and
+	   -- push a real customer past it — the same reason every rule above is
+	   -- ordered where it is.
+	   --
+	   -- An EMPTY list admits everyone. A deployment that cannot say which
+	   -- domains are its own must not guess: a queue with colleagues in it is a
+	   -- visible annoyance, and a queue that dropped a customer whose domain
+	   -- merely resembles ours is the silent failure this file exists to avoid.
+	   --
+	   -- Matched on the address's domain, and on a subdomain of one of ours, the
+	   -- way the seam's own set does — mail from a departmental host is still
+	   -- from a colleague.
+	   AND (%[14]s OR NOT EXISTS (
+	         SELECT 1 FROM activity_participant ours
+	          WHERE ours.activity_id = a.id
+	            AND ours.role = 'from'
+	            AND EXISTS (
+	                  SELECT 1 FROM unnest($%[15]d::text[]) AS own(domain)
+	                   WHERE lower(split_part(ours.address, '@', 2)) = own.domain
+	                      OR lower(split_part(ours.address, '@', 2))
+	                         LIKE '%%.' || own.domain)))
 	   -- The obvious machines, excluded BEFORE the cap. Filtering them after
 	   -- LIMIT lets two hundred notification threads fill the scan and push a
 	   -- real customer past it, and the page then says nobody is waiting —

--- a/backend/internal/modules/capture/owndomainstore.go
+++ b/backend/internal/modules/capture/owndomainstore.go
@@ -295,3 +295,32 @@ func ValidOwnDomain(raw string) (string, error) {
 	}
 	return ascii, nil
 }
+
+// ColleagueDomainsTx is the vouched-for own-domain set, read inside a
+// transaction the caller already holds.
+//
+// It exists beside Colleagues rather than replacing it because the two differ
+// in exactly the way that matters to a caller comparing several reads: this one
+// borrows the caller's transaction, so a set of counts meant to differ by one
+// rule sees ONE snapshot of the domains. Colleagues opens its own, which is
+// right for a single question asked once.
+//
+// Gated as an activity read, not a person read. The caller is judging
+// correspondence — which messages are a colleague's — and the grant that let
+// them read the message is the grant that answers it. Requiring person:read
+// would refuse a reader who may see the mail but not the contact, which is a
+// narrowing that has nothing to do with the question.
+//
+// Returns the normalized domains rather than the set, because the caller tests
+// them in SQL: a predicate cannot run before a scan cap, and a colleague rule
+// applied after one lets internal threads fill the scan.
+func (s *OwnDomainStore) ColleagueDomainsTx(ctx context.Context, tx pgx.Tx) ([]string, error) {
+	if err := auth.Require(ctx, "activity", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	own, err := trustedOwnDomainsTx(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	return own.Domains(), nil
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -233,7 +233,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
 
-## Prohibition (42)
+## Prohibition (43)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -261,6 +261,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `modulepoolsharing_test.go` | H2 | Pool-sharing discipline for the module suites, as a fitness function. |
 | `moduletablespelling_test.go` | H2 | A package that names its table does not pass that name as a bare string. |
 | `onecurrencyconversion_test.go` | H2 | Converting money to the base currency has one implementation. |
+| `owndomainpredicate_test.go` | H2 | One spelling of "this message came from one of our own domains". |
 | `pipefailgrepq_test.go` | H2 | A shell gate does not decide its verdict through a pipe that can break. |
 | `promptexcerpt_test.go` | H2 | A prompt built from a crawled page is bounded by this product, not by the site. |
 | `promptfence_test.go` | H1 | Prompt-boundary fitness functions: no prompt may declare a data boundary the writer of that data can spell. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28716,6 +28716,13 @@ export interface components {
          * @description How much waiting work each hiding rule is keeping off one reader's queue, at one
          *     instant. Every count is of THREADS, matching what the queue counts: a customer who
          *     wrote three times is waiting once.
+         *
+         *     THE FIGURES DO NOT ADD UP, and that is deliberate. Each is the difference made by
+         *     relaxing ONE rule with the others still in force, because a reader needs to know
+         *     which rule to look at rather than a total they cannot act on. A thread held back
+         *     by two rules therefore appears in NEITHER figure: relaxing either one alone still
+         *     leaves the other hiding it. Summing these to estimate the hidden total
+         *     under-reports it.
          */
         HiddenBacklog: {
             /**
@@ -28762,6 +28769,17 @@ export interface components {
              *     that reason rather than folded into a total.
              */
             unlinked: number;
+            /**
+             * @description Mail from one of the workspace's own email domains. ALSO NOBODY'S CHOICE, and
+             *     watched because the rule is only as good as the domain list behind it: a
+             *     domain entered by mistake suppresses a real customer's correspondence for
+             *     everybody, and this is the figure that would show it.
+             *
+             *     The domains are the vouched-for ones — those the company claims and those an
+             *     administrator confirmed — never every domain a connected mailbox happened to
+             *     see. A contractor's genuine account at a customer must not read as internal.
+             */
+            colleagues: number;
             /**
              * @description True when a read stopped at its own scan bound, which makes every figure above
              *     it a FLOOR rather than a count.
@@ -28985,7 +29003,7 @@ export interface components {
              * @description Which fact this is. The client writes the phrase.
              * @enum {string}
              */
-            kind: "pinned" | "buyer_wrote_last" | "waiting_days" | "overdue" | "due_today" | "closing_soon" | "expected_revenue" | "material" | "below_material" | "quiet_days" | "no_champion" | "promised" | "approved_and_failed" | "blocks_customer_work" | "routine" | "repeated_failure" | "legal_deadline" | "meeting_soon" | "meeting_unprepared" | "response_overdue" | "response_due_soon" | "unassigned" | "stale";
+            kind: "pinned" | "buyer_wrote_last" | "waiting_days" | "overdue" | "due_today" | "closing_soon" | "expected_revenue" | "material" | "below_material" | "quiet_days" | "no_champion" | "promised" | "approved_and_failed" | "blocks_customer_work" | "routine" | "repeated_failure" | "legal_deadline" | "meeting_soon" | "meeting_unprepared" | "response_overdue" | "response_due_soon" | "unassigned" | "stale" | "no_reply_history";
             value?: components["schemas"]["WorklistValue"];
         };
         /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7935,6 +7935,9 @@ export const de = {
   "worklist.hidden.unlinked": "Keinem Datensatz zugeordnet",
   "worklist.hidden.unlinked.detail":
     "Meist kein Vertrieb. Manchmal ein Kunde, den niemand zuordnen konnte.",
+  "worklist.hidden.colleagues": "Von einer unserer eigenen Domains",
+  "worklist.hidden.colleagues.detail":
+    "Kolleginnen und Kollegen, keine Kundschaft. Eine falsch eingetragene Domain verbirgt echte Post.",
   "worklist.hidden.notSales": "Als vertriebsfremd eingestuft",
   "worklist.hidden.notSales.detail":
     "Für die gesamte Organisation verborgen, und es hebt sich nicht auf.",
@@ -7992,6 +7995,7 @@ export const de = {
   "worklist.because.response_due_soon.value": "Antwort fällig bis {value}",
   "worklist.because.unassigned": "niemand zuständig",
   "worklist.because.stale": "wartet schon lange",
+  "worklist.because.no_reply_history": "kein Schriftwechsel bisher",
   "worklist.above.pin": "Über dem Nächsten, weil du es angeheftet hast.",
   "worklist.above.level": "Über dem Nächsten, weil es dringlichere Arbeit ist.",
   "worklist.above.deadline": "Über dem Nächsten wegen des Datums.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8017,6 +8017,9 @@ export const en = {
   "worklist.hidden.unlinked": "Attached to no record",
   "worklist.hidden.unlinked.detail":
     "Usually not sales. Sometimes a customer nobody managed to file.",
+  "worklist.hidden.colleagues": "From one of our own domains",
+  "worklist.hidden.colleagues.detail":
+    "A colleague, not a customer. A mistyped domain hides a real one.",
   "worklist.hidden.notSales": "Judged not sales work",
   "worklist.hidden.notSales.detail":
     "Hidden from the whole organization, and it does not lift.",
@@ -8073,6 +8076,7 @@ export const en = {
   "worklist.because.response_due_soon.value": "reply due by {value}",
   "worklist.because.unassigned": "nobody owns it",
   "worklist.because.stale": "waiting a long time",
+  "worklist.because.no_reply_history": "no reply history",
   "worklist.above.pin": "Above the next because you pinned it.",
   "worklist.above.level":
     "Above the next because it is a more pressing kind of work.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7845,6 +7845,9 @@ export const vi = {
   "worklist.hidden.unlinked": "Không gắn với hồ sơ nào",
   "worklist.hidden.unlinked.detail":
     "Thường không phải bán hàng. Đôi khi là khách hàng không ai kịp lưu hồ sơ.",
+  "worklist.hidden.colleagues": "Từ tên miền của chính chúng ta",
+  "worklist.hidden.colleagues.detail":
+    "Đồng nghiệp, không phải khách hàng. Một tên miền nhập sai sẽ giấu đi thư thật.",
   "worklist.hidden.notSales": "Được đánh giá không phải việc bán hàng",
   "worklist.hidden.notSales.detail": "Ẩn với toàn bộ tổ chức, và không tự bỏ.",
   "worklist.hidden.setAside": "Bạn đã gác lại",
@@ -7900,6 +7903,7 @@ export const vi = {
   "worklist.because.response_due_soon.value": "cần trả lời trước {value}",
   "worklist.because.unassigned": "chưa có ai phụ trách",
   "worklist.because.stale": "đã chờ rất lâu",
+  "worklist.because.no_reply_history": "chưa từng trao đổi",
   "worklist.above.pin": "Trên mục kế vì bạn đã ghim.",
   "worklist.above.level": "Trên mục kế vì đây là loại việc gấp hơn.",
   "worklist.above.deadline": "Trên mục kế nhờ ngày hạn.",

--- a/frontend/src/screens/worklist.copy.ts
+++ b/frontend/src/screens/worklist.copy.ts
@@ -186,6 +186,7 @@ const KNOWN_REASONS = {
   response_due_soon: true,
   unassigned: true,
   stale: true,
+  no_reply_history: true,
 } as const;
 
 type KnownReason = keyof typeof KNOWN_REASONS;

--- a/frontend/src/screens/worklist.hidden.stories.tsx
+++ b/frontend/src/screens/worklist.hidden.stories.tsx
@@ -34,6 +34,7 @@ const base = {
   not_sales: 0,
   past_horizon: 0,
   unlinked: 0,
+  colleagues: 0,
   truncated: false,
   clear: false,
 };
@@ -42,6 +43,13 @@ const base = {
 // wrote months ago and was never answered is what this reading exists to find.
 export const NobodyChoseThis: Story = {
   args: { backlog: { ...base, past_horizon: 4, unlinked: 2 } },
+};
+
+// The colleague rule is only as good as the domain list behind it. A figure
+// this large says somebody's own-domain entry is swallowing real mail, which is
+// the failure it exists to make visible.
+export const OurOwnDomainsHideTooMuch: Story = {
+  args: { backlog: { ...base, colleagues: 9 } },
 };
 
 // Every rule holding something, which is what a queue in trouble looks like.

--- a/frontend/src/screens/worklist.hidden.test.tsx
+++ b/frontend/src/screens/worklist.hidden.test.tsx
@@ -25,6 +25,7 @@ function backlog(over: Partial<HiddenBacklog> = {}): HiddenBacklog {
     not_sales: 0,
     past_horizon: 0,
     unlinked: 0,
+    colleagues: 0,
     truncated: false,
     clear: true,
     ...over,

--- a/frontend/src/screens/worklist.hidden.tsx
+++ b/frontend/src/screens/worklist.hidden.tsx
@@ -106,6 +106,13 @@ export function HiddenFigures({
           t={t}
         />
         <Reading
+          count={backlog.colleagues}
+          label={t("worklist.hidden.colleagues")}
+          detail={t("worklist.hidden.colleagues.detail")}
+          locale={locale}
+          t={t}
+        />
+        <Reading
           count={backlog.not_sales}
           label={t("worklist.hidden.notSales")}
           detail={t("worklist.hidden.notSales.detail")}


### PR DESCRIPTION
The `customer_waiting` queue was showing archived mail nobody is waiting on. Lars gave three examples and each failed for a different reason: a colleague at our own domain, a calendar invitation, and a report sent to a desk address.

The measured root cause is one clause. The rule meant to prove a customer is waiting accepts a link to any **person** ([waitingsql.go:174](backend/internal/modules/activities/waitingsql.go#L174)), and capture mints a person for nearly every correspondent. Over 30 days of one real mailbox that admits **108 of 135** inbound messages; the arms with a state check behind them admit **5**. The rule's own comment says it exists because the older version "was true of a rep's dentist" — the dentist has a person record too.

## Two rules, and they may do different things

**A colleague's message is excluded.** The evidence is a fact about us: a domain an administrator vouched for. `activities` may not import `capture`, and `trustedOwnDomainsTx` is unexported, so the domains arrive through an `OwnDomains` seam bound in compose — the shape `colleagueDomains` in `sendpath.go` already uses. Two details are load-bearing:

- The list is read **inside the caller's transaction**. The strict read and the four relaxed reads beside it must see one snapshot, or two counts meant to differ by a single rule differ by an administrator's edit instead. The existing `Colleagues` method opens its own transaction and gates on `person:read`; `ColleagueDomainsTx` gates on `activity:read`, which is the grant that actually answers "is this correspondence mine to read".
- The test runs **in SQL, before the scan cap**. A Go predicate over the returned rows would let internal threads fill the scan and push a real customer past it — the reason every other rule in that file is ordered where it is.

Unbound, nobody is excluded. A deployment that cannot say which domains are its own must not guess.

**A thread we never wrote on is demoted, not hidden.** This is the change from the plan's first draft, and it is the important one. `threadKey` ([mailmap.go:267](backend/internal/modules/capture/mailmap/mailmap.go#L267)) derives thread identity from the `References` root, else `In-Reply-To`, else *the message's own id* — and it deliberately refuses a subject fallback. A client that strips reply headers therefore gives every message its own thread, and a live conversation reads as a stranger's first mail. Excluding on that loses a customer with nothing on the page to say so, which is the one failure this queue must not have. The open-deal fallback does not save it either: linking collapsed in September (23 of 631 inbound linked, against 132 of 160 in August).

So the row keeps its place and loses the band. Being wrong costs a scroll. Money outranks it, exactly as it outranks staleness.

## The guardrail

The colleague rule gets its own figure in `/worklist/hidden`, because the rule is only as good as the domain list behind it: a domain entered by mistake suppresses a real customer's correspondence for everybody, silently, and this is the number that would show it. The demotion needs no figure — it hides nothing, which is a second argument for it.

The contract now states what the figures are and are not. Each is the difference made by relaxing **one** rule with the others still in force, so a thread held back by two appears in **neither**, and summing them under-reports the hidden total. That was always true of this endpoint and was never written down.

## Also in this change

- `responsemetrics.go` mirrors the queue's sales arms by hand and now takes the colleague rule from the same snapshot. Without it an unanswered internal thread drags the response rate down over work the queue never showed anyone. Its comment said "three arms" where there are four.
- `classify.go` crossed the 500-line cap; the per-item readings every lane shares moved to `itemreadings.go`.
- Three attention fixtures set `Engaged` explicitly. Each varies one dimension — staleness, crowding, who leads the day — and the new rule demotes to the same band, so leaving it unset would measure two rules and report whichever fired first.

## Tests

Every rule mutation-checked one clause at a time, with an admit case beside each refuse case:

| Mutation | Fails |
|---|---|
| colleague clause always true | the own-domain and subdomain tests, alone |
| engagement ignores `(occurred_at, id)` ordering | the future-dated-outbound test, alone |
| engagement always false | the earlier-outbound test, alone |
| demotion never fires | the demoted-not-dropped test, alone |
| money no longer outranks | both funded-wait tests |
| colleague relaxation not applied | the new hidden figure, alone |

The ordering test earned its keep: the first version used an **archived** later outbound, which `archived_at IS NULL` already excluded for a different reason — the mutation stayed green. It now uses a **future-dated** one, which the reply anti-join's `occurred_at <= asOf` lets through. That is a real shape: a scheduled send must not make a customer look answered.

`make check-backend`, `make check-fe`, the activities and compose integration lanes, and `craft static --strict` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a colleagues category to hidden worklist counts, with explanations for messages from internal domains.
  * Added a “no reply history” reason for worklist items.
  * Waiting conversations now indicate whether prior engagement exists.

* **Bug Fixes**
  * Improved filtering of internal-domain messages, including subdomains, while preserving customer messages.
  * Unengaged waits are demoted with an explanation instead of being removed.
  * Response metrics now exclude internal-domain correspondence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The waiting queue was showing archived mail nobody is waiting on, because the rule that proves a customer is waiting accepted a link to any person, and capture mints a person for nearly every correspondent. It now excludes mail from our own domains and demotes, instead of hiding, threads we never replied to — hiding would lose live customers, since thread identity comes from reply headers that some clients strip.

**The two rules**
- Colleague mail is excluded using vouched-for domains from `capture`, read inside the caller's transaction so strict and relaxed counts share one snapshot. The match reads the domain after the last at-sign and compares suffixes with `right()`, never LIKE, so quoted local parts and wildcard characters can't suppress a real customer. Queue and response readings render this from one fragment held by a prohibition gate. Unbound, nobody is excluded.
- Threads with no earlier outbound get a `no_reply_history` reason and drop a band; an open deal keeps them in the top band.

**Hidden figure and metrics**
- `/worklist/hidden` adds a required `colleagues` figure, and the contract now documents that the figures are marginal and do not sum to a total.
- First-response metrics apply the same colleague exclusion from the same snapshot, so internal threads no longer drag the response rate down.
- Shared per-item readings moved from `classify.go` to `itemreadings.go`.

<sup>Written for commit 1bfbfd548240246880bf9fe631c3b41ad68aba88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

