### PR TITLE
A record says who it is for

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -23349,6 +23349,20 @@ components:
         full_name: { type: string, description: Always present (display name). }
         title: { type: [string, 'null'], description: Denormalized current title; authoritative title is on the employment relationship. }
         owner_id: { type: [string, 'null'], format: uuid }
+        visibility:
+          type: string
+          enum: [workspace, owner]
+          readOnly: true
+          description: >-
+            Who this record is for. `workspace` is every seat that holds the read grant.
+            `owner` is capture privacy: a connector made this record from a message nothing
+            had judged yet, and it belongs to the mailbox owner alone until something does —
+            not to their team, their manager, or an admin.
+            You are only ever sent a row you may already read, so this discloses nothing new;
+            it says WHY you can see it, which is what lets a page tell "private to you" from
+            "shared with everybody" instead of leaving the owner to guess. An `owner` row
+            reaches the workspace through a verdict or through the owner's own
+            `POST /people/{id}/publish`, and never travels back.
         writable:
           type: boolean
           readOnly: true
@@ -23660,6 +23674,20 @@ components:
           enum: [null, '1-10', '11-50', '51-200', '201-500', '501-1000', '1001-5000', '5000+']
         address: { $ref: '#/components/schemas/Address' }
         owner_id: { type: [string, 'null'], format: uuid }
+        visibility:
+          type: string
+          enum: [workspace, owner]
+          readOnly: true
+          description: >-
+            Who this record is for. `workspace` is every seat that holds the read grant.
+            `owner` is capture privacy: a connector made this record from a message nothing
+            had judged yet, and it belongs to the mailbox owner alone until something does —
+            not to their team, their manager, or an admin.
+            You are only ever sent a row you may already read, so this discloses nothing new;
+            it says WHY you can see it, which is what lets a page tell "private to you" from
+            "shared with everybody" instead of leaving the owner to guess. An `owner` row
+            reaches the workspace through a verdict or through the owner's own
+            `POST /people/{id}/publish`, and never travels back.
         writable:
           type: boolean
           readOnly: true

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -23686,8 +23686,8 @@ components:
             You are only ever sent a row you may already read, so this discloses nothing new;
             it says WHY you can see it, which is what lets a page tell "private to you" from
             "shared with everybody" instead of leaving the owner to guess. An `owner` row
-            reaches the workspace through a verdict or through the owner's own
-            `POST /people/{id}/publish`, and never travels back.
+            reaches the workspace through a sender verdict, and never travels back. There is no
+            owner-driven door for an organization: `POST /people/{id}/publish` is a person's.
         writable:
           type: boolean
           readOnly: true

--- a/backend/internal/compose/capturepromote_integration_test.go
+++ b/backend/internal/compose/capturepromote_integration_test.go
@@ -26,9 +26,11 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/margince/margince/backend/internal/compose/integration"
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/modules/people"
 	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/database/storekit"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -826,4 +828,61 @@ func seatCtx(e *integration.Env, user ids.UUID) context.Context {
 			RowScope: principal.RowScopeAll,
 		},
 	})
