### PR TITLE
The forecast's buckets are a filter, so a tile can have a door

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3856,6 +3856,16 @@ paths:
         - name: status
           in: query
           schema: { type: string, enum: [open, won, lost] }
+        - name: forecast_category
+          in: query
+          schema: { type: string, enum: [commit, best_case, pipeline, omitted] }
+          description: |
+            One of the forecast's named buckets. The same `deal.forecast_category` the forecast
+            reads, so a tile's figure and the list behind it are one answer rather than two
+            derivations that can disagree.
+
+            A deal carrying no category is in no bucket and is returned by none of the four —
+            the buckets partition the CATEGORISED pipeline, not the pipeline.
         - name: stalled
           in: query
           schema: { type: boolean }

--- a/backend/internal/compose/integration/dealforecastcategory_integration_test.go
+++ b/backend/internal/compose/integration/dealforecastcategory_integration_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The forecast's buckets, as a list a reader can open.
+//
+// The five forecast tiles partition the pipeline into named buckets and each
+// is a number with no door: "which deals are in commit" is the first question
+// anyone asks of one, and no wire filter could express it.
+//
+// Against a real database because the point is the PREDICATE — that an
+// uncategorised deal joins no bucket rather than quietly appearing in
+// whichever one is asked for, which is a fact about SQL's NULL comparison
+// rather than about Go.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/compose/installseam"
+	"github.com/margince/margince/backend/internal/modules/deals"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+)
+
+type forecastBucketFixture struct {
+	store *deals.Store
+	ctx   context.Context
+}
+
+// named returns the names of the deals one filter selects, so a failure says
+// which deal was wrongly in or out rather than only how many.
+func (f forecastBucketFixture) named(t *testing.T, category *string) []string {
+	t.Helper()
+	list, _, err := f.store.ListDeals(f.ctx, deals.ListDealsInput{ForecastCategory: category})
+	if err != nil {
+		t.Fatalf("ListDeals: %v", err)
+	}
+	names := make([]string, 0, len(list))
+	for _, deal := range list {
+		names = append(names, deal.Name)
+	}
+	return names
+}
+
+func TestTheForecastBucketsPartitionTheCategorisedPipeline(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	store := deals.NewStore(e.DB(), installseam.Deals())
+	ctx := e.As(e.Rep1, nil, dealCFVPerms)
+	f := forecastBucketFixture{store: store, ctx: ctx}
+
+	for name, category := range map[string]string{
+		"Commit One":  "commit",
+		"Commit Two":  "commit",
+		"Best Case":   "best_case",
+		"In Pipeline": "pipeline",
+		"Omitted":     "omitted",
+	} {
+		created, err := store.CreateDeal(ctx, deals.CreateDealInput{
+			Name: name, PipelineID: pipeline, StageID: open, Source: "ui",
+		})
+		if err != nil {
+			t.Fatalf("seeding %q: %v", name, err)
+		}
+		bucket := category
+		if _, err := store.UpdateDeal(ctx, dealIDOf(ids.UUID(created.Id)),
+			deals.UpdateDealInput{ForecastCategory: &bucket}); err != nil {
+			t.Fatalf("categorising %q: %v", name, err)
+		}
+	}
+	// The one that belongs to no bucket, which is the case the predicate is
+	// really about: it must be absent from every one of the four.
+	if _, err := store.CreateDeal(ctx, deals.CreateDealInput{
+		Name: "Uncategorised", PipelineID: pipeline, StageID: open, Source: "ui",
+	}); err != nil {
+		t.Fatalf("seeding the uncategorised deal: %v", err)
+	}
+
+	commit := "commit"
+	if got := f.named(t, &commit); len(got) != 2 {
+		t.Errorf("the commit bucket holds %v, want the two commit deals", got)
+	}
+	for _, category := range []string{"commit", "best_case", "pipeline", "omitted"} {
+		bucket := category
+		for _, name := range f.named(t, &bucket) {
+			if name == "Uncategorised" {
+				t.Errorf("the %q bucket holds the uncategorised deal — a deal in no "+
+					"bucket must not join whichever one is asked for", category)
+			}
+		}
+	}
+	// Unfiltered still answers everything, so the filter narrows rather than
+	// the fixture being thin.
+	if got := f.named(t, nil); len(got) != 6 {
+		t.Errorf("the unfiltered list holds %d deals, want all 6", len(got))
+	}
+}

