### PR TITLE
A marker is a request, and a classifier's verdict is not one

### DIFF
--- a/backend/internal/compose/integration/capture/capture_posture_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_posture_integration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/margince/margince/backend/internal/compose"
 	"github.com/margince/margince/backend/internal/compose/integration"
+	activitiesmod "github.com/margince/margince/backend/internal/modules/activities"
 	capturemod "github.com/margince/margince/backend/internal/modules/capture"
 	"github.com/margince/margince/backend/internal/platform/database"
 	"github.com/margince/margince/backend/internal/platform/settings"
@@ -637,4 +638,136 @@ func threadVerdictStatus(t *testing.T, e *integration.SearchEnv, user ids.UUID, 
 		t.Fatalf("reading the thread verdict: %v", err)
 	}
 	return status
+}
+
+// TestAClassifierVerdictIsNotASendersMarking holds apart the two things that
+// once shared the word `explicitly_confidential`.
+//
+// A SENDER's subject-line marking is row-carried and survives an opening
+// verdict: a person marked that message, and no model and no later pass
+// overrules a person. A CLASSIFIER's answer of the same name is a judgement,
+// and the seat whose mail it is may disagree with it.
+//
+// Sharing the word made the second behave like the first. The reported symptom:
+// an ordinary deal thread was judged confidential, and the rep pressed Share.
+// The ledger recorded shared_by_owner, the derivation ran, read
+// `explicitly_confidential` off the row, treated it as the sender's own marking
+// and left the message held. The share worked and the hold ignored it, with
+// nothing on screen saying why.
+//
+// Both directions are asserted, because fixing one alone is the regression: a
+// change that made every hold clearable would publish the messages a sender
+// explicitly marked.
+func TestAClassifierVerdictIsNotASendersMarking(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+	allowSharedPosture(t, e)
+	setPosture(t, env, e.Rep1, capturemod.PostureClassified)
+
+	// A classifier's hold, on a subject carrying no marker at all. The kind is
+	// the model's own `explicitly_confidential`, which is what the shipped
+	// classifier returned on the reported thread.
+	sync(t, emailWithSubject("john@mii.example", "John Khoury", captureOwner,
+		"verdict-share-1@mii.example", "Re: Follow up"))
+	judged := oneActivityID(t, e)
+	recordThreadVerdict(t, e, e.Rep1, judged, capturemod.VerdictHeld, "explicitly_confidential")
+	if got, reason := audienceOf(t, e, judged); got != "participants" {
+		t.Fatalf("a held message is %q / %q, want it held before the share", got, reason)
+	} else if reason == "explicitly_confidential" {
+		t.Fatalf("a CLASSIFIER's answer reached the row as %q, the word reserved for a sender's "+
+			"own subject-line marking: that word is row-carried, so the verdict became a hold "+
+			"its owner cannot clear", reason)
+	}
+
+	// The owner shares it, which is the whole point of a judgement being a
+	// judgement: it is theirs to disagree with.
+	shareThreadAsOwner(t, e, e.Rep1, judged)
+	if got, reason := audienceOf(t, e, judged); got != "workspace" {
+		t.Fatalf("after the owner shared it the message is %q / %q, want workspace: "+
+			"the share reached the ledger and the derivation ignored it", got, reason)
+	}
+
+	// The other direction. A sender's marking is NOT the owner's to overrule,
+	// and it still is not.
+	sync(t, emailWithSubject("anwalt@studiolegal.example", "Dr. Legal", captureOwner,
+		"verdict-share-2@studiolegal.example", "[Vertraulich] Aufhebungsvertrag"))
+	marked := newestActivityID(t, e)
+	if got, reason := audienceOf(t, e, marked); got != "participants" || reason != "explicitly_confidential" {
+		t.Fatalf("a marked message is %q / %q, want participants / explicitly_confidential", got, reason)
+	}
+	shareThreadAsOwner(t, e, e.Rep1, marked)
+	if got, reason := audienceOf(t, e, marked); got != "participants" || reason != "explicitly_confidential" {
+		t.Fatalf("a message its SENDER marked is %q / %q after an owner share, want it still "+
+			"held: the marking is not the recipient's to lift", got, reason)
+	}
+}
+
+// recordThreadVerdict drives the real writer — the store method the
+// confidentiality engine calls — rather than an INSERT of the row it produces.
+// The translation under test lives inside that method, so a seeded row would
+// bypass exactly the code this scenario is about.
+func recordThreadVerdict(
+	t *testing.T, e *integration.SearchEnv, seat, activityID ids.UUID, status, kind string,
+) {
+	t.Helper()
+	ctx := seatContext(e, seat)
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		var threadKey string
+		if err := tx.QueryRow(ctx,
+			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1`, activityID).Scan(&threadKey); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO capture_thread_verdict (thread_key, user_id, status, kind, seen_addresses, resolved_at)
+			VALUES ($1, $2, $3, $4, ARRAY[]::text[], now())
+			ON CONFLICT (thread_key, user_id) DO UPDATE SET status = $3, kind = $4`,
+			threadKey, seat, status, kind); err != nil {
+			return err
+		}
+		return capturemod.NewThreadVerdictStore(nil).RecordOutcomeTx(ctx, tx,
+			capturemod.PendingThread{ThreadKey: threadKey, UserID: seat, ActivityID: activityID},
+			status, kind)
+	}); err != nil {
+		t.Fatalf("recording the thread verdict: %v", err)
+	}
+	recomputeAudience(t, e, seat, activityID)
+}
+
+// shareThreadAsOwner runs the owner's own share, through the store method the
+// thread-audience endpoint calls, and then the derivation that endpoint runs
+// after it. Both are the shipped writers: the scenario is about what the
+// derivation does with what the share wrote, so a seeded ledger row would test
+// neither half.
+func shareThreadAsOwner(t *testing.T, e *integration.SearchEnv, seat, activityID ids.UUID) {
+	t.Helper()
+	ctx := seatContext(e, seat)
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		var threadKey string
+		if err := tx.QueryRow(ctx,
+			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1`, activityID).Scan(&threadKey); err != nil {
+			return err
+		}
+		return capturemod.NewThreadVerdictStore(nil).DecideAsOwner(ctx, tx, threadKey, true)
+	}); err != nil {
+		t.Fatalf("sharing the thread as its owner: %v", err)
+	}
+	recomputeAudience(t, e, seat, activityID)
+}
+
+// recomputeAudience runs the derivation the way every product writer does after
+// changing a contribution.
+//
+// The SEAT's context, not the admin's: the derivation writes an audit row, and a
+// row with no actor behind it is a change nobody made. That context is threaded
+// into the call rather than a fresh Background one, which is where the actor
+// lives.
+func recomputeAudience(t *testing.T, e *integration.SearchEnv, seat, activityID ids.UUID) {
+	t.Helper()
+	ctx := seatContext(e, seat)
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return activitiesmod.RecomputeAudienceTx(
+			ctx, tx, ids.From[ids.ActivityKind](activityID))
+	}); err != nil {
+		t.Fatalf("recomputing the audience: %v", err)
+	}
 }

--- a/backend/internal/modules/capture/confidentialmarkers.go
+++ b/backend/internal/modules/capture/confidentialmarkers.go
@@ -24,8 +24,21 @@ import (
 
 // confidentialMarkers are the whole-word subject markers that hold a message.
 //
-// Whole-word, so "NDA" does not fire on "AGENDA" and "vertraulich" does not
-// fire inside a longer compound the sender did not mean as a marker. The
+// Every word here is one a sender writes IN ORDER TO MARK the message. That is
+// the test this list is kept to, and it is why the names of agreements are not
+// on it.
+//
+// "NDA" and "non-disclosure" were, and they are the wrong kind of word. An NDA
+// is a routine agreement between two COMPANIES — signed by the company rather
+// than by a person — and that one exists is not itself a secret. "Re: NDA",
+// "NDA signed" and "NDA für das Projekt" are threads ABOUT ordinary
+// contracting, so holding them took a deal's own paperwork away from the team
+// doing the deal. Naming a document is not asking for confidence: the material
+// the document covers may well be, and a sender who wants that held writes one
+// of the words below.
+//
+// Whole-word, so "vertraulich" does not fire inside a longer compound the
+// sender did not mean as a marker. The
 // German words carry their inflected endings because a subject reads
 // "Vertrauliche Unterlagen" as readily as "[Vertraulich]".
 // The German endings are the full set a subject line uses, not a sample: -en is
@@ -33,11 +46,16 @@ import (
 // vertraulichen Behandlung" dative), and each ending missing here is a message
 // its sender explicitly marked that publishes to the workspace.
 //
+// "Vertraulichkeitsvereinbarung" is the German for an NDA and stays, which is
+// not the exception it looks like: a sender typing it has written "vertraulich"
+// at the front of the word, and it is what a DACH sender reaches for when
+// marking. The English abbreviation carries no such marking sense.
+//
 // No separate arm for "[Vertraulich]" or "streng vertraulich": a bracket and a
 // space are both word boundaries, so the inflected arm already matches them.
 var confidentialMarkers = regexp.MustCompile(
 	`(?i)(\bvertraulich(e|en|em|er|es)?\b|\bvertraulichkeitsvereinbarung\b|` +
-		`\bconfidential\b|\bprivileged\b|\bnon-disclosure\b|\bNDA\b)`)
+		`\bconfidential\b|\bprivileged\b)`)
 
 // explicitlyConfidential answers whether a subject line carries a marker its
 // sender meant as one.

--- a/backend/internal/modules/capture/confidentialmarkers_test.go
+++ b/backend/internal/modules/capture/confidentialmarkers_test.go
@@ -24,12 +24,20 @@ func TestASubjectMarkerIsRecognisedInTheFormsSendersActuallyWrite(t *testing.T) 
 		{"Vertraulichen Unterlagen im Anhang", true, "accusative, the most common ending in a subject"},
 		{"Vertraulichem Schreiben", true, "dative"},
 		{"Zur vertraulichen Behandlung", true, "the phrase a German business letter actually uses"},
-		{"Vertraulichkeitsvereinbarung", true, "the German word for an NDA"},
-		{"Non-disclosure agreement", true, "its English name, which NDA alone would miss"},
-		{"NDA for review", true, "the abbreviation, whole-word"},
+		{"Vertraulichkeitsvereinbarung", true, "the German word for an NDA — and a sender typing it has written \"vertraulich\" at the front of it, which is the marking this list is for"},
 		{"Confidential: Q3 numbers", true, "the English marker"},
 
-		{"AGENDA for Monday", false, "NDA inside a longer word is not a marker"},
+		// Naming an agreement is not asking for confidence. An NDA is a routine
+		// contract between two COMPANIES, signed by the company rather than by a
+		// person, and that one exists is not itself a secret. These are threads
+		// ABOUT ordinary contracting, and holding them took a deal's own
+		// paperwork away from the team doing the deal.
+		{"NDA for review", false, "the abbreviation names a document and asks for nothing"},
+		{"Non-disclosure agreement", false, "the same document, written out"},
+		{"Re: NDA", false, "the shape a real thread takes"},
+		{"NDA signed, we can proceed", false, "ordinary deal progress, which is what a rep needs their team to see"},
+
+		{"AGENDA for Monday", false, "never a marker even while NDA was one: the match is whole-word"},
 		{"Quarterly report", false, "ordinary mail"},
 		{"", false, "no subject at all"},
 	} {

--- a/backend/internal/modules/capture/threadsiblings.go
+++ b/backend/internal/modules/capture/threadsiblings.go
@@ -161,7 +161,7 @@ func stampSiblingsTx(
 		   SET verdict_status = $3, verdict_reason = NULLIF($4, '')
 		 WHERE user_id = $1 AND activity_id = ANY($2)
 		   AND (verdict_status IS NULL OR verdict_status = $5)`,
-		user, ids_, status, kind, VerdictPending)
+		user, ids_, status, rowReasonForKind(kind), VerdictPending)
 	if err != nil {
 		return fmt.Errorf("capture: recording a thread verdict on its earlier messages: %w", err)
 	}

