### PR TITLE
Publishing a captured contact leaves a trace

### DIFF
--- a/backend/internal/compose/capturepromote_integration_test.go
+++ b/backend/internal/compose/capturepromote_integration_test.go
@@ -677,3 +677,75 @@ func personIDFor(t *testing.T, e *integration.Env, email string) ids.PersonID {
 	}
 	return id
 }
+
+// TestPublishingACapturedContactLeavesATrace holds the trail on the write that
+// most needs one.
+//
+// A contact stops being one person's and becomes everybody's. "Which contacts
+// were published, when, and on whose authority" is answered from audit_log or
+// it is not answered at all — and until this, the visibility flip was a bare
+// UPDATE while every other write on the record audited and emitted.
+func TestPublishingACapturedContactLeavesATrace(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "trace@partner.example"
+
+	seedAttestedOutbound(t, e, "trace-out-1", sender, "trace-t1")
+	captureInboundThroughRealSink(t, e, e.Rep1, "trace-in-1", sender, "trace-t1")
+	personID := personIDFor(t, e, sender)
+	if got, _ := personVisibility(t, e, sender); got != "owner" {
+		t.Fatalf("a fresh capture is %q, want owner", got)
+	}
+	before := countVisibilityAudits(t, e, personID)
+
+	dispositionID, queued := openDisposition(t, e, sender)
+	if !queued {
+		t.Fatal("no question was opened for a corresponded sender")
+	}
+	brain := &scriptedVerdictBrain{verdicts: map[string]string{dispositionID.String(): capture.KindPerson}}
+	runVerdict(t, e, brain)
+	if got, _ := personVisibility(t, e, sender); got != "workspace" {
+		t.Fatalf("after a person verdict the contact is %q, want workspace", got)
+	}
+
+	if after := countVisibilityAudits(t, e, personID); after != before+1 {
+		t.Fatalf("publishing the contact wrote %d audit row(s) naming visibility, want 1: "+
+			"nothing records that this contact became visible to the workspace", after-before)
+	}
+	if n := countOutboxFor(t, e, personID); n == 0 {
+		t.Fatal("publishing the contact emitted no event, so nothing downstream learns the " +
+			"record changed hands")
+	}
+}
+
+// countVisibilityAudits counts audit rows on a person naming the visibility
+// column, in either image.
+func countVisibilityAudits(t *testing.T, e *integration.Env, id ids.PersonID) int {
+	t.Helper()
+	var n int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT count(*) FROM audit_log
+			 WHERE entity_type = 'person' AND entity_id = $1
+			   AND (after ? 'visibility' OR before ? 'visibility')`, id.UUID).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting visibility audits: %v", err)
+	}
+	return n
+}
+
+// countOutboxFor counts the events published about a record.
+func countOutboxFor(t *testing.T, e *integration.Env, id ids.PersonID) int {
+	t.Helper()
+	var n int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT count(*) FROM event_outbox
+			 WHERE envelope->>'type' = 'person.updated'
+			   AND envelope->'entity'->>'id' = $1
+			   AND envelope->'payload'->'changed_fields' ? 'visibility'`,
+			id.UUID.String()).Scan(&n)
+	}); err != nil {
+		t.Fatalf("counting outbox rows: %v", err)
+	}
+	return n
+}

--- a/backend/internal/modules/people/capturescope.go
+++ b/backend/internal/modules/people/capturescope.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -37,6 +39,10 @@ import (
 // The guard is on the ROW's visibility rather than on what the caller believes:
 // the UPDATE matches nothing when the row is already workspace, so a second
 // ensure over the same person writes nothing whatever it thought it was doing.
+// fieldVisibility names the column in an audit image, so the word a reader
+// greps for is the word the table uses.
+const fieldVisibility = "visibility"
+
 func promoteIfWorkspaceScoped(ctx context.Context, tx pgx.Tx, id ids.PersonID, ownerScoped bool) error {
 	if ownerScoped {
 		// Nothing to do, and saying so here saves a statement per captured
@@ -57,8 +63,25 @@ func promoteIfWorkspaceScoped(ctx context.Context, tx pgx.Tx, id ids.PersonID, o
 		return fmt.Errorf("people: promoting a judged counterparty to the workspace: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		// Already the workspace's, or archived. Both are answers, not faults.
+		// Already the workspace's, or archived. Both are answers, not faults,
+		// and neither is a change to record: an audit row about a write that
+		// moved nothing puts a lie in the compliance trail.
 		return nil
 	}
-	return nil
+	// A contact stops being one person's and becomes everybody's, which is the
+	// most disclosure-relevant write this module makes and the one that was
+	// leaving no trace. "Which contacts were published, when, and on whose
+	// authority" is answered from audit_log or it is not answered at all.
+	//
+	// The before-image is what the guard above already proved: the row was
+	// owner-scoped, or the UPDATE would have matched nothing.
+	auditID, err := storekit.Audit(ctx, tx, "update", entityPerson, id.UUID,
+		map[string]any{fieldVisibility: visibilityOwner},
+		map[string]any{fieldVisibility: visibilityWorkspace})
+	if err != nil {
+		return fmt.Errorf("people: recording a captured contact's promotion: %w", err)
+	}
+	return storekit.EmitEvent(ctx, tx, auditID, id.UUID, crmcontracts.PublicEventPersonUpdated{
+		ChangedFields: map[string]any{fieldVisibility: visibilityWorkspace},
+	})
 }


### PR DESCRIPTION
The moment a contact stops being one person's and becomes everybody's was a bare `UPDATE`. No audit row, no event — while the cohort repair beside it audits and emits, and so does every other write on a person.

It is the most disclosure-relevant write the people module makes. "Which contacts were published, when, and on whose authority" is answered from `audit_log` or it is not answered at all, and until now it was not: the only evidence a contact had ever been private was that it no longer was. That also defeats the access audit's own recommendation to derive operational health from the write shape.

The promotion now audits and emits in the transaction that performs it. The before-image is what the guard already proved — the row was owner-scoped, or the statement would have matched nothing — and the event carries the changed field so a subscriber learns the record changed hands.

The `RowsAffected() == 0` branch stays silent. An audit row about a write that moved nothing puts a lie in the compliance trail, which is the failure this change exists to prevent, not to commit in the other direction. That branch matters in practice: the capture sink reaches this function on every message from an already-promoted sender.

## Tests

One integration test asserting both the audit row and the outbox event after a real `person` verdict, mutation-checked by reverting the write.

Full `make check-backend`, `make craft-static`, and the `internal/modules/people` and `internal/compose` integration lanes green. Codex review returned no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishing a captured contact (a `person` verdict that flips a contact from owner-scoped to workspace visibility) now writes an audit row and emits a `person.updated` event in the same transaction, so the visibility flip is no longer a silent `UPDATE`. The no-op branch (`RowsAffected() == 0`) still returns without recording anything — an audit row for a write that moved nothing would corrupt the compliance trail, and the capture sink hits this path on every message from an already-promoted sender. Added one integration test that asserts both the audit row and the outbox event after a real `person` verdict.

<sup>Written for commit d334a910c1b87b730ee0de1f1e3ecc238f60fbd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publishing a captured contact now updates its visibility to the workspace.
  * Successful visibility changes are recorded in the audit history and generate a person-updated notification for connected systems.

* **Bug Fixes**
  * Prevented audit records and update notifications from being created when no contact visibility change occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->