### PR TITLE
An explicit yes is what permits ordinary correspondence

### DIFF
--- a/backend/internal/modules/consent/correspondenceconsent_integration_test.go
+++ b/backend/internal/modules/consent/correspondenceconsent_integration_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package consent
+
+// What an explicit answer about ordinary correspondence is worth.
+//
+// An integration test because the defect these pin was invisible to every unit
+// test in the tree: the arm READ the wrong table. Only the real query against a
+// real row shows that a `granted` person_consent row now reaches the verdict,
+// and that a withdrawal still beats it.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+// grant records the subject's own answer through the production writer.
+//
+// Store.Record rather than an INSERT: the row this arm reads is the one the
+// endpoint writes, and a hand-inserted row would prove the query works against
+// a shape nothing in production produces.
+func (e *qualifyingEnv) grant(t *testing.T, state string) {
+	t.Helper()
+	source := "verbal"
+	if _, err := e.store.Record(e.ctx, RecordInput{
+		PersonID:  e.person,
+		PurposeID: ids.From[ids.PurposeKind](ids.MustParse(e.correspondence.ID)),
+		NewState:  state,
+		Source:    &source,
+	}); err != nil {
+		t.Fatalf("recording consent %q: %v", state, err)
+	}
+}
+
+// TestAnExplicitYesAuthorizesCorrespondence is the defect this file exists for.
+//
+// A person who has said in as many words that we may write to them was refused
+// until they happened to send an inbound message, because the arm read
+// qualifying events and never the recorded answer. Mutation: drop the
+// `granted` branch from correspondenceVerdict and this fails on the first
+// assertion, with the verdict still unknown.
+func TestAnExplicitYesAuthorizesCorrespondence(t *testing.T) {
+	e := setupQualifying(t)
+
+	// Nothing on the timeline: no inbound, no deal, no recorded exchange. The
+	// ONLY thing that will change is the person's own answer.
+	if before := e.verdict(t); before.State != VerdictUnknown {
+		t.Fatalf("the starting verdict = %q, want unknown", before.State)
+	}
+
+	e.grant(t, "granted")
+
+	after := e.verdict(t)
+	if after.State != VerdictAllowed {
+		t.Fatalf("the verdict after an explicit yes = %q (%s), want allowed",
+			after.State, after.Reason)
+	}
+	// The reason has to name the answer, not a qualifying event: there is no
+	// event here, and a verdict citing one would be describing something that
+	// never happened.
+	if after.Qualifying != nil {
+		t.Errorf("the verdict cites the qualifying event %+v, want the recorded answer",
+			after.Qualifying)
+	}
+}
+
+// TestAWithdrawalStillBeatsAQualifyingEvent holds the direction the fix must
+// not break. objectionStands runs before the class arms, so reading the grant
+// first must not give a withdrawn person a way back in through the timeline.
+//
+// Mutation: move the objectionStands call below the class switch and this
+// fails — the inbound message answers instead.
+func TestAWithdrawalStillBeatsAQualifyingEvent(t *testing.T) {
+	e := setupQualifying(t)
+
+	met := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	if _, err := e.store.RecordQualifyingEvent(e.ctx, e.person, RecordQualifyingEventInput{
+		Kind:       "in_person",
+		Note:       "Met at the Frankfurt trade fair, stand B12.",
+		OccurredAt: met,
+	}); err != nil {
+		t.Fatalf("recording the exchange: %v", err)
+	}
+	if allowed := e.verdict(t); allowed.State != VerdictAllowed {
+		t.Fatalf("the verdict on the exchange alone = %q, want allowed", allowed.State)
+	}
+
+	e.grant(t, "withdrawn")
+
+	after := e.verdict(t)
+	if after.State != VerdictBlocked {
+		t.Fatalf("the verdict after a withdrawal = %q (%s), want blocked",
+			after.State, after.Reason)
+	}
+	if after.Code != BlockObjection {
+		t.Errorf("the block code = %q, want %q", after.Code, BlockObjection)
+	}
+}
+
+// TestTheTimelineStillAnswersForSomebodyWhoNeverSaid keeps the implied arm
+// reachable. It answers for the overwhelming majority of people, who record no
+// answer either way, and reading the grant first must not have shadowed it.
+//
+// Mutation: return early from correspondenceVerdict on any non-granted state
+// and this fails.
+func TestTheTimelineStillAnswersForSomebodyWhoNeverSaid(t *testing.T) {
+	e := setupQualifying(t)
+
+	met := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	if _, err := e.store.RecordQualifyingEvent(e.ctx, e.person, RecordQualifyingEventInput{
+		Kind:       "in_person",
+		Note:       "They asked for a quote at the stand.",
+		OccurredAt: met,
+	}); err != nil {
+		t.Fatalf("recording the exchange: %v", err)
+	}
+
+	after := e.verdict(t)
+	if after.State != VerdictAllowed {
+		t.Fatalf("the verdict = %q (%s), want allowed", after.State, after.Reason)
+	}
+	if after.Qualifying == nil || after.Qualifying.Kind != "in_person" {
+		t.Errorf("the verdict cites %+v, want the in-person exchange", after.Qualifying)
+	}
+}