--- a/backend/internal/compose/overlayread.go
+++ b/backend/internal/compose/overlayread.go
@@ -51,14 +51,15 @@ const (
 	// narrowing at all, which the native path treats as a no-op — refusing it
 	// would 422 a request that answers 200 natively, for a dial the caller
 	// effectively did not set.
-	paramUnassigned     = "unassigned"
-	paramPipelineID     = "pipeline_id"
-	paramStageID        = "stage_id"
-	paramOrganizationID = "organization_id"
-	paramStatus         = "status"
-	paramKind           = "kind"
-	paramTag            = "tag_id"
-	paramTagMode        = "tag_mode"
+	paramUnassigned       = "unassigned"
+	paramPipelineID       = "pipeline_id"
+	paramStageID          = "stage_id"
+	paramOrganizationID   = "organization_id"
+	paramStatus           = "status"
+	paramForecastCategory = "forecast_category"
+	paramKind             = "kind"
+	paramTag              = "tag_id"
+	paramTagMode          = "tag_mode"
 	// paramCapturedByKind is refused in overlay mode rather than ignored:
 	// captured_by is OUR provenance column, stamped from the principal that
 	// wrote the row. Mirror rows are the incumbent's records, created in the
@@ -310,6 +311,12 @@ func (s Server) ListDeals(w http.ResponseWriter, r *http.Request, params crmcont
 			// project would answer the whole mirror while reading as that
 			// project's deals.
 			{"project_id", params.ProjectId != nil},
+			// The forecast's buckets are OUR column too. A mirrored deal
+			// carries the incumbent's own forecast field, which this product
+			// neither writes nor maps, so there is nothing here to narrow by —
+			// and answering the whole mirror while reading as "the commit
+			// bucket" is the failure this list refuses rather than makes.
+			{paramForecastCategory, params.ForecastCategory != nil},
 		},
 		nil, params.Cursor, params.Limit, overlayWireDeal,
 		func(data []crmcontracts.Deal, page crmcontracts.PageInfo) any {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14239,6 +14239,30 @@ func (e ListDealsParamsStatus) Valid() bool {
 	}
 }
 
+// Defines values for ListDealsParamsForecastCategory.
+const (
+	ListDealsParamsForecastCategoryBestCase ListDealsParamsForecastCategory = "best_case"
+	ListDealsParamsForecastCategoryCommit   ListDealsParamsForecastCategory = "commit"
+	ListDealsParamsForecastCategoryOmitted  ListDealsParamsForecastCategory = "omitted"
+	ListDealsParamsForecastCategoryPipeline ListDealsParamsForecastCategory = "pipeline"
+)
+
+// Valid indicates whether the value is a known member of the ListDealsParamsForecastCategory enum.
+func (e ListDealsParamsForecastCategory) Valid() bool {
+	switch e {
+	case ListDealsParamsForecastCategoryBestCase:
+		return true
+	case ListDealsParamsForecastCategoryCommit:
+		return true
+	case ListDealsParamsForecastCategoryOmitted:
+		return true
+	case ListDealsParamsForecastCategoryPipeline:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListDealsParamsPartnerAttribution.
 const (
 	Influenced ListDealsParamsPartnerAttribution = "influenced"
@@ -15333,19 +15357,19 @@ func (e ListSignalsParamsResolutionState) Valid() bool {
 
 // Defines values for SetWeeklyPlanCommitmentStateJSONBodyState.
 const (
-	SetWeeklyPlanCommitmentStateJSONBodyStateDone    SetWeeklyPlanCommitmentStateJSONBodyState = "done"
-	SetWeeklyPlanCommitmentStateJSONBodyStateDropped SetWeeklyPlanCommitmentStateJSONBodyState = "dropped"
-	SetWeeklyPlanCommitmentStateJSONBodyStateOpen    SetWeeklyPlanCommitmentStateJSONBodyState = "open"
+	Done    SetWeeklyPlanCommitmentStateJSONBodyState = "done"
+	Dropped SetWeeklyPlanCommitmentStateJSONBodyState = "dropped"
+	Open    SetWeeklyPlanCommitmentStateJSONBodyState = "open"
 )
 
 // Valid indicates whether the value is a known member of the SetWeeklyPlanCommitmentStateJSONBodyState enum.
 func (e SetWeeklyPlanCommitmentStateJSONBodyState) Valid() bool {
 	switch e {
-	case SetWeeklyPlanCommitmentStateJSONBodyStateDone:
+	case Done:
 		return true
-	case SetWeeklyPlanCommitmentStateJSONBodyStateDropped:
+	case Dropped:
 		return true
-	case SetWeeklyPlanCommitmentStateJSONBodyStateOpen:
+	case Open:
 		return true
 	default:
 		return false
@@ -34399,6 +34423,14 @@ type ListDealsParams struct {
 	OrganizationId *openapi_types.UUID    `form:"organization_id,omitempty" json:"organization_id,omitempty"`
 	Status         *ListDealsParamsStatus `form:"status,omitempty" json:"status,omitempty"`
 
+	// ForecastCategory One of the forecast's named buckets. The same `deal.forecast_category` the forecast
+	// reads, so a tile's figure and the list behind it are one answer rather than two
+	// derivations that can disagree.
+	//
+	// A deal carrying no category is in no bucket and is returned by none of the four —
+	// the buckets partition the CATEGORISED pipeline, not the pipeline.
+	ForecastCategory *ListDealsParamsForecastCategory `form:"forecast_category,omitempty" json:"forecast_category,omitempty"`
+
 	// Stalled Deterministic stalled flag (no activity past the threshold).
 	Stalled *bool `form:"stalled,omitempty" json:"stalled,omitempty"`
 
@@ -34430,6 +34462,9 @@ type ListDealsParams struct {
 
 // ListDealsParamsStatus defines parameters for ListDeals.
 type ListDealsParamsStatus string
+
+// ListDealsParamsForecastCategory defines parameters for ListDeals.
+type ListDealsParamsForecastCategory string
 
 // ListDealsParamsPartnerAttribution defines parameters for ListDeals.
 type ListDealsParamsPartnerAttribution string
@@ -59088,6 +59123,19 @@ func (siw *ServerInterfaceWrapper) ListDeals(w http.ResponseWriter, r *http.Requ
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "status"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "status", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "forecast_category" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "forecast_category", r.URL.Query(), &params.ForecastCategory, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "forecast_category"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "forecast_category", Err: err})
 		}
 		return
 	}

--- a/backend/internal/modules/agents/recordshapes_gen.go
+++ b/backend/internal/modules/agents/recordshapes_gen.go
@@ -63,6 +63,7 @@ var listRecordFilters = map[string][]listFilter{
 		{Name: "unassigned", Type: "boolean"},
 	},
 	"deal": {
+		{Name: "forecast_category", Type: "string", Enum: []string{"commit", "best_case", "pipeline", "omitted"}},
 		{Name: "organization_id", Type: "string"},
 		{Name: "owner_id", Type: "string"},
 		{Name: "partner_attribution", Type: "string", Enum: []string{"sourced", "influenced"}},

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -85,7 +85,12 @@ type ListDealsInput struct {
 	// partner is named at all.
 	PartnerAttribution *string
 	Status             *string
-	Stalled            *bool
+	// ForecastCategory narrows to one of the forecast's named buckets —
+	// commit, best_case, pipeline, omitted. The column the FORECAST reads, so
+	// a tile's number and the list behind it are one answer rather than two
+	// derivations that can disagree.
+	ForecastCategory *string
+	Stalled          *bool
 	// QuietForDays narrows to open deals idle at least this long, which is the
 	// stalled rule at a caller-named window (QuietSQL). Separate from Stalled
 	// because they answer different questions: Stalled is the product-wide
@@ -274,6 +279,13 @@ func appendDealFilters(ctx context.Context, where []string, in ListDealsInput, a
 	}
 	if in.Status != nil {
 		where = append(where, storekit.SQLf("status = $%d", arg(*in.Status)))
+	}
+	if in.ForecastCategory != nil {
+		// A deal with no category is in no bucket, which the NULL comparison
+		// gives for free: the five tiles partition the CATEGORISED pipeline,
+		// and an uncategorised deal belongs to none of them rather than
+		// quietly joining whichever one is asked for.
+		where = append(where, storekit.SQLf("forecast_category = $%d", arg(*in.ForecastCategory)))
 	}
 	if in.Stalled != nil {
 		if *in.Stalled {

--- a/backend/internal/modules/deals/handlers_deal.go
+++ b/backend/internal/modules/deals/handlers_deal.go
@@ -61,6 +61,10 @@ func (h Handlers) ListDeals(w http.ResponseWriter, r *http.Request, params crmco
 		s := string(*params.Status)
 		in.Status = &s
 	}
+	if params.ForecastCategory != nil {
+		category := string(*params.ForecastCategory)
+		in.ForecastCategory = &category
+	}
 
 	deals, page, err := h.store.ListDeals(r.Context(), in)
 	if err != nil {

--- a/backend/internal/modules/deals/listfilters.go
+++ b/backend/internal/modules/deals/listfilters.go
@@ -31,6 +31,7 @@ const (
 	filterStageID            = "stage_id"
 	filterStalled            = "stalled"
 	filterStatus             = "status"
+	filterForecastCategory   = "forecast_category"
 	filterKey                = "key"
 	filterPhase              = "phase"
 )
@@ -59,6 +60,8 @@ var dealListFilters = storekit.FilterSet[ListDealsInput]{
 	filterStageID:        storekit.FilterID(func(in *ListDealsInput, id *ids.StageID) { in.StageID = id }),
 	filterStalled:        storekit.FilterFlag(func(in *ListDealsInput, v *bool) { in.Stalled = v }),
 	filterStatus:         storekit.FilterWord(func(in *ListDealsInput, v *string) { in.Status = v }),
+	filterForecastCategory: storekit.FilterWord(
+		func(in *ListDealsInput, v *string) { in.ForecastCategory = v }),
 }
 
 // ListFilters names what SearchEntity can narrow one entity type by.

--- a/backend/internal/modules/deals/listfilters_test.go
+++ b/backend/internal/modules/deals/listfilters_test.go
@@ -22,6 +22,7 @@ func TestEveryDeclaredDealsFilterNarrowsSomething(t *testing.T) {
 	assertEveryFilterNarrows(t, "deal", dealListFilters, map[string]string{
 		"organization_id": id, "owner_id": id, "partner_org_id": id, "partner_sourced": "true",
 		"partner_attribution": "sourced",
+		"forecast_category":   "commit",
 		"pipeline_id":         id, "project_id": id, "stage_id": id, "stalled": "false", "status": "open",
 		"tag_id": id, "tag_mode": "all",
 	})
@@ -38,7 +39,8 @@ func TestEachDealsEntityIsOfferedItsOwnVocabulary(t *testing.T) {
 		want   []string
 	}{
 		{datasource.EntityDeal, []string{
-			"organization_id", "owner_id", "partner_attribution", "partner_org_id", "partner_sourced",
+			"forecast_category", "organization_id", "owner_id", "partner_attribution",
+			"partner_org_id", "partner_sourced",
 			"pipeline_id", "project_id", "stage_id", "stalled", "status",
 			"tag_id", "tag_mode",
 		}},

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,7 +6,7 @@
   "catalog": {
     "tools": 72,
     "system_frame_tokens": 353,
-    "tokens": 20865,
+    "tokens": 20878,
     "median_tool_tokens": 262,
     "mean_tool_tokens": 289
   },
@@ -21,9 +21,9 @@
         "read_brief",
         "read_record"
       ],
-      "tokens": 1621,
+      "tokens": 1634,
       "percent_of_ceiling": 6,
-      "headroom_tokens": 15787,
+      "headroom_tokens": 15774,
       "dangling_cross_references": [
         "annotate_brief → log_activity",
         "catch_me_up_on → prep_for_meeting",
@@ -46,9 +46,9 @@
         "review_commitments",
         "whats_slipping_this_week"
       ],
-      "tokens": 2453,
-      "percent_of_ceiling": 9,
-      "headroom_tokens": 14955,
+      "tokens": 2467,
+      "percent_of_ceiling": 10,
+      "headroom_tokens": 14941,
       "dangling_cross_references": [
         "at_risk_relationships → account_coverage",
         "at_risk_relationships → intro_path_to",
@@ -95,12 +95,12 @@
       "tokens": 572
     },
     {
-      "name": "resolve_entities",
-      "tokens": 498
+      "name": "list_records",
+      "tokens": 508
     },
     {
-      "name": "list_records",
-      "tokens": 494
+      "name": "resolve_entities",
+      "tokens": 498
     },
     {
       "name": "query_workspace",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -30,15 +30,15 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 
 | Agent | Tools | Tokens | Of the window | Headroom | Dangling refs | Temptation |
 |---|---:|---:|---:|---:|---:|---:|
-| `morning_brief` | 5 | 1621 | 6% | 15787 | 6 | 5 |
-| `overnight_at_risk_sweep` | 7 | 2453 | 9% | 14955 | 15 | 8 |
-| _whole served catalog, for scale_ | 72 | 20865 | 84% | — | — | — |
+| `morning_brief` | 5 | 1634 | 6% | 15774 | 6 | 5 |
+| `overnight_at_risk_sweep` | 7 | 2467 | 10% | 14941 | 15 | 8 |
+| _whole served catalog, for scale_ | 72 | 20878 | 84% | — | — | — |
 
 ### `morning_brief`
 
 > Assemble the Morning Brief for this workspace: enumerate open deals, read the ones with recent activity, and produce a ranked list (at most 7) of deals the team can win this week. For each: why it is on the list, what changed recently, and one recommended next move — every claim grounded in a record you actually read, citing its id. A quiet day yields a short list; never pad it.
 
-Attaches 5 tools for 1621 tokens, leaving 15787 of its budget and 22955 tokens of the
+Attaches 5 tools for 1634 tokens, leaving 15774 of its budget and 22942 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `annotate_brief`
@@ -61,7 +61,7 @@ cannot call, so a run may spend a step discovering the refusal:
 
 > Sweep this workspace's open deals for risk: find deals with no activity in 14+ days, stakeholders gone quiet, or missing next steps. Log ONE note activity per at-risk deal summarizing the risk and the evidence (cite the records you read). Do not advance stages, send anything, or archive anything.
 
-Attaches 7 tools for 2453 tokens, leaving 14955 of its budget and 22123 tokens of the
+Attaches 7 tools for 2467 tokens, leaving 14941 of its budget and 22109 tokens of the
 window for the goal, the grounding and everything it reads.
 
 - `at_risk_relationships`
@@ -144,8 +144,8 @@ a term in an addition.
 | `log_activity` | 635 | 1 scenario |
 | `send_email` | 588 | 1 scenario |
 | `update_record` | 572 | 4 scenarios |
+| `list_records` | 508 | — |
 | `resolve_entities` | 498 | — |
-| `list_records` | 494 | — |
 | `query_workspace` | 484 | 3 scenarios |
 | `advance_deal` | 443 | 1 scenario |
 | `send_message` | 431 | — |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 72,
     "resources": 11,
-    "tool_catalog_bytes": 204295,
+    "tool_catalog_bytes": 204350,
     "resource_catalog_bytes": 4251,
-    "approx_wire_tokens_total": 52136,
+    "approx_wire_tokens_total": 52150,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 49898,
-      "input_schema_bytes": 41225,
+      "input_schema_bytes": 41280,
       "output_schema_bytes": 97625,
-      "description_plus_input_schema_bytes": 91123
+      "description_plus_input_schema_bytes": 91178
     }
   },
   "tools": {
@@ -5958,7 +5958,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag_id (a), tag_mode (any|all|none) organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other), tag_id (a), tag_mode (any|all|none) deal — organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost), tag_id (a), tag_mode (any|all|none) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
+              "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag_id (a), tag_mode (any|all|none) organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other), tag_id (a), tag_mode (any|all|none) deal — forecast_category (commit|best_case|pipeline|omitted), organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost), tag_id (a), tag_mode (any|all|none) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
               "type": "object"
             },
             "limit": {

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -13,9 +13,9 @@ receives it. This page is rendered from that file.
 |---|---:|
 | Tools | 72 |
 | Resources | 11 |
-| Tool catalog | 199.5 KB |
+| Tool catalog | 199.6 KB |
 | Resource catalog | 4.2 KB |
-| Approx. wire tokens | 52136 |
+| Approx. wire tokens | 52150 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -100,7 +100,7 @@ resource, the way `margince://schema/record-fields` did, not by writing less.
 | [`list_colleagues`](#list_colleagues) | List colleagues | yes |  | 1.9 KB |
 | [`list_input_checks`](#list_input_checks) | What the forecast's inputs still need | yes |  | 2.1 KB |
 | [`list_pipelines`](#list_pipelines) | List pipelines and their stages | yes |  | 2.3 KB |
-| [`list_records`](#list_records) | List records | yes |  | 3.2 KB |
+| [`list_records`](#list_records) | List records | yes |  | 3.3 KB |
 | [`list_tags`](#list_tags) | List tags | yes |  | 1.6 KB |
 | [`log_activity`](#log_activity) | Log an activity |  |  | 3.8 KB |
 | [`merge_records`](#merge_records) | Merge two records |  |  | 2.4 KB |
@@ -6634,7 +6634,7 @@ Enumerate the people, organizations, deals, leads or projects that meet exact co
       "additionalProperties": {
         "type": "string"
       },
-      "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag_id (a), tag_mode (any|all|none) organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other), tag_id (a), tag_mode (any|all|none) deal — organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost), tag_id (a), tag_mode (any|all|none) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
+      "description": "Narrow the list. Every operand is a string, booleans included (\"true\"). Each record_type takes only its own: person — owner_id, tag_id (a), tag_mode (any|all|none) organization — domain, lifecycle (unknown|target|prospect|opportunity|customer|former_customer|disqualified), owner_id, relationship_type (customer|partner|supplier|investor|portfolio_company|competitor|other), tag_id (a), tag_mode (any|all|none) deal — forecast_category (commit|best_case|pipeline|omitted), organization_id, owner_id, partner_attribution (sourced|influenced), partner_org_id, partner_sourced (b), pipeline_id, project_id, stage_id, stalled (b), status (open|won|lost), tag_id (a), tag_mode (any|all|none) lead — min_score (i), owner_id, status (new|contacted|engaged|promoted|disqualified) project — key, organization_id, owner_id, phase (initiative|pursuing|delivering|closed) A pipeline_id or stage_id comes from list_pipelines; nothing else on this surface yields one.",
       "type": "object"
     },
     "limit": {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -33378,6 +33378,15 @@ export interface operations {
                 owner_id?: string;
                 organization_id?: string;
                 status?: "open" | "won" | "lost";
+                /**
+                 * @description One of the forecast's named buckets. The same `deal.forecast_category` the forecast
+                 *     reads, so a tile's figure and the list behind it are one answer rather than two
+                 *     derivations that can disagree.
+                 *
+                 *     A deal carrying no category is in no bucket and is returned by none of the four —
+                 *     the buckets partition the CATEGORISED pipeline, not the pipeline.
+                 */
+                forecast_category?: "commit" | "best_case" | "pipeline" | "omitted";
                 /** @description Deterministic stalled flag (no activity past the threshold). */
                 stalled?: boolean;
                 /** @description Filter to the deals belonging to one body of work. */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2307,6 +2307,8 @@ export const de = {
   "deals.filterOwnerMe": "Meine Deals",
   "deals.filterPartner": "Partner",
   "deals.filterPartnerAnyOne": "Alle Partner",
+  "deals.filterForecast": "Forecast",
+  "deals.filterForecastAll": "Jede Forecast-Kategorie",
   "deals.filterPartnerSourced": "Über Partner",
   "deals.filterStageAll": "Alle Phasen",
   "deals.filterOrgAll": "Alle Firmen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2344,6 +2344,8 @@ export const en = {
   "deals.filterOwnerMe": "My deals",
   "deals.filterPartner": "Partner",
   "deals.filterPartnerAnyOne": "Any partner",
+  "deals.filterForecast": "Forecast",
+  "deals.filterForecastAll": "Any forecast category",
   "deals.filterPartnerSourced": "Partner-sourced",
   "deals.filterStageAll": "All stages",
   "deals.filterOrgAll": "All companies",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2285,6 +2285,8 @@ export const vi = {
   "deals.filterOwnerMe": "Deal của tôi",
   "deals.filterPartner": "Đối tác",
   "deals.filterPartnerAnyOne": "Mọi đối tác",
+  "deals.filterForecast": "Dự báo",
+  "deals.filterForecastAll": "Mọi hạng mục dự báo",
   "deals.filterPartnerSourced": "Do đối tác mang về",
   "deals.filterStageAll": "Mọi giai đoạn",
   "deals.filterOrgAll": "Mọi công ty",

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -1653,6 +1653,34 @@ describe("DealsScreen filters", () => {
       expect(urls.some((u) => u.includes("stalled=true"))).toBe(true),
     );
   });
+
+  // The forecast's buckets, as a dial. Five tiles on the analytics page
+  // partition the pipeline into named buckets and each was a figure with no
+  // door — "which deals are in commit" is the first question anyone asks of
+  // one, and no wire filter could express it.
+  it("the forecast filter narrows the deals query to one bucket", async () => {
+    const urls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({})], { onDealsUrl: (u) => urls.push(u) }),
+    );
+    render(<DealsScreen />);
+    await screen.findByText("Fleet retrofit");
+    await userEvent.click(screen.getByRole("button", { name: "Table" }));
+
+    await userEvent.click(screen.getByRole("button", { name: "Filter" }));
+    const menu = screen.getByRole("group", { name: "Filter" });
+    await userEvent.click(
+      within(menu).getByRole("button", { name: "Forecast" }),
+    );
+    await userEvent.click(within(menu).getByRole("button", { name: "Commit" }));
+
+    await waitFor(() =>
+      expect(urls.some((u) => u.includes("forecast_category=commit"))).toBe(
+        true,
+      ),
+    );
+  });
 });
 
 /**

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -262,6 +262,30 @@ function withDialSet(params: UrlParams, key: string, value: string): UrlParams {
   return next;
 }
 
+// FORECAST_FILTER_VALUES are the four buckets a deal's own column can hold.
+// `slipped` is the report's derivation from a claimed category and a close
+// date, so it is a dimension of the forecast tiles and never a filter here.
+const FORECAST_FILTER_VALUES = [
+  "commit",
+  "best_case",
+  "pipeline",
+  "omitted",
+] as const;
+
+// forecastCategoryFilter narrows a stored dial to what the wire admits.
+//
+// The value arrives as a bare string because a SAVED VIEW carries it, and a
+// view written before a category was renamed — or by hand — can hold anything.
+// An unadmitted value selects nothing rather than being sent: the request
+// would be refused, and a list that fails to load says less than one that
+// simply is not narrowed. Same reading `tag_mode` takes of a stored mode its
+// own enum no longer admits.
+function forecastCategoryFilter(
+  value: string | undefined,
+): (typeof FORECAST_FILTER_VALUES)[number] | undefined {
+  return FORECAST_FILTER_VALUES.find((admitted) => admitted === value);
+}
+
 // dealsQueryParams builds the native board's /deals query — the full dial
 // set (pipeline/stage/owner/org filters + sort). It is never called in
 // overlay mode (useDeals is disabled there and OverlayDealsTable sends its
@@ -278,6 +302,7 @@ function dealsQueryParams(f: DealFilters) {
     organization_id: filters.organization_id || undefined,
     partner_org_id: filters.partner_org_id || undefined,
     stalled: filters.stalled === "true" ? true : undefined,
+    forecast_category: forecastCategoryFilter(filters.forecast_category),
     partner_sourced: filters.partner_sourced === "true" ? true : undefined,
     // Several ids and their mode, out of the one comma-joined string the
     // address carries them in. Spelled by the shared encoder rather than here,
@@ -2104,6 +2129,24 @@ function dealSurfaceChips({
       label: "deals.filterPartnerSourced",
       allLabel: "deals.filterPartnerAll",
       options: [{ value: "true", label: "deals.filterPartnerSourced" }],
+    },
+    // The forecast's own buckets, in the order the tiles read them. Four, not
+    // five: `slipped` is derived by the report from a claimed category and a
+    // close date, so there is no column to filter on and a chip offering it
+    // would narrow to nothing.
+    //
+    // Unconditional, unlike the two above: the vocabulary is the schema's, so
+    // there is no moment when the options are not yet known.
+    {
+      key: "forecast_category",
+      label: "deals.filterForecast",
+      allLabel: "deals.filterForecastAll",
+      options: [
+        { value: "commit", label: "deal.fcCommit" },
+        { value: "best_case", label: "deal.fcBestCase" },
+        { value: "pipeline", label: "deal.fcPipeline" },
+        { value: "omitted", label: "deal.fcOmitted" },
+      ],
     },
     // Which partner, not just whether there is one. Absent entirely
     // when the installation has made no company a partner: a picker


### PR DESCRIPTION
Addresses #3861 — the one filter that ticket recommends, on its own reasoning:

> `forecast_category`. It is the one where the gap is most visible to a rep … `deal.forecast_category` is already a stored column, so this is a filter over an existing column rather than new state.

The other four are left, with the ticket's own arguments: `status` **already exists** on the wire (`crm.yaml:3856`) and only the frontend does not pass it; "already won" has no clean stage id; the evidence filter is a derived predicate; the classify sentence needs a list surface that does not exist.

## What it does

`GET /deals` gains `forecast_category` over `deal.forecast_category` — the column the forecast itself reads, so a tile's figure and the list behind it are **one answer** rather than two derivations that can disagree.

A deal carrying no category is returned by none of the four buckets. They partition the *categorised* pipeline, not the pipeline, and NULL comparison gives that for free rather than by a special case.

**Four, not five.** `slipped` is the report's derivation from a claimed category and a past/absent close date, so there is no column to filter on and a chip offering it would narrow to nothing.

## The dial, and what it does not reach yet

The deals table gets the filter chip, which makes this usable **today** — a reader can narrow the list to `commit` without leaving the screen.

Wiring the analytics tiles as doors is separate machinery and is not here: `DealsScreen` takes only `startCreating`, and its list state (`ListQuery`) never reaches the address, so there is no way to hand it a bucket from another screen. That is the same gap the ticket's other "figure with no door" instances hit, and it deserves its own change.

**A saved view can carry a category the enum no longer admits** — written by hand, or before a rename — so the value is narrowed to the four before it is sent. An unadmitted one selects nothing rather than 422-ing a list that would otherwise load, which is the reading `tag_mode` already takes of a stored mode.

## Overlay refuses it, and that is the point

Two gates caught real work rather than bookkeeping:

- `TestEveryDeclaredNarrowingParameterIsForwardedOrRefusedByItsOverlayShadow` — a mirrored deal carries the *incumbent's* forecast field, which this product neither writes nor maps. Dropping the dial would answer the whole mirror while reading as "the commit bucket", so overlay **refuses** it, alongside `project_id` and `partner_attribution` for the same reason.
- `TestEveryDeclaredDealsFilterNarrowsSomething` / `TestEachDealsEntityIsOfferedItsOwnVocabulary` — both censuses require the new filter to prove it narrows and to appear in the offered vocabulary.

## Tests

`TestTheForecastBucketsPartitionTheCategorisedPipeline` seeds two commit deals, one of each other bucket and one **uncategorised**, then asserts every bucket excludes the uncategorised deal and the unfiltered list still answers all six — so the filter narrows rather than the fixture being thin.

Frontend: the chip adds `forecast_category=commit` to the deals query. Mutation — dropping the param from `dealsQueryParams` fails only that case.

`make check-backend` and `make check-fe` green; the two agent-surface goldens regenerated from the types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b1jSBftJqGvaQ7ejTgnQ6