### PR TITLE
Nothing guesses which audience write a message takes

### DIFF
--- a/frontend/src/screens/audiencemembers.tsx
+++ b/frontend/src/screens/audiencemembers.tsx
@@ -50,6 +50,23 @@ export const AUDIENCE_HINT: Record<ActivityAudience, MessageKey> = {
   selected: "compose.audienceSelectedHint",
 };
 
+// Why a captured message is held, in the reader's words. A reason the server
+// learned to give and this map has not falls back to nothing rather than to the
+// raw token: a badge reading `financial_corporate` beside a customer's mail is
+// worse than no badge at all.
+//
+// The server sends this token two ways — as `audience_reason` on an Activity
+// and as `explanation` on an EmailAccess, which `readEmailAccess` fills from
+// the same column. One map, so the row and the drawer name a held message the
+// same way.
+export const AUDIENCE_REASON_LABEL: Record<string, MessageKey> = {
+  posture: "compose.reason.posture",
+  workspace_floor: "compose.reason.workspaceFloor",
+  no_record: "compose.reason.noRecord",
+  pending_verdict: "compose.reason.pendingVerdict",
+  manual: "compose.reason.manual",
+};
+
 /** One pickable seat or team, flattened out of the two rosters. */
 type Candidate = {
   kind: RosterKind;

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1767,32 +1767,57 @@ describe("TimelineActions", () => {
     );
   });
 
-  // Which audience control a timeline row offers cannot be keyed off
-  // `audience_reason`: that field is null on an untouched CAPTURED row and
-  // non-null on a NARROWED hand-typed one — the opposite of what each case
-  // needs.
+  // An EMAIL's audience is changed from the message, in the drawer, where the
+  // server states which of the two writes it would accept as `change_mode`.
+  // The row used to decide that here by testing `captured_by` for a
+  // `connector:` prefix — a backend ownership rule spelled in display code.
   //