--- a/backend/internal/modules/consent/qualifyingground.go
+++ b/backend/internal/modules/consent/qualifyingground.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// What on the record implies that correspondence is lawful, when the subject
+// has recorded no answer of their own.
+//
+// Split from verdict.go for the file-length ceiling, and the seam is the honest
+// one: that file decides a VERDICT from a person's own answer and this one
+// finds the IMPLIED ground beneath it. The two are asked in that order —
+// correspondenceVerdict reads the recorded state first and only reaches here
+// when there is none — so keeping them apart keeps the precedence visible.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// latestQualifyingEvent finds the most recent thing on the record that makes
+// correspondence lawful.
+//
+// It looks in two places, and the order is the point. A TYPED row wins: an
+// in-person exchange or an inquiry is something a named human recorded, and it
+// carries the note or the reference a dispute asks for. Failing that the
+// captured timeline answers for itself — an inbound message from this person IS
+// the qualifying event, which is what "deterministic and derivable from
+// captured data" means (ADR-0098 D2).
+//
+// Deriving rather than requiring a written row is what keeps the rule honest on
+// day one: every mailbox this product has ever captured already contains the
+// evidence, and a model that only recognised events recorded after this build
+// shipped would tell a rep they may not answer somebody who wrote to them last
+// week.
+func latestQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (QualifyingEvent, eventSource, error) {
+	event, found, err := recordedQualifyingEvent(ctx, tx, personID)
+	if err != nil {
+		return QualifyingEvent{}, sourceNone, err
+	}
+	if found {
+		return event, sourceRecorded, nil
+	}
+	event, found, err = inboundQualifyingEvent(ctx, tx, personID)
+	if err != nil {
+		return QualifyingEvent{}, sourceNone, err
+	}
+	if found {
+		return event, sourceDerived, nil
+	}
+	return QualifyingEvent{}, sourceNone, nil
+}
+
+// eventSource says where a qualifying event came from, and therefore whether
+// the transmit path still owes it a stamp.
+//
+// One value rather than two adjacent bools: `found` and `derived` are the same
+// type in neighbouring positions, so nothing but care stopped a future arm
+// returning them the wrong way round — and returning them the wrong way round
+// means either stamping a duplicate of a row that already exists, or relying on
+// a basis that was never written down.
+type eventSource int
+
+const (
+	// sourceNone: nothing on the record makes correspondence lawful.
+	sourceNone eventSource = iota
+	// sourceRecorded: a stored row already proves it, so there is nothing to stamp.
+	sourceRecorded
+	// sourceDerived: read off the timeline, and the transmit path must record it
+	// before relying on it (Art 5(2)).
+	sourceDerived
+)
+
+// RecordDerivedQualifyingEvent stamps a derived qualifying event onto the
+// record, so what authorized a send is a fact somebody can look up rather than
+// a computation this build happened to make.
+//
+// ADR-0098 D2 requires the flip be "stamped with which event and when", and
+// Art 5(2) is why: a lawful basis nobody wrote down is an assertion, and the
+// controller carries the burden of showing it. Deriving the event at read time
+// answers the question correctly; it does not answer it accountably.
+//
+// Only the TRANSMIT path calls this. A preview authorizes nothing, and writing
+// a legal fact because somebody opened a composer would record a basis for a
+// message that was never sent.
+//
+// The insert is idempotent on the source record — the same inbound message
+// re-derived on the next send must not stack a second row claiming a second
+// event happened — and the guarantee is the database's unique index, not a
+// check this function performs and a concurrent caller races past.
+func RecordDerivedQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string, event QualifyingEvent, capturedBy string) error {
+	// ON CONFLICT, not NOT EXISTS: two concurrent sends to the same person both
+	// pass a read-then-write check and both insert. The unique index on the
+	// source record is what actually makes this idempotent.
+	_, err := tx.Exec(ctx, `
+		INSERT INTO consent_qualifying_event
+			(person_id, kind, source_entity_type, source_entity_id,
+			 occurred_at, source, captured_by)
+		VALUES ($1, $2, $3, $4, $5, 'derived', $6)
+		ON CONFLICT (person_id, source_entity_type, source_entity_id)
+		  WHERE source_entity_id IS NOT NULL
+		  DO NOTHING`,
+		personID, event.Kind, event.SourceEntityType, event.SourceEntityID,
+		event.OccurredAt, capturedBy)
+	if err != nil {
+		return fmt.Errorf("consent: stamp the qualifying event that allowed this send: %w", err)
+	}
+	return nil
+}
+
+// recordedQualifyingEvent reads a row a human or an integration wrote.
+func recordedQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (QualifyingEvent, bool, error) {
+	var event QualifyingEvent
+	var sourceType, sourceID, note *string
+	err := tx.QueryRow(ctx, `
+		SELECT kind, occurred_at, source_entity_type, source_entity_id, note
+		FROM consent_qualifying_event
+		WHERE person_id = $1
+		ORDER BY occurred_at DESC
+		LIMIT 1`, personID).Scan(&event.Kind, &event.OccurredAt, &sourceType, &sourceID, &note)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return QualifyingEvent{}, false, nil
+	}
+	if err != nil {
+		return QualifyingEvent{}, false, fmt.Errorf("read the qualifying event: %w", err)
+	}
+	if sourceType != nil {
+		event.SourceEntityType = *sourceType
+	}
+	if sourceID != nil {
+		event.SourceEntityID = *sourceID
+	}
+	if note != nil {
+		event.Note = *note
+	}
+	return event, true, nil
+}
+
+// inboundQualifyingEvent derives the event from the captured timeline: they
+// wrote to us, and the message itself is the proof.
+//
+// The activity is reached through activity_link, the same table every
+// person-scoped timeline read walks, so this cannot count a message the record
+// does not show.
+func inboundQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (QualifyingEvent, bool, error) {
+	var event QualifyingEvent
+	var activityID string
+	err := tx.QueryRow(ctx, `
+		SELECT a.id, a.occurred_at
+		FROM activity a
+		JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
+		WHERE a.direction = 'inbound' AND a.archived_at IS NULL
+		ORDER BY a.occurred_at DESC
+		LIMIT 1`, personID).Scan(&activityID, &event.OccurredAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return QualifyingEvent{}, false, nil
+	}
+	if err != nil {
+		return QualifyingEvent{}, false, fmt.Errorf("read the inbound qualifying message: %w", err)
+	}
+	event.Kind = "inbound_message"
+	event.SourceEntityType = "activity"
+	event.SourceEntityID = activityID
+	return event, true, nil
+}

