### PR TITLE
The nightly input check actually runs

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -590,6 +590,41 @@ kinds:
       today: the worker records its own failure and returns nil, so the ladder
       is walked only for a fault the sidecar's backoff does not own.
 
+  assurance_sweep:
+    role: dispatcher
+    go_type: AssuranceSweepArgs
+    queue: default
+    timeout: 2m
+    opts_owner: caller
+    cadence: 24h
+    fans_out_to: assurance_workspace
+    fan_out_unit: workspace
+    reason: >-
+      Daily, because the check is what the Forecast tab's readiness verdict,
+      coverage line and findings are all read from, and a check that never runs
+      leaves every one of them with nothing to say. Run at boot like the other
+      passes here, and for a sharper reason than most: until the first run
+      exists the read answers 404, which the tab renders as a failed panel — so
+      the gap between an install starting and its first check is time a person
+      spends looking at what reads like a broken page.
+
+  assurance_workspace:
+    role: worker
+    go_type: AssuranceWorkspaceArgs
+    queue: default
+    timeout: 5m
+    max_attempts: 3
+    opts_owner: fan_out
+    args:
+      Workspace: id
+    reason: >-
+      One tenant's input check: every rule asked of every live open deal, with
+      the sources the run could reach recorded beside the findings. Three
+      attempts, the house number — a run that could not read an upstream
+      finishes as `incomplete` rather than failing, so a retry here is for a
+      pass that did not finish at all, and the next daily tick supersedes
+      whatever the last one came to.
+
   close_date_sweep:
     role: dispatcher
     go_type: CloseDateSweepArgs

--- a/backend/api/public-events.yaml
+++ b/backend/api/public-events.yaml
@@ -1853,7 +1853,7 @@ components:
     PublicEventForecastAssuranceCreated:
       type: object
       x-event-type: forecast.assurance_created
-      x-entity-type: user
+      x-entity-type: assurance_run
       x-version: 1
       description: >-
         Payload for forecast.assurance_created — a nightly input check finished, and