-  // thread_key alone is not the fix either: outboundmessage.go stamps a
-  // hand-typed REPLY with the RFC822 thread it answers too, so a rep's own
-  // threaded reply would carry one — and ThreadAudienceAction's own endpoint
-  // 404s on a thread_key with no capture_import row behind it
-  // (capture/threadverdict.go's inner join). captured_by's prefix is what
-  // actually says capture wrote the row — `connector:<name>:<uuid>`, never
-  // `human:<uuid>` or `agent:<id>` — in every direction.
-  it("offers the thread-level control on captured mail before it is ever narrowed", () => {
+  // Both shapes are asserted, because the deleted inference existed precisely
+  // to tell them apart: a captured row and a hand-typed one now get the same
+  // answer, which is no audience control on the row at all.
+  it("offers no audience control on an email row, whoever captured it", () => {
+    stubRoutes();
     const captured: Activity = {
       ...activity202,
       id: "a4",
       captured_by: "connector:gmail:u1",
       thread_key: "thread:abc",
-      audience_reason: undefined,
     };
-    stubRoutes();
-    render(
+    const { unmount } = render(
       <TimelineActions activity={captured} entityType="deal" entityId="d1" />,
     );
-    expect(screen.getByRole("button", { name: "Share thread" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Share thread" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Visibility" })).toBeNull();
+    // Relink still draws, so the two absences above are the gate rather than a
+    // component that never mounted at all.
+    expect(screen.getByRole("button", { name: "Relink" })).toBeTruthy();
+    unmount();
+
+    const handTyped: Activity = {
+      ...activity202,
+      id: "a5",
+      captured_by: "human:u1",
+      audience: "participants",
+    };
+    render(
+      <TimelineActions activity={handTyped} entityType="deal" entityId="d1" />,
+    );
+    expect(screen.queryByRole("button", { name: "Visibility" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Relink" })).toBeTruthy();
+  });
+
+  // A note, a call or a meeting has no drawer to be sent to, and its audience
+  // is never derived — so the row keeps the control for every kind but email.
+  it("keeps the audience control on a row that is not an email", () => {
+    stubRoutes();
+    render(
+      <TimelineActions
+        activity={{ ...activity202, id: "a7", kind: "note" }}
+        entityType="deal"
+        entityId="d1"
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Visibility" })).toBeTruthy();
   });
 
   // `selected` is the API's third audience and the dialog offered two, because
@@ -1831,6 +1856,11 @@ describe("TimelineActions", () => {
         activity={{
           ...activity202,
           id: "a6",
+          // A NOTE, because this dialog is the row's and the row no longer
+          // draws it for an email. The claims below are about the picker and
+          // the write it sends, which are the same for every kind that still
+          // has one.
+          kind: "note",
           captured_by: "human:u1",
           version: 3,
         }}
@@ -1898,7 +1928,10 @@ describe("TimelineActions", () => {
       <TimelineActions
         activity={{
           ...activity202,
-          id: "a7",
+          id: "a8",
+          // A note, for the same reason as the test above: this dialog is the
+          // row's, and an email row no longer draws one.
+          kind: "note",
           captured_by: "human:u1",
           version: 3,
         }}
@@ -1918,49 +1951,25 @@ describe("TimelineActions", () => {
     ).toBe(true);
   });
 
-  it("keeps the per-message control on hand-typed mail once narrowed", () => {
-    const narrowedHandTyped: Activity = {
-      ...activity202,
-      id: "a5",
-      captured_by: "human:u1",
-      audience: "participants",
-      audience_reason: "manual",
-      thread_key: undefined,
-    };
+  // A withheld row offers nothing: somebody outside the audience has no
+  // standing to change who else is in it. The kind that still draws the
+  // control is the one that has to prove this.
+  it("offers no audience control on a withheld row", () => {
     stubRoutes();
     render(
       <TimelineActions
-        activity={narrowedHandTyped}
+        activity={{
+          ...activity202,
+          id: "a9",
+          kind: "note",
+          content_state: "withheld",
+        }}
         entityType="deal"
         entityId="d1"
       />,
     );
-    expect(screen.getByRole("button", { name: "Visibility" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Share thread" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Keep private" })).toBeNull();
-  });
-
-  // The regression thread_key alone would have caused: a rep's own reply
-  // within an existing conversation is hand-typed, not captured, but it is
-  // threaded like everything else in that conversation.
-  it("keeps the per-message control on a hand-typed reply that carries a thread_key too", () => {
-    const threadedReply: Activity = {
-      ...activity202,
-      id: "a6",
-      captured_by: "human:u1",
-      thread_key: "thread:existing-conversation",
-      audience_reason: undefined,
-    };
-    stubRoutes();
-    render(
-      <TimelineActions
-        activity={threadedReply}
-        entityType="deal"
-        entityId="d1"
-      />,
-    );
-    expect(screen.getByRole("button", { name: "Visibility" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Share thread" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Visibility" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Relink" })).toBeTruthy();
   });
 });
 

--- a/frontend/src/screens/emailaccesseditor.tsx
+++ b/frontend/src/screens/emailaccesseditor.tsx
@@ -33,6 +33,7 @@ import {
   AUDIENCE_CHOICES,
   AUDIENCE_HINT,
   AUDIENCE_LABEL,
+  AUDIENCE_REASON_LABEL,
   AudienceMembers,
   memberKey,
   useAudienceCandidates,
@@ -71,6 +72,7 @@ export function EmailAccessEditor({
 }: Readonly<{ presentation: EmailPresentation }>) {
   const t = useT();
   const { access } = presentation;
+  const reasonKey = AUDIENCE_REASON_LABEL[access.explanation ?? ""];
   return (
     <div className="emailaccess">
       <div className="emailaccess__verdict">
@@ -84,8 +86,14 @@ export function EmailAccessEditor({
       {/* WHY, when the server gave a reason. A held message the reader can see
           the outline of is otherwise a limit with no author: the reason names
           what decided it, which is what a person disagreeing with the verdict
-          needs before they can argue with it. */}
-      {access.explanation && <p className="t-caption">{access.explanation}</p>}
+          needs before they can argue with it.
+
+          `explanation` is a TOKEN, not a sentence — `readEmailAccess` fills it
+          from the same `audience_reason` column the timeline row reads — so it
+          is translated through the shared map. Printing it raw would put
+          `pending_verdict` on the screen. A reason the server learned to give
+          and the map has not draws nothing rather than the token. */}
+      {reasonKey && <p className="t-caption">{t(reasonKey)}</p>}
       <NamedMembers access={access} />
       {/* The control only where the server says this caller's write would be
           taken. `can_change` and `change_mode` are decided by the authority

--- a/frontend/src/screens/timelineactions.tsx
+++ b/frontend/src/screens/timelineactions.tsx
@@ -1,20 +1,23 @@
 // The per-row action cluster the 360 timelines mount in each entry's action
-// slot, and the two audience controls behind it.
+// slot, and the audience control behind it.
 //
 // Lifted out of compose.tsx, which is 3,459 lines and was answering two
 // unrelated questions: how a person writes a message, and what a reader may do
-// to one already on a timeline. Nothing here changed in the move — the writes
-// now go through the shared audience service, which is where the thread
-// decision was already spelled a second time.
+// to one already on a timeline. The writes go through the shared audience
+// service, which is where the thread decision was already spelled a second
+// time.
+//
+// An EMAIL's audience is not changed from here. It is changed in the drawer,
+// which loads the access block and is told by the server which write it may
+// perform — so the row no longer guesses that from `captured_by`.
 
 import { type ReactNode, useState } from "react";
 
 import type { components } from "../api/schema";
-import { Badge, Button } from "../design-system/atoms";
+import { Button } from "../design-system/atoms";
 import { ChoiceList } from "../design-system/choicelist";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { useT } from "../i18n";
-import type { MessageKey } from "../i18n/en";
 import { entityTimelineKeys } from "./activitykeys";
 import {
   AUDIENCE_CHOICES,
@@ -23,7 +26,7 @@ import {
   AudienceMembers,
   useAudienceCandidates,
 } from "./audiencemembers";
-import { useMessageAudience, useThreadAudience } from "./audienceservice";
+import { useMessageAudience } from "./audienceservice";
 import { problemMessageOf } from "./common";
 // Reply and Relink stay in compose.tsx for now: they are the composer's own
 // verbs, and moving them too would make a behaviour-preserving extraction into
@@ -85,34 +88,23 @@ export function TimelineActions({
       <Button small onClick={() => setRelink(true)}>
         {t("compose.relink")}
       </Button>
-      {/* Captured mail's audience is derived, never a direct write, and
-          ThreadAudienceAction's own endpoint refuses a thread_key with no
-          capture_import row behind it (capture/threadverdict.go). A hand-typed
-          REPLY carries a thread_key too — outboundmessage.go stamps every send
-          with the RFC822 thread it answers, imported or not — so thread_key
-          alone would route a rep's own threaded reply to the one control that
-          404s on it. `audience_reason` is no better a signal: it is null on an
-          untouched captured row (the wrong per-message dialog offered first)
-          and non-null on a narrowed hand-typed one, whose missing
-          capture_import row makes ThreadAudienceAction disappear for good.
-          captured_by's own prefix is what actually says "capture wrote this"
-          — `connector:<name>:<uuid>`, never `human:<uuid>` or `agent:<id>` —
-          so it is the one signal correct in every direction.
+      {/* An EMAIL's audience is changed from the message, in the drawer, where
+          the server states which write it would accept as `change_mode` and the
+          editor opens on the set already standing. The row used to decide that
+          here by testing `captured_by` for a `connector:` prefix — a backend
+          ownership rule spelled in display code, in a second language, where
+          the next change to what makes an audience derived would not find it.
 
-          This inference is display code holding a backend ownership rule. The
-          server answers the same question properly as `change_mode`, but on
-          the email PRESENTATION rather than on the summary a list row carries
-          — so the honest place to spend it is the drawer's own access editor,
-          where the presentation is already loaded. Deleting the inference here
-          before that editor exists would take the audience control off every
-          timeline row and give nothing back (margince#3811). */}
-      {(activity.captured_by ?? "").startsWith("connector:") ? (
-        <ThreadAudienceAction
-          activity={activity}
-          entityType={entityType}
-          entityId={entityId}
-        />
-      ) : (
+          It could not simply be deleted: `change_mode` costs two per-row
+          authorization queries (EnsureActivityWritable and callerIsSenderSeat
+          in activities/emailaccess.go), which is why it rides the presentation
+          and not the summary a twenty-row page ships. What removes the guess is
+          having somewhere better to ask, and the drawer is that.
+
+          Every other kind keeps its control. A note, a call or a meeting has no
+          drawer to be sent to, and its audience is never derived — there was
+          never a question to guess at for those, only the one write. */}
+      {activity.kind !== "email" && (
         <AudienceAction
           activity={activity}
           entityType={entityType}
@@ -134,85 +126,15 @@ export function TimelineActions({
   );
 }
 
-// Why a captured message is held, in the reader's words. A reason the server
-// learned to give and this map has not falls back to nothing rather than to the
-// raw token: a badge reading `financial_corporate` beside a customer's mail is
-// worse than no badge at all.
-const audienceReasonLabel: Record<string, MessageKey> = {
-  posture: "compose.reason.posture",
-  workspace_floor: "compose.reason.workspaceFloor",
-  no_record: "compose.reason.noRecord",
-  pending_verdict: "compose.reason.pendingVerdict",
-  manual: "compose.reason.manual",
-};
-
-// ThreadAudienceAction shares or keeps back a whole THREAD, for a message that
-// came from a mailbox.
+// AudienceAction limits (or re-opens) who may read ONE row's content — a note,
+// a call, a meeting, a channel message. Per row on purpose: a thread is not a
+// unit of trust, and the contact stays visible to everyone either way. Absent
+// on a row the reader cannot read in full: somebody who is not in the audience
+// has no standing to change it.
 //
-// Captured mail does not take the per-message dialog: its audience is derived
-// from what every importing mailbox asks for, so a direct write is refused
-// (`audience_is_derived`) and pointed here. The unit is the thread rather than
-// the message because that is what a person decides about — nobody shares the
-// third reply and keeps the fourth.
-//
-// The decision releases only the CALLER's hold. A thread two colleagues
-// imported opens when both allow it, so the outcome reports how many other
-// seats still hold it — a count and never a name, because whose mail a person
-// keeps private is itself private.
-function ThreadAudienceAction({
-  activity,
-  entityType,
-  entityId,
-}: Readonly<{
-  activity: Activity;
-  entityType: RelinkKind;
-  entityId: string;
-}>) {
-  const t = useT();
-  const [held, setHeld] = useState<number | null>(null);
-  const shared = activity.audience === "workspace";
-  const threadKey = activity.thread_key;
-  const mutation = useThreadAudience({
-    invalidate: () => entityTimelineKeys(entityType, entityId),
-    onSettled: ({ outcome }) => {
-      // A share that did not open the thread means somebody else still holds
-      // it. Saying so is the difference between a control that looks broken
-      // and one that reports what actually happened.
-      setHeld(outcome && !outcome.shared ? outcome.held_by_others : null);
-    },
-  });
-  // Withheld content carries no reason either, so there is nothing to draw and
-  // no standing to change it.
-  if (activity.content_state === "withheld" || !threadKey) {
-    return null;
-  }
-  const reasonKey = audienceReasonLabel[activity.audience_reason ?? ""];
-  return (
-    <>
-      {!shared && reasonKey && <Badge tone="warn">{t(reasonKey)}</Badge>}
-      <Button
-        small
-        pending={mutation.isPending}
-        onClick={() => {
-          setHeld(null);
-          mutation.mutate({ threadKey, share: !shared });
-        }}
-      >
-        {shared ? t("compose.threadKeepPrivate") : t("compose.threadShare")}
-      </Button>
-      {held !== null && (
-        <span className="t-caption">
-          {t("compose.threadStillHeld").replace("{count}", String(held))}
-        </span>
-      )}
-    </>
-  );
-}
-
-// AudienceAction limits (or re-opens) who may read ONE message's content. Per
-// message on purpose: a thread is not a unit of trust, and the contact stays
-// visible to everyone either way. Absent on a row the reader cannot read in
-// full — somebody who is not in the audience has no standing to change it.
+// An email does not come here. Its audience may be derived from what every
+// importing mailbox asked for, which is a different write, and the drawer is
+// where the server states which one it would accept.
 export function AudienceAction({
   activity,
   entityType,
@@ -229,14 +151,12 @@ export function AudienceAction({
   // The set the reader is building. Read only when `selected` is the choice,
   // and submitted as the FULL replacement set, which is what the write takes.
   //
-  // It starts EMPTY even on a message that is already limited, and that is a
-  // boundary rather than an oversight: `selected_members` rides EmailAccess,
-  // gated on `can_change`, and a timeline row carries no access block — reading
-  // one per row would be a detail fetch per visible line. So this dialog names
-  // a new set rather than editing the standing one, and the confirm below
-  // refuses an empty set so nobody narrows a message to nobody by pressing it
-  // twice. Editing an existing set in place belongs in the drawer, which
-  // already holds the access block it would start from.
+  // It starts EMPTY even on a row that is already limited, and that is a
+  // boundary rather than an oversight: who is named rides the access block,
+  // which only an email has and only the drawer's read fetches. A note carries
+  // no such read, so this dialog names a NEW set rather than editing the
+  // standing one, and the confirm below refuses an empty set so nobody narrows
+  // a row to nobody by pressing it twice.
   const [members, setMembers] = useState<AudienceMember[]>([]);
   // Fetched only while the dialog is open: the roster is two reads, and a
   // timeline of twenty rows would otherwise fire them per row on mount.


### PR DESCRIPTION
Follow-up to #4019, which built the drawer's access editor. This spends it.

## The guess

`timelineactions.tsx` chose between the thread-scoped and message-scoped audience controls by testing whether `captured_by` starts with `connector:`. A backend ownership rule spelled in display code, in a second language — and only one of the two copies is the authority. The next change to what makes an audience derived would have had to find the one in the browser.

The server has answered this properly all along, as `EmailAccess.change_mode`, computed from the same `capture_import` test the write itself applies.

## Why it could not just be read on the row

`change_mode` costs **two per-row authorization queries** — `EnsureActivityWritable` and `callerIsSenderSeat` in `activities/emailaccess.go`. That is why it rides `EmailPresentation` and not the `EmailSummary` a twenty-row page ships; putting it on the summary is a permissions computation per visible line.

So the fix is not to move the field. It is to have somewhere better to ask, and #4019 built that.

## What changes

An **email** row offers no audience control. A reader changes who may read a message from the message, in the drawer, where the server states which write it would accept and the editor opens on the set already standing.

**Every other kind keeps its control unchanged.** A note, a call, a meeting or a channel message has no drawer to be sent to, and its audience is never derived — there was never a question to guess at for those, only the one write. This is where I departed from issue #3811, which says the row's control "goes away entirely": that holds for email and would have left notes with no way to set an audience at all.

`ThreadAudienceAction` is deleted rather than left standing — the drawer's `ThreadContribution` does that job now.

## A defect found on the way

The row drew a **translated** badge for a held message's reason. The drawer printed `access.explanation` raw — and that field is the same `audience_reason` **token**, which `readEmailAccess` copies straight from the column. The editor merged yesterday would have shown `pending_verdict` on screen.

Both now read one label map, which is why `AUDIENCE_REASON_LABEL` moved to `audiencemembers.tsx` beside the rest of the audience vocabulary. This is exactly the failure the row's own comment warned about: a badge reading `financial_corporate` beside a customer's mail is worse than no badge.

## Tests

Three that existed only to prove the deleted routing are replaced by one holding the new rule **in both directions** — a captured row and a hand-typed one now get the same answer, which is no control on the row. Each asserts Relink still draws, so the absence is the gate rather than a component that never mounted.

Two that prove the member picker and its write are repointed at a `note`, the kind that still draws the dialog. Their claims — the agent seat is excluded, the write submits one replacement set, an empty set is refused — are unchanged and still held.

Added: a non-email row keeps the control, and a withheld row offers nothing.

Mutation-checked: replacing `activity.kind !== "email"` with `true` fails exactly the new test and nothing else.

## Done-criterion

The plan's `grep 'startsWith("connector:")' frontend/src` now returns one hit, `leads.tsx:651`, which reads a **lead's source** to decide field editability. Unrelated to email or to audience; the plan's grep was too broad to ever pass.

## Verification

- `make check-fe` — green (6278 tests)
- `emailpresentation_test.go` both directions — green
- No Go changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the timeline row's guess about which audience control to show. Email rows previously tested `captured_by` for a `connector:` prefix to decide between thread-level and message-level controls; that inference is gone. Now an email row offers no audience control at all — the audience is changed from the message drawer, where the server states the correct write mode via `change_mode`. Non-email rows (notes, calls, meetings) keep the existing control.

Also fixes a defect where the drawer printed a held message's reason as a raw token (e.g. `pending_verdict`) instead of a translated label. Both the row badge and the drawer now share the same `AUDIENCE_REASON_LABEL` map.

<sup>Written for commit 5f5d6df985a69a39d91218d1208621f0d0ab8a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized explanations for recognized audience-hold reasons in the email access editor.
  - Unknown or unavailable reason codes are now omitted instead of shown as raw text.

- **Changes**
  - Removed audience controls from email timeline entries.
  - Audience controls remain available for eligible notes, calls, meetings, and channel messages.
  - Updated audience selection behavior to create a new selected-member set rather than edit existing access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->