--- a/backend/internal/modules/consent/verdict.go
+++ b/backend/internal/modules/consent/verdict.go
@@ -132,25 +132,7 @@ func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose P
 		return Verdict{State: VerdictAllowed, Reason: "account and contract notices need no consent"}, nil
 
 	case ClassBusinessCorrespondence:
-		event, source, err := latestQualifyingEvent(ctx, tx, personID)
-		if err != nil {
-			return Verdict{}, err
-		}
-		if source == sourceNone {
-			// No inbound, no inquiry, no deal, no recorded exchange. There is
-			// nothing here to balance, so this is not the easy Art 6(1)(f) case
-			// and the honest answer is that nobody has decided.
-			return Verdict{
-				State:  VerdictUnknown,
-				Reason: "they have never written to you and no deal or inquiry connects you",
-			}, nil
-		}
-		return Verdict{
-			State:             VerdictAllowed,
-			Reason:            qualifyingReason(event),
-			Qualifying:        &event,
-			QualifyingDerived: source == sourceDerived,
-		}, nil
+		return correspondenceVerdict(ctx, tx, personID, purpose)
 
 	case ClassPhoneOutreach:
 		// Dormant by decision: the purpose exists so the model is complete. A
@@ -160,6 +142,66 @@ func VerdictForPerson(ctx context.Context, tx pgx.Tx, personID string, purpose P
 	default:
 		return marketingVerdict(ctx, tx, personID, purpose)
 	}
