### PR TITLE
compose(attention): the overnight brief's own deal is priced like its sibling

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -38192,13 +38192,13 @@ components:
             the sum rather than counted as nothing, so a partly priced day reports what it
             could price and says so through `revenue_currency`.
 
-            It is a FLOOR on what is drifting, never a total, and two things put work
-            outside it. A deal nobody could price is one. The other is that only the
-            at-risk lane goes through the currency conversion, so a deal reaching the page
-            from the overnight brief draws an amount on its own card and adds nothing
-            here. Both are why `more_available` matters: read this figure as "at least
-            this much", and read the `deals_at_risk` entry in `counts` for how many deals
-            stand behind it.
+            It is a FLOOR on what is drifting, never a total: a deal nobody could price
+            is left out, whichever lane surfaced it. A deal reaching the page from both
+            the overnight brief and the at-risk lane at once is counted only ONCE — it
+            is one deal's value, not one value per card it happens to appear on. This is
+            why `more_available` matters: read this figure as "at least this much", and
+            read the `deals_at_risk` entry in `counts` for how many deals stand behind
+            it.
         revenue_currency:
           type: [string, 'null']
           pattern: '^[A-Z]{3}$'

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -38196,9 +38196,10 @@ components:
             is left out, whichever lane surfaced it. A deal reaching the page from both
             the overnight brief and the at-risk lane at once is counted only ONCE — it
             is one deal's value, not one value per card it happens to appear on. This is
-            why `more_available` matters: read this figure as "at least this much", and
-            read the `deals_at_risk` entry in `counts` for how many deals stand behind
-            it.
+            why `more_available` matters: read this figure as "at least this much". The
+            `deals_at_risk` entry in `counts` is a CARD count, not a deal count — the same
+            deal reaching the page from both lanes is two cards there, so it can exceed
+            the number of distinct deals this figure priced.
         revenue_currency:
           type: [string, 'null']
           pattern: '^[A-Z]{3}$'

--- a/backend/internal/compose/attention/basemoney.go
+++ b/backend/internal/compose/attention/basemoney.go
@@ -118,16 +118,23 @@ func (s *Service) priceDayOnto(ctx context.Context, day crmcontracts.Attention) 
 
 // priceTheDay converts the amounts the ordering is about to compare.
 //
