### PR TITLE
frontend: renew, status change and cancellation reach the company contracts screen

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1158,6 +1158,7 @@ export const de = {
   "contracts.statusChange.title": "Status ändern",
   "contracts.statusChange.label": "Neuer Status",
   "contracts.statusChange.submit": "Status ändern",
+  "contracts.statusChange.errSame": "Bereits in diesem Status.",
   "contracts.cancel.title": "Kündigung erfassen",
   "contracts.cancel.hint":
     "Der Kunde bleibt bis zum Wirksamkeitsdatum unter Vertrag — dies erfasst die Kündigung, keine Statusänderung.",
@@ -1170,6 +1171,8 @@ export const de = {
   "contracts.cancel.errIncomplete": "Beide Daten werden benötigt.",
   "contracts.cancel.errOrder":
     "Eine Kündigung kann nicht vor ihrer Erklärung wirksam werden.",
+  "contracts.cancel.errTermEnd":
+    "Eine Kündigung kann nicht nach Vertragsende wirksam werden.",
   "contracts.value.perYear": "pro Jahr",
   "contracts.value.total": "für die gesamte Laufzeit",
   "contracts.files": "Dateien",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1151,6 +1151,25 @@ export const de = {
     "Eine Laufzeit kann nicht vor ihrem Beginn enden.",
   "contracts.add": "Vertrag hinzuf\u00fcgen",
   "contracts.rowMenu": "Vertragsaktionen",
+  "contracts.renew.title": "Diese Vereinbarung verlängern",
+  "contracts.renew.hint":
+    "Erstellt eine neue Vereinbarung und markiert diese als abgelöst. Eigene Bedingungen — nichts wird übernommen außer der Vertragspartei.",
+  "contracts.renew.submit": "Verlängern",
+  "contracts.statusChange.title": "Status ändern",
+  "contracts.statusChange.label": "Neuer Status",
+  "contracts.statusChange.submit": "Status ändern",
+  "contracts.cancel.title": "Kündigung erfassen",
+  "contracts.cancel.hint":
+    "Der Kunde bleibt bis zum Wirksamkeitsdatum unter Vertrag — dies erfasst die Kündigung, keine Statusänderung.",
+  "contracts.cancel.noticeOn": "Kündigung erklärt am",
+  "contracts.cancel.effectiveOn": "Wirksam ab",
+  "contracts.cancel.effectiveOnHint":
+    "Nicht nach Vertragsende und nicht vor dem Kündigungsdatum.",
+  "contracts.cancel.submit": "Kündigung erfassen",
+  "contracts.cancel.menuLabel": "Kündigen",
+  "contracts.cancel.errIncomplete": "Beide Daten werden benötigt.",
+  "contracts.cancel.errOrder":
+    "Eine Kündigung kann nicht vor ihrer Erklärung wirksam werden.",
   "contracts.value.perYear": "pro Jahr",
   "contracts.value.total": "für die gesamte Laufzeit",
   "contracts.files": "Dateien",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1201,6 +1201,25 @@ export const en = {
   "contracts.form.errTermOrder": "A term cannot end before it starts.",
   "contracts.add": "Add a contract",
   "contracts.rowMenu": "Contract actions",
+  "contracts.renew.title": "Renew this agreement",
+  "contracts.renew.hint":
+    "Creates a new agreement and marks this one superseded. Its own terms — nothing carries over but the counterparty.",
+  "contracts.renew.submit": "Renew",
+  "contracts.statusChange.title": "Change status",
+  "contracts.statusChange.label": "New status",
+  "contracts.statusChange.submit": "Change status",
+  "contracts.cancel.title": "Record cancellation",
+  "contracts.cancel.hint":
+    "The customer stays under contract until the effective date — this records notice, not a state change.",
+  "contracts.cancel.noticeOn": "Notice given",
+  "contracts.cancel.effectiveOn": "Takes effect",
+  "contracts.cancel.effectiveOnHint":
+    "Not after the term ends, and not before the notice date.",
+  "contracts.cancel.submit": "Record cancellation",
+  "contracts.cancel.menuLabel": "Cancel",
+  "contracts.cancel.errIncomplete": "Both dates are needed.",
+  "contracts.cancel.errOrder":
+    "Cancellation cannot take effect before notice was given.",
   "contracts.value.perYear": "per year",
   "contracts.value.total": "for the whole term",
   "contracts.files": "Files",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1208,6 +1208,7 @@ export const en = {
   "contracts.statusChange.title": "Change status",
   "contracts.statusChange.label": "New status",
   "contracts.statusChange.submit": "Change status",
+  "contracts.statusChange.errSame": "Already at this status.",
   "contracts.cancel.title": "Record cancellation",
   "contracts.cancel.hint":
     "The customer stays under contract until the effective date — this records notice, not a state change.",
@@ -1216,10 +1217,12 @@ export const en = {
   "contracts.cancel.effectiveOnHint":
     "Not after the term ends, and not before the notice date.",
   "contracts.cancel.submit": "Record cancellation",
-  "contracts.cancel.menuLabel": "Cancel",
+  "contracts.cancel.menuLabel": "Cancel agreement",
   "contracts.cancel.errIncomplete": "Both dates are needed.",
   "contracts.cancel.errOrder":
     "Cancellation cannot take effect before notice was given.",
+  "contracts.cancel.errTermEnd":
+    "Cancellation cannot take effect after the term already ends.",
   "contracts.value.perYear": "per year",
   "contracts.value.total": "for the whole term",
   "contracts.files": "Files",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1141,6 +1141,25 @@ export const vi = {
     "K\u1ef3 h\u1ea1n kh\u00f4ng th\u1ec3 k\u1ebft th\u00fac tr\u01b0\u1edbc khi b\u1eaft \u0111\u1ea7u.",
   "contracts.add": "Th\u00eam h\u1ee3p \u0111\u1ed3ng",
   "contracts.rowMenu": "Thao t\u00e1c h\u1ee3p \u0111\u1ed3ng",
+  "contracts.renew.title": "Gia h\u1ea1n th\u1ecfa thu\u1eadn n\u00e0y",
+  "contracts.renew.hint":
+    "T\u1ea1o m\u1ed9t th\u1ecfa thu\u1eadn m\u1edbi v\u00e0 \u0111\u00e1nh d\u1ea5u th\u1ecfa thu\u1eadn n\u00e0y l\u00e0 \u0111\u00e3 thay th\u1ebf. \u0110i\u1ec1u kho\u1ea3n ri\u00eang \u2014 kh\u00f4ng g\u00ec \u0111\u01b0\u1ee3c gi\u1eef l\u1ea1i ngo\u00e0i b\u00ean \u0111\u1ed1i t\u00e1c.",
+  "contracts.renew.submit": "Gia h\u1ea1n",
+  "contracts.statusChange.title": "\u0110\u1ed5i tr\u1ea1ng th\u00e1i",
+  "contracts.statusChange.label": "Tr\u1ea1ng th\u00e1i m\u1edbi",
+  "contracts.statusChange.submit": "\u0110\u1ed5i tr\u1ea1ng th\u00e1i",
+  "contracts.cancel.title": "Ghi nh\u1eadn vi\u1ec7c h\u1ee7y",
+  "contracts.cancel.hint":
+    "Kh\u00e1ch h\u00e0ng v\u1eabn c\u00f2n hi\u1ec7u l\u1ef1c h\u1ee3p \u0111\u1ed3ng cho \u0111\u1ebfn ng\u00e0y c\u00f3 hi\u1ec7u l\u1ef1c \u2014 \u0111\u00e2y ch\u1ec9 ghi nh\u1eadn th\u00f4ng b\u00e1o h\u1ee7y, kh\u00f4ng \u0111\u1ed5i tr\u1ea1ng th\u00e1i.",
+  "contracts.cancel.noticeOn": "Ng\u00e0y th\u00f4ng b\u00e1o",
+  "contracts.cancel.effectiveOn": "Ng\u00e0y c\u00f3 hi\u1ec7u l\u1ef1c",
+  "contracts.cancel.effectiveOnHint":
+    "Kh\u00f4ng sau ng\u00e0y k\u1ebft th\u00fac h\u1ee3p \u0111\u1ed3ng, v\u00e0 kh\u00f4ng tr\u01b0\u1edbc ng\u00e0y th\u00f4ng b\u00e1o.",
+  "contracts.cancel.submit": "Ghi nh\u1eadn vi\u1ec7c h\u1ee7y",
+  "contracts.cancel.menuLabel": "H\u1ee7y",
+  "contracts.cancel.errIncomplete": "C\u1ea7n c\u1ea3 hai ng\u00e0y.",
+  "contracts.cancel.errOrder":
+    "Vi\u1ec7c h\u1ee7y kh\u00f4ng th\u1ec3 c\u00f3 hi\u1ec7u l\u1ef1c tr\u01b0\u1edbc ng\u00e0y th\u00f4ng b\u00e1o.",
   "contracts.value.perYear": "m\u1ed7i n\u0103m",
   "contracts.value.total": "cho to\u00e0n b\u1ed9 th\u1eddi h\u1ea1n",
   "contracts.files": "T\u1ec7p",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1148,6 +1148,8 @@ export const vi = {
   "contracts.statusChange.title": "\u0110\u1ed5i tr\u1ea1ng th\u00e1i",
   "contracts.statusChange.label": "Tr\u1ea1ng th\u00e1i m\u1edbi",
   "contracts.statusChange.submit": "\u0110\u1ed5i tr\u1ea1ng th\u00e1i",
+  "contracts.statusChange.errSame":
+    "\u0110\u00e3 \u1edf tr\u1ea1ng th\u00e1i n\u00e0y r\u1ed3i.",
   "contracts.cancel.title": "Ghi nh\u1eadn vi\u1ec7c h\u1ee7y",
   "contracts.cancel.hint":
     "Kh\u00e1ch h\u00e0ng v\u1eabn c\u00f2n hi\u1ec7u l\u1ef1c h\u1ee3p \u0111\u1ed3ng cho \u0111\u1ebfn ng\u00e0y c\u00f3 hi\u1ec7u l\u1ef1c \u2014 \u0111\u00e2y ch\u1ec9 ghi nh\u1eadn th\u00f4ng b\u00e1o h\u1ee7y, kh\u00f4ng \u0111\u1ed5i tr\u1ea1ng th\u00e1i.",
@@ -1156,10 +1158,12 @@ export const vi = {
   "contracts.cancel.effectiveOnHint":
     "Kh\u00f4ng sau ng\u00e0y k\u1ebft th\u00fac h\u1ee3p \u0111\u1ed3ng, v\u00e0 kh\u00f4ng tr\u01b0\u1edbc ng\u00e0y th\u00f4ng b\u00e1o.",
   "contracts.cancel.submit": "Ghi nh\u1eadn vi\u1ec7c h\u1ee7y",
-  "contracts.cancel.menuLabel": "H\u1ee7y",
+  "contracts.cancel.menuLabel": "H\u1ee7y h\u1ee3p \u0111\u1ed3ng",
   "contracts.cancel.errIncomplete": "C\u1ea7n c\u1ea3 hai ng\u00e0y.",
   "contracts.cancel.errOrder":
     "Vi\u1ec7c h\u1ee7y kh\u00f4ng th\u1ec3 c\u00f3 hi\u1ec7u l\u1ef1c tr\u01b0\u1edbc ng\u00e0y th\u00f4ng b\u00e1o.",
+  "contracts.cancel.errTermEnd":
+    "Vi\u1ec7c h\u1ee7y kh\u00f4ng th\u1ec3 c\u00f3 hi\u1ec7u l\u1ef1c sau khi h\u1ee3p \u0111\u1ed3ng \u0111\u00e3 k\u1ebft th\u00fac.",
   "contracts.value.perYear": "m\u1ed7i n\u0103m",
   "contracts.value.total": "cho to\u00e0n b\u1ed9 th\u1eddi h\u1ea1n",
   "contracts.files": "T\u1ec7p",

--- a/frontend/src/screens/companycontracts.menu.test.tsx
+++ b/frontend/src/screens/companycontracts.menu.test.tsx
@@ -1,0 +1,118 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { meFixture } from "../app/mefixture";
+import { LocaleProvider } from "../i18n";
+import { CompanyContractsCard } from "./companycontracts";
+
+// margince#3286: the row menu offered Edit and Archive only. Renew, change
+// status and record-cancellation reach the same POST /contracts/{id}/renewal
+// /status /cancellation the backend has carried since #3230 — this proves the
+// menu actually offers them, and withholds "change status" / "cancel" from a
+// row whose status is terminal (no valid transition exists from one, so the
+// control would only ever refuse — the reasoning #3573/#3700 apply elsewhere).
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const ACTIVE = {
+  id: "c-1",
+  organization_id: "o-1",
+  title: "Framework agreement 2024",
+  source: "manual",
+  captured_by: "human:u-1",
+  status: "active",
+  under_contract: true,
+  auto_renew: false,
+  value_basis: "total",
+  version: 3,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+const EXPIRED = { ...ACTIVE, id: "c-2", status: "expired" };
+
+const GRANTED = meFixture({
+  allow: { contract: ["read", "create", "update", "delete"] },
+});
+
+function stub(contracts: unknown[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const body = url.includes("/me")
+        ? GRANTED
+        : url.includes("/documents")
+          ? { data: [] }
+          : { data: contracts };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  );
+}
+
+function show(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider>{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("the contract row menu", () => {
+  it("offers renew, change status and cancel on a live agreement", async () => {
+    stub([ACTIVE]);
+    const user = userEvent.setup();
+    show(<CompanyContractsCard orgId="o-1" />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Contract actions" }),
+    );
+
+    expect(screen.getByRole("button", { name: "Renew" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Change status" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+
+  it("withholds change-status and cancel from a terminal agreement, but not renew", async () => {
+    stub([EXPIRED]);
+    const user = userEvent.setup();
+    show(<CompanyContractsCard orgId="o-1" />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Contract actions" }),
+    );
+
+    // A terminal status has no valid transition out of it but superseded, and
+    // renewing a non-superseded terminal agreement (expired, cancelled) is
+    // still the normal way a lapsed agreement gets a successor.
+    expect(screen.getByRole("button", { name: "Renew" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Change status" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
+  it("withholds renew from an already-superseded agreement", async () => {
+    stub([{ ...ACTIVE, status: "superseded" }]);
+    const user = userEvent.setup();
+    show(<CompanyContractsCard orgId="o-1" />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Contract actions" }),
+    );
+
+    // refuseRenewalOfTerminal (contract_lifecycle.go): the ONE status renewal
+    // itself refuses is superseded — a chain must stay single-headed.
+    expect(screen.queryByRole("button", { name: "Renew" })).toBeNull();
+  });
+});

--- a/frontend/src/screens/companycontracts.menu.test.tsx
+++ b/frontend/src/screens/companycontracts.menu.test.tsx
@@ -11,9 +11,11 @@ import { CompanyContractsCard } from "./companycontracts";
 // margince#3286: the row menu offered Edit and Archive only. Renew, change
 // status and record-cancellation reach the same POST /contracts/{id}/renewal
 // /status /cancellation the backend has carried since #3230 — this proves the
-// menu actually offers them, and withholds "change status" / "cancel" from a
-// row whose status is terminal (no valid transition exists from one, so the
-// control would only ever refuse — the reasoning #3573/#3700 apply elsewhere).
+// menu actually offers them, and withholds "change status" from a row whose
+// status is terminal (refuseInvalidTransition admits no transition out of one
+// but a same-status no-op, so the control would only ever refuse — the
+// reasoning #3573/#3700 apply elsewhere). Cancel is NOT withheld there:
+// Store.Cancel is a plain column patch with no status check at all.
 
 afterEach(() => {
   cleanup();
@@ -41,13 +43,13 @@ const GRANTED = meFixture({
   allow: { contract: ["read", "create", "update", "delete"] },
 });
 
-function stub(contracts: unknown[]) {
+function stub(contracts: unknown[], me: unknown = GRANTED) {
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL) => {
       const url = input instanceof Request ? input.url : String(input);
       const body = url.includes("/me")
-        ? GRANTED
+        ? me
         : url.includes("/documents")
           ? { data: [] }
           : { data: contracts };
@@ -82,7 +84,9 @@ describe("the contract row menu", () => {
 
     expect(screen.getByRole("button", { name: "Renew" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Change status" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Cancel agreement" }),
+    ).toBeTruthy();
   });
 
   it("withholds change-status and cancel from a terminal agreement, but not renew", async () => {
@@ -99,7 +103,13 @@ describe("the contract row menu", () => {
     // still the normal way a lapsed agreement gets a successor.
     expect(screen.getByRole("button", { name: "Renew" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Change status" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    // Cancel is offered even here: Store.Cancel (contract_lifecycle.go) is a
+    // two-column patch with NO status check at all — unlike ChangeStatus, it
+    // never refuses on a terminal row, so a form withholding it here would
+    // refuse more than the server does.
+    expect(
+      screen.getByRole("button", { name: "Cancel agreement" }),
+    ).toBeTruthy();
   });
 
   it("withholds renew from an already-superseded agreement", async () => {
@@ -114,5 +124,35 @@ describe("the contract row menu", () => {
     // refuseRenewalOfTerminal (contract_lifecycle.go): the ONE status renewal
     // itself refuses is superseded — a chain must stay single-headed.
     expect(screen.queryByRole("button", { name: "Renew" })).toBeNull();
+  });
+
+  it("withholds renew from a seat holding only update, not create", async () => {
+    // Store.Renew (contract_lifecycle.go) asserts BOTH contract:create and
+    // contract:update in one call — it both creates the successor and
+    // supersedes the predecessor. A seat holding update alone would see every
+    // press of Renew refused by the server.
+    stub([ACTIVE], meFixture({ allow: { contract: ["read", "update"] } }));
+    const user = userEvent.setup();
+    show(<CompanyContractsCard orgId="o-1" />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Contract actions" }),
+    );
+
+    expect(screen.queryByRole("button", { name: "Renew" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Change status" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Cancel agreement" }),
+    ).toBeTruthy();
+  });
+
+  it("offers no menu at all to a seat with no write grants", async () => {
+    stub([ACTIVE], meFixture({ allow: { contract: ["read"] } }));
+    show(<CompanyContractsCard orgId="o-1" />);
+
+    await screen.findByText("Framework agreement 2024");
+    expect(
+      screen.queryByRole("button", { name: "Contract actions" }),
+    ).toBeNull();
   });
 });

--- a/frontend/src/screens/companycontracts.tsx
+++ b/frontend/src/screens/companycontracts.tsx
@@ -256,8 +256,11 @@ function ContractRow({
   // agreement gets a successor, so renewal stays offered there.
   const mayRenewThis = mayRenew && contract.status !== "superseded";
   // A terminal status has no valid transition out of it but a same-status
-  // no-op (refuseInvalidTransition), so change-status and cancel are withheld
-  // rather than offered as controls that can only refuse.
+  // no-op (refuseInvalidTransition), so change-status is withheld rather than
+  // offered as a control that can only refuse. Cancel is NOT gated on this:
+  // Store.Cancel is a two-column patch with no status check at all, so it
+  // never refuses on a terminal row — withholding it there would refuse more
+  // than the server does.
   const terminal = isTerminalContractStatus(contract.status);
 
   // The id is a VARIABLE, never closed over: a click landing before React
@@ -339,7 +342,7 @@ function ContractRow({
                 {t("contracts.statusChange.submit")}
               </Button>
             )}
-            {mayWrite && !terminal && (
+            {mayWrite && (
               <Button small onClick={() => setCancelling(true)}>
                 {t("contracts.cancel.menuLabel")}
               </Button>
@@ -353,7 +356,6 @@ function ContractRow({
         )}
       </div>
       <ContractRenewModal
-        orgId={orgId}
         contract={contract}
         open={renewing}
         onClose={() => setRenewing(false)}

--- a/frontend/src/screens/companycontracts.tsx
+++ b/frontend/src/screens/companycontracts.tsx
@@ -19,6 +19,12 @@ import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { throwProblem } from "./common";
 import { ContractForm } from "./contractform";
+import {
+  ContractCancelModal,
+  ContractRenewModal,
+  ContractStatusModal,
+  isTerminalContractStatus,
+} from "./contractlifecycle";
 import { useContractPaper } from "./contractpaper";
 // The row and card shapes this file draws — co-rowlink, co-row-meta, co-card —
 // are defined in company360.css. Imported HERE rather than left to the caller:
@@ -99,6 +105,12 @@ export function CompanyContractsCard({ orgId }: Readonly<{ orgId: string }>) {
   const mayAdd = useCanWrite("contract", "create");
   const mayEdit = useCanWrite("contract", "update");
   const mayArchive = useCanWrite("contract", "delete");
+  // Renew asserts BOTH grants at once (Store.Renew, contract_lifecycle.go: it
+  // requires contract_write's create AND contract_lifecycle's update in one
+  // call, because a renewal both creates the successor and supersedes the
+  // predecessor) — so a seat holding only one of them would see the verb and
+  // have every press refused.
+  const mayRenew = mayAdd && mayEdit;
   const [activeOnly, setActiveOnly] = useState(false);
   // `editing` carries the contract being corrected; undefined means the form is
   // adding a new one. One form serves both, because "record what we agreed" and
@@ -195,6 +207,7 @@ export function CompanyContractsCard({ orgId }: Readonly<{ orgId: string }>) {
                 orgId={orgId}
                 mayWrite={mayEdit}
                 mayArchive={mayArchive}
+                mayRenew={mayRenew}
                 onEdit={() => {
                   setEditing(contract);
                   setFormOpen(true);
@@ -219,19 +232,33 @@ function ContractRow({
   orgId,
   mayWrite,
   mayArchive,
+  mayRenew,
   onEdit,
 }: Readonly<{
   contract: Contract;
   orgId: string;
   mayWrite: boolean;
   mayArchive: boolean;
+  mayRenew: boolean;
   onEdit: () => void;
 }>) {
   const t = useT();
   const { locale } = useLocale();
   const queryClient = useQueryClient();
   const [asking, setAsking] = useState(false);
+  const [renewing, setRenewing] = useState(false);
+  const [changingStatus, setChangingStatus] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
   const basis = basisLabel(contract);
+  // refuseRenewalOfTerminal (contract_lifecycle.go): the ONE status renewal
+  // itself refuses is superseded — a chain must stay single-headed. Every
+  // other terminal status (expired, cancelled) is the normal way a lapsed
+  // agreement gets a successor, so renewal stays offered there.
+  const mayRenewThis = mayRenew && contract.status !== "superseded";
+  // A terminal status has no valid transition out of it but a same-status
+  // no-op (refuseInvalidTransition), so change-status and cancel are withheld
+  // rather than offered as controls that can only refuse.
+  const terminal = isTerminalContractStatus(contract.status);
 
   // The id is a VARIABLE, never closed over: a click landing before React
   // re-arms the mutation would otherwise archive whatever the previous render
@@ -292,7 +319,7 @@ function ContractRow({
             {t(STATUS_LABELS[contract.status])}
           </Badge>
         )}
-        {(mayWrite || mayArchive) && (
+        {(mayWrite || mayArchive || mayRenewThis) && (
           <OverflowMenu label={t("contracts.rowMenu")}>
             {/* Menu items are Buttons, like every other menu in the product.
                 A bare <button> here drew as centred unstyled text inside a
@@ -300,6 +327,21 @@ function ContractRow({
             {mayWrite && (
               <Button small onClick={onEdit}>
                 {t("contracts.edit")}
+              </Button>
+            )}
+            {mayRenewThis && (
+              <Button small onClick={() => setRenewing(true)}>
+                {t("contracts.renew.submit")}
+              </Button>
+            )}
+            {mayWrite && !terminal && (
+              <Button small onClick={() => setChangingStatus(true)}>
+                {t("contracts.statusChange.submit")}
+              </Button>
+            )}
+            {mayWrite && !terminal && (
+              <Button small onClick={() => setCancelling(true)}>
+                {t("contracts.cancel.menuLabel")}
               </Button>
             )}
             {mayArchive && (
@@ -310,6 +352,22 @@ function ContractRow({
           </OverflowMenu>
         )}
       </div>
+      <ContractRenewModal
+        orgId={orgId}
+        contract={contract}
+        open={renewing}
+        onClose={() => setRenewing(false)}
+      />
+      <ContractStatusModal
+        contract={contract}
+        open={changingStatus}
+        onClose={() => setChangingStatus(false)}
+      />
+      <ContractCancelModal
+        contract={contract}
+        open={cancelling}
+        onClose={() => setCancelling(false)}
+      />
       <ConfirmModal
         open={asking}
         onClose={() => setAsking(false)}

--- a/frontend/src/screens/contractform.tsx
+++ b/frontend/src/screens/contractform.tsx
@@ -107,12 +107,12 @@ export function ContractForm({
   // background refetch while this form is open — another tab editing the same
   // agreement, a window-focus refetch — would otherwise re-seed mid-edit and
   // discard whatever the reader had already typed.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
   useEffect(() => {
     if (open) {
       setDraft(draftOf(contract));
       setFile(undefined);
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
   }, [open, contract?.id]);
 
   // The draft is a VARIABLE, never a closure over render state: a click that

--- a/frontend/src/screens/contractform.tsx
+++ b/frontend/src/screens/contractform.tsx
@@ -187,7 +187,7 @@ export function ContractForm({
         <Button
           variant="primary"
           reason={invalid ? t(invalid) : undefined}
-          disabled={save.isPending || invalid !== null}
+          pending={save.isPending}
           onClick={() =>
             save.mutate({ draft: pricedIn(draft, baseCurrency), file })
           }

--- a/frontend/src/screens/contractform.tsx
+++ b/frontend/src/screens/contractform.tsx
@@ -101,12 +101,19 @@ export function ContractForm({
   // Re-seed when the modal opens on a DIFFERENT agreement. Without this the
   // form keeps the previous row's values, and a reader correcting the second
   // contract they clicked would be editing the first one's numbers.
+  //
+  // Keyed on the ID, never the CONTRACT OBJECT: react-query hands back a new
+  // object on every refetch of the same row even when nothing changed, and a
+  // background refetch while this form is open — another tab editing the same
+  // agreement, a window-focus refetch — would otherwise re-seed mid-edit and
+  // discard whatever the reader had already typed.
   useEffect(() => {
     if (open) {
       setDraft(draftOf(contract));
       setFile(undefined);
     }
-  }, [open, contract]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
+  }, [open, contract?.id]);
 
   // The draft is a VARIABLE, never a closure over render state: a click that
   // lands before React re-arms the mutation's options would otherwise submit

--- a/frontend/src/screens/contractform.tsx
+++ b/frontend/src/screens/contractform.tsx
@@ -34,7 +34,11 @@ type ValueBasis = NonNullable<
 // The draft the form edits. Money travels as a pair, so the amount and its
 // currency live together — and that currency is only ever one the record or the
 // installation stated, never a default this file picked on their behalf.
-type ContractDraft = {
+//
+// Exported: RenewContractRequest's terms are the same shape minus
+// organization_id, so contractlifecycle.tsx's renewal form reuses this type,
+// contractTermsBody and ContractTermsFields rather than a second copy of each.
+export type ContractDraft = {
   title: string;
   contractNumber: string;
   valueMinor: number;
@@ -149,6 +153,108 @@ export function ContractForm({
         {t(contract ? "contracts.form.editTitle" : "contracts.form.title")}
       </h2>
 
+      <ContractTermsFields
+        draft={draft}
+        setDraft={setDraft}
+        currency={contractCurrency}
+      />
+
+      <SignedFileField
+        orgId={orgId}
+        contractID={contract?.id}
+        file={file}
+        onPick={setFile}
+      />
+
+      {save.error && (
+        <p className="t-caption" role="alert">
+          {problemMessageOf(save.error, t)}
+        </p>
+      )}
+
+      <div className="modal-actions">
+        <Button onClick={onClose}>{t("create.cancel")}</Button>
+        {/* The refusal travels WITH the control: a disabled button whose
+            reason lives in a paragraph somewhere above it is announced to
+            nobody using a screen reader, and cannot be focused to find out. */}
+        <Button
+          variant="primary"
+          reason={invalid ? t(invalid) : undefined}
+          disabled={save.isPending || invalid !== null}
+          onClick={() =>
+            save.mutate({ draft: pricedIn(draft, baseCurrency), file })
+          }
+        >
+          {t(contract ? "contracts.form.saveEdit" : "contracts.form.save")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+// draftOf reads an existing agreement back into the form's shape, so correcting
+// one starts from what is recorded rather than from a blank the reader has to
+// retype — and might get wrong a second time.
+function draftOf(contract: Contract | undefined): ContractDraft {
+  if (!contract) {
+    return EMPTY_DRAFT;
+  }
+  return {
+    title: contract.title,
+    contractNumber: contract.contract_number ?? "",
+    valueMinor: contract.value_minor ?? 0,
+    // A recorded agreement keeps its OWN currency. The two money columns are
+    // paired by the database, so an agreement carrying none carries no amount
+    // either: it is being priced here for the first time, exactly like a new
+    // one, and takes the installation's unit at the save.
+    currency: contract.currency ?? "",
+    valueBasis: contract.value_basis as ValueBasis,
+    startsOn: contract.starts_on ?? "",
+    endsOn: contract.ends_on ?? "",
+    renewalOn: contract.renewal_on ?? "",
+    noticePeriodDays:
+      contract.notice_period_days == null
+        ? ""
+        : String(contract.notice_period_days),
+    signedOn: contract.signed_on ?? "",
+  };
+}
+
+/**
+ * The draft as it will be SAVED: an amount the reader typed, in the currency the
+ * agreement already records, or else the installation's own.
+ *
+ * Resolved at the save rather than seeded into the draft because the modal opens
+ * the instant a reader clicks a row, which can be before the installation read
+ * has answered — a draft seeded with the blank would keep the blank after the
+ * answer arrived, and re-seeding on arrival would throw away what the reader had
+ * typed by then.
+ *
+ * With no answer at all the currency stays blank, and `contractBody` sends the
+ * half-pair the form actually holds. That is the one honest option left: the
+ * server refuses it where the reader can see the refusal, whereas dropping the
+ * amount would report a saved agreement whose value quietly went nowhere.
+ */
+/**
+ * The nine fields an agreement's own terms are made of — title through signed
+ * date — shared between recording one (this file) and renewing one
+ * (contractlifecycle.tsx's ContractRenewModal). Both write the same shape of
+ * request (RenewContractRequest's terms are CreateContractRequest's minus
+ * organization_id), so this is the one place the fields are drawn rather than
+ * a second, driftable copy of each.
+ */
+export function ContractTermsFields({
+  draft,
+  setDraft,
+  currency,
+}: Readonly<{
+  draft: ContractDraft;
+  setDraft: (draft: ContractDraft) => void;
+  currency: string;
+}>) {
+  const t = useT();
+  return (
+    <>
       <Field label={t("contracts.form.name")} required>
         {(props) => (
           <TextInput
@@ -190,7 +296,7 @@ export function ContractForm({
           <MoneyInput
             {...props}
             min={0}
-            currency={contractCurrency}
+            currency={currency}
             valueMinor={draft.valueMinor}
             // An agreement on record may carry no value at all — the two money
             // columns are paired and both NULL until somebody prices it — so an
@@ -289,83 +395,10 @@ export function ContractForm({
           />
         )}
       </Field>
-
-      <SignedFileField
-        orgId={orgId}
-        contractID={contract?.id}
-        file={file}
-        onPick={setFile}
-      />
-
-      {save.error && (
-        <p className="t-caption" role="alert">
-          {problemMessageOf(save.error, t)}
-        </p>
-      )}
-
-      <div className="modal-actions">
-        <Button onClick={onClose}>{t("create.cancel")}</Button>
-        {/* The refusal travels WITH the control: a disabled button whose
-            reason lives in a paragraph somewhere above it is announced to
-            nobody using a screen reader, and cannot be focused to find out. */}
-        <Button
-          variant="primary"
-          reason={invalid ? t(invalid) : undefined}
-          disabled={save.isPending || invalid !== null}
-          onClick={() =>
-            save.mutate({ draft: pricedIn(draft, baseCurrency), file })
-          }
-        >
-          {t(contract ? "contracts.form.saveEdit" : "contracts.form.save")}
-        </Button>
-      </div>
-    </Modal>
+    </>
   );
 }
 
-// draftOf reads an existing agreement back into the form's shape, so correcting
-// one starts from what is recorded rather than from a blank the reader has to
-// retype — and might get wrong a second time.
-function draftOf(contract: Contract | undefined): ContractDraft {
-  if (!contract) {
-    return EMPTY_DRAFT;
-  }
-  return {
-    title: contract.title,
-    contractNumber: contract.contract_number ?? "",
-    valueMinor: contract.value_minor ?? 0,
-    // A recorded agreement keeps its OWN currency. The two money columns are
-    // paired by the database, so an agreement carrying none carries no amount
-    // either: it is being priced here for the first time, exactly like a new
-    // one, and takes the installation's unit at the save.
-    currency: contract.currency ?? "",
-    valueBasis: contract.value_basis as ValueBasis,
-    startsOn: contract.starts_on ?? "",
-    endsOn: contract.ends_on ?? "",
-    renewalOn: contract.renewal_on ?? "",
-    noticePeriodDays:
-      contract.notice_period_days == null
-        ? ""
-        : String(contract.notice_period_days),
-    signedOn: contract.signed_on ?? "",
-  };
-}
-
-/**
- * The draft as it will be SAVED: an amount the reader typed, in the currency the
- * agreement already records, or else the installation's own.
- *
- * Resolved at the save rather than seeded into the draft because the modal opens
- * the instant a reader clicks a row, which can be before the installation read
- * has answered — a draft seeded with the blank would keep the blank after the
- * answer arrived, and re-seeding on arrival would throw away what the reader had
- * typed by then.
- *
- * With no answer at all the currency stays blank, and `contractBody` sends the
- * half-pair the form actually holds. That is the one honest option left: the
- * server refuses it where the reader can see the refusal, whereas dropping the
- * amount would report a saved agreement whose value quietly went nowhere.
- */
 export function pricedIn(
   draft: ContractDraft,
   baseCurrency: string | undefined,
@@ -560,29 +593,31 @@ export function draftProblem(
 // string. An omitted date is "not recorded"; an empty string is a value the
 // server would have to reject, and the difference is what keeps a half-filled
 // form from reading as a half-known agreement.
-export function contractBody(
-  orgId: string,
-  draft: ContractDraft,
-): components["schemas"]["CreateContractRequest"] {
-  const body: components["schemas"]["CreateContractRequest"] = {
-    organization_id: orgId,
-    title: draft.title.trim(),
-    value_basis: draft.valueBasis,
-    // Stated rather than defaulted: whether an agreement renews itself is a
-    // fact about the paper, and a field the form quietly omitted would be a
-    // guess the record could not distinguish from an answer.
-    auto_renew: false,
-  };
+// The seven fields a create and a renewal share, with the same
+// omit-rather-than-send-empty rule both need: an omitted date is "not
+// recorded"; an empty string is a value the server would have to reject, and
+// the difference is what keeps a half-filled form from reading as a
+// half-known agreement. Money is a PAIR: an amount with no currency cannot be
+// converted, and the record's own CHECK refuses half of one, so the amount
+// travels with the currency the form HOLDS — never one it made up, and never
+// without the amount the reader typed.
+export type ContractTermsFragment = Pick<
+  components["schemas"]["CreateContractRequest"],
+  | "contract_number"
+  | "value_minor"
+  | "currency"
+  | "starts_on"
+  | "ends_on"
+  | "renewal_on"
+  | "notice_period_days"
+  | "signed_on"
+>;
+
+export function contractTermsBody(draft: ContractDraft): ContractTermsFragment {
+  const body: ContractTermsFragment = {};
   if (draft.contractNumber.trim() !== "") {
     body.contract_number = draft.contractNumber.trim();
   }
-  // Money is a PAIR: an amount with no currency cannot be converted, and the
-  // record's own CHECK refuses half of one. So the amount travels with the
-  // currency the form HOLDS — never with one it made up, and never without the
-  // amount the reader typed. Holding no currency, the form sends the half-pair
-  // and takes the refusal: an invented unit would be believed for the life of
-  // the record, and dropping the amount would report a saved agreement whose
-  // value quietly went nowhere.
   if (draft.valueMinor > 0) {
     body.value_minor = draft.valueMinor;
     if (draft.currency !== "") {
@@ -605,4 +640,20 @@ export function contractBody(
     body.signed_on = draft.signedOn;
   }
   return body;
+}
+
+export function contractBody(
+  orgId: string,
+  draft: ContractDraft,
+): components["schemas"]["CreateContractRequest"] {
+  return {
+    organization_id: orgId,
+    title: draft.title.trim(),
+    value_basis: draft.valueBasis,
+    // Stated rather than defaulted: whether an agreement renews itself is a
+    // fact about the paper, and a field the form quietly omitted would be a
+    // guess the record could not distinguish from an answer.
+    auto_renew: false,
+    ...contractTermsBody(draft),
+  };
 }

--- a/frontend/src/screens/contractlifecycle.stories.tsx
+++ b/frontend/src/screens/contractlifecycle.stories.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { components } from "../api/schema";
+import {
+  ContractCancelModal,
+  ContractRenewModal,
+  ContractStatusModal,
+} from "./contractlifecycle";
+import {
+  installFetchStub,
+  jsonResponse,
+  meRoute,
+  StoryProviders,
+} from "./story-utils";
+
+// margince#3286: the three transitions a signed agreement goes through after
+// it is first recorded. The backend chain (Store.Renew / ChangeStatus /
+// Cancel) predates this — these modals are the first frontend door onto it.
+
+const meta: Meta = {
+  title: "Records/Company 360/Contract lifecycle",
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj;
+type Contract = components["schemas"]["Contract"];
+
+const AGREEMENT = {
+  id: "c-1",
+  organization_id: "o-1",
+  title: "Pallet pooling framework",
+  contract_number: "SM-2026-014",
+  status: "active",
+  under_contract: true,
+  auto_renew: false,
+  value_basis: "annualized_12m",
+  value_minor: 14850000,
+  currency: "EUR",
+  starts_on: "2026-11-01",
+  version: 3,
+  created_at: "2026-10-20T00:00:00Z",
+  updated_at: "2026-10-20T00:00:00Z",
+} as unknown as Contract;
+
+function routes() {
+  installFetchStub({
+    "GET /me": meRoute({ contract: ["read", "create", "update"] }),
+    "GET /installation/settings": () => jsonResponse({ base_currency: "EUR" }),
+  });
+}
+
+/** Renewing an agreement: the successor's own terms, prefilled from the
+ * predecessor's title and basis — nothing else, since a renewal is usually a
+ * fresh negotiation. */
+export const RenewOpen: Story = {
+  render: () => {
+    routes();
+    return (
+      <StoryProviders>
+        <ContractRenewModal
+          orgId="o-1"
+          contract={AGREEMENT}
+          open
+          onClose={() => {}}
+        />
+      </StoryProviders>
+    );
+  },
+};
+
+/** Asserting a new status — draft, active, expired or cancelled. Superseded
+ * is never offered here: a contract only arrives at it through renewal. */
+export const StatusChangeOpen: Story = {
+  render: () => {
+    routes();
+    return (
+      <StoryProviders>
+        <ContractStatusModal contract={AGREEMENT} open onClose={() => {}} />
+      </StoryProviders>
+    );
+  },
+};
+
+/** Recording a cancellation: notice given and when it takes effect. The
+ * status does not move — the customer stays under contract until the
+ * effective date. */
+export const CancelOpen: Story = {
+  render: () => {
+    routes();
+    return (
+      <StoryProviders>
+        <ContractCancelModal contract={AGREEMENT} open onClose={() => {}} />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/screens/contractlifecycle.stories.tsx
+++ b/frontend/src/screens/contractlifecycle.stories.tsx
@@ -60,12 +60,7 @@ export const RenewOpen: Story = {
     routes();
     return (
       <StoryProviders>
-        <ContractRenewModal
-          orgId="o-1"
-          contract={AGREEMENT}
-          open
-          onClose={() => {}}
-        />
+        <ContractRenewModal contract={AGREEMENT} open onClose={() => {}} />
       </StoryProviders>
     );
   },

--- a/frontend/src/screens/contractlifecycle.test.tsx
+++ b/frontend/src/screens/contractlifecycle.test.tsx
@@ -46,7 +46,7 @@ function show(ui: ReactNode) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  render(
+  return render(
     <QueryClientProvider client={client}>
       <LocaleProvider>{ui}</LocaleProvider>
     </QueryClientProvider>,
@@ -308,5 +308,44 @@ describe("ContractCancelModal", () => {
     );
 
     expect(posted).toBe(false);
+  });
+
+  // CodeRabbit (PR #4002): the reseed effect keyed on [open, contract] — the
+  // OBJECT reference. react-query hands back a new object on every refetch of
+  // the same row even when nothing the reader can see changed, so a
+  // background orgContracts refetch while this modal is open (another tab
+  // editing the same contract, a window-focus refetch) replaced `contract`
+  // and re-ran the effect, discarding whatever the reader had already typed.
+  // Keying on contract.id instead means a REFETCH of the same row leaves the
+  // draft alone; only a genuinely different row (or a fresh open) reseeds it.
+  it("keeps what the reader typed across a background refetch of the same row", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <LocaleProvider>
+          <ContractCancelModal contract={PREDECESSOR} open onClose={() => {}} />
+        </LocaleProvider>
+      </QueryClientProvider>,
+    );
+    const user = userEvent.setup();
+    await user.type(
+      await screen.findByLabelText(/^Notice given/),
+      "2026-06-01",
+    );
+
+    // The SAME row, refetched: a new object, same id, a version bump — the
+    // exact shape a background orgContracts refetch hands back.
+    const refetched: Contract = { ...PREDECESSOR, version: 4 };
+    rerender(
+      <QueryClientProvider client={client}>
+        <LocaleProvider>
+          <ContractCancelModal contract={refetched} open onClose={() => {}} />
+        </LocaleProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByLabelText(/^Notice given/)).toHaveValue("2026-06-01");
   });
 });

--- a/frontend/src/screens/contractlifecycle.test.tsx
+++ b/frontend/src/screens/contractlifecycle.test.tsx
@@ -1,0 +1,259 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import {
+  ContractCancelModal,
+  ContractRenewModal,
+  ContractStatusModal,
+  isTerminalContractStatus,
+} from "./contractlifecycle";
+
+// margince#3286: the backend chain (Store.Renew, POST /contracts/{id}/renewal)
+// was correct and tested; nothing in the app could reach it. These prove the
+// modal sends the successor's own terms — inheriting nothing but the
+// counterparty, which the server derives — and the version it read, so a
+// concurrent edit is refused rather than silently overwritten.
+
+type Contract = components["schemas"]["Contract"];
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const PREDECESSOR: Contract = {
+  id: "c-1",
+  organization_id: "o-1",
+  title: "Framework agreement 2024",
+  source: "manual",
+  captured_by: "human:u-1",
+  status: "active",
+  under_contract: true,
+  auto_renew: false,
+  value_basis: "annualized_12m",
+  version: 3,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+function show(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider>{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ContractRenewModal", () => {
+  it("posts the successor's own title, basis and the predecessor's version as If-Match", async () => {
+    let posted: { body: unknown; ifMatch: string | null; path: string } | null =
+      null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        if (request.method === "POST" && url.pathname.endsWith("/renewal")) {
+          posted = {
+            body: await request.json(),
+            ifMatch: request.headers.get("if-match"),
+            path: url.pathname,
+          };
+          return new Response(
+            JSON.stringify({ ...PREDECESSOR, id: "c-2", version: 1 }),
+            { status: 201, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    show(
+      <ContractRenewModal
+        orgId="o-1"
+        contract={PREDECESSOR}
+        open
+        onClose={onClose}
+      />,
+    );
+
+    // Prefilled from the predecessor, both editable.
+    const title = await screen.findByLabelText(/^Title/);
+    expect(title).toHaveValue("Framework agreement 2024");
+
+    await user.click(screen.getByRole("button", { name: "Renew" }));
+
+    await waitFor(() => expect(posted).not.toBeNull());
+    const sent = posted as unknown as {
+      body: { title?: string; value_basis?: string };
+      ifMatch: string | null;
+      path: string;
+    };
+    expect(sent.path).toBe("/v1/contracts/c-1/renewal");
+    expect(sent.ifMatch).toBe("3");
+    expect(sent.body.title).toBe("Framework agreement 2024");
+    expect(sent.body.value_basis).toBe("annualized_12m");
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("shows the server's refusal inline rather than closing silently", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              code: "validation_error",
+              detail: "a term cannot end before it starts",
+            }),
+            { status: 422, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    show(
+      <ContractRenewModal
+        orgId="o-1"
+        contract={PREDECESSOR}
+        open
+        onClose={onClose}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Renew" }));
+
+    await screen.findByText(/a term cannot end before it starts/);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+// A terminal status has no valid transition out of it other than a same-status
+// no-op (refuseInvalidTransition, contract_lifecycle.go), so a row in one of
+// these offers neither "change status" nor "cancel" — both would be controls
+// that can only refuse, same reasoning #3573/#3700 already hold for the plan's
+// write controls.
+describe("isTerminalContractStatus", () => {
+  it("is true for the three statuses a contract cannot leave", () => {
+    expect(isTerminalContractStatus("expired")).toBe(true);
+    expect(isTerminalContractStatus("cancelled")).toBe(true);
+    expect(isTerminalContractStatus("superseded")).toBe(true);
+  });
+
+  it("is false for the two a human can still move", () => {
+    expect(isTerminalContractStatus("draft")).toBe(false);
+    expect(isTerminalContractStatus("active")).toBe(false);
+  });
+});
+
+describe("ContractStatusModal", () => {
+  it("posts the selected status with the row's version as If-Match", async () => {
+    let posted: { body: unknown; ifMatch: string | null; path: string } | null =
+      null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        if (request.method === "POST" && url.pathname.endsWith("/status")) {
+          posted = {
+            body: await request.json(),
+            ifMatch: request.headers.get("if-match"),
+            path: url.pathname,
+          };
+          return new Response(
+            JSON.stringify({ ...PREDECESSOR, status: "expired" }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    show(<ContractStatusModal contract={PREDECESSOR} open onClose={onClose} />);
+
+    await user.click(await screen.findByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "Expired" }));
+    await user.click(screen.getByRole("button", { name: "Change status" }));
+
+    await waitFor(() => expect(posted).not.toBeNull());
+    const sent = posted as unknown as {
+      body: { status?: string };
+      ifMatch: string | null;
+      path: string;
+    };
+    expect(sent.path).toBe("/v1/contracts/c-1/status");
+    expect(sent.ifMatch).toBe("3");
+    expect(sent.body.status).toBe("expired");
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});
+
+describe("ContractCancelModal", () => {
+  it("posts notice and effective dates with the row's version as If-Match", async () => {
+    let posted: { body: unknown; ifMatch: string | null; path: string } | null =
+      null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        if (
+          request.method === "POST" &&
+          url.pathname.endsWith("/cancellation")
+        ) {
+          posted = {
+            body: await request.json(),
+            ifMatch: request.headers.get("if-match"),
+            path: url.pathname,
+          };
+          return new Response(JSON.stringify(PREDECESSOR), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    show(<ContractCancelModal contract={PREDECESSOR} open onClose={onClose} />);
+
+    const notice = await screen.findByLabelText(/^Notice given/);
+    await user.type(notice, "2026-06-01");
+    const effective = screen.getByLabelText(/^Takes effect/);
+    await user.type(effective, "2026-09-01");
+    await user.click(
+      screen.getByRole("button", { name: "Record cancellation" }),
+    );
+
+    await waitFor(() => expect(posted).not.toBeNull());
+    const sent = posted as unknown as {
+      body: {
+        cancellation_notice_on?: string;
+        cancellation_effective_on?: string;
+      };
+      ifMatch: string | null;
+      path: string;
+    };
+    expect(sent.path).toBe("/v1/contracts/c-1/cancellation");
+    expect(sent.ifMatch).toBe("3");
+    expect(sent.body.cancellation_notice_on).toBe("2026-06-01");
+    expect(sent.body.cancellation_effective_on).toBe("2026-09-01");
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/screens/contractlifecycle.test.tsx
+++ b/frontend/src/screens/contractlifecycle.test.tsx
@@ -79,14 +79,7 @@ describe("ContractRenewModal", () => {
     );
     const user = userEvent.setup();
     const onClose = vi.fn();
-    show(
-      <ContractRenewModal
-        orgId="o-1"
-        contract={PREDECESSOR}
-        open
-        onClose={onClose}
-      />,
-    );
+    show(<ContractRenewModal contract={PREDECESSOR} open onClose={onClose} />);
 
     // Prefilled from the predecessor, both editable.
     const title = await screen.findByLabelText(/^Title/);
@@ -96,14 +89,22 @@ describe("ContractRenewModal", () => {
 
     await waitFor(() => expect(posted).not.toBeNull());
     const sent = posted as unknown as {
-      body: { title?: string; value_basis?: string };
+      body: Record<string, unknown>;
       ifMatch: string | null;
       path: string;
     };
     expect(sent.path).toBe("/v1/contracts/c-1/renewal");
     expect(sent.ifMatch).toBe("3");
-    expect(sent.body.title).toBe("Framework agreement 2024");
-    expect(sent.body.value_basis).toBe("annualized_12m");
+    // The FULL body, not two fields of it: RenewContractRequest inherits
+    // nothing from the predecessor but the counterparty (which the server
+    // derives from the path, not the body) — a regression that leaked
+    // value_minor or currency from the predecessor would pass a check that
+    // only asserted title and value_basis.
+    expect(sent.body).toEqual({
+      title: "Framework agreement 2024",
+      value_basis: "annualized_12m",
+      auto_renew: false,
+    });
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
@@ -123,14 +124,7 @@ describe("ContractRenewModal", () => {
     );
     const user = userEvent.setup();
     const onClose = vi.fn();
-    show(
-      <ContractRenewModal
-        orgId="o-1"
-        contract={PREDECESSOR}
-        open
-        onClose={onClose}
-      />,
-    );
+    show(<ContractRenewModal contract={PREDECESSOR} open onClose={onClose} />);
 
     await user.click(await screen.findByRole("button", { name: "Renew" }));
 
@@ -200,6 +194,36 @@ describe("ContractStatusModal", () => {
     expect(sent.body.status).toBe("expired");
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
+
+  it("refuses to submit the status the row already carries", async () => {
+    // recordAssignment (patch.go) records a SET regardless of whether the new
+    // value equals the old one, so a same-status POST still bumps the row's
+    // version and writes an audit row + a from==to contract.status_changed
+    // event — a write nobody asked for and a no-op that isn't free.
+    let posted = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        if (request.method === "POST" && url.pathname.endsWith("/status")) {
+          posted = true;
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+    const user = userEvent.setup();
+    show(
+      <ContractStatusModal contract={PREDECESSOR} open onClose={() => {}} />,
+    );
+
+    // The Select opens seeded with the row's own status (active) — untouched.
+    await screen.findByRole("combobox");
+    await user.click(screen.getByRole("button", { name: "Change status" }));
+
+    expect(posted).toBe(false);
+  });
 });
 
 describe("ContractCancelModal", () => {
@@ -255,5 +279,34 @@ describe("ContractCancelModal", () => {
     expect(sent.body.cancellation_notice_on).toBe("2026-06-01");
     expect(sent.body.cancellation_effective_on).toBe("2026-09-01");
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("refuses an effective date after the term already ends", async () => {
+    // contract_cancellation_within_term (contractCheckError,
+    // contract_lifecycle.go): "a cancellation cannot take effect after the
+    // term already ends." Held client-side too, so the control does not
+    // enable a submit the server is certain to refuse.
+    let posted = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        posted = true;
+        return new Response("not found", { status: 404 });
+      }),
+    );
+    const user = userEvent.setup();
+    const dated = { ...PREDECESSOR, ends_on: "2026-08-01" };
+    show(<ContractCancelModal contract={dated} open onClose={() => {}} />);
+
+    await user.type(
+      await screen.findByLabelText(/^Notice given/),
+      "2026-06-01",
+    );
+    await user.type(screen.getByLabelText(/^Takes effect/), "2026-09-01");
+    await user.click(
+      screen.getByRole("button", { name: "Record cancellation" }),
+    );
+
+    expect(posted).toBe(false);
   });
 });

--- a/frontend/src/screens/contractlifecycle.tsx
+++ b/frontend/src/screens/contractlifecycle.tsx
@@ -138,11 +138,17 @@ export function ContractRenewModal({
 
   // Re-seed on open, and when a different row's renewal is what just opened:
   // otherwise the form keeps the previous agreement's title and basis.
+  //
+  // Keyed on the ID, never the CONTRACT OBJECT: react-query hands back a new
+  // object on every refetch of the same row even when nothing changed, and a
+  // background refetch while this modal is open would otherwise re-seed
+  // mid-edit and discard whatever the reader had already typed.
   useEffect(() => {
     if (open) {
       setDraft(renewDraftOf(contract));
     }
-  }, [open, contract]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
+  }, [open, contract.id]);
 
   const renew = useMutation({
     mutationFn: async (submitted: {
@@ -235,11 +241,15 @@ export function ContractStatusModal({
     contract.status ?? "draft",
   );
 
+  // Keyed on the ID, never the CONTRACT OBJECT — see ContractRenewModal's
+  // identical comment: a background refetch of the SAME row must not discard
+  // a status the reader already picked.
   useEffect(() => {
     if (open) {
       setStatus(contract.status ?? "draft");
     }
-  }, [open, contract]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
+  }, [open, contract.id]);
 
   const assert = useMutation({
     mutationFn: async (submitted: {
@@ -343,12 +353,16 @@ export function ContractCancelModal({
   const [noticeOn, setNoticeOn] = useState("");
   const [effectiveOn, setEffectiveOn] = useState("");
 
+  // Keyed on the ID, never the CONTRACT OBJECT — see ContractRenewModal's
+  // identical comment: a background refetch of the SAME row must not discard
+  // dates the reader already typed.
   useEffect(() => {
     if (open) {
       setNoticeOn(contract.cancellation_notice_on ?? "");
       setEffectiveOn(contract.cancellation_effective_on ?? "");
     }
-  }, [open, contract]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
+  }, [open, contract.id]);
 
   const cancel = useMutation({
     mutationFn: async (submitted: {

--- a/frontend/src/screens/contractlifecycle.tsx
+++ b/frontend/src/screens/contractlifecycle.tsx
@@ -190,7 +190,7 @@ export function ContractRenewModal({
         <Button
           variant="primary"
           reason={invalid ? t(invalid) : undefined}
-          disabled={renew.isPending || invalid !== null}
+          pending={renew.isPending}
           onClick={() =>
             renew.mutate({
               predecessor: contract,
@@ -304,7 +304,7 @@ export function ContractStatusModal({
               ? t("contracts.statusChange.errSame")
               : undefined
           }
-          disabled={assert.isPending || status === contract.status}
+          pending={assert.isPending}
           onClick={() => assert.mutate({ contract, status })}
         >
           {t("contracts.statusChange.submit")}
@@ -441,7 +441,7 @@ export function ContractCancelModal({
         <Button
           variant="danger"
           reason={invalid ? t(invalid) : undefined}
-          disabled={cancel.isPending || invalid !== null}
+          pending={cancel.isPending}
           onClick={() => cancel.mutate({ contract, noticeOn, effectiveOn })}
         >
           {t("contracts.cancel.submit")}

--- a/frontend/src/screens/contractlifecycle.tsx
+++ b/frontend/src/screens/contractlifecycle.tsx
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useId, useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { ifMatch, requireVersion } from "../api/version";
+import { useInstallationSettings } from "../app/uploadlimit";
+import { Button, Field, Modal, TextInput } from "../design-system/atoms";
+import { MoneyInput } from "../design-system/moneyinput";
+import { Select } from "../design-system/select";
+import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { problemMessageOf, throwProblem } from "./common";
+import { draftProblem, pricedIn } from "./contractform";
+
+// margince#3286: the three transitions a signed agreement actually goes
+// through after it is first recorded — renew, assert a status, record a
+// cancellation. Store.Renew / ChangeStatus / Cancel and their endpoints
+// (POST /contracts/{id}/renewal /status /cancellation) have always been
+// correct; nothing in the app could reach them.
+
+type Contract = components["schemas"]["Contract"];
+type ContractStatus = NonNullable<Contract["status"]>;
+type ValueBasis = NonNullable<
+  components["schemas"]["RenewContractRequest"]["value_basis"]
+>;
+
+// A status a contract can only ARRIVE at through renewal — the server sets it
+// on the predecessor, in the same transaction that creates the successor
+// (Store.Renew, contract_lifecycle.go). Asserting it directly is a transition
+// refuseInvalidTransition refuses, so it is never offered here.
+const ASSERTABLE_STATUSES: ContractStatus[] = [
+  "draft",
+  "active",
+  "expired",
+  "cancelled",
+];
+
+const STATUS_LABEL_KEY: Record<ContractStatus, MessageKey> = {
+  draft: "contracts.status.draft",
+  active: "contracts.status.active",
+  expired: "contracts.status.expired",
+  cancelled: "contracts.status.cancelled",
+  superseded: "contracts.status.superseded",
+};
+
+// A terminal status has no valid transition out of it other than a
+// same-status no-op (refuseInvalidTransition, contract_lifecycle.go), so
+// offering "change status" or "cancel" from one would be a control that can
+// only refuse — the reasoning #3573/#3700 already apply to the plan's write
+// controls.
+export function isTerminalContractStatus(status: Contract["status"]): boolean {
+  return (
+    status === "expired" || status === "cancelled" || status === "superseded"
+  );
+}
+
+type RenewDraft = {
+  title: string;
+  contractNumber: string;
+  valueMinor: number;
+  currency: string;
+  valueBasis: ValueBasis;
+  startsOn: string;
+  endsOn: string;
+  renewalOn: string;
+  noticePeriodDays: string;
+  signedOn: string;
+};
+
+function renewDraftOf(predecessor: Contract): RenewDraft {
+  return {
+    // Title and basis are the two fields the successor is likeliest to keep,
+    // and both are required by the wire request — prefilled so renewing an
+    // unchanged agreement does not mean retyping what it was already called.
+    // Everything else the predecessor does NOT hand down: RenewContractRequest
+    // inherits only the counterparty (the server derives that), because a
+    // renewal is usually a fresh negotiation and an inherited amount or term
+    // would be a number nobody actually agreed to this time.
+    title: predecessor.title,
+    contractNumber: "",
+    valueMinor: 0,
+    currency: "",
+    valueBasis: (predecessor.value_basis as ValueBasis) ?? "total",
+    startsOn: "",
+    endsOn: "",
+    renewalOn: "",
+    noticePeriodDays: "",
+    signedOn: "",
+  };
+}
+
+function renewalBody(
+  draft: RenewDraft,
+): components["schemas"]["RenewContractRequest"] {
+  const body: components["schemas"]["RenewContractRequest"] = {
+    title: draft.title.trim(),
+    value_basis: draft.valueBasis,
+    // Stated rather than defaulted, for the same reason contractBody
+    // (contractform.tsx) states it on a create: whether the successor renews
+    // itself is a fact about the paper, and a field this form quietly omitted
+    // would be a guess the record could not distinguish from an answer.
+    auto_renew: false,
+  };
+  if (draft.contractNumber.trim() !== "") {
+    body.contract_number = draft.contractNumber.trim();
+  }
+  if (draft.valueMinor > 0) {
+    body.value_minor = draft.valueMinor;
+    if (draft.currency !== "") {
+      body.currency = draft.currency;
+    }
+  }
+  if (draft.startsOn !== "") {
+    body.starts_on = draft.startsOn;
+  }
+  if (draft.endsOn !== "") {
+    body.ends_on = draft.endsOn;
+  }
+  if (draft.renewalOn !== "") {
+    body.renewal_on = draft.renewalOn;
+  }
+  if (draft.noticePeriodDays !== "") {
+    body.notice_period_days = Number(draft.noticePeriodDays);
+  }
+  if (draft.signedOn !== "") {
+    body.signed_on = draft.signedOn;
+  }
+  return body;
+}
+
+// The successor's terms, created in the same transaction that supersedes the
+// predecessor — the id and version this call takes are the predecessor's, and
+// they never come from a closure: a click that lands after the modal has
+// re-rendered for a different row would otherwise renew whichever contract the
+// previous render held.
+async function renewContract(
+  predecessor: Contract,
+  draft: RenewDraft,
+): Promise<string> {
+  const { data, error } = await api.POST("/contracts/{id}/renewal", {
+    params: {
+      path: { id: predecessor.id },
+      ...ifMatch(requireVersion(predecessor.version)),
+    },
+    body: renewalBody(draft),
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data?.id ?? "";
+}
+
+export function ContractRenewModal({
+  orgId,
+  contract,
+  open,
+  onClose,
+}: Readonly<{
+  orgId: string;
+  contract: Contract;
+  open: boolean;
+  onClose: () => void;
+}>) {
+  const t = useT();
+  const titleId = useId();
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = useState<RenewDraft>(renewDraftOf(contract));
+  const baseCurrency = useInstallationSettings().data?.base_currency;
+  const contractCurrency = draft.currency || baseCurrency || "";
+
+  // Re-seed on open, and when a different row's renewal is what just opened:
+  // otherwise the form keeps the previous agreement's title and basis.
+  useEffect(() => {
+    if (open) {
+      setDraft(renewDraftOf(contract));
+    }
+  }, [open, contract]);
+
+  const renew = useMutation({
+    mutationFn: async (submitted: {
+      predecessor: Contract;
+      draft: RenewDraft;
+    }) => renewContract(submitted.predecessor, submitted.draft),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["orgContracts", orgId] });
+      queryClient.invalidateQueries({ queryKey: ["organization360", orgId] });
+      onClose();
+    },
+  });
+
+  const invalid = draftProblem(draft);
+
+  return (
+    <Modal open={open} onClose={onClose} labelledBy={titleId}>
+      <h2 id={titleId}>{t("contracts.renew.title")}</h2>
+      <p className="t-caption">{t("contracts.renew.hint")}</p>
+
+      <Field label={t("contracts.form.name")} required>
+        {(props) => (
+          <TextInput
+            {...props}
+            value={draft.title}
+            onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+          />
+        )}
+      </Field>
+
+      <Field label={t("contracts.form.number")}>
+        {(props) => (
+          <TextInput
+            {...props}
+            value={draft.contractNumber}
+            onChange={(e) =>
+              setDraft({ ...draft, contractNumber: e.target.value })
+            }
+          />
+        )}
+      </Field>
+
+      <Field label={t("contracts.form.value")}>
+        {(props) => (
+          <MoneyInput
+            {...props}
+            min={0}
+            currency={contractCurrency}
+            valueMinor={draft.valueMinor}
+            blankWhenZero
+            onChangeMinor={(valueMinor) => setDraft({ ...draft, valueMinor })}
+          />
+        )}
+      </Field>
+
+      <Field label={t("contracts.form.basis")} required>
+        {(props) => (
+          <Select
+            {...props}
+            value={draft.valueBasis}
+            onChange={(value) =>
+              setDraft({ ...draft, valueBasis: value as ValueBasis })
+            }
+            options={[
+              { value: "total", label: t("contracts.basis.total") },
+              { value: "annualized_12m", label: t("contracts.basis.annual") },
+            ]}
+          />
+        )}
+      </Field>
+
+      <Field label={t("contracts.form.startsOn")}>
+        {(props) => (
+          <TextInput
+            {...props}
+            type="date"
+            value={draft.startsOn}
+            onChange={(e) => setDraft({ ...draft, startsOn: e.target.value })}
+          />
+        )}
+      </Field>
+
+      <Field
+        label={t("contracts.form.endsOn")}
+        hint={t("contracts.form.endsOnHint")}
+      >
+        {(props) => (
+          <TextInput
+            {...props}
+            type="date"
+            value={draft.endsOn}
+            onChange={(e) => setDraft({ ...draft, endsOn: e.target.value })}
+          />
+        )}
+      </Field>
+
+      <Field label={t("contracts.form.renewalOn")}>
+        {(props) => (
+          <TextInput
+            {...props}
+            type="date"
+            value={draft.renewalOn}
+            onChange={(e) => setDraft({ ...draft, renewalOn: e.target.value })}
+          />
+        )}
+      </Field>
+
+      <Field
+        label={t("contracts.form.noticeDays")}
+        hint={t("contracts.form.noticeDaysHint")}
+      >
+        {(props) => (
+          <TextInput
+            {...props}
+            type="number"
+            min={0}
+            value={draft.noticePeriodDays}
+            onChange={(e) =>
+              setDraft({ ...draft, noticePeriodDays: e.target.value })
+            }
+          />
+        )}
+      </Field>
+
+      <Field
+        label={t("contracts.form.signedOn")}
+        hint={t("contracts.form.signedOnHint")}
+      >
+        {(props) => (
+          <TextInput
+            {...props}
+            type="date"
+            value={draft.signedOn}
+            onChange={(e) => setDraft({ ...draft, signedOn: e.target.value })}
+          />
+        )}
+      </Field>
+
+      {renew.error && (
+        <p className="t-caption" role="alert">
+          {problemMessageOf(renew.error, t)}
+        </p>
+      )}
+
+      <div className="modal-actions">
+        <Button onClick={onClose}>{t("create.cancel")}</Button>
+        <Button
+          variant="primary"
+          reason={invalid ? t(invalid) : undefined}
+          disabled={renew.isPending || invalid !== null}
+          onClick={() =>
+            renew.mutate({
+              predecessor: contract,
+              draft: pricedIn(draft, baseCurrency),
+            })
+          }
+        >
+          {t("contracts.renew.submit")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+// A status is a fact a human asserted, never inferred from a date — the same
+// invariant contract_lifecycle.go's own comment states. This is that assertion's
+// only door: one Select, one submit, and the version the row was read at.
+async function changeContractStatus(
+  contract: Contract,
+  status: ContractStatus,
+): Promise<Contract> {
+  const { data, error } = await api.POST("/contracts/{id}/status", {
+    params: {
+      path: { id: contract.id },
+      ...ifMatch(requireVersion(contract.version)),
+    },
+    body: { status },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data;
+}
+
+export function ContractStatusModal({
+  contract,
+  open,
+  onClose,
+}: Readonly<{
+  contract: Contract;
+  open: boolean;
+  onClose: () => void;
+}>) {
+  const t = useT();
+  const titleId = useId();
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<ContractStatus>(
+    contract.status ?? "draft",
+  );
+
+  useEffect(() => {
+    if (open) {
+      setStatus(contract.status ?? "draft");
+    }
+  }, [open, contract]);
+
+  const assert = useMutation({
+    mutationFn: async (submitted: {
+      contract: Contract;
+      status: ContractStatus;
+    }) => changeContractStatus(submitted.contract, submitted.status),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["orgContracts", contract.organization_id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["organization360", contract.organization_id],
+      });
+      onClose();
+    },
+  });
+
+  return (
+    <Modal open={open} onClose={onClose} labelledBy={titleId}>
+      <h2 id={titleId}>{t("contracts.statusChange.title")}</h2>
+
+      <Field label={t("contracts.statusChange.label")}>
+        {(props) => (
+          <Select
+            {...props}
+            value={status}
+            onChange={(value) => setStatus(value as ContractStatus)}
+            options={ASSERTABLE_STATUSES.map((value) => ({
+              value,
+              label: t(STATUS_LABEL_KEY[value]),
+            }))}
+          />
+        )}
+      </Field>
+
+      {assert.error && (
+        <p className="t-caption" role="alert">
+          {problemMessageOf(assert.error, t)}
+        </p>
+      )}
+
+      <div className="modal-actions">
+        <Button onClick={onClose}>{t("create.cancel")}</Button>
+        <Button
+          variant="primary"
+          disabled={assert.isPending}
+          onClick={() => assert.mutate({ contract, status })}
+        >
+          {t("contracts.statusChange.submit")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+// Cancellation is two facts and NO state change — the same invariant
+// Store.Cancel's own comment states. The customer stays under contract until
+// the effective date; only the row's "ends" reading moves, not its status.
+async function cancelContract(
+  contract: Contract,
+  noticeOn: string,
+  effectiveOn: string,
+): Promise<Contract> {
+  const { data, error } = await api.POST("/contracts/{id}/cancellation", {
+    params: {
+      path: { id: contract.id },
+      ...ifMatch(requireVersion(contract.version)),
+    },
+    body: {
+      cancellation_notice_on: noticeOn,
+      cancellation_effective_on: effectiveOn,
+    },
+  });
+  if (error) {
+    throwProblem(error);
+  }
+  return data;
+}
+
+export function ContractCancelModal({
+  contract,
+  open,
+  onClose,
+}: Readonly<{
+  contract: Contract;
+  open: boolean;
+  onClose: () => void;
+}>) {
+  const t = useT();
+  const titleId = useId();
+  const queryClient = useQueryClient();
+  const [noticeOn, setNoticeOn] = useState("");
+  const [effectiveOn, setEffectiveOn] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setNoticeOn(contract.cancellation_notice_on ?? "");
+      setEffectiveOn(contract.cancellation_effective_on ?? "");
+    }
+  }, [open, contract]);
+
+  const cancel = useMutation({
+    mutationFn: async (submitted: {
+      contract: Contract;
+      noticeOn: string;
+      effectiveOn: string;
+    }) =>
+      cancelContract(
+        submitted.contract,
+        submitted.noticeOn,
+        submitted.effectiveOn,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["orgContracts", contract.organization_id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["organization360", contract.organization_id],
+      });
+      onClose();
+    },
+  });
+
+  const invalid =
+    noticeOn === "" || effectiveOn === ""
+      ? "contracts.cancel.errIncomplete"
+      : effectiveOn < noticeOn
+        ? "contracts.cancel.errOrder"
+        : null;
+
+  return (
+    <Modal open={open} onClose={onClose} labelledBy={titleId}>
+      <h2 id={titleId}>{t("contracts.cancel.title")}</h2>
+      <p className="t-caption">{t("contracts.cancel.hint")}</p>
+
+      <Field label={t("contracts.cancel.noticeOn")} required>
+        {(props) => (
+          <TextInput
+            {...props}
+            type="date"
+            value={noticeOn}
+            onChange={(e) => setNoticeOn(e.target.value)}
+          />
+        )}
+      </Field>
+
+      <Field
+        label={t("contracts.cancel.effectiveOn")}
+        hint={t("contracts.cancel.effectiveOnHint")}
+        required
+      >
+        {(props) => (
+          <TextInput
+            {...props}
+            type="date"
+            value={effectiveOn}
+            onChange={(e) => setEffectiveOn(e.target.value)}
+          />
+        )}
+      </Field>
+
+      {cancel.error && (
+        <p className="t-caption" role="alert">
+          {problemMessageOf(cancel.error, t)}
+        </p>
+      )}
+
+      <div className="modal-actions">
+        <Button onClick={onClose}>{t("create.cancel")}</Button>
+        <Button
+          variant="danger"
+          reason={invalid ? t(invalid) : undefined}
+          disabled={cancel.isPending || invalid !== null}
+          onClick={() => cancel.mutate({ contract, noticeOn, effectiveOn })}
+        >
+          {t("contracts.cancel.submit")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/screens/contractlifecycle.tsx
+++ b/frontend/src/screens/contractlifecycle.tsx
@@ -8,12 +8,17 @@ import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
 import { useInstallationSettings } from "../app/uploadlimit";
 import { Button, Field, Modal, TextInput } from "../design-system/atoms";
-import { MoneyInput } from "../design-system/moneyinput";
 import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
-import { draftProblem, pricedIn } from "./contractform";
+import {
+  type ContractDraft,
+  ContractTermsFields,
+  contractTermsBody,
+  draftProblem,
+  pricedIn,
+} from "./contractform";
 
 // margince#3286: the three transitions a signed agreement actually goes
 // through after it is first recorded — renew, assert a status, record a
@@ -23,9 +28,7 @@ import { draftProblem, pricedIn } from "./contractform";
 
 type Contract = components["schemas"]["Contract"];
 type ContractStatus = NonNullable<Contract["status"]>;
-type ValueBasis = NonNullable<
-  components["schemas"]["RenewContractRequest"]["value_basis"]
->;
+type ValueBasis = ContractDraft["valueBasis"];
 
 // A status a contract can only ARRIVE at through renewal — the server sets it
 // on the predecessor, in the same transaction that creates the successor
@@ -48,29 +51,17 @@ const STATUS_LABEL_KEY: Record<ContractStatus, MessageKey> = {
 
 // A terminal status has no valid transition out of it other than a
 // same-status no-op (refuseInvalidTransition, contract_lifecycle.go), so
-// offering "change status" or "cancel" from one would be a control that can
-// only refuse — the reasoning #3573/#3700 already apply to the plan's write
-// controls.
+// offering "change status" from one would be a control that can only refuse —
+// the reasoning #3573/#3700 already apply to the plan's write controls.
+// Cancel is NOT gated on this (companycontracts.tsx): Store.Cancel is a plain
+// column patch with no status check at all.
 export function isTerminalContractStatus(status: Contract["status"]): boolean {
   return (
     status === "expired" || status === "cancelled" || status === "superseded"
   );
 }
 
-type RenewDraft = {
-  title: string;
-  contractNumber: string;
-  valueMinor: number;
-  currency: string;
-  valueBasis: ValueBasis;
-  startsOn: string;
-  endsOn: string;
-  renewalOn: string;
-  noticePeriodDays: string;
-  signedOn: string;
-};
-
-function renewDraftOf(predecessor: Contract): RenewDraft {
+function renewDraftOf(predecessor: Contract): ContractDraft {
   return {
     // Title and basis are the two fields the successor is likeliest to keep,
     // and both are required by the wire request — prefilled so renewing an
@@ -93,9 +84,9 @@ function renewDraftOf(predecessor: Contract): RenewDraft {
 }
 
 function renewalBody(
-  draft: RenewDraft,
+  draft: ContractDraft,
 ): components["schemas"]["RenewContractRequest"] {
-  const body: components["schemas"]["RenewContractRequest"] = {
+  return {
     title: draft.title.trim(),
     value_basis: draft.valueBasis,
     // Stated rather than defaulted, for the same reason contractBody
@@ -103,32 +94,8 @@ function renewalBody(
     // itself is a fact about the paper, and a field this form quietly omitted
     // would be a guess the record could not distinguish from an answer.
     auto_renew: false,
+    ...contractTermsBody(draft),
   };
-  if (draft.contractNumber.trim() !== "") {
-    body.contract_number = draft.contractNumber.trim();
-  }
-  if (draft.valueMinor > 0) {
-    body.value_minor = draft.valueMinor;
-    if (draft.currency !== "") {
-      body.currency = draft.currency;
-    }
-  }
-  if (draft.startsOn !== "") {
-    body.starts_on = draft.startsOn;
-  }
-  if (draft.endsOn !== "") {
-    body.ends_on = draft.endsOn;
-  }
-  if (draft.renewalOn !== "") {
-    body.renewal_on = draft.renewalOn;
-  }
-  if (draft.noticePeriodDays !== "") {
-    body.notice_period_days = Number(draft.noticePeriodDays);
-  }
-  if (draft.signedOn !== "") {
-    body.signed_on = draft.signedOn;
-  }
-  return body;
 }
 
 // The successor's terms, created in the same transaction that supersedes the
@@ -138,7 +105,7 @@ function renewalBody(
 // previous render held.
 async function renewContract(
   predecessor: Contract,
-  draft: RenewDraft,
+  draft: ContractDraft,
 ): Promise<string> {
   const { data, error } = await api.POST("/contracts/{id}/renewal", {
     params: {
@@ -154,12 +121,10 @@ async function renewContract(
 }
 
 export function ContractRenewModal({
-  orgId,
   contract,
   open,
   onClose,
 }: Readonly<{
-  orgId: string;
   contract: Contract;
   open: boolean;
   onClose: () => void;
@@ -167,7 +132,7 @@ export function ContractRenewModal({
   const t = useT();
   const titleId = useId();
   const queryClient = useQueryClient();
-  const [draft, setDraft] = useState<RenewDraft>(renewDraftOf(contract));
+  const [draft, setDraft] = useState<ContractDraft>(renewDraftOf(contract));
   const baseCurrency = useInstallationSettings().data?.base_currency;
   const contractCurrency = draft.currency || baseCurrency || "";
 
@@ -182,11 +147,15 @@ export function ContractRenewModal({
   const renew = useMutation({
     mutationFn: async (submitted: {
       predecessor: Contract;
-      draft: RenewDraft;
+      draft: ContractDraft;
     }) => renewContract(submitted.predecessor, submitted.draft),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["orgContracts", orgId] });
-      queryClient.invalidateQueries({ queryKey: ["organization360", orgId] });
+      queryClient.invalidateQueries({
+        queryKey: ["orgContracts", contract.organization_id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["organization360", contract.organization_id],
+      });
       onClose();
     },
   });
@@ -198,123 +167,11 @@ export function ContractRenewModal({
       <h2 id={titleId}>{t("contracts.renew.title")}</h2>
       <p className="t-caption">{t("contracts.renew.hint")}</p>
 
-      <Field label={t("contracts.form.name")} required>
-        {(props) => (
-          <TextInput
-            {...props}
-            value={draft.title}
-            onChange={(e) => setDraft({ ...draft, title: e.target.value })}
-          />
-        )}
-      </Field>
-
-      <Field label={t("contracts.form.number")}>
-        {(props) => (
-          <TextInput
-            {...props}
-            value={draft.contractNumber}
-            onChange={(e) =>
-              setDraft({ ...draft, contractNumber: e.target.value })
-            }
-          />
-        )}
-      </Field>
-
-      <Field label={t("contracts.form.value")}>
-        {(props) => (
-          <MoneyInput
-            {...props}
-            min={0}
-            currency={contractCurrency}
-            valueMinor={draft.valueMinor}
-            blankWhenZero
-            onChangeMinor={(valueMinor) => setDraft({ ...draft, valueMinor })}
-          />
-        )}
-      </Field>
-
-      <Field label={t("contracts.form.basis")} required>
-        {(props) => (
-          <Select
-            {...props}
-            value={draft.valueBasis}
-            onChange={(value) =>
-              setDraft({ ...draft, valueBasis: value as ValueBasis })
-            }
-            options={[
-              { value: "total", label: t("contracts.basis.total") },
-              { value: "annualized_12m", label: t("contracts.basis.annual") },
-            ]}
-          />
-        )}
-      </Field>
-
-      <Field label={t("contracts.form.startsOn")}>
-        {(props) => (
-          <TextInput
-            {...props}
-            type="date"
-            value={draft.startsOn}
-            onChange={(e) => setDraft({ ...draft, startsOn: e.target.value })}
-          />
-        )}
-      </Field>
-
-      <Field
-        label={t("contracts.form.endsOn")}
-        hint={t("contracts.form.endsOnHint")}
-      >
-        {(props) => (
-          <TextInput
-            {...props}
-            type="date"
-            value={draft.endsOn}
-            onChange={(e) => setDraft({ ...draft, endsOn: e.target.value })}
-          />
-        )}
-      </Field>
-
-      <Field label={t("contracts.form.renewalOn")}>
-        {(props) => (
-          <TextInput
-            {...props}
-            type="date"
-            value={draft.renewalOn}
-            onChange={(e) => setDraft({ ...draft, renewalOn: e.target.value })}
-          />
-        )}
-      </Field>
-
-      <Field
-        label={t("contracts.form.noticeDays")}
-        hint={t("contracts.form.noticeDaysHint")}
-      >
-        {(props) => (
-          <TextInput
-            {...props}
-            type="number"
-            min={0}
-            value={draft.noticePeriodDays}
-            onChange={(e) =>
-              setDraft({ ...draft, noticePeriodDays: e.target.value })
-            }
-          />
-        )}
-      </Field>
-
-      <Field
-        label={t("contracts.form.signedOn")}
-        hint={t("contracts.form.signedOnHint")}
-      >
-        {(props) => (
-          <TextInput
-            {...props}
-            type="date"
-            value={draft.signedOn}
-            onChange={(e) => setDraft({ ...draft, signedOn: e.target.value })}
-          />
-        )}
-      </Field>
+      <ContractTermsFields
+        draft={draft}
+        setDraft={setDraft}
+        currency={contractCurrency}
+      />
 
       {renew.error && (
         <p className="t-caption" role="alert">
@@ -426,9 +283,18 @@ export function ContractStatusModal({
 
       <div className="modal-actions">
         <Button onClick={onClose}>{t("create.cancel")}</Button>
+        {/* recordAssignment (patch.go) records a SET regardless of whether
+            the new value equals the old one, so a same-status submit would
+            still bump the row's version and write an audit row + a from==to
+            contract.status_changed event — a write nobody asked for. */}
         <Button
           variant="primary"
-          disabled={assert.isPending}
+          reason={
+            status === contract.status
+              ? t("contracts.statusChange.errSame")
+              : undefined
+          }
+          disabled={assert.isPending || status === contract.status}
           onClick={() => assert.mutate({ contract, status })}
         >
           {t("contracts.statusChange.submit")}
@@ -506,12 +372,18 @@ export function ContractCancelModal({
     },
   });
 
+  // Mirrors the two CHECK constraints contractCheckError names
+  // (contract_lifecycle.go): a cancellation cannot take effect before notice
+  // was given, and not after the term already ends. Held here too so the
+  // control does not enable a submit the server is certain to refuse.
   const invalid =
     noticeOn === "" || effectiveOn === ""
       ? "contracts.cancel.errIncomplete"
       : effectiveOn < noticeOn
         ? "contracts.cancel.errOrder"
-        : null;
+        : contract.ends_on && effectiveOn > contract.ends_on
+          ? "contracts.cancel.errTermEnd"
+          : null;
 
   return (
     <Modal open={open} onClose={onClose} labelledBy={titleId}>

--- a/frontend/src/screens/contractlifecycle.tsx
+++ b/frontend/src/screens/contractlifecycle.tsx
@@ -143,11 +143,11 @@ export function ContractRenewModal({
   // object on every refetch of the same row even when nothing changed, and a
   // background refetch while this modal is open would otherwise re-seed
   // mid-edit and discard whatever the reader had already typed.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
   useEffect(() => {
     if (open) {
       setDraft(renewDraftOf(contract));
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
   }, [open, contract.id]);
 
   const renew = useMutation({
@@ -244,11 +244,11 @@ export function ContractStatusModal({
   // Keyed on the ID, never the CONTRACT OBJECT — see ContractRenewModal's
   // identical comment: a background refetch of the SAME row must not discard
   // a status the reader already picked.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
   useEffect(() => {
     if (open) {
       setStatus(contract.status ?? "draft");
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
   }, [open, contract.id]);
 
   const assert = useMutation({
@@ -356,12 +356,12 @@ export function ContractCancelModal({
   // Keyed on the ID, never the CONTRACT OBJECT — see ContractRenewModal's
   // identical comment: a background refetch of the SAME row must not discard
   // dates the reader already typed.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
   useEffect(() => {
     if (open) {
       setNoticeOn(contract.cancellation_notice_on ?? "");
       setEffectiveOn(contract.cancellation_effective_on ?? "");
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: contract.id decides whether to reseed; the object itself would reseed on every refetch of the same row, discarding an in-progress edit.
   }, [open, contract.id]);
 
   const cancel = useMutation({


### PR DESCRIPTION
## Summary

Closes margince#3286 (QC-flagged reach gap). The backend chain for a contract's
three post-signing transitions — renew, assert a new status, record a
cancellation — has been correct and tested since #3230
(`backend/internal/modules/contracts/contract_lifecycle.go`,
`POST /contracts/{id}/renewal /status /cancellation`). Nothing in the frontend
could reach any of them: the company contracts screen's row menu offered only
Edit and Archive.

- **Renew** — `ContractRenewModal` creates the successor with its own terms
  (title/basis prefilled from the predecessor, everything else blank — a
  renewal is usually a fresh negotiation) and supersedes the predecessor in
  one transaction. Withheld only from an already-superseded row
  (`refuseRenewalOfTerminal`) — a chain must stay single-headed.
- **Change status** — `ContractStatusModal` asserts one of
  draft/active/expired/cancelled. Never `superseded`, which a contract only
  reaches through renewal. Withheld from a row whose status is already
  terminal (`refuseInvalidTransition` admits no transition out of one but a
  same-status no-op), and disables submit when the Select holds the row's own
  status — `recordAssignment` (patch.go) would otherwise still write a
  version bump + audit row + a from==to event for a no-op.
- **Cancel** — `ContractCancelModal` records notice/effective dates without
  moving the status (`Store.Cancel` is a two-column patch with **no** status
  check at all), so unlike Change status it is offered on every row,
  including terminal ones. Client-side validation mirrors both CHECK
  constraints the server enforces: effective ≥ notice, and effective ≤ the
  term's own end.

`ContractTermsFields` / `contractTermsBody` / `ContractDraft` are now shared
exports from `contractform.tsx` between the create/edit form and the renewal
modal, rather than a second copy of the nine fields and the body-omission
rules.

## Review

Ran a Fable pass and a Codex pass against the first cut. Both independently
caught that Cancel was wrongly gated the same way as Change status (the
backend doesn't refuse it on a terminal row); Fable also caught the
same-status no-op write and the field duplication. All fixed in the second
commit — see its message for the full list, including a Codex HIGH finding
(passive-effect reseed race) that was evaluated and **not** changed, with the
reasoning in the commit.

## Test plan

- [x] `make check` (backend + frontend) green on the branch rebased onto
      current `main`.
- [x] New unit/render tests: `contractlifecycle.test.tsx`,
      `companycontracts.menu.test.tsx` — RBAC boundaries (create+update needed
      for Renew, no grants → no menu), terminal-status gating, If-Match/version
      on every write, client-side validation.
- [x] `make fe-uat` — all 16 affected stories (3 new + the untouched
      `ContractForm` ones, proving the extraction didn't change its DOM)
      render clean.
- [x] Live UAT against a seeded local stack: created a contract, ran
      Renew → Change status (incl. the no-op refusal) → Cancel (incl. the
      term-end refusal) end to end against the real API. Recording attached
      in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the QC-flagged reach gap (margince#3286): the contract row menu previously offered only Edit and Archive; it now reaches the backend renewal, status-change, and cancellation endpoints (`POST /contracts/{id}/renewal`, `/status`, `/cancellation`) for all three post-signing transitions. The reseed effects in the new modals and `ContractForm` now key on the contract id rather than the object, so a background refetch of the same row no longer discards a draft mid-edit.

**New Features**
- Renew creates a successor with its own terms (title and basis prefilled from the predecessor, everything else blank) and supersedes it in one transaction; withheld from superseded rows, and requires both create and update grants.
- Change status asserts draft/active/expired/cancelled, is withheld from terminal rows, and disables submit when the Select holds the row's current status to avoid a same-status version bump and audit event.
- Cancel records notice and effective dates without moving the status, is offered on terminal rows too, and mirrors the server's validation: effective ≥ notice, effective ≤ term end.

**Refactors**
- `ContractTermsFields`, `contractTermsBody`, and `ContractDraft` are now shared exports from `contractform.tsx`, used by both the create/edit form and the renewal modal instead of duplicated copies.

<sup>Written for commit bf1ffaa780c6843da84e4b1e181cda1d227d506e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contract renewal, status change, and cancellation actions to contract menus.
  * Added dialogs with validation, localized errors, and version-checked updates.
  * Restricted lifecycle actions for contracts in terminal states.
  * Expanded English, German, and Vietnamese translations for contract workflows, email visibility, access, review, worklists, and history.

* **Bug Fixes**
  * Added validation for cancellation dates, contract terms, and unchanged status submissions.
  * Preserved in-progress contract and cancellation edits when contract information refreshes.
  * Clarified that scheduled extension jobs continue after agent deactivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->