+}
+
+// correspondenceVerdict answers for ordinary business correspondence: the
+// person's own recorded answer first, and only then what the record implies.
+//
+// THE ORDER IS THE FIX. This arm used to read qualifying events alone, so an
+// explicit `granted` row authorized nothing: a person who had said in as many
+// words that we may write to them was refused until they happened to send an
+// inbound message, while one inbound message opened every unrelated send. A
+// recorded answer is the strongest thing a subject can give us about their own
+// correspondence, and reading it second — or, as here, not at all — inverted
+// that.
+//
+// A withdrawal needs no branch here. objectionStands runs before this for every
+// class and every purpose, so a withdrawn row has already blocked.
+//
+// The implied arm below is unchanged and stays second: it is the Art 6(1)(f)
+// reading of a relationship the subject started, and it is what answers for the
+// overwhelming majority of people, who never record an answer either way.
+func correspondenceVerdict(ctx context.Context, tx pgx.Tx, personID string, purpose PurposeRow) (Verdict, error) {
+	// requiresDOI is passed as the purpose declares it rather than as a
+	// constant false. Correspondence does not demand the round trip today, and
+	// hard-coding that here would silently ignore an installation that turned
+	// it on for this purpose.
+	state, granted, err := recordedState(ctx, tx, personID, purpose.ID, purpose.RequiresDOI)
+	if err != nil {
+		return Verdict{}, err
+	}
+	if granted {
+		return Verdict{State: VerdictAllowed, Reason: "they said we may write to them"}, nil
+	}
+	if state == string(StateGranted) && purpose.RequiresDOI {
+		// Granted but never confirmed, on an installation that demands the
+		// round trip for this purpose. Falling through to the implied arm
+		// would let the timeline supply what the confirmation did not.
+		return Verdict{
+			State:  VerdictBlocked,
+			Reason: "consent was recorded but never confirmed by the double opt-in",
+			Code:   BlockUnconfirmedDOI,
+		}, nil
+	}
+	event, source, err := latestQualifyingEvent(ctx, tx, personID)
+	if err != nil {
+		return Verdict{}, err
+	}
+	if source == sourceNone {
+		// No answer on file, no inbound, no inquiry, no deal, no recorded
+		// exchange. There is nothing here to balance, so this is not the easy
+		// Art 6(1)(f) case and the honest answer is that nobody has decided.
+		return Verdict{
+			State:  VerdictUnknown,
+			Reason: "they have never written to you and no deal or inquiry connects you",
+		}, nil
+	}
+	return Verdict{
+		State:             VerdictAllowed,
+		Reason:            qualifyingReason(event),
+		Qualifying:        &event,
+		QualifyingDerived: source == sourceDerived,
+	}, nil
 }
 
 // marketingVerdict is the strict arm, unchanged in strictness by ADR-0098:
@@ -261,152 +303,6 @@ func objectionStands(ctx context.Context, tx pgx.Tx, personID, purposeID string)
 		return false, time.Time{}, fmt.Errorf("read the objection's proof: %w", err)
 	}
 	return true, at, nil
