### PR TITLE
A staged action and a forecast call name the seat that answers for them

### DIFF
--- a/backend/gates/approvalselfonlyreaders_test.go
+++ b/backend/gates/approvalselfonlyreaders_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every approvals reader that filters rows by the decision grants also applies
+// the self-only narrowing.
+//
+// decidable() is the module's ONE visibility predicate and it has two authority
+// halves: the grants approving a row would take (requireDecisionGrants), and the
+// narrowing to the single seat a row was staged FOR (withheldFromOtherSeats) —
+// a linkedin_match, a vcard_create, a held_draft. The two target-filtered reads
+// settle target visibility once for the record instead of per row, so they
+// cannot call decidable and must spell the per-row halves themselves. One of
+// them spelled only the first half, and the omission is invisible in the code:
+// a reader that never applied the narrowing looks exactly like one that never
+// needed to, and its rows are a colleague's imported address book.
+//
+// So the obligation is derived rather than listed: whoever asks the grant
+// question about a row is a reader deciding what a caller may SEE, and owes the
+// narrowing in the same breath. A fourth reader added tomorrow inherits it
+// without anybody remembering to add it here.
+//
+// The rule is deliberately about DIRECT calls. requireDecisionGrants is the
+// half a reader reaches for when it is filtering per row, and a function that
+// reaches it only through decidable already has both halves — widening to
+// transitive reach would put every caller of decidable in the corpus and each
+// would need a waiver saying "discharged by decidable", which is a list of
+// sentences nobody reads standing in for the rule itself.
+
+import (
+	"sort"
+	"testing"
+)
+
+const (
+	// approvalsPackage is the module whose readers this census governs.
+	approvalsPackage = "internal/modules/approvals"
+
+	// grantHalf is the authority half every per-row reader already spells, and
+	// so the marker that SELECTS the corpus: asking it is what makes a function
+	// a per-row visibility filter.
+	grantHalf = "requireDecisionGrants"
+
+	// seatHalf is the half the target-filtered readers dropped. Naming both
+	// symbols here is what makes the census fail loudly on a rename instead of
+	// walking an empty corpus and reporting PASS.
+	seatHalf = "withheldFromOtherSeats"
+)
+
+func TestEveryApprovalsGrantFilterAlsoAppliesTheSelfOnlyNarrowing(t *testing.T) {
+	t.Parallel()
+	graph := packageCallGraph(t, approvalsPackage)
+
+	// Under-recognition is the one way this census must not break: a renamed or
+	// deleted predicate would leave nothing to select on, and an empty corpus
+	// reads exactly like a clean one. Both halves are asserted present as
+	// declarations before the walk trusts anything the walk found.
+	for _, half := range []string{grantHalf, seatHalf} {
+		if _, declared := graph[half]; !declared {
+			t.Fatalf("%s is not declared in %s — this census selects and certifies on those two names, "+
+				"so a rename leaves it sweeping nothing while still reporting PASS",
+				half, approvalsPackage)
+		}
+	}
+
+	var corpus, missing []string
+	for name, fn := range graph {
+		if name == grantHalf || !fn.calls[grantHalf] {
+			continue
+		}
+		corpus = append(corpus, name)
+		if !fn.calls[seatHalf] {
+			missing = append(missing, name)
+		}
+	}
+	if len(corpus) == 0 {
+		t.Fatalf("no function in %s filters rows with %s — the corpus is empty, "+
+			"which is this census reporting PASS over a tree it cannot see",
+			approvalsPackage, grantHalf)
+	}
+	sort.Strings(missing)
+	for _, name := range missing {
+		t.Errorf("%s filters approval rows with %s but never calls %s: it serves a caller "+
+			"the stagings staged for OTHER seats — a colleague's linkedin_match, vcard_create "+
+			"or held_draft, whose summary and proposed_change ARE that private row's content",
+			name, grantHalf, seatHalf)
+	}
+}

