### PR TITLE
A duplicate pair offers its verbs only to someone who can settle it

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -1079,7 +1079,11 @@ paths:
       description: |
         Merge A→B relinks A's emails/phones/relationships/activity links to B with zero
         orphaned FKs, archives A with `merged_into_id = B` (features/01 §1.3). One audit
-        transaction; reversible within audit.
+        transaction.
+
+        **Not reversible.** The audit trail records what happened; it does not undo it, and no
+        endpoint does — a merged dedupe pair answers `not_undoable`. B also keeps whatever it
+        took from A. Treat this as destructive and confirm before calling it.
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'
         - $ref: '#/components/parameters/IfMatch'
@@ -2410,8 +2414,12 @@ paths:
       description: |
         Merge A→B relinks A's domains, people-employment, deals, relationships and activity links to
         B with zero orphaned FKs, archives A with `merged_into_id = B`. Mirrors person merge
-        (features/01 §1.3). One audit transaction (action `merge`); reversible within audit. This is
+        (features/01 §1.3). One audit transaction (action `merge`). This is
         the org half of the `merge_records` MCP verb.
+
+        **Not reversible**, exactly as the person half is not: the audit trail records the merge,
+        nothing undoes it, a merged dedupe pair answers `not_undoable`, and B keeps what it took
+        from A. Treat this as destructive and confirm before calling it.
       x-mcp-tool: { verb: merge_records, record_type: organization, tier: auto_execute, scope: write }
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'

--- a/backend/gates/mergedecidableauthority_test.go
+++ b/backend/gates/mergedecidableauthority_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind parity H2
+
+package gates
+
+// Who may settle a duplicate pair has ONE answer, and the card must ask the
+// same thing the write asks.
+//
+// Two surfaces decide it. The disposition endpoint refuses a caller who cannot
+// write both records (ensurePairWritable → auth.EnsureWritable), and the
+// Worklist card decides whether to offer the verbs at all
+// (Store.DecidableForMerge). They are separate code paths because one runs at
+// the write and the other while rendering a feed, and nothing structural stops
+// the second from growing its own idea of authority.
+//
+// If it does, the failure is silent and lands on the reader: a card that offers
+// a verb the endpoint refuses is the button that told a rep to try again
+// forever, and a card that withholds one the endpoint would accept hides work
+// from the person whose job it is.
+//
+// So DecidableForMerge must reach its answer through auth.WritableSubset — the
+// same visibility-and-write-authority pair EnsureWritable asks, asked set-wise.
+// Re-deriving it here from owner_id, record_grant or a role's row scope is what
+// this gate refuses, whatever the re-derivation happens to conclude today.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+const (
+	decidableFile   = "internal/modules/people/mergeface.go"
+	decidableMethod = "DecidableForMerge"
+)
+
+// decidableForbidden are the ways a second answer gets written. Each is a
+// legitimate token elsewhere in the tree — the point is that the authority
+// question is not answered by hand HERE.
+var decidableForbidden = []string{
+	"owner_id",
+	"record_grant",
+	"RowScope",
+	"Unbounded",
+	"writeAuthorityPredicate",
+}
+
+func TestTheMergeCardAsksTheSameAuthorityTheWriteAsks(t *testing.T) {
+	t.Parallel()
+	body := methodSource(t, decidableFile, decidableMethod)
+
+	if !strings.Contains(body, "auth.WritableSubset") {
+		t.Errorf("%s does not call auth.WritableSubset.\n\n"+
+			"The card's offer and the disposition endpoint's refusal have to be two readings of\n"+
+			"one authority. Reaching the answer any other way lets the button and the write drift,\n"+
+			"and the reader is the one who finds out.", decidableMethod)
+	}
+	for _, forbidden := range decidableForbidden {
+		if strings.Contains(body, forbidden) {
+			t.Errorf("%s mentions %q, which is the authority rule being re-derived rather than asked.\n\n"+
+				"auth.WritableSubset already answers visibility and write authority together. A second\n"+
+				"spelling here is a second answer to one question, and the two will disagree.",
+				decidableMethod, forbidden)
+		}
+	}
+}
+
+// methodSource returns the source text of one method, so a gate can assert what
+// it does and does not reach for.
+func methodSource(t *testing.T, file, method string) string {
+	t.Helper()
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", file, err)
+	}
+	for _, decl := range parsed.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != method || fn.Body == nil {
+			continue
+		}
+		start := fset.Position(fn.Body.Pos()).Offset
+		end := fset.Position(fn.Body.End()).Offset
+		return readFile(t, file)[start:end]
+	}
+	t.Fatalf("%s has no method %s — a gate whose subject moved reports PASS on a smaller tree", file, method)
+	return ""
+}

