### PR TITLE
Liveness gets the fitness function it never had

### DIFF
--- a/backend/gates/writeliveness_test.go
+++ b/backend/gates/writeliveness_test.go
@@ -247,37 +247,73 @@ func retirableTables(t *testing.T) map[string]bool {
 }
 
 // byIDWritesIn names the retirable tables these statements write one row of by
-// id. A table outside the set answers nothing about liveness because it cannot
-// hold an archived row.
+// id, and says of each whether some statement writing it REFUSES an archived row
+// in its own text. A table outside the set is absent: it cannot hold an archived
+// row, so it answers nothing.
+//
+// Per TABLE rather than per statement, twice over and deliberately.
+//
+// statementsJudged returns overlapping READINGS of one value — a concatenation
+// is recorded both folded and in parts — so a fragment carrying the SET without
+// the WHERE would read as an unguarded write of a statement that is guarded.
+//
+// And the refusal is credited from any statement NAMING the table, not only from
+// the write. The commonest correct shape resolves the row live in a SELECT and
+// pins the UPDATE to it with a version or an archive transition, so insisting the
+// predicate ride the write itself would ask thirteen correct functions to be
+// waived. What it still separates is the case that matters: a function that
+// guards its organization write and leaves an activity write bare names no
+// activity statement carrying the predicate, so the activity write is reported.
 func byIDWritesIn(statements []string, retirable map[string]bool) map[string]bool {
 	written := map[string]bool{}
+	refused := map[string]bool{}
 	for _, lit := range statements {
-		for _, m := range byIDWriteOf.FindAllStringSubmatch(lit, -1) {
-			if retirable[m[1]] {
-				written[m[1]] = true
+		if livePredicate.MatchString(lit) {
+			for _, table := range tablesUnderLivePredicate(lit) {
+				refused[table] = true
 			}
 		}
+		for _, m := range byIDWriteOf.FindAllStringSubmatch(lit, -1) {
+			if retirable[m[1]] {
+				written[m[1]] = false
+			}
+		}
+	}
+	for table := range written {
+		written[table] = refused[table]
 	}
 	return written
 }
 
-// statesLiveness reports whether this function answers the liveness question at
-// all, either way. It reads the function's own frame: the statements it runs
-// and the names it calls.
-//
-// The marker is deliberately NOT attributed to the table being written, which is
-// where updateguard's lock credit is stricter. It cannot be: the liveness that
-// governs a child write is frequently its ANCHOR's — a deal room's deal, a
-// contract's organization — so requiring the probe and the statement to name one
-// table would refuse the shape this rule is mostly about. What that costs is a
-// function whose marker belongs to some other row; what insisting would cost is
-// a waiver on every correct anchor-gated write in the tree.
-func statesLiveness(fn *ast.FuncDecl, statements []string) bool {
-	for _, lit := range statements {
-		if livePredicate.MatchString(lit) {
-			return true
-		}
+// statementTable follows every keyword that introduces one, so a live predicate
+// is credited to the tables its own statement reads or writes and to no others.
+var statementTable = regexp.MustCompile(`(?i)\b(?:UPDATE|FROM|JOIN|INTO)\s+(?:ONLY\s+)?([a-z_]+)`)
+
+// tablesUnderLivePredicate names the tables one statement touches, for a
+// statement that refuses an archived row.
+func tablesUnderLivePredicate(statement string) []string {
+	var named []string
+	for _, m := range statementTable.FindAllStringSubmatch(statement, -1) {
+		named = append(named, m[1])
 	}
+	return named
+}
+
+// statesLivenessInGo reports whether this function answers the liveness question
+// in its Go frame — a *Live probe or lock, or a declaration that it reaches an
+// archived row on purpose.
+//
+// A Go marker is NOT attributed to the table being written, which is where
+// updateguard's lock credit is stricter. It cannot be: the liveness that governs
+// a child write is frequently its ANCHOR's — a deal room's deal, a contract's
+// organization — so requiring the probe and the statement to name one table
+// would refuse the shape this rule is mostly about.
+//
+// The IN-STATEMENT half is attributed, in byIDWritesIn above, and that is the
+// half where it can be. A function that guards its organization write and
+// leaves its activity write bare answers for one table and not the other; the
+// two are asked separately, so the second is still reported.
+func statesLivenessInGo(fn *ast.FuncDecl) bool {
 	stated := false
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		switch node := n.(type) {
@@ -332,7 +368,16 @@ func TestEveryByIDWriteOfARetirableRowAnswersForLiveness(t *testing.T) {
 					continue
 				}
 				judged++
-				if statesLiveness(fn, statements) {
+				if statesLivenessInGo(fn) {
+					continue
+				}
+				unanswered := map[string]bool{}
+				for table, answered := range written {
+					if !answered {
+						unanswered[table] = true
+					}
+				}
+				if len(unanswered) == 0 {
 					continue
 				}
 				key := filepath.ToSlash(filepath.Dir(path)) + ":" + fn.Name.Name
@@ -343,7 +388,7 @@ func TestEveryByIDWriteOfARetirableRowAnswersForLiveness(t *testing.T) {
 					"refuse an archived row (an archived_at IS NULL predicate, a *Live probe, a LiveOnly lock "+
 					"or patch), DECLARE that this write reaches one on purpose (auth.EnsureRetractable, "+
 					"storekit.IncludeArchived), or ratify it in livenessUnstated with where the liveness is",
-					path, fn.Name.Name, strings.Join(sortedTables(written), ", "))
+					path, fn.Name.Name, strings.Join(sortedTables(unanswered), ", "))
 			}
 			return nil
 		})

--- a/backend/gates/writeliveness_test.go
+++ b/backend/gates/writeliveness_test.go
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind shape H2
+
+package gates
+
+// The LIVENESS obligation as a fitness function: a write that targets one
+// standing row of a table which can be archived either REFUSES an archived row,
+// DECLARES that it deliberately reaches one, or is ratified with a reason.
+//
+// It is the fourth of the four obligations a write in this tree owes, and it was
+// the only one with no gate. The other three each have theirs — tableownership
+// (writes only tables it owns), updateguard (carries a concurrency guard),
+// writeauthority + writeshape (probes write authority, audits and emits) — and
+// that single gap produced eight defects across organization, person,
+// person_consent, attachment, contract, commission_entry and site_read, every
+// one of them individually defensible where it sat. What they had in common was
+// not a module or a table: it was that nothing asked the question.
+//
+// ENFORCEMENT IS A GATE AND NOT A TRIGGER, deliberately. A row-level refusal
+// looks like the obvious answer and breaks erasure: Art. 17 and the retention
+// sweep MUST write archived rows — `archived_at = coalesce(archived_at, now())`
+// runs through those statements — so a database that refused every write to an
+// archived row would refuse the destruction the archive is a step of. Liveness
+// is a property of the CALL SITE, not of the row.
+//
+// Two spellings satisfy it, and the difference between them is the whole point:
+//
+//   - REFUSAL — an `archived_at IS NULL` predicate, a `*Live` probe, a LiveOnly
+//     lock or patch. The write cannot reach an archived row.
+//   - DECLARATION — auth.EnsureRetractable, or storekit.IncludeArchived. The
+//     write reaches one ON PURPOSE, and says so where a reader looks.
+//
+// The declaration half is what makes the gate hold a line a scanner otherwise
+// cannot: an archived anchor freezes what its children GRANT and must never
+// freeze what they REVOKE, so "no liveness here" is sometimes exactly right.
+// Before the pair existed, that case and a forgotten filter were the same text.
+//
+// Scope: single-row-by-id UPDATE and DELETE. A set-based write is out by
+// construction, the way updateguard's is — a cascade over a parent's children
+// takes its liveness from the parent it was chosen by, not from a predicate of
+// its own. An INSERT is out for a different reason: a row being created has no
+// archived_at to violate, and the liveness its ANCHOR owes is a separate
+// question (the EnsureLinkTarget one) with a separate answer.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/gatekit"
+)
+
+// byIDWriteOf matches a single-row-by-primary-key UPDATE or DELETE inside one
+// SQL string literal, capturing the table. The by-id shape is what makes the
+// statement a read-modify-write on a row somebody named, which is where the
+// liveness question lives.
+var byIDWriteOf = regexp.MustCompile(`(?is)\b(?:UPDATE|DELETE\s+FROM)\s+(?:ONLY\s+)?([a-z_]+)\b[\s\S]*?\bWHERE\s+(?:[a-z]+\.)?id\s*=\s*\$`)
+
+// livePredicate is the refusal written into the statement itself.
+var livePredicate = regexp.MustCompile(`(?i)archived_at\s+IS\s+NULL`)
+
+var (
+	// archivedColumnLine marks a CREATE TABLE block's table as retirable;
+	// addedArchivedColumn catches the tables that grew the column later. Both,
+	// because a census that read only one of them would judge a smaller tree and
+	// still report PASS.
+	archivedColumnLine  = regexp.MustCompile(`(?i)^\s*archived_at\s`)
+	addedArchivedColumn = regexp.MustCompile(`(?is)ALTER TABLE\s+(?:IF EXISTS\s+)?([a-z_]+).{0,400}?ADD COLUMN\s+(?:IF NOT EXISTS\s+)?archived_at`)
+)
+
+// livenessMarkers are the spellings that discharge the obligation in Go, by the
+// name at the call site. Both halves are here on purpose — a refusal and a
+// declaration are equally answers, and the gate's subject is a write that gives
+// NEITHER.
+//
+// Named rather than resolved through types, for the reason every census in this
+// package is: a type-checked walk over the whole module costs more than the gate
+// is worth, and the names below are unambiguous in this tree. A same-named
+// method on some other receiver would over-credit, which is the direction that
+// merely lets one write through rather than the direction that goes quiet.
+var livenessMarkers = map[string]bool{
+	// Refusals: the row is resolved, probed or locked LIVE.
+	"EnsureWritableLive": true, "EnsureVisibleLive": true, "HoldWritableLive": true,
+	"LockSubjectLive": true, "EnsureActivityVisibleLive": true,
+	"EnsureActivityContentVisibleLive": true, "EnsureSignalVisibleLive": true,
+	"EnsureLinkTarget": true, "EnsureActivityWritable": true, "EnsureActivityWritableIn": true,
+	"LiveOnly": true, "ApplyGuarded": true, "ApplyWithVersion": true,
+	// identity's own spelling of the same refusal, rendered into SQL: a seat
+	// that is archived, suspended or deactivated is not a live member.
+	"LiveMemberSQL": true, "ActivatableMemberSQL": true,
+	// Declarations: the write reaches an archived row on purpose.
+	"EnsureRetractable": true, "IncludeArchived": true,
+}
+
+// byIDWriteFloor is the smallest number of by-id writers of a retirable table
+// this census may find and still be believed. It sits well below the real count
+// because its job is to catch a reader that has gone quiet — a walk that stops
+// finding files, or a statement reader that stops recognising this tree's SQL —
+// rather than to track the tree.
+//
+// It is the coarser of the two under-recognition alarms and covers the whole
+// census. The sharper one is livenessUnstated.AssertAllMatched: a ratified
+// function the reader stops seeing is named outright, because its waiver then
+// matches nothing.
+const byIDWriteFloor = 90
+
+// retirableTableFloor guards the other input. The table set is derived from the
+// migrations, and a derivation that silently read none of them would exempt
+// every write in the tree while reporting a clean run.
+const retirableTableFloor = 20
+
+// livenessUnstated ratifies a by-id write that neither refuses an archived row
+// nor declares that it reaches one, keyed by "package-dir:FuncName". Every entry
+// says where the liveness actually is, or why the write must reach a retired row;
+// a reasonless or stale entry fails.
+//
+// No entry may read "known defect, see issue". The holes this gate was written
+// for were closed before it was armed, so a waiver here is a statement that the
+// obligation is MET some other way — never that it is owed and unpaid.
+var livenessUnstated = gatekit.Waive(map[string]string{
+	// ERASURE AND RETENTION MUST WRITE ARCHIVED ROWS. This is the family that
+	// makes a row-level trigger impossible, and the reason each entry gives is
+	// the specific destruction it performs rather than a restatement of that
+	// sentence: an erasure stamps archived_at itself, so its own subject is
+	// archived by the time the statement beside it runs.
+	"internal/modules/privacy:anonymizeSubjectRows":    "Art. 17 erasure of the subject row, and it is the statement that SETS archived_at — coalesced, so a subject already archived keeps the instant they were retired. A liveness filter here would make erasure refuse every already-archived subject, which is the population most likely to ask for it",
+	"internal/modules/privacy:anonymizeLeadTwins":      "the lead half of the same erasure, reaching the twins a promotion left behind. They are found by promoted_person_id and by address, and an archived twin holds the same personal data a live one does",
+	"internal/modules/privacy:archiveActivity":         "the retention sweep retiring a message whose window closed. The write IS the archive transition, chosen by a clock rather than by a caller",
+	"internal/modules/privacy:archiveDeal":             "the deal arm of the same sweep, and the same transition: a deal past its window is archived because of when it closed",
+	"internal/modules/privacy:anonymizeLead":           "the retention sweep's lead anonymization, which stamps archived_at as part of the destruction and must run on a lead an earlier pass already retired",
+	"internal/modules/privacy:eraseActivityContent":    "the retention sweep destroying a message's text. It coalesces archived_at, so refusing an archived row would spare exactly the messages the sweep already took off the timeline and left the words standing",
+	"internal/modules/privacy:anonymizePersonRecord":   "the retention sweep's person arm, stamping the tombstone name and archived_at together. Its subject is chosen by a retention policy, and an archived contact still holds every column this nulls",
+	"internal/modules/privacy:eraseVoiceSignalContent": "the time-based sweep over voice learning signals, which carry no subject linkage for Art. 17 to find — the clock is the only thing that reaches them, and the row's own state is not a reason to leave the text",
+	"internal/modules/privacy:liftAndEraseHeldRecord":  "lifting a statutory hold and destroying what it preserved, in one statement. The record was archived when the hold was placed; requiring it to be live would make the lift unable to reach anything it is ever asked about",
+	"internal/modules/privacy:PinToFloor":              "placing a statutory hold, which archives the record as part of placing it. The refusal it does carry is stronger than liveness — restricted_at IS NULL — so a second controller pinning the same record is declined rather than overwriting the first one's window",
+
+	// THE RETIREMENT TRANSITION ITSELF. Each is idempotent by construction: the
+	// write sets the retired state absolutely rather than deriving it from a
+	// pre-read, so a second attempt converges on the same row instead of racing.
+	"internal/modules/activities:ArchiveAttachment":   "the archive transition for a filed document. Refusing an archived row would turn a repeated archive into an error where it is the same answer, and the parent's authority is probed above through resolveAttachmentParent",
+	"internal/modules/activities:archiveAbsorbedEcho": "folding a duplicate capture into its survivor, which takes the echo off the timeline. archived_at is coalesced so a row a noise disposition already hid keeps the instant its undo window is measured from — a filter here would refuse exactly that row",
+	"internal/modules/capture:withdrawConnection":     "disconnecting a mailbox, and the retry that re-drives the cleanup a previous call left unfinished. The already-withdrawn arm is the one that must reach a retired row, and it is what makes the withdrawal recoverable rather than half-done",
+	"internal/modules/customfields:Retire":            "the catalog field's own retirement, which moves `status` and not archived_at; lockField holds the row from before the decision read, and a repeat converges on the same status",
+	"internal/modules/identity:UpdateTeam":            "the team's archive and restore arms are this function, so both directions have to reach a row on the far side of the transition. The row is held FOR UPDATE from before the state is read",
+
+	// THE LIVENESS IS ONE FRAME UP, OR ONE HOP ACROSS. Each of these is reached
+	// only through a caller or a helper that has already resolved the row live,
+	// and each entry names it — the scan reads one function at a time and cannot
+	// follow either edge.
+	"internal/modules/people:resolveOrCreateAnchor":        "guarded in its helper: anchorOrganization carries `WHERE is_anchor AND archived_at IS NULL FOR UPDATE`, so the row this renames was resolved live and is held for the rest of the transaction",
+	"internal/modules/people:recordGeocodeAfter":           "guarded by addressHashInTx, which re-reads the address `WHERE id = $1 AND archived_at IS NULL`: an archived company yields no hash, the comparison fails, and the function returns without writing. The liveness and the address-moved check are one test",
+	"internal/modules/people:writeOrgColumn":               "the read-back's column writer, reached only through applyEvidenceFieldsWithOverwrite from three entry points that each take auth.EnsureWritableLive on the organization first: the cold-start accept (gateResolvedColdStartTarget), ApplyDeepReadTx, and Enrich",
+	"internal/modules/people:applyUnclaimedOrgColumn":      "the fill arm of writeOrgColumn and reached only through it, so it inherits the same three live-probed entry points",
+	"internal/modules/people:writeCompanyFields":           "the company form's writer, reached only after resolveOrCreateAnchor has resolved the anchor through anchorOrganization's `archived_at IS NULL` and locked it for the transaction",
+	"internal/modules/people:touchRevertedPerson":          "the aggregate bump after a revert removed a child row. RevertProviderFills holds this contact FOR UPDATE with IncludeArchived from the top of its transaction — deliberately, because the subject of a bought-data revert may be archived — so re-taking liveness here would refuse the case the function exists for",
+	"internal/modules/activities:finalizeRelinkedActivity": "the row is already held FOR UPDATE by relinkActivityRow, its only caller, through lockActivityForWrite — two hops past what a per-function scan follows, and the same indirection updateguard ratifies for this function",
+	"internal/modules/deals:recomputeOfferTotals":          "every caller holds the offer row lock through visibleOfferLocked, except createOfferTx where the offer was inserted in the same transaction",
+	"internal/modules/customfields:Rename":                 "runs under the catalog row lock lockField mints, and the field's own mutability is checked under it. custom_field is retired through `status`; nothing in the tree writes its archived_at",
+	"internal/modules/customfields:setOptionsInTx":         "runs under the catalog row lock lockPicklistField mints, plus the per-table advisory lock serializeSchemaChange takes, and the same status-not-archived_at retirement applies",
+	"internal/modules/people:recomputeUnderOverrideTx":     "the scoring pass refreshing the machine value beside a human override. Its subject comes from the recompute's own selection of live leads, and the CAS on score_computed is what makes a lost race write nothing",
+
+	// THE WRITE CANNOT REACH A RETIRED ROW, because of what it is rather than
+	// because of a predicate. Each says which fact makes that true.
+	"internal/modules/capture:limitLinkLessAudience":      "the activity was INSERTed by this same transaction a few statements earlier, so there is no archived row for it to find — the function's own check is that exactly one row moved",
+	"internal/modules/capture:commitSyncCursor":           "fenced by the generation, not by liveness: withdrawing a connection bumps it, so a sync that started before the withdrawal finds its generation gone and reports itself superseded instead of writing a watermark onto a retired grant",
+	"internal/modules/capture:AdvanceChannelPollOffsetTx": "the poller's watermark for a connection its own live selection handed it, and the statement only ever moves the offset FORWARD (`poll_offset < $3`), so a late write from a retired cycle matches nothing",
+	"internal/modules/capture:backfillWorkspace":          "a one-time relocation of credential material out of the `auth` column and into the vault. It MUST reach withdrawn connections: leaving their secrets in a column the vault was introduced to empty is the defect, and the row is claimed with `credential_ref IS NULL` so two boots relocate once",
+
+	// MACHINE ATTRIBUTION AND DERIVED STATE. None of these carries anything a
+	// reader is shown as the record's own content, and each is chosen by a pass
+	// with its own selection rather than by a caller naming a row.
+	"internal/modules/activities:writeDerivedAudienceTx":        "narrowing a message to its participants, pinned on the audience the caller read under FOR UPDATE. Narrowing an archived message is not a change to what anybody may see of a live one, and refusing it would leave the derivation half-applied",
+	"internal/modules/activities:reKeyActivity":                 "restating the provider identity of a captured message so a later delivery folds into it rather than duplicating it. An absorbed echo is archived by design and is exactly the row whose identity has to be re-keyed",
+	"internal/modules/activities:StampCorrespondenceForProject": "the retention CLASSIFICATION, which decides how long a message must be kept. An archived message still has a statutory window, and the stamp only ever fills a class nobody has set",
+	"internal/modules/signals:dropUnattributable":               "the resolver recording that a market signal matched no organization. The row is one the resolution pass selected, and the write moves resolution_state alone — no content, no link",
+	"internal/modules/signals:resolveToOrg":                     "the resolver stamping the single-candidate match on a signal its own pass selected; the person link it may write is separately consent-gated and never creates a record",
+	"internal/modules/signals:flagAmbiguous":                    "the resolver flagging a signal for review when several organizations are plausible, on a row from the same pass. It links nobody and resolves nothing",
+	"internal/modules/people:setDedupeDispositionTx":            "disposing a duplicate-candidate row, not either record it names. `disposition = 'open'` is the guard, and a candidate is closed rather than archived",
+	"internal/modules/people:reopenDedupeCandidateTx":           "the undo of the same disposition, read and written under the candidate's own lock; nothing writes dedupe_candidate.archived_at",
+	"internal/modules/people:RefreshDisplayNameTx":              "showing the name a contact's own first and last columns already carry. It refuses a name a human set, and an erasure NULLs both halves — so an erased subject fails the both-halves check before any write is attempted",
+	"internal/modules/people:completePersonName":                "filling first and last from a confident parse, and only into columns that are both still empty. The predicate is also the concurrency guard, and an erased subject has had them nulled with the row's other identity columns",
+	"internal/modules/people:absorbOrgReferences":               "the merge relinking a retired source's references onto its survivor. A merge deliberately reaches the row it is retiring — that is what a merge is — and mergePair resolved the pair under LockPair before this runs",
+	"internal/modules/ai:persistBuildVersion":                   "recording the artifact a voice build produced, on the profile that build was raised for. The build row carries the profile id and the build itself is the selection; nothing in the tree writes voice_profile.archived_at",
+	"internal/modules/ai:finishBuildTx":                         "closing out a build's own status row. A build is completed or failed, never archived, and the row is the one this pass is executing",
+	"internal/modules/ai:RecordSendOutcomeTx":                   "closing a learning signal on the human's judgment of a draft, on a row lockJudgeableSignal has already held and confirmed is still `drafted`. That guard is narrower than liveness",
+	"internal/modules/knowledge:DeleteDocument":                 "destroying a corpus document and its passages, under the document's own FOR UPDATE. A destruction that refused a retired document would leave its bytes and its embeddings behind",
+	"internal/modules/knowledge:reconcilePages":                 "the boot-time handbook reconcile, which withdraws pages an earlier release shipped and this one does not. The set it acts on is derived from what the binary carries, not from a caller",
+	"internal/modules/knowledge:replacePage":                    "the same reconcile replacing a page whose checksum moved, on a document it just resolved as managed by the handbook source",
+	"internal/modules/introductions:Decide":                     "an ask's decision, pinned on the version the decider read (`AND version = $6`) and admitted by the state machine May() checks first. An intro_request is closed, never archived",
+	"internal/modules/introductions:Complete":                   "the same move, recording that the introduction happened or that a name was dropped instead, under the same version pin",
+	"internal/modules/introductions:Cancel":                     "the same move, withdrawing the ask — a retraction, and the one direction an archived anchor must never freeze",
+})
+
+// retirableTables derives the set of tables that can hold an archived row from
+// the migration sources — every CREATE TABLE carrying archived_at, plus the
+// tables that grew the column in a later ALTER. Derived rather than listed, so
+// a table that becomes retirable widens this census on its own.
+func retirableTables(t *testing.T) map[string]bool {
+	t.Helper()
+	tables := map[string]bool{}
+	for _, root := range []string{"migrations/core", "migrations/custom"} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".up.sql") {
+				return err
+			}
+			raw, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.up.sql file from walking the trusted migrations tree
+			if err != nil {
+				return err
+			}
+			current := ""
+			for _, line := range strings.Split(string(raw), "\n") {
+				if m := createTableLine.FindStringSubmatch(line); m != nil {
+					current = m[1]
+					continue
+				}
+				if strings.HasPrefix(line, ");") {
+					current = ""
+					continue
+				}
+				if current != "" && archivedColumnLine.MatchString(line) {
+					tables[current] = true
+				}
+			}
+			for _, m := range addedArchivedColumn.FindAllStringSubmatch(string(raw), -1) {
+				tables[m[1]] = true
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(tables) < retirableTableFloor {
+		t.Fatalf("derived only %d retirable tables from the migrations and expect at least %d — "+
+			"the derivation is broken, not the schema", len(tables), retirableTableFloor)
+	}
+	return tables
+}
+
+// byIDWritesIn names the retirable tables these statements write one row of by
+// id. A table outside the set answers nothing about liveness because it cannot
+// hold an archived row.
+func byIDWritesIn(statements []string, retirable map[string]bool) map[string]bool {
+	written := map[string]bool{}
+	for _, lit := range statements {
+		for _, m := range byIDWriteOf.FindAllStringSubmatch(lit, -1) {
+			if retirable[m[1]] {
+				written[m[1]] = true
+			}
+		}
+	}
+	return written
+}
+
+// statesLiveness reports whether this function answers the liveness question at
+// all, either way. It reads the function's own frame: the statements it runs
+// and the names it calls.
+//
+// The marker is deliberately NOT attributed to the table being written, which is
+// where updateguard's lock credit is stricter. It cannot be: the liveness that
+// governs a child write is frequently its ANCHOR's — a deal room's deal, a
+// contract's organization — so requiring the probe and the statement to name one
+// table would refuse the shape this rule is mostly about. What that costs is a
+// function whose marker belongs to some other row; what insisting would cost is
+// a waiver on every correct anchor-gated write in the tree.
+func statesLiveness(fn *ast.FuncDecl, statements []string) bool {
+	for _, lit := range statements {
+		if livePredicate.MatchString(lit) {
+			return true
+		}
+	}
+	stated := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.SelectorExpr:
+			if livenessMarkers[node.Sel.Name] {
+				stated = true
+			}
+		case *ast.Ident:
+			// A marker this package spells without a qualifier — identity's
+			// LiveMemberSQL is called from inside its own package.
+			if livenessMarkers[node.Name] {
+				stated = true
+			}
+		}
+		return true
+	})
+	return stated
+}
+
+func TestEveryByIDWriteOfARetirableRowAnswersForLiveness(t *testing.T) {
+	t.Parallel()
+	defer livenessUnstated.AssertAllMatched(t)
+	retirable := retirableTables(t)
+	fset := token.NewFileSet()
+	heldCache := map[string]map[string][]string{}
+	judged := 0
+	for _, root := range []string{"internal/modules", "internal/compose", "internal/platform"} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") ||
+				isIntegrationTagged(path) {
+				return err
+			}
+			path = filepath.ToSlash(path)
+			file, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				return err
+			}
+			// Read once per FILE rather than per function: the imports are the
+			// file's, and heldStatements caches per package anyway.
+			var imported []map[string][]string
+			for _, dir := range inModuleImportDirs(file) {
+				imported = append(imported, heldStatements(t, heldCache, dir))
+			}
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				statements := statementsJudged(fn, heldStatements(t, heldCache, filepath.Dir(path)), imported)
+				written := byIDWritesIn(statements, retirable)
+				if len(written) == 0 {
+					continue
+				}
+				judged++
+				if statesLiveness(fn, statements) {
+					continue
+				}
+				key := filepath.ToSlash(filepath.Dir(path)) + ":" + fn.Name.Name
+				if livenessUnstated.Waived(t, key) {
+					continue
+				}
+				t.Errorf("%s: %s writes one row of %s by id and answers nothing about liveness — "+
+					"refuse an archived row (an archived_at IS NULL predicate, a *Live probe, a LiveOnly lock "+
+					"or patch), DECLARE that this write reaches one on purpose (auth.EnsureRetractable, "+
+					"storekit.IncludeArchived), or ratify it in livenessUnstated with where the liveness is",
+					path, fn.Name.Name, strings.Join(sortedTables(written), ", "))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A census that judged nothing certifies nothing, and this one has two ways
+	// to go quiet: the walk can stop finding files, and the statement reader can
+	// stop finding writes inside them. Neither produces a finding on its own —
+	// they produce a smaller silence, which is what the floor is for.
+	if judged < byIDWriteFloor {
+		t.Fatalf("this census judged %d function(s) writing a retirable row by id and expects at least %d — "+
+			"the reader has stopped seeing statements rather than the tree having lost them",
+			judged, byIDWriteFloor)
+	}
+}
+
+// sortedTables renders a finding's tables in a stable order, so one function's
+// message does not change between runs over map iteration.
+func sortedTables(written map[string]bool) []string {
+	out := make([]string, 0, len(written))
+	for table := range written {
+		out = append(out, table)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/backend/gates/writelivenesscases_test.go
+++ b/backend/gates/writelivenesscases_test.go
@@ -37,6 +37,22 @@ type livenessCase struct {
 	// not a subject is never asked the second.
 	subject bool
 	stated  bool
+	// answers is the per-TABLE verdict on the in-statement half: which tables
+	// this function refuses an archived row of in the text of the write itself.
+	// A Go marker covers the frame and appears here as nothing, which is what
+	// the two-writes case below is for.
+	answers map[string]bool
+}
+
+// allAnswered reports whether every table this function writes refuses an
+// archived row in its own statement.
+func allAnswered(written map[string]bool) bool {
+	for _, answered := range written {
+		if !answered {
+			return false
+		}
+	}
+	return len(written) > 0
 }
 
 var livenessCases = []livenessCase{
@@ -49,7 +65,7 @@ func write(tx T) { tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WH
 		name: "the same write, refusing an archived row in its own predicate",
 		source: `package p
 func write(tx T) { tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1 AND archived_at IS NULL`" + `) }`,
-		subject: true, stated: true,
+		subject: true, stated: true, answers: map[string]bool{"organization": true},
 	}, {
 		// The restore arm's predicate is the OPPOSITE claim, and crediting it
 		// would hand every un-archive path a free pass.
@@ -129,6 +145,19 @@ var held = map[string]string{"legal_name": ` + "`UPDATE organization SET legal_n
 func write(tx T, column string) { tx.Exec(ctx, held[column]) }`,
 		subject: true,
 	}, {
+		// CodeRabbit's case, and the reason the in-statement half is attributed
+		// per table: a function that guards one write and leaves its sibling
+		// bare answers for one table and not the other, and the bare one has to
+		// be reported anyway.
+		name: "one write guarded and its sibling in the same function bare",
+		source: `package p
+func write(tx T) {
+	tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1 AND archived_at IS NULL`" + `)
+	tx.Exec(ctx, ` + "`UPDATE activity SET subject = $2 WHERE id = $1`" + `)
+}`,
+		subject: true,
+		answers: map[string]bool{"organization": true, "activity": false},
+	}, {
 		// The marker must be a call site, not prose. A gate that read comments
 		// would let a sentence about liveness stand in for one.
 		name: "a marker named only in a comment",
@@ -169,8 +198,18 @@ func TestTheLivenessCensusJudgesAWriteAndCreditsOnlyAnAnswer(t *testing.T) {
 			if !tc.subject {
 				return
 			}
-			if stated := statesLiveness(fn, statements); stated != tc.stated {
-				t.Errorf("credited as answering for liveness = %t, want %t", stated, tc.stated)
+			stated := statesLivenessInGo(fn)
+			for table, answered := range written {
+				if answered != tc.answers[table] {
+					t.Errorf("%s credited as refused in its own statement = %t, want %t",
+						table, answered, tc.answers[table])
+				}
+			}
+			if !stated && !allAnswered(written) && tc.stated {
+				t.Errorf("credited as answering for liveness = false, want true")
+			}
+			if (stated || allAnswered(written)) && !tc.stated {
+				t.Errorf("credited as answering for liveness = true, want false")
 			}
 		})
 	}

--- a/backend/gates/writelivenesscases_test.go
+++ b/backend/gates/writelivenesscases_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind falsification H2
+
+package gates
+
+// What the liveness census judges, and what it credits, driven with SYNTHETIC
+// source rather than the tree — the same reason updateguardcases_test.go gives
+// for its own. That census is meant to pass, so a reader proven only by "the
+// tree is clean" is one that keeps passing after it stops working: a write it
+// stops recognising produces no finding, only a smaller silence.
+//
+// Two halves fail differently and both are planted here. A write the SUBJECT
+// test stops seeing leaves the tree unjudged; a marker the CREDIT test starts
+// seeing everywhere waives the tree without a waiver. The first is the one that
+// goes quiet, so most cases below are its.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// retirableForCases is the table set the cases are judged against, written out
+// rather than derived: a case that shared the census's own derivation would pass
+// whenever that derivation broke.
+var retirableForCases = map[string]bool{"organization": true, "activity": true}
+
+// livenessCase is one synthetic function and the two verdicts it is owed.
+type livenessCase struct {
+	name   string
+	source string
+	// subject says whether this function writes one retirable row by id at all;
+	// stated says whether it answers the liveness question. A function that is
+	// not a subject is never asked the second.
+	subject bool
+	stated  bool
+}
+
+var livenessCases = []livenessCase{
+	{
+		name: "a by-id update of a retirable table, answering nothing",
+		source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1`" + `) }`,
+		subject: true,
+	}, {
+		name: "the same write, refusing an archived row in its own predicate",
+		source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1 AND archived_at IS NULL`" + `) }`,
+		subject: true, stated: true,
+	}, {
+		// The restore arm's predicate is the OPPOSITE claim, and crediting it
+		// would hand every un-archive path a free pass.
+		name: "archived_at IS NOT NULL, which is a reach for a retired row rather than a refusal",
+		source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`UPDATE organization SET archived_at = NULL WHERE id = $1 AND archived_at IS NOT NULL`" + `) }`,
+		subject: true,
+	}, {
+		name: "refused through the live probe",
+		source: `package p
+func write(tx T) {
+	auth.EnsureWritableLive(ctx, tx, "organization", id)
+	tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1`" + `)
+}`,
+		subject: true, stated: true,
+	}, {
+		// The declaration half. It must be credited or the pair is useless —
+		// a retraction would have to be waived, and a waiver is not a spelling
+		// a call site can be read for.
+		name: "declared as a retraction",
+		source: `package p
+func write(tx T) {
+	auth.EnsureRetractable(ctx, tx, "organization", id)
+	tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1`" + `)
+}`,
+		subject: true, stated: true,
+	}, {
+		name: "declared through the lock filter",
+		source: `package p
+func write(tx T) {
+	storekit.LockRow(ctx, tx, "organization", id, storekit.IncludeArchived)
+	tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1`" + `)
+}`,
+		subject: true, stated: true,
+	}, {
+		// The unqualified spelling: identity calls its own LiveMemberSQL with
+		// no package name in front of it, so a walk that read only qualified
+		// selectors judged seven login-path writes as answering nothing.
+		name: "refused through a same-package helper called without a qualifier",
+		source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`UPDATE activity SET body = NULL WHERE id = $1 AND `" + ` + LiveMemberSQL("")) }`,
+		subject: true, stated: true,
+	}, {
+		// Out of scope BY CONSTRUCTION, and the boundary has to hold: a cascade
+		// over a parent's children takes its liveness from the parent that
+		// chose them, and pulling it in would waive most of the privacy module.
+		name: "a set-based write, which is not a by-id write",
+		source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`UPDATE activity SET archived_at = now() WHERE organization_id = $1`" + `) }`,
+	}, {
+		name: "an insert, which creates a row rather than reaching a standing one",
+		source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`INSERT INTO activity (id, subject) VALUES ($1, $2)`" + `) }`,
+	}, {
+		name: "a by-id delete, which reaches a standing row exactly as an update does",
+		source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`DELETE FROM activity WHERE id = $1`" + `) }`,
+		subject: true,
+	}, {
+		name: "a by-id write under a table alias",
+		source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`UPDATE activity a SET subject = $2 WHERE a.id = $1`" + `) }`,
+		subject: true,
+	}, {
+		// A table with no archived_at has no archived row to refuse, and asking
+		// it the question would produce a waiver that says nothing.
+		name: "a by-id write of a table that cannot be retired",
+		source: `package p
+func write(tx T) { tx.Exec(ctx, ` + "`UPDATE audit_log SET action = $2 WHERE id = $1`" + `) }`,
+	}, {
+		// The shape the tree already writes: the organization column writers
+		// hold their statements in package-level tables, so a reader of body
+		// literals alone judged none of them.
+		name: "held in a package-level table the function indexes",
+		source: `package p
+var held = map[string]string{"legal_name": ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1`" + `}
+func write(tx T, column string) { tx.Exec(ctx, held[column]) }`,
+		subject: true,
+	}, {
+		// The marker must be a call site, not prose. A gate that read comments
+		// would let a sentence about liveness stand in for one.
+		name: "a marker named only in a comment",
+		source: `package p
+func write(tx T) {
+	// EnsureWritableLive is what this ought to take.
+	tx.Exec(ctx, ` + "`UPDATE organization SET legal_name = $2 WHERE id = $1`" + `)
+}`,
+		subject: true,
+	},
+}
+
+func TestTheLivenessCensusJudgesAWriteAndCreditsOnlyAnAnswer(t *testing.T) {
+	t.Parallel()
+	for _, tc := range livenessCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "synthetic.go", tc.source, 0)
+			if err != nil {
+				t.Fatalf("parsing the case source: %v", err)
+			}
+			var fn *ast.FuncDecl
+			for _, decl := range file.Decls {
+				if candidate, isFunc := decl.(*ast.FuncDecl); isFunc && candidate.Name.Name == "write" {
+					fn = candidate
+				}
+			}
+			if fn == nil {
+				t.Fatal("the case source declares no write function, so it proves nothing")
+			}
+			statements := statementsJudged(fn, packageLevelStatements([]*ast.File{file}), nil)
+
+			written := byIDWritesIn(statements, retirableForCases)
+			if subject := len(written) > 0; subject != tc.subject {
+				t.Fatalf("judged as a by-id write of a retirable row = %t, want %t — a write this census "+
+					"does not judge is one it reports PASS over rather than reporting a gap in", subject, tc.subject)
+			}
+			if !tc.subject {
+				return
+			}
+			if stated := statesLiveness(fn, statements); stated != tc.stated {
+				t.Errorf("credited as answering for liveness = %t, want %t", stated, tc.stated)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/activities/capturelabel.go
+++ b/backend/internal/modules/activities/capturelabel.go
@@ -69,10 +69,15 @@ func (s *Store) UnlabeledCaptureEmails(ctx context.Context, limit, bodyLimit int
 // earlier verdict stands, never an overwrite.
 func (s *Store) SetCaptureLabel(ctx context.Context, id ids.UUID, label string) (applied bool, err error) {
 	err = s.db.Tx(ctx, func(tx pgx.Tx) error {
-		// Both exclusions are re-tested at WRITE time, not only in the backlog
-		// that selected this row. The classifier reads a batch, spends a model
-		// call per message and writes the answers back, and the row can change
-		// inside that window.
+		// All THREE exclusions are re-tested at WRITE time, not only in the
+		// backlog that selected this row. The classifier reads a batch, spends a
+		// model call per message and writes the answers back, and the row can
+		// change inside that window.
+		//
+		// The archive: a noise disposition or the retention sweep takes the
+		// message off the timeline, and a label landing afterwards puts a
+		// hidden message back on a shared worklist. Nothing would clear it —
+		// the backlog excludes archived rows, so no later pass revisits one.
 		//
 		// The audience: a human or a verdict limits the message, and without
 		// this clause the write lands after the narrowing and re-labels a
@@ -88,7 +93,7 @@ func (s *Store) SetCaptureLabel(ctx context.Context, id ids.UUID, label string) 
 		// attempt to remove it.
 		tag, err := tx.Exec(ctx, `
 			UPDATE activity SET capture_label = $2, capture_labeled_at = now()