--- a/backend/gates/forecastscopeauthority_test.go
+++ b/backend/gates/forecastscopeauthority_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//gate:kind census H2
+
+package gates
+
+// Every forecasting store entry point that RECORDS against a scope asks whether
+// its caller answers for that scope.
+//
+// The object grant and the scope are different questions, and the module asked
+// only the first: auth.Require says a seat may make forecast calls at all and
+// nothing about WHOSE. So a manager holding forecast.create recorded a
+// commitment against a rival team — attributed to that team, superseding its
+// standing call, and unremovable, since no seat holds forecast.update or
+// forecast.delete — and any forecast.read holder read back every owner's
+// committed number and the note explaining it.
+//
+// The corpus is DERIVED three ways over, because the defect was one entry point
+// looking exactly like its gated siblings:
+//
+//   - the scope-bearing TYPES are read off the package's own struct
+//     declarations — anything with a `Scope` field — so a future NewProjection
+//     carrying one is in the corpus without being named here;
+//   - the ENTRY POINTS are the exported methods on the store whose parameters
+//     name Scope or one of those types;
+//   - and of those, the ones that WRITE, found by following the package's own
+//     calls to a statement that inserts a forecast row.
+//
+// The write half is what makes the corpus right rather than merely large. A
+// READ does not belong here: measuring a population and asserting a number for
+// it are different questions, and the read one is answered once in the
+// composition layer with a live-membership query this module cannot make. A
+// census that demanded this gate on the readers too would be demanding a second,
+// narrower copy of that rule — and it would refuse the team manager the resolver
+// had just admitted to their teammate's figures.
+//
+// A gate that hard-codes part of its subject has become a second copy of it,
+// and this one owns no list to go stale. What it does name is the two symbols
+// it selects and certifies on, and it fails loudly rather than sweeping an
+// empty corpus if either is renamed away.
+
+import (
+	"go/ast"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+const (
+	// forecastingPackage is the module this census governs.
+	forecastingPackage = "internal/modules/forecasting"
+
+	// forecastStoreType is the store whose exported methods are the entry points.
+	forecastStoreType = "Store"
+
+	// forecastScopeType is the type that makes an entry point's subject a
+	// particular team or owner rather than the installation.
+	forecastScopeType = "Scope"
+
+	// forecastScopeGate names the gate every such entry point owes: "may this
+	// caller record against this scope".
+	forecastScopeGate = "requireForecastScope"
+)
+
+func TestEveryForecastScopeWriterAsksWhoAnswersForTheScope(t *testing.T) {
+	t.Parallel()
+	files := parsePackageFiles(t, forecastingPackage)
+	graph := packageCallGraph(t, forecastingPackage)
+
+	if _, declared := graph[forecastScopeGate]; !declared {
+		t.Fatalf("%s is not declared in %s — this census certifies on that name, so a rename "+
+			"leaves it passing every entry point while none of them gates a scope",
+			forecastScopeGate, forecastingPackage)
+	}
+
+	// The types that carry a scope: Scope itself, and every struct in the
+	// package holding one. Read off the declarations so an input type added
+	// later inherits the obligation instead of quietly escaping the corpus.
+	carriers := map[string]bool{forecastScopeType: true}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			generic, isGeneric := decl.(*ast.GenDecl)
+			if !isGeneric {
+				continue
+			}
+			for _, spec := range generic.Specs {
+				typeSpec, isType := spec.(*ast.TypeSpec)
+				if !isType {
+					continue
+				}
+				structType, isStruct := typeSpec.Type.(*ast.StructType)
+				if !isStruct {
+					continue
+				}
+				for _, field := range structType.Fields.List {
+					if ident, isIdent := field.Type.(*ast.Ident); isIdent && ident.Name == forecastScopeType {
+						carriers[typeSpec.Name.Name] = true
+					}
+				}
+			}
+		}
+	}
+	if len(carriers) < 2 {
+		t.Fatalf("only %s itself was found to carry a scope in %s — the walk over the package's "+
+			"struct declarations found nothing, which is this census reporting PASS over a tree it cannot read",
+			forecastScopeType, forecastingPackage)
+	}
+
+	var corpus, missing []string
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || fn.Body == nil || !fn.Name.IsExported() ||
+				receiverTypeName(fn) != forecastStoreType || !namesACarrier(fn, carriers) {
+				continue
+			}
+			name := scrubKey(forecastStoreType, fn.Name.Name)
+			if !reachesAForecastInsert(graph, name, map[string]bool{}) {
+				continue
+			}
+			corpus = append(corpus, name)
+			if !reachesForecastScopeGate(graph, name, map[string]bool{}) {
+				missing = append(missing, name)
+			}
+		}
+	}
+	if len(corpus) == 0 {
+		t.Fatalf("no exported %s method in %s both names a scope-bearing type and reaches a forecast "+
+			"INSERT — the corpus is empty, which is the one way a census fails without saying so",
+			forecastStoreType, forecastingPackage)
+	}
+	sort.Strings(missing)
+	for _, name := range missing {
+		t.Errorf("%s records against a scope but never reaches %s: the object grant is its whole gate, "+
+			"so a seat that may call a forecast at all may call it for every team and every owner",
+			name, forecastScopeGate)
+	}
+}
+
+// namesACarrier reports whether any parameter's type is one of the scope-bearing
+// types — written flat rather than as a nested type walk because these
+// signatures pass them by value or by pointer and nothing else.
+func namesACarrier(fn *ast.FuncDecl, carriers map[string]bool) bool {
+	if fn.Type.Params == nil {
+		return false
+	}
+	for _, param := range fn.Type.Params.List {
+		typ := param.Type
+		if star, isStar := typ.(*ast.StarExpr); isStar {
+			typ = star.X
+		}
+		if ident, isIdent := typ.(*ast.Ident); isIdent && carriers[ident.Name] {
+			return true
+		}
+	}
+	return false
+}
+
+// forecastInsert matches a statement that writes a forecast row. Matched against
+// the statements the walk collects rather than against a function name, so a
+// writer spelled differently tomorrow is still recognised as one.
+var forecastInsert = regexp.MustCompile(`(?is)INSERT\s+INTO\s+forecast`)
+
+// reachesAForecastInsert follows same-package calls to the statement itself,
+// because the exported entry points do not hold their own SQL — RecordCall
+// validates and delegates, and the INSERT lives a frame or two down.
+func reachesAForecastInsert(graph map[string]*graphFunc, from string, seen map[string]bool) bool {
+	if seen[from] {
+		return false
+	}
+	seen[from] = true
+	fn, known := graph[from]
+	if !known {
+		return false
+	}
+	for _, statement := range fn.statements {
+		if forecastInsert.MatchString(statement) {
+			return true
+		}
+	}
+	for callee := range fn.calls {
+		if reachesAForecastInsert(graph, callee, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+// reachesForecastScopeGate follows same-package calls, so an entry point that
+// discharges the obligation through a helper is certified by what the helper
+// does rather than by where the words appear.
+func reachesForecastScopeGate(graph map[string]*graphFunc, from string, seen map[string]bool) bool {
+	if seen[from] {
+		return false
+	}
+	seen[from] = true
+	fn, known := graph[from]
+	if !known {
+		return false
+	}
+	for callee := range fn.calls {
+		if callee == forecastScopeGate || reachesForecastScopeGate(graph, callee, seen) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/modules/approvals/authority.go
+++ b/backend/internal/modules/approvals/authority.go
@@ -363,17 +363,33 @@ func decidable(ctx context.Context, tx pgx.Tx, p principal.Principal, a row) (bo
 	if requireDecisionGrants(p, a) != nil {
 		return false, nil
 	}
-	if selfOnlyKinds[a.Kind] || stagedForStagerOnly(a.TargetType, a.TargetID != nil) {
-		// Two routes to the same predicate: a kind whose subject is one member's
-		// own business, and a staged create against a table whose rows belong to
-		// one human each — where no row exists yet for an ownership probe to ask.
-		// Fail-closed on a missing stager: a proposal nobody is recorded for is
-		// one nobody may read, not one everybody may.
-		if a.OnBehalfOf == nil || p.UserID == ids.Nil || a.OnBehalfOf.UUID != p.UserID {
-			return false, nil
-		}
+	if withheldFromOtherSeats(p, a) {
+		return false, nil
 	}
 	return targetDecidable(ctx, tx, a.TargetType, a.TargetID)
+}
+
+// withheldFromOtherSeats is the self-only narrowing of decidable, spelled once
+// because three reads apply it: the inbox scan through decidable, and the two
+// target-filtered reads (inbox.listForTarget, Service.PendingForTarget) which
+// settle target visibility for the record instead of per row and so cannot call
+// decidable itself. It reports the rows this caller must NOT see — true when the
+// staging is bound to one seat and p is not it.
+//
+// Two routes to the same predicate: a kind whose subject is one member's own
+// business, and a staged create against a table whose rows belong to one human
+// each — where no row exists yet for an ownership probe to ask. Fail-closed on a
+// missing stager: a proposal nobody is recorded for is one nobody may read, not
+// one everybody may.
+//
+// Held by: TestEveryApprovalsGrantFilterAlsoAppliesTheSelfOnlyNarrowing
+// (backend/gates/approvalselfonlyreaders_test.go) — it fails when a reader
+// filters rows with requireDecisionGrants and does not also call this.
+func withheldFromOtherSeats(p principal.Principal, a row) bool {
+	if !selfOnlyKinds[a.Kind] && !stagedForStagerOnly(a.TargetType, a.TargetID != nil) {
+		return false
+	}
+	return a.OnBehalfOf == nil || p.UserID == ids.Nil || a.OnBehalfOf.UUID != p.UserID
 }
 
 func requireDecisionGrants(p principal.Principal, a row) error {

--- a/backend/internal/modules/approvals/crosspassportdecide_integration_test.go
+++ b/backend/internal/modules/approvals/crosspassportdecide_integration_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package approvals
+
+// A second agent passport, lent by a SECOND human, approving a
+// confirmation-required action it never staged — against a real database.
+//
+// The self-approval rule bound the CREDENTIAL and nothing bound the PERSON, so
+// two passports lent by two people walked a confirm-first action through end to
+// end — A's stages, B's approves, A's redeems — and the decide route is itself
+// auto_execute, so B's approval needed no confirmation of its own. The whole
+// "a human must look at this" guarantee of the tier was satisfied by a second
+// autonomous agent instead of a person.
+//
+// It lives here rather than in the unit suite because approval.passport_id and
+// approval.on_behalf_of are foreign keys: the two credentials and the two
+// people have to be real rows, and a fabricated id exercises a shape the
+// database refuses rather than the rule under test.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// lentPassport mints a real credential for one human and returns the agent
+// context that asserts it, carrying the write cap a decision spends.
+func (e *stagingEnv) lentPassport(t *testing.T, human ids.UUID) context.Context {
+	t.Helper()
+	passport := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO passport (id, on_behalf_of, granted_by, token_hash, scopes, expires_at)
+		VALUES ($1, $2, $2, $3, ARRAY['read','write'], now() + interval '30 days')`,
+		passport, human, "hash-"+passport.String()); err != nil {
+		t.Fatalf("seeding the lent passport: %v", err)
+	}
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:" + human.String(),
+		PassportID: passport, OnBehalfOf: human, UserID: human,
+		Scopes: principal.NewScopeSet(principal.ScopeWrite),
+		Permissions: principal.Permissions{
+			RowScope: principal.RowScopeAll,
+			Objects: map[string]principal.ObjectGrant{
+				tableOrganization: {Create: true, Read: true, Update: true, Delete: true},
+			},
+		},
+	})
+}
+
+func TestASecondPersonsPassportDoesNotReleaseAConfirmationRequiredAction(t *testing.T) {
+	e := setupStaging(t)
+	ctx := context.Background()
+
+	// The second human. A real row: on_behalf_of is a foreign key.
+	second := ids.NewV7()
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Second')`,
+		second, "second-"+second.String()+"@st.test"); err != nil {
+		t.Fatalf("seeding the second human: %v", err)
+	}
+	target := ids.NewV7()
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO organization (id, display_name, source, captured_by)
+		VALUES ($1, 'Gitex', 'gmail:seed', 'connector:gmail')`, target); err != nil {
+		t.Fatalf("seeding the target: %v", err)
+	}
+
+	// The three credentials the sequence needs, minted ONCE each: redemption is
+	// bound to the passport that staged, so a fresh context per call would
+	// exercise that binding instead of the rule under test.
+	stager := e.lentPassport(t, e.rep)       // A's, which stages and redeems
+	sameperson := e.lentPassport(t, e.rep)   // A's SECOND, the sanctioned decider
+	otherperson := e.lentPassport(t, second) // B's, the attacker
+
+	staging := func(name, hash string) StageInput {
+		return StageInput{
+			Kind:           "org_name_promotion",
+			ProposedChange: []byte(`{"proposed_name":"` + name + `"}`),
+			DiffHash:       hash + "-" + target.String(),
+			TargetType:     tableOrganization,
+			TargetID:       target,
+			Summary:        "Rename Gitex to " + name + "?",
+		}
+	}
+
+	// Step 1: A's passport stages the confirm-first action.
+	attacked := staging("Gitex Global", "cross-passport")
+	staged, err := e.svc.Stage(stager, attacked)
+	if err != nil {
+		t.Fatalf("staging as the first person's agent: %v", err)
+	}
+
+	// Step 2, and the defect: B's passport — a different token, a different
+	// human, never having seen the proposal — approves it. The exact sentinel,
+	// because the surface answers 403 on this refusal and a bare non-nil check
+	// would stay green if it became an unrelated internal failure.
+	if _, err := e.svc.Decide(otherperson, staged, true, nil); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("a second person's passport approved an action staged for somebody else → %v, want "+
+			"ErrPermissionDenied — two agents then push any confirmation-required mutation through "+
+			"end to end with no human in the loop", err)
+	}
+
+	// A rejection is still allowed: it discards the proposal and cannot
+	// escalate, and an agent unable to take a request off a desk is an obstacle
+	// rather than a rule.
+	if _, err := e.svc.Decide(otherperson, staged, false, nil); err != nil {
+		t.Errorf("a second person's passport could not REJECT the proposal: %v", err)
+	}
+
+	// THE POSITIVE CONTROL, and it runs all three steps to the
+	// end. Without it this test also passes when no passport can decide anything
+	// and the tier has simply stopped working: a SECOND credential of the SAME
+	// person releases it, and A's staging credential then redeems and the effect
+	// runs — the path the product deliberately allows, because that person could
+	// have answered it in the CRM themselves.
+	control := staging("Gitex Worldwide", "same-person")
+	sanctioned, err := e.svc.Stage(stager, control)
+	if err != nil {
+		t.Fatalf("staging the control proposal: %v", err)
+	}
+	if _, err := e.svc.Decide(sameperson, sanctioned, true, nil); err != nil {
+		t.Fatalf("another credential of the SAME person was refused: %v — the rule binds the person, "+
+			"not the credential, and this is the path the product deliberately allows", err)
+	}
+	// Redeeming is step 3, and it is also what keeps this test
+	// out of the lapse sweep's count: that sweep is database-wide and counts
+	// approved stagings nobody came back for, so a control stopping at the
+	// decision would leave a row the sweep's own tests report as a second lapse.
+	if _, _, err := e.svc.Redeem(stager, sanctioned, control.Kind, control.DiffHash); err != nil {
+		t.Errorf("the staging credential could not redeem what its person released: %v", err)
+	}
+}

--- a/backend/internal/modules/approvals/decidingactor.go
+++ b/backend/internal/modules/approvals/decidingactor.go
@@ -99,9 +99,11 @@ func ReleaseSends(kind string) bool { return sendingKinds[kind] }
 // agentMayDecide bounds what a PASSPORT may do to one staged proposal, given
 // that actingForAHuman has already admitted it as somebody's agent.
 //
-// Two questions, one place, because they fail the same way if either is missed:
-// a credential must not release what its human did not lend it, and it must not
-// be the thing that confirms its own proposal.
+// Three questions, one place, because they fail the same way if any is missed:
+// a credential must not release what its human did not lend it, it must not be
+// the thing that confirms its own proposal, and it must not stand in for a
+// person it does not act for — two passports lent by two people otherwise walk
+// a confirm-first action through end to end with nobody having looked.
 //
 // A human decides on the strength of their seat and their grants; an agent
 // decides on the strength of a credential a human minted with a fixed set of
@@ -137,6 +139,37 @@ func agentMayDecide(p principal.Principal, a row, approve bool) error {
 	if approve && a.PassportID != nil && p.PassportID != ids.Nil && a.PassportID.UUID == p.PassportID {
 		return fmt.Errorf("this credential proposed the action, so it does not also release it — "+
 			"the person it acts for answers it in the CRM: %w", apperrors.ErrPermissionDenied)
+	}
+	// AND IT DOES NOT CONFIRM ANOTHER PERSON'S. The rule above binds the
+	// credential; this one binds the PERSON behind it, and without the second the
+	// first buys nothing. Two humans each lend a passport: A's stages the
+	// confirm-first call, B's approves it, A's redeems it, and the whole tier has
+	// been satisfied by two autonomous agents with nobody having looked. The
+	// decide route is itself auto_execute, so B's approval needed no confirmation
+	// of its own — which is what turns a bounded loan into a way around the tier
+	// rather than an exercise of it.
+	//
+	// What a lent credential may answer is what the person who lent it could have
+	// answered in the CRM themselves, and a proposal staged for somebody else is
+	// not that. UserID, not OnBehalfOf, is the comparison: a passport carries its
+	// lender's user id (AgentIdentity.Principal), so this is the same "is this
+	// your own business" test decidable() applies to a self-only kind, asked of
+	// the decision instead of the read.
+	//
+	// A row with NO recorded human — a SERVER proposal, which attributableStager
+	// guarantees is what a NULL passport_id means — is deliberately outside the
+	// rule. It is the unattended policy apply (compose/autoapply.go), which
+	// releases under the OWNER's own authority and is bounded by that rather than
+	// by a staging nobody made on anybody's behalf.
+	//
+	// Approve only, for the reason the self-approval rule is: a rejection
+	// discards a proposal and cannot escalate, and an agent unable to take a
+	// request off a desk is an obstacle rather than a rule.
+	if approve && a.OnBehalfOf != nil &&
+		(p.UserID == ids.Nil || a.OnBehalfOf.UUID != p.UserID) {
+		return fmt.Errorf("this credential acts for somebody other than the person this action was "+
+			"staged for, so it does not release it — that person answers it themselves: %w",
+			apperrors.ErrPermissionDenied)
 	}
 	kind := a.Kind
 	// A step-up is a question ABOUT this credential — how much of what it may

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -265,8 +265,10 @@ func scanInbox(ctx context.Context, tx pgx.Tx, p principal.Principal, in ListInp
 //
 // Every row shares that target, so the target-visibility half of decidable is
 // asked ONCE for the record rather than once per row — the inbox's per-row
-// probe exists only because its rows point at different records. The per-kind
-// grant check still varies by row and stays in the loop.
+// probe exists only because its rows point at different records. The two halves
+// that vary by row stay in the loop: the per-kind grant check, and the self-only
+// narrowing (withheldFromOtherSeats), which is per-row because it compares the
+// caller against the seat THAT ROW was staged for and not against the target.
 //
 // A target the caller could not read — its type ungranted, or its row outside
 // their scope — answers an EMPTY list, never a refusal: nothing staged against a
@@ -293,7 +295,9 @@ func listForTarget(ctx context.Context, tx pgx.Tx, p principal.Principal, in Lis
 	if len(batch) == PendingScanCap {
 		scanned = &batch[len(batch)-1]
 	}
-	granted := func(a row) (bool, error) { return requireDecisionGrants(p, a) == nil, nil }
+	granted := func(a row) (bool, error) {
+		return requireDecisionGrants(p, a) == nil && !withheldFromOtherSeats(p, a), nil
+	}
 	out, _, err := appendDecidable(batch, nil, in.Limit+1, granted)
 	if err != nil {
 		return nil, storekit.Page{}, err

--- a/backend/internal/modules/approvals/pendingfortarget.go
+++ b/backend/internal/modules/approvals/pendingfortarget.go
@@ -32,7 +32,9 @@ import (
 // Every row here shares ONE target, so the target-visibility half of
 // decidable is asked once for the record rather than once per row — the
 // inbox's per-row probe exists because its rows point at different records.
-// The per-kind grant check still varies by row and stays in the loop.
+// The two halves that vary by row stay in the loop: the per-kind grant check,
+// and the self-only narrowing (withheldFromOtherSeats), which compares the
+// caller against the seat each ROW was staged for and not against the target.
 //
 // The scan is bounded at PendingScanCap rows so one record page cannot pay
 // for an unbounded backlog. A caller counting rather than listing must treat
@@ -75,6 +77,13 @@ func (s *Service) PendingForTarget(ctx context.Context, tx pgx.Tx, targetType st
 			continue
 		}
 		if requireDecisionGrants(p, a) != nil {
+			continue
+		}
+		if withheldFromOtherSeats(p, a) {
+			// A self-only staging is one seat's own business, so it is absent
+			// from a colleague's record page for the same reason it is absent
+			// from their inbox — the panel is the same side channel List
+			// refuses to be.
 			continue
 		}
 		out = append(out, wire(a, now))

--- a/backend/internal/modules/approvals/selfonlytarget_integration_test.go
+++ b/backend/internal/modules/approvals/selfonlytarget_integration_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package approvals
+
+// The self-only narrowing on the TWO target-filtered reads, against a real
+// database — the property the unit suite cannot reach, because both reads open
+// with a target-visibility probe that needs the row to exist.
+//
+// The inbox scan applies decidable() per row and always narrowed correctly. The
+// target-filtered reads settle target visibility once for the record and then
+// filter each row themselves, and both filtered on the decision grants alone: a
+// colleague holding person.update and able to read the contact received another
+// member's linkedin_match in full — the connection's real name and employer out
+// of a private address book, third parties who never agreed to be in this CRM.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// seatFor is the colleague seat the leak was read from: person grants outright
+// and row scope over every row, which is what a manager, ops or management grid
+// actually holds. If this seat cannot see the row, no weaker one can.
+func seatFor(ws, user ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		Permissions: principal.Permissions{
+			RowScope: principal.RowScopeAll,
+			Objects: map[string]principal.ObjectGrant{
+				tablePerson: {Create: true, Read: true, Update: true, Delete: true},
+			},
+		},
+	})
+}
+
+func TestASelfOnlyStagingIsAbsentFromAColleaguesTargetFilteredReads(t *testing.T) {
+	e := setupStaging(t)
+	ctx := context.Background()
+
+	// The colleague: a real row, because on_behalf_of is a foreign key and a
+	// fabricated id would be refused by the database before any assertion runs.
+	colleague := ids.NewV7()
+	if _, err := e.owner.Exec(ctx,
+		`INSERT INTO app_user (id, email, display_name) VALUES ($1, $2, 'Colleague')`,
+		colleague, "colleague-"+colleague.String()+"@st.test"); err != nil {
+		t.Fatalf("seeding the colleague: %v", err)
+	}
+	// The contact the match is staged against. Both reads open with a
+	// target-visibility probe, so a target that does not exist would answer
+	// empty for a reason that has nothing to do with the narrowing under test.
+	target := ids.NewV7()
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO person (id, full_name, source, captured_by)
+		VALUES ($1, 'Jan Dow', 'linkedin:seed', 'connector:linkedin')`, target); err != nil {
+		t.Fatalf("seeding the contact: %v", err)
+	}
+
+	// Staged through the REAL writer, on the shape the importer produces: an
+	// agent acting for e.rep, which is what stamps on_behalf_of with a person
+	// rather than leaving it NULL. A test that wrote the row itself would be
+	// asserting over a shape production does not make.
+	staged, err := e.svc.Stage(e.asAgent(t), StageInput{
+		Kind:           kindLinkedInMatch,
+		ProposedChange: []byte(`{"connection_name":"Jane Doe","connection_company":"Contoso GmbH"}`),
+		DiffHash:       "linkedin-match-" + target.String(),
+		TargetType:     tablePerson,
+		TargetID:       target,
+		Summary:        "Jane Doe at Contoso GmbH looks like Jan Dow",
+	})
+	if err != nil {
+		t.Fatalf("staging the match: %v", err)
+	}
+
+	targetType := tablePerson
+	read := func(t *testing.T, as context.Context) (int, int) {
+		t.Helper()
+		listed, _, listErr := e.svc.List(as, ListInput{TargetType: &targetType, TargetID: &target})
+		if listErr != nil {
+			t.Fatalf("List(targeted): %v", listErr)
+		}
+		var panel int
+		if err := e.svc.db.Tx(as, func(tx pgx.Tx) error {
+			out, pendErr := e.svc.PendingForTarget(as, tx, targetType, target, PendingScanCap)
+			panel = len(out)
+			return pendErr
+		}); err != nil {
+			t.Fatalf("PendingForTarget: %v", err)
+		}
+		return len(listed), panel
+	}
+
+	// THE LEAK. The colleague holds every person grant and every row, so
+	// requireDecisionGrants and targetVisible both pass — and the self-only
+	// narrowing is the only thing standing between them and the row.
+	if listed, panel := read(t, seatFor(e.ws, colleague)); listed != 0 || panel != 0 {
+		t.Errorf("a colleague read %d row(s) from List(targeted) and %d from PendingForTarget for a "+
+			"linkedin_match staged for somebody else — the staged change carries a third party's real "+
+			"name and employer out of that member's private address book", listed, panel)
+	}
+
+	// THE POSITIVE CONTROL, and it is what makes the assertion above mean
+	// anything: without it this test also passes when both reads are broken and
+	// return nothing to anyone.
+	listed, panel := read(t, seatFor(e.ws, e.rep))
+	if listed != 1 || panel != 1 {
+		t.Errorf("the member it was staged for read %d row(s) from List(targeted) and %d from "+
+			"PendingForTarget, want 1 and 1 — the narrowing withholds the proposal from its own subject",
+			listed, panel)
+	}
+	if listed == 1 {
+		// The row is the one staged here rather than some other pending proposal
+		// against the same contact, so "1" is this proposal and not a coincidence.
+		rows, _, err := e.svc.List(seatFor(e.ws, e.rep), ListInput{TargetType: &targetType, TargetID: &target})
+		if err != nil {
+			t.Fatalf("re-reading the subject's own list: %v", err)
+		}
+		if rows[0].ID != staged {
+			t.Errorf("the subject's list carries %v, want the staged match %v", rows[0].ID, staged)
+		}
+	}
+}

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -275,13 +275,21 @@ func TestAgentReleaseSpendsTheCapsTheReleaseSpends(t *testing.T) {
 func TestACredentialDoesNotReleaseTheProposalItMade(t *testing.T) {
 	mine := ids.NewV7()
 	theirs := ids.NewV7()
+	lender := ids.NewV7()
+	someoneElse := ids.NewV7()
 	proposer := principal.Principal{
-		Type: principal.PrincipalAgent, ID: "agent:test", OnBehalfOf: ids.NewV7(),
+		Type: principal.PrincipalAgent, ID: "agent:test", UserID: lender, OnBehalfOf: lender,
 		PassportID: mine, Scopes: principal.NewScopeSet(principal.ScopeWrite),
 	}
-	stagedBy := func(id ids.UUID) row {
-		passport := ids.From[ids.PassportKind](id)
-		return row{Kind: "advance_deal", PassportID: &passport}
+	// A staging carries BOTH halves, because an agent one always does:
+	// attributableStager refuses a passport-less agent staging, and
+	// insertProposalInTx writes on_behalf_of from the same principal. A fixture
+	// omitting the human is a shape production cannot produce, and it is the
+	// shape under which a rule about that human passes without being asked.
+	stagedBy := func(passportID, human ids.UUID) row {
+		passport := ids.From[ids.PassportKind](passportID)
+		on := ids.From[ids.UserKind](human)
+		return row{Kind: "advance_deal", PassportID: &passport, OnBehalfOf: &on}
 	}
 
 	cases := []struct {
@@ -290,12 +298,22 @@ func TestACredentialDoesNotReleaseTheProposalItMade(t *testing.T) {
 		approve bool
 		want    bool // admitted
 	}{
-		{"the proposer cannot approve its own row", stagedBy(mine), true, false},
+		{"the proposer cannot approve its own row", stagedBy(mine, lender), true, false},
 		// Deliberately allowed: an agent that changes its mind takes its own
 		// request off somebody's desk rather than leaving it there.
-		{"but it may still reject its own row", stagedBy(mine), false, true},
-		{"another credential's row it may approve", stagedBy(theirs), true, true},
-		// serverProposed: a row nobody's passport staged is not self-approval.
+		{"but it may still reject its own row", stagedBy(mine, lender), false, true},
+		// Another CREDENTIAL of the same person: the lender could have answered
+		// this in the CRM themselves, so answering it on a second credential they
+		// minted is the same person answering.
+		{"another credential of the same person it may approve", stagedBy(theirs, lender), true, true},
+		// Another PERSON's, which is the loop the tier exists to stop: two
+		// passports lent by two people push a confirm-first action through end to
+		// end and no human ever looks.
+		{"another person's row it does not approve", stagedBy(theirs, someoneElse), true, false},
+		{"but it may still reject another person's row", stagedBy(theirs, someoneElse), false, true},
+		// serverProposed: a row nobody's passport staged is not self-approval,
+		// and one staged on nobody's behalf is the unattended policy apply,
+		// bounded by the owner's own authority rather than by a staging.
 		{"a server-proposed row is nobody's own", row{Kind: "advance_deal"}, true, true},
 	}
 	for _, tc := range cases {

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -632,13 +632,10 @@ func TestASelfOnlyKindIsUndecidableByAnyoneButItsSubject(t *testing.T) {
 		t.Fatal("linkedin_match is not self-only — a colleague's imported network is readable from the inbox")
 	}
 
-	// The predicate itself, exercised the way decidable applies it.
-	selfOnly := func(p principal.Principal, a row) bool {
-		if !selfOnlyKinds[a.Kind] {
-			return true
-		}
-		return a.OnBehalfOf != nil && p.UserID != ids.Nil && a.OnBehalfOf.UUID == p.UserID
-	}
+	// The production predicate itself, not a copy of it: a re-spelled rule in a
+	// test proves the test, and this one went on passing while the two
+	// target-filtered readers had no self-only narrowing at all.
+	selfOnly := func(p principal.Principal, a row) bool { return !withheldFromOtherSeats(p, a) }
 	if selfOnly(admin, staged) {
 		t.Error("an all-scope admin can decide a LinkedIn match staged for somebody else")
 	}
@@ -648,6 +645,72 @@ func TestASelfOnlyKindIsUndecidableByAnyoneButItsSubject(t *testing.T) {
 	// A proposal with no recorded subject is nobody's to read, not everybody's.
 	if selfOnly(owner, row{Kind: "linkedin_match"}) {
 		t.Error("a self-only proposal with no subject was treated as decidable")
+	}
+}
+
+// withheldFromOtherSeats is the half of decidable the two target-filtered reads
+// (inbox.listForTarget, Service.PendingForTarget) have to spell for themselves,
+// because they settle target visibility once for the record instead of per row.
+// Both once spelled only the grant half, so a colleague's linkedin_match,
+// vcard_create and held_draft were readable from any record page they were
+// staged against.
+//
+// The walk is DERIVED over selfOnlyKinds and over the probe classification
+// stagedForStagerOnly reads, so a kind or a personal table enrolled tomorrow is
+// covered without anybody remembering this test exists. Each shape is asserted
+// three ways — withheld from a colleague, served to its own seat, withheld from
+// everyone when no seat is recorded — because a predicate that answers "withheld"
+// unconditionally also passes a test that only checks the refusal.
+func TestEverySelfOnlyShapeIsWithheldFromEverySeatButTheOneItWasStagedFor(t *testing.T) {
+	mine, theirs := ids.NewV7(), ids.NewV7()
+	subject := ids.From[ids.UserKind](mine)
+	stager := principal.Principal{UserID: mine, Permissions: principal.Permissions{RowScope: principal.RowScopeAll}}
+	colleague := principal.Principal{UserID: theirs, Permissions: principal.Permissions{RowScope: principal.RowScopeAll}}
+
+	shapes := map[string]row{}
+	for kind := range selfOnlyKinds {
+		shapes["kind "+kind] = row{Kind: kind}
+	}
+	// The other route to the same predicate: a create staged against a table
+	// whose rows belong to one human each, where no row exists yet for an
+	// ownership probe to ask. Read off the probe table rather than named, so an
+	// enrolment there lands here too.
+	for targetType, probe := range targetProbes {
+		if probe != probeOwnerOnly {
+			continue
+		}
+		shapes["id-less create against "+targetType] = row{Kind: "create_record", TargetType: &targetType}
+	}
+	if len(shapes) == 0 {
+		t.Fatal("no self-only shape found at all — this walk covers nothing")
+	}
+
+	for name, staged := range shapes {
+		t.Run(name, func(t *testing.T) {
+			forMe := staged
+			forMe.OnBehalfOf = &subject
+			if !withheldFromOtherSeats(colleague, forMe) {
+				t.Error("a colleague may read a staging filed for somebody else — the inbox is a side channel over one member's private business")
+			}
+			if withheldFromOtherSeats(stager, forMe) {
+				t.Error("the member it was staged for cannot read their own staging, so the narrowing withholds it from everybody")
+			}
+			// Fail-closed: a proposal nobody is recorded for is one nobody may
+			// read, not one everybody may.
+			if !withheldFromOtherSeats(stager, staged) {
+				t.Error("a staging with no recorded seat was served")
+			}
+		})
+	}
+
+	// The positive control. Without it this test also passes when the predicate
+	// withholds every row of every kind and the inbox serves nothing at all.
+	shared := row{Kind: "merge_records", OnBehalfOf: &subject}
+	if selfOnlyKinds[shared.Kind] {
+		t.Fatal("the control kind is itself self-only, so it proves nothing about a shared one")
+	}
+	if withheldFromOtherSeats(colleague, shared) {
+		t.Error("a SHARED kind was withheld from a colleague — the inbox is a shared surface and triage is the point")
 	}
 }
 

--- a/backend/internal/modules/forecasting/scopeauthority.go
+++ b/backend/internal/modules/forecasting/scopeauthority.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package forecasting
+
+// Who may record a forecast against a scope.
+//
+// Separate from store.go because it is a different question from how a call is
+// written: that file spells the transaction, the supersession and the audit
+// row, and this one spells the single rule about WHOSE forecast a caller may
+// assert — the rule the object grant never carried.
+
+import (
+	"context"
+	"slices"
+
+	"github.com/margince/margince/backend/internal/platform/auth"
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+// requireForecastScope is the gate every entry point that RECORDS a scope runs:
+// the object grant, then the shape, then the scope itself.
+//
+// The object grant says a seat may make forecast calls at all; it says nothing
+// about WHOSE, and that was the whole gate. So a seat holding forecast.create
+// recorded a commitment against any owner's or team's scope — stored under that
+// scope, superseding its standing call, and unremovable, since no seat holds
+// forecast.update or forecast.delete. The owning migration always stated the
+// rule ("an assertion about a team's forecast, made by whoever is accountable
+// for it"); nothing enforced the second half of that sentence.
+//
+// WRITES ONLY, and the asymmetry is the point rather than an omission. Measuring
+// a population and asserting a number for it are different questions with
+// different answers: a team manager may legitimately MEASURE a teammate's
+// pipeline, and the composition layer decides that once for every analytics
+// surface (compose.AnalyticsPopulationClause), using a live-membership read this
+// module cannot make — it owns no tables and may not import identity. Recording
+// a call is the stricter question, it is asked of a scope taken verbatim from a
+// request body that never reaches that resolver, and it is the module's own. A
+// second, narrower copy of the read rule here would refuse the very manager the
+// resolver had just admitted.
+//
+// The shape is checked BEFORE the authority so that a scope_kind nobody
+// recognises is a malformed request for every caller. Checked after, an
+// unbounded seat was told its field was wrong while a bounded one was told the
+// thing it named does not exist — one defect reported two ways, decided by the
+// reader's privilege.
+//
+// Held by: TestEveryForecastScopeWriterAsksWhoAnswersForTheScope
+// (backend/gates/forecastscopeauthority_test.go) — it fails when an exported
+// store method records against a scope-bearing type and does not reach this.
+func requireForecastScope(ctx context.Context, scope Scope) error {
+	if err := auth.Require(ctx, "forecast", principal.ActionCreate); err != nil {
+		return err
+	}
+	if err := checkScope(scope); err != nil {
+		return err
+	}
+	return requireScopeAuthority(ctx, scope)
+}
+
+// requireScopeAuthority refuses a scope this caller may not RECORD against.
+//
+// Answered from the principal rather than from a membership query: the auth
+// layer has already resolved the caller's LIVE team memberships onto TeamIDs —
+// an archived team resolves neither row scope nor a team share — so the module
+// keeps the property its package doc rests on, owning no tables and needing no
+// database to decide anything.
+//
+// A miss is ErrNotFound rather than ErrPermissionDenied, which is the answer the
+// analytics resolver gives for the same reason: a refusal naming a specific id
+// confirms that id exists, which is the disclosure the rule is for.
+//
+// The WORKSPACE scope is deliberately not narrowed. It names no subject, so
+// there is no membership to test and nobody is more accountable for it than
+// anybody else holding the grant; what bounds it is the object grant, exactly
+// as before this check existed.
+//
+// The switch is total over what checkScope admits, and checkScope runs first.
+// The trailing refusal is the fail-closed default for a kind added to that
+// vocabulary and not to this rule — the direction an authorization predicate
+// has to fail in.
+func requireScopeAuthority(ctx context.Context, scope Scope) error {
+	p, ok := principal.Actor(ctx)
+	if !ok {
+		// No resolved actor is no authority over anyone's scope. Fail closed:
+		// a caller the auth layer could not identify is not every caller.
+		return apperrors.ErrNotFound
+	}
+	if auth.Unbounded(p) {
+		return nil
+	}
+	switch scope.Kind {
+	case ScopeWorkspace:
+		return nil
+	case ScopeOwner:
+		if scope.ID != nil && *scope.ID == p.UserID && !p.UserID.IsZero() {
+			return nil
+		}
+	case ScopeTeam:
+		if scope.ID != nil && slices.Contains(p.TeamIDs, *scope.ID) {
+			return nil
+		}
+	}
+	return apperrors.ErrNotFound
+}

--- a/backend/internal/modules/forecasting/scopeauthority_integration_test.go
+++ b/backend/internal/modules/forecasting/scopeauthority_integration_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package forecasting
+
+// The scope gate on the WRITE, through the real store against a real database —
+// the half a unit test over requireScopeAuthority cannot reach, which is that
+// the entry points actually run it before touching the table.
+//
+// A call is an assertion about a scope, made by whoever is accountable for it,
+// and the object grant was the whole gate: a manager holding forecast.create
+// recorded a commitment against a rival team's scope — stored with that team's
+// scope_id, superseding their standing call, and unremovable, since no seat
+// holds forecast.update or forecast.delete.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+	"github.com/margince/margince/backend/internal/shared/kernel/values"
+)
+
+// asBounded is the seat the tampering was done from: forecast.create and
+// forecast.read outright, and row scope BELOW all — which is what `manager`
+// actually holds. e.as() carries RowScopeAll, and an unbounded seat answers for
+// the installation by definition, so it could not show this rule working.
+func (e *snapshotEnv) asBounded(teams ...ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.rep.String(), UserID: e.rep,
+		TeamIDs: teams,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"manager"},
+			Objects:  map[string]principal.ObjectGrant{"forecast": {Read: true, Create: true}},
+			RowScope: principal.RowScopeTeam,
+		},
+	})
+}
+
+func TestAForecastCallIsRefusedAgainstAScopeTheCallerDoesNotAnswerFor(t *testing.T) {
+	e := setupSnapshot(t)
+	zone := time.UTC
+	period, err := ResolvePeriod(PeriodQuarter, time.Date(2026, time.May, 14, 12, 0, 0, 0, zone), 1, zone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call := func(scope Scope) NewCall {
+		return NewCall{Period: period, Scope: scope, AmountMinor: 100000, Currency: "EUR", Note: "revised"}
+	}
+	mine, theirs := ids.NewV7(), ids.NewV7()
+	someoneElse := ids.NewV7()
+	ctx := e.asBounded(mine)
+
+	// THE TAMPER. Both halves of it: a rival team's scope and another
+	// individual's. The exact sentinel, because ErrNotFound is the refusal this
+	// gate owes — whether a rival team has called this period is itself the
+	// disclosure, so a permission denial would leak the existence it withholds.
+	for _, scope := range []Scope{{Kind: ScopeTeam, ID: &theirs}, {Kind: ScopeOwner, ID: &someoneElse}} {
+		if _, err := e.store.RecordCall(ctx, call(scope)); !errors.Is(err, apperrors.ErrNotFound) {
+			t.Errorf("recording a call against %s scope %v → %v, want ErrNotFound — the row would be "+
+				"stored under that scope and supersede its standing call, with no seat holding "+
+				"forecast.update or forecast.delete to remove it", scope.Kind, *scope.ID, err)
+		}
+	}
+	// A scope_kind nobody recognises is a malformed request for EVERY caller.
+	// Checked after the authority instead of before, this seat was told the
+	// thing it named does not exist while an all-scope seat was told its field
+	// was wrong — one defect reported two ways, decided by the reader.
+	var parse *values.ParseError
+	_, err = e.store.RecordCall(ctx, call(Scope{Kind: "managed_teams", ID: &mine}))
+	if !errors.As(err, &parse) || parse.Field != "scope_kind" {
+		t.Errorf("recording against a resolved-only kind → %v, want a scope_kind ParseError", err)
+	}
+
+	// THE POSITIVE CONTROLS, and they are what make the refusals above mean
+	// anything: without them this test also passes when the store refuses every
+	// scope and nobody can call a forecast at all.
+	own := Scope{Kind: ScopeOwner, ID: &e.rep}
+	if _, err := e.store.RecordCall(ctx, call(own)); err != nil {
+		t.Fatalf("the caller was refused their OWN owner scope: %v", err)
+	}
+	if _, err := e.store.RecordCall(ctx, call(Scope{Kind: ScopeTeam, ID: &mine})); err != nil {
+		t.Fatalf("the caller was refused a team they are a member of: %v", err)
+	}
+	// The workspace scope names no subject, so the object grant is what bounds
+	// it — unchanged by this gate, and asserted so a later narrowing is a
+	// deliberate edit rather than a surprise.
+	if _, err := e.store.RecordCall(ctx, call(Scope{Kind: ScopeWorkspace})); err != nil {
+		t.Fatalf("the caller was refused the workspace scope: %v", err)
+	}
+	// And the write it was allowed reads back, so the refusals above are this
+	// gate working rather than the store refusing everything.
+	back, err := e.store.CurrentCall(ctx, period, own)
+	if err != nil {
+		t.Fatalf("reading back the caller's own standing call: %v", err)
+	}
+	if back.AmountMinor != 100000 || back.Note != "revised" {
+		t.Errorf("read back amount %d note %q, want 100000 and \"revised\"", back.AmountMinor, back.Note)
+	}
+
+	// THE READ IS DELIBERATELY NOT NARROWED HERE, and this asserts that on
+	// purpose rather than leaving it to be discovered. Which population a caller
+	// may MEASURE is settled once in the composition layer, against the caller's
+	// lens and a live-membership read this module cannot make, and it is WIDER
+	// than the recording rule: a team manager may read a teammate's figures.
+	// Re-asking the recording question here would refuse the very manager that
+	// resolver had just admitted, so a future narrowing of this call has to fail
+	// this line and be argued for.
+	if _, err := e.store.CurrentCall(ctx, period, Scope{Kind: ScopeOwner, ID: &someoneElse}); err != nil &&
+		!errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("reading another owner's standing call → %v, want either the row or "+
+			"no-standing-call; the population question belongs to the composition layer", err)
+	}
+}

--- a/backend/internal/modules/forecasting/scopeauthority_test.go
+++ b/backend/internal/modules/forecasting/scopeauthority_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package forecasting
+
+// A call is an assertion about a scope, made by whoever is accountable for it.
+// The object grant says a seat may make calls at all and nothing about WHOSE,
+// so it was the whole gate and a manager could record a commitment against a
+// rival team — attributed to that team, superseding its standing call, and
+// unremovable, since no seat holds forecast.update or forecast.delete.
+//
+// This is the RECORDING rule and not a reading one. Which population a caller
+// may MEASURE is a different question with a wider answer — a team manager may
+// read a teammate's figures — and the composition layer settles that once for
+// every analytics surface, with a live-membership query this module cannot
+// make. Asserting a number for a scope is the stricter question and the only
+// one asked here.
+//
+// Every case here asserts the EXACT refusal, not merely "not allowed". The
+// refusal has to be ErrNotFound: whether a rival team has called this period is
+// itself the disclosure, so ErrPermissionDenied would leak the existence the
+// gate withholds, and a shape error would say the scope was merely malformed.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/margince/margince/backend/internal/shared/apperrors"
+	"github.com/margince/margince/backend/internal/shared/kernel/ids"
+	"github.com/margince/margince/backend/internal/shared/kernel/principal"
+)
+
+func TestAScopeIsAnsweredForOnlyByTheSeatAccountableForIt(t *testing.T) {
+	me, someoneElse := ids.NewV7(), ids.NewV7()
+	myTeam, theirTeam := ids.NewV7(), ids.NewV7()
+
+	seat := func(scope principal.RowScope, teams ...ids.UUID) principal.Principal {
+		return principal.Principal{
+			Type: principal.PrincipalHuman, UserID: me, TeamIDs: teams,
+			Permissions: principal.Permissions{RowScope: scope},
+		}
+	}
+	owner := func(id ids.UUID) Scope { return Scope{Kind: ScopeOwner, ID: &id} }
+	team := func(id ids.UUID) Scope { return Scope{Kind: ScopeTeam, ID: &id} }
+
+	cases := []struct {
+		name  string
+		actor principal.Principal
+		scope Scope
+		allow bool
+	}{
+		{"my own owner scope", seat(principal.RowScopeOwn), owner(me), true},
+		{"a colleague's owner scope", seat(principal.RowScopeOwn), owner(someoneElse), false},
+		{"a colleague's owner scope, from a team seat", seat(principal.RowScopeTeam, myTeam), owner(someoneElse), false},
+		{"a team I am on", seat(principal.RowScopeTeam, myTeam), team(myTeam), true},
+		{"a team I am not on", seat(principal.RowScopeTeam, myTeam), team(theirTeam), false},
+		{"a team, from a seat on no team at all", seat(principal.RowScopeOwn), team(myTeam), false},
+		// The workspace scope names no subject, so there is no membership to
+		// test and the object grant is what bounds it — unchanged, and asserted
+		// so a later narrowing of it is a deliberate edit rather than a surprise.
+		{"the workspace scope", seat(principal.RowScopeOwn), Scope{Kind: ScopeWorkspace}, true},
+		// An all-scope seat answers for the installation by definition, and the
+		// system principal is how the snapshot pass takes every scope's call.
+		{"a rival team, held by an all-scope seat", seat(principal.RowScopeAll), team(theirTeam), true},
+		{"a colleague's owner scope, held by the system", principal.Principal{Type: principal.PrincipalSystem}, owner(someoneElse), true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := requireScopeAuthority(principal.WithActor(context.Background(), c.actor), c.scope)
+			switch {
+			case c.allow && err != nil:
+				t.Errorf("the seat accountable for this scope was refused: %v", err)
+			case !c.allow && !errors.Is(err, apperrors.ErrNotFound):
+				t.Errorf("a scope this seat does not answer for was allowed or refused the wrong way: %v — "+
+					"the refusal must be ErrNotFound, so the answer reads the same as a scope that was never called",
+					err)
+			}
+		})
+	}
+}
+
+// A context the auth layer never resolved an actor onto is not every caller.
+func TestAnUnidentifiedCallerAnswersForNoScope(t *testing.T) {
+	id := ids.NewV7()
+	for _, scope := range []Scope{{Kind: ScopeWorkspace}, {Kind: ScopeOwner, ID: &id}, {Kind: ScopeTeam, ID: &id}} {
+		if err := requireScopeAuthority(context.Background(), scope); !errors.Is(err, apperrors.ErrNotFound) {
+			t.Errorf("scope %q with no actor on the context: %v, want ErrNotFound", scope.Kind, err)
+		}
+	}
+}
+
+// requireForecastScope runs checkScope before this, so a named scope carrying no
+// id is refused as a malformed request long before it arrives. The predicate is
+// still asserted directly on that shape: it is exported to nobody and guarded by
+// one caller today, and "some caller validated first" is the assumption a nil
+// dereference is made of.
+func TestANamedScopeWithNoSubjectIsRefusedRatherThanDereferenced(t *testing.T) {
+	actor := principal.Principal{
+		Type: principal.PrincipalHuman, UserID: ids.NewV7(),
+		Permissions: principal.Permissions{RowScope: principal.RowScopeOwn},
+	}
+	ctx := principal.WithActor(context.Background(), actor)
+	for _, kind := range []string{ScopeOwner, ScopeTeam} {
+		if err := requireScopeAuthority(ctx, Scope{Kind: kind}); !errors.Is(err, apperrors.ErrNotFound) {
+			t.Errorf("scope %q with no id: %v, want ErrNotFound", kind, err)
+		}
+	}
+}

--- a/backend/internal/modules/forecasting/snapshot.go
+++ b/backend/internal/modules/forecasting/snapshot.go
@@ -73,7 +73,11 @@ type NewSnapshot struct {
 // question about two recorded states, and a snapshot without its rows can only
 // say that a number changed.
 func (s *Store) TakeSnapshot(ctx context.Context, tx pgx.Tx, in NewSnapshot) (ids.UUID, error) {
-	if err := auth.Require(ctx, "forecast", principal.ActionCreate); err != nil {
+	// The scope half of the gate for the same reason the call has it: this
+	// freezes a number AGAINST a named team or owner, and a seat that may take
+	// snapshots at all is not thereby accountable for every scope in the
+	// installation.
+	if err := requireForecastScope(ctx, in.Scope); err != nil {
 		return ids.Nil, err
 	}
 	if err := checkSnapshot(in); err != nil {

--- a/backend/internal/modules/forecasting/store.go
+++ b/backend/internal/modules/forecasting/store.go
@@ -110,7 +110,7 @@ type NewCall struct {
 // predecessor and the chain forks — two heads, and no way to say which was
 // current.
 func (s *Store) RecordCall(ctx context.Context, in NewCall) (Call, error) {
-	if err := auth.Require(ctx, "forecast", principal.ActionCreate); err != nil {
+	if err := requireForecastScope(ctx, in.Scope); err != nil {
 		return Call{}, err
 	}
 	note, err := checkCall(in)
@@ -141,7 +141,7 @@ func (s *Store) RecordCall(ctx context.Context, in NewCall) (Call, error) {
 // the caller: an entry point that trusts its caller to have checked is one
 // deletion away from being an ungated write.
 func (s *Store) RecordCallTx(ctx context.Context, tx pgx.Tx, in NewCall) (Call, error) {
-	if err := auth.Require(ctx, "forecast", principal.ActionCreate); err != nil {
+	if err := requireForecastScope(ctx, in.Scope); err != nil {
 		return Call{}, err
 	}
 	note, err := checkCall(in)
@@ -333,9 +333,9 @@ func (s *Store) CurrentCallTx(ctx context.Context, tx pgx.Tx, period Period, sco
 
 // standingCallTx is the lookup itself. Ungated on purpose and unexported for
 // exactly that reason: its two callers are CurrentCallTx, which gates read, and
-// the write path, which has already required create on the same object. A
-// second Require there would refuse a manager who may call but not read, which
-// is not a seat this product has.
+// the write path, which has already required create on the same object AND
+// answered for the scope. A second Require here would refuse a manager who may
+// call but not read, which is not a seat this product has.
 func (s *Store) standingCallTx(ctx context.Context, tx pgx.Tx, period Period, scope Scope) (Call, error) {
 	var out Call
 	var note *string

--- a/docs/reference/gate-inventory.md
+++ b/docs/reference/gate-inventory.md
@@ -97,7 +97,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `workflowactor_test.go` | H2 | The id a workflow write is attributed to, and the id the selectors that recognise those writes look for, are ONE id. |
 | `worklistbounds_test.go` | H2 | The worklist reports a source as possibly having more work behind it when its lane came back exactly at its bound. |
 
-## Census (106)
+## Census (108)
 
 | Gate | Hardness | What it holds |
 |---|---|---|
@@ -109,6 +109,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `aitaskrailcensus_test.go` | H2 | Every AI task this build can run reports into the AI-activity projection. |
 | `aitaskwiring_test.go` | H2 | The census says a site EXISTS; this says a process role runs it. |
 | `analyticsscope_test.go` | H2 | Every path that renders a report spec's population applies that spec's row narrowings. |
+| `approvalselfonlyreaders_test.go` | H2 | Every approvals reader that filters rows by the decision grants also applies the self-only narrowing. |
 | `assurancerules_test.go` | H3 | Every assurance rule proves both halves of its judgement. |
 | `audiencereaders_test.go` | H2 | A message's AUDIENCE says who may read its content. |
 | `audienceretractioncallers_test.go` | H3 | activities.RetractDerivedForActivityTx documents that it is not atomic with the narrowing it follows, and the sentence is only true while every caller is an async consumer reacting to a COMMITTED audience change. |
@@ -142,6 +143,7 @@ The eight shapes, what each is for, and how each one silently passes:
 | `extensioncapabilitycensus_test.go` | H2 | Every capability the extension tier publishes must have a live unit declaring it. |
 | `extensionsignored_test.go` | H3 | The enabled set must be a set git actually has. |
 | `fliponehandle_test.go` | H2 | The overlay flip runs on ONE workspace binding, and this is what keeps it so. |
+| `forecastscopeauthority_test.go` | H2 | Every forecasting store entry point that RECORDS against a scope asks whether its caller answers for that scope. |
 | `gatecensus_test.go` | H2 | The census over this repo's own gate machinery: a gate's exceptions are held to the standard the gate holds its subjects to. |
 | `gateinventory_test.go` | H3 | The gate inventory: every gate in this package declares its own shape, and the reference page listing them is rendered from those declarations. |
 | `insertattemptcaps_test.go` | H2 | An insert that names no MaxAttempts does not run without a retry ladder — it runs on River's default of 25, on attempt-to-the-fourth backoff, which reaches days. |


### PR DESCRIPTION
## What

Three authorization gaps, each the same shape: a check that bound one thing and was read as binding another. One commit per fix.

- **A target-filtered approval read applies the self-only narrowing.** `decidable()` is the approvals module's one visibility predicate and carries two per-row authority halves — the grants a release would take, and the narrowing to the single seat a row was staged *for*. The two target-filtered reads settle target visibility once for the record instead of per row, so they spell the per-row halves themselves, and both spelled only the first. The narrowing is now one function, `withheldFromOtherSeats`, called by all three readers.
- **A forecast call names a scope its caller answers for.** The object grant says a seat may make forecast calls at all and nothing about *whose*. `requireForecastScope` is now the gate every entry point that RECORDS a scope runs: the object grant, then the shape, then the scope. It is answered from the principal, whose live team memberships the auth layer has already resolved, so the module keeps the property its package doc rests on — owning no tables and needing no database to decide anything. A miss is `ErrNotFound`, so existence stays hidden. The workspace scope names no subject and stays bounded by the object grant alone, as before.
- **A lent credential does not release another person's staged action.** `agentMayDecide` refused a credential the row it had itself staged. That binds the *credential*; nothing bound the *person*. A lent credential now releases only what the person who lent it could have answered in the CRM themselves.

`TakeSnapshot` freezes a number against a named scope through the same shape and took the object grant alone, so it is fixed here too rather than left for the next reader.

**The forecast gate is on the WRITE only, and that asymmetry is deliberate.** Measuring a population and asserting a number for it are different questions with different answers: a team manager may legitimately *measure* a teammate's pipeline, and #4077 now settles that once for every analytics surface in `AnalyticsPopulationClause`, using a live-membership read this module cannot make — it owns no tables and may not import identity. Recording a call is the stricter question, it is asked of a scope taken verbatim from a request body that never reaches that resolver, and it is the module's own. A second, narrower copy of the read rule in the store would refuse the very manager the resolver had just admitted, so the reads keep the object grant they had and the store test asserts that on purpose.

**Rebased onto #4077, which overtook one hunk of this branch.** My first push also fixed `forecastScopeClause`, which queried `team_member` — a table no migration creates — so every team-scoped read errored instead of narrowing. #4077 deleted that function outright and replaced it with `liveTeamMembersSQL`, which reads `team_membership` joined to a live team *and* a live member. That is a strictly better fix than mine, so my hunk is dropped and this branch no longer touches `forecastseam.go`.

## Why

Each is an obligation this tree states somewhere and enforced nowhere.

- `authority.go` documents the self-only narrowing in its own words, and `pendingfortarget.go` claimed to be "filtered by the same decidability rule the inbox uses" — which was not true at the line that did the filtering.
- The migration owning `forecast_call` states the rule as "an assertion about a team's forecast, made by whoever is accountable for it". Nothing enforced the second half of that sentence, and `RecordForecastCall` still takes its scope verbatim from the body without passing through the analytics resolver.
- `agentMayDecide` reasons at length about why a credential must not confirm its own proposal, and stops there — so the rule held for one credential and not for two.

Each is held by a fitness function rather than a point fix. Both censuses derive their corpus from the tree — the approvals one selects whoever asks the grant question; the forecasting one reads the scope-bearing types off the package's own struct declarations and then keeps the ones that reach a forecast INSERT — so a reader or writer added later inherits the obligation instead of relying on someone remembering. Both fail loudly if a symbol they select on is renamed, rather than sweeping an empty corpus and reporting PASS.

**Behaviour changes worth a reviewer's attention**

- A bounded seat recording a call against a scope it does not answer for now gets 404 where it got 201. Reads are unchanged by this branch.
- A `scope_kind` nobody recognises is now a `scope_kind` ParseError for every caller on the write path. Previously the shape was checked after the authority, so an unbounded seat was told its field was wrong while a bounded one was told the thing it named does not exist — one defect reported two ways, decided by the reader's privilege. (Raised by CodeRabbit; see the thread.)
- An agent credential deciding a staging filed for a different person now gets 403 on approve. Rejection is unchanged: it discards a proposal and cannot escalate, so an agent can still take a request off a desk. A server-proposed row stays outside the rule, so the unattended policy apply is unaffected.
- Two existing unit tests changed. One re-spelled the self-only rule instead of calling production and passed throughout; it now calls the predicate itself. The other's fixture omitted `on_behalf_of` — a shape production cannot produce, and one under which a rule about that person passes without being asked.

## How verified

Re-run in full after the rebase, on a clean LF checkout of this branch:

- **Full backend unit + gate suite** (`go test ./...`): the failure set is a strict subset of the baseline taken on the same checkout before this branch existed — **zero introduced**, and two fixed upstream since.
- **Integration lane against a real Postgres** (`make test-it`) for `approvals`, `forecasting` and `compose`: green apart from failures present in that same baseline (`TestWriteSetupTokenFile*`, Windows file-permission semantics).
- **`craft static --strict`** over every changed Go file: 0 blocker, 0 major, 0 minor. It caught `store.go` crossing the 500-line file ceiling after the rework, which is why the gate now lives in its own `scopeauthority.go` — a different question from how a call is written.
- Plus the two whole-tree scripts the pre-push hook runs, and `craft-residue`.
- **Every new gate and test was run in both directions** — each fails on the reintroduced defect and passes on the fix, including the three integration tests, which reproduce the original behaviour exactly before the fix is applied. Each carries a positive control asserting the allowed case still works, and each asserts the exact sentinel rather than "not 200".

**On the shard 5/6 failure in the previous run:** it was `TestARedismissalNamesTheDeadlineItReplaced` in `internal/modules/people`, comparing a Postgres microsecond timestamp (`…319426Z`) against a Go nanosecond one (`…319426794Z`). It reproduces locally with this entire branch reverted, and `internal/modules/people` depends on neither package this branch changes. Pre-existing, and not something a security branch should quietly absorb — happy to open an issue for it.

`make check` was not run as one target locally: this working copy is a Windows checkout with `core.autocrlf=true`, which fails byte-comparing gates on files this branch never touches. Its lanes were run individually on a clean LF checkout instead.

- [ ] `make check` is green — see the note above; run lane by lane on a clean checkout, deferring to CI
- [x] `make test-integration` is green — run per-package against a real Postgres for every package this touches
- [x] `make craft-static` reports no new blockers
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document — a decision is cited by its number (this repository is public)

Deliberately no reproduction steps here, in either the description or the code comments: the tests state the invariant and the refusal, not a recipe.

## AI involvement

AI-assisted throughout, under my review: the analysis, the patches, the two censuses, the unit tests and the three integration tests were drafted by Claude Code and checked by me against the source and against a real database. The verification above was actually executed, not asserted — including running each new gate against the reintroduced defect to confirm it fails, which is the only evidence that a green gate means anything, and reverting the branch entirely to confirm the shard failure was not ours.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can **explain every line** in it — human-written or AI-assisted. Commits are signed off (`git commit -s`, DCO).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted approval records staged for another person or seat from target-filtered views.
  * Prevented agents from approving actions staged for a different person while preserving permitted rejection workflows.
  * Enforced authority checks for forecast recording and snapshot creation based on the requested scope.
  * Unauthorized or unresolved forecast scope access now returns a not-found response.

* **Documentation**
  * Updated the authorization gate inventory with additional coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->