### PR TITLE
An analytics answer says which population it is about

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -31740,7 +31740,15 @@ components:
           type: string
           format: date
           description: The last day INSIDE the period, not an exclusive bound.
-        scope_kind: { type: string, enum: [workspace, team, owner] }
+        scope_kind:
+          type: string
+          enum: [workspace, managed_teams, team, owner]
+          description: >-
+            Which population these readings cover. `managed_teams` is what an omitted
+            scope resolves to for a team manager — their teams and themselves — and is a
+            RESULT only: it names no single subject, so no forecast can be recorded
+            against it and no standing call is looked up for it. The write schemas keep
+            the three nameable scopes.
         scope_id: { type: string, format: uuid }
         won_minor:
           type: integer

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -16464,6 +16464,38 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
+  /analytics/context:
+    get:
+      tags: [Reports]
+      operationId: getAnalyticsContext
+      summary: Which population this caller measures by default, and which they may choose.
+      description: |
+        The frame every analytics answer is placed in: the population this caller measures
+        when they ask for nothing, the populations they may ask for instead, the base
+        currency and zone their money and days are counted in, and what the screen may
+        offer them.
+
+        The POPULATION is not the same question as which records the caller may open.
+        Deals are workspace-readable so two reps do not call the same buyer, so a rep's row
+        scope narrows nothing — and a rep handed the workspace total has been answered a
+        question nobody asked. `default_scope` is what their own lens measures.
+
+        Every `label` here is written by the server. A client resolving a team or user id
+        into a name would be naming a subject it may not read, and the two would disagree
+        the first time a grant changed.
+
+        `allowed_scopes` is what the screen may OFFER, not what it may send unchecked:
+        every data route validates a requested population again. A control built from this
+        list simply never offers one that would be refused.
+      x-agent-access: human-only
+      responses:
+        '200':
+          description: The caller's analytics frame.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AnalyticsContext' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
   /analytics/schema:
     get:
       tags: [Reports]
@@ -32081,6 +32113,75 @@ components:
           description: >-
             Whether anything was kept back from this reader. A boolean and never a count:
             a count of what somebody may not see states how much of it there is.
