### PR TITLE
The disagreement between the two send authorities is read on a cadence

### DIFF
--- a/backend/api/jobs.yaml
+++ b/backend/api/jobs.yaml
@@ -697,6 +697,28 @@ kinds:
       may run the connector's prior-send lookup, and then transmits — four
       network round trips, each of which can be slow before it is wrong.
 
+  comms_authz_disagreement:
+    role: worker
+    go_type: AuthzDisagreementArgs
+    queue: default
+    timeout: 2m
+    opts_owner: caller
+    cadence: 24h
+    args: {}
+    reason: >-
+      The outbound engine has run in observe mode since it shipped: it decides,
+      records, and the old purpose gate rules. Ending that is a decision
+      somebody has to make on evidence, and this pass is what produces the
+      evidence without anybody remembering to ask for it. Daily, because the
+      question it answers moves at the speed of a rollout rather than a request,
+      and because the window it reads is a day: each pass reports what the two
+      authorities did differently SINCE THE LAST ONE, so two consecutive lines
+      can be compared. Unbounded the reading only ever grows, and a
+      disagreement that appeared this week disappears under the weight of one
+      fixed months ago. Cheap: one grouped read over an index on decided_at,
+      and on an installation whose authorities agree it finds nothing and says
+      so once.
+
   comms_scheduled_send_recovery:
     role: worker
     go_type: ScheduledSendRecoveryArgs