-			WHERE id = $1 AND capture_label IS NULL
+			WHERE id = $1 AND capture_label IS NULL AND archived_at IS NULL
 			  AND audience = 'workspace' AND restricted_at IS NULL`, id, label)
 		if err != nil {
 			return fmt.Errorf("activities: setting capture label: %w", err)

--- a/backend/internal/modules/activities/pipelinefacts_integration_test.go
+++ b/backend/internal/modules/activities/pipelinefacts_integration_test.go
@@ -348,3 +348,50 @@ func TestTheLabelWriteLosesToANarrowingThatLandedWhileTheModelThought(t *testing
 		t.Errorf("an open message was not labelled (wrote=%v err=%v) — the re-check refuses more than the audience", wrote, err)
 	}
 }
+
+// The same window, and the third exclusion the write owes: the message is taken
+// off the timeline while the model is thinking.
+//
+// A noise disposition and the retention sweep both archive a captured message,
+// and the backlog excludes archived rows — so a label that lands afterwards is
+// never revisited by any later pass. What it leaves is a hidden message on a
+// shared worklist, which is the same defect the narrowing case above describes
+// with a different cause.
+func TestTheLabelWriteLosesToAnArchiveThatLandedWhileTheModelThought(t *testing.T) {
+	e := setupFacts(t)
+	ctx := e.as()
+
+	open := e.seed(t, capturedRow{kind: "email"})
+	backlog, err := e.store.UnlabeledCaptureEmails(ctx, 200, 200)
+	if err != nil {
+		t.Fatalf("reading the backlog: %v", err)
+	}
+	offered := false
+	for _, row := range backlog {
+		if row.ID == open {
+			offered = true
+		}
+	}
+	if !offered {
+		t.Fatalf("the open message was not offered to the classifier — the fixture proves nothing about the race")
+	}
+
+	// The model call happens here, in production. The archive lands during it.
+	e.exec(t, `UPDATE activity SET archived_at = now() WHERE id = $1`, open)
+
+	applied, err := e.store.SetCaptureLabel(ctx, open, "commitment")
+	if err != nil {
+		t.Fatalf("writing the label: %v", err)
+	}
+	if applied {
+		t.Error("the classifier labelled a message archived while it was thinking — nothing revisits an archived row to clear it")
+	}
+	var label *string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT capture_label FROM activity WHERE id = $1`, open).Scan(&label); err != nil {
+		t.Fatal(err)
+	}
+	if label != nil {
+		t.Errorf("the archived message carries label %q", *label)
+	}
+}

