### PR TITLE
fix(attention): main is red since #3995 — the cross-source fixtures assert the demoted case

### DIFF
--- a/backend/internal/compose/attention/crosssourcerank_test.go
+++ b/backend/internal/compose/attention/crosssourcerank_test.go
@@ -57,6 +57,11 @@ func TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem(t *testing.T) {
 			Subject:    "Can you confirm the retrofit price?",
 			Since:      rankInstant.Add(-72 * time.Hour),
 			PersonID:   waitPerson,
+			// A conversation we are already in, which is what earns this row
+			// the top band at all: a wait with nothing to prove we ever wrote
+			// is demoted to routine, and the order below would then be
+			// asserting that instead of what it says.
+			Engaged: true,
 		}},
 		crmcontracts.Attention{
 			AsOf:        rankInstant,
@@ -90,6 +95,10 @@ func TestSystemNewsNeverLeadsACustomerWaiting(t *testing.T) {
 			Subject:    "Still waiting on that quote",
 			Since:      rankInstant.Add(-2 * time.Hour),
 			PersonID:   waitPerson,
+			// The customer in the name is one we have answered before. An
+			// unproven wait is routine by design, so leaving this false would
+			// make the test demand the opposite of the rule it is checking.
+			Engaged: true,
 		}},
 		crmcontracts.Attention{
 			AsOf:             rankInstant,


### PR DESCRIPTION
`main` has been red since [#3995](https://github.com/margince/margince/pull/3995).
Two tests in `internal/compose/attention` fail on a clean checkout of the tip:

```
--- FAIL: TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem
    ranked [meeting promise risk notice …a001], wanted [meeting …a001 promise risk notice]
--- FAIL: TestSystemNewsNeverLeadsACustomerWaiting
    the page led with [automation capture sync …a001] over a customer waiting two hours
```

In both, the waiting customer ranks **last** — below a hygiene notice in the
first, below three system rows in the second.

## Root cause

Bisected: green at `5de83df4d^`, red at `5de83df4d` (#3995). I reproduced both
against `origin/main` in a separate worktree before touching anything, so this
is main's state and not a local artefact.

#3995 added the rule that a wait with nothing to prove we ever wrote, and no
money on the thread, leaves the top band (`classify.go`):

```go
unproven := !waiting.Engaged && !waiting.HasOpenDeal
if unproven {
    level = levelRoutine
}
```

`Engaged` is a bool, so **a fixture written before the field existed asserts the
demoted case by saying nothing.** That is what happened here: the two
`WaitingCustomer` fixtures in `crosssourcerank_test.go` predate the field, so
they now classify as routine and sort beneath hygiene — which is exactly what
the ordering below them says must never happen.

#3995 knew this. It updated the `WaitingCustomer` fixtures in `worklist_test.go`
for precisely this reason, one of them carrying the comment:

> A conversation we are already in. Only such a wait leads the day — one where
> nothing proves we ever wrote is demoted, and **a fixture leaving this false
> would be asserting the opposite claim.**

It just did not reach `crosssourcerank_test.go`. I checked all 41
`WaitingCustomer` construction sites in the tree: those two are the only ones
that both omit `Engaged` and assert the top band, which is why exactly two tests
fail and not thirty.

## Why the fixtures and not the rule

The rule is deliberate and well covered — `waitingfreshness_test.go` asserts the
demotion, the `no_reply_history` reason, and the engaged case that must not
carry it. Its comment accepts the cost explicitly: *"DEMOTED, never dropped …
the cost of being wrong is a scroll instead."* An unproven wait sitting in the
routine band is that scroll, by design.

So the product is right and the fixtures were stating the opposite of what their
own assertions demand. Both now say `Engaged`, with the reason beside them —
a reader meeting `Engaged: true` in a ranking test needs to know it is load
bearing, not decoration.

## Verification

- `make check` from the repo root — green, both halves, 8m54s, zero failures
- `go test ./internal/compose/attention/` — ok
- Nine added lines, all in one `_test.go`; no production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated waiting-customer test scenarios to represent previously answered conversations.
  * Ensured customer-priority ranking assertions use the intended conversation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->