--- a/backend/internal/compose/authzdisagreement.go
+++ b/backend/internal/compose/authzdisagreement.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The daily reading of how far apart the two outbound authorities are.
+//
+// The engine has run in observe mode since it shipped: it decides, records, and
+// the old purpose gate rules. Ending that is a decision somebody has to make on
+// evidence, and this pass is what puts the evidence in front of them without
+// anybody remembering to ask.
+//
+// It exists because the same reading as a typed subcommand was one nobody would
+// ever run. The number that decides a rollout is not one an operator thinks to
+// go and fetch — a stored measurement nobody sweeps is not a control, which is
+// the rule this repository already applies to a retention deadline and applies
+// here for the same reason.
+//
+// It DECIDES nothing and writes no domain row. Enforcement is a setting a human
+// changes after reading this; a pass that flipped a category itself would be a
+// second authority over what may be sent, and the whole point of the observe
+// period is that there is exactly one until somebody decides otherwise.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/margince/margince/backend/internal/modules/consent"
+	"github.com/margince/margince/backend/internal/modules/identity"
+	"github.com/margince/margince/backend/internal/platform/jobs"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// AuthzDisagreementArgs carries nothing: the pass reads a fixed window back from
+// its own run time, so there is no argument a caller could supply that would not
+// be a second answer to what the cadence already says.
+type AuthzDisagreementArgs struct{}
+
+// Kind is the stable job identifier River persists in river_job.
+func (AuthzDisagreementArgs) Kind() string { return "comms_authz_disagreement" }
+
+// disagreementWindow is how far back one pass reads.
+//
+// Matched to the cadence rather than chosen independently: the pass runs daily
+// and reads a day, so consecutive lines describe consecutive periods and can be
+// compared. A window shorter than the cadence would leave gaps no reading ever
+// covers, and a longer one would report the same disagreement on several days
+// running, which reads as a growing problem when it is one problem counted
+// repeatedly.
+//
+// Slightly wider than the cadence, because a pass that starts late must not
+// leave the minutes before it unread.
+const disagreementWindow = 25 * time.Hour
+
+// authzDisagreementWorker reads the two authorities against each other.
+type authzDisagreementWorker struct {
+	identity *identity.Service
+	store    *consent.Store
+	now      func() time.Time
+	log      *slog.Logger
+}
+
+func newAuthzDisagreementWorker(
+	idsvc *identity.Service, store *consent.Store, now func() time.Time, log *slog.Logger,
+) *authzDisagreementWorker {
+	return &authzDisagreementWorker{identity: idsvc, store: store, now: now, log: log}
+}
+
+func (w *authzDisagreementWorker) Work(ctx context.Context, _ *river.Job[AuthzDisagreementArgs]) error {
+	// The installation's own workspace, on the context rather than left to the
+	// store's handle to resolve, so this pass and the rows it reads agree on
+	// which workspace it is acting in.
+	ctx, err := installationJobCtx(ctx, w.identity)
+	if err != nil {
+		return jobs.FaultContext(ctx, fmt.Errorf("comms_authz_disagreement: resolving the installation: %w", err))
+	}
+	// The system principal, because this is the installation asking about its
+	// own rollout rather than a seat asking about a person. Nothing the reading
+	// returns names a subject: no address, no consent state, only how two rules
+	// have compared.
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:authz_disagreement",
+	})
+
+	since := w.now().Add(-disagreementWindow)
+	report, err := w.store.DisagreementReportSince(ctx, since)
+	if err != nil {
+		return jobs.FaultContext(ctx, fmt.Errorf("comms_authz_disagreement: reading the disagreement: %w", err))
+	}
+	w.report(ctx, since, report)
+	return nil
+}
+
+// report writes the pass's finding as structured lines.
+//
+// AGREEMENT IS LOGGED TOO, at info and once. A pass that spoke only when it
+// found something would leave an operator unable to tell "the authorities agree"
+// from "the pass has not run since March", and those call for opposite actions.
+func (w *authzDisagreementWorker) report(
+	ctx context.Context, since time.Time, report []consent.Disagreement,
+) {
+	if len(report) == 0 {
+		w.log.InfoContext(ctx, "the outbound engine and the old purpose gate agreed on every delivery",
+			"since", since)
+		return
+	}
+	var stopping, starting int
+	for _, d := range report {
+		if d.EngineIsStricter {
+			stopping += d.Deliveries
+		} else {
+			starting += d.Deliveries
+		}
+		// One line per SHAPE, because the shape is the finding. A total alone
+		// reads as alarming and may be entirely correct — four thousand
+		// deliveries under the legacy transactional purpose are exactly what
+		// the engine exists to stop — so the category and the reason travel
+		// with the count.
+		w.log.InfoContext(ctx, "the outbound authorities differed",
+			"category", d.Category, "reason", d.ReasonCode,
+			"engine", d.EngineVerdict, "old_gate", d.LegacyVerdict,
+			"engine_is_stricter", d.EngineIsStricter,
+			"deliveries", d.Deliveries, "recipients", d.Decisions)
+	}
+	// WARN on the summary, because a non-zero `stopping` is what an operator has
+	// to weigh before enforcing: it is the mail that would have stopped. The
+	// other direction is real and worth seeing, and is not what makes a rollout
+	// dangerous.
+	w.log.WarnContext(ctx, "enforcing the outbound engine would have changed what was sent",
+		"since", since, "would_stop", stopping, "would_start", starting)
+}
+
+// addAuthzDisagreementWorker wires the pass. Its SCHEDULE is placed with the
+// others in wireJobs, because this pass takes no conditional wiring — it reads a
+// table every installation has — and a helper that only ever returns
+// periodicFor's answer would hide the cadence from the list where every other
+// unconditional one is read.
+func addAuthzDisagreementWorker(reg *jobRegistry, pool *pgxpool.Pool, log *slog.Logger) {
+	addDeclaredWorker[AuthzDisagreementArgs](reg, newAuthzDisagreementWorker(
+		identity.NewService(pool), consent.NewStore(InstallationDB(pool)), time.Now, log))
+}