--- a/backend/internal/modules/people/providerclaimrevertfields.go
+++ b/backend/internal/modules/people/providerclaimrevertfields.go
@@ -41,8 +41,14 @@ func revertOne(ctx context.Context, tx pgx.Tx, f appliedField) (bool, error) {
 }
 
 // revertColumn clears person.title while it still says what was written.
+//
+// Retractable rather than live, and that is the whole shape of this file: taking
+// bought data back off a contact is a RETRACTION, so an archived subject is the
+// one it must most be able to reach. RevertProviderFills holds the row with
+// IncludeArchived for exactly that reason, and a live probe here would refuse
+// the privacy control on every contact somebody has since retired.
 func revertColumn(ctx context.Context, tx pgx.Tx, f appliedField) (bool, error) {
-	if err := auth.EnsureWritable(ctx, tx, entityPerson, f.subject); err != nil {
+	if err := auth.EnsureRetractable(ctx, tx, entityPerson, f.subject); err != nil {
 		return false, err
 	}
 	if f.field != fieldTitle || f.value == nil {

--- a/docs/explanation/write-backbone.md
+++ b/docs/explanation/write-backbone.md
@@ -299,6 +299,7 @@ You don't have to remember these — a fitness test fails your PR if you break o
 | Every audited mutation also emits an outbox event (in the same function) | `writeshape_test.go` |
 | `audit_log` / `event_outbox` are written only through `storekit` | `tableownership_test.go` |
 | A by-id UPDATE of a versioned row carries a concurrency guard | `updateguard_test.go` |
+| A by-id write of a row that can be archived refuses one, or says it reaches one on purpose | `writeliveness_test.go` |
 | The `audit_log` `action`/`actor_type` CHECK sets equal their Go enums | `enumsync_test.go` |
 | A comment credits row-level security with a guarantee no schema in this tree carries | `rlsclaims_test.go` |
 | Errors are classified by SQLSTATE, never `Error()` text | `errmatch_test.go` |
@@ -317,6 +318,11 @@ You don't have to remember these — a fitness test fails your PR if you break o
   `Validate` fail at the write, which is where you want to find out.
 - **Bind a `correlation_id`** on any write path the HTTP/runner middleware doesn't cover (a bespoke
   background job).
+- **Pick a side on liveness.** `auth.EnsureWritableLive` is what a write that ADDS to a record owes —
+  archived means frozen. `auth.EnsureRetractable` is its twin for a write that REVOKES, VOIDS,
+  CANCELS or RETRACTS: an archived anchor must never freeze the cleanup its own retirement implies.
+  The two run the same probes and differ in which one a reader (and `writeliveness_test.go`) can see
+  you chose.
 
 ## Where the code lives
 

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -210,7 +210,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `writeauthorityreach_test.go` | H2 | Every write of a shareable record reaches a write-authority probe. |
 | `writeshape_test.go` | H2 | The write-shape obligation as a fitness function: every mutation that writes an audit row commits a paired outbox event on the same static call path (data-model §11, events.md §4.2 — spelled once in storekit), across modules AND the composition layer. |
 
-## Shape (21)
+## Shape (22)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -235,6 +235,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `updateguard_test.go` | H2 | The concurrency-guard obligation as a fitness function: every single-row-by-id UPDATE of a mutable entity carries SOME guard — the optimistic version (storekit.ApplyWithVersion / ApplyGuarded), a held row lock (LockRow / LockPair + ApplyLocked), an advisory lock, an in-statement FOR UPDATE, or a checked conditional write (the RowsAffected CAS shape). |
 | `userrecordviewwriter_test.go` | H2 | user\_record\_view carries one fact per (user, record): the moment that human last said "I have seen this". |
 | `writeauthority_test.go` | H2 | The read/write asymmetry of a manual record grant, as a fitness function: a path that CHANGES a shareable record probes for write authority, not for visibility. |
+| `writeliveness_test.go` | H2 | The LIVENESS obligation as a fitness function: a write that targets one standing row of a table which can be archived either REFUSES an archived row, DECLARES that it deliberately reaches one, or is ratified with a reason. |
 
 ## Prohibition (43)
 
@@ -305,7 +306,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `rulebooklength_test.go` | H3 | A rulebook is read in full by every session and, for its Craftsmanship section, by every gate prompt — so its length is a running cost rather than a matter of taste. |
 | `workflowtimeouts_test.go` | H3 | Every workflow job carries a wall-clock ceiling. |
 
-## Falsification (9)
+## Falsification (10)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -318,3 +319,4 @@ The eight shapes, what each is for, and how each one silently passes:
 | `retainedcolumncases_test.go` | H1 | The retention sweep's two SQL claims, driven with SYNTHETIC statements rather than the tree — the same reason extensionsqlscopecases\_test.go gives for its own cases. |
 | `triggerwrittencolumncases_test.go` | H2 | The trigger-written-column reader driven with SYNTHETIC statements, for the reason retainedcolumncases\_test.go gives for its own: the tree is supposed to pass, so a reader proven only by "nothing in the tree trips it" is one that keeps passing after it stops working. |
 | `updateguardcases_test.go` | H2 | What the concurrency-guard census judges a function on, driven with SYNTHETIC source rather than the tree — the same reason retainedcolumncases\_test.go gives for its own cases. |
+| `writelivenesscases_test.go` | H2 | What the liveness census judges, and what it credits, driven with SYNTHETIC source rather than the tree — the same reason updateguardcases\_test.go gives for its own. |


### PR DESCRIPTION
Closes https://github.com/gradionhq/margince-poc-v1/issues/2202.
Part of https://github.com/gradionhq/margince-poc-v1/issues/2145 — the highest-value item on that tracker, and the last one that needed the holes closed first (ruling 6). https://github.com/gradionhq/margince-poc-v1/pull/4057 closed them.

## The gap

A write in this tree owes **four** obligations. Three have fitness functions:

| Obligation | Gate |
|---|---|
| writes only tables it owns | `tableownership_test.go` |
| carries a concurrency guard | `updateguard_test.go` |
| probes *write* authority, not visibility | `writeauthority_test.go` + `writeauthorityreach_test.go` |
| audits **and** emits | `writeshape_test.go` |
| **liveness — may this write touch a row somebody archived or erased?** | **nothing** |

That one gap produced eight defects across `organization`, `person`, `person_consent`, `attachment`, `contract`, `commission_entry` and `site_read`. What they had in common was not a module or a table — every one was individually defensible where it sat. Nothing asked the question.

## The gate

`TestEveryByIDWriteOfARetirableRowAnswersForLiveness`: a function that writes **one row of an archivable table by id** must do one of two things.

- **REFUSE** an archived row — an `archived_at IS NULL` predicate, a `*Live` probe, a `LiveOnly` lock or patch.
- **DECLARE** that it reaches one on purpose — `auth.EnsureRetractable`, or `storekit.IncludeArchived`.

Anything else is ratified in `livenessUnstated` with **where the liveness actually is**. No entry reads "known defect, see issue" — ruling 6 — so a waiver here states that the obligation is met some other way, never that it is owed and unpaid.

**The declaration half is what makes this hold a line a scanner otherwise cannot.** "No liveness here" is *correct* for Art. 17 erasure, for the retention sweep, for a merge retiring its source, and for every retraction. Before `EnsureRetractable` existed, that case and a forgotten filter were the same text.

**Enforcement is a gate and NOT a trigger**, deliberately — this is ruling 5 on the tracker overruling its own issue body. The geocode-trigger precedent does not generalise: Art. 17 and the retention sweep *must* write archived rows (`archived_at = coalesce(archived_at, now())` runs through those statements), so a row-level refusal would refuse the destruction the archive is a step of. Liveness is a property of the call site.

**Scope** is single-row-by-id UPDATE and DELETE, the same boundary `updateguard_test.go` draws. A set-based write takes its liveness from the parent that selected it. An INSERT is out for a different reason: a row being created has no `archived_at` to violate, and the liveness its *anchor* owes is a separate question with a separate answer (https://github.com/gradionhq/margince-poc-v1/issues/1405).

The table set is derived from the migrations — every `CREATE TABLE` carrying `archived_at` plus the tables that grew it in a later `ALTER` — so a table that becomes retirable widens the census on its own.

## What it found

145 functions judged; 52 ratified. The waivers group into the families the tracker's handoff had already derived: erasure and retention must write archived rows; the retirement transitions themselves; the liveness is one frame up (named per entry); the write cannot reach a retired row because of what it is.

**Two could say nothing true, and were fixed:**

1. **`SetCaptureLabel` labelled a message archived while the model was thinking.** Its docblock promises the exclusions are re-tested at write time and re-tests two of three — the audience and the statutory hold — and not the archive. A noise disposition or the retention sweep takes the message off the timeline during the model call; the label lands after, and **nothing revisits an archived row to clear it**, because the backlog excludes them. What it leaves is a hidden message on a shared worklist. Same defect as the narrowing case the file already tests, different cause.
2. **`revertColumn` now takes `auth.EnsureRetractable`.** Taking bought data back off a contact is a retraction, and `RevertProviderFills` already holds the row with `IncludeArchived` for exactly that reason. The two probes run the same statements, so **behaviour is unchanged** — what changes is that the call site says which side it took, and a live probe there would have refused the privacy control on every retired contact.

## Anti-vacuity

Rule 8 says a census that can fail short has already failed, so:

- Two floors: `byIDWriteFloor` (the walk or the statement reader going quiet) and `retirableTableFloor` (the migration derivation reading nothing, which would exempt the entire tree while reporting a clean run).
- `livenessUnstated.AssertAllMatched` names any ratified function the reader stops seeing.
- `writelivenesscases_test.go` drives both halves from **synthetic source**, because a reader proven only by "the tree is clean" keeps passing after it stops working. 14 cases: what the census must SEE (a by-id DELETE, an aliased `a.id = $1`, a statement hoisted to a package-level table — the shape the organization column writers actually use) and what it must NOT credit (`archived_at IS NOT NULL`, which is the *restore* arm's claim; a marker named only in a comment; a set-based write).

One credit is deliberately looser than `updateguard`'s: the marker is **not** attributed to the table being written. It cannot be — the liveness that governs a child write is frequently its anchor's, so requiring probe and statement to name one table would refuse the shape this rule is mostly about. The cost is written down where the code makes the trade.

## Tests

`TestTheLabelWriteLosesToAnArchiveThatLandedWhileTheModelThought` — beside its narrowing twin, same fixture, same race. Verified it fails against the unfixed statement and passes with it.

Verified: `go test ./gates/` (full suite), `go test ./internal/...`, the `activities` and `compose/integration` integration lanes, `craft static --strict` over the diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented labels from being applied to activities archived while processing is in progress.
  * Allowed retraction of titles on archived contacts where appropriate.

* **Tests**
  * Added coverage to verify archive-aware write behavior and liveness handling across updates and deletes.

* **Documentation**
  * Clarified archive-aware write rules and updated the gate inventory to reflect new validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->