--- a/backend/internal/modules/capture/threadverdict.go
+++ b/backend/internal/modules/capture/threadverdict.go
@@ -361,7 +361,7 @@ func (s *ThreadVerdictStore) RecordOutcomeTx(
 		UPDATE capture_import
 		   SET verdict_status = $3, verdict_reason = NULLIF($4, '')
 		 WHERE activity_id = $1 AND user_id = $2`,
-		row.ActivityID, row.UserID, status, kind)
+		row.ActivityID, row.UserID, status, rowReasonForKind(kind))
 	if err != nil {
 		return fmt.Errorf("capture: recording a thread verdict on its import row: %w", err)
 	}

--- a/backend/internal/modules/capture/verdictinherit.go
+++ b/backend/internal/modules/capture/verdictinherit.go
@@ -47,6 +47,45 @@ const (
 // privately, whose parties are genuine contacts.
 const ThreadKindPersonal = "personal"
 
+// threadKindExplicitlyConfidential is the classifier's answer for a thread whose
+// own text asks for confidence. Spelled here only to be translated away — see
+// rowReasonForKind.
+const threadKindExplicitlyConfidential = "explicitly_confidential"
+
+// verdictReasonGeneric mirrors activities.ReasonVerdict, which this module may
+// not import.
+const verdictReasonGeneric = "verdict"
+
+// rowReasonForKind is the word a verdict's kind carries onto the message row.
+//
+// Every kind travels as itself, so a held message says what held it: `legal`,
+// `personnel` and `security_incident` all reach the reader that way. One does
+// not.
+//
+// `explicitly_confidential` is the classifier's name for "the text asks for
+// confidence", and it is ALSO the reason the sink writes when a SENDER marked
+// the subject line. Those look alike and behave nothing alike: the activities
+// derivation carries the sink's reason among the holds that survive an opening
+// verdict, because a person marked that message and no model overrules a
+// person. A model's own answer belongs in no such set — it is a judgement, and
+// the seat whose mail it is may disagree with it.
+//
+// Sharing one word made a model verdict unclearable. A rep whose ordinary deal
+// thread was judged confidential pressed Share; the ledger recorded
+// `shared_by_owner`, the derivation ran, read `explicitly_confidential` off the
+// row, treated it as the sender's own marking and left the message held. The
+// share worked and the hold ignored it, with nothing on screen to say why.
+//
+// So a classifier's version becomes the generic `verdict`, which holds exactly
+// as firmly and clears when its owner says so. The sink's marker keeps the word
+// and keeps its standing.
+func rowReasonForKind(kind string) string {
+	if kind == threadKindExplicitlyConfidential {
+		return verdictReasonGeneric
+	}
+	return kind
+}
+
 // inheritedVerdictTx answers the verdict status this message takes from its
 // thread, or "" when it takes none and the posture decides.
 //


### PR DESCRIPTION
Follow-up to #4048, from the same reported screen. That PR fixed the prompt that produced a wrong verdict and the label map that hid it. These are the two reasons the message stayed hidden afterwards.

## 1. "NDA" was a subject-line marker

`confidentialMarkers` held `\bNDA\b` and `\bnon-disclosure\b`. Neither is a sender asking for confidence.

An NDA is a routine agreement between two **companies** — signed by the company rather than by a person — and that one exists is not itself a secret. So `Re: NDA`, `NDA signed` and `NDA für das Projekt` are threads *about* ordinary contracting, and holding them took a deal's own paperwork away from the team doing the deal. This path needs no model at all: the regex holds the message inside the capture transaction.

The list's own doc already stated the test — *"every word here is one a sender chose in order to mark a message"* — and these two failed it. The words that **are** a request stay: `vertraulich` and its inflections, `confidential`, `privileged`.

`Vertraulichkeitsvereinbarung` stays too, which is not the exception it looks like: it is the German for an NDA, but a sender typing it has written "vertraulich" at the front of the word, and it is what a DACH sender reaches for when marking. The English abbreviation carries no such sense.

## 2. A classifier's verdict landed in the unclearable bucket

This is the "share doesn't work" half, and it is the more serious one.

`explicitly_confidential` names two different things:

- the reason the **sink** writes when a sender marked the subject line. `rowCarriedHold` keeps it among the holds that survive an opening verdict, because a person marked that message and no model overrules a person. Correct.
- the **classifier's** answer for "the text asks for confidence". A judgement, and the seat whose mail it is may disagree with it.

`RecordOutcomeTx` wrote the kind onto the row verbatim, so the second landed in the first's set.

**What that did:** the rep pressed Share. `DecideAsOwner` recorded `shared_by_owner` on the ledger and on the import row. The seam ran the derivation. The derivation read `explicitly_confidential` off the row, treated it as the sender's own marking, and left the message at `participants`. The share worked and the hold ignored it — with nothing on screen saying why, because of the missing label #4048 fixed.

`rowReasonForKind` translates at the boundary: a classifier's version becomes the generic `verdict`, which holds exactly as firmly and clears when its owner says so. Every other kind still travels as itself, so a held message still says whether it was `legal`, `personnel` or a security incident. Both writers of the column go through the one helper.

## Tests

`TestAClassifierVerdictIsNotASendersMarking` asserts **both directions**, through the shipped writers rather than seeded rows — `RecordOutcomeTx`, `DecideAsOwner` and `RecomputeAudienceTx` are the real ones, since the translation under test lives inside the first.

Mutation-checked one clause at a time:
- removing the translation → fails on the classifier verdict reaching the row as the reserved word
- removing `ReasonConfidentialMarker` from `rowCarriedHold` → fails on the sender-marked message being published by an owner share

Fixing one direction alone is the regression, which is why both are in one test.

The marker spec table carries the real shapes now, including `Re: NDA` and `NDA signed, we can proceed`. `AGENDA for Monday` stays as a case and keeps its own reason: it was never a marker even while NDA was one, because the match is whole-word.

## What this does NOT do

It does not re-decide mail already judged. The stored verdict on an existing row stands; this changes what gets decided next, and makes the owner's share work on what is already there.

## Verification

- `make check-backend` — green
- `make test-it DIR=backend/internal/compose/integration/capture` — green, whole lane
- `craft static --strict` — 0 blocker, 0 major, 0 minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two reasons a message stayed held after its owner shared it: `NDA` and `non-disclosure` were treated as subject-line confidentiality markers, and a classifier's `explicitly_confidential` verdict was recorded into the bucket reserved for a sender's own marking. Both now behave correctly: `NDA` threads publish normally, and a shared classifier hold clears.

- Removed `NDA` and `non-disclosure` from the marker list; naming an agreement is not asking for confidence.
- Kept `Vertraulichkeitsvereinbarung`, the German for an NDA, because typing it is marking.
- A classifier's verdict now records as the generic `verdict` reason through one shared helper.
- A sender's subject-line marking keeps `explicitly_confidential` and still survives opening verdicts and owner shares.
- Existing stored verdicts are not re-decided; the change affects verdicts recorded from now on.

<sup>Written for commit 606b8b5decae9bd6edeea9fe783d9a80c1f3a7ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

