### PR TITLE
A contact says who can see it, and the edit controls fail closed

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -320,7 +320,7 @@ export const de = {
   "share.downgradeConfirm": "Auf {to} reduzieren",
   "share.seatCeiling":
     "Dieser Sitzplatz ist nur lesend und kann daher keinen Schreibzugriff auf einen Datensatz erhalten. Erhöhen Sie zuerst die Sitzplatzstufe, oder gewähren Sie Lesezugriff.",
-  "share.whoHasAccess": "Wer hat Zugriff",
+  "share.whoHasAccess": "Ausdrücklich geteilt",
   "share.grantedBy": "gewährt von",
   "share.revoke": "Widerrufen",
   "share.revokeConfirm":
@@ -3058,7 +3058,14 @@ export const de = {
   "log.save": "Erfassen",
   "log.saving": "Wird erfasst…",
 
+  "personAccess.title": "Wer diesen Kontakt sieht",
+  "personAccess.privateToYou":
+    "Nur für Sie. Ihr Postfach hat diesen Kontakt angelegt, und niemand sonst im Unternehmen sieht ihn — auch nicht Ihr Team und keine Administration.",
+  "personAccess.organization": "Alle im Unternehmen sehen diesen Kontakt.",
+  "personAccess.share": "Mit dem Unternehmen teilen",
+  "personAccess.published": "Das Unternehmen sieht diesen Kontakt jetzt.",
   "compose.reply": "Antworten",
+  "compose.writeEmail": "E-Mail schreiben",
   "compose.relink": "Neu verknüpfen",
   "compose.draftWithAi": "Mit KI entwerfen",
   "compose.drafting": "Wird entworfen…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -343,7 +343,7 @@ export const en = {
   "share.downgradeConfirm": "Reduce to {to}",
   "share.seatCeiling":
     "This seat is read-only, so it cannot hold write access to a record. Raise the seat first, or grant read.",
-  "share.whoHasAccess": "Who has access",
+  "share.whoHasAccess": "Explicit shares",
   "share.grantedBy": "granted by",
   "share.revoke": "Revoke",
   "share.revokeConfirm":
@@ -3101,7 +3101,15 @@ export const en = {
   "log.save": "Log",
   "log.saving": "Logging…",
 
+  "personAccess.title": "Who can see this contact",
+  "personAccess.privateToYou":
+    "Private to you. Your mailbox created this contact, and nobody else in the organization can see it — not your team, and not an admin.",
+  "personAccess.organization":
+    "Everyone in the organization can see this contact.",
+  "personAccess.share": "Share with the organization",
+  "personAccess.published": "The organization can see this contact now.",
   "compose.reply": "Reply",
+  "compose.writeEmail": "Write email",
   "compose.relink": "Relink",
   "compose.draftWithAi": "Draft with AI",
   "compose.drafting": "Drafting…",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -327,7 +327,7 @@ export const vi = {
   "share.downgradeConfirm": "Giảm xuống {to}",
   "share.seatCeiling":
     "Chỗ ngồi này chỉ đọc nên không thể nhận quyền ghi trên một bản ghi. Hãy nâng cấp chỗ ngồi trước, hoặc chỉ cấp quyền đọc.",
-  "share.whoHasAccess": "Ai có quyền truy cập",
+  "share.whoHasAccess": "Chia sẻ cụ thể",
   "share.grantedBy": "cấp bởi",
   "share.revoke": "Thu hồi",
   "share.revokeConfirm":
@@ -3026,7 +3026,15 @@ export const vi = {
   "log.save": "Ghi nhận",
   "log.saving": "Đang ghi nhận…",
 
+  "personAccess.title": "Ai xem được liên hệ này",
+  "personAccess.privateToYou":
+    "Riêng của bạn. Hộp thư của bạn đã tạo liên hệ này, và không ai khác trong tổ chức xem được — kể cả nhóm của bạn và quản trị viên.",
+  "personAccess.organization":
+    "Mọi người trong tổ chức đều xem được liên hệ này.",
+  "personAccess.share": "Chia sẻ với tổ chức",
+  "personAccess.published": "Tổ chức đã xem được liên hệ này.",
   "compose.reply": "Trả lời",
+  "compose.writeEmail": "Viết email",
   "compose.relink": "Liên kết lại",
   "compose.draftWithAi": "Soạn bằng AI",
   "compose.drafting": "Đang soạn…",

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -3,7 +3,7 @@ import { Fragment, type ReactElement, useId } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
-import { useCanWrite } from "../app/capability";
+import { useCanWrite, useCanWriteRecord } from "../app/capability";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import { Badge, Button, OverflowMenu } from "../design-system/atoms";
@@ -322,10 +322,10 @@ export function CompanyLifecycleControl({
   org,
 }: Readonly<{ org: Organization }>) {
   const t = useT();
-  // useCanWrite, not useCan: these controls issue a PATCH, and the licensing
-  // middleware refuses a mutation from a read seat before RBAC is consulted.
+  // useCanWriteRecord, not useCanWrite: the grant and the seat say this ROLE
+  // may change accounts, and the row says whether this one is theirs to change.
   // Gating on the grant alone offers an active control whose save is rejected.
-  const canUpdate = useCanWrite("organization", "update");
+  const canUpdate = useCanWriteRecord("organization", org);
   const readOnlyReason = useCompanyReadOnlyReason(org);
   const patch = useCompanyFieldPatch(org);
   return (
@@ -388,10 +388,17 @@ export function CompanyOwnerControl({
   hideLabel,
 }: Readonly<{ org: Organization; hideLabel?: boolean }>) {
   const t = useT();
-  // useCanWrite, not useCan: these controls issue a PATCH, and the licensing
-  // middleware refuses a mutation from a read seat before RBAC is consulted.
-  // Gating on the grant alone offers an active control whose save is rejected.
-  const canUpdate = useCanWrite("organization", "update");
+  // Two different questions, deliberately.
+  //
+  // Changing the owner of an OWNED account is a write to that row, so it takes
+  // the row's own answer. Claiming an UNOWNED one cannot: `writable` is false
+  // precisely because nobody owns it yet, and gating the claim on it would
+  // close the only door out of that state. The claim is its own authority and
+  // the server holds it — this is the grant plus the seat, which is what the
+  // claim endpoint itself requires.
+  const canClaim = useCanWrite("organization", "update");
+  const canUpdate =
+    useCanWriteRecord("organization", org) || (!org.owner_id && canClaim);
   const readOnlyReason = useCompanyReadOnlyReason(org);
   const patch = useCompanyFieldPatch(org);
   const claim = useClaimRecord("organization", org.id, org.version);

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -3204,6 +3204,7 @@ export function ChannelReplyAction({
   entityType,
   entityId,
   personId,
+  contentWithheld,
 }: Readonly<{
   activityId: string;
   kind: Activity["kind"];
@@ -3211,6 +3212,10 @@ export function ChannelReplyAction({
   entityType: RelinkKind;
   entityId: string;
   personId?: string;
+  // The row's content is not this reader's to see. The verb still works —
+  // writing to the contact is not reading their mail — but it is not a REPLY,
+  // and calling it one claims access to the message being answered.
+  contentWithheld?: boolean;
 }>) {
   const t = useT();
   const [reply, setReply] = useState(false);
@@ -3225,7 +3230,7 @@ export function ChannelReplyAction({
   return (
     <>
       <Button small onClick={() => setReply(true)}>
-        {t("compose.reply")}
+        {contentWithheld ? t("compose.writeEmail") : t("compose.reply")}
       </Button>
       {reply && (
         <ComposeModal

--- a/frontend/src/screens/consent.test.tsx
+++ b/frontend/src/screens/consent.test.tsx
@@ -33,6 +33,21 @@ function render(ui: ReactNode) {
   );
 }
 
+// A full seat holding person.update — the default these tests run under.
+const SEAT_MAY_WRITE = {
+  user: { id: "u1", email: "rep@example.test", full_name: "A Rep" },
+  authorization: {
+    seat_type: "full",
+    objects: { person: { read: true, update: true } },
+  },
+};
+
+// The row the section is asked about. `writable` is what the server answers per
+// caller per row, and the section fails closed without it — a fixture that
+// omits it describes a contact this reader may not edit, which is a different
+// test than the one each of these means to be.
+const writablePerson = { writable: true };
+
 const PURPOSES = {
   data: [
     {
@@ -107,6 +122,11 @@ function stubRoutes(
       sent.push({ key, url: url.pathname + url.search, body });
       const override = overrides[key];
       if (override) return override();
+      // A full seat holding person.update, which every one of these tests
+      // assumed before the grant was asked for: they are about what the
+      // section SENDS, and a reader who may not write it sends nothing. The
+      // permission axis has its own tests below.
+      if (key === "GET /me") return jsonResponse(SEAT_MAY_WRITE);
       if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
       if (key === "GET /people/person-1/consent") return jsonResponse(CONSENT);
       return jsonResponse({});
@@ -137,14 +157,14 @@ afterEach(() => {
 describe("ConsentSection", () => {
   it("renders unknown distinctly from withdrawn — no record is not a withdrawal", async () => {
     stubRoutes();
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     expect(await screen.findByText(/no record/i)).toBeInTheDocument();
   });
 
   // G-4: the events[] the Person 360 currently drops. Art. 7 demonstrability.
   it("shows the append-only proof log for a purpose", async () => {
     stubRoutes();
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     const row = await findConsentRow("Deal messages");
     await userEvent.click(
       within(row).getByRole("button", { name: /proof log/i }),
@@ -157,7 +177,7 @@ describe("ConsentSection", () => {
   // human who is not necessarily whoever is looking at this proof.
   it("names the actual human actor rather than claiming the viewer typed it", async () => {
     stubRoutes();
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     const row = await findConsentRow("Deal messages");
     await userEvent.click(
       within(row).getByRole("button", { name: /proof log/i }),
@@ -185,7 +205,7 @@ describe("ConsentSection", () => {
           ],
         }),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     const row = await findConsentRow("Deal messages");
     await userEvent.click(
       within(row).getByRole("button", { name: /proof log/i }),
@@ -198,7 +218,7 @@ describe("ConsentSection", () => {
   // log must still be reachable and say so honestly, not hide the toggle.
   it("shows the honest empty state for a purpose with no consent record", async () => {
     stubRoutes();
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     const row = await findConsentRow("Marketing");
     await userEvent.click(
       within(row).getByRole("button", { name: /proof log/i }),
@@ -213,7 +233,7 @@ describe("ConsentSection", () => {
   // operator can type is a confirmation an operator can forge.
   it("offers no token field on a purpose that requires double opt-in", async () => {
     stubRoutes();
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     await screen.findByText("Marketing");
     expect(screen.queryByLabelText(/confirmation token/i)).toBeNull();
     expect(
@@ -226,7 +246,7 @@ describe("ConsentSection", () => {
   // subject's right and never needs a round trip.
   it("offers no Grant on a double-opt-in row nobody here can grant", async () => {
     stubRoutes();
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     await screen.findByText("Marketing");
     // The fixture holds a granted non-DOI purpose and an unknown DOI one. The
     // granted row keeps Withdraw; the DOI row offers nothing, so no Grant
@@ -239,7 +259,7 @@ describe("ConsentSection", () => {
 
   it("says who confirms a double-opt-in purpose, on that row only", async () => {
     stubRoutes();
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     await screen.findByText("Marketing");
     // One row requires DOI in the fixture; the note belongs to it alone.
     expect(
@@ -259,7 +279,7 @@ describe("ConsentSection", () => {
           state: "withdrawn",
         }),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     await screen.findByText("Marketing");
     await userEvent.click(
       screen.getAllByRole("button", { name: /^withdraw$/i })[0],
@@ -282,7 +302,7 @@ describe("ConsentSection", () => {
           state: "withdrawn",
         }),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     await userEvent.click(
       await screen.findByRole("button", { name: /^withdraw$/i }),
     );
@@ -329,7 +349,7 @@ describe("ConsentSection", () => {
           state: "granted",
         }),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     // Both p1 (withdrawn) and p2 (unknown) show a Grant button here; [0] is
     // p1's — rows render in the order GET /people/{id}/consent lists them.
     await screen.findByText("Deal messages");
@@ -385,7 +405,7 @@ describe("ConsentSection", () => {
           state: "withdrawn",
         }),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     const row = await findConsentRow("Deal messages");
     await userEvent.click(
       within(row).getByRole("button", { name: /proof log/i }),
@@ -409,7 +429,7 @@ describe("ConsentSection", () => {
   // issuance endpoint, so there is no capability for an operator to read.
   it("never asks the server to issue a double-opt-in token", async () => {
     const sent = stubRoutes();
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     await screen.findByText("Marketing");
     await userEvent.click(
       screen.getAllByRole("button", { name: /^withdraw$/i })[0],
@@ -432,7 +452,7 @@ describe("ConsentSection", () => {
       "GET /people/person-1/consent": () =>
         jsonResponse({ state: [], events: [] }),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     expect(await screen.findByText(/no consent purposes/i)).toBeInTheDocument();
   });
 
@@ -441,7 +461,7 @@ describe("ConsentSection", () => {
       "GET /people/person-1/consent": () =>
         jsonResponse({ title: "boom", status: 500 }, 500),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     expect(
       await screen.findByRole("button", { name: /retry/i }),
     ).toBeInTheDocument();
@@ -456,7 +476,7 @@ describe("ConsentSection", () => {
     stubRoutes({
       "GET /consent-purposes": () => jsonResponse({ title: "boom" }, 500),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
     expect(
       await screen.findByText(/couldn't load the consent purpose catalogue/i),
     ).toBeInTheDocument();
@@ -499,7 +519,7 @@ describe("asking a contact to confirm their details", () => {
       },
       sent,
     );
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
 
     await userEvent.click(await screen.findByTestId("confirm-details-ask"));
 
@@ -531,7 +551,7 @@ describe("asking a contact to confirm their details", () => {
           201,
         ),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
 
     await userEvent.click(await screen.findByTestId("confirm-details-ask"));
 
@@ -553,7 +573,7 @@ describe("asking a contact to confirm their details", () => {
           201,
         ),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
 
     await userEvent.click(await screen.findByTestId("confirm-details-ask"));
 
@@ -578,7 +598,7 @@ describe("asking a contact to confirm their details", () => {
           422,
         ),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
 
     await userEvent.click(await screen.findByTestId("confirm-details-ask"));
 
@@ -599,7 +619,7 @@ describe("asking a contact to confirm their details", () => {
           },
         }),
     });
-    render(<ConsentSection personId="person-1" />);
+    render(<ConsentSection personId="person-1" person={writablePerson} />);
 
     // Waited for rather than asserted immediately: the capability arrives
     // asynchronously, so an absence checked too early passes for the wrong

--- a/frontend/src/screens/consent.tsx
+++ b/frontend/src/screens/consent.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useCanWrite } from "../app/capability";
+import { useCanWriteRecord } from "../app/capability";
 import {
   Badge,
   Button,
@@ -186,11 +186,13 @@ function MutationError({ error }: Readonly<{ error: unknown }>) {
 // surface verbatim (a DOI-required purpose 422s here rather than silently
 // no-opping) so the human sees exactly why the toggle didn't take.
 function ConsentRow({
+  mayWrite,
   personId,
   entry,
   purpose,
   events,
 }: Readonly<{
+  mayWrite: boolean;
   personId: string;
   entry: PersonConsentState;
   purpose: ConsentPurpose | undefined;
@@ -245,7 +247,7 @@ function ConsentRow({
             is what disappears — the server refuses it, because only the subject
             can confirm a purpose that requires the round trip, so offering the
             button would promise something every click fails to do. */}
-        {(granted || !requiresDoi) && (
+        {mayWrite && (granted || !requiresDoi) && (
           <Button
             small
             disabled={setState.isPending}
@@ -265,7 +267,15 @@ function ConsentRow({
   );
 }
 
-export function ConsentSection({ personId }: Readonly<{ personId: string }>) {
+export function ConsentSection({
+  personId,
+  person,
+}: Readonly<{ personId: string; person?: { readonly writable?: boolean } }>) {
+  // Every verb in this section writes to the PERSON, so they share one
+  // decision: the role's grant and this row's own `writable`. Absent fails
+  // closed, which is what a section rendered before its record has loaded
+  // should do — an editor drawn on a maybe is a control the save refuses.
+  const mayWrite = useCanWriteRecord("person", person);
   const t = useT();
   const consentQuery = usePersonConsent(personId);
   const purposesQuery = useConsentPurposes();
@@ -303,6 +313,7 @@ export function ConsentSection({ personId }: Readonly<{ personId: string }>) {
         <div>
           {consent.state.map((entry) => (
             <ConsentRow
+              mayWrite={mayWrite}
               key={entry.purpose_id}
               personId={personId}
               entry={entry}
@@ -335,7 +346,11 @@ export function ConsentSection({ personId }: Readonly<{ personId: string }>) {
           asked for, and React would otherwise reuse this component across a
           navigation between two cached contacts and leave the previous
           contact's address sitting under the new record. */}
-      <ConfirmDetailsAction key={personId} personId={personId} />
+      <ConfirmDetailsAction
+        key={personId}
+        personId={personId}
+        mayWrite={mayWrite}
+      />
     </Card>
   );
 }
@@ -364,11 +379,13 @@ function sentenceFor(
  * its own: the answer came from the subject's mailbox. So this surface offers
  * the act and reports where it went, and cannot aim it anywhere.
  */
-function ConfirmDetailsAction({ personId }: Readonly<{ personId: string }>) {
+function ConfirmDetailsAction({
+  personId,
+  mayWrite,
+}: Readonly<{ personId: string; mayWrite: boolean }>) {
   const t = useT();
   const { locale } = useLocale();
   const zone = viewerZone();
-  const mayAsk = useCanWrite("person", "update");
   const ask = useMutation({
     // Keyed on the person, so a result belongs to the record it was asked
     // about. React reuses this component across a navigation between two
@@ -388,7 +405,7 @@ function ConfirmDetailsAction({ personId }: Readonly<{ personId: string }>) {
     },
   });
 
-  if (!mayAsk) {
+  if (!mayWrite) {
     return null;
   }
   return (

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -684,7 +684,9 @@ function PersonTabPanels({
       {/* Consent renders on a thin record too: it is not an absence
           but a guard — what you may send is a live fact whether or
           not anyone has written to them yet. */}
-      {tab === "overview" && <ConsentSection personId={person.id} />}
+      {tab === "overview" && (
+        <ConsentSection personId={person.id} person={person} />
+      )}
       {tab === "overview" && view && (
         <EnrichedFields personId={id} view={view} />
       )}

--- a/frontend/src/screens/personaccess.test.tsx
+++ b/frontend/src/screens/personaccess.test.tsx
@@ -76,7 +76,7 @@ afterEach(() => {
 describe("PersonAccess", () => {
   it("says a captured contact is private to the reader, which no other surface does", async () => {
     stub();
-    draw({ ...base, visibility: "owner", writable: true });
+    draw({ ...base, visibility: "owner", writable: true, owner_id: "u1" });
     expect(await screen.findByText(/private to you/i)).toBeTruthy();
   });
 
@@ -91,7 +91,7 @@ describe("PersonAccess", () => {
   it("offers the owner the one verb that changes the answer", async () => {
     const sent: string[] = [];
     stub(sent);
-    draw({ ...base, visibility: "owner", writable: true });
+    draw({ ...base, visibility: "owner", writable: true, owner_id: "u1" });
     await userEvent.click(
       await screen.findByRole("button", {
         name: /share with the organization/i,
@@ -102,7 +102,29 @@ describe("PersonAccess", () => {
 
   it("offers no verb to a reader who is not the owner", async () => {
     stub();
-    draw({ ...base, visibility: "owner", writable: false });
+    draw({
+      ...base,
+      visibility: "owner",
+      writable: false,
+      owner_id: "someone-else",
+    });
+    expect(await screen.findByText(/private to you/i)).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /share with the organization/i }),
+    ).toBeNull();
+  });
+
+  it("offers no verb to a colleague holding a write grant", async () => {
+    // `writable` is true for a write grant and for an unbounded seat, neither
+    // of which is the mailbox this contact came from. The endpoint matches on
+    // owner_id exactly, so a button drawn on writability would 404 the click.
+    stub();
+    draw({
+      ...base,
+      visibility: "owner",
+      writable: true,
+      owner_id: "someone-else",
+    });
     expect(await screen.findByText(/private to you/i)).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: /share with the organization/i }),
@@ -111,7 +133,7 @@ describe("PersonAccess", () => {
 
   it("offers no verb on a contact the organization can already see", async () => {
     stub();
-    draw({ ...base, visibility: "workspace", writable: true });
+    draw({ ...base, visibility: "workspace", writable: true, owner_id: "u1" });
     expect(
       await screen.findByText(/everyone in the organization/i),
     ).toBeTruthy();

--- a/frontend/src/screens/personaccess.test.tsx
+++ b/frontend/src/screens/personaccess.test.tsx
@@ -1,0 +1,130 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { components } from "../api/schema";
+import { ToastProvider, ToastRegion } from "../design-system/toast";
+import { PersonAccess } from "./personaccess";
+
+type Person = components["schemas"]["Person"];
+
+const base: Person = {
+  id: "p-1",
+  full_name: "Dana Buyer",
+  source: "gmail:seed",
+  captured_by: "connector:gmail",
+  created_at: "2026-06-01T08:00:00Z",
+  updated_at: "2026-08-01T08:00:00Z",
+};
+
+const seatMayWrite = {
+  user: { id: "u1", email: "rep@example.test", full_name: "A Rep" },
+  authorization: {
+    seat_type: "full",
+    objects: { person: { read: true, update: true } },
+  },
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function stub(sent: string[] = []) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      sent.push(key);
+      if (key === "GET /me") return json(seatMayWrite);
+      return json({});
+    }),
+  );
+}
+
+function draw(person: Person) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <PersonAccess person={person} />
+        <ToastRegion />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => localStorage.setItem("margince.workspaceSlug", "acme"));
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("PersonAccess", () => {
+  it("says a captured contact is private to the reader, which no other surface does", async () => {
+    stub();
+    draw({ ...base, visibility: "owner", writable: true });
+    expect(await screen.findByText(/private to you/i)).toBeTruthy();
+  });
+
+  it("says a promoted contact is the organization's", async () => {
+    stub();
+    draw({ ...base, visibility: "workspace", writable: true });
+    expect(
+      await screen.findByText(/everyone in the organization/i),
+    ).toBeTruthy();
+  });
+
+  it("offers the owner the one verb that changes the answer", async () => {
+    const sent: string[] = [];
+    stub(sent);
+    draw({ ...base, visibility: "owner", writable: true });
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: /share with the organization/i,
+      }),
+    );
+    expect(sent).toContain("POST /people/p-1/publish");
+  });
+
+  it("offers no verb to a reader who is not the owner", async () => {
+    stub();
+    draw({ ...base, visibility: "owner", writable: false });
+    expect(await screen.findByText(/private to you/i)).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /share with the organization/i }),
+    ).toBeNull();
+  });
+
+  it("offers no verb on a contact the organization can already see", async () => {
+    stub();
+    draw({ ...base, visibility: "workspace", writable: true });
+    expect(
+      await screen.findByText(/everyone in the organization/i),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /share with the organization/i }),
+    ).toBeNull();
+  });
+
+  it("draws nothing at all when the server sent no visibility", () => {
+    // A server too old to send it, or a path that does not. Guessing
+    // `workspace` would tell a reader their private contact is public.
+    stub();
+    const { container } = draw({ ...base, writable: true });
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/frontend/src/screens/personaccess.tsx
+++ b/frontend/src/screens/personaccess.tsx
@@ -1,0 +1,78 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { useCanWriteRecord } from "../app/capability";
+import { Button } from "../design-system/atoms";
+import { Panel, PanelBody } from "../design-system/panel";
+import { useToast } from "../design-system/toast";
+import { useT } from "../i18n";
+import { throwProblem } from "./common";
+
+type Person = components["schemas"]["Person"];
+
+/**
+ * PersonAccess says who this contact is for, and gives its owner the one verb
+ * that changes the answer.
+ *
+ * The question it answers is not "may I edit this" — `writable` already says
+ * that, and the edit affordances draw themselves from it. It is "why can I see
+ * this at all", which until the server sent `visibility` no surface could
+ * answer: a contact private to the reader's own mailbox and one shared with
+ * the whole organization looked identical, and the owner of the private one
+ * had no way to tell, let alone to change it.
+ *
+ * Absent `visibility` renders nothing rather than guessing. A panel that
+ * assumed `workspace` would tell a reader their private contact is public.
+ */
+export function PersonAccess({ person }: Readonly<{ person: Person }>) {
+  const t = useT();
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const mayWrite = useCanWriteRecord("person", person);
+
+  const publish = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await api.POST("/people/{id}/publish", {
+        params: { path: { id } },
+      });
+      if (error) {
+        throwProblem(error);
+      }
+    },
+    onSuccess: async () => {
+      toast.show(t("personAccess.published"));
+      await queryClient.invalidateQueries({
+        queryKey: ["person360", person.id],
+      });
+    },
+  });
+
+  if (!person.visibility) {
+    return null;
+  }
+  const isPrivate = person.visibility === "owner";
+  return (
+    <Panel title={t("personAccess.title")}>
+      <PanelBody>
+        <p className="t-small">
+          {isPrivate
+            ? t("personAccess.privateToYou")
+            : t("personAccess.organization")}
+        </p>
+        {/* The verb belongs to the OWNER, and `writable` is how the server
+            already tells us who that is on a capture-private row: nobody else
+            can write one. Offering it to a reader who cannot would produce a
+            404, which is the right answer to the wrong question being asked. */}
+        {isPrivate && mayWrite && (
+          <Button
+            small
+            disabled={publish.isPending}
+            onClick={() => publish.mutate(person.id)}
+          >
+            {t("personAccess.share")}
+          </Button>
+        )}
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/frontend/src/screens/personaccess.tsx
+++ b/frontend/src/screens/personaccess.tsx
@@ -1,12 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useCanWriteRecord } from "../app/capability";
 import { Button } from "../design-system/atoms";
 import { Panel, PanelBody } from "../design-system/panel";
 import { useToast } from "../design-system/toast";
 import { useT } from "../i18n";
-import { throwProblem } from "./common";
+import { throwProblem, useViewerId } from "./common";
 
 type Person = components["schemas"]["Person"];
 
@@ -28,7 +27,13 @@ export function PersonAccess({ person }: Readonly<{ person: Person }>) {
   const t = useT();
   const toast = useToast();
   const queryClient = useQueryClient();
-  const mayWrite = useCanWriteRecord("person", person);
+  // OWNERSHIP, not writability. `writable` is true for a write grant and for
+  // an unbounded seat as well, and neither of those is the mailbox this
+  // contact came from — the endpoint matches on owner_id exactly and answers
+  // 404 to everybody else. Offering the button on `writable` would show it to
+  // a colleague holding a grant and then fail their click.
+  const viewerId = useViewerId();
+  const isOwner = Boolean(viewerId) && person.owner_id === viewerId;
 
   const publish = useMutation({
     mutationFn: async (id: string) => {
@@ -59,11 +64,7 @@ export function PersonAccess({ person }: Readonly<{ person: Person }>) {
             ? t("personAccess.privateToYou")
             : t("personAccess.organization")}
         </p>
-        {/* The verb belongs to the OWNER, and `writable` is how the server
-            already tells us who that is on a capture-private row: nobody else
-            can write one. Offering it to a reader who cannot would produce a
-            404, which is the right answer to the wrong question being asked. */}
-        {isPrivate && mayWrite && (
+        {isPrivate && isOwner && (
           <Button
             small
             disabled={publish.isPending}

--- a/frontend/src/screens/personcorrections.test.tsx
+++ b/frontend/src/screens/personcorrections.test.tsx
@@ -29,6 +29,10 @@ const person: components["schemas"]["Person"] = {
   captured_by: "human:u-1",
   created_at: "2026-06-01T08:00:00Z",
   updated_at: "2026-08-01T08:00:00Z",
+  // The server's own per-row answer. A correction writes to this contact, so
+  // the section asks for it; a fixture that omitted it would describe a record
+  // this reader may not edit, which is a different test.
+  writable: true,
 };
 
 // Typed against the contract rather than cast into it: a fixture that dropped a

--- a/frontend/src/screens/personcorrections.tsx
+++ b/frontend/src/screens/personcorrections.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import { api } from "../api/client";
 import type { components } from "../api/schema";
-import { useCanWrite } from "../app/capability";
+import { useCanWriteRecord } from "../app/capability";
 import { useRecordZone } from "../app/recordzone";
 import {
   Badge,
@@ -43,7 +43,9 @@ export function EnrichedFields({
   view,
 }: Readonly<{ personId: string; view: Person360 }>) {
   const t = useT();
-  const mayCorrect = useCanWrite("person", "update");
+  // The row as well as the grant: a correction writes to this contact, and a
+  // reader who may not edit it is not offered a form the save refuses.
+  const mayCorrect = useCanWriteRecord("person", view.person);
   const fields = view.profile_fields ?? [];
   if (fields.length === 0) {
     return null;

--- a/frontend/src/screens/personpage.test.tsx
+++ b/frontend/src/screens/personpage.test.tsx
@@ -44,6 +44,10 @@ const view: Person360 = {
   person: {
     id: "p-1",
     full_name: "Dana Buyer",
+    // The server's own per-row answer, which every edit affordance on this
+    // page asks for. Absent it the fixture describes a contact this reader
+    // may not write, and the controls correctly disappear.
+    writable: true,
     emails: [
       {
         id: "pe-1",

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -65,6 +65,7 @@ import type { Transport } from "./persontransports";
 import { primaryTransportAction, useTransports } from "./persontransports";
 import { RecordReading, RecordReadingPair } from "./record360";
 import { EmailVerb, RecordEmailAside } from "./recordemail";
+import { ShareAction } from "./share";
 import "./person360.css";
 import { buyingRoleLabel } from "./companypeople/summary";
 
@@ -502,7 +503,7 @@ export function PersonPageV2({
             {/* What this person has agreed to, and the one way to ask them
                 directly. It renders on a thin record too: what you may send is
                 a live fact whether or not anyone has written to them yet. */}
-            <ConsentSection personId={id} />
+            <ConsentSection personId={id} person={view.data.person} />
             {/* The fields Margince read off a signature or a card, and the
                 one place a reader can confirm or correct them. */}
             <EnrichedFields personId={id} view={view.data} />
@@ -1038,6 +1039,10 @@ function PersonActions({
         >
           {t("record.fullHistory")}
         </Button>
+        {/* Companies, deals, leads and projects all carry this. A contact did
+            not, so the one record type most likely to be private to one seat
+            was the one with no way to hand it to a colleague. */}
+        <ShareAction recordType="person" recordId={personId} />
       </OverflowMenu>
     </>
   );

--- a/frontend/src/screens/personrail.test.tsx
+++ b/frontend/src/screens/personrail.test.tsx
@@ -54,6 +54,10 @@ const person: components["schemas"]["Person"] = {
   captured_by: "human:u-1",
   created_at: "2026-06-01T08:00:00Z",
   updated_at: "2026-08-01T08:00:00Z",
+  // The server's own per-row answer, which the rail's edit affordances ask
+  // for. Absent it, this fixture describes a contact this reader may not
+  // write, and every editor correctly disappears.
+  writable: true,
 };
 
 function inboundEmail(): Activity {

--- a/frontend/src/screens/personrail.tsx
+++ b/frontend/src/screens/personrail.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch, requireVersion } from "../api/version";
-import { useCan, useCanWriteRecord } from "../app/capability";
+import { useCanWriteRecord } from "../app/capability";
 import { useRecordZone } from "../app/recordzone";
 import { navigate } from "../app/router";
 import {
@@ -51,6 +51,7 @@ import { problemMessageOf, throwProblem, useSorMode } from "./common";
 import { CounterpartyHoldRow } from "./counterparty-hold";
 import { stillHeld, today } from "./employmentcurrency";
 import { interactionIcon } from "./interactionchrome";
+import { PersonAccess } from "./personaccess";
 import { daysSinceInbound, isQuiet } from "./personquiet";
 import { consentWord } from "./personreadings";
 import { personTabRoute } from "./persontab";
@@ -158,9 +159,12 @@ export function PersonRail({
       <WhoKnows view={view} firstName={firstName} />
       <SignalsAndRisks view={view} />
       <ConsentAndChannels view={view} guard={guard} />
-      {/* Beside consent, because it is the same subject from the seat's own
-          side: consent says what this contact allows us to send, the hold
-          says what the seat is willing for colleagues to read. */}
+      {/* Three neighbours answering three halves of one question, in the
+          order a reader asks them: who can see this RECORD, what this contact
+          allows us to send, and what the seat is willing for colleagues to
+          read of their own mail with them. They were easy to confuse while
+          only two of them were on the page. */}
+      <PersonAccess person={view.person} />
       <PersonHoldSection view={view} />
       <PersonTagsSection view={view} />
       <RecentActivity view={view} onOpenEmail={onOpenEmail} />
@@ -472,7 +476,10 @@ function PhoneRow({ person }: Readonly<{ person: Person }>) {
 function DetailsGrid({ view }: Readonly<{ view: Person360 }>) {
   const t = useT();
   const person = view.person;
-  const canUpdate = useCan("person", "update");
+  // useCanWriteRecord, not useCan: the object grant says this ROLE may edit
+  // contacts, and the row says whether this one is theirs to edit. Offering an
+  // editor on a colleague's record produces a form the save refuses.
+  const canUpdate = useCanWriteRecord("person", person);
   const readOnlyReason = usePersonReadOnlyReason(person);
   const patch = usePersonFieldPatch(person);
   const row: DetailsRowProps = {
@@ -650,10 +657,10 @@ function Employers({ view }: Readonly<{ view: Person360 }>) {
   const t = useT();
   const person = view.person;
   const readOnlyReason = usePersonReadOnlyReason(person);
-  // The same grant and the same read-only reasons DetailsGrid gates its own
+  // The same decision and the same read-only reasons DetailsGrid gates its own
   // edit affordances on — a reader who cannot edit the person's own fields
   // cannot edit which company they work at either.
-  const canEdit = useCan("person", "update") && !readOnlyReason;
+  const canEdit = useCanWriteRecord("person", person) && !readOnlyReason;
   const actions = useEmploymentActions(person.id);
   const [adding, setAdding] = useState(false);
   const [removing, setRemoving] = useState<Employment | null>(null);

--- a/frontend/src/screens/timelineactions.tsx
+++ b/frontend/src/screens/timelineactions.tsx
@@ -80,6 +80,7 @@ export function TimelineActions({
         entityType={entityType}
         entityId={entityId}
         personId={personId}
+        contentWithheld={activity.content_state === "withheld"}
       />
       {extra?.(activity)}
       <Button small onClick={() => setRelink(true)}>


### PR DESCRIPTION
Three findings from the access audit on the contact page, all the same shape: a control drawn on a question nobody asked the server.

## The page could not say who a contact is for

`visibility` now rides the wire (#4022), so a rail panel says **private to you** or **everyone in the organization** — and for the owner of a private one, offers the verb that changes it, through the endpoint added in #4008. A contact whose visibility the server did not send draws nothing rather than guessing: assuming `workspace` would tell a reader their private contact is public.

Contacts also had no Share action at all, while companies, deals, leads and projects all did. The record type most likely to be private to one seat was the one with no way to hand it to a colleague.

## Several editors asked the wrong question

They checked whether the **role** may edit contacts, never whether **this row** is the reader's to edit — so a rep was offered working-looking editors on a colleague's record that the save refuses. Details, Employers, enrichment corrections, consent grant and withdraw, and the account lifecycle and owner controls now take the row's own answer.

The owner control keeps the object grant for its unowned case, deliberately: `writable` is false on an unowned account precisely because nobody owns it, and gating the claim on it would close the only door out of that state.

## Reply on a withheld row

Now says "Write email". The verb works — writing to a contact is not reading their mail — but calling it a reply claims access to the message being answered.

## Review finding, mine

The panel first offered publish on `writable`, reading it as "is the owner". It is not: a live write grant satisfies it, and so does an unbounded seat, while the endpoint matches on `owner_id` exactly. A colleague holding a grant would have been shown the button and had their click 404. It gates on ownership now, with a test for exactly that case.

Codex also found `AskTheRegister` in `companyvatmark.tsx` gating on the object grant while its endpoint runs `EnsureWritableLive`. Same class, but it reaches a file this change does not touch — filed as #4035.

## Tests

A new suite for the panel (7 cases, including the write-grantee), plus five fixtures that gained `writable: true`. Those fixtures had described a contact the reader may not edit, and every editor correctly disappeared — the change working, and the reason each fixture now says what it claims.

`make check-fe` green: **6285 tests**. `make check-backend` green apart from the two attention-feed tests that fail on clean `main` (#4011).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the contact page's access controls so they reflect what the server actually answers: who can see a contact, and whether this reader may edit this row. The page previously could not show a contact's visibility, and several editors checked role permissions without checking whether the current reader owned the row.

**Changes**
- A new rail panel shows "private to you" or "everyone in the organization" from the `visibility` field and offers the owner a share action (absent `visibility`, it draws nothing rather than guessing).
- Contacts now have a Share action in the overflow menu, matching the other record types.
- Edit controls for details, employers, corrections, consent, and account lifecycle now check the row's `writable` flag in addition to the role grant.
- The account owner control keeps the object grant for claiming unowned accounts, since `writable` is false there by design.
- Reply on a withheld row now says "Write email" instead of "Reply".
- The share action gates on ownership, not writability, so a write grantee won't see a button that 404s.

<sup>Written for commit 0deae0856ce7eb4fbbeecd8a17b485c64514d9f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a contact access panel showing private and organization-visible status, with an option for owners to publish private contacts.
  * Added sharing controls to the person page.
  * Added a “Write email” action when reply content is unavailable.

* **Permissions**
  * Updated contact, consent, company, correction, and employment editing controls to respect record-level write access.

* **Localization**
  * Added and updated English, German, and Vietnamese translations for contact visibility, sharing, and email composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->