### PR TITLE
frontend: the rail's orb is the agent again, not a status light

### DIFF
--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -69,25 +69,45 @@
 .arhit {
   position: relative;
   display: flex;
-  /* A CARD, the mock's shape: the ball at the rail's row scale beside two
-     lines of text, on the pane with the agent's own indigo washed over it and
-     its own edge. The ball led the rail at hero size once; it read as an
-     object placed on the sidebar rather than as one of its rows. */
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
-  gap: var(--space-3);
+  /* No gap. The ball's own box already carries the air around it (the halo is
+     drawn inside it), so a gap here is a second helping of the same space and it
+     read as the caption belonging to something else. */
+  gap: 0;
   width: 100%;
-  padding: var(--space-3);
-  border: 1px solid var(--aiMed);
+  /* Tight. The ball is the biggest thing in the chrome and it needs room to be
+     read, not room around the room: with no card to hold, air above and below it
+     is just rail nobody uses. */
+  padding: 0 0 var(--space-1);
+  border: 0;
+  /* Nothing draws this corner. It is here for the focus ring, which is the one
+     time this control does take an outline and needs it to follow the shape a
+     reader expects. */
   border-radius: var(--r-md);
-  background:
-    linear-gradient(160deg, var(--aiLight), transparent 80%), var(--pane);
+  /* The light the orb spills, and nothing under it. No panel fill, because a
+     fill needs an edge to end at, an edge needs a corner, and a corner around a
+     centred figure with a caption under it is a playing card. This wash fades
+     out before it reaches anything, so a reader sees the rail lit from within
+     rather than a lit object placed on the rail. */
+  background: radial-gradient(
+    88% 58% at 50% 32%,
+    color-mix(in srgb, var(--arTone) 6%, transparent),
+    transparent 62%
+  );
   color: var(--textPrimary);
-  text-align: left;
+  text-align: center;
   cursor: pointer;
 }
+/* Hover raises the light rather than filling a shape: a tinted rectangle
+   appearing under the pointer would put the card back for as long as the pointer
+   was there. */
 .arhit:hover {
-  border-color: var(--aiText);
+  background: radial-gradient(
+    88% 58% at 50% 32%,
+    color-mix(in srgb, var(--arTone) 12%, transparent),
+    transparent 62%
+  );
 }
 .arhit:focus-visible {
   outline: var(--focus-ring);
@@ -121,13 +141,14 @@
      different diameters. 172px is a step under the width the card could give
      it — the ball leads the rail without crowding the destinations above it —
      and 18vh is what a short window can, whichever is smaller. */
-  --coreSize: 34px;
-  --coreGlass: 30px;
+  --coreSize: min(172px, 18vh);
+  --coreGlass: calc(var(--coreSize) - 6px);
   /* The viewport cap is for a hero standing in a content column; the rail's own
      width and height are the only caps this one needs. */
   --coreCap: 100%;
-  /* Nearly all of the halo off: in a card this small the ball IS the signal,
-     and a bloom would cross the words beside it. */
+  /* Nearly all of the halo off. At this size the ball IS the signal: a bloom
+     wide enough to suit a hero reaches the destinations above it, and with no
+     card edge to contain it there is nothing to stop it either. */
   --coreHalo: 0.08;
   flex: none;
 }
@@ -137,15 +158,17 @@
   z-index: 1;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 1px; /* ds:ignore two lines of one reading, not spaced content */
   width: 100%;
   min-width: 0;
-  padding: 0;
+  /* The ball takes the rail's full width; the words take a margin back, or a
+     long line runs into the edge of the rail. */
+  padding: 0 var(--space-2);
 }
 .arline {
   max-width: 100%;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-body);
   line-height: 1.3;
   color: var(--textPrimary);
   /* Two lines, always. Not "up to two": the line changes several times a second
@@ -161,7 +184,6 @@
   min-height: 2.6em;
   overflow: hidden;
   align-content: start;
-  font-weight: var(--fw-medium);
 }
 /* What the TOOL is fetching, under the agent's line and plainly subordinate to
    it. The two are different subjects and both can be true at once, so the
@@ -216,7 +238,7 @@
 .arspend {
   display: flex;
   align-items: baseline;
-  justify-content: flex-start;
+  justify-content: center;
   gap: var(--space-1);
   width: 100%;
   min-width: 0;
@@ -246,11 +268,10 @@
 }
 
 .archev {
-  /* At the card's right edge, in the row: the card is one line of things
-     beside each other, and the chevron is the last of them. */
-  position: static;
+  position: absolute;
   z-index: 1;
