### PR TITLE
main is red: two breakages, both from PRs whose gates were not extended

### DIFF
--- a/backend/internal/compose/analyticsreporttool.go
+++ b/backend/internal/compose/analyticsreporttool.go
@@ -54,15 +54,20 @@ func analyticsReportComposer(pool *pgxpool.Pool, floor analyticsquery.Floor) age
 			return nil, err
 		}
 
+		// Encoded one block at a time rather than as one array, because the
+		// result carries them as a slice — see ComposeAnalyticsReportResult
+		// for why the advertised schema depends on which of the two it is.
+		//
 		// Empty, never nil: a document that rendered no blocks cannot happen —
 		// Validate refuses one — but a nil here would marshal to null, which a
 		// model reads as "unknown" rather than as "none".
-		if blocks == nil {
-			blocks = []RenderedBlock{}
-		}
-		encoded, err := json.Marshal(blocks)
-		if err != nil {
-			return nil, fmt.Errorf("compose: rendering a composed report: %w", err)
+		encoded := make([]json.RawMessage, 0, len(blocks))
+		for _, block := range blocks {
+			raw, err := json.Marshal(block)
+			if err != nil {
+				return nil, fmt.Errorf("compose: rendering a composed report: %w", err)
+			}
+			encoded = append(encoded, raw)
 		}
 		return json.Marshal(agents.ComposeAnalyticsReportResult{Blocks: encoded})
 	}

