### PR TITLE
An unchecked forecast says so, instead of reading as a broken screen

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3237,6 +3237,8 @@ export const de = {
   "review.allSourcesRead": "Alle Quellen wurden gelesen.",
   "review.sourcesUnread":
     "Nicht gelesen: {sources}. Die Befunde unten decken nur ab, was geprüft werden konnte.",
+  "review.notCheckedYet":
+    "Es wurde noch nichts geprüft — für diese Installation ist noch kein nächtlicher Lauf abgeschlossen. Die Werte oben beruhen auf den Daten, wie sie sind.",
   "review.nothingToCheck": "Nichts zu prüfen.",
   "review.answer": "Prüfen",
   "review.closePast": "Abschlussdatum ist verstrichen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3285,6 +3285,8 @@ export const en = {
   "review.allSourcesRead": "Every source was read.",
   "review.sourcesUnread":
     "Not read: {sources}. Findings below cover only what could be checked.",
+  "review.notCheckedYet":
+    "Nothing has been checked yet — no nightly run has completed for this installation. The readings above stand on the records as they are.",
   "review.nothingToCheck": "Nothing to check.",
   "review.answer": "Answer",
   "review.closePast": "Close date has passed",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3202,6 +3202,8 @@ export const vi = {
   "review.allSourcesRead": "Đã đọc mọi nguồn.",
   "review.sourcesUnread":
     "Chưa đọc: {sources}. Các phát hiện bên dưới chỉ bao gồm những gì kiểm tra được.",
+  "review.notCheckedYet":
+    "Chưa có gì được kiểm tra — chưa có lần chạy hằng đêm nào hoàn tất cho bản cài đặt này. Các số liệu ở trên dựa trên dữ liệu hiện có.",
   "review.nothingToCheck": "Không có gì để kiểm tra.",
   "review.answer": "Trả lời",
   "review.closePast": "Ngày chốt đã qua",

--- a/frontend/src/screens/analytics.forecast.review.tsx
+++ b/frontend/src/screens/analytics.forecast.review.tsx
@@ -30,19 +30,42 @@ export function ForecastReview() {
   const assurance = useQuery({
     queryKey: ["forecast-assurance"],
     queryFn: async () => {
-      const { data, error } = await api.GET("/forecast/assurance", {});
+      const { data, error, response } = await api.GET(
+        "/forecast/assurance",
+        {},
+      );
+      // 404 is this endpoint's ANSWER, not its failure: the contract says "no
+      // run has completed yet. A fresh installation has not been checked."
+      // Thrown as a problem it reached the error gate and the panel read
+      // "Couldn't load this view. not found" — which tells a reader the screen
+      // is broken when what happened is that nothing has looked yet, and those
+      // are opposite instructions about whether to trust the numbers above.
+      if (response.status === 404) {
+        return null;
+      }
       if (error) {
         throwProblem(error);
       }
-      return data;
+      return data ?? null;
     },
   });
 
   return (
     <QueryGate query={assurance}>
-      {(run) => (
-        <ReviewPanel run={run} locale={locale} title={t("review.title")} />
-      )}
+      {(run) =>
+        run === null ? (
+          <Panel title={t("review.title")}>
+            <PanelBody>
+              {/* Said plainly, because the alternative reading is dangerous: a
+                  reader who takes an unchecked pipeline for a clean one has
+                  been told the opposite of what happened. */}
+              <p>{t("review.notCheckedYet")}</p>
+            </PanelBody>
+          </Panel>
+        ) : (
+          <ReviewPanel run={run} locale={locale} title={t("review.title")} />
+        )
+      }
     </QueryGate>
   );
 }

--- a/frontend/src/screens/analytics.forecast.test.tsx
+++ b/frontend/src/screens/analytics.forecast.test.tsx
@@ -61,6 +61,10 @@ function readings(over: Record<string, unknown> = {}) {
 type StubOpts = {
   readings?: Record<string, unknown>;
   onCall?: (body: Record<string, unknown>) => void;
+  // assuranceStatus lets a test ask for the answer a FRESH installation gets,
+  // where no nightly run has completed. Every other test here stubs a finished
+  // run, which is why that case went unrendered until somebody opened the page.
+  assuranceStatus?: number;
 };
 
 function forecastStub(opts: StubOpts = {}) {
@@ -79,6 +83,14 @@ function forecastStub(opts: StubOpts = {}) {
       return jsonResponse({ data: [] });
     }
     if (url.includes("/forecast/assurance")) {
+      if (opts.assuranceStatus === 404) {
+        // What the contract says a fresh installation gets: "no run has
+        // completed yet".
+        return jsonResponse(
+          { type: "about:blank", title: "Not Found", status: 404 },
+          404,
+        );
+      }
       // The run the review panel reads. Its own endpoint, so a test about the
       // call editor does not depend on what the check happened to find.
       return jsonResponse({
@@ -198,5 +210,24 @@ describe("ForecastView", () => {
     expect(await screen.findByText("Eligible deals")).toBeTruthy();
     expect(screen.getByText("Exchange rate missing")).toBeTruthy();
     expect(screen.getByText("2")).toBeTruthy();
+  });
+
+  // A fresh installation has been checked by nobody, and the panel must say so.
+  //
+  // 404 is this endpoint's ANSWER — the contract spells it "no run has
+  // completed yet" — so rendering it through the error gate told a reader the
+  // screen was broken when nothing had looked yet. Those are opposite
+  // instructions about whether to trust the readings above, which is why the
+  // wrong one is worth a test rather than a glance.
+  it("says nothing has been checked when no run has completed", async () => {
+    vi.stubGlobal("fetch", forecastStub({ assuranceStatus: 404 }));
+    render(<ForecastView />);
+
+    expect(
+      await screen.findByText(/Nothing has been checked yet/),
+    ).toBeTruthy();
+    // And NOT the broken-view state, which is what shipped.
+    expect(screen.queryByText(/Couldn't load this view/)).toBeNull();
+    expect(screen.queryByText(/not found/)).toBeNull();
   });
 });


### PR DESCRIPTION
On the Analytics → Forecast tab, the review panel rendered:

> **Couldn't load this view.**
> `not found`

`GET /forecast/assurance` answers 404 when no nightly run has completed, and the contract says so in as many words: *"No run has completed yet. A fresh installation has not been checked."* The panel threw that at `QueryGate`, which renders any error as a broken view.

So a reader who had never run the check was told the screen was broken. Those are opposite instructions about whether to trust the readings above it — one says the software failed, the other says nothing has looked yet — and the panel was giving the wrong one.

## The fix

404 returns `null` and renders the state plainly:

> **What should be checked before the call?**
> Nothing has been checked yet — no nightly run has completed for this installation. The readings above stand on the records as they are.

Said plainly on purpose: a reader who takes an unchecked pipeline for a clean one has been told the opposite of what happened, which is the same misreading the coverage line in this panel already exists to prevent.

Follows the house pattern for an endpoint whose 404 is an answer — the same `response.status === 404` check `companytechnical`, `companyvatmark` and `confirm` already use.

## How it was missed

Every test in `analytics.forecast.test.tsx` stubbed a **completed** run, so the unchecked case had no coverage at all. The new test supplies the 404 the contract describes and asserts both halves: that the state renders, and that the broken-view text does not.

Mutation-checked — removing the guard fails it with `Unable to find an element with the text: /Nothing has been checked yet/`.

## Verified

Loaded in a browser against a copy of the demo database (63 deals, real seats) as **manager** and as **rep**; both see the new state. Copy added in en, de and vi.

## Noticed, not fixed here

A rep sees the "Update the current call" button, and the backend correctly refuses her — `403 forecast.create: permission denied`, where a manager gets `201`. Not a security hole, but a control that always fails for that role. Pre-existing and separate from this bug; left alone rather than widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Forecast review panel so an installation that has never had a nightly run no longer shows the broken-screen error "Couldn't load this view. not found". A 404 from `/forecast/assurance` is the endpoint's way of saying nothing has been checked yet, so the panel now renders a plain "Nothing has been checked yet" state with copy in en, de, and vi.

**Notes**
- The unchecked case had no test coverage because every test stubbed a completed run; the new test asserts the new state renders and the broken-view text does not.
- Pre-existing and separate: reps see an "Update the current call" button that the backend always refuses with 403; left alone rather than widened into this PR.

<sup>Written for commit 056eb13a5ef111b5ec9f3d185f68c12a052276f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Not checked yet” state for installations without a completed nightly forecast check.
  * Added English, German, and Vietnamese translations for the new review state.

* **Bug Fixes**
  * Forecast review pages now display an informative status instead of an error when no assurance check has completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->