### PR TITLE
A draft that lost its sender's voice says so

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -29421,6 +29421,7 @@ components:
         ai_disclosure: { type: [string, 'null'], readOnly: true, description: 'The machine-readable Art. 50 disclosure line; non-null iff ai_generated=true.' }
         voice_profile_version: { type: [integer, 'null'], readOnly: true, minimum: 1, description: 'The Voice DNA PROFILE version (not a model version) that styled this draft — the "built from your corpus · vN" provenance; null when no ready voice profile shaped it.' }
         draft_ref: { type: [string, 'null'], readOnly: true, description: 'Opaque reference identifying this served voice draft for learning feedback (rejectVoiceDraft); null when no voice profile styled it.' }
+        voice_degraded: { type: boolean, readOnly: true, description: 'True when the sender''s voice could not even be looked up, so this draft may be missing a voice its sender built. Distinct from voice_profile_version being null, which also covers the ordinary no-profile case. A client should say so: the sender cannot detect a missing voice by reading the text. Absent reads as false.' }
 
     ReplyRecipient:
       type: object
@@ -29504,6 +29505,14 @@ components:
           description: >-
             Opaque reference identifying this served draft. Null here: recording a draft for
             voice learning is a WRITE, and this operation performs none.
+        voice_degraded:
+          type: boolean
+          readOnly: true
+          description: >-
+            True when the sender's voice could not even be looked up, so this draft may be
+            missing a voice its sender built. Distinct from voice_profile_version being null,
+            which also covers the ordinary no-profile case. A client should say so: the sender
+            cannot detect a missing voice by reading the text. Absent reads as false.
 
     AccountDraftReason:
       type: object

--- a/backend/internal/compose/accountdraft/service.go
+++ b/backend/internal/compose/accountdraft/service.go
@@ -161,11 +161,12 @@ func (s *Service) Draft(
 	in.Dossier = s.facts(ctx, orgID)
 	// Loaded after the 360 read, so a caller who may not read this account is
 	// refused before their voice profile is touched at all.
-	draft, by, err := Write(ctx, s.lane, in, draftvoice.Load(ctx, s.voice, s.log))
+	voice := draftvoice.Load(ctx, s.voice, s.log)
+	draft, by, err := Write(ctx, s.lane, in, voice)
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}
-	out := wire(draft, by)
+	out := wire(draft, by, voice.Degraded)
 	// The scoped read's own report of what the narrowing kept, so the
 	// composer's scope line counts what the draft was actually written from.
 	out.Scope = view.Scope
