### PR TITLE
An owner shares the contact their own mailbox made

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -12796,6 +12796,40 @@ paths:
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
+  /people/{id}/publish:
+    parameters:
+      - $ref: '#/components/parameters/Id'
+    post:
+      tags: [People]
+      operationId: publishCapturedPerson
+      security: [ { cookieAuth: [] } ]   # human session only
+      x-agent-access: human-only
+      summary: Share a contact your mailbox created with the rest of the organization.
+      description: |
+        A contact a connector created from a message nothing had judged yet is yours alone until
+        something judges it. Usually that is the sender classifier. This is the door for when it
+        never will: the ceiling on open questions refused to ask and the correspondence went quiet,
+        or the answer was `advisor` and you disagree, or you simply know who this is.
+
+        The OWNER is taken from your session, never from the request. That is what ties the
+        authority to the row: naming somebody else's capture-private contact answers 404, the same
+        as a contact that does not exist, because existence is what capture privacy hides. It is
+        also why an admin cannot do this on your behalf — the boundary is the importing user's, and
+        a seniority override would be the disclosure it exists to prevent.
+
+        The contact's own mail and meetings follow it, so a colleague opening the record finds the
+        history rather than a name nobody has ever spoken to. Individual messages keep their own
+        audience: publishing the CONTACT is not publishing the correspondence.
+
+        One direction only. A contact the organization can see is not narrowed back by this door or
+        any other, because a colleague may already have written to them on the strength of seeing
+        them.
+      responses:
+        '204': { description: The contact is the organization's. }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
   /people/{id}/consent/confirm-request:
     parameters:
       - $ref: '#/components/parameters/Id'

--- a/backend/gates/writeauthorityreach_test.go
+++ b/backend/gates/writeauthorityreach_test.go
@@ -48,6 +48,8 @@ const wantMinimumShareableWriters = 15
 // merely inconvenient: where the probe is simply a no-op today it was added
 // instead, because a no-op costs nothing and closes the drift.
 var writesWithoutARowProbe = gatekit.Waive(map[string]string{
+	"internal/modules/people:PromoteOwnCapturedPerson": "the mailbox owner publishing a contact their own capture made. A row probe would be the WRONG test and a wider one: EnsureWritable answers \"may this caller edit this record\", which a write grant or a team scope satisfies — and neither is authority to publish somebody else's private correspondence. Capture privacy is the importing user's alone and does not yield to row scope (auth/rowscope.go), so the row test here is OWNERSHIP, and it is in the UPDATE's own predicate (owner_id = the authenticated principal) where nothing can route around it. A miss is ErrNotFound rather than a permission error, because existence is what the boundary hides. The object grant is still taken, through auth.Require",
+
 	// Rows chosen by a CLOCK, not by a caller. A row-scope probe would narrow
 	// each sweep to whichever seat's rows the running principal could write and
 	// leave every other subject's record untouched — for retention that is the

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -530,6 +530,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/people/{id}/merge":                                         {Op: "mergePerson", Access: "tool", Tool: "merge_records", RecordType: "person", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/people/{id}/moment/dismiss":                                {Op: "dismissPersonMoment", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/people/{id}/profile-fields/{field}/restore":                {Op: "restorePersonProfileField", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/people/{id}/publish":                                       {Op: "publishCapturedPerson", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/people/{id}/research":                                      {Op: "runPersonResearch", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/people/{id}/research/save":                                 {Op: "savePersonResearch", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/people/{id}/view-ack":                                      {Op: "acknowledgePersonView", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/capturepromote_integration_test.go
+++ b/backend/internal/compose/capturepromote_integration_test.go
@@ -16,6 +16,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -28,6 +29,7 @@ import (
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
 	"github.com/margince/margince/backend/internal/shared/ports/connector"
@@ -748,4 +750,80 @@ func countOutboxFor(t *testing.T, e *integration.Env, id ids.PersonID) int {
 		t.Fatalf("counting outbox rows: %v", err)
 	}
 	return n
+}
+
+// TestAnOwnerPublishesTheirOwnCapturedContact is the door out of capture
+// privacy for a contact no classifier will ever settle.
+//
+// The ceiling refuses to ask and the correspondence goes quiet, or the answer
+// is `advisor` and the owner disagrees, or they simply know who this is. Until
+// this, the only route out of `owner` was a verdict, so those contacts had none.
+func TestAnOwnerPublishesTheirOwnCapturedContact(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "eigen@partner.example"
+
+	seedAttestedOutbound(t, e, "own-out-1", sender, "own-t1")
+	captureInboundThroughRealSink(t, e, e.Rep1, "own-in-1", sender, "own-t1")
+	personID := personIDFor(t, e, sender)
+	if got, _ := personVisibility(t, e, sender); got != "owner" {
+		t.Fatalf("a fresh capture is %q, want owner", got)
+	}
+
+	store := people.NewStore(InstallationDB(e.Pool))
+	if err := store.PromoteOwnCapturedPerson(seatCtx(e, e.Rep1), personID); err != nil {
+		t.Fatalf("the owner publishing their own contact: %v", err)
+	}
+	if got, _ := personVisibility(t, e, sender); got != "workspace" {
+		t.Fatalf("after the owner published it the contact is %q, want workspace", got)
+	}
+	// The trail, on the same terms as a verdict's promotion.
+	if n := countVisibilityAudits(t, e, personID); n != 1 {
+		t.Fatalf("publishing wrote %d audit row(s) naming visibility, want 1", n)
+	}
+}
+
+// TestOnlyTheOwnerPublishesACapturedContact is the security case.
+//
+// Capture privacy is the importing user's, and seniority does not override it:
+// an admin reading a colleague's unpromoted captured contacts is precisely the
+// disclosure the boundary exists to prevent. A promotion that matched on the
+// address rather than on the owner would have published a colleague's contact
+// to anybody who could reach this door.
+func TestOnlyTheOwnerPublishesACapturedContact(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "fremd@partner.example"
+
+	seedAttestedOutbound(t, e, "other-out-1", sender, "other-t1")
+	captureInboundThroughRealSink(t, e, e.Rep1, "other-in-1", sender, "other-t1")
+	personID := personIDFor(t, e, sender)
+
+	store := people.NewStore(InstallationDB(e.Pool))
+	for _, seat := range []struct {
+		name string
+		user ids.UUID
+	}{{"a colleague", e.Rep2}, {"an admin", e.AdminUser}} {
+		err := store.PromoteOwnCapturedPerson(seatCtx(e, seat.user), personID)
+		if !errors.Is(err, apperrors.ErrNotFound) {
+			t.Fatalf("%s publishing somebody else's capture-private contact: err = %v, want ErrNotFound — "+
+				"a 403 would confirm the contact exists, which is what the boundary hides", seat.name, err)
+		}
+	}
+	if got, _ := personVisibility(t, e, sender); got != "owner" {
+		t.Fatalf("the contact is %q after two refused attempts, want owner", got)
+	}
+}
+
+// seatCtx is one seat acting as themselves, which is the only principal the
+// capture-privacy door accepts.
+func seatCtx(e *integration.Env, user ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(),
+		UserID: user, SeatType: principal.SeatFull,
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"person": {Read: true, Update: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
 }

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -1679,6 +1679,10 @@ func (stubs) RestorePersonProfileField(w nethttp.ResponseWriter, r *nethttp.Requ
 	httperr.NotImplemented(w, r, "RestorePersonProfileField")
 }
 
+func (stubs) PublishCapturedPerson(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
+	httperr.NotImplemented(w, r, "PublishCapturedPerson")
+}
+
 func (stubs) RunPersonResearch(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
 	httperr.NotImplemented(w, r, "RunPersonResearch")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -47224,6 +47224,9 @@ type ServerInterface interface {
 	// Put back the value a newer statement replaced.
 	// (POST /people/{id}/profile-fields/{field}/restore)
 	RestorePersonProfileField(w http.ResponseWriter, r *http.Request, id Id, field PersonProfileFieldKey)
+	// Share a contact your mailbox created with the rest of the organization.
+	// (POST /people/{id}/publish)
+	PublishCapturedPerson(w http.ResponseWriter, r *http.Request, id Id)
 	// Ask the connected provider what is publicly known about this person.
 	// (POST /people/{id}/research)
 	RunPersonResearch(w http.ResponseWriter, r *http.Request, id Id)
@@ -50197,6 +50200,12 @@ func (_ Unimplemented) GetPersonProfileFields(w http.ResponseWriter, r *http.Req
 // Put back the value a newer statement replaced.
 // (POST /people/{id}/profile-fields/{field}/restore)
 func (_ Unimplemented) RestorePersonProfileField(w http.ResponseWriter, r *http.Request, id Id, field PersonProfileFieldKey) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Share a contact your mailbox created with the rest of the organization.
+// (POST /people/{id}/publish)
+func (_ Unimplemented) PublishCapturedPerson(w http.ResponseWriter, r *http.Request, id Id) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -68484,6 +68493,38 @@ func (siw *ServerInterfaceWrapper) RestorePersonProfileField(w http.ResponseWrit
 	handler.ServeHTTP(w, r)
 }
 
+// PublishCapturedPerson operation middleware
+func (siw *ServerInterfaceWrapper) PublishCapturedPerson(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PublishCapturedPerson(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // RunPersonResearch operation middleware
 func (siw *ServerInterfaceWrapper) RunPersonResearch(w http.ResponseWriter, r *http.Request) {
 
@@ -77286,6 +77327,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/people/{id}/profile-fields/{field}/restore", wrapper.RestorePersonProfileField)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/people/{id}/publish", wrapper.PublishCapturedPerson)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/people/{id}/research", wrapper.RunPersonResearch)

--- a/backend/internal/modules/people/handlers_person.go
+++ b/backend/internal/modules/people/handlers_person.go
@@ -282,6 +282,21 @@ func (h Handlers) ArchivePerson(w http.ResponseWriter, r *http.Request, id crmco
 	httperr.WriteJSON(w, http.StatusOK, person)
 }
 
+// PublishCapturedPerson shares a contact the caller's own mailbox created.
+//
+// No If-Match. The version guards a field edit against a concurrent one; this
+// write is idempotent in the only direction it goes, and a contact the
+// organization can already see answers the same 404 as one that was never the
+// caller's — so a stale version could not produce a wrong outcome, only a
+// confusing refusal.
+func (h Handlers) PublishCapturedPerson(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
+	if err := h.store.PromoteOwnCapturedPerson(r.Context(), pathID[ids.PersonKind](id)); err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func pageInfo(p storekit.Page) crmcontracts.PageInfo {
 	info := crmcontracts.PageInfo{HasMore: p.HasMore}
 	if p.NextCursor != "" {

--- a/backend/internal/modules/people/promoteown.go
+++ b/backend/internal/modules/people/promoteown.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The owner publishing their own captured contact.
+//
+// Capture privacy is the importing user's, not a tier of row scope: an admin
+// reading a colleague's unpromoted captured contacts is precisely the
+// disclosure the boundary exists to prevent. The other side of that is that the
+// owner CAN decide, and until now they had no way to say so — the only route
+// out of `owner` was a classifier verdict, and a contact the ceiling never
+// asked about, or that a model judged an advisor, had none at all.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// PromoteOwnCapturedPerson publishes a captured contact to the workspace, on
+// the authority of the seat whose mailbox it came from.
+//
+// The owner is taken from the AUTHENTICATED principal and written into the
+// statement, never accepted from the caller. That is what ties the human's
+// authorisation to the row being disclosed: a request naming somebody else's
+// private contact matches nothing, and a promotion by email match — the shape
+// the verdict path uses, under a system principal that bypasses both object
+// RBAC and capture privacy — would have published a colleague's contact to
+// anybody who could reach this door.
+//
+// A miss is ErrNotFound, not a permission error: a colleague's capture-private
+// contact must not be distinguishable from one that does not exist.
+func (s *Store) PromoteOwnCapturedPerson(ctx context.Context, id ids.PersonID) error {
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Type != principal.PrincipalHuman || actor.UserID == ids.Nil {
+		// The mailbox owner is a person. A connector or the verdict engine
+		// reaches the workspace through their own path, which is judged rather
+		// than asserted.
+		return apperrors.ErrPermissionDenied
+	}
+	if !actor.SeatType.CanMutate() {
+		return apperrors.ErrPermissionDenied
+	}
+	// The object grant, on the same terms as any other person write. The row
+	// half is NOT auth.EnsureWritable: that answers "may this caller edit this
+	// record", which a write grant or a team scope can satisfy — and neither is
+	// authority to publish somebody's private correspondence. Capture privacy
+	// is the importing user's alone, so the row test is ownership, and it lives
+	// in the statement below where it cannot be skipped.
+	if err := auth.Require(ctx, entityPerson, principal.ActionUpdate); err != nil {
+		return err
+	}
+	return s.db.Tx(ctx, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `
+			UPDATE person SET visibility = $3
+			 WHERE id = $1 AND owner_id = $2
+			   AND visibility = $4 AND archived_at IS NULL`,
+			id.UUID, actor.UserID, visibilityWorkspace, visibilityOwner)
+		if err != nil {
+			return fmt.Errorf("people: publishing a captured contact: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			// Not theirs, not private, or not there. All three answer the same
+			// way: existence is what the boundary hides.
+			return apperrors.ErrNotFound
+		}
+		auditID, err := storekit.Audit(ctx, tx, "update", entityPerson, id.UUID,
+			map[string]any{fieldVisibility: visibilityOwner},
+			map[string]any{fieldVisibility: visibilityWorkspace})
+		if err != nil {
+			return fmt.Errorf("people: recording a captured contact's publication: %w", err)
+		}
+		if err := storekit.EmitEvent(ctx, tx, auditID, id.UUID,
+			crmcontracts.PublicEventPersonUpdated{
+				ChangedFields: map[string]any{fieldVisibility: visibilityWorkspace},
+			}); err != nil {
+			return err
+		}
+		// The mail and meetings that were only ever linked to this contact
+		// follow it. Without this the record is visible and its history is not,
+		// which reads to a colleague as a contact nobody has ever spoken to.
+		_, err = s.PromotePersonCohortTx(ctx, tx, id)
+		return err
+	})
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -8670,6 +8670,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/people/{id}/publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Share a contact your mailbox created with the rest of the organization.
+         * @description A contact a connector created from a message nothing had judged yet is yours alone until
+         *     something judges it. Usually that is the sender classifier. This is the door for when it
+         *     never will: the ceiling on open questions refused to ask and the correspondence went quiet,
+         *     or the answer was `advisor` and you disagree, or you simply know who this is.
+         *
+         *     The OWNER is taken from your session, never from the request. That is what ties the
+         *     authority to the row: naming somebody else's capture-private contact answers 404, the same
+         *     as a contact that does not exist, because existence is what capture privacy hides. It is
+         *     also why an admin cannot do this on your behalf — the boundary is the importing user's, and
+         *     a seniority override would be the disclosure it exists to prevent.
+         *
+         *     The contact's own mail and meetings follow it, so a colleague opening the record finds the
+         *     history rather than a name nobody has ever spoken to. Individual messages keep their own
+         *     audience: publishing the CONTACT is not publishing the correspondence.
+         *
+         *     One direction only. A contact the organization can see is not narrowed back by this door or
+         *     any other, because a colleague may already have written to them on the strength of seeing
+         *     them.
+         */
+        post: operations["publishCapturedPerson"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/people/{id}/consent/confirm-request": {
         parameters: {
             query?: never;
@@ -43038,6 +43078,30 @@ export interface operations {
             404: components["responses"]["NotFound"];
             409: components["responses"]["Conflict"];
             422: components["responses"]["ValidationError"];
+        };
+    };
+    publishCapturedPerson: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The contact is the organization's. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
         };
     };
     requestDetailsConfirmation: {


### PR DESCRIPTION
Capture privacy is the importing user's: an admin reading a colleague's unpromoted captured contacts is precisely the disclosure the boundary exists to prevent. The other side of that is that the **owner** can decide — and until now they had no way to say so. The only route out of `owner` was a classifier verdict, so a contact the ceiling never asked about, or one a model called an advisor when the owner knows better, had no route at all.

`POST /people/{id}/publish` is that door.

## Where the security lives

The owner is read from the authenticated session and written into the `UPDATE`'s own predicate, never accepted from the request. A promotion matching on the address instead — the shape the verdict path uses, under a system principal that bypasses both object RBAC and capture privacy — would have published a colleague's contact to anybody who could reach this door.

A miss answers **404, not 403**. A permission error would confirm the contact exists, and existence is what capture privacy hides. It is one statement, not two checks: not yours, already shared, and not there all fail the same predicate.

The row test is ownership rather than `auth.EnsureWritable`, and the ratification says why: `EnsureWritable` answers "may this caller edit this record", which a write grant or a team scope satisfies, and neither is authority to publish somebody's private correspondence. The object grant is still taken through `auth.Require`.

## What follows the contact

Its mail and meetings, through the existing cohort repair. A record visible with its history missing reads to a colleague as somebody nobody has ever spoken to. Individual messages keep their own audience: publishing the contact is not publishing the correspondence, and a message another seat's mailbox is still holding stays held.

## Review

The Codex pass timed out, so this went through the repo's own `security-redteam` instead. **No exploitable findings.** It independently traced the obvious escalation chain — claim ownership first, then publish — and confirmed it is closed: `EnsureClaimable` composes the capture-privacy arm, so a colleague's owner-private person is already a 404 at the claim door. It also confirmed `x-agent-access: human-only` is enforced at the agent gate rather than being documentation, and that the check order leaks nothing.

## Tests

Two integration tests, both mutation-checked: the owner publishes and gets an audit row; a colleague **and** an admin both get `ErrNotFound` and the row is unchanged. Reverting the owner predicate makes the second fail.

Full `make check-backend`, `make check-fe`, `make craft-static`, and the `internal/compose` and `internal/modules/people` lanes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `POST /people/{id}/publish` so the owner of a captured contact can share it with the workspace when no classifier verdict will do. Previously, the only route out of `owner` visibility was a classifier verdict; now the importing user can publish a contact their mailbox created.

**Security**
- The owner is read from the authenticated session, never from the request, and written into the UPDATE's predicate.
- A miss returns 404, not 403, so a colleague's private contact is indistinguishable from one that doesn't exist.
- The row test is ownership, not `auth.EnsureWritable`; an admin cannot publish on the owner's behalf.
- Publishing the contact also makes its mail and meetings visible, but individual messages keep their own audience.
- This is one-way; a published contact cannot be narrowed back.

<sup>Written for commit 584b796ad457b25ad6703bebb0313dcc5f3e4e47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option for users to publish their own connector-captured private contacts to the organization.
  * Publishing includes the contact’s email and meeting history while preserving individual message audiences.
  * The action records an audit entry and returns confirmation upon success.
  * Access is limited to the importing user; colleagues and administrators cannot publish the contact on their behalf.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->