-}
-
-// latestQualifyingEvent finds the most recent thing on the record that makes
-// correspondence lawful.
-//
-// It looks in two places, and the order is the point. A TYPED row wins: an
-// in-person exchange or an inquiry is something a named human recorded, and it
-// carries the note or the reference a dispute asks for. Failing that the
-// captured timeline answers for itself — an inbound message from this person IS
-// the qualifying event, which is what "deterministic and derivable from
-// captured data" means (ADR-0098 D2).
-//
-// Deriving rather than requiring a written row is what keeps the rule honest on
-// day one: every mailbox this product has ever captured already contains the
-// evidence, and a model that only recognised events recorded after this build
-// shipped would tell a rep they may not answer somebody who wrote to them last
-// week.
-func latestQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (QualifyingEvent, eventSource, error) {
-	event, found, err := recordedQualifyingEvent(ctx, tx, personID)
-	if err != nil {
-		return QualifyingEvent{}, sourceNone, err
-	}
-	if found {
-		return event, sourceRecorded, nil
-	}
-	event, found, err = inboundQualifyingEvent(ctx, tx, personID)
-	if err != nil {
-		return QualifyingEvent{}, sourceNone, err
-	}
-	if found {
-		return event, sourceDerived, nil
-	}
-	return QualifyingEvent{}, sourceNone, nil
-}
-
-// eventSource says where a qualifying event came from, and therefore whether
-// the transmit path still owes it a stamp.
-//
-// One value rather than two adjacent bools: `found` and `derived` are the same
-// type in neighbouring positions, so nothing but care stopped a future arm
-// returning them the wrong way round — and returning them the wrong way round
-// means either stamping a duplicate of a row that already exists, or relying on
-// a basis that was never written down.
-type eventSource int
-
-const (
-	// sourceNone: nothing on the record makes correspondence lawful.
-	sourceNone eventSource = iota
-	// sourceRecorded: a stored row already proves it, so there is nothing to stamp.
-	sourceRecorded
-	// sourceDerived: read off the timeline, and the transmit path must record it
-	// before relying on it (Art 5(2)).
-	sourceDerived
-)
-
-// RecordDerivedQualifyingEvent stamps a derived qualifying event onto the
-// record, so what authorized a send is a fact somebody can look up rather than
-// a computation this build happened to make.
-//
-// ADR-0098 D2 requires the flip be "stamped with which event and when", and
-// Art 5(2) is why: a lawful basis nobody wrote down is an assertion, and the
-// controller carries the burden of showing it. Deriving the event at read time
-// answers the question correctly; it does not answer it accountably.
-//
-// Only the TRANSMIT path calls this. A preview authorizes nothing, and writing
-// a legal fact because somebody opened a composer would record a basis for a
-// message that was never sent.
-//
-// The insert is idempotent on the source record — the same inbound message
-// re-derived on the next send must not stack a second row claiming a second
-// event happened — and the guarantee is the database's unique index, not a
-// check this function performs and a concurrent caller races past.
-func RecordDerivedQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string, event QualifyingEvent, capturedBy string) error {
-	// ON CONFLICT, not NOT EXISTS: two concurrent sends to the same person both
-	// pass a read-then-write check and both insert. The unique index on the
-	// source record is what actually makes this idempotent.
-	_, err := tx.Exec(ctx, `
-		INSERT INTO consent_qualifying_event
-			(person_id, kind, source_entity_type, source_entity_id,
-			 occurred_at, source, captured_by)
-		VALUES ($1, $2, $3, $4, $5, 'derived', $6)
-		ON CONFLICT (person_id, source_entity_type, source_entity_id)
-		  WHERE source_entity_id IS NOT NULL
-		  DO NOTHING`,
-		personID, event.Kind, event.SourceEntityType, event.SourceEntityID,
-		event.OccurredAt, capturedBy)
-	if err != nil {
-		return fmt.Errorf("consent: stamp the qualifying event that allowed this send: %w", err)
-	}
-	return nil
-}
-
-// recordedQualifyingEvent reads a row a human or an integration wrote.
-func recordedQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (QualifyingEvent, bool, error) {
-	var event QualifyingEvent
-	var sourceType, sourceID, note *string
-	err := tx.QueryRow(ctx, `
-		SELECT kind, occurred_at, source_entity_type, source_entity_id, note
-		FROM consent_qualifying_event
-		WHERE person_id = $1
-		ORDER BY occurred_at DESC
-		LIMIT 1`, personID).Scan(&event.Kind, &event.OccurredAt, &sourceType, &sourceID, &note)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return QualifyingEvent{}, false, nil
-	}
-	if err != nil {
-		return QualifyingEvent{}, false, fmt.Errorf("read the qualifying event: %w", err)
-	}
-	if sourceType != nil {
-		event.SourceEntityType = *sourceType
-	}
-	if sourceID != nil {
-		event.SourceEntityID = *sourceID
-	}
-	if note != nil {
-		event.Note = *note
-	}
-	return event, true, nil
-}
-
-// inboundQualifyingEvent derives the event from the captured timeline: they
-// wrote to us, and the message itself is the proof.
-//
-// The activity is reached through activity_link, the same table every
-// person-scoped timeline read walks, so this cannot count a message the record
-// does not show.
-func inboundQualifyingEvent(ctx context.Context, tx pgx.Tx, personID string) (QualifyingEvent, bool, error) {
-	var event QualifyingEvent
-	var activityID string
-	err := tx.QueryRow(ctx, `
-		SELECT a.id, a.occurred_at
-		FROM activity a
-		JOIN activity_link l ON l.activity_id = a.id AND l.person_id = $1
-		WHERE a.direction = 'inbound' AND a.archived_at IS NULL
-		ORDER BY a.occurred_at DESC
-		LIMIT 1`, personID).Scan(&activityID, &event.OccurredAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return QualifyingEvent{}, false, nil
-	}
-	if err != nil {
-		return QualifyingEvent{}, false, fmt.Errorf("read the inbound qualifying message: %w", err)
-	}
-	event.Kind = "inbound_message"
-	event.SourceEntityType = "activity"
-	event.SourceEntityID = activityID
-	return event, true, nil
 }
 
 // recordedState reads the person's own decision for this purpose, and whether


