### PR TITLE
main is red: three i18n catalogs are not formatted

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3230,7 +3230,8 @@ export const de = {
   "tasks.isDone": "Abgeschlossen",
   "tasks.logged": "Erfasst",
 
-  "analytics.sub": "nur offene Deals, jeder einzeln in {currency} umgerechnet — ungewichtet neben gewichtet",
+  "analytics.sub":
+    "nur offene Deals, jeder einzeln in {currency} umgerechnet — ungewichtet neben gewichtet",
   "analytics.currency": "Währung",
   "analytics.count": "Deals",
   "analytics.unweighted": "Ungewichtet",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3279,7 +3279,8 @@ export const en = {
   "tasks.isDone": "Completed",
   "tasks.logged": "Logged",
 
-  "analytics.sub": "open deals only, each converted into {currency} — unweighted next to weighted",
+  "analytics.sub":
+    "open deals only, each converted into {currency} — unweighted next to weighted",
   "analytics.currency": "Currency",
   "analytics.count": "Deals",
   "analytics.unweighted": "Unweighted",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -3197,7 +3197,8 @@ export const vi = {
   "tasks.isDone": "Đã hoàn thành",
   "tasks.logged": "Đã ghi nhận",
 
-  "analytics.sub": "chỉ deal đang mở, mỗi deal quy đổi riêng sang {currency} — chưa trọng số cạnh có trọng số",
+  "analytics.sub":
+    "chỉ deal đang mở, mỗi deal quy đổi riêng sang {currency} — chưa trọng số cạnh có trọng số",
   "analytics.currency": "Tiền tệ",
   "analytics.count": "Deal",
   "analytics.unweighted": "Chưa trọng số",


### PR DESCRIPTION
`frontend / fe-quality` fails on every open pull request. Reproduced on plain `origin/main`.

## What

#4099 added `analytics.sub` to `en.ts`, `de.ts` and `vi.ts`. The line is long enough that biome wraps it, and it landed unwrapped — so `pnpm lint`, which is `biome check` with formatting included, reports:

```
Checked 1627 files in 2s. No fixes applied.
Found 3 errors.
```

## The fix

Biome's own output — `biome check --write` — which touched exactly those three lines and nothing else. **No string changed**, in any language; the wrap is where the formatter puts it.

## What I deliberately did not fix

The same run reports six `noUselessFragments` findings in `deals.tsx`, `leads.tsx`, `personpage.tsx` and `project360.tsx`. Those are **INFO, not errors** — they are not what fails the lane, and they predate this.

Left alone on purpose: they are a separate judgement about JSX in four screens, and folding them in would put an unreviewed change to those files inside a commit whose entire claim is that it changed no meaning. Worth a ticket if anyone wants them gone.

`make fe-lint` now passes; `make fe-typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)