### PR TITLE
updateTag's comment describes the door it actually opens

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8007,8 +8007,18 @@ paths:
     patch:
       tags: [Tags]
       operationId: updateTag
-      # Human-only for the same reason createTag is: renaming a word every seat
-      # can already apply changes what a filter selects for everyone at once.
+      # Reachable by an agent, and governed by the grant rather than by the
+      # door, exactly as createTag is: editing needs tag.update, which the
+      # seeded roles give Admin and Ops alone. A seat trusted to rename a word
+      # in the UI is trusted to do it here; a rep holding only tag.read is
+      # refused either way.
+      #
+      # A rename reaches every seat at once — it changes what a saved filter
+      # selects for people who never touched the tag — and that is ACCEPTED
+      # under tag.update rather than prevented by closing the door. The seats
+      # holding the grant are the ones the workspace already trusts with a
+      # workspace-wide vocabulary change; a door closed to agents would not
+      # have made the effect smaller, only harder to reach.
       x-mcp-tool: { verb: update_tag, record_type: tag, tier: auto_execute, scope: write }
       summary: Rename, recolour or describe a tag.
       parameters:


### PR DESCRIPTION
Closes #3871.

The comment said the operation was human-only. The line directly under it declared it an agent-callable tool at `auto_execute`, and the declaration is the one that runs — `agentpolicy_gen.go` carries it, `tools_tagvocab.go` registers it.

It is a leftover from `1208fdab2` (#3822), which opened both tag doors and rewrote `createTag`'s comment to explain the new reasoning without rewriting this one.

## What the replacement keeps

The old text raised a real consequence: a rename reaches every seat at once — it changes what a saved filter selects for people who never touched the tag. #3822 did not address that; it **accepted** it under the `tag.update` grant. Deleting the sentence would erase a live concern, so the new comment states it as an accepted cost rather than as a reason the door is closed:

> A rename reaches every seat at once … and that is ACCEPTED under `tag.update` rather than prevented by closing the door. The seats holding the grant are the ones the workspace already trusts with a workspace-wide vocabulary change; a door closed to agents would not have made the effect smaller, only harder to reach.

Written as it was, the argument stood as the standing justification for the opposite conclusion, which is why the reasoning was lost in both directions.

## Checked for siblings

Two things, since a stale comment beside a live declaration is a class rather than an instance:

- **Every `x-mcp-tool:` line whose preceding comment block says "human-only"** — two hits. This one, and `read_brief`, whose comment says *"the queue's MARKS stay human-only below"*: that is about a different operation and is correct. So one real instance.
- **Every operation declaring both `x-mcp-tool` and `x-agent-access: human-only`** — zero. That is the mechanical version of this contradiction and the contract is already clean of it.

I did not add a gate. The first check is prose-matching and its one false positive out of two hits is the reason: it would need a waiver the day it was armed, over text a reader has to judge anyway. The second is precise but has nothing to hold today, and a gate with no planted case cannot show it would notice. The ticket is right that nothing mechanical catches this one.

## Verification

`make gen` produces byte-identical artifacts before and after — no generator, gate or runtime reads the comment. `make check-backend` green, contract drift included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b1jSBftJqGvaQ7ejTgnQ6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified tag update access requirements for agents.
  * Documented that workspace-wide tag renames are available to roles with the appropriate tag update permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->