### PR TITLE
fix(e2e): analytics asks for its own frame, and the mock stops answering as a record

### DIFF
--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -2275,6 +2275,25 @@ export async function mockApi(
         computed_at: "2026-07-13T00:00:00Z",
       });
     }
+    // Analytics' frame, BEFORE the record-context match below: that one tests
+    // a substring, so it answered this route with a 360's envelope — a body
+    // with no `default_scope`, which took every analytics screen to the error
+    // boundary and the rail with it. Named in full here because the two share
+    // a word and nothing else.
+    if (path === "/analytics/context") {
+      const workspace = { kind: "workspace", label: "Whole workspace" };
+      return json({
+        default_scope: workspace,
+        allowed_scopes: [workspace],
+        capabilities: {
+          view_manager_forecast: true,
+          submit_manager_forecast: true,
+        },
+        as_of: "2026-07-13T00:00:00Z",
+        timezone: "Europe/Berlin",
+        base_currency: "EUR",
+      });
+    }
     // RS-3's context panel and the IT-1 tool console both read fixed-shape
     // envelopes the list catch-all below doesn't produce (`{sections:[]}`,
     // `{data:[AgentTool]}` vs `{data:[],page}`) — mock them explicitly so a


### PR DESCRIPTION
## What

The e2e mock answers `/analytics/context` with an analytics frame instead of a record's context envelope. One route, placed above the substring match that was catching it.

## Why

The `uat` lane is red on `main` today, and not with a failing assertion — with a route that will not mount. Ten acceptance tests fail across the axe sweeps, the heading census and the 390px pass, plus `history.spec.ts`, which navigates through a rail that never appears. Every one of them is an analytics route.

The analytics scope work added a read of `/analytics/context`. The mock matched it with

```ts
if (path.includes("/context")) {
  return json({ anchor: { type: "person", id: "x" }, sections: [] });
}
```

— a branch written for a record's context panel. That body carries no `default_scope`; the screen reads the field off it and throws, so the whole screen goes to its error boundary and `nav.rail` never renders. The failures read as an accessibility problem and a heading problem and a layout problem, and are one missing mock.

What makes this worth fixing at the mock rather than at the screen: the substring match is the defect. `/analytics/context` and a record's context panel share one word and nothing else, and a test double that answers a route it was never written for is worse than one that 404s — a 404 would have named itself. The branch's own comment says it exists so a surface does not crash on an undefined field, which is precisely what happened to the surface it did not name. Naming the analytics route in full, above it, is the smallest change that makes the double honest.

## How verified

- Reproduced on a clean `origin/main` checkout first: the same ten failures, so this is not one PR's problem. Captured the actual response body to find the cause rather than reading the assertions.
- With this route: those ten pass.
- Full Playwright suite on this branch: **264 passed, 54 skipped, 0 failed**.
- `tsc -b` and biome clean.

- [x] `make check` — frontend only; no product code changes, `check-backend` untouched
- [x] `make test-integration` not needed: this is a test double, no tenant data, RLS or write-shape change
- [x] `make craft-static`: no Go files touched
- [x] This diff and description carry no secrets, no customer data, no local machine paths, and nothing quoted from or pointing at a private document

## AI involvement

Found and written by Claude Code. The failure surfaced on an unrelated pull request's `uat` lane; I reproduced it on `main` before concluding it was not that change's, then traced it to the mock by reading the response the screen actually received.

## Accountability

By opening this PR I confirm I am **accountable** for this change and can
**explain every line** in it — human-written or AI-assisted. Commits are signed
off (`git commit -s`, DCO). See [CONTRIBUTING.md](/CONTRIBUTING.md) and the
[Code of Conduct](/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC

---
_Generated by [Claude Code](https://claude.ai/code/session_017783CSwvEYLLZ9gYdEeDyC)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the e2e mock so `/analytics/context` returns a real analytics frame instead of a record's context envelope, which was crashing every analytics screen into its error boundary and failing ten acceptance tests.

- The old substring match (`path.includes("/context")`) answered the analytics route with a body lacking `default_scope`.
- The exact-match route sits above that substring match, so the record context path is unaffected.
- Full Playwright suite passes on this branch: 264 passed, 54 skipped, 0 failed.

<sup>Written for commit 71c1a74a8aa5412b650fe26f51c369ffa516a242. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/margince/margince/pull/4100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added explicit analytics context test data, including workspace scope, forecasting capabilities, timestamp, timezone, and base currency.
  * Improved end-to-end test consistency by defining the analytics context response before broader context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->