+}
+
+// TestARecordSaysWhoItIsFor puts capture privacy on the wire.
+//
+// A client could see that it may not WRITE a row and not that the row it is
+// reading is private to the person reading it. Without the field a page cannot
+// tell "private to you" from "shared with everybody", which is the question the
+// owner of a captured contact is actually asking.
+//
+// It discloses nothing: a caller is only ever sent a row they may already read.
+func TestARecordSaysWhoItIsFor(t *testing.T) {
+	e := integration.Setup(t)
+	const sender = "sicht@partner.example"
+
+	seedAttestedOutbound(t, e, "vis-out-1", sender, "vis-t1")
+	captureInboundThroughRealSink(t, e, e.Rep1, "vis-in-1", sender, "vis-t1")
+	personID := personIDFor(t, e, sender)
+
+	store := people.NewStore(InstallationDB(e.Pool))
+	owner := seatCtx(e, e.Rep1)
+
+	got, err := store.GetPerson(owner, personID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("the owner reading their own captured contact: %v", err)
+	}
+	if got.Visibility == nil || *got.Visibility != crmcontracts.PersonVisibilityOwner {
+		t.Fatalf("a fresh capture reads %v, want owner — a page cannot say \"private to you\" "+
+			"about a field the server never sends", got.Visibility)
+	}
+
+	// And it follows the record when the owner publishes it.
+	if err := store.PromoteOwnCapturedPerson(owner, personID); err != nil {
+		t.Fatalf("publishing: %v", err)
+	}
+	after, err := store.GetPerson(owner, personID, storekit.LiveOnly)
+	if err != nil {
+		t.Fatalf("reading it back: %v", err)
+	}
+	if after.Visibility == nil || *after.Visibility != crmcontracts.PersonVisibilityWorkspace {
+		t.Fatalf("after publishing it reads %v, want workspace", after.Visibility)
+	}
+
+	// The list carries it too: the two paths share one scanner, and a field on
+	// only one of them is how a page shows a badge that vanishes on refresh.
+	listed, _, err := store.ListPeople(owner, people.ListPeopleInput{})
+	if err != nil {
+		t.Fatalf("listing: %v", err)
+	}
+	for _, p := range listed {
+		if ids.UUID(p.Id) == personID.UUID {
+			if p.Visibility == nil || *p.Visibility != crmcontracts.PersonVisibilityWorkspace {
+				t.Fatalf("the listed row reads %v, want workspace", p.Visibility)
+			}
+			return
+		}
+	}
+	t.Fatal("the published contact is missing from the owner's own list")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -7372,6 +7372,24 @@ func (e OrganizationSizeBand) Valid() bool {
 	}
 }
 