--- a/backend/internal/compose/attention/crosssourcerank_test.go
+++ b/backend/internal/compose/attention/crosssourcerank_test.go
@@ -57,6 +57,12 @@ func TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem(t *testing.T) {
 			Subject:    "Can you confirm the retrofit price?",
 			Since:      rankInstant.Add(-72 * time.Hour),
 			PersonID:   waitPerson,
+			// A thread the workspace has written on before. Without it the row
+			// is an UNPROVEN wait, which classifyWaiting demotes to routine on
+			// purpose — a correct answer to a different question, and one that
+			// would leave this test asserting the cross-source order of rows
+			// that no longer span the levels it is about.
+			Engaged: true,
 		}},
 		crmcontracts.Attention{
 			AsOf:        rankInstant,
@@ -90,6 +96,10 @@ func TestSystemNewsNeverLeadsACustomerWaiting(t *testing.T) {
 			Subject:    "Still waiting on that quote",
 			Since:      rankInstant.Add(-2 * time.Hour),
 			PersonID:   waitPerson,
+			// See the sibling above: an unproven wait is routine by design, and
+			// the claim under test is that hygiene never outranks a customer we
+			// are actually in conversation with.
+			Engaged: true,
 		}},
 		crmcontracts.Attention{
 			AsOf:             rankInstant,

--- a/backend/internal/compose/integration/toolschema_conformance_integration_test.go
+++ b/backend/internal/compose/integration/toolschema_conformance_integration_test.go
@@ -282,6 +282,14 @@ func TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas(t *testing.T) {
 		{"forecast_input_checks", `{}`},
 		{"list_input_checks", `{}`},
 		{"data_coverage", `{}`},
+		// The report surface: the block grammar a document is written in, and
+		// a document composed through it. Invoked with a text-only block on
+		// purpose — the figure-bearing kinds resolve against a run, and what
+		// this lane holds is the ENVELOPE the composer answers in, which is
+		// the same for a document whose blocks carry figures and one whose do
+		// not. Both tools take the read scope and neither stages anything.
+		{"describe_report_blocks", `{}`},
+		{"compose_analytics_report", `{"blocks":[{"kind":"title","text":"Pipeline this quarter"}]}`},
 		// The confirm-first queue read back through its own doors.
 		{"list_approvals", `{}`},
 		{"read_approval", `{"staged_action_id":"` + waiting.String() + `"}`},

--- a/backend/internal/modules/agents/testdata/outputshapes.json
+++ b/backend/internal/modules/agents/testdata/outputshapes.json
@@ -1462,7 +1462,10 @@
         "type": "object",
         "properties": {
           "blocks": {
-            "type": "object"
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
           }
         },
         "required": [

--- a/backend/internal/modules/agents/tools_analyticsreport.go
+++ b/backend/internal/modules/agents/tools_analyticsreport.go
@@ -94,7 +94,14 @@ func (t composeAnalyticsReport) Spec() mcp.ToolSpec {
 type ComposeAnalyticsReportResult struct {
 	// Blocks carries each composed block with its figures resolved, in the
 	// order the document composed them.
-	Blocks json.RawMessage `json:"blocks"`
+	//
+	// A slice of raw blocks rather than one raw array, because the two say
+	// different things in the DERIVED schema: schemaFor describes a
+	// json.RawMessage as an object with nothing said about its members, which
+	// is honest for a document and a lie for a list. Held as a slice, the
+	// advertised shape is an array of opaque blocks — which is exactly what a
+	// caller gets, and what the block kinds are still free to vary inside.
+	Blocks []json.RawMessage `json:"blocks"`
 }
 
 func (t composeAnalyticsReport) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,15 +10,15 @@
   "totals": {
     "tools": 72,
     "resources": 11,
-    "tool_catalog_bytes": 204270,
+    "tool_catalog_bytes": 204295,
     "resource_catalog_bytes": 4251,
-    "approx_wire_tokens_total": 52130,
+    "approx_wire_tokens_total": 52136,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 49898,
       "input_schema_bytes": 41225,
-      "output_schema_bytes": 97600,
+      "output_schema_bytes": 97625,
       "description_plus_input_schema_bytes": 91123
     }
   },
@@ -2075,7 +2075,10 @@
             "data": {
               "properties": {
                 "blocks": {
-                  "type": "object"
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
                 }
               },
               "required": [

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -15,7 +15,7 @@ receives it. This page is rendered from that file.
 | Resources | 11 |
 | Tool catalog | 199.5 KB |
 | Resource catalog | 4.2 KB |
-| Approx. wire tokens | 52130 |
+| Approx. wire tokens | 52136 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -2507,7 +2507,10 @@ Render a report whose every figure comes from a saved analytics run. The documen
     "data": {
       "properties": {
         "blocks": {
-          "type": "object"
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
         }
       },
       "required": [


### PR DESCRIPTION
`main` is red twice over. Both failures are on every open PR, and each one blocks the other's CI, so they land together.

## 1. `compose/attention` — the cross-source fixtures predate the engagement rule

`go test ./internal/compose/attention` fails on `origin/main`.

#3995 (5de83df4d) added the unproven-wait demotion in `classifyWaiting`:

```go
unproven := !waiting.Engaged && !waiting.HasOpenDeal
if unproven {
	level = levelRoutine
}
```

Every fixture in the package meaning *a customer genuinely waiting on us* was updated to say `Engaged: true` — `worklist_test.go`, `waitingfreshness_test.go`. `crosssourcerank_test.go` builds its `WaitingCustomer` by hand and was missed, so both of its cases now describe an unproven wait:

- `TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem` — `ranked [meeting promise risk notice …a001], wanted [meeting …a001 promise risk notice]`.
- `TestSystemNewsNeverLeadsACustomerWaiting` — the page leads with the automation row, which is the thing that test exists to refuse.

Both rows span levels on purpose. Demoting one to routine quietly changed the subject of each test. Fixed by saying `Engaged: true`, as every sibling fixture does.

Production is unaffected: `attentionwaitingseam.go:113` carries `Engaged: row.Engaged` from the query, and it is the only construction of `attention.WaitingCustomer` outside tests.

## 2. `compose/integration` — two report tools were registered but never invoked

`TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas` fails naming them:

> `compose_analytics_report` is registered but never invoked here, so nothing holds its result to the schema or the envelope.

#3999 registered `compose_analytics_report` and `describe_report_blocks` without extending the conformance lane. Adding the two calls found a real defect behind the first.

**`ComposeAnalyticsReportResult.Blocks` advertised an object and answered with an array.** It held the rendered blocks as one `json.RawMessage`, and `schemaFor` describes a `json.RawMessage` as `{"type":"object"}` — deliberately, and honestly, for a document whose members are another module's. It is wrong for a list. So the published `OutputSchema` said `blocks` was an object while every response carried an array, and a client validating against the schema this server advertises rejects all of them.

Held as `[]json.RawMessage`, the derived schema becomes an array of opaque blocks — what a caller actually receives, with the block kinds still free to vary inside it, which is the property the raw type was chosen for. `testdata/outputshapes.json` and `docs/reference/mcp-info.*` are regenerated from the types, and carry only this change.

`compose_analytics_report` is invoked with a text-only `title` block: the figure-bearing kinds resolve against a run, and what this lane holds is the envelope, which is the same either way.

## Verification

- `go test ./internal/compose/attention` — was FAIL on `origin/main`, now `ok`.
- `make test-it DIR=backend/internal/compose/integration RUN=TestToolAnswersReachableWithoutApprovalSatisfyTheirSchemas` — was FAIL, now `ok`, with both new tools passing.
- `go test ./internal/compose/ ./internal/modules/agents/` — green, including the two golden-file gates.
- `make check-backend` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b1jSBftJqGvaQ7ejTgnQ6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Analytics reports now return rendered report blocks as an array, allowing multiple blocks to be handled consistently.
  - Report output schemas clearly describe each block as an object within the array.

- **Documentation**
  - Updated the MCP reference documentation and catalog to reflect the revised analytics report response format.

- **Bug Fixes**
  - Improved handling of individual report blocks, including clearer error reporting when a block cannot be encoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->