### PR TITLE
Read how far apart the two authorities are, before deciding to enforce

### DIFF
--- a/backend/cmd/worker/authzdisagreement.go
+++ b/backend/cmd/worker/authzdisagreement.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// `worker authz-disagreement` — how far apart the outbound engine and the old
+// purpose gate have been.
+//
+// The engine has run in observe mode since it shipped: it decides, records, and
+// the old gate rules. Ending that is a decision somebody has to make on
+// evidence, and this is the evidence. Enforcing a rule nobody has measured is
+// how a compliance change becomes an outage.
+//
+// A subcommand rather than an endpoint because the question is asked once,
+// before a rollout, by whoever is deciding — not by the product on every page
+// load. It reads and writes nothing.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// runAuthzDisagreement prints the report, strictest-first.
+//
+// The ORDER is the point: an operator asking "what does enforcing cost me" is
+// asking about mail that stops, so the rows where the engine refuses what the
+// old gate allowed come first and carry a marker. The other direction is real
+// and worth seeing — it is mail enforcement would START allowing — but it is
+// not what makes a rollout dangerous.
+func runAuthzDisagreement(ctx context.Context, pool *pgxpool.Pool, args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("authz-disagreement", flag.ContinueOnError)
+	fs.SetOutput(stdout)
+	workspace := fs.String("workspace", "", "workspace id to report on (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *workspace == "" {
+		return fmt.Errorf("authz-disagreement: --workspace is required")
+	}
+	wsID, err := ids.Parse(*workspace)
+	if err != nil {
+		return fmt.Errorf("authz-disagreement: --workspace is not an id: %w", err)
+	}
+
+	// The system principal, because this is the installation asking about its
+	// own rollout rather than a seat asking about a person. Nothing it returns
+	// names a subject: no address, no consent state, only how two rules have
+	// compared.
+	ctx = principal.WithWorkspaceID(ctx, wsID)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:authz_disagreement",
+	})
+
+	store := consent.NewStore(database.BindTo(pool, ids.From[ids.WorkspaceKind](wsID)))
+	report, err := store.DisagreementReport(ctx)
+	if err != nil {
+		return err
+	}
+	if len(report) == 0 {
+		_, _ = fmt.Fprintln(stdout, "The engine and the old purpose gate have not disagreed about any delivery.")
+		return nil
+	}
+	return writeDisagreements(stdout, report)
+}
+
+// writeDisagreements renders the table and the one-line summary under it.
+func writeDisagreements(stdout io.Writer, report []consent.Disagreement) error {
+	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "DIRECTION\tCATEGORY\tREASON\tENGINE\tOLD GATE\tMESSAGES\tRECIPIENTS")
+	var stopping, starting int
+	for _, d := range report {
+		direction := "would start"
+		if d.EngineIsStricter {
+			direction = "WOULD STOP"
+			stopping += d.Deliveries
+		} else {
+			starting += d.Deliveries
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%d\n",
+			direction, d.Category, d.ReasonCode, d.EngineVerdict, d.LegacyVerdict,
+			d.Deliveries, d.Decisions)
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("authz-disagreement: writing the report: %w", err)
+	}
+	_, _ = fmt.Fprintf(stdout,
+		"\nEnforcing the engine today would stop %d message(s) that went out, and allow %d that did not.\n",
+		stopping, starting)
+	return nil
+}

--- a/backend/cmd/worker/authzdisagreement.go
+++ b/backend/cmd/worker/authzdisagreement.go
@@ -99,3 +99,21 @@ func writeDisagreements(stdout io.Writer, report []consent.Disagreement) error {
 		stopping, starting)
 	return nil
 }
+
+// runDatabaseSubcommand dispatches the subcommands that need a database, and
+// reports whether it handled the arguments.
+//
+// Separate from runDebugSubcommand (boot.go) because of WHEN it runs, not what
+// it contains: those loops take no DSN and run before the worker flags, while
+// these read the installation's own rows and must run after the role and
+// release assertions — a report against a schema this binary does not agree
+// with is a report about something else.
+func runDatabaseSubcommand(ctx context.Context, pool *pgxpool.Pool, args []string, stdout io.Writer) (bool, error) {
+	if len(args) == 0 {
+		return false, nil
+	}
+	if args[0] == "authz-disagreement" {
+		return true, runAuthzDisagreement(ctx, pool, args[1:], stdout)
+	}
+	return false, nil
+}

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -92,6 +92,14 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	if err := compose.AssertInstallationRelease(ctx, pool, logger, buildinfo.ReleaseVersion); err != nil {
 		return err
 	}
