### PR TITLE
fix: main is green on the frontend lane again

### DIFF
--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -2195,6 +2195,29 @@ export async function mockApi(
         ]),
       );
     }
+    // The frame every Analytics answer is placed in. Without it the screen's
+    // own context query throws and the whole route renders the error boundary
+    // — which is not "analytics has a defect" but "this mock does not serve an
+    // endpoint the screen now reads", and it takes the shell down with it, so
+    // every sweep over #/analytics fails on a missing nav rail rather than on
+    // anything it was measuring.
+    //
+    // One allowed scope, and it is the default: this fixture's reader measures
+    // the workspace. A second would put a population picker on screen that no
+    // AC below is about.
+    if (path === "/analytics/context") {
+      return json({
+        default_scope: { kind: "workspace", label: "Everyone" },
+        allowed_scopes: [{ kind: "workspace", label: "Everyone" }],
+        capabilities: {
+          view_manager_forecast: true,
+          submit_manager_forecast: true,
+        },
+        as_of: "2026-03-04T09:00:00Z",
+        timezone: "Europe/Berlin",
+        base_currency: "EUR",
+      });
+    }
     if (path.startsWith("/reports/")) {
       return json({
         report: "deals-by-stage",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3230,7 +3230,8 @@ export const de = {
   "tasks.isDone": "Abgeschlossen",
   "tasks.logged": "Erfasst",
 
-  "analytics.sub": "nur offene Deals, jeder einzeln in {currency} umgerechnet — ungewichtet neben gewichtet",
+  "analytics.sub":
+    "nur offene Deals, jeder einzeln in {currency} umgerechnet — ungewichtet neben gewichtet",
   "analytics.currency": "Währung",
   "analytics.count": "Deals",
   "analytics.unweighted": "Ungewichtet",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3279,7 +3279,8 @@ export const en = {
   "tasks.isDone": "Completed",
   "tasks.logged": "Logged",
 
-  "analytics.sub": "open deals only, each converted into {currency} — unweighted next to weighted",
+  "analytics.sub":
+    "open deals only, each converted into {currency} — unweighted next to weighted",
   "analytics.currency": "Currency",
   "analytics.count": "Deals",
   "analytics.unweighted": "Unweighted",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3197,7 +3197,8 @@ export const vi = {
   "tasks.isDone": "Đã hoàn thành",
   "tasks.logged": "Đã ghi nhận",
 
-  "analytics.sub": "chỉ deal đang mở, mỗi deal quy đổi riêng sang {currency} — chưa trọng số cạnh có trọng số",
+  "analytics.sub":
+    "chỉ deal đang mở, mỗi deal quy đổi riêng sang {currency} — chưa trọng số cạnh có trọng số",
   "analytics.currency": "Tiền tệ",
   "analytics.count": "Deal",
   "analytics.unweighted": "Chưa trọng số",


### PR DESCRIPTION
`make check-fe` fails on `main` right now, for two unrelated reasons that landed in the same lane. Neither has a ticket; both are one line of cause each.

**1. `fe-lint` — three format errors.** `pnpm lint` is `biome check`, not `biome lint`, so a formatting difference is an *error* and not an info. The `analytics.sub` line in each of `en.ts`, `de.ts` and `vi.ts` is past the print width and was committed unformatted by #3777. Only those three lines move.

The six `noUselessFragments` findings in `deals`, `leads`, `personpage` and `project360` are **infos** — they do not fail the lane, and fixing them here would drag six unrelated screens into a red-main PR. Worth a ticket, not worth this diff.

**2. The mocked UAT sweep — every test over `#/analytics`.** #4077 gave Analytics a context query, `GET /analytics/context`, the frame every answer is placed in. `e2e/seed.ts` does not serve it, so the query throws, the screen renders the app error boundary, and the shell goes with it: ten tests fail on a **missing nav rail**, which names nothing about the cause. I bisected rather than guessed — green at `b648ee43d`, red at `257e22e32`, which is #4077 itself.

The mock offers one allowed scope and makes it the default. A second would put a population picker on screen that none of the ACs below it are about.

### Why one PR

Two causes, one lane, one `make check-fe`. Splitting them costs two full CI runs to unbreak one gate.

### Checks

`make check-fe` green locally, including the ten previously-failing UAT tests.

### Coordination

Announced as a red-main fix. I checked open PRs first and found none in flight against either cause; if one appears I will close this in its favour.