--- a/backend/internal/compose/assurancejob_integration_test.go
+++ b/backend/internal/compose/assurancejob_integration_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The nightly input check against a real database.
+//
+// It has to be an integration test rather than a unit one, because what was
+// missing was never a function — Scan, every rule and both seams have been here
+// and covered all along — but a CALLER wired to them. What is asserted here is
+// the thing whose absence nothing could fail on: that after the pass runs,
+// LatestRun answers a run.
+//
+// That read is what the Forecast tab opens on. Before this job existed it
+// returned ErrNotFound on every installation for ever, and the tab rendered it
+// as "Couldn't load this view." above a dead Retry — the one element on the
+// page that looks like the application is broken, on every load, for every
+// seat.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+
+	"github.com/margince/margince/backend/internal/compose/integration"
+	"github.com/margince/margince/backend/internal/modules/assurance"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+)
+
+// assuranceJobEnv is one workspace holding an open deal for the pass to examine.
+type assuranceJobEnv struct {
+	*integration.Env
+	worker *assuranceWorkspaceWorker
+	at     time.Time
+}
+
+func setupAssuranceJob(t *testing.T) *assuranceJobEnv {
+	t.Helper()
+	e := integration.Setup(t)
+	pipeline, open, _ := integration.DealFixture(t, e)
+	at := time.Now().UTC()
+
+	// One live open deal, so the run has a subject and its eligible count is
+	// not zero. A pass over an empty pipeline writes a run too, and this suite
+	// could not tell that apart from a pass that read nothing at all.
+	owner := integration.OwnerConn(t)
+	if _, err := owner.Exec(context.Background(), `
+		INSERT INTO deal (pipeline_id, stage_id, name, owner_id, status, source, captured_by,
+		                  amount_minor, currency, expected_close_date)
+		VALUES ($1, $2, 'Assurance Fixture', $3, 'open', 'manual', 'test', 4200000, 'EUR', $4)`,
+		pipeline, open, e.Rep1, at.AddDate(0, 0, 3)); err != nil {
+		t.Fatalf("seeding the deal the check examines: %v", err)
+	}
+	return &assuranceJobEnv{
+		Env: e,
+		worker: &assuranceWorkspaceWorker{
+			pool: e.Pool,
+			now:  func() time.Time { return at },
+			log:  slog.New(slog.DiscardHandler),
+		},
+		at: at,
+	}
+}
+
+// run drives the worker exactly as River would.
+func (e *assuranceJobEnv) run(t *testing.T) error {
+	t.Helper()
+	return e.worker.Work(context.Background(), &river.Job[AssuranceWorkspaceArgs]{
+		JobRow: &rivertype.JobRow{},
+		Args:   AssuranceWorkspaceArgs{Workspace: e.WS},
+	})
+}
+
+// latestRun is the read the Forecast tab opens on, taken as an ordinary seat
+// rather than as the fleet: what this ticket is about is what a PERSON gets.
+func (e *assuranceJobEnv) latestRun(t *testing.T) (assurance.Run, error) {
+	t.Helper()
+	return assurance.NewStore(InstallationDB(e.Pool)).LatestRun(e.Admin())
+}
+
+// Before the pass exists there is nothing to read, and that is the state the
+// whole ticket is about — asserted here so the case below is a change rather
+// than a coincidence.
+func TestTheForecastReviewHasNothingToReadUntilTheCheckHasRun(t *testing.T) {
+	e := setupAssuranceJob(t)
+
+	if _, err := e.latestRun(t); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("a workspace whose inputs have never been checked answered %v, "+
+			"wanted ErrNotFound — the rest of this suite proves nothing if the read "+
+			"was already satisfied before the pass ran", err)
+	}
+}
+
+func TestTheNightlyCheckLeavesARunTheForecastReviewCanRead(t *testing.T) {
+	e := setupAssuranceJob(t)
+
+	if err := e.run(t); err != nil {
+		t.Fatalf("the nightly check: %v", err)
+	}
+
+	run, err := e.latestRun(t)
+	if err != nil {
+		t.Fatalf("reading the run the check just wrote: %v — this is the 404 the "+
+			"Forecast tab renders as a failed panel", err)
+	}
+	if run.Status == assurance.StatusRunning {
+		t.Error("the pass left its run at `running`, which LatestRun skips — the tab " +
+			"would read 404 with a finished-looking row sitting in the table")
+	}
+	if run.Readiness == nil || *run.Readiness == "" {
+		t.Error("the run carries no readiness verdict, which is the whole of what the " +
+			"panel reads it for")
+	}
+	if run.EligibleDeals == 0 {
+		t.Error("the run examined no deals, so it was written by a pass that read " +
+			"nothing — the fixture seeds one live open deal for it to find")
+	}
+}
+
+// A second pass in one day is ordinary: the dispatcher ticks more than once so
+// a worker that was down still backfills, and River retries a failed attempt.
+// Nothing arbitrates assurance_run to one row per day, and nothing should —
+// each pass is a fresh answer and the reader takes the newest — so the second
+// run must succeed and must be the one the tab then reads.
+func TestASecondCheckSupersedesTheFirstRatherThanFailing(t *testing.T) {
+	e := setupAssuranceJob(t)
+
+	if err := e.run(t); err != nil {
+		t.Fatalf("the first check: %v", err)
+	}
+	first, err := e.latestRun(t)
+	if err != nil {
+		t.Fatalf("reading the first run: %v", err)
+	}
+
+	e.worker.now = func() time.Time { return e.at.Add(time.Hour) }
+	if err := e.run(t); err != nil {
+		t.Fatalf("the second check: %v", err)
+	}
+
+	second, err := e.latestRun(t)
+	if err != nil {
+		t.Fatalf("reading the second run: %v", err)
+	}
+	if second.ID == first.ID {
+		t.Error("the second pass wrote no run of its own, so the tab keeps reading " +
+			"a verdict from a check that ran earlier than the one that just finished")
+	}
+}

