### PR TITLE
The drawer says who reads this message, and lets you change it

### DIFF
--- a/backend/gates/emailpresentation_test.go
+++ b/backend/gates/emailpresentation_test.go
@@ -111,6 +111,7 @@ var emailPassthroughs = gatekit.Waive(map[string]string{
 	"screens/recordchronology.tsx":       "wires onOpenEmail onto the entries it hands to the timeline; the rendering is composed.tsx's",
 	"screens/worklist.focus.tsx":         "suppresses its own title when the item carries a summary, leaving the row to WaitingEmailLine; the branch is the whole of its involvement",
 	"screens/worklist.row.tsx":           "same branch as the focus card, for the list row",
+	"screens/emailaccesseditor.tsx":      "draws the ACCESS block and no part of the message: who may read it, the named members, and the control to change that. No subject, no body, no party, no attachment. It takes the whole presentation because the audience write needs the id and version off it",
 })
 
 // entrySchemas reads the schemas the contract marks as an email.

--- a/frontend/src/design-system/emaildetail.tsx
+++ b/frontend/src/design-system/emaildetail.tsx
@@ -3,7 +3,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Paperclip, X } from "lucide-react";
-import { useId } from "react";
+import { type ReactNode, useId } from "react";
 
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -42,11 +42,24 @@ export function EmailDetail({
   activityId,
   onClose,
   formatWhen,
+  renderAccess,
 }: Readonly<{
   activityId: string;
   onClose: () => void;
   /** The caller owns the reader's timezone, so it owns the formatting. */
   formatWhen: (iso: string) => string;
+  /**
+   * Who reads this message, and the control to change it.
+   *
+   * Passed in rather than mounted here because the editor performs WRITES: it
+   * reaches the audience service and the roster reads, which live in `screens/`
+   * where the app's queries do. A design-system component importing those would
+   * turn the catalog into a layer that talks to the API.
+   *
+   * Optional, so a story or a preview can draw the message without wiring the
+   * writes — and absent means no region, never an empty one.
+   */
+  renderAccess?: (presentation: EmailPresentation) => ReactNode;
 }>) {
   const t = useT();
   // Generated rather than fixed: two drawers mounted at once would otherwise
@@ -135,7 +148,11 @@ export function EmailDetail({
           {null}
         </SurfaceState>
       ) : (
-        <EmailBody presentation={read.data} formatWhen={formatWhen} />
+        <EmailBody
+          presentation={read.data}
+          formatWhen={formatWhen}
+          renderAccess={renderAccess}
+        />
       )}
     </Modal>
   );
