### PR TITLE
A conversation on the thread opens the message it names

### DIFF
--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -2422,6 +2422,11 @@ function CompanyOverviewStack({
             // is one of ours, and the account's own people are the other side
             // of it.
             nameOf={nameOf}
+            // The page's own router, which already sends an `activity` to the
+            // email drawer for every cited chip on this account
+            // (citationOpensEmail). The thread takes that same door rather
+            // than a second opener somebody would have to keep in step.
+            onOpenEmail={(activityId) => onOpenRecord("activity", activityId)}
           />
           <ThreadFold
             view={view}

--- a/frontend/src/screens/personpage.tsx
+++ b/frontend/src/screens/personpage.tsx
@@ -476,6 +476,7 @@ export function PersonPageV2({
                 view={view.data}
                 onAction={runAction}
                 onOpenTasks={() => navigate({ screen: "worklist" })}
+                onOpenEmail={setOpenEmail}
               />
               <RecordReadingPair>
                 <PersonMemory view={view.data} onOpenEmail={setOpenEmail} />

--- a/frontend/src/screens/persontoday.tsx
+++ b/frontend/src/screens/persontoday.tsx
@@ -111,6 +111,7 @@ export function PersonToday({
   view,
   onAction,
   onOpenTasks,
+  onOpenEmail,
 }: Readonly<{
   // Absent when the caller lacks a grant the rule needs — the server names the
   // section in `sections_omitted` — and the page still opens on the call and
@@ -126,6 +127,9 @@ export function PersonToday({
   onAction: (action: PersonMomentAction) => void;
   // Where the day's work sends a reader for the whole task list.
   onOpenTasks?: () => void;
+  // Opens a message the thread cites. The page owns its one drawer, so this
+  // card asks rather than mounting a second one over it.
+  onOpenEmail?: (activityId: string) => void;
 }>) {
   const plural = usePlural();
   const t = useT();
@@ -154,6 +158,7 @@ export function PersonToday({
           <RecordSpine
             source={spineSourceOf(view)}
             commercial={{ next_close_on: view.commercial?.deal?.close_date }}
+            onOpenEmail={onOpenEmail}
           />
         </CallCard>
         <TodayPanel onOpenTasks={onOpenTasks} notice={withheld}>
@@ -207,6 +212,7 @@ export function PersonToday({
         <RecordSpine
           source={spineSourceOf(view)}
           commercial={{ next_close_on: view.commercial?.deal?.close_date }}
+          onOpenEmail={onOpenEmail}
         />
       </CallCard>
       <TodayPanel onOpenTasks={onOpenTasks} notice={withheld}>

--- a/frontend/src/screens/record360/spine.test.tsx
+++ b/frontend/src/screens/record360/spine.test.tsx
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { components } from "../../api/schema";
@@ -49,6 +50,7 @@ function view(overrides: Record<string, unknown> = {}): View {
 function draw(
   v: View,
   nameOf?: (entityType: string, entityId: string) => string | undefined,
+  onOpenEmail?: (activityId: string) => void,
 ) {
   render(
     <LocaleProvider initial="en">
@@ -56,6 +58,7 @@ function draw(
         source={v}
         commercial={v?.state_strip?.commercial}
         nameOf={nameOf}
+        onOpenEmail={onOpenEmail}
       />
     </LocaleProvider>,
   );
@@ -79,6 +82,10 @@ function activities(
     // reading is gated on kind, only that it is absent on that one row.
     host_user_id?: string;
     direction?: "inbound" | "outbound";
+    // What the server sends for a `kind=email` row and for no other kind. A
+    // mail fixture without it models a shape the API does not return, so a
+    // stop judged against it proves nothing about a real message.
+    emailStatus?: "team" | "participants" | "selected" | "withheld";
   }[],
 ) {
   return {
@@ -92,6 +99,17 @@ function activities(
       links: row.links ?? [],
       host_user_id: row.host_user_id ?? null,
       direction: row.direction ?? null,
+      email_summary: row.emailStatus
+        ? {
+            activity_id: row.id,
+            occurred_at: row.at,
+            version: 1,
+            subject: row.subject,
+            display_status: row.emailStatus,
+            move: "none",
+            attachment_count: 0,
+          }
+        : null,
       source: "manual",
       captured_by: "human:test",
       created_at: row.at,
@@ -1017,5 +1035,117 @@ describe("who held a meeting", () => {
     expect(screen.getByText("Email to Dana Otieno")).toBeTruthy();
     expect(screen.queryByText(/met Dana Otieno/)).toBeNull();
     expect(screen.queryByText(/Lena Fischer/)).toBeNull();
+  });
+});
+
+// A stop names a conversation. When that conversation is mail the reader may
+// read, naming it and opening it are the same act — the thread is where a
+// reader asks "what was that about", and the answer is the message.
+describe("a conversation the reader can open", () => {
+  // Two conversations, so the older one is a stop that leads with its subject
+  // rather than with "You last spoke".
+  const twoMails = (over: Record<string, unknown> = {}) =>
+    view({
+      last_outbound_at: SPOKE,
+      activities: activities([
+        {
+          id: "a-new",
+          kind: "email",
+          subject: "About capacity",
+          at: SPOKE,
+          emailStatus: "team",
+        },
+        {
+          id: "a-old",
+          kind: "email",
+          subject: "About scope",
+          at: "2026-08-10T09:00:00Z",
+          emailStatus: "team",
+        },
+      ]),
+      ...over,
+    });
+
+  it("opens the newest message of the conversation it names", async () => {
+    const opened: string[] = [];
+    draw(twoMails(), undefined, (activityId) => opened.push(activityId));
+
+    await userEvent.click(screen.getByRole("button", { name: /About scope/ }));
+
+    // The conversation's newest message, which is the one it is dated and
+    // titled by. A stop that opened some other message of the thread would
+    // show the reader something other than what they pressed.
+    expect(opened).toEqual(["a-old"]);
+  });
+
+  it("names a call without offering to open it", () => {
+    draw(
+      view({
+        last_outbound_at: SPOKE,
+        activities: activities([
+          {
+            id: "a-mail",
+            kind: "email",
+            subject: "About capacity",
+            at: SPOKE,
+            emailStatus: "team",
+          },
+          {
+            id: "a-call",
+            kind: "call",
+            subject: "Quick check-in",
+            at: "2026-08-10T09:00:00Z",
+          },
+        ]),
+      }),
+      undefined,
+      () => {},
+    );
+
+    // There is no message behind a call to open, and drawing an envelope
+    // beside one would claim a transport nobody checked.
+    expect(screen.getByText("Quick check-in")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Quick check-in/ })).toBeNull();
+  });
+
+  it("names a withheld conversation without offering to open it", () => {
+    draw(
+      view({
+        last_outbound_at: SPOKE,
+        activities: activities([
+          {
+            id: "a-mail",
+            kind: "email",
+            subject: "About capacity",
+            at: SPOKE,
+            emailStatus: "team",
+          },
+          {
+            id: "a-private",
+            kind: "email",
+            subject: "About the offer",
+            at: "2026-08-10T09:00:00Z",
+            emailStatus: "withheld",
+          },
+        ]),
+      }),
+      undefined,
+      () => {},
+    );
+
+    // A control that opened a placeholder teaches a reader that citations do
+    // not work, which costs more than the press it saves.
+    expect(
+      screen.queryByRole("button", { name: /About the offer/ }),
+    ).toBeNull();
+  });
+
+  it("draws plain subjects when the host offers no drawer", () => {
+    draw(twoMails());
+
+    // The other direction: a host with nowhere to send a reader gets text, not
+    // a control that leads nowhere.
+    expect(screen.getByText("About scope")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /About scope/ })).toBeNull();
   });
 });

--- a/frontend/src/screens/record360/spine.tsx
+++ b/frontend/src/screens/record360/spine.tsx
@@ -18,6 +18,7 @@
 import type { ReactNode } from "react";
 
 import { useRecordZone } from "../../app/recordzone";
+import { EmailReference } from "../../design-system/emailreference";
 import { PanelBody } from "../../design-system/panel";
 import {
   mergePeople,
@@ -67,9 +68,19 @@ export type SpineSource = {
   } | null;
   activities?: {
     data: readonly {
+      // The row's own id, which is what a stop opens when the conversation is
+      // mail. Required rather than optional: every activity has one, and a
+      // shape that admitted its absence would let a caller hand this thread
+      // rows it could name and never open.
+      id: string;
       kind: string;
       subject?: string | null;
       occurred_at?: string | null;
+      // Present exactly when the row is an email, which is how a stop tells a
+      // mail conversation from a call without reading the kind string. It also
+      // carries whether the words are this reader's: a withheld message names
+      // itself and opens nothing.
+      email_summary?: { display_status: string } | null;
       // Capture's own conversation id. What makes a thread a thread — a note
       // or a hand-logged call carries none, and those fall back to their
       // subject.
@@ -134,8 +145,12 @@ export function RecordSpine({
   source,
   commercial,
   nameOf,
+  onOpenEmail,
 }: Readonly<{
   source?: SpineSource;
+  // Opens a cited message. The record page owns its one drawer, so the thread
+  // asks rather than mounting a second one behind the first.
+  onOpenEmail?: (activityId: string) => void;
   // What a linked record is called. Handed in, because the names live in the
   // sections around this one and the thread holds no read of its own: a
   // conversation the thread cannot name a person for says the kind alone
@@ -158,6 +173,7 @@ export function RecordSpine({
     zone,
     commercial,
     nameOf,
+    onOpenEmail,
     asOf: source.as_of,
   });
   if (stops.length === 0) {
@@ -234,6 +250,10 @@ type Ctx = {
   zone: string;
   commercial?: SpineCommercial | null;
   nameOf?: (entityType: string, entityId: string) => string | undefined;
+  // Opens a cited message in the record page's own drawer. Optional, so a
+  // story or a host with no drawer draws the subject as plain text rather than
+  // a control that leads nowhere.
+  onOpenEmail?: (activityId: string) => void;
 };
 
 // The thread, oldest first: the conversations that have happened, the silence
@@ -438,6 +458,13 @@ type Exchange = {
   readonly subject: string;
   readonly kind: ExchangeKind;
   readonly count: number;
+  // The NEWEST message's id, when this conversation is mail the reader may
+  // read. That message is what the thread is dated and titled by, so it is the
+  // one a reader pressing the stop means. Undefined for a call or a meeting,
+  // and for a message whose content is not theirs — `email_summary` answers
+  // both questions, being absent for every kind but email and carrying the
+  // withheld status when the words are not the reader's.
+  readonly emailId?: string;
   // Who was on it, in the order the conversation introduced them. A mail or a
   // call with no name beside it is a subject line and nothing a reader can act
   // on: the whole question is who they have to go back to.
@@ -575,15 +602,38 @@ function earlierStop(
 // what happened, and repeating one label down the thread would say nothing.
 function pastStop(conversation: Exchange, newest: boolean, ctx: Ctx): Stop {
   const relation = relationLine(conversation, ctx);
+  // A mail conversation names its message the way every other citation of one
+  // does, and opens it. A call or a meeting keeps the plain subject: there is
+  // no message behind those to open, and drawing an envelope beside one would
+  // claim a transport nobody checked.
+  const subject =
+    conversation.emailId && ctx.onOpenEmail ? (
+      <EmailReference
+        subject={conversation.subject}
+        onOpen={openEmail(conversation.emailId, ctx.onOpenEmail)}
+      />
+    ) : (
+      conversation.subject
+    );
   return {
     key: `said-${conversation.key}`,
     tone: "past",
     when: on(conversation.at, ctx),
-    title: newest ? ctx.t("co.spine.lastSpoke") : conversation.subject,
+    title: newest ? ctx.t("co.spine.lastSpoke") : subject,
     // The newest stop's title is the label the gap below counts from, so its
     // subject moves into the second line and the relation joins it there.
-    detail: newest ? saidLines(conversation.subject, relation) : relation,
+    detail: newest ? saidLines(subject, relation) : relation,
   };
+}
+
+// Bound here rather than in the JSX so the narrowed id is what the closure
+// captures — `conversation.emailId` is optional, and a callback reading it
+// again would be reading a `string | undefined`.
+function openEmail(
+  activityId: string,
+  onOpenEmail: (activityId: string) => void,
+): () => void {
+  return () => onOpenEmail(activityId);
 }
 
 // The record's conversations, newest first, each folded to one entry.
@@ -646,6 +696,10 @@ function exchanges(view: SpineSource, ctx: Ctx): Exchange[] {
             count: 1,
             people,
             direction: entry.direction,
+            // Set from the FIRST row of a conversation, which this list orders
+            // newest-first — the same row the date and subject above come
+            // from, so the stop opens the message it is showing.
+            emailId: openableEmailId(entry),
             host: entry.host_user_id
               ? ctx.nameOf?.("user", entry.host_user_id)
               : undefined,
@@ -653,6 +707,26 @@ function exchanges(view: SpineSource, ctx: Ctx): Exchange[] {
     );
   }
   return [...conversations.values()];
+}
+
+/**
+ * The id of a message this stop can open, or nothing.
+ *
+ * Both conditions come off `email_summary` rather than off the kind string:
+ * the server sets it only for `kind=email`, and a message outside the reader's
+ * audience carries it with `display_status: withheld`. A stop that offered to
+ * open one of those would be a control that draws a placeholder — the reader
+ * learns citations do not work, which costs more than the press it saves.
+ */
+function openableEmailId(entry: {
+  id: string;
+  email_summary?: { display_status: string } | null;
+}): string | undefined {
+  const summary = entry.email_summary;
+  if (!summary || summary.display_status === "withheld") {
+    return undefined;
+  }
+  return entry.id;
 }
 
 // What the exchange WAS, and between whom: "Email to Frédéric de Gombert",
@@ -709,7 +783,9 @@ function preposition(conversation: Exchange): MessageKey {
 // recognises and the relation is the half that says whose move it is; run
 // together with a separator the subject stopped being findable, reading as one
 // long caption where a reader is scanning for a thread they remember.
-function saidLines(what: string | undefined, relation: string): ReactNode {
+// `what` is a node rather than a string because a mail conversation names its
+// message as a citation that opens, and a call names its subject as text.
+function saidLines(what: ReactNode, relation: string): ReactNode {
   if (!what) {
     return relation;
   }


### PR DESCRIPTION
Fifth and last of the email-unification follow-ups, after #4019, #4023, #4027 and #4033. This is the plan's PR5 item for the relationship spine.

## What it fixes

The relationship spine names each conversation by its subject and gave a reader nowhere to go with it. The thread is where somebody asks *"what was that about"* — and the answer, the message, sat one tab away on the timeline.

A mail conversation now names its newest message as `EmailReference` and opens it. **The newest is the right one**: it is what the conversation is dated and titled by after a mid-thread rename, so the stop opens the message it is showing.

## Two conditions, both off `email_summary`

Neither reads the kind string:

- The server sets `email_summary` only for `kind=email`, so a **call or meeting keeps its plain subject**. Drawing an envelope beside a call would claim a transport nobody checked — the bug the person brief's chips already had once.
- A withheld message carries the summary with `display_status: withheld`, so a conversation whose words are not the reader's **names itself and offers nothing to press**. A control that opened a placeholder teaches a reader citations do not work.

Both mutation-checked, one clause at a time.

## The opener is the page's

On the account it is the same router that already sends a cited `activity` to the drawer (`citationOpensEmail`), so the thread takes that door rather than a second one somebody would have to keep in step. On the person page it is `setOpenEmail`, threaded through `PersonToday` beside the `PersonMemory` that already takes it.

A host that passes none — the timeline tab's own thread — draws plain subjects rather than a control that leads nowhere. That direction is tested too.

## `SpineSource` gains two fields

It is a hand-written structural type, deliberately narrow (its comment explains why: a narrower shape compiles against the vanilla schema and fails against a composed one). `id` is **required** rather than optional — every activity has one, and admitting its absence would let a caller hand the thread rows it can name and never open.

## Deliberately NOT done: the deal Context panel

The plan also lists `context.tsx`'s activity refs. I did not do it:

- **Nothing in the tree emits an `activity` `ContextEntityRef`.** Only the generated contract mentions the constant; no server code produces one. The branch has no producer, so an email renderer there is speculative code.
- `ContextItem` carries no way to tell an email from a call and **no withheld state** — so it could not make either of the two decisions above correctly.

Adding it would mean guessing at a shape the server does not send.

## Verification

- `make check-fe` — green (6289 tests)
- `emailpresentation_test.go` both directions — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes a mail conversation on the relationship spine open its newest message, so naming a conversation and opening it are the same act instead of leaving the reader one tab away from the answer.

- Mail conversations now render their newest message as an `EmailReference` that opens it in the page's existing email drawer.
- Calls, meetings, and withheld messages keep their plain subject and offer nothing to press.
- Hosts without an email drawer (such as the timeline tab's own thread) draw plain subjects rather than a control that leads nowhere.
- `SpineSource` now requires `id` per activity and reads `email_summary` rather than the kind string to decide openability.

<sup>Written for commit 09d12851f2ab4edf07d9c2c070cba8099d03256f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email activities in record timelines can now open the relevant email conversation.
  * Email subjects are interactive when an available, non-withheld message exists.
  * The newest openable email is selected automatically when a conversation contains multiple messages.

* **Bug Fixes**
  * Calls, meetings, withheld emails, and unavailable messages remain non-interactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->