### PR TITLE
The Pipeline frame stops denominating figures it did not convert

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3241,7 +3241,7 @@ export const de = {
   "analytics.share.copyFailed":
     "Der Link konnte nicht kopiert werden. Markieren Sie ihn oben und kopieren Sie ihn von Hand.",
   "analytics.share.done": "Fertig",
-  "analytics.frame": "Stand {asOf} · {zone} · {currency}",
+  "analytics.frame": "Stand {asOf} · {zone}",
   "review.title": "Was sollte vor dem Call geprüft werden?",
   "review.ready": "Bereit",
   "review.readyWithExceptions": "Bereit, mit Anmerkungen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3290,7 +3290,7 @@ export const en = {
   "analytics.share.copyFailed":
     "The link could not be copied. Select it above and copy it by hand.",
   "analytics.share.done": "Done",
-  "analytics.frame": "As of {asOf} · {zone} · {currency}",
+  "analytics.frame": "As of {asOf} · {zone}",
   "review.title": "What should be checked before the call?",
   "review.ready": "Ready",
   "review.readyWithExceptions": "Ready, with notes",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3207,7 +3207,7 @@ export const vi = {
   "analytics.share.copyFailed":
     "Không thể sao chép liên kết. Hãy chọn ở trên và sao chép thủ công.",
   "analytics.share.done": "Xong",
-  "analytics.frame": "Tính đến {asOf} · {zone} · {currency}",
+  "analytics.frame": "Tính đến {asOf} · {zone}",
   "review.title": "Cần kiểm tra gì trước cuộc gọi?",
   "review.ready": "Sẵn sàng",
   "review.readyWithExceptions": "Sẵn sàng, có lưu ý",

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -645,9 +645,9 @@ describe("sectionFromAddress", () => {
 const SECTION_REPORT_COUNT_PIPELINE = 3;
 
 describe("the report frame", () => {
-  // A total with no zone and no currency beside it is a number the reader
-  // places by assumption, and the assumption is their own zone.
-  it("names the instant, the zone and the currency the figures were cut in", async () => {
+  // A total with no zone beside it is a number the reader places by
+  // assumption, and the assumption is their own zone.
+  it("names the instant and the zone the figures were cut in", async () => {
     vi.stubGlobal("fetch", reportsStub());
     render(<AnalyticsScreen />);
     await openPipeline();
@@ -657,11 +657,31 @@ describe("the report frame", () => {
     // instant they do not.
     const captions = await screen.findAllByText(/Europe\/Berlin/);
     expect(captions).toHaveLength(SECTION_REPORT_COUNT_PIPELINE);
-    expect(captions[0].textContent).toContain("EUR");
   });
 
-  // A server mid-upgrade sends a partial frame. Naming two of the three would
-  // be worse than naming none, so the caption is drawn or it is not.
+  // And it names NO currency. Every report on this tab is denominated per
+  // currency — the stage table prints a row per stage per currency — so a
+  // code in the frame reads as the denomination of numbers that were never
+  // converted into it. The figures on screen here are EUR and USD at once,
+  // and a reader taking the old caption at its word read the USD total as
+  // euros.
+  it("claims no currency for figures that are in several", async () => {
+    vi.stubGlobal("fetch", reportsStub());
+    render(<AnalyticsScreen />);
+    await openPipeline();
+
+    const captions = await screen.findAllByText(/Europe\/Berlin/);
+    for (const caption of captions) {
+      expect(caption.textContent).not.toMatch(/\b(EUR|USD|VND)\b/);
+    }
+    // The currency is not LOST, it moved to where it is true: the forecast
+    // strip labels each band with its own code. Asserted here so this cannot
+    // pass by the screen having stopped saying which currency anything is in.
+    expect(screen.getAllByText("EUR").length).toBeGreaterThan(0);
+  });
+
+  // A server mid-upgrade sends a partial frame. Naming one of the two would be
+  // worse than naming none, so the caption is drawn or it is not.
   it("draws no caption at all when the server sent only part of the frame", async () => {
     vi.stubGlobal("fetch", reportsStub({ partialFrame: true }));
     render(<AnalyticsScreen />);

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -763,18 +763,34 @@ function ReportCard({
             {report === "deals-by-stage" && (
               <StageTable rows={run.rows} stages={stages} locale={locale} />
             )}
-            {/* The frame every figure above was cut in. A total with no zone
-                and no currency beside it is a number a reader places by
-                assumption, and the assumption is usually their own zone.
-                Drawn only when the server sent a whole frame: a caption
-                naming two of the three would be worse than none, and a
-                server mid-upgrade is exactly where a partial one arrives. */}
-            {run.as_of && run.timezone && run.base_currency && (
+            {/* The frame every figure above was cut in: the instant, and the
+                zone that instant is stated in. A total with no zone beside it
+                is a number a reader places by assumption, and the assumption
+                is usually their own.
+
+                It does NOT state a currency, and that is the point. Every
+                report on this tab is denominated PER CURRENCY — the stage
+                table prints a row per stage per currency, the forecast strip
+                bands its tiles by currency and labels each band with the code
+                — so the figures above are in several currencies at once and
+                none of them is the installation's base.
+
+                The frame used to end in `run.base_currency`, which read as the
+                denomination of numbers that were never converted into it: a
+                reader taking it at its word read ₫367,620,000,000 as a euro
+                figure. Whether this tab should convert instead is a product
+                question and is open; until it is answered, saying nothing
+                about currency here is the only honest option, because each
+                block already says its own.
+
+                Drawn only when the server sent both halves: a caption naming
+                one of the two would be worse than none, and a server
+                mid-upgrade is exactly where a partial one arrives. */}
+            {run.as_of && run.timezone && (
               <p className="sub analytics-frame">
                 {t("analytics.frame", {
                   asOf: formatDateTime(run.as_of, locale, run.timezone),
                   zone: run.timezone,
-                  currency: run.base_currency,
                 })}
               </p>
             )}


### PR DESCRIPTION
Addresses the factual half of #3857. **Not closing it** — the framing question that ticket raises is a product call and stays open; see the last section.

## The false statement

Every report on the Pipeline tab is denominated **per currency**: the stage table prints a row per stage per currency, `ForecastStrip` bands its tiles by currency and labels each band with the code, and `byCurrency()` exists to do exactly that.

The frame under them read:

```
As of 03/09/2026, 08:42 · Europe/Berlin · EUR
```

The trailing code is `run.base_currency` — the installation's base — stamped on a screen of totals that were never converted into it. A reader taking it at its word reads `₫367,620,000,000` as a euro figure.

The frame now states the **instant and the zone** and says nothing about currency. Each block already says its own, which is where that statement is true.

## Why this is not choosing between the ticket's three options

#3857 offers: keep the split and fix the frame; convert like the Forecast tab; or name both frames on the tabs. It says, correctly, *"I have no view on which — it is a product call about what the report is for."*

This changes none of that. It removes a caption that is **false under every one of the three**: converting later restores a currency to the frame, because there would then be one figure it is the denomination of. Removing a wrong label is not the same as deciding what the report should be, and the wider question is commented back on the ticket.

## One judgement worth naming

`base_currency` also leaves the render guard, which used to be `as_of && timezone && base_currency`. Holding the caption back for a field it no longer reads would withhold a true statement about the instant and the zone over an absent one nobody asked for. The partial-frame case still works: that fixture drops `timezone` too, so the caption is still withheld when the server is mid-upgrade.

## Tests

The existing case asserted the currency was present, so it is split in two:

- the frame names the instant and the zone — one caption per report, unchanged;
- **it claims no currency**, asserted against `/\b(EUR|USD|VND)\b/` on every caption, *and* that `EUR` still appears elsewhere on the screen. That second half matters: without it the test would pass if the page had simply stopped saying which currency anything is in. The code is not lost, it moved to where it is true.

Mutation: appending the base currency back into the zone slot fails only the new case.

`make check-fe` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b1jSBftJqGvaQ7ejTgnQ6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Analytics frame captions now show only the reporting date and timezone.
  * Captions appear when date and timezone information is available, without requiring a frame-level currency.
  * Currency labels remain visible on individual report rows.
  * Updated English, German, and Vietnamese translations and related analytics coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->