--- a/backend/internal/compose/assuranceseam.go
+++ b/backend/internal/compose/assuranceseam.go
@@ -34,6 +34,13 @@ import (
 // caller's own row scope before rendering — the list endpoint, the headline
 // counts, the brief candidate, the worklist row and the task subject line. A
 // finding about a deal the reader cannot open is a finding they never see.
+//
+// The deal a message is filed against is `activity_link.deal_id`, not a generic
+// `entity_id` — that column does not exist, and `entity_type` only says which
+// of the five id columns is the populated one (the `activity_link_shape` check
+// enforces exactly one). The query named a column the table has never had, and
+// nothing failed: this seam had no caller, and the scanner's own suite passes a
+// SubjectsFunc of its own, so the real one was never once executed.
 func AssuranceSubjects(ctx context.Context, tx pgx.Tx) ([]assurance.Subject, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT d.id, d.owner_id, d.amount_minor, d.currency,
@@ -42,7 +49,7 @@ func AssuranceSubjects(ctx context.Context, tx pgx.Tx) ([]assurance.Subject, err
 		       (SELECT max(a.occurred_at)
 		          FROM activity a
 		          JOIN activity_link al ON al.activity_id = a.id
-		         WHERE al.entity_type = 'deal' AND al.entity_id = d.id
+		         WHERE al.deal_id = d.id
 		           AND a.direction = 'inbound'
 		           AND a.archived_at IS NULL) AS last_inbound_at
 		FROM deal d

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "951f9851b633a7ea201a8c1374cda5ad3b917bc9fcf8e33606f2373b1c3a2a81"
+const jobContractHash = "55d44c83adbe4ac7d484b31dfa7f5138ebf219f4f0020035be110be7a8cecc81"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -32,6 +32,8 @@ type declaredJobArgs interface {
 		AiModelRateRefreshArgs |
 		ApprovalAutoApplyArgs |
 		ApprovalExpiryArgs |
+		AssuranceSweepArgs |
+		AssuranceWorkspaceArgs |
 		BriefGenerateArgs |
 		BriefGenerateWorkspaceArgs |
 		CaptureAutoEnrichSweepArgs |
@@ -144,6 +146,7 @@ func addDeclaredWorkerWithTimeout[T declaredJobArgs](reg *jobRegistry, w jobs.Wo
 // The declared dispatchers: each enumerates the fleet and enqueues, and does
 // no tenant work of its own.
 var (
+	_ jobs.FleetWide = AssuranceSweepArgs{}
 	_ jobs.FleetWide = BriefGenerateArgs{}
 	_ jobs.FleetWide = CaptureAutoEnrichSweepArgs{}
 	_ jobs.FleetWide = CaptureClassifyArgs{}
@@ -179,6 +182,7 @@ var (
 // in its own args.
 var (
 	_ jobs.WorkspaceScoped = AiModelRateRefreshArgs{}
+	_ jobs.WorkspaceScoped = AssuranceWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = BriefGenerateWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = CaptureAutoEnrichWorkspaceArgs{}
 	_ jobs.WorkspaceScoped = CaptureBackfillArgs{}

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -399,6 +399,7 @@ func wireJobs(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*jobRe
 		// cadence, the configuration it needs, and what an absent dependency
 		// costs it — so every one of them is named here whether or not this
 		// boot ends up placing it.
+		periodicFor(cfg, AssuranceSweepArgs{}),
 		periodicFor(cfg, CloseDateSweepArgs{}),
 		periodicFor(cfg, FollowUpReconcileArgs{}),
 		periodicFor(cfg, TimeScanArgs{}),

--- a/backend/internal/compose/jobs_assurance.go
+++ b/backend/internal/compose/jobs_assurance.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The nightly input check: the caller three shipped surfaces were waiting for.
+//
+// assurance.NewScanner had exactly one caller in the tree and it was a test.
+// So Scan never ran, StartRun never inserted, and LatestRun answered ErrNotFound
+// for ever — which the Forecast tab renders as a failed panel, on every load,
+// for every seat, on a default install. The module itself works and is covered;
+// what was missing was the pass, and absence has no line to be wrong on.
+//
+// The pass runs as the SYSTEM across the whole pipeline, which is what
+// AssuranceSubjects is unscoped for: a duplicate-detection rule that saw one
+// rep's deals would report no duplicates. What that costs is paid on the way
+// out — every reader of a finding passes through their own row scope first.
+//
+// It is assembled from the two seams that already existed for it
+// (AssuranceSubjects, AssuranceCoverage) rather than reading deals of its own.
+// A pass that re-derived its subjects would be a second answer to which deals
+// are in the pipeline, and the run's coverage line would stop describing the
+// read it was taken from.
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/margince/margince/backend/internal/modules/assurance"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// AssuranceSweepArgs schedules one input check across the fleet.
+type AssuranceSweepArgs struct{}
+
+// Kind is the stable job identifier River persists in river_job.
+func (AssuranceSweepArgs) Kind() string { return "assurance_sweep" }
+
+// FleetWide marks this a dispatcher: it enumerates and enqueues, and does no
+// tenant work of its own (jobs.FleetWide).
+func (AssuranceSweepArgs) FleetWide() {}
+
+// AssuranceWorkspaceArgs is one workspace's input check.
+type AssuranceWorkspaceArgs struct {
+	Workspace ids.UUID `json:"workspace_id"`
+}
+
+// Kind is the stable job identifier River persists in river_job.
+func (AssuranceWorkspaceArgs) Kind() string { return "assurance_workspace" }
+
+// WorkspaceID binds this pass to its tenant (jobs.WorkspaceScoped).
+func (a AssuranceWorkspaceArgs) WorkspaceID() ids.UUID { return a.Workspace }
+
+// assuranceSweepWorker is the dispatcher: it enumerates and enqueues, and
+// touches no tenant data itself.
+type assuranceSweepWorker struct {
+	pool *pgxpool.Pool
+}
+
+func (w *assuranceSweepWorker) Work(ctx context.Context, _ *river.Job[AssuranceSweepArgs]) error {
+	return jobs.FaultContext(ctx, dispatchPerWorkspace(ctx, w.pool,
+		workspaceSweepOpts(AssuranceWorkspaceArgs{}.Kind()),
+		func(ws ids.UUID) river.JobArgs { return AssuranceWorkspaceArgs{Workspace: ws} }))
+}
+
+// assuranceActor is the principal the nightly pass runs as, and therefore the
+// one every run it starts is attributed to. Declared rather than typed at the
+// call site because the suite asserting that attribution has to name the same
+// principal the worker binds, and two hand-typed copies would agree only until
+// one of them moved.
+const assuranceActor = "system:assurance"
+
+// assuranceWorkspaceWorker checks one tenant's forecast inputs.
+type assuranceWorkspaceWorker struct {
+	pool *pgxpool.Pool
+	now  func() time.Time
+	log  *slog.Logger
+}
+
+func (w *assuranceWorkspaceWorker) Work(
+	ctx context.Context, job *river.Job[AssuranceWorkspaceArgs],
+) error {
+	wsCtx, err := workspaceJobCtx(ctx, job.Args)
+	if err != nil {
+		return jobs.FaultContext(ctx, err)
+	}
+	wsCtx = principal.WithActor(wsCtx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: assuranceActor,
+	})
+	wsCtx = principal.WithCorrelationID(wsCtx, ids.NewV7())
+	return jobs.FaultContext(ctx, w.check(wsCtx, job.Args.Workspace))
+}
+
+// check runs one pass and reports what it came to.
+//
+// Scan never refuses to start, and this must not either: a source that could
+// not be read makes the run INCOMPLETE and its readiness `checks_incomplete`,
+// which is a run that says so, rather than no run at all. Returning an error
+// on an incomplete pass would leave River retrying a state the pass already
+// recorded correctly.
+//
+// The outcome is logged at info because it is the one line an operator has
+// saying the check happened: the surfaces read the row, not the log, so a pass
+// that had stopped running entirely would otherwise be visible only as a page
+// that stopped changing.
+func (w *assuranceWorkspaceWorker) check(ctx context.Context, ws ids.UUID) error {
+	scanner := assurance.NewScanner(
+		assurance.NewStore(InstallationDB(w.pool)),
+		AssuranceSubjects, AssuranceCoverage, assurance.DefaultConfig(),
+	)
+	result, err := scanner.Scan(ctx, w.now())
+	if err != nil {
+		return err
+	}
+	w.log.InfoContext(ctx, "the forecast's inputs were checked",
+		"workspace_id", ws, "run_id", result.RunID,
+		"eligible_deals", result.EligibleDeals, "findings", result.Findings,
+		"readiness", result.Readiness, "status", result.Status)
+	return nil
+}

--- a/backend/internal/compose/jobs_databasesweeps.go
+++ b/backend/internal/compose/jobs_databasesweeps.go
@@ -5,6 +5,7 @@ package compose
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -38,6 +39,10 @@ func addDatabaseOnlySweepJobs(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Lo
 	addDeclaredWorker[CloseDateWorkspaceArgs](reg, &closeDateWorkspaceWorker{corrector: NewCloseDateCorrector(pool, log)})
 	addDeclaredWorker[FollowUpReconcileArgs](reg, &followUpReconcileWorker{pool: pool})
 	addDeclaredWorker[FollowUpWorkspaceArgs](reg, &followUpWorkspaceWorker{reconciler: NewFollowUpReconciler(pool, log)})
+	addDeclaredWorker[AssuranceSweepArgs](reg, &assuranceSweepWorker{pool: pool})
+	addDeclaredWorker[AssuranceWorkspaceArgs](reg, &assuranceWorkspaceWorker{
+		pool: pool, now: func() time.Time { return time.Now().UTC() }, log: log,
+	})
 	addDeclaredWorker[TimeScanArgs](reg, &timeScanWorker{pool: pool})
 	addDeclaredWorker[TimeScanWorkspaceArgs](reg, &timeScanWorkspaceWorker{pool: pool, log: log})
 	addDeclaredWorker[IdempotencyRetentionArgs](reg, &idempotencyRetentionWorker{pool: pool})

--- a/backend/internal/compose/workspaceguard_test.go
+++ b/backend/internal/compose/workspaceguard_test.go
@@ -144,6 +144,9 @@ func zeroPayloadRefusalDrivers() map[string]func(context.Context) error {
 		VCardIngestArgs{}.Kind(): func(ctx context.Context) error {
 			return (&vcardIngestWorker{}).Work(ctx, &river.Job[VCardIngestArgs]{})
 		},
+		AssuranceWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
+			return (&assuranceWorkspaceWorker{}).Work(ctx, &river.Job[AssuranceWorkspaceArgs]{})
+		},
 		CloseDateWorkspaceArgs{}.Kind(): func(ctx context.Context) error {
 			return (&closeDateWorkspaceWorker{}).Work(ctx, &river.Job[CloseDateWorkspaceArgs]{})
 		},

--- a/backend/internal/contracts/publicevents_gen.go
+++ b/backend/internal/contracts/publicevents_gen.go
@@ -2366,7 +2366,7 @@ func (PublicEventEngagementReply) EntityType() string { return "activity" }
 
 func (PublicEventForecastAssuranceCreated) EventType() string { return "forecast.assurance_created" }
 
-func (PublicEventForecastAssuranceCreated) EntityType() string { return "user" }
+func (PublicEventForecastAssuranceCreated) EntityType() string { return "assurance_run" }
 
 func (PublicEventForecastCreated) EventType() string { return "forecast.created" }
 

--- a/backend/internal/modules/assurance/store.go
+++ b/backend/internal/modules/assurance/store.go
@@ -243,19 +243,7 @@ func (s *Store) FinishRun(
 		verdict := crmcontracts.PublicEventForecastAssuranceCreatedReadiness(readiness)
 		event.Readiness = &verdict
 	}
-	return storekit.EmitEvent(ctx, tx, auditID, actorForEvent(ctx), event)
-}
-
-// actorForEvent is who a run is attributed to.
-//
-// A nightly pass has no human behind it, and the entity a stream is keyed by
-// cannot be absent — so the system's own runs carry the nil id rather than
-// borrowing a person who did not ask for them.
-func actorForEvent(ctx context.Context) ids.UUID {
-	if actor, ok := principal.Actor(ctx); ok {
-		return actor.UserID
-	}
-	return ids.Nil
+	return storekit.EmitEvent(ctx, tx, auditID, runID, event)
 }
 
 // LatestRun answers the most recent completed pass.

--- a/backend/internal/modules/webhooks/deliveryvisibility.go
+++ b/backend/internal/modules/webhooks/deliveryvisibility.go
@@ -94,6 +94,14 @@ var workspaceLevelEntities = map[string]struct{}{
 	"passport":                {},
 	"onboarding_wizard_state": {},
 	"incumbent_connection":    {},
+	// A nightly input check is a fact about the whole pipeline, not about any
+	// owner's slice of it: the run examines every live open deal, and its
+	// envelope carries only the counts and the readiness verdict. The FINDINGS
+	// deliberately do not ride along — they are a read away, under the
+	// reader's own row scope — which is exactly the bare-ref justification this
+	// list is for. A run keyed to an owner would also be a lie about what was
+	// checked.
+	"assurance_run": {},
 }
 
 // deferredDeliveryEvents are subscribable events whose subject cannot be

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "951f9851b633a7ea201a8c1374cda5ad3b917bc9fcf8e33606f2373b1c3a2a81"
+const JobContractHash = "55d44c83adbe4ac7d484b31dfa7f5138ebf219f4f0020035be110be7a8cecc81"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -87,6 +87,27 @@ var specs = map[string]Spec{
 		MaxAttempts: 1,
 		OptsOwner:   OptsArgs,
 		Cadence:     Cadence{Fixed: 5 * time.Minute},
+	},
+	"assurance_sweep": {
+		Kind:       "assurance_sweep",
+		GoType:     "AssuranceSweepArgs",
+		Role:       Dispatcher,
+		Queue:      "default",
+		Timeout:    TimeoutPolicy{Fixed: 2 * time.Minute},
+		FanOutUnit: FanOutWorkspace,
+		FanOutTo:   "assurance_workspace",
+		OptsOwner:  OptsCaller,
+		Cadence:    Cadence{Fixed: 24 * time.Hour},
+	},
+	"assurance_workspace": {
+		Kind:        "assurance_workspace",
+		GoType:      "AssuranceWorkspaceArgs",
+		Role:        Worker,
+		Queue:       "default",
+		Timeout:     TimeoutPolicy{Fixed: 5 * time.Minute},
+		MaxAttempts: 3,
+		OptsOwner:   OptsFanOut,
+		Args:        []ArgField{{Name: "Workspace"}},
 	},
 	"brief_generate": {
 		Kind:       "brief_generate",


### PR DESCRIPTION
Closes #3877.

## The defect

`assurance.NewScanner` had exactly one caller in the tree and it was a test. So `Scan` never ran, `StartRun` never inserted, and `LatestRun` answered `ErrNotFound` for ever. The Forecast tab opens on that read, so every seat, every load, on a default install got:

> **Couldn't load this view.** / `not found` / [Retry]

It is the one element on the page that looks like the application is broken, and `Retry` cannot help — it refetches a call that cannot start to answer until a row exists. Everything the three feature PRs shipped (readiness verdict, coverage line, findings) was unreachable behind it.

Nothing failed, because this is absence-shaped: `scan_integration_test.go` builds the scanner itself, so every rule, the store and both seams are covered and green. What was missing was the caller, and there is no line to be wrong.

## The fix

The pass is wired beside the other scheduled sweeps — `assurance_sweep` (dispatcher) fanning out to `assurance_workspace` — assembled from the two seams that already existed for it (`AssuranceSubjects`, `AssuranceCoverage`) rather than reading deals of its own.

It runs **at boot as well as daily**, for a sharper reason than most passes here: until the first run exists the read 404s, so the gap between an install starting and its first check is time a person spends looking at what reads like a fault.

## Two defects wiring it uncovered

Neither had any way to surface while the seams had no caller. Both are why this was not a one-line wiring change.

**1. `AssuranceSubjects` named a column that does not exist.** It joined `activity_link` on `entity_id`; that table has never had one — `entity_type` only says which of its five id columns is populated, and the `activity_link_shape` check enforces exactly one. The query could not run at all. It went unnoticed because the scanner's own suite passes a `SubjectsFunc` of its own, so the production seam had never once been executed. Now `al.deal_id = d.id`.

**2. `forecast.assurance_created` could not be emitted by anything.** It declared `x-entity-type: user`. The entity ref is a **read-back handle** — a type and an id a consumer fetches under its own scope — and a nightly pass has no user, so a system-produced event could only carry a nil id and be rejected as *"a partially populated entity ref"*. There was no principal under which this event could be emitted.

It names the run now (`x-entity-type: assurance_run`), which is what its payload has always carried and what a consumer would actually read back, and `assurance_run` joins `workspaceLevelEntities`: a check of the whole pipeline is nobody's row, and the findings deliberately do not ride along — they are a read away, under the reader's own scope, which is exactly that list's bare-ref justification. The `TestEverySubscribableEventIsDeliveryResolvable` gate forced that choice rather than letting it default, which is what it is for.

**No subscriber can have received one of these** — nothing has ever emitted the event — so the contract change is a rename of something that has never been on the wire.

## Note for #3989

`forecast.snapshot_created` carries the identical `x-entity-type: user` and the identical problem, and #3989 gives it its first system producer. Commented there; it needs the same two-line treatment and I will apply it on that branch rather than reaching across.

## Tests

`assurancejob_integration_test.go`, three cases against a real database:

- the read answers `ErrNotFound` **before** the pass runs — asserted so the case below is a change rather than a coincidence;
- after the pass, `LatestRun` answers a finished run carrying a readiness verdict and a non-zero eligible count (the fixture seeds one live open deal, so a pass that read nothing is distinguishable from one that read the pipeline);
- a second pass in one day supersedes the first rather than failing — the dispatcher ticks more than once so a downed worker still backfills, and River retries.

Each of the two defects above was found by these tests failing, not by reading.

`make check-backend` green; `craft static --strict` clean on all five changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b1jSBftJqGvaQ7ejTgnQ6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily assurance checks that run across all workspaces.
  * Added workspace-specific assurance processing with automatic retries and failure handling.
  * Assurance results are now available through workspace webhooks and are associated with assurance runs.

* **Bug Fixes**
  * Fixed inbound deal activity lookups so assurance checks can complete successfully.

* **Tests**
  * Added coverage for initial checks, completed results, and subsequent checks superseding earlier runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->