### PR TITLE
The axe sweep runs the heading rules it was reporting green without

### DIFF
--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -1374,10 +1374,40 @@ function isContrastReading(data: unknown): data is ContrastReading {
   );
 }
 
-async function expectNoAaViolations(page: Page, screen: string) {
-  const results = await new AxeBuilder({ page })
+// HEADING_RULES are run BESIDE the WCAG tags rather than inside them, because
+// axe tags both `best-practice` only. Neither carries a WCAG tag, so the tag
+// list below ran neither on any route: the sweep read a smaller rule set than
+// "the axe sweep is green" implies, with no failing assertion to say so.
+//
+// By id rather than by adding the `best-practice` tag, which would widen the
+// sweep well past headings in one step. These two are the measured gap;
+// adopting the rest of best-practice is a separate decision with its own tail.
+const HEADING_RULES = ["heading-order", "page-has-heading-one"];
+
+// TWO ANALYSES, and it has to be two.
+//
+// `AxeBuilder.withRules` does not ADD to `withTags` — it sets
+// `runOnly: {type: "rule"}`, replacing the tag selection outright, and the
+// library's own doc says the two cannot be combined. Chaining them narrows the
+// sweep from every WCAG rule to these two, which is a worse version of the
+// defect this exists to fix and would have reported PASS the whole way.
+//
+// So the tags run, the rules run, and the violations are read together.
+async function axeFindings(page: Page) {
+  const wcag = await new AxeBuilder({ page })
     .withTags(["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"])
     .analyze();
+  const headings = await new AxeBuilder({ page })
+    .withRules(HEADING_RULES)
+    .analyze();
+  return {
+    violations: [...wcag.violations, ...headings.violations],
+    incomplete: [...wcag.incomplete, ...headings.incomplete],
+  };
+}
+
+async function expectNoAaViolations(page: Page, screen: string) {
+  const results = await axeFindings(page);
   const undecided = results.incomplete.flatMap((check) =>
     check.nodes.map(
       (node) =>
@@ -1485,6 +1515,30 @@ test.describe("B-EP09.21: WCAG 2.2 AA (axe), dark palette", () => {
       await expectSettingsViewLanded(page, screen);
       await settleAnimations(page);
       await expectNoAaViolations(page, `${screen} (dark)`);
+    });
+  }
+});
+
+// EXACTLY one h1 per route, which axe does not answer: `page-has-heading-one`
+// asks whether there is AT LEAST one, and two page titles in one document is
+// the failure a reader navigating by heading actually meets — they cannot tell
+// which is the page.
+//
+// Across both route lists rather than the three routes AC-shell-1k names, so a
+// new route inherits the check instead of needing somebody to remember it.
+// That test keeps its own cases: it asserts WHICH heading wins on a record,
+// which is a claim about the identity block rather than about the count.
+test.describe("one page heading per route", () => {
+  for (const screen of [...CORE_SCREENS, ...ADDRESSED_VIEWS]) {
+    test(`#/${screen} has exactly one h1`, async ({ page }) => {
+      await page.goto(`/#/${screen}`);
+      await page.waitForLoadState("networkidle");
+      // A page that threw during render has almost no accessibility tree, so
+      // "no h1" would read as a heading defect when it is a crash. Same guard,
+      // and the same reason, as the axe sweeps below.
+      await expectShellRendered(page);
+      await expectSettingsViewLanded(page, screen);
+      await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
     });
   }
 });

--- a/frontend/src/app/agentrail.css
+++ b/frontend/src/app/agentrail.css
@@ -655,7 +655,16 @@
 .arsect + .arsect {
   margin-top: var(--space-3);
 }
-.arsect h4 {
+/* The panel is a labelled region with no heading of its own, so its sections
+   sit directly under the PAGE's h1. They were h4, which skipped two levels and
+   made every route carrying an open panel fail `heading-order` — invisibly,
+   because axe tags that rule best-practice and the sweep ran WCAG tags only.
+
+   h2 rather than a new panel title: the head already restates what the panel is
+   about in `.arptitle`, and promoting a sentence that changes with the agent's
+   state to a heading would name the region differently every time it opened.
+   The size below is unchanged, so nothing moves on screen. */
+.arsect h2 {
   display: flex;
   align-items: baseline;
   gap: var(--space-2);

--- a/frontend/src/app/agentrail.test.tsx
+++ b/frontend/src/app/agentrail.test.tsx
@@ -1213,7 +1213,7 @@ describe("AgentRail", () => {
     const { container } = render(ROUTE);
     await openPanel(user, container);
     await waitFor(() => expect(runLines()).toEqual([BRIEF_RUNNING]));
-    const headings = [...panel().querySelectorAll(".arsect h4")].map(
+    const headings = [...panel().querySelectorAll(".arsect h2")].map(
       (el) => el.textContent,
     );
     expect(headings[0]).toBe("Running now");

--- a/frontend/src/app/agentrail.tsx
+++ b/frontend/src/app/agentrail.tsx
@@ -505,7 +505,7 @@ function RunSection({
   }
   return (
     <div className="arsect">
-      <h4>{t(heading)}</h4>
+      <h2>{t(heading)}</h2>
       <ul className="arruns">
         {said.map(({ item, line }) => (
           <li className="arbox arrun" key={item.id}>
@@ -610,7 +610,7 @@ function AgentPanel({
           the agent looked, and there is nothing waiting. */}
       {signals.waiting !== undefined && (
         <div className="arsect">
-          <h4>{LABELS.acrossWorkspace}</h4>
+          <h2>{LABELS.acrossWorkspace}</h2>
           {signals.waiting === 0 ? (
             <p className="arnone">{LABELS.allClear}</p>
           ) : (
@@ -632,12 +632,12 @@ function AgentPanel({
       )}
 
       <div className="arsect">
-        <h4>
+        <h2>
           {LABELS.recap}
           <a className="arplain" href={AI_SETTINGS_HREF}>
             {LABELS.fullLog}
           </a>
-        </h4>
+        </h2>
         <Recap recent={model} />
       </div>
 
@@ -660,7 +660,7 @@ function AgentPanel({
           place in an installation. */}
       {uiPreviewAgentStatesEnabled() && (
         <div className="arsect arstates">
-          <h4>{LABELS.states}</h4>
+          <h2>{LABELS.states}</h2>
           <div className="archips">
             {/* The chips hold one state still; this plays the whole run. A state
                 a reviewer can only hold is a state nobody can judge the motion


### PR DESCRIPTION
Closes #3858. The ticket filed the cost as unknown — *"nobody knows what the first green run costs"*. **It was one violation.**

## The gap

`ac.spec.ts` configured axe with `["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"]`. axe tags `heading-order` and `page-has-heading-one` as **`best-practice` only** — neither carries a WCAG tag, so neither ran on any of the ~20 swept routes.

The sweep did not error, skip or warn. It read a smaller rule set than *"the axe sweep is green"* implies and reported success: a census failing short, with no assertion to notice it by.

## A trap worth recording, because I fell in it first

**`AxeBuilder.withRules` does not add to `withTags`.** It sets `runOnly: {type: "rule", values: [...]}`, replacing the tag selection outright, and the library's own doc comment says the two cannot be combined.

So the obvious one-line fix — chaining `.withTags(...).withRules(["heading-order", "page-has-heading-one"])` — narrows the sweep from every WCAG rule to exactly two. That is a strictly worse version of the defect being fixed, and it **reports PASS the whole way**. I wrote it, ran it, and it looked like a success: 149 passed, the heading violation found. Only reading `@axe-core/playwright`'s source showed what it had cost.

The fix is two analyses — the tags run, the rules run, the violations are read together. By rule id rather than by adding the `best-practice` tag, which would widen the sweep well past headings in one step; that is a separate decision with its own tail, as the ticket says.

## The one violation

The agent panel's sections were `h4` inside a `<section aria-label>` with no heading of its own, so they skipped from the page's `h1` — every route with the panel open failed `heading-order`, invisibly.

They are `h2` now: the panel is a labelled region, and its sections sit directly under the page's h1. Not a new panel title — the head already restates what the panel is about in `.arptitle`, and promoting a sentence that changes with the agent's state to a heading would name the region differently every time it opened. **The font-size rule is unchanged, so nothing moves on screen.**

## And option 3, which turned out to be free

Exactly **one** h1 per route, across `CORE_SCREENS` + `ADDRESSED_VIEWS` rather than the three routes `AC-shell-1k` names — so a new route inherits the check. Axe only asks whether there is *at least* one; two page titles in one document is the failure a reader navigating by heading actually meets.

32 routes, **no further fixes needed**. `AC-shell-1k` keeps its own cases: it asserts *which* heading wins on a record, which is a claim about the identity block rather than about the count.

## Verification

| | |
|---|---|
| before | 151 tests, heading rules never ran |
| with rules armed, h4 in place | **2 failed** — both the same `heading-order: .arsect:nth-child(2) > h4` |
| after the h2 fix | **151 passed** |
| plus the h1 sweep | **183 passed** |

Mutation: restoring the `h4`s fails `heading-order` and nothing else. `make check-fe` green; the agent-rail unit suite (63 tests) green.

Both `dist` rebuilds were needed to see real results — the preview serves the built bundle, which is the same stale-artifact trap #3959 was about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b1jSBftJqGvaQ7ejTgnQ6