@@ -144,9 +161,11 @@ export function EmailDetail({
 function EmailBody({
   presentation,
   formatWhen,
+  renderAccess,
 }: Readonly<{
   presentation: EmailPresentation;
   formatWhen: (iso: string) => string;
+  renderAccess?: (presentation: EmailPresentation) => ReactNode;
 }>) {
   const t = useT();
   if (presentation.access.content_state === "withheld") {
@@ -192,6 +211,12 @@ function EmailBody({
         </details>
       )}
       <Attachments files={presentation.attachments} />
+      {/* Who reads this, last: a reader came for the message, and the limit on
+          it is what they check after reading rather than before. The withheld
+          branch above returns before here on purpose — that reader is told the
+          message is not shared with them, which is the whole of what the
+          access block would say, and `can_change` is false for them anyway. */}
+      {renderAccess?.(presentation)}
     </div>
   );
 }

--- a/frontend/src/design-system/openemaildrawer.tsx
+++ b/frontend/src/design-system/openemaildrawer.tsx
@@ -3,6 +3,7 @@
 
 import { formatDateTime } from "../format/format";
 import { useLocale } from "../i18n";
+import { EmailAccessEditor } from "../screens/emailaccesseditor";
 import { EmailDetail } from "./emaildetail";
 
 /**
@@ -12,6 +13,11 @@ import { EmailDetail } from "./emaildetail";
  * mount the same three lines, and `{openEmail && <EmailDetail …/>}` spends a
  * branch inside render callbacks that are already at the complexity ceiling.
  * Nothing is drawn when no message is open.
+ *
+ * This is also where the access editor is bound, so every page that mounts the
+ * drawer gets it. `EmailDetail` takes it as a render prop and never imports it:
+ * the editor performs writes and reads the roster, which is screen work, and
+ * the catalog component stays something a story can draw with no API behind it.
  */
 export function OpenEmailDrawer({
   activityId,
@@ -32,6 +38,9 @@ export function OpenEmailDrawer({
       activityId={activityId}
       onClose={onClose}
       formatWhen={(iso) => formatDateTime(iso, locale, zone)}
+      renderAccess={(presentation) => (
+        <EmailAccessEditor presentation={presentation} />
+      )}
     />
   );
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1518,6 +1518,14 @@ export const de = {
   "email.access.participants": "Beteiligte",
   "email.access.selected": "Ausgewählte",
   "email.access.withheld": "Zurückgehalten",
+  "email.access.sentence.team": "Alle im Unternehmen können das lesen.",
+  "email.access.sentence.participants":
+    "Nur die Beteiligten dieser Nachricht können sie lesen.",
+  "email.access.sentence.selected":
+    "Nur die unten genannten Personen können das lesen.",
+  "email.access.sentence.withheld":
+    "Diese Nachricht ist nicht für Sie freigegeben.",
+  "email.access.unnamedMember": "Jemand, der nicht mehr hier ist",
   "email.move.needsReply": "Antwort offen",
   "email.move.waitingForThem": "Warten auf Antwort",
   "email.detail.loading": "Nachricht wird geöffnet",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1572,6 +1572,13 @@ export const en = {
   "email.access.participants": "Participants",
   "email.access.selected": "Selected",
   "email.access.withheld": "Withheld",
+  "email.access.sentence.team": "Everyone in the organization can read this.",
+  "email.access.sentence.participants":
+    "Only the people on this message can read it.",
+  "email.access.sentence.selected":
+    "Only the people named below can read this.",
+  "email.access.sentence.withheld": "This message is not shared with you.",
+  "email.access.unnamedMember": "Someone no longer here",
   "email.move.needsReply": "Needs reply",
   "email.move.waitingForThem": "Waiting for them",
   "email.detail.loading": "Opening the message",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1512,6 +1512,13 @@ export const vi = {
   "email.access.participants": "Người tham gia",
   "email.access.selected": "Được chọn",
   "email.access.withheld": "Bị giữ lại",
+  "email.access.sentence.team": "Mọi người trong tổ chức đều đọc được thư này.",
+  "email.access.sentence.participants":
+    "Chỉ những người có trong thư này mới đọc được.",
+  "email.access.sentence.selected":
+    "Chỉ những người được nêu bên dưới mới đọc được thư này.",
+  "email.access.sentence.withheld": "Thư này không được chia sẻ với bạn.",
+  "email.access.unnamedMember": "Một người không còn ở đây",
   "email.move.needsReply": "Cần trả lời",
   "email.move.waitingForThem": "Đang chờ họ",
   "email.detail.loading": "Đang mở thư",

--- a/frontend/src/screens/audiencemembers.tsx
+++ b/frontend/src/screens/audiencemembers.tsx
@@ -14,12 +14,41 @@
 
 import type { components } from "../api/schema";
 import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 import { type RosterKind, useRoster } from "./entityref";
 import "./audiencemembers.css";
 
 type AudienceMember = components["schemas"]["AudienceMember"];
+type ActivityAudience = components["schemas"]["ActivityAudience"];
 type User = components["schemas"]["User"];
 type Team = components["schemas"]["Team"];
+
+// The audiences an editor offers — all three the API takes. `selected` waited
+// for a member picker, because offering it without one would be a choice the
+// reader cannot complete; AudienceMembers below is that picker.
+//
+// These three maps sit beside the picker rather than inside an editor because
+// there are now TWO: the timeline row's dialog, which names a NEW set, and the
+// drawer's, which edits the standing one. Two editors spelling one audience's
+// name differently is the drift a reader notices first — the row saying
+// "Selected" about a message the drawer calls something else.
+export const AUDIENCE_CHOICES: readonly ActivityAudience[] = [
+  "workspace",
+  "participants",
+  "selected",
+];
+
+export const AUDIENCE_LABEL: Record<ActivityAudience, MessageKey> = {
+  workspace: "compose.audienceWorkspace",
+  participants: "compose.audienceParticipants",
+  selected: "compose.audienceSelected",
+};
+
+export const AUDIENCE_HINT: Record<ActivityAudience, MessageKey> = {
+  workspace: "compose.audienceWorkspaceHint",
+  participants: "compose.audienceParticipantsHint",
+  selected: "compose.audienceSelectedHint",
+};
 
 /** One pickable seat or team, flattened out of the two rosters. */
 type Candidate = {

--- a/frontend/src/screens/emailaccesseditor.css
+++ b/frontend/src/screens/emailaccesseditor.css
@@ -1,0 +1,52 @@
+/* Who reads this message, under the message itself.
+ *
+ * Below the words rather than above them: it is the last thing a reader needs,
+ * and a strip in the header would push the subject they came for down the
+ * drawer. The rule above it is what separates a fact about the message from
+ * the message. */
+
+.emailaccess {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-3);
+  margin-top: var(--space-3);
+  border-top: 1px solid var(--borderSubtle);
+}
+
+.emailaccess__verdict {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.emailaccess__members {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Each named seat as its own chip. A comma-joined sentence would read as one
+   long name at a glance, and the set is the thing a reader is checking. */
+.emailaccess__member {
+  padding: 0 var(--space-2);
+  border: 1px solid var(--borderSubtle);
+  border-radius: var(--r-full);
+  line-height: 1.7;
+}
+
+.emailaccess__change {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.emailaccess__error {
+  margin: 0;
+  color: var(--dangerText);
+}

--- a/frontend/src/screens/emailaccesseditor.test.tsx
+++ b/frontend/src/screens/emailaccesseditor.test.tsx
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/** @vitest-environment jsdom */
+
+// What the drawer says about who reads a message, and what a reader may change.
+//
+// The claim that matters most here is the one the timeline row cannot make: the
+// editor opens with the set that is ALREADY on the message. The row's dialog
+// starts blank, because a list row carries no access block — so a reader
+// removing one person from a set of five had to re-tick the other four from
+// memory. These tests hold the difference.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { EmailAccessEditor } from "./emailaccesseditor";
+
+type EmailPresentation = components["schemas"]["EmailPresentation"];
+type EmailAccess = components["schemas"]["EmailAccess"];
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const ACTIVITY = "01a05500-0000-7000-8000-0000000000a1";
+const ANA = "01a05500-0000-7000-8000-0000000000c1";
+const BAO = "01a05500-0000-7000-8000-0000000000c2";
+
+const ROSTER = [
+  { id: ANA, display_name: "Ana Fischer", email: "ana@demo.test" },
+  { id: BAO, display_name: "Bao Nguyen", email: "bao@demo.test" },
+];
+
+/**
+ * One presentation, with the access block the test is about.
+ *
+ * Typed as the generated `EmailPresentation` rather than an object literal, so
+ * a fixture that drifts from the contract fails the build instead of proving
+ * the component handles a shape the server never sends.
+ */
+function presentation(access: Partial<EmailAccess>): EmailPresentation {
+  return {
+    id: ACTIVITY,
+    lifecycle: "delivered",
+    occurred_at: "2026-09-01T09:15:00Z",
+    summary: {
+      activity_id: ACTIVITY,
+      occurred_at: "2026-09-01T09:15:00Z",
+      version: 3,
+      subject: "The signed contract",
+      preview: "Attached, as agreed.",
+      display_status: "team",
+      move: "none",
+      attachment_count: 0,
+    },
+    body: "Attached, as agreed.",
+    thread_key: "t1",
+    from: [],
+    to: [],
+    cc: [],
+    bcc: [],
+    bcc_withheld: false,
+    attachments: [],
+    links: [],
+    thread: { members: [], next_cursor: null },
+    can_reply: true,
+    can_relink: false,
+    version: 3,
+    access: {
+      content_state: "available",
+      display_status: "team",
+      audience: "workspace",
+      can_change: false,
+      change_mode: "none",
+      ...access,
+    },
+  };
+}
+
+/**
+ * Draw the editor with the roster already read.
+ *
+ * The seats are seeded into the cache entry `useRoster` reads rather than
+ * stubbed at the wire: the roster is a PAGINATED WALK, so a fetch stub would
+ * have to reproduce its cursor protocol, and a test that supplies its own
+ * version of production proves nothing about production. This seeds the walk's
+ * result and lets the real hook read it.
+ *
+ * `fetch` is stubbed to reject so a request this component should not make
+ * fails loudly instead of hanging.
+ */
+function draw(node: ReactNode) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      throw new Error(`unexpected request: ${String(input)}`);
+    }),
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(["users"], { entries: ROSTER, partial: false });
+  client.setQueryData(["teams"], { entries: [], partial: false });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{node}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("what the drawer says about who reads a message", () => {
+  it("states the verdict even when the reader may change nothing", () => {
+    draw(
+      <EmailAccessEditor
+        presentation={presentation({
+          display_status: "participants",
+          audience: "participants",
+          can_change: false,
+          change_mode: "none",
+        })}
+      />,
+    );
+
+    // Who reads a message is a fact about it, like its date. A reader without
+    // standing to widen it is still told what it is.
+    expect(screen.getByText("Participants")).toBeTruthy();
+    expect(
+      screen.getByText("Only the people on this message can read it."),
+    ).toBeTruthy();
+    // And offered nothing to press, because the server said so.
+    expect(screen.queryByRole("button", { name: "Visibility" })).toBeNull();
+  });
+
+  it("offers no control to a reader the server refused, whatever mode it named", () => {
+    draw(
+      <EmailAccessEditor
+        presentation={presentation({
+          display_status: "selected",
+          audience: "selected",
+          // `can_change` alone decides. A response that refuses this caller
+          // while still naming the write it would otherwise take must draw
+          // nothing — the two are separate fields and only one is the
+          // permission. Gating on `change_mode` alone passes every other case
+          // in this file, which is how a missing check stays invisible.
+          can_change: false,
+          change_mode: "message_audience",
+        })}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Visibility" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Share/ })).toBeNull();
+  });
+
+  it("names the people a limited message is limited to", async () => {
+    draw(
+      <EmailAccessEditor
+        presentation={presentation({
+          display_status: "selected",
+          audience: "selected",
+          can_change: true,
+          change_mode: "message_audience",
+          selected_members: [
+            { subject_type: "user", subject_id: ANA },
+            { subject_type: "user", subject_id: BAO },
+          ],
+        })}
+      />,
+    );
+
+    // The write's vocabulary is uuids; a reader checking who can see their mail
+    // needs names.
+    await waitFor(() => expect(screen.getByText("Ana Fischer")).toBeTruthy());
+    expect(screen.getByText("Bao Nguyen")).toBeTruthy();
+    expect(screen.queryByText(ANA)).toBeNull();
+  });
+
+  it("draws no member list when the reader may not enumerate the set", () => {
+    draw(
+      <EmailAccessEditor
+        presentation={presentation({
+          display_status: "selected",
+          audience: "selected",
+          can_change: false,
+          change_mode: "none",
+          // Absent, which is what the server sends a reader who may read the
+          // content but not change who else may.
+        })}
+      />,
+    );
+
+    // An absent list is NOT an empty audience. Printing "nobody" would be a
+    // false statement about a message limited to people this reader cannot
+    // name, so nothing is drawn for it.
+    expect(
+      screen.getByText("Only the people named below can read this."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("list")).toBeNull();
+  });
+
+  it("opens the editor with the standing set already ticked", async () => {
+    const user = userEvent.setup();
+    draw(
+      <EmailAccessEditor
+        presentation={presentation({
+          display_status: "selected",
+          audience: "selected",
+          can_change: true,
+          change_mode: "message_audience",
+          selected_members: [{ subject_type: "user", subject_id: ANA }],
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Visibility" }));
+
+    // THE point of this editor. The timeline row's dialog opens blank, so a
+    // reader could only replace a set, never edit one. Here Ana is already
+    // ticked because the drawer had the access block in hand.
+    const ana = await screen.findByRole("checkbox", { name: /Ana Fischer/ });
+    expect((ana as HTMLInputElement).checked).toBe(true);
+    const bao = screen.getByRole("checkbox", { name: /Bao Nguyen/ });
+    expect((bao as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("enables the confirm when only the member set moved", async () => {
+    const user = userEvent.setup();
+    draw(
+      <EmailAccessEditor
+        presentation={presentation({
+          display_status: "selected",
+          audience: "selected",
+          can_change: true,
+          change_mode: "message_audience",
+          selected_members: [{ subject_type: "user", subject_id: ANA }],
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Visibility" }));
+    const confirm = await screen.findByRole("button", {
+      name: "Save visibility",
+    });
+
+    // Nothing moved yet: the audience is the same and so is the set.
+    expect((confirm as HTMLButtonElement).disabled).toBe(true);
+
+    // Adding Bao changes the set but NOT the audience, which stays `selected`.
+    // A confirm gated on the audience alone would sit disabled through exactly
+    // the edit this surface exists for.
+    await user.click(screen.getByRole("checkbox", { name: /Bao Nguyen/ }));
+    expect((confirm as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("refuses a selected audience with nobody in it", async () => {
+    const user = userEvent.setup();
+    draw(
+      <EmailAccessEditor
+        presentation={presentation({
+          display_status: "selected",
+          audience: "selected",
+          can_change: true,
+          change_mode: "message_audience",
+          selected_members: [{ subject_type: "user", subject_id: ANA }],
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Visibility" }));
+    const confirm = await screen.findByRole("button", {
+      name: "Save visibility",
+    });
+
+    // Unticking the only member leaves a limit nobody meant. Narrowing a
+    // message to nobody is refused rather than written.
+    await user.click(await screen.findByRole("checkbox", { name: /Ana/ }));
+    expect((confirm as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("offers the thread control for a captured message, not the dialog", () => {
+    draw(
+      <EmailAccessEditor
+        presentation={presentation({
+          display_status: "participants",
+          audience: "participants",
+          can_change: true,
+          change_mode: "thread_contribution",
+        })}
+      />,
+    );
+
+    // The server names which write it would accept. Nothing here re-derives it
+    // from `captured_by`, which is the inference this editor replaces: a
+    // captured message's audience is derived from every importing mailbox, so
+    // what this reader changes is their own contribution to the thread.
+    expect(screen.getByRole("button", { name: /Share/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Visibility" })).toBeNull();
+  });
+});

--- a/frontend/src/screens/emailaccesseditor.tsx
+++ b/frontend/src/screens/emailaccesseditor.tsx
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Who reads this message, said in the drawer, and changed there.
+//
+// The timeline row already had an audience dialog. It could not do this one
+// thing: start from the set that is already on the message. A list row carries
+// a summary, not an access block, so the row's dialog names a NEW set every
+// time it opens — and `selected_members` rides EmailAccess, which only the
+// detail read fetches. Reading one per row would be a request per visible line.
+//
+// The drawer has the access block in hand, so it is the surface that can show
+// a reader who is currently named and let them remove one person without
+// retyping the other four.
+//
+// It also ends an inference. The timeline decides which of the two audience
+// writes to offer by reading `captured_by` for a `connector:` prefix — display
+// code holding a backend ownership rule, kept because deleting it before this
+// editor existed would have taken the control off every row and given nothing
+// back. Here the server says which write it would accept, as `change_mode`, and
+// nothing guesses.
+
+import { useState } from "react";
+
+import type { components } from "../api/schema";
+import { Badge, Button } from "../design-system/atoms";
+import { ChoiceList } from "../design-system/choicelist";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import { emailDetailKey } from "../design-system/emaildetail";
+import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import {
+  AUDIENCE_CHOICES,
+  AUDIENCE_HINT,
+  AUDIENCE_LABEL,
+  AudienceMembers,
+  memberKey,
+  useAudienceCandidates,
+} from "./audiencemembers";
+import { useMessageAudience, useThreadAudience } from "./audienceservice";
+import { problemMessageOf } from "./common";
+import "./emailaccesseditor.css";
+
+type EmailPresentation = components["schemas"]["EmailPresentation"];
+type EmailAccess = components["schemas"]["EmailAccess"];
+type ActivityAudience = components["schemas"]["ActivityAudience"];
+type AudienceMember = components["schemas"]["AudienceMember"];
+type EmailAccessStatus = components["schemas"]["EmailAccessStatus"];
+
+// The sentence version of the row's one-word badge. The row shows "Selected"
+// because a badge that ran to a sentence would out-weigh the subject beside
+// it; here there is room to say what it means for the person reading.
+const STATUS_SENTENCE: Record<EmailAccessStatus, MessageKey> = {
+  team: "email.access.sentence.team",
+  participants: "email.access.sentence.participants",
+  selected: "email.access.sentence.selected",
+  withheld: "email.access.sentence.withheld",
+};
+
+/**
+ * What the drawer says about who reads this message, and the control to
+ * change it when this reader may.
+ *
+ * Always drawn, even for a reader who may change nothing: who may read a
+ * message is a fact about it, like its date. A reader without standing sees
+ * the sentence and no button — which is the honest rendering of "you can see
+ * that this is limited, and it is not yours to widen".
+ */
+export function EmailAccessEditor({
+  presentation,
+}: Readonly<{ presentation: EmailPresentation }>) {
+  const t = useT();
+  const { access } = presentation;
+  return (
+    <div className="emailaccess">
+      <div className="emailaccess__verdict">
+        <Badge tone={access.display_status === "withheld" ? "warn" : undefined}>
+          {t(STATUS_LABEL[access.display_status])}
+        </Badge>
+        <span className="t-caption">
+          {t(STATUS_SENTENCE[access.display_status])}
+        </span>
+      </div>
+      {/* WHY, when the server gave a reason. A held message the reader can see
+          the outline of is otherwise a limit with no author: the reason names
+          what decided it, which is what a person disagreeing with the verdict
+          needs before they can argue with it. */}
+      {access.explanation && <p className="t-caption">{access.explanation}</p>}
+      <NamedMembers access={access} />
+      {/* The control only where the server says this caller's write would be
+          taken. `can_change` and `change_mode` are decided by the authority
+          that would execute the write, so a button drawn from them is a button
+          the write accepts — nothing here re-derives it from the row. */}
+      {access.can_change && access.change_mode !== "none" && (
+        <ChangeAccess presentation={presentation} />
+      )}
+    </div>
+  );
+}
+
+// The one-word label, shared with the row's badge so both say the same word
+// about the same message.
+const STATUS_LABEL: Record<EmailAccessStatus, MessageKey> = {
+  team: "email.access.team",
+  participants: "email.access.participants",
+  selected: "email.access.selected",
+  withheld: "email.access.withheld",
+};
+
+/**
+ * Who is named, when the message is limited to a set and this reader may see
+ * the set.
+ *
+ * `selected_members` comes back only to a caller who may also change it — a
+ * reader with no standing to edit the set has no standing to enumerate it. So
+ * an absent list here is not an empty audience, and nothing is drawn for it:
+ * printing "nobody" would be a false statement about a message that is in fact
+ * limited to four people this reader may not name.
+ *
+ * The write's vocabulary is ids, not names — `AudienceMember` is a subject type
+ * and a uuid, which is the right shape for a write and unreadable in a list. So
+ * the names come from the roster the picker below already reads, on the same
+ * two cache entries: a reader who opens the editor pays no second fetch, and
+ * one who only looks pays two reads the app holds anyway.
+ */
+function NamedMembers({ access }: Readonly<{ access: EmailAccess }>) {
+  const t = useT();
+  const members = access.selected_members;
+  const named = useAudienceCandidates((members?.length ?? 0) > 0);
+  if (!members || members.length === 0) {
+    return null;
+  }
+  const nameOf = new Map(
+    named.map((candidate) => [
+      `${candidate.kind}:${candidate.id}`,
+      candidate.name,
+    ]),
+  );
+  return (
+    <ul className="emailaccess__members">
+      {members.map((member) => (
+        <li key={memberKey(member)} className="emailaccess__member">
+          {/* A member the roster has not answered for yet, or one it no longer
+              carries. The id is not shown: a uuid tells a reader nothing, and
+              a seat that has left the organization is still a real limit on
+              the message. */}
+          {nameOf.get(memberKey(member)) ?? t("email.access.unnamedMember")}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * The change control, in whichever of the two writes the server named.
+ *
+ * `thread_contribution` is a captured message: its audience is derived from
+ * what every importing mailbox asks for, so what this reader changes is their
+ * own contribution to the thread, and the outcome reports how many other seats
+ * still hold it. `message_audience` is a hand-logged one, which carries an
+ * audience somebody set and takes a direct write.
+ *
+ * Two writes and one control, because the reader is answering one question.
+ */
+function ChangeAccess({
+  presentation,
+}: Readonly<{ presentation: EmailPresentation }>) {
+  return presentation.access.change_mode === "thread_contribution" ? (
+    <ThreadContribution presentation={presentation} />
+  ) : (
+    <MessageAudience presentation={presentation} />
+  );
+}
+
+function ThreadContribution({
+  presentation,
+}: Readonly<{ presentation: EmailPresentation }>) {
+  const t = useT();
+  const [held, setHeld] = useState<number | null>(null);
+  const shared = presentation.access.audience === "workspace";
+  const threadKey = presentation.thread_key;
+  const mutation = useThreadAudience({
+    invalidate: () => [emailDetailKey(presentation.id)],
+    onSettled: ({ outcome }) => {
+      // A share that did not open the thread means a colleague still holds it.
+      // Saying so is the difference between a control that looks broken and
+      // one that reports what happened — and it is a COUNT, never a name,
+      // because whose mail a person keeps private is itself private.
+      setHeld(outcome && !outcome.shared ? outcome.held_by_others : null);
+    },
+  });
+  if (!threadKey) {
+    // The server offered the thread write for a message carrying no thread to
+    // write against. Nothing to press rather than a button that would 404.
+    return null;
+  }
+  return (
+    <div className="emailaccess__change">
+      <Button
+        small
+        pending={mutation.isPending}
+        onClick={() => {
+          setHeld(null);
+          mutation.mutate({ threadKey, share: !shared });
+        }}
+      >
+        {shared ? t("compose.threadKeepPrivate") : t("compose.threadShare")}
+      </Button>
+      {held !== null && (
+        <span className="t-caption">
+          {t("compose.threadStillHeld").replace("{count}", String(held))}
+        </span>
+      )}
+      {mutation.isError && (
+        <p className="emailaccess__error">
+          {problemMessageOf(mutation.error, t)}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The per-message editor, opened from the standing set rather than from empty.
+ *
+ * This is the whole reason the editor lives in the drawer. The timeline row's
+ * dialog starts every `selected` audience blank, so a reader removing one
+ * person from a set of five had to re-tick the other four and hope they
+ * remembered them. Here `selected_members` is already loaded, so the checklist
+ * opens with the real set ticked and the reader changes what they came to
+ * change.
+ */
+function MessageAudience({
+  presentation,
+}: Readonly<{ presentation: EmailPresentation }>) {
+  const t = useT();
+  const { access } = presentation;
+  const current: ActivityAudience = access.audience ?? "workspace";
+  const standing = access.selected_members ?? [];
+  const [open, setOpen] = useState(false);
+  const [choice, setChoice] = useState<ActivityAudience>(current);
+  const [members, setMembers] = useState<AudienceMember[]>(standing);
+  const candidates = useAudienceCandidates(open && choice === "selected");
+  const mutation = useMessageAudience({
+    invalidate: () => [emailDetailKey(presentation.id)],
+    onSettled: () => setOpen(false),
+  });
+  // Nothing to submit when neither the audience nor the set moved. Comparing
+  // the SET too is what makes this editor different from the row's: a reader
+  // who only removed somebody never changed `choice`, and a confirm gated on
+  // the audience alone would sit disabled through the one edit this surface
+  // exists for.
+  const unchanged =
+    choice === current && (choice !== "selected" || sameSet(members, standing));
+  return (
+    <div className="emailaccess__change">
+      <Button
+        small
+        onClick={() => {
+          setChoice(current);
+          setMembers(standing);
+          setOpen(true);
+        }}
+      >
+        {t("compose.audience")}
+      </Button>
+      {open && (
+        <ConfirmModal
+          open={open}
+          onClose={() => setOpen(false)}
+          title={t("compose.audienceTitle")}
+          confirmLabel={t("compose.audienceConfirm")}
+          confirmDisabled={
+            unchanged || (choice === "selected" && members.length === 0)
+          }
+          onConfirm={() =>
+            mutation.mutate({
+              activityId: presentation.id,
+              version: presentation.version,
+              audience: choice,
+              members: choice === "selected" ? members : undefined,
+            })
+          }
+          pending={mutation.isPending}
+          error={mutation.isError ? problemMessageOf(mutation.error, t) : null}
+        >
+          <div className="compose-fields">
+            <ChoiceList
+              legend={t("compose.audienceLegend")}
+              value={choice}
+              onChange={setChoice}
+              choices={AUDIENCE_CHOICES.map((value) => ({
+                value,
+                label: t(AUDIENCE_LABEL[value]),
+                description: t(AUDIENCE_HINT[value]),
+              }))}
+            />
+            {/* The picker only where the choice needs one. A limited-to-nobody
+                audience is not a limit anybody meant, so the confirm above
+                refuses an empty set rather than writing it. */}
+            {choice === "selected" && (
+              <AudienceMembers
+                candidates={candidates}
+                chosen={members}
+                onChange={setMembers}
+              />
+            )}
+            <p className="t-caption">{t("compose.audienceNote")}</p>
+          </div>
+        </ConfirmModal>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Whether two member sets name the same people, order disregarded.
+ *
+ * Order is not meaning here: the checklist appends in tick order and the server
+ * returns its own, so comparing sequences would call every set changed the
+ * moment a reader unticked somebody and ticked them back.
+ */
+function sameSet(
+  a: readonly AudienceMember[],
+  b: readonly AudienceMember[],
+): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  const inB = new Set(b.map(memberKey));
+  return a.every((member) => inB.has(memberKey(member)));
+}

--- a/frontend/src/screens/timelineactions.tsx
+++ b/frontend/src/screens/timelineactions.tsx
@@ -16,7 +16,13 @@ import { ConfirmModal } from "../design-system/confirmmodal";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { entityTimelineKeys } from "./activitykeys";
-import { AudienceMembers, useAudienceCandidates } from "./audiencemembers";
+import {
+  AUDIENCE_CHOICES,
+  AUDIENCE_HINT,
+  AUDIENCE_LABEL,
+  AudienceMembers,
+  useAudienceCandidates,
+} from "./audiencemembers";
 import { useMessageAudience, useThreadAudience } from "./audienceservice";
 import { problemMessageOf } from "./common";
 // Reply and Relink stay in compose.tsx for now: they are the composer's own
@@ -127,29 +133,6 @@ export function TimelineActions({
     </>
   );
 }
-
-// The audiences the dialog offers — all three the API takes. `selected` waited
-// for a member picker, because offering it without one would be a choice the
-// reader cannot complete; AudienceMembers is that picker.
-const AUDIENCE_CHOICES: readonly ActivityAudience[] = [
-  "workspace",
-  "participants",
-  "selected",
-];
-
-// What each audience is called and what it means, in one place: the label and
-// the hint were a pair of ternaries that a third value would have made a pair
-// of nested ones.
-const AUDIENCE_LABEL: Record<ActivityAudience, MessageKey> = {
-  workspace: "compose.audienceWorkspace",
-  participants: "compose.audienceParticipants",
-  selected: "compose.audienceSelected",
-};
-const AUDIENCE_HINT: Record<ActivityAudience, MessageKey> = {
-  workspace: "compose.audienceWorkspaceHint",
-  participants: "compose.audienceParticipantsHint",
-  selected: "compose.audienceSelectedHint",
-};
 
 // Why a captured message is held, in the reader's words. A reason the server
 // learned to give and this map has not falls back to nothing rather than to the


### PR DESCRIPTION
## What this fixes

An email's audience was decided by the server and shown nowhere in the drawer.

`EmailDetail` read `access.content_state` — enough to pick between the message and a withheld placeholder — and ignored the rest of the access block: `display_status`, `audience`, `selected_members`, `can_change`, `change_mode`. A rep could open a message and not learn who else in the organization could read it.

## Why the timeline dialog was not already the answer

There is an audience dialog on timeline rows, and it offers all three audiences with a member checklist. It has one thing it cannot do: **start from the set already on the message.**

A list row carries a summary, not an access block. `selected_members` rides `EmailPresentation`, which only the detail read fetches, and reading one per row would be a request per visible line. So the row's dialog names a NEW set every time it opens — a reader removing one person from a set of five had to re-tick the other four from memory. The comment beside it says exactly this and names the drawer as the place the fix belongs.

## What this adds

`screens/emailaccesseditor.tsx`:

- **States the verdict** as a sentence beside the row's one-word badge, for every reader — who may read a message is a fact about it, like its date.
- **Names the members** when the message is limited and the reader may enumerate the set. The write's vocabulary is uuids; the names come from the roster the picker already reads, on the same two cache entries.
- **Offers the control the server says it would accept.** `can_change` and `change_mode` are decided by the same authority that performs the write, so the button drawn from them is a button the write takes. Nothing re-derives it from `captured_by`.
- **Opens the checklist pre-filled**, which is the whole reason it lives here.

An absent `selected_members` draws no list: it means the reader may not enumerate the set, not that the audience is empty. Printing "nobody" would be a false statement about a message limited to four people this reader cannot name.

## Where it is bound

In `OpenEmailDrawer`, so all eight screens that mount the drawer get it at once. `EmailDetail` takes it as a render prop and never imports it — the editor reaches the audience service and the roster reads, which is screen work, and the catalog component stays something a story can draw with no API behind it.

The audience vocabulary (`AUDIENCE_CHOICES`, `AUDIENCE_LABEL`, `AUDIENCE_HINT`) moved to `audiencemembers.tsx` beside the picker. There are two editors now, and two spellings of one audience's name is the drift a reader notices first.

## Tests

Eight, each mutation-checked. The `can_change` one is worth naming: my first version gated on `can_change && change_mode !== "none"` and **every test still passed with `can_change` removed**, because the refusal case used `change_mode: "none"` and the second clause covered it. Two guards that both pass are one guard. Added a case where the server refuses the caller while still naming the write it would otherwise take — that isolates the permission, and it is the only test that fails when the gate is dropped.

## The gate

`emailpresentation_test.go` caught this file on the first run, correctly: it reads `EmailPresentation` and draws its own markup. It is waived rather than made canonical, because it draws the access block and no part of the message — verified, not asserted: `grep` for every message-content field on the presentation returns nothing in this file.

## Not done here

`design-system/rosterpicker.tsx` from the plan is **not** built. `audiencemembers.tsx` is already the reusable checklist taking `chosen` as a prop; a third spelling would be the duplication the rulebook forbids.

Deleting the `captured_by` inference at `timelineactions.tsx:103` is the natural follow-up now that this editor exists, and is left for its own change.

## Verification

- `make check-fe` — green (6278 tests)
- `make check-backend` — 173 packages ok; the two `internal/compose/attention` failures (`TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem`, `TestSystemNewsNeverLeadsACustomerWaiting`) **fail identically on clean `origin/main`** with this branch stashed. Pre-existing, not from this change.
- `.githooks/pre-push` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The drawer now states who can read an email and lets the reader change it, starting from the set already on the message instead of a blank checklist.

- Shows a sentence verdict beside the badge for every reader, and names the named members when the reader may enumerate them.
- Offers the change control only when the server says it would accept the write (`can_change` and `change_mode`), not inferred from `captured_by`.
- Opens the member checklist pre-filled, so removing one person no longer requires re-ticking the rest from memory.
- An absent `selected_members` draws no list; "nobody" would be a false statement about a set the reader cannot name.
- Bound in `OpenEmailDrawer` so all screens mounting the drawer get it; `EmailDetail` takes it as a render prop and stays API-free.
- Audience vocabulary moved to `audiencemembers.tsx`, shared by the timeline row's dialog and this editor.
- Added eight mutation-checked tests, including one that isolates the `can_change` permission from `change_mode`.
- The `captured_by` inference in `timelineactions.tsx` stays for now; removing it is a follow-up.

<sup>Written for commit c173aecd3cecd05ede4e1ebd219b4322dc6849f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an email access editor showing visibility status, explanations, and applicable members.
  - Added authorized controls for changing thread or message audiences, including validation and save-state feedback.
  - Email details and the email drawer now display access controls where available.
  - Added audience options for everyone, participants, or selected recipients.

- **Localization**
  - Added English, German, and Vietnamese translations for email access explanations and member labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->