### PR TITLE
A model composes a report through the same engine a person does

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16530,7 +16530,12 @@ paths:
         values for its cells. Nothing is dropped: a document that cannot be rendered whole
         is refused, because a report missing a block it was composed with says something
         different from the report that was composed.
-      x-agent-access: human-only
+      # compose_analytics_report. Auto-execute rather than staged: rendering
+      # reads, stores nothing and moves no record, and every figure it returns
+      # is one the caller could have read directly — the document only decides
+      # which of them appear together.
+      x-mcp-tool: { verb: compose_analytics_report, tier: auto_execute, scope: read }
+
       requestBody:
         required: true
         content:

--- a/backend/internal/compose/agentapps_test.go
+++ b/backend/internal/compose/agentapps_test.go
@@ -289,10 +289,11 @@ func TestTheProductionProvidersClaimDisjointURIs(t *testing.T) {
 	// commit it is wired rather than the commit somebody remembers this test.
 	wired := mcpResourceProviders(
 		agents.NewCapabilitiesResource(NewRegistry(nil, SendPath{})), nil, primedViews(t, everyDeclaredView()))
-	if len(wired) != 5 {
+	if len(wired) != 6 {
 		t.Fatalf("the transport composes %d resource providers; this gate knows how to reason about "+
-			"capabilities, the query vocabulary, the write vocabulary, the report vocabulary and the "+
-			"views. Add the new one's URI below before it can collide with one of them", len(wired))
+			"capabilities, the query vocabulary, the write vocabulary, the report vocabulary, the "+
+			"report block grammar and the views. Add the new one's URI below before it can collide "+
+			"with one of them", len(wired))
 	}
 	for _, r := range primedViews(t, everyDeclaredView()).Resources(readerCtx()) {
 		if !strings.HasPrefix(r.URI, mcp.AppURIScheme) {
@@ -308,6 +309,7 @@ func TestTheProductionProvidersClaimDisjointURIs(t *testing.T) {
 		"the query vocabulary":  search.QuerySchemaURI,
 		"the write vocabulary":  agents.RecordFieldsURI,
 		"the report vocabulary": agents.ReportVocabularyURI,
+		"the block grammar":     agents.ReportBlocksURI,
 		"capabilities":          agents.CapabilitiesURI,
 	}
 	// A SET, not a pairwise comparison. Two documents could be checked against

--- a/backend/internal/compose/agentcommand.go
+++ b/backend/internal/compose/agentcommand.go
@@ -217,6 +217,7 @@ var restCommands = map[string]func(pol agentPolicy, deps restCommandDeps, r *htt
 	"relinkThread":           relinkThreadCommand,
 	"relinkActivities":       relinkActivitiesCommand,
 	"runReport":              runReportCommand,
+	"renderAnalyticsReport":  composeReportCommand,
 
 	// The two decisions, over four routes. They are the only entries here whose
 	// command names no target record, and the resolver says why: the row a

--- a/backend/internal/compose/agentcommandauto.go
+++ b/backend/internal/compose/agentcommandauto.go
@@ -153,6 +153,32 @@ func runReportCommand(_ agentPolicy, _ restCommandDeps, r *http.Request, _ []byt
 	return agents.NewRunReportCall(agents.RunReportCommand{Report: report}), nil
 }
 
+// composeReportCommand decodes POST /v1/analytics/reports/render.
+//
+// The route is a POST because a report document does not fit a query string,
+// not because it writes: rendering stores nothing and moves no record. It still
+// decodes into a command, because the gate that requires one keys on the METHOD
+// — and that is the right key, since a door reached by an agent must be able to
+// say what an approval of it would bind to even when the answer is "no record".
+//
+// Only the block count is read. Decoding the citations to summarise the figures
+// would state numbers from the COMPOSER's view, and the approver may be
+// entitled to fewer.
+//
+//nolint:ireturn // a decoder's whole product is the erased command-and-resolver pair restCommands is typed by
+func composeReportCommand(_ agentPolicy, _ restCommandDeps, _ *http.Request, body []byte) (agents.GovernedCall, error) {
+	var in struct {
+		Blocks []json.RawMessage `json:"blocks"`
+	}
+	if err := json.Unmarshal(body, &in); err != nil {
+		// Returned as-is, the way every other decoder in this file reports a
+		// body it cannot read: the HTTP layer maps a decode failure already,
+		// and a second wrapping here would be a second spelling of one answer.
+		return nil, err
+	}
+	return agents.NewComposeReportCall(agents.ComposeReportCommand{Blocks: len(in.Blocks)}), nil
+}
+
 // decideApprovalCommand decodes a decision on ONE staged proposal. The verdict
 // is read off the route rather than the body: approve and reject are two
 // operations over one decision, and the body carries only the reason.

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -389,7 +389,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/ai/feedback":                                               {Op: "recordAIFeedback", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/analytics/explain":                                         {Op: "explainAnalyticsCell", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/analytics/query":                                           {Op: "runAnalyticsQuery", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
-	"POST /v1/analytics/reports/render":                                  {Op: "renderAnalyticsReport", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/analytics/reports/render":                                  {Op: "renderAnalyticsReport", Access: "tool", Tool: "compose_analytics_report", RecordType: "", Tier: "auto_execute", Scope: "read"},
 	"POST /v1/analytics/runs/{run_id}/cells/explain":                     {Op: "explainReportRunCell", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/approval-bundles/{bundle_id}/approve":                      {Op: "approveApprovalBundle", Access: "tool", Tool: "decide_approval_bundle", RecordType: "", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/approval-bundles/{bundle_id}/reject":                       {Op: "rejectApprovalBundle", Access: "tool", Tool: "decide_approval_bundle", RecordType: "", Tier: "auto_execute", Scope: "write"},

--- a/backend/internal/compose/agenttoolparity_test.go
+++ b/backend/internal/compose/agenttoolparity_test.go
@@ -185,6 +185,14 @@ var composedIntents = map[string]bool{
 	// and the vocabulary it names is the engine's own compile-time table, so it
 	// names nothing about a workspace at all.
 	"describe_report_vocabulary": true,
+	// describe_report_blocks answers the document
+	// margince://schema/report-blocks publishes, for the same caller and the
+	// same reason: the Surface-B runner is offered no resource step. It backs
+	// no REST operation either — `renderAnalyticsReport` renders a document,
+	// and no operation answers what a document may CONTAIN. Read-only, it
+	// returns no records, and the grammar it names is the engine's own
+	// compile-time list, so it names nothing about a workspace at all.
+	"describe_report_blocks": true,
 	// search_context ranks across record types through the retrieval index,
 	// which no single list operation is: `GET /search` is the lexical half
 	// alone and answers no vector lane, and the records the sweep names are

--- a/backend/internal/compose/analyticsreporttool.go
+++ b/backend/internal/compose/analyticsreporttool.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// compose_analytics_report on the tool surface, answered by the SAME validator
+// and renderer the HTTP surface uses.
+//
+// One engine, two transports. The tool decodes its own arguments — a model
+// sends a document, not an http.Request — and everything after that is
+// RenderReport, so the two surfaces cannot come to disagree about what a report
+// may say or what a figure resolves to.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
+	"github.com/margince/margince/backend/internal/compose/reportdoc"
+	"github.com/margince/margince/backend/internal/modules/agents"
+	"github.com/margince/margince/backend/internal/modules/forecasting"
+)
+
+// analyticsReportComposer renders a composed document for the tool surface.
+//
+// The floor is the installation's, taken here the way the HTTP handler takes
+// it: a figure a person may not see is a figure a model asking on their behalf
+// may not see either, and a tool that floored differently would be a second
+// answer to what a reader is allowed to be told.
+func analyticsReportComposer(pool *pgxpool.Pool, floor analyticsquery.Floor) agents.AnalyticsReportComposer {
+	store := forecasting.NewStore(InstallationDB(pool))
+	return func(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+		var doc reportdoc.Document
+		if err := json.Unmarshal(in, &doc); err != nil {
+			// A malformed payload is the caller's, so it unwraps to the same
+			// sentinel a malformed block does rather than reading as a server
+			// fault the caller cannot act on.
+			return nil, &reportdoc.InvalidError{
+				Where:  "document",
+				Reason: "is not a report document",
+			}
+		}
+
+		var blocks []RenderedBlock
+		if err := store.InTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+			var err error
+			blocks, err = RenderReport(ctx, tx, doc, floor)
+			return err
+		}); err != nil {
+			return nil, err
+		}
+
+		// Empty, never nil: a document that rendered no blocks cannot happen —
+		// Validate refuses one — but a nil here would marshal to null, which a
+		// model reads as "unknown" rather than as "none".
+		if blocks == nil {
+			blocks = []RenderedBlock{}
+		}
+		encoded, err := json.Marshal(blocks)
+		if err != nil {
+			return nil, fmt.Errorf("compose: rendering a composed report: %w", err)
+		}
+		return json.Marshal(agents.ComposeAnalyticsReportResult{Blocks: encoded})
+	}
+}

--- a/backend/internal/compose/mcpresources.go
+++ b/backend/internal/compose/mcpresources.go
@@ -74,6 +74,7 @@ func mcpResourceProviders(capabilities mcp.ResourceProvider, vocabulary mcp.Reso
 		capabilities, vocabulary,
 		agents.RecordFieldsResource{},
 		agents.NewReportVocabularyResource(reportToolCatalog()),
+		agents.NewReportBlocksResource(reportBlockGrammar()),
 	}
 	// views is nil for a role that composes none — a worker, or an api whose
 	// connector gate is off. composeResources drops it, which is the same

--- a/backend/internal/compose/mcpresources_test.go
+++ b/backend/internal/compose/mcpresources_test.go
@@ -188,14 +188,15 @@ func TestARoleWithNoViewProviderComposesTheRestAndServesIt(t *testing.T) {
 	// the contract alone, so no deployment can lack it and a role that dropped
 	// it would leave both write tools pointing at nothing; capabilities is
 	// derived from the registry the transport already holds, so no role can
-	// serve tools and fail to describe them; and the report vocabulary comes
-	// from the engine's compile-time catalog, which run_report is registered
-	// against on every build.
+	// serve tools and fail to describe them; and the report vocabulary and the
+	// block grammar come from compile-time tables, which run_report and
+	// compose_analytics_report are registered against on every build.
 	want := []string{
 		"margince://schema/query",
 		agents.RecordFieldsURI,
 		agents.CapabilitiesURI,
 		agents.ReportVocabularyURI,
+		agents.ReportBlocksURI,
 	}
 	if len(published) != len(want) {
 		t.Fatalf("the composed surface published %v, want exactly %v", published, want)

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/margince/margince/backend/internal/compose/analyticsquery"
 	"github.com/margince/margince/backend/internal/modules/activities"
 	"github.com/margince/margince/backend/internal/modules/agents"
 	"github.com/margince/margince/backend/internal/modules/approvals"
@@ -184,6 +185,19 @@ func registryWithGate(db *database.DB, gate *auth.Gate, drafter activities.Email
 		nativeOnlyReportVocabularyReader{mode: sorMode, inner: agents.NewReportVocabularyResource(reportToolCatalog())})
 	// The forecast, read through the same assembler the HTTP surface uses, so
 	// the two transports cannot disagree about what a quarter contains.
+	// A report whose every figure came from a saved run, rendered through the
+	// SAME validator and renderer POST /analytics/reports/render calls. The
+	// floor is DefaultFloor on both paths: a figure a person may not see is one
+	// a model asking on their behalf may not see either.
+	agents.RegisterAnalyticsReportTool(registry,
+		analyticsReportComposer(pool, analyticsquery.DefaultFloor))
+	// The grammar that document is written in, as a TOOL and not only as the
+	// margince://schema/report-blocks resource — same reason
+	// describe_report_vocabulary exists beside run_report: the Surface-B runner
+	// is offered no resource step, so for a scheduled agent this is the only
+	// route to the kinds compose_analytics_report refuses against.
+	agents.RegisterReportBlocksTool(registry,
+		agents.NewReportBlocksResource(reportBlockGrammar()))
 	agents.RegisterForecastTool(registry, forecastToolReader(pool))
 	agents.RegisterMovementTool(registry, movementToolReader(pool))
 	agents.RegisterAssuranceTool(registry, assuranceToolReader(pool))

--- a/backend/internal/compose/reportblocksseam.go
+++ b/backend/internal/compose/reportblocksseam.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The block grammar, handed to the tool surface from the package that owns it.
+//
+// reportdoc decides what a document may contain and refuses against exactly
+// this list. Passing it through rather than restating it in agents/ is what
+// keeps one grammar: a kind added to reportdoc appears in the published
+// document without anybody remembering to add it twice.
+
+import (
+	"github.com/margince/margince/backend/internal/compose/reportdoc"
+	"github.com/margince/margince/backend/internal/modules/agents"
+)
+
+// reportBlockGrammar renders reportdoc's own catalog in the shape the tool
+// surface publishes.
+//
+// The two structs are separate because agents/ may not import compose — the
+// module DAG forbids it — so this is the seam, and its only job is the
+// field-for-field carry. Nothing here decides anything.
+func reportBlockGrammar() agents.BlockGrammar {
+	described := reportdoc.Catalog()
+	blocks := make([]agents.BlockDescription, 0, len(described))
+	for _, b := range described {
+		blocks = append(blocks, agents.BlockDescription{
+			Kind:          b.Kind,
+			TakesCells:    b.TakesCells,
+			TakesText:     b.TakesText,
+			TakesSeverity: b.TakesSeverity,
+		})
+	}
+	return agents.BlockGrammar{Blocks: blocks, Severities: reportdoc.Severities()}
+}

--- a/backend/internal/compose/reportdoc/block.go
+++ b/backend/internal/compose/reportdoc/block.go
@@ -126,25 +126,29 @@ func (k Kind) carriesFigures() bool {
 }
 
 // known says whether a kind is in the grammar.
+//
+// Derived from allKinds, which is also what the published catalog iterates, so
+// a kind added in one place is accepted and described in one edit. A switch
+// here beside that list would be two copies of the grammar, disagreeing the
+// first time a block was added.
 func (k Kind) known() bool {
-	switch k {
-	case KindTitle, KindSubtitle, KindScope, KindGeneratedAt, KindSummary,
-		KindMethodology, KindFollowUps, KindStatStrip, KindBar, KindWaterfall,
-		KindRankedList, KindRecordTable, KindCallout, KindEvidenceDrawer:
-		return true
-	default:
-		return false
+	for _, known := range allKinds {
+		if k == known {
+			return true
+		}
 	}
+	return false
 }
 
-// known says whether a severity is in the closed set.
+// known says whether a severity is in the closed set. Derived from
+// allSeverities for the same reason Kind.known is derived from allKinds.
 func (s Severity) known() bool {
-	switch s {
-	case SeverityNote, SeverityWarning, SeverityPartial, SeverityUnknown, SeverityUnsupported:
-		return true
-	default:
-		return false
+	for _, known := range allSeverities {
+		if s == known {
+			return true
+		}
 	}
+	return false
 }
 
 // blockRef names a block in a refusal so a composer can find it.

--- a/backend/internal/compose/reportdoc/catalog.go
+++ b/backend/internal/compose/reportdoc/catalog.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package reportdoc
+
+// The grammar, described for a caller that has to write one.
+//
+// Derived from the same predicates the validator refuses with — Kind.known(),
+// Kind.carriesFigures(), Severity.known() — rather than typed out beside them.
+// A hand-written list here would be a second copy of the grammar, and the two
+// would disagree the first time a block was added: the document would name a
+// kind the validator refuses, or omit one it accepts.
+
+// BlockDescription is one kind, as a composer needs to know it.
+type BlockDescription struct {
+	Kind string `json:"kind"`
+	// TakesCells says the kind renders figures, and must name at least one
+	// cell. False means a cell on it is refused: the figure would be composed
+	// and never shown.
+	TakesCells bool `json:"takes_cells"`
+	// TakesText says the kind renders the composer's own words.
+	TakesText bool `json:"takes_text"`
+	// TakesSeverity is true only for a callout, which states its kind.
+	TakesSeverity bool `json:"takes_severity"`
+}
+
+// Catalog describes every block a document may carry.
+//
+// Iterated over the declared order rather than a map, so two calls return one
+// document and a caller diffing them sees nothing move.
+func Catalog() []BlockDescription {
+	out := make([]BlockDescription, 0, len(allKinds))
+	for _, k := range allKinds {
+		out = append(out, BlockDescription{
+			Kind:          string(k),
+			TakesCells:    k.carriesFigures() || k == KindSummary || k == KindEvidenceDrawer,
+			TakesText:     !k.carriesFigures(),
+			TakesSeverity: k == KindCallout,
+		})
+	}
+	return out
+}
+
+// Severities lists the closed severity set a callout may state.
+func Severities() []string {
+	out := make([]string, 0, len(allSeverities))
+	for _, s := range allSeverities {
+		out = append(out, string(s))
+	}
+	return out
+}
+
+// allKinds is the declared order the catalog is published in — prose first,
+// then figures, then what a reader is owed when a figure is incomplete.
+//
+// Kind.known() is derived FROM this rather than switching separately, so a kind
+// added here is accepted by the validator and described by the catalog in one
+// edit. The alternative — a switch beside a list — is the two-copies defect
+// this file exists to avoid.
+var allKinds = []Kind{
+	KindTitle, KindSubtitle, KindScope, KindGeneratedAt, KindSummary,
+	KindMethodology, KindFollowUps,
+	KindStatStrip, KindBar, KindWaterfall, KindRankedList, KindRecordTable,
+	KindCallout, KindEvidenceDrawer,
+}
+
+// allSeverities is the closed set, in the order a reader meets them.
+var allSeverities = []Severity{
+	SeverityNote, SeverityWarning, SeverityPartial, SeverityUnknown, SeverityUnsupported,
+}
+
+// KindNames lists every accepted kind, for a refusal that names the whole set.
+func KindNames() []string {
+	out := make([]string, 0, len(allKinds))
+	for _, k := range allKinds {
+		out = append(out, string(k))
+	}
+	return out
+}

--- a/backend/internal/compose/reportdoc/validate.go
+++ b/backend/internal/compose/reportdoc/validate.go
@@ -76,9 +76,14 @@ func Validate(doc Document) ([]ids.UUID, error) {
 		if !b.Kind.known() {
 			return nil, &InvalidError{
 				Where: where,
-				Reason: "no such block kind — a renderer meeting one either draws something " +
+				// The whole set, so a caller that guessed pays one refusal
+				// rather than a lookup — which is what lets the tool
+				// description name the vocabulary document without ordering a
+				// read of it.
+				Reason: "no such block kind. A renderer meeting one either draws something " +
 					"nobody specified or drops it silently, and a report missing a block it " +
-					"was composed with says something different from the one composed",
+					"was composed with says something different from the one composed. The " +
+					"kinds are: " + strings.Join(KindNames(), ", "),
 			}
 		}
 		if err := checkNoLiteral(b, where); err != nil {

--- a/backend/internal/compose/reportrender.go
+++ b/backend/internal/compose/reportrender.go
@@ -28,20 +28,25 @@ import (
 )
 
 // RenderedValue is one figure as this reader may see it.
+// The json tags are the WIRE SHAPE, and both surfaces serve it. Without them
+// the tool surface answered Go field names (`Value`, `Withheld`) while the HTTP
+// handler mapped the same struct to its contract's snake_case — two surfaces
+// disagreeing about one document, which is the drift the seam exists to
+// prevent.
 type RenderedValue struct {
 	// Value is nil for a withheld figure AND for a cell that resolved to
 	// nothing. Withheld tells the two apart, which matters: one is a number
 	// somebody may not see, the other is a number that does not exist.
-	Value    any
-	Withheld bool
+	Value    any  `json:"value,omitempty"`
+	Withheld bool `json:"withheld"`
 }
 
 // RenderedBlock is one block with its figures filled in.
 type RenderedBlock struct {
-	Kind     string
-	Text     string
-	Severity string
-	Values   []RenderedValue
+	Kind     string          `json:"kind"`
+	Text     string          `json:"text,omitempty"`
+	Severity string          `json:"severity,omitempty"`
+	Values   []RenderedValue `json:"values"`
 }
 
 // RenderReport resolves every figure a document cites.

--- a/backend/internal/compose/reportrun_integration_test.go
+++ b/backend/internal/compose/reportrun_integration_test.go
@@ -19,6 +19,7 @@ package compose
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -548,4 +549,121 @@ func (e *forecastEnv) render(
 			return err
 		})
 	return out, err
+}
+
+// The tool surface and the web surface answer with one engine.
+//
+// Not a style point. A model composing a report and a person composing the same
+// one must get the same figures and the same refusals — two renderers would
+// drift, and the first sign of it would be a model reporting a number the
+// screen does not show.
+func TestTheReportToolAndTheRouteRenderTheSameDocument(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	for i := 0; i < 6; i++ {
+		e.seedOpenDeal(t, "Deal", 20, &e.Rep1, &amount, nil)
+	}
+	ctx := e.askerCtx()
+	runID := e.saveRun(ctx, t, countAllDeals())
+
+	doc := reportdoc.Document{Blocks: []reportdoc.Block{
+		{Kind: reportdoc.KindStatStrip, Cells: []reportdoc.Cell{
+			{RunID: runID.String(), Column: measureAlias},
+		}},
+	}}
+
+	viaRoute, err := e.render(ctx, t, doc)
+	if err != nil {
+		t.Fatalf("rendering through the route: %v", err)
+	}
+	viaTool, err := e.composeTool(ctx, t, doc)
+	if err != nil {
+		t.Fatalf("rendering through the tool: %v", err)
+	}
+
+	// Compared against the CONTRACT's own field names, not against
+	// json.Marshal of the route's struct. Marshalling both sides would move
+	// them together: renaming a json tag would change the expectation and the
+	// answer at once, and the test would pass through the exact divergence it
+	// exists to catch. These strings come from crm.yaml's RenderedBlock.
+	var toolDoc struct {
+		Blocks []struct {
+			Kind   string `json:"kind"`
+			Values []struct {
+				Value    any  `json:"value"`
+				Withheld bool `json:"withheld"`
+			} `json:"values"`
+		} `json:"blocks"`
+	}
+	if err := json.Unmarshal(viaTool, &toolDoc); err != nil {
+		t.Fatalf("the tool's answer is not the contract's shape: %v (%s)", err, viaTool)
+	}
+	if len(toolDoc.Blocks) != len(viaRoute) {
+		t.Fatalf("the route rendered %d blocks and the tool %d",
+			len(viaRoute), len(toolDoc.Blocks))
+	}
+	for i, want := range viaRoute {
+		got := toolDoc.Blocks[i]
+		if got.Kind != want.Kind {
+			t.Errorf("block %d: the route calls it %q and the tool %q", i, want.Kind, got.Kind)
+		}
+		if len(got.Values) != len(want.Values) {
+			t.Fatalf("block %d: the route rendered %d figures and the tool %d",
+				i, len(want.Values), len(got.Values))
+		}
+		for j, wantValue := range want.Values {
+			gotValue := got.Values[j]
+			if fmt.Sprint(gotValue.Value) != fmt.Sprint(wantValue.Value) {
+				t.Errorf("block %d figure %d: the route says %v and the tool %v",
+					i, j, wantValue.Value, gotValue.Value)
+			}
+			if gotValue.Withheld != wantValue.Withheld {
+				t.Errorf("block %d figure %d: the route says withheld=%v and the tool %v",
+					i, j, wantValue.Withheld, gotValue.Withheld)
+			}
+		}
+	}
+}
+
+// The literal rule holds on the tool surface too.
+//
+// This is the one a model is most likely to break: it has a number in hand from
+// its own reasoning and a handle beside it, and writing both looks like being
+// helpful. The refusal must reach it with the reason.
+func TestTheReportToolRefusesALiteralBesideAHandle(t *testing.T) {
+	e := setupForecast(t)
+	amount := int64(100_000)
+	for i := 0; i < 6; i++ {
+		e.seedOpenDeal(t, "Deal", 20, &e.Rep1, &amount, nil)
+	}
+	ctx := e.askerCtx()
+	runID := e.saveRun(ctx, t, countAllDeals())
+
+	plausible := 6.0
+	_, err := e.composeTool(ctx, t, reportdoc.Document{Blocks: []reportdoc.Block{
+		{
+			Kind:  reportdoc.KindStatStrip,
+			Value: &plausible,
+			Cells: []reportdoc.Cell{{RunID: runID.String(), Column: measureAlias}},
+		},
+	}})
+	if err == nil {
+		t.Fatal("the tool accepted a literal beside a handle — and the literal was the " +
+			"CORRECT number, which is the case a reader could never catch")
+	}
+	if !strings.Contains(err.Error(), "BOTH") {
+		t.Errorf("the tool's refusal does not tell the model why carrying both is the "+
+			"problem: %v", err)
+	}
+}
+
+func (e *forecastEnv) composeTool(
+	ctx context.Context, t *testing.T, doc reportdoc.Document,
+) (json.RawMessage, error) {
+	t.Helper()
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("encoding the document: %v", err)
+	}
+	return analyticsReportComposer(e.Pool, analyticsquery.DefaultFloor)(ctx, encoded)
 }

--- a/backend/internal/modules/agents/commandauto.go
+++ b/backend/internal/modules/agents/commandauto.go
@@ -316,42 +316,6 @@ func requireLinkTarget(entityType string) error {
 	return &BadArgsError{Cause: fmt.Errorf("entity_type %q is not a link target", entityType)}
 }
 
-// RunReportCommand is one report run, whichever door asked for it. The report
-// KEY is the whole of it: the plan arguments narrow what is counted, and the
-// engine — not this seam — owns which of them a report accepts.
-type RunReportCommand struct {
-	Report string
-}
-
-// NewRunReportCall binds one report run to the resolver that answers for it.
-// It holds no dependency: a report names no record at all.
-//
-//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
-func NewRunReportCall(cmd RunReportCommand) GovernedCall {
-	return bind[RunReportCommand](runReportResolver{}, cmd)
-}
-
-type runReportResolver struct{}
-
-// Subject names NO record, and that is the honest answer rather than a gap: a
-// report is an aggregate over rows the caller's own scope already bounds, so
-// there is no row an approval could bind to, pin, or be probed against. What
-// it does supply is the KEY — the one thing that says which aggregate is being
-// released — where the route walk it replaces could only offer an empty target
-// with no name attached.
-func (runReportResolver) Subject(_ context.Context, cmd RunReportCommand) (StageInfo, error) {
-	return StageInfo{Summary: fmt.Sprintf("Run report %s", cmd.Report)}, nil
-}
-
-// Guards stands down: the report key's vocabulary is the engine's catalog,
-// which this module is handed rather than owns (ReportRunner, tools_report.go),
-// and a key outside it is refused by the engine at execution with the catalog
-// in hand. Restating it here would be a second answer that drifts the moment an
-// installation's catalog does.
-func (runReportResolver) Guards(_ context.Context, _ RunReportCommand) error {
-	return nil
-}
-
 // DecideApprovalCommand is one person's answer to one staged proposal,
 // whichever door asked for it. Approve is the answer itself, and it belongs to
 // the command rather than to the route because the two routes that carry it are

--- a/backend/internal/modules/agents/commandreport.go
+++ b/backend/internal/modules/agents/commandreport.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The two report commands: running one, and composing a document of several.
+//
+// Together because they are one concept — an aggregate over rows the caller's
+// own scope already bounds — and both resolvers answer the same way: NO record.
+// There is no row an approval could bind to or be probed against, so what each
+// supplies instead is the one fact that says which aggregate is being released.
+
+import (
+	"context"
+	"fmt"
+)
+
+// RunReportCommand is one report run, whichever door asked for it. The report
+// KEY is the whole of it: the plan arguments narrow what is counted, and the
+// engine — not this seam — owns which of them a report accepts.
+type RunReportCommand struct {
+	Report string
+}
+
+// NewRunReportCall binds one report run to the resolver that answers for it.
+// It holds no dependency: a report names no record at all.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewRunReportCall(cmd RunReportCommand) GovernedCall {
+	return bind[RunReportCommand](runReportResolver{}, cmd)
+}
+
+type runReportResolver struct{}
+
+// Subject names NO record, and that is the honest answer rather than a gap: a
+// report is an aggregate over rows the caller's own scope already bounds, so
+// there is no row an approval could bind to, pin, or be probed against. What
+// it does supply is the KEY — the one thing that says which aggregate is being
+// released — where the route walk it replaces could only offer an empty target
+// with no name attached.
+func (runReportResolver) Subject(_ context.Context, cmd RunReportCommand) (StageInfo, error) {
+	return StageInfo{Summary: fmt.Sprintf("Run report %s", cmd.Report)}, nil
+}
+
+// Guards stands down: the report key's vocabulary is the engine's catalog,
+// which this module is handed rather than owns (ReportRunner, tools_report.go),
+// and a key outside it is refused by the engine at execution with the catalog
+// in hand. Restating it here would be a second answer that drifts the moment an
+// installation's catalog does.
+func (runReportResolver) Guards(_ context.Context, _ RunReportCommand) error {
+	return nil
+}
+
+// ComposeReportCommand is one report rendering, whichever door asked for it.
+//
+// The block COUNT is the whole of it. The figures are not part of the command
+// and must not be: each is a citation resolved under the reading caller's own
+// authority at render time, so a summary naming them would state numbers the
+// approver may not be entitled to see — and would state them from the
+// composer's view rather than the reader's.
+type ComposeReportCommand struct {
+	Blocks int
+}
+
+// NewComposeReportCall binds one report rendering to the resolver that answers
+// for it. It holds no dependency: a report names no record at all.
+//
+//nolint:ireturn // the call IS the product: a resolver named concretely here is exactly the thing that must not leave this package
+func NewComposeReportCall(cmd ComposeReportCommand) GovernedCall {
+	return bind[ComposeReportCommand](composeReportResolver{}, cmd)
+}
+
+type composeReportResolver struct{}
+
+// Subject names NO record, for the reason a report run names none: the document
+// is an arrangement of aggregates over rows the caller's own scope already
+// bounds, and there is no row an approval could bind to or be probed against.
+// What it supplies instead is the SIZE — the one thing that says how much is
+// being released — where a route walk could offer only an empty target.
+func (composeReportResolver) Subject(_ context.Context, cmd ComposeReportCommand) (StageInfo, error) {
+	return StageInfo{Summary: fmt.Sprintf("Compose a report of %d block(s)", cmd.Blocks)}, nil
+}
+
+// Guards stands down: what a document may contain is the block grammar's, which
+// this module is handed rather than owns, and a block outside it is refused at
+// execution with the whole set in hand. Restating the grammar here would be a
+// second answer that drifts the moment a block kind is added.
+func (composeReportResolver) Guards(_ context.Context, _ ComposeReportCommand) error {
+	return nil
+}

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -178,6 +178,8 @@ func fullRegistry(t *testing.T) *Registry {
 	RegisterCoreTools(r, nil, nil, nil, nil, nil, nil)
 	RegisterPipelineTool(r, func(context.Context) ([]Pipeline, error) { return nil, nil })
 	RegisterReportTool(r, nil, probeReportCatalog)
+	RegisterAnalyticsReportTool(r, nil)
+	RegisterReportBlocksTool(r, NewReportBlocksResource(BlockGrammar{}))
 	RegisterForecastTool(r, nil)
 	RegisterMovementTool(r, nil)
 	RegisterAssuranceTool(r, nil)

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -241,6 +241,10 @@ func idProbeDispatcher(t *testing.T) *Dispatcher {
 	RegisterReportTool(r, func(context.Context, string, json.RawMessage) (json.RawMessage, error) {
 		return nil, errSeamReached
 	}, probeReportCatalog)
+	RegisterAnalyticsReportTool(r, func(context.Context, json.RawMessage) (json.RawMessage, error) {
+		return nil, errSeamReached
+	})
+	RegisterReportBlocksTool(r, NewReportBlocksResource(BlockGrammar{}))
 	RegisterForecastTool(r, func(context.Context, ForecastRequest) (json.RawMessage, error) {
 		return nil, errSeamReached
 	})

--- a/backend/internal/modules/agents/reportblocksdoc.go
+++ b/backend/internal/modules/agents/reportblocksdoc.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// `margince://schema/report-blocks` — the block grammar compose_analytics_report
+// accepts, published as a document rather than recited into that tool's own
+// description.
+//
+// The same move the report plan vocabulary made, for the same measured reason:
+// fourteen block kinds with their fields is text every client holds for a whole
+// session and every scheduled run re-sends on every step, to answer a question
+// one call asks once. What stays in the tool is the rule a caller gets wrong —
+// never write a number — because that one is not lookup-able, it is a habit.
+//
+// This is not schema deferral. Everything deciding whether a call is
+// WELL-FORMED stays in the tool's own input schema; what moves is which KIND
+// names that schema's open `kind` string admits, and it moves because the
+// refusal path is loud: an unknown kind is refused by name with the whole set.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+)
+
+// ReportBlocksURI is the document's stable identity.
+const ReportBlocksURI = "margince://schema/report-blocks"
+
+// reportBlocksResourceName is the catalogue entry's name member.
+const reportBlocksResourceName = "report_blocks"
+
+// reportBlocksVersion identifies the document's SHAPE, not its content. A
+// caller caching it needs to know when the shape changed; the grammar moves on
+// its own schedule and is re-read either way.
+const reportBlocksVersion = "1"
+
+// reportBlocksNotation states the one rule a composer gets wrong, because it is
+// the rule no field list can carry: a figure is never written, only cited.
+const reportBlocksNotation = "A block carries STRUCTURE and WORDS; a figure is named, never written. " +
+	"Every number cites a saved run and a cell inside it, and the server resolves that citation " +
+	"under the reading caller's own authority. A block carrying a literal number is refused EVEN " +
+	"WHEN a valid citation sits beside it: the literal is what would render, the two can " +
+	"disagree, and no reader could tell the page shows a figure the database never computed."
+
+// ReportBlocksReader is the seam the describe tool reads through.
+type ReportBlocksReader interface {
+	ReportBlocksDocument(ctx context.Context) (json.RawMessage, error)
+}
+
+// BlockGrammar is the grammar as the owning package describes it.
+//
+// An interface rather than the concrete type, because reportdoc lives in
+// compose and this module may not import it — the composition root passes the
+// description in, the same way the report catalog is passed to the vocabulary
+// resource.
+type BlockGrammar struct {
+	Blocks     []BlockDescription `json:"blocks"`
+	Severities []string           `json:"severities"`
+}
+
+// BlockDescription is one block kind, as a composer needs to know it.
+type BlockDescription struct {
+	Kind          string `json:"kind"`
+	TakesCells    bool   `json:"takes_cells"`
+	TakesText     bool   `json:"takes_text"`
+	TakesSeverity bool   `json:"takes_severity"`
+}
+
+// ReportBlocksResource publishes the block grammar.
+type ReportBlocksResource struct{ grammar BlockGrammar }
+
+// NewReportBlocksResource binds the document to the grammar it describes.
+func NewReportBlocksResource(grammar BlockGrammar) ReportBlocksResource {
+	return ReportBlocksResource{grammar: grammar}
+}
+
+// Resources advertises the one document this provider publishes.
+func (ReportBlocksResource) Resources(context.Context) []mcp.Resource {
+	return []mcp.Resource{{
+		URI:   ReportBlocksURI,
+		Name:  reportBlocksResourceName,
+		Title: "Report block grammar",
+		// ScopeRead, matching compose_analytics_report: a caller admitted to
+		// the tool is admitted to the grammar it refuses against.
+		RequiredScope: principal.ScopeRead,
+		MIMEType:      mimeApplicationJSON,
+		// Says what it HOLDS, not when to fetch it. A description that orders a
+		// read draws reads from runs with nothing to compose.
+		Description: "The blocks a report may carry: each kind, whether it renders figures, " +
+			"words or both, and the severities a callout may state. " +
+			"compose_analytics_report names this document instead of carrying it.",
+	}}
+}
+
+// ReadResource composes the document. An unknown URI answers ErrNotFound,
+// matching every other read on this surface.
+func (r ReportBlocksResource) ReadResource(ctx context.Context, uri string) (mcp.ResourceContents, error) {
+	if uri != ReportBlocksURI {
+		return mcp.ResourceContents{}, fmt.Errorf("agents: resource %q: %w", uri, apperrors.ErrNotFound)
+	}
+	body, err := r.ReportBlocksDocument(ctx)
+	if err != nil {
+		return mcp.ResourceContents{}, err
+	}
+	return mcp.ResourceContents{URI: uri, MIMEType: mimeApplicationJSON, Text: string(body)}, nil
+}
+
+// ReportBlocksDocument composes the published document.
+//
+// Held by: TestTheBlocksResourceAndTheSeamServeTheSameBytes
+// (internal/modules/agents/reportblocksdoc_test.go)
+//
+// The resource read above and describe_report_blocks both call THIS, so the two
+// doors serve one byte sequence rather than two renderings that agree today.
+func (r ReportBlocksResource) ReportBlocksDocument(context.Context) (json.RawMessage, error) {
+	body, err := json.Marshal(reportBlocksDoc{
+		Version:    reportBlocksVersion,
+		Notation:   reportBlocksNotation,
+		Blocks:     r.grammar.Blocks,
+		Severities: r.grammar.Severities,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agents: rendering the report block grammar: %w", err)
+	}
+	return body, nil
+}
+
+var (
+	_ mcp.ResourceProvider = ReportBlocksResource{}
+	_ ReportBlocksReader   = ReportBlocksResource{}
+)
+
+// reportBlocksDoc is the published shape.
+type reportBlocksDoc struct {
+	Version    string             `json:"version"`
+	Notation   string             `json:"notation"`
+	Blocks     []BlockDescription `json:"blocks"`
+	Severities []string           `json:"severities"`
+}

--- a/backend/internal/modules/agents/reportblocksdoc_test.go
+++ b/backend/internal/modules/agents/reportblocksdoc_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The block grammar has two doors and one composition.
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func aGrammar() BlockGrammar {
+	return BlockGrammar{
+		Blocks: []BlockDescription{
+			{Kind: "title", TakesText: true},
+			{Kind: "stat_strip", TakesCells: true},
+			{Kind: "callout", TakesText: true, TakesSeverity: true},
+		},
+		Severities: []string{"note", "warning"},
+	}
+}
+
+// The resource and the tool seam serve the SAME bytes.
+//
+// Two doors onto one document is the point of publishing it at all: a caller
+// that reads resources and a scheduled agent that cannot must be told the same
+// grammar. Two renderings would agree today and drift the first time one grew a
+// field.
+func TestTheBlocksResourceAndTheSeamServeTheSameBytes(t *testing.T) {
+	r := NewReportBlocksResource(aGrammar())
+	ctx := context.Background()
+
+	viaSeam, err := r.ReportBlocksDocument(ctx)
+	if err != nil {
+		t.Fatalf("composing through the seam: %v", err)
+	}
+	viaResource, err := r.ReadResource(ctx, ReportBlocksURI)
+	if err != nil {
+		t.Fatalf("reading through the resource: %v", err)
+	}
+	if viaResource.Text != string(viaSeam) {
+		t.Errorf("the two doors serve different bytes.\nresource: %s\nseam:     %s",
+			viaResource.Text, viaSeam)
+	}
+}
+
+// The document carries the grammar it was handed, and the rule a field list
+// cannot carry.
+func TestTheBlocksDocumentCarriesTheGrammarAndTheRule(t *testing.T) {
+	body, err := NewReportBlocksResource(aGrammar()).ReportBlocksDocument(context.Background())
+	if err != nil {
+		t.Fatalf("composing the document: %v", err)
+	}
+	for _, want := range []string{"title", "stat_strip", "callout", "note", "warning"} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("the document does not carry %q: %s", want, body)
+		}
+	}
+	// The literal rule travels with the grammar, because it is the one thing a
+	// composer gets wrong that no list of kinds and fields would tell them.
+	if !strings.Contains(string(body), "EVEN WHEN") {
+		t.Error("the document does not carry the rule that a literal is refused beside a " +
+			"valid citation — the one thing a field list cannot say")
+	}
+}
+
+// An unknown URI reads as not-found, matching every other read on this surface.
+func TestTheBlocksResourceRefusesAnotherURI(t *testing.T) {
+	if _, err := NewReportBlocksResource(aGrammar()).
+		ReadResource(context.Background(), "margince://schema/reports"); err == nil {
+		t.Error("the block grammar answered for another document's URI")
+	}
+}

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -1455,6 +1455,97 @@
       "warnings"
     ]
   },
+  "compose_analytics_report": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "blocks": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "blocks"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
   "create_record": {
     "type": "object",
     "properties": {
@@ -2276,6 +2367,97 @@
         },
         "required": [
           "vocabulary"
+        ]
+      },
+      "evidence": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "captured_by": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "record_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id",
+            "record_type"
+          ]
+        }
+      },
+      "freshness": {
+        "type": "object",
+        "properties": {
+          "authoritative": {
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authoritative"
+        ]
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "trace_id": {
+        "type": "string"
+      },
+      "trust": {
+        "type": "string"
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "required": [
+      "data",
+      "evidence",
+      "freshness",
+      "schema_version",
+      "trace_id",
+      "trust",
+      "warnings"
+    ]
+  },
+  "describe_report_blocks": {
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "blocks": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "blocks"
         ]
       },
       "evidence": {

--- a/backend/internal/modules/agents/toolcopy_analyticsreport.go
+++ b/backend/internal/modules/agents/toolcopy_analyticsreport.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// Written copy for composing a report. See toolcopy.go for what each field
+// answers.
+//
+// The BLOCK VOCABULARY is deliberately not here. Fourteen block kinds with
+// their fields would be run_report's 3.4KB mistake again — text every client
+// holds for a session and every scheduled run re-sends on every step, to answer
+// a question one call asks once. It lives in the margince://schema/report-blocks
+// resource and describe_report_blocks, the same move #3950 made for the report
+// vocabulary.
+//
+// This copy NAMES that document and never orders a read of it. The refusal path
+// is what makes that safe: a kind outside the grammar is refused by name with
+// the whole set, so a caller that guesses wrong pays one refusal — where an
+// instruction to read first costs a turn on every goal, including the ones with
+// nothing to look up.
+var composeAnalyticsReportCopy = toolCopy{
+	Purpose: "Render a report whose every figure comes from a saved analytics run. The " +
+		"document carries the STRUCTURE and the WORDS; each number names a run id and a cell " +
+		"inside it, and the server resolves those handles under the reader's own authority.",
+	Limits: "It writes no number of its own and refuses any document that does. A block " +
+		"carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the " +
+		"literal is what renders, the two can disagree, and no reader could tell the page " +
+		"shows a figure the database never computed. Save a run first — run an analytics " +
+		"query with save, and cite the run id it answers with.",
+	Instead: "Ask analytics_query for one number when a figure is what is wanted. This " +
+		"composes a DOCUMENT of several, which is worth the round trip only when the answer " +
+		"is a report somebody reads. describe_report_blocks holds the block kinds and their " +
+		"fields for a caller that wants them before composing.",
+	Retain: "Never put a number in a block — cite the cell that holds it. A block kind " +
+		"outside the grammar is refused BY NAME with the whole set, so a first attempt costs " +
+		"one refusal rather than a lookup.",
+}

--- a/backend/internal/modules/agents/toolcopy_reportblocks.go
+++ b/backend/internal/modules/agents/toolcopy_reportblocks.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// Written copy for the report block grammar. See toolcopy.go for what each
+// field answers.
+
+var describeReportBlocksCopy = toolCopy{
+	Purpose: "Answer what a compose_analytics_report document may CONTAIN: every block kind, " +
+		"whether it renders figures or words, and the severities a callout may state.",
+	Limits: "It describes the grammar; it composes nothing and returns no numbers. It is NOT " +
+		"a prerequisite — an unknown block kind is refused by name with the whole set, so a " +
+		"first attempt costs one refusal. The grammar is the same for every caller, because it " +
+		"is the engine's and not a workspace's.",
+	Instead: "Compose directly when the blocks needed are the obvious ones, and read the " +
+		"refusal when a kind is wrong — it carries the accepted set. This tool answers the " +
+		"same document as the margince://schema/report-blocks resource, for a caller that " +
+		"reads tools rather than resources.",
+	Retain: "A figure is never written into a block, only cited: every number names a saved " +
+		"run and a cell inside it. A block carrying a literal number is refused even beside a " +
+		"valid citation.",
+}

--- a/backend/internal/modules/agents/tools_analyticsreport.go
+++ b/backend/internal/modules/agents/tools_analyticsreport.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// compose_analytics_report — a report whose every figure came from the
+// database.
+//
+// The tool takes a document and hands it to the same validator and renderer the
+// HTTP surface uses. It does not decide what a block may contain and it does
+// not resolve a handle: both live in compose, behind one seam, so the tool
+// surface and the web surface cannot come to disagree about what a report may
+// say.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+)
+
+// AnalyticsReportComposer renders a validated document. Implemented in compose,
+// over the same RenderReport the HTTP handler calls.
+type AnalyticsReportComposer func(ctx context.Context, doc json.RawMessage) (json.RawMessage, error)
+
+// RegisterAnalyticsReportTool adds the composer to the surface.
+func RegisterAnalyticsReportTool(r *Registry, render AnalyticsReportComposer) {
+	r.Register(composeAnalyticsReport{render: render})
+}
+
+type composeAnalyticsReport struct {
+	render AnalyticsReportComposer
+}
+
+func (t composeAnalyticsReport) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "compose_analytics_report", Title: "Compose an analytics report",
+		Version:     toolVersionV1,
+		Description: composeAnalyticsReportCopy.render(),
+		// Read, not write: composing renders a document from runs that already
+		// exist. Nothing is stored and no record moves, so a write scope would
+		// claim an authority this never uses.
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		// The block vocabulary is NOT restated here. `kind` is left an open
+		// string in the schema and closed by the validator, which refuses an
+		// unknown kind BY NAME with the set — the same trade run_report makes
+		// for its per-report vocabularies. Reciting fourteen block kinds and
+		// their fields would cost more of every caller's window, every step,
+		// than the one round trip it saves.
+		InputSchema: schema(`{
+			"type": "object",
+			"required": ["blocks"],
+			"additionalProperties": false,
+			"properties": {
+				"blocks": {
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"type": "object",
+						"required": ["kind"],
+						"additionalProperties": false,
+						"properties": {
+							"kind": {"type": "string"},
+							"text": {"type": "string"},
+							"severity": {"type": "string"},
+							"cells": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"required": ["run_id", "column"],
+									"additionalProperties": false,
+									"properties": {
+										"run_id": {"type": "string"},
+										"column": {"type": "string"},
+										"group": {"type": "array"}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}`),
+		OutputSchema: schemaFor[ComposeAnalyticsReportResult](),
+	}
+}
+
+// ComposeAnalyticsReportResult is the rendered document.
+//
+// Blocks is raw rather than typed here for the reason the vocabulary is not in
+// the schema: the block shapes are compose's, and a second Go spelling of them
+// in this package would be the drift the seam exists to prevent.
+type ComposeAnalyticsReportResult struct {
+	// Blocks carries each composed block with its figures resolved, in the
+	// order the document composed them.
+	Blocks json.RawMessage `json:"blocks"`
+}
+
+func (t composeAnalyticsReport) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	// Passed through unparsed. The document's shape is decided by the
+	// validator, which refuses by naming the block and the reason; decoding it
+	// into a second set of Go types here would be a second answer to what a
+	// report may contain.
+	return t.render(ctx, in)
+}

--- a/backend/internal/modules/agents/tools_reportblocks.go
+++ b/backend/internal/modules/agents/tools_reportblocks.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// describe_report_blocks — the block grammar as a tool, beside the
+// margince://schema/report-blocks resource.
+//
+// Both doors for the same reason describe_report_vocabulary exists beside
+// margince://schema/reports: the Surface-B runner is offered no resource step
+// at all, so for a scheduled agent a tool is the ONLY route to the names
+// compose_analytics_report refuses against.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/mcp"
+)
+
+// RegisterReportBlocksTool adds the grammar reader to the surface.
+func RegisterReportBlocksTool(r *Registry, read ReportBlocksReader) {
+	r.Register(describeReportBlocks{read: read})
+}
+
+type describeReportBlocks struct {
+	read ReportBlocksReader
+}
+
+// DescribeReportBlocksResult is the document, unwrapped.
+type DescribeReportBlocksResult struct {
+	Blocks json.RawMessage `json:"blocks"`
+}
+
+func (t describeReportBlocks) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "describe_report_blocks", Title: "Describe the report block grammar",
+		Version:       toolVersionV1,
+		Description:   describeReportBlocksCopy.render(),
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		// No arguments. The grammar is the same for every caller — it is the
+		// engine's, not a workspace's — so a filter would only let one narrow
+		// what it already receives, at the cost of a name it could spell wrong.
+		InputSchema:  schema(`{"type":"object","properties":{},"additionalProperties":false}`),
+		OutputSchema: schemaFor[DescribeReportBlocksResult](),
+	}
+}
+
+func (t describeReportBlocks) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	// Decoded even with nothing to read, because decodeNoArguments is what
+	// enforces the declared additionalProperties: false — without it a call
+	// carrying a stray key is accepted silently.
+	if err := decodeNoArguments(in); err != nil {
+		return nil, err
+	}
+	// The resource's own composition, not a second rendering of the grammar.
+	body, err := t.read.ReportBlocksDocument(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(DescribeReportBlocksResult{Blocks: body})
+}

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -4,11 +4,11 @@
   "per_agent_listing_budget": 17408,
   "whole_catalog_floor": 21504,
   "catalog": {
-    "tools": 70,
+    "tools": 72,
     "system_frame_tokens": 353,
-    "tokens": 20230,
+    "tokens": 20865,
     "median_tool_tokens": 262,
-    "mean_tool_tokens": 288
+    "mean_tool_tokens": 289
   },
   "agents": [
     {
@@ -139,6 +139,10 @@
       "tokens": 393
     },
     {
+      "name": "compose_analytics_report",
+      "tokens": 389
+    },
+    {
       "name": "search_records",
       "tokens": 385
     },
@@ -220,6 +224,10 @@
     },
     {
       "name": "account_coverage",
+      "tokens": 245
+    },
+    {
+      "name": "describe_report_blocks",
       "tokens": 245
     },
     {

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1621 | 6% | 15787 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2453 | 9% | 14955 | 15 | 8 |
-| _whole served catalog, for scale_ | 70 | 20230 | 82% | — | — | — |
+| _whole served catalog, for scale_ | 72 | 20865 | 84% | — | — | — |
 
 ### `morning_brief`
 
@@ -129,7 +129,7 @@ Every scenario in the corpus was read; none was skipped.
 
 ## What each tool costs, largest first
 
-Median 262 tokens, mean 288, across 70 served tools.
+Median 262 tokens, mean 289, across 72 served tools.
 
 **These do not sum to the catalog total.** Each row is one tool rendered alone and
 divided by four, so every row carries its own rounding; the catalog figure divides
@@ -155,6 +155,7 @@ a term in an addition.
 | `create_record` | 398 | 1 scenario |
 | `book_meeting` | 393 | — |
 | `enrich` | 393 | — |
+| `compose_analytics_report` | 389 | — |
 | `search_records` | 385 | 6 scenarios |
 | `forecast_movement` | 351 | — |
 | `describe_report_vocabulary` | 349 | — |
@@ -176,6 +177,7 @@ a term in an addition.
 | `archive_record` | 261 | — |
 | `forecast_input_checks` | 252 | — |
 | `account_coverage` | 245 | 2 scenarios |
+| `describe_report_blocks` | 245 | — |
 | `decide_approval_bundle` | 235 | — |
 | `qualify_lead` | 230 | — |
 | `apply_tag` | 227 | — |

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -156,6 +156,7 @@ Columns:
 | `remove_tag` | 🟢 | `write` | — | Takes a tag off a record; native, for the reason `apply_tag` gives |
 | `review_commitments` | 🟢 | `read` | — | `unsupported_by_sor` (native-only guard): the mirror holds no task projection |
 | `run_report` | 🟢 | `read` | — | `unsupported_by_sor` (no incumbent analogue) |
+| `compose_analytics_report` | 🟢 | `read` | — | Renders a document whose every figure cites a saved analytics run; it writes no number of its own and stores nothing |
 | `forecast_readings` | 🟢 | `read` | — | Reads deals, stages and the installation's fiscal settings, so it answers only where those live |
 | `forecast_movement` | 🟢 | `read` | — | Diffs two stored snapshots, so it answers only where snapshots exist |
 | `forecast_input_checks` | 🟢 | `read` | — | Reads the nightly run's own record, so it answers only where a run has completed |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -8,18 +8,18 @@
     "enrich"
   ],
   "totals": {
-    "tools": 70,
-    "resources": 10,
-    "tool_catalog_bytes": 199450,
-    "resource_catalog_bytes": 3915,
-    "approx_wire_tokens_total": 50841,
+    "tools": 72,
+    "resources": 11,
+    "tool_catalog_bytes": 204270,
+    "resource_catalog_bytes": 4251,
+    "approx_wire_tokens_total": 52130,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
-      "description_bytes": 47770,
-      "input_schema_bytes": 40667,
-      "output_schema_bytes": 95916,
-      "description_plus_input_schema_bytes": 88437
+      "description_bytes": 49898,
+      "input_schema_bytes": 41225,
+      "output_schema_bytes": 97600,
+      "description_plus_input_schema_bytes": 91123
     }
   },
   "tools": {
@@ -2012,6 +2012,160 @@
       {
         "annotations": {
           "openWorldHint": false,
+          "readOnlyHint": true,
+          "title": "Compose an analytics report"
+        },
+        "description": "Render a report whose every figure comes from a saved analytics run. The document carries the STRUCTURE and the WORDS; each number names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope \"read\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "blocks": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "cells": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "column": {
+                          "type": "string"
+                        },
+                        "group": {
+                          "type": "array"
+                        },
+                        "run_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "run_id",
+                        "column"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "severity": {
+                    "type": "string"
+                  },
+                  "text": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "required": [
+            "blocks"
+          ],
+          "type": "object"
+        },
+        "name": "compose_analytics_report",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "blocks": {
+                  "type": "object"
+                }
+              },
+              "required": [
+                "blocks"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Compose an analytics report"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
           "readOnlyHint": false,
           "title": "Create a record"
         },