--- a/backend/internal/compose/authzdisagreement_test.go
+++ b/backend/internal/compose/authzdisagreement_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// That the daily reading is actually PLACED, and reads the window it says.
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/platform/jobs"
+)
+
+// THE SCHEDULE HAS TO REACH THE RUNNER, which is a different claim from the
+// cadence being declared.
+//
+// A pass whose worker is wired and whose schedule is not runs never, and every
+// symptom of that is silence: no job row, no error, no log line. That is not
+// hypothetical — this pass was written with its schedule returned from a helper
+// that wireJobs did not call, and the dev stack simply never produced a report
+// while every sibling pass ran normally.
+//
+// It reads the SOURCE because river.PeriodicJob has only unexported fields:
+// nothing in the built slice can be asked which kind it carries, so a test over
+// the returned value can only count schedules and would pass with this one
+// missing. An earlier draft did exactly that, and the mutation below survived
+// it.
+//
+// Mutation: drop the periodicFor line from wireJobs and this fails.
+func TestTheDisagreementReadingIsScheduled(t *testing.T) {
+	t.Parallel()
+
+	if got := periodicFor(JobRunnerConfig{}, AuthzDisagreementArgs{}); len(got) != 1 {
+		t.Fatalf("periodicFor placed %d schedules for the disagreement reading, want 1", len(got))
+	}
+
+	source, err := os.ReadFile("jobs.go")
+	if err != nil {
+		t.Fatalf("reading the wiring: %v", err)
+	}
+	placement := "periodicFor(cfg, AuthzDisagreementArgs{})"
+	if !strings.Contains(string(source), placement) {
+		t.Errorf("jobs.go does not place %s: the worker is wired and the pass runs never, "+
+			"and every symptom of that is silence", placement)
+	}
+	// Under-recognition: if the placement spelling changed wholesale, the check
+	// above would report a missing schedule that is present. Every sibling
+	// placement uses this form, so finding none means the file was restructured
+	// and this test has to be rewritten rather than believed.
+	if strings.Count(string(source), "periodicFor(cfg, ") < 2 {
+		t.Fatal("jobs.go holds fewer than two periodicFor placements: the wiring has been " +
+			"restructured and this test is reading for a form that no longer exists")
+	}
+}
+
+// THE WINDOW MATCHES THE CADENCE, and slightly exceeds it.
+//
+// Consecutive passes must describe consecutive periods: a window shorter than
+// the cadence leaves minutes no reading ever covers, and a longer one reports
+// one disagreement on several days running, which reads as a growing problem
+// when it is one problem counted repeatedly. The excess is what absorbs a pass
+// that starts late.
+//
+// Mutation: set disagreementWindow below the cadence and this fails.
+func TestTheWindowCoversTheCadenceItRunsOn(t *testing.T) {
+	t.Parallel()
+
+	spec, declared := jobs.SpecFor(AuthzDisagreementArgs{}.Kind())
+	if !declared {
+		t.Fatalf("api/jobs.yaml does not declare %q", AuthzDisagreementArgs{}.Kind())
+	}
+	cadence := spec.Cadence.Fixed
+	if cadence <= 0 {
+		t.Fatalf("the disagreement reading declares no fixed cadence (%v): the window below has "+
+			"nothing to be measured against", cadence)
+	}
+	if disagreementWindow < cadence {
+		t.Errorf("the window is %v and the cadence %v: the minutes between them are read by no "+
+			"pass at all", disagreementWindow, cadence)
+	}
+	// An unbounded excess would defeat the point of a window. A day's slack on a
+	// daily pass is the intent; a week's would report the same disagreement
+	// seven times.
+	if slack := disagreementWindow - cadence; slack > cadence {
+		t.Errorf("the window exceeds the cadence by %v, more than the cadence itself: each pass "+
+			"re-reports what the last one already did", slack)
+	}
+}

