### PR TITLE
Capture declares the ledger it owns

### DIFF
--- a/backend/internal/modules/capture/doc.go
+++ b/backend/internal/modules/capture/doc.go
@@ -24,6 +24,9 @@
 // seat keeps out of the shared timeline) and capture_thread_verdict (what a
 // classifier concluded about one thread, for one seat) and
 // capture_sender_override (what a person decided about a sender, which the
-// machine consults first and never writes over).
+// machine consults first and never writes over) and
+// capture_pending_counterparty (the open question about whose record an
+// address is — raised at capture, re-raised by the sweep for a contact the
+// ceiling refused, and resolved by the verdict engine).
 // Imports shared + platform only; never a sibling module.
 package capture


### PR DESCRIPTION
`capture_pending_counterparty` is assigned to the capture module by the enforced ownership map (`backend/gates/tableownership_test.go`), and the sweep added in #3994 writes it. The package's own `doc.go` never listed it.

The gate reads the map rather than the comment, so nothing failed. That is the problem: `doc.go` is what a reader consults to learn what a module owns, and it was one table short of the truth.

Found while verifying the access-rights plan was fully implemented. The other loose ends from that verification became issues rather than code: #4041 (paid enrichment asks only for a human), #4042 (effective access on the share screen), #4043 (privacy-safe capture health for admins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the capture module's `doc.go` to list `capture_pending_counterparty` as a table the module owns, matching the enforced ownership map. Previously the doc omitted it, which misled readers about the module's responsibilities.

<sup>Written for commit 09cbe7a68e386f63576a79edc43278d35b6a2d32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package documentation to include tracking of unresolved address ownership during capture and resolution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->