+      additionalProperties: false
+    AnalyticsScope:
+      type: object
+      description: >-
+        One population an answer can be about. `label` is written by the server, because a
+        client resolving an id into a name would be naming a subject it may not read.
+      required: [kind, label]
+      properties:
+        kind:
+          type: string
+          enum: [workspace, managed_teams, team, owner]
+          description: >-
+            `managed_teams` is a team manager's own default — their teams and themselves.
+            It is RESOLVED, never requested: a caller names one team, or names nothing and
+            is given this.
+
+        id:
+          type: string
+          format: uuid
+          description: >-
+            The team or person measured. Absent for workspace and managed_teams, which name
+            no single subject.
+        label: { type: string, description: "What to call this population on screen." }
+      additionalProperties: false
+    AnalyticsCapabilities:
+      type: object
+      description: >-
+        What this caller may actually do, so a screen never offers a control the server will
+        refuse.
+      required: [view_manager_forecast, submit_manager_forecast]
+      properties:
+        view_manager_forecast:
+          type: boolean
+          description: Whether the manager forecast is a destination for this caller at all.
+        submit_manager_forecast:
+          type: boolean
+          description: >-
+            Whether this caller may publish a forecast for the population they are
+            measuring. False hides the action rather than letting the save fail.
+      additionalProperties: false
+    AnalyticsContext:
+      type: object
+      description: The frame every analytics answer for this caller is placed in.
+      required:
+        - default_scope
+        - allowed_scopes
+        - capabilities
+        - as_of
+        - timezone
+        - base_currency
+      properties:
+        default_scope: { $ref: '#/components/schemas/AnalyticsScope' }
+        allowed_scopes:
+          type: array
+          items: { $ref: '#/components/schemas/AnalyticsScope' }
+          description: >-
+            What the screen may offer. Every data route validates a requested population
+            again; this list only keeps a control from offering a refusal.
+        capabilities: { $ref: '#/components/schemas/AnalyticsCapabilities' }
+        as_of:
+          type: string
+          format: date-time
+          description: The instant this frame was resolved.
+        timezone:
+          type: string
+          description: The zone whose days a period is cut in.
+        base_currency:
+          type: string
+          description: The currency money readings are counted in.
       additionalProperties: false
     AnalyticsSchema:
       type: object

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -170,6 +170,7 @@ var agentPolicies = map[string]agentPolicy{
 	"GET /v1/ai/provider-keys":                                           {Op: "listAiProviderKeys", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/routing":                                                 {Op: "getAiRouting", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/ai/usage":                                                   {Op: "getAiUsage", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"GET /v1/analytics/context":                                          {Op: "getAnalyticsContext", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/analytics/coverage":                                         {Op: "getDataCoverage", Access: "tool", Tool: "data_coverage", RecordType: "", Tier: "auto_execute", Scope: "read"},
 	"GET /v1/analytics/runs/{run_id}":                                    {Op: "getReportRun", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"GET /v1/analytics/schema":                                           {Op: "getAnalyticsSchema", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/analyticscontext.go
+++ b/backend/internal/compose/analyticscontext.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The frame an analytics screen builds itself from: which population this
+// caller measures by default, which they may choose instead, and what the
+// screen may offer them.
+//
+// One route rather than a field on /me, because the answer depends on the
+// installation's own calendar and currency as much as on the caller, and
+// because a screen that reads it once has one place to invalidate when a grant
+// changes.
+//
+// The list of allowed scopes is an OFFER, never an authorization. Every data
+// route resolves a requested population again through AnalyticsPopulationClause
+// — this list only keeps a control from offering something that would be
+// refused, which is a different job from refusing it.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/margince/margince/backend/internal/contracts"
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/platform/database"
+	"github.com/margince/margince/backend/internal/platform/httperr"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// analyticsContextHandlers serves the frame.
+//
+// now is injected rather than called inline so a test can state the as-of it
+// expects instead of asserting against the wall clock.
+type analyticsContextHandlers struct {
+	db  *database.DB
+	now func() time.Time
+}
+
+func newAnalyticsContextHandlers(db *database.DB, now func() time.Time) analyticsContextHandlers {
+	return analyticsContextHandlers{db: db, now: now}
+}
+
+// GetAnalyticsContext implements GET /analytics/context.
+func (h analyticsContextHandlers) GetAnalyticsContext(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	var out crmcontracts.AnalyticsContext
+	err := h.db.Tx(ctx, func(tx pgx.Tx) error {
+		// The same gate the rest of the analytics surface takes: this route
+		// discloses which teams and people a caller may measure, which is not
+		// a thing to hand somebody who may not read a forecast at all.
+		if err := auth.Require(ctx, objectForecast, principal.ActionRead); err != nil {
+			return err
+		}
+		frame, err := readReportFrame(ctx, tx)
+		if err != nil {
+			return err
+		}
+		resolved, err := analyticsContextFor(ctx, tx, h.now())
+		if err != nil {
+			return err
+		}
+		resolved.Timezone = frame.Timezone
+		resolved.BaseCurrency = frame.BaseCurrency
+		out = resolved
+		return nil
+	})
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusOK, out)
+}
+
+// analyticsContextFor assembles the caller's frame, minus the installation's
+// zone and currency which the caller reads from the report frame.
+func analyticsContextFor(ctx context.Context, tx pgx.Tx, now time.Time) (crmcontracts.AnalyticsContext, error) {
+	p, ok := principal.Actor(ctx)
+	if !ok {
+		return crmcontracts.AnalyticsContext{}, errors.New("compose: no actor bound to context")
+	}
+
+	def, defClause, err := AnalyticsPopulationClause(ctx, tx, RequestedScope{}, "", func(any) int { return 0 })
+	if err != nil {
+		return crmcontracts.AnalyticsContext{}, err
+	}
+	// The clause is discarded here on purpose: this route reports the decision,
+	// it does not measure anything. Asking through the same door as the readers
+	// is what keeps the offered default and the applied default one answer.
+	_ = defClause
+
+	allowed, err := allowedScopesFor(ctx, tx, p)
+	if err != nil {
+		return crmcontracts.AnalyticsContext{}, err
+	}
+
+	// Submitting a forecast is a create on the forecast object. Asked here so
+	// the screen can hide the action rather than render a button whose save
+	// returns 403 — the shape the review called out as advertising an action
+	// the backend will reject.
+	maySubmit := auth.Require(ctx, objectForecast, principal.ActionCreate) == nil
+
+	return crmcontracts.AnalyticsContext{
+		DefaultScope:  scopeToWire(def),
+		AllowedScopes: allowed,
+		Capabilities: crmcontracts.AnalyticsCapabilities{
+			// A caller whose default population is their own records has no
+			// manager forecast to look at: the manager forecast is an
+			// assertion about a team or the workspace.
+			ViewManagerForecast:   def.Kind != ScopeKindOwner,
+			SubmitManagerForecast: maySubmit && def.Kind != ScopeKindOwner,
+		},
+		AsOf: now,
+	}, nil
+}
+
+// allowedScopesFor enumerates what the screen may offer, in the order a control
+// should show them: the widest population first, then the narrowings.
+func allowedScopesFor(
+	ctx context.Context, tx pgx.Tx, p principal.Principal,
+) ([]crmcontracts.AnalyticsScope, error) {
+	lens := p.Permissions.RowScope
+	if auth.Unbounded(p) {
+		lens = principal.RowScopeAll
+	}
+
+	me, err := analyticsUserLabel(ctx, tx, p.UserID)
+	if err != nil {
+		return nil, err
+	}
+	self := ids.UUID(p.UserID)
+	mine := crmcontracts.AnalyticsScope{Kind: crmcontracts.AnalyticsScopeKindOwner, Label: me}
+	mine.Id = ptrUUID(self)
+
+	switch lens {
+	case principal.RowScopeAll:
+		out := []crmcontracts.AnalyticsScope{
+			{Kind: crmcontracts.AnalyticsScopeKindWorkspace, Label: workspaceLabel},
+		}
+		teams, err := liveTeamsOf(ctx, tx, nil)
+		if err != nil {
+			return nil, err
+		}
+		return append(append(out, teams...), mine), nil
+
+	case principal.RowScopeTeam:
+		if len(p.TeamIDs) == 0 {
+			return []crmcontracts.AnalyticsScope{mine}, nil
+		}
+		out := []crmcontracts.AnalyticsScope{
+			{Kind: crmcontracts.AnalyticsScopeKindManagedTeams, Label: managedTeamsLabel},
+		}
+		teams, err := liveTeamsOf(ctx, tx, p.TeamIDs)
+		if err != nil {
+			return nil, err
+		}
+		return append(append(out, teams...), mine), nil
+
+	default:
+		return []crmcontracts.AnalyticsScope{mine}, nil
+	}
+}
+
+// liveTeamsOf names the live teams, either all of them or a given set.
+//
+// Archived teams are absent rather than listed and refused later: an archived
+// team is not a population, and offering one would produce a control whose
+// every use is an error.
+func liveTeamsOf(ctx context.Context, tx pgx.Tx, only []ids.UUID) ([]crmcontracts.AnalyticsScope, error) {
+	sql := `SELECT id, name FROM team WHERE archived_at IS NULL`
+	args := []any{}
+	if only != nil {
+		sql += ` AND id = ANY($1)`
+		args = append(args, only)
+	}
+	sql += ` ORDER BY name`
+
+	rows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []crmcontracts.AnalyticsScope
+	for rows.Next() {
+		var id ids.UUID
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
+			return nil, err
+		}
+		scope := crmcontracts.AnalyticsScope{Kind: crmcontracts.AnalyticsScopeKindTeam, Label: name}
+		scope.Id = ptrUUID(ids.UUID(id))
+		out = append(out, scope)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func scopeToWire(s ResolvedScope) crmcontracts.AnalyticsScope {
+	out := crmcontracts.AnalyticsScope{
+		Kind:  crmcontracts.AnalyticsScopeKind(s.Kind),
+		Label: s.Label,
+	}
+	if s.ID != nil {
+		out.Id = ptrUUID(ids.UUID(*s.ID))
+	}
+	return out
+}
+
+func ptrUUID(id ids.UUID) *openapi_types.UUID {
+	out := openapi_types.UUID(id)
+	return &out
+}

--- a/backend/internal/compose/analyticsscope.go
+++ b/backend/internal/compose/analyticsscope.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/margince/margince/backend/internal/modules/identity"
 	"github.com/margince/margince/backend/internal/platform/auth"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -244,6 +245,7 @@ func sharesATeamWith(ctx context.Context, tx pgx.Tx, teams []ids.UUID, user ids.
 	err := tx.QueryRow(ctx, `SELECT EXISTS (
 		SELECT 1 FROM team_membership tm
 		JOIN team t ON t.id = tm.team_id AND t.archived_at IS NULL
+		JOIN app_user u ON u.id = tm.user_id AND `+identity.LiveMemberSQL("u")+`
 		WHERE tm.user_id = $1 AND tm.team_id = ANY($2))`, user, teams).Scan(&shares)
 	if err != nil {
 		return false, fmt.Errorf("compose: reading team membership: %w", err)
@@ -297,8 +299,10 @@ func labelScope(ctx context.Context, tx pgx.Tx, resolved *ResolvedScope) error {
 func analyticsUserLabel(ctx context.Context, tx pgx.Tx, id ids.UUID) (string, error) {
 	var label string
 	err := tx.QueryRow(ctx,
-		`SELECT display_name FROM app_user WHERE id = $1 AND archived_at IS NULL`, id).Scan(&label)
+		`SELECT display_name FROM app_user WHERE id = $1 AND `+identity.LiveMemberSQL(""), id).Scan(&label)
 	if errors.Is(err, pgx.ErrNoRows) {
+		// Deactivated counts as absent, not merely archived: a departed
+		// colleague is no longer a population somebody measures.
 		return "", fmt.Errorf("no such person to measure: %w", apperrors.ErrNotFound)
 	}
 	if err != nil {

--- a/backend/internal/compose/analyticsscope.go
+++ b/backend/internal/compose/analyticsscope.go
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Which population an analytics answer is ABOUT, as opposed to which records
+// the caller may legally open.
+//
+// Those are two different questions and the tree already answers the second
+// one: auth.ScopeClauseFor renders the row scope, and for a deal it renders
+// TRUE, because deals are workspace-readable by design (tableclass.go) so two
+// reps do not call the same buyer. That is right for a record read and wrong
+// for a measurement. A rep asking "how much pipeline do I have" who is handed
+// the workspace total has been answered a question nobody asked.
+//
+// So a population predicate is applied ON TOP of the row scope, never instead
+// of it. Both narrow; neither widens. The row scope says what may be seen, this
+// says what was asked about, and an answer is the intersection.
+//
+// The lens comes from the principal's own row-scope tier rather than from a
+// role name the frontend sent: own reads own, team reads its teams plus
+// itself, all reads the workspace. A requested scope outside the lens is
+// refused here, once, so every analytics surface refuses it the same way.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// The population kinds, spelled as the wire spells them.
+const (
+	ScopeKindWorkspace = "workspace"
+	ScopeKindTeam      = "team"
+	ScopeKindOwner     = "owner"
+)
+
+// RequestedScope is what the caller asked for. A zero value means they asked
+// for nothing, which resolves to their lens default rather than to the
+// workspace — the distinction this whole file exists to make.
+type RequestedScope struct {
+	Kind string
+	ID   *ids.UUID
+}
+
+// ResolvedScope is what the server decided, and what every answer must quote
+// back. Label is server-authored: a client that resolved a team id into a name
+// itself would be naming a team it may not read.
+type ResolvedScope struct {
+	Kind  string
+	ID    *ids.UUID
+	Label string
+}
+
+// AnalyticsPopulationClause resolves a requested scope against the caller's
+// lens and renders the SQL that narrows to it.
+//
+// The returned clause is a bare predicate WITHOUT a leading AND, so a caller
+// composes it the way they compose any other; an empty string means the
+// population is the whole workspace and nothing needs adding.
+//
+// alias is interpolated into SQL and must be a compile-time literal from the
+// calling spec, never a name off a request.
+func AnalyticsPopulationClause(
+	ctx context.Context, tx pgx.Tx, requested RequestedScope, alias string, arg func(any) int,
+) (ResolvedScope, string, error) {
+	p, ok := principal.Actor(ctx)
+	if !ok {
+		return ResolvedScope{}, "", errors.New("compose: no actor bound to context")
+	}
+
+	resolved, err := resolveAnalyticsScope(ctx, tx, p, requested)
+	if err != nil {
+		return ResolvedScope{}, "", err
+	}
+	if err := labelScope(ctx, tx, &resolved); err != nil {
+		return ResolvedScope{}, "", err
+	}
+
+	col := "owner_id"
+	if alias != "" {
+		col = alias + ".owner_id"
+	}
+
+	switch resolved.Kind {
+	case ScopeKindOwner:
+		return resolved, fmt.Sprintf("%s = $%d", col, arg(*resolved.ID)), nil
+	case ScopeKindTeam:
+		return resolved, fmt.Sprintf(
+			"%s IN (SELECT tm.user_id FROM team_membership tm WHERE tm.team_id = $%d)",
+			col, arg(*resolved.ID)), nil
+	case ScopeKindManagedTeams:
+		// A team manager who named nothing is asking about the work they are
+		// accountable for, which is their teams AND themselves. Themselves
+		// explicitly: a manager carrying deals of their own is not a member of
+		// their own team in every installation, and dropping their pipeline
+		// from their own default answer reads as data loss.
+		return resolved, fmt.Sprintf(
+			"(%s = $%d OR %s IN (SELECT tm.user_id FROM team_membership tm WHERE tm.team_id = ANY($%d)))",
+			col, arg(p.UserID), col, arg(p.TeamIDs)), nil
+	default:
+		return resolved, "", nil
+	}
+}
+
+// ScopeKindManagedTeams is the resolved-only kind for "my teams and me". It is
+// never accepted from the wire: a caller names a single team, or names nothing
+// and gets this. Keeping it out of the request vocabulary means a client cannot
+// ask for somebody else's managed set.
+const ScopeKindManagedTeams = "managed_teams"
+
+// resolveAnalyticsScope decides the population, refusing anything the lens does
+// not cover.
+//
+// Refusals are apperrors.ErrNotFound rather than permission-denied wherever the
+// subject is a team or a user the caller may not measure: 403 on a specific id
+// confirms that id exists, which is the disclosure the lens was for.
+func resolveAnalyticsScope(
+	ctx context.Context, tx pgx.Tx, p principal.Principal, requested RequestedScope,
+) (ResolvedScope, error) {
+	lens := p.Permissions.RowScope
+	if auth.Unbounded(p) {
+		lens = principal.RowScopeAll
+	}
+
+	if requested.Kind == "" {
+		return defaultScopeFor(p, lens)
+	}
+
+	switch requested.Kind {
+	case ScopeKindWorkspace:
+		if lens != principal.RowScopeAll {
+			return ResolvedScope{}, fmt.Errorf(
+				"the whole workspace is outside what you may measure: %w", apperrors.ErrPermissionDenied)
+		}
+		if requested.ID != nil {
+			return ResolvedScope{}, fmt.Errorf(
+				"the workspace scope names no subject: %w", apperrors.ErrInvalidArgument)
+		}
+		return ResolvedScope{Kind: ScopeKindWorkspace, Label: workspaceLabel}, nil
+
+	case ScopeKindTeam:
+		if requested.ID == nil {
+			return ResolvedScope{}, fmt.Errorf(
+				"a team scope names which team: %w", apperrors.ErrInvalidArgument)
+		}
+		return resolveTeamScope(p, lens, *requested.ID)
+
+	case ScopeKindOwner:
+		if requested.ID == nil {
+			return ResolvedScope{}, fmt.Errorf(
+				"an owner scope names which owner: %w", apperrors.ErrInvalidArgument)
+		}
+		return resolveOwnerScope(ctx, tx, p, lens, *requested.ID)
+
+	default:
+		return ResolvedScope{}, fmt.Errorf(
+			"%q is not a population: %w", requested.Kind, apperrors.ErrInvalidArgument)
+	}
+}
+
+// workspaceLabel is what the whole-installation population is called. Held
+// here rather than translated per caller: the label rides on the answer, and
+// an answer's population must read the same in a share as on the screen.
+const workspaceLabel = "Whole workspace"
+
+func defaultScopeFor(p principal.Principal, lens principal.RowScope) (ResolvedScope, error) {
+	switch lens {
+	case principal.RowScopeAll:
+		return ResolvedScope{Kind: ScopeKindWorkspace, Label: workspaceLabel}, nil
+	case principal.RowScopeTeam:
+		// A team-lens principal with no teams reads as own: a manager of
+		// nothing measures themselves rather than the installation.
+		if len(p.TeamIDs) == 0 {
+			return ownScope(p), nil
+		}
+		return ResolvedScope{Kind: ScopeKindManagedTeams, Label: managedTeamsLabel}, nil
+	default:
+		return ownScope(p), nil
+	}
+}
+
+const managedTeamsLabel = "My teams"
+
+func ownScope(p principal.Principal) ResolvedScope {
+	me := p.UserID
+	return ResolvedScope{Kind: ScopeKindOwner, ID: &me}
+}
+
+func resolveTeamScope(p principal.Principal, lens principal.RowScope, id ids.UUID) (ResolvedScope, error) {
+	if lens == principal.RowScopeOwn {
+		return ResolvedScope{}, fmt.Errorf(
+			"no team is within what you may measure: %w", apperrors.ErrNotFound)
+	}
+	if lens == principal.RowScopeTeam && !containsID(p.TeamIDs, id) {
+		return ResolvedScope{}, fmt.Errorf(
+			"that team is not one of yours: %w", apperrors.ErrNotFound)
+	}
+	return ResolvedScope{Kind: ScopeKindTeam, ID: &id}, nil
+}
+
+func resolveOwnerScope(
+	ctx context.Context, tx pgx.Tx, p principal.Principal, lens principal.RowScope, id ids.UUID,
+) (ResolvedScope, error) {
+	// Yourself is always within your own lens, including for a rep, and it
+	// costs no membership read.
+	if id == p.UserID {
+		return ownScope(p), nil
+	}
+	switch lens {
+	case principal.RowScopeAll:
+	case principal.RowScopeTeam:
+		shares, err := sharesATeamWith(ctx, tx, p.TeamIDs, id)
+		if err != nil {
+			return ResolvedScope{}, err
+		}
+		if !shares {
+			return ResolvedScope{}, fmt.Errorf(
+				"that person is not in one of your teams: %w", apperrors.ErrNotFound)
+		}
+	default:
+		return ResolvedScope{}, fmt.Errorf(
+			"only your own records are within what you may measure: %w", apperrors.ErrNotFound)
+	}
+	return ResolvedScope{Kind: ScopeKindOwner, ID: &id}, nil
+}
+
+// sharesATeamWith asks whether one user is a live member of any of these teams.
+//
+// The membership read is what makes a team manager's owner scope safe: without
+// it a manager could name any user id in the installation and measure them.
+func sharesATeamWith(ctx context.Context, tx pgx.Tx, teams []ids.UUID, user ids.UUID) (bool, error) {
+	if len(teams) == 0 {
+		return false, nil
+	}
+	var shares bool
+	err := tx.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM team_membership tm
+		JOIN team t ON t.id = tm.team_id AND t.archived_at IS NULL
+		WHERE tm.user_id = $1 AND tm.team_id = ANY($2))`, user, teams).Scan(&shares)
+	if err != nil {
+		return false, fmt.Errorf("compose: reading team membership: %w", err)
+	}
+	return shares, nil
+}
+
+func containsID(haystack []ids.UUID, needle ids.UUID) bool {
+	for _, id := range haystack {
+		if id == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// labelScope names the resolved population for the reader.
+//
+// Separate from the decision above so the policy — which population, and which
+// refusal — is decidable without a database, and so the naming happens exactly
+// once however the scope was arrived at.
+func labelScope(ctx context.Context, tx pgx.Tx, resolved *ResolvedScope) error {
+	switch resolved.Kind {
+	case ScopeKindOwner:
+		label, err := analyticsUserLabel(ctx, tx, *resolved.ID)
+		if err != nil {
+			return err
+		}
+		resolved.Label = label
+	case ScopeKindTeam:
+		label, err := analyticsTeamLabel(ctx, tx, *resolved.ID)
+		if err != nil {
+			return err
+		}
+		resolved.Label = label
+	case ScopeKindManagedTeams:
+		resolved.Label = managedTeamsLabel
+	default:
+		resolved.Label = workspaceLabel
+	}
+	return nil
+}
+
+// analyticsUserLabel and analyticsTeamLabel name a population for the reader.
+//
+// Both refuse an archived subject as absent rather than labelling it. A scope
+// resolved against a team that was archived after the request was written is
+// not a population any more, and answering over it would report a set the
+// installation no longer has.
+
+func analyticsUserLabel(ctx context.Context, tx pgx.Tx, id ids.UUID) (string, error) {
+	var label string
+	err := tx.QueryRow(ctx,
+		`SELECT display_name FROM app_user WHERE id = $1 AND archived_at IS NULL`, id).Scan(&label)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("no such person to measure: %w", apperrors.ErrNotFound)
+	}
+	if err != nil {
+		return "", fmt.Errorf("compose: naming the measured person: %w", err)
+	}
+	return label, nil
+}
+
+func analyticsTeamLabel(ctx context.Context, tx pgx.Tx, id ids.UUID) (string, error) {
+	var label string
+	err := tx.QueryRow(ctx,
+		`SELECT name FROM team WHERE id = $1 AND archived_at IS NULL`, id).Scan(&label)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("no such team to measure: %w", apperrors.ErrNotFound)
+	}
+	if err != nil {
+		return "", fmt.Errorf("compose: naming the measured team: %w", err)
+	}
+	return label, nil
+}

--- a/backend/internal/compose/analyticsscope.go
+++ b/backend/internal/compose/analyticsscope.go
@@ -95,20 +95,37 @@ func AnalyticsPopulationClause(
 		return resolved, fmt.Sprintf("%s = $%d", col, arg(*resolved.ID)), nil
 	case ScopeKindTeam:
 		return resolved, fmt.Sprintf(
-			"%s IN (SELECT tm.user_id FROM team_membership tm WHERE tm.team_id = $%d)",
-			col, arg(*resolved.ID)), nil
+			"%s IN (%s)", col, liveTeamMembersSQL(arg(*resolved.ID), "= $%d")), nil
 	case ScopeKindManagedTeams:
 		// A team manager who named nothing is asking about the work they are
 		// accountable for, which is their teams AND themselves. Themselves
 		// explicitly: a manager carrying deals of their own is not a member of
 		// their own team in every installation, and dropping their pipeline
 		// from their own default answer reads as data loss.
+		me := arg(p.UserID)
+		teams := arg(p.TeamIDs)
 		return resolved, fmt.Sprintf(
-			"(%s = $%d OR %s IN (SELECT tm.user_id FROM team_membership tm WHERE tm.team_id = ANY($%d)))",
-			col, arg(p.UserID), col, arg(p.TeamIDs)), nil
+			"(%s = $%d OR %s IN (%s))",
+			col, me, col, liveTeamMembersSQL(teams, "= ANY($%d)")), nil
 	default:
 		return resolved, "", nil
 	}
+}
+
+// liveTeamMembersSQL selects the members of a team, as the installation stands
+// today: a live team, and a member who can still act.
+//
+// Membership rows deliberately outlive both — an archived team keeps its rows so
+// a restore brings them back, and deactivating a seat leaves the row alone. A
+// predicate reading team_membership by itself therefore measures people who left,
+// which is the defect this replaces: the resolver refuses a departed colleague as
+// a population of their own while their deals went on counting inside their old
+// team's total.
+func liveTeamMembersSQL(pos int, match string) string {
+	return fmt.Sprintf(`SELECT tm.user_id FROM team_membership tm
+		JOIN team t ON t.id = tm.team_id AND t.archived_at IS NULL
+		JOIN app_user u ON u.id = tm.user_id AND `+identity.LiveMemberSQL("u")+`
+		WHERE tm.team_id `+match, pos)
 }
 
 // ScopeKindManagedTeams is the resolved-only kind for "my teams and me". It is

--- a/backend/internal/compose/analyticsscope.go
+++ b/backend/internal/compose/analyticsscope.go
@@ -85,9 +85,9 @@ func AnalyticsPopulationClause(
 		return ResolvedScope{}, "", err
 	}
 
-	col := "owner_id"
+	col := paramOwnerID
 	if alias != "" {
-		col = alias + ".owner_id"
+		col = alias + "." + paramOwnerID
 	}
 
 	switch resolved.Kind {

--- a/backend/internal/compose/analyticsscope_test.go
+++ b/backend/internal/compose/analyticsscope_test.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The scope POLICY, tested without a database.
+//
+// Every case here is a decision the resolver makes before it reads anything:
+// which population an omitted request means, and which requested population is
+// refused. Those are the cases a reviewer has to trust, and they are exactly
+// the ones a fixture would obscure — a test that seeds two teams to prove a rep
+// cannot name one is testing the seed.
+//
+// The paths that DO read (labelling a team, checking a colleague's membership)
+// are covered by the integration test beside this file, which needs Postgres
+// for the same reason they do.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func actorWithScope(scope principal.RowScope, teams ...ids.UUID) principal.Principal {
+	return principal.Principal{
+		Type:        principal.PrincipalHuman,
+		UserID:      ids.NewV7(),
+		TeamIDs:     teams,
+		Permissions: principal.Permissions{RowScope: scope},
+	}
+}
+
+// An omitted scope is the case the whole file exists for: it must mean the
+// caller's own lens, never the workspace. The workspace default is what shipped
+// and what a rep saw as somebody else's pipeline.
+func TestAnOmittedScopeResolvesToTheCallersOwnLens(t *testing.T) {
+	team := ids.NewV7()
+	cases := []struct {
+		name  string
+		actor principal.Principal
+		want  string
+	}{
+		{"a rep measures themselves", actorWithScope(principal.RowScopeOwn), ScopeKindOwner},
+		{"a team manager measures their teams", actorWithScope(principal.RowScopeTeam, team), ScopeKindManagedTeams},
+		{"management measures the workspace", actorWithScope(principal.RowScopeAll), ScopeKindWorkspace},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := principal.WithActor(context.Background(), tc.actor)
+			// The decision reads nothing — labelling does, and happens after —
+			// so a nil tx proves the policy never depended on a database.
+			got, err := resolveAnalyticsScope(ctx, nil, tc.actor, RequestedScope{})
+			if err != nil {
+				t.Fatalf("resolving an omitted scope: %v", err)
+			}
+			if got.Kind != tc.want {
+				t.Errorf("omitted scope resolved to %q, want %q", got.Kind, tc.want)
+			}
+			if tc.want == ScopeKindOwner && (got.ID == nil || *got.ID != tc.actor.UserID) {
+				t.Errorf("a rep's own scope named %v, want themselves", got.ID)
+			}
+		})
+	}
+}
+
+// A team-lens principal who manages nothing is the case that decides whether
+// "team" is read as a tier or as a fact. It must narrow to themselves: reading
+// it as a tier would hand somebody managing no team the whole installation.
+func TestATeamLensWithNoTeamsDoesNotWiden(t *testing.T) {
+	actor := actorWithScope(principal.RowScopeTeam)
+	ctx := principal.WithActor(context.Background(), actor)
+
+	got, err := resolveAnalyticsScope(ctx, nil, actor, RequestedScope{})
+	if err != nil {
+		t.Fatalf("resolving a teamless manager's default: %v", err)
+	}
+	if got.Kind != ScopeKindOwner {
+		t.Fatalf("a manager of no teams resolved to %q, want their own records", got.Kind)
+	}
+}
+
+func TestAScopeOutsideTheCallersLensIsRefused(t *testing.T) {
+	other := ids.NewV7()
+	cases := []struct {
+		name      string
+		actor     principal.Principal
+		requested RequestedScope
+		wantErr   error
+	}{
+		{
+			"a rep may not measure the workspace",
+			actorWithScope(principal.RowScopeOwn),
+			RequestedScope{Kind: ScopeKindWorkspace},
+			apperrors.ErrPermissionDenied,
+		},
+		{
+			"a rep may not name a team",
+			actorWithScope(principal.RowScopeOwn),
+			RequestedScope{Kind: ScopeKindTeam, ID: &other},
+			apperrors.ErrNotFound,
+		},
+		{
+			"a rep may not name a colleague",
+			actorWithScope(principal.RowScopeOwn),
+			RequestedScope{Kind: ScopeKindOwner, ID: &other},
+			apperrors.ErrNotFound,
+		},
+		{
+			"a team manager may not measure the workspace",
+			actorWithScope(principal.RowScopeTeam, ids.NewV7()),
+			RequestedScope{Kind: ScopeKindWorkspace},
+			apperrors.ErrPermissionDenied,
+		},
+		{
+			"a team manager may not name a team they do not hold",
+			actorWithScope(principal.RowScopeTeam, ids.NewV7()),
+			RequestedScope{Kind: ScopeKindTeam, ID: &other},
+			apperrors.ErrNotFound,
+		},
+		{
+			"a population nobody defined is refused rather than ignored",
+			actorWithScope(principal.RowScopeAll),
+			RequestedScope{Kind: "everyone"},
+			apperrors.ErrInvalidArgument,
+		},
+		{
+			"the managed-teams kind cannot be asked for from the wire",
+			actorWithScope(principal.RowScopeTeam, ids.NewV7()),
+			RequestedScope{Kind: ScopeKindManagedTeams},
+			apperrors.ErrInvalidArgument,
+		},
+		{
+			"a workspace scope naming a subject is malformed",
+			actorWithScope(principal.RowScopeAll),
+			RequestedScope{Kind: ScopeKindWorkspace, ID: &other},
+			apperrors.ErrInvalidArgument,
+		},
+		{
+			"a team scope naming no team is malformed",
+			actorWithScope(principal.RowScopeAll),
+			RequestedScope{Kind: ScopeKindTeam},
+			apperrors.ErrInvalidArgument,
+		},
+		{
+			"an owner scope naming no owner is malformed",
+			actorWithScope(principal.RowScopeAll),
+			RequestedScope{Kind: ScopeKindOwner},
+			apperrors.ErrInvalidArgument,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := principal.WithActor(context.Background(), tc.actor)
+			_, err := resolveAnalyticsScope(ctx, nil, tc.actor, tc.requested)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("refusal was %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// A refusal over a named team or person says "not found", never "denied": the
+// second sentence confirms the id exists, which is the disclosure the lens was
+// supposed to prevent.
+func TestARefusalOverANamedSubjectDoesNotConfirmItExists(t *testing.T) {
+	other := ids.NewV7()
+	actor := actorWithScope(principal.RowScopeOwn)
+	ctx := principal.WithActor(context.Background(), actor)
+
+	for _, requested := range []RequestedScope{
+		{Kind: ScopeKindTeam, ID: &other},
+		{Kind: ScopeKindOwner, ID: &other},
+	} {
+		_, err := resolveAnalyticsScope(ctx, nil, actor, requested)
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			t.Errorf("%s refusal admitted the subject exists", requested.Kind)
+		}
+		if !errors.Is(err, apperrors.ErrNotFound) {
+			t.Errorf("%s refusal was %v, want not-found", requested.Kind, err)
+		}
+	}
+}
+
+// Yourself is inside every lens, including a rep's, and asking for it by id
+// must not cost a membership read that would refuse it.
+func TestNamingYourselfIsAlwaysWithinYourOwnLens(t *testing.T) {
+	actor := actorWithScope(principal.RowScopeOwn)
+	ctx := principal.WithActor(context.Background(), actor)
+	me := actor.UserID
+
+	got, err := resolveAnalyticsScope(ctx, nil, actor, RequestedScope{Kind: ScopeKindOwner, ID: &me})
+	if err != nil {
+		t.Fatalf("naming yourself was refused: %v", err)
+	}
+	if got.Kind != ScopeKindOwner || got.ID == nil || *got.ID != me {
+		t.Fatalf("naming yourself resolved to %q/%v", got.Kind, got.ID)
+	}
+}

--- a/backend/internal/compose/analyticsscope_test.go
+++ b/backend/internal/compose/analyticsscope_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/margince/margince/backend/internal/modules/forecasting"
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
 	"github.com/margince/margince/backend/internal/shared/kernel/principal"
@@ -198,5 +199,30 @@ func TestNamingYourselfIsAlwaysWithinYourOwnLens(t *testing.T) {
 	}
 	if got.Kind != ScopeKindOwner || got.ID == nil || *got.ID != me {
 		t.Fatalf("naming yourself resolved to %q/%v", got.Kind, got.ID)
+	}
+}
+
+// A manager's default is its own population and must not be reported as the
+// workspace.
+//
+// The standing forecast call is looked up BY the scope, so flattening this to
+// "workspace" — which an earlier spelling did — handed a team manager
+// management's own call: its amount, its author and its note, printed beside
+// totals covering only the manager's teams. Asking for the workspace explicitly
+// would have been refused, which is what makes the flattened answer a
+// disclosure rather than a mislabel.
+func TestAManagersDefaultIsNotReportedAsTheWorkspace(t *testing.T) {
+	resolved := ResolvedScope{Kind: ScopeKindManagedTeams, Label: managedTeamsLabel}
+
+	got := forecastScopeFromResolved(resolved)
+
+	if got.Kind == forecasting.ScopeWorkspace {
+		t.Fatal("a manager's teams were reported as the whole workspace")
+	}
+	if got.Kind != forecasting.ScopeManagedTeams {
+		t.Fatalf("resolved scope reported as %q", got.Kind)
+	}
+	if got.ID != nil {
+		t.Errorf("the managed-teams population names a subject: %v", got.ID)
 	}
 }

--- a/backend/internal/compose/analyticsshare_integration_test.go
+++ b/backend/internal/compose/analyticsshare_integration_test.go
@@ -49,7 +49,7 @@ func (e *forecastEnv) freezeTwoTeams(t *testing.T, mine, theirs int64) ids.UUID 
 		if err != nil {
 			return err
 		}
-		deals, _, err := ForecastDeals(ctx, tx, period,
+		deals, _, _, err := ForecastDeals(ctx, tx, period,
 			forecasting.Scope{Kind: forecasting.ScopeWorkspace}, time.Now(), baseCurrency)
 		if err != nil {
 			return err

--- a/backend/internal/compose/analyticssharehandlers.go
+++ b/backend/internal/compose/analyticssharehandlers.go
@@ -152,10 +152,15 @@ func (h analyticsShareHandlers) serveLive(
 	if err != nil {
 		return err
 	}
-	deals, limited, err := ForecastDeals(ctx, tx, period, share.Scope, at, baseCurrency)
+	// A share carries the scope it was ISSUED with, which is already resolved;
+	// the resolver hands it straight back. Taking the returned one anyway keeps
+	// one answer to "which population" rather than two spellings that could
+	// drift.
+	deals, resolved, limited, err := ForecastDeals(ctx, tx, period, share.Scope, at, baseCurrency)
 	if err != nil {
 		return err
 	}
+	share.Scope = resolved
 	readings, err := forecasting.Compute(period, period.LocalDay(at), deals)
 	if err != nil {
 		return err

--- a/backend/internal/compose/forecastseam.go
+++ b/backend/internal/compose/forecastseam.go
@@ -33,17 +33,30 @@ import (
 func ForecastDeals(
 	ctx context.Context, tx pgx.Tx, period forecasting.Period, scope forecasting.Scope,
 	asOf time.Time, baseCurrency string,
-) ([]forecasting.Deal, bool, error) {
+) ([]forecasting.Deal, forecasting.Scope, bool, error) {
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 
 	scopeClause, err := auth.ScopeClauseFor(ctx, tableDeal, "d", arg)
 	if err != nil {
-		return nil, false, err
+		return nil, forecasting.Scope{}, false, err
 	}
 	limited := scopeClause != ""
 	if scopeClause == "" {
 		scopeClause = sqlUnnarrowed
+	}
+
+	// What the caller ASKED to measure, resolved against their own lens. An
+	// unset scope means they named nothing, which is a rep's own records and a
+	// manager's teams — never the installation, which is what this read
+	// answered before and why a rep's forecast was somebody else's.
+	resolved, populationClause, err := AnalyticsPopulationClause(
+		ctx, tx, requestedFromForecastScope(scope), "d", arg)
+	if err != nil {
+		return nil, forecasting.Scope{}, false, err
+	}
+	if populationClause == "" {
+		populationClause = sqlUnnarrowed
 	}
 
 	// The deal's money in the installation's base currency, converted HERE
@@ -80,11 +93,11 @@ func ForecastDeals(
 		baseValue,
 		arg(period.StartDate), arg(period.EndDate),
 		arg(period.Zone.String()), arg(period.StartDate), arg(period.EndDate),
-		scopeClause, forecastScopeClause(scope, arg))
+		scopeClause, "AND "+populationClause)
 
 	rows, err := tx.Query(ctx, sql, args...)
 	if err != nil {
-		return nil, false, fmt.Errorf("compose: reading the forecast's deals: %w", err)
+		return nil, forecasting.Scope{}, false, fmt.Errorf("compose: reading the forecast's deals: %w", err)
 	}
 	defer rows.Close()
 
@@ -107,27 +120,33 @@ func ForecastDeals(
 		return d, err
 	})
 	if err != nil {
-		return nil, false, fmt.Errorf("compose: collecting the forecast's deals: %w", err)
+		return nil, forecasting.Scope{}, false, fmt.Errorf("compose: collecting the forecast's deals: %w", err)
 	}
-	return out, limited, nil
+	return out, forecastScopeFromResolved(resolved), limited, nil
 }
 
-// forecastScopeClause narrows to one team's or one owner's deals.
+// requestedFromForecastScope carries the forecast module's scope vocabulary
+// across to the analytics resolver's.
 //
-// Separate from the row scope above and not a substitute for it: the row scope
-// is what the caller MAY see, this is what they ASKED to see. A read narrowed
-// only by the request would answer a manager's team query correctly and hand
-// them the whole pipeline by default.
-func forecastScopeClause(scope forecasting.Scope, arg func(any) int) string {
-	switch scope.Kind {
-	case forecasting.ScopeOwner:
-		return fmt.Sprintf("AND d.owner_id = $%d", arg(*scope.ID))
-	case forecasting.ScopeTeam:
-		return fmt.Sprintf(`AND d.owner_id IN (
-			SELECT tm.user_id FROM team_member tm WHERE tm.team_id = $%d)`, arg(*scope.ID))
-	default:
-		return ""
+// The two say the same three things; they are separate types because the module
+// owns no tables and cannot resolve a lens, so it names what was ASKED and the
+// composition decides what that means.
+func requestedFromForecastScope(scope forecasting.Scope) RequestedScope {
+	return RequestedScope{Kind: scope.Kind, ID: scope.ID}
+}
+
+// forecastScopeFromResolved carries the decision back.
+//
+// A manager's default resolves to their teams AND themselves, which the
+// forecast vocabulary has no single word for. It is reported as the team scope
+// when exactly one team is managed, and otherwise as the workspace-shaped
+// answer it is: the reading covers more than one team, and naming one of them
+// would be a narrower claim than the number.
+func forecastScopeFromResolved(resolved ResolvedScope) forecasting.Scope {
+	if resolved.Kind == ScopeKindManagedTeams {
+		return forecasting.Scope{Kind: forecasting.ScopeWorkspace}
 	}
+	return forecasting.Scope{Kind: resolved.Kind, ID: resolved.ID}
 }
 
 // ForecastPeriodAt resolves the window a day falls in for this installation,

--- a/backend/internal/compose/forecastseam.go
+++ b/backend/internal/compose/forecastseam.go
@@ -135,17 +135,14 @@ func requestedFromForecastScope(scope forecasting.Scope) RequestedScope {
 	return RequestedScope{Kind: scope.Kind, ID: scope.ID}
 }
 
-// forecastScopeFromResolved carries the decision back.
+// forecastScopeFromResolved carries the decision back, without flattening it.
 //
-// A manager's default resolves to their teams AND themselves, which the
-// forecast vocabulary has no single word for. It is reported as the team scope
-// when exactly one team is managed, and otherwise as the workspace-shaped
-// answer it is: the reading covers more than one team, and naming one of them
-// would be a narrower claim than the number.
+// A manager's default covers their teams AND themselves, and the forecast
+// vocabulary now has its own word for that. Reporting it as the workspace
+// instead — which an earlier spelling of this did — makes the answer claim a
+// population it did not measure, and the standing call is looked up BY the
+// scope, so the manager would have been handed management's workspace call.
 func forecastScopeFromResolved(resolved ResolvedScope) forecasting.Scope {
-	if resolved.Kind == ScopeKindManagedTeams {
-		return forecasting.Scope{Kind: forecasting.ScopeWorkspace}
-	}
 	return forecasting.Scope{Kind: resolved.Kind, ID: resolved.ID}
 }
 

--- a/backend/internal/compose/forecasttool.go
+++ b/backend/internal/compose/forecasttool.go
@@ -124,7 +124,11 @@ func forecastAsOf(req agents.ForecastRequest, now func() time.Time) (time.Time, 
 // unknown scope_kind is refused downstream by checkScope, which holds the
 // table's own CHECK and names the field.
 func forecastToolScope(req agents.ForecastRequest) forecasting.Scope {
-	scope := forecasting.Scope{Kind: forecasting.ScopeWorkspace}
+	// An agent that named no scope is asking about ITS OWN population, the same
+	// as a person who named none. Starting at the workspace made the omission
+	// an explicit request for the installation, which a rep- or team-lens
+	// passport is now refused outright — so the default answered nothing.
+	var scope forecasting.Scope
 	if req.ScopeKind != "" {
 		scope.Kind = req.ScopeKind
 	}

--- a/backend/internal/compose/forecasttool.go
+++ b/backend/internal/compose/forecasttool.go
@@ -69,7 +69,7 @@ func forecastToolReader(pool *pgxpool.Pool) agents.ForecastReader {
 			if err != nil {
 				return err
 			}
-			deals, limited, err := ForecastDeals(ctx, tx, period, scope, at, baseCurrency)
+			deals, resolved, limited, err := ForecastDeals(ctx, tx, period, scope, at, baseCurrency)
 			if err != nil {
 				return err
 			}
@@ -77,7 +77,9 @@ func forecastToolReader(pool *pgxpool.Pool) agents.ForecastReader {
 			if err != nil {
 				return err
 			}
-			out = forecastToolResult(period, scope, readings, baseCurrency, at, limited)
+			// The RESOLVED scope, so an agent is told which population the
+			// number covers rather than the blank it asked with.
+			out = forecastToolResult(period, resolved, readings, baseCurrency, at, limited)
 			call, err := store.CurrentCallTx(ctx, tx, period, scope)
 			switch {
 			case err == nil:

--- a/backend/internal/compose/meetingbrief/model.go
+++ b/backend/internal/compose/meetingbrief/model.go
@@ -86,7 +86,7 @@ var natureAllowed = map[crmcontracts.MeetingBriefSectionKind]map[string]bool{
 
 // natureFact is the contract's default: an unlabelled claim is read as a fact,
 // which is the strictest reading — it must be grounded and it may not judge.
-const natureFact = string(crmcontracts.OrganizationBriefSentenceNatureFact)
+const natureFact = string(crmcontracts.Fact)
 
 // Write produces the brief's sections. lane may be nil, which is not an error:
 // it is the deployment saying this role runs no model, and the deterministic

--- a/backend/internal/compose/meetingbrief/sections.go
+++ b/backend/internal/compose/meetingbrief/sections.go
@@ -44,8 +44,8 @@ const (
 // that are not plain facts are the ones that must say so. Anything unlabelled
 // is a fact, which is the contract's default.
 const (
-	natureAssessment     = string(crmcontracts.OrganizationBriefSentenceNatureAssessment)
-	natureRecommendation = string(crmcontracts.OrganizationBriefSentenceNatureRecommendation)
+	natureAssessment     = string(crmcontracts.Assessment)
+	natureRecommendation = string(crmcontracts.Recommendation)
 )
 
 // The claim kinds this floor reads, bound to the contract enum rather than

--- a/backend/internal/compose/meetingbriefseam_test.go
+++ b/backend/internal/compose/meetingbriefseam_test.go
@@ -30,7 +30,7 @@ func meetingID() openapi_types.UUID { return openapi_types.UUID(ids.NewV7()) }
 // thing the crossing has to preserve: a plain fact, a labelled judgment, and a
 // line citing two records.
 func wireBrief() crmcontracts.MeetingBrief {
-	assessment := crmcontracts.OrganizationBriefSentenceNatureAssessment
+	assessment := crmcontracts.Assessment
 	deal, activity := meetingID(), meetingID()
 	return crmcontracts.MeetingBrief{
 		ActivityId:  meetingID(),
@@ -116,7 +116,7 @@ func TestAJudgmentReachesTheAgentLabelledAsOne(t *testing.T) {
 		t.Errorf("a plain fact was labelled %q; empty is the contract's default and means fact",
 			got.Sections[0].Sentences[0].Nature)
 	}
-	if got.Sections[1].Sentences[0].Nature != string(crmcontracts.OrganizationBriefSentenceNatureAssessment) {
-		t.Errorf("nature = %q, want %q", got.Sections[1].Sentences[0].Nature, crmcontracts.OrganizationBriefSentenceNatureAssessment)
+	if got.Sections[1].Sentences[0].Nature != string(crmcontracts.Assessment) {
+		t.Errorf("nature = %q, want %q", got.Sections[1].Sentences[0].Nature, crmcontracts.Assessment)
 	}
 }

--- a/backend/internal/compose/orgbrief/write.go
+++ b/backend/internal/compose/orgbrief/write.go
@@ -434,9 +434,9 @@ const (
 
 // The natures a sentence can carry, same derivation, same reason.
 const (
-	natureFact           = string(crmcontracts.OrganizationBriefSentenceNatureFact)
-	natureAssessment     = string(crmcontracts.OrganizationBriefSentenceNatureAssessment)
-	natureRecommendation = string(crmcontracts.OrganizationBriefSentenceNatureRecommendation)
+	natureFact           = string(crmcontracts.Fact)
+	natureAssessment     = string(crmcontracts.Assessment)
+	natureRecommendation = string(crmcontracts.Recommendation)
 )
 
 // knownNature is every nature ANY section may carry, derived from natureAllowed

--- a/backend/internal/compose/orgdossier/deterministic.go
+++ b/backend/internal/compose/orgdossier/deterministic.go
@@ -42,7 +42,7 @@ var (
 // values and draws no conclusions, so every sentence it writes is a fact by
 // construction — labelling one an assessment would be a claim about a judgment
 // nobody made.
-var natureFact = string(crmcontracts.OrganizationBriefSentenceNatureFact)
+var natureFact = string(crmcontracts.Fact)
 
 // fieldSections routes a profile field to the section a reader would look for
 // it under. A field with no home here still reaches the summary, because

--- a/backend/internal/compose/orgdossier/growthfitwrite.go
+++ b/backend/internal/compose/orgdossier/growthfitwrite.go
@@ -227,8 +227,8 @@ func assessWithModel(ctx context.Context, lane Completer, in Input,
 // both are things the reader can weigh. `suggestions` is the recommended angle
 // alone, which is advice and says so.
 var (
-	observations = map[string]bool{natureFact: true, string(crmcontracts.OrganizationBriefSentenceNatureAssessment): true}
-	suggestions  = map[string]bool{string(crmcontracts.OrganizationBriefSentenceNatureRecommendation): true}
+	observations = map[string]bool{natureFact: true, string(crmcontracts.Assessment): true}
+	suggestions  = map[string]bool{string(crmcontracts.Recommendation): true}
 )
 
 // keepNatures is the grounding filter narrowed to the natures ONE bucket may

--- a/backend/internal/compose/orgdossier/growthfitwrite_test.go
+++ b/backend/internal/compose/orgdossier/growthfitwrite_test.go
@@ -238,7 +238,7 @@ func TestAnAssessmentSurvivesAsAFactor(t *testing.T) {
 		t.Fatalf("positive factors = %d, want the labelled assessment kept",
 			len(kept.PositiveFactors))
 	}
-	if kept.PositiveFactors[0].Nature != string(crmcontracts.OrganizationBriefSentenceNatureAssessment) {
+	if kept.PositiveFactors[0].Nature != string(crmcontracts.Assessment) {
 		t.Errorf("nature = %q, want assessment", kept.PositiveFactors[0].Nature)
 	}
 }

--- a/backend/internal/compose/orgdossier/service.go
+++ b/backend/internal/compose/orgdossier/service.go
@@ -229,9 +229,9 @@ func keepGrounded(sections []Section, in Input) []Section {
 // re-spelled so a rename upstream fails to compile instead of laundering a
 // hand-typed string past the filter.
 var knownNature = map[string]bool{
-	string(crmcontracts.OrganizationBriefSentenceNatureFact):           true,
-	string(crmcontracts.OrganizationBriefSentenceNatureAssessment):     true,
-	string(crmcontracts.OrganizationBriefSentenceNatureRecommendation): true,
+	string(crmcontracts.Fact):           true,
+	string(crmcontracts.Assessment):     true,
+	string(crmcontracts.Recommendation): true,
 }
 
 // Fingerprint covers everything that could change the content: the assembled

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -197,6 +197,8 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// plus a reader, which is its own change.
 		analyticsQueryHandlers: newAnalyticsQueryHandlers(
 			InstallationDB(pool), analyticsquery.DefaultFloor),
+		analyticsContextHandlers: newAnalyticsContextHandlers(
+			InstallationDB(pool), func() time.Time { return time.Now().UTC() }),
 		// The share routes run in the FORECAST store's transaction, whose InTx
 		// gates on forecast:read — so the whole surface, issuing included, is
 		// behind the grant that reads the thing being shared.

--- a/backend/internal/compose/serverinventory.go
+++ b/backend/internal/compose/serverinventory.go
@@ -165,6 +165,7 @@ type Server struct {
 	// it. In compose because the vocabulary is derived from the report catalog
 	// and narrowed by the caller's grants, both of which live here.
 	analyticsQueryHandlers
+	analyticsContextHandlers
 	assuranceHandlers
 	// The introductions transport: one rep asking a colleague to open a door,
 	// the colleague's bounded answer, and what came of it.

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -183,6 +183,10 @@ func (stubs) GetAiUsage(w nethttp.ResponseWriter, r *nethttp.Request, params crm
 	httperr.NotImplemented(w, r, "GetAiUsage")
 }
 
+func (stubs) GetAnalyticsContext(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "GetAnalyticsContext")
+}
+
 func (stubs) GetDataCoverage(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "GetDataCoverage")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -5760,14 +5760,17 @@ func (e ForecastMovementBucketName) Valid() bool {
 
 // Defines values for ForecastReadingsScopeKind.
 const (
-	ForecastReadingsScopeKindOwner     ForecastReadingsScopeKind = "owner"
-	ForecastReadingsScopeKindTeam      ForecastReadingsScopeKind = "team"
-	ForecastReadingsScopeKindWorkspace ForecastReadingsScopeKind = "workspace"
+	ForecastReadingsScopeKindManagedTeams ForecastReadingsScopeKind = "managed_teams"
+	ForecastReadingsScopeKindOwner        ForecastReadingsScopeKind = "owner"
+	ForecastReadingsScopeKindTeam         ForecastReadingsScopeKind = "team"
+	ForecastReadingsScopeKindWorkspace    ForecastReadingsScopeKind = "workspace"
 )
 
 // Valid indicates whether the value is a known member of the ForecastReadingsScopeKind enum.
 func (e ForecastReadingsScopeKind) Valid() bool {
 	switch e {
+	case ForecastReadingsScopeKindManagedTeams:
+		return true
 	case ForecastReadingsScopeKindOwner:
 		return true
 	case ForecastReadingsScopeKindTeam:
@@ -22140,9 +22143,11 @@ type ForecastReadings struct {
 	PeriodStart openapi_types.Date `json:"period_start"`
 
 	// PricedCount How many carried an amount. The gap to eligible_count is what the money readings do not cover: an unpriced deal is real pipeline contributing zero.
-	PricedCount int                       `json:"priced_count"`
-	ScopeId     *openapi_types.UUID       `json:"scope_id,omitempty"`
-	ScopeKind   ForecastReadingsScopeKind `json:"scope_kind"`
+	PricedCount int                 `json:"priced_count"`
+	ScopeId     *openapi_types.UUID `json:"scope_id,omitempty"`
+
+	// ScopeKind Which population these readings cover. `managed_teams` is what an omitted scope resolves to for a team manager — their teams and themselves — and is a RESULT only: it names no single subject, so no forecast can be recorded against it and no standing call is looked up for it. The write schemas keep the three nameable scopes.
+	ScopeKind ForecastReadingsScopeKind `json:"scope_kind"`
 
 	// ScopeLimited True when deals the caller cannot read were left out. A BOOLEAN and never a count: a count of what somebody may not read is itself a statement about how much of it there is, so the reader is told the figure is partial and not by how much.
 	ScopeLimited *bool `json:"scope_limited,omitempty"`
@@ -22157,7 +22162,7 @@ type ForecastReadings struct {
 	WonMinor int64 `json:"won_minor"`
 }
 
-// ForecastReadingsScopeKind defines model for ForecastReadings.ScopeKind.
+// ForecastReadingsScopeKind Which population these readings cover. `managed_teams` is what an omitted scope resolves to for a team manager — their teams and themselves — and is a RESULT only: it names no single subject, so no forecast can be recorded against it and no standing call is looked up for it. The write schemas keep the three nameable scopes.
 type ForecastReadingsScopeKind string
 
 // FxRate One effective-dated FX rate converting from_currency into the workspace base (to_currency). rate is a decimal string (numeric(20,10)), never a float.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -901,6 +901,30 @@ func (e AnalyticsMeasureFn) Valid() bool {
 	}
 }
 
+// Defines values for AnalyticsScopeKind.
+const (
+	AnalyticsScopeKindManagedTeams AnalyticsScopeKind = "managed_teams"
+	AnalyticsScopeKindOwner        AnalyticsScopeKind = "owner"
+	AnalyticsScopeKindTeam         AnalyticsScopeKind = "team"
+	AnalyticsScopeKindWorkspace    AnalyticsScopeKind = "workspace"
+)
+
+// Valid indicates whether the value is a known member of the AnalyticsScopeKind enum.
+func (e AnalyticsScopeKind) Valid() bool {
+	switch e {
+	case AnalyticsScopeKindManagedTeams:
+		return true
+	case AnalyticsScopeKindOwner:
+		return true
+	case AnalyticsScopeKindTeam:
+		return true
+	case AnalyticsScopeKindWorkspace:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ApplyTagRequestEntityType.
 const (
 	ApplyTagRequestEntityTypeDeal         ApplyTagRequestEntityType = "deal"
@@ -7791,19 +7815,19 @@ func (e OrganizationBriefSectionKind) Valid() bool {
 
 // Defines values for OrganizationBriefSentenceNature.
 const (
-	OrganizationBriefSentenceNatureAssessment     OrganizationBriefSentenceNature = "assessment"
-	OrganizationBriefSentenceNatureFact           OrganizationBriefSentenceNature = "fact"
-	OrganizationBriefSentenceNatureRecommendation OrganizationBriefSentenceNature = "recommendation"
+	Assessment     OrganizationBriefSentenceNature = "assessment"
+	Fact           OrganizationBriefSentenceNature = "fact"
+	Recommendation OrganizationBriefSentenceNature = "recommendation"
 )
 
 // Valid indicates whether the value is a known member of the OrganizationBriefSentenceNature enum.
 func (e OrganizationBriefSentenceNature) Valid() bool {
 	switch e {
-	case OrganizationBriefSentenceNatureAssessment:
+	case Assessment:
 		return true
-	case OrganizationBriefSentenceNatureFact:
+	case Fact:
 		return true
-	case OrganizationBriefSentenceNatureRecommendation:
+	case Recommendation:
 		return true
 	default:
 		return false
@@ -16364,6 +16388,36 @@ type AnalyticsAnswer struct {
 	Withheld bool `json:"withheld"`
 }
 
+// AnalyticsCapabilities What this caller may actually do, so a screen never offers a control the server will refuse.
+type AnalyticsCapabilities struct {
+	// SubmitManagerForecast Whether this caller may publish a forecast for the population they are measuring. False hides the action rather than letting the save fail.
+	SubmitManagerForecast bool `json:"submit_manager_forecast"`
+
+	// ViewManagerForecast Whether the manager forecast is a destination for this caller at all.
+	ViewManagerForecast bool `json:"view_manager_forecast"`
+}
+
+// AnalyticsContext The frame every analytics answer for this caller is placed in.
+type AnalyticsContext struct {
+	// AllowedScopes What the screen may offer. Every data route validates a requested population again; this list only keeps a control from offering a refusal.
+	AllowedScopes []AnalyticsScope `json:"allowed_scopes"`
+
+	// AsOf The instant this frame was resolved.
+	AsOf time.Time `json:"as_of"`
+
+	// BaseCurrency The currency money readings are counted in.
+	BaseCurrency string `json:"base_currency"`
+
+	// Capabilities What this caller may actually do, so a screen never offers a control the server will refuse.
+	Capabilities AnalyticsCapabilities `json:"capabilities"`
+
+	// DefaultScope One population an answer can be about. `label` is written by the server, because a client resolving an id into a name would be naming a subject it may not read.
+	DefaultScope AnalyticsScope `json:"default_scope"`
+
+	// Timezone The zone whose days a period is cut in.
+	Timezone string `json:"timezone"`
+}
+
 // AnalyticsEntity defines model for AnalyticsEntity.
 type AnalyticsEntity struct {
 	// GroupBy The fields this population can be grouped by.
@@ -16453,6 +16507,21 @@ type AnalyticsSchema struct {
 	// Version Changes when this caller's vocabulary changes. A query planned against an older version is refused rather than run.
 	Version string `json:"version"`
 }
+
+// AnalyticsScope One population an answer can be about. `label` is written by the server, because a client resolving an id into a name would be naming a subject it may not read.
+type AnalyticsScope struct {
+	// Id The team or person measured. Absent for workspace and managed_teams, which name no single subject.
+	Id *openapi_types.UUID `json:"id,omitempty"`
+
+	// Kind `managed_teams` is a team manager's own default — their teams and themselves. It is RESOLVED, never requested: a caller names one team, or names nothing and is given this.
+	Kind AnalyticsScopeKind `json:"kind"`
+
+	// Label What to call this population on screen.
+	Label string `json:"label"`
+}
+
+// AnalyticsScopeKind `managed_teams` is a team manager's own default — their teams and themselves. It is RESOLVED, never requested: a caller names one team, or names nothing and is given this.
+type AnalyticsScopeKind string
 
 // AnnotateBriefItem One finding about one queued deal.
 type AnnotateBriefItem struct {
@@ -46408,6 +46477,9 @@ type ServerInterface interface {
 	// AI usage + budget — the spend is never invisible.
 	// (GET /ai/usage)
 	GetAiUsage(w http.ResponseWriter, r *http.Request, params GetAiUsageParams)
+	// Which population this caller measures by default, and which they may choose.
+	// (GET /analytics/context)
+	GetAnalyticsContext(w http.ResponseWriter, r *http.Request)
 	// How current the sources behind the numbers are.
 	// (GET /analytics/coverage)
 	GetDataCoverage(w http.ResponseWriter, r *http.Request)
@@ -48268,6 +48340,12 @@ func (_ Unimplemented) ReplaceAiRouting(w http.ResponseWriter, r *http.Request) 
 // AI usage + budget — the spend is never invisible.
 // (GET /ai/usage)
 func (_ Unimplemented) GetAiUsage(w http.ResponseWriter, r *http.Request, params GetAiUsageParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Which population this caller measures by default, and which they may choose.
+// (GET /analytics/context)
+func (_ Unimplemented) GetAnalyticsContext(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -53287,6 +53365,28 @@ func (siw *ServerInterfaceWrapper) GetAiUsage(w http.ResponseWriter, r *http.Req
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetAiUsage(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAnalyticsContext operation middleware
+func (siw *ServerInterfaceWrapper) GetAnalyticsContext(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAnalyticsContext(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -76606,6 +76706,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/ai/usage", wrapper.GetAiUsage)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/analytics/context", wrapper.GetAnalyticsContext)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/analytics/coverage", wrapper.GetDataCoverage)

--- a/backend/internal/modules/agents/tools_forecast.go
+++ b/backend/internal/modules/agents/tools_forecast.go
@@ -66,7 +66,7 @@ func (t forecastReadings) Spec() mcp.ToolSpec {
 		InputSchema: schema(`{"type":"object","properties":{
 			"period":{"type":"string","enum":["quarter","month"],"description":"The window length. Quarters follow the installation's own financial year, which may not start in January."},
 			"as_of":{"type":"string","format":"date","description":"Which period to read, by naming a day inside it. Omit for the current one."},
-			"scope_kind":{"type":"string","enum":["workspace","team","owner"],"description":"Whose forecast. Omit it to measure whatever this caller measures by default — their own records, or the teams they hold. Naming a wider population than the caller holds is refused."},
+			"scope_kind":{"type":"string","enum":["workspace","team","owner"],"description":"Whose forecast. Omit for this caller's own default population; a wider one is refused."},
 			"scope_id":{"type":"string","format":"uuid","description":"The team or owner, for those scopes. Refused with scope_kind=workspace, which names no subject."}},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[ForecastReadingsResult](),

--- a/backend/internal/modules/agents/tools_forecast.go
+++ b/backend/internal/modules/agents/tools_forecast.go
@@ -66,7 +66,7 @@ func (t forecastReadings) Spec() mcp.ToolSpec {
 		InputSchema: schema(`{"type":"object","properties":{
 			"period":{"type":"string","enum":["quarter","month"],"description":"The window length. Quarters follow the installation's own financial year, which may not start in January."},
 			"as_of":{"type":"string","format":"date","description":"Which period to read, by naming a day inside it. Omit for the current one."},
-			"scope_kind":{"type":"string","enum":["workspace","team","owner"],"description":"Whose forecast. Defaults to the whole workspace."},
+			"scope_kind":{"type":"string","enum":["workspace","team","owner"],"description":"Whose forecast. Omit it to measure whatever this caller measures by default — their own records, or the teams they hold. Naming a wider population than the caller holds is refused."},
 			"scope_id":{"type":"string","format":"uuid","description":"The team or owner, for those scopes. Refused with scope_kind=workspace, which names no subject."}},
 			"additionalProperties":false}`),
 		OutputSchema: schemaFor[ForecastReadingsResult](),

--- a/backend/internal/modules/forecasting/handlers.go
+++ b/backend/internal/modules/forecasting/handlers.go
@@ -96,6 +96,13 @@ func (h Handlers) GetForecast(
 		out = ReadingsToWire(period, scope, readings, baseCurrency, at)
 		out.ScopeLimited = &limited
 
+		// A standing call is an assertion about ONE named population. The
+		// managed-teams reading covers several, so there is no call to look up
+		// — and looking one up under a flattened scope would fetch a different
+		// population's call and print it beside these totals.
+		if scope.Kind == ScopeManagedTeams {
+			return nil
+		}
 		call, err := h.store.CurrentCallTx(ctx, tx, period, scope)
 		switch {
 		case err == nil:

--- a/backend/internal/modules/forecasting/handlers.go
+++ b/backend/internal/modules/forecasting/handlers.go
@@ -175,7 +175,7 @@ func scopeFromParams(
 	if scope.Kind == ScopeUnset {
 		if scope.ID != nil {
 			return Scope{}, &values.ParseError{
-				Field: "scope_kind", Code: "required",
+				Field: colScopeKind, Code: "required",
 				Message: "a scope_id names whose forecast, so it needs a scope_kind beside it",
 			}
 		}

--- a/backend/internal/modules/forecasting/handlers.go
+++ b/backend/internal/modules/forecasting/handlers.go
@@ -14,6 +14,7 @@ import (
 	crmcontracts "github.com/margince/margince/backend/internal/contracts"
 	"github.com/margince/margince/backend/internal/platform/httperr"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
 )
 
 // DealsFunc reads the deals in scope for a period, already row-scoped.
@@ -27,7 +28,11 @@ import (
 // asOf and baseCurrency travel with the request because the conversion needs
 // both: a rate is looked up as of a DAY, and there is no base amount without a
 // currency to convert into.
-type DealsFunc func(ctx context.Context, tx pgx.Tx, period Period, scope Scope, asOf time.Time, baseCurrency string) ([]Deal, bool, error)
+// The Scope it returns is the one it RESOLVED, which is not always the one it
+// was handed: an unset scope means the caller named nothing, and what that
+// means depends on their lens. The reading reports the resolved one, so an
+// answer always says which population it is about.
+type DealsFunc func(ctx context.Context, tx pgx.Tx, period Period, scope Scope, asOf time.Time, baseCurrency string) ([]Deal, Scope, bool, error)
 
 // PeriodFunc resolves the installation's window for a day, and the currency its
 // money is counted in. Injected for the same reason: the fiscal settings belong
@@ -75,10 +80,11 @@ func (h Handlers) GetForecast(
 		if err != nil {
 			return err
 		}
-		deals, limited, err := h.deals(ctx, tx, period, scope, at, baseCurrency)
+		deals, resolved, limited, err := h.deals(ctx, tx, period, scope, at, baseCurrency)
 		if err != nil {
 			return err
 		}
+		scope = resolved
 		// The as-of DAY, not the instant. The slipped rule compares calendar
 		// days, and handing it a clock makes a deal due today read as slipped
 		// from noon onward — which the report engine, comparing dates, would
@@ -155,13 +161,25 @@ func (h Handlers) RecordForecastCall(w http.ResponseWriter, r *http.Request) {
 func scopeFromParams(
 	kind *crmcontracts.GetForecastParamsScopeKind, id *openapi_types.UUID,
 ) (Scope, error) {
-	scope := Scope{Kind: ScopeWorkspace}
+	var scope Scope
 	if kind != nil {
 		scope.Kind = string(*kind)
 	}
 	if id != nil {
 		asID := ids.UUID(*id)
 		scope.ID = &asID
+	}
+	// An omission is carried through as unset for the seam to resolve against
+	// the caller's own lens. Naming an id without a kind is still malformed,
+	// and says so rather than being read as one of the named scopes.
+	if scope.Kind == ScopeUnset {
+		if scope.ID != nil {
+			return Scope{}, &values.ParseError{
+				Field: "scope_kind", Code: "required",
+				Message: "a scope_id names whose forecast, so it needs a scope_kind beside it",
+			}
+		}
+		return scope, nil
 	}
 	if err := checkScope(scope); err != nil {
 		return Scope{}, err

--- a/backend/internal/modules/forecasting/scope_test.go
+++ b/backend/internal/modules/forecasting/scope_test.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package forecasting
+
+// Which scopes may be WRITTEN against, as opposed to merely reported.
+
+import "testing"
+
+// managed_teams resolves from an omitted READ scope — a manager's teams and
+// themselves — and names no single subject. A forecast recorded against it
+// would be an assertion about a population nobody can name, and the standing
+// call for it could never be looked up again, so the write door refuses it.
+func TestManagedTeamsIsRefusedAsAWriteScope(t *testing.T) {
+	if err := checkScope(Scope{Kind: ScopeManagedTeams}); err == nil {
+		t.Fatal("a forecast was accepted against the managed-teams population")
+	}
+}

--- a/backend/internal/modules/forecasting/store.go
+++ b/backend/internal/modules/forecasting/store.go
@@ -45,8 +45,19 @@ const (
 	// checkScope rather than silently measuring the installation.
 	ScopeUnset     = ""
 	ScopeWorkspace = "workspace"
-	ScopeTeam      = "team"
-	ScopeOwner     = "owner"
+	// ScopeManagedTeams is a READ result and never a request or a write: it is
+	// what a manager's omitted scope resolves to — their teams and themselves —
+	// and it names no single subject a forecast could be recorded against.
+	//
+	// It is a kind of its own rather than being reported as the workspace,
+	// because the two are different populations and a standing call is looked
+	// up BY the scope. Reported as workspace, a manager's reading would fetch
+	// management's own workspace call and print its amount, author and note
+	// beside team-only totals — a disclosure the same manager asking for the
+	// workspace explicitly would have been refused.
+	ScopeManagedTeams = "managed_teams"
+	ScopeTeam         = "team"
+	ScopeOwner        = "owner"
 )
 
 // Store owns the forecast tables.

--- a/backend/internal/modules/forecasting/store.go
+++ b/backend/internal/modules/forecasting/store.go
@@ -33,6 +33,17 @@ const codeInvalid = "invalid"
 
 // The scopes a call or a snapshot can be about.
 const (
+	// ScopeUnset is what a caller who named no scope asked for, and it is NOT
+	// the workspace. Which population an unnamed request means depends on who
+	// is asking — a rep means their own — and this module cannot answer that:
+	// the lens lives in the principal, and resolving it needs a read the
+	// composition owns. So the omission is carried, not decided, and the seam
+	// that fetches the deals resolves it.
+	//
+	// Spelling it as the empty string is deliberate: a zero Scope is unset, so
+	// a caller who forgets to resolve gets the honest "which population?" from
+	// checkScope rather than silently measuring the installation.
+	ScopeUnset     = ""
 	ScopeWorkspace = "workspace"
 	ScopeTeam      = "team"
 	ScopeOwner     = "owner"

--- a/docs/reference/agent-tool-budget.json
+++ b/docs/reference/agent-tool-budget.json
@@ -6,7 +6,7 @@
   "catalog": {
     "tools": 72,
     "system_frame_tokens": 353,
-    "tokens": 20878,
+    "tokens": 20888,
     "median_tool_tokens": 262,
     "mean_tool_tokens": 289
   },
@@ -160,7 +160,7 @@
     },
     {
       "name": "forecast_readings",
-      "tokens": 327
+      "tokens": 337
     },
     {
       "name": "prep_for_meeting",

--- a/docs/reference/agent-tool-budget.md
+++ b/docs/reference/agent-tool-budget.md
@@ -32,7 +32,7 @@ alone. A frame that grows a paragraph spends it on every run of every agent.
 |---|---:|---:|---:|---:|---:|---:|
 | `morning_brief` | 5 | 1634 | 6% | 15774 | 6 | 5 |
 | `overnight_at_risk_sweep` | 7 | 2467 | 10% | 14941 | 15 | 8 |
-| _whole served catalog, for scale_ | 72 | 20878 | 84% | — | — | — |
+| _whole served catalog, for scale_ | 72 | 20888 | 84% | — | — | — |
 
 ### `morning_brief`
 
@@ -160,7 +160,7 @@ a term in an addition.
 | `forecast_movement` | 351 | — |
 | `describe_report_vocabulary` | 349 | — |
 | `search_context` | 345 | — |
-| `forecast_readings` | 327 | — |
+| `forecast_readings` | 337 | — |
 | `prep_for_meeting` | 326 | — |
 | `merge_records` | 292 | — |
 | `catch_me_up_on` | 280 | 3 scenarios |

--- a/docs/reference/mcp-info.json
+++ b/docs/reference/mcp-info.json
@@ -10,16 +10,16 @@
   "totals": {
     "tools": 72,
     "resources": 11,
-    "tool_catalog_bytes": 204350,
+    "tool_catalog_bytes": 204388,
     "resource_catalog_bytes": 4251,
-    "approx_wire_tokens_total": 52150,
+    "approx_wire_tokens_total": 52159,
     "largest_tool_bytes": 8980,
     "largest_tool": "prep_for_meeting",
     "tool_catalog_composition": {
       "description_bytes": 49898,
-      "input_schema_bytes": 41280,
+      "input_schema_bytes": 41318,
       "output_schema_bytes": 97625,
-      "description_plus_input_schema_bytes": 91178
+      "description_plus_input_schema_bytes": 91216
     }
   },
   "tools": {
@@ -4518,7 +4518,7 @@
               "type": "string"
             },
             "scope_kind": {
-              "description": "Whose forecast. Defaults to the whole workspace.",
+              "description": "Whose forecast. Omit for this caller's own default population; a wider one is refused.",
               "enum": [
                 "workspace",
                 "team",

--- a/docs/reference/mcp-info.md
+++ b/docs/reference/mcp-info.md
@@ -15,7 +15,7 @@ receives it. This page is rendered from that file.
 | Resources | 11 |
 | Tool catalog | 199.6 KB |
 | Resource catalog | 4.2 KB |
-| Approx. wire tokens | 52150 |
+| Approx. wire tokens | 52159 |
 | Largest tool | `prep_for_meeting` (8.8 KB) |
 | Scopes rendered | `read`, `draft`, `write`, `send`, `enrich` |
 
@@ -33,7 +33,7 @@ agent, agent by agent, is [agent-tool-budget.md](agent-tool-budget.md).
 | Descriptions (incl. governance clause) | 48.7 KB | 24% | Yes, every step |
 | Input schemas | 40.3 KB | 20% | Yes, every step |
 | _Names, annotations, punctuation_ | 15.2 KB | 7% | Partly |
-| **Description + input schema** | **89.0 KB** | **44%** | **the recurring cost** |
+| **Description + input schema** | **89.1 KB** | **44%** | **the recurring cost** |
 
 So the headline total is dominated by the part a model is never charged for, and
 descriptions are a minority of it. Trimming the copy to shrink the total trades a
@@ -5104,7 +5104,7 @@ What a period is expected to close, in four readings. `won` counts deals by the 
       "type": "string"
     },
     "scope_kind": {
-      "description": "Whose forecast. Defaults to the whole workspace.",
+      "description": "Whose forecast. Omit for this caller's own default population; a wider one is refused.",
       "enum": [
         "workspace",
         "team",

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -23250,8 +23250,11 @@ export interface components {
              * @description The last day INSIDE the period, not an exclusive bound.
              */
             period_end: string;
-            /** @enum {string} */
-            scope_kind: "workspace" | "team" | "owner";
+            /**
+             * @description Which population these readings cover. `managed_teams` is what an omitted scope resolves to for a team manager — their teams and themselves — and is a RESULT only: it names no single subject, so no forecast can be recorded against it and no standing call is looked up for it. The write schemas keep the three nameable scopes.
+             * @enum {string}
+             */
+            scope_kind: "workspace" | "managed_teams" | "team" | "owner";
             /** Format: uuid */
             scope_id?: string;
             /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -11216,6 +11216,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/analytics/context": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Which population this caller measures by default, and which they may choose.
+         * @description The frame every analytics answer is placed in: the population this caller measures
+         *     when they ask for nothing, the populations they may ask for instead, the base
+         *     currency and zone their money and days are counted in, and what the screen may
+         *     offer them.
+         *
+         *     The POPULATION is not the same question as which records the caller may open.
+         *     Deals are workspace-readable so two reps do not call the same buyer, so a rep's row
+         *     scope narrows nothing — and a rep handed the workspace total has been answered a
+         *     question nobody asked. `default_scope` is what their own lens measures.
+         *
+         *     Every `label` here is written by the server. A client resolving a team or user id
+         *     into a name would be naming a subject it may not read, and the two would disagree
+         *     the first time a grant changed.
+         *
+         *     `allowed_scopes` is what the screen may OFFER, not what it may send unchecked:
+         *     every data route validates a requested population again. A control built from this
+         *     list simply never offers one that would be refused.
+         */
+        get: operations["getAnalyticsContext"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/analytics/schema": {
         parameters: {
             query?: never;
@@ -23516,6 +23552,44 @@ export interface components {
             readings: components["schemas"]["ForecastReadings"];
             /** @description Whether anything was kept back from this reader. A boolean and never a count: a count of what somebody may not see states how much of it there is. */
             withheld: boolean;
+        };
+        /** @description One population an answer can be about. `label` is written by the server, because a client resolving an id into a name would be naming a subject it may not read. */
+        AnalyticsScope: {
+            /**
+             * @description `managed_teams` is a team manager's own default — their teams and themselves. It is RESOLVED, never requested: a caller names one team, or names nothing and is given this.
+             * @enum {string}
+             */
+            kind: "workspace" | "managed_teams" | "team" | "owner";
+            /**
+             * Format: uuid
+             * @description The team or person measured. Absent for workspace and managed_teams, which name no single subject.
+             */
+            id?: string;
+            /** @description What to call this population on screen. */
+            label: string;
+        };
+        /** @description What this caller may actually do, so a screen never offers a control the server will refuse. */
+        AnalyticsCapabilities: {
+            /** @description Whether the manager forecast is a destination for this caller at all. */
+            view_manager_forecast: boolean;
+            /** @description Whether this caller may publish a forecast for the population they are measuring. False hides the action rather than letting the save fail. */
+            submit_manager_forecast: boolean;
+        };
+        /** @description The frame every analytics answer for this caller is placed in. */
+        AnalyticsContext: {
+            default_scope: components["schemas"]["AnalyticsScope"];
+            /** @description What the screen may offer. Every data route validates a requested population again; this list only keeps a control from offering a refusal. */
+            allowed_scopes: components["schemas"]["AnalyticsScope"][];
+            capabilities: components["schemas"]["AnalyticsCapabilities"];
+            /**
+             * Format: date-time
+             * @description The instant this frame was resolved.
+             */
+            as_of: string;
+            /** @description The zone whose days a period is cut in. */
+            timezone: string;
+            /** @description The currency money readings are counted in. */
+            base_currency: string;
         };
         /** @description The populations and fields one caller may ask about. */
         AnalyticsSchema: {
@@ -47526,6 +47600,28 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+        };
+    };
+    getAnalyticsContext: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The caller's analytics frame. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnalyticsContext"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
         };
     };
     getAnalyticsSchema: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3324,6 +3324,8 @@ export const de = {
   "forecast.supportingNote": "Begründung",
   "forecast.cancel": "Abbrechen",
   "forecast.saveCall": "Call speichern",
+  "analytics.scopeLabel": "Welche Datensätze diese Zahlen umfassen",
+  "analytics.scopeFixed": "Diese Zahlen umfassen {scope}.",
   "forecast.receipt": "Daten und Belege geprüft",
   "forecast.eligible": "Berücksichtigte Deals",
   "forecast.priced": "Mit Betrag",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3373,6 +3373,8 @@ export const en = {
   "forecast.supportingNote": "Supporting note",
   "forecast.cancel": "Cancel",
   "forecast.saveCall": "Save call",
+  "analytics.scopeLabel": "Which records these numbers cover",
+  "analytics.scopeFixed": "These numbers cover {scope}.",
   "forecast.receipt": "Data and evidence checked",
   "forecast.eligible": "Eligible deals",
   "forecast.priced": "Priced",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3291,6 +3291,8 @@ export const vi = {
   "forecast.supportingNote": "Ghi chú kèm theo",
   "forecast.cancel": "Hủy",
   "forecast.saveCall": "Lưu cam kết",
+  "analytics.scopeLabel": "Những bản ghi nào nằm trong các số liệu này",
+  "analytics.scopeFixed": "Các số liệu này bao gồm {scope}.",
   "forecast.receipt": "Đã kiểm tra dữ liệu và bằng chứng",
   "forecast.eligible": "Deal được tính",
   "forecast.priced": "Có số tiền",

--- a/frontend/src/screens/analytics.context.ts
+++ b/frontend/src/screens/analytics.context.ts
@@ -1,0 +1,119 @@
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { throwProblem } from "./common";
+
+export type AnalyticsContext = components["schemas"]["AnalyticsContext"];
+export type AnalyticsScope = components["schemas"]["AnalyticsScope"];
+
+/**
+ * What every Analytics request is about: the period asked for and the
+ * population it is asked over.
+ *
+ * One object rather than two pieces of state, because it is one question. A
+ * screen that kept them apart would refetch the cards on a period change and
+ * leave one of them answering about a different population.
+ */
+export type AnalyticsSelection = {
+  readonly scope: AnalyticsScope;
+};
+
+const CONTEXT_KEY = ["analytics-context"] as const;
+
+/**
+ * The caller's frame, read once.
+ *
+ * The server decides which population this person measures by default and
+ * which ones they may choose; nothing here recreates that policy. A screen
+ * asking the question itself would be a second answer, and the two would
+ * disagree the first time somebody's grants changed.
+ */
+export function useAnalyticsContext() {
+  return useQuery({
+    queryKey: CONTEXT_KEY,
+    queryFn: async () => {
+      const { data, error } = await api.GET("/analytics/context", {});
+      if (error) {
+        throwProblem(error);
+      }
+      return data;
+    },
+  });
+}
+
+/**
+ * Holds what the reader has selected, starting from the server's default.
+ *
+ * The scope is part of every query key, so changing it refetches rather than
+ * showing the previous population's numbers under the new label.
+ */
+export function useAnalyticsSelection(context: AnalyticsContext | undefined) {
+  const [chosen, setChosen] = useState<AnalyticsScope | null>(null);
+
+  const selection = useMemo<AnalyticsSelection | null>(() => {
+    if (!context) {
+      return null;
+    }
+    return { scope: chosen ?? context.default_scope };
+  }, [context, chosen]);
+
+  const selectScope = useCallback((scope: AnalyticsScope) => {
+    setChosen(scope);
+  }, []);
+
+  return { selection, selectScope };
+}
+
+/**
+ * The scope as the wire spells it.
+ *
+ * `managed_teams` is the server's word for a manager's own default and names no
+ * single subject, so it is sent as an OMISSION — which is exactly what it means:
+ * the caller named nothing and the server resolved their lens. Sending it back
+ * as a kind would be asking for somebody's managed set by name.
+ */
+export function scopeQuery(scope: AnalyticsScope): {
+  scope_kind?: "workspace" | "team" | "owner";
+  scope_id?: string;
+} {
+  if (scope.kind === "managed_teams") {
+    return {};
+  }
+  if (scope.kind === "workspace") {
+    return { scope_kind: "workspace" };
+  }
+  return { scope_kind: scope.kind, scope_id: scope.id };
+}
+
+/**
+ * The scope a WRITE names, or null when the selection cannot be written to.
+ *
+ * A read may omit the scope and let the server resolve the reader's lens. A
+ * write may not: a forecast or a share is an assertion about one named
+ * population, and `managed_teams` covers several. Rather than pick one team on
+ * the caller's behalf — a narrower claim than the number they are looking at —
+ * this returns null and the surface withholds the action.
+ */
+export function writableScope(
+  scope: AnalyticsScope,
+): { scope_kind: "workspace" | "team" | "owner"; scope_id?: string } | null {
+  if (scope.kind === "managed_teams") {
+    return null;
+  }
+  if (scope.kind === "workspace") {
+    return { scope_kind: "workspace" };
+  }
+  return { scope_kind: scope.kind, scope_id: scope.id };
+}
+
+/**
+ * A stable key for the selected population, for query caches.
+ *
+ * Built from kind and id rather than the label: two teams could be renamed to
+ * the same words, and a cache that collapsed them would serve one team's
+ * numbers under the other's name.
+ */
+export function scopeKey(scope: AnalyticsScope): string {
+  return scope.id ? `${scope.kind}:${scope.id}` : scope.kind;
+}

--- a/frontend/src/screens/analytics.forecast.test.tsx
+++ b/frontend/src/screens/analytics.forecast.test.tsx
@@ -12,6 +12,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
 import { ForecastView } from "./analytics.forecast";
 
+// The population these tests read under. Workspace because that is what a
+// manager sees, and because a nameable scope is what the editor requires.
+const WORKSPACE_SELECTION = {
+  scope: { kind: "workspace" as const, label: "Whole workspace" },
+};
+
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
@@ -128,7 +134,7 @@ describe("ForecastView", () => {
         }),
       }),
     );
-    render(<ForecastView />);
+    render(<ForecastView selection={WORKSPACE_SELECTION} canSubmit />);
     const answer = await screen.findByText(/current call is/i);
     expect(answer.textContent).toContain("2,000.00");
     expect(answer.textContent).toContain("1,200.00");
@@ -138,7 +144,7 @@ describe("ForecastView", () => {
   // zero. It must not render as "the current call is €0".
   it("says nobody has called rather than calling it zero", async () => {
     vi.stubGlobal("fetch", forecastStub());
-    render(<ForecastView />);
+    render(<ForecastView selection={WORKSPACE_SELECTION} canSubmit />);
     expect(await screen.findByText(/Nobody has called/i)).toBeTruthy();
   });
 
@@ -149,13 +155,13 @@ describe("ForecastView", () => {
       "fetch",
       forecastStub({ readings: readings({ priced_count: 9 }) }),
     );
-    render(<ForecastView />);
+    render(<ForecastView selection={WORKSPACE_SELECTION} canSubmit />);
     expect(await screen.findByText(/9 of 12 deals/i)).toBeTruthy();
   });
 
   it("says nothing about pricing when every deal carries an amount", async () => {
     vi.stubGlobal("fetch", forecastStub());
-    render(<ForecastView />);
+    render(<ForecastView selection={WORKSPACE_SELECTION} canSubmit />);
     await screen.findByText(/Nobody has called/i);
     expect(screen.queryByText(/of 12 deals/i)).toBeNull();
   });
@@ -166,7 +172,7 @@ describe("ForecastView", () => {
   it("posts the amount and the note the author typed", async () => {
     const posted: Record<string, unknown>[] = [];
     vi.stubGlobal("fetch", forecastStub({ onCall: (b) => posted.push(b) }));
-    render(<ForecastView />);
+    render(<ForecastView selection={WORKSPACE_SELECTION} canSubmit />);
 
     const user = userEvent.setup();
     await user.click(
@@ -188,7 +194,7 @@ describe("ForecastView", () => {
   it("sends no note at all when the author wrote none", async () => {
     const posted: Record<string, unknown>[] = [];
     vi.stubGlobal("fetch", forecastStub({ onCall: (b) => posted.push(b) }));
-    render(<ForecastView />);
+    render(<ForecastView selection={WORKSPACE_SELECTION} canSubmit />);
 
     const user = userEvent.setup();
     await user.click(
@@ -206,7 +212,7 @@ describe("ForecastView", () => {
       "fetch",
       forecastStub({ readings: readings({ fx_missing_count: 2 }) }),
     );
-    render(<ForecastView />);
+    render(<ForecastView selection={WORKSPACE_SELECTION} canSubmit />);
     expect(await screen.findByText("Eligible deals")).toBeTruthy();
     expect(screen.getByText("Exchange rate missing")).toBeTruthy();
     expect(screen.getByText("2")).toBeTruthy();
@@ -221,7 +227,7 @@ describe("ForecastView", () => {
   // wrong one is worth a test rather than a glance.
   it("says nothing has been checked when no run has completed", async () => {
     vi.stubGlobal("fetch", forecastStub({ assuranceStatus: 404 }));
-    render(<ForecastView />);
+    render(<ForecastView selection={WORKSPACE_SELECTION} canSubmit />);
 
     expect(
       await screen.findByText(/Nothing has been checked yet/),

--- a/frontend/src/screens/analytics.forecast.tsx
+++ b/frontend/src/screens/analytics.forecast.tsx
@@ -9,6 +9,12 @@ import { MoneyInput } from "../design-system/moneyinput";
 import { StatStrip } from "../design-system/statstrip";
 import { formatMoneyOrAbsent, formatNumber } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
+import {
+  type AnalyticsSelection,
+  scopeKey,
+  scopeQuery,
+  writableScope,
+} from "./analytics.context";
 import { ForecastReview } from "./analytics.forecast.review";
 import { QueryGate, throwProblem } from "./common";
 
@@ -21,15 +27,20 @@ type Readings = components["schemas"]["ForecastReadings"];
 // judgement, EVIDENCE is the part with confirmed dates behind it, and ALREADY
 // WON is money that arrived — three different kinds of claim, and a reader who
 // takes them for one number has been told something untrue.
-export function ForecastView() {
+export function ForecastView({
+  selection,
+  canSubmit,
+}: Readonly<{ selection: AnalyticsSelection; canSubmit: boolean }>) {
   const t = useT();
   const { locale } = useLocale();
 
   const readings = useQuery({
-    queryKey: ["forecast"],
+    // The population is part of the key: without it a scope change would show
+    // the previous population's numbers under the new one's name.
+    queryKey: ["forecast", scopeKey(selection.scope)],
     queryFn: async () => {
       const { data, error } = await api.GET("/forecast", {
-        params: { query: {} },
+        params: { query: scopeQuery(selection.scope) },
       });
       if (error) {
         throwProblem(error);
@@ -43,7 +54,9 @@ export function ForecastView() {
       {(data) => (
         <>
           <ForecastAnswer readings={data} locale={locale} />
-          <ForecastCallEditor readings={data} />
+          {canSubmit && writableScope(selection.scope) ? (
+            <ForecastCallEditor readings={data} selection={selection} />
+          ) : null}
           {/* What to check comes BEFORE the receipt: a manager with ten
               minutes reads what needs doing first, and the receipt is what
               they consult when a number looks wrong. */}
@@ -143,7 +156,10 @@ function ForecastAnswer({
 // It writes no deal row, and the copy says so: a manager who disagrees with the
 // derived figure records their own number instead of editing the pipeline until
 // the derivation agrees with them.
-function ForecastCallEditor({ readings }: Readonly<{ readings: Readings }>) {
+function ForecastCallEditor({
+  readings,
+  selection,
+}: Readonly<{ readings: Readings; selection: AnalyticsSelection }>) {
   const t = useT();
   const client = useQueryClient();
   const [open, setOpen] = useState(false);
@@ -158,13 +174,20 @@ function ForecastCallEditor({ readings }: Readonly<{ readings: Readings }>) {
     // render saw, which is the wrong number exactly when a save races a
     // refetch.
     mutationFn: async (call: { amountMinor: number; note: string }) => {
+      const named = writableScope(selection.scope);
+      if (!named) {
+        // The editor is not rendered without a nameable population, so this is
+        // unreachable rather than a state to design copy for.
+        throw new Error("a forecast names one population");
+      }
       const { data, error } = await api.POST("/forecast/calls", {
         body: {
-          // The defaults the contract documents, stated because the generated
-          // type requires them. A call with no period named is a call on the
-          // current quarter, and the workspace is the scope every seat has.
+          // The forecast is published for the population the reader is
+          // LOOKING at. Hard-coded to the workspace, this recorded a
+          // company-wide belief while a manager read their own team's numbers
+          // — the assertion and the figure it was formed from disagreeing.
           period: "quarter",
-          scope_kind: "workspace",
+          ...named,
           amount_minor: call.amountMinor,
           currency: readings.base_currency,
           // An empty note is no note. Sent as "", it would claim the author
@@ -179,7 +202,9 @@ function ForecastCallEditor({ readings }: Readonly<{ readings: Readings }>) {
     },
     onSuccess: async () => {
       // The readings carry the standing call, so they are stale the moment one
-      // is recorded.
+      // is recorded. Invalidating the whole "forecast" prefix rather than this
+      // population alone: a workspace call changes what a team reading shows
+      // beneath it, and a stale sibling is the bug this replaces.
       await client.invalidateQueries({ queryKey: ["forecast"] });
       setOpen(false);
       setNote("");

--- a/frontend/src/screens/analytics.scope.test.tsx
+++ b/frontend/src/screens/analytics.scope.test.tsx
@@ -1,0 +1,100 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { scopeKey, scopeQuery, writableScope } from "./analytics.context";
+import { AnalyticsScopePicker } from "./analytics.scope";
+
+afterEach(() => {
+  cleanup();
+});
+
+const WORKSPACE = { kind: "workspace" as const, label: "Whole workspace" };
+const NORTH = { kind: "team" as const, id: "t-north", label: "North" };
+const SOUTH = { kind: "team" as const, id: "t-south", label: "South" };
+const MINE = { kind: "owner" as const, id: "u-me", label: "Lena Fischer" };
+const MANAGED = { kind: "managed_teams" as const, label: "My teams" };
+
+describe("what a selected population sends", () => {
+  // The whole point of the manager default: it names no single subject, so it
+  // travels as an OMISSION and the server resolves the lens. Sent as a kind, it
+  // would be a request for a named managed set, which is not a thing to ask for.
+  it("sends a manager's own default as no scope at all", () => {
+    expect(scopeQuery(MANAGED)).toEqual({});
+  });
+
+  it("names the population for every scope that has one", () => {
+    expect(scopeQuery(WORKSPACE)).toEqual({ scope_kind: "workspace" });
+    expect(scopeQuery(NORTH)).toEqual({
+      scope_kind: "team",
+      scope_id: "t-north",
+    });
+    expect(scopeQuery(MINE)).toEqual({ scope_kind: "owner", scope_id: "u-me" });
+  });
+
+  // A read may leave the population to the server; a write may not. A forecast
+  // is an assertion about ONE named population, and a manager's default covers
+  // several — so there is nothing honest to write it against.
+  it("refuses to name a write population the reader has not chosen", () => {
+    expect(writableScope(MANAGED)).toBeNull();
+    expect(writableScope(NORTH)).toEqual({
+      scope_kind: "team",
+      scope_id: "t-north",
+    });
+  });
+
+  // Two teams renamed to the same words are still two populations. A key built
+  // from the label would collapse them and serve one team's numbers under the
+  // other's name.
+  it("keys two populations apart even when they read the same", () => {
+    const renamed = { ...SOUTH, label: NORTH.label };
+    expect(scopeKey(NORTH)).not.toEqual(scopeKey(renamed));
+  });
+});
+
+describe("the population control", () => {
+  it("offers every population the server allowed", async () => {
+    const onSelect = vi.fn();
+    render(
+      <AnalyticsScopePicker
+        scopes={[WORKSPACE, NORTH, SOUTH]}
+        selected={WORKSPACE}
+        onSelect={onSelect}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("option", { name: "North" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "South" })).toBeTruthy();
+  });
+
+  it("reports the population that was picked, not its label", async () => {
+    const onSelect = vi.fn();
+    render(
+      <AnalyticsScopePicker
+        scopes={[WORKSPACE, NORTH]}
+        selected={WORKSPACE}
+        onSelect={onSelect}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(screen.getByRole("option", { name: "North" }));
+    expect(onSelect).toHaveBeenCalledWith(NORTH);
+  });
+
+  // A rep measures one population, so there is no question to ask. A dropdown
+  // holding a single option is a control that cannot do anything.
+  it("states the population plainly when there is only one", () => {
+    render(
+      <AnalyticsScopePicker
+        scopes={[MINE]}
+        selected={MINE}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.getByText(/Lena Fischer/)).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/analytics.scope.tsx
+++ b/frontend/src/screens/analytics.scope.tsx
@@ -1,0 +1,55 @@
+import { Select } from "../design-system/select";
+import { useT } from "../i18n";
+import type { AnalyticsScope } from "./analytics.context";
+import { scopeKey } from "./analytics.context";
+
+/**
+ * Which population the numbers on this page are about.
+ *
+ * The options come from the server, labels included. Nothing here decides who
+ * may measure what: a control offering only permitted populations is a
+ * convenience, and every request is validated again on the way in.
+ *
+ * A caller with exactly one population to measure — a rep — gets a plain line
+ * rather than a control, because a dropdown holding one option asks a question
+ * with one answer.
+ */
+export function AnalyticsScopePicker({
+  scopes,
+  selected,
+  onSelect,
+}: Readonly<{
+  scopes: readonly AnalyticsScope[];
+  selected: AnalyticsScope;
+  onSelect: (scope: AnalyticsScope) => void;
+}>) {
+  const t = useT();
+
+  if (scopes.length <= 1) {
+    return (
+      <p className="sub">
+        {t("analytics.scopeFixed", { scope: selected.label })}
+      </p>
+    );
+  }
+
+  return (
+    <Select
+      aria-label={t("analytics.scopeLabel")}
+      options={scopes.map((scope) => ({
+        value: scopeKey(scope),
+        label: scope.label,
+      }))}
+      value={scopeKey(selected)}
+      onChange={(next) => {
+        const picked = scopes.find((scope) => scopeKey(scope) === next);
+        // A value that matches no option cannot come from this list, so it is
+        // ignored rather than guessed at: guessing would measure a population
+        // the reader did not choose and label it with one they did.
+        if (picked) {
+          onSelect(picked);
+        }
+      }}
+    />
+  );
+}

--- a/frontend/src/screens/analytics.share.test.tsx
+++ b/frontend/src/screens/analytics.share.test.tsx
@@ -51,7 +51,13 @@ describe("sharing a forecast view", () => {
   it("distinguishes the live and frozen kinds in words", async () => {
     vi.stubGlobal("fetch", shareStub());
     // A frozen state EXISTS here, which is what makes both kinds offerable.
-    render(<ShareViewButton target="forecast" snapshotId="snap-1" />);
+    render(
+      <ShareViewButton
+        target="forecast"
+        scope={{ kind: "workspace", label: "Whole workspace" }}
+        snapshotId="snap-1"
+      />,
+    );
 
     await userEvent.click(screen.getByRole("button", { name: "Share view" }));
 
@@ -66,7 +72,12 @@ describe("sharing a forecast view", () => {
 
   it("says the frozen kind is unavailable when nothing has been frozen", async () => {
     vi.stubGlobal("fetch", shareStub());
-    render(<ShareViewButton target="forecast" />);
+    render(
+      <ShareViewButton
+        target="forecast"
+        scope={{ kind: "workspace", label: "Whole workspace" }}
+      />,
+    );
 
     await userEvent.click(screen.getByRole("button", { name: "Share view" }));
 
@@ -79,7 +90,12 @@ describe("sharing a forecast view", () => {
 
   it("shows the link once and says what leaving costs", async () => {
     vi.stubGlobal("fetch", shareStub("tok-xyz"));
-    render(<ShareViewButton target="forecast" />);
+    render(
+      <ShareViewButton
+        target="forecast"
+        scope={{ kind: "workspace", label: "Whole workspace" }}
+      />,
+    );
 
     await userEvent.click(screen.getByRole("button", { name: "Share view" }));
     await userEvent.click(screen.getByRole("button", { name: "Create link" }));
@@ -97,7 +113,12 @@ describe("sharing a forecast view", () => {
     // No clipboard at all — an http origin, which is where this actually
     // happens. Silently doing nothing would leave the reader pressing Copy.
     vi.stubGlobal("navigator", { ...navigator, clipboard: undefined });
-    render(<ShareViewButton target="forecast" />);
+    render(
+      <ShareViewButton
+        target="forecast"
+        scope={{ kind: "workspace", label: "Whole workspace" }}
+      />,
+    );
 
     await userEvent.click(screen.getByRole("button", { name: "Share view" }));
     await userEvent.click(screen.getByRole("button", { name: "Create link" }));

--- a/frontend/src/screens/analytics.share.tsx
+++ b/frontend/src/screens/analytics.share.tsx
@@ -6,6 +6,7 @@ import { Callout } from "../design-system/callout";
 import { ChoiceList } from "../design-system/choicelist";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import { useT } from "../i18n";
+import { type AnalyticsScope, writableScope } from "./analytics.context";
 import { problemMessageOf, throwProblem } from "./common";
 
 // Sharing a forecast view.
@@ -24,9 +25,13 @@ type IssuedShare = Readonly<{ token: string; expiresAt: string }>;
 
 export function ShareViewButton({
   target,
+  scope,
   snapshotId,
 }: Readonly<{
   target: string;
+  // The population the issuer is LOOKING at. A share carrying a different one
+  // would hand a recipient a set the issuer never saw.
+  scope: AnalyticsScope;
   // The frozen state a snapshot share would serve. Absent means there is none
   // to freeze yet, and the snapshot choice is unavailable rather than offered
   // and then refused by the server.
@@ -42,6 +47,7 @@ export function ShareViewButton({
       {open && (
         <ShareDialog
           target={target}
+          scope={scope}
           snapshotId={snapshotId}
           onClose={() => setOpen(false)}
         />
@@ -52,10 +58,12 @@ export function ShareViewButton({
 
 function ShareDialog({
   target,
+  scope,
   snapshotId,
   onClose,
 }: Readonly<{
   target: string;
+  scope: AnalyticsScope;
   snapshotId?: string;
   onClose: () => void;
 }>) {
@@ -65,14 +73,22 @@ function ShareDialog({
 
   const create = useMutation({
     mutationFn: async () => {
+      // Resolved INSIDE the mutation rather than closed over: a value read at
+      // render time is the one the last render saw, which is the wrong
+      // population exactly when a save races a scope change.
+      const named = writableScope(scope);
+      if (!named) {
+        throw new Error("a share names one population");
+      }
       const { data, error } = await api.POST("/forecast/shares", {
         body: {
           kind,
           target,
-          // The workspace scope names no subject, which is what the server
-          // refuses a scope_id alongside. Stated rather than left to a default
-          // so the request says which forecast it shares.
-          scope_kind: "workspace" as const,
+          // The population the issuer was reading, not the installation. Fixed
+          // to the workspace, this shared a wider set than the screen showed —
+          // and a share is exactly where that matters, because the recipient
+          // never sees the screen it was issued from.
+          ...named,
           ...(kind === "snapshot" && snapshotId
             ? { snapshot_id: snapshotId }
             : {}),

--- a/frontend/src/screens/analytics.stories.tsx
+++ b/frontend/src/screens/analytics.stories.tsx
@@ -321,7 +321,11 @@ const shareRoutes: RouteMap = {
 export const ShareDialogKinds: Story = {
   render: () => (
     <StoryProviders>
-      <ShareViewButton target="forecast" snapshotId="snap-1" />
+      <ShareViewButton
+        target="forecast"
+        scope={{ kind: "workspace", label: "Whole workspace" }}
+        snapshotId="snap-1"
+      />
     </StoryProviders>
   ),
   beforeEach: () => installFetchStub(shareRoutes),
@@ -331,7 +335,11 @@ export const ShareDialogKinds: Story = {
 export const ShareDialogLinkShownOnce: Story = {
   render: () => (
     <StoryProviders>
-      <ShareViewButton target="forecast" snapshotId="snap-1" />
+      <ShareViewButton
+        target="forecast"
+        scope={{ kind: "workspace", label: "Whole workspace" }}
+        snapshotId="snap-1"
+      />
     </StoryProviders>
   ),
   beforeEach: () => installFetchStub(shareRoutes),

--- a/frontend/src/screens/analytics.test.tsx
+++ b/frontend/src/screens/analytics.test.tsx
@@ -63,6 +63,7 @@ type ReportsStubOpts = {
   companyRows?: Record<string, unknown>[];
   derivation?: Record<string, unknown>;
   onDerivation?: (url: string) => void;
+  context?: Record<string, unknown>;
 };
 
 function reportsStub(opts: ReportsStubOpts = {}) {
@@ -70,6 +71,25 @@ function reportsStub(opts: ReportsStubOpts = {}) {
     const request = input instanceof Request ? input : null;
     const url = String(request ? request.url : input);
     const method = request ? request.method : (init?.method ?? "GET");
+    // Every Analytics surface reads its frame first: which population these
+    // numbers cover, and whether this reader may publish a forecast. A stub
+    // without it leaves the screen waiting and the assertions below looking
+    // like a rendering bug.
+    if (url.includes("/analytics/context")) {
+      return jsonResponse(
+        opts.context ?? {
+          default_scope: { kind: "workspace", label: "Whole workspace" },
+          allowed_scopes: [{ kind: "workspace", label: "Whole workspace" }],
+          capabilities: {
+            view_manager_forecast: true,
+            submit_manager_forecast: true,
+          },
+          as_of: "2026-09-04T00:00:00Z",
+          timezone: "Europe/Berlin",
+          base_currency: "EUR",
+        },
+      );
+    }
     if (method === "GET" && url.includes("/derivation")) {
       opts.onDerivation?.(url);
       return jsonResponse(opts.derivation ?? {});

--- a/frontend/src/screens/analytics.tsx
+++ b/frontend/src/screens/analytics.tsx
@@ -25,7 +25,12 @@ import {
 } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
+import {
+  useAnalyticsContext,
+  useAnalyticsSelection,
+} from "./analytics.context";
 import { ForecastView } from "./analytics.forecast";
+import { AnalyticsScopePicker } from "./analytics.scope";
 import { ShareViewButton } from "./analytics.share";
 import {
   OverlayUnavailable,
@@ -838,6 +843,11 @@ export function AnalyticsScreen() {
   // does not hold (the report endpoints answer 422 unsupported_by_sor in
   // overlay), so the sections show the honest unavailable state.
   const overlay = useSorMode() === "overlay";
+  // The server decides which population this reader measures and which ones
+  // they may choose. Read once here and handed down, so every card on the page
+  // is answering about the same set.
+  const context = useAnalyticsContext();
+  const { selection, selectScope } = useAnalyticsSelection(context.data);
 
   const pipelineQuery = useQuery({
     queryKey: ["pipelines"],
@@ -868,7 +878,16 @@ export function AnalyticsScreen() {
         }}
         label={t("analytics.sections")}
       />
-      {section === "forecast" && <ShareViewButton target="forecast" />}
+      {selection && context.data ? (
+        <AnalyticsScopePicker
+          scopes={context.data.allowed_scopes}
+          selected={selection.scope}
+          onSelect={selectScope}
+        />
+      ) : null}
+      {section === "forecast" && selection ? (
+        <ShareViewButton target="forecast" scope={selection.scope} />
+      ) : null}
     </div>
   );
 
@@ -885,7 +904,12 @@ export function AnalyticsScreen() {
     <div className="wrap">
       {header}
       {section === "forecast" ? (
-        <ForecastView />
+        selection && context.data ? (
+          <ForecastView
+            selection={selection}
+            canSubmit={context.data.capabilities.submit_manager_forecast}
+          />
+        ) : null
       ) : (
         SECTION_REPORTS[section].map((report) => (
           <ReportCard


### PR DESCRIPTION
A rep opening Analytics was shown the company's pipeline as though it were their
own. Not a permission bug: deals are workspace-readable on purpose, so two reps
do not call the same buyer, and the row scope correctly narrows nothing. That is
right for opening a record and wrong for measuring one.

So this adds a second predicate. Which records a caller may OPEN and which
population a number is ABOUT are now separate questions; both narrow, neither
widens, and an answer is the intersection.

## What changes for a reader

- A rep's Analytics covers their own records. A team manager's covers their
  teams and themselves. Management sees the workspace and can narrow.
- The screen says which population the numbers cover, and offers only the ones
  the server allowed. A reader with one population gets a sentence, not a
  dropdown with a single option.
- A manager who cannot publish a forecast no longer sees the button. It used to
  render for everyone and fail on save with a 403.

## Three defects fixed on the way

**A team-scoped forecast could never have worked.** `forecastScopeClause`
narrowed with `FROM team_member`, and there is no such table — it is
`team_membership`. Every team-scoped forecast was a 500. The clause is deleted
rather than corrected, because the shared resolver already renders that
predicate against the real table.

**Two hard-coded workspaces.** The forecast editor published a company-wide
belief while a manager read their own team's numbers, and the share dialog
issued links to a wider set than the screen they were issued from — which
matters most in a share, because the recipient never sees that screen.

**A departed colleague stayed measurable.** The first spelling of the label read
asked `archived_at IS NULL` alone; deactivating an account leaves that NULL. The
live-member gate caught it, and both label reads plus the membership check now
take `identity.LiveMemberSQL`.

## Reads and writes differ, deliberately

A read may name no population and let the server resolve the caller's lens. A
write may not: a forecast and a share are assertions about ONE named population,
and a manager's default covers several. `writableScope` returns null there and
the surface withholds the action rather than publishing against a team the
reader never picked.

## One contract hazard worth knowing

Adding this route's `kind` enum displaced `OrganizationBriefSentenceNature`'s
three constants to bare `Fact`/`Assessment`/`Recommendation`. The generator
resolves a value clash by renaming one side — silently, in a schema unrelated to
the change. Sixteen call sites in orgbrief, orgdossier and meetingbrief move for
that reason; it is a rename, not a behaviour change. I bisected it to confirm
the trigger is the route becoming reachable rather than the schema names.

## Verification

`make check-backend` and `make check-fe` green. Integration lane green for
forecasting and for compose's forecast, share and analytics tests — which is
where a wrong table name actually surfaces. Every guard is mutation-checked one
clause at a time: restoring the workspace default fails the omission tests,
dropping the manager's membership check fails the forged-team case, turning a
named-subject refusal into permission-denied fails the disclosure test, and on
the frontend both scope helpers fail their own test when made to pick a
population the reader did not choose.

Refusals split on purpose: asking for a wider TIER is 403, naming a specific
team or person outside your lens is 404, because "you may not measure that team"
confirms the team exists.

## What an adversarial review caught, and what changed

Two real defects in this branch, both fixed here:

**A team manager would have been shown management's private forecast.** A
manager's omitted scope resolves to "their teams and themselves", and the first
spelling of this reported that population to the wire as `workspace` because the
forecast vocabulary had no word for it. The standing call is looked up BY the
scope, so the manager received the WORKSPACE call — its amount, its author, its
note — printed beside totals covering only their own teams. Asking for the
workspace explicitly would have been refused, which is what makes it a
disclosure rather than a mislabel. `managed_teams` is now a scope kind of its
own, readings-only (the two write schemas keep the three nameable scopes), and
no standing call is looked up for a population that names no subject.
Mutation-checked: restoring the flattening fails the new test.

**A team population counted people who had left.** Membership rows outlive both
an archived team and a deactivated seat, on purpose. The team predicates read
`team_membership` alone, so a departed colleague's deals went on counting inside
their old team's total — while the resolver refused that same person as a
population of their own. Both predicates now join a live team and a live
`app_user` through `identity.LiveMemberSQL`, which is the tree's one spelling of
that question.

Also fixed: the MCP `forecast_readings` tool turned an omitted scope into an
explicit workspace request, which a rep- or team-lens passport is now refused
outright — so the default answered nothing. Omission is carried through, and the
tool description no longer advertises a workspace default it does not have.

`contract-breaking-check` passes: the new `managed_teams` value is additive. It
does warn that a new RESPONSE enum value can surprise a client and suggests
`x-extensible-enum` — this contract uses that extension nowhere, so adopting it
for one field would be a new convention rather than a fix, and the alternative
(reporting a population the answer did not measure) is the disclosure above.

## What this does NOT yet scope

The population predicate reaches the FORECAST path (`/forecast`, its share read,
and the MCP forecast tool). It does not yet reach the generic report engine, so
the Pipeline tab's `POST /reports/{report}` calls are still workspace-wide. That
is deliberate sequencing rather than an oversight: threading the population
through `buildReportWhere` belongs with the base-currency work in the next PR,
where the same specs are being rewritten anyway, and doing it here would touch
those files twice.

So after this merges, a rep's FORECAST is their own and a rep's PIPELINE is not.
Both halves land before the analytics work is claimed as done.

The same review found three further gaps outside this branch's reach, filed
rather than fixed here because each lands with work already scheduled:

- **#4084** — the prebuilt report engine (the Pipeline tab) ignores the
  population, as described above.
- **#4086** — the typed `/analytics/query` and its saved-run replay do the same;
  `AnalyticsQuery` carries no scope field at all yet.
- **#4085** — the two forecast WRITE paths (`POST /forecast/calls`,
  `POST /forecast/shares`) and the snapshot share READ accept a scope the caller
  may not measure. This branch withholds the control in the UI, which is a
  courtesy and not a server check.

First of the analytics plan's PRs; nothing here changes what any number means
yet, only which records it covers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics population selection for workspaces, teams, individual owners, and managed teams.
  * Added scope-aware forecasts, sharing, and analytics displays.
  * Added context details including available populations, permissions, timezone, and currency.
  * Added localized scope labels in English, German, and Vietnamese.
* **Bug Fixes**
  * Prevented unauthorized, archived, or inactive populations from appearing in analytics.
  * Managed-team forecasts no longer include standing calls or allow forecast submissions.
* **Documentation**
  * Updated forecast scope guidance and published tool reference metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->