-// Only the at-risk lane feeds the expected-revenue tie-break and the material
-// bar, so only its amounts are priced. An unbound seam, or a day with nothing
-// to price, answers the zero dayMoney and costs no read.
+// The at-risk lane and the overnight brief both carry a drifting deal under
+// the same "deals_at_risk" category (classifyRisk, classifyBriefItem) — money
+// is a property of the DEAL, not of which lane happened to put it on the
+// queue today, so both are priced here in one batch. An unbound seam, or a
+// day with nothing to price, answers the zero dayMoney and costs no read.
 func (s *Service) priceTheDay(ctx context.Context, day crmcontracts.Attention) (dayMoney, error) {
-	if s.fx == nil || day.AtRisk == nil {
+	if s.fx == nil {
 		return dayMoney{}, nil
 	}
-	items := make([]string, 0, len(*day.AtRisk))
-	amounts := make([]CurrencyAmount, 0, len(*day.AtRisk))
-	for _, item := range *day.AtRisk {
+	var lanes []crmcontracts.AttentionItem
+	if day.AtRisk != nil {
+		lanes = append(lanes, *day.AtRisk...)
+	}
+	lanes = append(lanes, day.ThisMorning...)
+	items := make([]string, 0, len(lanes))
+	amounts := make([]CurrencyAmount, 0, len(lanes))
+	for _, item := range lanes {
 		// An amount with no currency cannot be converted, and under a bound
 		// seam it cannot be compared either: it is left out here, so the item
 		// ranks as unpriced rather than as a number in unknowable units.

--- a/backend/internal/compose/attention/basemoney.go
+++ b/backend/internal/compose/attention/basemoney.go
@@ -66,8 +66,9 @@ type dayMoney struct {
 	// which is why ran is what the readers below ask.
 	base string
 	// byItem is each priced lane item's expected revenue in the base currency,
-	// keyed by the item's id. An at-risk item absent here, on a day that ran,
-	// is one the estate could not price.
+	// keyed by the item's id — an at-risk row's own id, or a brief row's own
+	// entry id, never the deal id the two can share. A deals_at_risk item
+	// absent here, on a day that ran, is one the estate could not price.
 	byItem map[string]int64
 }
 
@@ -147,8 +148,8 @@ func (s *Service) priceTheDay(ctx context.Context, day crmcontracts.Attention) (
 	if len(amounts) == 0 {
 		// The seam is bound and there was nothing to ask it. That is a day
 		// that RAN with nothing priced, not a day with no conversion: every
-		// at-risk deal is unpriced, and none of them may be compared as a raw
-		// integer.
+		// deals_at_risk item across both lanes is unpriced, and none of them
+		// may be compared as a raw integer.
 		return dayMoney{ran: true}, nil
 	}
 	converted, base, err := s.fx.ToBase(ctx, day.AsOf, amounts)

--- a/backend/internal/compose/attention/basemoney.go
+++ b/backend/internal/compose/attention/basemoney.go
@@ -66,9 +66,12 @@ type dayMoney struct {
 	// which is why ran is what the readers below ask.
 	base string
 	// byItem is each priced lane item's expected revenue in the base currency,
-	// keyed by the item's id — an at-risk row's own id, or a brief row's own
-	// entry id, never the deal id the two can share. A deals_at_risk item
-	// absent here, on a day that ran, is one the estate could not price.
+	// keyed by the ROW's id — for an at-risk row that happens to equal the
+	// deal id (riskItem sets Id to the deal's own), for a brief row it is the
+	// brief entry's own id instead. Never a key the two lanes share, which is
+	// why readingsOf dedupes by Subject.Id rather than by this map's own key.
+	// A deals_at_risk item absent here, on a day that ran, is one the estate
+	// could not price.
 	byItem map[string]int64
 }
 

--- a/backend/internal/compose/attention/basemoney_test.go
+++ b/backend/internal/compose/attention/basemoney_test.go
@@ -372,12 +372,10 @@ func TestAnUnboundSeamCarriesNoExpectedMinorBase(t *testing.T) {
 	}
 }
 
-// margince#3653: the overnight brief's own lane (classifyBriefItem) never ran
-// its item through the same pricing classifyRisk gives the identical fact for
-// a "deals_at_risk" row in the sibling lane — the SAME category, since a brief
-// item is a drifting deal too. A client reading the brief row found
-// ExpectedMinorBase always null, and had no way to state or total what the
-// morning's suggested-first deal was worth.
+// The overnight brief's own lane (classifyBriefItem) runs its item through
+// the same pricing classifyRisk gives the identical fact for a
+// "deals_at_risk" row in the sibling lane — the SAME category, since a brief
+// item is a drifting deal too.
 func TestTheBriefItemLaneAlsoCarriesTheConvertedExpectedRevenue(t *testing.T) {
 	day := crmcontracts.Attention{
 		AsOf: rankInstant,
@@ -446,15 +444,13 @@ func TestASharedDealCountsOnceTowardRevenueAtRiskAcrossBothLanes(t *testing.T) {
 	}
 }
 
-// Pricing the brief lane is not free of ranking consequences, and this is the
-// one the fix genuinely changes: a brief item and a plain task both classify
-// at levelAgreed with no deadline, so before this fix they always tied
-// through to id order — the brief item's ExpectedMinorBase was always unset.
-// Now a priced brief item's money tiebreak (byExpected, rank.go) beats a
-// task with none, the same way a material deal already beats an unpriced one.
-// Named here rather than left as a side effect an unrelated test would need
-// to notice breaking.
-func TestAPricedBriefItemNowWinsTheMoneyTiebreakOverAPlainTask(t *testing.T) {
+// A brief item and a plain task both classify at levelAgreed with no
+// deadline, so a priced brief item's money tiebreak (byExpected, rank.go)
+// decides between them — the same way a material at-risk deal already beats
+// an unpriced one. Pricing the brief lane is not free of ranking
+// consequences, and this test names the one it has rather than leaving it
+// for an unrelated test to notice breaking.
+func TestAPricedBriefItemWinsTheMoneyTiebreakOverAPlainTask(t *testing.T) {
 	day := crmcontracts.Attention{
 		AsOf:        rankInstant,
 		ThisMorning: []crmcontracts.AttentionItem{item("brief", "brief_item", withPricedDeal(fiveMillionYen))},

--- a/backend/internal/compose/attention/basemoney_test.go
+++ b/backend/internal/compose/attention/basemoney_test.go
@@ -369,3 +369,50 @@ func TestAnUnboundSeamCarriesNoExpectedMinorBase(t *testing.T) {
 		t.Fatalf("expected_minor_base = %v with no FX seam bound at all", *deal.ExpectedMinorBase)
 	}
 }
+
+// margince#3653: the overnight brief's own lane (classifyBriefItem) never ran
+// its item through the same pricing classifyRisk gives the identical fact for
+// a "deals_at_risk" row in the sibling lane — the SAME category, since a brief
+// item is a drifting deal too. A client reading the brief row found
+// ExpectedMinorBase always null, and had no way to state or total what the
+// morning's suggested-first deal was worth.
+func TestTheBriefItemLaneAlsoCarriesTheConvertedExpectedRevenue(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		ThisMorning: []crmcontracts.AttentionItem{
+			item("brief-yen", "brief_item", withPricedDeal(fiveMillionYen)),
+		},
+	}
+	fx := stubFX{base: "EUR", answers: map[CurrencyAmount]int64{fiveMillionYen: 3_000_000}}
+
+	out := pricedWorklist(t, fx, day)
+
+	deal := out.Queue[0].Deal
+	if deal == nil {
+		t.Fatal("the row carries no deal facts at all")
+	}
+	if deal.ExpectedMinorBase == nil || *deal.ExpectedMinorBase != 3_000_000 {
+		t.Fatalf("expected_minor_base = %v, wanted 3000000 (the converted €30,000)", deal.ExpectedMinorBase)
+	}
+}
+
+// The same fix must also reach the day's revenue-at-risk reading: it sums
+// every row of the "deals_at_risk" category regardless of which lane produced
+// it (readingsOf), so a brief item priced but never marked hasExpected would
+// silently vanish from a total the strip states as complete.
+func TestTheBriefItemLaneCountsTowardRevenueAtRisk(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		ThisMorning: []crmcontracts.AttentionItem{
+			item("brief-yen", "brief_item", withPricedDeal(fiveMillionYen)),
+		},
+	}
+	fx := stubFX{base: "EUR", answers: map[CurrencyAmount]int64{fiveMillionYen: 3_000_000}}
+
+	out := pricedWorklist(t, fx, day)
+
+	if out.Readings.RevenueAtRiskMinor == nil || *out.Readings.RevenueAtRiskMinor != 3_000_000 {
+		t.Fatalf("revenue_at_risk_minor = %v, wanted 3000000 — the brief item's own priced amount",
+			out.Readings.RevenueAtRiskMinor)
+	}
+}

--- a/backend/internal/compose/attention/basemoney_test.go
+++ b/backend/internal/compose/attention/basemoney_test.go
@@ -15,10 +15,12 @@ package attention
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 )
 
 // stubFX answers a conversion the fixtures state outright, keyed by the
@@ -411,8 +413,69 @@ func TestTheBriefItemLaneCountsTowardRevenueAtRisk(t *testing.T) {
 
 	out := pricedWorklist(t, fx, day)
 
-	if out.Readings.RevenueAtRiskMinor == nil || *out.Readings.RevenueAtRiskMinor != 3_000_000 {
-		t.Fatalf("revenue_at_risk_minor = %v, wanted 3000000 — the brief item's own priced amount",
-			out.Readings.RevenueAtRiskMinor)
+	if got := out.Readings.RevenueAtRiskMinor; got == nil || *got != 3_000_000 {
+		t.Fatalf("revenue_at_risk_minor = %s, wanted 3000000 — the brief item's own priced amount", ptrInt64(got))
 	}
+}
+
+// The same deal genuinely reaches the page from BOTH lanes at once —
+// TestABoundResolverNamesEveryCardOnce (labels_test.go) is production's own
+// proof of the shape: two brief entries and one at-risk row, all naming one
+// deal. Each row is priced independently (a different id per row: the risk
+// row's own id equals the deal's, a brief row's id is the brief entry's own —
+// render.go/rendersilence.go), so summing every priced row without deduping
+// by the DEAL they share would count that one deal's value once per row it
+// happens to appear in.
+func TestASharedDealCountsOnceTowardRevenueAtRiskAcrossBothLanes(t *testing.T) {
+	deal := ids.NewV7()
+	day := crmcontracts.Attention{
+		AsOf: rankInstant,
+		AtRisk: lane(item("risk-row", "deal_at_risk",
+			withPricedDeal(fiveMillionYen), withDealSubject(deal))),
+		ThisMorning: []crmcontracts.AttentionItem{
+			item("brief-row-1", "brief_item", withPricedDeal(fiveMillionYen), withDealSubject(deal)),
+			item("brief-row-2", "brief_item", withPricedDeal(fiveMillionYen), withDealSubject(deal)),
+		},
+	}
+	fx := stubFX{base: "EUR", answers: map[CurrencyAmount]int64{fiveMillionYen: 3_000_000}}
+
+	out := pricedWorklist(t, fx, day)
+
+	if got := out.Readings.RevenueAtRiskMinor; got == nil || *got != 3_000_000 {
+		t.Fatalf("revenue_at_risk_minor = %s, wanted 3000000 once — three cards, one deal, one figure", ptrInt64(got))
+	}
+}
+
+// Pricing the brief lane is not free of ranking consequences, and this is the
+// one the fix genuinely changes: a brief item and a plain task both classify
+// at levelAgreed with no deadline, so before this fix they always tied
+// through to id order — the brief item's ExpectedMinorBase was always unset.
+// Now a priced brief item's money tiebreak (byExpected, rank.go) beats a
+// task with none, the same way a material deal already beats an unpriced one.
+// Named here rather than left as a side effect an unrelated test would need
+// to notice breaking.
+func TestAPricedBriefItemNowWinsTheMoneyTiebreakOverAPlainTask(t *testing.T) {
+	day := crmcontracts.Attention{
+		AsOf:        rankInstant,
+		ThisMorning: []crmcontracts.AttentionItem{item("brief", "brief_item", withPricedDeal(fiveMillionYen))},
+		Planned:     []crmcontracts.AttentionItem{item("task", "task")},
+	}
+	fx := stubFX{base: "EUR", answers: map[CurrencyAmount]int64{fiveMillionYen: 3_000_000}}
+
+	out := pricedWorklist(t, fx, day)
+
+	assertOrder(t, out.Queue, "brief", "task")
+	comparison := out.Queue[0].AboveNext
+	if comparison == nil || comparison.Comparator != crmcontracts.WorklistComparisonComparatorExpectedRevenue {
+		t.Fatalf("the brief item leads the task by %+v, wanted expected_revenue", comparison)
+	}
+}
+
+// ptrInt64 prints a *int64's VALUE in a failure message, never the pointer's
+// own address — %v on the field directly names an address nobody asked for.
+func ptrInt64(p *int64) string {
+	if p == nil {
+		return "nil"
+	}
+	return fmt.Sprint(*p)
 }

--- a/backend/internal/compose/attention/classify.go
+++ b/backend/internal/compose/attention/classify.go
@@ -64,7 +64,9 @@ func classifyDay(day crmcontracts.Attention, asOf time.Time, money dayMoney) []r
 	rows := make([]ranked, 0, 64)
 	bar := materialBarOf(day, money)
 	rows = appendLane(rows, day.Meetings, asOf, classifyMeeting)
-	rows = appendLane(rows, &day.ThisMorning, asOf, classifyBriefItem)
+	rows = appendLane(rows, &day.ThisMorning, asOf, func(item crmcontracts.AttentionItem, at time.Time) ranked {
+		return classifyBriefItem(item, at, money)
+	})
 	rows = appendLane(rows, day.Commitments, asOf, classifyCommitment)
 	rows = appendLane(rows, day.DidNotRun, asOf, classifyFailedApproval)
 	rows = appendLane(rows, day.Dsr, asOf, classifyDSR)

--- a/backend/internal/compose/attention/classifybrief.go
+++ b/backend/internal/compose/attention/classifybrief.go
@@ -32,20 +32,15 @@ import (
 // item.Overdue onto row.Overdue; there is nothing left to set here.
 //
 // Priced the same way classifyRisk prices its own "deals_at_risk" row for the
-// identical deal — money is a property of the DEAL, not of which lane put it
-// on the queue today. Without this a client reading a brief row found
-// ExpectedMinorBase always null and the day's revenue-at-risk reading
-// (readingsOf, which sums every "deals_at_risk" row regardless of lane)
-// silently dropped whatever the morning's suggested-first deal was worth.
+// identical deal, through the one shared priceDealsAtRiskRow — money is a
+// property of the DEAL, not of which lane put it on the queue today.
 func classifyBriefItem(item crmcontracts.AttentionItem, asOf time.Time, money dayMoney) ranked {
 	row := base(item, levelAgreed, "deals_at_risk", "deal_drifts")
 	if item.DueAt != nil {
 		row.Because = append(row.Because, reason("closing_soon", nil))
 	}
 	expected, known := expectedRevenue(item, money)
-	if row.Deal != nil && money.converted() && known {
-		row.Deal.ExpectedMinorBase = &expected
-	}
+	priceDealsAtRiskRow(&row, expected, known, money)
 	return ranked{
 		item:             row,
 		deadlineAt:       deadlineOf(item.DueAt),

--- a/backend/internal/compose/attention/classifybrief.go
+++ b/backend/internal/compose/attention/classifybrief.go
@@ -30,15 +30,29 @@ import (
 // stating deals.CloseIsOverdue's own verdict, the identical rule the sibling
 // "deals_at_risk" row for the same deal is judged by. base() already carries
 // item.Overdue onto row.Overdue; there is nothing left to set here.
-func classifyBriefItem(item crmcontracts.AttentionItem, asOf time.Time) ranked {
+//
+// Priced the same way classifyRisk prices its own "deals_at_risk" row for the
+// identical deal — money is a property of the DEAL, not of which lane put it
+// on the queue today. Without this a client reading a brief row found
+// ExpectedMinorBase always null and the day's revenue-at-risk reading
+// (readingsOf, which sums every "deals_at_risk" row regardless of lane)
+// silently dropped whatever the morning's suggested-first deal was worth.
+func classifyBriefItem(item crmcontracts.AttentionItem, asOf time.Time, money dayMoney) ranked {
 	row := base(item, levelAgreed, "deals_at_risk", "deal_drifts")
 	if item.DueAt != nil {
 		row.Because = append(row.Because, reason("closing_soon", nil))
 	}
+	expected, known := expectedRevenue(item, money)
+	if row.Deal != nil && money.converted() && known {
+		row.Deal.ExpectedMinorBase = &expected
+	}
 	return ranked{
-		item:       row,
-		deadlineAt: deadlineOf(item.DueAt),
-		overdue:    item.Overdue != nil && *item.Overdue,
-		occurredAt: occurredOf(item, asOf),
+		item:             row,
+		deadlineAt:       deadlineOf(item.DueAt),
+		overdue:          item.Overdue != nil && *item.Overdue,
+		expectedBase:     expected,
+		hasExpected:      known,
+		expectedCurrency: money.base,
+		occurredAt:       occurredOf(item, asOf),
 	}
 }

--- a/backend/internal/compose/attention/classifybrief_test.go
+++ b/backend/internal/compose/attention/classifybrief_test.go
@@ -23,7 +23,7 @@ func TestClassifyBriefItemStampsItsDeadline(t *testing.T) {
 		Overdue: &overdue,
 	}
 
-	got := classifyBriefItem(item, rankInstant)
+	got := classifyBriefItem(item, rankInstant, dayMoney{})
 
 	if got.deadlineAt.IsZero() {
 		t.Fatal("deadlineAt is zero; the ordering can never read the close date the row was given")
@@ -58,7 +58,7 @@ func TestClassifyBriefItemTrustsTheDealsCalendarOverdueVerdictOverAnInstantCompa
 		Overdue: &notOverdue,
 	}
 
-	got := classifyBriefItem(item, rankInstant)
+	got := classifyBriefItem(item, rankInstant, dayMoney{})
 
 	if got.overdue {
 		t.Fatal("a deal due TODAY was marked overdue — the brief row disagrees with the at-risk row for the identical deal")
@@ -82,7 +82,7 @@ func TestClassifyBriefItemNamesTheCloseDateLikeItsRiskLaneSibling(t *testing.T) 
 		DueAt:  &closes,
 	}
 
-	got := classifyBriefItem(item, rankInstant)
+	got := classifyBriefItem(item, rankInstant, dayMoney{})
 
 	if got.overdue {
 		t.Fatal("a close date three months out was marked overdue")

--- a/backend/internal/compose/attention/classifyrisk.go
+++ b/backend/internal/compose/attention/classifyrisk.go
@@ -37,16 +37,7 @@ func classifyRisk(item crmcontracts.AttentionItem, asOf time.Time, bar materialB
 		level = levelMaterialRisk
 	}
 	row := base(item, level, "deals_at_risk", consequence)
-	// The contract's own per-row figure, sent rather than left for a client to
-	// re-derive from `because`/`above_next` — set only once conversion actually
-	// ran and priced this item (money.converted() below is the raw-amount
-	// guard). expectedRevenue already answers known=false for a deal with no
-	// amount, an unpriced converted item, or a converted figure with no base
-	// currency named, so this is the one place that answer is spent rather
-	// than a second copy of any of its three reasons.
-	if row.Deal != nil && money.converted() && known {
-		row.Deal.ExpectedMinorBase = &expected
-	}
+	priceDealsAtRiskRow(&row, expected, known, money)
 	// The reason carries the figure the verdict actually weighed, in the units
 	// it was weighed in — the base currency once conversion ran — so a reader
 	// comparing it against the summary's threshold compares like with like.
@@ -133,6 +124,22 @@ func expectedRevenue(item crmcontracts.AttentionItem, money dayMoney) (int64, bo
 	}
 	converted, priced := money.byItem[item.Id]
 	return converted, priced
+}
+
+// priceDealsAtRiskRow writes the contract's per-row ExpectedMinorBase, the
+// one place this guard is spelled: classifyRisk and classifyBriefItem both
+// produce a "deals_at_risk" row for a deal, and a second copy of the guard is
+// a second answer to "is this row priced" that the two could drift apart on.
+//
+// Set only once conversion actually ran (money.converted() is the raw-amount
+// guard) and the deal WAS priced — expected/known already answer false for a
+// deal with no amount, an unpriced converted item, or a converted figure with
+// no base currency named, so this is the one place that answer is spent
+// rather than a second copy of any of its three reasons.
+func priceDealsAtRiskRow(row *crmcontracts.WorklistItem, expected int64, known bool, money dayMoney) {
+	if row.Deal != nil && money.converted() && known {
+		row.Deal.ExpectedMinorBase = &expected
+	}
 }
 
 // moneyOf carries the deal's own currency beside the amount. An amount without

--- a/backend/internal/compose/attention/readings.go
+++ b/backend/internal/compose/attention/readings.go
@@ -62,9 +62,9 @@ func readingsOf(
 	// labels_test.go: two brief entries and one at-risk row for one deal),
 	// each with its OWN row id, priced independently by priceTheDay. Summing
 	// every row would count that one deal's value once per card it happens to
-	// surface on. countedDeals holds the deal ids already summed, keyed by the
-	// one field every deals_at_risk row names it by regardless of which lane
-	// produced the row (riskItem/briefItem both set Subject to the deal).
+	// surface on. countedDeals holds the deal ids already summed, keyed by
+	// Subject.Id — both current producers (riskItem, briefItem) set it to
+	// the deal, and it is the only field the two lanes' rows share.
 	countedDeals := map[openapi_types.UUID]bool{}
 	for _, row := range considered {
 		switch row.item.Category {
@@ -82,6 +82,13 @@ func readingsOf(
 			if !row.hasExpected {
 				continue
 			}
+			// Both current producers (riskItem, briefItem — rendersilence.go,
+			// render.go) always set Subject to the deal, so this dedupe always
+			// applies to a deals_at_risk row in practice. A row that somehow
+			// carried none could not be told apart from any other deal and
+			// would fall back to being summed unconditionally, exactly as it
+			// was before the dedupe existed — a nil Subject is not a shape
+			// either producer emits, not a case this switch chooses to trust.
 			if row.item.Subject != nil {
 				if countedDeals[row.item.Subject.Id] {
 					continue

--- a/backend/internal/compose/attention/readings.go
+++ b/backend/internal/compose/attention/readings.go
@@ -13,6 +13,8 @@ package attention
 // pill.
 
 import (
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 )
 
@@ -54,6 +56,16 @@ func readingsOf(
 	var revenue int64
 	var priced bool
 	var currency string
+	// One deal can genuinely carry more than one deals_at_risk ROW — the
+	// overnight brief and the at-risk producer both watch the same open
+	// pipeline independently (TestABoundResolverNamesEveryCardOnce,
+	// labels_test.go: two brief entries and one at-risk row for one deal),
+	// each with its OWN row id, priced independently by priceTheDay. Summing
+	// every row would count that one deal's value once per card it happens to
+	// surface on. countedDeals holds the deal ids already summed, keyed by the
+	// one field every deals_at_risk row names it by regardless of which lane
+	// produced the row (riskItem/briefItem both set Subject to the deal).
+	countedDeals := map[openapi_types.UUID]bool{}
 	for _, row := range considered {
 		switch row.item.Category {
 		case crmcontracts.WorklistItemCategoryCustomerWaiting:
@@ -69,6 +81,12 @@ func readingsOf(
 		case crmcontracts.WorklistItemCategoryDealsAtRisk:
 			if !row.hasExpected {
 				continue
+			}
+			if row.item.Subject != nil {
+				if countedDeals[row.item.Subject.Id] {
+					continue
+				}
+				countedDeals[row.item.Subject.Id] = true
 			}
 			revenue += row.expectedBase
 			// Taking the units from the ROW keeps the currency travelling with

--- a/backend/internal/compose/attention/readings_test.go
+++ b/backend/internal/compose/attention/readings_test.go
@@ -164,16 +164,12 @@ func TestAConvertedSumNamesTheBaseCurrency(t *testing.T) {
 	}
 }
 
-// A deal reaching the page from the overnight brief lands in `deals_at_risk`
-// and is never priced: `classifyBriefItem` sets no expected figure, and
-// `priceTheDay` converts only the at-risk lane. So its card can show an amount
-// while the strip's sum does not include it.
-//
-// The contract says this out loud — the figure is a floor, not a total — and
-// this test is what keeps the two agreeing. Widening the conversion to the brief
-// lane would change what the ORDERING weighs, not just this sum, so it is filed
-// rather than done here; when it is done, this test fails and says so.
-func TestTheSumCoversTheAtRiskLaneOnlyAndSaysSo(t *testing.T) {
+// A deal reaching the page from the overnight brief lands in the same
+// `deals_at_risk` category an at-risk row for it would (margince#3653):
+// `classifyBriefItem` prices it exactly the way `classifyRisk` prices the
+// identical fact for its own lane, so the strip's sum covers both rather than
+// silently excluding whichever deal the brief happened to surface first.
+func TestTheSumCoversBothDealsAtRiskLanes(t *testing.T) {
 	day := crmcontracts.Attention{
 		AsOf:   rankInstant,
 		AtRisk: lane(item("priced", "deal_at_risk", withDeal(300_00))),
@@ -201,10 +197,8 @@ func TestTheSumCoversTheAtRiskLaneOnlyAndSaysSo(t *testing.T) {
 	if got.RevenueAtRiskMinor == nil {
 		t.Fatal("the at-risk deal should still be summed")
 	}
-	if *got.RevenueAtRiskMinor != 300_00 {
-		t.Fatalf(
-			"summed %d — if the brief lane is now priced too, widen this test and the contract prose with it",
-			*got.RevenueAtRiskMinor)
+	if *got.RevenueAtRiskMinor != 1_200_00 {
+		t.Fatalf("summed %d, wanted 300_00 (at-risk) + 900_00 (brief) = 1_200_00", *got.RevenueAtRiskMinor)
 	}
 }
 

--- a/backend/internal/compose/attention/readings_test.go
+++ b/backend/internal/compose/attention/readings_test.go
@@ -165,10 +165,9 @@ func TestAConvertedSumNamesTheBaseCurrency(t *testing.T) {
 }
 
 // A deal reaching the page from the overnight brief lands in the same
-// `deals_at_risk` category an at-risk row for it would (margince#3653):
-// `classifyBriefItem` prices it exactly the way `classifyRisk` prices the
-// identical fact for its own lane, so the strip's sum covers both rather than
-// silently excluding whichever deal the brief happened to surface first.
+// `deals_at_risk` category an at-risk row for it would: `classifyBriefItem`
+// prices it exactly the way `classifyRisk` prices the identical fact for its
+// own lane, so the strip's sum covers both.
 func TestTheSumCoversBothDealsAtRiskLanes(t *testing.T) {
 	day := crmcontracts.Attention{
 		AsOf:   rankInstant,

--- a/backend/internal/compose/attention/worklist_test.go
+++ b/backend/internal/compose/attention/worklist_test.go
@@ -288,6 +288,14 @@ func withOverdue(past bool) func(*crmcontracts.AttentionItem) {
 	return func(i *crmcontracts.AttentionItem) { i.Overdue = &past }
 }
 
+// withDealSubject names the deal a row is ABOUT, the way riskItem and
+// briefItem both set it in production (render.go, rendersilence.go) — the one
+// field that identifies the same deal across two rows with different ids and
+// different sources.
+func withDealSubject(deal ids.UUID) func(*crmcontracts.AttentionItem) {
+	return func(i *crmcontracts.AttentionItem) { i.Subject = subjectOf(subjectDeal, deal) }
+}
+
 // The deal's own figures have to reach the row, or the client reads a second
 // endpoint per line to draw a card this one could have completed.
 func TestARiskRowCarriesTheDealsFigures(t *testing.T) {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -32987,13 +32987,13 @@ type WorklistReadings struct {
 	// the sum rather than counted as nothing, so a partly priced day reports what it
 	// could price and says so through `revenue_currency`.
 	//
-	// It is a FLOOR on what is drifting, never a total, and two things put work
-	// outside it. A deal nobody could price is one. The other is that only the
-	// at-risk lane goes through the currency conversion, so a deal reaching the page
-	// from the overnight brief draws an amount on its own card and adds nothing
-	// here. Both are why `more_available` matters: read this figure as "at least
-	// this much", and read the `deals_at_risk` entry in `counts` for how many deals
-	// stand behind it.
+	// It is a FLOOR on what is drifting, never a total: a deal nobody could price
+	// is left out, whichever lane surfaced it. A deal reaching the page from both
+	// the overnight brief and the at-risk lane at once is counted only ONCE — it
+	// is one deal's value, not one value per card it happens to appear on. This is
+	// why `more_available` matters: read this figure as "at least this much", and
+	// read the `deals_at_risk` entry in `counts` for how many deals stand behind
+	// it.
 	RevenueAtRiskMinor *int64 `json:"revenue_at_risk_minor"`
 
 	// RevenueCurrency The currency `revenue_at_risk_minor` is stated in — the installation's base

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -32991,9 +32991,10 @@ type WorklistReadings struct {
 	// is left out, whichever lane surfaced it. A deal reaching the page from both
 	// the overnight brief and the at-risk lane at once is counted only ONCE — it
 	// is one deal's value, not one value per card it happens to appear on. This is
-	// why `more_available` matters: read this figure as "at least this much", and
-	// read the `deals_at_risk` entry in `counts` for how many deals stand behind
-	// it.
+	// why `more_available` matters: read this figure as "at least this much". The
+	// `deals_at_risk` entry in `counts` is a CARD count, not a deal count — the same
+	// deal reaching the page from both lanes is two cards there, so it can exceed
+	// the number of distinct deals this figure priced.
 	RevenueAtRiskMinor *int64 `json:"revenue_at_risk_minor"`
 
 	// RevenueCurrency The currency `revenue_at_risk_minor` is stated in — the installation's base

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28796,9 +28796,10 @@ export interface components {
              *     is left out, whichever lane surfaced it. A deal reaching the page from both
              *     the overnight brief and the at-risk lane at once is counted only ONCE — it
              *     is one deal's value, not one value per card it happens to appear on. This is
-             *     why `more_available` matters: read this figure as "at least this much", and
-             *     read the `deals_at_risk` entry in `counts` for how many deals stand behind
-             *     it.
+             *     why `more_available` matters: read this figure as "at least this much". The
+             *     `deals_at_risk` entry in `counts` is a CARD count, not a deal count — the same
+             *     deal reaching the page from both lanes is two cards there, so it can exceed
+             *     the number of distinct deals this figure priced.
              */
             revenue_at_risk_minor: number | null;
             /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -28792,13 +28792,13 @@ export interface components {
              *     the sum rather than counted as nothing, so a partly priced day reports what it
              *     could price and says so through `revenue_currency`.
              *
-             *     It is a FLOOR on what is drifting, never a total, and two things put work
-             *     outside it. A deal nobody could price is one. The other is that only the
-             *     at-risk lane goes through the currency conversion, so a deal reaching the page
-             *     from the overnight brief draws an amount on its own card and adds nothing
-             *     here. Both are why `more_available` matters: read this figure as "at least
-             *     this much", and read the `deals_at_risk` entry in `counts` for how many deals
-             *     stand behind it.
+             *     It is a FLOOR on what is drifting, never a total: a deal nobody could price
+             *     is left out, whichever lane surfaced it. A deal reaching the page from both
+             *     the overnight brief and the at-risk lane at once is counted only ONCE — it
+             *     is one deal's value, not one value per card it happens to appear on. This is
+             *     why `more_available` matters: read this figure as "at least this much", and
+             *     read the `deals_at_risk` entry in `counts` for how many deals stand behind
+             *     it.
              */
             revenue_at_risk_minor: number | null;
             /**


### PR DESCRIPTION
## Summary

Closes margince#3653 (QC-narrowed from margince#3315). `classifyRisk` (the
"deals_at_risk" lane) prices its row with the base-currency
`WorklistDealFacts.expected_minor_base` the contract promises. `classifyBriefItem`
(the overnight-brief lane) produces rows in the **same** `deals_at_risk`
category for the same shape of deal, and never priced them — a client reading
a brief row always found `expected_minor_base` null.

Two changes, one commit:

1. `classifyBriefItem` now runs the exact same `expectedRevenue`/`dayMoney`
   pricing block `classifyRisk` does, setting `ExpectedMinorBase` and the
   ranking-internal `expectedBase`/`hasExpected`/`expectedCurrency` fields.
2. `priceTheDay` (the FX-conversion batch that feeds both classifiers) only
   ever collected amounts from `day.AtRisk` — a brief-only deal's amount was
   never even sent to the conversion seam, so (1) alone would have changed
   nothing. It now batches `day.ThisMorning`'s deals into the same call.
   Money is a property of the deal, not of which lane surfaced it today.

`readingsOf`'s `RevenueAtRiskMinor` reading gets the fix for free — it already
sums every row of the `deals_at_risk` category regardless of lane, so a brief
item priced but never marked `hasExpected` was silently absent from a total
the strip states as complete.

`TestTheSumCoversTheAtRiskLaneOnlyAndSaysSo` was the previous author's own
documented gate on this exact gap — the comment named the fix and said the
test would fail the day it landed. Widened to
`TestTheSumCoversBothDealsAtRiskLanes` per its own instruction, rather than
deleted. `materialBarOf` (the pipeline-median bar `classifyRisk` alone uses
for its own material/agreed level split) stays `AtRisk`-only on purpose —
verified it and confirmed brief items never consult it, so nothing there
needed widening.

## Known pre-existing failure — not touched here

`make check-go` is currently red on an unrelated regression in this same
package: `TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem` and
`TestSystemNewsNeverLeadsACustomerWaiting` (a customer-waiting row losing its
top-of-queue rank). Bisected (by another session working the same area this
cycle) to `5de83df4d` ("The waiting queue asks who wrote, and whether we ever
answered", #3995) — confirmed deterministic on a clean checkout at that exact
commit and still present at current tip. Not this PR's fix; tracked
separately. `craft static` and every other backend package pass clean on this
branch.

## Test plan

- [x] New/widened unit tests in `basemoney_test.go`, `readings_test.go`,
      `classifybrief_test.go` proving the priced figure, the widened revenue
      reading, and that the existing brief-item overdue/deadline behavior is
      unchanged.
- [x] `go vet` + `gofmt` clean; `golangci-lint` 0 issues; `craft static`
      0 findings on the changed files.
- [x] Full `go test ./...` — every package green except the two pre-existing,
      unrelated failures above (confirmed via `git stash` against a clean
      rebase: they fail identically with zero local changes).
- [x] Fable + Codex review passes on the diff (see follow-up commit, if any,
      for fixes).

No UI surface changes — this is a pure backend contract/ranking fix with no
browser UAT to record; the unit-test coverage above is the verification
surface for a contract field and an internal money-conversion batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes margince#3653: deals surfacing through the overnight brief are now priced exactly like their at-risk siblings, and a deal appearing in both lanes counts once in the revenue-at-risk total.

- `classifyBriefItem` and `priceTheDay` now price brief-lane deals the same way as at-risk deals, so `expected_minor_base` is no longer null on brief rows and the revenue reading sums both lanes.
- The revenue reading now dedupes priced rows by deal subject, so a deal surfaced by both lanes contributes once, not once per card.
- The `revenue_at_risk_minor` contract prose now states the dedupe and clarifies that the `deals_at_risk` count is per card, not per deal.

**Known pre-existing failure**
- `TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem` and `TestSystemNewsNeverLeadsACustomerWaiting` fail on a clean checkout of `main`; unrelated to this PR and not touched here.

<sup>Written for commit efbb539e21ec3ab53b4dc1d30b44b33b3e86f88f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Currency conversion now applies consistently to at-risk deals and morning brief items.
  * Morning brief entries display converted expected revenue.
  * Revenue-at-risk totals include eligible morning brief deals and count duplicate deals once.
  * Unpriceable deals are excluded from revenue floor calculations.

* **New Features**
  * Added clearer worklist handling for messages that ask nothing.
  * Added person visibility, replace-all email updates, meeting outcomes, and voice-quality indicators.

* **Documentation**
  * Clarified revenue floor behavior and availability indicators.

* **Tests**
  * Added coverage for revenue conversion, ranking, and duplicate deal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->