--- a/backend/internal/compose/jobkinds_gen.go
+++ b/backend/internal/compose/jobkinds_gen.go
@@ -13,7 +13,7 @@ import (
 // jobContractHash is the sha256 of api/jobs.yaml this file was generated
 // from — the same fingerprint jobs.JobContractHash carries, so a stale
 // half of the pair is visible without diffing the two tables.
-const jobContractHash = "4f394316081d41593140ebfb38580b802a9774a81121b166467f6dd59fd347b5"
+const jobContractHash = "866f761a923c8a1e38bcf0899d0aac3d280fa739a277c726711914ff8269d37d"
 
 // declaredJobArgs is every args type api/jobs.yaml declares, and nothing
 // else. A job kind the file has never heard of cannot satisfy it, so it
@@ -55,6 +55,7 @@ type declaredJobArgs interface {
 		CheckOrganizationVatArgs |
 		CloseDateSweepArgs |
 		CloseDateWorkspaceArgs |
+		AuthzDisagreementArgs |
 		ScheduledSendArgs |
 		ScheduledSendRecoveryArgs |
 		SendEmailArgs |

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -380,6 +380,7 @@ func wireJobs(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*jobRe
 	addGmailCaptureJobs(reg, pool, cfg, log)
 	addGraphWatchJobs(reg, cfg, log)
 	addOverlayJobs(reg, pool, cfg, log)
+	addAuthzDisagreementWorker(reg, pool, log)
 
 	periodic := slices.Concat(
 		// The passes that register themselves: each helper wires its own
@@ -432,6 +433,7 @@ func wireJobs(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*jobRe
 		periodicFor(cfg, GmailWatchArgs{}),
 		periodicFor(cfg, GraphWatchArgs{}),
 		periodicFor(cfg, OverlayReconcileArgs{}),
+		periodicFor(cfg, AuthzDisagreementArgs{}),
 	)
 
 	return reg, periodic

--- a/backend/internal/modules/consent/authorizedisagreement.go
+++ b/backend/internal/modules/consent/authorizedisagreement.go
@@ -21,6 +21,7 @@ package consent
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -65,20 +66,45 @@ type Disagreement struct {
 // operational question about the product, and the audience is whoever decides
 // whether to enforce.
 func (s *Store) DisagreementReport(ctx context.Context) ([]Disagreement, error) {
+	return s.DisagreementReportSince(ctx, time.Time{})
+}
+
+// DisagreementReportSince is the same reading bounded to decisions taken at or
+// after `since`. A zero time means every decision on record.
+//
+// The window is what makes the reading answerable on a cadence. Unbounded, the
+// report only ever grows: a pass reads everything the last pass read plus a
+// little, so a disagreement that appeared this week is invisible under the
+// weight of one that was fixed months ago, and two consecutive runs cannot be
+// compared. Bounded, each pass answers a question with a subject — "what
+// happened since last time" — which is the only form in which a repeated
+// measurement says anything new.
+func (s *Store) DisagreementReportSince(ctx context.Context, since time.Time) ([]Disagreement, error) {
 	if err := auth.Require(ctx, authorizationModesObject, principal.ActionRead); err != nil {
 		return nil, err
 	}
 	var out []Disagreement
 	err := s.db.Tx(ctx, func(tx pgx.Tx) error {
+		// $2 is compared rather than branched on, and a ZERO time is what makes
+		// that work: Go's zero time is year 1, so `decided_at >= $2` is true for
+		// every row and the unwindowed reading needs no second query text. Two
+		// query texts would be two answers to one question, and the one nobody
+		// ran on a cadence is the one that would drift.
+		//
+		// An earlier draft mapped the zero time to SQL NULL for legibility. A
+		// mutation check killed it: removing the mapping changed no test, because
+		// year 1 and "no bound" select the same rows. An indirection no behaviour
+		// depends on is one the next reader has to verify for nothing.
 		rows, err := tx.Query(ctx, `
 			SELECT resolved_category, reason_code, verdict, legacy_verdict,
 			       count(DISTINCT delivery_id), count(*)
 			  FROM communication_decision
 			 WHERE legacy_verdict IS NOT NULL
 			   AND legacy_verdict <> verdict
+			   AND decided_at >= $2
 			 GROUP BY resolved_category, reason_code, verdict, legacy_verdict
 			 ORDER BY count(DISTINCT delivery_id) DESC, resolved_category, reason_code
-			 LIMIT $1`, disagreementLimit)
+			 LIMIT $1`, disagreementLimit, since)
 		if err != nil {
 			return fmt.Errorf("consent: read how the two authorities have differed: %w", err)
 		}

--- a/backend/internal/modules/consent/authorizedisagreement_integration_test.go
+++ b/backend/internal/modules/consent/authorizedisagreement_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/margince/margince/backend/internal/shared/apperrors"
 	"github.com/margince/margince/backend/internal/shared/kernel/ids"
@@ -187,5 +188,91 @@ func TestTheLegacyTransactionalAllowIsWhatEnforcementWouldStop(t *testing.T) {
 	}
 	if got.ReasonCode != commsauthz.ReasonLegacyTransactionalUnevidenced {
 		t.Errorf("reason = %q, want the legacy-transactional code so an operator can see WHY", got.ReasonCode)
+	}
+}
+
+// plantDecisionAt writes a transmit decision stamped at a chosen instant, which
+// is what the window reads on.
+func (e *resolveEnv) plantDecisionAt(t *testing.T, category, reason, engine, legacy string, at time.Time) {
+	t.Helper()
+	delivery := e.plantDelivery(t)
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO communication_decision
+		  (delivery_id, attempt, decision_set_id, recipient_address, phase,
+		   resolved_category, verdict, reason_code, legacy_verdict, mode, actor, decided_at)
+		VALUES ($1, 1, $2, 'someone@corp.test', 'transmit', $3, $4, $5, $6, 'observe', 'test', $7)`,
+		delivery, ids.NewV7(), category, engine, reason, legacy, at); err != nil {
+		t.Fatalf("planting the decision: %v", err)
+	}
+}
+
+// reportSince reads the windowed report.
+func (e *resolveEnv) reportSince(t *testing.T, since time.Time) []Disagreement {
+	t.Helper()
+	out, err := e.store.DisagreementReportSince(e.ctx, since)
+	if err != nil {
+		t.Fatalf("reading the windowed report: %v", err)
+	}
+	return out
+}
+
+// THE WINDOW IS WHAT MAKES A REPEATED READING SAY ANYTHING. Unbounded, each pass
+// re-reads what the last one read plus a little, so a disagreement that appeared
+// today is invisible under one that was fixed months ago.
+//
+// Mutation: drop the decided_at clause from the query and this fails, the old
+// row coming back inside a window it is far outside.
+func TestTheWindowExcludesADisagreementOlderThanIt(t *testing.T) {
+	e := setupResolve(t)
+	now := time.Now()
+	e.plantDecisionAt(t, "account_notice", commsauthz.ReasonLegacyTransactionalUnevidenced,
+		string(commsauthz.VerdictReview), string(commsauthz.VerdictAllow), now.Add(-30*24*time.Hour))
+	e.plantDecisionAt(t, "reply_to_inbound", commsauthz.ReasonAllowed,
+		string(commsauthz.VerdictAllow), string(commsauthz.VerdictDeny), now.Add(-time.Hour))
+
+	within := e.reportSince(t, now.Add(-25*time.Hour))
+	if len(within) != 1 {
+		t.Fatalf("the windowed report carries %d shapes, want only the recent one", len(within))
+	}
+	if within[0].Category != "reply_to_inbound" {
+		t.Errorf("the window returned %q, want the decision taken inside it", within[0].Category)
+	}
+}
+
+// A ZERO WINDOW IS EVERY DECISION, which is what the one-off subcommand asks
+// for. Both readings are one query text, and the zero time is what makes that
+// possible: Go's zero time is year 1, so the bound admits every row.
+//
+// This pins the entry point rather than the clause — the test above holds the
+// clause. Kept separate because the unwindowed reading is a caller with its own
+// promise: DisagreementReport must keep answering about all of history however
+// the windowed one is later tuned.
+func TestAZeroWindowReadsEveryDecisionOnRecord(t *testing.T) {
+	e := setupResolve(t)
+	now := time.Now()
+	e.plantDecisionAt(t, "account_notice", commsauthz.ReasonLegacyTransactionalUnevidenced,
+		string(commsauthz.VerdictReview), string(commsauthz.VerdictAllow), now.Add(-90*24*time.Hour))
+
+	if got := e.reportSince(t, time.Time{}); len(got) != 1 {
+		t.Fatalf("the unwindowed report carries %d shapes, want the one on record", len(got))
+	}
+	// And the unwindowed entry point answers the same, because it IS this call.
+	if got := e.report(t); len(got) != 1 {
+		t.Fatalf("DisagreementReport carries %d shapes, want the same one", len(got))
+	}
+}
+
+// THE WINDOW IS A LOWER BOUND, not a range. A decision taken after the pass
+// started — one racing the read — is reported rather than dropped, because a
+// disagreement nobody ever reports is the failure this whole reading exists to
+// prevent.
+func TestTheWindowHasNoUpperBound(t *testing.T) {
+	e := setupResolve(t)
+	e.plantDecisionAt(t, "account_notice", commsauthz.ReasonLegacyTransactionalUnevidenced,
+		string(commsauthz.VerdictReview), string(commsauthz.VerdictAllow),
+		time.Now().Add(time.Minute))
+
+	if got := e.reportSince(t, time.Now().Add(-time.Hour)); len(got) != 1 {
+		t.Fatalf("the report carries %d shapes, want the decision taken after the window opened", len(got))
 	}
 }

--- a/backend/internal/platform/jobs/specs_gen.go
+++ b/backend/internal/platform/jobs/specs_gen.go
@@ -11,7 +11,7 @@ import "time"
 // would believe. It says nothing about the file on disk — a pair
 // regenerated TOGETHER from a stale contract matches here, and the drift
 // gate is what catches that.
-const JobContractHash = "4f394316081d41593140ebfb38580b802a9774a81121b166467f6dd59fd347b5"
+const JobContractHash = "866f761a923c8a1e38bcf0899d0aac3d280fa739a277c726711914ff8269d37d"
 
 // specs is every declared kind. A kind absent from this table is a kind
 // nobody declared, and MustBeTotal is what names them: the runner calls it
@@ -336,6 +336,15 @@ var specs = map[string]Spec{
 		MaxAttempts: 5,
 		OptsOwner:   OptsFanOut,
 		Args:        []ArgField{{Name: "Workspace"}},
+	},
+	"comms_authz_disagreement": {
+		Kind:      "comms_authz_disagreement",
+		GoType:    "AuthzDisagreementArgs",
+		Role:      Worker,
+		Queue:     "default",
+		Timeout:   TimeoutPolicy{Fixed: 2 * time.Minute},
+		OptsOwner: OptsCaller,
+		Cadence:   Cadence{Fixed: 24 * time.Hour},
 	},
 	"comms_scheduled_send": {
 		Kind:         "comms_scheduled_send",


### PR DESCRIPTION
The outbound engine has run in observe mode since it shipped: it decides,
records, and the old purpose gate rules. Ending that is a decision somebody
makes on evidence — and the evidence existed only as a subcommand nobody would
think to type. A measurement nobody sweeps is not a control, which is the rule
this repository already applies to a retention deadline.

## The window

`DisagreementReportSince` bounds the reading. Unbounded, each pass re-reads what
the last one read plus a little, so a disagreement that appeared this week is
invisible under one fixed months ago and two runs cannot be compared.

Both readings are **one query text**. Go's zero time is year 1, so the bound
admits every row and the unwindowed entry point needs no second query. An
earlier draft mapped the zero time to SQL NULL for legibility; a mutation check
killed it — year 1 and "no bound" select the same rows, so no test could tell
them apart, and an indirection no behaviour depends on is one the next reader
verifies for nothing.

## The pass

`comms_authz_disagreement`, daily, window 25h — matched to the cadence and
slightly over it, so a pass that starts late leaves no minutes unread and no
pass re-reports a whole day.

It logs the shape (category, reason, direction, counts) plus a summary naming
what enforcing would have stopped. **Agreement is logged too**, at info and
once: a pass that spoke only on a finding would leave an operator unable to tell
"the authorities agree" from "the pass has not run since March", and those call
for opposite actions.

It decides nothing and writes no domain row. Enforcement stays a setting a human
changes after reading this — a pass that flipped a category itself would be a
second authority over what may be sent.

## Tests

`TestTheDisagreementReadingIsScheduled` reads the wiring **source**, not the
built slice, because `river.PeriodicJob` has only unexported fields: a test over
the returned value can only count schedules. An earlier draft did exactly that
and the mutation survived it. It carries an under-recognition guard so a
restructured `jobs.go` fails rather than reporting a missing schedule that is
present.

| Mutation | Caught by |
|---|---|
| Window clause neutered (arity kept) | `TestTheWindowExcludesADisagreementOlderThanIt` |
| `periodicFor` line dropped from `wireJobs` | `TestTheDisagreementReadingIsScheduled` |
| Zero time passed as a real bound | nothing — which is why the NULL mapping was deleted rather than kept |

Also: `TestTheWindowHasNoUpperBound` (a decision racing the read is reported,
not dropped) and `TestTheWindowCoversTheCadenceItRunsOn` (the window may not
fall below the cadence, nor exceed it by more than itself).

## Not in this change

**The pass is not yet demonstrated running on a dev stack.** Every static check
agrees it should: the spec is declared with a 24h fixed cadence and no
registration gate, `periodicFor` returns a schedule for it, and the placement is
in `wireJobs`. On my stack the boot batch inserted its siblings and not this
kind, and I could not account for the difference before this change grew too
large to keep holding. Worth a look before anybody relies on the daily line.

**The CLI ergonomics fix is deliberately absent.** `worker --dsn X
authz-disagreement` still silently boots the job runtime instead of reporting,
because `flag.Parse` stops at the first non-flag argument. I built a fix, found
it needed argument surgery across two parsers, and reverted it rather than
carry that in a change about the queued reading. `MARGINCE_DSN` with the
subcommand first is the working invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the disagreement reading between the outbound engine and the old purpose gate from a one-off subcommand into a daily scheduled pass that reads a fixed window, so consecutive runs are comparable and the evidence for ending the engine's observe mode accumulates on its own.

- `DisagreementReportSince` bounds the reading to a window (25h against the 24h cadence) so a late-starting pass leaves no minutes unread; a zero `since` reads all history through the same query text.
- `comms_authz_disagreement` logs each disagreement shape (category, reason, direction, counts) and a summary naming what enforcement would have stopped; agreement is logged once at info so a silent pass is distinguishable from agreement.
- The pass decides nothing and writes no domain rows; enforcement stays a setting a human changes.

**Not in this change**
- The pass has not been demonstrated running on a dev stack; verify before relying on the daily line.
- The CLI ergonomics fix is deliberately absent: `worker --dsn X authz-disagreement` still boots the job runtime. Use `MARGINCE_DSN` with the subcommand first.

<sup>Written for commit 779d76ed92f20fe61e7a8f20c7f6411718039ecf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daily authorization consistency check for outbound communications.
  * Reports differences between current and legacy authorization decisions, including categories where deliveries could stop or start.
  * Reports can now be limited to decisions made since a specified time, supporting focused monitoring windows.

* **Tests**
  * Added coverage confirming scheduled execution and accurate reporting windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->