### PR TITLE
Who reads this message, said in the header — and an owner's share that works

### DIFF
--- a/backend/internal/compose/integration/capture/capture_posture_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_posture_integration_test.go
@@ -733,25 +733,42 @@ func recordThreadVerdict(
 	recomputeAudience(t, e, seat, activityID)
 }
 
-// shareThreadAsOwner runs the owner's own share, through the store method the
-// thread-audience endpoint calls, and then the derivation that endpoint runs
-// after it. Both are the shipped writers: the scenario is about what the
-// derivation does with what the share wrote, so a seeded ledger row would test
-// neither half.
+// shareThreadAsOwner presses Share the way the endpoint does: through
+// ThreadAudienceSetter.Decide, which is the whole shipped path.
+//
+// It used to call DecideAsOwner and then the derivation by hand, and that is
+// precisely what a test must not do — the assembled version left out the step
+// between them, so a defect living in the seam was invisible to it while the
+// product had it. The setter runs the ledger write, the hold clear and the
+// recompute in one transaction, and this asks for all three.
 func shareThreadAsOwner(t *testing.T, e *integration.SearchEnv, seat, activityID ids.UUID) {
 	t.Helper()
-	ctx := seatContext(e, seat)
+	ctx := sharingContext(e, seat)
+	var threadKey string
 	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
-		var threadKey string
-		if err := tx.QueryRow(ctx,
-			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1`, activityID).Scan(&threadKey); err != nil {
-			return err
-		}
-		return capturemod.NewThreadVerdictStore(nil).DecideAsOwner(ctx, tx, threadKey, true)
+		return tx.QueryRow(ctx,
+			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1`, activityID).Scan(&threadKey)
 	}); err != nil {
+		t.Fatalf("reading the thread to share: %v", err)
+	}
+	if _, err := compose.NewThreadAudienceSetter(e.Pool).Decide(ctx, threadKey, true); err != nil {
 		t.Fatalf("sharing the thread as its owner: %v", err)
 	}