-  margin-left: auto;
+  bottom: var(--space-2);
+  right: var(--space-2);
   color: var(--textMeta);
   transition: transform 0.25s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
@@ -289,6 +310,41 @@
  * the same object. Last the words go and the orb reports alone, exactly as it
  * does on the collapsed rail.
  */
+@media (max-height: 860px) {
+  .arblock {
+    margin-top: var(--space-1);
+  }
+  .arhit {
+    gap: 2px; /* ds:ignore the last of the air between the ball and its line */
+    padding: 0 0 var(--space-1);
+  }
+}
+@media (max-height: 780px) {
+  .arhit {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1) var(--space-2);
+    text-align: left;
+  }
+  .arorb {
+    --coreSize: 56px;
+    --coreGlass: 50px;
+  }
+  .arwords {
+    align-items: flex-start;
+    padding: 0;
+  }
+  .arspend {
+    justify-content: flex-start;
+  }
+  /* The corner belongs to a column. On a row the chevron sits in the flow, or
+     it lands on top of the words. */
+  .archev {
+    position: static;
+    margin-left: auto;
+  }
+}
 @media (max-height: 620px) {
   .arwords {
     display: none;
@@ -311,12 +367,12 @@
   display: none;
 }
 .rail.collapsed .arhit {
-  /* Collapsed, the card goes and the ball stands alone in the column, centred
-     on the rows' glyph axis like every other mark in the rail. */
-  justify-content: center;
   padding: var(--space-2) 0;
-  border-color: transparent;
-  background: none;
+}
+.rail.collapsed .arorb {
+  --coreSize: 56px;
+  --coreGlass: 48px;
+  --coreHalo: 0.5;
 }
 
 /* ===== The phone bar's centre cell =====


### PR DESCRIPTION
## What

The agent card in the rail goes back to the column it was: the orb takes the height the rail can give it, the words sit centred under it, the spend below them, and the chevron in the corner. Collapsed, the rail still gets its small disc.

## Why

The card had become a row — a small disc beside its words, inside a bordered box. At that size the orb reads as a status indicator rather than as the agent, which is the one thing the rail exists to carry. The tone wash belongs to the card itself rather than to a border drawn around it, because the wash is the state and a border is just a box.

The height ladders come back with it, and they are the reason the orb can be large at all: a short viewport shrinks the orb rather than pushing the spend off the bottom of the rail. The collapsed rail keeps the small disc, which is the one place a small one is right.

Only `agentrail.css` changes. No markup, no tokens, no component contract.

## How verified

- `make fe-quality`: the design-system gates (`check-ds-spacing`, `check-ds-purity`, `check-space-tokens`, `check-font-lock`, `check-icon-glyph`), the drift check, biome and the composed typecheck are all clean.
- `vitest run src/app`: 560 passed across 47 files, the rail's own suites included.
- Checked in the running app at 1440px in both the expanded and collapsed rail, and against the short-viewport ladders.

- [x] `make check` frontend half is green; `check-backend` untouched (no Go change)
- [x] `make test-integration` not needed: no tenant data, RLS or write-shape change
- [x] `make craft-static`: no Go files touched
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

The stylesheet was written by Claude Code. Jo asked for the orb at its former size and reviewed the result on the running page.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. Commits are signed
off (`git commit -s`, DCO). See [CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC

---
_Generated by [Claude Code](https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the rail's orb as the agent itself rather than a small status-light-style disc, so the rail again reads as carrying the agent.

- The agent card is a column again: orb takes the rail's available height, words centered under it, spend below, chevron in the corner.
- The orb scales with viewport height, so a short window shrinks the orb instead of pushing the spend off the rail.
- Height breakpoints compact the layout on short viewports; the collapsed rail keeps the small disc.
- Only `agentrail.css` changes — no markup, tokens, or component contract.

<sup>Written for commit ede1e9c8f508c61d61a2dbe095b24e47d73df2d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the agent rail to a centered, frameless orb-and-caption layout.
  * Improved spacing, alignment, sizing, and chevron positioning.
  * Added responsive behavior for compact windows and smaller screens.
  * Simplified the collapsed rail appearance by removing its border and background while emphasizing the orb.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->