--- a/backend/gates/mergedecidableauthority_test.go
+++ b/backend/gates/mergedecidableauthority_test.go
@@ -36,57 +36,128 @@ import (
 const (
 	decidableFile   = "internal/modules/people/mergeface.go"
 	decidableMethod = "DecidableForMerge"
+	decidableAsks   = "auth.WritableSubset"
 )
 
-// decidableForbidden are the ways a second answer gets written. Each is a
-// legitimate token elsewhere in the tree — the point is that the authority
-// question is not answered by hand HERE.
+// decidableForbidden are the ways a second answer gets written: the columns the
+// authority rule lives in, and the auth internals that render it. Each is
+// legitimate elsewhere in the tree — the point is that this method does not
+// answer the question itself.
+//
+// Matched against CALLS and SQL STRINGS rather than the method's text, so a
+// sentence in a comment explaining why the rule is not re-derived here does not
+// read as the re-derivation it is describing.
 var decidableForbidden = []string{
 	"owner_id",
 	"record_grant",
 	"RowScope",
 	"Unbounded",
 	"writeAuthorityPredicate",
+	"VisibleSubset",
 }
 
 func TestTheMergeCardAsksTheSameAuthorityTheWriteAsks(t *testing.T) {
 	t.Parallel()
-	body := methodSource(t, decidableFile, decidableMethod)
+	body := methodBody(t, decidableFile, decidableMethod)
 
-	if !strings.Contains(body, "auth.WritableSubset") {
-		t.Errorf("%s does not call auth.WritableSubset.\n\n"+
+	// A CALL, not a mention. Asserting on the method's text would be satisfied
+	// by a comment naming the helper while the code beneath it did something
+	// else entirely — which is the one failure a gate over authority must not
+	// have.
+	if !callsQualified(body, decidableAsks) {
+		t.Errorf("%s does not CALL %s.\n\n"+
 			"The card's offer and the disposition endpoint's refusal have to be two readings of\n"+
 			"one authority. Reaching the answer any other way lets the button and the write drift,\n"+
-			"and the reader is the one who finds out.", decidableMethod)
+			"and the reader is the one who finds out.", decidableMethod, decidableAsks)
 	}
 	for _, forbidden := range decidableForbidden {
-		if strings.Contains(body, forbidden) {
-			t.Errorf("%s mentions %q, which is the authority rule being re-derived rather than asked.\n\n"+
+		if where := reachesFor(body, forbidden); where != "" {
+			t.Errorf("%s %s %q, which is the authority rule being re-derived rather than asked.\n\n"+
 				"auth.WritableSubset already answers visibility and write authority together. A second\n"+
 				"spelling here is a second answer to one question, and the two will disagree.",
-				decidableMethod, forbidden)
+				decidableMethod, where, forbidden)
 		}
 	}
 }
 
-// methodSource returns the source text of one method, so a gate can assert what
-// it does and does not reach for.
-func methodSource(t *testing.T, file, method string) string {
+// callsQualified reports whether the body calls the named function, spelled
+// `pkg.Name`.
+func callsQualified(body *ast.BlockStmt, want string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if qualifiedCallee(call.Fun) == want {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// reachesFor reports how the body reaches for a forbidden name — as a call or
+// identifier, or inside a SQL string — and returns "" when it does not.
+func reachesFor(body *ast.BlockStmt, forbidden string) string {
+	var how string
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.CallExpr:
+			if strings.Contains(qualifiedCallee(node.Fun), forbidden) {
+				how = "calls"
+			}
+		case *ast.SelectorExpr:
+			if strings.Contains(node.Sel.Name, forbidden) {
+				how = "reads"
+			}
+		case *ast.Ident:
+			if node.Name == forbidden {
+				how = "names"
+			}
+		case *ast.BasicLit:
+			// A column name only ever appears here inside SQL, which is the
+			// re-derivation this gate is really about.
+			if node.Kind == token.STRING && strings.Contains(node.Value, forbidden) {
+				how = "queries"
+			}
+		}
+		return how == ""
+	})
+	return how
+}
+
+// qualifiedCallee is calleeName's package-qualified sibling: this gate has to
+// tell auth.WritableSubset from any other WritableSubset, and the bare name
+// cannot.
+func qualifiedCallee(fun ast.Expr) string {
+	switch node := fun.(type) {
+	case *ast.Ident:
+		return node.Name
+	case *ast.SelectorExpr:
+		if pkg, ok := node.X.(*ast.Ident); ok {
+			return pkg.Name + "." + node.Sel.Name
+		}
+		return node.Sel.Name
+	default:
+		return ""
+	}
+}
+
+// methodBody returns one method's body, so a gate can assert what the code
+// does rather than what its comments say.
+func methodBody(t *testing.T, file, method string) *ast.BlockStmt {
 	t.Helper()
-	fset := token.NewFileSet()
-	parsed, err := parser.ParseFile(fset, file, nil, 0)
+	parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
 	if err != nil {
 		t.Fatalf("parsing %s: %v", file, err)
 	}
 	for _, decl := range parsed.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Name.Name != method || fn.Body == nil {
-			continue
+		if ok && fn.Name.Name == method && fn.Body != nil {
+			return fn.Body
 		}
-		start := fset.Position(fn.Body.Pos()).Offset
-		end := fset.Position(fn.Body.End()).Offset
-		return readFile(t, file)[start:end]
 	}
 	t.Fatalf("%s has no method %s — a gate whose subject moved reports PASS on a smaller tree", file, method)
-	return ""
+	return nil
 }

--- a/backend/internal/compose/attention/feed.go
+++ b/backend/internal/compose/attention/feed.go
@@ -374,9 +374,13 @@ func (s *Service) decisionsToDepth(ctx context.Context, depth int) ([]crmcontrac
 	if err != nil {
 		return nil, laneCount{}, err
 	}
+	decidable, err := s.decidablePairs(ctx, pairs)
+	if err != nil {
+		return nil, laneCount{}, err
+	}
 	duplicates := make([]crmcontracts.AttentionItem, 0, len(pairs))
 	for _, pair := range pairs {
-		duplicates = append(duplicates, s.duplicateItem(pair, named))
+		duplicates = append(duplicates, s.duplicateItem(pair, named, decidable))
 	}
 	approvals := make([]crmcontracts.AttentionItem, 0, len(staged))
 	for _, approval := range staged {

--- a/backend/internal/compose/attention/feed_test.go
+++ b/backend/internal/compose/attention/feed_test.go
@@ -55,6 +55,12 @@ type stubDuplicates struct {
 	// asked records every batch the lane requested, so a test can count the
 	// reads rather than assume them.
 	asked *[]string
+	// undecidable is a record this caller may READ but could not CHANGE — the
+	// case a rep meets on every pair a colleague owns. The pair is still named
+	// in full; only the verb is withheld.
+	undecidable ids.UUID
+	// decideErr is an authority read that BROKE rather than one that refused.
+	decideErr error
 }
 
 func (s stubDuplicates) OpenCandidates(context.Context, int) ([]DuplicatePair, error) {
@@ -82,6 +88,23 @@ func (s stubDuplicates) DescribeMany(
 		faces[id] = RecordFace{Label: "Record " + id.String()[:8]}
 	}
 	return faces, nil
+}
+
+// DecidableSubset answers writability. Every record is decidable unless a test
+// names one that is not: the lane's other cases are about naming and ordering,
+// and a stub that withheld the verb by default would make each of them assert
+// the absence of a button for the wrong reason.
+func (s stubDuplicates) DecidableSubset(
+	_ context.Context, _ string, rowIDs []ids.UUID,
+) (map[ids.UUID]bool, error) {
+	if s.decideErr != nil {
+		return nil, s.decideErr
+	}
+	writable := make(map[ids.UUID]bool, len(rowIDs))
+	for _, id := range rowIDs {
+		writable[id] = id != s.undecidable
+	}
+	return writable, nil
 }
 
 type stubTasks struct {
@@ -452,6 +475,83 @@ func TestAnUnreadableSideCostsTheMergeVerbRatherThanLeakingTheRecord(t *testing.
 		if action == "merge" {
 			t.Error("merge is offered over a record the reader cannot see")
 		}
+	}
+}
+
+// A pair naming a record the reader may see but could not change offers no
+// verb. This is the ordinary case for a rep: everyone here reads every
+// colleague's customer records and can write almost none of them, so a merge
+// button decided by visibility refused every press it invited.
+func TestAPairTheReaderCannotChangeIsShownWithoutAVerb(t *testing.T) {
+	theirs := ids.NewV7()
+	svc := NewService(
+		stubApprovals{},
+		stubDuplicates{open: 1, undecidable: theirs, pairs: []DuplicatePair{{
+			ID: ids.NewV7(), EntityType: "person", Confidence: 0.9,
+			LeftID: ids.NewV7(), RightID: theirs,
+		}}},
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	// The pair is still NAMED. Withholding the verb is not withholding the
+	// fact: a reader who cannot merge these two still needs to know a duplicate
+	// is waiting, and who it is about.
+	if out.NeedsYou[0].Pair == nil {
+		t.Fatal("a pair the reader may read was hidden because they cannot decide it")
+	}
+	for _, action := range out.NeedsYou[0].Actions {
+		if action == "merge" {
+			t.Error("merge is offered over a record the reader cannot change, which is the press that always refused")
+		}
+	}
+}
+
+// Authority over ONE side is not authority to decide the pair: the merge
+// archives one record and rewrites the other, so half the authority settles
+// nothing and a verb offered on it would refuse.
+func TestOwningOneSideOfAPairDoesNotOfferTheVerb(t *testing.T) {
+	mine, theirs := ids.NewV7(), ids.NewV7()
+	svc := NewService(
+		stubApprovals{},
+		stubDuplicates{open: 1, undecidable: theirs, pairs: []DuplicatePair{{
+			ID: ids.NewV7(), EntityType: "organization", Confidence: 1,
+			LeftID: mine, RightID: theirs,
+		}}},
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	if len(out.NeedsYou[0].Actions) != 0 {
+		t.Errorf("actions %v offered on a pair the reader owns half of", out.NeedsYou[0].Actions)
+	}
+}
+
+// A reader who can change both records still gets the verb. Without this the
+// two tests above would pass against a lane that had simply stopped offering
+// merge to anybody.
+func TestAPairTheReaderCanChangeStillOffersTheVerb(t *testing.T) {
+	svc := NewService(
+		stubApprovals{},
+		stubDuplicates{open: 1, pairs: []DuplicatePair{{
+			ID: ids.NewV7(), EntityType: "person", Confidence: 0.9,
+			LeftID: ids.NewV7(), RightID: ids.NewV7(),
+		}}},
+		&stubTasks{}, stubReceipts{}, stubBriefing{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fixedClock)
+	out, err := svc.Assemble(context.Background())
+	if err != nil {
+		t.Fatalf("assembling: %v", err)
+	}
+	var offered bool
+	for _, action := range out.NeedsYou[0].Actions {
+		if action == "merge" {
+			offered = true
+		}
+	}
+	if !offered {
+		t.Error("a steward who can change both records was offered no way to settle the pair")
 	}
 }
 

--- a/backend/internal/compose/attention/lanes.go
+++ b/backend/internal/compose/attention/lanes.go
@@ -71,10 +71,17 @@ type ApprovalQuery struct {
 // naming them one by one is twenty scoped reads on the surface a rep opens first
 // every morning. An id the reader may not see is simply ABSENT from the answer,
 // which is what its refusal meant.
+//
+// DecidableSubset asks the OTHER question about the same records: not whether
+// this reader may see them, but whether they could change them. Settling a pair
+// archives one record and rewrites the other, so a reader holding neither
+// side's write authority has no verb to be offered — and the card is where they
+// should learn that, rather than from a refusal after the press.
 type Duplicates interface {
 	OpenCandidates(ctx context.Context, limit int) ([]DuplicatePair, error)
 	CountOpen(ctx context.Context) (int, error)
 	DescribeMany(ctx context.Context, entityType string, rowIDs []ids.UUID) (map[ids.UUID]RecordFace, error)
+	DecidableSubset(ctx context.Context, entityType string, rowIDs []ids.UUID) (map[ids.UUID]bool, error)
 }
 
 // DuplicatePair is one open candidate: the pair, and what the detector saw.

--- a/backend/internal/compose/attention/render.go
+++ b/backend/internal/compose/attention/render.go
@@ -42,8 +42,16 @@ const actionOpen crmcontracts.AttentionItemActions = "open"
 // reader is told a duplicate is waiting and cannot act on it here, which is the
 // honest answer: the alternative is a merge button over a record they cannot
 // read.
+//
+// The verb needs MORE than that read, and this is where the two questions part.
+// Settling a pair archives one record and rewrites the other, so it is offered
+// only to a reader who could change BOTH — the records' owner, or a seat that
+// writes the whole workspace. Everyone else sees the pair and no verb, because
+// they are the ones who cannot act on it. Offered on visibility alone, the
+// button refused every press on a pair whose two records had different owners,
+// and the surface then advised trying again.
 func (s *Service) duplicateItem(
-	pair DuplicatePair, known pairFaces,
+	pair DuplicatePair, known pairFaces, decidable pairAuthority,
 ) crmcontracts.AttentionItem {
 	kind := pair.EntityType
 	confidence := float32(pair.Confidence)
@@ -64,13 +72,26 @@ func (s *Service) duplicateItem(
 		Right:    right,
 		Evidence: evidenceRows(pair.Evidence),
 	}
-	item.Actions = []crmcontracts.AttentionItemActions{"merge"}
+	if decidable.both(pair.EntityType, pair.LeftID, pair.RightID) {
+		item.Actions = []crmcontracts.AttentionItemActions{"merge"}
+	}
 	return item
 }
 
 // pairFaces holds the records a page names, keyed by entity type then by id. An
 // id with no entry is one this reader may not see.
 type pairFaces map[string]map[ids.UUID]RecordFace
+
+// pairAuthority holds which records the reader could change, keyed the same way
+// pairFaces is. An id with no entry is one they could not.
+type pairAuthority map[string]map[ids.UUID]bool
+
+// both is the pair's own question: a merge touches two records, so authority
+// over one of them is not authority to decide it.
+func (a pairAuthority) both(entityType string, left, right ids.UUID) bool {
+	rows := a[entityType]
+	return rows[left] && rows[right]
+}
 
 func (f pairFaces) side(entityType string, id ids.UUID) (crmcontracts.AttentionPairSide, bool) {
 	face, ok := f[entityType][id]
@@ -110,6 +131,33 @@ func (s *Service) namePairs(ctx context.Context, pairs []DuplicatePair) (pairFac
 		named[entityType] = faces
 	}
 	return named, nil
+}
+
+// decidablePairs asks which of the page's records the reader could change, one
+// query per entity type, exactly as namePairs asks who they may see.
+//
+// A refusal is treated the same way and for the same reason: it means "no verb
+// on these", which is a complete answer, and letting it empty the whole lane
+// would cost the reader pairs they are entitled to look at. Any other error is
+// returned, because a database that will not answer is not a permission
+// verdict.
+func (s *Service) decidablePairs(ctx context.Context, pairs []DuplicatePair) (pairAuthority, error) {
+	wanted := map[string][]ids.UUID{}
+	for _, pair := range pairs {
+		wanted[pair.EntityType] = append(wanted[pair.EntityType], pair.LeftID, pair.RightID)
+	}
+	authority := make(pairAuthority, len(wanted))
+	for entityType, rowIDs := range wanted {
+		writable, err := s.duplicates.DecidableSubset(ctx, entityType, rowIDs)
+		switch {
+		case errors.Is(err, apperrors.ErrPermissionDenied), errors.Is(err, apperrors.ErrNotFound):
+			continue
+		case err != nil:
+			return nil, err
+		}
+		authority[entityType] = writable
+	}
+	return authority, nil
 }
 
 func pairSide(id ids.UUID, face RecordFace) crmcontracts.AttentionPairSide {

--- a/backend/internal/compose/attentionseam.go
+++ b/backend/internal/compose/attentionseam.go
@@ -120,6 +120,21 @@ func (d attentionDuplicates) DescribeMany(
 	return faces, nil
 }
 
+// DecidableSubset answers which of these records the reader could change, which
+// is what decides whether the card offers a verb at all.
+//
+// It goes through the same store as the naming read, so the card's offer and
+// the disposition endpoint's refusal are two readings of one authority rather
+// than two rules that can drift.
+func (d attentionDuplicates) DecidableSubset(
+	ctx context.Context, entityType string, rowIDs []ids.UUID,
+) (map[ids.UUID]bool, error) {
+	if entityType != flipObjectPerson && entityType != flipObjectOrganization && entityType != flipObjectLead {
+		return nil, apperrors.ErrNotFound
+	}
+	return d.store.DecidableForMerge(ctx, entityType, rowIDs)
+}
+
 func (d attentionDuplicates) CountOpen(ctx context.Context) (int, error) {
 	return d.store.CountOpenDedupeCandidates(ctx)
 }

--- a/backend/internal/modules/people/dedupequeue_integration_test.go
+++ b/backend/internal/modules/people/dedupequeue_integration_test.go
@@ -775,3 +775,52 @@ func TestOpenCandidatesNamingIsSilentForARecordTypeWithNoQueue(t *testing.T) {
 		t.Fatalf("got %d candidates for a type that has no queue, want 0", len(rows))
 	}
 }
+
+// What the CARD offers and what the ENDPOINT accepts have to be one answer.
+//
+// The Worklist decides whether to draw the verbs by asking DecidableForMerge;
+// the disposition endpoint decides whether to accept the press by asking
+// ensurePairWritable. They are separate paths, so this pins them against the
+// same fixtures: a seat owning both records is offered the verbs and admitted,
+// and a seat owning neither is offered nothing and refused.
+//
+// A unit test cannot hold this. Both answers come out of SQL predicates over
+// owner_id and record_grant, which is exactly what a stub replaces.
+func TestTheMergeCardAgreesWithTheDispositionEndpoint(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	left, right := seedOrgPair(ctx, t, e)
+	c := openCandidates(ctx, t, e, "organization")[0]
+
+	// The owner of BOTH records: the endpoint admits this seat, so the card
+	// must offer it the verbs.
+	owner := e.asOwnScoped(e.rep)
+	decidable, err := e.store.DecidableForMerge(owner, entityOrganization, []ids.UUID{left, right})
+	if err != nil {
+		t.Fatalf("asking what the owner may decide: %v", err)
+	}
+	if !decidable[left] || !decidable[right] {
+		t.Fatalf("the card withheld the verbs from a seat owning both records (left=%v right=%v), "+
+			"and the endpoint would have accepted its press", decidable[left], decidable[right])
+	}
+
+	// The colleague owns NEITHER record. They may read the pair — everyone here
+	// reads the workspace's customer records — and the endpoint refuses them,
+	// so the card must not offer what would refuse.
+	colleague := e.asOwnScoped(e.otherRep)
+	withheld, err := e.store.DecidableForMerge(colleague, entityOrganization, []ids.UUID{left, right})
+	if err != nil {
+		t.Fatalf("asking what a colleague may decide: %v", err)
+	}
+	if withheld[left] || withheld[right] {
+		t.Fatalf("the card offered a verb over records the colleague owns neither of "+
+			"(left=%v right=%v) — the press this invites is the 403 that told them to try again",
+			withheld[left], withheld[right])
+	}
+	// And the endpoint really does refuse, so the assertion above is pinned to
+	// the behaviour rather than to an assumption about it.
+	if _, err := e.store.DisposeDedupeCandidate(colleague, c.ID, "not_a_duplicate", nil); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("the endpoint admitted a colleague owning neither record (%v), "+
+			"so withholding the verb from them is the card disagreeing with the write", err)
+	}
+}

--- a/backend/internal/modules/people/mergeface.go
+++ b/backend/internal/modules/people/mergeface.go
@@ -87,6 +87,46 @@ func (s *Store) DescribeForMerge(
 	return faces, nil
 }
 
+// DecidableForMerge answers which of these records the caller could CHANGE.
+//
+// The merge card asks it because settling a pair is not a read: the loser is
+// archived and the survivor is relinked and filled, so the verb needs write
+// authority over BOTH sides. Offering it on visibility alone is what produced a
+// button that refused every press — a rep sees every colleague's records here
+// and can change almost none of them.
+//
+// It answers with auth.WritableSubset, the same pair of questions
+// EnsureWritable asks at the write itself, so the card and the endpoint cannot
+// disagree about who may decide. A record the caller may not see is absent
+// exactly as it is from DescribeForMerge, and the two absences mean the same
+// thing.
+//
+// The OBJECT grant is deliberately NOT required here. A reader whose role lacks
+// the update verb is a legitimate caller asking a question whose answer is "no
+// verb for you", and WritableSubset already answers it that way — refusing the
+// whole read would cost them the card as well, which is the pair they are
+// entitled to see.
+func (s *Store) DecidableForMerge(
+	ctx context.Context, entityType string, rowIDs []ids.UUID,
+) (map[ids.UUID]bool, error) {
+	if len(rowIDs) == 0 {
+		return map[ids.UUID]bool{}, nil
+	}
+	if !isMergeFaceEntity(entityType) {
+		return nil, fmt.Errorf("people: %q has no merge face: %w", entityType, apperrors.ErrNotFound)
+	}
+	var decidable map[ids.UUID]bool
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		var err error
+		decidable, err = auth.WritableSubset(ctx, tx, entityType, rowIDs)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return decidable, nil
+}
+
 // isMergeFaceEntity is the closed set this read serves. Named rather than left
 // to the switch below so an unknown type is refused before a transaction is
 // opened, and refused the same way whatever the caller asked for.

--- a/backend/internal/modules/people/mergeface.go
+++ b/backend/internal/modules/people/mergeface.go
@@ -101,6 +101,9 @@ func (s *Store) DescribeForMerge(
 // exactly as it is from DescribeForMerge, and the two absences mean the same
 // thing.
 //
+// Held by: TestTheMergeCardAsksTheSameAuthorityTheWriteAsks
+// (backend/gates/mergedecidableauthority_test.go)
+//
 // The OBJECT grant is deliberately NOT required here. A reader whose role lacks
 // the update verb is a legitimate caller asking a question whose answer is "no
 // verb for you", and WritableSubset already answers it that way — refusing the

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -15,7 +15,7 @@ edit its `//gate:kind` line, then regenerate from the backend directory:
 The eight shapes, what each is for, and how each one silently passes:
 [gate-patterns.md](gate-patterns.md).
 
-## Parity (73)
+## Parity (74)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -70,6 +70,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `languageset_test.go` | H3 | The languages the product speaks are declared in more than one place, and they have to agree. |
 | `mailbrieflink_test.go` | H1 | The Brief's address is spelled twice: the frontend routes it (frontend/src/screens/brief.view.ts) and outbound mail links to it (internal/platform/mailcopy/link.go), because a message has to name a view before the app it opens is running. |
 | `mailcopy_test.go` | H2 | The weekly message's labels are the weekly PANEL's labels. |
+| `mergedecidableauthority_test.go` | H2 | Who may settle a duplicate pair has ONE answer, and the card must ask the same thing the write asks. |
 | `minorunitscale_test.go` | H3 | A currency's minor-unit scale — 100 for EUR, 1000 for KWD, 1 for VND — is one fact, and the table that holds it lives in shared/kernel/values. |
 | `modulecatalogtables_test.go` | H2 | The module catalog's Owns-tables column is the ownership map. |
 | `netguardparity_test.go` | H3 | The egress SSRF denylist exists twice, and this is where the two are held equal. |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -516,7 +516,11 @@ export interface paths {
          * Merge this person into a target (non-lossy).
          * @description Merge A→B relinks A's emails/phones/relationships/activity links to B with zero
          *     orphaned FKs, archives A with `merged_into_id = B` (features/01 §1.3). One audit
-         *     transaction; reversible within audit.
+         *     transaction.
+         *
+         *     **Not reversible.** The audit trail records what happened; it does not undo it, and no
+         *     endpoint does — a merged dedupe pair answers `not_undoable`. B also keeps whatever it
+         *     took from A. Treat this as destructive and confirm before calling it.
          */
         post: operations["mergePerson"];
         delete?: never;
@@ -1486,8 +1490,12 @@ export interface paths {
          * Merge this organization into a target (non-lossy).
          * @description Merge A→B relinks A's domains, people-employment, deals, relationships and activity links to
          *     B with zero orphaned FKs, archives A with `merged_into_id = B`. Mirrors person merge
-         *     (features/01 §1.3). One audit transaction (action `merge`); reversible within audit. This is
+         *     (features/01 §1.3). One audit transaction (action `merge`). This is
          *     the org half of the `merge_records` MCP verb.
+         *
+         *     **Not reversible**, exactly as the person half is not: the audit trail records the merge,
+         *     nothing undoes it, a merged dedupe pair answers `not_undoable`, and B keeps what it took
+         *     from A. Treat this as destructive and confirm before calling it.
          */
         post: operations["mergeOrganization"];
         delete?: never;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7885,6 +7885,12 @@ export const de = {
   "worklist.pair.related": "{count} verknüpft",
   "worklist.pair.failed":
     "Paar konnte nicht entschieden werden. Bitte erneut versuchen.",
+  "worklist.pair.refused":
+    "Sie können dieses Paar nicht entscheiden. Beide Datensätze müssten Ihnen gehören — eine Administratorin oder eine Vertriebsleitung kann es entscheiden.",
+  "worklist.pair.alreadySettled":
+    "Jemand war schneller: Das Paar ist bereits entschieden und aus der Liste verschwunden.",
+  "worklist.pair.stewardOnly":
+    "Nur wer beide Datensätze ändern darf, kann das entscheiden — eine Administratorin oder eine Vertriebsleitung.",
   "worklist.needsPrep": "Unvorbereitet",
   "worklist.pane.title": "Zu diesem Datensatz",
   "worklist.pane.openRow": "Zeigen, worum es bei {position}, {title}, geht",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -7888,7 +7888,7 @@ export const de = {
   "worklist.pair.refused":
     "Sie können dieses Paar nicht entscheiden. Beide Datensätze müssten Ihnen gehören — eine Administratorin oder eine Vertriebsleitung kann es entscheiden.",
   "worklist.pair.alreadySettled":
-    "Jemand war schneller: Das Paar ist bereits entschieden und aus der Liste verschwunden.",
+    "Das Paar konnte so nicht entschieden werden — vielleicht war jemand schneller, vielleicht haben sich die Datensätze geändert. Bitte die Liste neu laden.",
   "worklist.pair.stewardOnly":
     "Nur wer beide Datensätze ändern darf, kann das entscheiden — eine Administratorin oder eine Vertriebsleitung.",
   "worklist.needsPrep": "Unvorbereitet",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7971,7 +7971,7 @@ export const en = {
   "worklist.pair.refused":
     "You cannot settle this pair. Both records have to be yours to change, so an admin or a sales lead can settle it.",
   "worklist.pair.alreadySettled":
-    "Somebody settled this pair first. It is gone from the list.",
+    "This pair could not be settled the way you asked — somebody may have decided it first, or the records changed under you. Reload the list to see where it stands.",
   "worklist.pair.stewardOnly":
     "Only somebody who can change both records can settle this — an admin or a sales lead.",
   "worklist.needsPrep": "Needs prep",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -7968,6 +7968,12 @@ export const en = {
   "worklist.pair.notDuplicate": "Not the same",
   "worklist.pair.related": "{count} linked",
   "worklist.pair.failed": "Could not settle the pair. Try again.",
+  "worklist.pair.refused":
+    "You cannot settle this pair. Both records have to be yours to change, so an admin or a sales lead can settle it.",
+  "worklist.pair.alreadySettled":
+    "Somebody settled this pair first. It is gone from the list.",
+  "worklist.pair.stewardOnly":
+    "Only somebody who can change both records can settle this — an admin or a sales lead.",
   "worklist.needsPrep": "Needs prep",
   "worklist.pane.title": "About this record",
   "worklist.pane.openRow": "Show what {position}, {title}, is about",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7797,7 +7797,7 @@ export const vi = {
   "worklist.pair.refused":
     "Bạn không thể xử lý cặp này. Bạn phải sửa được cả hai bản ghi, nên quản trị viên hoặc trưởng nhóm kinh doanh sẽ xử lý.",
   "worklist.pair.alreadySettled":
-    "Người khác đã xử lý cặp này trước. Nó không còn trong danh sách.",
+    "Không xử lý được cặp này theo cách bạn chọn — có thể người khác đã quyết định trước, hoặc bản ghi đã thay đổi. Hãy tải lại danh sách.",
   "worklist.pair.stewardOnly":
     "Chỉ người sửa được cả hai bản ghi mới xử lý được — quản trị viên hoặc trưởng nhóm kinh doanh.",
   "worklist.needsPrep": "Chưa chuẩn bị",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -7794,6 +7794,12 @@ export const vi = {
   "worklist.pair.notDuplicate": "Không trùng nhau",
   "worklist.pair.related": "{count} liên kết",
   "worklist.pair.failed": "Không quyết định được cặp này. Hãy thử lại.",
+  "worklist.pair.refused":
+    "Bạn không thể xử lý cặp này. Bạn phải sửa được cả hai bản ghi, nên quản trị viên hoặc trưởng nhóm kinh doanh sẽ xử lý.",
+  "worklist.pair.alreadySettled":
+    "Người khác đã xử lý cặp này trước. Nó không còn trong danh sách.",
+  "worklist.pair.stewardOnly":
+    "Chỉ người sửa được cả hai bản ghi mới xử lý được — quản trị viên hoặc trưởng nhóm kinh doanh.",
   "worklist.needsPrep": "Chưa chuẩn bị",
   "worklist.pane.title": "Về bản ghi này",
   "worklist.pane.openRow": "Xem mục {position}, {title}, về ai",

--- a/frontend/src/screens/worklist.css
+++ b/frontend/src/screens/worklist.css
@@ -279,6 +279,13 @@
   font-weight: 600;
 }
 
+/* Where the verbs would have been, for a reader who may not settle the pair.
+   It stands in the buttons' own place so the card still reads as one thought:
+   here are two records, and here is why nothing is being asked of you. */
+.worklist-pair-steward {
+  margin: 0;
+}
+
 /* The snooze spans, stacked inside their popover: three short verbs read as a
    list of choices rather than as a sentence when they sit on one line. */
 .worklist-snooze-spans {

--- a/frontend/src/screens/worklist.pair.stories.tsx
+++ b/frontend/src/screens/worklist.pair.stories.tsx
@@ -94,3 +94,11 @@ export const WithoutCounts: Story = {
 export const Withheld: Story = {
   args: { item: pairRow({ pair: undefined, actions: [] }) },
 };
+
+// Both records READ, neither of them the reader's to change: the ordinary case
+// for a rep looking at a colleague's duplicates. The pair is named in full so
+// they know what is waiting, and the verbs are replaced by the sentence that
+// says who can settle it — rather than by buttons that would refuse.
+export const NotYoursToSettle: Story = {
+  args: { item: pairRow({ actions: [] }) },
+};

--- a/frontend/src/screens/worklist.pair.test.tsx
+++ b/frontend/src/screens/worklist.pair.test.tsx
@@ -163,10 +163,11 @@ describe("deciding a duplicate pair on the row", () => {
   // A refused decision leaves the row rendering exactly as an unpressed one
   // does, and the reader believes the pair is settled when it is not.
   //
-  // A CONFLICT is its own answer: somebody settled the pair first, so the row
-  // is gone rather than waiting. Telling this reader to try again would send
-  // them back to a decision nobody is asking for any more.
-  it("says the pair was already settled when the server answers conflict", async () => {
+  // A CONFLICT means the decision did not land as asked — a colleague settled
+  // it first, or the records moved underneath. It deliberately does NOT claim
+  // the pair is gone: a merge the server refuses REOPENS the candidate, so
+  // "already settled" would be false exactly when the reader needs the truth.
+  it("says the decision did not land when the server answers conflict", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -181,7 +182,11 @@ describe("deciding a duplicate pair on the row", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Not the same" }));
 
-    expect(await screen.findByText(/settled this pair first/)).toBeTruthy();
+    expect(
+      await screen.findByText(/could not be settled the way you asked/),
+    ).toBeTruthy();
+    // Never the claim that it is gone: a refused merge puts the pair back.
+    expect(screen.queryByText(/gone from the list/)).toBeNull();
   });
 
   // A REFUSAL will refuse again however often it is pressed, so "try again" is

--- a/frontend/src/screens/worklist.pair.test.tsx
+++ b/frontend/src/screens/worklist.pair.test.tsx
@@ -215,7 +215,9 @@ describe("deciding a duplicate pair on the row", () => {
     expect(screen.getByText("Acme GmbH")).toBeTruthy();
     expect(screen.getByText("ACME Gmbh")).toBeTruthy();
     expect(screen.queryByRole("button")).toBeNull();
-    expect(screen.getByText(/Only somebody who can change both records/)).toBeTruthy();
+    expect(
+      screen.getByText(/Only somebody who can change both records/),
+    ).toBeTruthy();
   });
 
   // The steward still gets the verbs. Without this the case above would pass

--- a/frontend/src/screens/worklist.pair.test.tsx
+++ b/frontend/src/screens/worklist.pair.test.tsx
@@ -162,7 +162,11 @@ describe("deciding a duplicate pair on the row", () => {
 
   // A refused decision leaves the row rendering exactly as an unpressed one
   // does, and the reader believes the pair is settled when it is not.
-  it("says so when the decision is refused", async () => {
+  //
+  // A CONFLICT is its own answer: somebody settled the pair first, so the row
+  // is gone rather than waiting. Telling this reader to try again would send
+  // them back to a decision nobody is asking for any more.
+  it("says the pair was already settled when the server answers conflict", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -177,6 +181,49 @@ describe("deciding a duplicate pair on the row", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Not the same" }));
 
-    expect(await screen.findByText(/Could not settle the pair/)).toBeTruthy();
+    expect(await screen.findByText(/settled this pair first/)).toBeTruthy();
+  });
+
+  // A REFUSAL will refuse again however often it is pressed, so "try again" is
+  // the one instruction that must not appear. This is the toast a rep met on
+  // every pair spanning two owners.
+  it("names the steward when the decision is refused, and never says try again", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ code: "permission_denied" }), {
+            status: 403,
+            headers: { "content-type": "application/problem+json" },
+          }),
+      ),
+    );
+    draw(pairRow());
+
+    await userEvent.click(screen.getByRole("button", { name: "Not the same" }));
+
+    expect(await screen.findByText(/cannot settle this pair/)).toBeTruthy();
+    expect(screen.queryByText(/Try again/)).toBeNull();
+  });
+
+  // The pair is still SHOWN — a reader who cannot settle it still needs to know
+  // a duplicate is waiting — but nothing is offered, because every press would
+  // refuse.
+  it("shows the pair without verbs when the server offered no merge", () => {
+    draw(pairRow({ actions: [] }));
+
+    expect(screen.getByText("Acme GmbH")).toBeTruthy();
+    expect(screen.getByText("ACME Gmbh")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText(/Only somebody who can change both records/)).toBeTruthy();
+  });
+
+  // The steward still gets the verbs. Without this the case above would pass
+  // against a card that had simply stopped offering them to anybody.
+  it("offers the verbs when the server offered merge", () => {
+    draw(pairRow());
+
+    expect(screen.getByRole("button", { name: "Keep Acme GmbH" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Not the same" })).toBeTruthy();
   });
 });

--- a/frontend/src/screens/worklist.pair.tsx
+++ b/frontend/src/screens/worklist.pair.tsx
@@ -19,6 +19,7 @@ import { Button } from "../design-system/atoms";
 import { useToast } from "../design-system/toast";
 import { formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
+import { problemCodeOf } from "./common";
 import { useDedupeDisposition } from "./dedupe.queries";
 import { type WorklistItem, worklistKey } from "./worklist.queries";
 
@@ -29,6 +30,14 @@ import { type WorklistItem, worklistKey } from "./worklist.queries";
  * is one whose reader may not see both sides, and the lane already withheld the
  * `merge` verb for exactly that reason — so there is nothing here to draw and
  * no decision to offer.
+ *
+ * The verbs are drawn only where the server OFFERED them. Settling a pair
+ * archives one record and rewrites the other, so it belongs to whoever could
+ * change both — the owner, or a workspace-wide seat. A reader without that
+ * authority still sees the pair, because knowing a duplicate is waiting is not
+ * the same as being able to settle it, and is told who can. Rendering the
+ * buttons for everybody is what produced a control that refused every press a
+ * rep made on a colleague's records, then advised trying again.
  */
 export function PairDecision({ item }: Readonly<{ item: WorklistItem }>) {
   const t = useT();
@@ -39,6 +48,7 @@ export function PairDecision({ item }: Readonly<{ item: WorklistItem }>) {
   if (!pair) {
     return null;
   }
+  const mayDecide = item.actions?.includes("merge") ?? false;
   const answer = (
     disposition: "merge" | "not_a_duplicate",
     winnerId?: string,
@@ -48,7 +58,21 @@ export function PairDecision({ item }: Readonly<{ item: WorklistItem }>) {
       {
         // A refused decision leaves the row exactly as an unpressed one looks.
         // Without this the reader believes the pair is settled and it is not.
-        onError: () => toast.show(t("worklist.pair.failed"), { mark: false }),
+        //
+        // THREE outcomes, not one. A refusal will refuse again however many
+        // times it is pressed, so "try again" is the wrong instruction — the
+        // reader needs a steward. A conflict means somebody settled the pair
+        // first, and the row is already gone. Only the rest is worth a retry.
+        onError: (error) => {
+          const code = problemCodeOf(error);
+          const message =
+            code === "permission_denied"
+              ? "worklist.pair.refused"
+              : code === "conflict"
+                ? "worklist.pair.alreadySettled"
+                : "worklist.pair.failed";
+          toast.show(t(message), { mark: false });
+        },
       },
     );
   return (
@@ -77,24 +101,35 @@ export function PairDecision({ item }: Readonly<{ item: WorklistItem }>) {
                 a reader who is not looking at the layout — a screen reader,
                 a keyboard walking the controls — no way to tell which record
                 they are about to archive. */}
-            <Button
-              small
-              variant="primary"
-              pending={decide.isPending}
-              onClick={() => answer("merge", side.id)}
-            >
-              {t("worklist.pair.keep", { name: side.label })}
-            </Button>
+            {mayDecide && (
+              <Button
+                small
+                variant="primary"
+                pending={decide.isPending}
+                onClick={() => answer("merge", side.id)}
+              >
+                {t("worklist.pair.keep", { name: side.label })}
+              </Button>
+            )}
           </li>
         ))}
       </ul>
-      <Button
-        small
-        pending={decide.isPending}
-        onClick={() => answer("not_a_duplicate")}
-      >
-        {t("worklist.pair.notDuplicate")}
-      </Button>
+      {mayDecide ? (
+        <Button
+          small
+          pending={decide.isPending}
+          onClick={() => answer("not_a_duplicate")}
+        >
+          {t("worklist.pair.notDuplicate")}
+        </Button>
+      ) : (
+        // Said in words rather than shown as disabled buttons. A greyed-out
+        // control asks the reader to work out why it is grey; a sentence tells
+        // them the pair is real, that they cannot settle it, and who can.
+        <p className="t-caption worklist-pair-steward">
+          {t("worklist.pair.stewardOnly")}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## The bug

Pressing **Keep this one** or **Not the same** on a duplicate pair in the Worklist showed "Could not settle the pair. Try again." — every time, forever.

The disposition endpoint requires write authority on **both** records (`ensurePairWritable` → `auth.EnsureWritable`), because settling a pair archives one and rewrites the other. The Worklist offered the verbs on **visibility** alone. In this workspace everyone reads every colleague's customer records and can write almost none of them, so a rep was invited to press a button that could only refuse.

No deadlock underneath it: `admin`, `management` and `ops` seats carry `row_scope = all`, which short-circuits the write check, so a cross-owner pair is settleable today — by a steward, not by the rep looking at it.

## The change

- `people.Store.DecidableForMerge` answers, via `auth.WritableSubset`, which of a set of records the caller could change. Same visibility-and-write-authority pair `EnsureWritable` asks, asked set-wise.
- `attention.Duplicates` gains `DecidableSubset`; the lane emits the `merge` action only when the reader can write **both** sides.
- `PairDecision` respects `item.actions`. Without it the pair is still **shown** — a duplicate waiting is worth knowing about — with a sentence naming who can settle it instead of buttons that would refuse.
- A refusal (403) and a conflict (409) get their own copy. "Try again" was wrong advice for a permission no amount of pressing grants, and wrong again for a pair a colleague already settled.
- Two `crm.yaml` merge descriptions claimed the operation was **"reversible within audit"**. It is not: nothing undoes a merge, a merged dedupe pair answers `not_undoable`, and the survivor keeps what it took. Both now say so.
- New gate `TestTheMergeCardAsksTheSameAuthorityTheWriteAsks` holds the card's authority read to `auth.WritableSubset`, so the button and the write cannot drift apart.

## Tests

Backend: three lane cases — a pair the reader cannot change carries no verb, owning one side is not enough, and a reader who can change both still gets it. Frontend: the steward sentence replaces the verbs, the verbs return for a steward, and 403/409 produce their own words. Both guards mutation-checked (revert the guard → the new tests fail; the new gate fires on a re-derived authority).

`make check` green, both halves. Craft, RLS and jurisdiction gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Worklist's duplicate-pair buttons so a merge verb is offered only to someone who can settle the pair. Previously the buttons appeared to anyone who could read both records, but settling archives one and rewrites the other, which requires write authority over both — so in this workspace every press refused with "Could not settle the pair. Try again."

- The duplicates lane asks `auth.WritableSubset` (the same authority the disposition endpoint uses) and emits the `merge` action only when the reader can change both sides.
- The pair still appears without buttons for readers who can't settle it, with a sentence saying an admin or sales lead can.
- A 403 refusal and a 409 conflict each get their own message; the conflict one says the decision didn't land and asks to reload, since a refused merge reopens the candidate.
- The person and organization merge descriptions in `crm.yaml` no longer claim merges are reversible within audit.
- A parity gate holds the card's authority read to `auth.WritableSubset` by reading the AST, so a comment naming the helper can't satisfy it, and an integration test pins the card's offer against the endpoint's refusal on real Postgres.

<sup>Written for commit 214e777a212b9b5bf514fec676ae86a56c12f50f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Duplicate pairs now show merge controls only when both records can be modified.
  - Read-only users can view duplicate details with a steward-only explanation instead of action buttons.
  - Added localized messages for permission refusals, already-settled pairs, and steward-only handling in English, German, and Vietnamese.

- **Bug Fixes**
  - Improved worklist feedback for permission errors and conflicts, including clearer messages and appropriate retry behavior.
  - Clarified that person and organization merges cannot be undone and that transferred data remains on the surviving record.

- **Documentation**
  - Updated merge endpoint documentation with irreversible-merge behavior and related response details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->