### PR TITLE
A dismissal's audit image says an instant the column can hold

### DIFF
--- a/backend/internal/modules/people/nudgedismissal.go
+++ b/backend/internal/modules/people/nudgedismissal.go
@@ -89,7 +89,17 @@ func (s *Store) DismissRelationshipNudge(
 		// time.Now() rather than an injected clock, matching every other write
 		// in this store. The tests below assert the SPAN the row carries rather
 		// than an instant, so nothing here needs a clock held still.
-		until := time.Now().UTC().AddDate(0, 0, days)
+		//
+		// TRUNCATED TO THE MICROSECOND, because that is all a timestamptz holds.
+		// This value goes into the audit row's after-image as well as into the
+		// column, and the NEXT dismissal images what it displaced by reading the
+		// column back — so an image carrying nanoseconds names an instant the
+		// row never held, and the two images of one deadline stop matching.
+		//
+		// The precision of time.Now() is the platform's: nanoseconds on Linux,
+		// microseconds on Darwin. Without this the trail is right on one
+		// developer's machine and wrong in CI, which is how it got here.
+		until := time.Now().UTC().Truncate(time.Microsecond).AddDate(0, 0, days)
 		// What deadline was already standing, read under the person lock taken
 		// above so the upsert below cannot race it. A re-dismissal REPLACES this
 		// value, and an audit row that named only the new one would leave

--- a/backend/internal/modules/people/nudgedismissal_integration_test.go
+++ b/backend/internal/modules/people/nudgedismissal_integration_test.go
@@ -233,6 +233,31 @@ func TestARedismissalNamesTheDeadlineItReplaced(t *testing.T) {
 	if after["dismissed_until"] == before["dismissed_until"] {
 		t.Error("the images agree, so the row records a replacement of nothing")
 	}
+	// And the image is one the COLUMN could hold. The assertion above binds only
+	// where time.Now() carries nanoseconds — Linux, and so CI — while on Darwin
+	// it is microseconds already and a nanosecond image would pass here and fail
+	// there. This asks the question directly, so the answer does not depend on
+	// whose machine is asking.
+	stamped, isText := after["dismissed_until"].(string)
+	if !isText {
+		t.Fatalf("the image holds %T, want the instant as a string", after["dismissed_until"])
+	}
+	assertMicrosecondAligned(t, stamped)
+}
+
+// assertMicrosecondAligned refuses an audit image carrying precision timestamptz
+// cannot store. An instant the row never held is one no later before-image can
+// be compared against, which is the whole use of the trail here.
+func assertMicrosecondAligned(t *testing.T, stamped string) {
+	t.Helper()
+	moment, err := time.Parse(time.RFC3339Nano, stamped)
+	if err != nil {
+		t.Fatalf("the image holds %q, which is not an instant: %v", stamped, err)
+	}
+	if sub := moment.Nanosecond() % int(time.Microsecond); sub != 0 {
+		t.Errorf("the image says %s, %dns finer than the column can hold — "+
+			"the next dismissal reads the column back and would image a different instant", stamped, sub)
+	}
 }
 
 // latestPersonAuditPair reads BOTH images of the newest update on one person.


### PR DESCRIPTION
`TestARedismissalNamesTheDeadlineItReplaced` fails on **every** CI run and passes on a Mac. That shape is the bug, not a flake.

```
nudgedismissal_integration_test.go:230: the before image says 2026-09-07T06:46:41.259035Z,
    want the deadline that was standing (2026-09-07T06:46:41.259035256Z)
```

## What is wrong

`DismissRelationshipNudge` computes the deadline with `time.Now()`, **whose precision is the platform's** — nanoseconds on Linux, microseconds on Darwin. That one value goes two places:

- into the `audit_log` after-image, as the Go value;
- into `relationship_nudge_dismissal.dismissed_until`, a `timestamptz`, which holds **microseconds**.

The next dismissal images what it displaced by reading the column back. So on Linux the two images of one deadline differ in their nanoseconds, and the trail cannot say the second replaced the first — which is the whole thing that test exists to assert, and the whole reason the before-image is written at all.

## The fix

Truncate at the source. The row is what the image has to describe, so an image finer than the row is a claim about an instant that never existed.

## The test binds everywhere now

The existing assertion only fires where the clock is finer than the column — Linux, and so CI — which is exactly why this reached `main` green from a Mac. It asks the question directly as well now: an audit image carrying precision `timestamptz` cannot store is refused whatever machine is asking.

Verified by adding 256ns at the source and running locally on Darwin: the run then reproduces CI's failure exactly, **both** assertions firing. With the truncation, `make lint`, `craft static --strict` and the `people` integration lane are green.

Found while landing https://github.com/gradionhq/margince-poc-v1/pull/4072, which this blocks. Introduced by https://github.com/gradionhq/margince-poc-v1/pull/4065.