@@ -3170,6 +3324,112 @@
           "type": "object"
         },
         "title": "Describe the query vocabulary"
+      },
+      {
+        "annotations": {
+          "openWorldHint": false,
+          "readOnlyHint": true,
+          "title": "Describe the report block grammar"
+        },
+        "description": "Answer what a compose_analytics_report document may CONTAIN: every block kind, whether it renders figures or words, and the severities a callout may state. It describes the grammar; it composes nothing and returns no numbers. It is NOT a prerequisite — an unknown block kind is refused by name with the whole set, so a first attempt costs one refusal. The grammar is the same for every caller, because it is the engine's and not a workspace's. Compose directly when the blocks needed are the obvious ones, and read the refusal when a kind is wrong — it carries the accepted set. This tool answers the same document as the margince://schema/report-blocks resource, for a caller that reads tools rather than resources. A figure is never written into a block, only cited: every number names a saved run and a cell inside it. A block carrying a literal number is refused even beside a valid citation. (Governance: runs immediately; requires passport scope \"read\".)",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {},
+          "type": "object"
+        },
+        "name": "describe_report_blocks",
+        "outputSchema": {
+          "properties": {
+            "data": {
+              "properties": {
+                "blocks": {
+                  "type": "object"
+                }
+              },
+              "required": [
+                "blocks"
+              ],
+              "type": "object"
+            },
+            "evidence": {
+              "items": {
+                "properties": {
+                  "captured_by": {
+                    "type": "string"
+                  },
+                  "record_id": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "record_type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "record_id",
+                  "record_type"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "properties": {
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "last_synced_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "authoritative"
+              ],
+              "type": "object"
+            },
+            "schema_version": {
+              "type": "string"
+            },
+            "trace_id": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            },
+            "warnings": {
+              "items": {
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "message"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "data",
+            "evidence",
+            "freshness",
+            "schema_version",
+            "trace_id",
+            "trust",
+            "warnings"
+          ],
+          "type": "object"
+        },
+        "title": "Describe the report block grammar"
       },
       {
         "annotations": {
@@ -13123,6 +13383,13 @@
         "uri": "margince://schema/reports"
       },
       {
+        "description": "The blocks a report may carry: each kind, whether it renders figures, words or both, and the severities a callout may state. compose_analytics_report names this document instead of carrying it.",
+        "mimeType": "application/json",
+        "name": "report_blocks",
+        "title": "Report block grammar",
+        "uri": "margince://schema/report-blocks"
+      },
+      {
         "_meta": {
           "ui": {
             "csp": {
@@ -13238,9 +13505,10 @@
     "ttlMs": 60000
   },
   "documents": {
-    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":70,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"annotate_brief\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"create_record\",\"create_tag\",\"create_task\",\"data_coverage\",\"decide_approval\",\"decide_approval_bundle\",\"describe_query_vocabulary\",\"describe_report_vocabulary\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"forecast_input_checks\",\"forecast_movement\",\"forecast_readings\",\"get_record_tags\",\"get_tag\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_input_checks\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"update_tag\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\",\"merge_tags\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
+    "margince://capabilities": "{\"version\":\"1\",\"governance\":{\"scopes_held\":[\"draft\",\"enrich\",\"read\",\"send\",\"write\"],\"model\":\"A call either executes under this passport's authority or stages an approval a human decides. An agent can never exceed the human who granted the passport, and every call is re-authorised at the moment it runs, so a revoked grant binds mid-session.\",\"host_confirmation\":\"A confirmation your own client shows the user is NOT one of these approvals. A staged call is decided in Margince and returns its outcome here.\"},\"verbs\":{\"offered\":72,\"execute_directly\":[\"account_coverage\",\"advance_project_phase\",\"annotate_brief\",\"apply_tag\",\"archive_record\",\"at_risk_relationships\",\"book_meeting\",\"catch_me_up_on\",\"check_availability\",\"check_location_support\",\"commit_import\",\"compose_analytics_report\",\"create_record\",\"create_tag\",\"create_task\",\"data_coverage\",\"decide_approval\",\"decide_approval_bundle\",\"describe_query_vocabulary\",\"describe_report_blocks\",\"describe_report_vocabulary\",\"disqualify_lead\",\"draft_email\",\"draft_follow_ups_for\",\"forecast_input_checks\",\"forecast_movement\",\"forecast_readings\",\"get_record_tags\",\"get_tag\",\"intro_path_to\",\"list_approvals\",\"list_channel_providers\",\"list_colleagues\",\"list_input_checks\",\"list_pipelines\",\"list_records\",\"list_tags\",\"log_activity\",\"merge_records\",\"prep_for_meeting\",\"prepare_handoff\",\"preview_import\",\"promote_lead\",\"qualify_lead\",\"query_workspace\",\"read_approval\",\"read_brief\",\"read_import_report\",\"read_import_run\",\"read_project_360\",\"read_record\",\"remove_tag\",\"resolve_entities\",\"review_commitments\",\"run_report\",\"search_context\",\"search_records\",\"send_account_email\",\"send_email\",\"send_message\",\"update_record\",\"update_tag\",\"whats_slipping_this_week\",\"who_knows\",\"whoami\"],\"stage_for_approval\":[\"enrich\",\"merge_tags\"],\"decided_per_call\":[\"advance_deal\",\"progress_deal\",\"relink_activities\",\"relink_activity\",\"relink_thread\"],\"decided_per_call_reason\":\"The tier depends on the arguments — the same verb can execute or stage depending on what it is asked to do.\"}}",
     "margince://schema/query": "{\"version\":\"v1\",\"grammar\":{\"predicates\":\"{\\\"field\\\": \\u003cname below\\u003e, \\\"op\\\": \\u003cop the field admits\\u003e, \\\"value\\\": \\u003coperand\\u003e} — or \\\"values\\\": [...] for \\\"in\\\". Clauses are combined with AND.\",\"semantic_target\":\"\\\"similar_to\\\": \\u003cfree text\\u003e — one similarity clause, ranked by the hybrid retriever.\",\"traversal\":\"\\\"traverse\\\": {\\\"relation\\\": \\u003crelation below\\u003e, \\\"where\\\": [...]} — exactly one hop. A second hop is refused; ask it as its own query.\",\"limit\":\"\\\"limit\\\": 1..200; omit for the default page.\",\"refusal\":\"Anything outside this vocabulary is refused with a typed clarification naming what was not understood. Nothing is coerced, and no plan is narrowed to the part that was recognised.\"},\"targets\":[],\"unavailable\":[]}",
     "margince://schema/record-fields": "{\"version\":\"1\",\"notation\":\"A key with no `?` is REQUIRED by the contract; `?` marks one the body may omit. A name not listed is not a field: it is refused by name, never stored silently.\",\"create_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, channel_provider?: string, direction?: \\\"inbound\\\"|\\\"outbound\\\", due_at?: rfc3339, duration_seconds?: integer, kind: \\\"email\\\"|\\\"call\\\"|\\\"meeting\\\"|\\\"note\\\"|\\\"task\\\"|\\\"message\\\", links?: [{entity_id: uuid, entity_type: \\\"person\\\"|\\\"organization\\\"|\\\"deal\\\"|\\\"lead\\\"|\\\"project\\\"}], meeting_status?: \\\"booked\\\"|\\\"held\\\"|\\\"no_show\\\"|\\\"canceled\\\", occurred_at?: rfc3339, raw?: object, remind_at?: rfc3339, source?: string, source_id?: string, source_system?: string, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, name: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, pipeline_id: uuid, project_id?: uuid, source?: string, stage_id: uuid}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, linkedin_url?: string, owner_id?: uuid, project_id?: uuid, source?: string, source_id?: string, source_system?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\"|\\\"promoted\\\"|\\\"disqualified\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, owner_id?: uuid, parent_org_id?: uuid, size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\", source?: string}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, emails?: [{email: email, email_type?: \\\"work\\\"|\\\"personal\\\"|\\\"other\\\", is_primary?: boolean, position?: integer}], first_name?: string, full_name: string, last_name?: string, owner_id?: uuid, phones?: [{is_primary?: boolean, phone: string, phone_type?: \\\"work\\\"|\\\"mobile\\\"|\\\"home\\\"|\\\"other\\\", position?: integer}], social?: object, source?: string, title?: string}\",\"project\":\"{description?: string, name: string, organization_id: uuid, owner_id?: uuid, source?: string, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{counterparty_org_id?: uuid, counterparty_person_id?: uuid, deal_id?: uuid, ended_at?: YYYY-MM-DD, is_current_primary?: boolean, kind: \\\"employment\\\"|\\\"deal_stakeholder\\\"|\\\"project_stakeholder\\\"|\\\"partner_of\\\"|\\\"referred_by\\\"|\\\"co_sell_with\\\"|\\\"works_with\\\", organization_id?: uuid, person_id?: uuid, project_id?: uuid, role?: string, source?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` is accepted but overwritten — this surface stamps its own provenance.\",\"A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else on this surface yields them, and neither is defaultable.\",\"A person's employer is a relationship, not a field on the person: record_type=relationship with kind=employment, person_id and organization_id. Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — employment: person + organization; deal_stakeholder: deal + person; project_stakeholder: project + person; partner_of, referred_by and co_sell_with: organization + counterparty_org_id. An edge is not searchable, so keep the id a relationship write returns.\",\"An activity is not searchable — search_records does not serve it — so keep the id an activity write returns; read_record answers it by that id.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"A recording of a conversation is logged with `source_system: \\\"transcript\\\"` — that value is what has it read for next steps and commitments; any other value stores the text and reads nothing.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]},\"update_record\":{\"fields\":{\"activity\":\"{assignee_id?: uuid, body?: string, due_at?: rfc3339, is_done?: boolean, occurred_at?: rfc3339, remind_at?: rfc3339, subject?: string}\",\"deal\":\"{amount_minor?: integer, currency?: string, expected_close_date?: YYYY-MM-DD, forecast_category?: \\\"commit\\\"|\\\"best_case\\\"|\\\"pipeline\\\"|\\\"omitted\\\", fx_rate_date?: YYYY-MM-DD, fx_rate_to_base?: string, lost_reason?: string, name?: string, organization_id?: uuid, owner_id?: uuid, partner_attribution?: \\\"sourced\\\"|\\\"influenced\\\", partner_org_id?: uuid, project_id?: uuid, status?: \\\"open\\\"|\\\"won\\\"|\\\"lost\\\", wait_until?: YYYY-MM-DD}\",\"lead\":\"{candidate_org_key?: string, company_name?: string, email?: email, full_name?: string, owner_id?: uuid, project_id?: uuid, score?: integer, score_override_reason?: string, source?: string, status?: \\\"new\\\"|\\\"contacted\\\"|\\\"engaged\\\", title?: string}\",\"organization\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, description?: string, display_name?: string, domains?: [{domain: string, is_primary?: boolean}], industry?: string, legal_name?: string, lifecycle?: \\\"unknown\\\"|\\\"target\\\"|\\\"prospect\\\"|\\\"opportunity\\\"|\\\"customer\\\"|\\\"former_customer\\\"|\\\"disqualified\\\", linkedin_url?: string, owner_id?: uuid, parent_org_id?: uuid, relationship_types?: [\\\"customer\\\"|\\\"partner\\\"|\\\"supplier\\\"|\\\"investor\\\"|\\\"portfolio_company\\\"|\\\"competitor\\\"|\\\"other\\\"], size_band?: \\\"1-10\\\"|\\\"11-50\\\"|\\\"51-200\\\"|\\\"201-500\\\"|\\\"501-1000\\\"|\\\"1001-5000\\\"|\\\"5000+\\\"}\",\"person\":\"{address?: {city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, region?: string}, first_name?: string, full_name?: string, last_name?: string, owner_id?: uuid, social?: object, title?: string}\",\"project\":\"{description?: string, ended_at?: YYYY-MM-DD, name?: string, owner_id?: uuid, started_at?: YYYY-MM-DD, target_end_date?: YYYY-MM-DD}\",\"relationship\":\"{ended_at?: YYYY-MM-DD, is_current_primary?: boolean, role?: string, started_at?: YYYY-MM-DD}\"},\"notes\":[\"A task is record_type=activity with kind=task.\",\"`source` on a lead is the administered lead-source key (see Settings › Data model); a patch corrects it, and the score follows.\",\"A person's employer is NOT a field here: employment is a relationship, created and archived as record_type=relationship — its endpoints are what it IS, so they cannot be patched.\",\"An activity's links are NOT patchable, here or by any tool on this surface: this write changes what an activity says, never who it is about.\",\"`assignee_id` and `owner_id` take a COLLEAGUE's id — list_colleagues answers those, whoami answers your own. A person id is a contact and is refused.\",\"An organization's `description` is the header's standing answer to what the company SELLS, and a site read fills it from the company's own website. Omit it rather than summarising a meeting or a document into it; what one conversation covered belongs on that activity.\",\"Extra keys must be named cf_\\u003cslug\\u003e and are read as custom-field values; any other key is REFUSED by name, so an unknown field is never a silent loss. A cf_ key whose custom field is not ACTIVE in this workspace is the one that is: the write reports success and drops the value, so re-read the record if you are unsure a cf_ value landed.\",\"No custom fields on activity or relationship: those types carry no cf_ values at all, so a cf_ key there is refused rather than stored.\"]}}",
+    "margince://schema/report-blocks": "{\"version\":\"1\",\"notation\":\"A block carries STRUCTURE and WORDS; a figure is named, never written. Every number cites a saved run and a cell inside it, and the server resolves that citation under the reading caller's own authority. A block carrying a literal number is refused EVEN WHEN a valid citation sits beside it: the literal is what would render, the two can disagree, and no reader could tell the page shows a figure the database never computed.\",\"blocks\":[{\"kind\":\"title\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"subtitle\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"scope\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"generated_at\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"summary\",\"takes_cells\":true,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"methodology\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"follow_ups\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":false},{\"kind\":\"stat_strip\",\"takes_cells\":true,\"takes_text\":false,\"takes_severity\":false},{\"kind\":\"bar\",\"takes_cells\":true,\"takes_text\":false,\"takes_severity\":false},{\"kind\":\"waterfall\",\"takes_cells\":true,\"takes_text\":false,\"takes_severity\":false},{\"kind\":\"ranked_list\",\"takes_cells\":true,\"takes_text\":false,\"takes_severity\":false},{\"kind\":\"record_table\",\"takes_cells\":true,\"takes_text\":false,\"takes_severity\":false},{\"kind\":\"callout\",\"takes_cells\":false,\"takes_text\":true,\"takes_severity\":true},{\"kind\":\"evidence_drawer\",\"takes_cells\":true,\"takes_text\":true,\"takes_severity\":false}],\"severities\":[\"note\",\"warning\",\"partial\",\"unknown\",\"unsupported\"]}",
     "margince://schema/reports": "{\"version\":\"1\",\"notation\":\"Each report accepts ONLY the names listed under it. `group_by` and `aggregates` take names from their own lists; `filters` is one object whose keys come from the `filters` list, which holds both equality predicates and numeric thresholds. A name outside a report's list is refused by name, with that list, rather than approximated.\",\"reports\":[{\"report\":\"activities-by-kind\",\"group_by\":[\"direction\",\"kind\",\"project\",\"project_id\"],\"filters\":[\"direction\",\"kind\",\"project_id\"],\"aggregates\":[],\"defaults\":\"count as activities grouped by kind\",\"notes\":\"project_id admits exactly the activities filed under that project (an activity_link row naming it); an activity filed nowhere, or under another project, is excluded\"},{\"report\":\"deals-by-stage\",\"group_by\":[\"currency\",\"partner_org_id\",\"pipeline_id\",\"stage_id\",\"status\",\"win_probability\"],\"filters\":[\"currency\",\"organization_id\",\"owner_id\",\"partner_org_id\",\"partner_sourced\",\"pipeline_id\",\"project_id\",\"stalled\",\"status\"],\"aggregates\":[\"amount_minor\",\"weighted_amount_minor\"],\"defaults\":\"count as deals, sum(amount_minor) as amount_minor_sum grouped by stage_id, currency\"},{\"report\":\"forecast\",\"group_by\":[\"currency\",\"forecast_category\",\"owner_id\",\"partner_org_id\",\"pipeline_id\",\"stage_id\",\"win_probability\"],\"filters\":[\"currency\",\"forecast_category\",\"owner_id\",\"partner_org_id\",\"pipeline_id\",\"project_id\",\"stage_id\"],\"aggregates\":[\"amount_minor\",\"weighted_amount_minor\"],\"defaults\":\"count as deals, sum(amount_minor) as unweighted_minor, sum(weighted_amount_minor) as weighted_minor grouped by forecast_category, currency\"},{\"report\":\"open-deals-per-company\",\"group_by\":[\"currency\",\"organization_id\",\"owner_id\"],\"filters\":[\"currency\",\"owner_id\",\"pipeline_id\",\"project_id\"],\"aggregates\":[\"amount_minor\"],\"defaults\":\"count as open_deals grouped by organization_id\"},{\"report\":\"project-commitments\",\"group_by\":[\"key\",\"name\",\"organization_id\",\"owner_id\",\"phase\",\"project_id\"],\"filters\":[\"organization_id\",\"owner_id\",\"phase\"],\"aggregates\":[\"open_commitments\",\"overdue_commitments\"],\"defaults\":\"sum(overdue_commitments) as overdue_commitments, sum(open_commitments) as open_commitments grouped by project_id, name, key, phase, owner_id\",\"notes\":\"rows are ordered most overdue first\"},{\"report\":\"projects-by-phase\",\"group_by\":[\"organization_id\",\"owner_id\",\"phase\"],\"filters\":[\"organization_id\",\"owner_id\",\"phase\"],\"aggregates\":[\"open_deal_value_minor\",\"won_deal_value_minor\"],\"defaults\":\"count as projects, sum(open_deal_value_minor) as open_deal_value_minor, sum(won_deal_value_minor) as won_deal_value_minor grouped by phase\",\"notes\":\"deal values are in the installation's base currency; an open deal in another currency counts nothing until it closes\"},{\"report\":\"projects-gone-quiet\",\"group_by\":[\"key\",\"last_activity_at\",\"name\",\"organization_id\",\"owner_id\",\"phase\",\"project_id\",\"quiet_since\"],\"filters\":[\"days\",\"organization_id\",\"owner_id\",\"phase\"],\"aggregates\":[],\"defaults\":\"count as projects grouped by project_id, name, key, phase, owner_id, last_activity_at, quiet_since\",\"notes\":\"`days` is a whole number of days of silence, default 30; quiet_since is when the silence began\"},{\"report\":\"stage-age\",\"group_by\":[\"owner_id\",\"pipeline_id\",\"stage_id\"],\"filters\":[\"owner_id\",\"pipeline_id\"],\"aggregates\":[\"days_in_stage\"],\"defaults\":\"count as deals, median(days_in_stage) as median_days, p75(days_in_stage) as p75_days grouped by stage_id\"},{\"report\":\"win-loss\",\"group_by\":[\"currency\",\"organization_id\",\"owner_id\",\"period_month\",\"period_quarter\",\"period_year\",\"pipeline_id\",\"source\",\"status\"],\"filters\":[\"currency\",\"organization_id\",\"owner_id\",\"period_month\",\"period_quarter\",\"period_year\",\"pipeline_id\",\"project_id\",\"source\",\"status\"],\"aggregates\":[\"amount_minor\"],\"defaults\":\"count as deals, sum(amount_minor) as amount_minor_sum grouped by status, currency\"}],\"notes\":[\"A `pipeline_id` or `stage_id` used in a plan comes from list_pipelines.\"]}",
     "ui://margince/account-brief.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",
     "ui://margince/commitments.html": "(not published here: a ui:// document is fetched from a web origin at boot, so its bytes are a property of the deployment rather than of this build)",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -11,11 +11,11 @@ receives it. This page is rendered from that file.
 
 | | |
 |---|---:|
-| Tools | 70 |
-| Resources | 10 |
-| Tool catalog | 194.8 KB |
-| Resource catalog | 3.8 KB |
-| Approx. wire tokens | 50841 |
+| Tools | 72 |
+| Resources | 11 |
+| Tool catalog | 199.5 KB |
+| Resource catalog | 4.2 KB |
+| Approx. wire tokens | 52130 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -29,11 +29,11 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 
 | Part | Bytes | Share | In a run's prompt? |
 |---|---:|---:|---|
-| Output schemas | 93.7 KB | 48% | **No** — a result's shape, never listed to a model |
-| Descriptions (incl. governance clause) | 46.7 KB | 23% | Yes, every step |
-| Input schemas | 39.7 KB | 20% | Yes, every step |
-| _Names, annotations, punctuation_ | 14.7 KB | 7% | Partly |
-| **Description + input schema** | **86.4 KB** | **44%** | **the recurring cost** |
+| Output schemas | 95.3 KB | 47% | **No** — a result's shape, never listed to a model |
+| Descriptions (incl. governance clause) | 48.7 KB | 24% | Yes, every step |
+| Input schemas | 40.3 KB | 20% | Yes, every step |
+| _Names, annotations, punctuation_ | 15.2 KB | 7% | Partly |
+| **Description + input schema** | **89.0 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -45,12 +45,13 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 
 ## Index
 
-### Resources (10)
+### Resources (11)
 
 - [`margince://capabilities`](#capabilities) — What this installation can do
 - [`margince://schema/query`](#query_vocabulary) — Workspace query vocabulary
 - [`margince://schema/record-fields`](#record_fields) — Record write vocabulary
 - [`margince://schema/reports`](#report_vocabulary) — Report plan vocabulary
+- [`margince://schema/report-blocks`](#report_blocks) — Report block grammar
 - [`ui://margince/account-brief.html`](#account_brief_view) — Morning brief
 - [`ui://margince/relationship-map.html`](#relationship_map_view) — Who knows this contact
 - [`ui://margince/commitments.html`](#commitments_view) — Open commitments
@@ -58,7 +59,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 - [`ui://margince/pipeline-review.html`](#pipeline_review_view) — Pipeline review
 - [`ui://margince/geo-probe.html`](#geo_probe_view) — Location check
 
-### Tools (70)
+### Tools (72)
 
 | Tool | What it is for | Read-only | View | Size |
 |---|---|:-:|---|---:|
@@ -74,6 +75,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`check_availability`](#check_availability) | Check calendar availability | yes |  | 2.2 KB |
 | [`check_location_support`](#check_location_support) | Can a card read this device's location | yes | [`ui://margince/geo-probe.html`](#geo_probe_view) | 1.8 KB |
 | [`commit_import`](#commit_import) | Commit an import |  |  | 1.7 KB |
+| [`compose_analytics_report`](#compose_analytics_report) | Compose an analytics report | yes |  | 2.6 KB |
 | [`create_record`](#create_record) | Create a record |  |  | 3.3 KB |
 | [`create_tag`](#create_tag) | Create a tag |  |  | 1.9 KB |
 | [`create_task`](#create_task) | Create a task |  |  | 2.2 KB |
@@ -81,6 +83,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`decide_approval`](#decide_approval) | Approve or reject one staged action |  |  | 2.9 KB |
 | [`decide_approval_bundle`](#decide_approval_bundle) | Approve or reject one act's proposals together |  |  | 2.9 KB |
 | [`describe_query_vocabulary`](#describe_query_vocabulary) | Describe the query vocabulary | yes |  | 2.1 KB |
+| [`describe_report_blocks`](#describe_report_blocks) | Describe the report block grammar | yes |  | 2.0 KB |
 | [`describe_report_vocabulary`](#describe_report_vocabulary) | Describe the report vocabulary | yes |  | 2.4 KB |
 | [`disqualify_lead`](#disqualify_lead) | Disqualify a lead |  |  | 1.9 KB |
 | [`draft_email`](#draft_email) | Draft an email |  |  | 2.5 KB |
@@ -170,6 +173,14 @@ The fields create_record and update_record accept for each record_type: which ar
 **Report plan vocabulary**
 
 What each prebuilt report accepts in a run_report plan: the names its group_by, filters and aggregates admit, what it answers with no plan at all, and what a filter means when its name alone does not say. run_report names this document instead of carrying it.
+
+### report_blocks
+
+`margince://schema/report-blocks` · application/json
+
+**Report block grammar**
+
+The blocks a report may carry: each kind, whether it renders figures, words or both, and the severities a callout may state. compose_analytics_report names this document instead of carrying it.
 
 ### account_brief_view
 
@@ -2422,6 +2433,170 @@ Write a checked import into the workspace, once a person approves. Only from awa
 
 </details>
 
+### compose_analytics_report
+
+**Compose an analytics report**
+
+Render a report whose every figure comes from a saved analytics run. The document carries the STRUCTURE and the WORDS; each number names a run id and a cell inside it, and the server resolves those handles under the reader's own authority. It writes no number of its own and refuses any document that does. A block carrying a literal figure is refused EVEN WHEN a valid handle sits beside it: the literal is what renders, the two can disagree, and no reader could tell the page shows a figure the database never computed. Save a run first — run an analytics query with save, and cite the run id it answers with. Ask analytics_query for one number when a figure is what is wanted. This composes a DOCUMENT of several, which is worth the round trip only when the answer is a report somebody reads. describe_report_blocks holds the block kinds and their fields for a caller that wants them before composing. Never put a number in a block — cite the cell that holds it. A block kind outside the grammar is refused BY NAME with the whole set, so a first attempt costs one refusal rather than a lookup. (Governance: runs immediately; requires passport scope "read".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "blocks": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "cells": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "column": {
+                  "type": "string"
+                },
+                "group": {
+                  "type": "array"
+                },
+                "run_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "run_id",
+                "column"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "type": "object"
+      },
+      "minItems": 1,
+      "type": "array"
+    }
+  },
+  "required": [
+    "blocks"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "blocks": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "blocks"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
 ### create_record
 
 **Create a record**
@@ -3569,6 +3744,122 @@ Answer what a query plan may SAY in this workspace: the record types that can be
       },
       "required": [
         "vocabulary"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "properties": {
+          "captured_by": {
+            "type": "string"
+          },
+          "record_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "record_type": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "record_id",
+          "record_type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "freshness": {
+      "properties": {
+        "authoritative": {
+          "type": "boolean"
+        },
+        "last_synced_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authoritative"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "trust": {
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "data",
+    "evidence",
+    "freshness",
+    "schema_version",
+    "trace_id",
+    "trust",
+    "warnings"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+### describe_report_blocks
+
+**Describe the report block grammar**
+
+Answer what a compose_analytics_report document may CONTAIN: every block kind, whether it renders figures or words, and the severities a callout may state. It describes the grammar; it composes nothing and returns no numbers. It is NOT a prerequisite — an unknown block kind is refused by name with the whole set, so a first attempt costs one refusal. The grammar is the same for every caller, because it is the engine's and not a workspace's. Compose directly when the blocks needed are the obvious ones, and read the refusal when a kind is wrong — it carries the accepted set. This tool answers the same document as the margince://schema/report-blocks resource, for a caller that reads tools rather than resources. A figure is never written into a block, only cited: every number names a saved run and a cell inside it. A block carrying a literal number is refused even beside a valid citation. (Governance: runs immediately; requires passport scope "read".)
+
+<details><summary>Input schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {},
+  "type": "object"
+}
+```
+
+</details>
+
+<details><summary>Output schema</summary>
+
+```json
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "blocks": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "blocks"
       ],
       "type": "object"
     },


### PR DESCRIPTION
Completes PR 14 of the analytics plan. `compose_analytics_report` puts the report surface on the tool catalog, so a model can compose an evidenced report and not only a person.

## It fits without touching the ceiling

The budget is why this was deferred. The fix is the move #3950 made for `run_report`, not a bigger number.

Fourteen block kinds with their fields would be that tool 3.4KB mistake again — text every client holds for a whole session and every scheduled run re-sends on every step, to answer a question one call asks once. So the vocabulary is published as `margince://schema/report-blocks` and `describe_report_blocks`; `kind` stays an open string in the input schema, closed by the validator, and an unknown kind is refused BY NAME with the whole set.

| | tokens |
|---|---|
| `compose_analytics_report` | 376 |
| `describe_report_blocks` | 259 |
| both together | 635 |
| `run_report` alone, for scale | 786 |

Catalog: **72 tools, 20,865 of 21,504, 639 spare.** `PromptTokenCeiling` untouched — it is derived arithmetic from the local provider context window (32,768 = 24,576 prompt + 4,096 completion, rounded), and exceeding it truncates a completion inside a reasoning model thinking, which returns well-formed empty content and reads as a bad model.

## One engine, two transports

The tool hands its document to the same `reportdoc.Validate` and `RenderReport` that `POST /analytics/reports/render` calls, behind one seam in `compose`. It decides nothing about what a block may contain and resolves no handle itself.

`TestTheReportToolAndTheRouteRenderTheSameDocument` found a real defect on its first run: `RenderedBlock` carried no json tags, so the tool served `Kind`/`Values` while the HTTP handler served the contract `kind`/`values` — two surfaces disagreeing about one document. The tags are now the wire shape both serve.

**That test also failed its own mutation check at first.** It compared the tool answer against `json.Marshal` of the route struct, so renaming a tag moved the expectation and the answer together and it passed straight through the divergence it exists to catch. It now decodes into the contract own field names, and the same mutation fails it.

## The literal rule reaches the tool surface

Which is where it matters most: a model has a number in its own reasoning and a handle beside it, and writing both looks like being helpful. `TestTheReportToolRefusesALiteralBesideAHandle` supplies the *correct* number — the case a reader could never catch — and expects refusal.

## Governance

- `x-mcp-tool` on `renderAnalyticsReport`; `describe_report_blocks` is a composed intent, like its sibling `describe_report_vocabulary`.
- The route decodes into a governed call carrying **only the block count**. Summarising the figures would state numbers from the composer view, and the approver may be entitled to fewer — the same reason `run_report` names its report key and no rows.
- Listed in `docs/reference/agent-tools.md`, which is what a reader consults before granting a passport.

## Also

`Kind.known()` and the published catalog now read one `allKinds` list, so adding a block kind is one edit rather than two that can disagree. `commandauto.go` passed the 500-line cap, so the two report commands moved to `commandreport.go` — they are one concept, both resolving to no record.

## Verified live

Both tools served, read-scoped, neither description reciting the vocabulary. A saved run rendered through the shared path returned `{"value":10,"withheld":false}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `compose_analytics_report` so a model can compose and render an analytics report through the same validator and renderer the `POST /analytics/reports/render` route uses. The block grammar is published as the `margince://schema/report-blocks` resource and `describe_report_blocks` tool rather than typed into the tool description, keeping the catalog inside the token budget.

**Bug Fixes**
- `RenderedBlock` and `RenderedValue` now carry the contract's JSON tags, so the tool and the HTTP route serve the same `kind`/`values` wire shape.
- The tool/route parity test now decodes into the contract's field names, so tag drift fails it instead of passing through.

**Migration**
- `POST /v1/analytics/reports/render` is governed as `compose_analytics_report` (auto-execute, read scope) instead of `human-only`, and the approval carries only the block count, not the figures.
- Block kinds now come from one `allKinds` list shared by the validator and the published catalog, so adding a kind is one edit.

<sup>Written for commit 8ead23e79220da7cb4ff557c0016af8e3c336d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/3999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only tool for composing analytics reports from saved run and cell references.
  - Added a tool that describes supported report blocks, fields, and severity levels.
  - Published a report-block schema resource for programmatic discovery.
  - Report results now include structured blocks, resolved values, and withheld-state details.

- **Bug Fixes**
  - Improved validation feedback by listing supported report block kinds.
  - Reports reject literal figures and unknown block types, ensuring figures reference saved analytics results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->