+	// A DB-backed subcommand, dispatched HERE rather than beside the DB-less
+	// ones: it reads the installation's own decision history, so it must run
+	// against a schema and a contract this binary agrees with — the two
+	// assertions above are what establish that.
+	if len(args) > 0 && args[0] == "authz-disagreement" {
+		return runAuthzDisagreement(ctx, pool, args[1:], stdout)
+	}
+
 	// And again on a tick, because the boot check answers once.
 	ctx, stopForReleaseSkew, releaseSkewErr := watchReleaseSkew(ctx, pool, logger)
 	defer stopForReleaseSkew()

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -76,28 +76,11 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	}
 	// Registered before the lanes' join below, so LIFO closes the pool after it.
 	defer pool.Close()
-	// Before any lane runs: a pool connecting as a role row-level security
-	// does not bind serves every tenant's rows to every job, and nothing later
-	// in this boot would say so.
-	if err := compose.AssertRuntimeRole(ctx, pool); err != nil {
+	if err := assertMayWorkAgainst(ctx, pool, logger); err != nil {
 		return err
 	}
-
-	// Before this role does ANY work: a worker from a different release than the
-	// one this installation records is half of a torn tag pull, and it stops
-	// rather than run the outbox relay, the retention evaluator and the agent
-	// runner against a schema and a contract that are not its own
-	// (compose/releaseversion.go carries why). Ahead of the composition record
-	// below, because a role that must not run must not write either.
-	if err := compose.AssertInstallationRelease(ctx, pool, logger, buildinfo.ReleaseVersion); err != nil {
+	if handled, err := runDatabaseSubcommand(ctx, pool, args, stdout); handled {
 		return err
-	}
-	// A DB-backed subcommand, dispatched HERE rather than beside the DB-less
-	// ones: it reads the installation's own decision history, so it must run
-	// against a schema and a contract this binary agrees with — the two
-	// assertions above are what establish that.
-	if len(args) > 0 && args[0] == "authz-disagreement" {
-		return runAuthzDisagreement(ctx, pool, args[1:], stdout)
 	}
 
 	// And again on a tick, because the boot check answers once.
@@ -439,4 +422,24 @@ func watchReleaseSkew(
 		stop()
 	}()
 	return ctx, stop, refused
+}
+
+// assertMayWorkAgainst refuses the two ways this binary could work against a
+// database it should not touch.
+//
+// The ROLE, because a pool connecting as a role row-level security does not
+// bind serves every tenant's rows to every job, and nothing later in this boot
+// would say so. The RELEASE, because a worker from a different release than the
+// one this installation records is half of a torn tag pull, and it stops rather
+// than run the outbox relay, the retention evaluator and the agent runner
+// against a schema and a contract that are not its own
+// (compose/releaseversion.go carries why).
+//
+// Both before this role does ANY work, and ahead of the composition record: a
+// role that must not run must not write either.
+func assertMayWorkAgainst(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) error {
+	if err := compose.AssertRuntimeRole(ctx, pool); err != nil {
+		return err
+	}
+	return compose.AssertInstallationRelease(ctx, pool, logger, buildinfo.ReleaseVersion)
 }

--- a/backend/internal/modules/consent/authorizedisagreement.go
+++ b/backend/internal/modules/consent/authorizedisagreement.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// How far apart the engine and the old purpose gate are, read from the record
+// rather than guessed.
+//
+// The engine has run in observe mode since it shipped: it decides, records, and
+// the old gate rules. That was always meant to end in a measurement — enforcing
+// a rule nobody has measured is how a compliance change becomes an outage, and
+// the one number that decides whether enforcement is safe is how often the two
+// already disagree, broken down by what the disagreement WAS.
+//
+// A count alone would not answer it. "The engine is stricter on 4,000
+// deliveries" reads as alarming and may be entirely correct — those may all be
+// the legacy transactional purpose, which was an unconditional allow and is
+// exactly what the engine exists to stop. What an operator needs is the shape:
+// which category, which reason, and which direction.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// disagreementLimit bounds the report. It groups rather than lists, so the
+// cardinality is (categories × reasons × directions) and small by construction;
+// the limit is a guard against a vocabulary that grew, not a page size.
+const disagreementLimit = 200
+
+// Disagreement is one shape of answer the two authorities gave differently, and
+// how often.
+type Disagreement struct {
+	// Category is what the engine resolved the message to be.
+	Category string
+	// ReasonCode is why the engine answered as it did.
+	ReasonCode string
+	// EngineVerdict and LegacyVerdict are the two answers.
+	EngineVerdict string
+	LegacyVerdict string
+	// Deliveries is how many distinct messages carry this shape. Distinct,
+	// because one message to five recipients is one send an operator would have
+	// to explain, not five.
+	Deliveries int
+	// Decisions is how many recipient-level decisions carry it.
+	Decisions int
+	// EngineIsStricter reports the direction that matters: the engine refusing
+	// something the old gate allowed is what would stop mail on a flip. The
+	// other direction is the engine permitting something the old gate refused,
+	// which enforcement would START allowing.
+	EngineIsStricter bool
+}
+
+// DisagreementReport reads how the engine and the old gate have differed.
+//
+// Gated on reading the installation's own settings rather than on a person:
+// this discloses nothing about any subject — no address, no name, no consent
+// state — only how two rules have compared across the installation. It is an
+// operational question about the product, and the audience is whoever decides
+// whether to enforce.
+func (s *Store) DisagreementReport(ctx context.Context) ([]Disagreement, error) {
+	if err := auth.Require(ctx, authorizationModesObject, principal.ActionRead); err != nil {
+		return nil, err
+	}
+	var out []Disagreement
+	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT resolved_category, reason_code, verdict, legacy_verdict,
+			       count(DISTINCT delivery_id), count(*)
+			  FROM communication_decision
+			 WHERE legacy_verdict IS NOT NULL
+			   AND legacy_verdict <> verdict
+			 GROUP BY resolved_category, reason_code, verdict, legacy_verdict
+			 ORDER BY count(DISTINCT delivery_id) DESC, resolved_category, reason_code
+			 LIMIT $1`, disagreementLimit)
+		if err != nil {
+			return fmt.Errorf("consent: read how the two authorities have differed: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var d Disagreement
+			if err := rows.Scan(&d.Category, &d.ReasonCode, &d.EngineVerdict,
+				&d.LegacyVerdict, &d.Deliveries, &d.Decisions); err != nil {
+				return fmt.Errorf("consent: read how the two authorities have differed: %w", err)
+			}
+			// The old gate answers allow or deny; the engine also answers
+			// review. Anything that is not an allow would stop the send once
+			// the engine rules, so review counts as stricter here — an operator
+			// asking "what would enforcing cost me" is asking about mail that
+			// stops, and a review stops it just as a deny does.
+			d.EngineIsStricter = d.LegacyVerdict == string(commsauthz.VerdictAllow) &&
+				d.EngineVerdict != string(commsauthz.VerdictAllow)
+			out = append(out, d)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/modules/consent/authorizedisagreement_integration_test.go
+++ b/backend/internal/modules/consent/authorizedisagreement_integration_test.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// What the disagreement report says, and the one thing it must never get wrong:
+// which direction a difference runs in.
+//
+// An operator reads this to decide whether enforcing the engine is safe. A
+// report that called a stricter engine "more permissive" would tell them the
+// opposite of the truth about mail that is going to stop.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// plantDecision writes one transmit decision with the two verdicts set.
+func (e *resolveEnv) plantDecision(t *testing.T, category, reason, engine, legacy string) {
+	t.Helper()
+	delivery := e.plantDelivery(t)
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO communication_decision
+		  (delivery_id, attempt, decision_set_id, recipient_address, phase,
+		   resolved_category, verdict, reason_code, legacy_verdict, mode, actor)
+		VALUES ($1, 1, $2, 'someone@corp.test', 'transmit', $3, $4, $5, $6, 'observe', 'test')`,
+		delivery, ids.NewV7(), category, engine, reason, legacy); err != nil {
+		t.Fatalf("planting the decision: %v", err)
+	}
+}
+
+// THE DIRECTION. An engine refusing what the old gate allowed is mail that
+// STOPS when enforcement lands; the reverse is mail that starts. An operator
+// deciding whether to flip is asking about the first.
+//
+// Mutation: swap the two sides of the EngineIsStricter comparison and this
+// fails.
+func TestTheReportSaysWhichWayADisagreementRuns(t *testing.T) {
+	e := setupResolve(t)
+	// The legacy transactional allow the engine will not reproduce.
+	e.plantDecision(t, "account_notice", commsauthz.ReasonLegacyTransactionalUnevidenced,
+		string(commsauthz.VerdictReview), string(commsauthz.VerdictAllow))
+	// And the other way: a reply the engine allows on the thread alone, which
+	// the old gate refused for want of a qualifying event.
+	e.plantDecision(t, "reply_to_inbound", commsauthz.ReasonAllowed,
+		string(commsauthz.VerdictAllow), string(commsauthz.VerdictDeny))
+
+	report := e.report(t)
+	if len(report) != 2 {
+		t.Fatalf("the report carries %d shapes, want 2", len(report))
+	}
+	byCategory := map[string]Disagreement{}
+	for _, d := range report {
+		byCategory[d.Category] = d
+	}
+	if got := byCategory["account_notice"]; !got.EngineIsStricter {
+		t.Error("an engine review against a legacy allow was not reported as stricter — that is mail that stops")
+	}
+	if got := byCategory["reply_to_inbound"]; got.EngineIsStricter {
+		t.Error("an engine allow against a legacy deny was reported as stricter, which is backwards")
+	}
+}
+
+// AGREEMENT IS NOT REPORTED. The report exists to show what differs, and rows
+// where the two agreed are the overwhelming majority — including them would
+// bury the answer in the thing that is already fine.
+func TestTheReportCarriesOnlyDisagreements(t *testing.T) {
+	e := setupResolve(t)
+	e.plantDecision(t, "reply_to_inbound", commsauthz.ReasonAllowed,
+		string(commsauthz.VerdictAllow), string(commsauthz.VerdictAllow))
+
+	if report := e.report(t); len(report) != 0 {
+		t.Fatalf("the report carries %d shapes for a decision both authorities agreed on, want none", len(report))
+	}
+}
+
+// A DECISION THE OLD GATE NEVER ANSWERED is not a disagreement. legacy_verdict
+// is nullable — a staging decision carries none — and NULL <> 'allow' is
+// unknown in SQL, so this passes today; it is asserted so a rewrite that
+// coalesced the column would fail rather than invent thousands of differences.
+func TestADecisionWithNoLegacyAnswerIsNotADisagreement(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO communication_decision
+		  (delivery_id, attempt, decision_set_id, recipient_address, phase,
+		   resolved_category, verdict, reason_code, mode, actor)
+		VALUES ($1, 0, $2, 'someone@corp.test', 'staging', 'marketing', 'review',
+		        'no_compatible_evidence', 'observe', 'test')`,
+		delivery, ids.NewV7()); err != nil {
+		t.Fatal(err)
+	}
+
+	if report := e.report(t); len(report) != 0 {
+		t.Fatalf("a decision the old gate never answered was reported as a disagreement: %+v", report)
+	}
+}
+
+// ONE MESSAGE TO FIVE PEOPLE IS ONE MESSAGE. An operator asking what
+// enforcement costs is asking how many SENDS stop, not how many rows changed —
+// counting recipients would inflate the number by the size of the To line.
+func TestOneMessageToSeveralRecipientsCountsOnce(t *testing.T) {
+	e := setupResolve(t)
+	delivery := e.plantDelivery(t)
+	for _, address := range []string{"a@corp.test", "b@corp.test", "c@corp.test"} {
+		if _, err := e.owner.Exec(context.Background(), `
+			INSERT INTO communication_decision
+			  (delivery_id, attempt, decision_set_id, recipient_address, phase,
+			   resolved_category, verdict, reason_code, legacy_verdict, mode, actor)
+			VALUES ($1, 1, $2, $3, 'transmit', 'account_notice', 'review',
+			        'legacy_transactional_unevidenced', 'allow', 'observe', 'test')`,
+			delivery, ids.NewV7(), address); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	report := e.report(t)
+	if len(report) != 1 {
+		t.Fatalf("the report carries %d shapes, want 1", len(report))
+	}
+	if report[0].Deliveries != 1 {
+		t.Errorf("deliveries = %d, want 1 — three recipients are one message", report[0].Deliveries)
+	}
+	if report[0].Decisions != 3 {
+		t.Errorf("decisions = %d, want 3 — the per-recipient count is the other half of the answer", report[0].Decisions)
+	}
+}
+
+// The report discloses nothing about any subject, so it is gated on reading the
+// installation's own settings rather than on a person. A caller without that
+// grant is refused.
+func TestTheReportNeedsTheSettingsReadGrant(t *testing.T) {
+	e := setupResolve(t)
+	e.dropGrant(t, authorizationModesObject)
+
+	_, err := e.store.DisagreementReport(e.ctx)
+	if err == nil {
+		t.Fatal("a caller with no settings-read grant read the report")
+	}
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("refused with %v, want ErrPermissionDenied", err)
+	}
+}
+
+// report runs the reader.
+func (e *resolveEnv) report(t *testing.T) []Disagreement {
+	t.Helper()
+	out, err := e.store.DisagreementReport(e.ctx)
+	if err != nil {
+		t.Fatalf("reading the report: %v", err)
+	}
+	return out
+}
+
+// THE SHAPE THE ROLLOUT DECISION TURNS ON. The legacy transactional purpose is
+// an unconditional allow the engine will not reproduce without evidence, so
+// every operational message sent under it is a disagreement — and enforcing
+// would stop all of them.
+//
+// Asserted as a scenario rather than left to be discovered in production,
+// because it is the single largest population the report will show and the one
+// an operator has to understand before flipping anything.
+func TestTheLegacyTransactionalAllowIsWhatEnforcementWouldStop(t *testing.T) {
+	e := setupResolve(t)
+	for range 3 {
+		e.plantDecision(t, "account_notice", commsauthz.ReasonLegacyTransactionalUnevidenced,
+			string(commsauthz.VerdictReview), string(commsauthz.VerdictAllow))
+	}
+
+	report := e.report(t)
+	if len(report) != 1 {
+		t.Fatalf("the report carries %d shapes, want the one", len(report))
+	}
+	got := report[0]
+	if !got.EngineIsStricter {
+		t.Fatal("the legacy transactional allow was not reported as mail that stops")
+	}
+	if got.Deliveries != 3 {
+		t.Errorf("deliveries = %d, want 3", got.Deliveries)
+	}
+	if got.ReasonCode != commsauthz.ReasonLegacyTransactionalUnevidenced {
+		t.Errorf("reason = %q, want the legacy-transactional code so an operator can see WHY", got.ReasonCode)
+	}
+}

--- a/backend/internal/modules/consent/authorizeresolve_integration_test.go
+++ b/backend/internal/modules/consent/authorizeresolve_integration_test.go
@@ -124,6 +124,10 @@ func setupResolve(t *testing.T) *resolveEnv {
 				"person":   {Read: true},
 				"finance":  {Read: true},
 				"contract": {Read: true},
+				// The installation's own settings, which is what the
+				// disagreement report is gated on: it discloses nothing about
+				// any subject, only how two rules have compared.
+				"installation_settings": {Read: true},
 			},
 			RowScope: principal.RowScopeAll,
 		},


### PR DESCRIPTION
The outbound engine has run in observe mode since it shipped: it decides, records, and the old purpose gate rules. That was always meant to end in a measurement. This is the measurement.

Third of three. [#3990](https://github.com/margince/margince/pull/3990) made the engine resolve what a message is; [#4001](https://github.com/margince/margince/pull/4001) made it verify a claim against the record; this reads what the two have disagreed about.

```
worker authz-disagreement --workspace <id>
```

## What it answers

**Which direction** is the column that matters. An engine refusing what the old gate allowed is mail that **stops** when enforcement lands; the reverse is mail that starts. An operator asking what enforcing costs them is asking about the first, so those rows come first and carry a marker, and the summary line says both numbers plainly.

A count alone would not answer it. *"The engine is stricter on 4,000 deliveries"* reads as alarming and may be entirely correct — those may all be the legacy `transactional` purpose, which is an unconditional allow and is exactly what the engine exists to stop. So the report groups by category, reason and direction, and counts **distinct deliveries** beside recipient-level decisions: one message to five people is one send somebody would have to explain, not five.

```
DIRECTION   CATEGORY        REASON                            ENGINE  OLD GATE  MESSAGES  RECIPIENTS
WOULD STOP  account_notice  legacy_transactional_unevidenced  review  allow     1         1

Enforcing the engine today would stop 1 message(s) that went out, and allow 0 that did not.
```

A subcommand rather than an endpoint: the question is asked once, before a rollout decision, by whoever is deciding. It reads and writes nothing, and it is gated on reading the installation's own settings rather than on a person — it discloses nothing about any subject, no address and no consent state, only how two rules have compared.

## What it says today: nothing

Run against the dev database, there are **zero decision rows** — anywhere outside test fixtures. No installation has sent mail through the engine yet.

That is the honest answer, and it is why this lands on its own rather than with a flip attached. **There is no evidence to enforce on, so proposing enforcement now would be proposing it blind.** I verified the tool renders a populated table by seeding one row by hand, reading it back, and deleting it again — the empty result is the data being empty, not the reader being broken.

## What the decision will turn on

Reading the two paths side by side, the disagreement is exhaustively:

| Case | Old gate | Engine | Direction |
|---|---|---|---|
| `transactional` purpose | unconditional allow | `account_notice`, unsupported | **engine stricter** |
| `business_correspondence` with a qualifying event | allow | same | agree |
| `business_correspondence` without one | review | allow if a thread or deal supports it | engine more permissive |
| Reply on a thread the subject started | needs a qualifying event | allow on the thread | engine more permissive |
| Live deal, recipient is a stakeholder | needs a qualifying event | allow on the deal | engine more permissive |

The first row is the whole risk: `transactional` is an unconditional allow today, so every operational message sent under it is a disagreement, and enforcing would stop all of them. `TestTheLegacyTransactionalAllowIsWhatEnforcementWouldStop` pins that shape so the largest population is named in a test rather than discovered in production.

## Along the way

`run()` in the worker was 83 code lines against a ceiling of 80 before this branch touched it. The craft gate is diff-scoped, so a file I am editing is mine to bring under: `assertMayWorkAgainst` pairs the two refusals answering one question (the runtime role and the installation release), and `runDatabaseSubcommand` sits beside the existing `runDebugSubcommand`, separate because of *when* it runs rather than what it holds.

## Gates

`make check-backend` green apart from two pre-existing `compose/attention` failures I confirmed are on `origin/main` independently of this branch — [#4011](https://github.com/margince/margince/pull/4011) already owns them. `make craft-static` green. Consent integration lane green. Every guard mutation-checked: swapping the direction comparison, dropping the disagreement filter, and counting recipients as messages each fail their own named test.

## Not in this PR

The flip itself, and the four gates the original plan attached to it. Both wait on data this reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `worker authz-disagreement --workspace <id>` so an operator can read, before deciding to enforce, how far apart the outbound engine and the old purpose gate have been.

- Reports disagreements grouped by category, reason, and direction, listing rows where the engine refuses what the old gate allowed first, since those are the sends enforcement would stop.
- Counts distinct deliveries beside recipient-level decisions, and the summary line states both totals.
- Run against the dev database it returns zero rows, so a flip would not be proposed blind.
- The worker boot now folds the role and release assertions into `assertMayWorkAgainst`, and the new subcommand dispatches through `runDatabaseSubcommand`.

<sup>Written for commit 14381d0a1c78db8a517d1b7ffc7ddd3168a1528a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a worker database command for reviewing disagreements between current and legacy consent decisions.
  * Reports disagreement categories, decision directions, affected deliveries, and decision totals, ordered from strictest outcomes first.
  * Requires appropriate settings-read authorization and clearly indicates when no disagreements are found.

* **Bug Fixes**
  * Improved worker startup validation before processing database commands.

* **Tests**
  * Added coverage for disagreement direction, aggregation, authorization, and excluded decision scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->