### PR TITLE
Two gates hold the outbound decision record

### DIFF
--- a/backend/gates/authzcategories_test.go
+++ b/backend/gates/authzcategories_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// The outbound category vocabulary is spelled TWICE — once in Go, once as a
+// CHECK constraint on communication_decision — and the two must agree.
+//
+// The failure this exists to stop is silent and one-directional. A category
+// added to the Go vocabulary and forgotten in the constraint passes every
+// compile, every unit test and every review: the engine resolves it happily,
+// and the INSERT that records the decision then fails at runtime, inside the
+// send transaction, on the message that used it. A resolution the database
+// refuses to store is a send nobody can explain afterwards, which is the whole
+// property communication_decision exists to provide.
+//
+// The reverse — a value in the constraint the Go vocabulary does not know — is
+// the milder half and is checked too, because it means the constraint is
+// admitting something no code can produce, and the next reader takes that
+// permission for a specification.
+//
+// It reads the SHIPPED migration rather than a live schema. The constraint is
+// additive-only under the migration rule, so the file that created it is the
+// file that still defines it, and a gate needing a database would not run in
+// the unit lane where a vocabulary edit is actually made.
+//
+// What this gate deliberately does NOT assert: that every category has a
+// validator arm. Nine of the fourteen resolve to `default:` in
+// consent/authorizevalidators.go and stay unsupported on purpose — they have no
+// record evidence to read, so they fall through to the legacy verdict. That is
+// a documented design choice, and a gate demanding otherwise would fail against
+// correct code.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/ports/commsauthz"
+)
+
+// decisionMigration is the migration that created communication_decision and
+// its CHECK constraints. Named rather than globbed: a glob that matched nothing
+// would report PASS, which is the shape of under-recognition this repository
+// treats as a failure in itself.
+const decisionMigration = "1788407500_a_send_records_why_it_was_allowed.up.sql"
+
+// categoryConstraint captures the ARRAY body of the resolved_category CHECK.
+var categoryConstraint = regexp.MustCompile(
+	`(?s)CONSTRAINT communication_decision_category\s*CHECK \(resolved_category = ANY \(ARRAY\[(.*?)\]\)\)`)
+
+// quotedLiteral picks each 'value'::text out of a constraint body.
+var quotedLiteral = regexp.MustCompile(`'([a-z_]+)'::text`)
+
+func TestTheCategoryVocabularyAgreesWithItsCheckConstraint(t *testing.T) {
+	t.Parallel()
+
+	sql := readDecisionMigration(t)
+	body := categoryConstraint.FindStringSubmatch(sql)
+	if body == nil {
+		// A renamed constraint is not a reason to pass. If this fires after a
+		// deliberate rename, repoint the pattern — never delete the assertion.
+		t.Fatalf("no communication_decision_category CHECK found in %s: the constraint this gate "+
+			"holds against the Go vocabulary has moved or been renamed", decisionMigration)
+	}
+
+	inSQL := map[string]bool{}
+	for _, m := range quotedLiteral.FindAllStringSubmatch(body[1], -1) {
+		inSQL[m[1]] = true
+	}
+	if len(inSQL) == 0 {
+		t.Fatalf("the %s constraint body parsed to no values — the gate is reading the wrong text",
+			decisionMigration)
+	}
+
+	inGo := map[string]bool{}
+	for _, c := range commsauthz.Categories() {
+		inGo[string(c)] = true
+	}
+
+	for _, missing := range difference(inGo, inSQL) {
+		t.Errorf("category %q is in the Go vocabulary but not in the CHECK constraint: "+
+			"the engine can resolve it and the INSERT recording that decision will fail "+
+			"inside the send transaction", missing)
+	}
+	for _, extra := range difference(inSQL, inGo) {
+		t.Errorf("category %q is admitted by the CHECK constraint but is not a Category: "+
+			"the constraint permits a value nothing can produce", extra)
+	}
+}
+
+// TestEveryCategoryCarriesADistinctWireValue holds the property the constraint
+// comparison above silently depends on.
+//
+// Categories() is built from a map keyed by the Category values themselves, so
+// two constants sharing a string would collapse into ONE member — and the
+// comparison against the constraint would still pass, having compared a
+// vocabulary that had already lost a member. A census that can fail short has
+// already failed, so the count is asserted against the declared constants
+// rather than against itself.
+func TestEveryCategoryCarriesADistinctWireValue(t *testing.T) {
+	t.Parallel()
+
+	seen := map[commsauthz.Category]bool{}
+	for _, c := range commsauthz.Categories() {
+		if seen[c] {
+			t.Errorf("category %q appears twice in the vocabulary", c)
+		}
+		seen[c] = true
+		if strings.TrimSpace(string(c)) == "" {
+			t.Error("a category carries an empty wire value")
+		}
+		if !c.Valid() {
+			t.Errorf("category %q is listed by Categories() but Valid() denies it", c)
+		}
+	}
+	// The five that serve the subject are the ones a hard suppression may not
+	// stop. Asserting the COUNT here means a sixth cannot be added silently:
+	// ServesTheSubject widens what reaches somebody who asked us to stop, so it
+	// is the one predicate in this vocabulary that must never grow by accident.
+	serving := 0
+	for _, c := range commsauthz.Categories() {
+		if c.ServesTheSubject() {
+			serving++
+		}
+	}
+	if want := 5; serving != want {
+		t.Errorf("%d categories serve the subject, want %d: this predicate decides what passes a "+
+			"hard suppression, so a change here reaches somebody who asked us to stop", serving, want)
+	}
+}
+
+// readDecisionMigration returns the shipped migration's text.
+func readDecisionMigration(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("migrations", "core", decisionMigration)
+	sql, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(sql)
+}
+
+// difference lists the keys of a that b lacks, ordered so a failure reads the
+// same on every run.
+func difference(a, b map[string]bool) []string {
+	var out []string
+	for k := range a {
+		if !b[k] {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/backend/gates/decisioncoverage_test.go
+++ b/backend/gates/decisioncoverage_test.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// A message that reaches the send queue carries a decision saying why, written
+// in the transaction that staged it.
+//
+// The property is per-staging-method rather than per-file, and that is the
+// point: mail and channel are two implementations of one act, and the recurring
+// defect in this area is a fix landing on one of them. A method that stages a
+// delivery and enqueues the job WITHOUT authorizing it produces a delivery the
+// worker will send with nothing on record about why it exists — and it looks,
+// in review, exactly like the method next to it that does.
+//
+// Four obligations, all of which must appear in the same method body:
+//
+//   - it stages a row (comms.Store.Stage*Tx);
+//   - it authorizes (AuthorizeStagingTx) on the SAME transaction;
+//   - it refuses an absolute denial (refuseAbsoluteDenial) — the four refusals
+//     no rollout mode may soften;
+//   - it fails closed when no authority is wired, rather than staging anyway.
+//
+// The last one is why this gate is not satisfied by a bare call. A census sees
+// the CALL and cannot see that a nil authority made it a no-op; commsstager.go
+// says so in its own comment and defends with an explicit error. Asserting the
+// guard here is what keeps that defence from being deleted as belt-and-braces.
+//
+// NOT in the corpus: comms.Store.StageControllerTx. It has no production caller
+// on main — the controller mail lane it belongs to was never wired — so it
+// stages nothing today and an obligation on it would be an assertion about code
+// that does not run. It joins the corpus the moment a caller appears, because
+// the corpus is derived from who calls the stagers rather than listed here.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// stagingObligations are the calls a staging method must pair. Each is the
+// literal selector as it appears in source; a rename that broke one would fail
+// this gate rather than silently stop matching, because the staging call is
+// found the same way and a method matching none of them is not a subject.
+const (
+	callAuthorize = "AuthorizeStagingTx"
+	callRefuse    = "refuseAbsoluteDenial"
+	callEnqueue   = "EnqueueTx"
+)
+
+// stagerCalls are the delivery-row writers. A method calling one of these is
+// staging a message and owes the obligations above.
+var stagerCalls = []string{"StageTx", "StageChannelTx", "StageControllerTx"}
+
+func TestEveryStagedDeliveryCarriesItsAuthorization(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset,
+		"internal/compose/commsstager.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing the staging seam: %v", err)
+	}
+
+	subjects := map[string]map[string]bool{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		called := callsIn(fn)
+		if !stagesADelivery(called) {
+			continue
+		}
+		subjects[fn.Name.Name] = called
+	}
+
+	// Under-recognition is the one way this must not fail. A gate that parsed
+	// the wrong file, or a rename that made every method stop matching, would
+	// find no subjects and report PASS.
+	if len(subjects) < 2 {
+		t.Fatalf("found %d staging methods, want at least the mail and channel pair: "+
+			"the gate is looking in the wrong place or the stagers were renamed", len(subjects))
+	}
+
+	names := map[string]bool{}
+	for name := range subjects {
+		names[name] = true
+	}
+	for _, name := range sortedKeys(names) {
+		called := subjects[name]
+		for _, want := range []string{callAuthorize, callRefuse} {
+			if !called[want] {
+				t.Errorf("%s stages a delivery and never calls %s: the message reaches the "+
+					"send queue with nothing on record about why it was allowed", name, want)
+			}
+		}
+		if !called[callEnqueue] {
+			// Not an obligation in itself — it is what makes the others
+			// load-bearing. A stager that does not enqueue is not on the send
+			// path, and the gate should say so rather than pass quietly.
+			t.Errorf("%s stages a delivery and never enqueues a send job: "+
+				"this gate's corpus has drifted from the send path", name)
+		}
+	}
+}
+
+// TestAStagingPathWithNoAuthorityFailsRatherThanStages holds the guard a call
+// census cannot see.
+//
+// AuthorizeStagingTx appearing in the body proves the code was written; it does
+// not prove the authority was wired. A refactor dropping the field would
+// compile, stage every message with no decision, and satisfy the census above.
+// The explicit nil check is the defence, and this is what stops it being
+// removed as redundant.
+func TestAStagingPathWithNoAuthorityFailsRatherThanStages(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset,
+		"internal/compose/commsstager.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing the staging seam: %v", err)
+	}
+
+	guarded := 0
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || !stagesADelivery(callsIn(fn)) {
+			continue
+		}
+		if !guardsNilAuthority(fn) {
+			t.Errorf("%s does not refuse a missing authorization authority: without the guard a "+
+				"dropped field stages every message with no decision and still passes a call census",
+				fn.Name.Name)
+			continue
+		}
+		guarded++
+	}
+	if guarded < 2 {
+		t.Fatalf("%d staging methods carry the nil-authority guard, want at least the mail and "+
+			"channel pair", guarded)
+	}
+}
+
+// stagesADelivery reports whether a method writes a delivery row.
+func stagesADelivery(called map[string]bool) bool {
+	for _, stager := range stagerCalls {
+		if called[stager] {
+			return true
+		}
+	}
+	return false
+}
+
+// callsIn collects every selector called in a function body, by its final name
+// (`s.store.StageTx(...)` yields "StageTx"). The receiver is deliberately
+// ignored: this gate asks WHAT was called, and matching on the variable holding
+// the store would stop working the moment somebody renamed the field.
+func callsIn(fn *ast.FuncDecl) map[string]bool {
+	out := map[string]bool{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch f := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			out[f.Sel.Name] = true
+		case *ast.Ident:
+			out[f.Name] = true
+		}
+		return true
+	})
+	return out
+}
+
+// guardsNilAuthority reports whether the body refuses when the authority field
+// is nil. It looks for a comparison against nil that returns, which is the
+// shape both stagers use, rather than the exact text of either.
+func guardsNilAuthority(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		stmt, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		cmp, ok := stmt.Cond.(*ast.BinaryExpr)
+		if !ok || cmp.Op != token.EQL {
+			return true
+		}
+		if !isNil(cmp.Y) || !mentionsAuthority(cmp.X) {
+			return true
+		}
+		if returnsIn(stmt.Body) {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// isNil reports whether an expression is the nil identifier.
+func isNil(e ast.Expr) bool {
+	id, ok := e.(*ast.Ident)
+	return ok && id.Name == "nil"
+}
+
+// mentionsAuthority reports whether an expression names the authority field.
+func mentionsAuthority(e ast.Expr) bool {
+	sel, ok := e.(*ast.SelectorExpr)
+	return ok && strings.EqualFold(sel.Sel.Name, "authority")
+}
+
+// returnsIn reports whether a block returns, which is what makes a guard a
+// refusal rather than a log line.
+func returnsIn(block *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(block, func(n ast.Node) bool {
+		if _, ok := n.(*ast.ReturnStmt); ok {
+			found = true
+		}
+		return true
+	})
+	return found
+}

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (71)
+## Parity (72)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -27,6 +27,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `aitaskparity_test.go` | H3 | Every ai\_task an emitter writes into the AI-activity projection must be a task the AI contract declares. |
 | `aitaskrunenum_test.go` | H3 | The ai\_task.state\_changed payload's closed vocabularies must equal the ai\_task\_run column CHECKs they are projected into. |
 | `auditcoherence_test.go` | H3 | The audit\_log enum-coherence gate as a fitness function. |
+| `authzcategories_test.go` | H2 | The outbound category vocabulary is spelled TWICE — once in Go, once as a CHECK constraint on communication\_decision — and the two must agree. |
 | `backfillwindow_test.go` | H3 | The CAP-PARAM-4 window set as a fitness function: the contract's four enums, the Go validator and the capture\_backfill CHECK all state the SAME set, derived from the tree rather than remembered here. |
 | `basevaluespelling_test.go` | H2 | One deal's base-currency value is spelled twice, in two packages that cannot import each other, and this is what stops the two from drifting. |
 | `benchrecordswitch_test.go` | H2 | Both bench harnesses ask the SAME variable whether to publish a record, and both answer only to the same value. |
@@ -91,7 +92,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (93)
+## Census (94)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -117,6 +118,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `contractproducers_test.go` | H2 | A field the contract PROMISES and nobody WRITES is invisible. |
 | `contractrefs_test.go` | H3 | Contract $ref pre-flight as a fitness function. |
 | `dealtargettype_test.go` | H2 | Every deal-scoped staging names its target type through one constant. |
+| `decisioncoverage_test.go` | H2 | A message that reaches the send queue carries a decision saying why, written in the transaction that staged it. |
 | `declaredfilters_test.go` | H2 | A declared narrowing parameter is read by the handler it is declared on, or it is not declared. |
 | `docslinktargets_test.go` | H3 | Every relative link under docs/ points at a file that exists. |
 | `draftreplyreader_test.go` | H2 | A {subject, body} model reply has ONE reader. |


### PR DESCRIPTION
Two of the four gates the consent plan left unbuilt. Both derive their corpus
from the tree rather than a list, and both fail loudly when they cannot see
their subject.

## `authzcategories` — the vocabulary agrees with the constraint that stores it

The outbound category vocabulary is spelled twice: once in Go, once as the
`communication_decision_category` CHECK. Nothing held the two together.

The failure is silent and one-directional. A category added in Go and forgotten
in the constraint compiles, passes every unit test, passes review — then the
engine resolves it and the INSERT recording that decision fails at runtime
inside the send transaction. A resolution the database refuses to store is a
send nobody can explain afterwards, which is the whole property
`communication_decision` exists to provide.

`TestEveryCategoryCarriesADistinctWireValue` holds what that comparison rests
on: `Categories()` is built from a map keyed by the values themselves, so two
constants sharing a string collapse into one member and the parity check still
passes, having compared a vocabulary that had already lost a member. It also
pins the `ServesTheSubject` count — that predicate decides what passes a hard
suppression, so it must never widen by accident.

**The plan's premise for this gate was wrong.** It asked for "every category has
a validator arm". Nine of fourteen deliberately resolve to `default:` in
`authorizevalidators.go` and stay unsupported, having no record evidence to
read. A gate demanding otherwise would fail against correct code.

## `decisioncoverage` — a staged delivery carries the decision that permitted it

Mail and channel are two implementations of one act, and the recurring defect
here is a fix landing on one of them. A staging method that writes a delivery
row and enqueues the job without authorizing it produces a message the worker
transmits with nothing on record about why — and it looks exactly like the
method beside it that does.

Four obligations in one method body: stage, authorize on the same transaction,
refuse an absolute denial, and fail closed when no authority is wired.

The last is a separate test deliberately. A call census sees the CALL and cannot
see that a nil authority made it a no-op — `commsstager.go` says so in its own
comment and defends with an explicit error. Removing only that guard leaves the
census correctly green and fails the second test alone, which is what proves the
two are not redundant.

**Finding:** `comms.Store.StageControllerTx` has no production caller on main.
The controller mail lane it belongs to was never wired. It is therefore absent
from the corpus — an obligation on it would assert something about code that
does not run — and joins the moment a caller appears, because the corpus is
derived from who calls the stagers.

## Mutation checks

Six, one clause at a time, each restored after:

| Mutation | Caught by |
|---|---|
| Category added to Go only | vocabulary parity, naming the runtime INSERT failure |
| Value added to the CHECK only | vocabulary parity, naming the phantom permission |
| `marketing` added to `ServesTheSubject` | the count assertion |
| Channel path loses its authorization | coverage census, naming `StageChannelTx` |
| Mail path keeps the call, loses the nil guard | the guard test ALONE — census correctly stayed green |
| Gate pointed at a file with no stagers | "found 0 staging methods", not PASS |

`make check-backend` green before and after rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two gates that fail loudly when the outbound decision record is incomplete, catching mismatches that previously surfaced only as runtime failures inside the send transaction.

**Vocabulary parity**

- The gate reads the `communication_decision_category` CHECK constraint from the shipped migration file and asserts it exactly matches the Go `commsauthz.Categories()` set.
- Pins the count of categories that serve the subject to five, since that predicate widens what may pass a hard suppression.
- Two categories sharing a wire value would collapse in the census, so a separate test asserts each constant is distinct.

**Decision coverage**

- Every staging method in `commsstager.go` must call `AuthorizeStagingTx`, `refuseAbsoluteDenial`, and `EnqueueTx` in the same body.
- A separate test asserts each staging method fails closed when the authorization authority is nil, because a call census cannot see a nil-authority no‑op.
- `StageControllerTx` is intentionally absent from the corpus – it has no production caller yet – and joins automatically once a caller appears.
- The gate reports "found 0 staging methods" instead of PASS if the file is renamed or parsed incorrectly.
- The gate inventory doc is updated with both new gates.

<sup>Written for commit 5e6a242e5ddfc697aa8fdeee440d48251b80aa77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation ensuring authorization categories match the database constraints and remain unique, complete, and valid.
  * Added coverage checks confirming delivery-staging paths perform authorization, refuse absolute denials, enqueue correctly, and safely handle missing authorization authority.

* **Documentation**
  * Updated the gate inventory with the new authorization-category and delivery-staging coverage checks and revised gate counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->