### PR TITLE
A cited message is named by its subject, and opens

### DIFF
--- a/frontend/src/screens/personcards.tsx
+++ b/frontend/src/screens/personcards.tsx
@@ -4,6 +4,7 @@ import type { components } from "../api/schema";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Avatar, Badge, Button, Checkbox } from "../design-system/atoms";
+import { EmailReference } from "../design-system/emailreference";
 import { Panel, PanelBody, PanelRow } from "../design-system/panel";
 import {
   formatDate,
@@ -33,10 +34,17 @@ export function PersonBriefCard({
   brief,
   loading,
   view,
+  onOpenEmail,
 }: Readonly<{
   brief: PersonBrief | undefined;
   loading: boolean;
   view: Person360;
+  /**
+   * Opens a cited message in the record's email drawer. The page owns the
+   * drawer, so it owns the opener; a card that mounted its own would put a
+   * second one behind the first.
+   */
+  onOpenEmail?: (activityId: string) => void;
 }>) {
   const t = useT();
   const viewerId = useViewerId();
@@ -110,6 +118,7 @@ export function PersonBriefCard({
                   key={key}
                   cited={cited}
                   activity={citedActivities.get(cited.entity_id)}
+                  onOpenEmail={onOpenEmail}
                 />
               ))}
             </div>
@@ -198,10 +207,39 @@ function commercialLine(
 function SourceChip({
   cited,
   activity,
-}: Readonly<{ cited: BriefEvidence; activity: Activity | undefined }>) {
+  onOpenEmail,
+}: Readonly<{
+  cited: BriefEvidence;
+  activity: Activity | undefined;
+  onOpenEmail?: (activityId: string) => void;
+}>) {
   const t = useT();
+  const { locale } = useLocale();
+  const recordZone = useRecordZone();
   const interactionLabel = useInteractionLabel();
   if (cited.entity_type === "activity") {
+    // A cited EMAIL is named by its subject and openable, like every other
+    // citation of a message in the product. A chip reading "Email" tells a
+    // reader which transport carried the sentence and nothing about which
+    // message — and the one they want is the one the sentence rests on.
+    //
+    // `email_summary` is the server's own answer to "is this an email", set
+    // only for kind=email, so nothing here decides it from the kind string. A
+    // withheld message carries the summary with its subject nulled, and the
+    // reference draws the withheld wording and opens nothing.
+    const summary = activity?.email_summary;
+    if (summary) {
+      return (
+        <EmailReference
+          subject={summary.subject}
+          occurredAt={formatDate(summary.occurred_at, locale, recordZone)}
+          withheld={summary.display_status === "withheld"}
+          onOpen={
+            onOpenEmail ? () => onOpenEmail(summary.activity_id) : undefined
+          }
+        />
+      );
+    }
     return (
       <span className="pe-memory-channel">
         {interactionIcon(activity?.kind)}

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -488,6 +488,7 @@ export function PersonPageV2({
               brief={brief.data}
               loading={brief.isLoading}
               view={view.data}
+              onOpenEmail={setOpenEmail}
             />
             {(hasCommercial(view.data) || hasMatters(view.data)) && (
               <RecordReadingPair>

--- a/frontend/src/screens/persontransport.test.tsx
+++ b/frontend/src/screens/persontransport.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   within,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
@@ -60,6 +61,25 @@ const aChatMessage = anActivity({
   subject: null,
   body: "họ đã nhắn tin",
   source: "ext:zalo-oa:zalo",
+});
+
+// A mail the reader may read, carrying the summary the server sets for every
+// kind=email row. Without it this row models a shape the API does not send,
+// and the citation would be judged against a message that is not one.
+const aReadableMail = anActivity({
+  id: "a-mail",
+  kind: "email",
+  subject: "Re: the pilot",
+  email_summary: {
+    activity_id: "a-mail",
+    occurred_at: AT,
+    display_status: "team",
+    attachment_count: 0,
+    move: "none",
+    version: 1,
+    subject: "Re: the pilot",
+    preview: "they wrote",
+  },
 });
 
 // A withheld mail that STILL carries its subject, its body and a summary. The
@@ -222,18 +242,63 @@ describe("the relationship brief's source chips", () => {
     expect(chip.querySelector(".lucide-mail")).toBeNull();
   });
 
-  it("names a cited mail thread as mail", () => {
+  // A cited EMAIL is named by its SUBJECT and opens, like every other citation
+  // of a message in the product. Naming the transport told a reader which pipe
+  // carried the sentence and nothing about which message — and the message is
+  // what they are reaching for when they press a source.
+  it("names a cited mail by its subject and opens it", async () => {
+    const onOpenEmail = vi.fn();
+    render(
+      <PersonBriefCard
+        brief={briefCiting("activity", "a-mail")}
+        loading={false}
+        view={viewWith({ activities: [aReadableMail] })}
+        onOpenEmail={onOpenEmail}
+      />,
+    );
+
+    const cite = screen.getByRole("button", { name: /Re: the pilot/ });
+    await userEvent.click(cite);
+    expect(onOpenEmail).toHaveBeenCalledWith("a-mail");
+  });
+
+  // The transport chip is still right for every kind that is NOT mail, which
+  // is the direction a one-sided change would break: a card that stopped
+  // naming transports altogether would pass an email-only assertion.
+  it("still names the transport of a cited call", () => {
     const { container } = render(
       <PersonBriefCard
-        brief={briefCiting("activity", "a-1")}
+        brief={briefCiting("activity", "a-call")}
         loading={false}
-        view={viewWith({ activities: [anActivity({})] })}
+        view={{
+          ...viewWith({
+            activities: [anActivity({ id: "a-call", kind: "call" })],
+          }),
+        }}
       />,
     );
 
     const chip = transportCell(container);
-    expect(chip.textContent).toBe("Email");
-    expect(chip.querySelector(".lucide-mail")).toBeTruthy();
+    expect(chip.textContent).toBe("Call");
+  });
+
+  // A message this reader is outside the audience of names no subject and
+  // opens nothing. The citation says a source exists without disclosing it.
+  it("neither names nor opens a cited mail that is withheld", () => {
+    const onOpenEmail = vi.fn();
+    render(
+      <PersonBriefCard
+        brief={briefCiting("activity", "a-withheld")}
+        loading={false}
+        view={viewWith({ activities: [aWithheldMail] })}
+        onOpenEmail={onOpenEmail}
+      />,
+    );
+
+    expect(screen.queryByText("Angebot Q4")).toBeNull();
+    expect(screen.getByText("Not shared with you")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Angebot Q4/ })).toBeNull();
+    expect(onOpenEmail).not.toHaveBeenCalled();
   });
 
   // The brief cites what the WRITER read, which is not bounded by the page of


### PR DESCRIPTION
Third of the email-unification follow-ups, after #4019 and #4023. This is the plan's PR8 item for the person brief.

## What it changes

The relationship brief's source chips named the **transport** that carried a sentence's evidence — "Email", "Zalo OA", "Call". For a chat message or a call that is the right answer and stays. For mail it told a reader which pipe carried the sentence and nothing about *which message*, and the message is what they are reaching for when they press a source.

A cited email now draws `EmailReference`: subject, date, and the same drawer every other citation of a message opens.

## How it decides a row is mail

`email_summary`, which the server sets only for `kind=email`. Nothing here reads the kind string to work that out — the contract already answers it, and `sectionstimeline.go:264` populates the field on exactly the Person360 timeline this card resolves citations from.

## Withheld

A message the reader is outside the audience of names no subject and opens nothing. The summary carries `display_status: withheld` (set *after* the withholding transform, so a withheld row gets the withheld summary), and `EmailReference` draws the withheld wording and drops the opener. A citation says a source exists without disclosing it.

## A fixture that modelled a shape the API does not send

The existing "names a cited mail thread as mail" test built an email row with **no `email_summary`** — which the server never returns for `kind=email`. It would have gone on passing against the branch this change does not take, and proved nothing about production.

It now carries the summary. A `call` row holds the other direction: a card that stopped naming transports altogether would pass an email-only assertion, and the transport chip is still correct for every kind that is not mail.

Mutation-checked: forcing `summary` to undefined fails exactly the two new email tests and leaves the transport tests green.

## Verification

- `make check-fe` — green (6280 tests)
- `emailpresentation_test.go` both directions — green. `personcards.tsx` now satisfies the census by mounting a canonical component rather than needing a waiver.

One flake seen and dismissed: `onboarding-conversation/company-act-refusal.test.tsx` timed out at 4150ms on one full-suite run, passes alone and on re-run, and touches nothing this diff changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the relationship brief's source chips so a cited email is named by its subject and opens the email drawer, instead of a chip that only said "Email". Calls and other transports keep their transport chip.

- `email_summary`, which the server sets only for `kind=email`, decides a row is mail; nothing reads the kind string.
- A withheld email shows the withheld wording and opens nothing.
- Fixes a test fixture that modelled an email row without `email_summary`, which the API never sends.

<sup>Written for commit 4bdc0acfd3e4c6b5904dc723ff70328606260d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Person brief cards now display cited email subjects and timestamps.
  - Selecting a cited email opens the shared email drawer.
  - Withheld emails remain private and do not reveal their subject or provide an opening action.
  - Non-email and unresolved activity citations continue to display their existing generic activity information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->