### PR TITLE
chore: the env template offers the Gmail push variables its Outlook twin already did

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,18 @@ MARGINCE_GMAIL_CLIENT_ID=
 MARGINCE_GMAIL_CLIENT_SECRET=
 MARGINCE_GRAPH_CLIENT_ID=
 MARGINCE_GRAPH_CLIENT_SECRET=
+# Gmail push (optional — capture polls without it). Two independent halves: the
+# TOPIC runs on the WORKER and turns the watch register+renew job on, and empty
+# leaves capture on the poll; the TOKEN runs on the api as the shared secret on
+# the Pub/Sub push subscription URL, and is what mounts POST /webhooks/gmail at
+# all (empty = route absent). Audience and service account are the hardening
+# pair — set BOTH and the webhook additionally verifies Google's OIDC token on
+# each push, rather than trusting the URL secret alone.
+# Topic form: projects/<project>/topics/<topic>
+MARGINCE_GMAIL_PUBSUB_TOPIC=
+MARGINCE_GMAIL_PUSH_TOKEN=
+MARGINCE_GMAIL_PUSH_AUDIENCE=
+MARGINCE_GMAIL_PUSH_SERVICE_ACCOUNT=
 # Outlook push. The api's token and the worker's URL must carry the same secret.
 MARGINCE_GRAPH_NOTIFICATION_URL=
 MARGINCE_GRAPH_PUSH_TOKEN=


### PR DESCRIPTION
Follow-up to #3945, which fixed the Microsoft SSO entry and flagged this as the
adjacent gap it deliberately left out.

## The asymmetry

`.env.example` carries the Outlook push pair:

```
# Outlook push. The api's token and the worker's URL must carry the same secret.
MARGINCE_GRAPH_NOTIFICATION_URL=
MARGINCE_GRAPH_PUSH_TOKEN=
```

and nothing for Gmail push, though `docs/reference/configuration.md` documents
both connectors side by side (lines 479-483) and they gate the same shape of
feature. An operator working from the template could reach Outlook push and not
Gmail push — a difference in the template, not in the product.

## What is added

Four variables, beside the Outlook block so the two read as the pair they are,
in the file's existing style (the sibling block carries no `[required for X]`
marker, so this one doesn't either):

- `MARGINCE_GMAIL_PUBSUB_TOPIC` — **worker**; turns the watch register+renew job
  on, empty leaves capture on the poll
- `MARGINCE_GMAIL_PUSH_TOKEN` — **api**; the shared secret on the Pub/Sub push
  subscription URL, and what mounts `POST /webhooks/gmail` at all
- `MARGINCE_GMAIL_PUSH_AUDIENCE` / `MARGINCE_GMAIL_PUSH_SERVICE_ACCOUNT` — the
  hardening pair: set both and the webhook additionally verifies Google's OIDC
  token on each push rather than trusting the URL secret alone

The comment says which half runs in which role, because that is the thing the
reference table makes you cross-reference and the one an operator gets wrong.

## What is deliberately NOT added

`MARGINCE_GMAIL_JWKS_URL` is the fifth Gmail variable absent from the template,
and it stays absent. `configuration.md` marks it *test/dev only* — it overrides
Google's OIDC JWKS endpoint — so it belongs with the lane-only variables the
template already omits, not in the file an operator is handed. Naming it here
would invite someone to point a production installation's key discovery
somewhere else.

## Verification

- `backend/gates/envcontract_test.go` — all five obligations pass, including
  `TestEnvExampleNamesOnlyLiveVars` (all four names are Go-read, so live)
- No Go files changed, so `craft static --strict` is a no-op on this diff

**One caveat on the local run:** `make check` is red on this branch, and it is
red on `origin/main` too, identically — `internal/compose/attention`
`TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem` and
`TestSystemNewsNeverLeadsACustomerWaiting` both fail on a clean checkout of the
tip. I verified that in a separate worktree at `origin/main` before pushing. It
is unrelated to this diff — a `.env.example` edit cannot reach that package —
and CI path-filters the backend lane away for a diff with no Go files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional configuration settings for Gmail Pub/Sub push notifications, including the topic, shared token, OIDC audience, and service account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->