### PR TITLE
A capture trace names the message it is about, and opens it

### DIFF
--- a/frontend/src/screens/capture-activity-drawer.tsx
+++ b/frontend/src/screens/capture-activity-drawer.tsx
@@ -3,12 +3,18 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
+import type { components } from "../api/schema";
 import { Modal, Skeleton } from "../design-system/atoms";
+import { EmailReference } from "../design-system/emailreference";
 import { PipelineLadder } from "../design-system/pipelineladder";
 import { SurfaceState } from "../design-system/surfacestate";
-import { useT } from "../i18n";
+import { formatDateTime } from "../format/format";
+import { viewerZone } from "../format/timezone";
+import { useLocale, useT } from "../i18n";
 import { useProviderLabel } from "./channelproviders";
 import { throwProblem } from "./common";
+
+type TraceEntry = components["schemas"]["CaptureTraceEntry"];
 
 // The drill-down: what the pipeline did with ONE message, step by step.
 //
@@ -23,9 +29,29 @@ import { throwProblem } from "./common";
 
 export function CaptureActivityDrawer({
   traceId,
+  message,
+  onOpenEmail,
   onClose,
-}: Readonly<{ traceId: string; onClose: () => void }>) {
+}: Readonly<{
+  traceId: string;
+  /**
+   * The row this drawer was opened from, which is what knows WHICH message the
+   * ladder is about. The pipeline read below is keyed by the trace and answers
+   * with rungs; the correspondence is already on screen behind the drawer, so
+   * naming it here costs no request and no contract field.
+   */
+  message?: TraceEntry;
+  /**
+   * Opens the message itself. The page owns that drawer and CLOSES this one
+   * first: two `Modal placement="right"` sheets at once are two focus traps
+   * and two Escape handlers over one another, so the reader moves from the
+   * trace to the message rather than stacking them.
+   */
+  onOpenEmail?: (activityId: string) => void;
+  onClose: () => void;
+}>) {
   const t = useT();
+  const { locale } = useLocale();
   const providerLabel = useProviderLabel();
   const trace = useQuery({
     queryKey: ["capture-trace-pipeline", traceId],
@@ -47,6 +73,28 @@ export function CaptureActivityDrawer({
     >
       <h2 id="capture-pipeline-title">{t("pipeline.title")}</h2>
       <p className="capture-activity__drawer-sub">{t("pipeline.sub")}</p>
+      {/* WHICH message this ladder is about, named the way every other citation
+          of a message in the product names one. The reader arrived here from a
+          row that showed a sender and a subject in the trace's own layout; this
+          is the same fact, drawn once, and it opens.
+
+          `activity_id` is the server's gate: it is set only where a timeline
+          row exists AND this caller may read it, so an entry whose message
+          moved out of their scope names itself and offers nothing to press,
+          rather than handing back a link that proves the row exists. */}
+      {message && (
+        <p className="capture-activity__drawer-message">
+          <EmailReference
+            subject={message.subject}
+            occurredAt={formatDateTime(
+              message.occurred_at,
+              locale,
+              viewerZone(),
+            )}
+            onOpen={openerFor(message, onOpenEmail)}
+          />
+        </p>
+      )}
       {trace.isPending ? (
         <Skeleton width="100%" height={240} />
       ) : trace.data ? (
@@ -78,4 +126,23 @@ export function CaptureActivityDrawer({
       )}
     </Modal>
   );
+}
+
+/**
+ * The opener for a traced message, or nothing.
+ *
+ * A function rather than a conditional in the JSX because both facts have to
+ * hold at the same moment and TypeScript has to see it: `activity_id` is null
+ * for a message that never became a row and for one this caller may not read,
+ * and a page that passed no opener has nowhere to send them either way.
+ */
+function openerFor(
+  message: TraceEntry,
+  onOpenEmail: ((activityId: string) => void) | undefined,
+): (() => void) | undefined {
+  const activityId = message.activity_id;
+  if (!activityId || !onOpenEmail) {
+    return undefined;
+  }
+  return () => onOpenEmail(activityId);
 }

--- a/frontend/src/screens/capture-activity.css
+++ b/frontend/src/screens/capture-activity.css
@@ -173,3 +173,10 @@
   font-size: var(--fs-sm);
   margin: 0 0 var(--space-3);
 }
+
+/* WHICH message the ladder below is about. Not muted like the two lines above
+   it: those describe the surface, while this names the correspondence the
+   reader came to check and is the one line here they can act on. */
+.capture-activity__drawer-message {
+  margin: 0 0 var(--space-3);
+}

--- a/frontend/src/screens/capture-activity.test.tsx
+++ b/frontend/src/screens/capture-activity.test.tsx
@@ -9,6 +9,7 @@ import {
   cleanup,
   render as rtlRender,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -42,6 +43,46 @@ function windowBody(over: Record<string, unknown> = {}) {
     payload_capture_enabled: false,
     window_hours: 24,
     ...over,
+  };
+}
+
+// The message a trace's citation opens, in the shape the presentation read
+// answers with.
+function presentationBody() {
+  return {
+    id: "01930000-0000-7000-8000-00000000d001",
+    lifecycle: "delivered",
+    occurred_at: "2026-08-15T09:12:00Z",
+    summary: {
+      activity_id: "01930000-0000-7000-8000-00000000d001",
+      occurred_at: "2026-08-15T09:12:00Z",
+      version: 1,
+      subject: "Re: the pilot",
+      preview: "they wrote",
+      display_status: "team",
+      move: "none",
+      attachment_count: 0,
+    },
+    body: "they wrote",
+    thread_key: null,
+    from: [],
+    to: [],
+    cc: [],
+    bcc: [],
+    bcc_withheld: false,
+    attachments: [],
+    links: [],
+    thread: { members: [], next_cursor: null },
+    access: {
+      content_state: "available",
+      display_status: "team",
+      audience: "workspace",
+      can_change: false,
+      change_mode: "none",
+    },
+    can_reply: false,
+    can_relink: false,
+    version: 1,
   };
 }
 
@@ -135,6 +176,12 @@ function renderTab(
       }
       if (key.startsWith("GET /capture/traces/")) {
         return jsonResponse(ladderBody());
+      }
+      // The message a trace's citation opens. Answered here rather than left
+      // to the catch-all below, because `{}` is not an EmailPresentation and
+      // the drawer would throw on a shape the server never sends.
+      if (key.includes("/email-presentation")) {
+        return jsonResponse(presentationBody());
       }
       return jsonResponse({});
     }),
@@ -483,5 +530,76 @@ describe("the pipeline drill-down", () => {
     expect(
       await screen.findByText(/turned payload capture off/i),
     ).toBeInTheDocument();
+  });
+
+  // A trace is read to reconcile what the pipeline did against a message the
+  // reader remembers sending. Naming that message, and opening it, is what
+  // turns the ladder from a diagnostic into an answer.
+  it("names the traced message and opens it", async () => {
+    const user = userEvent.setup();
+    renderTab(
+      windowBody({
+        payload_capture_enabled: true,
+        data: [
+          {
+            ...ROW,
+            outcome: "captured",
+            reason: null,
+            activity_id: "01930000-0000-7000-8000-00000000d001",
+            counterparty: "dana@acme.test",
+            subject: "Re: the pilot",
+          },
+        ],
+      }),
+    );
+    await openLog();
+    await user.click(
+      screen.getByRole("button", { name: /every step this message/i }),
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /Re: the pilot/ }),
+    );
+
+    // The trace drawer gives way rather than stacking: two right-anchored
+    // sheets at once are two focus traps and two Escape handlers over one
+    // another, so the reader moves from the trace to the message.
+    await waitFor(() =>
+      expect(screen.queryByText("Sentiment scoring")).not.toBeInTheDocument(),
+    );
+  });
+
+  // `activity_id` is the server's gate — set only where a timeline row exists
+  // AND this caller may read it. An entry whose message is out of their scope
+  // names itself and offers nothing to press, rather than handing back a
+  // control that would prove the row exists.
+  it("names a traced message it cannot open, without offering to", async () => {
+    const user = userEvent.setup();
+    renderTab(
+      windowBody({
+        payload_capture_enabled: true,
+        data: [
+          {
+            ...ROW,
+            outcome: "captured",
+            reason: null,
+            activity_id: null,
+            counterparty: "dana@acme.test",
+            subject: "Re: the pilot",
+          },
+        ],
+      }),
+    );
+    await openLog();
+    await user.click(
+      screen.getByRole("button", { name: /every step this message/i }),
+    );
+
+    // The ladder is open, so the absence below is the gate rather than a
+    // drawer that never rendered.
+    await screen.findByText("Sentiment scoring");
+    expect(
+      screen.queryByRole("button", { name: /Re: the pilot/ }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/capture-activity.tsx
+++ b/frontend/src/screens/capture-activity.tsx
@@ -13,6 +13,7 @@ import {
   SegmentedControl,
   StatCard,
 } from "../design-system/atoms";
+import { OpenEmailDrawer } from "../design-system/openemaildrawer";
 import { Panel, PanelBody } from "../design-system/panel";
 import { SettingList, SettingRow } from "../design-system/settingrow";
 import { StatStrip } from "../design-system/statstrip";
@@ -24,6 +25,7 @@ import { CaptureActivityDrawer } from "./capture-activity-drawer";
 import { CaptureExclusionsCard } from "./capture-exclusions";
 import { useProviderLabel } from "./channelproviders";
 import { QueryGate, throwProblem } from "./common";
+import { useOpenEmail } from "./openemail";
 
 // Settings → Capture activity: what the pipeline did with the reader's own
 // messages in the last 24 hours.
@@ -200,7 +202,12 @@ function CaptureActivityWindow({ scope }: Readonly<{ scope: Scope }>) {
   const t = useT();
   const { locale } = useLocale();
   const [filter, setFilter] = useState<Outcome | null>(null);
-  const [openTrace, setOpenTrace] = useState<string | null>(null);
+  // The ENTRY rather than its id, because the drawer names the message the
+  // trace is about and the row is what knows it. The pipeline read the drawer
+  // makes is keyed by trace and returns rungs, not correspondence — asking it
+  // for a subject would be a contract change to carry a fact already on screen.
+  const [openTrace, setOpenTrace] = useState<TraceEntry | null>(null);
+  const [openEmail, setOpenEmail] = useOpenEmail();
   // Paged, because the window is 24 hours and a busy mailbox fills more than
   // one page of it. Without this the funnel could honestly say 300 captured
   // while the list showed 50 and nothing said the rest existed.
@@ -301,7 +308,7 @@ function CaptureActivityWindow({ scope }: Readonly<{ scope: Scope }>) {
                         key={entry.id}
                         entry={entry}
                         payloads={first.payload_capture_enabled}
-                        onOpen={() => setOpenTrace(entry.id)}
+                        onOpen={() => setOpenTrace(entry)}
                       />
                     ))}
                   </ul>
@@ -323,10 +330,24 @@ function CaptureActivityWindow({ scope }: Readonly<{ scope: Scope }>) {
             </Disclosure>
             {openTrace && (
               <CaptureActivityDrawer
-                traceId={openTrace}
+                traceId={openTrace.id}
+                message={openTrace}
+                onOpenEmail={(activityId) => {
+                  // The trace drawer closes as the message opens. Two
+                  // right-anchored sheets at once are two focus traps and two
+                  // Escape handlers stacked, and the reader is moving from the
+                  // trace to the message rather than reading both.
+                  setOpenTrace(null);
+                  setOpenEmail(activityId);
+                }}
                 onClose={() => setOpenTrace(null)}
               />
             )}
+            <OpenEmailDrawer
+              activityId={openEmail}
+              zone={viewerZone()}
+              onClose={() => setOpenEmail(null)}
+            />
           </>
         );
       }}


### PR DESCRIPTION
Fourth of the email-unification follow-ups, after #4019, #4023 and #4027. This is the plan's PR9 item for the capture trace.

## What it fixes

The pipeline drill-down showed a reader every step a message went through and never said **which message**. They arrived from a row that had a sender and subject on it, pressed into the ladder, and the ladder spoke only about stages — so reconciling "I sent that at 9:04" against what the pipeline did meant holding the row in their head behind a drawer that covered it.

The drawer now names the message as `EmailReference` — the same citation every other surface uses — and opens it.

## The privacy gate is the server's

`CaptureTraceEntry.activity_id` is set only where a timeline row exists **and** this caller may read it. The contract's own words: *"an entry whose activity moved out of their row scope still lists, with no link, rather than handing back an existence proof."*

That is used directly as the opener's gate. No link means no control, not a control that 404s.

## One drawer at a time

The trace drawer **closes** as the message opens. Two `Modal placement="right"` sheets at once are two focus traps and two Escape handlers stacked, and the reader is moving from the trace to the message rather than reading both. The `OpenEmailDrawer` catalog entry warns about exactly this.

## No contract change

The row's state now carries the entry rather than its id. The pipeline read is keyed by trace and answers with rungs; asking it for a subject would be a contract change to carry a fact already on screen behind the drawer.

## Deliberately NOT done: `pipelineladder.tsx`

The plan also asks for the ladder's per-rung sender+subject line to become an `EmailReference`. I did not do it, and I think the plan is wrong here:

- A `PipelineStageRung` has **no `activity_id` and no `occurred_at`** — a reference built from one would open nothing and show no date.
- `subject_kind` is `[message, sender, domain, thread]`, and the schema says plainly that *"the stages do not share a subject: the verdict is asked once per SENDER, so rendering it without saying whose would read as a claim about this one message."*

Printing "the message" on a rung whose answer is about the sender would state something the ladder does not mean. Those values are per-stage diagnostics and the ladder's whole point.

## Tests

Two new, both mutation-checked:
- names the traced message and opens it — fails when the trace drawer is left open on top
- names a traced message it cannot open, without offering to — fails when the `activity_id` gate is dropped

The fetch stub gained an email-presentation route: `{}` is not an `EmailPresentation` and the drawer threw on a shape the server never sends.

## Verification

- `make check-fe` — green (6284 tests)
- `emailpresentation_test.go` both directions — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the message a capture trace is about and opens it, so the pipeline drill-down no longer leaves the reader holding the row's sender and subject in their head.

- The trace drawer cites the message as `EmailReference` and opens it, using `activity_id` as the server's gate: no link when the message is out of the reader's scope.
- The trace drawer closes as the message opens, so two right-anchored modals don't stack focus traps and Escape handlers.
- The row state now carries the trace entry instead of its id.
- The per-rung sender and subject lines in `pipelineladder.tsx` stay unchanged: a rung has no `activity_id` or `occurred_at`, and `subject_kind` means a rung's verdict is per-sender, not per-message.
- Adds two mutation-checked tests and an email-presentation route to the fetch stub.

<sup>Written for commit c88a7785adb96019fcc5719a1be8c0bd9f6cf5d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capture activity details now display the related message identifier.
  * Traced messages with an available activity reference can be opened directly in the email drawer.
  * Email details respect the viewer’s locale and time zone.
* **Bug Fixes**
  * Messages without an accessible activity reference remain identifiable without showing an unavailable open action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->