### PR DESCRIPTION
## The defect

`VerdictForPerson`'s `ClassBusinessCorrespondence` arm read qualifying events — an
inbound message, a deal, an inquiry — and never read the person's own recorded
`person_consent` grant. A `granted` row for this class authorized nothing.

Two consequences, both reproduced end to end on a dev stack against the real
send endpoint:

- A person who explicitly said we may write to them was refused
  `409 consent_not_granted` until they happened to send an inbound message.
- One inbound message then opened every unrelated send, including cold
  outreach linked only to the person with no deal.

This PR fixes the first. The second is a product decision and is deliberately
left alone — tightening it would refuse mail that goes out today.

## The change

`correspondenceVerdict` reads `recordedState` first: an explicit grant allows on
its own ground. The implied arm is unchanged and stays second, because it is
what answers for the overwhelming majority of people, who record no answer
either way.

`objectionStands` already ran before the class switch, so a withdrawal still
beats both. That is now pinned by a test rather than assumed.

`purpose.RequiresDOI` is consulted for this class where it was not before. It is
false for correspondence today; hard-coding that here would have silently
ignored an installation that turned it on. This is strictly tighter than the
previous behaviour — an unconfirmed grant now blocks where an inbound message
used to rescue it.

The 500-line ceiling forced a split: the qualifying-event readers move to
`qualifyingground.go` unchanged. That puts the recorded answer and the implied
ground in separate files, in the order they are asked.

## Verified

| Case | Before | After |
|---|---|---|
| No history, no answer on file | 409 | 409 |
| Same person, after an explicit grant | **409** | **202** |
| Same person, after a withdrawal | 409 | 409 |

Three integration tests, each mutation-checked one clause at a time:

- `TestAnExplicitYesAuthorizesCorrespondence` — neutralize the granted branch,
  fails with "the verdict after an explicit yes = unknown".
- `TestAWithdrawalStillBeatsAQualifyingEvent` — neutralize `objectionStands`,
  fails with the exchange answering instead.
- `TestTheTimelineStillAnswersForSomebodyWhoNeverSaid` — short-circuit the
  implied arm, fails.

Tests seed through `Store.Record`, the production writer, not hand-inserted rows.

`make check-backend` green before and after rebase; full consent integration
lane green. A security review pass found no exploitable finding and confirmed
the file split is byte-identical movement.

## How it was found

By driving real mail through the real send doors on a dev stack, not by a
failing test. No test in the tree covered a grant on this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes correspondence consent so an explicit `granted` consent now authorizes sends, where before only qualifying events like inbound messages did.

- Reads the person's recorded consent state before falling back to the implied qualifying-event ground.
- A withdrawal still beats both paths; now pinned by a test.
- Consults `purpose.RequiresDOI` for this class; an unconfirmed grant now blocks where an inbound message used to rescue it.
- Moves the qualifying-event readers to `qualifyingground.go` unchanged.

<sup>Written for commit f49326de4e97fb288bc354b176f3f93f5a2bdebb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Correspondence eligibility now prioritizes explicit consent decisions, including withdrawals that block correspondence.
  - When no recorded answer exists, qualifying events can establish eligibility.
  - The system can derive a qualifying basis from recent inbound activity and retain it for future consent decisions.
  - Unconfirmed double opt-in remains blocked when required.

- **Tests**
  - Added integration coverage for consent grants, withdrawals, qualifying events, verdict reasons, and blocking outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->