-	recomputeAudience(t, e, seat, activityID)
+}
+
+// sharingContext is one seat with the grant the endpoint checks. Decide asks
+// for activity:update before it writes anything, so a context without it would
+// prove only that the gate is there.
+func sharingContext(e *integration.SearchEnv, user ids.UUID) context.Context {
+	ctx := seatContext(e, user)
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		SeatType: principal.SeatFull,
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"activity": {Read: true, Update: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
 }
 
 // recomputeAudience runs the derivation the way every product writer does after
@@ -769,5 +786,102 @@ func recomputeAudience(t *testing.T, e *integration.SearchEnv, seat, activityID 
 			ctx, tx, ids.From[ids.ActivityKind](activityID))
 	}); err != nil {
 		t.Fatalf("recomputing the audience: %v", err)
+	}
+}
+
+// TestAnOwnerShareLiftsAVerdictHoldAndNothingElse is the reported bug and its
+// three boundaries.
+//
+// A row-carried hold outranks an opening contribution, which is right for the
+// holds a recipient may not lift and wrong for the one they may. The owner
+// pressed Share; the ledger recorded shared_by_owner, the derivation ran, read
+// the verdict's own reason off the row and left the message held. The share
+// worked and the hold ignored it, however many times it was pressed.
+//
+// The three that must NOT move are asserted beside it, because a clear that was
+// one word too wide would publish mail nobody decided to publish.
+func TestAnOwnerShareLiftsAVerdictHoldAndNothingElse(t *testing.T) {
+	env := newCaptureEnv(t)
+	e, sync := env.e, env.sync
+	allowSharedPosture(t, e)
+	setPosture(t, env, e.Rep1, capturemod.PostureClassified)
+
+	// A classifier held it, answering `explicitly_confidential` — the kind that
+	// collides with a sender's own marking and lands on the row as the marking's
+	// word. That collision is what made the share inert: the row could not say
+	// which of the two held it, so it refused to let either be lifted. The
+	// subject carries no marker at all, which is the whole point.
+	sync(t, emailWithSubject("john@mii.example", "John Khoury", captureOwner,
+		"ownershare-1@mii.example", "Re: Follow up"))
+	judged := oneActivityID(t, e)
+	recordThreadVerdict(t, e, e.Rep1, judged, capturemod.VerdictHeld, "explicitly_confidential")
+	// The row as a binary BEFORE rowReasonForKind wrote it: the kind reached the
+	// column verbatim. Written here rather than left to the current writer,
+	// which translates it away — these are the rows already in the field, and
+	// they are what a rep cannot share. Set through the import row and the
+	// derivation, so the activity's own reason is derived rather than dictated.
+	setImportVerdictReason(t, e, e.Rep1, judged, "explicitly_confidential")
+	recomputeAudience(t, e, e.Rep1, judged)
+	if got, _ := audienceOf(t, e, judged); got != "participants" {
+		t.Fatalf("a message a verdict held is %q, want it held before the share", got)
+	}
+	shareThreadAsOwner(t, e, e.Rep1, judged)
+	if got, reason := audienceOf(t, e, judged); got != "workspace" {
+		t.Fatalf("after its owner shared it the message is %q / %q, want workspace: the share "+
+			"reached the ledger and the row's own reason outranked it", got, reason)
+	}
+
+	// A SENDER's marking is not the recipient's to lift.
+	sync(t, emailWithSubject("anwalt@studiolegal.example", "Dr. Legal", captureOwner,
+		"ownershare-2@studiolegal.example", "[Vertraulich] Aufhebungsvertrag"))
+	marked := newestActivityID(t, e)
+	shareThreadAsOwner(t, e, e.Rep1, marked)
+	if got, reason := audienceOf(t, e, marked); got != "participants" || reason != "explicitly_confidential" {
+		t.Fatalf("a message its SENDER marked is %q / %q after an owner share, want it still held",
+			got, reason)
+	}
+
+	// A COUNTERPARTY hold is this seat's standing decision about a person.
+	// Sharing one thread says nothing about whether they want that party's mail
+	// in a shared CRM.
+	holdCounterparty(t, e, e.Rep1, capturemod.HoldKindDomain, "ownerhold.example")
+	sync(t, email("partner@ownerhold.example", "Partner", captureOwner,
+		"ownershare-3@ownerhold.example", ""))
+	heldParty := newestActivityID(t, e)
+	shareThreadAsOwner(t, e, e.Rep1, heldParty)
+	if got, reason := audienceOf(t, e, heldParty); got != "participants" || reason != "counterparty" {
+		t.Fatalf("a counterparty hold is %q / %q after an owner share, want it still held", got, reason)
+	}
+
+	// And the WORKSPACE floor, which one seat cannot overrule.
+	setMailSharing(t, e, false)
+	sync(t, customerMail("ownershare-4@acme.example"))
+	floored := newestActivityID(t, e)
+	shareThreadAsOwner(t, e, e.Rep1, floored)
+	if got, reason := audienceOf(t, e, floored); got != "participants" || reason != "workspace_floor" {
+		t.Fatalf("the workspace floor is %q / %q after an owner share, want it still held", got, reason)
+	}
+}
+
+// setImportVerdictReason puts an import row back into the shape a verdict wrote
+// before rowReasonForKind translated the classifier's kind away.
+//
+// The COLUMN is set and the derivation is left to decide what the activity row
+// says about it, so the scenario still turns on production's own reading. There
+// is no product path to this state any more — that is the fix — and the rows it
+// reproduces are the ones already captured, which is exactly why the share has
+// to work on them.
+func setImportVerdictReason(
+	t *testing.T, e *integration.SearchEnv, seat, activityID ids.UUID, reason string,
+) {
+	t.Helper()
+	ctx := seatContext(e, seat)
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			UPDATE capture_import SET verdict_reason = $3
+			 WHERE activity_id = $1 AND user_id = $2`, activityID, seat, reason)
+		return err
+	}); err != nil {
+		t.Fatalf("restoring the pre-translation verdict reason: %v", err)
 	}
 }

--- a/backend/internal/compose/threadaudience.go
+++ b/backend/internal/compose/threadaudience.go
@@ -110,6 +110,38 @@ func (s *ThreadAudienceSetter) Decide(ctx context.Context, threadKey string, sha
 		if err := s.threads.DecideAsOwner(ctx, tx, threadKey, share); err != nil {
 			return err
 		}
+		// A hold a CLASSIFIER placed is the owner's to disagree with, and the
+		// row carries it independently of the ledger: the derivation below reads
+		// `audience_reason` off the activity, and a row-carried hold outranks an
+		// opening contribution. Without this the share was inert — the ledger
+		// said shared_by_owner, the recompute read the verdict's own reason off
+		// the row, and the message stayed held however often it was pressed.
+		//
+		// The two modules answer the halves each owns: capture reads its ledger
+		// to say whether a CLASSIFIER is what judged this thread — a verdict
+		// records the kind it concluded, a sender's marking records none — and
+		// activities writes the column. Neither can do the other's half, which
+		// is what makes this a seam rather than indirection.
+		//
+		// Only when SHARING. Re-holding a thread removes nothing, and the
+		// reasons this leaves alone — a sender's own subject marking, a
+		// counterparty hold, the workspace floor — are not a recipient's to
+		// lift. ClearConfidentialityVerdictHoldTx enumerates them.
+		if share {
+			judged, err := capture.ThreadJudgedByClassifierTx(ctx, tx, threadKey, actor.UserID)
+			if err != nil {
+				return err
+			}
+			if judged {
+				activityIDs := make([]ids.ActivityID, 0, len(messages))
+				for _, id := range messages {
+					activityIDs = append(activityIDs, ids.From[ids.ActivityKind](id))
+				}
+				if err := activities.ClearConfidentialityVerdictHoldTx(ctx, tx, activityIDs); err != nil {
+					return err
+				}
+			}
+		}
 		for _, id := range messages {
 			if err := activities.RecomputeAudienceTx(ctx, tx, ids.From[ids.ActivityKind](id)); err != nil {
 				return err

--- a/backend/internal/modules/activities/audiencerecompute.go
+++ b/backend/internal/modules/activities/audiencerecompute.go
@@ -435,3 +435,56 @@ func ClearCounterpartyHoldTx(ctx context.Context, tx pgx.Tx, activityIDs []ids.A
 	}
 	return nil
 }
+
+// ClearConfidentialityVerdictHoldTx removes the one row-carried hold an owner
+// is entitled to lift: a CLASSIFIER's confidentiality answer.
+//
+// Its sibling above clears a counterparty hold; this exists for the same reason
+// and answers a different question. A row-carried hold outranks an opening
+// contribution, which is right for the holds a recipient may not lift and wrong
+// for the one they may. The owner pressed Share, the ledger recorded
+// `shared_by_owner`, the derivation ran, read the row's reason and left the
+// message held — the share worked and the hold ignored it.
+//
+// The predicate is the subtle part. `explicitly_confidential` on a row means
+// two things that cannot be told apart by the word:
+//
+//   - the SENDER marked their own subject line. Not a recipient's to lift.
+//   - a CLASSIFIER concluded the text asks for confidence. A judgement, and the
+//     owner may disagree with it.
+//
+// So the CALLER decides which rows qualify and this writes them. capture owns
+// the thread ledger and can see that a row's hold came from a classifier — a
+// verdict recorded a `kind`, a sink marking never does — while this module owns
+// `activity` and is the only one entitled to write the column. Reading the
+// ledger here would be a module reaching into a sibling's table, which the
+// ownership gate refuses and which would put the same rule in two places.
+//
+// Newer rows do not need any of this: capture's rowReasonForKind now sends a
+// classifier's answer to the row as the generic `verdict`, which is not
+// row-carried at all. The rows judged before that landed still carry the word,
+// and they are the ones a rep cannot share today.
+//
+// Every other reason is left where it is: `counterparty` is this seat's standing
+// decision about a PERSON rather than this message, `workspace_floor` is an
+// admin's decision one seat cannot overrule, and `no_record` / `no_counterparty`
+// are the capture ladder's filing facts rather than judgements about
+// confidentiality. The value predicate stays in the UPDATE even though the
+// caller has already chosen the ids, for the reason its sibling states: the
+// column has more than one writer, and each has to say which values are its own
+// to clear.
+func ClearConfidentialityVerdictHoldTx(
+	ctx context.Context, tx pgx.Tx, activityIDs []ids.ActivityID,
+) error {
+	if len(activityIDs) == 0 {
+		return nil
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE activity
+		   SET audience_reason = NULL
+		 WHERE id = ANY($1) AND audience_reason = $2`,
+		activityIDs, ReasonConfidentialMarker); err != nil {
+		return fmt.Errorf("activities: clearing a confidentiality verdict the owner has shared past: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/modules/capture/threadownerdecision.go
+++ b/backend/internal/modules/capture/threadownerdecision.go
@@ -119,3 +119,33 @@ func ThreadActivityIDsTx(ctx context.Context, tx pgx.Tx, threadKey string, user 
 	}
 	return out, nil
 }
+
+// ThreadJudgedByClassifierTx answers whether this seat's verdict on a thread
+// came from a CLASSIFIER rather than from the sender's own subject marking.
+//
+// The two are indistinguishable on the activity row, where both spell their
+// reason `explicitly_confidential`, and they are not the same fact: a marking
+// is the sender's and no recipient lifts it, while a verdict is a judgement its
+// owner may disagree with. The ledger is where they differ — a verdict records
+// the `kind` it concluded, and a marking records none — so the question is
+// asked here, of the table this module owns, and answered for the caller that
+// owns the column.
+//
+// False for a thread with no ledger row at all, which is the honest answer:
+// nothing judged it, so nothing of the classifier's is there to lift.
+func ThreadJudgedByClassifierTx(
+	ctx context.Context, tx pgx.Tx, threadKey string, user ids.UUID,
+) (bool, error) {
+	if threadKey == "" || user == ids.Nil {
+		return false, nil
+	}
+	var judged bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		  SELECT 1 FROM capture_thread_verdict
+		   WHERE thread_key = $1 AND user_id = $2 AND kind IS NOT NULL)`,
+		threadKey, user).Scan(&judged); err != nil {
+		return false, fmt.Errorf("capture: reading whether a classifier judged this thread: %w", err)
+	}
+	return judged, nil
+}

--- a/frontend/src/design-system/emaildetail.css
+++ b/frontend/src/design-system/emaildetail.css
@@ -1,9 +1,11 @@
 /* The email drawer's own chrome. The Modal supplies the surface, the edge and
  * the focus trap; this is only what a message needs inside one. */
 
+/* The flex sizing lives on the heading block around this now, so the title is
+   only type: a second `flex: 1` here would stretch it inside a column and push
+   its own markers away from it. */
 .emaildetail__title {
-  margin: 0 0 var(--space-3);
-  flex: 1;
+  margin: 0;
   min-width: 0;
   font-size: var(--fs-h3);
 }
@@ -76,6 +78,23 @@
   align-items: start;
   gap: var(--space-2);
   justify-content: space-between;
+  /* The gap under the header, which used to come from the title's own bottom
+     margin. It moved here when the markers joined the title in a block: a
+     margin on the type would have sat between the subject and its badges
+     instead of under both. */
+  margin-bottom: var(--space-3);
+}
+
+/* The subject with its access markers under it, as one block beside the close
+   button. Stacked rather than inline: a subject runs to a line and a half on a
+   narrow drawer, and badges sharing that line would sit wherever it happened
+   to end. */
+.emaildetail__heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 0;
 }
 
 /* What came with the message. A list, not a grid: filenames run to very

--- a/frontend/src/design-system/emaildetail.tsx
+++ b/frontend/src/design-system/emaildetail.tsx
@@ -43,11 +43,22 @@ export function EmailDetail({
   onClose,
   formatWhen,
   renderAccess,
+  renderAccessMarkers,
 }: Readonly<{
   activityId: string;
   onClose: () => void;
   /** The caller owns the reader's timezone, so it owns the formatting. */
   formatWhen: (iso: string) => string;
+  /**
+   * What this message's access IS, as markers beside the subject.
+   *
+   * Separate from `renderAccess` because the two answer different questions at
+   * different moments: this is the glance a reader takes before reading, and
+   * that is the sentence and the control they reach for after. Splitting them
+   * is also what keeps the header short — a paragraph beside a subject line
+   * pushes the message itself below the fold.
+   */
+  renderAccessMarkers?: (access: EmailPresentation["access"]) => ReactNode;
   /**
    * Who reads this message, and the control to change it.
    *
@@ -116,9 +127,22 @@ export function EmailDetail({
           Modal builds for keyboard users becomes a trap in the ordinary sense
           without this. */}
       <div className="emaildetail__head">
-        <h2 id={titleId} className="emaildetail__title">
-          {title}
-        </h2>
+        <div className="emaildetail__heading">
+          <h2 id={titleId} className="emaildetail__title">
+            {title}
+          </h2>
+          {/* WHAT this message's access is, beside its subject. A limit is a
+              fact about a message like its date, and a reader wants it before
+              they read rather than after: under the body these markers sat
+              below the attachments, so on anything longer than a screen the
+              first sign a message was confidential arrived once the reader had
+              already finished it.
+
+              Drawn from the read the drawer has already made, so a header with
+              no markers is a message whose access block did not arrive — never
+              one whose access nobody asked about. */}
+          {read.data && renderAccessMarkers?.(read.data.access)}
+        </div>
         <Button
           small
           iconOnly

--- a/frontend/src/design-system/emailentry.stories.tsx
+++ b/frontend/src/design-system/emailentry.stories.tsx
@@ -259,3 +259,60 @@ export const RecordDrawer: StoryObj = {
     );
   },
 };
+
+/**
+ * The drawer for a message something HELD, which is the state the access
+ * markers exist for.
+ *
+ * Two badges beside the subject: what the limit is, and what decided it. The
+ * pair is the picture worth having, because a header carrying only "Participants"
+ * tells a reader they cannot widen the message and not why — and a reader who
+ * cannot see the verdict cannot tell a correct one from a wrong one.
+ *
+ * `can_change` is true here, so the sentence and the control under the body are
+ * drawn too: this is the whole arrangement, header and footer, in one shot.
+ */
+export const RecordDrawerHeld: StoryObj = {
+  render: () => {
+    installFetchStub({
+      "GET /activities/11111111-1111-4111-8111-111111111111/email-presentation":
+        () =>
+          jsonResponse({
+            id: BASE.activity_id,
+            lifecycle: "delivered",
+            occurred_at: BASE.occurred_at,
+            summary: { ...BASE, display_status: "participants" },
+            body: "Können wir Dienstag kurz sprechen?\n\nViele Grüße\nAna",
+            from: [
+              { address: "ana@brandt.example", display_name: "Ana Sommer" },
+            ],
+            to: [],
+            cc: [],
+            bcc: [],
+            bcc_withheld: false,
+            attachments: [],
+            links: [],
+            access: {
+              content_state: "available",
+              display_status: "participants",
+              audience: "participants",
+              explanation: "explicitly_confidential",
+              can_change: true,
+              change_mode: "thread_contribution",
+            },
+            can_reply: true,
+            can_relink: false,
+            version: 3,
+          }),
+    });
+    return (
+      <StoryProviders>
+        <OpenEmailDrawer
+          activityId={BASE.activity_id}
+          zone={viewerZone()}
+          onClose={() => {}}
+        />
+      </StoryProviders>
+    );
+  },
+};

--- a/frontend/src/design-system/openemaildrawer.tsx
+++ b/frontend/src/design-system/openemaildrawer.tsx
@@ -3,7 +3,10 @@
 
 import { formatDateTime } from "../format/format";
 import { useLocale } from "../i18n";
-import { EmailAccessEditor } from "../screens/emailaccesseditor";
+import {
+  EmailAccessEditor,
+  EmailAccessMarkers,
+} from "../screens/emailaccesseditor";
 import { EmailDetail } from "./emaildetail";
 
 /**
@@ -38,6 +41,7 @@ export function OpenEmailDrawer({
       activityId={activityId}
       onClose={onClose}
       formatWhen={(iso) => formatDateTime(iso, locale, zone)}
+      renderAccessMarkers={(access) => <EmailAccessMarkers access={access} />}
       renderAccess={(presentation) => (
         <EmailAccessEditor presentation={presentation} />
       )}

--- a/frontend/src/screens/emailaccesseditor.css
+++ b/frontend/src/screens/emailaccesseditor.css
@@ -1,9 +1,13 @@
-/* Who reads this message, under the message itself.
+/* Who reads this message, in two places for two moments.
  *
- * Below the words rather than above them: it is the last thing a reader needs,
- * and a strip in the header would push the subject they came for down the
- * drawer. The rule above it is what separates a fact about the message from
- * the message. */
+ * The MARKERS sit in the header beside the subject, because a limit is a fact
+ * about a message like its date and a reader wants it before they read. They
+ * are badges and nothing else: a sentence up there pushes the message itself
+ * below the fold.
+ *
+ * The SENTENCE, the names and the control stay under the body, which is where
+ * a reader goes once they have read the thing and want to act on it. The rule
+ * above them separates a fact about the message from the message. */
 
 .emailaccess {
   display: flex;
@@ -14,11 +18,19 @@
   border-top: 1px solid var(--borderSubtle);
 }
 
-.emailaccess__verdict {
+/* The header's own row of badges, which wraps rather than pushing the close
+   button off the edge on a narrow drawer. */
+.emailaccess__markers {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   flex-wrap: wrap;
+}
+
+.emailaccess__sentence {
+  margin: 0;
+  color: var(--textSecondary);
+  font-size: var(--fs-sm);
 }
 
 .emailaccess__members {

--- a/frontend/src/screens/emailaccesseditor.test.tsx
+++ b/frontend/src/screens/emailaccesseditor.test.tsx
@@ -19,7 +19,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
-import { EmailAccessEditor } from "./emailaccesseditor";
+import { EmailAccessEditor, EmailAccessMarkers } from "./emailaccesseditor";
 
 type EmailPresentation = components["schemas"]["EmailPresentation"];
 type EmailAccess = components["schemas"]["EmailAccess"];
@@ -130,7 +130,10 @@ describe("what the drawer says about who reads a message", () => {
 
     // Who reads a message is a fact about it, like its date. A reader without
     // standing to widen it is still told what it is.
-    expect(screen.getByText("Participants")).toBeTruthy();
+    //
+    // The one-word badge is NOT here: it is a marker and lives in the header,
+    // beside the subject, so a reader meets it before the message rather than
+    // under it. This half is the sentence that explains it.
     expect(
       screen.getByText("Only the people on this message can read it."),
     ).toBeTruthy();
@@ -302,5 +305,87 @@ describe("what the drawer says about who reads a message", () => {
     // what this reader changes is their own contribution to the thread.
     expect(screen.getByRole("button", { name: /Share/ })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Visibility" })).toBeNull();
+  });
+});
+
+// The header's own half: what a reader meets BEFORE the message.
+describe("the access markers beside the subject", () => {
+  it("names the audience and the reason that decided it", () => {
+    draw(
+      <EmailAccessMarkers
+        access={
+          presentation({
+            display_status: "participants",
+            audience: "participants",
+            explanation: "explicitly_confidential",
+          }).access
+        }
+      />,
+    );
+
+    // Two facts, two badges: what the limit IS, and what decided it. The
+    // reason arrives as a token and is translated — a header reading
+    // `explicitly_confidential` would be worse than one reading nothing.
+    expect(screen.getByText("Participants")).toBeTruthy();
+    expect(screen.getByText("Marked confidential")).toBeTruthy();
+    expect(screen.queryByText("explicitly_confidential")).toBeNull();
+  });
+
+  it("draws no reason badge when the server gave none", () => {
+    draw(
+      <EmailAccessMarkers
+        access={
+          presentation({
+            display_status: "team",
+            audience: "workspace",
+          }).access
+        }
+      />,
+    );
+
+    // A message nothing held has nothing to explain, and an empty second badge
+    // beside the first would read as a fact the response failed to fill in.
+    expect(screen.getByText("Team")).toBeTruthy();
+    expect(screen.queryByText("Marked confidential")).toBeNull();
+  });
+
+  it("draws no reason badge for a token it cannot name", () => {
+    draw(
+      <EmailAccessMarkers
+        access={
+          presentation({
+            display_status: "participants",
+            audience: "participants",
+            explanation: "a_reason_shipped_after_this_build",
+          }).access
+        }
+      />,
+    );
+
+    // A reason the server learned to give and the map has not renders nothing
+    // rather than the raw token. The gate holds the two sides together; this
+    // is what the screen does while they are apart.
+    expect(screen.getByText("Participants")).toBeTruthy();
+    expect(screen.queryByText("a_reason_shipped_after_this_build")).toBeNull();
+  });
+
+  it("draws the withheld state as a caution, not as a quiet marker", () => {
+    const { container } = draw(
+      <EmailAccessMarkers
+        access={
+          presentation({
+            display_status: "withheld",
+            content_state: "withheld",
+          }).access
+        }
+      />,
+    );
+
+    // `withheld` is the one state about the READER rather than the message,
+    // and it is why the body below it is empty. Every other state is a message
+    // working as intended and takes the quiet form.
+    const badge = container.querySelector(".badge");
+    expect(badge?.className).toContain("badge-warn");
+    expect(badge?.className).not.toContain("badge-quiet");
   });
 });

--- a/frontend/src/screens/emailaccesseditor.tsx
+++ b/frontend/src/screens/emailaccesseditor.tsx
@@ -59,41 +59,65 @@ const STATUS_SENTENCE: Record<EmailAccessStatus, MessageKey> = {
 };
 
 /**
- * What the drawer says about who reads this message, and the control to
- * change it when this reader may.
+ * WHAT this message's access is, as markers beside its subject.
  *
- * Always drawn, even for a reader who may change nothing: who may read a
- * message is a fact about it, like its date. A reader without standing sees
- * the sentence and no button — which is the honest rendering of "you can see
- * that this is limited, and it is not yours to widen".
+ * In the HEADER, because a limit is a fact about a message like its date and
+ * its sender, and a reader wants it before they read rather than after. Under
+ * the body it sat below the attachments, so on anything longer than a screen
+ * the first sign that a message was confidential came after the reader had
+ * finished reading it.
+ *
+ * Quiet badges, which the catalog asks for where a surface carries more than
+ * one: a row of filled pills reads as decoration and a reader learns to skip
+ * it. `withheld` is the exception and stays filled — it is the one state about
+ * the READER rather than the message, and it is why the body below is empty.
+ *
+ * The sentence does NOT come along. A header holds what a glance needs; the
+ * paragraph explaining what "Participants" means to this reader belongs beside
+ * the control that changes it.
+ */
+export function EmailAccessMarkers({
+  access,
+}: Readonly<{ access: EmailAccess }>) {
+  const t = useT();
+  const withheld = access.display_status === "withheld";
+  // WHY, when the server gave a reason. `explanation` is a TOKEN, not a
+  // sentence — `readEmailAccess` fills it from the same `audience_reason`
+  // column the timeline row reads — so it is translated through the shared
+  // map. Printing it raw would put `pending_verdict` on the screen, and a
+  // reason the server learned to give and the map has not draws nothing.
+  const reasonKey = AUDIENCE_REASON_LABEL[access.explanation ?? ""];
+  return (
+    <div className="emailaccess__markers">
+      <Badge tone={withheld ? "warn" : undefined} quiet={!withheld}>
+        {t(STATUS_LABEL[access.display_status])}
+      </Badge>
+      {reasonKey && <Badge quiet>{t(reasonKey)}</Badge>}
+    </div>
+  );
+}
+
+/**
+ * WHO reads this message, said in full, and the control to change it when this
+ * reader may.
+ *
+ * Always drawn, even for a reader who may change nothing: a reader without
+ * standing sees the sentence and no button, which is the honest rendering of
+ * "you can see that this is limited, and it is not yours to widen".
+ *
+ * The markers above are its other half and are NOT repeated here — the header
+ * carries the badge, this carries the sentence, the names and the verb.
  */
 export function EmailAccessEditor({
   presentation,
 }: Readonly<{ presentation: EmailPresentation }>) {
   const t = useT();
   const { access } = presentation;
-  const reasonKey = AUDIENCE_REASON_LABEL[access.explanation ?? ""];
   return (
     <div className="emailaccess">
-      <div className="emailaccess__verdict">
-        <Badge tone={access.display_status === "withheld" ? "warn" : undefined}>
-          {t(STATUS_LABEL[access.display_status])}
-        </Badge>
-        <span className="t-caption">
-          {t(STATUS_SENTENCE[access.display_status])}
-        </span>
-      </div>
-      {/* WHY, when the server gave a reason. A held message the reader can see
-          the outline of is otherwise a limit with no author: the reason names
-          what decided it, which is what a person disagreeing with the verdict
-          needs before they can argue with it.
-
-          `explanation` is a TOKEN, not a sentence — `readEmailAccess` fills it
-          from the same `audience_reason` column the timeline row reads — so it
-          is translated through the shared map. Printing it raw would put
-          `pending_verdict` on the screen. A reason the server learned to give
-          and the map has not draws nothing rather than the token. */}
-      {reasonKey && <p className="t-caption">{t(reasonKey)}</p>}
+      <p className="emailaccess__sentence">
+        {t(STATUS_SENTENCE[access.display_status])}
+      </p>
       <NamedMembers access={access} />
       {/* The control only where the server says this caller's write would be
           taken. `can_change` and `change_mode` are decided by the authority


### PR DESCRIPTION
Two halves of the same screen, from a reported drawer.

## 1. The design

The access markers sat **under the body**, below the attachments. On anything longer than a screen the first sign a message was confidential arrived *after* the reader had finished reading it.

They move into the header beside the subject, where a limit belongs — it is a fact about a message like its date and its sender.

Two **quiet** badges: what the limit IS, and what decided it. That is the form the catalog asks for where a surface carries more than one (`Badge`'s own doc: "a stack of filled pills reads as decoration a reader learns to skip"). `withheld` stays filled — it is the one state about the *reader* rather than the message, and it is why the body below it is empty.

The sentence, the named members and the control stay under the body, which is where a reader goes once they have read the thing and want to act on it. Header for the glance, footer for the verb.

`RecordDrawerHeld` is the new story: the held state with both badges and the control, which is the arrangement worth a picture.

## 2. The share that did nothing

It was inert on **every message a classifier had already judged** — the reported symptom, and pressing the button again could never have fixed it.

A row-carried hold outranks an opening contribution. That is right for the holds a recipient may not lift and wrong for the one they may. The owner pressed Share, `DecideAsOwner` recorded `shared_by_owner` on the ledger and the import row, the derivation ran, read `explicitly_confidential` off the activity row and left the message held. `DecideAsOwner` writes `verdict_status` and never the reason beside it, so the stale word survived every press.

**The word cannot tell the two apart.** On a row `explicitly_confidential` means both *"the sender marked their subject line"* (not a recipient's to lift) and *"a classifier concluded the text asks for confidence"* (a judgement its owner may disagree with).

So the **ledger** decides, not the word. `capture.ThreadJudgedByClassifierTx` reads its own table — a verdict records the `kind` it concluded, a sender's marking records none — and `activities.ClearConfidentialityVerdictHoldTx` writes the column it owns. Neither module can do the other's half; that is what makes this a seam rather than indirection, and reading the ledger from `activities` is what the table-ownership gate refuses.

On live data this is 18 of 28 stuck rows: `explicitly_confidential` with **no marker anywhere in the subject**. The other 10 have a real marking and correctly stay held.

### What is deliberately left alone

Each asserted, because a clear one word too wide would publish mail nobody decided to publish:

- a **sender's own subject marking** — not the recipient's to lift
- a **counterparty hold** — this seat's standing decision about a *person*, not about this message
- the **workspace floor** — an admin's decision one seat cannot overrule
- `no_record` / `no_counterparty` — the capture ladder's filing facts, not judgements about confidentiality

## Tests

`TestAnOwnerShareLiftsAVerdictHoldAndNothingElse` covers the bug and all four boundaries. Mutation-checked one clause at a time:
- disabling the clear → the reported bug reappears, and only that case fails
- ignoring the ledger answer → a sender's marking gets **published**, caught by two tests

Four new frontend tests on the markers, also mutation-checked: dropping the reason badge, and drawing `withheld` quiet, each fail exactly one.

**One test helper was lying.** `shareThreadAsOwner` reassembled the endpoint from its parts — `DecideAsOwner`, then the derivation, by hand — so a defect living *between* them was invisible to it while the product had it. It now calls `ThreadAudienceSetter.Decide`, the shipped path, which is why it can see this bug at all.

## What this does NOT do

It does not re-decide mail already judged, and it does not repair the 18 rows in place — it makes Share work on them. The owner presses it once and the message opens.

## Verification

- `make check-backend` — green
- `make check-fe` — green (6318 tests)
- `make test-it DIR=backend/internal/compose/integration/capture` — green, whole lane
- `craft static --strict` — 0 blocker, 0 major, 0 minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the email drawer's access markers into the header beside the subject so a reader sees a message's confidentiality before reading it, and fixes owner Share, which left classifier-held messages held no matter how often the owner pressed it.

**Bug Fixes**
- Share now lifts a classifier's hold only when the `capture` ledger confirms a verdict judged the thread; a sender's own subject marking records no `kind`.
- Sender markings, counterparty holds, and the workspace floor stay untouched; already-held rows work without being re-decided or repaired.
- The integration helper now drives Share through the shipped `ThreadAudienceSetter.Decide` path, which is how the bug became visible.

**Refactors**
- The drawer's markers are two quiet badges beside the subject, with `withheld` staying filled; the sentence, member names, and control stay under the body.

<sup>Written for commit bc4a4089a2415b282dfd8de1feca60e75391a978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sharing a thread can now lift classifier-based confidentiality holds when appropriate.
  * Other confidentiality restrictions, counterparty holds, and workspace sharing limits remain unchanged.
  * Email access status and audience markers now appear beside the message subject.
* **UI Improvements**
  * Access explanations and actions are displayed below the message body for clearer separation.
  * Access indicators now support translated, unavailable, and withheld-state messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->