+// Defines values for OrganizationVisibility.
+const (
+	OrganizationVisibilityOwner     OrganizationVisibility = "owner"
+	OrganizationVisibilityWorkspace OrganizationVisibility = "workspace"
+)
+
+// Valid indicates whether the value is a known member of the OrganizationVisibility enum.
+func (e OrganizationVisibility) Valid() bool {
+	switch e {
+	case OrganizationVisibilityOwner:
+		return true
+	case OrganizationVisibilityWorkspace:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for Organization360SectionsOmitted.
 const (
 	Organization360SectionsOmittedActivities       Organization360SectionsOmitted = "activities"
@@ -8518,6 +8536,24 @@ func (e PartnerRelationshipStage) Valid() bool {
 	case PartnerRelationshipStageNoFit:
 		return true
 	case PartnerRelationshipStageResearch:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PersonVisibility.
+const (
+	PersonVisibilityOwner     PersonVisibility = "owner"
+	PersonVisibilityWorkspace PersonVisibility = "workspace"
+)
+
+// Valid indicates whether the value is a known member of the PersonVisibility enum.
+func (e PersonVisibility) Valid() bool {
+	switch e {
+	case PersonVisibilityOwner:
+		return true
+	case PersonVisibilityWorkspace:
 		return true
 	default:
 		return false
@@ -14898,19 +14934,19 @@ func (e ListPeopleParamsCapturedByKind) Valid() bool {
 
 // Defines values for ListPeopleParamsTagMode.
 const (
-	ListPeopleParamsTagModeAll  ListPeopleParamsTagMode = "all"
-	ListPeopleParamsTagModeAny  ListPeopleParamsTagMode = "any"
-	ListPeopleParamsTagModeNone ListPeopleParamsTagMode = "none"
+	All  ListPeopleParamsTagMode = "all"
+	Any  ListPeopleParamsTagMode = "any"
+	None ListPeopleParamsTagMode = "none"
 )
 
 // Valid indicates whether the value is a known member of the ListPeopleParamsTagMode enum.
 func (e ListPeopleParamsTagMode) Valid() bool {
 	switch e {
-	case ListPeopleParamsTagModeAll:
+	case All:
 		return true
-	case ListPeopleParamsTagModeAny:
+	case Any:
 		return true
-	case ListPeopleParamsTagModeNone:
+	case None:
 		return true
 	default:
 		return false
@@ -24944,6 +24980,9 @@ type Organization struct {
 	// not only overlay mode.
 	Version *RowVersion `json:"version,omitempty"`
 
+	// Visibility Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a verdict or through the owner's own `POST /people/{id}/publish`, and never travels back.
+	Visibility *OrganizationVisibility `json:"visibility,omitempty"`
+
 	// WebsiteUrl The company's readable website, DERIVED from its primary domain row. There is deliberately no website column — a second store for a fact organization_domain already owns is the duplication ADR-0085 closes. Not accepted on write.
 	WebsiteUrl *string `json:"website_url,omitempty"`
 
@@ -24963,6 +25002,9 @@ type OrganizationRelationshipTypes string
 
 // OrganizationSizeBand defines model for Organization.SizeBand.
 type OrganizationSizeBand string
+
+// OrganizationVisibility Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a verdict or through the owner's own `POST /people/{id}/publish`, and never travels back.
+type OrganizationVisibility string
 
 // Organization360 The company record page in one payload. Every section except `organization` is
 // optional: absent means the caller lacks its grant, and `sections_omitted` names it.
@@ -26926,10 +26968,16 @@ type Person struct {
 	// not only overlay mode.
 	Version *RowVersion `json:"version,omitempty"`
 
+	// Visibility Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a verdict or through the owner's own `POST /people/{id}/publish`, and never travels back.
+	Visibility *PersonVisibility `json:"visibility,omitempty"`
+
 	// Writable Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed.
 	Writable             *bool                  `json:"writable,omitempty"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
+
+// PersonVisibility Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a verdict or through the owner's own `POST /people/{id}/publish`, and never travels back.
+type PersonVisibility string
 
 // Person360 The person record page in one payload (PO-EXT-3). Every section except `person` is
 // optional: absent means the caller lacks its grant, and `sections_omitted` names it.
@@ -42961,6 +43009,14 @@ func (a *Organization) UnmarshalJSON(b []byte) error {
 		delete(object, "version")
 	}
 
+	if raw, found := object["visibility"]; found {
+		err = json.Unmarshal(raw, &a.Visibility)
+		if err != nil {
+			return fmt.Errorf("error reading 'visibility': %w", err)
+		}
+		delete(object, "visibility")
+	}
+
 	if raw, found := object["website_url"]; found {
 		err = json.Unmarshal(raw, &a.WebsiteUrl)
 		if err != nil {
@@ -43198,6 +43254,13 @@ func (a Organization) MarshalJSON() ([]byte, error) {
 		object["version"], err = json.Marshal(a.Version)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'version': %w", err)
+		}
+	}
+
+	if a.Visibility != nil {
+		object["visibility"], err = json.Marshal(a.Visibility)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'visibility': %w", err)
 		}
 	}
 
@@ -43441,6 +43504,14 @@ func (a *Person) UnmarshalJSON(b []byte) error {
 		delete(object, "version")
 	}
 
+	if raw, found := object["visibility"]; found {
+		err = json.Unmarshal(raw, &a.Visibility)
+		if err != nil {
+			return fmt.Errorf("error reading 'visibility': %w", err)
+		}
+		delete(object, "visibility")
+	}
+
 	if raw, found := object["writable"]; found {
 		err = json.Unmarshal(raw, &a.Writable)
 		if err != nil {
@@ -43621,6 +43692,13 @@ func (a Person) MarshalJSON() ([]byte, error) {
 		object["version"], err = json.Marshal(a.Version)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'version': %w", err)
+		}
+	}
+
+	if a.Visibility != nil {
+		object["visibility"], err = json.Marshal(a.Visibility)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'visibility': %w", err)
 		}
 	}
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -24980,7 +24980,7 @@ type Organization struct {
 	// not only overlay mode.
 	Version *RowVersion `json:"version,omitempty"`
 
-	// Visibility Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a verdict or through the owner's own `POST /people/{id}/publish`, and never travels back.
+	// Visibility Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a sender verdict, and never travels back. There is no owner-driven door for an organization: `POST /people/{id}/publish` is a person's.
 	Visibility *OrganizationVisibility `json:"visibility,omitempty"`
 
 	// WebsiteUrl The company's readable website, DERIVED from its primary domain row. There is deliberately no website column — a second store for a fact organization_domain already owns is the duplication ADR-0085 closes. Not accepted on write.
@@ -25003,7 +25003,7 @@ type OrganizationRelationshipTypes string
 // OrganizationSizeBand defines model for Organization.SizeBand.
 type OrganizationSizeBand string
 
-// OrganizationVisibility Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a verdict or through the owner's own `POST /people/{id}/publish`, and never travels back.
+// OrganizationVisibility Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a sender verdict, and never travels back. There is no owner-driven door for an organization: `POST /people/{id}/publish` is a person's.
 type OrganizationVisibility string
 
 // Organization360 The company record page in one payload. Every section except `organization` is

--- a/backend/internal/modules/knowledge/handbook/seats-roles-and-access.md
+++ b/backend/internal/modules/knowledge/handbook/seats-roles-and-access.md
@@ -62,8 +62,8 @@ The licence is checked offline at start-up. It is never phoned home.
 
 | Role | Sees | Changes |
 |---|---|---|
-| **Admin** | everything | everything, configuration included |
-| **Ops** | everything | everything — the same grid as Admin |
+| **Admin** | every normal record, and all configuration | everything, configuration included |
+| **Ops** | every normal record, and all configuration | everything — the same grid as Admin |
 | **Management** | every record in the organization | every record; no administrative power |
 | **Team Lead** | records | records they own; configuration read-only; no access to exchange rates, model prices, imports or retention |
 | **User** | records | records they own; configuration read-only; full control of their own saved views |
@@ -87,13 +87,29 @@ Three levels: **own**, **team**, **all**.
 
 Here is the part that differs from most CRMs, and it is deliberate:
 
-> **Reading a contact, company, lead or deal ignores row scope entirely.**
+> **Reading a contact, company, lead, deal or project ignores row scope
+> entirely.**
 
-Every seat holding the read permission reads every contact, company, lead and
-deal in the organization. The app states it: "Reads every contact, company, lead
-and deal in the organization."
+Every seat holding the read permission reads every contact, company, lead, deal
+and project in the organization. The app states it: "Reads every contact,
+company, lead and deal in the organization."
 
-Row scope governs **writes**, and it governs **projects**. Not customer reads.
+Row scope governs **writes**. Not customer reads. Projects used to be the
+exception and are not any more: a consultant delivering a project they neither
+owned nor were granted got a 404, which is not a privacy boundary, only a
+broken one.
+
+Two things the word "everything" above does NOT cover, for any role including
+Admin, because neither is a tier of row scope:
+
+- **Correspondence you were not part of.** Mail and meetings carry their own
+  audience, and seniority does not override it.
+- **A captured contact still private to the person whose mailbox made it.** A
+  connector creates a contact from a message nothing has judged yet, and it
+  belongs to that seat alone until a classifier judges the sender or the owner
+  publishes it themselves. An admin gets a 404, which is the point: connecting
+  a mailbox with a year of history must not put every correspondent, a lawyer
+  and a doctor among them, in front of the organization.
 
 The reasoning is that a shared pipeline is the point. Two narrowings survive: a
 record created by a connector can stay private to its owner until promoted, and a

--- a/backend/internal/modules/overlay/fieldbinding.go
+++ b/backend/internal/modules/overlay/fieldbinding.go
@@ -154,6 +154,10 @@ var personBindings = EntityBinding{
 			WireSlot: "writable", Disposition: DispositionNativeOnly,
 			Reason: "Whether THIS caller may change the row, answered by this installation's own write gate from its ownership, teams and record grants. An incumbent CRM's permission model is not those, so a mirrored value would be a different question's answer wearing this field's name.",
 		},
+		{
+			WireSlot: "visibility", Disposition: DispositionNativeOnly,
+			Reason: "Capture privacy: whether a connector made this record from a message nothing had judged yet, so it belongs to the mailbox owner alone until something does. It is a fact about THIS installation's own ingestion, and an incumbent CRM that never held the mailbox has no answer to mirror — a row read through an overlay is the incumbent's, which is to say already shared with whoever the incumbent shares it with.",
+		},
 		{WireSlot: "first_name", CanonicalKey: "first_name", Incumbent: []string{"firstname"}, Disposition: DispositionMapped},
 		{WireSlot: "last_name", CanonicalKey: "last_name", Incumbent: []string{"lastname"}, Disposition: DispositionMapped},
 		{WireSlot: "full_name", CanonicalKey: "full_name", Incumbent: []string{"firstname", "lastname", "email"}, Transform: "full_name", Disposition: DispositionMapped},
@@ -212,6 +216,10 @@ var organizationBindings = EntityBinding{
 		{
 			WireSlot: "writable", Disposition: DispositionNativeOnly,
 			Reason: "Whether THIS caller may change the row, answered by this installation's own write gate from its ownership, teams and record grants. An incumbent CRM's permission model is not those, so a mirrored value would be a different question's answer wearing this field's name.",
+		},
+		{
+			WireSlot: "visibility", Disposition: DispositionNativeOnly,
+			Reason: "Capture privacy: whether a connector made this record from a message nothing had judged yet, so it belongs to the mailbox owner alone until something does. It is a fact about THIS installation's own ingestion, and an incumbent CRM that never held the mailbox has no answer to mirror — a row read through an overlay is the incumbent's, which is to say already shared with whoever the incumbent shares it with.",
 		},
 		{WireSlot: "display_name", CanonicalKey: "display_name", Incumbent: []string{"name"}, Disposition: DispositionMapped},
 		{WireSlot: "industry", CanonicalKey: "industry", Incumbent: []string{"industry"}, Disposition: DispositionMapped},

--- a/backend/internal/modules/people/organization_read.go
+++ b/backend/internal/modules/people/organization_read.go
@@ -145,9 +145,10 @@ func scanOrganization(row pgx.Row, active []fieldcatalog.Column, extra ...any) (
 	var logoObjectKey *string
 	var linkedinURL *string
 	var version int64
+	var visibility string
 
 	dests := []any{
-		&id, &o.DisplayName, &o.LegalName, &o.Description, &o.Industry, &o.SizeBand, &ownerID,
+		&id, &o.DisplayName, &o.LegalName, &o.Description, &o.Industry, &o.SizeBand, &ownerID, &visibility,
 		&addr.Line1, &addr.Line2, &addr.City, &addr.Region, &addr.PostalCode, &addr.Country,
 		&classification, &lifecycle, &relevance, &parentID, &mergedInto, &logoObjectKey, &linkedinURL, &o.Source, &o.CapturedBy,
 		&version, &o.CreatedAt, &o.UpdatedAt, &o.ArchivedAt, &o.IsAnchor,
@@ -163,6 +164,9 @@ func scanOrganization(row pgx.Row, active []fieldcatalog.Column, extra ...any) (
 
 	o.Id = openapi_types.UUID(id)
 	o.OwnerId = uuidPtr(ownerID)
+	if v := crmcontracts.OrganizationVisibility(visibility); v != "" {
+		o.Visibility = &v
+	}
 	o.ParentOrgId = uuidPtr(parentID)
 	o.MergedIntoId = uuidPtr(mergedInto)
 	cls := crmcontracts.OrganizationClassification(classification)

--- a/backend/internal/modules/people/organizationarchive.go
+++ b/backend/internal/modules/people/organizationarchive.go
@@ -132,7 +132,7 @@ func (s *Store) ArchiveOrganization(ctx context.Context, id ids.OrganizationID, 
 	return out, err
 }
 
-const orgColumns = `id, display_name, legal_name, description, industry, size_band, owner_id,
+const orgColumns = `id, display_name, legal_name, description, industry, size_band, owner_id, visibility,
 	address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
 	classification, lifecycle, relevance, parent_org_id, merged_into_id, logo_object_key, linkedin_url, source, captured_by,
 	version, created_at, updated_at, archived_at, is_anchor, last_activity_at`

--- a/backend/internal/modules/people/person_children.go
+++ b/backend/internal/modules/people/person_children.go
@@ -272,7 +272,7 @@ func ensurePersonEmailsUnclaimedExcept(ctx context.Context, tx pgx.Tx, self ids.
 	return nil
 }
 
-const personColumns = `id, full_name, first_name, last_name, title, owner_id,
+const personColumns = `id, full_name, first_name, last_name, title, owner_id, visibility,
 	address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
 	merged_into_id, converted_from_lead_id, source, captured_by,
 	version, created_at, updated_at, archived_at, last_activity_at`
@@ -310,9 +310,10 @@ func scanPerson(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcon
 	var ownerID, mergedInto, fromLead *ids.UUID
 	var addr crmcontracts.Address
 	var version int64
+	var visibility string
 
 	dests := []any{
-		&id, &p.FullName, &p.FirstName, &p.LastName, &p.Title, &ownerID,
+		&id, &p.FullName, &p.FirstName, &p.LastName, &p.Title, &ownerID, &visibility,
 		&addr.Line1, &addr.Line2, &addr.City, &addr.Region, &addr.PostalCode, &addr.Country,
 		&mergedInto, &fromLead, &p.Source, &p.CapturedBy,
 		&version, &p.CreatedAt, &p.UpdatedAt, &p.ArchivedAt, &p.LastActivityAt,
@@ -327,6 +328,9 @@ func scanPerson(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcon
 
 	p.Id = openapi_types.UUID(id)
 	p.OwnerId = uuidPtr(ownerID)
+	if v := crmcontracts.PersonVisibility(visibility); v != "" {
+		p.Visibility = &v
+	}
 	p.MergedIntoId = uuidPtr(mergedInto)
 	p.ConvertedFromLeadId = uuidPtr(fromLead)
 	if a := addressOrNil(addr); a != nil {

--- a/docs/handbook/seats-roles-and-access.md
+++ b/docs/handbook/seats-roles-and-access.md
@@ -62,8 +62,8 @@ The licence is checked offline at start-up. It is never phoned home.
 
 | Role | Sees | Changes |
 |---|---|---|
-| **Admin** | everything | everything, configuration included |
-| **Ops** | everything | everything — the same grid as Admin |
+| **Admin** | every normal record, and all configuration | everything, configuration included |
+| **Ops** | every normal record, and all configuration | everything — the same grid as Admin |
 | **Management** | every record in the organization | every record; no administrative power |
 | **Team Lead** | records | records they own; configuration read-only; no access to exchange rates, model prices, imports or retention |
 | **User** | records | records they own; configuration read-only; full control of their own saved views |
@@ -87,13 +87,29 @@ Three levels: **own**, **team**, **all**.
 
 Here is the part that differs from most CRMs, and it is deliberate:
 
-> **Reading a contact, company, lead or deal ignores row scope entirely.**
+> **Reading a contact, company, lead, deal or project ignores row scope
+> entirely.**
 
-Every seat holding the read permission reads every contact, company, lead and
-deal in the organization. The app states it: "Reads every contact, company, lead
-and deal in the organization."
+Every seat holding the read permission reads every contact, company, lead, deal
+and project in the organization. The app states it: "Reads every contact,
+company, lead and deal in the organization."
 
-Row scope governs **writes**, and it governs **projects**. Not customer reads.
+Row scope governs **writes**. Not customer reads. Projects used to be the
+exception and are not any more: a consultant delivering a project they neither
+owned nor were granted got a 404, which is not a privacy boundary, only a
+broken one.
+
+Two things the word "everything" above does NOT cover, for any role including
+Admin, because neither is a tier of row scope:
+
+- **Correspondence you were not part of.** Mail and meetings carry their own
+  audience, and seniority does not override it.
+- **A captured contact still private to the person whose mailbox made it.** A
+  connector creates a contact from a message nothing has judged yet, and it
+  belongs to that seat alone until a classifier judges the sender or the owner
+  publishes it themselves. An admin gets a 404, which is the point: connecting
+  a mailbox with a year of history must not put every correspondent, a lawyer
+  and a doctor among them, in front of the organization.
 
 The reasoning is that a shared pipeline is the point. Two narrowings survive: a
 record created by a connector can stay private to its owner until promoted, and a

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16511,7 +16511,7 @@ export interface components {
             /** Format: uuid */
             owner_id?: string | null;
             /**
-             * @description Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a verdict or through the owner's own `POST /people/{id}/publish`, and never travels back.
+             * @description Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a sender verdict, and never travels back. There is no owner-driven door for an organization: `POST /people/{id}/publish` is a person's.
              * @enum {string}
              */
             readonly visibility?: "workspace" | "owner";

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -16256,6 +16256,11 @@ export interface components {
             title?: string | null;
             /** Format: uuid */
             owner_id?: string | null;
+            /**
+             * @description Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a verdict or through the owner's own `POST /people/{id}/publish`, and never travels back.
+             * @enum {string}
+             */
+            readonly visibility?: "workspace" | "owner";
             /** @description Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed. */
             readonly writable?: boolean;
             /** @description { linkedin, twitter, github, ... } */
@@ -16505,6 +16510,11 @@ export interface components {
             address?: components["schemas"]["Address"];
             /** Format: uuid */
             owner_id?: string | null;
+            /**
+             * @description Who this record is for. `workspace` is every seat that holds the read grant. `owner` is capture privacy: a connector made this record from a message nothing had judged yet, and it belongs to the mailbox owner alone until something does — not to their team, their manager, or an admin. You are only ever sent a row you may already read, so this discloses nothing new; it says WHY you can see it, which is what lets a page tell "private to you" from "shared with everybody" instead of leaving the owner to guess. An `owner` row reaches the workspace through a verdict or through the owner's own `POST /people/{id}/publish`, and never travels back.
+             * @enum {string}
+             */
+            readonly visibility?: "workspace" | "owner";
             /** @description Whether THIS caller may change THIS row: the same question the server's write gate answers on a mutation — the owner, the owner's team where the role is team-scoped, a live `write` record grant, or an unbounded seat. Server-computed per row, per caller. It is a UX signal, never the enforcement. A client uses it to draw or withhold edit affordances so a reader is not offered a control the save would refuse; the server refuses an unauthorized write with 403 whatever this said. Absent means NOT writable, so a client reading a response from a server too old to send it fails closed. */
             readonly writable?: boolean;
             /**


### PR DESCRIPTION
A client could see that it may not **write** a row and not that the row it was reading is private to the person reading it. So a page could not tell "private to you" from "shared with everybody" — exactly the question the owner of a captured contact is asking, and the reason the access audit found people guessing.

`Person` and `Organization` now carry `visibility` on the wire. It discloses nothing: a caller is only ever sent a row they may already read, and this says **why** they can see it. Only those two, because they are the only records capture privacy applies to — a deal or a project is never one mailbox's.

The field rides the shared column lists and scanners, so the single read and the list agree. A field on only one of them is how a page shows a badge that vanishes on refresh.

## The handbook was two sentences out of date

Both in the direction that overstates what a role can see.

**"Admin sees everything"** is not true and has not been. Two things it does not cover, for any role: correspondence you were not part of, and a captured contact still private to the mailbox that made it. Both are now written where somebody reading about roles will find them, rather than only in a carve-out further down.

**Projects** were moved to workspace reads some time ago — a consultant delivering a project they neither owned nor were granted got a 404 — but this page still promised row scoping. The generated RBAC matrix and the code already agreed with each other; only the handbook disagreed with both.

## Review

Codex checked the disclosure question on both the single-read and list paths for both types, plus search and embedding, and confirmed the row-scope clause is applied before any row is scanned. It also confirmed no other production path builds these contract structs. It caught one real defect: the `Organization.visibility` description was copied from `Person` and promised `POST /people/{id}/publish`, which only ever updates a person. Fixed.

## Note on main

`TestTheDayIsOrderedAcrossItsSourcesAndNotOnlyWithinThem` and `TestSystemNewsNeverLeadsACustomerWaiting` fail on clean `main` and are unrelated to this diff. PR #4011 is already open for them.

Everything else green: `make check-backend`, `make check-fe`, `make craft-static`, and the `internal/modules/people` and `internal/compose` integration lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `visibility` to `Person` and `Organization` responses so a page can tell a record private to the reader from one shared with the whole workspace. It reads `owner` for captured contacts still private to the mailbox that made them and `workspace` once shared; it discloses nothing new because a caller is only ever sent a row they may already read. The field rides the shared column lists and scanners, so the single-read and list paths agree, and it is native-only, never mirrored from an incumbent CRM.

**Handbook**

Corrects `seats-roles-and-access.md`, which overstated what Admin and Ops can see (correspondence they were not part of, and captured contacts still private to their mailbox) and still promised project row scoping that code removed some time ago.

<sup>Written for commit 93f2c4ea04be05b40480e42d634b200400118679. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CRM API responses now include whether people and organizations are visible to the workspace or only their owner.
  - Owner-private captured contacts can become workspace-visible through the applicable publication or promotion process.

- **Documentation**
  - Clarified Admin and Ops access: read permissions provide organization-wide access to projects, while row-level scope continues to govern writes.
  - Documented privacy exceptions for correspondence and connector-captured contacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->