@@ -177,14 +178,15 @@ func (s *Service) Draft(
 // draft_ref is deliberately absent. The reply drafter returns one so the voice
 // model can learn from what the rep changed — and recording a served draft is
 // a WRITE, which this operation does not perform.
-func wire(draft Draft, by crmcontracts.WrittenBy) crmcontracts.AccountEmailDraft {
+func wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool) crmcontracts.AccountEmailDraft {
 	aiWritten := by == crmcontracts.Model
 	out := crmcontracts.AccountEmailDraft{
-		Subject:     draft.Subject,
-		Body:        draft.Body,
-		GeneratedBy: by,
-		AiGenerated: &aiWritten,
-		Reasoning:   wireReasons(draft.Reasoning),
+		Subject:       draft.Subject,
+		Body:          draft.Body,
+		GeneratedBy:   by,
+		AiGenerated:   &aiWritten,
+		Reasoning:     wireReasons(draft.Reasoning),
+		VoiceDegraded: &voiceDegraded,
 	}
 	if len(draft.To) > 0 {
 		to := make([]openapi_types.Email, 0, len(draft.To))

--- a/backend/internal/compose/accountdraft/write_test.go
+++ b/backend/internal/compose/accountdraft/write_test.go
@@ -226,6 +226,20 @@ func TestDraftingNeverReturnsADraftRef(t *testing.T) {
 	}
 }
 
+// The account composer's wire mapping is a second spelling of persondraft.Wire,
+// so the degraded flag is pinned here too — in both states, because a client
+// reading an absent field as false must not see "fine" for a lost voice.
+func TestWireCarriesTheVoiceDegradedFlag(t *testing.T) {
+	degraded := wire(Deterministic(sampleInput()), crmcontracts.Deterministic, true)
+	if degraded.VoiceDegraded == nil || !*degraded.VoiceDegraded {
+		t.Fatal("a degraded voice load must be stamped on the wire draft")
+	}
+	clean := wire(Deterministic(sampleInput()), crmcontracts.Deterministic, false)
+	if clean.VoiceDegraded == nil || *clean.VoiceDegraded {
+		t.Fatal("a clean load must stamp voice_degraded=false, not omit it")
+	}
+}
+
 // A model that wraps its JSON in a ```json fence has answered correctly, and
 // this surface used to fail it while the reply surface — same models, same
 // ladder — accepted it. The rule is ai.Unfence's own: one reduction defines

--- a/backend/internal/compose/accountdraft/write_test.go
+++ b/backend/internal/compose/accountdraft/write_test.go
@@ -220,7 +220,7 @@ func TestTheCallersOwnIntentIsOutsideTheFence(t *testing.T) {
 func TestDraftingNeverReturnsADraftRef(t *testing.T) {
 	// draft_ref exists so a served draft can be scored later, which is a
 	// write. This operation performs none, so the field stays null.
-	out := wire(Deterministic(sampleInput()), crmcontracts.Deterministic)
+	out := wire(Deterministic(sampleInput()), crmcontracts.Deterministic, false)
 	if out.DraftRef != nil {
 		t.Fatalf("draft_ref = %v, want null: recording a served draft is a write", out.DraftRef)
 	}

--- a/backend/internal/compose/draftvoice/voice.go
+++ b/backend/internal/compose/draftvoice/voice.go
@@ -27,16 +27,26 @@ type Reader interface {
 // profile, and a draft written without one is the product working. OK is what
 // separates "this rep has a voice" from "this rep does not", and every caller
 // branches on it rather than on a nil check somewhere further down.
+//
+// Degraded is the third state, and it is not absence: the read FAILED, so
+// nobody knows whether this rep has a voice. A draft served under it may be
+// missing a voice its sender built, which the sender cannot see in the text —
+// their own writing is the one register they do not proofread for. Every
+// response that could have been voiced carries this flag so the surface can
+// say so instead of passing the draft off as the plain kind.
 type Context struct {
-	Profile ai.VoiceProfile
-	Version ai.VoiceProfileVersion
-	OK      bool
+	Profile  ai.VoiceProfile
+	Version  ai.VoiceProfileVersion
+	OK       bool
+	Degraded bool
 }
 
 // Load resolves the actor's active voice. A lookup failure degrades to no voice
-// with the reason logged: a broken voice read must never take drafting down,
-// because the draft is the thing the rep asked for and the voice is how it is
-// phrased. reader may be nil, which is a deployment that wired no voice lane.
+// with the reason logged and the Context marked Degraded: a broken voice read
+// must never take drafting down, because the draft is the thing the rep asked
+// for and the voice is how it is phrased — but the caller's response must be
+// able to say the voice was lost rather than absent. reader may be nil, which
+// is a deployment that wired no voice lane and degrades nothing.
 func Load(ctx context.Context, reader Reader, log *slog.Logger) Context {
 	if reader == nil {
 		return Context{}
@@ -47,7 +57,7 @@ func Load(ctx context.Context, reader Reader, log *slog.Logger) Context {
 			log = slog.Default()
 		}
 		log.WarnContext(ctx, "voice profile lookup failed; drafting without voice", "err", err)
-		return Context{}
+		return Context{Degraded: true}
 	}
 	return Context{Profile: profile, Version: version, OK: ok}
 }

--- a/backend/internal/compose/draftvoice/voice_test.go
+++ b/backend/internal/compose/draftvoice/voice_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package draftvoice
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/modules/ai"
+)
+
+type readerFunc func(ctx context.Context) (ai.VoiceProfile, ai.VoiceProfileVersion, bool, error)
+
+func (f readerFunc) ActiveVoiceForActor(ctx context.Context) (ai.VoiceProfile, ai.VoiceProfileVersion, bool, error) {
+	return f(ctx)
+}
+
+// A failed lookup and an absent profile are different answers, and the wire
+// flag is the only way a sender learns about the first: the draft text reads
+// the same either way.
+func TestLoadTellsAFailedLookupFromAnAbsentProfile(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	failing := readerFunc(func(context.Context) (ai.VoiceProfile, ai.VoiceProfileVersion, bool, error) {
+		return ai.VoiceProfile{}, ai.VoiceProfileVersion{}, false, errors.New("connection refused")
+	})
+	got := Load(ctx, failing, nil)
+	if !got.Degraded {
+		t.Fatal("a lookup error must mark the context Degraded, or the loss is invisible on the wire")
+	}
+	if got.OK {
+		t.Fatal("a degraded context must not claim a loaded voice")
+	}
+
+	absent := readerFunc(func(context.Context) (ai.VoiceProfile, ai.VoiceProfileVersion, bool, error) {
+		return ai.VoiceProfile{}, ai.VoiceProfileVersion{}, false, nil
+	})
+	if got := Load(ctx, absent, nil); got.Degraded || got.OK {
+		t.Fatal("no profile is the product working: neither OK nor Degraded")
+	}
+
+	if got := Load(ctx, nil, nil); got.Degraded || got.OK {
+		t.Fatal("a deployment with no voice lane degrades nothing")
+	}
+}

--- a/backend/internal/compose/leaddraft/service.go
+++ b/backend/internal/compose/leaddraft/service.go
@@ -127,9 +127,10 @@ func (s *Service) Draft(
 	in := FromLead(lead, activities, req.Intent, envelope)
 	// Loaded after the lead read, so a caller who may not see this lead is
 	// refused before their voice profile is touched at all.
-	draft, by, err := persondraft.Write(ctx, s.lane, in, draftvoice.Load(ctx, s.voice, s.log))
+	voice := draftvoice.Load(ctx, s.voice, s.log)
+	draft, by, err := persondraft.Write(ctx, s.lane, in, voice)
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}
-	return persondraft.Wire(draft, by), nil
+	return persondraft.Wire(draft, by, voice.Degraded), nil
 }

--- a/backend/internal/compose/persondraft/service.go
+++ b/backend/internal/compose/persondraft/service.go
@@ -123,11 +123,12 @@ func (s *Service) Draft(
 	}
 	// Loaded after the 360 read, so a caller who may not read this person is
 	// refused before their voice profile is touched at all.
-	draft, by, err := Write(ctx, s.lane, in, draftvoice.Load(ctx, s.voice, s.log))
+	voice := draftvoice.Load(ctx, s.voice, s.log)
+	draft, by, err := Write(ctx, s.lane, in, voice)
 	if err != nil {
 		return crmcontracts.AccountEmailDraft{}, err
 	}
-	out := Wire(draft, by)
+	out := Wire(draft, by, voice.Degraded)
 	// The scoped read's own report of what the narrowing kept, so the
 	// composer's scope line counts what the draft was actually written from.
 	out.Scope = view.Scope
@@ -144,14 +145,15 @@ func (s *Service) Draft(
 // same writer, and a second mapping of one Draft onto one AccountEmailDraft is
 // two answers to one question — including which of them stamps the Art. 50
 // disclosure, which is the half a reader would notice missing.
-func Wire(draft Draft, by crmcontracts.WrittenBy) crmcontracts.AccountEmailDraft {
+func Wire(draft Draft, by crmcontracts.WrittenBy, voiceDegraded bool) crmcontracts.AccountEmailDraft {
 	aiWritten := by == crmcontracts.Model
 	out := crmcontracts.AccountEmailDraft{
-		Subject:     draft.Subject,
-		Body:        draft.Body,
-		GeneratedBy: by,
-		AiGenerated: &aiWritten,
-		Reasoning:   wireReasons(draft.Reasoning),
+		Subject:       draft.Subject,
+		Body:          draft.Body,
+		GeneratedBy:   by,
+		AiGenerated:   &aiWritten,
+		Reasoning:     wireReasons(draft.Reasoning),
+		VoiceDegraded: &voiceDegraded,
 	}
 	if len(draft.To) > 0 {
 		to := make([]openapi_types.Email, 0, len(draft.To))

--- a/backend/internal/compose/persondraft/wire_test.go
+++ b/backend/internal/compose/persondraft/wire_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package persondraft
+
+import (
+	"testing"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+)
+
+// The degraded flag must reach the wire in both states: a client that reads an
+// absent field as false would otherwise show "fine" for a draft whose voice
+// was lost, which is the exact silence this field exists to end.
+func TestWireCarriesTheVoiceDegradedFlag(t *testing.T) {
+	t.Parallel()
+	draft := Draft{Subject: "s", Body: "b"}
+
+	degraded := Wire(draft, crmcontracts.Model, true)
+	if degraded.VoiceDegraded == nil || !*degraded.VoiceDegraded {
+		t.Fatal("a degraded voice load must be stamped on the wire draft")
+	}
+
+	clean := Wire(draft, crmcontracts.Model, false)
+	if clean.VoiceDegraded == nil || *clean.VoiceDegraded {
+		t.Fatal("a clean load must stamp voice_degraded=false, not omit it")
+	}
+}

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -167,7 +167,7 @@ func (d replyDrafter) DraftEmailWithProvenance(ctx context.Context, anchor ids.U
 		// Drafting is an assistive read, not the authority to send. Preserve
 		// the deterministic floor and leave the routed ai_call failure visible.
 		d.logger().WarnContext(ctx, "model reply draft unavailable; using deterministic draft", "err", err)
-		return activities.DraftResult{Subject: fallbackSubject, Body: fallbackBody}, nil
+		return activities.DraftResult{Subject: fallbackSubject, Body: fallbackBody, VoiceDegraded: voice.Degraded}, nil
 	}
 	disclosure := signals.Art50Disclosure
 	return activities.DraftResult{
@@ -177,6 +177,7 @@ func (d replyDrafter) DraftEmailWithProvenance(ctx context.Context, anchor ids.U
 		AIDisclosure:        &disclosure,
 		VoiceProfileVersion: voiceVersion,
 		DraftRef:            draftRef,
+		VoiceDegraded:       voice.Degraded,
 	}, nil
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15564,6 +15564,9 @@ type AccountEmailDraft struct {
 	Subject string                 `json:"subject"`
 	To      *[]openapi_types.Email `json:"to,omitempty"`
 
+	// VoiceDegraded True when the sender's voice could not even be looked up, so this draft may be missing a voice its sender built. Distinct from voice_profile_version being null, which also covers the ordinary no-profile case. A client should say so: the sender cannot detect a missing voice by reading the text. Absent reads as false.
+	VoiceDegraded *bool `json:"voice_degraded,omitempty"`
+
 	// VoiceProfileVersion The Voice DNA profile version that styled this draft; null when no ready profile shaped it.
 	VoiceProfileVersion *int `json:"voice_profile_version,omitempty"`
 }
@@ -21377,6 +21380,9 @@ type EmailDraft struct {
 	InReplyToActivityId *openapi_types.UUID    `json:"in_reply_to_activity_id,omitempty"`
 	Subject             string                 `json:"subject"`
 	To                  *[]openapi_types.Email `json:"to,omitempty"`
+
+	// VoiceDegraded True when the sender's voice could not even be looked up, so this draft may be missing a voice its sender built. Distinct from voice_profile_version being null, which also covers the ordinary no-profile case. A client should say so: the sender cannot detect a missing voice by reading the text. Absent reads as false.
+	VoiceDegraded *bool `json:"voice_degraded,omitempty"`
 
 	// VoiceProfileVersion The Voice DNA PROFILE version (not a model version) that styled this draft — the "built from your corpus · vN" provenance; null when no ready voice profile shaped it.
 	VoiceProfileVersion *int `json:"voice_profile_version,omitempty"`

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -13,7 +13,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
-	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
 	"github.com/margince/margince/backend/internal/shared/kernel/draftfloor"
@@ -69,84 +68,6 @@ func (h Handlers) WithSendAuthority(authority SendAuthority) Handlers {
 func (h Handlers) WithRecipientDirectory(dir RecipientDirectory) Handlers {
 	h.store = h.store.WithRecipientDirectory(dir)
 	return h
-}
-
-// WithEmailDrafter returns handlers whose draft endpoint uses the injected
-// compose path. Drafting only proposes text; the send endpoint remains a
-// separate consent-gated operation.
-func (h Handlers) WithEmailDrafter(drafter EmailDrafter) Handlers {
-	h.emailDrafter = drafter
-	return h
-}
-
-// DraftResult is one prepared draft with its provenance: whether a model
-// produced it (Art. 50 disclosure) and which Voice DNA version styled it.
-type DraftResult struct {
-	Subject             string
-	Body                string
-	AIGenerated         bool
-	AIDisclosure        *string
-	VoiceProfileVersion *int
-	// DraftRef identifies this served voice draft for learning feedback
-	// (rejectVoiceDraft); nil when no voice profile styled it.
-	DraftRef *string
-}
-
-// FirstEmailDrafter drafts a message that OPENS a conversation, where
-// EmailDrafter answers one.
-//
-// It is a second method rather than an anchor that may be zero, because the two
-// take different evidence and a nil anchor would let a caller ask the reply
-// path a question it has no answer for. A reply reads the activity it answers —
-// its subject, its body, how long ago it arrived, who sent it. A first message
-// has none of that in existence: the caller's intent is the only subject
-// material there is, and everything else the draft is written from (the
-// language, the clock, who is signing) is server-derived either way.
-//
-// A drafter that implements only EmailDrafter leaves the first-message path on
-// the deterministic floor, which is what a deployment running no model gets on
-// both paths.
-type FirstEmailDrafter interface {
-	DraftFirstEmail(ctx context.Context, intent string) (string, string, error)
-}
-
-// ProvenanceEmailDrafter is the richer drafting seam: same draft, plus the
-// provenance the HTTP response stamps. A drafter that implements it is
-// preferred over the plain EmailDrafter shape; the plain seam stays for
-// consumers (agents, automation) whose surfaces carry text only.
-type ProvenanceEmailDrafter interface {
-	DraftEmailWithProvenance(ctx context.Context, anchor ids.UUID, intent string) (DraftResult, error)
-}
-
-func (h Handlers) DraftEmail(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
-	var req struct {
-		Intent *string `json:"intent"`
-	}
-	if r.ContentLength > 0 && !httperr.Decode(w, r, &req) {
-		return
-	}
-	intent := ""
-	if req.Intent != nil {
-		intent = *req.Intent
-	}
-	ctx := r.Context()
-	result, err := h.prepareEmailDraft(ctx, ids.UUID(id), intent)
-	if err != nil {
-		writeStoreErr(w, r, err)
-		return
-	}
-
-	replyTo := openapi_types.UUID(ids.UUID(id))
-	httperr.WriteJSON(w, http.StatusOK, crmcontracts.EmailDraft{
-		Subject:             result.Subject,
-		Body:                result.Body,
-		To:                  h.replyAddresses(ctx, ids.From[ids.ActivityKind](ids.UUID(id))),
-		InReplyToActivityId: &replyTo,
-		AiGenerated:         &result.AIGenerated,
-		AiDisclosure:        result.AIDisclosure,
-		VoiceProfileVersion: result.VoiceProfileVersion,
-		DraftRef:            result.DraftRef,
-	})
 }
 
 // GetReplyRecipient answers who a reply to this message would go to, without
@@ -223,33 +144,6 @@ func (h Handlers) replyAddresses(ctx context.Context, anchor ids.ActivityID) *[]
 		return nil
 	}
 	return &[]openapi_types.Email{openapi_types.Email(address)}
-}
-
-func (h Handlers) prepareEmailDraft(ctx context.Context, anchor ids.UUID, intent string) (DraftResult, error) {
-	if provenance, ok := h.emailDrafter.(ProvenanceEmailDrafter); ok {
-		return provenance.DraftEmailWithProvenance(ctx, anchor, intent)
-	}
-	if h.emailDrafter != nil {
-		subject, body, err := h.emailDrafter.DraftEmail(ctx, anchor, intent)
-		return DraftResult{Subject: subject, Body: body}, err
-	}
-	activity, err := h.store.GetActivityContent(ctx, ids.From[ids.ActivityKind](anchor), storekit.LiveOnly)
-	if err != nil {
-		return DraftResult{}, err
-	}
-	answering := DraftContext{
-		Band:      convstate.BandFresh,
-		Threaded:  IsMailThread(activity.Kind, activity.Direction),
-		Recipient: h.store.GreetingName(ctx, ids.From[ids.ActivityKind](anchor)),
-	}
-	if activity.Subject != nil {
-		answering.Topic = *activity.Subject
-	}
-	if activity.Body != nil {
-		answering.Body = *activity.Body
-	}
-	subject, body := DeterministicEmailDraft(answering, intent)
-	return DraftResult{Subject: subject, Body: body}, nil
 }
 
 // DeterministicEmailDraft is the shared no-model floor for every drafting

--- a/backend/internal/modules/activities/handlers_emaildraft.go
+++ b/backend/internal/modules/activities/handlers_emaildraft.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// The draft half of the email surface: the seams a compose path plugs into,
+// the provenance a served draft carries, and the endpoint that returns one.
+// Sending lives in handlers_email.go — drafting only proposes text and the
+// send endpoint remains a separate consent-gated operation.
+
+import (
+	"context"
+	"net/http"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/convstate"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// WithEmailDrafter returns handlers whose draft endpoint uses the injected
+// compose path.
+func (h Handlers) WithEmailDrafter(drafter EmailDrafter) Handlers {
+	h.emailDrafter = drafter
+	return h
+}
+
+// DraftResult is one prepared draft with its provenance: whether a model
+// produced it (Art. 50 disclosure) and which Voice DNA version styled it.
+type DraftResult struct {
+	Subject             string
+	Body                string
+	AIGenerated         bool
+	AIDisclosure        *string
+	VoiceProfileVersion *int
+	// DraftRef identifies this served voice draft for learning feedback
+	// (rejectVoiceDraft); nil when no voice profile styled it.
+	DraftRef *string
+	// VoiceDegraded says the sender's voice could not even be looked up, so
+	// nobody knows whether a profile should have styled this draft. It is
+	// distinct from a nil VoiceProfileVersion, which also covers the ordinary
+	// no-profile case, and it is the one state the sender cannot detect by
+	// reading the text.
+	VoiceDegraded bool
+}
+
+// FirstEmailDrafter drafts a message that OPENS a conversation, where
+// EmailDrafter answers one.
+//
+// It is a second method rather than an anchor that may be zero, because the two
+// take different evidence and a nil anchor would let a caller ask the reply
+// path a question it has no answer for. A reply reads the activity it answers —
+// its subject, its body, how long ago it arrived, who sent it. A first message
+// has none of that in existence: the caller's intent is the only subject
+// material there is, and everything else the draft is written from (the
+// language, the clock, who is signing) is server-derived either way.
+//
+// A drafter that implements only EmailDrafter leaves the first-message path on
+// the deterministic floor, which is what a deployment running no model gets on
+// both paths.
+type FirstEmailDrafter interface {
+	DraftFirstEmail(ctx context.Context, intent string) (string, string, error)
+}
+
+// ProvenanceEmailDrafter is the richer drafting seam: same draft, plus the
+// provenance the HTTP response stamps. A drafter that implements it is
+// preferred over the plain EmailDrafter shape; the plain seam stays for
+// consumers (agents, automation) whose surfaces carry text only.
+type ProvenanceEmailDrafter interface {
+	DraftEmailWithProvenance(ctx context.Context, anchor ids.UUID, intent string) (DraftResult, error)
+}
+
+func (h Handlers) DraftEmail(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
+	var req struct {
+		Intent *string `json:"intent"`
+	}
+	if r.ContentLength > 0 && !httperr.Decode(w, r, &req) {
+		return
+	}
+	intent := ""
+	if req.Intent != nil {
+		intent = *req.Intent
+	}
+	ctx := r.Context()
+	result, err := h.prepareEmailDraft(ctx, ids.UUID(id), intent)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+
+	replyTo := openapi_types.UUID(ids.UUID(id))
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.EmailDraft{
+		Subject:             result.Subject,
+		Body:                result.Body,
+		To:                  h.replyAddresses(ctx, ids.From[ids.ActivityKind](ids.UUID(id))),
+		InReplyToActivityId: &replyTo,
+		AiGenerated:         &result.AIGenerated,
+		AiDisclosure:        result.AIDisclosure,
+		VoiceProfileVersion: result.VoiceProfileVersion,
+		DraftRef:            result.DraftRef,
+		VoiceDegraded:       &result.VoiceDegraded,
+	})
+}
+
+func (h Handlers) prepareEmailDraft(ctx context.Context, anchor ids.UUID, intent string) (DraftResult, error) {
+	if provenance, ok := h.emailDrafter.(ProvenanceEmailDrafter); ok {
+		return provenance.DraftEmailWithProvenance(ctx, anchor, intent)
+	}
+	if h.emailDrafter != nil {
+		subject, body, err := h.emailDrafter.DraftEmail(ctx, anchor, intent)
+		return DraftResult{Subject: subject, Body: body}, err
+	}
+	activity, err := h.store.GetActivityContent(ctx, ids.From[ids.ActivityKind](anchor), storekit.LiveOnly)
+	if err != nil {
+		return DraftResult{}, err
+	}
+	answering := DraftContext{
+		Band:      convstate.BandFresh,
+		Threaded:  IsMailThread(activity.Kind, activity.Direction),
+		Recipient: h.store.GreetingName(ctx, ids.From[ids.ActivityKind](anchor)),
+	}
+	if activity.Subject != nil {
+		answering.Topic = *activity.Subject
+	}
+	if activity.Body != nil {
+		answering.Body = *activity.Body
+	}
+	subject, body := DeterministicEmailDraft(answering, intent)
+	return DraftResult{Subject: subject, Body: body}, nil
+}

--- a/backend/internal/modules/activities/handlers_emaildraft.go
+++ b/backend/internal/modules/activities/handlers_emaildraft.go
@@ -73,6 +73,10 @@ type ProvenanceEmailDrafter interface {
 	DraftEmailWithProvenance(ctx context.Context, anchor ids.UUID, intent string) (DraftResult, error)
 }
 
+// DraftEmail serves a reply draft for the anchored activity, with its
+// provenance: the Art. 50 disclosure, the voice version that styled it, and
+// whether the sender's voice was lost on the way (voice_degraded). Drafting
+// never sends; the send endpoint stays a separate consent-gated operation.
 func (h Handlers) DraftEmail(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
 	var req struct {
 		Intent *string `json:"intent"`

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -21191,6 +21191,8 @@ export interface components {
             readonly voice_profile_version?: number | null;
             /** @description Opaque reference identifying this served voice draft for learning feedback (rejectVoiceDraft); null when no voice profile styled it. */
             readonly draft_ref: string | null;
+            /** @description True when the sender's voice could not even be looked up, so this draft may be missing a voice its sender built. Distinct from voice_profile_version being null, which also covers the ordinary no-profile case. A client should say so: the sender cannot detect a missing voice by reading the text. Absent reads as false. */
+            readonly voice_degraded?: boolean;
         };
         /**
          * @description Who a reply to a message is addressed to: one person, resolved from the
@@ -21243,6 +21245,8 @@ export interface components {
             readonly voice_profile_version?: number | null;
             /** @description Opaque reference identifying this served draft. Null here: recording a draft for voice learning is a WRITE, and this operation performs none. */
             readonly draft_ref?: string | null;
+            /** @description True when the sender's voice could not even be looked up, so this draft may be missing a voice its sender built. Distinct from voice_profile_version being null, which also covers the ordinary no-profile case. A client should say so: the sender cannot detect a missing voice by reading the text. Absent reads as false. */
+            readonly voice_degraded?: boolean;
         };
         /**
          * @description One thing the draft was written from, named so the reader can check it rather than

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3069,6 +3069,8 @@ export const de = {
   "compose.aiDisclosureFallback":
     "Dieser Entwurf stammt von einer KI. Lesen und überarbeiten Sie ihn, bevor Sie senden.",
   "compose.voiceVersion": "Aus Ihrem Korpus gebaut · v{n}",
+  "compose.voiceDegraded":
+    "Ihr Stimmprofil konnte nicht geladen werden – dieser Entwurf ist nicht in Ihrer Stimme geschrieben. Erstellen Sie den Entwurf neu oder überarbeiten Sie ihn vor dem Senden.",
   "compose.provisional": "Vorläufige Stimme",
   "compose.provisionalHint":
     "Ihre Voice DNA wird noch aufgebaut. Sie prägt diesen Entwurf schon genauso wie eine fertige — es wird nichts zurückgehalten.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3112,6 +3112,8 @@ export const en = {
   "compose.aiDisclosureFallback":
     "This draft was produced by AI. Read it and edit it before you send.",
   "compose.voiceVersion": "Built from your corpus · v{n}",
+  "compose.voiceDegraded":
+    "Your voice profile couldn't be loaded, so this draft is not written in your voice. Draft again, or edit before sending.",
   "compose.provisional": "Provisional voice",
   "compose.provisionalHint":
     "Your Voice DNA is still being built. It already shapes this draft exactly as a finished one would — nothing is held back.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3037,6 +3037,8 @@ export const vi = {
   "compose.aiDisclosureFallback":
     "Bản nháp này do AI tạo. Hãy đọc và sửa trước khi gửi.",
   "compose.voiceVersion": "Dựng từ kho văn bản của bạn · v{n}",
+  "compose.voiceDegraded":
+    "Không tải được hồ sơ giọng văn của bạn, nên bản nháp này không viết theo giọng của bạn. Hãy soạn lại bản nháp hoặc chỉnh sửa trước khi gửi.",
   "compose.provisional": "Giọng tạm thời",
   "compose.provisionalHint":
     "Voice DNA của bạn vẫn đang được dựng. Giọng đó đã định hình bản nháp này y như một bản đã hoàn thiện — không giữ lại gì cả.",

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -602,6 +602,67 @@ describe("ComposeModal", () => {
     expect(screen.getByText("Provisional voice")).toBeTruthy();
   });
 
+  it("warns when the sender's voice could not be loaded for the draft", async () => {
+    stubRoutes({
+      "POST /activities/act-1/draft-email": () =>
+        jsonResponse({
+          subject: "Re: Q3 numbers",
+          body: "Thanks for the note.",
+          ai_generated: true,
+          ai_disclosure: "AI-assisted draft (Art. 50).",
+          voice_profile_version: null,
+          draft_ref: null,
+          voice_degraded: true,
+        }),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    expect(await screen.findByText(/not written in your voice/)).toBeTruthy();
+  });
+
+  it("stays quiet about the voice when a draft simply has no profile behind it", async () => {
+    stubRoutes({
+      "POST /activities/act-1/draft-email": () =>
+        jsonResponse({
+          subject: "Re: Q3 numbers",
+          body: "Thanks for the note.",
+          ai_generated: true,
+          ai_disclosure: "AI-assisted draft (Art. 50).",
+          voice_profile_version: null,
+          draft_ref: null,
+          voice_degraded: false,
+        }),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    expect(await screen.findByDisplayValue("Re: Q3 numbers")).toBeTruthy();
+    expect(screen.queryByText(/not written in your voice/)).toBeNull();
+  });
+
   it("flags nothing provisional when the profile is past that band", async () => {
     stubRoutes({
       "GET /voice-profiles": () =>

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -92,7 +92,7 @@ type VoiceProfile = components["schemas"]["VoiceProfile"];
 // output on this surface, whatever the human then does to the words.
 type DraftProvenance = Pick<
   EmailDraft,
-  "ai_generated" | "ai_disclosure" | "voice_profile_version"
+  "ai_generated" | "ai_disclosure" | "voice_profile_version" | "voice_degraded"
 >;
 
 // The link targets a relink can point at (relinkActivity's entity_type enum,
@@ -377,6 +377,7 @@ function fillFromDraft(
       ai_generated: drafted.ai_generated ?? false,
       ai_disclosure: drafted.ai_disclosure,
       voice_profile_version: drafted.voice_profile_version,
+      voice_degraded: drafted.voice_degraded ?? false,
     });
     form.setReasoning(result.reasoning ?? []);
     form.setScope(result.scope);
@@ -802,6 +803,7 @@ type DraftResult =
             | "ai_generated"
             | "ai_disclosure"
             | "voice_profile_version"
+            | "voice_degraded"
           >
         >;
       // Present only on the account-started path; a reply explains itself by
@@ -1528,6 +1530,13 @@ function DraftBand({
         {provenance.ai_disclosure || t("compose.aiDisclosureFallback")}
       </p>
       <DraftReasons reasons={reasons} onOpenRecord={openCited} />
+      {provenance.voice_degraded && (
+        // The one loss a sender cannot see in the text: their own voice is
+        // the register nobody proofreads for.
+        <Callout tone="warn" live="status">
+          {t("compose.voiceDegraded")}
+        </Callout>
+      )}
       {provenance.voice_profile_version != null && (
         <>
           <p className="t-caption">


### PR DESCRIPTION
## What

A failed voice-profile lookup degrades a draft silently today: the rep gets a plain model draft that reads exactly like a working one, and the only trace is one warn line in the API log. That is how a real incident stayed invisible for two days — five drafts served without the sender's voice between Sep 3 and Sep 4, detected only because the sender noticed the register himself. The sender cannot detect a missing voice by reading the text: their own register is the one thing they do not proofread for.

## How

- `draftvoice.Load` marks its error path with a new `Context.Degraded`, distinct from the ordinary no-profile case (`OK=false, Degraded=false`) and from a deployment with no voice lane at all.
- Every drafting surface carries the flag to the wire as `voice_degraded`: `EmailDraft` (reply path) and `AccountEmailDraft` (person, account, lead composers). The reply path threads it through `activities.DraftResult`; the composers hoist their `draftvoice.Load` call and stamp it in `persondraft.Wire` / `accountdraft.wire`.
- The compose drawer shows a `tone="warn"` callout in the AI-disclosure band when the flag is set ("…this draft is not written in your voice…", en/de/vi), and stays quiet when a draft simply has no profile behind it.
- MCP's `draft_email` verb maps onto the same REST operation, so the field flows there with no extra wiring.

## Along the way

- `handlers_email.go` crossed the 500-line file ceiling and is split by concept: the drafting seams, provenance type and draft endpoint move to `handlers_emaildraft.go`; sending stays. No behaviour change in the move.
- `accountdraft.wire` gains the same both-states `voice_degraded` test `persondraft.Wire` has — it is a second spelling of the same mapping, and nothing failed when it alone stopped threading the flag.

## Tests

- `draftvoice` gains its first unit test: a lookup error is `Degraded`, an absent profile is not, a nil reader is not.
- Wire tests on both composer mappings: the flag reaches the contract in both states (a client reading an absent field as false must not see "fine" for a lost voice).
- Drawer tests: the warning renders on `voice_degraded: true` and does not render for a plain no-profile draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mailbox owners can publish captured contacts to the workspace.
  - Contact visibility now distinguishes workspace-visible records from owner-private captures.
  - Email drafts support first-message generation and include draft-status details.
  - AI-generated drafts indicate when the sender’s voice profile could not be loaded.

- **Bug Fixes**
  - Drafts no longer show voice warnings when no voice profile exists normally.
  - Email visibility controls are hidden for withheld records.

- **Localization**
  - Added voice-profile and email-visibility translations in English, German, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->